### PR TITLE
fix(install): stop gating the connectivity warning on a policy-blocked search engine probe

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1223,7 +1223,13 @@ check_network_prerequisites() {
 
     local url
     local failed=false
-    local checks=("https://pypi.org/simple/" "https://duckduckgo.com/")
+    # Install-critical hosts only: pypi.org serves the venv, github.com serves the
+    # clone. A "web search works" proxy like duckduckgo.com is intentionally NOT a
+    # gate — it is policy-blocked on mainland-China networks where the install
+    # itself works fine, and a probe that fails there printed a false
+    # "Network checks failed" warning before a single byte was fetched.
+    local checks=("https://pypi.org/simple/" "https://github.com/")
+    local web_search_reachable=true
 
     if ! command -v curl >/dev/null 2>&1; then
         log_warn "curl not found; skipping connectivity probes"
@@ -1236,6 +1242,16 @@ check_network_prerequisites() {
     local pids=()
     local tmpdir
     tmpdir=$(mktemp -d)
+    # Informational web-search probe (duckduckgo.com) — never gates the warning:
+    # on networks where it is policy-blocked, everything the installer needs can
+    # still be reachable, so its failure is only mentioned, never counted.
+    local web_search_reachable=true
+    (
+        if ! curl -fsSI --max-time 8 "https://duckduckgo.com/" >/dev/null 2>&1; then
+            : > "$tmpdir/web_search_blocked"
+        fi
+    ) &
+    pids+=($!)
     local i=0
     for url in "${checks[@]}"; do
         (
@@ -1256,7 +1272,14 @@ check_network_prerequisites() {
         fi
         i=$((i + 1))
     done
+    if [ -e "$tmpdir/web_search_blocked" ]; then
+        web_search_reachable=false
+    fi
     rm -rf "$tmpdir"
+
+    if [ "$failed" = false ] && [ "$web_search_reachable" = false ]; then
+        log_info "Web search (duckduckgo.com) is unreachable; the install itself is not affected."
+    fi
 
     if [ "$failed" = false ]; then
         log_success "Internet connectivity looks good"
@@ -1267,7 +1290,7 @@ check_network_prerequisites() {
         log_warn "Termux network prerequisites may be incomplete."
         log_info "Try: pkg install -y ca-certificates curl && pkg update"
         log_info "If mirrors are stale: termux-change-repo"
-        log_info "Then test: curl -I https://pypi.org/simple/ && curl -I https://duckduckgo.com/"
+        log_info "Then test: curl -I https://pypi.org/simple/ && curl -I https://github.com/"
     else
         log_warn "Network checks failed. Hermes install may complete, but web search and dependency downloads can fail."
         log_info "Verify internet/DNS and retry if pip install fails."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1245,7 +1245,6 @@ check_network_prerequisites() {
     # Informational web-search probe (duckduckgo.com) — never gates the warning:
     # on networks where it is policy-blocked, everything the installer needs can
     # still be reachable, so its failure is only mentioned, never counted.
-    local web_search_reachable=true
     (
         if ! curl -fsSI --max-time 8 "https://duckduckgo.com/" >/dev/null 2>&1; then
             : > "$tmpdir/web_search_blocked"

--- a/tests/test_install_sh_termux_network_prereqs.py
+++ b/tests/test_install_sh_termux_network_prereqs.py
@@ -9,14 +9,33 @@ INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 def test_termux_pkg_list_includes_network_basics() -> None:
     text = INSTALL_SH.read_text()
-    assert "local termux_pkgs=(clang rust make pkg-config libffi openssl ca-certificates curl)" in text
+    assert (
+        "local termux_pkgs=(clang rust make pkg-config libffi openssl ca-certificates curl)"
+        in text
+    )
 
 
 def test_install_script_has_connectivity_probe_and_termux_guidance() -> None:
     text = INSTALL_SH.read_text()
     assert "check_network_prerequisites()" in text
     assert "https://pypi.org/simple/" in text
-    assert "https://duckduckgo.com/" in text
+    assert "https://github.com/" in text
     assert "termux-change-repo" in text
     assert "pkg install -y ca-certificates curl && pkg update" in text
     assert "check_network_prerequisites" in text
+
+
+def test_web_search_probe_never_gates_the_connectivity_warning() -> None:
+    # duckduckgo.com is policy-blocked on networks where the install itself works;
+    # its probe result must be informational only and must not set failed=true.
+    text = INSTALL_SH.read_text()
+    assert 'local checks=("https://pypi.org/simple/" "https://github.com/")' in text
+    assert '"$tmpdir/web_search_blocked"' in text
+    assert "web_search_reachable" in text
+    # the DDG probe writes its own marker instead of joining the gating loop
+    checks_loop = text[
+        text.index('for url in "${checks[@]}"') : text.index('rm -rf "$tmpdir"')
+    ]
+    assert "duckduckgo.com" not in checks_loop
+    # the manual Termux test hint points at install-critical hosts, not DDG
+    assert "curl -I https://pypi.org/simple/ && curl -I https://github.com/" in text


### PR DESCRIPTION
## What

`scripts/install.sh` gated its connectivity warning on two probes: `pypi.org/simple/` and `duckduckgo.com/`. On networks where duckduckgo.com is policy-blocked (mainland China — #106025's exact case) while every install-critical host is reachable, the installer printed a false `⚠ Network checks failed. Hermes install may complete, but web search and dependency downloads can fail.` before fetching a single byte.

## Fix

- The gating probe list is now install-critical hosts only: `https://pypi.org/simple/` (venv) + `https://github.com/` (clone source — if *that* is unreachable the warning is honest).
- The duckduckgo.com probe is kept but demoted to **informational**: it runs in the same parallel batch, writes its own marker, and when it alone fails prints one `log_info` line (`Web search (duckduckgo.com) is unreachable; the install itself is not affected.`) without ever setting `failed=true`.
- The Termux manual-test hint now points at `pypi.org + github.com` instead of `duckduckgo.com`.
- No retry logic, timeouts, or parallel structure touched — probe semantics only.

## Tests

`tests/test_install_sh_termux_network_prereqs.py`:
- updated the literal-host assertions (github.com in, DDG out of the gate list);
- new `test_web_search_probe_never_gates_the_connectivity_warning`: asserts the gate list, the separate `web_search_blocked` marker + `web_search_reachable` flag, that the DDG host is absent from the gating loop slice, and that the Termux hint names the install-critical hosts.

Verified locally:
- `bash -n scripts/install.sh` clean;
- extracted `check_network_prerequisites` and ran it against three simulated networks (mocked `curl`): healthy → `✓ Internet connectivity looks good`; DDG-blocked-only → info line + still `✓ looks good` (no warning — the issue's scenario); all-hosts-down → the warning path is preserved;
- mutation check: restoring DDG into the gate list makes the new test fail (RED), the fixed tree passes (GREEN).

Closes #106025.