### PR TITLE
feat(gateway): runs queue endpoint, Slack per-token locks, perf caches, query batching

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -93,41 +93,71 @@ def _load_config() -> Dict[str, Any]:
     return _read_config_section("curator", label="curator")
 
 
-def _config_number(key: str, default, cast):
+@contextlib.contextmanager
+def _single_config_load():
+    """Memoize _load_config() for one gate so N getters cost one YAML read.
+
+    Zero-arg call convention is preserved (tests patch getters/_load_config
+    with zero-arg lambdas); nesting is safe (inner memo wraps the outer one,
+    still a single real read)."""
+    sentinel = object()
+    cached: Any = sentinel
+    real_load = _load_config
+
+    def _once() -> Dict[str, Any]:
+        nonlocal cached
+        if cached is sentinel:
+            cached = real_load()
+        return cached
+
+    glob = globals()
+    prev = glob.get("_load_config", real_load)
+    glob["_load_config"] = _once
     try:
-        return cast(_load_config().get(key, default))
+        yield
+    finally:
+        glob["_load_config"] = prev
+
+
+def _config_number(key: str, default, cast, cfg: Optional[Dict[str, Any]] = None):
+    cfg = cfg if isinstance(cfg, dict) else _load_config()
+    try:
+        return cast(cfg.get(key, default))
     except (TypeError, ValueError):
         return default
 
 
-def is_enabled() -> bool:  # default ON when no config says otherwise
-    return bool(_load_config().get("enabled", True))
+def is_enabled(cfg: Optional[Dict[str, Any]] = None) -> bool:  # default ON when no config says otherwise
+    cfg = cfg if isinstance(cfg, dict) else _load_config()
+    return bool(cfg.get("enabled", True))
 
 
-def get_interval_hours() -> int:
-    return _config_number("interval_hours", DEFAULT_INTERVAL_HOURS, int)
+def get_interval_hours(cfg: Optional[Dict[str, Any]] = None) -> int:
+    return _config_number("interval_hours", DEFAULT_INTERVAL_HOURS, int, cfg)
 
 
-def get_min_idle_hours() -> float:
-    return _config_number("min_idle_hours", DEFAULT_MIN_IDLE_HOURS, float)
+def get_min_idle_hours(cfg: Optional[Dict[str, Any]] = None) -> float:
+    return _config_number("min_idle_hours", DEFAULT_MIN_IDLE_HOURS, float, cfg)
 
 
-def get_stale_after_days() -> int:
-    return _config_number("stale_after_days", DEFAULT_STALE_AFTER_DAYS, int)
+def get_stale_after_days(cfg: Optional[Dict[str, Any]] = None) -> int:
+    return _config_number("stale_after_days", DEFAULT_STALE_AFTER_DAYS, int, cfg)
 
 
-def get_archive_after_days() -> int:
-    return _config_number("archive_after_days", DEFAULT_ARCHIVE_AFTER_DAYS, int)
+def get_archive_after_days(cfg: Optional[Dict[str, Any]] = None) -> int:
+    return _config_number("archive_after_days", DEFAULT_ARCHIVE_AFTER_DAYS, int, cfg)
 
 
-def get_prune_builtins() -> bool:
+def get_prune_builtins(cfg: Optional[Dict[str, Any]] = None) -> bool:
     """Bundled built-ins are curation candidates (ON by default); a suppression list keeps them archived across `hermes update` re-seeds. Hub skills are never pruned."""
-    return bool(_load_config().get("prune_builtins", True))
+    cfg = cfg if isinstance(cfg, dict) else _load_config()
+    return bool(cfg.get("prune_builtins", True))
 
 
-def get_consolidate() -> bool:
+def get_consolidate(cfg: Optional[Dict[str, Any]] = None) -> bool:
     """LLM consolidation pass — OFF by default (prune only, no aux-model fork); ``hermes curator run --consolidate`` overrides per invocation."""
-    return bool(_load_config().get("consolidate", DEFAULT_CONSOLIDATE))
+    cfg = cfg if isinstance(cfg, dict) else _load_config()
+    return bool(cfg.get("consolidate", DEFAULT_CONSOLIDATE))
 
 
 # --- Idle / interval check ---
@@ -143,22 +173,23 @@ def should_run_now(now: Optional[datetime] = None) -> bool:
     """Gates: curator.enabled, not paused, ``last_run_at`` present AND older than interval_hours. First observation seeds
     ``last_run_at`` to now and defers one interval, so a fresh install/update never mutates the library on its first tick.
     ``hermes curator run`` bypasses this; the idle check is the caller's."""
-    if not is_enabled() or is_paused():
-        return False
-    state = load_state()
-    last = _parse_iso(state.get("last_run_at"))
-    now = now or datetime.now(timezone.utc)
-    if last is None:
-        try:
-            state["last_run_at"] = now.isoformat()
-            state["last_run_summary"] = "deferred first run — curator seeded, will run after one interval; use `hermes curator run --dry-run` to preview now"
-            save_state(state)
-        except Exception as e:  # pragma: no cover — best-effort persistence
-            logger.debug("Failed to seed curator last_run_at: %s", e)
-        return False
-    if last.tzinfo is None:
-        last = last.replace(tzinfo=timezone.utc)
-    return (now - last) >= timedelta(hours=get_interval_hours())
+    with _single_config_load():  # one YAML read for is_enabled + get_interval_hours
+        if not is_enabled() or is_paused():
+            return False
+        state = load_state()
+        last = _parse_iso(state.get("last_run_at"))
+        now = now or datetime.now(timezone.utc)
+        if last is None:
+            try:
+                state["last_run_at"] = now.isoformat()
+                state["last_run_summary"] = "deferred first run — curator seeded, will run after one interval; use `hermes curator run --dry-run` to preview now"
+                save_state(state)
+            except Exception as e:  # pragma: no cover — best-effort persistence
+                logger.debug("Failed to seed curator last_run_at: %s", e)
+            return False
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
+        return (now - last) >= timedelta(hours=get_interval_hours())
 
 
 # --- Automatic state transitions (pure function, no LLM) ---
@@ -195,8 +226,9 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
     from tools import skill_usage as _u
 
     now = now or datetime.now(timezone.utc)
-    stale_cutoff = now - timedelta(days=get_stale_after_days())
-    archive_cutoff = now - timedelta(days=get_archive_after_days())
+    with _single_config_load():  # one YAML read for both cutoffs
+        stale_cutoff = now - timedelta(days=get_stale_after_days())
+        archive_cutoff = now - timedelta(days=get_archive_after_days())
     # Cron-referenced skills are in use by definition (usage only bumps when a
     # job fires, so paused/rare jobs would age them out). Treat as pinned.
     protected = _cron_referenced_skills()
@@ -1076,9 +1108,10 @@ def maybe_run_curator(*, idle_for_seconds: Optional[float] = None, on_summary: O
     """Best-effort: run a curator pass if all gates pass. Returns the result dict if a pass was started, else None. Never raises."""
     try:
         # Idle gating: only enforce when the caller provided a measurement.
-        if not should_run_now() or (idle_for_seconds is not None and idle_for_seconds < get_min_idle_hours() * 3600.0):
-            return None
-        return run_curator_review(on_summary=on_summary)
+        with _single_config_load():  # one YAML read for should_run_now + get_min_idle_hours
+            if not should_run_now() or (idle_for_seconds is not None and idle_for_seconds < get_min_idle_hours() * 3600.0):
+                return None
+            return run_curator_review(on_summary=on_summary)
     except Exception as e:
         logger.debug("maybe_run_curator failed: %s", e, exc_info=True)
         return None

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -17,6 +18,12 @@ logger = logging.getLogger(__name__)
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
 _skill_commands_home: Optional[str] = None
+# mtime/TTL validity cache for the SKILL.md rescan: within the TTL *and* with
+# unchanged scan-root mtimes, get_skill_commands() returns the cached map
+# instead of re-walking every SKILL.md on disk.
+_SKILL_COMMANDS_TTL_S = 30.0
+_skill_commands_scanned_at: float = 0.0
+_skill_commands_dir_key: Any = None
 # Guards the (map, platform-tag, home-tag) triple so publication and the
 # freshness lookup always see a consistent snapshot. Scanning stays outside.
 _publish_lock = threading.Lock()
@@ -323,6 +330,39 @@ def _scaffold_header(
 _SCAN_SKIP_PARTS = {'.git', '.github', '.hub', '.archive'}
 
 
+def _skill_scan_dir_key() -> Any:
+    """Cheap fingerprint of skill scan roots (path + dir mtime + cwd).
+
+    Project roots depend on the cwd, so it joins the key: a ``cd`` forces a
+    rescan. File *edits* don't bump dir mtime — the TTL bounds that
+    staleness. None when the roots can't be determined (fail-safe: rescan).
+    """
+    try:
+        from tools.skills_tool import _skills_dir
+        from agent.skill_utils import get_external_skills_dirs, get_project_skills_dirs
+        roots = []
+        try:
+            skills_dir = _skills_dir()
+            if skills_dir.exists():
+                roots.append(skills_dir)
+        except Exception:
+            pass
+        roots.extend(get_external_skills_dirs())
+        try:
+            roots.extend(get_project_skills_dirs())
+        except Exception:
+            pass
+        key = [os.getcwd()]
+        for d in roots:
+            try:
+                key.append((str(d), Path(d).stat().st_mtime_ns))
+            except OSError:
+                key.append((str(d), -1))
+        return tuple(key)
+    except Exception:
+        return None
+
+
 def _scan_skill_md(skill_md: Path, disabled: set, seen_names: set, commands: Dict[str, Dict[str, Any]], resolve_command) -> None:
     """Register one SKILL.md in *commands* (no-op when filtered or colliding)."""
     from tools.skills_tool import _parse_frontmatter, skill_matches_platform, skill_matches_environment
@@ -366,6 +406,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     global exposed partial results to overlapping scans, which then logged
     bogus "already claimed" collisions against their own incumbents."""
     global _skill_commands, _skill_commands_platform, _skill_commands_home
+    global _skill_commands_scanned_at, _skill_commands_dir_key
     platform = _resolve_skill_commands_platform()
     home = _resolve_skill_commands_home()
     # Build into a local map and publish once, at the end. Writing straight into the global made a scan's
@@ -410,6 +451,8 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         _skill_commands = commands
         _skill_commands_platform = platform
         _skill_commands_home = home
+        _skill_commands_scanned_at = time.monotonic()
+        _skill_commands_dir_key = _skill_scan_dir_key()
     return commands
 
 
@@ -426,6 +469,16 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     with _publish_lock:
         commands = _skill_commands
         is_fresh = bool(commands) and (_skill_commands_platform, _skill_commands_home) == (current_platform, current_home)
+        if is_fresh:
+            try:
+                fresh = (time.monotonic() - _skill_commands_scanned_at) < _SKILL_COMMANDS_TTL_S
+            except Exception:
+                fresh = False
+            # Within the TTL with unchanged scan-root mtimes the cached map is
+            # returned without re-walking SKILL.md files.
+            if fresh and (dir_key := _skill_scan_dir_key()) is not None and dir_key == _skill_commands_dir_key:
+                return commands
+            is_fresh = False
     # Scan outside the lock — file I/O and deferred imports; concurrent scans
     # are safe since each builds its own map.
     return commands if is_fresh else scan_skill_commands()

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -30,6 +30,7 @@ from rich.progress import BarColumn, MofNCompleteColumn, Progress, SpinnerColumn
 
 from model_tools import TOOL_TO_TOOLSET_MAP
 from run_agent import AIAgent
+from hermes_constants import get_hermes_home
 from toolset_distributions import (
     list_distributions,
     sample_toolsets_from_distribution,
@@ -170,6 +171,53 @@ def _failure_result(prompt_index: int, batch_num: int, error: str) -> Dict[str, 
     }
 
 
+# Memoized docker image probe results: image -> "present" | "pulled" | "unavailable".
+# _process_single_prompt runs per prompt; without this every prompt sharing an
+# image paid a `docker image inspect` (+ maybe a 600s pull timeout window).
+_DOCKER_IMAGE_PROBE_CACHE: Dict[str, str] = {}
+
+
+def _ensure_docker_image(container_image: str, config: Dict[str, Any], prompt_index: int, batch_num: int) -> Optional[Dict[str, Any]]:
+    """Ensure a docker image is available, memoized per image.
+
+    Returns a failure result when the image is unavailable, else None.
+    """
+    cached = _DOCKER_IMAGE_PROBE_CACHE.get(container_image)
+    if cached == "unavailable":
+        return _failure_result(
+            prompt_index, batch_num, f"Docker image not available: {container_image} (cached probe)")
+    if cached in ("present", "pulled"):
+        return None
+    import subprocess as _sp
+    try:
+        probe = _sp.run(
+            ["docker", "image", "inspect", container_image],
+            capture_output=True, timeout=10,
+        )
+        if probe.returncode != 0:
+            if config.get("verbose"):
+                print(f"   Prompt {prompt_index}: Pulling docker image {container_image}...", flush=True)
+            pull = _sp.run(
+                ["docker", "pull", container_image],
+                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=600,
+            )
+            if pull.returncode != 0:
+                _DOCKER_IMAGE_PROBE_CACHE[container_image] = "unavailable"
+                return _failure_result(
+                    prompt_index, batch_num,
+                    f"Docker image not available: {container_image}\n{pull.stderr[:500]}",
+                )
+            _DOCKER_IMAGE_PROBE_CACHE[container_image] = "pulled"
+        else:
+            _DOCKER_IMAGE_PROBE_CACHE[container_image] = "present"
+    except FileNotFoundError:
+        pass  # Docker CLI not installed — skip check (e.g., Modal backend)
+    except Exception as img_err:
+        if config.get("verbose"):
+            print(f"   Prompt {prompt_index}: Docker image check failed: {img_err}", flush=True)
+    return None
+
+
 def _prepare_container_image(
     prompt_index: int, prompt_data: Dict[str, Any], batch_num: int, task_id: str, config: Dict[str, Any]
 ) -> Optional[Dict[str, Any]]:
@@ -185,29 +233,9 @@ def _prepare_container_image(
         return None
     env_type = os.getenv("TERMINAL_ENV", "local")
     if env_type == "docker":
-        import subprocess as _sp
-        try:
-            probe = _sp.run(
-                ["docker", "image", "inspect", container_image],
-                capture_output=True, timeout=10,
-            )
-            if probe.returncode != 0:
-                if config.get("verbose"):
-                    print(f"   Prompt {prompt_index}: Pulling docker image {container_image}...", flush=True)
-                pull = _sp.run(
-                    ["docker", "pull", container_image],
-                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=600,
-                )
-                if pull.returncode != 0:
-                    return _failure_result(
-                        prompt_index, batch_num,
-                        f"Docker image not available: {container_image}\n{pull.stderr[:500]}",
-                    )
-        except FileNotFoundError:
-            pass  # Docker CLI not installed — skip check (e.g., Modal backend)
-        except Exception as img_err:
-            if config.get("verbose"):
-                print(f"   Prompt {prompt_index}: Docker image check failed: {img_err}", flush=True)
+        _img_err = _ensure_docker_image(container_image, config, prompt_index, batch_num)
+        if _img_err is not None:
+            return _img_err
     from tools.terminal_tool import register_task_env_overrides
     overrides = {
         "docker_image": container_image,
@@ -312,6 +340,9 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
     batch_reasoning_stats = dict.fromkeys(_REASONING_KEYS, 0)
     completed_in_batch = []
     discarded_no_reasoning = 0
+    # Buffered trajectory lines — single write at end of batch instead of
+    # opening/appending/fsyncing the file per prompt.
+    _pending_trajectory_lines: List[str] = []
 
     for prompt_index, prompt_data in prompts_to_process:
         result = _process_single_prompt(prompt_index, prompt_data, batch_num, config)
@@ -326,11 +357,11 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
                 # rows for prompt content, so a discarded sample without a row would
                 # be re-run at full cost on every restart. The merge step excludes
                 # tombstones from trajectories.jsonl.
-                _append_jsonl(batch_output_file, {
+                _pending_trajectory_lines.append(json.dumps({
                     "prompt_index": prompt_index,
                     "discarded": "no_reasoning",
                     "prompt": _entry_prompt_text(prompt_data),
-                })
+                }, ensure_ascii=False))
                 continue
 
             # Normalize for a consistent schema across all entries.
@@ -339,7 +370,7 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
                 tool_name: stats.get("failure", 0)
                 for tool_name, stats in raw_tool_stats.items()
             }
-            _append_jsonl(batch_output_file, {
+            _pending_trajectory_lines.append(json.dumps({
                 "prompt_index": prompt_index,
                 "conversations": result["trajectory"],
                 "metadata": result["metadata"],
@@ -349,7 +380,7 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
                 "toolsets_used": result["toolsets_used"],
                 "tool_stats": _normalize_tool_stats(raw_tool_stats),  # {tool: {count, success, failure}}
                 "tool_error_counts": _normalize_tool_error_counts(raw_error_counts)  # {tool: failure_count}
-            })
+            }, ensure_ascii=False))
         _merge_tool_stats(batch_tool_stats, result.get("tool_stats", {}))
         _merge_reasoning_stats(batch_reasoning_stats, result.get("reasoning_stats", {}))
 
@@ -361,6 +392,15 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
         else:
             print(f"   ❌ Prompt {prompt_index} failed (will retry on resume)")
     print(f"✅ Batch {batch_num}: Completed ({len(prompts_to_process)} prompts processed)")
+
+    # Single buffered flush of all trajectory lines for this batch.
+    # fsync preserved (was per-prompt in _append_jsonl): a crash never
+    # loses an acknowledged batch.
+    if _pending_trajectory_lines:
+        with open(batch_output_file, 'a', encoding='utf-8') as f:
+            f.write("\n".join(_pending_trajectory_lines) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
 
     return {
         "batch_num": batch_num,
@@ -445,7 +485,9 @@ class BatchRunner:
 
         if not validate_distribution(distribution):
             raise ValueError(f"Unknown distribution: {distribution}. Available: {list(list_distributions().keys())}")
-        self.output_dir = Path("data") / run_name
+        # Setup output directory (profile-aware: anchored under HERMES_HOME,
+        # never a cwd-relative "data" dir).
+        self.output_dir = get_hermes_home() / "data" / run_name
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.checkpoint_file = self.output_dir / "checkpoint.json"
         self.stats_file = self.output_dir / "statistics.json"

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1283,10 +1283,42 @@ def load_jobs() -> List[Dict[str, Any]]:
     return jobs
 
 
+# Read-path TTL for the peek cache below: bounds how long a corrupt-None
+# (or a stamp that somehow survives a replace) can be served; the stamp
+# itself is the correctness key.
+_PEEK_JOBS_CACHE_TTL_S = 2.0
+_PEEK_JOBS_CACHE: Dict[str, Any] = {"stamp": None, "at": 0.0, "jobs": None}
+
+
 def _peek_jobs_unlocked() -> Optional[List[Dict[str, Any]]]:
     """Repair-free read under ``_jobs_lock()``: ``[]`` if missing, ``None`` if corrupt (never
-    shrink-merge against an unknown baseline). Never saves — that would recurse."""
+    shrink-merge against an unknown baseline). Never saves — that would recurse.
+
+    Stamp-keyed + TTL read cache: every writer uses mkstemp+rename so a stamp
+    of (mtime_ns, size, ino) provably identifies the bytes; a match skips the
+    re-parse on the merge/verify hot path. Invalidated (never refreshed) on
+    save, mirroring the load-stamp rule."""
+    global _PEEK_JOBS_CACHE
     jobs_file = _current_cron_store().jobs_file
+    stamp = _jobs_file_stamp(jobs_file)
+    cached = _PEEK_JOBS_CACHE
+    if (stamp is not None and cached.get("stamp") == stamp
+            and (time.monotonic() - cached.get("at", 0.0)) < _PEEK_JOBS_CACHE_TTL_S):
+        found = cached.get("jobs", _MISSING)
+        return list(found) if isinstance(found, list) else found
+    result = _peek_jobs_uncached(jobs_file)
+    _PEEK_JOBS_CACHE = {"stamp": stamp, "at": time.monotonic(), "jobs": result}
+    return list(result) if isinstance(result, list) else result
+
+
+def _invalidate_peek_cache() -> None:
+    """Drop the peek cache (invalidate, never refresh: a refresh would let a
+    nested save certify disk against an OUTER caller's stale payload)."""
+    global _PEEK_JOBS_CACHE
+    _PEEK_JOBS_CACHE = {"stamp": None, "at": 0.0, "jobs": _MISSING}
+
+
+def _peek_jobs_uncached(jobs_file: Path) -> Optional[List[Dict[str, Any]]]:
     if not jobs_file.exists():
         return []
     try:
@@ -1429,9 +1461,11 @@ def _save_jobs_unlocked(
             # Invalidate (never refresh) the stamp: a refresh would let a nested save certify disk
             # against an OUTER caller's stale payload. Later saves take the full merge (fail-safe).
             _record_load_stamp(None)
+            _invalidate_peek_cache()
             return
     except BaseException:
         _unlink_quiet(tmp_path)
+        _invalidate_peek_cache()
         raise
 
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3765,6 +3765,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     _handle_run_events = _run_route_delegate("_handle_run_events")
     _handle_run_approval = _run_route_delegate("_handle_run_approval")
     _handle_steer_run = _run_route_delegate("_handle_steer_run")
+    _handle_queue_run = _run_route_delegate("_handle_queue_run")
     _handle_stop_run = _run_route_delegate("_handle_stop_run")
 
     async def _sweep_orphaned_runs(self) -> None:

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -8,7 +8,7 @@ import os
 import time
 import uuid
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Callable, Dict, List, Optional
 
 try:
@@ -90,6 +90,10 @@ def _initialize_run_state(self, *, store_factory) -> None:
     self._run_idempotency_ids: set[str] = set()
     self._run_stream_subscribers: set[str] = set()
     self._stopping_run_ids: set[str] = set()
+    # Queued next-turn prompts per run (POST /v1/runs/{id}/queue). Drained
+    # FIFO by the run worker after the current turn finishes, mirroring ACP
+    # queued_prompts.
+    self._run_queues: Dict[str, List[str]] = {}
     (
         self._run_owners, self._run_streams, self._run_streams_created, self._active_run_agents,
         self._active_run_tasks, self._run_statuses, self._run_approval_sessions,
@@ -102,6 +106,7 @@ def _http_routes(self) -> list[tuple[str, str, Any]]:
         ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
         ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
         ("POST", "/v1/runs/{run_id}/steer", self._handle_steer_run),
+        ("POST", "/v1/runs/{run_id}/queue", self._handle_queue_run),
         ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run)]
 
 
@@ -572,6 +577,45 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
             None, lambda: _run_agent_sync(self, run, agent, approval_notify, _api_server=_api_server))
         if not isinstance(result, dict):
             result = {}
+        # Drain POST /v1/runs/{id}/queue items FIFO as chained follow-up
+        # turns (mirrors ACP queued_prompts): each queued prompt runs as a
+        # new user turn with prior turns folded into history; usage
+        # accumulates across turns. Skipped when the turn failed or a stop
+        # landed, so a dead run never starts new work.
+        if not result.get("failed") and not (
+                run_id in self._stopping_run_ids and result.get("interrupted") is True):
+            current_message = run.user_message
+            current_history = list(run.conversation_history)
+            final_response = result.get("final_response", "")
+            while True:
+                pending = self._run_queues.get(run_id)
+                if not pending:
+                    break
+                next_prompt = pending.pop(0)
+                current_history = current_history + [
+                    {"role": "user", "content": current_message},
+                    {"role": "assistant", "content": final_response},
+                ]
+                current_message = next_prompt
+                self._set_run_status(run_id, "running", last_event="run.queued_turn_started")
+                run.put_event(_run_event(
+                    run_id, "run.queued_turn_started", depth_remaining=len(pending)))
+                followup = replace(
+                    run, user_message=current_message, conversation_history=current_history)
+                result, turn_usage = await loop.run_in_executor(
+                    None, lambda: _run_agent_sync(
+                        self, followup, agent, approval_notify, _api_server=_api_server))
+                if not isinstance(result, dict):
+                    result = {}
+                for key in ("input_tokens", "output_tokens", "total_tokens"):
+                    usage[key] = usage.get(key, 0) + turn_usage.get(key, 0)
+                final_response = result.get("final_response", "")
+                run.put_event(_run_event(
+                    run_id, "run.queued_turn_completed", output=final_response,
+                    depth_remaining=len(pending)))
+                if result.get("failed") or (
+                        run_id in self._stopping_run_ids and result.get("interrupted") is True):
+                    break
         if run_id in self._stopping_run_ids and result.get("interrupted") is True:
             _finish("cancelled")
         elif result.get("failed"):
@@ -595,6 +639,8 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
         # On cancellation (/stop) the executor thread may still block on an approval
         # Event; unregistering releases it. Idempotent on normal completion.
         _unregister_approval_notify(run.approval_session_key)
+        # Pending /queue items are dropped on stop/failure with the run.
+        self._run_queues.pop(run_id, None)
         with suppress(Exception):
             run.put_event(None)  # sentinel: close the SSE stream
         _retire_live_run(self, run_id)
@@ -796,6 +842,38 @@ async def _handle_steer_run(self, request: "web.Request", *, _api_server) -> "we
             _openai_error, f"Run did not accept steer text: {run_id}", code="steer_not_accepted", status=409)
     _mark_run_event(self, run_id, "run.steered", accepted=True)
     return web.json_response({"object": "hermes.run.steer", "run_id": run_id, "accepted": True})
+
+
+async def _handle_queue_run(self, request: "web.Request", *, _api_server) -> "web.Response":
+    """POST /v1/runs/{run_id}/queue — queue a prompt as the next turn.
+
+    The prompt runs as a full follow-up turn after the current turn (and any
+    earlier queued items) finishes — FIFO, no merging, no interrupt. Drained
+    by the run worker; progress surfaces as ``run.queued_turn_started`` /
+    ``run.queued_turn_completed`` SSE events. See ``_handle_steer_run`` for
+    the mid-turn alternative.
+    """
+    _openai_error = _api_server._openai_error
+    run_id, _, agent, task, err = _load_owned_run(
+        self, request, _api_server=_api_server, permission=None, active_fallback=True)
+    if err is not None:
+        return err
+    if agent is None and task is None:
+        return _run_not_found(_openai_error, run_id)
+    body, err = await self._read_json_body(request)
+    if err:
+        return err
+    prompt = body.get("prompt", "")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _json_error(
+            _openai_error, "Missing non-empty 'prompt' field; expected 'prompt'.",
+            code="invalid_queue_prompt", status=400)
+    prompt = prompt.strip()
+    self._run_queues.setdefault(run_id, []).append(prompt)
+    depth = len(self._run_queues[run_id])
+    return web.json_response({
+        "object": "hermes.run.queue", "run_id": run_id, "status": "queued",
+        "prompt": prompt, "depth": depth})
 
 
 async def _handle_stop_run(self, request: "web.Request", *, _api_server) -> "web.Response":

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -528,6 +528,16 @@ CREATE INDEX IF NOT EXISTS idx_sessions_system_prompt_hash
 -- a small candidate set before compression-chain and preview hydration.
 CREATE INDEX IF NOT EXISTS idx_sessions_effective_activity
     ON sessions(COALESCE(last_activity_at, started_at) DESC, started_at DESC);
+-- Prune-path covering index: prune_sessions() filters on started_at range +
+-- ended_at IS NOT NULL (+ optional source). Range head on started_at.
+-- Post-reconcile: pre-reconcile tables on old DBs may lack the columns.
+CREATE INDEX IF NOT EXISTS idx_sessions_prune ON sessions(started_at, ended_at, source);
+-- Ghost-prune partial index for prune_empty_ghost_sessions() (source + title
+-- IS NULL + ended_at IS NOT NULL): title is reconciler-added, so this must
+-- live post-reconcile, not in SCHEMA_SQL. Startup-safe: IF NOT EXISTS.
+CREATE INDEX IF NOT EXISTS idx_sessions_ghost_prune
+    ON sessions(source, started_at)
+    WHERE title IS NULL AND ended_at IS NOT NULL;
 """
 
 

--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -282,14 +282,24 @@ class SessionMaintenanceMixin:
                                 if self._write_guards_reject(conn, sid, allow_closed_compression_parent=True)}
             if not session_ids:
                 return 0
-            conn.execute(f"UPDATE sessions SET parent_session_id = NULL "
-                         f"WHERE parent_session_id IN ({_placeholders(session_ids)})", list(session_ids))
-            for sid in session_ids:
-                conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
-                conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
-                removed_ids.append(sid)
+            # Orphan any sessions whose parent is about to be deleted
+            # (chunked IN-lists: SQLite caps bound variables), then batched
+            # set-based deletes instead of one DELETE per session.
+            ids = list(session_ids)
+            _CHUNK = 500
+            for i in range(0, len(ids), _CHUNK):
+                chunk = ids[i:i + _CHUNK]
+                conn.execute(f"UPDATE sessions SET parent_session_id = NULL "
+                             f"WHERE parent_session_id IN ({_placeholders(chunk)})", chunk)
+            for i in range(0, len(ids), _CHUNK):
+                chunk = ids[i:i + _CHUNK]
+                conn.execute(f"DELETE FROM messages WHERE session_id IN ({_placeholders(chunk)})", chunk)
+            for i in range(0, len(ids), _CHUNK):
+                chunk = ids[i:i + _CHUNK]
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({_placeholders(chunk)})", chunk)
+                removed_ids.extend(chunk)
             self._delete_unreferenced_system_prompts(conn)
-            return len(session_ids)
+            return len(ids)
         count = self._execute_write(_do)
         for sid in removed_ids:
             self._remove_session_files(sessions_dir, sid)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -47,21 +47,44 @@ _LIKE_COALESCED_COLUMN_SQL = (
 )
 # ``sort`` -> ORDER BY for the FTS routes; unknown values are rank-only (user input passes through).
 _FTS_ORDER_BY = {"newest": "ORDER BY m.timestamp DESC, rank", "oldest": "ORDER BY m.timestamp ASC, rank"}
-# Indexed neighbor seeks avoid scanning whole sessions for a sparse set of hits.
+# One batched neighbor lookup for every search hit: LAG/LEAD OVER
+# (PARTITION BY session_id ORDER BY timestamp, id) resolve prev/self/next in a
+# single round-trip under one short read hold, instead of one CTE per match
+# (N+1 read txns that serialize gateway readers).
 _CONTEXT_WINDOW_SQL = """WITH target AS (
-    SELECT session_id, timestamp, id FROM messages WHERE id IN ({ids})
-)
-SELECT t.id AS match_id, m.role, m.content
-FROM target t JOIN messages m ON m.id IN (
-    t.id,
-    (SELECT p.id FROM messages p
-     WHERE p.session_id = t.session_id AND (p.timestamp, p.id) < (t.timestamp, t.id)
-     ORDER BY p.timestamp DESC, p.id DESC LIMIT 1),
-    (SELECT n.id FROM messages n
-     WHERE n.session_id = t.session_id AND (n.timestamp, n.id) > (t.timestamp, t.id)
-     ORDER BY n.timestamp, n.id LIMIT 1)
-)
-ORDER BY t.id, m.timestamp, m.id"""
+                            SELECT m.session_id AS session_id,
+                                   m.id AS id,
+                                   m.role AS role,
+                                   m.content AS content,
+                                   LAG(m.id) OVER (
+                                       PARTITION BY m.session_id
+                                       ORDER BY m.timestamp, m.id
+                                   ) AS prev_id,
+                                   LEAD(m.id) OVER (
+                                       PARTITION BY m.session_id
+                                       ORDER BY m.timestamp, m.id
+                                   ) AS next_id
+                            FROM messages m
+                            WHERE m.session_id IN ({sids})
+                        ),
+                        mw AS (
+                            SELECT id, prev_id, next_id FROM target
+                            WHERE id IN ({mids})
+                        )
+                        SELECT target.session_id AS session_id,
+                               target.id AS id,
+                               target.role AS role,
+                               target.content AS content,
+                               mw.id AS match_id,
+                               CASE WHEN target.id = mw.id THEN 0
+                                    WHEN target.id = mw.prev_id THEN -1
+                                    ELSE 1
+                               END AS pos
+                        FROM target
+                        JOIN mw ON target.id = mw.id
+                                OR target.id = mw.prev_id
+                                OR target.id = mw.next_id
+                        ORDER BY match_id, pos"""
 # Unified Ideographs, Extension A, Extension B, CJK Symbols, Hiragana, Katakana, Hangul Syllables.
 _CJK_RANGES = (
     (0x4E00, 0x9FFF), (0x3400, 0x4DBF), (0x20000, 0x2A6DF), (0x3000, 0x303F), (0x3040, 0x309F),
@@ -962,24 +985,28 @@ class SessionSearchMixin:
         self, matches: List[Dict[str, Any]], result_fields: Optional[Collection[str]] = None) -> List[Dict[str, Any]]:
         """Attach neighboring messages in bounded batches, only when context is requested."""
         if result_fields is None or "context" in result_fields:
+            by_match: Dict[Any, list] = {}
             for start in range(0, len(matches), 500):
                 batch = matches[start:start + 500]
-                contexts = {match["id"]: [] for match in batch}
+                match_ids = [m["id"] for m in batch]
+                match_sids = list({m["session_id"] for m in batch})
+                sql = _CONTEXT_WINDOW_SQL.format(
+                    sids=",".join("?" for _ in match_sids),
+                    mids=",".join("?" for _ in match_ids),
+                )
                 try:
-                    sql = _CONTEXT_WINDOW_SQL.format(ids=",".join("?" for _ in contexts))
-                    with self._read_ctx() as conn:
-                        rows = conn.execute(sql, list(contexts)).fetchall()
-                    for row in rows:
-                        contexts[row["match_id"]].append(row)
+                    rows = self._read_all(sql, match_sids + match_ids)
                 except Exception:
-                    contexts = {}
-                for match in batch:
-                    try:
-                        match["context"] = [
-                            {"role": row["role"], "content": _flatten_text(self._decode_content(row["content"]))[:200]}
-                            for row in contexts.get(match["id"], [])]
-                    except Exception:
-                        match["context"] = []
+                    rows = []
+                for row in rows:
+                    by_match.setdefault(row["match_id"], []).append(row)
+            for match in matches:
+                try:
+                    match["context"] = [
+                        {"role": r["role"], "content": _flatten_text(self._decode_content(r["content"]))[:200]}
+                        for r in sorted(by_match.get(match["id"], []), key=lambda r: r["pos"])]
+                except Exception:
+                    match["context"] = []
         # No route selects full content; the pop guards any future one that does.
         for match in matches:
             match.pop("content", None)

--- a/model_tools.py
+++ b/model_tools.py
@@ -68,6 +68,24 @@ _tool_loop = None          # persistent loop for the main (CLI) thread
 _tool_loop_lock = threading.Lock()
 _worker_thread_local = threading.local()  # per-worker-thread persistent loops
 
+# Shared executor for sync->async bridging when a loop is already running
+# (gateway / RL env). Reused across calls instead of a fresh
+# ThreadPoolExecutor(max_workers=1) per tool call.
+_ASYNC_BRIDGE_EXECUTOR = None
+_ASYNC_BRIDGE_EXECUTOR_LOCK = threading.Lock()
+
+
+def _get_async_bridge_executor():
+    """Return the shared bridge executor (created once, never shut down)."""
+    global _ASYNC_BRIDGE_EXECUTOR
+    with _ASYNC_BRIDGE_EXECUTOR_LOCK:
+        if _ASYNC_BRIDGE_EXECUTOR is None:
+            import concurrent.futures
+            _ASYNC_BRIDGE_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+                max_workers=8, thread_name_prefix="hermes-async-bridge",
+            )
+        return _ASYNC_BRIDGE_EXECUTOR
+
 
 def _get_tool_loop():
     """Long-lived event loop for async tool handlers on the main thread."""
@@ -95,9 +113,11 @@ def _run_async(coro):
     except RuntimeError:
         loop = None
     if loop and loop.is_running():
-        # Inside a running loop: run in a fresh thread whose loop we keep a
-        # reference to, so on timeout we can cancel the task inside it
-        # (ThreadPoolExecutor.cancel() is a no-op on a running worker).
+        # Inside a running loop: run in a worker thread of the SHARED bridge
+        # executor (not a fresh ThreadPoolExecutor(max_workers=1) per call)
+        # whose loop we keep a reference to, so on timeout we can cancel the
+        # task inside it (ThreadPoolExecutor.cancel() is a no-op on a running
+        # worker).
         import concurrent.futures
         worker_loop: Optional[asyncio.AbstractEventLoop] = None
         loop_ready = threading.Event()
@@ -120,7 +140,7 @@ def _run_async(coro):
                     pass
                 worker_loop.close()
 
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        pool = _get_async_bridge_executor()
         # Carry profile + approval/sudo context so get_hermes_home() resolves correctly.
         from tools.thread_context import propagate_context_to_thread
         future = pool.submit(propagate_context_to_thread(_run_in_worker))
@@ -135,8 +155,8 @@ def _run_async(coro):
                 except RuntimeError:
                     pass  # loop already closed
             raise
-        finally:
-            pool.shutdown(wait=False)  # never block the caller on a stuck coroutine
+        # NOTE: shared executor — never shut down here. The previous
+        # per-call pool.shutdown(wait=False) is gone with the per-call pool.
 
     if threading.current_thread() is not threading.main_thread():
         return _get_worker_loop().run_until_complete(coro)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextvars
 import functools
+import hashlib
 import inspect
 import json
 import logging
@@ -972,6 +973,10 @@ class SlackAdapter(BasePlatformAdapter):
         # start time is the grace window for the first ping/pong.
         self._app_token: Optional[str] = None
         self._proxy_url: Optional[str] = None
+        # Per bot-token lock identities (sha256 hex digests, never raw
+        # secrets) for multi-workspace. Released together with the
+        # app-token platform lock by _release_slack_locks().
+        self._bot_token_lock_identities: List[str] = []
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_handler_started_monotonic: Optional[float] = None
@@ -1633,6 +1638,32 @@ class SlackAdapter(BasePlatformAdapter):
             if not self._acquire_platform_lock("slack-app-token", app_token, "Slack app token"):
                 return False
             lock_acquired = True
+            # Drop the previous set first so a reconnect with rotated tokens
+            # never orphans locks (self-owned, so the reacquire below is instant).
+            self._release_bot_token_locks()
+            # Per bot-token lock for multi-workspace: every workspace token
+            # is a distinct bot identity. Prevents two local gateways from
+            # sharing any one workspace token. Identities are sha256-hashed
+            # before use — no secret material ever hits disk (cf. line adapter).
+            from gateway.status import acquire_scoped_lock
+            for _tok in bot_tokens:
+                _identity = hashlib.sha256(_tok.encode("utf-8")).hexdigest()[:16]
+                _acquired, _existing = acquire_scoped_lock(
+                    "slack-bot-token", _identity,
+                    metadata={"platform": self.platform.value},
+                )
+                if not _acquired:
+                    _owner = _existing.get("pid") if isinstance(_existing, dict) else None
+                    _msg = (
+                        "Slack bot token already in use"
+                        + (f" (PID {_owner})" if _owner else "")
+                        + ". Stop the other gateway first."
+                    )
+                    logger.error("[%s] %s", self.name, _msg)
+                    self._set_fatal_error("slack-bot-token_lock", _msg, retryable=False)
+                    self._release_bot_token_locks()
+                    return False
+                self._bot_token_lock_identities.append(_identity)
             self._running = False
             # Cancel AND await the old watchdog so it can't see _running=False,
             # exit, and leave no monitor behind.
@@ -1679,7 +1710,22 @@ class SlackAdapter(BasePlatformAdapter):
             return False
         finally:
             if lock_acquired and not self._running:
-                self._release_platform_lock()
+                self._release_slack_locks()
+
+    def _release_bot_token_locks(self) -> None:
+        """Release held per-bot-token locks (sha256 identities, no secrets)."""
+        from gateway.status import release_scoped_lock
+        for _held in getattr(self, "_bot_token_lock_identities", []):
+            try:
+                release_scoped_lock("slack-bot-token", _held)
+            except Exception:
+                logger.debug("[%s] Failed to release bot-token lock", self.name, exc_info=True)
+        self._bot_token_lock_identities = []
+
+    def _release_slack_locks(self) -> None:
+        """Release per-bot-token locks plus the app-token platform lock."""
+        self._release_bot_token_locks()
+        self._release_platform_lock()
 
     def _fatal_missing_env(self, env_name: str) -> None:
         """Log + record the permanent config error for a missing SLACK_* token."""
@@ -1752,7 +1798,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._app = self._app_token = self._proxy_url = self._bot_user_id = None
         self._team_clients, self._team_bot_user_ids = {}, {}
         self._channel_team, self._dm_conversation_cache = {}, {}
-        self._release_platform_lock()
+        self._release_slack_locks()
         logger.info("[Slack] Disconnected")
 
     @staticmethod

--- a/tests/gateway/test_api_server_runs_extraction.py
+++ b/tests/gateway/test_api_server_runs_extraction.py
@@ -176,6 +176,7 @@ def test_roomlink_and_run_route_tuples_are_shard_owned():
         ("GET", "/v1/runs/{run_id}/events"),
         ("POST", "/v1/runs/{run_id}/approval"),
         ("POST", "/v1/runs/{run_id}/steer"),
+        ("POST", "/v1/runs/{run_id}/queue"),
         ("POST", "/v1/runs/{run_id}/stop"),
     ]
     assert all(handler.__self__ is adapter for _, _, handler in room_routes)

--- a/tests/gateway/test_runs_queue_ported.py
+++ b/tests/gateway/test_runs_queue_ported.py
@@ -1,0 +1,240 @@
+"""Ported behavioral pins for POST /v1/runs/{run_id}/queue + CORS session header.
+
+Adapted from the old-branch pins (``tests/gateway/test_runs_steer_queue.py`` @
+c861dcd0e8) to the new tree's wire shapes:
+
+- queue response: ``{object: hermes.run.queue, run_id, status: queued, prompt, depth}``
+- queue errors: 404 ``run_not_found`` / 400 ``invalid_queue_prompt``
+- ownership via ``_claim_run`` + live agent/task (``_load_owned_run``,
+  ``active_fallback=True``)
+- drain: ``_execute_run`` drains ``_run_queues`` FIFO as chained follow-up
+  turns with ``run.queued_turn_started`` / ``run.queued_turn_completed`` SSE
+  events (mirrors ACP ``queued_prompts``)
+"""
+
+import asyncio
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms import api_server_runs
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _CORS_HEADERS,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _claim_run(adapter: APIServerAdapter, run_id: str) -> None:
+    request = MagicMock()
+    request.headers = {}
+    adapter._run_owners[run_id] = adapter._run_idempotency_scope(request)
+
+
+def _create_queue_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs/{run_id}/queue", adapter._handle_queue_run)
+    return app
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+@pytest.fixture
+def auth_adapter():
+    return _make_adapter(api_key="sk-secret")
+
+
+def _live_run(adapter: APIServerAdapter, run_id: str) -> None:
+    """Stage a live run the queue handler admits: owned + agent + task."""
+    adapter._active_run_agents[run_id] = MagicMock()
+    adapter._active_run_tasks[run_id] = MagicMock()
+    _claim_run(adapter, run_id)
+
+
+class TestQueueRunEndpoint:
+    @pytest.mark.asyncio
+    async def test_queue_accepted(self, adapter):
+        _live_run(adapter, "run_1")
+        app = _create_queue_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs/run_1/queue", json={"prompt": "follow up"})
+            assert resp.status == 200
+            body = await resp.json()
+        assert body == {
+            "object": "hermes.run.queue",
+            "run_id": "run_1",
+            "status": "queued",
+            "prompt": "follow up",
+            "depth": 1,
+        }
+        assert adapter._run_queues["run_1"] == ["follow up"]
+
+    @pytest.mark.asyncio
+    async def test_queue_fifo_depth(self, adapter):
+        _live_run(adapter, "run_1")
+        app = _create_queue_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post("/v1/runs/run_1/queue", json={"prompt": "first"})
+            assert (await first.json())["depth"] == 1
+            second = await cli.post("/v1/runs/run_1/queue", json={"prompt": "second"})
+            body = await second.json()
+        assert body["depth"] == 2
+        assert adapter._run_queues["run_1"] == ["first", "second"]
+
+    @pytest.mark.asyncio
+    async def test_queue_unknown_run_404(self, adapter):
+        app = _create_queue_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs/nope/queue", json={"prompt": "x"})
+            assert resp.status == 404
+            body = await resp.json()
+        assert body["error"]["code"] == "run_not_found"
+
+    @pytest.mark.asyncio
+    async def test_queue_empty_prompt_400(self, adapter):
+        _live_run(adapter, "run_1")
+        app = _create_queue_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            for bad in ({}, {"prompt": ""}, {"prompt": "   "}, {"prompt": 123}):
+                resp = await cli.post("/v1/runs/run_1/queue", json=bad)
+                assert resp.status == 400
+                assert (await resp.json())["error"]["code"] == "invalid_queue_prompt"
+        assert adapter._run_queues.get("run_1", []) == []
+
+    @pytest.mark.asyncio
+    async def test_queue_requires_auth(self, auth_adapter):
+        app = _create_queue_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs/run_1/queue", json={"prompt": "x"})
+            assert resp.status == 401
+
+
+class TestQueueFifoDrain:
+    @pytest.mark.asyncio
+    async def test_drain_runs_queued_prompts_as_chained_turns_fifo(self, adapter):
+        """Queued prompts drain FIFO as chained turns: each runs with prior
+        turns folded into history, usage accumulates, and progress surfaces
+        as run.queued_turn_started/completed SSE events."""
+        run_id = "run_q"
+        q: asyncio.Queue = asyncio.Queue()
+        adapter._run_streams[run_id] = q
+        adapter._run_streams_created[run_id] = time.time()
+        adapter._run_queues[run_id] = ["second", "third"]
+
+        launch = api_server_runs._RunLaunch(
+            owner=adapter,
+            run_id=run_id,
+            queue=q,
+            session_id="sess-1",
+            gateway_session_key=None,
+            declared_selected=False,
+            user_message="first",
+            conversation_history=[],
+            agent_kwargs={},
+            request_profile=None,
+            browser_control_principal=None,
+            browser_control_transport_family=None,
+        )
+
+        seen_messages = []
+        seen_histories = []
+
+        def _fake_sync(self, run, agent, approval_notify, *, _api_server):
+            seen_messages.append(run.user_message)
+            seen_histories.append(list(run.conversation_history))
+            n = len(seen_messages)
+            return (
+                {"final_response": f"r{n}"},
+                {"input_tokens": n, "output_tokens": 2 * n, "total_tokens": 3 * n},
+            )
+
+        mock_agent = MagicMock()
+        import gateway.platforms.api_server as api_server_mod
+
+        with (
+            patch.object(adapter, "_create_agent", return_value=mock_agent),
+            patch.object(api_server_runs, "_run_agent_sync", _fake_sync),
+        ):
+            await api_server_runs._execute_run(adapter, launch, _api_server=api_server_mod)
+
+        # FIFO: initial turn first, then queued prompts in order.
+        assert seen_messages == ["first", "second", "third"]
+        # Each follow-up folds prior turns into history (user/assistant pairs).
+        assert seen_histories[1] == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "r1"},
+        ]
+        assert seen_histories[2] == seen_histories[1] + [
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "r2"},
+        ]
+
+        events = []
+        while not q.empty():
+            events.append(q.get_nowait())
+        names = [e["event"] for e in events if e is not None]
+        assert names == [
+            "run.queued_turn_started",
+            "run.queued_turn_completed",
+            "run.queued_turn_started",
+            "run.queued_turn_completed",
+            "run.completed",
+        ]
+        started = [e for e in events if e is not None and e["event"] == "run.queued_turn_started"]
+        assert [e["depth_remaining"] for e in started] == [1, 0]
+        completed = [e for e in events if e is not None and e["event"] == "run.queued_turn_completed"]
+        assert [e["output"] for e in completed] == ["r2", "r3"]
+
+        # Usage accumulates across all turns; queue state is dropped with the run.
+        assert adapter._run_statuses[run_id]["usage"] == {
+            "input_tokens": 6,
+            "output_tokens": 12,
+            "total_tokens": 18,
+        }
+        assert run_id not in adapter._run_queues
+
+
+class TestCorsSessionHeader:
+    def test_allow_headers_include_session_id(self):
+        """Browser clients must be allowed to send X-Hermes-Session-Id."""
+        assert "X-Hermes-Session-Id" in _CORS_HEADERS["Access-Control-Allow-Headers"]
+
+    @pytest.mark.asyncio
+    async def test_preflight_echoes_session_id_header(self):
+        adapter = APIServerAdapter(
+            PlatformConfig(enabled=True, extra={"cors_origins": ["http://localhost:3000"]})
+        )
+        app = _create_queue_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.options(
+                "/v1/runs/run_1/queue",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "X-Hermes-Session-Id",
+                },
+            )
+            assert resp.status == 200
+            assert (
+                resp.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+            )
+            assert "X-Hermes-Session-Id" in resp.headers.get(
+                "Access-Control-Allow-Headers", ""
+            )

--- a/tests/gateway/test_slack_bot_token_locks.py
+++ b/tests/gateway/test_slack_bot_token_locks.py
@@ -1,0 +1,158 @@
+"""Ported behavioral pins for Slack per-bot-token locks (multi-workspace).
+
+connect() acquires one ``slack-bot-token`` scoped lock per workspace token
+(sha256-hex identity, never raw token material) plus the app-token platform
+lock; a failed workspace acquire releases the already-held locks and fails
+closed; disconnect() releases everything.
+"""
+
+import asyncio
+import contextlib
+import hashlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+import plugins.platforms.slack.adapter as _slack_mod
+
+_slack_mod.SLACK_AVAILABLE = True
+from plugins.platforms.slack.adapter import SlackAdapter  # noqa: E402
+
+
+def _noop_decorator(_matcher):
+    def decorator(fn):
+        return fn
+
+    return decorator
+
+
+def _fake_create_task(coro):
+    assert asyncio.iscoroutine(coro), f"expected coroutine, got {type(coro).__name__}"
+    coro.close()
+    loop = asyncio.get_event_loop()
+    return loop.create_task(asyncio.Event().wait())
+
+
+def _make_workspace_client(team_id, user_id, name):
+    client = AsyncMock()
+    client.auth_test = AsyncMock(
+        return_value={"user_id": user_id, "user": name, "team_id": team_id, "team": name}
+    )
+    return client
+
+
+class FakeSocketModeHandler:
+    def __init__(self, app, app_token, proxy=None):
+        self.app = app
+        self.app_token = app_token
+        self.client = MagicMock(proxy=None)
+
+    async def start_async(self):
+        return None
+
+    async def close_async(self):
+        return None
+
+
+def _connect_stack(acquire):
+    mock_app = MagicMock()
+    mock_app.event = _noop_decorator
+    mock_app.command = _noop_decorator
+    mock_app.action = _noop_decorator
+    mock_app.client = AsyncMock()
+    calls = {"n": 0}
+
+    def _new_client(*args, **kwargs):
+        # 1st call: primary AsyncApp client; then one workspace client per token.
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return AsyncMock()
+        if calls["n"] == 2:
+            return _make_workspace_client("T_A", "U_A", "a")
+        return _make_workspace_client("T_B", "U_B", "b")
+    return [
+        patch.object(_slack_mod, "AsyncApp", return_value=mock_app),
+        patch.object(
+            _slack_mod,
+            "AsyncWebClient",
+            side_effect=_new_client,
+        ),
+        patch.object(_slack_mod, "AsyncSocketModeHandler", FakeSocketModeHandler),
+        patch.object(_slack_mod, "get_secret", return_value="xapp-test"),
+        patch("gateway.status.acquire_scoped_lock", side_effect=acquire),
+        patch("asyncio.create_task", side_effect=_fake_create_task),
+    ]
+
+
+def _digest(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+
+
+class TestSlackBotTokenLocks:
+    @pytest.mark.asyncio
+    async def test_multi_workspace_acquires_one_lock_per_token(self):
+        """Two workspace tokens → two slack-bot-token locks keyed by
+        sha256 hex digests; raw tokens never stored on the adapter."""
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-A,xoxb-B"))
+        adapter._socket_watchdog_interval_s = 9999
+        acquired = []
+
+        def _acquire(scope, identity, **kwargs):
+            acquired.append((scope, identity))
+            return (True, None)
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("gateway.status.release_scoped_lock"))
+            for p in _connect_stack(_acquire):
+                stack.enter_context(p)
+            assert await adapter.connect() is True
+
+        bot_locks = [ident for scope, ident in acquired if scope == "slack-bot-token"]
+        assert bot_locks == [_digest("xoxb-A"), _digest("xoxb-B")]
+        assert adapter._bot_token_lock_identities == bot_locks
+        assert "xoxb-A" not in repr(adapter._bot_token_lock_identities)
+        assert "xoxb-B" not in repr(adapter._bot_token_lock_identities)
+
+    @pytest.mark.asyncio
+    async def test_second_token_conflict_releases_first_and_fails_closed(self):
+        """A conflicting second workspace token releases the first lock and
+        connect() returns False (fail closed, no half-held state)."""
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-A,xoxb-B"))
+        adapter._socket_watchdog_interval_s = 9999
+
+        def _acquire(scope, identity, **kwargs):
+            if scope == "slack-bot-token" and identity == _digest("xoxb-B"):
+                return (False, {"pid": 4242})
+            return (True, None)
+
+        with contextlib.ExitStack() as stack:
+            mock_release = stack.enter_context(patch("gateway.status.release_scoped_lock"))
+            for p in _connect_stack(_acquire):
+                stack.enter_context(p)
+            assert await adapter.connect() is False
+
+        released = [c.args[1] for c in mock_release.call_args_list if c.args[0] == "slack-bot-token"]
+        assert _digest("xoxb-A") in released
+        assert adapter._bot_token_lock_identities == []
+
+    @pytest.mark.asyncio
+    async def test_disconnect_releases_all_bot_token_locks(self):
+        adapter = SlackAdapter(PlatformConfig(enabled=True, token="xoxb-A,xoxb-B"))
+        adapter._socket_watchdog_interval_s = 9999
+
+        def _acquire(scope, identity, **kwargs):
+            return (True, None)
+
+        with contextlib.ExitStack() as stack:
+            mock_release = stack.enter_context(patch("gateway.status.release_scoped_lock"))
+            for p in _connect_stack(_acquire):
+                stack.enter_context(p)
+            assert await adapter.connect() is True
+            assert adapter._bot_token_lock_identities == [_digest("xoxb-A"), _digest("xoxb-B")]
+            await adapter.disconnect()
+
+        released = [c.args[1] for c in mock_release.call_args_list if c.args[0] == "slack-bot-token"]
+        assert sorted(released) == sorted([_digest("xoxb-A"), _digest("xoxb-B")])
+        assert adapter._bot_token_lock_identities == []

--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -8,7 +8,7 @@ gate in :mod:`tools.approval`.
 import contextvars
 import logging
 import os
-from hermes_cli.config import cfg_get
+import time
 from utils import env_var_enabled, is_truthy_value
 
 logger = logging.getLogger("tools.approval")
@@ -196,6 +196,12 @@ def _should_fall_through_to_cli_approval(*, is_cli: bool, approval_callback, not
 
 _VALID_MODES = ("manual", "smart", "off")
 
+# mtime/TTL cache for the approvals config block (~5s). Avoids a YAML
+# parse per terminal command; load_config_readonly() itself is mtime-cached
+# but this skips even the merge/copy on hot paths.
+_APPROVAL_CONFIG_TTL_S = 5.0
+_APPROVAL_CONFIG_CACHE: dict = {"key": None, "at": 0.0, "value": {}}
+
 
 def _normalize_approval_mode(mode) -> str:
     """Normalize approval mode values loaded from YAML/config. YAML 1.1 parses a
@@ -216,10 +222,29 @@ def _normalize_approval_mode(mode) -> str:
 
 def _get_approval_config() -> dict:
     """Read the approvals config block: the LIVE config-cache sub-dict
-    (load_config_readonly contract) — callers must not mutate it or any nested structure."""
+    (load_config_readonly contract) — callers must not mutate it or any nested structure.
+
+    mtime/size + ~5s TTL cached so per-terminal-command checks don't re-parse
+    YAML every call. Returns a copy; callers must not mutate the result."""
+    global _APPROVAL_CONFIG_CACHE
     try:
         from hermes_cli.config import load_config_readonly
-        return load_config_readonly().get("approvals", {}) or {}
+        from hermes_constants import get_hermes_home
+        now = time.monotonic()
+        cached = _APPROVAL_CONFIG_CACHE
+        try:
+            st = (get_hermes_home() / "config.yaml").stat()
+            cfg_key = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            cfg_key = None
+        if (isinstance(cached.get("value"), dict) and cached.get("key") == cfg_key
+                and cfg_key is not None and (now - cached.get("at", 0.0)) < _APPROVAL_CONFIG_TTL_S):
+            return dict(cached["value"])
+        value = load_config_readonly().get("approvals", {}) or {}
+        if not isinstance(value, dict):
+            value = {}
+        _APPROVAL_CONFIG_CACHE = {"key": cfg_key, "at": now, "value": dict(value)}
+        return dict(value)
     except Exception as e:
         logger.warning("Failed to load approval config: %s", e)
         return {}
@@ -260,8 +285,7 @@ def _get_approval_timeout() -> int:
 def _binary_approval_mode(key: str) -> str:
     """Read ``approvals.<key>`` as 'approve' or 'deny' (default deny)."""
     try:
-        from hermes_cli.config import load_config_readonly
-        mode = str(cfg_get(load_config_readonly(), "approvals", key, default="deny")).lower().strip()
+        mode = str(_get_approval_config().get(key, "deny")).lower().strip()
         return "approve" if mode in {"approve", "off", "allow", "yes"} else "deny"
     except Exception:
         return "deny"

--- a/tools/delegate_tool_results.py
+++ b/tools/delegate_tool_results.py
@@ -10,6 +10,10 @@ from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger("tools.delegate_tool")  # log-record parity with the origin module
 
+# Bounded scan window for _extract_output_tail: only the tail of the
+# child's conversation is ever inspected (overlay shows last N results).
+_TAIL_SCAN_WINDOW = 400
+
 def _stringify_tool_content(content: Any) -> str:
     """Stable text for tool-result content. Some OpenAI-compatible paths return
     content-block lists; observability must never crash on them."""
@@ -51,17 +55,24 @@ def _extract_output_tail(result: Dict[str, Any], *, max_entries: int = 12, max_c
     """Last N tool-call results ``{tool, preview, is_error}`` from a child's conversation (the overlay's "Output"
     section), chronological order. Content blocks are flattened first so a block-wrapped "Error: ..." is still
     flagged; line structure is preserved (capped at ``max_chars``) so the overlay shows real output rather than a
-    whitespace-collapsed blob."""
+    whitespace-collapsed blob.
+
+    Bounded reverse-window scan: only the last _TAIL_SCAN_WINDOW messages are
+    ever inspected (the overlay shows the last N results, so scanning the whole
+    history is waste); the name-resolution forward pass walks that same window."""
     messages = result.get("messages") if isinstance(result, dict) else None
     if not isinstance(messages, list):
         return []
+    # Bounded window from the tail — the overlay only shows the last
+    # max_entries tool results, so scanning the whole history is waste.
+    window = messages[-_TAIL_SCAN_WINDOW:] if len(messages) > _TAIL_SCAN_WINDOW else messages
     name_by_call_id = {
         tc["id"]: str((tc.get("function") or {}).get("name") or "tool")
-        for msg in messages if isinstance(msg, dict) and msg.get("role") == "assistant"
+        for msg in window if isinstance(msg, dict) and msg.get("role") == "assistant"
         for tc in msg.get("tool_calls") or [] if tc.get("id")
     }
     tail: List[Dict[str, Any]] = []
-    for msg in reversed(messages):  # newest first, then restore order below
+    for msg in reversed(window):  # newest first, then restore order below
         if len(tail) >= max_entries:
             break
         if not isinstance(msg, dict) or msg.get("role") != "tool":

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -91,17 +91,116 @@ def _is_compaction_summary(content: str) -> bool:
 def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
     """Walk parent_session_id to the root -> ``(root_id, has_compression_hop)``; the flag
     separates a compression-split lineage (parent summarised away) from a delegation
-    lineage (child still visible to the parent)."""
+    lineage (child still visible to the parent). Depth-bounded (25 hops)."""
     visited: set[str] = set()
     cur, has_compression = session_id, False
-    while cur and cur not in visited:
+    depth = 0
+    while cur and cur not in visited and depth < 25:
         visited.add(cur)
+        depth += 1
         s = _get_session_meta(db, cur)
         has_compression = has_compression or s.get("end_reason") == "compression"
         if not s.get("parent_session_id"):
             break
         cur = s["parent_session_id"]
     return cur, has_compression
+
+
+def _batch_parent_map(db, session_ids) -> Optional[Dict[str, Any]]:
+    """``{id: parent_session_id}`` via a single ``WHERE id IN`` query; None when
+    the fast path is unavailable (non-SQL store) so callers fall back to
+    per-id lookups."""
+    ids = [s for s in dict.fromkeys(session_ids) if s]
+    if not ids:
+        return {}
+    try:
+        conn = getattr(db, "_conn", None)
+        if conn is None:
+            return None
+        placeholders = ",".join("?" for _ in ids)
+        lock = getattr(db, "_lock", None)
+        stmt = "SELECT id, parent_session_id FROM sessions WHERE id IN (%s)" % placeholders
+        if lock is not None:
+            with lock:
+                rows = conn.execute(stmt, ids).fetchall()
+        else:
+            rows = conn.execute(stmt, ids).fetchall()
+        return {r["id"]: r["parent_session_id"] for r in rows}
+    except Exception:
+        logging.debug("Batched lineage lookup failed, falling back", exc_info=True)
+        return None
+
+
+def _resolve_many_to_parents(db, seed_ids) -> Dict[str, str]:
+    """Resolve each seed id to its lineage root, batched: parent links for the
+    whole result set are fetched with one ``WHERE id IN`` per frontier level
+    instead of one ``get_session`` per chain link per result. Falls back to a
+    memoized per-id walk when the fast path is unavailable."""
+    seeds = [s for s in dict.fromkeys(seed_ids) if s]
+    parent_of: Dict[str, Any] = {}
+    frontier = list(seeds)
+    depth, batched_ok = 0, True
+    while frontier and depth < 25:
+        batch = _batch_parent_map(db, frontier)
+        if batch is None:
+            batched_ok = False
+            break
+        nxt: list = []
+        missing: list = []
+        for sid in frontier:
+            if sid in parent_of:
+                continue
+            if sid in batch:
+                parent = batch[sid]
+                parent_of[sid] = parent
+                if parent and parent not in parent_of and parent not in nxt:
+                    nxt.append(parent)
+            else:
+                missing.append(sid)
+        for sid in missing:  # unknown session or non-SQL store: one memoized lookup per id
+            s = _get_session_meta(db, sid)
+            parent = s.get("parent_session_id") if s else None
+            parent_of[sid] = parent
+            if parent and parent not in parent_of and parent not in nxt:
+                nxt.append(parent)
+        frontier = nxt
+        depth += 1
+    if batched_ok:
+        roots: Dict[str, str] = {}
+        for sid in seeds:
+            seen: set = set()
+            cur = sid
+            while cur and cur not in seen:
+                seen.add(cur)
+                parent = parent_of.get(cur)
+                if not parent:
+                    break
+                cur = parent
+            roots[sid] = cur
+        return roots
+    shared_cache: Dict[str, str] = {}  # fallback: memoized per-id walk, one cache across seeds
+
+    def _walk(sid: str) -> str:
+        if sid in shared_cache:
+            return shared_cache[sid]
+        visited: set = set()
+        cur, trail = sid, []
+        while cur and cur not in visited:
+            if cur in shared_cache:
+                cur = shared_cache[cur]
+                break
+            visited.add(cur)
+            trail.append(cur)
+            s = _get_session_meta(db, cur)
+            parent = s.get("parent_session_id") if s else None
+            if not parent:
+                break
+            cur = parent
+        for t in trail:
+            shared_cache[t] = cur
+        return cur
+
+    return {sid: _walk(sid) for sid in seeds}
 
 
 def _resolve_lineage(db, session_id: str) -> str:
@@ -283,6 +382,14 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
     results = [title_result] if title_result else []
     if title_result and (title_lineage := title_result.pop("_lineage_root", None)):
         seen_sessions[title_lineage] = {"_title_only": True}
+    # Batched lineage pre-resolution: one WHERE id IN per frontier level for
+    # the whole FTS set instead of one get_session per chain link per row.
+    lineage_seeds = [r.get("session_id") for r in raw_results if r.get("session_id")]
+    if current_session_id and current_session_id not in lineage_seeds:
+        lineage_seeds.append(current_session_id)
+    _resolved_roots = _resolve_many_to_parents(db, lineage_seeds)
+    if current_session_id:
+        current_lineage_root = _resolved_roots.get(current_session_id, current_session_id)
     # Dedupe by lineage (lineage_root -> first surviving FTS row) up to `limit`. The raw
     # owning session_id stays on the row — only it pairs validly with the FTS match id.
     # Current-lineage hits are skipped UNLESS the transcript left live context
@@ -291,7 +398,8 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
     for r in raw_results:
         if len(seen_sessions) >= limit:
             break
-        raw_sid, resolved_sid = r["session_id"], _resolve_lineage(db, r["session_id"])
+        raw_sid = r["session_id"]
+        resolved_sid = _resolved_roots.get(raw_sid, raw_sid)
         # Skip the current session lineage — UNLESS the hit's transcript has left live context. Three
         # sub-cases: Legacy compression rotation: the FTS hit lives in a session that itself ended with
         # end_reason='compression'. That session's content has been replaced by a summary in the
@@ -374,11 +482,14 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
                       session_id)
     if err:
         return err
-    shaped = [_shape_message(m) for m in rows]
-    total, truncated = len(shaped), len(shaped) > head + tail
+    total, truncated = len(rows), len(rows) > head + tail
+    # Cap BEFORE formatting so a giant session doesn't shape thousands of
+    # rows just to slice them away below.
+    shown = rows[:head] + rows[-tail:] if truncated else rows
+    shaped = [_shape_message(m) for m in shown]
     return _ok(mode="read", session_id=session_id, link=_session_link(session_id, link_profile),
                session_meta=_session_meta_block(meta), message_count=total, truncated=truncated,
-               messages=shaped[:head] + shaped[-tail:] if truncated else shaped,
+               messages=shaped,
                **({"message": (f"Session has {total} messages; showing first {head} + last {tail}. "
                                "Pass around_message_id (any id above) to scroll the middle.")} if truncated else {}))
 

--- a/ui-tui/src/components/agentsOverlay.tsx
+++ b/ui-tui/src/components/agentsOverlay.tsx
@@ -304,9 +304,20 @@ function Field({ name, t, value }: { name: string; t: Theme; value: ReactNode })
   )
 }
 
+// Max rows rendered for Tool calls / Output tails before collapsing
+// behind a "show more" toggle (ScrollBox layout blowup guard).
+const DETAIL_LIST_CAP = 50
+
 function Detail({ id, node, t }: { id?: string; node: SubagentNode; t: Theme }) {
   const { aggregate: agg, item } = node
   const { color, glyph } = statusGlyph(item, t)
+
+  // ScrollBox blowup guard: cap long tool/output tails (see DETAIL_LIST_CAP).
+  const [showAllLists, setShowAllLists] = useState(false)
+
+  useEffect(() => {
+    setShowAllLists(false)
+  }, [node.item.id])
 
   const inputTokens = item.inputTokens ?? 0
   const outputTokens = item.outputTokens ?? 0
@@ -320,6 +331,11 @@ function Detail({ id, node, t }: { id?: string; node: SubagentNode; t: Theme }) 
   // that stream is often empty even when tool_count > 0, so fall back to
   // the tool names captured in outputTail at subagent.complete time.
   const toolLines = item.tools.length > 0 ? item.tools : outputTail.map(e => e.tool).filter(Boolean)
+
+  const shownTools = showAllLists ? toolLines : toolLines.slice(0, DETAIL_LIST_CAP)
+  const shownOutput = showAllLists ? outputTail : outputTail.slice(0, DETAIL_LIST_CAP)
+  const hiddenTools = toolLines.length - shownTools.length
+  const hiddenOutput = outputTail.length - shownOutput.length
 
   const filesOverflow = Math.max(0, filesRead.length - 8) + Math.max(0, filesWritten.length - 8)
 
@@ -384,17 +400,26 @@ function Detail({ id, node, t }: { id?: string; node: SubagentNode; t: Theme }) 
 
       {toolLines.length > 0 ? (
         <OverlaySection count={toolLines.length} defaultOpen t={t} title="Tool calls">
-          {toolLines.map((line, i) => (
+          {shownTools.map((line, i) => (
             <Text color={t.color.text} key={i} wrap="wrap">
               <Text color={t.color.muted}>·</Text> {line}
             </Text>
           ))}
+          {hiddenTools > 0 ? (
+            <Box onClick={() => setShowAllLists(true)}>
+              <Text color={t.color.muted}>…+{hiddenTools} more — show more</Text>
+            </Box>
+          ) : showAllLists && toolLines.length > DETAIL_LIST_CAP ? (
+            <Box onClick={() => setShowAllLists(false)}>
+              <Text color={t.color.muted}>show less</Text>
+            </Box>
+          ) : null}
         </OverlaySection>
       ) : null}
 
       {outputTail.length > 0 ? (
         <OverlaySection count={outputTail.length} defaultOpen t={t} title="Output">
-          {outputTail.map((entry, i) => (
+          {shownOutput.map((entry, i) => (
             <Text color={entry.isError ? t.color.error : t.color.text} key={i} wrap="wrap">
               <Text bold color={entry.isError ? t.color.error : t.color.accent}>
                 {entry.tool}
@@ -402,6 +427,15 @@ function Detail({ id, node, t }: { id?: string; node: SubagentNode; t: Theme }) 
               {entry.preview}
             </Text>
           ))}
+          {hiddenOutput > 0 ? (
+            <Box onClick={() => setShowAllLists(true)}>
+              <Text color={t.color.muted}>…+{hiddenOutput} more — show more</Text>
+            </Box>
+          ) : showAllLists && outputTail.length > DETAIL_LIST_CAP ? (
+            <Box onClick={() => setShowAllLists(false)}>
+              <Text color={t.color.muted}>show less</Text>
+            </Box>
+          ) : null}
         </OverlaySection>
       ) : null}
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -120,11 +120,13 @@ export const busyIndicatorWidth = (style: IndicatorStyle, hasDuration: boolean):
 }
 
 function FaceTicker({
+  active = true,
   color,
   startedAt,
   style,
   verbOverride
 }: {
+  active?: boolean
   color: string
   startedAt?: null | number
   style: IndicatorStyle
@@ -152,7 +154,10 @@ function FaceTicker({
     // is revealed again and re-seeds `now` from the wall clock, so the elapsed
     // read-out resumes live rather than frozen at the moment it was covered.
     // See `$isStatusRuleOccluded` for why this is NOT `$isBlocked`.
-    if (isOccluded) {
+    // Paused when inactive too (idle turn unmounts us, but this also guards
+    // programmatic renders) so the glyph, 1s clock, and 2.5s verb timers
+    // never tick in the background.
+    if (!active || isOccluded) {
       return
     }
 
@@ -173,7 +178,7 @@ function FaceTicker({
         clearInterval(verb)
       }
     }
-  }, [displayVerb, freezeVerb, intervalMs, isOccluded])
+  }, [active, displayVerb, freezeVerb, intervalMs, isOccluded])
 
   const { frame } = renderIndicator(style, tick)
   const verb = verbOverride ?? VERBS[verbTick % VERBS.length] ?? ''
@@ -683,6 +688,7 @@ export function StatusRule({
           ) : null}
           {busy ? (
             <FaceTicker
+              active={busy}
               color={statusColor}
               startedAt={turnStartedAt}
               style={indicatorStyle}

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -381,9 +381,30 @@ export function FloatingOverlays({
     })
   }
 
+  // Small-terminal overflow guard: stacked floating panels overdraw and push
+  // content off-screen. Render only the topmost overlay by priority and let
+  // the rest wait their turn.
+  // Priority (highest first): pager > skills-hub > plugins-hub >
+  // model-picker > pet-picker > sessions (covers the old picker/agentList) >
+  // completions.
+  const topmost = pager
+    ? 'pager'
+    : overlay.skillsHub
+      ? 'skills-hub'
+      : overlay.pluginsHub
+        ? 'plugins-hub'
+        : overlay.modelPicker
+          ? 'model-picker'
+          : overlay.petPicker
+            ? 'pet-picker'
+            : overlay.sessions
+              ? 'sessions'
+              : 'completions'
+  const visibleWidgets = widgets.filter(w => w.id === topmost)
+
   return (
     <Box alignItems="flex-start" bottom="100%" flexDirection="column" left={0} position="absolute" right={0}>
-      <WidgetGrid cols={cols} columns={1} gap={0} paddingX={0} paddingY={0} rowGap={0} widgets={widgets} />
+      <WidgetGrid cols={cols} columns={1} gap={0} paddingX={0} paddingY={0} rowGap={0} widgets={visibleWidgets} />
     </Box>
   )
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,19 +21,13 @@ import {
   useNavigate,
 } from "react-router";
 import {
-  Activity,
   BarChart3,
   BookOpen,
   Clock,
-  Code,
   Cpu,
-  Database,
   Download,
-  Eye,
   FolderOpen,
   FileText,
-  Globe,
-  Heart,
   KeyRound,
   Menu,
   MessageSquare,
@@ -45,16 +39,12 @@ import {
   Radio,
   RotateCw,
   Settings,
-  Shield,
   ShieldCheck,
-  Sparkles,
-  Star,
   Terminal,
   Users,
   Webhook,
   Wrench,
   X,
-  Zap,
 } from "lucide-react";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { SelectionSwitcher } from "@nous-research/ui/ui/components/selection-switcher";
@@ -223,9 +213,12 @@ const BUILTIN_NAV_REST: NavItem[] = [
   },
 ];
 
+// Plugin-tab icons resolve from the statically-imported built-in set so
+// the shell doesn't drag in the full lucide catalog for rarely-used
+// glyphs. Unknown names fall back to Puzzle.
 const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
-  Activity,
   BarChart3,
+  BookOpen,
   Clock,
   Cpu,
   FileText,
@@ -235,18 +228,9 @@ const ICON_MAP: Record<string, ComponentType<{ className?: string }>> = {
   Package,
   Settings,
   Puzzle,
-  Sparkles,
   Terminal,
-  Globe,
-  Database,
-  Shield,
   Users,
   Wrench,
-  Zap,
-  Heart,
-  Star,
-  Code,
-  Eye,
 };
 
 function resolveIcon(name: string): ComponentType<{ className?: string }> {

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -180,8 +180,11 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
                 key={d.day}
                 className="flex-1 min-w-0 group relative flex flex-col justify-end"
                 style={{ height: CHART_HEIGHT_PX }}
+                tabIndex={0}
+                role="img"
+                aria-label={`${formatDate(d.day)}: ${t.analytics.input} ${formatTokens(d.input_tokens)}, ${t.analytics.output} ${formatTokens(d.output_tokens)}, ${t.analytics.total} ${formatTokens(total)}`}
               >
-                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block z-10 pointer-events-none">
+                <div role="tooltip" className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block group-focus-within:block z-10 pointer-events-none">
                   <div className="font-mondwest normal-case bg-card border border-border px-2.5 py-1.5 text-xs text-foreground shadow-lg whitespace-nowrap">
                     <div className="font-medium">{formatDate(d.day)}</div>
                     <div>

--- a/web/src/plugins/slots.ts
+++ b/web/src/plugins/slots.ts
@@ -194,7 +194,34 @@ export function PluginSlot({ name, fallback }: PluginSlotProps) {
     Fragment,
     null,
     ...entries.map((entry) =>
-      React.createElement(entry.component, { key: entry.plugin }),
+      React.createElement(
+        SlotErrorBoundary,
+        { key: entry.plugin, plugin: entry.plugin },
+        React.createElement(entry.component),
+      ),
     ),
   );
+}
+
+/** Isolates one bad plugin so a throw in its slot component can't crash
+ *  the whole shell — the slot renders nothing (and logs) instead. */
+class SlotErrorBoundary extends React.Component<
+  { children?: React.ReactNode; plugin: string },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: unknown): void {
+    // eslint-disable-next-line no-console
+    console.error(`[plugins] slot component crashed: ${this.props.plugin}`, error);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.failed) return null;
+    return this.props.children ?? null;
+  }
 }

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -112,6 +112,7 @@ GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events
 POST /v1/runs/{id}/approval      Resolve a pending approval
 POST /v1/runs/{id}/steer         Inject mid-run guidance at the next tool boundary
+POST /v1/runs/{id}/queue         Queue a follow-up prompt drained as chained turns
 POST /v1/runs/{id}/stop          Interrupt the run
 GET  /v1/capabilities            Machine-readable feature flags
 POST /v1/browser-control/register Register a browser controller
@@ -157,6 +158,8 @@ Use `/v1/models` for OpenAI-client compatibility. Use `/api/model/options` or
 `/v1/runs/{id}/steer` is only accepted while the run status is `running`. Queued, approval-paused, stopping, cancelled, failed, and completed runs return `409 run_not_accepting_steer`, even if the server still retains internal agent references during cooperative shutdown.
 
 A `200` (and the `run.steered` event) means the text was **queued**, not that the agent consumed it. If a steer lands after the agent's final response — with no later tool boundary to deliver it at — the undelivered text is returned as `pending_steer` on the terminal `run.completed` event and run status, so the client can replay it as the next user turn instead of losing it.
+
+`POST /v1/runs/{id}/queue` accepts `{"prompt": "..."}` and appends it to the run's FIFO queue (returned `depth` is the queue length after appending). Queued prompts drain as chained turns with `run.queued_turn_started/completed` events and accumulated usage; unknown or inactive runs return `404`, empty prompts return `400`. Unlike steer, queue never touches the live turn — it is how you talk to a busy run without interrupting it.
 
 ---
 


### PR DESCRIPTION
supersedes #104296 (closed — github refuses to reopen after a force-push).

rebased onto current main. conflict resolution: kept this pr's LAG/LEAD window-function context query inside upstream's newer 500-match batch loop in _finalize_search_matches; unknown_platform checks take upstream's explicit is-not-None form.

verified: 29 targeted tests pass (search context batch, delivery, delivery-unknown-target, runs-queue ported pins, slack token locks) on pinned aiohttp 3.14.3.