### PR TITLE
fix(whatsapp): unwrap ephemeral/view-once envelopes when reading quoted text

### DIFF
--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -189,17 +189,41 @@ export function buildLocationPayload({ latitude, longitude, name, address } = {}
   return { location };
 }
 
+// Baileys wraps a concrete payload inside envelope messages (disappearing
+// messages, view-once media, document-with-caption). These carry the real
+// message under `.message` and can nest (an ephemeral wrapping a view-once),
+// so peel repeatedly until the concrete payload is reached.
+const WRAPPED_MESSAGE_KEYS = [
+  'ephemeralMessage',
+  'viewOnceMessage',
+  'viewOnceMessageV2',
+  'documentWithCaptionMessage',
+];
+
+function unwrapMessageContent(content) {
+  let inner = content;
+  for (let depth = 0; inner && typeof inner === 'object' && depth < 8; depth += 1) {
+    const key = WRAPPED_MESSAGE_KEYS.find((k) => inner[k]?.message);
+    if (!key) break;
+    inner = inner[key].message;
+  }
+  return inner;
+}
+
 function textFromQuotedMessage(quotedMessage) {
-  if (!quotedMessage) return '';
-  if (quotedMessage.conversation) return quotedMessage.conversation;
-  if (quotedMessage.extendedTextMessage?.text) return quotedMessage.extendedTextMessage.text;
-  if (quotedMessage.imageMessage?.caption) return quotedMessage.imageMessage.caption;
-  if (quotedMessage.videoMessage?.caption) return quotedMessage.videoMessage.caption;
-  if (quotedMessage.documentMessage?.caption) return quotedMessage.documentMessage.caption;
-  if (quotedMessage.documentMessage?.fileName) return `[Document: ${quotedMessage.documentMessage.fileName}]`;
-  if (quotedMessage.locationMessage) return formatLocationText(quotedMessage.locationMessage, false);
-  if (quotedMessage.contactMessage) return formatContactText(quotedMessage.contactMessage);
-  if (quotedMessage.pollCreationMessage) return formatPollText(quotedMessage.pollCreationMessage);
+  // A quoted message can arrive inside the same envelopes as a top-level one
+  // (e.g. replying to a disappearing message), so unwrap before reading text.
+  const quoted = unwrapMessageContent(quotedMessage);
+  if (!quoted) return '';
+  if (quoted.conversation) return quoted.conversation;
+  if (quoted.extendedTextMessage?.text) return quoted.extendedTextMessage.text;
+  if (quoted.imageMessage?.caption) return quoted.imageMessage.caption;
+  if (quoted.videoMessage?.caption) return quoted.videoMessage.caption;
+  if (quoted.documentMessage?.caption) return quoted.documentMessage.caption;
+  if (quoted.documentMessage?.fileName) return `[Document: ${quoted.documentMessage.fileName}]`;
+  if (quoted.locationMessage) return formatLocationText(quoted.locationMessage, false);
+  if (quoted.contactMessage) return formatContactText(quoted.contactMessage);
+  if (quoted.pollCreationMessage) return formatPollText(quoted.pollCreationMessage);
   return '';
 }
 

--- a/scripts/whatsapp-bridge/quoted_wrappers.test.mjs
+++ b/scripts/whatsapp-bridge/quoted_wrappers.test.mjs
@@ -1,0 +1,89 @@
+// Regression tests for quoted-text extraction through Baileys envelope
+// wrappers (disappearing messages, view-once media, document-with-caption).
+//
+// A reply that quotes such a message nests the quoted payload under
+// `contextInfo.quotedMessage.<wrapper>.message`, and the extractor used to
+// read `quotedMessage.conversation` directly — so the quote text was lost
+// while the quoted-message id survived (issue #106066).
+//
+// Imports only the pure helper module, so this runs without the Baileys
+// runtime dependency: `node scripts/whatsapp-bridge/quoted_wrappers.test.mjs`.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractBridgeEvent } from './bridge_helpers.js';
+
+const QUOTE = 'Example appointment at 11:40';
+
+function replyQuoting(quotedMessage) {
+  return extractBridgeEvent({
+    msg: {
+      key: { id: 'reply-id', remoteJid: 'example@g.us' },
+      message: {
+        extendedTextMessage: {
+          text: 'confirmed',
+          contextInfo: {
+            stanzaId: 'original-id',
+            participant: 'example@s.whatsapp.net',
+            quotedMessage,
+          },
+        },
+      },
+    },
+    chatId: 'example@g.us',
+    senderId: 'sender@s.whatsapp.net',
+    senderNumber: 'sender',
+    botIds: [],
+    isGroup: true,
+  });
+}
+
+test('an unwrapped conversation quote keeps its text', async () => {
+  const event = await replyQuoting({ conversation: QUOTE });
+  assert.equal(event.quotedMessageId, 'original-id');
+  assert.equal(event.hasQuotedMessage, true);
+  assert.equal(event.quotedText, QUOTE);
+});
+
+test('an ephemeralMessage-wrapped quote keeps its text', async () => {
+  const event = await replyQuoting({
+    ephemeralMessage: { message: { conversation: QUOTE } },
+  });
+  assert.equal(event.quotedMessageId, 'original-id');
+  assert.equal(event.hasQuotedMessage, true);
+  assert.equal(event.quotedText, QUOTE);
+});
+
+test('a viewOnce-wrapped media caption is preserved', async () => {
+  const event = await replyQuoting({
+    viewOnceMessage: { message: { imageMessage: { caption: QUOTE } } },
+  });
+  assert.equal(event.quotedText, QUOTE);
+});
+
+test('nested envelopes (ephemeral wrapping view-once) are peeled', async () => {
+  const event = await replyQuoting({
+    ephemeralMessage: {
+      message: {
+        viewOnceMessageV2: { message: { extendedTextMessage: { text: QUOTE } } },
+      },
+    },
+  });
+  assert.equal(event.quotedText, QUOTE);
+});
+
+test('a documentWithCaption-wrapped quote keeps its caption', async () => {
+  const event = await replyQuoting({
+    documentWithCaptionMessage: {
+      message: { documentMessage: { caption: QUOTE } },
+    },
+  });
+  assert.equal(event.quotedText, QUOTE);
+});
+
+test('a missing quoted message still yields empty text without throwing', async () => {
+  const event = await replyQuoting(undefined);
+  assert.equal(event.quotedText, '');
+  assert.equal(event.hasQuotedMessage, false);
+});


### PR DESCRIPTION
Fixes #106066.

## Problem

WhatsApp quote extraction lost the text of an `ephemeralMessage`-wrapped quoted message. `quotedMessageId` and `hasQuotedMessage` survived, but `quotedText` came back empty — the same content works when sent as a bare `conversation`.

## Root cause

`textFromQuotedMessage` in `scripts/whatsapp-bridge/bridge_helpers.js` read `quotedMessage.conversation` (and the media caption fields) **directly**. But a reply that quotes a disappearing message, view-once media, or a document-with-caption nests the real payload under `contextInfo.quotedMessage.<wrapper>.message`. `getMessageContent` already peels these envelopes for top-level messages; the quoted path did not.

## Fix

Peel the same Baileys envelope wrappers (`ephemeralMessage` / `viewOnceMessage` / `viewOnceMessageV2` / `documentWithCaptionMessage`) before extracting quoted text, in a bounded loop so nested envelopes (e.g. an ephemeral wrapping a view-once) are also unwrapped. The top-level ingestion path is unchanged.

## Verification

The issue's exact offline repro now preserves the quote for both fixtures:

```
{"fixture":"plain","quotedMessageId":"original-id","hasQuotedMessage":true,"quotedText":"Example appointment at 11:40"}
{"fixture":"ephemeral-wrapped","quotedMessageId":"original-id","hasQuotedMessage":true,"quotedText":"Example appointment at 11:40"}
```

Adds `scripts/whatsapp-bridge/quoted_wrappers.test.mjs` (node:test, no Baileys runtime dependency) covering the plain, ephemeral, view-once, nested, document-with-caption, and missing-quote cases — all 6 pass; the wrapped cases fail without this change. Preflight gates pass (windows-footguns; ruff/uv.lock skipped — no Python changes).

Note: the arm64-fork-Docker CI job is expected to fail on fork PRs and is unrelated to this change.