### PR TITLE
fix(bot-relay): tolerate invalid envelope TTL config

### DIFF
--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -530,6 +530,12 @@ def test_drain_ttl_zero_disables_expiry(root, monkeypatch):
     assert [e["id"] for e in claimed] == [env["id"]]
 
 
+def test_invalid_ttl_config_falls_back_instead_of_breaking_drain(monkeypatch):
+    monkeypatch.setattr(bot_relay, "_bot_mode_cfg", lambda *args, **kwargs: "not-a-number")
+
+    assert bot_relay._envelope_ttl_seconds() == bot_relay.DEFAULT_ENVELOPE_TTL_SECONDS
+
+
 def test_ttl_config_read_is_lazy_and_defensive(monkeypatch):
     import builtins
 

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -180,7 +180,13 @@ def _envelope_ttl_seconds() -> int:
     """Configured drain TTL (``bot_mode.envelope_ttl_seconds``), read per-drain.
     ``0`` (or negative) disables expiry."""
     val = _bot_mode_cfg("envelope_ttl_seconds", loader="load_config_readonly")
-    return DEFAULT_ENVELOPE_TTL_SECONDS if val is None else int(val)
+    if val is None:
+        return DEFAULT_ENVELOPE_TTL_SECONDS
+    try:
+        return int(val)
+    except (TypeError, ValueError, OverflowError):
+        logger.debug("Invalid bot_mode.envelope_ttl_seconds %r; using fallback", val)
+        return DEFAULT_ENVELOPE_TTL_SECONDS
 
 
 def _target_liveness(root: Path | str, target: dict) -> Optional[bool]:


### PR DESCRIPTION
Related to #92760

## Failure mode

The relay reads `bot_mode.envelope_ttl_seconds` on every drain so configuration changes take effect without restarting the process. The previous path passed that value directly to `int()`.

One malformed value—such as a non-numeric string, an incompatible type, or an overflowing numeric object—therefore raised before the drain could inspect any envelope. Because the same configuration was read again on the next pass, all cross-connection deliveries remained stalled until the setting was repaired externally.

## Defensive parsing

Keep the existing lazy per-drain read, but treat invalid configuration as a local configuration failure rather than a relay-wide delivery failure:

- `None` selects `DEFAULT_ENVELOPE_TTL_SECONDS` as before;
- a valid integer-compatible value is used unchanged;
- zero and negative values retain the documented “expiry disabled” behavior;
- `TypeError`, `ValueError`, or `OverflowError` falls back to the documented default and emits a debug diagnostic.

The fallback does not rewrite the user's configuration, change envelope timestamps, or alter the stale-sweep policy. It only allows the current and subsequent drains to continue processing with the safe default.

## Delivery contract

A malformed optional TTL setting can no longer make otherwise valid queued envelopes undeliverable. Target selection, claim ownership, terminal settlement, and the zero/negative disable path are unchanged.

## Verification

- Added a focused regression that supplies `"not-a-number"` through the real configuration seam and verifies fallback to `DEFAULT_ENVELOPE_TTL_SECONDS`.
- Focused invalid-configuration test: **1 passed**.
- Relay, Bot Chat DM, gateway relay, and Windows-path matrix: **86 passed, 1 skipped** with file retries disabled.
- `git diff --check` passed.