### PR TITLE
fix(bot-relay): delete claimed payload after settlement

### DIFF
--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -132,6 +132,20 @@ def test_write_reply_validates_envelope_id(root):
     assert data["reply"] == "pong" and not data["error"]
 
 
+def test_write_reply_removes_settled_claimed_payload(root):
+    env = bot_relay.enqueue_envelope(
+        root, target=_rows()[1], message="private payload",
+        sender_profile="default", sender_handle="hermes",
+    )
+    assert bot_relay.claim_pending_envelopes(root)
+    claimed = bot_relay.relay_root(root) / bot_relay.CLAIMED_DIR / f"{env['id']}.json"
+    assert claimed.exists()
+
+    bot_relay.write_reply(root, env["id"], reply="done")
+
+    assert not claimed.exists(), "settled envelopes no longer need their plaintext payload"
+
+
 def test_write_reply_reason_passthrough_and_classification(root):
     # explicit reason is persisted verbatim
     path = bot_relay.write_reply(root, "c" * 32, error="boom", reason="delivery_timeout")

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -283,6 +283,8 @@ def write_reply(root: Path | str, envelope_id: str, *, reply: str = "", error: s
     path = base / REPLIES_DIR / f"{safe}.json"
     _atomic_write_json(path, {"id": safe, "at": int(time.time()), "reply": str(reply or ""), "error": err, "reason": code},
                        prefix=".rep-")
+    with contextlib.suppress(OSError):
+        (base / CLAIMED_DIR / f"{safe}.json").unlink()
     return path
 
 


### PR DESCRIPTION
Related to #91911

## Plaintext retention after settlement

When a target publishes a terminal reply, the relay atomically writes a reply receipt for the sender. The matching claimed envelope was previously left in `claimed/` until the six-hour stale sweep, even though no replay or recovery path consumes a claim after its terminal result exists.

That retained a second on-disk copy of the original cross-connection message plaintext for hours after delivery had already settled.

## Settlement ordering

Remove the claimed envelope only after the terminal reply has been durably published:

```text
validate envelope ID
atomically write terminal reply receipt
unlink matching claimed envelope
return reply path
```

The ordering preserves the terminal outcome as the source of truth. If reply publication fails, the claimed payload remains available under the existing recovery behavior. If cleanup alone fails, the reply is still complete and the later stale sweep can remove the redundant claim.

The unlink is intentionally best-effort and scoped to the validated envelope ID; cleanup failure cannot turn a successful reply into a relay error.

## Storage contract

- Pending envelopes are untouched.
- Only the matching settled claim is removed.
- Reply/error text and typed reason codes keep their existing receipt shape.
- Sender waiters continue to consume the terminal reply through the existing path.
- Claim ownership, atomic reply publication, retry behavior, and stale cleanup remain unchanged.

## Verification

The regression enqueues an envelope containing `private payload`, claims it through the real relay path, publishes a terminal reply, and verifies that the matching claimed file no longer exists afterward.

- Focused settlement-cleanup regression: **1 passed**.
- Relay, Bot Chat DM, gateway relay, and Windows-path matrix: **86 passed, 1 skipped** with file retries disabled.
- `git diff --check` passed.