### PR TITLE
fix(tools): honor discriminator in tool_call oneOf validation

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -930,3 +930,70 @@ class TestDeferredCallSchemaProbe:
         }, calls)
 
         assert validate_deferred_call_args(name, {"payload": {"anything": True}}) is None
+
+    def test_discriminated_oneof_accepts_valid_call(self):
+        # OpenAPI ``discriminator`` makes a ``oneOf`` mutually exclusive by a
+        # property value. Stock jsonschema ignores ``discriminator`` and enforces
+        # raw ``oneOf`` (exactly-one), which false-rejects a valid payload when
+        # branches overlap or are identical (e.g. an MCP server whose FACEBOOK and
+        # FORUMS branches are byte-identical). The probe must not block such a call.
+        from tools.tool_search import validate_deferred_call_args
+
+        def branch(required):
+            return {
+                "type": "object",
+                "properties": {
+                    "channel": {"type": "string"},
+                    "content": {"type": "string"},
+                    "sender": {"type": "string"},
+                },
+                "required": required,
+            }
+
+        calls = []
+        name = "mcp_probe_discriminated_oneof"
+        self._register_schema(name, "mcp-probe-discriminated-oneof", {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "discriminator": {"propertyName": "channel"},
+                    "oneOf": [
+                        branch(["channel", "sender", "content"]),  # EMAIL
+                        branch(["channel", "content"]),            # FACEBOOK
+                        branch(["channel", "content"]),            # FORUMS (identical)
+                    ],
+                },
+            },
+            "required": ["body"],
+        }, calls)
+
+        # A valid EMAIL payload matches every branch, so raw ``oneOf`` would reject it.
+        args = {"body": {"channel": "EMAIL", "sender": "a@b.com", "content": "hi"}}
+        assert validate_deferred_call_args(name, args) is None
+
+    def test_plain_oneof_without_discriminator_stays_strict(self):
+        # The discriminator relaxation must be scoped: a plain ``oneOf`` with no
+        # discriminator keeps exactly-one semantics, so a payload matching two
+        # branches is still rejected before dispatch.
+        from tools.tool_search import validate_deferred_call_args
+
+        calls = []
+        name = "mcp_probe_plain_oneof"
+        self._register_schema(name, "mcp-probe-plain-oneof", {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "oneOf": [
+                        {"type": "object", "properties": {"a": {"type": "string"}},
+                         "required": ["a"]},
+                        {"type": "object", "properties": {"b": {"type": "string"}},
+                         "required": ["b"]},
+                    ],
+                },
+            },
+            "required": ["body"],
+        }, calls)
+
+        err = validate_deferred_call_args(name, {"body": {"a": "x", "b": "y"}})
+        assert err is not None
+        assert calls == []

--- a/tools/tool_search_validation.py
+++ b/tools/tool_search_validation.py
@@ -26,6 +26,14 @@ def _schema_for_local_validation(node: Any) -> Any:
     normalized = {key: (copy.deepcopy(value) if key in _SCHEMA_LITERAL_KEYS
                         else _schema_for_local_validation(value))
                   for key, value in node.items() if key != "nullable"}
+    # OpenAPI ``discriminator`` makes a ``oneOf`` mutually exclusive by a property value.
+    # Stock jsonschema ignores ``discriminator`` and enforces raw ``oneOf`` (exactly-one),
+    # which false-rejects any payload matching >1 branch — fatal when branches overlap or
+    # are identical (e.g. Zoho Desk draftsReply's FACEBOOK/FORUMS branches). Relax to
+    # ``anyOf`` (at-least-one) when a discriminator is present: the discriminator already
+    # guarantees exclusivity, and this validator fails open by design. See #5149.
+    if isinstance(node.get("discriminator"), dict) and "oneOf" in normalized:
+        normalized["anyOf"] = normalized.pop("oneOf")
     if node.get("nullable") is not True:
         return normalized
     schema_type = normalized.get("type")


### PR DESCRIPTION
## What does this PR do?

Fixes a false rejection in the `tool_call` argument validator that makes an entire class of MCP tools uninvokable: any tool whose parameter schema is an OpenAPI **discriminated union** (`discriminator` + `oneOf`) with overlapping or identical branches.

`validate_deferred_call_args` (in `tools/tool_search_validation.py`) validates arguments with stock `jsonschema`, which does **not** implement the OpenAPI `discriminator` keyword — it silently ignores it and enforces the raw `oneOf` as "match exactly one branch". When two branches are identical or mutually inclusive, a valid payload matches ≥ 2 branches, so `oneOf` becomes unsatisfiable and the probe rejects the call with `... is valid under each of {...}. The tool was NOT invoked.` **before it ever reaches the MCP server.**

Real-world trigger: Zoho Desk's `draftsReply` / `sendReply` bodies are discriminated on `channel`, and their `FACEBOOK` and `FORUMS` branches are byte-identical and open (`additionalProperties` not restricted). Every valid `EMAIL` draft matches all three branches, so drafting/sending any Zoho Desk reply through Hermes is impossible. The same call succeeds in other MCP hosts that validate server-side (honoring the discriminator); it was blocked only by this local pre-dispatch probe.

## Related Issue

No existing issue for this exact case. Closest neighbors are distinct: #76119 (closed — the `required`-field probe, input side) and #9075 (open — discriminator on the **output**/`structuredContent` path in the MCP SDK). This PR addresses the **input-argument** `oneOf` path, which neither covers.

Fixes # (none — filing PR directly per template)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tool_search_validation.py` — in `_schema_for_local_validation`, when a schema node carries a `discriminator`, rewrite its `oneOf` to `anyOf` in the validation copy. The discriminator already guarantees branch exclusivity, so "at least one" is the correct check and identical branches stop being fatal. Plain `oneOf` **without** a discriminator keeps exactly-one semantics. This probe is fail-open by design, so relaxing here is consistent with its intent.
- `tests/tools/test_tool_search.py` — two behavior-contract tests: a discriminated union accepts a valid multi-branch-matching payload; a plain `oneOf` still rejects a double-match before dispatch.

## How to Test

1. **Red (bug present):** on `main`, register a deferred tool whose `body` is `{discriminator: {propertyName: "channel"}, oneOf: [EMAIL, FACEBOOK, FORUMS]}` with FACEBOOK/FORUMS identical, then `validate_deferred_call_args(name, {"body": {"channel": "EMAIL", ...}})` returns a `(oneOf)` validation error — the valid call is blocked.
2. **Green (fixed):** with this change the same call returns `None` (dispatches).
3. Run: `scripts/run_tests.sh tests/tools/test_tool_search.py` → 47 passed (45 existing + 2 new). New tests were confirmed red on unmodified `main` and green with the fix.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files)
- [x] I've run the test suite and all tests pass (`scripts/run_tests.sh tests/tools/test_tool_search.py` → 47 passed)
- [x] I've added tests for my changes (red/green behavior contracts)
- [x] I've tested on my platform: macOS (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal validator behavior; no user-facing docs or config keys)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure schema logic, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema/tool surface change)
