### PR TITLE
refactor(desktop): make unused rail-task helper deterministic

### DIFF
--- a/apps/desktop/src/store/activity.test.ts
+++ b/apps/desktop/src/store/activity.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { buildRailTasks } from './activity'
+
+afterEach(() => vi.useRealTimers())
+
+describe('buildRailTasks', () => {
+  it.each([
+    ['an unresolved running session', () => buildRailTasks(['session-a'], [], null, {})],
+    [
+      'a preview restart',
+      () => buildRailTasks([], [], { status: 'running', taskId: 'preview-a', url: 'http://localhost:3000' }, {})
+    ]
+  ])('keeps %s stable when inputs have not changed', (_label, build) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-08T00:00:00Z'))
+    const first = build()
+
+    vi.setSystemTime(new Date('2026-09-08T00:01:00Z'))
+    const second = build()
+
+    expect(second).toEqual(first)
+  })
+})

--- a/apps/desktop/src/store/activity.ts
+++ b/apps/desktop/src/store/activity.ts
@@ -44,7 +44,10 @@ export function buildRailTasks(
       label: session ? sessionTitle(session) : 'Session task',
       detail: 'Agent task running',
       status: 'running',
-      updatedAt: session?.last_active || Date.now() - index
+      // A running session that has not reached the sidebar cache still belongs
+      // ahead of historical tasks, but its sort key must not change on every
+      // render while the inputs are unchanged.
+      updatedAt: session?.last_active || Number.MAX_SAFE_INTEGER - index
     }
   })
 
@@ -56,7 +59,7 @@ export function buildRailTasks(
           detail: previewRestart.message || previewRestart.url,
           status:
             previewRestart.status === 'error' ? 'error' : previewRestart.status === 'running' ? 'running' : 'success',
-          updatedAt: Date.now()
+          updatedAt: Number.MAX_SAFE_INTEGER
         }
       ]
     : []


### PR DESCRIPTION
Related context: #56267. **Draft helper cleanup only; this PR does not establish or fix a reachable production rendering defect.**

## Actual scope

At head `f32938f55ef8948741df387ec39412538b5f3b9b`, `buildRailTasks()` in `apps/desktop/src/store/activity.ts` has no production caller found in the source. The exact-head `git grep` finds only the exported definition and `activity.test.ts` consumers. Current live UI/store paths do not exercise this helper.

The earlier description claiming visible row reshuffling and downstream UI updates was not supported by that reachability. Those runtime/performance claims are withdrawn. This is not evidence that #56267 is fixed.

## Helper-level change

For unresolved running sessions the helper uses `Number.MAX_SAFE_INTEGER - index`, and for an in-progress preview restart it uses `Number.MAX_SAFE_INTEGER`, instead of sampling wall time. Equal helper inputs therefore produce equal output values across clock changes. Resolved sessions retain stored activity timestamps; preview status/detail mapping is unchanged. This does not claim reference-identity stability or measured UI performance.

No production caller is added merely to make the change reachable. This PR stays draft pending a maintainer decision about retaining a helper cleanup versus a separately justified live-path change.

## Executed exact-head verification

Fork run: https://github.com/Xipong/hermes-agent/actions/runs/34707428541 — the `evidence (106040, ...)` matrix job checks out the above SHA unchanged.

- Full `src/store/activity.test.ts` in the real UI Vitest project: **2 passed, 0 failed**.
- Focused ESLint, renderer TypeScript `--noEmit`, `git diff --check`, and clean tracked checkout: passed.
- `git grep -n buildRailTasks -- apps/desktop/src`: only the helper definition and its test file.

These tests certify helper-level determinism, not product reachability or performance. Draft disposition remains independent of test success; no maintainer/design hold is lifted.