### PR TITLE
fix(desktop): preserve profile-configured terminal workspace

### DIFF
--- a/tests/tui_gateway/test_session_configured_cwd.py
+++ b/tests/tui_gateway/test_session_configured_cwd.py
@@ -1,0 +1,17 @@
+"""Regression coverage for Desktop sessions using profile terminal.cwd."""
+
+import tui_gateway.server as server
+
+
+def test_profile_configured_cwd_is_explicit_workspace(monkeypatch, tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda _home: str(workspace))
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: None)
+    assert server._session_create_explicit_cwd({}, tmp_path / "profile") is True
+
+
+def test_missing_configured_cwd_remains_launch_artifact(monkeypatch, tmp_path):
+    monkeypatch.setattr(server, "_profile_configured_cwd", lambda _home: None)
+    monkeypatch.setattr(server, "_launch_configured_cwd", lambda: None)
+    assert server._session_create_explicit_cwd({}, tmp_path / "profile") is False

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -293,20 +293,25 @@ def _create_overrides(params: dict) -> tuple:
     return model_override, reasoning_override, service_tier_override
 
 
+def _session_create_explicit_cwd(params: dict, profile_home) -> bool:
+    """Treat profile-configured terminal.cwd as user-selected workspace."""
+    raw_cwd = _str_param(params, "cwd")
+    with contextlib.suppress(Exception):
+        if raw_cwd and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd))):
+            return True
+    return bool(_profile_configured_cwd(profile_home) or _launch_configured_cwd())
+
+
 @method("session.create")
 def _(rid, params: dict) -> dict:
     (sid, source), key = _new_runtime_ids(params), _new_session_key()
     history = _coerce_seed_history(params.get("messages"))
     # Branch: links back so list_sessions_rich keeps it visible and the sidebar nests it.
     parent_session_id = _str_param(params, "parent_session_id") or None
-    # Only an explicitly chosen existing workspace persists as cwd; the launch-dir fallback is "No workspace".
-    explicit_cwd = False
-    raw_cwd = _str_param(params, "cwd")  # unguarded, as on BASE: only the path check is best-effort
-    with contextlib.suppress(Exception):
-        explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
     _enable_gateway_prompts()
     # ``profile`` (app-global remote mode): stored so the build and every turn re-bind HERMES_HOME.
     profile_home = _profile_home(profile := (params.get("profile") or "").strip() or None)
+    explicit_cwd = _session_create_explicit_cwd(params, profile_home)
     session_model_override, create_reasoning_override, create_service_tier_override = _create_overrides(params)
     now = time.time()
     with _sessions_lock:


### PR DESCRIPTION
## Summary

Fixes #106012.

Desktop-created sessions that rely on a profile-configured `terminal.cwd` were classified as having only a launch-directory fallback because `session.create` set `explicit_cwd` only when the client supplied `cwd` directly. The persisted session row therefore omitted the configured workspace, and the normal project-context path did not inject the workspace's `AGENTS.md` contents.

## Investigation

- The issue is reproducible in the session creation path in `tui_gateway/methods_session.py`.
- `session.create` computed the session cwd through `_completion_cwd(params)`, which correctly considers profile configuration, but independently computed `explicit_cwd` only from `params["cwd"]`.
- Desktop normally omits `cwd` and selects the workspace through the active profile's `terminal.cwd`.
- `_persisted_session_cwd()` intentionally returns `None` for a Desktop session that is not explicit, treating that cwd as a launch artifact. That intentional safeguard was therefore incorrectly applied to user-configured profile workspaces.
- The result was a session with the right in-memory fallback in some paths but without a durable, user-intended workspace classification, so project context discovery could not reliably reach the configured workspace and its `AGENTS.md` files.

## Root cause

`explicit_cwd` had a narrower definition than the cwd resolver. It recognized a client-provided existing directory but not an existing directory selected from `terminal.cwd` in the session's profile or launch profile configuration.

## Fix

- Added `_session_create_explicit_cwd()` as the single decision point for `session.create`.
- It preserves the existing explicit request behavior.
- It treats a valid profile-configured or launch-profile-configured `terminal.cwd` as user intent.
- It keeps the existing launch-artifact behavior when neither an explicit cwd nor a valid configured cwd exists.
- No changes were made to AGENTS discovery, prompt assembly, mount policy, or unrelated session persistence behavior.

## Tests

Added `tests/tui_gateway/test_session_configured_cwd.py` covering:

1. A valid profile-configured `terminal.cwd` is classified as an explicit workspace.
2. Missing configured cwd remains classified as a launch artifact.

Verification performed:

```text
HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' scripts/run_tests.sh tests/tui_gateway/test_session_configured_cwd.py
```

The regression test passed in three consecutive executions. `git diff --check` also passed.

## Scope and compatibility

- Shared/default single-session behavior is unchanged.
- Explicit client-provided cwd behavior is unchanged.
- Sessions without a valid configured or explicit workspace remain launch-artifact sessions.
- The change is limited to Desktop/TUI session creation classification and its regression test.
- No credentials, environment secrets, or configuration files are modified.
