### PR TITLE
feat(skills): add evidence merge ledger

### DIFF
--- a/contributors/emails/hermes-pi@nousresearch.com
+++ b/contributors/emails/hermes-pi@nousresearch.com
@@ -1,0 +1,1 @@
+ether-btc

--- a/tests/tools/test_skill_evidence_merge.py
+++ b/tests/tools/test_skill_evidence_merge.py
@@ -1,0 +1,227 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools import skill_manager_tool as smt
+from tools import skill_manager_batch as smb
+from tools import write_approval
+from tools.skill_evidence import EvidenceMergeError, merge_evidence
+
+
+BASE = """---
+name: test-skill
+description: Use when testing evidence merges. Keep evidence additive.
+evidence:
+  success_count: 11
+  fail_count: 1
+  steps: []
+  evolution: []
+---
+
+# Body
+
+Keep this byte-for-byte.
+"""
+
+
+def test_merge_is_additive_and_preserves_body():
+    out = merge_evidence(BASE, {"success_count": 1, "fail_count": 2})
+    assert "success_count: 12" in out
+    assert "fail_count: 3" in out
+    assert out.endswith("\n# Body\n\nKeep this byte-for-byte.\n")
+
+
+def test_merge_steps_and_evolution():
+    out = merge_evidence(BASE, {
+        "steps": [{"name": "unit", "ok": 2, "fail": 0}],
+        "evolution": [{"from": 0, "to": 1, "date": "2026-09-08", "reason": "verified"}],
+    })
+    assert "name: unit" in out and "version: 1" in out
+    assert "reason: verified" in out
+
+
+def test_merge_rejects_duplicate_and_negative():
+    with pytest.raises(EvidenceMergeError):
+        merge_evidence("---\nname: x\nname: y\n---\nbody\n", {"success_count": 1})
+    with pytest.raises(EvidenceMergeError):
+        merge_evidence(BASE, {"success_count": -1})
+    with pytest.raises(EvidenceMergeError):
+        merge_evidence(BASE, {"steps": [
+            {"name": "unit", "ok": 1, "fail": 0},
+            {"name": "unit", "ok": 1, "fail": 0},
+        ]})
+    with pytest.raises(EvidenceMergeError):
+        merge_evidence(BASE, {"evolution": [{
+            "from": 0, "to": "not-an-int", "date": "2026-09-08", "reason": "bad"}]})
+
+
+def test_skill_manage_rewrites_temp_skill_without_gate(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(BASE, encoding="utf-8")
+    with patch.object(smt, "SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+         patch.object(smt, "_run_write_gate", return_value=None):
+        result = json.loads(smt.skill_manage(
+            action="patch", name="test-skill", evidence_merge={"success_count": 1}))
+    assert result["success"] is True
+    assert "success_count: 12" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_stale_replay_is_rejected(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(BASE, encoding="utf-8")
+    with patch.object(smt, "SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        result = smt._act_patch({
+            "name": "test-skill", "content": None, "old_string": None, "new_string": None,
+            "file_path": None, "replace_all": False,
+            "evidence_merge": {"_source_digest": "wrong", "_candidate_content": BASE},
+        })
+    parsed = json.loads(result) if isinstance(result, str) else result
+    assert parsed["success"] is False
+    assert "stale" in parsed["error"]
+
+
+def test_staging_captures_candidate_and_digest(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(BASE, encoding="utf-8")
+    captured = {}
+
+    def fake_run(build):
+        class WA:
+            @staticmethod
+            def skill_gist(*args, **kwargs):
+                captured["gist"] = kwargs
+                return "gist"
+
+            @staticmethod
+            def skill_pending_diff(record):
+                return write_approval.skill_pending_diff(record)
+        captured["payload"], _ = build(WA)
+        return "staged"
+
+    with patch.object(smt, "SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+         patch.object(smt, "_run_write_gate", side_effect=fake_run):
+        result = smt._apply_skill_write_gate(
+            "patch", "test-skill", content=None, category=None, file_path=None,
+            file_content=None, old_string=None, new_string=None, replace_all=False,
+            absorbed_into=None, evidence_merge={"success_count": 1})
+    assert result == "staged"
+    staged = captured["payload"]["evidence_merge"]
+    assert staged["_source_digest"]
+    assert "success_count: 12" in staged["_candidate_content"]
+    assert captured["gist"]["content"] == staged["_candidate_content"]
+
+
+def test_evidence_merge_is_patch_only_and_batch_order_is_explicit():
+    error = lambda msg, success=False: json.dumps({"success": success, "error": msg})
+    flat = smt._apply_skill_write_gate(
+        "write_file", "test-skill", content=None, category=None, file_path="x",
+        file_content="x", old_string=None, new_string=None, replace_all=False,
+        absorbed_into=None, evidence_merge={"success_count": 1})
+    assert json.loads(flat)["success"] is False
+    _, result = smb._validate_batch_ops(
+        [{"action": "write_file", "name": "test-skill", "evidence_merge": {"success_count": 1}}],
+        None, error)
+    assert json.loads(result)["success"] is False
+    _, result = smb._validate_batch_ops(
+        [{"action": "patch", "name": "test-skill", "evidence_merge": {"success_count": 1}},
+         {"action": "patch", "name": "test-skill", "old_string": "a", "new_string": "b"}],
+        None, error)
+    assert json.loads(result)["success"] is False
+
+
+def test_flat_pending_preview_uses_frozen_candidate(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(BASE, encoding="utf-8")
+    candidate = BASE.replace("success_count: 11", "success_count: 12")
+    with patch.object(write_approval, "_find_skill_path", return_value=skill_dir):
+        preview = write_approval.skill_pending_diff({"payload": {
+            "action": "patch", "name": "test-skill",
+            "evidence_merge": {"_candidate_content": candidate},
+        }})
+    assert "success_count: 12" in preview
+    assert "success_count: 11" in preview
+    assert "success_count: 12" != preview.strip()
+
+
+def test_registered_dispatch_replays_evidence_merge(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(BASE, encoding="utf-8")
+    entry = smt.registry.get_entry("skill_manage")
+    assert entry is not None and entry.toolset == "skills"
+    with patch.object(smt, "SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+         patch.object(smt, "_run_write_gate", return_value=None):
+        result = json.loads(entry.handler({
+            "action": "patch", "name": "test-skill",
+            "evidence_merge": {"success_count": 1}}))
+    assert result["success"] is True
+    assert "success_count: 12" in (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_batch_preview_is_frozen_inside_evidence_payload(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(BASE, encoding="utf-8")
+    captured = {}
+
+    def fake_run(build):
+        class WA:
+            @staticmethod
+            def skill_pending_diff(record):
+                return write_approval.skill_pending_diff(record)
+
+            @staticmethod
+            def skill_gist(*args, **kwargs):
+                return "gist"
+
+        captured["payload"], _ = build(WA)
+        return "staged"
+
+    with patch.object(smt, "SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+         patch.object(smt, "_run_write_gate", side_effect=fake_run):
+        result = smb._skill_manage_batch(
+            [{"action": "patch", "name": "test-skill",
+              "evidence_merge": {"success_count": 1}}],
+            None, None, None)
+    assert result == "staged"
+    op = captured["payload"]["operations"][0]
+    assert "_preview" in op["evidence_merge"]
+    (skill_dir / "SKILL.md").write_text(BASE.replace("success_count: 11", "success_count: 99"), encoding="utf-8")
+    preview = write_approval.skill_pending_diff({"payload": captured["payload"]})
+    assert "success_count: 12" in preview
+    assert "success_count: 99" not in preview
+
+
+def test_final_guard_rejects_digest_drift_without_writing(tmp_path):
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(BASE, encoding="utf-8")
+    candidate = BASE.replace("success_count: 11", "success_count: 12")
+    with patch.object(smt, "SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+        result = smt._edit_skill("test-skill", candidate, expected_source_digest="wrong")
+    assert result["success"] is False
+    assert "stale" in result["error"]
+    assert (skill_dir / "SKILL.md").read_text(encoding="utf-8") == BASE
+
+
+def test_evidence_schema_describes_nested_contract():
+    schema = smt.SKILL_MANAGE_SCHEMA["parameters"]["properties"]["operations"]["items"]
+    evidence = schema["properties"]["evidence_merge"]
+    step = evidence["properties"]["steps"]["items"]
+    evolution = evidence["properties"]["evolution"]["items"]
+    assert step["required"] == ["name", "ok", "fail"]
+    assert step["additionalProperties"] is False
+    assert evolution["required"] == ["from", "to", "date", "reason"]
+    assert evolution["additionalProperties"] is False

--- a/tools/skill_evidence.py
+++ b/tools/skill_evidence.py
@@ -1,0 +1,188 @@
+"""Pure evidence-frontmatter merge helpers for skill_manage."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import yaml
+
+
+_ALLOWED_EVIDENCE = {"success_count", "fail_count", "steps", "evolution", "version", "updated"}
+_STEP_KEYS = {"name", "ok", "fail"}
+_EVOLUTION_KEYS = {"from", "to", "date", "reason"}
+
+
+class EvidenceMergeError(ValueError):
+    """Raised when evidence or a merge delta is malformed."""
+
+
+class _UniqueLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_mapping(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise EvidenceMergeError(f"duplicate YAML key: {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping)
+
+
+def _split_document(content: str) -> tuple[dict[str, Any], str]:
+    if not content.startswith("---\n"):
+        raise EvidenceMergeError("SKILL.md must start with YAML frontmatter")
+    marker = content.find("\n---\n", 4)
+    if marker < 0:
+        raise EvidenceMergeError("SKILL.md frontmatter is not closed")
+    raw = content[4:marker]
+    body = content[marker + len("\n---\n"):]
+    try:
+        data = yaml.load(raw, Loader=_UniqueLoader)  # nosec B506 — SafeLoader subclass rejects duplicate keys
+    except EvidenceMergeError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        raise EvidenceMergeError(f"malformed YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise EvidenceMergeError("frontmatter must be a mapping")
+    return data, body
+
+
+def _int(value: Any, label: str, *, nonnegative: bool = True) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise EvidenceMergeError(f"{label} must be an integer")
+    if nonnegative and value < 0:
+        raise EvidenceMergeError(f"{label} must be non-negative")
+    return value
+
+
+def _validate_evidence(value: Any) -> dict[str, Any]:
+    if value is None:
+        raise EvidenceMergeError("evidence must not be null")
+    if not isinstance(value, dict):
+        raise EvidenceMergeError("evidence must be a mapping")
+    unknown = set(value) - _ALLOWED_EVIDENCE
+    if unknown:
+        raise EvidenceMergeError(f"unknown evidence fields: {sorted(unknown)}")
+    result = dict(value)
+    result["success_count"] = _int(result.get("success_count", 0), "success_count")
+    result["fail_count"] = _int(result.get("fail_count", 0), "fail_count")
+    steps = result.get("steps", [])
+    if not isinstance(steps, list):
+        raise EvidenceMergeError("steps must be a list")
+    seen = set()
+    normalized_steps = []
+    for step in steps:
+        if not isinstance(step, dict) or set(step) != _STEP_KEYS:
+            raise EvidenceMergeError("each step must contain exactly name, ok, fail")
+        name = step.get("name")
+        if not isinstance(name, str) or not name:
+            raise EvidenceMergeError("step name must be a non-empty string")
+        if name in seen:
+            raise EvidenceMergeError(f"duplicate step name: {name}")
+        seen.add(name)
+        normalized_steps.append({"name": name, "ok": _int(step["ok"], f"step {name} ok"),
+                                 "fail": _int(step["fail"], f"step {name} fail")})
+    result["steps"] = normalized_steps
+    evolution = result.get("evolution", [])
+    if not isinstance(evolution, list):
+        raise EvidenceMergeError("evolution must be a list")
+    normalized_evolution = []
+    prior = 0
+    for item in evolution:
+        if not isinstance(item, dict) or set(item) != _EVOLUTION_KEYS:
+            raise EvidenceMergeError("each evolution item has exactly from, to, date, reason")
+        frm = _int(item["from"], "evolution.from")
+        to = _int(item["to"], "evolution.to")
+        if frm != prior or to <= frm:
+            raise EvidenceMergeError("evolution must be contiguous and increasing")
+        if not isinstance(item["date"], str) or not item["date"]:
+            raise EvidenceMergeError("evolution.date must be a non-empty string")
+        if not isinstance(item["reason"], str) or not item["reason"]:
+            raise EvidenceMergeError("evolution.reason must be a non-empty string")
+        normalized_evolution.append(dict(item))
+        prior = to
+    result["evolution"] = normalized_evolution
+    has_version = "version" in result
+    has_updated = "updated" in result
+    if has_version != has_updated:
+        raise EvidenceMergeError("version and updated must appear together")
+    if has_version:
+        result["version"] = _int(result["version"], "version")
+        if result["version"] != prior:
+            raise EvidenceMergeError("version must equal the end of evolution history")
+        if not isinstance(result["updated"], str) or not result["updated"]:
+            raise EvidenceMergeError("updated must be a non-empty string")
+    return result
+
+
+def merge_evidence(content: str, delta: dict[str, Any]) -> str:
+    """Return a merged SKILL.md or raise EvidenceMergeError; never writes files."""
+    if not isinstance(delta, dict) or not delta:
+        raise EvidenceMergeError("evidence_merge must be a non-empty mapping")
+    if set(delta) - _ALLOWED_EVIDENCE:
+        raise EvidenceMergeError(f"unknown merge fields: {sorted(set(delta) - _ALLOWED_EVIDENCE)}")
+    frontmatter, body = _split_document(content)
+    current = _validate_evidence(frontmatter.get("evidence", {}))
+    for field in ("success_count", "fail_count"):
+        if field in delta:
+            current[field] += _int(delta[field], field)
+    if "steps" in delta:
+        additions = delta["steps"]
+        if not isinstance(additions, list):
+            raise EvidenceMergeError("merge steps must be a list")
+        by_name = {s["name"]: s for s in current["steps"]}
+        delta_names = set()
+        for step in additions:
+            checked = _validate_evidence({"steps": [step]})["steps"][0]
+            if checked["name"] in delta_names:
+                raise EvidenceMergeError(f"duplicate merge step name: {checked['name']}")
+            delta_names.add(checked["name"])
+            existing = by_name.get(checked["name"])
+            if existing:
+                existing["ok"] += checked["ok"]
+                existing["fail"] += checked["fail"]
+            else:
+                current["steps"].append(checked)
+    if "evolution" in delta:
+        additions = delta["evolution"]
+        if not isinstance(additions, list):
+            raise EvidenceMergeError("merge evolution must be a list")
+        for item in additions:
+            if not isinstance(item, dict) or set(item) != _EVOLUTION_KEYS:
+                raise EvidenceMergeError("each merge evolution item has exactly from, to, date, reason")
+            frm = _int(item["from"], "merge evolution.from")
+            to = _int(item["to"], "merge evolution.to")
+            if not isinstance(item["date"], str) or not item["date"]:
+                raise EvidenceMergeError("merge evolution.date must be a non-empty string")
+            if not isinstance(item["reason"], str) or not item["reason"]:
+                raise EvidenceMergeError("merge evolution.reason must be a non-empty string")
+            expected = current.get("version", 0)
+            if frm != expected:
+                raise EvidenceMergeError("merge evolution.from must equal current version")
+            if to <= frm:
+                raise EvidenceMergeError("merge evolution.to must increase")
+            current["evolution"].append(dict(item))
+            current["version"] = to
+            current["updated"] = item["date"]
+    if "version" in delta or "updated" in delta:
+        if set(delta) & {"version", "updated"} != {"version", "updated"}:
+            raise EvidenceMergeError("version and updated must be supplied together")
+        if "evolution" not in delta:
+            raise EvidenceMergeError("version metadata requires evolution")
+    frontmatter["evidence"] = _validate_evidence(current)
+    try:
+        rendered = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).rstrip("\n")
+    except Exception as exc:  # noqa: BLE001
+        raise EvidenceMergeError(f"could not render frontmatter: {exc}") from exc
+    return f"---\n{rendered}\n---\n{body}"
+
+
+def content_digest(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()

--- a/tools/skill_manager_batch.py
+++ b/tools/skill_manager_batch.py
@@ -32,10 +32,17 @@ def _validate_batch_ops(operations, default_name, tool_error):
         if not nm:
             return fail(i, " needs a 'name' (the skill it targets).")
         names.append(nm)
+        if op.get("evidence_merge") is not None and act != "patch":
+            return fail(i, ": evidence_merge is supported only with action 'patch'.")
         if act == "create" and nm in names[:-1]:
             return fail(i, f": create for '{nm}' must precede that skill's other ops.")
         if (preflight := _background_review_preflight(act, nm)) is not None:
             return None, json.dumps(preflight, ensure_ascii=False)
+    # Evidence candidates are intentionally isolated: replaying them alongside another
+    # operation on the same skill would require simulating ordered in-memory state.
+    evidence_indexes = [i for i, op in enumerate(operations) if op.get("evidence_merge") is not None]
+    if evidence_indexes and (len(evidence_indexes) != 1 or len(operations) != 1):
+        return fail(evidence_indexes[0], ": evidence_merge batches must be the sole operation until ordered-state simulation is implemented.")
     # Clobber guard: a DESTRUCTIVE op (create/write_file/remove_file/full rewrite) on
     # a file an earlier op touched would SILENTLY discard its work — reject it.
     # Additive patches are always legal. Paths are normalized against spelling variants.
@@ -139,9 +146,34 @@ def _skill_manage_batch(operations, default_name: str = None, task_id: str = Non
         # Approval gate for the WHOLE batch as one pending write.
         def _staging(wa):
             acts = ", ".join(op["action"] for op in operations)
+            staged_ops = []
+            evidence_targets = set()
+            for op in operations:
+                staged = dict(op)
+                delta = op.get("evidence_merge")
+                if delta is not None:
+                    nm = op.get("name") or default_name
+                    if nm in evidence_targets:
+                        raise ValueError(f"duplicate evidence_merge target in batch: {nm}")
+                    evidence_targets.add(nm)
+                    found = _smt._find_skill(nm)
+                    if not found:
+                        raise ValueError(f"skill '{nm}' was not found")
+                    current = Path(found["path"]).joinpath("SKILL.md").read_text(encoding="utf-8")
+                    candidate = _smt.merge_evidence(current, delta)
+                    staged["evidence_merge"] = {
+                        **delta, "_source_digest": _smt.content_digest(current),
+                        "_candidate_content": candidate}
+                    staged["evidence_merge"]["_preview"] = wa.skill_pending_diff(
+                        {"payload": {"action": "patch", "name": nm,
+                                     "evidence_merge": staged["evidence_merge"]}})
+                staged_ops.append(staged)
             gist = f"batch({len(operations)} ops: {acts}) on {', '.join(sorted(set(names)))}"
-            return {"action": "batch", "operations": operations}, gist
-        staged = _smt._run_write_gate(_staging)
+            return {"action": "batch", "operations": staged_ops}, gist
+        try:
+            staged = _smt._run_write_gate(_staging)
+        except (ValueError, _smt.EvidenceMergeError, OSError) as exc:
+            return tool_error(f"cannot stage batch evidence_merge: {exc}", success=False)
         if staged is not None:
             return staged
     snap_root = Path(tempfile.mkdtemp(prefix="skill_batch_"))
@@ -149,6 +181,21 @@ def _skill_manage_batch(operations, default_name: str = None, task_id: str = Non
     if snap_err is not None:
         shutil.rmtree(snap_root, ignore_errors=True)
         return tool_error(snap_err, success=False)
+    # Approved evidence candidates are bound to the exact pre-stage source. Check every
+    # candidate before the first operation mutates any skill.
+    for op in operations:
+        evidence = op.get("evidence_merge")
+        if not isinstance(evidence, dict) or "_candidate_content" not in evidence:
+            continue
+        nm = op.get("name") or default_name
+        found = _smt._find_skill(nm)
+        if not found:
+            shutil.rmtree(snap_root, ignore_errors=True)
+            return tool_error(f"batch evidence_merge target disappeared: {nm}", success=False)
+        current = Path(found["path"]).joinpath("SKILL.md").read_text(encoding="utf-8")
+        if _smt.content_digest(current) != evidence.get("_source_digest"):
+            shutil.rmtree(snap_root, ignore_errors=True)
+            return tool_error(f"batch evidence_merge for '{nm}' is stale; source changed after approval", success=False)
     # Single-op path with the gate bypassed (the batch already cleared/staged it).
     results = []
     rollback_failed = False

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -9,7 +9,7 @@ existing skills (bundled, hub, user) are modified in place. Layout:
 
 import contextvars as _ctxvars
 import json
-from contextlib import suppress
+from contextlib import nullcontext, suppress
 import logging
 import re
 import shutil
@@ -33,8 +33,11 @@ from tools.skill_manager_guards import (
     _org_mirror_write_guard, _pinned_guard, _validate_delete_target, _is_background_review, _refusal as _err)
 from tools.skill_manager_batch import _skill_manage_batch
 from tools.skills_guard import scan_skill, should_allow_install, format_scan_report
+from tools.skill_evidence import EvidenceMergeError, content_digest, merge_evidence
 
 logger = logging.getLogger(__name__)
+
+_EVIDENCE_WRITE_LOCKS: Dict[Path, threading.RLock] = {}
 
 
 def _guard_agent_created_enabled() -> bool:
@@ -331,24 +334,29 @@ def _locate_for_write(name: str, action: str, not_found_suffix: str = "", *,
 
 
 def _guarded_write(name: str, skill_dir: Path, target: Path, action: str, label: str,
-                   content: str) -> Optional[Dict[str, Any]]:
+                   content: str, *, expected_source_digest: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Read-before-write guard (existing targets only), atomic write, then the security scan;
     a blocked scan restores the original (or unlinks a new file). Error dict or None."""
-    original = None
-    if target.exists():
-        if read_guard := _background_review_read_before_write_guard(name, target, action, label):
-            return read_guard
-        original = target.read_text(encoding="utf-8")
-    target.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_text(target, content, preserve_mode=True, create_mode=0o644)
-    scan_error = _security_scan_skill(skill_dir)
-    if not scan_error:
-        return None
-    if original is not None:
-        atomic_write_text(target, original, preserve_mode=True)
-    else:
-        target.unlink(missing_ok=True)
-    return _err(scan_error)
+    lock = (_EVIDENCE_WRITE_LOCKS.setdefault(target.resolve(), threading.RLock())
+            if expected_source_digest else nullcontext())
+    with lock:
+        original = None
+        if target.exists():
+            if read_guard := _background_review_read_before_write_guard(name, target, action, label):
+                return read_guard
+            original = target.read_text(encoding="utf-8")
+            if expected_source_digest and content_digest(original) != expected_source_digest:
+                return _err(f"Skill changed before guarded write; {label} replay is stale and was rejected.")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_text(target, content, preserve_mode=True, create_mode=0o644)
+        scan_error = _security_scan_skill(skill_dir)
+        if not scan_error:
+            return None
+        if original is not None:
+            atomic_write_text(target, original, preserve_mode=True)
+        else:
+            target.unlink(missing_ok=True)
+        return _err(scan_error)
 
 
 def _attach_org_note(result: Dict[str, Any], name: str, skill_dir: Path) -> Dict[str, Any]:
@@ -415,13 +423,15 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     return result
 
 
-def _edit_skill(name: str, content: str) -> Dict[str, Any]:
+def _edit_skill(name: str, content: str, *, expected_source_digest: Optional[str] = None) -> Dict[str, Any]:
     """Replace the SKILL.md of any existing skill (full rewrite)."""
     if err := _validate_frontmatter(content) or _validate_content_size(content):
         return _err(err)
     skill_dir, guard = _locate_for_write(name, "edit")
     # SKILL.md always exists here (_find_skill requires it), so a blocked scan restores it.
-    if guard := guard or _guarded_write(name, skill_dir, skill_dir / "SKILL.md", "edit", "SKILL.md", content):
+    if guard := guard or _guarded_write(
+            name, skill_dir, skill_dir / "SKILL.md", "edit", "SKILL.md", content,
+            expected_source_digest=expected_source_digest):
         return guard
     result = {
         "success": True, "message": f"Skill '{name}' updated (full rewrite).",
@@ -599,19 +609,42 @@ def _run_write_gate(build_staging):
 
 def _apply_skill_write_gate(action, name, **payload_kwargs):
     """Flat-shape gate: stage the full kwargs so approval can replay them; bypassed during replay."""
+    if payload_kwargs.get("evidence_merge") is not None and action != "patch":
+        return tool_error("evidence_merge is supported only with action 'patch'.", success=False)
     if action not in _ACTION_HANDLERS or _skill_gate_bypass.get():
         return None
     def _staging(wa):
-        payload = {"action": action, "name": name,
-                   **{k: v for k, v in payload_kwargs.items() if v is not None}}
+        staged_kwargs = dict(payload_kwargs)
         gist_kw = {k: payload_kwargs.get(k) or ""
                    for k in ("content", "file_path", "old_string", "new_string")}
+        evidence_merge = payload_kwargs.get("evidence_merge")
+        if evidence_merge is not None:
+            try:
+                found = _find_skill(name)
+                if not found:
+                    raise EvidenceMergeError(f"skill '{name}' was not found")
+                current = Path(found["path"]).joinpath("SKILL.md").read_text(encoding="utf-8")
+                candidate = merge_evidence(current, evidence_merge)
+                staged_kwargs["evidence_merge"] = {
+                    **evidence_merge, "_source_digest": content_digest(current),
+                    "_candidate_content": candidate}
+                staged_kwargs["evidence_merge"]["_preview"] = wa.skill_pending_diff(
+                    {"payload": {"action": "patch", "name": name,
+                                 "evidence_merge": staged_kwargs["evidence_merge"]}})
+                gist_kw = {"content": candidate}
+            except (EvidenceMergeError, OSError) as exc:
+                raise ValueError(f"cannot stage evidence_merge: {exc}") from exc
+        payload = {"action": action, "name": name,
+                   **{k: v for k, v in staged_kwargs.items() if v is not None}}
         return payload, wa.skill_gist(action, name, **gist_kw)
-    return _run_write_gate(_staging)
+    try:
+        return _run_write_gate(_staging)
+    except ValueError as exc:
+        return tool_error(str(exc), success=False)
 
 
 _FLAT_OP_KEYS = ("content", "category", "file_path", "file_content", "old_string", "new_string",
-                 "absorbed_into", "operations")
+                 "absorbed_into", "evidence_merge", "operations")
 
 
 def _skill_manage_from(payload: Dict[str, Any], **extra) -> str:
@@ -660,12 +693,32 @@ def _maybe_debounced_sync_push(skill_name: str) -> None:
 
 
 def _act_patch(a):
-    """Two shapes: old_string/new_string = targeted replacement (validated in _patch_skill so the
-    tool and the helper give the same guidance); content alone = full rewrite (the old 'edit')."""
-    if a["content"] and (a["old_string"] or a["new_string"] is not None):
+    """Three shapes: evidence_merge, old_string/new_string replacement, or full rewrite."""
+    if a["evidence_merge"] is not None:
+        if a["content"] is not None or a["old_string"] is not None or a["new_string"] is not None:
+            return tool_error("evidence_merge is mutually exclusive with content/old_string/new_string.", success=False)
+        found = _find_skill(a["name"])
+        if not found:
+            return _err(f"Skill '{a['name']}' was not found.")
+        target = Path(found["path"]) / "SKILL.md"
+        try:
+            current = target.read_text(encoding="utf-8")
+            merged = a["evidence_merge"]
+            if "_candidate_content" in merged:
+                if content_digest(current) != merged.get("_source_digest"):
+                    return _err("Skill changed since approval; evidence_merge replay is stale and was rejected.")
+                candidate = merged["_candidate_content"]
+            else:
+                candidate = merge_evidence(current, merged)
+        except (OSError, EvidenceMergeError) as exc:
+            return _err(f"evidence_merge rejected: {exc}")
+        return _edit_skill(
+            a["name"], candidate,
+            expected_source_digest=merged.get("_source_digest") if "_candidate_content" in merged else None)
+    if a["content"] is not None and (a["old_string"] is not None or a["new_string"] is not None):
         return tool_error("Pass EITHER content (full SKILL.md rewrite) OR "
                           "old_string/new_string (targeted replacement), not both.", success=False)
-    if a["content"]:
+    if a["content"] is not None:
         return _edit_skill(a["name"], a["content"])
     return _patch_skill(a["name"], a["old_string"], a["new_string"], a["file_path"], a["replace_all"])
 
@@ -736,7 +789,7 @@ def skill_manage(
     action: str, name: str, content: str = None, category: str = None, file_path: str = None,
     file_content: str = None, old_string: str = None, new_string: str = None,
     replace_all: bool = False, absorbed_into: str = None, task_id: str = None,
-    session_id: str = None, operations=None) -> str:
+    session_id: str = None, evidence_merge=None, operations=None) -> str:
     """Dispatch to the action handler -> JSON string. ``operations`` (atomic batch shape,
     see _skill_manage_batch) overrides the flat fields."""
     if operations is not None:
@@ -748,7 +801,7 @@ def skill_manage(
     # of origin; bypassed when replaying an approved staged write.
     args = dict(content=content, category=category, file_path=file_path, file_content=file_content,
                 old_string=old_string, new_string=new_string, replace_all=replace_all,
-                absorbed_into=absorbed_into)
+                absorbed_into=absorbed_into, evidence_merge=evidence_merge)
     if (gate_result := _apply_skill_write_gate(action, name, **args)) is not None:
         return gate_result
     # Ledger pre-capture: telemetry, not a gate — failures must NEVER block the mutation. delete
@@ -861,6 +914,30 @@ SKILL_MANAGE_SCHEMA = {
                         "file_content": {
                             "type": "string",
                             "description": "Content for write_file."
+                        },
+                        "evidence_merge": {
+                            "type": "object",
+                            "description": "patch-only additive evidence delta; mutually exclusive with content/old_string/new_string.",
+                            "properties": {
+                                "success_count": {"type": "integer", "minimum": 0},
+                                "fail_count": {"type": "integer", "minimum": 0},
+                                "steps": {"type": "array", "items": {
+                                    "type": "object", "required": ["name", "ok", "fail"],
+                                    "properties": {
+                                        "name": {"type": "string", "minLength": 1},
+                                        "ok": {"type": "integer", "minimum": 0},
+                                        "fail": {"type": "integer", "minimum": 0}},
+                                    "additionalProperties": False}},
+                                "evolution": {"type": "array", "items": {
+                                    "type": "object", "required": ["from", "to", "date", "reason"],
+                                    "properties": {
+                                        "from": {"type": "integer", "minimum": 0},
+                                        "to": {"type": "integer", "minimum": 0},
+                                        "date": {"type": "string", "minLength": 1},
+                                        "reason": {"type": "string", "minLength": 1}},
+                                    "additionalProperties": False}}
+                            },
+                            "additionalProperties": False
                         }
                     },
                     "required": ["name", "action"]

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -250,18 +250,47 @@ def _find_skill_path(name: str) -> Optional[Path]:
 
 
 def skill_pending_diff(record: Dict[str, Any]) -> str:
-    """Full content (create) or unified diff vs. the on-disk skill (edit/patch/write_file),
-    rendered by /skills diff <id> on surfaces that can show it."""
+    """Full content or unified diff for a pending skill write."""
     payload = record.get("payload", {})
     action = payload.get("action", "")
     name = payload.get("name", "")
     if action == "create":
         return payload.get("content") or ""
+    if action == "patch" and isinstance(payload.get("evidence_merge"), dict):
+        em = payload["evidence_merge"]
+        if "_preview" in em:
+            return em["_preview"]
+        if "_candidate_content" in em:
+            skill_dir = _find_skill_path(name)
+            current = (skill_dir / "SKILL.md").read_text(encoding="utf-8") if skill_dir else ""
+            diff = difflib.unified_diff(current.splitlines(keepends=True),
+                                        em["_candidate_content"].splitlines(keepends=True),
+                                        fromfile=f"a/{name}/SKILL.md", tofile=f"b/{name}/SKILL.md")
+            return "".join(diff) or "(no textual change)"
+    if action == "batch":
+        chunks = []
+        for i, op in enumerate(payload.get("operations", [])):
+            em = op.get("evidence_merge") if isinstance(op, dict) else None
+            if isinstance(em, dict) and "_preview" in em:
+                chunks.append(em["_preview"])
+                continue
+            if isinstance(em, dict) and "_candidate_content" in em:
+                skill_dir = _find_skill_path(op.get("name", name))
+                if not skill_dir:
+                    chunks.append(f"batch op {i}: target skill missing")
+                    continue
+                old = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+                diff = difflib.unified_diff(
+                    old.splitlines(keepends=True), em["_candidate_content"].splitlines(keepends=True),
+                    fromfile=f"a/{op.get('name', name)}/SKILL.md",
+                    tofile=f"b/{op.get('name', name)}/SKILL.md")
+                chunks.append("".join(diff))
+            else:
+                chunks.append(f"batch op {i}: {op.get('action', '?')} on {op.get('name', name)}")
+        return "".join(chunks) or "(empty batch)"
     if action not in {"edit", "patch", "write_file"}:
         return {"remove_file": f"remove file: {payload.get('file_path')} from skill '{name}'",
                 "delete": f"delete skill '{name}'"}.get(action, f"({action} on '{name}')")
-
-    # patch/write_file target a file inside the skill; edit always targets SKILL.md.
     target_label, current = "SKILL.md", ""
     skill_dir = _find_skill_path(name)
     if skill_dir:
@@ -270,7 +299,6 @@ def skill_pending_diff(record: Dict[str, Any]) -> str:
         with suppress(Exception):
             p = skill_dir / target_label
             current = p.read_text(encoding="utf-8") if p.exists() else ""
-
     if action == "patch":
         old_s, new_s = payload.get("old_string") or "", payload.get("new_string") or ""
         new = current.replace(old_s, new_s) if current else f"(patch {old_s!r} → {new_s!r})"


### PR DESCRIPTION
## What does this PR do?

Adds a patch-only `evidence_merge` shape to `skill_manage` for safely recording additive skill evidence in YAML frontmatter. It routes through the existing approval staging/replay path, freezes the candidate and preview at staging time, binds replay to the source digest, and rejects malformed or ambiguous evidence rather than silently rewriting skills.

## Related Issue

No existing issue matched `evidence_merge`, skill evidence frontmatter, or the requested ledger behavior. Related PR #100471 covers file-tool ledger attribution, which is distinct from this additive evidence merge capability.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_evidence.py` — additive evidence merge, duplicate-key/schema/type validation, byte-preserved body rendering, SHA-256 source digest.
- `tools/skill_manager_tool.py` — patch-only dispatch, approval staging, frozen candidate/preview, digest-bound guarded replay, schema wiring.
- `tools/skill_manager_batch.py` — explicit evidence-only batch restriction and pre-mutation stale digest check.
- `tools/write_approval.py` — frozen evidence candidate preview support.
- `tests/tools/test_skill_evidence_merge.py` — 12 merge and registered-path regression tests covering 75 test cases across the two focused files.
- `contributors/emails/hermes-pi@nousresearch.com` — maps the commit author email to the submitting GitHub account so the upstream attribution gate can verify provenance.

## How to Test

1. Use the existing development interpreter:
   `/home/hermes-pi/projects/hermes-agent/.venv/bin/python`
2. Run:
   `HERMES_PYTHON=/home/hermes-pi/projects/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/tools/test_skill_evidence_merge.py tests/tools/test_skill_manager_tool.py`
3. Result on the rebased candidate: **75 passed, 0 failed**.
4. Also verified: Ruff, Python compilation, and `git diff --check` pass; no dependency installation was performed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (RPi5)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Solar Pro 4 independent exact-tree review after rebasing onto current upstream `main`: APPROVE in artifact-focused and lifecycle-focused framings.
- Accepted informational limitations: ordered-state simulation is not implemented for multi-operation evidence batches; a narrow external-concurrency window remains between staging and execution; existing revert-scheduled plugin-compat shims remain unchanged.
