### PR TITLE
fix(desktop): fence draft suggestions after composer teardown

### DIFF
--- a/apps/desktop/src/store/composer-suggestions.test.ts
+++ b/apps/desktop/src/store/composer-suggestions.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   $composerSuggestionsBySession,
+  clearDraftSuggestions,
   type ComposerSuggestion,
   markSuggestionInvoked,
   offerSuggestions,
+  registerDraftProvider,
+  sampleComposerDraft,
   suggestionKey
 } from './composer-suggestions'
 
@@ -122,5 +125,31 @@ describe('composer suggestion bus', () => {
     expect($composerSuggestionsBySession.get().s9).toBe(first)
 
     offerSuggestions('s9', 'test', [])
+  })
+
+  it('does not restore draft suggestions after their composer is cleared', async () => {
+    vi.useFakeTimers()
+
+    let resolveProvider!: (suggestions: ComposerSuggestion[]) => void
+
+    const unregister = registerDraftProvider(
+      'late-provider',
+      () => new Promise(resolve => void (resolveProvider = resolve))
+    )
+
+    try {
+      sampleComposerDraft('closed-session', 'install linear')
+      await vi.advanceTimersByTimeAsync(600)
+      clearDraftSuggestions('closed-session')
+
+      resolveProvider([suggestion('late', 'late-provider')])
+      await vi.runAllTimersAsync()
+
+      expect(pillsFor('closed-session')).toEqual([])
+    } finally {
+      unregister()
+      clearDraftSuggestions('closed-session')
+      vi.useRealTimers()
+    }
   })
 })

--- a/apps/desktop/src/store/composer-suggestions.ts
+++ b/apps/desktop/src/store/composer-suggestions.ts
@@ -262,6 +262,7 @@ export function sampleComposerDraft(sessionId: string | null | undefined, text: 
   const key = keyFor(sessionId)
 
   window.clearTimeout(sampleTimers.get(key))
+  sampleTimers.delete(key)
 
   const generation = (sampleGenerations.get(key) ?? 0) + 1
   sampleGenerations.set(key, generation)
@@ -277,6 +278,7 @@ export function sampleComposerDraft(sessionId: string | null | undefined, text: 
   sampleTimers.set(
     key,
     window.setTimeout(() => {
+      sampleTimers.delete(key)
       void Promise.all(
         [...draftProviders.values()].map(provider =>
           provider({ sessionId: sessionId ?? null, text }).catch((): ComposerSuggestion[] => [])
@@ -301,6 +303,9 @@ export function clearDraftSuggestions(sessionId: string | null | undefined): voi
   const key = keyFor(sessionId)
 
   window.clearTimeout(sampleTimers.get(key))
+  sampleTimers.delete(key)
+  // Fence a provider that already started before this composer unmounted.
+  sampleGenerations.set(key, (sampleGenerations.get(key) ?? 0) + 1)
   draftOfferings.delete(key)
   publish(sessionId ?? null)
 }


### PR DESCRIPTION
Related to #56267

## Late-result race

Draft sampling is debounced, then awaits every registered provider before replacing that provider's visible suggestions for the session. `clearDraftSuggestions()` previously cancelled the pending timer and removed the current offering, but it did not invalidate a provider call that had already started.

A composer could therefore close cleanly, clear its pills, and then be repopulated by a late result from the retired lifecycle. Timer handles also remained in `sampleTimers` after cancellation or after the callback fired, leaving stale bookkeeping behind.

## Lifecycle fence

Use the existing per-session generation as the ownership boundary:

- every sample captures the current generation before provider work begins;
- clearing a composer advances that generation, invalidating any already-running sample;
- a late provider result may settle, but it cannot publish unless its captured generation still matches;
- cancelled timers are removed from the timer map immediately;
- fired timers remove their own handle before starting provider work.

The providers themselves are not force-cancelled, so their existing promise and error behavior is unchanged. The fix only prevents work owned by a closed composer from mutating visible state afterward.

## Teardown contract

After `clearDraftSuggestions(sessionId)` returns:

- no pending timer remains registered for that session;
- the visible draft offering is empty;
- any provider already in flight is fenced from publication;
- a later explicit sample starts under a fresh generation and works normally.

## Verification

The regression starts a real debounced provider request, clears the composer after the provider is in flight, then resolves that provider with a suggestion. The retired result settles without restoring any pill for the closed session.

- Full `composer-suggestions.test.ts`: **9 passed**.
- Focused ESLint passed.
- Desktop TypeScript compilation with `--noEmit` passed.
- `git diff --check` passed.