### PR TITLE
feat(cli): add hermes status --json for machine-readable state

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -347,15 +347,209 @@ _SECTIONS = (
     _render_sessions, _render_deep, _render_footer)
 
 
+def get_status_data(args=None) -> dict:
+    """Collect all Hermes Agent component status facts as a JSON-serializable dict."""
+    import hermes_cli
+
+    try:
+        config = load_config()
+    except Exception:
+        config = {}
+
+    # ESTOP
+    estop_state = None
+    try:
+        from agent.estop import get_state
+        estop_state = get_state()
+    except Exception:
+        pass
+
+    estop_info = {
+        "paused": estop_state is not None,
+        "reason": estop_state.get("reason") if estop_state else None,
+        "timestamp": estop_state.get("timestamp") if estop_state else None,
+    }
+
+    # Gateway
+    gateway_info = {
+        "running": False,
+        "manager": "unknown",
+        "pids": [],
+        "service_installed": False,
+        "service_running": False,
+    }
+    try:
+        from hermes_cli.gateway import get_gateway_runtime_snapshot
+        snapshot = get_gateway_runtime_snapshot()
+        gateway_info = {
+            "running": bool(snapshot.running),
+            "manager": snapshot.manager,
+            "pids": list(snapshot.gateway_pids or []),
+            "service_installed": bool(snapshot.service_installed),
+            "service_running": bool(snapshot.service_running),
+        }
+    except Exception:
+        platform = "termux" if _is_termux() else "linux" if sys.platform.startswith("linux") else sys.platform
+        status_text, manager = _GATEWAY_FALLBACK.get(platform, ("unknown", "(not supported on this platform)"))
+        gateway_info["manager"] = manager
+
+    # Terminal backend
+    terminal_cfg = config.get("terminal", {}) if isinstance(config.get("terminal"), dict) else {}
+    terminal_backend = os.getenv("TERMINAL_ENV", "") or terminal_cfg.get("backend", "local")
+    terminal_info = {
+        "backend": terminal_backend,
+        "sudo": bool(os.getenv("SUDO_PASSWORD", "")),
+    }
+
+    # Auth: API Keys (configured names only, never secret values)
+    from hermes_cli.status_auth import _API_KEYS, _OAUTH_BLOCKS
+    from hermes_cli.auth import get_anthropic_key
+
+    configured_api_keys = []
+    for name, env_ref in (*_API_KEYS.items(), ("Anthropic", get_anthropic_key)):
+        try:
+            val = env_ref() if callable(env_ref) else _first_env_value(env_ref)
+            if bool(val):
+                configured_api_keys.append(name)
+        except Exception:
+            pass
+
+    # Auth: OAuth Providers
+    import hermes_cli.auth as auth
+    oauth_providers = {}
+    for name, getter_name, hint, rows in _OAUTH_BLOCKS:
+        try:
+            getter = getattr(auth, getter_name, None)
+            st = getter() if getter else {}
+            oauth_providers[name] = {
+                "logged_in": bool(st.get("logged_in")),
+                "auth_file": st.get("auth_store") or st.get("auth_file"),
+                "last_refresh": st.get("last_refresh"),
+                "error": st.get("error") if not st.get("logged_in") else None,
+            }
+        except Exception as e:
+            oauth_providers[name] = {"logged_in": False, "error": str(e)}
+
+    # Platforms
+    platforms_info = {}
+    for name, (token_var, home_var) in _PLATFORMS.items():
+        has_token = bool(os.getenv(token_var, ""))
+        platforms_info[name] = {
+            "configured": has_token,
+            "home_channel": (os.getenv(home_var, "") or None) if home_var else None,
+        }
+    try:
+        from gateway.platform_registry import platform_registry
+        for entry in platform_registry.plugin_entries():
+            try:
+                configured = bool(entry.check_fn())
+            except Exception:
+                configured = False
+            platforms_info[entry.label] = {"configured": configured, "plugin": True}
+    except Exception:
+        pass
+
+    # Scheduled jobs
+    jobs_count = 0
+    jobs_file = get_hermes_home() / "cron" / "jobs.json"
+    if jobs_file.exists():
+        try:
+            data = _load_json(jobs_file)
+            jobs_count = len(data.get("jobs", [])) if isinstance(data, dict) else len(data) if isinstance(data, list) else 0
+        except Exception:
+            jobs_count = 0
+
+    # Sessions & Usage
+    active_sessions_count = 0
+    last_activity = None
+    total_sessions_count = 0
+    recent_sessions = []
+    usage_info = {"tokens": 0, "cost_usd": 0.0}
+
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        try:
+            gateway_rows = db.list_gateway_sessions(active_only=True) or []
+            active_sessions_count = len(gateway_rows)
+            freshest = max((float(r.get("last_active") or 0) for r in gateway_rows), default=0.0)
+            if freshest > 0:
+                last_activity = freshest
+
+            total_sessions_count = db.session_count()
+            recent_rows = db.list_recent_sessions_bounded(limit=10) or []
+            for r in recent_rows:
+                recent_sessions.append({
+                    "id": r.get("id"),
+                    "title": r.get("title"),
+                    "source": r.get("source"),
+                    "model": r.get("model"),
+                    "created_at": r.get("created_at"),
+                    "updated_at": r.get("updated_at") or r.get("last_active"),
+                })
+
+            usage_info = db.usage_totals()
+        finally:
+            db.close()
+    except Exception:
+        pass
+
+    # Slot usage
+    slots_info = None
+    try:
+        from hermes_cli.active_sessions import (
+            active_session_registry_snapshot, resolve_max_concurrent_sessions)
+        cap = resolve_max_concurrent_sessions(config)
+        if cap is not None:
+            held = active_session_registry_snapshot() or []
+            slots_info = {"in_use": len(held), "cap": cap}
+    except Exception:
+        pass
+
+    sessions_info = {
+        "active": active_sessions_count,
+        "total": total_sessions_count,
+        "last_activity": last_activity,
+        "recent": recent_sessions,
+        "slots": slots_info,
+    }
+
+    return {
+        "version": getattr(hermes_cli, "__version__", "unknown"),
+        "project_root": str(PROJECT_ROOT),
+        "python_version": sys.version.split()[0],
+        "env_file_exists": get_env_path().exists(),
+        "model": _configured_model_label(config),
+        "provider": _effective_provider_label(),
+        "estop": estop_info,
+        "gateway": gateway_info,
+        "terminal": terminal_info,
+        "auth": {
+            "api_keys": configured_api_keys,
+            "oauth": oauth_providers,
+        },
+        "platforms": platforms_info,
+        "cron": {
+            "jobs_count": jobs_count,
+        },
+        "sessions": sessions_info,
+        "usage": usage_info,
+    }
+
+
 def show_status(args):
     """Show status of all Hermes Agent components."""
+    if getattr(args, "json", False):
+        data = get_status_data(args)
+        print(json.dumps(data, indent=2))
+        return 0
+
     # Shared by section renderers: config, --deep, and the Nous login facts Auth Providers derives
     # for the later Nous Tool Gateway section.
     ctx = SimpleNamespace(deep=getattr(args, 'deep', False), config={}, nous_logged_in=False,
                           nous_inference_present=False, nous_account_info=None)
     for render in _SECTIONS:
         render(ctx)
-
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----
 # Names external plugins imported from this module before the Sep 2026 decomposition.

--- a/hermes_cli/subcommands/status.py
+++ b/hermes_cli/subcommands/status.py
@@ -1,8 +1,8 @@
 """``hermes status`` subcommand parser."""
 
-from __future__ import annotations
-
 from typing import Callable
+
+from hermes_cli.subcommands._shared import add_json_flag
 
 
 def build_status_parser(subparsers, *, cmd_status: Callable) -> None:
@@ -14,4 +14,5 @@ def build_status_parser(subparsers, *, cmd_status: Callable) -> None:
         "--all", action="store_true", help="Show all details (redacted for sharing)")
     status_parser.add_argument(
         "--deep", action="store_true", help="Run deep checks (may take longer)")
+    add_json_flag(status_parser, "Output status as JSON")
     status_parser.set_defaults(func=cmd_status)

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -250,3 +250,82 @@ def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, 
     assert "Active:       2 session(s)" in output
     assert "Last activity:" in output
     assert "1m ago" in output
+
+
+def test_show_status_json_schema_and_keys(monkeypatch, capsys, tmp_path):
+    """hermes status --json emits valid JSON with expected contract keys (#103176)."""
+    import json
+    from hermes_cli import status as status_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "test-model-42"}, raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False, json=True))
+    out = capsys.readouterr().out
+    data = json.loads(out)
+
+    assert isinstance(data, dict)
+    assert "version" in data
+    assert "model" in data
+    assert data["model"] == "test-model-42"
+    assert "provider" in data
+    assert "estop" in data
+    assert isinstance(data["estop"], dict)
+    assert "paused" in data["estop"]
+    assert "gateway" in data
+    assert isinstance(data["gateway"], dict)
+    assert "running" in data["gateway"]
+    assert "manager" in data["gateway"]
+    assert "auth" in data
+    assert isinstance(data["auth"], dict)
+    assert "api_keys" in data["auth"]
+    assert "oauth" in data["auth"]
+    assert "sessions" in data
+    assert isinstance(data["sessions"], dict)
+    assert "active" in data["sessions"]
+    assert "total" in data["sessions"]
+    assert "recent" in data["sessions"]
+    assert "usage" in data
+    assert isinstance(data["usage"], dict)
+    assert "tokens" in data["usage"]
+    assert "cost_usd" in data["usage"]
+
+
+def test_show_status_json_does_not_leak_secrets(monkeypatch, capsys, tmp_path):
+    """hermes status --json must never output secret API keys or token strings."""
+    import json
+    from hermes_cli import status as status_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    sentinel = "SUPER_SECRET_TOKEN_DO_NOT_LEAK_999888"
+    monkeypatch.setenv("OPENROUTER_API_KEY", sentinel)
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False, json=True))
+    out = capsys.readouterr().out
+    assert sentinel not in out
+
+    data = json.loads(out)
+    assert "OpenRouter" in data["auth"]["api_keys"]
+
+
+def test_show_status_json_estop_active(monkeypatch, capsys, tmp_path):
+    """hermes status --json reflects active ESTOP pause state and reason."""
+    import json
+    import agent.estop as estop_mod
+    from hermes_cli import status as status_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        estop_mod,
+        "get_state",
+        lambda: {"reason": "Maintenance window", "timestamp": 1757000000.0},
+        raising=False,
+    )
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False, json=True))
+    out = capsys.readouterr().out
+    data = json.loads(out)
+
+    assert data["estop"]["paused"] is True
+    assert data["estop"]["reason"] == "Maintenance window"
+    assert data["estop"]["timestamp"] == 1757000000.0


### PR DESCRIPTION
### Summary
Adds `--json` to `hermes status` to provide a stable, read-only status contract for desktop integrations (Omarchy widgets, Waybar, status panels) without scraping internal `state.db` or parsing text tables.

Fixes #103176

### Changes
- `hermes_cli/subcommands/status.py`: Attach `--json` via shared `add_json_flag`.
- `hermes_cli/status.py`: Implement `get_status_data()` separating status collection from ANSI terminal rendering. Includes version, resolved model/provider, gateway and ESTOP state, session summaries, token usage totals, and configured auth names.
- `tests/hermes_cli/test_status.py`: Add unit tests for JSON output schema, secret redaction invariants, and ESTOP state reporting.

### Verification
- `pytest tests/hermes_cli/test_status.py` passes (14/14).
- Verified `hermes status` (human-readable) remains unchanged.
- Verified `hermes status --json` produces valid JSON matching the schema.