### PR TITLE
fix(desktop): collect update stragglers before release

### DIFF
--- a/apps/desktop/electron/backend-release-gate.test.ts
+++ b/apps/desktop/electron/backend-release-gate.test.ts
@@ -102,6 +102,37 @@ describe('waitForBackendRelease (#74805 first-attempt race)', () => {
     expect(result.lingeringPids).toEqual([4021])
   })
 
+  it('collects a straggler before declaring an initially clear gate safe', async () => {
+    const clock = fakeClock()
+    let killedAt: number | null = null
+    let served = false
+
+    const deps = makeDeps({
+      now: clock.now,
+      sleep: clock.sleep,
+      collectStragglerPids: () => {
+        if (served) {
+          return []
+        }
+
+        served = true
+
+        return [7777]
+      },
+      killProcessTree: pid => {
+        killedAt = clock.now()
+        deps.kills.push(pid)
+      },
+      isPidAlive: pid => pid === 7777 && killedAt !== null && clock.now() < killedAt + RELEASE_GATE_POLL_MS
+    })
+
+    const result = await waitForBackendRelease([], deps, 'test')
+
+    expect(deps.kills).toEqual([7777])
+    expect(result.unlocked).toBe(true)
+    expect(clock.now()).toBeGreaterThanOrEqual(RELEASE_GATE_POLL_MS)
+  })
+
   it('kills and then waits out stragglers that respawn mid-teardown', async () => {
     // A pool entry registered mid-teardown appears on pass 2; the gate must
     // signal it AND add it to the exit-wait set.

--- a/apps/desktop/electron/backend-release-gate.test.ts
+++ b/apps/desktop/electron/backend-release-gate.test.ts
@@ -177,6 +177,43 @@ describe('waitForBackendRelease (#74805 first-attempt race)', () => {
     expect(clock.now()).toBeGreaterThanOrEqual((stragglerKilledAt ?? 0) + 2 * RELEASE_GATE_POLL_MS)
   })
 
+  it('collects a later-pass straggler before a previously busy gate can pass', async () => {
+    const clock = fakeClock()
+    let served = false
+    let killedAt: number | null = null
+
+    const deps = makeDeps({
+      now: clock.now,
+      sleep: clock.sleep,
+      collectStragglerPids: () => {
+        if (served || clock.now() < RELEASE_GATE_POLL_MS) {
+          return []
+        }
+
+        served = true
+
+        return [7777]
+      },
+      killProcessTree: pid => {
+        killedAt = clock.now()
+        deps.kills.push(pid)
+      },
+      isPidAlive: pid => {
+        if (pid === 4021) {
+          return clock.now() < RELEASE_GATE_POLL_MS
+        }
+
+        return pid === 7777 && killedAt !== null && clock.now() < killedAt + 2 * RELEASE_GATE_POLL_MS
+      }
+    })
+
+    const result = await waitForBackendRelease([4021], deps, 'later-pass')
+
+    expect(deps.kills).toEqual([7777])
+    expect(clock.now()).toBe(3 * RELEASE_GATE_POLL_MS)
+    expect(result).toEqual({ unlocked: true, lingeringPids: [] })
+  })
+
   it('ignores invalid PIDs in the seed and straggler sets', async () => {
     const deps = makeDeps({
       collectStragglerPids: () => [0, -4, NaN as unknown as number]

--- a/apps/desktop/electron/backend-release-gate.ts
+++ b/apps/desktop/electron/backend-release-gate.ts
@@ -73,22 +73,22 @@ export async function waitForBackendRelease(
   const deadline = deps.now() + deadlineMs
 
   while (deps.now() < deadline) {
+    // A supervised backend can respawn between kill and check (grandchildren,
+    // pool entries registered mid-teardown). Re-collect before the success
+    // check so an initially clear gate cannot miss a just-published straggler.
+    for (const pid of deps.collectStragglerPids()) {
+      if (Number.isInteger(pid) && pid > 0) {
+        killedPids.add(pid)
+        deps.killProcessTree(pid)
+      }
+    }
+
     const lingering = [...killedPids].filter(pid => deps.isPidAlive(pid))
 
     if (!deps.isShimLocked() && lingering.length === 0) {
       deps.log(`[${tag}] venv shim unlocked and ${killedPids.size} signalled backend PID(s) exited; safe to proceed`)
 
       return { unlocked: true, lingeringPids: [] }
-    }
-
-    // A supervised backend can respawn between kill and check (grandchildren,
-    // pool entries registered mid-teardown). Re-collect and re-kill each pass
-    // instead of trusting the initial sweep.
-    for (const pid of deps.collectStragglerPids()) {
-      if (Number.isInteger(pid) && pid > 0) {
-        killedPids.add(pid)
-        deps.killProcessTree(pid)
-      }
     }
 
     await deps.sleep(RELEASE_GATE_POLL_MS)


### PR DESCRIPTION
## Release-gate race

The Desktop updater checked its normal success condition before collecting newly published backend/straggler PIDs. When the shim was already unlocked and the initial PID set was empty, it could return immediately without discovering a supervised backend. The same ordering matters on a later pass after an initially known PID exits.

## Fix and precise contract

Each polling pass collects and signals newly discovered valid PIDs before computing the live set and evaluating the normal success condition. Before the deadline, the normal early-success path requires an unlocked shim and no live known backend PIDs. Repeated collection still catches mid-teardown respawns.

**The existing deadline escape hatch is unchanged:** if the deadline is reached with the shim unlocked, the function can return `unlocked: true` with nonempty `lingeringPids`. This PR does not change that policy, and `unlocked: true` is not a blanket guarantee that every tracked PID has exited. The earlier description overstated this guarantee.

The current shim probe is synchronous. Composition with an asynchronous shim probe, as discussed for #101502, needs an integration regression and a fresh PID/publication check after the await. This PR does not claim that separate async-composition boundary is solved.

## Review follow-up

Head: `45025cc596082777cf6a9155fcb12632373063bd`.

Added a later-pass regression: a known PID keeps the first pass busy; on the next pass that PID has exited but a newly published child appears. The gate must discover and signal the child and wait for its exit instead of returning using the old PID set. The follow-up changes only the test file; production logic and deadline semantics are unchanged.

## Executed verification

Fork validation: https://github.com/Xipong/hermes-agent/actions/runs/34707428541 — `release-gate` job.

- Moving collection back after the normal success check makes the new later-pass regression fail.
- Restoring the PR implementation: full `backend-release-gate.test.ts`: **8 passed, 0 failed**, including the existing deadline escape-hatch test.
- Focused ESLint, Electron TypeScript `--noEmit`, and `git diff --check`: passed.
- The verified candidate contains only the new 37-line regression and was fast-forwarded into this PR; temporary workflow files remain outside the PR.

This is Linux/fake-clock unit and typecheck evidence for the tested product tree, not native Windows updater acceptance or a claim that the new upstream head has passed CI.