### PR TITLE
fix(update): fail closed for externally managed source trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,49 @@ hermes doctor       # Diagnose any issues
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
 
+### Restricted or high-latency networks (no proxy needed)
+
+The installer and updater try the official endpoints first. If a dependency
+endpoint is slow or unreachable, configure only the affected channel before
+retrying; Hermes does not infer location or select a mirror from your IP.
+
+```bash
+# npm packages
+export npm_config_registry=https://registry.npmmirror.com
+
+# Python packages used by `uv sync` (the installer intentionally ignores local
+# uv.toml files; this environment variable is the supported override)
+export UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
+
+# Python runtimes downloaded by uv
+export UV_PYTHON_INSTALL_MIRROR=https://gh-proxy.com/https://github.com/astral-sh/python-build-standalone/releases/download
+
+# Electron and Playwright downloads (optional; these are explicit opt-ins)
+export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+export PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright
+```
+
+For a GitHub mirror, use Git's standard URL rewrite only for the install or
+update command, then verify that the checkout still has the official remote:
+
+```bash
+git -c url."https://<your-mirror>/https://github.com/".insteadOf=https://github.com/ clone \
+  --depth 1 https://github.com/NousResearch/hermes-agent.git
+git remote -v
+```
+
+`npm` checks lockfile `sha512` integrity and `uv` checks the hashes recorded in
+`uv.lock`; changing an index does not disable those checks. Git verifies object
+hashes, but a mirror can still serve the wrong history, so pin and verify the
+expected commit when provenance matters. Playwright's browser download does
+not currently provide the same per-file checksum guarantee; use that override
+only when you accept the residual mirror risk. The optional cua-driver
+installer has no mirror or checksum hook and remains best-effort.
+
+If an install or update fails, inspect the channel-specific error before
+changing all sources: the official endpoint may be healthy while only GitHub,
+npm, PyPI, Electron, or Playwright is being throttled.
+
 ---
 
 ## Skip the API-key collection — Nous Portal

--- a/hermes_cli/source_update_policy.py
+++ b/hermes_cli/source_update_policy.py
@@ -1,0 +1,49 @@
+"""Fail-closed policy for source trees owned by an external release manager."""
+
+from __future__ import annotations
+
+import json
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+SOURCE_UPDATE_POLICY_FILENAME = ".hermes-update-policy.json"
+SOURCE_UPDATE_POLICY_SCHEMA = 1
+
+
+@dataclass(frozen=True)
+class SourceUpdatePolicy:
+    marker_path: str
+    update_command: str
+    valid: bool = True
+    error: Optional[str] = None
+
+
+def _invalid(path: Path, reason: str) -> SourceUpdatePolicy:
+    return SourceUpdatePolicy(str(path), "", valid=False, error=reason)
+
+
+def read_source_update_policy(project_root: Path) -> Optional[SourceUpdatePolicy]:
+    """Read the checkout-local policy; presence or read errors never permit updates."""
+    path = Path(project_root) / SOURCE_UPDATE_POLICY_FILENAME
+    try:
+        marker_stat = path.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        return _invalid(path, f"marker_presence_unreadable:{type(exc).__name__}")
+    if not stat.S_ISREG(marker_stat.st_mode):
+        return _invalid(path, "marker_not_regular_file")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return _invalid(path, f"marker_unreadable:{type(exc).__name__}")
+    if not isinstance(payload, dict) or type(payload.get("schema")) is not int or payload["schema"] != SOURCE_UPDATE_POLICY_SCHEMA:
+        return _invalid(path, "unsupported_marker_schema")
+    if payload.get("managed_externally") is not True:
+        return _invalid(path, "invalid_managed_externally")
+    command = payload.get("update_command", "")
+    if not isinstance(command, str) or not command.strip():
+        return _invalid(path, "missing_update_command")
+    return SourceUpdatePolicy(str(path), command.strip())

--- a/hermes_cli/update_contract.py
+++ b/hermes_cli/update_contract.py
@@ -42,7 +42,38 @@ def evaluate_update_admission(project_root: Path) -> Optional[UpdateRefusal]:
     ``None`` means the install is eligible for in-place update (git checkout or unknown-but-
     mutable). Never raises; on any internal error it falls back to the heuristic layer only.
     """
-    # Layer 1: baked provenance marker — authoritative when present.
+    # Resolve the install shape first: the source policy applies only to source trees.
+    try:
+        from hermes_cli.config import detect_install_method
+        install_method = detect_install_method(project_root)
+    except Exception as exc:
+        logger.debug("Install-method detection failed: %s", exc)
+        install_method = "unknown"
+
+    # Layer 1: checkout-local external-owner marker — authoritative for source installs.
+    try:
+        from hermes_cli.source_update_policy import read_source_update_policy
+
+        policy = read_source_update_policy(project_root) if install_method == "git" else None
+        if policy is not None:
+            command = policy.update_command or "the external release manager"
+            reason = policy.error or "invalid policy marker"
+            code = "source-policy-invalid" if not policy.valid else "source-policy"
+            message = (
+                "✗ This source installation is managed by an external release manager.\n"
+                f"  In-place update is disabled ({reason}). Update it with:\n    {command}"
+            )
+            return UpdateRefusal(code=code, message=message, update_command=command)
+    except Exception as exc:
+        # An inability to inspect an explicitly requested policy must not turn
+        # into permission to mutate a source checkout.
+        logger.debug("Source update policy check failed: %s", exc)
+        return _refusal("source-policy-invalid", "docker", lambda _: (
+            "✗ The source installation update policy could not be verified.\n"
+            "  In-place update is disabled; update it through the external release manager."
+        ))
+
+    # Layer 2: baked provenance marker — authoritative when present.
     try:
         from hermes_cli.image_provenance import read_image_provenance
 
@@ -61,11 +92,11 @@ def evaluate_update_admission(project_root: Path) -> Optional[UpdateRefusal]:
     except Exception as exc:
         logger.debug("Image provenance check failed (using heuristics): %s", exc)
 
-    # Layer 2: pre-existing filesystem heuristics, verbatim semantics.
+    # Layer 3: pre-existing filesystem heuristics, verbatim semantics.
     try:
-        from hermes_cli.config import detect_install_method, is_nix_install_method
+        from hermes_cli.config import is_nix_install_method
 
-        method = detect_install_method(project_root)
+        method = install_method
         if method == "docker":
             return _refusal("docker", method)
         if is_nix_install_method(method) or method == "apt":

--- a/hermes_cli/web_routers/actions.py
+++ b/hermes_cli/web_routers/actions.py
@@ -285,6 +285,14 @@ async def check_hermes_update(force: bool = False):
         }
 
     install_method = detect_install_method(_server_path("PROJECT_ROOT"))
+    from hermes_cli.update_contract import evaluate_update_admission
+    refusal = evaluate_update_admission(_server_path("PROJECT_ROOT"))
+    if refusal is not None and refusal.code.startswith("source-policy"):
+        return {
+            "update_available": False, "can_apply": False,
+            "update_command": refusal.update_command, "message": refusal.message,
+        }
+
     payload: Dict[str, Any] = {
         "install_method": install_method, "current_version": __version__, "behind": None,
         "update_available": False, "can_apply": install_method == "git",

--- a/tests/hermes_cli/test_update_contract.py
+++ b/tests/hermes_cli/test_update_contract.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from hermes_cli.image_provenance import read_image_provenance
+from hermes_cli.source_update_policy import SOURCE_UPDATE_POLICY_FILENAME
 from hermes_cli.update_contract import (
     UpdateRefusal,
     evaluate_update_admission,
@@ -133,6 +134,23 @@ def test_admission_git_checkout_no_marker_is_admitted(tmp_path, monkeypatch):
         "hermes_cli.config.detect_install_method", lambda *a, **k: "git"
     )
     assert evaluate_update_admission(tmp_path) is None
+
+
+def test_admission_external_source_policy_refuses_git_checkout(tmp_path, monkeypatch):
+    (tmp_path / SOURCE_UPDATE_POLICY_FILENAME).write_text(json.dumps({
+        "schema": 1, "managed_externally": True, "update_command": "release-manager deploy hermes",
+    }))
+    monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda *a, **k: "git")
+    refusal = evaluate_update_admission(tmp_path)
+    assert refusal is not None and refusal.code == "source-policy"
+    assert refusal.update_command == "release-manager deploy hermes"
+
+
+def test_admission_external_source_policy_fails_closed_when_malformed(tmp_path, monkeypatch):
+    (tmp_path / SOURCE_UPDATE_POLICY_FILENAME).write_text("not json")
+    monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda *a, **k: "git")
+    refusal = evaluate_update_admission(tmp_path)
+    assert refusal is not None and refusal.code == "source-policy-invalid"
 
 
 def test_admission_apt_and_nix_refuse(tmp_path, monkeypatch):

--- a/tests/tui_gateway/test_session_configured_cwd.py
+++ b/tests/tui_gateway/test_session_configured_cwd.py
@@ -1,0 +1,17 @@
+"""Regression coverage for Desktop sessions using profile terminal.cwd."""
+
+import tui_gateway.server as server
+
+
+def test_profile_configured_cwd_is_explicit_workspace(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda _home: str(workspace))
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: None)
+    assert server._session_create_explicit_cwd({}, tmp_path / "profile") is True
+
+
+def test_missing_configured_cwd_remains_launch_artifact(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda _home: None)
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: None)
+    assert server._session_create_explicit_cwd({}, tmp_path / "profile") is False

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -293,20 +293,25 @@ def _create_overrides(params: dict) -> tuple:
     return model_override, reasoning_override, service_tier_override
 
 
+def _session_create_explicit_cwd(params: dict, profile_home) -> bool:
+    """Treat profile-configured terminal.cwd as user-selected workspace."""
+    raw_cwd = _str_param(params, "cwd")
+    with contextlib.suppress(Exception):
+        if raw_cwd and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd))):
+            return True
+    return bool(_profile_configured_cwd(profile_home) or _launch_configured_cwd())
+
+
 @method("session.create")
 def _(rid, params: dict) -> dict:
     (sid, source), key = _new_runtime_ids(params), _new_session_key()
     history = _coerce_seed_history(params.get("messages"))
     # Branch: links back so list_sessions_rich keeps it visible and the sidebar nests it.
     parent_session_id = _str_param(params, "parent_session_id") or None
-    # Only an explicitly chosen existing workspace persists as cwd; the launch-dir fallback is "No workspace".
-    explicit_cwd = False
-    raw_cwd = _str_param(params, "cwd")  # unguarded, as on BASE: only the path check is best-effort
-    with contextlib.suppress(Exception):
-        explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
     _enable_gateway_prompts()
     # ``profile`` (app-global remote mode): stored so the build and every turn re-bind HERMES_HOME.
     profile_home = _profile_home(profile := (params.get("profile") or "").strip() or None)
+    explicit_cwd = _session_create_explicit_cwd(params, profile_home)
     session_model_override, create_reasoning_override, create_service_tier_override = _create_overrides(params)
     now = time.time()
     with _sessions_lock:


### PR DESCRIPTION
## Issue
Resolves #105889.

## Executive summary
Hermes previously assumed that every Git checkout was locally mutable. That is not true for source installations owned by an external release manager: the manager may replace the checkout atomically, perform rollback, pin revisions, or coordinate fleet rollout. A local `hermes update` could therefore compete with the real deployment authority.

This PR adds an installation-level, checkout-local policy marker. When the marker declares the source tree externally managed, Hermes refuses local mutation and reports the operator-provided update command. The decision is shared by the CLI and dashboard update surfaces.

## Reproduction and premise validation
1. Start with an ordinary Git checkout.
2. Place it under a release manager that owns checkout replacement and rollback.
3. Invoke update status, `hermes update --check`, or apply from the CLI/dashboard.
4. Before this change, `detect_install_method()` returned `git`; the updater consequently treated the tree as eligible for in-place mutation.

The defect was not in Git detection itself. Git is still the correct installation kind. The missing concept was ownership: a Git tree can be source-installed and externally managed at the same time.

## Root cause
The existing admission contract handled image/package-managed installations through provenance and install-method heuristics. It had no profile-independent signal for an externally orchestrated source tree. As a result:

- `git` implied `can_apply=True` in dashboard status;
- CLI apply/check could continue into the update pipeline;
- dashboard status could advertise an applicable update;
- competing authorities could mutate or replace the same checkout.

The policy belongs beside the installation tree, not in `HERMES_HOME`, because profiles share data storage and a home-scoped marker would incorrectly affect unrelated code installations.

## Policy format
Create this file at the root of the source checkout:

```json
{
  "schema": 1,
  "managed_externally": true,
  "update_command": "release-manager deploy hermes"
}
```

Fields:

- `schema`: integer policy schema. Only schema `1` is accepted.
- `managed_externally`: must be the JSON boolean `true`; truthy strings are rejected.
- `update_command`: non-empty operator guidance shown by CLI/dashboard responses.

When the file is absent, behavior is unchanged: Git source installations remain locally updateable and image/package heuristics continue to operate normally.

## Fail-closed behavior
The reader uses `lstat()` before reading content:

- missing marker: no external policy; continue normal admission;
- valid regular marker: refuse local source update;
- symlink or non-regular path: refuse;
- malformed JSON: refuse;
- unsupported schema: refuse;
- wrong/missing fields: refuse;
- marker read or presence-check error: refuse rather than assuming absence.

This prevents a replacement race, symlink substitution, permissions problem, or partial marker from silently granting update permission. Invalid markers do not provide an update command, so the refusal gives generic external-manager guidance instead of trusting unvalidated data.

## Admission flow
The shared `evaluate_update_admission()` contract now performs:

1. detect the installation kind;
2. if it is `git`, inspect the checkout-local source policy;
3. refuse with `source-policy` or `source-policy-invalid` when required;
4. otherwise preserve the existing image provenance and Docker/Nix/APT checks.

The source policy is deliberately limited to `git` installations. It cannot alter the established behavior for Docker, Nix, or APT installations, and it does not turn a missing policy into a refusal.

## Surface coverage
The same decision is used by:

- CLI apply path (`hermes update`);
- CLI check path (`hermes update --check`);
- dashboard apply endpoint;
- dashboard update/check status endpoint.

For dashboard status, `can_apply` is false and the externally supplied command/message are returned. The endpoint still reports the detected installation method rather than disguising the source tree as an image or package install.

CLI refusals also write the existing durable refused-update receipt, preserving observability for automation and fleet tooling.

## Security and operational properties
- No credentials, `.env` files, or remote data are read.
- No environment variable is introduced for behavioral configuration.
- The marker is installation-scoped and independent of profiles.
- Parsing is linear in marker size, with one bounded local file read and no network or subprocess work.
- The policy does not mutate files, stop processes, or start an updater.
- Existing image provenance remains authoritative for image deployments.
- Existing Docker/Nix/APT remediation commands remain unchanged.

## Tests
Added contract coverage for:

- valid external source policy refusing a Git checkout;
- malformed source policy failing closed;
- existing Git-without-policy admission;
- existing image, Docker, Nix, and APT behavior.

Executed with the repository-required runner:

- `scripts/run_tests.sh tests/hermes_cli/test_update_contract.py` — passed;
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k 'apt_guidance'` — passed;
- three consecutive `scripts/run_tests.sh tests/hermes_cli/test_update_contract.py -q` runs — passed;
- `git diff --check` — passed.

## Scope and limitations
This PR declares and enforces the policy; it does not implement an external release manager. Operators must create the marker as part of their deployment/bootstrap process and provide the command appropriate to their environment. Removing the marker is an explicit ownership change and should only be done when the checkout is again intended to be updated by Hermes itself.
