### PR TITLE
fix(desktop): reject impossible backend ready ports

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -99,6 +99,15 @@ test('resolves with a HERMES_BACKEND_READY port (headless `serve`)', async () =>
   assert.equal(await p, 43210)
 })
 
+test('ignores out-of-range announcements until a valid TCP port arrives', async () => {
+  const child = makeFakeChild()
+  const p = waitForDashboardPort(child, 1000)
+
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=65536\n')
+  child.stdout.emit('data', 'HERMES_BACKEND_READY port=43210\n')
+  assert.equal(await p, 43210)
+})
+
 test('parses the port even when the line arrives split across chunks', async () => {
   const child = makeFakeChild()
   const p = waitForDashboardPort(child, 1000)
@@ -172,6 +181,8 @@ test('readDashboardReadyFile ignores missing, malformed, or invalid files', () =
     fs.writeFileSync(tmp.file, '{')
     assert.equal(readDashboardReadyFile(tmp.file), null)
     fs.writeFileSync(tmp.file, JSON.stringify({ port: 0 }))
+    assert.equal(readDashboardReadyFile(tmp.file), null)
+    fs.writeFileSync(tmp.file, JSON.stringify({ port: 65_536 }))
     assert.equal(readDashboardReadyFile(tmp.file), null)
   } finally {
     tmp.cleanup()

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -24,6 +24,34 @@ const DEFAULT_PORT_ANNOUNCE_TIMEOUT_MS = 90_000
 // (the historical default) so a malformed override can't reintroduce the loop.
 const MIN_PORT_ANNOUNCE_TIMEOUT_MS = 45_000
 
+function parseReadyPort(value: unknown): number | null {
+  const port = Number(value)
+
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : null
+}
+
+function findReadyPort(output: string, pattern: RegExp): number | null {
+  let remaining = output
+
+  while (remaining) {
+    const match = remaining.match(pattern)
+
+    if (!match) {
+      return null
+    }
+
+    const port = parseReadyPort(match[1])
+
+    if (port !== null) {
+      return port
+    }
+
+    remaining = remaining.slice((match.index ?? 0) + match[0].length)
+  }
+
+  return null
+}
+
 /**
  * Resolve the port-announcement deadline. Honors the
  * HERMES_DESKTOP_PORT_ANNOUNCE_TIMEOUT_MS env override (for users on slow
@@ -94,11 +122,11 @@ function waitForDashboardPort(
       while ((nl = buf.indexOf('\n')) !== -1) {
         const line = buf.slice(0, nl)
         buf = buf.slice(nl + 1)
-        const m = line.match(_READY_RE)
+        const port = findReadyPort(line, _READY_RE)
 
-        if (m) {
+        if (port !== null) {
           cleanup()
-          resolve(parseInt(m[1], 10))
+          resolve(port)
 
           return
         }
@@ -132,11 +160,11 @@ function waitForDashboardPort(
     // snapshot is empty; any await reintroduced between them makes this the live path again.
     if (!done) {
       const alreadyBuffered = bufferedOutput()
-      const m = alreadyBuffered ? alreadyBuffered.match(READY_IN_MERGED_OUTPUT_RE) : null
+      const port = findReadyPort(alreadyBuffered, READY_IN_MERGED_OUTPUT_RE)
 
-      if (m) {
+      if (port !== null) {
         cleanup()
-        resolve(parseInt(m[1], 10))
+        resolve(port)
       }
     }
   })
@@ -149,9 +177,8 @@ function readDashboardReadyFile(readyFile: fs.PathOrFileDescriptor) {
 
   try {
     const parsed = JSON.parse(fs.readFileSync(readyFile, 'utf8'))
-    const port = Number(parsed?.port)
 
-    return Number.isInteger(port) && port > 0 ? port : null
+    return parseReadyPort(parsed?.port)
   } catch {
     return null
   }


### PR DESCRIPTION
## Failure mode

Desktop backend readiness is accepted through two channels:

- a `HERMES_BACKEND_READY port=...` stdout sentinel;
- the dashboard ready-file JSON.

Both parsers accepted any positive integer. Values above `65535` could therefore be treated as a successful backend announcement even though they cannot identify a TCP port. The stdout path also stopped at the first matching sentinel instead of continuing to a later valid announcement.

## Fix

Use one `parseReadyPort()` contract for both channels: the value must be an integer in the complete TCP range **1–65535**.

The stdout scanner now walks all matching announcements in the buffered text. An invalid port is ignored and scanning continues until a valid sentinel appears or no match remains. The same validator is used for the ready file.

## Readiness contract

- Port `0`, negative values, fractions, non-numbers, and values above `65535` are rejected.
- A malformed or out-of-range sentinel does not complete startup.
- A later valid sentinel in the same stream can still complete startup.
- Existing split-chunk buffering, timeout handling, process-exit handling, and ready-file shape are unchanged.

## Verification

- Added a stdout regression that emits port `65536` followed by `43210`; startup ignores the first and resolves with the second.
- Added ready-file coverage for `65536` returning `null`.
- Full `backend-ready.test.ts`: **27 passed**.
- Focused ESLint, Electron TypeScript compilation, and `git diff --check` passed.