### PR TITLE
feat(gateway): fire on_message_merged when a busy follow-up is folded into the running turn

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3059,6 +3059,13 @@ class BasePlatformAdapter(ABC):
         if emoji:
             await add(chat_id, message_id, emoji)
 
+    async def on_message_merged(self, event: MessageEvent) -> None:
+        """Hook called when the gateway folds ``event`` into the turn already running for its session
+        (``busy_input_mode`` steer, or interrupt with a live-turn redirect) instead of starting a turn
+        for it. ``on_processing_start``/``on_processing_complete`` never fire for such an event — it is
+        consumed by the active turn. A queued follow-up is not merged: it gets its own turn and the
+        normal hooks. Default: no-op."""
+
     async def _run_processing_hook(self, hook_name: str, *args: Any, **kwargs: Any) -> None:
         """Run a lifecycle hook without letting failures break message flow."""
         hook = getattr(self, hook_name, None)

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -519,6 +519,8 @@ class GatewayBusySessionMixin:
             redirected = self._try_agent_verb(
                 running_agent, "redirect", (event.text or "").strip(), session_key, event=event
             )
+        if steered or redirected:
+            await self._notify_message_merged(event)
         return self._BusySteerOutcome(
             effective_mode=effective_mode, demoted_for_subagents=demoted_for_subagents,
             demoted_for_compression=demoted_for_compression, steered=steered, redirected=redirected,
@@ -539,6 +541,14 @@ class GatewayBusySessionMixin:
         except Exception as exc:
             logger.warning("Gateway %s failed for session %s: %s", verb, session_key, exc)
             return False
+
+    async def _notify_message_merged(self, event: MessageEvent) -> None:
+        """Tell the adapter ``event`` was folded into the running turn (steer/redirect): its text is
+        already inside the run, so ``on_processing_start``/``on_processing_complete`` never fire for it."""
+        adapter = self._adapter_for_source(event.source)
+        run_hook = getattr(adapter, "_run_processing_hook", None)
+        if callable(run_hook):
+            await run_hook("on_message_merged", event)
 
     async def _interrupt_running_agent_for_busy_event(self, event: MessageEvent, adapter, running_agent) -> None:
         """Interrupt mode: abort in-flight tool calls; the agent loop exits at its next check point."""

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -552,8 +552,9 @@ class GatewayInboundMixin:
     def _hm_text_only(event: "MessageEvent") -> bool:
         return event.message_type == MessageType.TEXT and not event.media_urls and not event.media_types
 
-    def _hm_busy_steer(self, event: "MessageEvent", running_agent: Any, _quick_key: str) -> None:
-        """Steer mode: inject text mid-run via ``agent.steer()``, else fall back to queue semantics."""
+    def _hm_busy_steer(self, event: "MessageEvent", running_agent: Any, _quick_key: str) -> bool:
+        """Steer mode: inject text mid-run via ``agent.steer()``, else fall back to queue semantics.
+        Returns True when the text landed in the running turn (the caller fires ``on_message_merged``)."""
         steer_text = (event.text or "").strip()
         steered = False
         if self._hm_text_only(event) and steer_text and hasattr(running_agent, "steer"):
@@ -563,9 +564,10 @@ class GatewayInboundMixin:
                 logger.warning("PRIORITY steer failed for session %s: %s", _quick_key, exc)
         if steered:
             logger.debug("PRIORITY steer for session %s", _quick_key)
-            return
+            return True
         logger.debug("PRIORITY steer-fallback-to-queue for session %s", _quick_key)
         self._queue_or_replace_pending_event(_quick_key, event)
+        return False
 
     async def _hm_busy_interrupt(
         self, event: "MessageEvent", source: SessionSource, running_agent: Any, _quick_key: str
@@ -581,6 +583,7 @@ class GatewayInboundMixin:
                     self._steer_text_with_origin((event.text or "").strip(), event)
                 ):
                     logger.debug("PRIORITY redirect for session %s", _quick_key)
+                    await self._notify_message_merged(event)
                     return
             except Exception as exc:
                 logger.warning("PRIORITY redirect failed for session %s: %s", _quick_key, exc)
@@ -634,7 +637,8 @@ class GatewayInboundMixin:
             self._queue_or_replace_pending_event(_quick_key, event)
             return None
         if effective_busy_input_mode == "steer":
-            self._hm_busy_steer(event, running_agent, _quick_key)
+            if self._hm_busy_steer(event, running_agent, _quick_key):
+                await self._notify_message_merged(event)
             return None
         # Subagent protection: an interrupt cascades through ``_active_children`` and aborts
         # in-flight delegate_task work (/stop reached its handler above — still an escape hatch).

--- a/tests/gateway/test_busy_merged_message_hook.py
+++ b/tests/gateway/test_busy_merged_message_hook.py
@@ -1,0 +1,156 @@
+"""``on_message_merged`` fires exactly once when a busy follow-up is folded into the running turn
+(steer, or interrupt redirect) and never when it is queued for a turn of its own.
+
+An adapter that keeps per-event state (an ack/receipt row per inbound message) otherwise cannot
+learn that a merged message was consumed: ``on_processing_start``/``on_processing_complete`` only
+fire for events that get their own turn."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult, SessionSource, build_session_key
+from gateway.platforms.event import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+
+
+class _Adapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test-token"), Platform.TELEGRAM)
+        self.merged = []
+        self.started = []
+        self.completed = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+    async def on_message_merged(self, event):
+        self.merged.append(event)
+
+    async def on_processing_start(self, event):
+        self.started.append(event)
+
+    async def on_processing_complete(self, event, outcome):
+        self.completed.append((event, outcome))
+
+
+def _event(text="follow up") -> MessageEvent:
+    return MessageEvent(
+        text=text, message_type=MessageType.TEXT, message_id="message-1",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1", chat_type="dm", user_id="user-1"),
+    )
+
+
+@pytest.fixture
+def runner(monkeypatch):
+    # No busy ack: the handler returns right after the steer/redirect/queue decision.
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+    monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "0")
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    runner._profile_adapters = {}
+    runner.adapters = {Platform.TELEGRAM: _Adapter()}
+    runner._sessions = {}
+    runner._draining = False
+    runner._restart_requested = False
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda source: True
+    runner._session_has_compression_in_flight = AsyncMock(return_value=False)
+    return runner
+
+
+def _running_agent(runner, session_key, *, steer=True, redirect=True):
+    agent = MagicMock()
+    agent._active_children = []
+    agent._supports_active_turn_redirect = True
+    agent.steer = MagicMock(return_value=steer)
+    agent.redirect = MagicMock(return_value=redirect)
+    runner._running_agents[session_key] = agent
+    return agent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["interrupt", "steer"])
+@pytest.mark.parametrize("path", ["busy_handler", "priority"])
+async def test_merged_follow_up_fires_on_message_merged_once(runner, mode, path):
+    runner._busy_input_mode = mode
+    adapter = runner.adapters[Platform.TELEGRAM]
+    event = _event()
+    session_key = build_session_key(event.source)
+    agent = _running_agent(runner, session_key)
+
+    if path == "busy_handler":
+        assert await runner._handle_active_session_busy_message(event, session_key) is True
+    else:
+        assert await runner._hm_handle_running_session_message(event, event.source, session_key) is None
+
+    verb = agent.redirect if mode == "interrupt" else agent.steer
+    verb.assert_called_once()
+    agent.interrupt.assert_not_called()
+    assert adapter.merged == [event]
+    assert adapter.started == [] and adapter.completed == []
+    assert session_key not in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["busy_handler", "priority"])
+async def test_queued_follow_up_does_not_fire_on_message_merged(runner, path):
+    runner._busy_input_mode = "queue"
+    runner._busy_text_mode = "queue"
+    adapter = runner.adapters[Platform.TELEGRAM]
+    event = _event()
+    session_key = build_session_key(event.source)
+    agent = _running_agent(runner, session_key)
+
+    if path == "busy_handler":
+        # False: the base adapter queues the event itself; nothing was merged.
+        assert await runner._handle_active_session_busy_message(event, session_key) is False
+    else:
+        assert await runner._hm_handle_running_session_message(event, event.source, session_key) is None
+        assert adapter._pending_messages[session_key] is event
+
+    agent.steer.assert_not_called()
+    agent.redirect.assert_not_called()
+    assert adapter.merged == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["interrupt", "steer"])
+@pytest.mark.parametrize("path", ["busy_handler", "priority"])
+async def test_rejected_steer_or_redirect_falls_back_without_on_message_merged(runner, mode, path):
+    """The agent refuses the mid-run text, so the event is queued (steer) or interrupts (redirect)
+    and later gets its own turn — it was not merged."""
+    runner._busy_input_mode = mode
+    adapter = runner.adapters[Platform.TELEGRAM]
+    event = _event()
+    session_key = build_session_key(event.source)
+    agent = _running_agent(runner, session_key, steer=False, redirect=False)
+
+    if path == "busy_handler":
+        assert await runner._handle_active_session_busy_message(event, session_key) is True
+    else:
+        assert await runner._hm_handle_running_session_message(event, event.source, session_key) is None
+
+    verb = agent.redirect if mode == "interrupt" else agent.steer
+    verb.assert_called_once()
+    assert adapter.merged == []
+    if mode == "steer":
+        assert adapter._pending_messages[session_key] is event
+    else:
+        agent.interrupt.assert_called_once_with("follow up")

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -82,6 +82,7 @@ def _make_adapter(platform_val="telegram"):
     adapter = MagicMock()
     adapter._pending_messages = {}
     adapter._send_with_retry = AsyncMock()
+    adapter._run_processing_hook = AsyncMock()
     adapter.config = MagicMock()
     adapter.config.extra = {}
     adapter.platform = MagicMock(value=platform_val)

--- a/tests/gateway/test_subagent_protection_30170.py
+++ b/tests/gateway/test_subagent_protection_30170.py
@@ -96,6 +96,7 @@ def _make_adapter() -> MagicMock:
     adapter = MagicMock()
     adapter._pending_messages = {}
     adapter._send_with_retry = AsyncMock()
+    adapter._run_processing_hook = AsyncMock()
     adapter.config = MagicMock()
     adapter.config.extra = {}
     adapter.platform = MagicMock(value="telegram")


### PR DESCRIPTION
## What does this PR do?

Gives platform adapters a lifecycle hook for the one case the existing pair cannot cover.

With `display.busy_input_mode: steer`, or `interrupt` when the runtime supports a live-turn redirect, a message that arrives mid-turn is injected into the running turn (`running_agent.steer()` / `running_agent.redirect()`) and never gets a turn of its own. `on_processing_start` / `on_processing_complete` only fire from `_process_message_background` (and, with #103465, the in-band queued drain), so for a merged message neither hook fires and the busy handler simply returns `True`. The adapter has no signal that the message was consumed.

That is fine for adapters whose per-message state is a reaction (nothing was ever added, nothing to swap). It is not fine for an adapter that keeps durable per-event state — one that records every inbound event before acknowledging it and settles the record in `on_processing_complete`. Such an adapter can only infer a merge by reading `_active_sessions` / `_pending_messages`, which misses the runner's overflow FIFO (`_BUSY_QUEUE_MAX_PENDING`).

The change adds `BasePlatformAdapter.on_message_merged(event)` with a no-op default, and fires it exactly once from every site that folds a message into the active turn:

- `GatewayRunner._resolve_busy_steer_or_redirect` (busy-session handler: steer, or interrupt redirect)
- `GatewayRunner._hm_busy_interrupt` (priority path: redirect)
- `GatewayRunner._hm_handle_running_session_message` after `_hm_busy_steer` (priority path: steer; `_hm_busy_steer` now returns whether the steer landed)

The call goes through the adapter's existing `_run_processing_hook`, so a failing hook is logged and never breaks message flow, same as the other two hooks.

Why a new hook and not a new `ProcessingOutcome` member: every in-tree override of `on_processing_complete` (Signal, webhook, Discord, Telegram, Slack, Matrix, Feishu, Google Chat, Photon, A2A, Relay) treats the call as "the turn for this event ended" — it removes the in-progress reaction, or ends the per-delivery session. A merged event never had `on_processing_start`, so routing it into `on_processing_complete` would trigger those side effects for an event they never acked. A separate no-op hook leaves every existing adapter's behaviour unchanged; no in-tree adapter overrides it.

Not changed on purpose:

- The queue path. A queued follow-up still gets its own turn and the normal hooks.
- A steer or redirect the agent rejects. The event falls back to queue (steer) or to `interrupt()` (interrupt mode) and will get its own turn, so the hook does not fire.
- The explicit `/steer` command. It is a slash command, dispatched through the command path, and out of scope here.
- The queued follow-up that `_run_agent_queued_followup` runs inside the original handler call. Today `on_processing_start`/`on_processing_complete` fire only for the event that opened the turn, never for that follow-up event, so an adapter with per-event state cannot settle it either. That is the same class of gap, but open PR #103465 already fixes it (fires both hooks around the follow-up turn, with cancel and exception handling and tests), so it is not duplicated here.

First consumer: an out-of-tree channel plugin (Relay) that persists every inbound event before ACK and needs to settle merged ones.

## Related Issue

No existing issue; searched `busy_input_mode`, `on_processing_complete`, and "steer redirect hook" across issues and PRs. #103465 is the sibling change (hooks for in-band queued follow-ups) and does not overlap: it covers the queue path, this covers the merge path. Together they make every consumed inbound event observable by the adapter.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/base.py` — `BasePlatformAdapter.on_message_merged(event)`, no-op default, docstring beside the two existing lifecycle hooks.
- `gateway/run_busy.py` — `GatewayRunner._notify_message_merged(event)` helper; called from `_resolve_busy_steer_or_redirect` after a successful steer or redirect.
- `gateway/run_inbound.py` — `_hm_busy_steer` returns `bool`; `_hm_busy_interrupt` and `_hm_handle_running_session_message` fire the hook after a successful redirect / steer.
- `tests/gateway/test_busy_merged_message_hook.py` — new, 10 cases (see below).
- `tests/gateway/test_busy_session_ack.py`, `tests/gateway/test_subagent_protection_30170.py` — the `MagicMock` adapter fixtures gain `_run_processing_hook = AsyncMock()` so the runner can await it, as it does on a real adapter.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_busy_merged_message_hook.py` — 10 passed.
   - `test_merged_follow_up_fires_on_message_merged_once[{busy_handler,priority}-{interrupt,steer}]`: hook fires once with the event; `on_processing_start`/`complete` do not; nothing queued.
   - `test_queued_follow_up_does_not_fire_on_message_merged[{busy_handler,priority}]`: queue mode, hook silent.
   - `test_rejected_steer_or_redirect_falls_back_without_on_message_merged[{busy_handler,priority}-{interrupt,steer}]`: agent rejects, event queued or interrupted, hook silent.
2. Each call site is covered by mutation: removing the busy-handler call fails the two `busy_handler-*` merge cases; removing the priority redirect call fails `priority-interrupt`; removing the priority steer call fails `priority-steer`; making the busy-handler call unconditional fails both `busy_handler-*` rejected cases.
3. `scripts/run_tests.sh tests/gateway/` on the branch: all busy-path files green (`test_busy_session_ack`, `test_busy_steer_origin`, `test_multiplex_busy_input_mode`, `test_subagent_protection_30170`, `test_compression_interrupt_demotion_56391`, `test_priority_path_compression_demotion_56391`, `test_busy_session_auth_bypass`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring; the adapter guide does not list the processing hooks today
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, no I/O
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

