### PR TITLE
perf(tools): resolve registry entries without copying all tools

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -3,10 +3,12 @@
 import json
 import logging
 import threading
+import tracemalloc
 from pathlib import Path
 from unittest.mock import patch
 
 from tools.registry import (
+    ToolEntry,
     ToolRegistry,
     _MAX_LOGGED_ERROR_CHARS,
     _MAX_TOOL_ERROR_CHARS,
@@ -388,6 +390,41 @@ class TestEmojiMetadata:
 
 
 class TestEntryLookup:
+    def test_lookup_allocation_does_not_scale_with_registry_size(self):
+        """Dispatch lookup must not copy thousands of unrelated MCP entries."""
+        reg = ToolRegistry()
+        reg._tools = {
+            f"mcp__synthetic__tool_{index}": ToolEntry(
+                name=f"mcp__synthetic__tool_{index}",
+                toolset="mcp-synthetic",
+                schema=_make_schema(f"mcp__synthetic__tool_{index}"),
+                handler=_dummy_handler,
+                check_fn=None,
+                requires_env=[],
+                is_async=False,
+                description="synthetic MCP tool",
+                emoji="",
+            )
+            for index in range(10_000)
+        }
+        expected = reg._tools["mcp__synthetic__tool_9999"]
+
+        was_tracing = tracemalloc.is_tracing()
+        if not was_tracing:
+            tracemalloc.start()
+        try:
+            baseline, _peak = tracemalloc.get_traced_memory()
+            tracemalloc.reset_peak()
+            for _ in range(100):
+                assert reg.get_entry(expected.name, scope="/tmp/synthetic-profile") is expected
+            _current, peak = tracemalloc.get_traced_memory()
+        finally:
+            if not was_tracing:
+                tracemalloc.stop()
+
+        assert peak - baseline < 64 * 1024
+        assert tracemalloc.is_tracing() is was_tracing
+
     def test_get_entry_returns_registered_entry(self):
         reg = ToolRegistry()
         reg.register(

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -439,7 +439,10 @@ class ToolRegistry:
     def get_entry(self, name: str, *, scope: Optional[str] = None) -> Optional[ToolEntry]:
         """Active profile's entry by name, falling back to global."""
         with self._lock:
-            return self._merged_tools(scope).get(name)
+            scoped = self._scoped_tools.get(scope or self.current_scope_key())
+            if scoped is not None and name in scoped:
+                return scoped[name]
+            return self._tools.get(name)
 
     def snapshot_registration(
         self, name: str, *, scope: Optional[str] = None) -> Optional[ToolEntry]:


### PR DESCRIPTION
Closes #106062

## Hot path

`ToolRegistry.get_entry()` resolved one tool by first constructing the complete merged registry for the active or explicit profile. The result was semantically correct, but each lookup copied every global entry plus the profile overlay before selecting a single name.

That cost is amplified by deferred catalog construction: `build_catalog()` asks the registry for metadata once per exposed tool, so copying the full registry inside every lookup creates quadratic work as MCP-heavy catalogs grow.

## Direct lookup contract

Resolve under the existing registry lock without materializing a merged dictionary:

1. resolve the explicit scope or current ambient scope;
2. check the profile overlay first;
3. use membership rather than truthiness, preserving intentionally falsey overlay values;
4. fall back to the global registry only when the overlay does not own that name.

Full-snapshot and enumeration methods continue to construct the merged view where callers actually need it. Lock ownership, ambient scope resolution, profile shadowing, and global fallback are unchanged.

## Measured impact

Real `build_catalog()` caller, synthetic in-process MCP-shaped entries, median of seven warm calls on Linux/WSL2 with CPython 3.11.15:

| Catalog entries | Before | After |
|---:|---:|---:|
| 100 | 0.917 ms | 0.781 ms |
| 1,000 | 14.542 ms | 8.260 ms |
| 5,000 stress case | 175.718 ms | 51.663 ms |

Every run validates returned names, ordering, and source classification. An isolated 10,000-entry fixture reduced peak traced allocation over 100 lookups from roughly **208 KB to 192 bytes**.

The catalog still pays its real tokenization and construction costs; this PR removes only the repeated merged-dictionary copy.

## Verification

- The allocation invariant is RED with the previous production lookup and GREEN with direct resolution.
- Canonical matrix: `tests/tools/test_registry.py`, plugin ownership, toolsets, and model tools — **121 passed**.
- Differential review covered explicit and ambient scopes, global fallback, shadowing, and falsey overlay values.
- Review caught a test-only interaction with pre-enabled `tracemalloc`. The final regression measures incremental peak after fixture construction, preserves the incoming tracing state, and stops only a tracer it started. It also passes under real `python -X tracemalloc=1` and still fails on the old lookup.
- `git diff --check` passed.

## Relationship to nearby work

Merged #92228 removes repeated filesystem resolution of the home key. This PR removes the separate merged-registry allocation. Profile-isolation work in #104534 and #80746 and reconnect work in #90342 address different contracts; no cache, invalidation policy, public API, dependency, or tool surface is added here.