### PR TITLE
feat(tts): auto-select Edge voices by detected language

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3196,6 +3196,10 @@ _PLATFORM_CONTAINER_KEYS = frozenset({"platforms"})
 # Top-level keys whose sub-keys are accepted without deep checking.
 _OPEN_SUBKEY_TOP_LEVEL_KEYS = _OPEN_DICT_TOP_LEVEL_KEYS | _DYNAMIC_TOP_LEVEL_KEYS | _SCHEMA_DEFINED_DICT_KEYS
 
+# Nested mappings whose keys are user-defined rather than schema-defined. The
+# validator accepts any descendant while keeping surrounding TTS keys strict.
+_OPEN_DICT_PATHS = frozenset({("tts", "edge", "voice_by_language")})
+
 
 def _known_top_level_keys() -> set[str]:
     """Return the union of known top-level config keys for validation."""
@@ -3244,6 +3248,8 @@ def _validate_config_key(key: str) -> tuple[bool, Optional[str]]:
     node: Any = DEFAULT_CONFIG.get(top)
     consumed = [top]
     for seg in segments[1:]:
+        if tuple(consumed) in _OPEN_DICT_PATHS:
+            return True, None
         if seg in _PLATFORM_CONTAINER_KEYS or not isinstance(node, dict):
             return True, None
         if seg not in node:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1000,6 +1000,8 @@ DEFAULT_CONFIG = {
         "edge": {
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
             "voice": "en-US-AriaNeural",
+            "auto_language": False,
+            "voice_by_language": {},
         },
         "elevenlabs": {
             "voice_id": "pNInz6obpgDQGcFmaJgB",  # Adam

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick
 # ElevenLabs / OpenAI / MiniMax instead).
 edge-tts = ["edge-tts==7.2.7"]
+tts-langdetect = ["langdetect==1.0.9", "six==1.17.0"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
@@ -498,6 +499,7 @@ httpx = false
 httpx2 = false
 huggingface_hub = false
 jinja2 = false
+langdetect = false
 lark-oapi = false
 markdown = false
 maturin = false
@@ -541,6 +543,7 @@ setuptools = false
 setuptools-rust = false
 wheel = false
 sherpa-onnx = false
+six = false
 slack-bolt = false
 slack-sdk = false
 snowballstemmer = false

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -119,6 +119,15 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_edge_voice_by_language_accepts_dynamic_language_code(
+        self, _isolated_hermes_home, capsys
+    ):
+        set_config_value("tts.edge.voice_by_language.pt-br", "pt-BR-FranciscaNeural")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        config = _read_config(_isolated_hermes_home)
+        assert "pt-br: pt-BR-FranciscaNeural" in config
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)
@@ -547,6 +556,7 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "tts.edge.voice_by_language.zh-cn",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key

--- a/tests/tools/test_tts_auto_language.py
+++ b/tests/tools/test_tts_auto_language.py
@@ -1,0 +1,155 @@
+"""Behavior contracts for Edge TTS automatic language voice routing."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tools import tts_tool, tts_tool_language
+
+
+def _configured(**edge_overrides):
+    edge = {
+        "voice": "fallback-voice",
+        "auto_language": True,
+        "voice_by_language": {
+            "en": "english-voice",
+            "fr": "french-voice",
+            "pt": "portuguese-voice",
+            "pt-br": "brazilian-voice",
+            "ZH_CN": "simplified-chinese-voice",
+        },
+    }
+    edge.update(edge_overrides)
+    return {"provider": "edge", "edge": edge}
+
+
+@pytest.mark.parametrize(
+    ("detected", "mapping", "expected_voice"),
+    [
+        ("pt-br", {"pt": "base", "pt-br": "exact"}, "exact"),
+        ("pt-pt", {"pt": "base"}, "base"),
+        ("zh-cn", {"ZH_CN": "normalized"}, "normalized"),
+        ("de", {"fr": "french"}, "fallback-voice"),
+        ("de", {"de": "", "fr": 123}, "fallback-voice"),
+    ],
+)
+def test_edge_voice_resolution_prefers_exact_then_base_without_mutation(
+    monkeypatch, detected, mapping, expected_voice
+):
+    config = _configured(voice_by_language=mapping)
+    original = copy.deepcopy(config)
+    monkeypatch.setattr(
+        tts_tool_language,
+        "_detect_dominant_language",
+        lambda _text: (detected, 0.99),
+    )
+
+    updated = tts_tool_language.with_edge_auto_language_voice(
+        config, "This response contains enough alphabetic characters"
+    )
+
+    assert updated["edge"]["voice"] == expected_voice
+    assert config == original
+
+
+@pytest.mark.parametrize(
+    (
+        "auto_language",
+        "text",
+        "ensure_error",
+        "probability",
+        "expected_voice",
+        "detect_calls",
+    ),
+    [
+        (True, "Ceci est une réponse française complète. " * 4, None, 0.99, "french-voice", 1),
+        (True, "This mixed response remains ambiguous. " * 4, None, 0.79, "fallback-voice", 1),
+        (True, "Bonjour", None, 0.99, "fallback-voice", 0),
+        (
+            True,
+            "Ceci est une réponse française complète. " * 4,
+            RuntimeError("disabled"),
+            0.99,
+            "fallback-voice",
+            0,
+        ),
+        (
+            False,
+            "Ceci est une réponse française complète. " * 4,
+            None,
+            0.99,
+            "fallback-voice",
+            0,
+        ),
+    ],
+)
+def test_edge_detection_is_lazy_deterministic_and_applied_once_to_all_chunks(
+    tmp_path,
+    monkeypatch,
+    auto_language,
+    text,
+    ensure_error,
+    probability,
+    expected_voice,
+    detect_calls,
+):
+    config = _configured(auto_language=auto_language, max_text_length=32)
+    original = copy.deepcopy(config)
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: config)
+
+    ensure = MagicMock(side_effect=ensure_error)
+    monkeypatch.setattr("tools.lazy_deps.ensure", ensure)
+    detector_factory = SimpleNamespace(seed=None)
+    detect_langs = MagicMock(
+        return_value=[SimpleNamespace(lang="FR", prob=probability)]
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "langdetect",
+        SimpleNamespace(DetectorFactory=detector_factory, detect_langs=detect_langs),
+    )
+
+    mock_communicate = MagicMock()
+
+    def communicate(_text, **_kwargs):
+        result = MagicMock()
+
+        async def save_audio(path):
+            Path(path).write_bytes(b"ID3audio")
+
+        result.save = AsyncMock(side_effect=save_audio)
+        return result
+
+    mock_communicate.side_effect = communicate
+    monkeypatch.setattr(
+        tts_tool,
+        "_import_edge_tts",
+        lambda: SimpleNamespace(Communicate=mock_communicate),
+    )
+
+    result = json.loads(
+        tts_tool.text_to_speech_tool(
+            text, output_path=str(tmp_path / "reply.mp3")
+        )
+    )
+
+    assert result["success"] is True
+    assert {call.kwargs["voice"] for call in mock_communicate.call_args_list} == {
+        expected_voice
+    }
+    if len(text.strip()) > 32:
+        assert result["chunk_count"] > 1
+    assert config == original
+    assert detect_langs.call_count == detect_calls
+    if detect_calls:
+        assert detector_factory.seed == 0
+        detect_langs.assert_called_once_with(text.strip())
+    if not auto_language or len(text) < tts_tool_language.MIN_LANGUAGE_LETTERS:
+        ensure.assert_not_called()

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -62,6 +62,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # Voxtral STT + TTS share the SDK.
     "tts.mistral": ("mistralai==2.4.8",),
     "tts.edge": ("edge-tts==7.2.7",),
+    "tts.langdetect": ("langdetect==1.0.9", "six==1.17.0"),
     "tts.elevenlabs": ("elevenlabs==1.59.0",),
 
     # ─── Speech-to-text providers ──────────────────────────────────────────

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -43,6 +43,7 @@ def _resolve_provider_key(env_var: str, provider_id: str) -> str:
     return resolve_provider_secret(env_var, provider_id, env_getter=get_env_value)
 
 
+from tools import tts_tool_language
 from tools.tts_command_provider import (
     BUILTIN_TTS_PROVIDERS, _configured_command_tts_output_path, _generate_command_tts,
     _get_command_tts_output_format, _is_command_tts_voice_compatible, _resolve_command_provider_config)
@@ -426,6 +427,8 @@ def text_to_speech_tool(
     if not text:
         return tool_error("Text is empty after TTS cleanup", success=False)
     tts_config, provider = _apply_call_overrides(_load_tts_config(), speed, provider)
+    if provider == "edge":
+        tts_config = tts_tool_language.with_edge_auto_language_voice(tts_config, text)
     command_provider_config = _resolve_command_provider_config(provider, tts_config)
     max_len = _resolve_max_text_length(provider, tts_config)
     chunks = _split_text_for_tts(text, max_len)

--- a/tools/tts_tool_language.py
+++ b/tools/tts_tool_language.py
@@ -1,0 +1,108 @@
+"""Optional language detection and per-language voice routing for Edge TTS."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, Optional
+
+from utils import is_truthy_value
+
+logger = logging.getLogger("tools.tts_tool")
+
+MIN_LANGUAGE_LETTERS = 8
+MIN_LANGUAGE_CONFIDENCE = 0.80
+
+_DETECTION_LOCK = threading.Lock()
+
+
+def _normalize_language_code(value: Any) -> str:
+    """Normalize detector/config language codes to lower-case BCP-47 form."""
+    return str(value or "").strip().replace("_", "-").lower()
+
+
+def _detect_dominant_language(text: str) -> Optional[tuple[str, float]]:
+    """Return ``(language, confidence)`` or ``None`` when detection is unsafe/unavailable."""
+    if sum(character.isalpha() for character in text) < MIN_LANGUAGE_LETTERS:
+        logger.info("TTS auto-language kept the fallback voice: text is too short to classify")
+        return None
+
+    try:
+        from tools.lazy_deps import ensure
+
+        ensure("tts.langdetect", prompt=False)
+        from langdetect import DetectorFactory, detect_langs
+
+        # langdetect documents ambiguous input as nondeterministic unless this
+        # process-wide seed is fixed. Serialize the seed + classify operation.
+        with _DETECTION_LOCK:
+            DetectorFactory.seed = 0
+            candidates = detect_langs(text)
+    except Exception as exc:
+        logger.warning("TTS auto-language detection unavailable; using fallback voice: %s", exc)
+        return None
+
+    if not candidates:
+        logger.info("TTS auto-language kept the fallback voice: detector returned no candidates")
+        return None
+    language = _normalize_language_code(getattr(candidates[0], "lang", ""))
+    try:
+        confidence = float(getattr(candidates[0], "prob", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    if not language or confidence < MIN_LANGUAGE_CONFIDENCE:
+        logger.info(
+            "TTS auto-language kept the fallback voice: language=%s confidence=%.3f",
+            language or "unknown",
+            confidence,
+        )
+        return None
+    return language, confidence
+
+
+def _normalized_voice_map(value: Any) -> Dict[str, str]:
+    """Return valid normalized language-to-voice entries from a config value."""
+    if not isinstance(value, dict):
+        return {}
+    voices: Dict[str, str] = {}
+    for raw_language, raw_voice in value.items():
+        language = _normalize_language_code(raw_language)
+        voice = raw_voice.strip() if isinstance(raw_voice, str) else ""
+        if language and voice:
+            voices[language] = voice
+    return voices
+
+
+def with_edge_auto_language_voice(tts_config: Dict[str, Any], text: str) -> Dict[str, Any]:
+    """Copy *tts_config* with one detected Edge voice, preserving it unchanged on fallback."""
+    edge_config = tts_config.get("edge")
+    if not isinstance(edge_config, dict) or not is_truthy_value(edge_config.get("auto_language")):
+        return tts_config
+    voices = _normalized_voice_map(edge_config.get("voice_by_language"))
+    if not voices:
+        return tts_config
+
+    detected = _detect_dominant_language(text)
+    if detected is None:
+        return tts_config
+    language, confidence = detected
+    voice = voices.get(language) or voices.get(language.partition("-")[0])
+    if not voice:
+        logger.info(
+            "TTS auto-language kept the fallback voice: language=%s confidence=%.3f has no mapping",
+            language,
+            confidence,
+        )
+        return tts_config
+
+    updated_edge = dict(edge_config)
+    updated_edge["voice"] = voice
+    updated = dict(tts_config)
+    updated["edge"] = updated_edge
+    logger.info(
+        "TTS auto-language selected language=%s confidence=%.3f voice=%s",
+        language,
+        confidence,
+        voice,
+    )
+    return updated

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-25T20:47:13.368681Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1874,6 +1874,10 @@ termux-all = [
     { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
+tts-langdetect = [
+    { name = "langdetect" },
+    { name = "six" },
+]
 tts-premium = [
     { name = "elevenlabs" },
 ]
@@ -1980,6 +1984,7 @@ requires-dist = [
     { name = "httpx2", marker = "extra == 'dev'", specifier = "==2.7.0" },
     { name = "httpx2", marker = "extra == 'mcp'", specifier = "==2.7.0" },
     { name = "jinja2", specifier = "==3.1.6" },
+    { name = "langdetect", marker = "extra == 'tts-langdetect'", specifier = "==1.0.9" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.1" },
@@ -2029,6 +2034,7 @@ requires-dist = [
     { name = "sentencepiece", marker = "extra == 'wake'", specifier = "==0.2.2" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = "==83.0.0" },
     { name = "sherpa-onnx", marker = "extra == 'wake'", specifier = "==1.13.4" },
+    { name = "six", marker = "extra == 'tts-langdetect'", specifier = "==1.17.0" },
     { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.30.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.30.0" },
     { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.43.0" },
@@ -2051,7 +2057,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "tts-langdetect", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2408,6 +2414,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
+
+[[package]]
+name = "langdetect"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474, upload-time = "2021-05-07T07:54:13.562Z" }
 
 [[package]]
 name = "lark-oapi"

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -49,6 +49,8 @@ tts:
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
     speed: 1.0                  # Converted to rate percentage (+/-%)
+    auto_language: false        # Detect the reply language and select a mapped Edge voice
+    voice_by_language: {}       # Language code -> Edge voice; `voice` remains the fallback
   elevenlabs:
     voice_id: "pNInz6obpgDQGcFmaJgB"  # Adam
     model_id: "eleven_multilingual_v2"
@@ -113,6 +115,36 @@ MiniMax TTS selects its region, endpoint, and credential together:
 - An explicitly selected region must have its matching credential. Hermes never borrows the other region's key. A `base_url` override does not change the selected credential, and an override pointing at the other region's official endpoint is rejected.
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
+
+### Automatic Edge voice selection
+
+Edge TTS can select one voice for the dominant language of each complete reply. This mode is opt-in and affects only the Edge provider:
+
+```yaml
+tts:
+  provider: edge
+  edge:
+    voice: en-US-AriaNeural       # Fallback voice
+    auto_language: true
+    voice_by_language:
+      en: en-US-AvaNeural
+      fr: fr-FR-DeniseNeural
+      pt: pt-PT-RaquelNeural
+      pt-br: pt-BR-FranciscaNeural
+      zh-cn: zh-CN-XiaoxiaoNeural
+```
+
+Mapping keys are case-insensitive BCP-47 language codes; underscores are normalized to hyphens. Hermes first looks for the exact detected code, such as `pt-br`, and then its primary language, such as `pt`. The configured `voice` is used when the text is too short, detection is uncertain or unavailable, or no mapping matches. A long reply is detected once before chunking, so every chunk uses the same voice.
+
+The optional `langdetect` dependency is loaded—and, when lazy installation is available, installed—only when `auto_language` is enabled and `voice_by_language` is non-empty. Installation or detection failures do not block speech synthesis. Detection requires at least eight alphabetic characters and 80% confidence.
+
+Mappings can also be added without editing YAML:
+
+```bash
+hermes config set tts.edge.auto_language true
+hermes config set tts.edge.voice_by_language.fr fr-FR-DeniseNeural
+hermes config set tts.edge.voice_by_language.pt-br pt-BR-FranciscaNeural
+```
 
 ### Gemini Persona Prompts
 


### PR DESCRIPTION
## Summary

- detect the dominant reply language with optional, lazy-loaded `langdetect`
- route Edge TTS through a configurable `voice_by_language` mapping
- keep `tts.edge.voice` as the non-blocking fallback and reuse one voice across all chunks

## Validation

- `135 passed` across TTS, config, and packaging tests
- manually verified English, French, Portuguese, and `zh-cn` routing

Fixes #26377
Related to #9535

Builds on #26422; original author preserved via cherry-pick.