### PR TITLE
fix(desktop): keep the active gateway default reachable in the fleet condensed profile dropdown (#106017)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
@@ -123,8 +123,9 @@ const connectionsRegistry = connectionsStore.$connectionsRegistry as ReturnType<
   typeof atom<DesktopConnectionsRegistry | null>
 >
 
-const { $profiles, $profileScope } = await import('@/store/profile')
+const { $activeGatewayProfile, $profiles, $profileScope } = await import('@/store/profile')
 const profiles = $profiles as ReturnType<typeof atom<Array<{ is_default: boolean; name: string }>>>
+const activeGatewayProfile = $activeGatewayProfile as ReturnType<typeof atom<string>>
 const profileScope = $profileScope as ReturnType<typeof atom<string>>
 const { _resetFleetRosterForTests } = await import('@/store/fleet-roster')
 
@@ -208,6 +209,7 @@ afterEach(() => {
   connectionsRegistry.set(null)
   activeConnectionId.set(null)
   profileScope.set('default')
+  activeGatewayProfile.set('default')
   profiles.set([{ is_default: true, name: 'default' }])
   delete (window as { hermesDesktop?: unknown }).hermesDesktop
 })
@@ -352,5 +354,49 @@ describe('ProfileRail fleet mode', () => {
 
     expect(screen.getByRole('button', { name: 'Profiles' })).toBeTruthy()
     expect(container.querySelector('[data-slot="profile-rail-rest-square"]')).toBeNull()
+  })
+
+  it('keeps the active gateway default reachable in the condensed dropdown from a named profile', async () => {
+    armFleet()
+    profiles.set([
+      { is_default: true, name: 'default' },
+      ...Array.from({ length: 11 }, (_, index) => ({ is_default: false, name: `p${index + 1}` }))
+    ])
+    // Switched away from default to a named profile on the active (remote) gateway.
+    activeGatewayProfile.set('p1')
+    profileScope.set('p1')
+    await renderFleet()
+
+    // Fleet condensed drops the default↔all home pill for the layers pill, so without
+    // surfacing default in the dropdown there is no way back to it (#106017).
+    const trigger = screen.getByRole('button', { name: 'Profiles' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    await screen.findByRole('menu')
+    // The active gateway's own rows are radio items; its default must be one of them.
+    const defaultRadio = screen.getByRole('menuitemradio', { name: 'default' })
+    expect(defaultRadio).toBeTruthy()
+
+    // Selecting it stays on the active gateway (selectProfile), never re-homes to
+    // another gateway's default (selectConnection).
+    fireEvent.click(defaultRadio)
+    expect(selectProfile).toHaveBeenCalledWith('default')
+    expect(selectConnection).not.toHaveBeenCalled()
+  })
+
+  it('identifies the active gateway default in the condensed trigger when it is active', async () => {
+    armFleet()
+    profiles.set([
+      { is_default: true, name: 'default' },
+      ...Array.from({ length: 11 }, (_, index) => ({ is_default: false, name: `p${index + 1}` }))
+    ])
+    // Default is the active profile: the trigger must name it, not fall back to
+    // the generic "Profiles" placeholder (#106017).
+    await renderFleet()
+
+    const trigger = screen.getByRole('button', { name: 'Profiles' })
+    expect(trigger.textContent).toContain('default')
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -455,7 +455,12 @@ export function ProfileRail() {
             onImport={() => void runImportProfileFlow()}
             onSelect={selectProfile}
             onSelectRest={switchToRest}
-            profiles={named}
+            // Fleet condensed swaps the default↔all home pill out for the layers pill, so the
+            // active gateway's default has no other control — surface it as a dropdown row like
+            // rest gateways do ([defaultAgent, ...named]) so it stays reachable and the trigger
+            // can identify it when active (#106017). Non-fleet keeps the home pill, so leave its
+            // dropdown byte-identical (named only).
+            profiles={fleet && defaultProfile ? [defaultProfile, ...named] : named}
             restGroups={restGroups}
           />
         </div>


### PR DESCRIPTION
## What does this PR do?

Fixes #106017: in Hermes Desktop **fleet** mode, once the fleet crosses `PROFILE_DROPDOWN_THRESHOLD` and the profile rail condenses to a dropdown, the active gateway's `default` profile becomes unreachable through the visible UI.

## Root cause

Two fleet-specific branches combine to hide it:

- Fleet mode replaces the default↔all *home* pill with the "all profiles on this gateway" **layers** pill, so there's no home control for the active gateway's default.
- The condensed dropdown is fed only `named = profiles.filter(p => !p.is_default)`, so the active gateway's `default` has no dropdown row either.

Result: after switching from `default` to a named profile there is no visible way back; when `default` is active the dropdown trigger shows the generic "Profiles" placeholder; and the only visible `default` row belongs to another gateway (`This device`), so selecting it re-homes the connection instead of returning to the active gateway's default. (The `mod+d` shortcut works but is undiscoverable.)

## The fix

In the condensed branch, when in fleet mode, surface the active gateway's default at the head of the dropdown — mirroring how rest gateways already render `[group.defaultAgent, ...group.named]`:

```tsx
profiles={fleet && defaultProfile ? [defaultProfile, ...named] : named}
```

- The default now appears as a selectable radio row on the active gateway and is chosen through the same `selectProfile` path — **not** `onSelectRest`/`selectConnection`, so it never switches gateways.
- `ProfileDropdown`'s value/label computation now finds `default` when it's active, so the trigger identifies it instead of falling back to the placeholder.
- **Non-fleet** condensed keeps its default↔all home pill, so its dropdown stays `named`-only — single-gateway rendering is byte-identical.

## Tests

Added to `profile-rail-fleet.test.tsx`:
- from a named profile on the active gateway, the condensed dropdown exposes the active gateway's `default` as a `menuitemradio`, and selecting it calls `selectProfile('default')` while `selectConnection` is never called (no re-home);
- when `default` is the active profile, the condensed trigger names it rather than showing the generic placeholder.

Whole fleet suite passes (10/10), and the single-gateway `profile-rail-connect` suite is unchanged (5/5).

Fixes #106017
