### PR TITLE
fix: install profile secret scope around external cron worker handoff

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2526,8 +2526,29 @@ def run_one_job(
     external_owner = os.environ.get("_HERMES_CRON_EXTERNAL_WORKER") == execution_id
     if not external_owner:
         try:
-            if _launch_external_cron_worker(job):
-                return True
+            # Env-passthrough resolution inside build_subprocess_env resolves credentials via
+            # get_secret() (env_passthrough.resolve_passthrough_value), which fails CLOSED when
+            # multiplexing is active and no profile secret scope is installed. The ticker thread
+            # dispatching a SECONDARY profile's job has no scope here (the in-process run path
+            # installs one at fire time), so the handoff raised UnscopedSecretError for the first
+            # passthrough-listed key it touched and the job never ran. Install the firing
+            # profile's scope around the handoff — same isolation the run path already provides.
+            _handoff_scope_token = None
+            try:
+                from agent.secret_scope import (
+                    build_profile_secret_scope, is_multiplex_active, set_secret_scope)
+                if is_multiplex_active():
+                    _handoff_scope_token = set_secret_scope(
+                        build_profile_secret_scope(_get_hermes_home()))
+            except Exception:
+                _handoff_scope_token = None
+            try:
+                if _launch_external_cron_worker(job):
+                    return True
+            finally:
+                if _handoff_scope_token is not None:
+                    from agent.secret_scope import reset_secret_scope
+                    reset_secret_scope(_handoff_scope_token)
         except Exception as handoff_error:
             error = f"Restart-safe cron worker dispatch failed: {handoff_error}"
             logger.error("Job '%s': %s", job["id"], error)


### PR DESCRIPTION
## Problem

Scheduled fires of **secondary-profile** cron jobs fail at dispatch when `gateway.multiplex_profiles: true`:

```
Job '...': Restart-safe cron worker dispatch failed: get_secret('REF_API_KEY') called with
no profile secret scope active while multiplexing is on. This credential read must run inside
a set_secret_scope(...) block (the per-turn / per-adapter profile scope).
```

The job never runs — no retry to a working path, just a failed fire.

## Root cause

`run_one_job` → `_launch_external_cron_worker` → `build_subprocess_env(scrub_secrets=True)` resolves `terminal.env_passthrough` entries via `get_secret()` (`env_passthrough.resolve_passthrough_value`). Under multiplexing, an unscoped `get_secret` **fails closed** (by design, `agent/secret_scope.py`). The ticker thread dispatching a secondary profile's job installs no scope at the handoff — the in-process run path installs one (`scheduler.py` ~2913, `set_secret_scope(build_profile_secret_scope(...))`), but the external-worker handoff path (~2527) missed it.

Notably: any credential in `env_passthrough` raises — we observed REF_API_KEY and BRAVE_API_KEY in sequence as keys were removed (whack-a-mole). Default-profile jobs were unaffected (they get a scope).

## Fix

Wrap the handoff in the firing profile's secret scope — the same isolation the in-process path already provides:

```python
_handoff_scope_token = None
try:
    from agent.secret_scope import (
        build_profile_secret_scope, is_multiplex_active, set_secret_scope)
    if is_multiplex_active():
        _handoff_scope_token = set_secret_scope(
            build_profile_secret_scope(_get_hermes_home()))
except Exception:
    _handoff_scope_token = None
try:
    if _launch_external_cron_worker(job):
        return True
finally:
    if _handoff_scope_token is not None:
        from agent.secret_scope import reset_secret_scope
        reset_secret_scope(_handoff_scope_token)
```

## Verification

Live multiplex gateway, 3 profiles (default + 2 bots), Linux:

- **Pre-patch:** scheduled ticks of a secondary-profile hourly job failed 4+ consecutive fires with the UnscopedSecretError above.
- **Post-patch:** every scheduled tick dispatches cleanly (10+ fires over a day). Manual `hermes cron run` never reproduced the issue (CLI runs go in-process) — scheduled ticks were required for verification.
- Patch verified in isolation: unscoped+multiplex-forced `resolve_passthrough_value('BRAVE_API_KEY')` raises the exact error; scoped to a profile it resolves (None for a profile without the key — correct fail-closed default, no raise).

Follow-up consideration: `_launch_external_cron_worker` could install the scope itself so future handoff callers inherit it, but I kept the fix minimal and localized to the dispatch seam.