### PR TITLE
fix(bot-relay): delete consumed reply receipts

### DIFF
--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -177,6 +177,7 @@ def test_waiter_picks_up_reply_within_a_sub_second_cadence(root):
     elapsed = time.monotonic() - started
     assert proc.returncode == 0 and "pong" in proc.stdout
     assert elapsed < 1.5, f"waiter took {elapsed:.2f}s to notice a reply written at 0.3s"
+    assert not reply_path.exists(), "consumed reply plaintext must be removed immediately"
 
 
 def test_roster_rejects_connection_id_outside_handle_charset(root):

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -335,7 +335,12 @@ def waiter_command(root: Path | str, envelope: dict) -> str:
         f"deadline = time.time() + {REPLY_WAIT_SECONDS}\n"
         "while time.time() < deadline:\n"
         "    if os.path.exists(p):\n"
-        "        d = json.load(open(p, encoding='utf-8'))\n"
+        "        with open(p, encoding='utf-8') as stream:\n"
+        "            d = json.load(stream)\n"
+        "        try:\n"
+        "            os.unlink(p)\n"
+        "        except OSError:\n"
+        "            pass\n"
         "        if d.get('error'):\n"
         # Typed reason code rides ahead of the free text so the sender can
         # branch on it without parsing provider prose.


### PR DESCRIPTION
Related to #91911

## Reply retention after consumption

The generated cross-connection waiter polls for a terminal reply receipt, parses it, prints either the reply or typed error, and exits. The waiter previously left the consumed receipt on disk until the six-hour stale sweep.

That retained terminal reply or error plaintext long after the sending process had successfully received it, despite there being no second consumer or replay contract for an already-consumed reply.

## Consume-before-display cleanup

The generated waiter now:

1. opens the reply with a context manager;
2. parses the complete JSON receipt;
3. attempts to unlink the receipt immediately after a successful parse;
4. continues through the existing error/reason classification and output path.

Parsing happens before deletion, so a truncated or unreadable reply is not discarded as successfully consumed. The unlink itself is best-effort: a filesystem cleanup failure does not hide a valid terminal result from the caller, and the existing stale sweep remains the fallback.

## Waiter contract

- Polling cadence and reply timeout are unchanged.
- Successful replies and typed failures retain their existing stdout/stderr and exit behavior.
- A receipt is removed only after valid JSON has been loaded into memory.
- There is no change to reply publication, envelope claiming, or target-side settlement.
- Each generated waiter still owns exactly one validated reply path.

## Verification

The focused test starts the generated waiter, publishes `pong` after 300 ms, and verifies all three observable properties:

- the waiter exits successfully with the reply;
- it notices the receipt within the existing sub-second cadence (`< 1.5 s` total);
- the consumed reply file no longer exists when the waiter exits.

- Focused waiter regression: **1 passed**.
- Relay, Bot Chat DM, gateway relay, and Windows-path matrix: **85 passed, 1 skipped** with file retries disabled.
- `git diff --check` passed.