### PR TITLE
fix(toolsets): key resolve_toolset memo by registry scope

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -327,6 +327,7 @@ class TestResolveToolsetMemo:
 
         registry_id = id(registry)
         generation = registry._generation
+        scope = registry.current_scope_key()
 
         first = resolve_toolset("hermes-cli")
         second = resolve_toolset("hermes-cli")
@@ -337,7 +338,7 @@ class TestResolveToolsetMemo:
             f"got {get_toolset_calls['n']} calls"
         )
         assert (
-            "hermes-cli", True, registry_id, generation
+            "hermes-cli", True, registry_id, generation, scope
         ) in toolsets_mod._resolve_toolset_memo
 
     def test_generation_bump_invalidates_memo(self, monkeypatch):
@@ -372,4 +373,36 @@ class TestResolveToolsetMemo:
         second = resolve_toolset("hermes-cli", include_registry=False)
         assert first == second
         assert first  # non-empty sanity
+
+    def test_scope_change_invalidates_memo(self, monkeypatch):
+        """Two multiplex profiles resolving the same registry-only toolset must not
+        share a cache entry (#106005 Bug 2): the memo key omitted the registry
+        scope, so a profile B resolve after profile A's could return A's tool
+        names even though B's own tools were registered under B's own scope."""
+        from tools.registry import registry
+
+        toolsets_mod._resolve_toolset_memo.clear()
+        registry.register(
+            name="__probe_scope_a_tool__", toolset="__probe_mcp_toolset__",
+            schema=_make_schema("__probe_scope_a_tool__"), handler=_dummy_handler,
+            scope="__probe_scope_a__",
+        )
+        registry.register(
+            name="__probe_scope_b_tool__", toolset="__probe_mcp_toolset__",
+            schema=_make_schema("__probe_scope_b_tool__"), handler=_dummy_handler,
+            scope="__probe_scope_b__",
+        )
+        try:
+            monkeypatch.setattr(ToolRegistry, "current_scope_key", staticmethod(lambda: "__probe_scope_a__"))
+            assert resolve_toolset("__probe_mcp_toolset__") == ["__probe_scope_a_tool__"]
+
+            monkeypatch.setattr(ToolRegistry, "current_scope_key", staticmethod(lambda: "__probe_scope_b__"))
+            b_view = resolve_toolset("__probe_mcp_toolset__")
+            assert b_view == ["__probe_scope_b_tool__"], (
+                f"profile B resolved profile A's memoized tool names: got {b_view}"
+            )
+        finally:
+            registry.deregister("__probe_scope_a_tool__", scope="__probe_scope_a__")
+            registry.deregister("__probe_scope_b_tool__", scope="__probe_scope_b__")
+            toolsets_mod._resolve_toolset_memo.clear()
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -254,9 +254,13 @@ def _registry_call(method: str, default):
         return default
 
 
-def _registry_generation() -> Tuple[int, int]:
+def _registry_generation() -> Tuple[int, int, str]:
+    """(id, generation, scope) — scope keeps the memo from serving one multiplexed
+    profile's resolution (and its registry-only MCP tool names) to another; see #106005."""
     reg = _registry()
-    return (id(reg), getattr(reg, "_generation", 0)) if reg is not None else (0, 0)
+    if reg is None:
+        return (0, 0, "")
+    return (id(reg), getattr(reg, "_generation", 0), reg.current_scope_key())
 
 
 def get_toolset(name: str, *, include_registry: bool = True) -> Optional[Dict[str, Any]]:
@@ -321,9 +325,9 @@ def bundle_non_core_tools(toolset_name: str) -> Set[str]:
     return to_remove - core
 
 
-# Memo keyed on (name, include_registry, id(registry), registry generation);
+# Memo keyed on (name, include_registry, id(registry), registry generation, scope);
 # engages only at the public entry (visited is None).
-_resolve_toolset_memo: Dict[Tuple[str, bool, int, int], List[str]] = {}
+_resolve_toolset_memo: Dict[Tuple[str, bool, int, int, str], List[str]] = {}
 
 
 def _plugin_platform_bundle(name: str) -> List[str]:


### PR DESCRIPTION
## What does this PR do?

Fixes bug 2 of #106005: `resolve_toolset()`'s memo (`_resolve_toolset_memo` in
`toolsets.py`) was keyed on `(name, include_registry, id(registry), registry
generation)` — no registry **scope**. Under `GATEWAY_MULTIPLEX_PROFILES=true`,
when two profiles share an MCP toolset alias (e.g. identically-named
`mcp_servers` entries), the second profile to resolve the alias could get back
the *first* profile's memoized tool names, even though its own tools were
correctly registered under its own registry scope. `registry.get_definitions()`
then filters those foreign-scope names out entirely, so the affected profile's
model receives an empty toolset for a toolset that, per the registry, is not
actually empty for that profile.

Fix: include `registry.current_scope_key()` in `_registry_generation()` (and
therefore in the memo key), so each multiplex profile's resolution is cached
independently. Outside multiplex this key is a constant per-process value, so
behavior there is unchanged.

### Scope note (why this isn't the full issue)

#106005 bundles three bugs. This PR only fixes bug 2:

- **Bug 3** (`get_mcp_status()` reporting connections as process-global /
  "false green" per-profile status) is **already fixed on current `main`** by
  `a6699d60f4` ("feat(mcp): expose profile-scoped cached connection health"),
  which added the exact `_server_scope_keys.get(name) == current_scope`
  filtering the issue asks for. Verified directly against `main`.
- **Bug 1** (`_select_new_servers` in `tools/mcp_tool_discovery.py` skipping a
  server name already claimed by another profile, so a second profile never
  connects/registers its own instance) is real and still present on `main`,
  but a correct fix needs a real design decision: `_servers`,
  `_server_connecting`, `_lazy_server_configs`, connect-cooldown state and
  `_parallel_safe_servers` are all keyed process-globally by bare server name
  and read from ~10 files (connection lifecycle, teardown, tool-call routing,
  status, schema cache). Re-keying all of that by `(scope, name)` — or sharing
  one connection across profiles and reference-counting its teardown — is a
  much larger change with real regression risk (e.g. a naive fix that just
  loosens the `_select_new_servers` candidate check would let a second
  profile's `_adopt_server()` overwrite the first profile's live connection in
  `_servers[name]`, breaking the first profile instead of fixing the second).
  That's out of scope for a minimal, safely-testable fix and needs maintainer
  input on the intended connection-sharing model.

## Related Issue

Addresses (does not fully close) #106005

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `toolsets.py`: `_registry_generation()` now returns `(id, generation,
  scope)` instead of `(id, generation)`; `_resolve_toolset_memo`'s key/type
  hint updated to match.
- `tests/test_toolsets.py`: updated `test_second_resolution_is_cached`'s memo
  tuple assertion to the new 5-tuple shape, and added
  `test_scope_change_invalidates_memo`, which registers tools for the same
  toolset name under two different registry scopes and asserts that resolving
  it under scope B doesn't return scope A's memoized names.

## How to Test

```
scripts/run_tests.sh tests/test_toolsets.py -q
```

Result on this branch:

```
Discovered 1 test files (~27 tests) under ['tests/test_toolsets.py']; running with -j 8
[100.0% |    27/~27 | ✓27 | ✗ 0] ✓ tests/test_toolsets.py (27✓, 1.6s)

=== Summary: 1 files, 27 tests passed, 0 failed (100% complete) in 1.6s (8 workers) ===
```

Proof the new test fails without the fix (reverted `toolsets.py` only, kept
the updated test file):

```
FAILED tests/test_toolsets.py::TestResolveToolsetMemo::test_second_resolution_is_cached
FAILED tests/test_toolsets.py::TestResolveToolsetMemo::test_scope_change_invalidates_memo
  AssertionError: profile B resolved profile A's memoized tool names: got ['__probe_scope_a_tool__']
  assert ['__probe_scope_a_tool__'] == ['__probe_scope_b_tool__']
```

Also ran the broader adjacent suite clean on this branch:

```
scripts/run_tests.sh tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py \
  tests/gateway/test_multiplex_toolsets_profile_isolation.py tests/hermes_cli/test_toolset_validation.py \
  tests/test_toolset_distributions.py -q
=== Summary: 5 files, 130 tests passed, 0 failed, 1 skipped (100% complete) ===
```

`ruff check toolsets.py tests/test_toolsets.py` — all checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/test_toolsets.py -q` (plus the adjacent MCP/toolset suites) and all tests pass
- [x] I've added a test for this change
- [ ] Tested on a specific platform — not applicable; pure Python registry/memo logic, no OS-specific behavior

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or architecture changed

---

**AI assistance disclosure:** this patch (root-cause read of `toolsets.py` /
`tools/registry.py` / `tools/mcp_tool*.py`, the fix, and the regression test)
was produced by an AI coding agent (Claude Code) under human supervision, from
a review of the issue and current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
