### PR TITLE
test(bot-mode): guard FIFO across mixed-version writers

### DIFF
--- a/tests/tools/test_bot_live_owner_delivery.py
+++ b/tests/tools/test_bot_live_owner_delivery.py
@@ -49,20 +49,49 @@ def test_delivery_is_idempotent_fenced_and_permanent(tmp_path, terminal_status):
             assert path.stat().st_mode & 0o077 == 0
 
 
-def test_admission_does_not_reread_permanent_receipts_for_sequence(tmp_path, monkeypatch):
+def test_fifo_with_legacy_writer_in_another_process(tmp_path):
     from tools import bot_live_delivery as mailbox
 
     owner = dict(profile_home=str(tmp_path.resolve()), session_id="chat",
                  lease_id="lease", live_session_id="live")
-    for i in range(3):
-        mailbox.deliver_to_live_owner(tmp_path, owner, f"old-{i}", delivery_id=f"{i + 1:032x}")
-    reads = []
-    real_read = mailbox._read
-    monkeypatch.setattr(mailbox, "_read", lambda path: reads.append(path) or real_read(path))
+    first = mailbox.deliver_to_live_owner(
+        tmp_path, owner, "first", delivery_id="a" * 32)
+    legacy_script = """
+import json
+import sys
+import time
+from tools import bot_live_delivery as mailbox
 
-    mailbox.deliver_to_live_owner(tmp_path, owner, "new", delivery_id="f" * 32)
+home, owner_json, message, key = sys.argv[1:]
+owner = json.loads(owner_json)
+pinned = mailbox._owner(home, owner)
+with mailbox._locked(home) as root:
+    path = root / f"{key}.json"
+    sequence = max((record.get("sequence", record["created_at"])
+                    for candidate in root.glob("*.json")
+                    if (record := mailbox._read(candidate)) is not None), default=0) + 1
+    record = dict(delivery_id=key, id=key, owner=pinned, **pinned,
+                  message=message, status="queued", created_at=time.time_ns(),
+                  sequence=sequence)
+    mailbox._write(path, record)
+print(json.dumps(record))
+"""
+    child = subprocess.run(
+        [sys.executable, "-c", legacy_script, str(tmp_path), json.dumps(owner),
+         "second", "f" * 32],
+        stdin=subprocess.DEVNULL, capture_output=True, text=True, timeout=30,
+    )
+    assert child.returncode == 0, child.stderr
+    second = json.loads(child.stdout)
+    third = mailbox.deliver_to_live_owner(
+        tmp_path, owner, "third", delivery_id="1" * 32)
 
-    assert [path.name for path in reads] == ["f" * 32 + ".json"]
+    assert [first["sequence"], second["sequence"], third["sequence"]] == [1, 2, 3]
+    claims = [mailbox.claim_pending_delivery(tmp_path, owner) for _ in range(3)]
+    assert all(claim is not None for claim in claims)
+    assert [claim["message"] for claim in claims if claim is not None] == [
+        "first", "second", "third",
+    ]
 
 
 def test_fifo_survives_clock_rollback(tmp_path, monkeypatch):

--- a/tests/tools/test_bot_live_owner_delivery.py
+++ b/tests/tools/test_bot_live_owner_delivery.py
@@ -49,6 +49,22 @@ def test_delivery_is_idempotent_fenced_and_permanent(tmp_path, terminal_status):
             assert path.stat().st_mode & 0o077 == 0
 
 
+def test_admission_does_not_reread_permanent_receipts_for_sequence(tmp_path, monkeypatch):
+    from tools import bot_live_delivery as mailbox
+
+    owner = dict(profile_home=str(tmp_path.resolve()), session_id="chat",
+                 lease_id="lease", live_session_id="live")
+    for i in range(3):
+        mailbox.deliver_to_live_owner(tmp_path, owner, f"old-{i}", delivery_id=f"{i + 1:032x}")
+    reads = []
+    real_read = mailbox._read
+    monkeypatch.setattr(mailbox, "_read", lambda path: reads.append(path) or real_read(path))
+
+    mailbox.deliver_to_live_owner(tmp_path, owner, "new", delivery_id="f" * 32)
+
+    assert [path.name for path in reads] == ["f" * 32 + ".json"]
+
+
 def test_fifo_survives_clock_rollback(tmp_path, monkeypatch):
     from tools import bot_live_delivery as mailbox
 

--- a/tools/bot_live_delivery.py
+++ b/tools/bot_live_delivery.py
@@ -20,6 +20,7 @@ from typing import Any
 from hermes_cli.active_sessions import _FileLock
 
 DELIVERY_DIR_NAME = "bot_live_delivery"
+_SEQUENCE_FILE = ".sequence"
 _OWNER_KEYS = ("profile_home", "session_id", "lease_id", "live_session_id")
 _TERMINAL = frozenset({"settled", "failed", "cancelled", "ambiguous"})
 
@@ -106,6 +107,27 @@ def _read(path: Path) -> dict[str, Any] | None:
         return None
 
 
+def _next_sequence(root: Path) -> int:
+    """Advance the durable FIFO high-water mark without rescanning permanent receipts."""
+    path = root / _SEQUENCE_FILE
+    try:
+        current = int(path.read_text(encoding="ascii"))
+    except (FileNotFoundError, ValueError):
+        current = max((record.get("sequence", record.get("created_at", 0))
+                       for candidate in root.glob("*.json")
+                       if (record := _read(candidate)) is not None), default=0)
+    fd, temporary = tempfile.mkstemp(dir=root, prefix=".sequence-")
+    try:
+        with os.fdopen(fd, "w", encoding="ascii") as stream:
+            stream.write(str(current + 1))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        Path(temporary).unlink(missing_ok=True)
+    return current + 1
+
+
 def _write(path: Path, record: dict[str, Any]) -> None:
     fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=".delivery-")
     try:
@@ -139,11 +161,9 @@ def deliver_to_live_owner(
             if existing["owner"] != pinned or existing["message"] != message:
                 raise ValueError("delivery id already belongs to a different payload")
             return existing
-        # Wall time can roll back. Permanent receipts retain the admission
-        # high-water mark, allocated while holding the cross-process lock.
-        sequence = max((record.get("sequence", record["created_at"])
-                        for candidate in root.glob("*.json")
-                        if (record := _read(candidate)) is not None), default=0) + 1
+        # Wall time can roll back. The durable high-water mark preserves FIFO
+        # without rereading every permanent receipt for each new admission.
+        sequence = _next_sequence(root)
         record = dict(delivery_id=key, id=key, owner=pinned, **pinned,
                       message=message, status="queued", created_at=time.time_ns(),
                       sequence=sequence)

--- a/tools/bot_live_delivery.py
+++ b/tools/bot_live_delivery.py
@@ -20,7 +20,6 @@ from typing import Any
 from hermes_cli.active_sessions import _FileLock
 
 DELIVERY_DIR_NAME = "bot_live_delivery"
-_SEQUENCE_FILE = ".sequence"
 _OWNER_KEYS = ("profile_home", "session_id", "lease_id", "live_session_id")
 _TERMINAL = frozenset({"settled", "failed", "cancelled", "ambiguous"})
 
@@ -107,27 +106,6 @@ def _read(path: Path) -> dict[str, Any] | None:
         return None
 
 
-def _next_sequence(root: Path) -> int:
-    """Advance the durable FIFO high-water mark without rescanning permanent receipts."""
-    path = root / _SEQUENCE_FILE
-    try:
-        current = int(path.read_text(encoding="ascii"))
-    except (FileNotFoundError, ValueError):
-        current = max((record.get("sequence", record.get("created_at", 0))
-                       for candidate in root.glob("*.json")
-                       if (record := _read(candidate)) is not None), default=0)
-    fd, temporary = tempfile.mkstemp(dir=root, prefix=".sequence-")
-    try:
-        with os.fdopen(fd, "w", encoding="ascii") as stream:
-            stream.write(str(current + 1))
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temporary, path)
-    finally:
-        Path(temporary).unlink(missing_ok=True)
-    return current + 1
-
-
 def _write(path: Path, record: dict[str, Any]) -> None:
     fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=".delivery-")
     try:
@@ -161,9 +139,11 @@ def deliver_to_live_owner(
             if existing["owner"] != pinned or existing["message"] != message:
                 raise ValueError("delivery id already belongs to a different payload")
             return existing
-        # Wall time can roll back. The durable high-water mark preserves FIFO
-        # without rereading every permanent receipt for each new admission.
-        sequence = _next_sequence(root)
+        # Wall time can roll back. Permanent receipts retain the admission
+        # high-water mark, allocated while holding the cross-process lock.
+        sequence = max((record.get("sequence", record["created_at"])
+                        for candidate in root.glob("*.json")
+                        if (record := _read(candidate)) is not None), default=0) + 1
         record = dict(delivery_id=key, id=key, owner=pinned, **pinned,
                       message=message, status="queued", created_at=time.time_ns(),
                       sequence=sequence)


### PR DESCRIPTION
Related to #91911

## Rejected optimization

A proposed `.sequence` sidecar attempted to make mailbox admission O(1) by storing the next durable sequence outside the receipt set. That value was authoritative only for updated writers.

During a rolling upgrade, a still-running pre-update process could scan the permanent receipts, allocate sequence `2`, and persist it without advancing the sidecar. The next updated writer would then trust the stale sidecar and allocate `2` again:

```text
current writer → 1
legacy writer  → 2
current writer → 2  (FIFO identity collision)
```

The sidecar cannot be made authoritative while compatible legacy writers are allowed to create receipts without participating in it.

## Final contract

Remove the unsafe optimization and retain the existing receipt scan while holding the cross-process mailbox lock. Permanent receipts remain the single durable source of truth for sequence allocation, so old and new processes observe the same high-water mark.

This intentionally gives up the proposed O(1) admission path in favor of mixed-version correctness. No runtime sidecar, migration, recovery rule, or second ordering authority remains in the final diff.

## Mixed-version regression

The new test runs the legacy allocation algorithm in a separate Python process between two current writers. It verifies both sides of the contract:

- durable sequences are exactly `1, 2, 3`;
- claims are returned in `first, second, third` order.

The child process imports the installed mailbox implementation and reproduces the old receipt-scanning writer directly; the test has no Git executable or repository-history dependency.

## Verification

- Against the rejected sidecar implementation, the regression was RED with sequences **`1, 2, 2`**.
- Focused mixed-writer regression: **1 passed** after removing the sidecar.
- Live-owner delivery, TUI gateway delivery, and Bot Chat DM matrix: **54 passed, 1 skipped** with file retries disabled.
- `git diff --check` passed.

## Final scope

The published PR is test-only and locks in the existing cross-process FIFO behavior. It does not claim an admission-speed improvement; its purpose is to prevent the unsafe optimization from returning without a mixed-version proof.