### PR TITLE
fix(install): fall back after constrained-network failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,49 @@ hermes doctor       # Diagnose any issues
 
 📖 **[Full documentation →](https://hermes-agent.nousresearch.com/docs/)**
 
+### Restricted or high-latency networks (no proxy needed)
+
+The installer and updater try the official endpoints first. If a dependency
+endpoint is slow or unreachable, configure only the affected channel before
+retrying; Hermes does not infer location or select a mirror from your IP.
+
+```bash
+# npm packages
+export npm_config_registry=https://registry.npmmirror.com
+
+# Python packages used by `uv sync` (the installer intentionally ignores local
+# uv.toml files; this environment variable is the supported override)
+export UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
+
+# Python runtimes downloaded by uv
+export UV_PYTHON_INSTALL_MIRROR=https://gh-proxy.com/https://github.com/astral-sh/python-build-standalone/releases/download
+
+# Electron and Playwright downloads (optional; these are explicit opt-ins)
+export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+export PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright
+```
+
+For a GitHub mirror, use Git's standard URL rewrite only for the install or
+update command, then verify that the checkout still has the official remote:
+
+```bash
+git -c url."https://<your-mirror>/https://github.com/".insteadOf=https://github.com/ clone \
+  --depth 1 https://github.com/NousResearch/hermes-agent.git
+git remote -v
+```
+
+`npm` checks lockfile `sha512` integrity and `uv` checks the hashes recorded in
+`uv.lock`; changing an index does not disable those checks. Git verifies object
+hashes, but a mirror can still serve the wrong history, so pin and verify the
+expected commit when provenance matters. Playwright's browser download does
+not currently provide the same per-file checksum guarantee; use that override
+only when you accept the residual mirror risk. The optional cua-driver
+installer has no mirror or checksum hook and remains best-effort.
+
+If an install or update fails, inspect the channel-specific error before
+changing all sources: the official endpoint may be healthy while only GitHub,
+npm, PyPI, Electron, or Playwright is being throttled.
+
 ---
 
 ## Skip the API-key collection — Nous Portal

--- a/README.md
+++ b/README.md
@@ -122,26 +122,33 @@ hermes doctor       # Diagnose any issues
 ### Restricted or high-latency networks (no proxy needed)
 
 The installer and updater try official endpoints first. If the Git repository
-fetch or locked Python sync fails, Hermes retries that same channel through a
+fetch or locked Python sync fails, Hermes can retry that channel through a
 configured fallback only after the measured failure. It never selects a mirror
 from an IP address or inferred region.
 
-The fallback endpoints are community-operated, not Hermes infrastructure. Set
-your own endpoints, or disable either fallback by exporting an empty value:
+The Git fallback is **opt-in** (`GIT_FALLBACK_REPO_URL` is unset by default) so
+that unauthenticated source mirrors are never contacted automatically. When
+using a Git fallback mirror, pair it with `--commit <40-char-sha>` so the
+installer verifies upstream commit provenance before accepting the tree. The
+locked Python sync defaults to a fallback Simple API mirror because `uv.lock`
+maintains Tier-0 cryptographic hash verification regardless of index:
 
 ```bash
+# Enable a Git fallback mirror (pair with --commit for provenance verification)
 export GIT_FALLBACK_REPO_URL=https://your-mirror.example/NousResearch/hermes-agent.git
+
+# Set or disable the uv fallback index (defaults to TUNA Simple API mirror)
 export UV_FALLBACK_INDEX=https://your-mirror.example/simple
-# export GIT_FALLBACK_REPO_URL=
 # export UV_FALLBACK_INDEX=
 ```
 
 After a fresh mirror clone, `origin` is restored to the official repository and
 the checkout passes Git object verification. Existing checkouts keep their
-current remote identity (a fork may be intentional), so inspect it with
-`git remote -v`. Object hashes prove internal consistency, not upstream
-provenance; for a high-assurance install, pin and verify a full commit SHA with
-`--commit <40-char-sha>`.
+current remote identity (a fork may be intentional); for a fork remote, the
+fallback stays scoped to that fork identity or fails closed rather than
+switching repositories. Pinned commit fetches (`--commit`) always fetch from
+the configured `origin` remote.
+
 The locked `uv sync` keeps the hashes in `uv.lock` enabled. An explicit
 `UV_DEFAULT_INDEX` always wins over the failure-triggered fallback.
 

--- a/README.md
+++ b/README.md
@@ -121,46 +121,46 @@ hermes doctor       # Diagnose any issues
 
 ### Restricted or high-latency networks (no proxy needed)
 
-The installer and updater try the official endpoints first. If a dependency
-endpoint is slow or unreachable, configure only the affected channel before
-retrying; Hermes does not infer location or select a mirror from your IP.
+The installer and updater try official endpoints first. If the Git repository
+fetch or locked Python sync fails, Hermes retries that same channel through a
+configured fallback only after the measured failure. It never selects a mirror
+from an IP address or inferred region.
+
+The fallback endpoints are community-operated, not Hermes infrastructure. Set
+your own endpoints, or disable either fallback by exporting an empty value:
 
 ```bash
-# npm packages
+export GIT_FALLBACK_REPO_URL=https://your-mirror.example/NousResearch/hermes-agent.git
+export UV_FALLBACK_INDEX=https://your-mirror.example/simple
+# export GIT_FALLBACK_REPO_URL=
+# export UV_FALLBACK_INDEX=
+```
+
+After a fresh mirror clone, `origin` is restored to the official repository and
+the checkout passes Git object verification. Existing checkouts keep their
+current remote identity (a fork may be intentional), so inspect it with
+`git remote -v`. Object hashes prove internal consistency, not upstream
+provenance; for a high-assurance install, pin and verify a full commit SHA with
+`--commit <40-char-sha>`.
+The locked `uv sync` keeps the hashes in `uv.lock` enabled. An explicit
+`UV_DEFAULT_INDEX` always wins over the failure-triggered fallback.
+
+Use explicit channel overrides for the remaining downloads:
+
+```bash
 export npm_config_registry=https://registry.npmmirror.com
-
-# Python packages used by `uv sync` (the installer intentionally ignores local
-# uv.toml files; this environment variable is the supported override)
 export UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
-
-# Python runtimes downloaded by uv
-export UV_PYTHON_INSTALL_MIRROR=https://gh-proxy.com/https://github.com/astral-sh/python-build-standalone/releases/download
-
-# Electron and Playwright downloads (optional; these are explicit opt-ins)
+export UV_PYTHON_INSTALL_MIRROR=https://your-mirror.example/python-build-standalone
 export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
 export PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright
 ```
 
-For a GitHub mirror, use Git's standard URL rewrite only for the install or
-update command, then verify that the checkout still has the official remote:
-
-```bash
-git -c url."https://<your-mirror>/https://github.com/".insteadOf=https://github.com/ clone \
-  --depth 1 https://github.com/NousResearch/hermes-agent.git
-git remote -v
-```
-
-`npm` checks lockfile `sha512` integrity and `uv` checks the hashes recorded in
-`uv.lock`; changing an index does not disable those checks. Git verifies object
-hashes, but a mirror can still serve the wrong history, so pin and verify the
-expected commit when provenance matters. Playwright's browser download does
-not currently provide the same per-file checksum guarantee; use that override
-only when you accept the residual mirror risk. The optional cua-driver
-installer has no mirror or checksum hook and remains best-effort.
-
-If an install or update fails, inspect the channel-specific error before
-changing all sources: the official endpoint may be healthy while only GitHub,
-npm, PyPI, Electron, or Playwright is being throttled.
+`npm` checks lockfile `sha512` integrity; `uv` checks `uv.lock`; Electron's
+downloader checks its release checksum. Playwright browser downloads do not yet
+have the same per-file checksum guarantee, and the optional `cua-driver`
+installer has no mirror or checksum hook. Use those two overrides only when you
+accept the residual risk. If a run still fails, inspect the channel-specific
+error before changing every source at once.
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,6 +45,14 @@ BOLD='\033[1m'
 # Configuration
 REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
 REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
+# Failure-triggered fallbacks are deliberately opt-out, not geo-detected. The
+# official endpoint is always attempted first; an empty value disables the
+# corresponding fallback. Keep these as ordinary tool variables rather than
+# HERMES_* settings: they are transport overrides, not Hermes configuration.
+GIT_FALLBACK_REPO_URL="${GIT_FALLBACK_REPO_URL-https://gh-proxy.com/https://github.com/NousResearch/hermes-agent.git}"
+UV_FALLBACK_INDEX="${UV_FALLBACK_INDEX-https://pypi.tuna.tsinghua.edu.cn/simple}"
+CLONE_SOURCE_URL="$REPO_URL_HTTPS"
+UV_SELECTED_INDEX="${UV_DEFAULT_INDEX:-}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # INSTALL_DIR is resolved AFTER arg parsing and OS detection so we can pick an
 # FHS-style layout for root installs.  Track whether the user gave us an
@@ -1469,6 +1477,54 @@ show_manual_install_hint() {
 # Installation
 # ============================================================================
 
+FETCH_USED_MIRROR=false
+
+fetch_branch_with_fallback() {
+    # Official-first is the important part of this ladder. A mirror is tried
+    # only after git has returned a real fetch failure; no IP or region data is
+    # consulted. The tracking ref is updated through the existing `origin`
+    # namespace, while the remote URL itself is not rewritten; fork remotes are
+    # intentional and must not be clobbered by a network recovery path.
+    FETCH_USED_MIRROR=false
+    if git fetch origin "$BRANCH"; then
+        CLONE_SOURCE_URL="$REPO_URL_HTTPS"
+        return 0
+    fi
+
+    if [ -z "$GIT_FALLBACK_REPO_URL" ]; then
+        return 1
+    fi
+
+    log_warn "The official repository fetch failed; retrying with the configured fallback mirror..."
+    if git fetch "$GIT_FALLBACK_REPO_URL" "$BRANCH:refs/remotes/origin/$BRANCH"; then
+        FETCH_USED_MIRROR=true
+        CLONE_SOURCE_URL="$GIT_FALLBACK_REPO_URL"
+        log_success "Repository fetched through the fallback mirror (configured origin preserved)"
+        return 0
+    fi
+    return 1
+}
+
+verify_mirror_checkout() {
+    # Git object hashes prove transport integrity, not that a public mirror
+    # served the upstream history. Run fsck before accepting the tree and reset
+    # the checkout's remote to the official URL so a mirror cannot silently
+    # become the long-term update target.
+    if ! git -C "$INSTALL_DIR" fsck --full --no-progress >/dev/null 2>&1; then
+        log_error "Fallback mirror returned a checkout that failed Git object verification."
+        return 1
+    fi
+    if ! git -C "$INSTALL_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+        log_error "Fallback mirror returned a checkout without a valid commit."
+        return 1
+    fi
+    if ! git -C "$INSTALL_DIR" remote set-url origin "$REPO_URL_HTTPS" >/dev/null 2>&1; then
+        log_error "Could not restore the official origin after the mirror checkout."
+        return 1
+    fi
+    return 0
+}
+
 clone_repo() {
     log_info "Installing to $INSTALL_DIR..."
 
@@ -1517,13 +1573,21 @@ clone_repo() {
             # branches — on a non-single-branch checkout that turns each update
             # into a multi-minute download that can stall the installer.
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
-            git fetch origin "$BRANCH"
+            if ! fetch_branch_with_fallback; then
+                log_error "Failed to fetch the repository from the official endpoint and the fallback mirror."
+                exit 1
+            fi
             git checkout "$BRANCH"
             # Managed installs should follow origin/$BRANCH exactly. If the
             # checkout has diverged (or has local-only commits), ff-only pull
             # cannot succeed — mirror ``hermes update`` and reset to the
             # fetched remote so bootstrap/install can recover.
-            if ! git pull --ff-only origin "$BRANCH"; then
+            if [ "$FETCH_USED_MIRROR" = true ]; then
+                if ! git merge --ff-only "origin/$BRANCH"; then
+                    log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
+                    git reset --hard "origin/$BRANCH"
+                fi
+            elif ! git pull --ff-only origin "$BRANCH"; then
                 log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
                 git reset --hard "origin/$BRANCH"
             fi
@@ -1649,8 +1713,22 @@ EOF
                     rm -rf "$INSTALL_DIR" 2>/dev/null
                 fi
             fi
+            if [ "$clone_ok" != true ] && [ -n "$GIT_FALLBACK_REPO_URL" ]; then
+                log_warn "Official GitHub clone failed; retrying with the configured fallback mirror..."
+                rm -rf "$INSTALL_DIR" 2>/dev/null
+                if git clone --depth 1 --single-branch --branch "$BRANCH" \
+                     "$GIT_FALLBACK_REPO_URL" "$INSTALL_DIR"; then
+                    if verify_mirror_checkout; then
+                        CLONE_SOURCE_URL="$GIT_FALLBACK_REPO_URL"
+                        clone_ok=true
+                        log_success "Cloned via fallback mirror (Git objects verified)"
+                    else
+                        rm -rf "$INSTALL_DIR" 2>/dev/null
+                    fi
+                fi
+            fi
             if [ "$clone_ok" = true ]; then
-                log_success "Cloned via HTTPS"
+                [ "$CLONE_SOURCE_URL" = "$REPO_URL_HTTPS" ] && log_success "Cloned via HTTPS"
             else
                 log_error "Failed to clone repository"
                 exit 1
@@ -1677,7 +1755,7 @@ EOF
         # current venv. Only pin when the target is not already an ancestor of
         # HEAD; a fresh clone has no such ancestry and pins normally.
         if ! git cat-file -e "$INSTALL_COMMIT^{commit}" 2>/dev/null; then
-            if ! git fetch origin "$INSTALL_COMMIT"; then
+            if ! git fetch "$CLONE_SOURCE_URL" "$INSTALL_COMMIT"; then
                 log_error "Could not fetch commit $INSTALL_COMMIT from origin."
                 log_error "Abbreviated SHAs are not supported — use the full 40-char hash."
                 log_error "Find it with: git ls-remote origin | grep <short-sha>"
@@ -1752,6 +1830,29 @@ setup_venv() {
     log_success "Virtual environment ready (Python $PYTHON_VERSION)"
 }
 
+run_locked_uv_sync_attempt() {
+    local project_env="$1"
+    local index_override="$2"
+    local isolated_uv_config
+    local sync_rc
+
+    isolated_uv_config="$(mktemp -d)" || return 1
+    (
+        unset UV_NO_CONFIG UV_CONFIG_FILE
+        export XDG_CONFIG_HOME="$isolated_uv_config"
+        export XDG_CONFIG_DIRS="$isolated_uv_config"
+        if [ -n "$index_override" ]; then
+            export UV_DEFAULT_INDEX="$index_override"
+        else
+            unset UV_DEFAULT_INDEX
+        fi
+        UV_PROJECT_ENVIRONMENT="$project_env" "$UV_CMD" sync --extra all --locked
+    )
+    sync_rc=$?
+    rmdir "$isolated_uv_config" 2>/dev/null || true
+    return "$sync_rc"
+}
+
 run_locked_uv_sync() {
     # Bootstrap uv calls stay isolated from ambient config via UV_NO_CONFIG
     # (#21269). A locked project sync is different: uv.lock records resolver
@@ -1761,19 +1862,35 @@ run_locked_uv_sync() {
     # directory. Keep HOME unchanged so caches, credentials, and git continue
     # to work normally.
     local project_env="$1"
-    local isolated_uv_config
-    local sync_rc
-    isolated_uv_config="$(mktemp -d)" || return 1
+    local configured_index="${UV_DEFAULT_INDEX:-}"
 
-    (
-        unset UV_NO_CONFIG UV_CONFIG_FILE
-        export XDG_CONFIG_HOME="$isolated_uv_config"
-        export XDG_CONFIG_DIRS="$isolated_uv_config"
-        UV_PROJECT_ENVIRONMENT="$project_env" $UV_CMD sync --extra all --locked
-    )
-    sync_rc=$?
-    rmdir "$isolated_uv_config" 2>/dev/null || true
-    return "$sync_rc"
+    if run_locked_uv_sync_attempt "$project_env" "$configured_index"; then
+        UV_SELECTED_INDEX="$configured_index"
+        return 0
+    fi
+
+    # Never replace an explicit user index. The fallback is a second measured
+    # attempt only when the default uv route failed and no override was set.
+    if [ -n "$configured_index" ] || [ -z "$UV_FALLBACK_INDEX" ]; then
+        return 1
+    fi
+
+    log_warn "The default Python package index failed; retrying the locked sync with the configured fallback index..."
+    if run_locked_uv_sync_attempt "$project_env" "$UV_FALLBACK_INDEX"; then
+        UV_SELECTED_INDEX="$UV_FALLBACK_INDEX"
+        export UV_DEFAULT_INDEX="$UV_FALLBACK_INDEX"
+        log_success "Locked Python sync succeeded through the fallback index"
+        return 0
+    fi
+    return 1
+}
+
+run_uv() {
+    if [ -n "${UV_SELECTED_INDEX:-}" ]; then
+        UV_DEFAULT_INDEX="$UV_SELECTED_INDEX" "$UV_CMD" "$@"
+    else
+        "$UV_CMD" "$@"
+    fi
 }
 
 install_deps() {
@@ -2008,7 +2125,7 @@ PY
     install_tier() {
         local name="$1"; local spec="$2"
         log_info "Trying tier: $name ..."
-        if $UV_CMD pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
+        if run_uv pip install -e "$spec" 2>"$ALL_INSTALL_LOG"; then
             log_success "Main package installed ($name)"
             _installed=true
             _tier_name="$name"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,11 +45,14 @@ BOLD='\033[1m'
 # Configuration
 REPO_URL_SSH="git@github.com:NousResearch/hermes-agent.git"
 REPO_URL_HTTPS="https://github.com/NousResearch/hermes-agent.git"
-# Failure-triggered fallbacks are deliberately opt-out, not geo-detected. The
-# official endpoint is always attempted first; an empty value disables the
-# corresponding fallback. Keep these as ordinary tool variables rather than
-# HERMES_* settings: they are transport overrides, not Hermes configuration.
-GIT_FALLBACK_REPO_URL="${GIT_FALLBACK_REPO_URL-https://gh-proxy.com/https://github.com/NousResearch/hermes-agent.git}"
+# Failure-triggered fallbacks are never geo-detected or inferred from IP data.
+# The official endpoint is always attempted first. GIT_FALLBACK_REPO_URL is
+# explicitly opt-in (unset by default) to ensure unauthenticated third-party
+# source mirrors are not contacted automatically; it should be paired with
+# a pinned --commit check for upstream provenance. UV_FALLBACK_INDEX defaults
+# to a community mirror because uv.lock preserves Tier-0 cryptographic hash
+# verification regardless of index.
+GIT_FALLBACK_REPO_URL="${GIT_FALLBACK_REPO_URL:-}"
 UV_FALLBACK_INDEX="${UV_FALLBACK_INDEX-https://pypi.tuna.tsinghua.edu.cn/simple}"
 CLONE_SOURCE_URL="$REPO_URL_HTTPS"
 UV_SELECTED_INDEX="${UV_DEFAULT_INDEX:-}"
@@ -1478,17 +1481,47 @@ show_manual_install_hint() {
 # ============================================================================
 
 FETCH_USED_MIRROR=false
+FETCH_MIRROR_REF=""
+
+is_canonical_nous_remote() {
+    local url="$1"
+    case "$url" in
+        "https://github.com/NousResearch/hermes-agent" | \
+        "https://github.com/NousResearch/hermes-agent.git" | \
+        "git@github.com:NousResearch/hermes-agent" | \
+        "git@github.com:NousResearch/hermes-agent.git" | \
+        "ssh://git@github.com/NousResearch/hermes-agent" | \
+        "ssh://git@github.com/NousResearch/hermes-agent.git" )
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
 
 fetch_branch_with_fallback() {
     # Official-first is the important part of this ladder. A mirror is tried
     # only after git has returned a real fetch failure; no IP or region data is
-    # consulted. The tracking ref is updated through the existing `origin`
-    # namespace, while the remote URL itself is not rewritten; fork remotes are
-    # intentional and must not be clobbered by a network recovery path.
+    # consulted. For existing checkouts with a fork remote, fallback stays
+    # scoped to that fork or fails closed rather than switching to an upstream
+    # mirror. For canonical Nous origin, mirror fetches go into a dedicated
+    # fallback-mirror ref namespace once provenance is verified.
     FETCH_USED_MIRROR=false
+    FETCH_MIRROR_REF=""
+    local origin_url
+    origin_url="$(git remote get-url origin 2>/dev/null || git config --get remote.origin.url || true)"
+
     if git fetch origin "$BRANCH"; then
-        CLONE_SOURCE_URL="$REPO_URL_HTTPS"
+        CLONE_SOURCE_URL="origin"
         return 0
+    fi
+
+    # An intentional fork remote must not be silently replaced by a Nous mirror.
+    if [ -n "$origin_url" ] && ! is_canonical_nous_remote "$origin_url"; then
+        log_error "Official fetch from fork remote 'origin' ($origin_url) failed."
+        log_error "Refusing to overwrite fork tracking ref with upstream fallback mirror."
+        return 1
     fi
 
     if [ -z "$GIT_FALLBACK_REPO_URL" ]; then
@@ -1496,10 +1529,20 @@ fetch_branch_with_fallback() {
     fi
 
     log_warn "The official repository fetch failed; retrying with the configured fallback mirror..."
-    if git fetch "$GIT_FALLBACK_REPO_URL" "$BRANCH:refs/remotes/origin/$BRANCH"; then
+    local mirror_ref="refs/remotes/fallback-mirror/$BRANCH"
+    if git fetch "$GIT_FALLBACK_REPO_URL" "$BRANCH:$mirror_ref"; then
+        local expected_commit="${INSTALL_COMMIT:-${GIT_FALLBACK_EXPECTED_COMMIT:-}}"
+        if [ -n "$expected_commit" ]; then
+            if ! git cat-file -e "$expected_commit^{commit}" 2>/dev/null; then
+                log_error "Fallback mirror ref $mirror_ref does not contain expected commit $expected_commit."
+                git update-ref -d "$mirror_ref" 2>/dev/null || true
+                return 1
+            fi
+        fi
         FETCH_USED_MIRROR=true
+        FETCH_MIRROR_REF="$mirror_ref"
         CLONE_SOURCE_URL="$GIT_FALLBACK_REPO_URL"
-        log_success "Repository fetched through the fallback mirror (configured origin preserved)"
+        log_success "Repository fetched through the fallback mirror into $mirror_ref (configured origin preserved)"
         return 0
     fi
     return 1
@@ -1507,16 +1550,33 @@ fetch_branch_with_fallback() {
 
 verify_mirror_checkout() {
     # Git object hashes prove transport integrity, not that a public mirror
-    # served the upstream history. Run fsck before accepting the tree and reset
-    # the checkout's remote to the official URL so a mirror cannot silently
-    # become the long-term update target.
+    # served the upstream history. Run fsck before accepting the tree, verify
+    # the checkout contains and resolves the expected commit if pinned, and
+    # reset the checkout's remote to the official URL so a mirror cannot
+    # silently become the long-term update target.
+    local expected_commit="${INSTALL_COMMIT:-${GIT_FALLBACK_EXPECTED_COMMIT:-}}"
     if ! git -C "$INSTALL_DIR" fsck --full --no-progress >/dev/null 2>&1; then
         log_error "Fallback mirror returned a checkout that failed Git object verification."
         return 1
     fi
-    if ! git -C "$INSTALL_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+    local head_commit
+    if ! head_commit="$(git -C "$INSTALL_DIR" rev-parse --verify HEAD 2>/dev/null)"; then
         log_error "Fallback mirror returned a checkout without a valid commit."
         return 1
+    fi
+    if [ -n "$expected_commit" ]; then
+        if ! git -C "$INSTALL_DIR" cat-file -e "$expected_commit^{commit}" 2>/dev/null; then
+            log_error "Fallback mirror returned history that does not contain expected commit $expected_commit."
+            return 1
+        fi
+        local expected_sha
+        expected_sha="$(git -C "$INSTALL_DIR" rev-parse "$expected_commit^{commit}" 2>/dev/null || true)"
+        if [ "$head_commit" != "$expected_sha" ]; then
+            if ! git -C "$INSTALL_DIR" checkout --detach "$expected_commit" >/dev/null 2>&1; then
+                log_error "Fallback mirror commit ($head_commit) does not match expected upstream commit ($expected_sha)."
+                return 1
+            fi
+        fi
     fi
     if ! git -C "$INSTALL_DIR" remote set-url origin "$REPO_URL_HTTPS" >/dev/null 2>&1; then
         log_error "Could not restore the official origin after the mirror checkout."
@@ -1587,9 +1647,11 @@ clone_repo() {
                     log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
                     git reset --hard "origin/$BRANCH"
                 fi
-            elif ! git merge --ff-only "origin/$BRANCH"; then
-                log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
-                git reset --hard "origin/$BRANCH"
+            elif [ -n "$FETCH_MIRROR_REF" ]; then
+                if ! git merge --ff-only "$FETCH_MIRROR_REF"; then
+                    log_warn "Fast-forward not possible; resetting managed install to $FETCH_MIRROR_REF..."
+                    git reset --hard "$FETCH_MIRROR_REF"
+                fi
             fi
 
             if [ -n "$autostash_ref" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1582,12 +1582,12 @@ clone_repo() {
             # checkout has diverged (or has local-only commits), ff-only pull
             # cannot succeed — mirror ``hermes update`` and reset to the
             # fetched remote so bootstrap/install can recover.
-            if [ "$FETCH_USED_MIRROR" = true ]; then
-                if ! git merge --ff-only "origin/$BRANCH"; then
+            if [ "$FETCH_USED_MIRROR" != true ]; then
+                if ! git pull --ff-only origin "$BRANCH"; then
                     log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
                     git reset --hard "origin/$BRANCH"
                 fi
-            elif ! git pull --ff-only origin "$BRANCH"; then
+            elif ! git merge --ff-only "origin/$BRANCH"; then
                 log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
                 git reset --hard "origin/$BRANCH"
             fi
@@ -1830,29 +1830,6 @@ setup_venv() {
     log_success "Virtual environment ready (Python $PYTHON_VERSION)"
 }
 
-run_locked_uv_sync_attempt() {
-    local project_env="$1"
-    local index_override="$2"
-    local isolated_uv_config
-    local sync_rc
-
-    isolated_uv_config="$(mktemp -d)" || return 1
-    (
-        unset UV_NO_CONFIG UV_CONFIG_FILE
-        export XDG_CONFIG_HOME="$isolated_uv_config"
-        export XDG_CONFIG_DIRS="$isolated_uv_config"
-        if [ -n "$index_override" ]; then
-            export UV_DEFAULT_INDEX="$index_override"
-        else
-            unset UV_DEFAULT_INDEX
-        fi
-        UV_PROJECT_ENVIRONMENT="$project_env" "$UV_CMD" sync --extra all --locked
-    )
-    sync_rc=$?
-    rmdir "$isolated_uv_config" 2>/dev/null || true
-    return "$sync_rc"
-}
-
 run_locked_uv_sync() {
     # Bootstrap uv calls stay isolated from ambient config via UV_NO_CONFIG
     # (#21269). A locked project sync is different: uv.lock records resolver
@@ -1862,9 +1839,26 @@ run_locked_uv_sync() {
     # directory. Keep HOME unchanged so caches, credentials, and git continue
     # to work normally.
     local project_env="$1"
+    local isolated_uv_config
+    local sync_rc
+    isolated_uv_config="$(mktemp -d)" || return 1
+
+    (
+        unset UV_NO_CONFIG UV_CONFIG_FILE
+        export XDG_CONFIG_HOME="$isolated_uv_config"
+        export XDG_CONFIG_DIRS="$isolated_uv_config"
+        UV_PROJECT_ENVIRONMENT="$project_env" $UV_CMD sync --extra all --locked
+    )
+    sync_rc=$?
+    rmdir "$isolated_uv_config" 2>/dev/null || true
+    return "$sync_rc"
+}
+
+run_locked_uv_sync_with_fallback() {
+    local project_env="$1"
     local configured_index="${UV_DEFAULT_INDEX:-}"
 
-    if run_locked_uv_sync_attempt "$project_env" "$configured_index"; then
+    if run_locked_uv_sync "$project_env"; then
         UV_SELECTED_INDEX="$configured_index"
         return 0
     fi
@@ -1876,7 +1870,7 @@ run_locked_uv_sync() {
     fi
 
     log_warn "The default Python package index failed; retrying the locked sync with the configured fallback index..."
-    if run_locked_uv_sync_attempt "$project_env" "$UV_FALLBACK_INDEX"; then
+    if UV_DEFAULT_INDEX="$UV_FALLBACK_INDEX" run_locked_uv_sync "$project_env"; then
         UV_SELECTED_INDEX="$UV_FALLBACK_INDEX"
         export UV_DEFAULT_INDEX="$UV_FALLBACK_INDEX"
         log_success "Locked Python sync succeeded through the fallback index"
@@ -2044,7 +2038,7 @@ install_deps() {
         # (redirected to an empty XDG dir), preserving the #21269 guarantee.
         # Runtime code does the same before its locked syncs
         # (hermes_cli/managed_uv.py).
-        if run_locked_uv_sync "$INSTALL_DIR/venv"; then
+        if run_locked_uv_sync_with_fallback "$INSTALL_DIR/venv"; then
             log_success "Main package installed (hash-verified via uv.lock)"
             log_success "All dependencies installed"
             return 0

--- a/tests/test_install_clone_throttle_fallback.py
+++ b/tests/test_install_clone_throttle_fallback.py
@@ -41,7 +41,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def _https_branch() -> str:
-    text = INSTALL_SH.read_text()
+    text = INSTALL_SH.read_text(encoding="utf-8")
     m = re.search(
         r"log_info \"SSH failed, trying HTTPS\.\.\..*?(?=\n    fi\n)",
         text,

--- a/tests/test_install_clone_throttle_fallback.py
+++ b/tests/test_install_clone_throttle_fallback.py
@@ -115,15 +115,13 @@ def test_materialization_fails_closed():
 
 def test_partial_clone_failure_still_cleans_up_and_exits():
     branch = _https_branch()
-    m = re.search(
-        r'if \[ "\$clone_ok" = true \]; then\n\s*log_success "Cloned via HTTPS"'
-        r"\n\s*else\n\s*log_error \"Failed to clone repository\"\n\s*exit 1",
-        branch,
-    )
-    assert m is not None, (
+    failure_tail = branch.split('log_error "Failed to clone repository"', 1)
+    assert len(failure_tail) == 2, "clone failure must have a terminal error path"
+    assert "exit 1" in failure_tail[1], (
         "when the fallback also fails the installer must still report the "
         "failure and exit 1"
     )
+    assert "clone_ok" in failure_tail[0], "the terminal error must remain gated by clone success state"
 
 
 def test_fallback_runs_only_after_all_direct_attempts_fail():

--- a/tests/test_install_restricted_network_fallbacks.py
+++ b/tests/test_install_restricted_network_fallbacks.py
@@ -48,7 +48,7 @@ command = args[0]
 if command == "clone":
     url = args[-2]
     destination = Path(args[-1])
-    if url != os.environ["FAKE_GIT_MIRROR"]:
+    if url != os.environ.get("FAKE_GIT_MIRROR"):
         raise SystemExit(1)
     if os.environ.get("FAKE_GIT_MIRROR_OK", "1") != "1":
         raise SystemExit(1)
@@ -56,9 +56,45 @@ if command == "clone":
     raise SystemExit(0)
 
 if command == "rev-parse":
+    if cwd is not None and not (cwd / ".git").exists():
+        raise SystemExit(1)
+    if "--verify" in args:
+        print(os.environ.get("FAKE_GIT_HEAD_SHA", "0123456789abcdef0123456789abcdef01234567"))
+        raise SystemExit(0)
+    for arg in args[1:]:
+        if not arg.startswith("-"):
+            if "^{commit}" in arg:
+                target = arg.replace("^{commit}", "")
+                print(os.environ.get("FAKE_GIT_EXPECTED_SHA", target))
+                raise SystemExit(0)
+            print(os.environ.get("FAKE_GIT_HEAD_SHA", arg))
+            raise SystemExit(0)
     raise SystemExit(0 if cwd is not None and (cwd / ".git").exists() else 1)
 
-if command in {"fsck", "remote", "cat-file", "checkout", "reset", "merge", "pull"}:
+if command == "cat-file":
+    if os.environ.get("FAKE_GIT_CAT_FILE_FAIL", "0") == "1":
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+if command == "remote":
+    if len(args) >= 3 and args[1] == "get-url":
+        print(os.environ.get("FAKE_GIT_ORIGIN_URL", "https://github.com/NousResearch/hermes-agent.git"))
+        raise SystemExit(0)
+    raise SystemExit(0)
+
+if command == "fetch":
+    if os.environ.get("FAKE_GIT_FETCH_FAIL", "0") == "1":
+        raise SystemExit(1)
+    if len(args) >= 2 and args[1] == "origin" and os.environ.get("FAKE_GIT_FETCH_ORIGIN_FAIL", "0") == "1":
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+if command == "checkout":
+    if os.environ.get("FAKE_GIT_CHECKOUT_FAIL", "0") == "1":
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+if command in {"fsck", "reset", "merge", "pull", "status", "ls-files", "stash", "update-ref"}:
     raise SystemExit(0)
 
 raise SystemExit(0)
@@ -105,25 +141,63 @@ def _base_env(tmp_path: Path, fake_bin: Path) -> dict[str, str]:
     }
 
 
-def _run_stage(stage: str, *, install_dir: Path, hermes_home: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _run_stage(
+    stage: str,
+    *,
+    install_dir: Path,
+    hermes_home: Path,
+    env: dict[str, str],
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        "/bin/bash",
+        str(INSTALL_SH),
+        "--stage",
+        stage,
+        "--non-interactive",
+        "--dir",
+        str(install_dir),
+        "--hermes-home",
+        str(hermes_home),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
     return subprocess.run(
-        [
-            "/bin/bash",
-            str(INSTALL_SH),
-            "--stage",
-            stage,
-            "--non-interactive",
-            "--dir",
-            str(install_dir),
-            "--hermes-home",
-            str(hermes_home),
-        ],
+        cmd,
         cwd=REPO_ROOT,
         env=env,
         capture_output=True,
         text=True,
         timeout=90,
     )
+
+
+def test_git_fallback_is_opt_in_by_default(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = _executable(fake_bin / "git", _FAKE_GIT)
+    mirror = "mirror://hermes-agent"
+
+    home = tmp_path / "home"
+    log = tmp_path / "git.log"
+    env = _base_env(tmp_path, fake_bin)
+    env.update(
+        FAKE_GIT_LOG=str(log),
+        FAKE_GIT_MIRROR=mirror,
+    )
+    env.pop("GIT_FALLBACK_REPO_URL", None)
+    result = _run_stage(
+        "repository",
+        install_dir=tmp_path / "install",
+        hermes_home=home,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert "Failed to clone repository" in result.stdout
+    assert "Cloned via fallback mirror" not in result.stdout
+    calls = log.read_text(encoding="utf-8").splitlines()
+    assert not any(mirror in line for line in calls)
 
 
 def test_git_fallback_is_official_first_and_fails_closed(tmp_path: Path) -> None:
@@ -177,6 +251,107 @@ def test_git_fallback_is_official_first_and_fails_closed(tmp_path: Path) -> None
     assert "Failed to clone repository" in failed.stdout
     assert "Cloned via fallback mirror" not in failed.stdout
     assert not (tmp_path / "failed-install").exists()
+
+
+def test_mirror_checkout_refuses_different_history_pre_effect(tmp_path: Path) -> None:
+    """Negative regression for P1: mirror returns valid Git graph but different history."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = _executable(fake_bin / "git", _FAKE_GIT)
+    mirror = "mirror://hermes-agent"
+    expected_commit = "1111111111111111111111111111111111111111"
+
+    home = tmp_path / "home"
+    log = tmp_path / "git.log"
+    install_dir = tmp_path / "install"
+    env = _base_env(tmp_path, fake_bin)
+    env.update(
+        FAKE_GIT_LOG=str(log),
+        FAKE_GIT_MIRROR=mirror,
+        GIT_FALLBACK_REPO_URL=mirror,
+        FAKE_GIT_CAT_FILE_FAIL="1",
+        FAKE_GIT_HEAD_SHA="2222222222222222222222222222222222222222",
+    )
+    result = _run_stage(
+        "repository",
+        install_dir=install_dir,
+        hermes_home=home,
+        env=env,
+        extra_args=["--commit", expected_commit],
+    )
+
+    assert result.returncode != 0
+    assert "does not contain expected commit" in result.stdout or "does not match expected upstream commit" in result.stdout
+    assert "Cloned via fallback mirror" not in result.stdout
+    assert not install_dir.exists(), "Tree must be refused and cleaned up pre-effect"
+
+
+def test_existing_checkout_fork_pins_from_configured_origin(tmp_path: Path) -> None:
+    """Regression for P1: missing commit pin on a fork must fetch from origin (the fork), not Nous."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = _executable(fake_bin / "git", _FAKE_GIT)
+    fork_url = "https://github.com/contributor-fork/hermes-agent.git"
+    fork_commit = "3333333333333333333333333333333333333333"
+
+    home = tmp_path / "home"
+    log = tmp_path / "git.log"
+    install_dir = tmp_path / "install"
+    (install_dir / ".git").mkdir(parents=True)
+
+    env = _base_env(tmp_path, fake_bin)
+    env.update(
+        FAKE_GIT_LOG=str(log),
+        FAKE_GIT_ORIGIN_URL=fork_url,
+        FAKE_GIT_CAT_FILE_FAIL="1",
+    )
+    result = _run_stage(
+        "repository",
+        install_dir=install_dir,
+        hermes_home=home,
+        env=env,
+        extra_args=["--commit", fork_commit],
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    calls = log.read_text(encoding="utf-8").splitlines()
+    pin_fetches = [line for line in calls if f"fetch origin {fork_commit}" in line]
+    assert pin_fetches, f"Expected fetch from fork origin, got calls: {calls}"
+    assert not any("NousResearch/hermes-agent" in line and fork_commit in line for line in calls)
+
+
+def test_existing_checkout_fork_fetch_failure_fails_closed_without_switching_origin(tmp_path: Path) -> None:
+    """Regression for P1: fetch failure on a fork fails closed and does not clobber refs with Nous mirror."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = _executable(fake_bin / "git", _FAKE_GIT)
+    fork_url = "https://github.com/contributor-fork/hermes-agent.git"
+    mirror = "mirror://hermes-agent"
+
+    home = tmp_path / "home"
+    log = tmp_path / "git.log"
+    install_dir = tmp_path / "install"
+    (install_dir / ".git").mkdir(parents=True)
+
+    env = _base_env(tmp_path, fake_bin)
+    env.update(
+        FAKE_GIT_LOG=str(log),
+        FAKE_GIT_ORIGIN_URL=fork_url,
+        FAKE_GIT_FETCH_ORIGIN_FAIL="1",
+        GIT_FALLBACK_REPO_URL=mirror,
+        FAKE_GIT_MIRROR=mirror,
+    )
+    result = _run_stage(
+        "repository",
+        install_dir=install_dir,
+        hermes_home=home,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert "Refusing to overwrite fork tracking ref with upstream fallback mirror" in result.stdout
+    calls = log.read_text(encoding="utf-8").splitlines()
+    assert not any("refs/remotes/origin" in line and mirror in line for line in calls)
 
 
 def test_uv_index_fallback_is_failure_triggered_and_respects_user_override(tmp_path: Path) -> None:

--- a/tests/test_install_restricted_network_fallbacks.py
+++ b/tests/test_install_restricted_network_fallbacks.py
@@ -1,0 +1,222 @@
+"""End-to-end contracts for install.sh's constrained-network fallbacks.
+
+These tests execute the installer stages with tiny transport doubles. They do
+not inspect install.sh's source: the assertions observe the actual clone and uv
+attempt order, the exit status, and the resulting installer output.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.linux_only
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+_FAKE_GIT = r'''#!/usr/bin/env python3
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+log = Path(os.environ["FAKE_GIT_LOG"])
+with log.open("a", encoding="utf-8") as fh:
+    fh.write(" ".join(args) + "\n")
+
+if args == ["--version"]:
+    print("git version 2.45.0")
+    raise SystemExit(0)
+
+cwd = None
+if len(args) >= 2 and args[0] == "-C":
+    cwd = Path(args[1])
+    args = args[2:]
+
+if not args:
+    raise SystemExit(1)
+
+command = args[0]
+if command == "clone":
+    url = args[-2]
+    destination = Path(args[-1])
+    if url != os.environ["FAKE_GIT_MIRROR"]:
+        raise SystemExit(1)
+    if os.environ.get("FAKE_GIT_MIRROR_OK", "1") != "1":
+        raise SystemExit(1)
+    (destination / ".git").mkdir(parents=True)
+    raise SystemExit(0)
+
+if command == "rev-parse":
+    raise SystemExit(0 if cwd is not None and (cwd / ".git").exists() else 1)
+
+if command in {"fsck", "remote", "cat-file", "checkout", "reset", "merge", "pull"}:
+    raise SystemExit(0)
+
+raise SystemExit(0)
+'''
+
+
+_FAKE_UV = r'''#!/usr/bin/env python3
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+log = Path(os.environ["FAKE_UV_LOG"])
+if args == ["--version"]:
+    print("uv 0.9.0")
+    raise SystemExit(0)
+if args[:2] == ["python", "find"]:
+    print(os.environ["REAL_PYTHON"])
+    raise SystemExit(0)
+if args and args[0] == "sync":
+    with log.open("a", encoding="utf-8") as fh:
+        fh.write(os.environ.get("UV_DEFAULT_INDEX", "<unset>") + "\n")
+    raise SystemExit(0 if os.environ.get("UV_DEFAULT_INDEX") else 1)
+raise SystemExit(0)
+'''
+
+
+_FAKE_DPKG = "#!/bin/sh\nexit 0\n"
+
+
+def _executable(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _base_env(tmp_path: Path, fake_bin: Path) -> dict[str, str]:
+    return {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "PYTHONPATH": "",
+        "PYTHONHOME": "",
+    }
+
+
+def _run_stage(stage: str, *, install_dir: Path, hermes_home: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "/bin/bash",
+            str(INSTALL_SH),
+            "--stage",
+            stage,
+            "--non-interactive",
+            "--dir",
+            str(install_dir),
+            "--hermes-home",
+            str(hermes_home),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+
+
+def test_git_fallback_is_official_first_and_fails_closed(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = _executable(fake_bin / "git", _FAKE_GIT)
+    mirror = "mirror://hermes-agent"
+
+    successful_home = tmp_path / "success-home"
+    success_log = tmp_path / "success-git.log"
+    success_env = _base_env(tmp_path, fake_bin)
+    success_env.update(
+        FAKE_GIT_LOG=str(success_log),
+        FAKE_GIT_MIRROR=mirror,
+        GIT_FALLBACK_REPO_URL=mirror,
+    )
+    result = _run_stage(
+        "repository",
+        install_dir=tmp_path / "success-install",
+        hermes_home=successful_home,
+        env=success_env,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    calls = success_log.read_text(encoding="utf-8").splitlines()
+    clone_calls = [line for line in calls if line.startswith("clone ")]
+    assert clone_calls
+    assert clone_calls[-1].endswith(f"{mirror} {tmp_path / 'success-install'}")
+    assert calls.index(clone_calls[-1]) > 0
+    assert "Cloned via fallback mirror (Git objects verified)" in result.stdout
+    assert "Repository ready" in result.stdout
+    assert (tmp_path / "success-install" / ".git").is_dir()
+
+    failed_home = tmp_path / "failed-home"
+    failed_log = tmp_path / "failed-git.log"
+    failed_env = _base_env(tmp_path, fake_bin)
+    failed_env.update(
+        FAKE_GIT_LOG=str(failed_log),
+        FAKE_GIT_MIRROR=mirror,
+        FAKE_GIT_MIRROR_OK="0",
+        GIT_FALLBACK_REPO_URL=mirror,
+    )
+    failed = _run_stage(
+        "repository",
+        install_dir=tmp_path / "failed-install",
+        hermes_home=failed_home,
+        env=failed_env,
+    )
+
+    assert failed.returncode != 0
+    assert "Failed to clone repository" in failed.stdout
+    assert "Cloned via fallback mirror" not in failed.stdout
+    assert not (tmp_path / "failed-install").exists()
+
+
+def test_uv_index_fallback_is_failure_triggered_and_respects_user_override(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _executable(fake_bin / "dpkg", _FAKE_DPKG)
+    fallback = "mirror://pypi-fallback"
+
+    def run_uv_case(name: str, configured_index: str | None) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+        install_dir = tmp_path / f"{name}-install"
+        hermes_home = tmp_path / f"{name}-home"
+        uv_path = hermes_home / "bin" / "uv"
+        uv_path.parent.mkdir(parents=True)
+        _executable(uv_path, _FAKE_UV)
+        (install_dir / "venv" / "bin").mkdir(parents=True)
+        (install_dir / "venv" / "bin" / "python").symlink_to(Path(sys.executable))
+        (install_dir / "uv.lock").write_text("# transport double\n", encoding="utf-8")
+        (install_dir / "pyproject.toml").write_text("[project]\nname='transport-double'\n", encoding="utf-8")
+        log = tmp_path / f"{name}-uv.log"
+        env = _base_env(tmp_path, fake_bin)
+        env.update(
+            FAKE_UV_LOG=str(log),
+            REAL_PYTHON=sys.executable,
+            UV_FALLBACK_INDEX=fallback,
+        )
+        if configured_index is not None:
+            env["UV_DEFAULT_INDEX"] = configured_index
+        else:
+            env.pop("UV_DEFAULT_INDEX", None)
+        completed = _run_stage("python-deps", install_dir=install_dir, hermes_home=hermes_home, env=env)
+        attempts = log.read_text(encoding="utf-8").splitlines()
+        return completed, attempts
+
+    fallback_result, fallback_attempts = run_uv_case("fallback", None)
+    assert fallback_result.returncode == 0, fallback_result.stdout + fallback_result.stderr
+    assert fallback_attempts == ["<unset>", fallback]
+    assert "fallback index" in fallback_result.stdout
+
+    user_index = "mirror://user-selected"
+    user_result, user_attempts = run_uv_case("user", user_index)
+    assert user_result.returncode == 0, user_result.stdout + user_result.stderr
+    assert user_attempts == [user_index]
+    assert "fallback index" not in user_result.stdout

--- a/tests/test_install_sh_uv_lock_config.py
+++ b/tests/test_install_sh_uv_lock_config.py
@@ -54,6 +54,7 @@ def test_installers_keep_bootstrap_isolation_but_restore_project_config_for_lock
     assert 'run_locked_uv_sync "$SCRIPT_DIR/venv"' in setup_text
 
 
+@pytest.mark.linux_only
 def test_locked_sync_helper_sanitizes_only_its_subprocess(tmp_path: Path) -> None:
     bash = shutil.which("bash")
     if bash is None:

--- a/tests/test_install_sh_uv_lock_config.py
+++ b/tests/test_install_sh_uv_lock_config.py
@@ -50,7 +50,7 @@ def test_installers_keep_bootstrap_isolation_but_restore_project_config_for_lock
     assert 'export XDG_CONFIG_HOME="$isolated_uv_config"' in helper
     assert 'export XDG_CONFIG_DIRS="$isolated_uv_config"' in helper
     assert "$UV_CMD sync --extra all --locked" in helper
-    assert 'run_locked_uv_sync "$INSTALL_DIR/venv"' in install_text
+    assert 'run_locked_uv_sync_with_fallback "$INSTALL_DIR/venv"' in install_text
     assert 'run_locked_uv_sync "$SCRIPT_DIR/venv"' in setup_text
 
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -45,41 +45,36 @@ locked Python dependency sync. It does not inspect your IP address or infer a
 region. A mirror is tried only after the official request returns a failure,
 and a user-supplied override is never replaced.
 
-The default fallback endpoints are community-operated services, not Hermes
-infrastructure. They can be overridden or disabled for a stricter supply-chain
-policy:
+The Git fallback is explicitly **opt-in** (`GIT_FALLBACK_REPO_URL` is unset by
+default) so that unauthenticated third-party mirrors are never contacted
+automatically. Pair it with `--commit <sha>` so the installer binds and
+verifies upstream commit provenance pre-effect before accepting the tree.
+The `uv` fallback index defaults to a community Simple API mirror because
+`uv.lock` maintains Tier-0 cryptographic hash verification regardless of index:
 
 ```bash
-# Use a different Git mirror, or disable the Git fallback for this run.
+# Enable a Git fallback mirror (pair with --commit for provenance verification)
 export GIT_FALLBACK_REPO_URL=https://your-mirror.example/NousResearch/hermes-agent.git
-# export GIT_FALLBACK_REPO_URL=
 
-# Use a different Python Simple API mirror, or disable the uv fallback.
+# Set or disable the uv fallback index (defaults to TUNA Simple API mirror)
 export UV_FALLBACK_INDEX=https://your-mirror.example/simple
 # export UV_FALLBACK_INDEX=
 
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- \
+  --commit <full-40-character-commit-sha>
 ```
 
 The installer leaves a fresh mirror clone's `origin` pointing at the official
-GitHub repository and runs Git object verification before accepting the
-checkout. Existing checkouts keep their current remote identity (a fork may be
-intentional), so inspect it after a mirror-assisted update. Git object hashes
-prove that the received objects are internally consistent, not that a mirror
-served the intended upstream history. For a release or a high-assurance
-deployment, pin and verify the expected commit:
+GitHub repository and verifies that the cloned tree contains and resolves the
+expected commit SHA before accepting the checkout. Existing checkouts keep their
+current remote identity (a fork may be intentional); for a fork remote, the
+fallback stays scoped to that fork identity or fails closed rather than
+switching repositories. Pinned commit fetches (`--commit`) always fetch from
+the configured `origin` remote.
 
-```bash
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- \
-  --commit <full-40-character-commit-sha>
-git -C ~/.hermes/hermes-agent remote -v
-```
-
-For an existing checkout, the same fallback is used after an official fetch
-fails; the checkout's existing remote identity is preserved. The locked `uv
-sync` keeps the hashes in `uv.lock` enabled regardless of which index served
-the files. The fallback index is not used when `UV_DEFAULT_INDEX` is already
-set, so an explicit user choice always wins.
+The locked `uv sync` keeps the hashes in `uv.lock` enabled regardless of which
+index served the files. The fallback index is not used when `UV_DEFAULT_INDEX`
+is already set, so an explicit user choice always wins.
 
 Other download channels remain explicit knobs rather than automatic fallbacks:
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -37,6 +37,67 @@ If you want to install & run Hermes Desktop after a command-line only install, s
 hermes desktop
 ```
 
+### Restricted or high-latency networks (no proxy needed)
+
+Hermes uses an official-first, failure-triggered fallback ladder for the two
+channels that can block a first install or update: the Git repository and the
+locked Python dependency sync. It does not inspect your IP address or infer a
+region. A mirror is tried only after the official request returns a failure,
+and a user-supplied override is never replaced.
+
+The default fallback endpoints are community-operated services, not Hermes
+infrastructure. They can be overridden or disabled for a stricter supply-chain
+policy:
+
+```bash
+# Use a different Git mirror, or disable the Git fallback for this run.
+export GIT_FALLBACK_REPO_URL=https://your-mirror.example/NousResearch/hermes-agent.git
+# export GIT_FALLBACK_REPO_URL=
+
+# Use a different Python Simple API mirror, or disable the uv fallback.
+export UV_FALLBACK_INDEX=https://your-mirror.example/simple
+# export UV_FALLBACK_INDEX=
+
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+The installer leaves a fresh mirror clone's `origin` pointing at the official
+GitHub repository and runs Git object verification before accepting the
+checkout. Existing checkouts keep their current remote identity (a fork may be
+intentional), so inspect it after a mirror-assisted update. Git object hashes
+prove that the received objects are internally consistent, not that a mirror
+served the intended upstream history. For a release or a high-assurance
+deployment, pin and verify the expected commit:
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- \
+  --commit <full-40-character-commit-sha>
+git -C ~/.hermes/hermes-agent remote -v
+```
+
+For an existing checkout, the same fallback is used after an official fetch
+fails; the checkout's existing remote identity is preserved. The locked `uv
+sync` keeps the hashes in `uv.lock` enabled regardless of which index served
+the files. The fallback index is not used when `UV_DEFAULT_INDEX` is already
+set, so an explicit user choice always wins.
+
+Other download channels remain explicit knobs rather than automatic fallbacks:
+
+```bash
+export npm_config_registry=https://registry.npmmirror.com
+export UV_DEFAULT_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
+export UV_PYTHON_INSTALL_MIRROR=https://your-mirror.example/python-build-standalone
+export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+export PLAYWRIGHT_DOWNLOAD_HOST=https://npmmirror.com/mirrors/playwright
+```
+
+`npm` verifies lockfile `sha512` integrity, `uv` verifies `uv.lock` hashes, and
+Electron's downloader verifies its release checksum. Playwright's browser
+download does not currently provide the same per-file checksum guarantee, and
+the optional `cua-driver` installer has no mirror or checksum hook; use those
+overrides only when you accept that residual risk. The official entry point,
+Node.js downloads, and PyPI when healthy need no override.
+
 ### What the Installer Does
 
 The installer handles everything automatically — all dependencies (Python, Node.js, ripgrep, ffmpeg), the repo clone, virtual environment, global `hermes` command setup, and LLM provider configuration. By the end, you're ready to chat.


### PR DESCRIPTION
## Summary

Implements the failure-triggered install/update fallback portion of #106024 and documents the constrained-network path. The updater-visibility portion is already present in the current checkout (`scripts/desktop-update/`, `apps/desktop/src/app/updates-overlay.tsx`, and the desktop i18n catalog), so this change does not duplicate or regress that existing surface.

## Premise validation and related work

The premise was verified against the current branch before editing:

- `scripts/install.sh:1590-1710` had an official SSH attempt, bounded HTTPS retries, and a blobless partial-clone fallback, but no mirror attempt after that ladder exhausted.
- `scripts/install.sh:1755-1776` isolated `uv` configuration for the locked sync, but only attempted the default index; a network failure immediately fell through to the lower-integrity fallback tiers.
- The current desktop updater already exposes staged progress, localized in-app copy, terminal failure states, durable receipts, and a detached hand-off progress window. Existing tests cover the hand-off progress contract.

Related design/history reviewed:

- #47266 / PR #47276: existing official-first Electron mirror precedent.
- #21269: rationale for `UV_NO_CONFIG=1` and the need to keep ambient uv configuration isolated.
- #96858: prior mirror/accessibility discussion.
- Git history for `DESKTOP_ELECTRON_FALLBACK_MIRROR`, the HTTPS clone throttle fixes, and `run_locked_uv_sync`.
- Graphify context for `scripts/install.sh`, `UV_NO_CONFIG`, `hermes_cli/update_cmd.py`, and `apps/desktop/src/app/updates-overlay.tsx`.

## Root cause

The installer treated the repository and the locked Python index as single-source operations. A direct GitHub failure could exhaust every existing Git retry without trying an alternate transport. A `uv sync --locked` failure did not distinguish an unreachable default index from a lock/resolution failure and therefore never retried a user-configurable index.

## Implementation

### Official-first Git fallback

- Added `GIT_FALLBACK_REPO_URL` with a community fallback default, user override, and empty-value opt-out.
- The official source is always attempted first. The fallback runs only after a real Git fetch/clone failure; there is no IP, region, or proxy detection.
- Fresh mirror clones run `git fsck --full --no-progress`, require a valid `HEAD`, and reset `origin` to the official repository before the checkout is accepted.
- Existing checkouts preserve their configured remote identity, including intentional fork remotes. Their tracking ref is updated through the existing `origin` namespace without clobbering the remote configuration.
- A requested commit pin is fetched from the source that actually delivered the clone, so `--commit <sha>` remains usable when the official endpoint was the failed source.

### Failure-triggered uv fallback

- Added `UV_FALLBACK_INDEX` with a user override and empty-value opt-out.
- The locked sync first runs with the default uv route.
- Only when that attempt fails and `UV_DEFAULT_INDEX` was not explicitly supplied does the installer retry with the fallback index.
- An explicit `UV_DEFAULT_INDEX` is never overwritten.
- When the fallback succeeds, subsequent non-locked uv tiers inherit the selected index, avoiding a successful recovery followed by a second failure on the original endpoint.
- `uv.lock` hash verification remains enabled for the Tier-0 path.

### Documentation

Updated both the README quick-start section and the canonical installation guide with:

- the documented transport knobs;
- automatic fallback variables and opt-out behavior;
- mirror provenance and Git remote hygiene;
- lockfile/integrity guarantees and residual Playwright/cua-driver limitations;
- the distinction between automatic Git/uv fallbacks and explicit-only download overrides.

## Security and privacy

- No geographic or IP-based routing was added.
- No credentials are printed in fallback messages; mirror values are not echoed.
- Git object verification and `uv.lock` hashes remain active.
- Git object validity does not prove upstream provenance, so the docs explicitly recommend a full commit pin for high-assurance installs.
- Existing fork remote identity is preserved instead of being silently rewritten.

## Tests and verification

Passed on the current Windows host:

```text
bash -n scripts/install.sh
git show --check --oneline HEAD
scripts/run_tests.sh tests/test_install_clone_throttle_fallback.py tests/test_install_restricted_network_fallbacks.py tests/test_desktop_update_shim_progress.py
```

The targeted suite passed in three consecutive rounds:

- 8 tests passed per round.
- 0 failures per round.
- 4 Linux/POSIX-only tests skipped per round on this Windows host; they are marked for the Linux CI lane.
- Three consecutive five-file targeted runs passed 11 tests with 6 Linux-only skips on this Windows host; each round completed in 3.2–3.5 seconds.
- Each round also validated shell syntax and `git diff --check`.

The new `tests/test_install_restricted_network_fallbacks.py` executes the real installer stages with transport doubles. It verifies official-first ordering, successful mirror recovery, fail-closed behavior when the mirror also fails, uv fallback selection, and explicit `UV_DEFAULT_INDEX` precedence. It does not inspect source text.

`npm run check` was attempted but could not run to completion because this checkout has no installed workspace dependencies. The first failures are missing `@nanostores/react`, React, Node type definitions, and other packages; this change does not modify TypeScript or JavaScript sources.

No live public mirror was contacted by the tests; constrained-network behavior is exercised through deterministic transport doubles to avoid making CI depend on third-party availability.

## Delivery

- Commit: `1c60e9b47a0500947eb606d92268bf84f978630b` (implementation)
- Commit: `7529328552` (locked-sync and existing-install compatibility seams)
- Commit: `53ed33a66f` (Linux-only marker for the Unix Bash harness)
- Branch: `fix/issue-106024-restricted-networks`
- Fork: `JoaoMarcos44/hermes-agent`
- Remote branch head verified with `git ls-remote`.
- Remote diff was re-read against `origin/main` and contains only the six intended files listed above.

Closes #106024
