### PR TITLE
fix(desktop): coalesce pooled remote liveness probes

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11786,7 +11786,10 @@ async function ensureRegistryBackend(
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
-    remoteBaseUrl: null
+    remoteBaseUrl: null,
+    // URL/cloud profiles from one registry source use the same endpoint and
+    // credentials. SSH profiles own distinct tunnels and must probe alone.
+    sharedProbeKey: source.kind === 'ssh' ? null : source.id
   }
 
   entry.connectionPromise = connectRegistryBackend(

--- a/apps/desktop/electron/power-resume-remote-revalidation.test.ts
+++ b/apps/desktop/electron/power-resume-remote-revalidation.test.ts
@@ -8,6 +8,7 @@ import {
   attachPowerResumeRemoteRevalidation,
   POWER_RESUME_REVALIDATION_HOLDOFF_MS,
   RemoteLivenessTracker,
+  revalidatePooledRemoteBackends,
   revalidateSuspectPooledRemoteBackends
 } from './remote-liveness'
 
@@ -154,24 +155,94 @@ describe('revalidateSuspectPooledRemoteBackends (#93910)', () => {
     expect(result).toEqual({ rebuilt: [], retired: [] })
   })
 
-  it('clears the shared failure streak for a retired base URL so the rebuilt tunnel starts clean', async () => {
-    const tracker = new RemoteLivenessTracker()
-    tracker.recordFailure('http://127.0.0.1:53101')
-    tracker.recordFailure('http://127.0.0.1:53101')
+  for (const shared of [false, true]) {
+    for (const transition of ['healthy', 'rebuilt', 'rebuild-failed', 'retire-failed']) {
+      it(`pooled failure-key: ${shared ? 'shared' : 'independent'} / ${transition}`, async () => {
+        const baseUrl = 'https://remote.example.com'
+        const tracker = new RemoteLivenessTracker(3, 60_000, () => 1_000)
 
-    await revalidateSuspectPooledRemoteBackends({
-      entries: [['conn:ssh-dead::default', remoteEntry('http://127.0.0.1:53101')]],
-      log: vi.fn(),
-      probe: vi.fn(async () => {
-        throw new Error('socket hang up')
-      }),
-      rebuild: vi.fn(async () => descriptor('http://127.0.0.1:53110')),
-      retire: vi.fn(async () => undefined),
-      tracker
-    })
+        const entry = (profile: string, sharedProbeKey?: string) => ({
+          connectionPromise: Promise.resolve({ baseUrl, mode: 'remote', profile }),
+          process: null,
+          remoteBaseUrl: `${baseUrl}/`,
+          sharedProbeKey
+        })
 
-    expect(tracker.recordFailure('http://127.0.0.1:53101')).toEqual({ failures: 1, shouldReset: false })
-  })
+        const recovering = entry('recovering', shared ? ' source-a ' : undefined)
+        const sibling = entry('sibling', 'source-a')
+        sibling.remoteBaseUrl = baseUrl
+        const unrelated = entry('unrelated', shared ? 'source-b' : undefined)
+        const recoveredEntries: Array<[string, typeof recovering]> = [['recovering', recovering]]
+
+        if (shared) {recoveredEntries.push(['sibling', sibling])}
+        const entries: Array<[string, typeof recovering]> = [...recoveredEntries, ['unrelated', unrelated]]
+
+        const offline = async () => {
+          throw new Error('offline')
+        }
+
+        const sweep = (selected = entries) =>
+          revalidatePooledRemoteBackends({
+            entries: selected,
+            log: () => undefined,
+            probe: offline,
+            stopBackend: () => undefined,
+            tracker
+          })
+
+        // Seed the actual background path, not a guessed tracker key.
+        await expect(sweep()).resolves.toEqual({ dropped: [] })
+        await expect(sweep()).resolves.toEqual({ dropped: [] })
+
+        const retire = vi.fn(async () => {
+          if (transition === 'retire-failed') {throw new Error('retire failed')}
+        })
+
+        const rebuild = vi.fn(async () => {
+          if (transition === 'rebuild-failed') {throw new Error('rebuild failed')}
+          recovering.connectionPromise = Promise.resolve({ baseUrl, mode: 'remote', profile: 'replacement' })
+        })
+
+        const result = await revalidateSuspectPooledRemoteBackends({
+          entries: [['recovering', recovering]],
+          log: () => undefined,
+          probe: transition === 'healthy' ? async () => undefined : offline,
+          rebuild,
+          retire,
+          tracker
+        })
+
+        if (transition === 'healthy') {
+          expect(result).toEqual({ rebuilt: [], retired: [] })
+          expect(retire).not.toHaveBeenCalled()
+          expect(rebuild).not.toHaveBeenCalled()
+        } else if (transition === 'retire-failed') {
+          expect(result).toEqual({ rebuilt: [], retired: [] })
+          expect(retire).toHaveBeenCalledOnce()
+          expect(rebuild).not.toHaveBeenCalled()
+        } else {
+          expect(result).toEqual({
+            rebuilt: transition === 'rebuilt' ? ['recovering'] : [],
+            retired: ['recovering']
+          })
+          expect(retire).toHaveBeenCalledOnce()
+          expect(rebuild).toHaveBeenCalledOnce()
+        }
+
+        const afterResume = await sweep()
+        const expectedDrops = transition === 'retire-failed' ? entries.map(([profile]) => profile) : ['unrelated']
+        expect(afterResume.dropped.slice().sort()).toEqual(expectedDrops.slice().sort())
+
+        if (transition !== 'retire-failed') {
+          // Reset is scoped to the exact shared group/profile. An
+          // unrelated same-URL profile keeps its pre-resume streak.
+          await expect(sweep(recoveredEntries)).resolves.toEqual({ dropped: [] })
+          const threshold = await sweep(recoveredEntries)
+          expect(threshold.dropped).toEqual(recoveredEntries.map(([profile]) => profile))
+        }
+      })
+    }
+  }
 })
 
 describe('attachPowerResumeRemoteRevalidation (#93910)', () => {

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -320,6 +320,7 @@ describe('revalidatePooledRemoteBackends', () => {
           remoteBaseUrl?: null | string
           authMode?: string
           connectionId?: string
+          sharedProbeKey?: string
           sharedRemote?: boolean
         }
       ]
@@ -412,15 +413,15 @@ describe('revalidatePooledRemoteBackends', () => {
     const pool = harness([
       [
         'coder',
-        { process: null, remoteBaseUrl: 'https://remote.example.com', connectionId: 'shared', sharedRemote: true }
+        { process: null, remoteBaseUrl: 'https://remote.example.com', connectionId: 'shared', sharedProbeKey: 'shared' }
       ],
       [
         'writer',
-        { process: null, remoteBaseUrl: 'https://remote.example.com/', connectionId: 'shared', sharedRemote: true }
+        { process: null, remoteBaseUrl: 'https://remote.example.com/', connectionId: 'shared', sharedProbeKey: 'shared' }
       ],
       [
         'reviewer',
-        { process: null, remoteBaseUrl: 'https://remote.example.com', connectionId: 'shared', sharedRemote: true }
+        { process: null, remoteBaseUrl: 'https://remote.example.com', connectionId: 'shared', sharedProbeKey: 'shared' }
       ]
     ])
 
@@ -521,6 +522,54 @@ describe('revalidatePooledRemoteBackends', () => {
     ).resolves.toEqual({ dropped: ['missing'] })
     expect(stopBackend).toHaveBeenCalledOnce()
     expect(stopBackend).toHaveBeenCalledWith('missing')
+  })
+
+  it('does not let one pending descriptor block an independent healthy probe', async () => {
+    let resolvePending: (connection: { baseUrl: string; profile: string }) => void = () => undefined
+
+    const pending = new Promise<{ baseUrl: string; profile: string }>(resolve => {
+      resolvePending = resolve
+    })
+
+    const entries: Array<
+      [
+        string,
+        {
+          process: null
+          remoteBaseUrl: string
+          connectionPromise: Promise<{ baseUrl: string; profile: string }>
+        }
+      ]
+    > = [
+      ['pending', { process: null, remoteBaseUrl: 'https://pending.example.com', connectionPromise: pending }],
+      [
+        'healthy',
+        {
+          process: null,
+          remoteBaseUrl: 'https://healthy.example.com',
+          connectionPromise: Promise.resolve({ baseUrl: 'https://healthy.example.com', profile: 'healthy' })
+        }
+      ]
+    ]
+
+    const probe = vi.fn(async () => undefined)
+
+    const run = revalidatePooledRemoteBackends({
+      entries,
+      log: vi.fn(),
+      probe,
+      stopBackend: vi.fn(),
+      tracker: new RemoteLivenessTracker()
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+    expect(probe).toHaveBeenCalledWith(expect.objectContaining({ profile: 'healthy' }), '/api/status', {
+      timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS
+    })
+
+    resolvePending({ baseUrl: 'https://pending.example.com', profile: 'pending' })
+    await run
+    expect(probe).toHaveBeenCalledTimes(2)
   })
 
   it('clears the streak when the host answers again', async () => {

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -304,16 +304,30 @@ describe('revalidatePooledRemoteBackends', () => {
   interface TestRemoteConnection {
     authMode?: string
     baseUrl: string
+    connectionId?: string
+    profile?: string
     process?: unknown
     remoteBaseUrl?: null | string
+    sharedRemote?: boolean
   }
 
   const harness = (
-    rawEntries: Array<[string, { process?: unknown; remoteBaseUrl?: null | string; authMode?: string }]>
+    rawEntries: Array<
+      [
+        string,
+        {
+          process?: unknown
+          remoteBaseUrl?: null | string
+          authMode?: string
+          connectionId?: string
+          sharedRemote?: boolean
+        }
+      ]
+    >
   ) => {
     const entries: Array<[string, TestRemoteConnection & { connectionPromise: Promise<TestRemoteConnection> }]> =
       rawEntries.map(([profile, entry]) => {
-        const connection = { ...entry, baseUrl: String(entry.remoteBaseUrl || '') }
+        const connection = { ...entry, baseUrl: String(entry.remoteBaseUrl || ''), profile }
 
         return [profile, { ...connection, connectionPromise: Promise.resolve(connection) }]
       })
@@ -396,9 +410,18 @@ describe('revalidatePooledRemoteBackends', () => {
 
   it('counts one host failure once when several profiles share its descriptor', async () => {
     const pool = harness([
-      ['coder', { process: null, remoteBaseUrl: 'https://remote.example.com' }],
-      ['writer', { process: null, remoteBaseUrl: 'https://remote.example.com/' }],
-      ['reviewer', { process: null, remoteBaseUrl: 'https://remote.example.com' }]
+      [
+        'coder',
+        { process: null, remoteBaseUrl: 'https://remote.example.com', connectionId: 'shared', sharedRemote: true }
+      ],
+      [
+        'writer',
+        { process: null, remoteBaseUrl: 'https://remote.example.com/', connectionId: 'shared', sharedRemote: true }
+      ],
+      [
+        'reviewer',
+        { process: null, remoteBaseUrl: 'https://remote.example.com', connectionId: 'shared', sharedRemote: true }
+      ]
     ])
 
     pool.unreachable.add('https://remote.example.com')
@@ -412,6 +435,92 @@ describe('revalidatePooledRemoteBackends', () => {
     await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder', 'writer', 'reviewer'] })
     expect(pool.probe).toHaveBeenCalledTimes(REMOTE_LIVENESS_FAILURE_LIMIT)
     expect(pool.stopBackend).toHaveBeenCalledTimes(3)
+  })
+
+  it('probes same-URL descriptors independently unless the producer marks them shared', async () => {
+    const entries: Array<
+      [
+        string,
+        {
+          process: null
+          remoteBaseUrl: string
+          connectionPromise: Promise<{ baseUrl: string; profile: string }> | null
+        }
+      ]
+    > = [
+      [
+        'dead',
+        {
+          process: null,
+          remoteBaseUrl: 'https://remote.example.com',
+          connectionPromise: Promise.resolve({ baseUrl: 'https://remote.example.com', profile: 'dead' })
+        }
+      ],
+      [
+        'healthy',
+        {
+          process: null,
+          remoteBaseUrl: 'https://remote.example.com',
+          connectionPromise: Promise.resolve({ baseUrl: 'https://remote.example.com', profile: 'healthy' })
+        }
+      ]
+    ]
+
+    const probe = vi.fn(async connection => {
+      if (connection.profile === 'dead') {
+        throw new Error('unreachable')
+      }
+    })
+
+    const stopBackend = vi.fn()
+
+    await expect(
+      revalidatePooledRemoteBackends({
+        entries,
+        log: vi.fn(),
+        probe,
+        stopBackend,
+        tracker: new RemoteLivenessTracker(1)
+      })
+    ).resolves.toEqual({ dropped: ['dead'] })
+    expect(probe).toHaveBeenCalledTimes(2)
+    expect(stopBackend).toHaveBeenCalledOnce()
+    expect(stopBackend).toHaveBeenCalledWith('dead')
+  })
+
+  it('does not let an unavailable descriptor evict a healthy same-URL sibling', async () => {
+    const healthy = { baseUrl: 'https://remote.example.com', profile: 'healthy' }
+
+    const entries: Array<
+      [
+        string,
+        {
+          process: null
+          remoteBaseUrl: string
+          connectionPromise: Promise<{ baseUrl: string; profile: string }> | null
+        }
+      ]
+    > = [
+      ['missing', { process: null, remoteBaseUrl: 'https://remote.example.com', connectionPromise: null }],
+      [
+        'healthy',
+        { process: null, remoteBaseUrl: 'https://remote.example.com', connectionPromise: Promise.resolve(healthy) }
+      ]
+    ]
+
+    const stopBackend = vi.fn()
+
+    await expect(
+      revalidatePooledRemoteBackends({
+        entries,
+        log: vi.fn(),
+        probe: vi.fn(async () => undefined),
+        stopBackend,
+        tracker: new RemoteLivenessTracker(1)
+      })
+    ).resolves.toEqual({ dropped: ['missing'] })
+    expect(stopBackend).toHaveBeenCalledOnce()
+    expect(stopBackend).toHaveBeenCalledWith('missing')
   })
 
   it('clears the streak when the host answers again', async () => {

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -394,6 +394,26 @@ describe('revalidatePooledRemoteBackends', () => {
     expect(pool.stopBackend).toHaveBeenCalledWith('coder')
   })
 
+  it('counts one host failure once when several profiles share its descriptor', async () => {
+    const pool = harness([
+      ['coder', { process: null, remoteBaseUrl: 'https://remote.example.com' }],
+      ['writer', { process: null, remoteBaseUrl: 'https://remote.example.com/' }],
+      ['reviewer', { process: null, remoteBaseUrl: 'https://remote.example.com' }]
+    ])
+
+    pool.unreachable.add('https://remote.example.com')
+    const tracker = new RemoteLivenessTracker()
+
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+    expect(pool.probe).toHaveBeenCalledTimes(1)
+    expect(pool.stopBackend).not.toHaveBeenCalled()
+
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: [] })
+    await expect(pool.run(tracker)).resolves.toEqual({ dropped: ['coder', 'writer', 'reviewer'] })
+    expect(pool.probe).toHaveBeenCalledTimes(REMOTE_LIVENESS_FAILURE_LIMIT)
+    expect(pool.stopBackend).toHaveBeenCalledTimes(3)
+  })
+
   it('clears the streak when the host answers again', async () => {
     const pool = harness([['coder', { process: null, remoteBaseUrl: 'https://remote.example.com' }]])
     const tracker = new RemoteLivenessTracker()

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -17,9 +17,7 @@ export interface RemoteLivenessFailure {
 
 interface RemoteConnectionDescriptor {
   baseUrl?: null | string
-  connectionId?: null | string
   mode?: null | string
-  sharedRemote?: boolean
 }
 
 export interface RevalidateRemoteConnectionOptions<TConnection extends RemoteConnectionDescriptor> {
@@ -178,6 +176,8 @@ export interface PooledRemoteEntry<TConnection extends RemoteConnectionDescripto
   connectionPromise?: null | Promise<TConnection>
   process?: unknown
   remoteBaseUrl?: null | string
+  /** Producer-owned identity for descriptors that make the same authenticated request. */
+  sharedProbeKey?: null | string
 }
 
 export interface RevalidatePooledRemoteBackendsOptions<TConnection extends RemoteConnectionDescriptor> {
@@ -208,49 +208,55 @@ export async function revalidatePooledRemoteBackends<TConnection extends RemoteC
   tracker
 }: RevalidatePooledRemoteBackendsOptions<TConnection>): Promise<{ dropped: string[] }> {
   const remotes = [...entries].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
-  const probeGroups = new Map<string, { connection: TConnection; profiles: string[] }>()
+  const probeGroups = new Map<string, typeof remotes>()
   const dropped: string[] = []
 
   for (const [profile, entry] of remotes) {
-    if (!entry.connectionPromise) {
-      log(`Pooled remote backend for profile "${profile}" has no connection descriptor; dropping stale entry.`)
-      stopBackend(profile)
-      dropped.push(profile)
-
-      continue
-    }
-
-    let connection: TConnection
-
-    try {
-      connection = await entry.connectionPromise
-    } catch {
-      log(`Pooled remote backend for profile "${profile}" has an unavailable connection descriptor; dropping stale entry.`)
-      stopBackend(profile)
-      dropped.push(profile)
-
-      continue
-    }
-
     const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
-    const connectionId = String(connection.connectionId ?? '').trim()
-    const sharesProbe = connection.sharedRemote === true && connectionId.length > 0
-    const failureKey = sharesProbe ? `shared:${connectionId}:${baseUrl}` : `profile:${profile}:${baseUrl}`
-    const group = probeGroups.get(failureKey)
+    const sharedProbeKey = String(entry.sharedProbeKey ?? '').trim()
+    const failureKey = sharedProbeKey ? `shared:${sharedProbeKey}:${baseUrl}` : `profile:${profile}:${baseUrl}`
+    const group = probeGroups.get(failureKey) ?? []
 
-    if (group) {
-      group.profiles.push(profile)
-    } else {
-      probeGroups.set(failureKey, { connection, profiles: [profile] })
-    }
+    group.push([profile, entry])
+    probeGroups.set(failureKey, group)
   }
 
   await Promise.all(
-    [...probeGroups].map(async ([failureKey, group]) => {
-      const profile = group.profiles[0]
+    [...probeGroups].map(async ([failureKey, members]) => {
+      const availableProfiles: string[] = []
+      let connection: TConnection | null = null
+
+      for (const [profile, entry] of members) {
+        if (!entry.connectionPromise) {
+          log(`Pooled remote backend for profile "${profile}" has no connection descriptor; dropping stale entry.`)
+          stopBackend(profile)
+          dropped.push(profile)
+
+          continue
+        }
+
+        try {
+          const resolved = await entry.connectionPromise
+
+          connection ??= resolved
+          availableProfiles.push(profile)
+        } catch {
+          log(
+            `Pooled remote backend for profile "${profile}" has an unavailable connection descriptor; dropping stale entry.`
+          )
+          stopBackend(profile)
+          dropped.push(profile)
+        }
+      }
+
+      if (!connection) {
+        return
+      }
+
+      const profile = availableProfiles[0]
 
       try {
-        await probe(group.connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+        await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
         tracker.recordSuccess(failureKey)
       } catch {
         const failure = tracker.recordFailure(failureKey)
@@ -265,7 +271,7 @@ export async function revalidatePooledRemoteBackends<TConnection extends RemoteC
 
         log(`Pooled remote backend for profile "${profile}" failed liveness probe; dropping stale descriptor.`)
 
-        for (const siblingProfile of group.profiles) {
+        for (const siblingProfile of availableProfiles) {
           stopBackend(siblingProfile)
           dropped.push(siblingProfile)
         }

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -205,11 +205,20 @@ export async function revalidatePooledRemoteBackends<TConnection extends RemoteC
   tracker
 }: RevalidatePooledRemoteBackendsOptions<TConnection>): Promise<{ dropped: string[] }> {
   const remotes = [...entries].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
+  const remotesByBaseUrl = new Map<string, typeof remotes>()
   const dropped: string[] = []
 
+  for (const remote of remotes) {
+    const baseUrl = String(remote[1].remoteBaseUrl).replace(/\/+$/, '')
+    const siblings = remotesByBaseUrl.get(baseUrl) ?? []
+
+    siblings.push(remote)
+    remotesByBaseUrl.set(baseUrl, siblings)
+  }
+
   await Promise.all(
-    remotes.map(async ([profile, entry]) => {
-      const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
+    [...remotesByBaseUrl].map(async ([baseUrl, siblings]) => {
+      const [profile, entry] = siblings[0]
 
       try {
         if (!entry.connectionPromise) {
@@ -231,8 +240,11 @@ export async function revalidatePooledRemoteBackends<TConnection extends RemoteC
         }
 
         log(`Pooled remote backend for profile "${profile}" failed liveness probe; dropping stale descriptor.`)
-        stopBackend(profile)
-        dropped.push(profile)
+
+        for (const [siblingProfile] of siblings) {
+          stopBackend(siblingProfile)
+          dropped.push(siblingProfile)
+        }
       }
     })
   )

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -17,7 +17,9 @@ export interface RemoteLivenessFailure {
 
 interface RemoteConnectionDescriptor {
   baseUrl?: null | string
+  connectionId?: null | string
   mode?: null | string
+  sharedRemote?: boolean
 }
 
 export interface RevalidateRemoteConnectionOptions<TConnection extends RemoteConnectionDescriptor> {
@@ -194,8 +196,9 @@ export interface RevalidatePooledRemoteBackendsOptions<TConnection extends Remot
  * keepalive touch keeps the idle reaper off it. Without this the pool serves a
  * descriptor for an unreachable host indefinitely.
  *
- * Entries share the primary's failure policy, keyed per base URL, so a profile
- * pointing at the same host as another does not burn the streak twice as fast.
+ * Descriptors explicitly marked as one shared remote connection share a probe
+ * and failure streak. Same-URL descriptors without that producer guarantee
+ * remain independent: they can represent different tunnels or credentials.
  */
 export async function revalidatePooledRemoteBackends<TConnection extends RemoteConnectionDescriptor>({
   entries,
@@ -205,31 +208,52 @@ export async function revalidatePooledRemoteBackends<TConnection extends RemoteC
   tracker
 }: RevalidatePooledRemoteBackendsOptions<TConnection>): Promise<{ dropped: string[] }> {
   const remotes = [...entries].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
-  const remotesByBaseUrl = new Map<string, typeof remotes>()
+  const probeGroups = new Map<string, { connection: TConnection; profiles: string[] }>()
   const dropped: string[] = []
 
-  for (const remote of remotes) {
-    const baseUrl = String(remote[1].remoteBaseUrl).replace(/\/+$/, '')
-    const siblings = remotesByBaseUrl.get(baseUrl) ?? []
+  for (const [profile, entry] of remotes) {
+    if (!entry.connectionPromise) {
+      log(`Pooled remote backend for profile "${profile}" has no connection descriptor; dropping stale entry.`)
+      stopBackend(profile)
+      dropped.push(profile)
 
-    siblings.push(remote)
-    remotesByBaseUrl.set(baseUrl, siblings)
+      continue
+    }
+
+    let connection: TConnection
+
+    try {
+      connection = await entry.connectionPromise
+    } catch {
+      log(`Pooled remote backend for profile "${profile}" has an unavailable connection descriptor; dropping stale entry.`)
+      stopBackend(profile)
+      dropped.push(profile)
+
+      continue
+    }
+
+    const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
+    const connectionId = String(connection.connectionId ?? '').trim()
+    const sharesProbe = connection.sharedRemote === true && connectionId.length > 0
+    const failureKey = sharesProbe ? `shared:${connectionId}:${baseUrl}` : `profile:${profile}:${baseUrl}`
+    const group = probeGroups.get(failureKey)
+
+    if (group) {
+      group.profiles.push(profile)
+    } else {
+      probeGroups.set(failureKey, { connection, profiles: [profile] })
+    }
   }
 
   await Promise.all(
-    [...remotesByBaseUrl].map(async ([baseUrl, siblings]) => {
-      const [profile, entry] = siblings[0]
+    [...probeGroups].map(async ([failureKey, group]) => {
+      const profile = group.profiles[0]
 
       try {
-        if (!entry.connectionPromise) {
-          throw new Error('Remote backend descriptor is unavailable.')
-        }
-
-        const connection = await entry.connectionPromise
-        await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
-        tracker.recordSuccess(baseUrl)
+        await probe(group.connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+        tracker.recordSuccess(failureKey)
       } catch {
-        const failure = tracker.recordFailure(baseUrl)
+        const failure = tracker.recordFailure(failureKey)
 
         if (!failure.shouldReset) {
           log(
@@ -241,7 +265,7 @@ export async function revalidatePooledRemoteBackends<TConnection extends RemoteC
 
         log(`Pooled remote backend for profile "${profile}" failed liveness probe; dropping stale descriptor.`)
 
-        for (const [siblingProfile] of siblings) {
+        for (const siblingProfile of group.profiles) {
           stopBackend(siblingProfile)
           dropped.push(siblingProfile)
         }

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -180,6 +180,14 @@ export interface PooledRemoteEntry<TConnection extends RemoteConnectionDescripto
   sharedProbeKey?: null | string
 }
 
+/** One ownership key for background observations and post-resume resets. */
+function pooledRemoteFailureKey(profile: string, entry: PooledRemoteEntry): string {
+  const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
+  const sharedProbeKey = String(entry.sharedProbeKey ?? '').trim()
+
+  return sharedProbeKey ? `shared:${sharedProbeKey}:${baseUrl}` : `profile:${profile}:${baseUrl}`
+}
+
 export interface RevalidatePooledRemoteBackendsOptions<TConnection extends RemoteConnectionDescriptor> {
   entries: Iterable<[string, PooledRemoteEntry<TConnection>]>
   log: (message: string) => void
@@ -212,9 +220,7 @@ export async function revalidatePooledRemoteBackends<TConnection extends RemoteC
   const dropped: string[] = []
 
   for (const [profile, entry] of remotes) {
-    const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
-    const sharedProbeKey = String(entry.sharedProbeKey ?? '').trim()
-    const failureKey = sharedProbeKey ? `shared:${sharedProbeKey}:${baseUrl}` : `profile:${profile}:${baseUrl}`
+    const failureKey = pooledRemoteFailureKey(profile, entry)
     const group = probeGroups.get(failureKey) ?? []
 
     group.push([profile, entry])
@@ -326,7 +332,7 @@ export async function revalidateSuspectPooledRemoteBackends<TConnection extends 
 
   await Promise.all(
     remotes.map(async ([poolKey, entry]) => {
-      const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
+      const failureKey = pooledRemoteFailureKey(poolKey, entry)
 
       try {
         if (!entry.connectionPromise) {
@@ -335,7 +341,7 @@ export async function revalidateSuspectPooledRemoteBackends<TConnection extends 
 
         const connection = await entry.connectionPromise
         await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
-        tracker.recordSuccess(baseUrl)
+        tracker.recordSuccess(failureKey)
 
         return
       } catch (probeError) {
@@ -360,7 +366,7 @@ export async function revalidateSuspectPooledRemoteBackends<TConnection extends 
       retired.push(poolKey)
       // The rebuilt tunnel must start from a clean failure state; stale
       // pre-sleep failures should not count against the fresh descriptor.
-      tracker.recordSuccess(baseUrl)
+      tracker.recordSuccess(failureKey)
 
       try {
         await rebuild(poolKey)


### PR DESCRIPTION
Related to #83134

## Failure mode

Several Desktop profiles can intentionally share one URL/cloud backend descriptor. Probing each profile independently lets one unreachable host consume a shared failure budget several times per sweep. URL equality alone is not a valid connection identity: independent SSH tunnels or credentials can use the same URL.

## Producer-owned identity

URL/cloud entries created by one registry source carry its `sharedProbeKey`; SSH entries remain independent. The canonical `pooledRemoteFailureKey()` combines the producer key (or independent profile key) with the normalized base URL. Background grouping, failure accounting, successful post-resume probes and successful retirement all use that same key.

Each explicitly shared group performs one background probe and advances one failure streak. Independent groups start concurrently. Null/rejected descriptors are dropped individually and cannot evict an otherwise healthy sibling. A failed retirement does not clear its still-installed descriptor's failure state. Successful retirement clears the old state before rebuilding, including when rebuilding must later be retried. The non-pooled primary connection's existing accounting is unchanged.

## Review follow-up — reset after resume

Head: `5a43d73280b39db3b7691b7f337d6b6cff4b3cb8`.

Addresses andrexibiza's observation that the new pooled keys were not propagated to the two post-resume reset paths. Clearing raw `baseUrl` left two pre-sleep failures intact and could retire a recovered connection on its next transient failure. Both paths now clear the exact canonical ownership key, without resetting unrelated same-URL profiles.

## Executed verification

Fork validation: https://github.com/Xipong/hermes-agent/actions/runs/34706937167

- Failing-before replay on `71c1e3bdaca631e44bcda6c4e83dff5a415a659d`: six recovery cases failed; two failed-retirement controls passed.
- After the fix: complete `remote-liveness.test.ts` and `power-resume-remote-revalidation.test.ts`: **44 passed, 0 failed**.
- Shared and independent modes cover successful resume, retire/rebuild, failed rebuild, failed retirement, normalization, fresh failure budgets and unrelated same-URL isolation.
- Focused ESLint, Electron TypeScript `--noEmit` and `git diff --check`: passed.

The tested two-file follow-up was published as a normal fast-forward after diff inspection. The original producer/grouping changes remain in the PR. Temporary workflow files exist only on the fork automation branch, not in this PR. These results certify the tested product tree in the fork run; they do not assert new-head upstream CI acceptance, a full repository suite, live SSH connections or native Desktop interaction.