### PR TITLE
fix(desktop): model catalog tests no longer poll after teardown

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -52,6 +52,9 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  // The backend mock echoes this snapshot; retire fixture jobs before jsdom
+  // disappears so an in-flight app-level poll cannot schedule another tick.
+  $localRuntimeJobs.set([])
   vi.clearAllMocks()
 })
 


### PR DESCRIPTION
Model catalog tests no longer leave running fixture jobs for a poll to reschedule after jsdom has been destroyed.

- Clear the fixture-owned job snapshot after React cleanup.
- Preserve the production app-lifetime poller, backend authority, error handling, and all seven existing catalog assertions; no new tests or production changes.

Root cause: the mocked backend echoes `$localRuntimeJobs`, but teardown previously left running rows behind, allowing an in-flight poll to reach `window.setTimeout` after environment destruction.

## Validation

**Live repro:** scheduling-controlled Vitest/jsdom integration on fresh main `22488b8c62d`: delay the mocked backend response with a real Node timer, perform actual jsdom teardown, and observe the real production poller. Before: one `ReferenceError: window is not defined` at `local-runtime-jobs.ts::poll`; after: the delayed response sees `[]` and no rejection. Both arms rendered the existing downloading-row test successfully. The observation window extends environment teardown; this is not native Electron E2E and the uninstrumented focused baseline passed.

| Check | Result |
| --- | --- |
| Real timer + actual environment teardown A/B | Before: late unhandled rejection; after: none |
| Catalog + search-fold fixtures | 8 tests passed |
| Entire shell test directory | 79 tests passed across 11 files |
| Touched-file ESLint, Windows-footgun check, compat-pointer check, diff whitespace | Passed |

The first wider local run hit host inotify exhaustion; reran with `CHOKIDAR_USEPOLLING=true --maxWorkers 2`. CI is pending. Repro probes are not committed. Local receipts: `/tmp/catalog-teardown-real-timer-{red,green}.log`, `/tmp/catalog-teardown-shell-green.log`, and `/tmp/catalog-teardown-probe.patch`.

Historical failure: https://github.com/NousResearch/hermes-agent/actions/runs/34275096607 (observed during #105960; unrelated to that PR's attention changes).

## Infographic

![Model catalog test teardown](https://v3b.fal.media/files/b/0aa9a599/gxGq0um3avnaKGLmas73z_L5cbDlPJ.png)
