### PR TITLE
fix(gateway): warm environment probe before the first turn

### DIFF
--- a/contributors/emails/francip@kortexa.ai
+++ b/contributors/emails/francip@kortexa.ai
@@ -1,0 +1,1 @@
+francip

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -100,6 +100,12 @@ class GatewayStartupMixin:
         self._startup_warmup_task = asyncio.ensure_future(self._warm_turn_prerequisites())
 
     async def _warm_turn_prerequisites(self) -> None:
+        """Overlap independent startup checks without constructing session-owned prompts."""
+        from gateway.run_startup_environment import warm_environment_probe
+
+        await asyncio.gather(self._warm_turn_tooling(), warm_environment_probe())
+
+    async def _warm_turn_tooling(self) -> None:
         """Initialize turn machinery on an executor thread before the gate opens. Never raises: a
         failed warm-up degrades to lazy init and must not block startup."""
         from gateway.run import _warm_turn_machinery_sync

--- a/gateway/run_startup_environment.py
+++ b/gateway/run_startup_environment.py
@@ -1,0 +1,36 @@
+"""Warm the existing process-local toolchain probe before the first gateway prompt."""
+
+import asyncio
+import logging
+import time
+
+from gateway.run_shutdown import _log_suppressed
+
+logger = logging.getLogger("gateway.run")
+
+
+def _warm_environment_probe_sync() -> bool:
+    from hermes_cli.config import load_config_readonly
+    from tools.env_probe import get_environment_probe_line
+
+    config = load_config_readonly() or {}
+    agent_config = config.get("agent")
+    if not isinstance(agent_config, dict):
+        agent_config = {}
+    if not agent_config.get("environment_probe", True):
+        return False
+    # This resolver owns remote-backend omission, the single worker, cache and
+    # bounded wait. Reuse it rather than taking a new prompt or tool snapshot.
+    get_environment_probe_line()
+    return True
+
+
+async def warm_environment_probe() -> None:
+    with _log_suppressed(
+        logging.WARNING, "Environment-probe warm-up failed; first inbound turn will initialize lazily",
+        exc_info=True,
+    ):
+        started = time.monotonic()
+        # Profile config and terminal-policy ContextVars must reach the resolver.
+        if await asyncio.to_thread(_warm_environment_probe_sync):
+            logger.info("Environment probe prepared in %.1fs", time.monotonic() - started)

--- a/tests/gateway/test_startup_environment_probe.py
+++ b/tests/gateway/test_startup_environment_probe.py
@@ -1,0 +1,120 @@
+"""The first gateway prompt reuses the enabled, profile-scoped startup probe."""
+
+import asyncio
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from gateway import run as gateway_run
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tools import env_probe
+from tools.terminal_scope import install_and_reset_profile_terminal_scope, terminal_env
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("enabled,backend", [(None, "local"), (True, "local"), (False, "local"), (True, "ssh")])
+async def test_startup_reuses_only_enabled_local_environment_probe(tmp_path, monkeypatch, enabled, backend):
+    """Real config, terminal scope, worker and cache; replace only the host inspection."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("TERMINAL_ENV", "ssh" if backend == "local" else "local")
+    monkeypatch.setattr(gateway_run, "_warm_turn_machinery_sync", lambda: 0)
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    config = {"terminal": {"backend": backend}, "agent": {}}
+    if enabled is not None:
+        config["agent"]["environment_probe"] = enabled
+    config_path = profile / "config.yaml"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    before = config_path.read_bytes()
+    loop_thread = threading.get_ident()
+    calls = []
+
+    def inspect_host():
+        assert threading.get_ident() != loop_thread
+        calls.append(True)
+        return "Python toolchain: fixture."
+
+    monkeypatch.setattr(env_probe, "_build_probe_line", inspect_host)
+    env_probe._reset_cache_for_tests()
+    home_token = set_hermes_home_override(profile)
+    try:
+        with install_and_reset_profile_terminal_scope(profile):
+            assert terminal_env("TERMINAL_ENV") == backend
+            runner = object.__new__(gateway_run.GatewayRunner)
+            await runner._warm_turn_prerequisites()
+            should_probe = enabled is not False and backend == "local"
+            assert bool(calls) is should_probe
+            if should_probe:
+                assert env_probe.get_environment_probe_line() == "Python toolchain: fixture."
+                await runner._warm_turn_prerequisites()
+                assert len(calls) == 1
+            assert config_path.read_bytes() == before
+    finally:
+        reset_hermes_home_override(home_token)
+        env_probe._reset_cache_for_tests()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ["slow", "disabled", "error"])
+async def test_environment_warmup_overlaps_tooling_and_keeps_startup_bounded(tmp_path, monkeypatch, case):
+    """A slow worker cannot hold the inbound gate or serialize the other warm-up."""
+    from hermes_cli import config as config_module
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text('{"agent":{"environment_probe":true}}', encoding="utf-8")
+    entered = threading.Event()
+    release = threading.Event()
+    tooling_done = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    calls = []
+
+    def inspect_host():
+        calls.append(True)
+        entered.set()
+        assert release.wait(10)
+        return "Python toolchain: fixture."
+
+    def tooling():
+        if case == "slow":
+            assert entered.wait(5)
+        loop.call_soon_threadsafe(tooling_done.set)
+        return 0
+
+    def bad_config():
+        raise OSError("fixture config unavailable")
+
+    monkeypatch.setattr(env_probe, "_build_probe_line", inspect_host)
+    monkeypatch.setattr(gateway_run, "_warm_turn_machinery_sync", tooling)
+    monkeypatch.setattr(gateway_run, "_startup_warmup_timeout_secs", lambda: 0 if case == "disabled" else 0.01)
+    if case == "error":
+        monkeypatch.setattr(config_module, "load_config_readonly", bad_config)
+    env_probe._reset_cache_for_tests()
+    runner = object.__new__(gateway_run.GatewayRunner)
+    try:
+        with install_and_reset_profile_terminal_scope(tmp_path):
+            runner._start_startup_warmup()
+            if case == "disabled":
+                assert runner._startup_warmup_task is None
+                assert calls == []
+                return
+            await asyncio.wait_for(tooling_done.wait(), timeout=6)
+            await runner._await_startup_warmup()
+            if case == "slow":
+                assert calls == [True]
+                assert not runner._startup_warmup_task.done()
+            release.set()
+            await asyncio.wait_for(runner._startup_warmup_task, timeout=5)
+            if case == "slow":
+                assert env_probe.get_environment_probe_line() == "Python toolchain: fixture."
+                assert calls == [True]
+            else:
+                assert calls == []
+    finally:
+        release.set()
+        task = getattr(runner, "_startup_warmup_task", None)
+        if task is not None and not task.done():
+            await asyncio.wait_for(task, timeout=5)
+        env_probe._reset_cache_for_tests()


### PR DESCRIPTION
## What does this PR do?

Warm the existing process-local environment probe alongside the gateway's startup prerequisites. Today the first AIAgent starts that worker, then its first system prompt waits for the Python/pip checks before calling the model.

This reuses get_environment_probe_line() on an executor thread, preserving profile ContextVars, the config opt-out, remote-backend omission, single-worker cache and bounded wait. The existing startup gate and lazy failure fallback remain unchanged. It does not construct an agent, freeze prompts/memory/tools, add configuration, or change the probe's subprocess implementation.

## Related Issue

Fixes #106064.

Separate from provider metadata warm-up (#105999); this wait also occurs with local models.

## Changes Made

- gateway/run_startup.py: run independent startup preparation concurrently.
- gateway/run_startup_environment.py: small profile-aware environment-probe warm-up.
- tests/gateway/test_startup_environment_probe.py: two parameterized behavior tests (seven cases), using real temporary profile configuration, terminal scope, worker and cache.
- Contributor email mapping for the existing attribution check.

## How to Test

Run the canonical runner:

```sh
scripts/run_tests.sh tests/gateway/test_startup_environment_probe.py tests/gateway/test_restart_resume_pending.py tests/tools/test_env_probe.py -j 2 --file-retries 0
```

- Upstream base 22488b8c62d3c92f25149053ae8df68fb0afcb35: regression suite reproduced 3 failures / 4 passes before the implementation.
- Candidate: 59 passed, zero failures or retries on Linux ARM64 and native macOS Apple Silicon (Python 3.11).
- Windows-footgun check passes for all three Python files; plugin-compat pointer check passes. Windows runtime has not been tested.
- Config bytes remain unchanged; disabled/remote paths do not inspect the host; repeated warm-up reuses one worker; a slow probe does not serialize tool preparation or defeat the bounded startup gate.

The real-subprocess diagnostic in #106064 measured 208–287 ms waiting for the local probe, with first-turn preparation falling from 281–356 ms to 59–66 ms when that probe ran beforehand. This is an isolated preparation result, not an end-to-end voice latency claim.

## Checklist

- [x] Read contribution guidance and searched for duplicates.
- [x] Focused conventional commits and regression coverage.
- [x] Targeted canonical tests pass on Linux and macOS.
- [x] Existing config and tool behavior preserved; no new dependencies.
- [x] Full Linux Python suite in CI: 46,204 passed, 0 failed, 440 skipped.
- [x] CI completed with no failed checks, including the existing macOS/Windows-specific lanes, Docker and Nix.
- [ ] Direct Windows runtime validation of the new warm-up path (not claimed by the OS-specific lane).


## Candidate path verification

A six-process macOS A/B compared the real candidate startup path with the prior runtime while keeping provider metadata warm-up in both arms. First-turn preparation was 342.6/339.3/332.9 ms on the base and 63.1/61.4/66.1 ms on the candidate. All five real Python/pip checks succeeded. The environment cache was ready when candidate startup returned, and was not ready on the base. Prompt/input hashes, tool definitions count and context limit matched across all six runs. Each process stopped before model inference and used a synthetic session database; production state was unchanged.

The backport plus existing model-metadata warm-up also passed 228 targeted tests on Linux and macOS. These numbers isolate preparation, not total voice latency.
