### PR TITLE
fix(gateway): treat a configured local terminal.cwd as a context workspace, not a launch artifact (#106012)

### DIFF
--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -512,6 +512,37 @@ def test_explicit_desktop_and_terminal_cwds_are_context_workspaces():
     ) is False
 
 
+def test_configured_local_terminal_cwd_is_a_context_workspace(tmp_path, monkeypatch):
+    """A profile-configured local ``terminal.cwd`` is deliberate intent, so a desktop
+    session on it is NOT a launch artifact — its AGENTS.md must load (#106012)."""
+    monkeypatch.setattr(server, "_effective_terminal_backend", lambda: "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    assert server._context_cwd_is_launch_artifact({"source": "desktop", "cwd": str(tmp_path)}) is False
+
+
+def test_missing_configured_terminal_cwd_stays_launch_artifact(tmp_path, monkeypatch):
+    """A configured cwd that does not exist falls back to the launch dir, so it stays an
+    artifact — keeping this gate in agreement with resolve_context_cwd()."""
+    monkeypatch.setattr(server, "_effective_terminal_backend", lambda: "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "does-not-exist"))
+    assert server._context_cwd_is_launch_artifact({"source": "desktop", "cwd": "/opt/hermes"}) is True
+
+
+def test_trivial_terminal_cwd_stays_launch_artifact(monkeypatch):
+    """Sentinel values (``.``/``auto``/``cwd``) carry no workspace intent."""
+    monkeypatch.setattr(server, "_effective_terminal_backend", lambda: "local")
+    monkeypatch.setenv("TERMINAL_CWD", "auto")
+    assert server._context_cwd_is_launch_artifact({"source": "desktop", "cwd": "/opt/hermes"}) is True
+
+
+def test_non_local_backend_terminal_cwd_stays_launch_artifact(tmp_path, monkeypatch):
+    """Non-local backends (docker/ssh) keep the launch-artifact classification: their cwd lives
+    inside the target environment and the fallback can be a previous session's launch dir."""
+    monkeypatch.setattr(server, "_effective_terminal_backend", lambda: "docker")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    assert server._context_cwd_is_launch_artifact({"source": "desktop", "cwd": str(tmp_path)}) is True
+
+
 @pytest.mark.parametrize(
     ("explicit_cwd", "launch_artifact"),
     [(True, False), (False, True)],

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -543,6 +543,33 @@ def test_non_local_backend_terminal_cwd_stays_launch_artifact(tmp_path, monkeypa
     assert server._context_cwd_is_launch_artifact({"source": "desktop", "cwd": str(tmp_path)}) is True
 
 
+def test_bound_profile_configured_cwd_is_a_context_workspace(tmp_path, monkeypatch):
+    """The intent gate is session-scoped: a session bound to a sibling profile takes its intent
+    from THAT profile's config, not the launch env. Here the launch env is unset but the bound
+    profile configures a real ``terminal.cwd``, so the desktop session is a context workspace."""
+    monkeypatch.setattr(server, "_effective_terminal_backend", lambda: "local")
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    profile_home = tmp_path / "profiles" / "ops"
+    profile_home.mkdir(parents=True)
+    (profile_home / "config.yaml").write_text(f"terminal:\n  cwd: {workspace}\n", encoding="utf-8")
+    session = {"source": "desktop", "cwd": str(workspace), "profile_home": str(profile_home)}
+    assert server._context_cwd_is_launch_artifact(session) is False
+
+
+def test_bound_profile_without_config_ignores_launch_env(tmp_path, monkeypatch):
+    """A bound sibling profile with no configured ``terminal.cwd`` must NOT inherit the launch
+    profile's ``TERMINAL_CWD`` (#40334): the gate stays session-scoped, so the desktop session
+    remains a launch artifact even though the launch env points at a real directory."""
+    monkeypatch.setattr(server, "_effective_terminal_backend", lambda: "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))  # launch profile's dir — exists, not a sentinel
+    profile_home = tmp_path / "profiles" / "ops"
+    profile_home.mkdir(parents=True)  # no config.yaml → no configured cwd for this profile
+    session = {"source": "desktop", "cwd": str(tmp_path), "profile_home": str(profile_home)}
+    assert server._context_cwd_is_launch_artifact(session) is True
+
+
 @pytest.mark.parametrize(
     ("explicit_cwd", "launch_artifact"),
     [(True, False), (False, True)],

--- a/tui_gateway/session_workdir.py
+++ b/tui_gateway/session_workdir.py
@@ -77,16 +77,27 @@ def _session_cwd(session: dict | None) -> str:
 _LAUNCH_CWD_NOT_A_WORKSPACE = {"desktop"}
 
 
-def _configured_terminal_cwd_intent() -> bool:
+def _configured_terminal_cwd_intent(session: dict | None = None) -> bool:
     """A deliberate, existing local ``terminal.cwd`` (env bridge or profile config) — the same
     workspace intent as launching the CLI in that directory, so its context files must load even
-    when a desktop session never set ``explicit_cwd`` (#106012). Mirrors the resolution in
-    ``_terminal_task_cwd_with_source``. Non-local backends are excluded (their cwd lives inside the
-    target environment, and under docker isolation the fallback is a PREVIOUS session's launch
-    artifact); trivial ``.``/``auto``/``cwd`` values carry no intent; a missing directory is left to
-    the launch-dir fallback so ``resolve_context_cwd`` and this gate agree on what actually loads."""
+    when a desktop session never set ``explicit_cwd`` (#106012).
+
+    Session-scoped, mirroring ``_completion_cwd``: a session bound to a sibling profile takes its
+    intent from THAT profile's config (``profile_home``), never the launch profile's process-global
+    ``TERMINAL_CWD`` (#40334) — otherwise a multiplexing gateway consults the wrong profile and this
+    gate disagrees with the session-scoped resolver. Only the launch profile (no ``profile_home``)
+    falls back to the env bridge / active-profile config. Non-local backends are excluded (their cwd
+    lives inside the target environment, and under docker isolation the fallback is a PREVIOUS
+    session's launch artifact); trivial ``.``/``auto``/``cwd`` values carry no intent; a missing
+    directory is left to the launch-dir fallback so ``resolve_context_cwd`` and this gate agree on
+    what actually loads."""
     if _effective_terminal_backend() != "local":
         return False
+    profile_home = (session or {}).get("profile_home")
+    if profile_home:
+        # A bound sibling profile: its own config decides intent (absolute/exists/sentinel semantics
+        # come from _profile_configured_cwd), never the launch profile's stale env var.
+        return _profile_configured_cwd(Path(profile_home)) is not None
     raw = (os.environ.get("TERMINAL_CWD", "").strip() or _workdir_terminal_cfg("cwd")).strip()
     if not raw or raw in {".", "auto", "cwd"}:
         return False
@@ -104,7 +115,7 @@ def _context_cwd_is_launch_artifact(session: dict | None) -> bool:
         session
         and not session.get("explicit_cwd")
         and _session_source(session) in _LAUNCH_CWD_NOT_A_WORKSPACE
-        and not _configured_terminal_cwd_intent()
+        and not _configured_terminal_cwd_intent(session)
     )
 
 

--- a/tui_gateway/session_workdir.py
+++ b/tui_gateway/session_workdir.py
@@ -77,9 +77,35 @@ def _session_cwd(session: dict | None) -> str:
 _LAUNCH_CWD_NOT_A_WORKSPACE = {"desktop"}
 
 
+def _configured_terminal_cwd_intent() -> bool:
+    """A deliberate, existing local ``terminal.cwd`` (env bridge or profile config) — the same
+    workspace intent as launching the CLI in that directory, so its context files must load even
+    when a desktop session never set ``explicit_cwd`` (#106012). Mirrors the resolution in
+    ``_terminal_task_cwd_with_source``. Non-local backends are excluded (their cwd lives inside the
+    target environment, and under docker isolation the fallback is a PREVIOUS session's launch
+    artifact); trivial ``.``/``auto``/``cwd`` values carry no intent; a missing directory is left to
+    the launch-dir fallback so ``resolve_context_cwd`` and this gate agree on what actually loads."""
+    if _effective_terminal_backend() != "local":
+        return False
+    raw = (os.environ.get("TERMINAL_CWD", "").strip() or _workdir_terminal_cfg("cwd")).strip()
+    if not raw or raw in {".", "auto", "cwd"}:
+        return False
+    with contextlib.suppress(Exception):
+        return os.path.isdir(os.path.expanduser(raw))
+    return False
+
+
 def _context_cwd_is_launch_artifact(session: dict | None) -> bool:
-    """Whether the session cwd came from app launch rather than user intent."""
-    return bool(session and not session.get("explicit_cwd") and _session_source(session) in _LAUNCH_CWD_NOT_A_WORKSPACE)
+    """Whether the session cwd came from app launch rather than user intent. A profile-configured
+    ``terminal.cwd`` is deliberate intent, not a launch artifact, so it does not count (#106012):
+    without this, a desktop session on such a profile advertised the workspace's AGENTS.md in its
+    snapshot but never injected its contents."""
+    return bool(
+        session
+        and not session.get("explicit_cwd")
+        and _session_source(session) in _LAUNCH_CWD_NOT_A_WORKSPACE
+        and not _configured_terminal_cwd_intent()
+    )
 
 
 def _persisted_session_cwd(session: dict) -> str | None:


### PR DESCRIPTION
## What does this PR do?

Fixes #106012: a desktop session whose working directory comes from a profile's `terminal.cwd` resolved that directory for terminal tools and listed its `AGENTS.md` under "Context files" in the workspace snapshot — but never injected the file's **contents** into the system prompt. The prompt advertised context it hadn't loaded.

## Root cause

Context-file discovery uses `agent/system_prompt.py`:

```python
launch_artifact = getattr(agent, "_context_cwd_is_launch_artifact", False)
build_context_files_prompt(cwd=None if launch_artifact else resolve_context_cwd(), ...)
```

`_context_cwd_is_launch_artifact` returns `True` for any `source='desktop'` session without `explicit_cwd` — a rule meant for sessions whose cwd is just the folder the bundle happened to open in. A profile-configured `terminal.cwd` never sets `explicit_cwd` (only a caller-passed cwd or an explicit workspace pick does), so the configured directory was classified as a launch artifact, `cwd` was forced to `None`, and `resolve_context_cwd()` — which already returns that `terminal.cwd` — was bypassed.

## The fix

A profile-configured `terminal.cwd` is deliberate workspace intent, the same as launching the CLI in that directory. `_context_cwd_is_launch_artifact` now excludes a desktop session when an **existing, non-trivial, local** `terminal.cwd` is configured, via a small `_configured_terminal_cwd_intent()` helper that mirrors the resolution already in `_terminal_task_cwd_with_source` (`TERMINAL_CWD` env bridge → `terminal.cwd` config). This keeps the gate in agreement with `resolve_context_cwd()` about what actually loads.

Deliberately conservative:
- **Local backend only** — a non-local (docker/ssh) cwd lives inside the target environment, and under docker isolation the fallback can be a *previous* session's launch artifact, so those keep the current classification.
- **Directory must exist** — a missing/sentinel (`.`/`auto`/`cwd`) value falls back to the launch dir, exactly as `resolve_context_cwd()` does, so the two never disagree.
- Desktop's install-tree guard (`allow_install_tree_fallback=False`) is untouched.

## Tests

Added to `tests/tui_gateway/test_projects_rpc.py`:
- an existing local `terminal.cwd` makes a desktop session a context workspace (not an artifact);
- a missing configured cwd stays a launch artifact (agrees with the fallback);
- sentinel `auto` stays a launch artifact;
- a non-local backend with a configured cwd stays a launch artifact.

`tests/tui_gateway/test_projects_rpc.py` and `tests/agent/test_system_prompt.py` pass (88).

Fixes #106012
