### PR TITLE
perf(state): batch message hydration in export_all

### DIFF
--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -258,7 +258,22 @@ class SessionPortabilityMixin:
 
     def export_all(self, source: str = None) -> List[Dict[str, Any]]:
         """Export all sessions (with messages) as dicts, e.g. for JSONL backup."""
-        return [self._with_messages(s) for s in self.search_sessions(source=source, limit=100000)]
+        sessions = self.search_sessions(source=source, limit=100000)
+        messages_by_session = {session["id"]: [] for session in sessions}
+        session_ids = list(messages_by_session)
+        # Stay below SQLite's legacy 999-variable limit while replacing the per-session N+1 reads.
+        for start in range(0, len(session_ids), 900):
+            chunk = session_ids[start:start + 900]
+            rows = self._read_all(
+                f"SELECT * FROM messages WHERE session_id IN ({','.join('?' for _ in chunk)}) "
+                "AND active = 1 ORDER BY session_id, id",
+                chunk,
+            )
+            for row in rows:
+                messages_by_session[row["session_id"]].append(
+                    self._row_to_message_dict(row, warn_context="get_messages", summary_flag=True)
+                )
+        return [{**session, "messages": messages_by_session[session["id"]]} for session in sessions]
 
     def adopt_session_lineage_from(self, donor_db: Any, session_id: str, *, retire_donor: bool = True) -> Dict[str, Any]:
         """Adopt *session_id*'s full compression lineage from *donor_db* (stranded-bot-session

--- a/tests/test_session_export_batch.py
+++ b/tests/test_session_export_batch.py
@@ -1,0 +1,41 @@
+from hermes_state import SessionDB
+
+
+def test_export_all_batches_message_reads_without_changing_export_rows(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        for index, source in enumerate(("cli", "telegram", "cli", "cli")):
+            session_id = f"session-{index}"
+            db.create_session(session_id=session_id, source=source)
+            db.append_messages_batch(
+                session_id,
+                [
+                    {"role": "user", "content": f"question {index}"},
+                    {
+                        "role": "assistant",
+                        "content": f"answer {index}",
+                        "tool_calls": [{"id": f"call-{index}", "type": "function"}],
+                    },
+                ],
+            )
+
+        sessions = db.search_sessions(source="cli", limit=100000)
+        expected = [
+            {**session, "messages": db.get_messages(session["id"])}
+            for session in sessions
+        ]
+
+        original_read_all = db._read_all
+        read_calls = 0
+
+        def counted_read_all(*args, **kwargs):
+            nonlocal read_calls
+            read_calls += 1
+            return original_read_all(*args, **kwargs)
+
+        monkeypatch.setattr(db, "_read_all", counted_read_all)
+
+        assert db.export_all(source="cli") == expected
+        assert read_calls <= 2
+    finally:
+        db.close()


### PR DESCRIPTION
Closes #106060

## N+1 export path

`SessionDB.export_all()` fetched the session list once and then called the ordinary per-session message reader for every exported row. A full backup of `N` sessions therefore issued `N + 1` database reads before JSON serialization or disk output began.

## Batched hydration

Keep the existing 100,000-session cap and session search order, but hydrate active messages in bounded groups of 900 session IDs. The batch size stays below SQLite's legacy 999-variable limit.

Rows are read in `(session_id, id)` order and decoded through the same `_row_to_message_dict()` path used by existing message reads. The final export is rebuilt in the original session order.

## Export contract preserved

- source filtering remains owned by `search_sessions()`;
- only active messages are exported;
- message order remains physical message-ID order within each session;
- system-prompt resolution and deduplication remain unchanged;
- the existing message decoder and compressed-summary flag behavior are reused;
- export still materializes the complete result and retains the 100,000-session ceiling;
- the batched read provides no stronger cross-batch snapshot guarantee than the previous sequence of per-session reads.

No schema, configuration, or public API changes.

## Measured impact

Real `SessionDB.export_all()` over temporary SQLite data with three messages per session, median of five calls on Linux/WSL2 with CPython 3.11.15:

| Sessions | Before | After | Message/session queries |
|---:|---:|---:|---:|
| 1,000 | 47.415 ms | 35.651 ms | 1,001 → 3 |
| 10,000 | 520.685 ms | 428.365 ms | 10,001 → 13 |

These timings cover the export operation before JSON serialization and disk writes. The issue contains the self-contained query-count reproducer.

## Verification

- The new invariant compares the complete batched export with the previous per-session result, including source filtering and tool-call rows.
- It fails on the previous implementation (`4 <= 2`) and passes with batching.
- Additional review exercised **905 selected sessions** across two batches, an inactive row, and a deduplicated system prompt with exact output parity.
- State-area run: **300 passed, 2 skipped**.
- Existing export/import subset: **7 passed**.
- `git diff --check` passed.

## Disclosed baseline failure

The monolithic state suite contains an unchanged failure in `TestFTS5Search.test_search_projection_skips_context_enrichment_queries`: its SQLite trace assertion expects one context query and observes zero. The same failure was reproduced on unmodified upstream; this PR changes neither that search path nor its test.

## Related work

#89944 concerns timing evidence, #53992 concerns logical lineage, and #89223 concerns filtered export behavior. They may require textual or semantic reconciliation, but none implements this message-hydration batching contract.