### PR TITLE
fix(desktop): recover event dedupe after clock rollback

### DIFF
--- a/apps/desktop/electron/event-dedupe.test.ts
+++ b/apps/desktop/electron/event-dedupe.test.ts
@@ -27,6 +27,14 @@ test('re-fires once the window elapses', () => {
   assert.equal(isDup('turnDone:s1', 1000), false, 'window elapsed → fires again')
 })
 
+test('clock rollback starts a fresh window instead of suppressing events until catch-up', () => {
+  const isDup = createEventDeduper(1000)
+
+  assert.equal(isDup('turnDone:s1', 10_000), false)
+  assert.equal(isDup('turnDone:s1', 5_000), false, 'older wall clock cannot make a claim live for 5 seconds')
+  assert.equal(isDup('turnDone:s1', 5_100), true, 'dedupe resumes from the rollback observation')
+})
+
 test('prunes stale keys so the map cannot grow unbounded', () => {
   const isDup = createEventDeduper(1000)
 

--- a/apps/desktop/electron/event-dedupe.ts
+++ b/apps/desktop/electron/event-dedupe.ts
@@ -16,7 +16,9 @@ export function createEventDeduper(intervalMs = DEDUPE_INTERVAL_MS) {
 
   return function isDuplicate(key: string, now = Date.now()): boolean {
     for (const [k, at] of lastSeenAt) {
-      if (now - at >= intervalMs) {
+      // Date.now() can move backwards after a host clock correction. Treat a
+      // future claim as stale rather than suppressing events until catch-up.
+      if (now < at || now - at >= intervalMs) {
         lastSeenAt.delete(k)
       }
     }


### PR DESCRIPTION
## Failure mode

The Desktop event deduper stores the wall-clock time of the last accepted one-shot event. If `Date.now()` moves backwards after a host clock correction, the stored timestamp appears to be in the future. The previous expiry check treated that claim as fresh until wall time caught up, suppressing legitimate events for the entire rollback interval.

## Fix

Treat a future timestamp as stale, remove it, and evaluate the current event as the beginning of a new dedupe window.

The resulting sequence is:

```text
first event at 10,000 ms   → accepted
clock rolls back to 5,000  → accepted; new window starts here
same event at 5,100        → deduplicated normally
```

## Behavior preserved

- Forward-moving clocks retain the existing interval semantics.
- Repeated events inside the configured window are still suppressed.
- Entries older than the window are still pruned so the map cannot grow without bound.
- No system-clock mutation or monotonic-time dependency is introduced; the deduper simply recovers defensively from an impossible future claim.

## Verification

- Added a regression covering rollback, immediate recovery, and normal dedupe after recovery.
- `event-dedupe.test.ts`: **5 passed**.
- Focused ESLint passed.
- Electron TypeScript compilation with `--noEmit` passed.
- `git diff --check` passed.