### PR TITLE
perf(prompt-caching): copy only mutable cache-plan rows

### DIFF
--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -245,10 +245,14 @@ def build_prompt_cache_plan(
     cache_ttl: str = "5m", native_anthropic: bool = False, static_system_prefix: str | None = None,
     direct_native_tool_cache: bool = False, tool_part_markers: bool = True,
 ) -> PromptCachePlan:
-    """Build isolated cache sections for one resolved request destination
+    """Build copy-on-write cache sections for one resolved request destination
     (``tool_part_markers=False`` keeps markers off role:tool parts on LiteLLM-style routes)."""
-    messages = copy.deepcopy(api_messages or [])
-    strip_anthropic_cache_control(messages)
+    messages = list(api_messages or [])
+    for i, msg in enumerate(messages):
+        if isinstance(msg, dict) and (
+            "cache_control" in msg or isinstance(msg.get("content"), list)
+        ):
+            messages[i] = strip_anthropic_cache_control([dict(msg)])[0]
     planned_tools = strip_anthropic_tool_cache_control(tools)
 
     if not direct_native_tool_cache or not planned_tools:
@@ -261,10 +265,12 @@ def build_prompt_cache_plan(
     if messages and isinstance(messages[0], dict) and messages[0].get("role") == "system":
         # Tool-cache layout: only the static prefix carries a system-side marker; the
         # volatile suffix's budget is spent on the tools array.
+        messages[0] = copy.deepcopy(messages[0])
         _apply_system_cache_markers(messages[0], marker, static_system_prefix,
                                     native_anthropic=True, mark_suffix=False, fallback_to_whole=False)
     planned_tools[-1]["cache_control"] = dict(marker)
     for endpoint in _completed_transaction_endpoint_indexes(messages, native_anthropic=True)[-2:]:
+        messages[endpoint] = copy.deepcopy(messages[endpoint])
         _apply_cache_marker(messages[endpoint], marker, native_anthropic=True)
 
     return PromptCachePlan(messages=messages, tools=planned_tools)

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -116,6 +116,60 @@ class TestPromptCachePlan:
         assert plan.tools[-1]["cache_control"] == MARKER
         assert _count_cache_markers(plan.messages, plan.tools) == 4
 
+    def test_shares_only_unmodified_history_rows(self):
+        """Request-local planning copies marker carriers, not the entire transcript."""
+        messages = _tool_heavy_native_history() + [
+            {"role": "user", "content": "third request"},
+            {
+                "role": "assistant", "content": "",
+                "tool_calls": [{
+                    "id": "third",
+                    "function": {"name": "tool_02", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "third", "content": "third result"},
+        ]
+        tools = _tool_heavy_native_tools()
+
+        for direct_tool_cache in (False, True):
+            original = copy.deepcopy(messages)
+            plan = build_prompt_cache_plan(
+                messages,
+                tools,
+                native_anthropic=True,
+                static_system_prefix="stable prefix",
+                direct_native_tool_cache=direct_tool_cache,
+            )
+
+            assert messages == original
+            assert plan.messages is not messages
+            assert plan.messages[1] is messages[1]
+            assert plan.messages[0] is not messages[0]
+            assert plan.messages[-1] is not messages[-1]
+
+    def test_unmarked_text_parts_keep_string_equivalent_cache_plan(self):
+        """Planner cleanup preserves plain-text canonicalization without stale markers."""
+        plain = _tool_heavy_native_history()
+        part_form = copy.deepcopy(plain)
+        part_form[0]["content"] = [
+            {"type": "text", "text": "stable prefix"},
+            {"type": "text", "text": plain[0]["content"][len("stable prefix"):]},
+        ]
+        part_form[1]["content"] = [{"type": "text", "text": plain[1]["content"]}]
+        original = copy.deepcopy(part_form)
+        for native in (False, True):
+            for direct in (False, True):
+                actual = build_prompt_cache_plan(
+                    part_form, _tool_heavy_native_tools(), native_anthropic=native,
+                    direct_native_tool_cache=direct, static_system_prefix="stable prefix",
+                )
+                expected = build_prompt_cache_plan(
+                    plain, _tool_heavy_native_tools(), native_anthropic=native,
+                    direct_native_tool_cache=direct, static_system_prefix="stable prefix",
+                )
+                assert actual == expected
+                assert part_form == original
+
     def test_unmarkable_endpoint_does_not_consume_a_slot(self):
         messages = [
             {"role": "system", "content": "stable prefix\nvolatile"},


### PR DESCRIPTION
Closes #106061

## Redundant full-history copy

`build_prompt_cache_plan()` began by deep-copying the complete provider message history, even though the planner mutates only a small set of rows: stale-marker carriers, list-valued content that needs canonical cleanup, the system row selected for decoration, and completed transaction endpoints selected for cache markers.

On long tool-heavy turns, that unconditional copy duplicated nested history structures before the request could be sent.

## Copy-on-write contract

The planner now shallow-copies the outer request list and detaches only rows whose provider-visible representation may change:

- rows containing stale `cache_control` metadata;
- rows with list-valued content that must pass through the existing canonicalizer;
- the direct-native system carrier before system-marker decoration;
- completed transaction endpoints before adding cache markers.

Unmodified rows remain shared only with the caller's **request-local structural copy**. Canonical history is still isolated at the actual request-assembly boundary. Modified rows are detached before mutation, and the tools array keeps its existing independent cleanup path.

## Exact behavior preservation

Unmarked list-valued content still requires cleanup: the legacy helper canonicalizes supported plain-text part shapes even when no stale marker is present. An intermediate candidate skipped that case and was rejected before publication.

The final regression compares plain strings with equivalent one-part user and two-part system content across native/non-native and direct-tool-cache layouts. Provider-visible messages, marker counts, tools, and caller input remain equal to the previous planner.

This PR does not change cache placement policy, TTLs, transcript retention, provider routing, or the four-marker budget.

## Measured impact

Real planner, 32 synthetic tool schemas, median of seven calls on Linux/WSL2 with CPython 3.11.15:

| Message rows | Before | After | Peak traced allocation before → after |
|---:|---:|---:|---:|
| 301 | 1.059 ms | 0.283 ms | 0.131 → 0.039 MiB |
| 1,501 | 4.987 ms | 0.592 ms | 0.746 → 0.091 MiB |
| 6,001 | 20.106 ms | 2.210 ms | 3.045 → 0.318 MiB |
| 12,001 stress case | 40.182 ms | 4.191 ms | 6.238 → 0.622 MiB |

The direct-native-tool layout showed the same scaling improvement: **41.481 ms → 3.948 ms** at 12,001 rows.

## Verification

- Allocation and identity invariant: RED on the previous implementation, GREEN on copy-on-write.
- Plain-text canonicalization invariant: RED on the rejected intermediate candidate, GREEN on the final patch.
- Final canonical matrix across seven planner, policy, auxiliary, and request files: **377 passed**.
- Generated differential probes matched the baseline across **86,400 combinations**, including unmarked lists, stale markers, multimodal/nested content, routing options, and real MoA mutation isolation.
- Independent final review found no security or logic issue.
- `git diff --check` passed. Local Ruff was unavailable in the shared virtual environment; repository CI remains responsible for that unchanged lint lane.

## Boundaries and related work

Unmodified result rows may alias the caller's request-local rows; callers continue to rely on the existing structural-copy boundary before planning. No canonical-history write-through, cache, invalidation owner, schema, or dependency is introduced. The separate tool-pairing optimization in #105660 is not duplicated.