### PR TITLE
fix(gateway): exclude launchd wrappers' supervised children from stale-process sweep

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -164,6 +164,7 @@ def _get_service_pids(all_profiles: bool = False) -> set:
                         pid = int(show.stdout.strip())
                         if pid > 0:
                             pids.add(pid)
+                            pids |= _gateway_descendants_of(pid)
                     except (ValueError, subprocess.TimeoutExpired):
                         pass
             except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -186,6 +187,7 @@ def _get_service_pids(all_profiles: bool = False) -> set:
                 continue
             if pid is not None and pid > 0:
                 pids.add(pid)
+                pids |= _gateway_descendants_of(pid)
         if all_profiles:
             # Prefix scan also catches ai.hermes.gateway* agents the label derivation can't map
             # (renamed profiles, other installs). Over-inclusion is safe: PIDs are only protected.
@@ -199,12 +201,46 @@ def _get_service_pids(all_profiles: bool = False) -> set:
                                 pid = int(parts[0])
                                 if pid > 0:
                                     pids.add(pid)
+                                    pids |= _gateway_descendants_of(pid)
                             except ValueError:
                                 pass
             except (FileNotFoundError, subprocess.TimeoutExpired):
                 pass
 
     return pids
+
+
+def _gateway_descendants_of(pid: int) -> set:
+    """Strictly matched gateway runtimes below a service manager's tracked PID.
+
+    systemd/launchd may report a wrapper (``doppler``, ``direnv``, Hermes'
+    ``stderr_timestamp``) rather than the gateway. Walk the complete subtree so service-owned
+    gateways are never swept as manual processes. Adapted from #66913 by @Tranquil-Flow.
+    """
+    if pid <= 1:
+        return set()
+    try:
+        import psutil  # type: ignore
+        from gateway.status import looks_like_gateway_command_line
+    except ImportError:
+        return set()
+    try:
+        descendants = psutil.Process(pid).children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return set()
+    except Exception:
+        return set()
+    found: set = set()
+    for child in descendants:
+        try:
+            command = " ".join(child.cmdline() or [])
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+        except Exception:
+            continue
+        if command and looks_like_gateway_command_line(command):
+            found.add(child.pid)
+    return found
 
 
 def _get_parent_pid(pid: int) -> int | None:

--- a/tests/hermes_cli/test_gateway_launchd_supervised_child.py
+++ b/tests/hermes_cli/test_gateway_launchd_supervised_child.py
@@ -1,0 +1,117 @@
+"""Service-wrapper gateway descendant discovery regressions (#66900, #105938).
+
+The recursive descendant design and strict command matching are adapted from PR #66913 by
+@Tranquil-Flow. This current-main variant covers the all-profiles service discovery contract used
+by update/reaper sweeps while preserving default profile scoping.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import psutil
+
+import hermes_cli.gateway as gateway
+
+
+class _FakeProc:
+    def __init__(self, pid, cmdline=(), children=()):
+        self.pid = pid
+        self._cmdline = list(cmdline)
+        self._children = list(children)
+
+    def children(self, recursive=False):
+        if not recursive:
+            return list(self._children)
+        found, pending = [], list(self._children)
+        while pending:
+            child = pending.pop()
+            found.append(child)
+            pending.extend(child._children)
+        return found
+
+    def cmdline(self):
+        return list(self._cmdline)
+
+
+def _gateway_proc(pid=503):
+    return _FakeProc(
+        pid,
+        ["python", "-m", "hermes_cli.main", "--profile", "default", "gateway", "run", "--external-supervisor"],
+    )
+
+
+def test_gateway_descendants_walks_nested_wrappers_and_uses_strict_matcher(monkeypatch):
+    gateway_child = _gateway_proc()
+    misleading = _FakeProc(504, ["sh", "-c", "echo gateway run"])
+    shell = _FakeProc(502, ["sh", "-c", "exec hermes"], [gateway_child, misleading])
+    wrapper = _FakeProc(501, ["python", "-m", "hermes_cli.stderr_timestamp"], [shell])
+    monkeypatch.setattr(psutil, "Process", lambda pid: wrapper)
+
+    assert gateway._gateway_descendants_of(501) == {503}
+
+
+def test_gateway_descendants_tolerates_vanished_wrapper(monkeypatch):
+    def missing(pid):
+        raise psutil.NoSuchProcess(pid)
+
+    monkeypatch.setattr(psutil, "Process", missing)
+    assert gateway._gateway_descendants_of(501) == set()
+
+
+def test_systemd_service_pid_includes_recursive_gateway_descendant(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "get_service_name", lambda: "hermes-gateway.service")
+    monkeypatch.setattr(gateway, "_gateway_descendants_of", lambda pid: {503})
+
+    def run(args, **kwargs):
+        if "list-units" in args:
+            return SimpleNamespace(returncode=0, stdout="hermes-gateway.service loaded active running\n", stderr="")
+        if "show" in args:
+            return SimpleNamespace(returncode=0, stdout="501\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway.subprocess, "run", run)
+    assert gateway._get_service_pids() == {501, 503}
+
+
+def test_launchd_default_scope_includes_recursive_gateway_descendant(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway.default")
+    monkeypatch.setattr(gateway, "_locate_launchd_gateway_service", lambda label: ("gui/501", 501))
+    monkeypatch.setattr(gateway, "_gateway_descendants_of", lambda pid: {503})
+
+    assert gateway._get_service_pids() == {501, 503}
+
+
+def test_launchd_fleet_prefix_scan_expands_each_unmapped_wrapper(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway.default")
+    monkeypatch.setattr(gateway, "launchd_gateway_labels_for_install", lambda: [])
+    monkeypatch.setattr(gateway, "_locate_launchd_gateway_service", lambda label: (None, None))
+    monkeypatch.setattr(gateway, "_gateway_descendants_of", lambda pid: {pid + 1})
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "run",
+        lambda args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="501\t-\tai.hermes.gateway.default\n601\t-\tai.hermes.gateway.other\n",
+            stderr="",
+        ),
+    )
+
+    assert gateway._get_service_pids(all_profiles=True) == {501, 502, 601, 602}
+
+
+def test_wrapped_service_gateway_is_excluded_from_manual_sweep(monkeypatch):
+    service_pids = {501, 503}
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "_scan_gateway_pids", lambda *args, **kwargs: [503, 700])
+
+    assert gateway.find_gateway_pids(
+        exclude_pids=service_pids,
+        all_profiles=True,
+    ) == [700]


### PR DESCRIPTION
## What does this PR do?

Protects service-managed gateway runtimes from being misclassified as manual/stale processes when systemd or launchd reports a wrapper PID instead of the real `gateway run` descendant.

On macOS this caused `hermes update` to restart each LaunchAgent, then SIGTERM its freshly-started gateway child during the manual sweep. launchd `KeepAlive` restarted it again, producing a double restart and interrupting in-flight cron work (#105938). The same ownership contract also applies to wrapped systemd `ExecStart` processes (#66900).

## Attribution

This current-main implementation salvages the recursive descendant-discovery design from #66913 by @Tranquil-Flow. The commit includes:

`Co-authored-by: Tranquil-Flow <66773372+Tranquil-Flow@users.noreply.github.com>`

## Changes

- For every service PID acquired from:
  - systemd user/system `MainPID`;
  - launchd domain-explicit label lookup;
  - launchd all-profile prefix scan;
  expand the PID set with gateway runtime descendants.
- Walk the complete descendant tree with `psutil.Process(pid).children(recursive=True)`, supporting wrapper → shell/helper → gateway layouts.
- Reuse `gateway.status.looks_like_gateway_command_line` instead of substring matching, so shell/log arguments containing `gateway run` are not falsely classified.
- Preserve current-profile versus `all_profiles=True` discovery scope; only descendants of an already-in-scope service PID are added.
- Fail safely when a wrapper exits, process inspection is denied, or a descendant disappears.

## Behavior

The update and orphan-reaper paths pass the expanded set into `find_gateway_pids(exclude_pids=...)`, so service-owned gateway descendants are protected while genuine manual gateways remain eligible for restart/reap. Default-scope status/cron consumers also receive the actual current profile's service-owned gateway identity.

## Validation

- **61 passed, 5 platform-marked skipped** across:
  - `test_gateway_launchd_supervised_child.py`
  - `test_gateway_proc_fallback.py`
  - `test_update_launchd_unloaded_gateway.py`
  - `test_gateway.py`
- Adjacent fleet suite: 49 passed / 2 platform skips; its only two failures are the documented pre-existing `TestIncompleteWarningMentionsLaunchctl` failures that reproduce on clean main.
- Mutation checks:
  - changing recursive traversal to direct children makes the nested-wrapper test fail;
  - replacing the canonical matcher with `"gateway run" in command` makes the strict negative test fail.
- `py_compile` and `git diff --check` pass.
- Independent final review found no blocker/high/medium.

Closes #105938. References #66900 and supersedes the conflicted implementation branch #66913 while preserving contributor credit.