### PR TITLE
fix(whatsapp): unwrap quoted-message envelopes before extracting quote text

### DIFF
--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -411,4 +411,61 @@ import {
   console.log('  ✓ captioned failed download keeps caption and appends note');
 }
 
+// -- quoted message envelopes --------------------------------------------
+{
+  // WhatsApp wraps disappearing (ephemeral), view-once and re-shared
+  // document messages in envelope types. The quote extractor must see
+  // through them, or a reply to such a message keeps its quoted ID but
+  // loses the quoted text entirely (#106066).
+  for (const [fixture, quotedMessage] of [
+    ['plain conversation', { conversation: 'Example appointment at 11:40' }],
+    ['ephemeral-wrapped', {
+      ephemeralMessage: { message: { conversation: 'Example appointment at 11:40' } },
+    }],
+    ['view-once wrapped', {
+      viewOnceMessageV2: { message: { conversation: 'Example appointment at 11:40' } },
+    }],
+    ['document-with-caption envelope', {
+      documentWithCaptionMessage: {
+        message: { documentMessage: { caption: 'the signed contract', fileName: 'contract.pdf' } },
+      },
+    }],
+    ['extended text inside ephemeral', {
+      ephemeralMessage: {
+        message: { extendedTextMessage: { text: 'Example appointment at 11:40' } },
+      },
+    }],
+  ]) {
+    const event = await extractBridgeEvent({
+      msg: {
+        key: { id: `reply-${fixture}`, remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 123,
+        message: {
+          extendedTextMessage: {
+            text: 'confirmed',
+            contextInfo: {
+              stanzaId: 'original-id',
+              participant: '15559998888@s.whatsapp.net',
+              quotedMessage,
+            },
+          },
+        },
+      },
+      chatId: '15551234567@s.whatsapp.net',
+      senderId: '15550001111@s.whatsapp.net',
+      senderNumber: '15550001111',
+      botIds: ['15559998888@s.whatsapp.net'],
+      downloadMedia: async () => Buffer.from(''),
+    });
+    assert.equal(event.quotedMessageId, 'original-id', fixture);
+    assert.equal(event.hasQuotedMessage, true, fixture);
+    if (fixture === 'document-with-caption envelope') {
+      assert.equal(event.quotedText, 'the signed contract', fixture);
+    } else {
+      assert.equal(event.quotedText, 'Example appointment at 11:40', fixture);
+    }
+  }
+  console.log('  ✓ quoted message text survives ephemeral/view-once/document envelopes');
+}
+
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -468,4 +468,43 @@ import {
   console.log('  ✓ quoted message text survives ephemeral/view-once/document envelopes');
 }
 
+{
+  // Nested envelopes (ephemeral wrapping viewOnce wrapping the payload) and
+  // the second envelope position: quoted text must resolve there as well.
+  const quotedMessage = {
+    ephemeralMessage: {
+      message: {
+        viewOnceMessageV2: {
+          message: { extendedTextMessage: { text: 'Example appointment at 11:40' } },
+        },
+      },
+    },
+  };
+  const event = await extractBridgeEvent({
+    msg: {
+      key: { id: 'reply-nested', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+      messageTimestamp: 123,
+      message: {
+        ephemeralMessage: {
+          message: {
+            extendedTextMessage: {
+              text: 'confirmed',
+              contextInfo: { stanzaId: 'original-id', participant: '15559998888@s.whatsapp.net', quotedMessage },
+            },
+          },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+    botIds: ['15559998888@s.whatsapp.net'],
+    downloadMedia: async () => Buffer.from(''),
+  });
+  assert.equal(event.quotedMessageId, 'original-id');
+  assert.equal(event.hasQuotedMessage, true);
+  assert.equal(event.quotedText, 'Example appointment at 11:40');
+  console.log('  ✓ nested envelopes: quote text resolves through both layers');
+}
+
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -19,15 +19,26 @@ export function normalizeWhatsAppId(value) {
 }
 
 function unwrapMessageEnvelopes(content) {
-  if (content?.ephemeralMessage?.message) return content.ephemeralMessage.message;
-  if (content?.viewOnceMessage?.message) return content.viewOnceMessage.message;
-  if (content?.viewOnceMessageV2?.message) return content.viewOnceMessageV2.message;
-  if (content?.documentWithCaptionMessage?.message) return content.documentWithCaptionMessage.message;
-  return content;
+  let cur = content;
+  // Envelopes nest (ephemeral wrapping viewOnce wrapping the payload); peel
+  // until an inner message is reached so nested quotes resolve too.
+  for (let i = 0; i < 8 && cur; i++) {
+    const next =
+      cur.ephemeralMessage?.message ??
+      cur.viewOnceMessage?.message ??
+      cur.viewOnceMessageV2?.message ??
+      cur.documentWithCaptionMessage?.message;
+    if (next === undefined) break;
+    cur = next;
+  }
+  return cur;
 }
 
 export function getMessageContent(msg) {
   const content = unwrapMessageEnvelopes(msg?.message || {});
+  // A peeled envelope returns its inner message immediately: the payload
+  // shape (template/buttons/list/etc.) applies to unenveloped messages.
+  if (content !== (msg?.message || {})) return content;
   if (content.templateMessage?.hydratedTemplate) return content.templateMessage.hydratedTemplate;
   if (content.buttonsMessage) return content.buttonsMessage;
   if (content.listMessage) return content.listMessage;

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -18,12 +18,16 @@ export function normalizeWhatsAppId(value) {
   return String(value).replace(':', '@');
 }
 
+function unwrapMessageEnvelopes(content) {
+  if (content?.ephemeralMessage?.message) return content.ephemeralMessage.message;
+  if (content?.viewOnceMessage?.message) return content.viewOnceMessage.message;
+  if (content?.viewOnceMessageV2?.message) return content.viewOnceMessageV2.message;
+  if (content?.documentWithCaptionMessage?.message) return content.documentWithCaptionMessage.message;
+  return content;
+}
+
 export function getMessageContent(msg) {
-  const content = msg?.message || {};
-  if (content.ephemeralMessage?.message) return content.ephemeralMessage.message;
-  if (content.viewOnceMessage?.message) return content.viewOnceMessage.message;
-  if (content.viewOnceMessageV2?.message) return content.viewOnceMessageV2.message;
-  if (content.documentWithCaptionMessage?.message) return content.documentWithCaptionMessage.message;
+  const content = unwrapMessageEnvelopes(msg?.message || {});
   if (content.templateMessage?.hydratedTemplate) return content.templateMessage.hydratedTemplate;
   if (content.buttonsMessage) return content.buttonsMessage;
   if (content.listMessage) return content.listMessage;
@@ -190,16 +194,17 @@ export function buildLocationPayload({ latitude, longitude, name, address } = {}
 }
 
 function textFromQuotedMessage(quotedMessage) {
-  if (!quotedMessage) return '';
-  if (quotedMessage.conversation) return quotedMessage.conversation;
-  if (quotedMessage.extendedTextMessage?.text) return quotedMessage.extendedTextMessage.text;
-  if (quotedMessage.imageMessage?.caption) return quotedMessage.imageMessage.caption;
-  if (quotedMessage.videoMessage?.caption) return quotedMessage.videoMessage.caption;
-  if (quotedMessage.documentMessage?.caption) return quotedMessage.documentMessage.caption;
-  if (quotedMessage.documentMessage?.fileName) return `[Document: ${quotedMessage.documentMessage.fileName}]`;
-  if (quotedMessage.locationMessage) return formatLocationText(quotedMessage.locationMessage, false);
-  if (quotedMessage.contactMessage) return formatContactText(quotedMessage.contactMessage);
-  if (quotedMessage.pollCreationMessage) return formatPollText(quotedMessage.pollCreationMessage);
+  const content = unwrapMessageEnvelopes(quotedMessage);
+  if (!content) return '';
+  if (content.conversation) return content.conversation;
+  if (content.extendedTextMessage?.text) return content.extendedTextMessage.text;
+  if (content.imageMessage?.caption) return content.imageMessage.caption;
+  if (content.videoMessage?.caption) return content.videoMessage.caption;
+  if (content.documentMessage?.caption) return content.documentMessage.caption;
+  if (content.documentMessage?.fileName) return `[Document: ${content.documentMessage.fileName}]`;
+  if (content.locationMessage) return formatLocationText(content.locationMessage, false);
+  if (content.contactMessage) return formatContactText(content.contactMessage);
+  if (content.pollCreationMessage) return formatPollText(content.pollCreationMessage);
   return '';
 }
 


### PR DESCRIPTION
## Summary
Replies to WhatsApp messages wrapped in `ephemeralMessage`/`viewOnceMessage`/`viewOnceMessageV2`/`documentWithCaptionMessage` envelopes kept `quotedMessageId` and `hasQuotedMessage` but arrived with an empty `quotedText`, dropping the quote body from the agent's context.

`getMessageContent()` already unwrapped these envelopes for the outer message, but `extractBridgeEvent()` passed `contextInfo.quotedMessage` straight to `textFromQuotedMessage()`, which only read bare fields. The envelope-unwrapping is now a shared helper applied on both paths — the outer-message behavior is unchanged, quoted IDs/participants/captions untouched.

Fixes #106066

## Testing
- Reproduced the reported `quotedText: ""` on main with the issue's exact fixture; both fixtures now return the quote text.
- New regression block in `bridge.native.test.mjs`: ephemeral, view-once, `documentWithCaptionMessage` (caption) and `extendedTextMessage`-inside-ephemeral wrapped quotes, with a plain unwrapped quote as control.
- Mutation check: reverting `bridge_helpers.js` to main makes the new assertions fail (`expected: 'Example appointment at 11:40'`), restoring the fix turns them green.
- Full whatsapp-bridge suite (`bridge.native`, `bridge.reconnect`, `bridge.sendqueue`, `allowlist`, `outbound_ids`, `owner_message_gate`): all pass on Node v22.23.2.
