### PR TITLE
fix(agent): route keyless local auxiliary providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -519,6 +519,17 @@ def _extract_url_query_params(url: str):
 # Warn only once per process about stale OPENAI_BASE_URL.
 _stale_base_url_warned = False
 
+# OpenAI-compatible local servers (Ollama, vLLM, llama.cpp server) are served by the
+# generic custom provider — mirroring hermes_cli.auth._PROVIDER_ALIASES. Without these
+# entries an explicit ``provider: ollama`` aux lane dead-ends in the unknown-provider arm
+# and raises a misleading ``OLLAMA_API_KEY`` error instead of using the lane's base_url
+# (#106010). Their OpenAI wire surface lives under /v1, so a bare host base_url needs
+# the /v1 tail (#106010).
+_LOCAL_SERVER_ALIASES = {
+    "ollama": "custom", "vllm": "custom", "llamacpp": "custom",
+    "llama.cpp": "custom", "llama-cpp": "custom",
+}
+
 _PROVIDER_ALIASES = {
     "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
     "x-ai": "xai", "x.ai": "xai", "grok": "xai",
@@ -534,7 +545,16 @@ _PROVIDER_ALIASES = {
     "tencent": "tencent-tokenhub", "tokenhub": "tencent-tokenhub", "tencent-cloud": "tencent-tokenhub",
     "tencentmaas": "tencent-tokenhub",
     "tokenplan": "tencent-tokenplan", "tencent-lkeap": "tencent-tokenplan",
+    **_LOCAL_SERVER_ALIASES,
 }
+
+
+def _bare_host_base_url(base_url: str) -> bool:
+    """True when a base URL is a bare host[:port] with no path component."""
+    try:
+        return urlparse(str(base_url or "").strip()).path.strip("/") == ""
+    except Exception:
+        return False
 
 
 def _normalize_aux_provider(provider: Optional[str]) -> str:
@@ -4542,6 +4562,8 @@ def _resolve_custom_branch(req: _ResolveRequest) -> _ResolveResult:
     custom_base = custom_key = wrap_base = ""
     if req.explicit_base_url:
         custom_base = _to_openai_base_url(req.explicit_base_url).strip()
+        if req.original_provider in _LOCAL_SERVER_ALIASES and _bare_host_base_url(custom_base):
+            custom_base = custom_base.rstrip("/") + "/v1"
         if req.api_mode == "anthropic_messages":
             wrap_base = (req.explicit_base_url or "").strip().rstrip("/")
         custom_key = (

--- a/tests/agent/test_auxiliary_ollama_local_provider.py
+++ b/tests/agent/test_auxiliary_ollama_local_provider.py
@@ -1,0 +1,133 @@
+"""Explicit ``provider: ollama`` (and sibling local-server aliases) must route through
+the ``custom`` branch like they do in the main runtime, so an aux lane pointing at a
+local Ollama/vLLM/llama.cpp server with an empty ``api_key`` builds a client with the
+``no-key-required`` placeholder instead of dead-ending in the unknown-provider arm.
+
+The bug (issue #106010): ``agent/auxiliary_client.py`` kept its own copy of the
+provider alias table without the "local server aliases" group that
+``hermes_cli.auth._PROVIDER_ALIASES`` has. An explicit ``provider: ollama`` lane with
+``base_url`` + empty ``api_key`` kept the ollama identity, matched no registry entry,
+and every call raised ``RuntimeError: Provider 'ollama' is set in config.yaml but no
+API key was found`` — while the same endpoint worked as ``provider: custom``.
+
+Secondary fix covered here: the OpenAI-compatible surface of these servers lives
+under ``/v1``, so a bare host base_url (``http://127.0.0.1:11434``) must gain the
+``/v1`` tail or the first request 404s on the server's native API.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_same_host_main_key():
+    # The key ladder falls back to the main config's key when hosts match; the
+    # placeholder assertions below need that rung to stay empty.
+    with patch("agent.auxiliary_client._read_main_api_key_if_same_host", return_value=None):
+        yield
+
+
+def _client_attr(client, attr: str) -> str:
+    for chain in ((attr,), ("_real_client", attr), ("_client", attr)):
+        obj = client
+        try:
+            for name in chain:
+                obj = getattr(obj, name)
+            return str(obj)
+        except AttributeError:
+            continue
+    return ""
+
+
+def test_ollama_bare_local_base_url_gets_v1_tail_and_placeholder_key(monkeypatch):
+    """provider: ollama + loopback base_url + empty api_key must resolve a client
+    (placeholder key, /v1 base) — not return None and raise downstream (#106010)."""
+    from agent.auxiliary_client import resolve_provider_client
+
+    client, _model = resolve_provider_client(
+        "ollama",
+        model="llama3.2",
+        explicit_base_url="http://127.0.0.1:11434",
+        explicit_api_key=None,
+    )
+    assert client is not None, (
+        "explicit provider: ollama with a local base_url must build a client via the "
+        "custom branch instead of dead-ending in the unknown-provider arm"
+    )
+    assert _client_attr(client, "base_url").rstrip("/") == "http://127.0.0.1:11434/v1"
+    assert _client_attr(client, "api_key") == "no-key-required"
+
+
+def test_ollama_explicit_api_key_passthrough_with_v1_tail(monkeypatch):
+    """An explicit api_key must be honored verbatim (not swapped for the placeholder),
+    with the /v1 tail still appended to a bare local base_url."""
+    from agent.auxiliary_client import resolve_provider_client
+
+    monkeypatch.setenv("HERMES_TEST_FAKE_KEY", "[REDACTED_TEST_KEY]")
+    client, _model = resolve_provider_client(
+        "ollama",
+        model="llama3.2",
+        explicit_base_url="http://localhost:11434",
+        explicit_api_key=os.environ["HERMES_TEST_FAKE_KEY"],
+    )
+    assert client is not None
+    assert _client_attr(client, "base_url").rstrip("/") == "http://localhost:11434/v1"
+    assert _client_attr(client, "api_key") == os.environ["HERMES_TEST_FAKE_KEY"]
+
+
+def test_ollama_base_url_with_path_not_rewritten(monkeypatch):
+    """A base_url that already carries a path (e.g. .../v1) must be kept as-is —
+    never double-appended."""
+    from agent.auxiliary_client import resolve_provider_client
+
+    monkeypatch.setenv("HERMES_TEST_FAKE_KEY", "[REDACTED_TEST_KEY]")
+    client, _model = resolve_provider_client(
+        "ollama",
+        model="llama3.2",
+        explicit_base_url="http://127.0.0.1:11434/v1",
+        explicit_api_key=os.environ["HERMES_TEST_FAKE_KEY"],
+    )
+    assert client is not None
+    assert _client_attr(client, "base_url").rstrip("/") == "http://127.0.0.1:11434/v1"
+
+
+def test_bare_custom_loopback_base_url_kept_as_is(monkeypatch):
+    """Only the local-server aliases get the /v1 tail: a literal ``provider: custom``
+    with a bare loopback base keeps its URL verbatim (existing custom semantics)."""
+    from agent.auxiliary_client import resolve_provider_client
+
+    monkeypatch.setenv("HERMES_TEST_FAKE_KEY", "[REDACTED_TEST_KEY]")
+    client, _model = resolve_provider_client(
+        "custom",
+        model="llama3.2",
+        explicit_base_url="http://127.0.0.1:11434",
+        explicit_api_key=os.environ["HERMES_TEST_FAKE_KEY"],
+    )
+    assert client is not None
+    assert _client_attr(client, "base_url").rstrip("/") == "http://127.0.0.1:11434"
+
+
+def test_vllm_local_server_alias_routes_the_same_way():
+    """Sibling local-server aliases (vllm, llama.cpp) share the custom routing and
+    the /v1 tail."""
+    from agent.auxiliary_client import resolve_provider_client
+
+    client, _model = resolve_provider_client(
+        "vllm",
+        model="Qwen3-32B",
+        explicit_base_url="http://127.0.0.1:8000",
+        explicit_api_key=None,
+    )
+    assert client is not None
+    assert _client_attr(client, "base_url").rstrip("/") == "http://127.0.0.1:8000/v1"
+    assert _client_attr(client, "api_key") == "no-key-required"


### PR DESCRIPTION
## Summary

Carry forward the verified fix for #106010 onto the current `main` branch. The original implementation is already published as #106018, but its head fork is read-only to this account (`viewerPermission=READ`), so this PR provides an authorized upstream-targeted carry-forward rather than leaving the issue dependent on an inaccessible branch.

The change routes explicit local-server auxiliary providers through the existing keyless `custom` path and normalizes bare local OpenAI-compatible endpoints to `/v1`.

## Observed problem

- Incorrect behavior: an auxiliary task configured with `provider: ollama`, a local `base_url` such as `http://127.0.0.1:11434`, and an empty `api_key` raises `RuntimeError: Provider 'ollama' is set in config.yaml but no API key was found` before a client is built.
- Incorrect follow-up behavior: routing the same bare endpoint through the custom branch without a `/v1` suffix sends requests to the native path and returns a 404 from Ollama-compatible servers.
- Expected behavior: local auxiliary aliases build a client with the existing `no-key-required` placeholder, use the OpenAI-compatible `/v1` surface for bare host URLs, preserve explicit keys, and leave literal `provider: custom` behavior unchanged.
- Reproduction: the new regression file failed on clean base `c076d653a216939b97a93ab0c10ce709bacde667` with 4 failures and 1 unrelated control pass; the exact baseline `call_llm` harness raised the reported `OLLAMA_API_KEY` error. No live provider or credential was used.

## Root cause

`agent/auxiliary_client.py` owns a private provider-alias table used by the auxiliary resolver. It lacked the local-server aliases already accepted by `hermes_cli.auth`:

- `ollama` -> `custom`
- `vllm` -> `custom`
- `llamacpp` -> `custom`
- `llama.cpp` -> `custom`
- `llama-cpp` -> `custom`

The task resolver intentionally preserves a named provider when a `base_url` is present but no key is configured. Consequently, `provider: ollama` reached `resolve_provider_client()` as `ollama`; it matched neither an explicit resolver branch nor a `PROVIDER_REGISTRY` row, returned `(None, None)`, and `_resolve_call_client()` converted that into the misleading missing-key exception.

The existing custom branch already supplies `no-key-required` for keyless custom endpoints. The issue's second variant exposed that bare local hosts also need the `/v1` OpenAI-compatible path; otherwise the first request targets the server's native API path and 404s.

## Impact and scope

- Affected: explicit auxiliary routes using `ollama`, `vllm`, `llamacpp`, `llama.cpp`, or `llama-cpp` with local OpenAI-compatible endpoints, especially keyless title generation, compression, tagger, summarization, and similar tasks.
- Not affected: `ollama-cloud`, `lmstudio`, literal `provider: custom`, non-local provider aliases, provider credentials, secret scopes, and the main-agent provider resolver.
- Security: no environment key is newly ungated. `OLLAMA_API_KEY` host gating is unchanged. The placeholder is reused only through the existing custom endpoint behavior. No real key, token, credential, or personal path is included in this PR.
- Compatibility: configured URLs that already have a path are unchanged; literal custom endpoints are deliberately not rewritten.
- Performance: alias resolution remains an O(1) dictionary lookup. Bare-host detection performs one bounded URL parse and no network or filesystem I/O. Auxiliary space is O(1) beyond the constructed client/request.

## Solution

- Added `_LOCAL_SERVER_ALIASES` and merged it into the auxiliary alias table.
- Added a bounded bare-host URL predicate.
- Appended `/v1` only when the request originated from a local-server alias and the explicit endpoint has no path.
- Kept explicit API-key passthrough, existing paths, and literal custom-provider URLs unchanged.

This is a carry-forward of the verified behavioral fix in #106018, rebased onto current `main`. The older #74320/#74280 work addresses the alias half only and was reviewed as missing a resolver-level regression; #106018 additionally covers the load-bearing `/v1` behavior. #21384 is an older closed Ollama alias fix from before the current resolver refactor. #40406 concerns same-endpoint credential inheritance and is unrelated to alias dispatch. #56448 and #62239 cover broader provider-alias synchronization but do not replace this focused auxiliary route fix.

## Compatibility and residual risks

No migration or configuration change is required. Existing configurations using `provider: custom` retain their prior URL semantics. A live Ollama/vLLM server was not available in this environment, so provider-network behavior remains covered by hermetic resolver assertions rather than a live network test. The implementation intentionally does not infer or expose credentials for local endpoints.

## Tests and verification

| Command / test | Purpose | Result |
|---|---|---|
| `scripts/run_tests.sh tests/agent/test_auxiliary_ollama_local_provider.py -q` on clean base `c076d653a216939b97a93ab0c10ce709bacde667` | Prove the regression test bites without the fix | 4 failed, 1 control passed; failures were `client is None` on the reported alias paths |
| `scripts/run_tests.sh tests/agent/test_auxiliary_ollama_local_provider.py -q` on this head | Verify keyless Ollama routing, `/v1` normalization, path preservation, custom compatibility, and vLLM sibling routing | 5 passed |
| `scripts/run_tests.sh tests/agent/test_auxiliary_ollama_local_provider.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_named_custom_providers.py -q` | Run the changed test plus nearest auxiliary resolver coverage | 229 passed, 0 failed |
| `ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_ollama_local_provider.py` | Lint changed files | Passed |
| Deterministic issue reproduction harness with sanitized environment | Exercise the public `call_llm` path without a live provider | Returned `OK`; constructed key was `no-key-required`; no credential material was used |
| Bounded resolver stress harness | Exercise 5 correctness checks, repeated aliases, concurrent calls, latency, and traced memory | Pre-publication round: all 5 checks passed, 125 concurrent calls, 2.390s, 4,081,163-byte peak. Post-publication rounds 1-3: all 5 checks passed in each round; 125 concurrent calls per round; 3.578s / 4,090,976-byte peak, 2.985s / 4,090,731-byte peak, and 2.235s / 4,092,311-byte peak respectively |

Post-publication verification used the exact pushed head `b3b23114d520d31d6264f84d5388de15b6620a35`; each round combined `scripts/run_tests.sh tests/agent/test_auxiliary_ollama_local_provider.py -q` with the five-check resolver stress harness. The stress harness is an in-process resolver/transport-construction check, not a benchmark of Ollama network capacity.

| `graphify update . --no-cluster` | Refresh the repository knowledge graph after the source edit | Completed AST extraction for 10,725 files. Graphify reported 4 pre-existing parse warnings in unrelated files; no LLM clustering was requested |
| `gh pr checks 106084 --repo NousResearch/hermes-agent --json name,state,link` | Read the published CI state | 8 checks reported: 5 `SUCCESS`, 3 `SKIPPED`, 0 failures. The PR merge state remains `BLOCKED`; this is not reported as merged or fully green |

## Files and documentation

- `agent/auxiliary_client.py`: local alias normalization and bare-host `/v1` routing.
- `tests/agent/test_auxiliary_ollama_local_provider.py`: focused regression and compatibility tests.
- No configuration schema, dependency, documentation-site, or release-note change is required.

## Delivery metadata

- Source issue: #106010
- Carry-forward source PR: #106018, head `2e1e5ecde7fcce41944fb386598e5e94954826e7` (original fork is read-only to this account)
- Prior alias-only candidate: #74320, left open and untouched
- Commit parent used for the carry-forward: `c076d653a216939b97a93ab0c10ce709bacde667`
- PR base ref readback: `main` at `ed6671db83c55998ed48bd995a4494ef5c84c23b`
- PR URL: https://github.com/NousResearch/hermes-agent/pull/106084
- Remote head readback: `b3b23114d520d31d6264f84d5388de15b6620a35`
- Remote changed files readback: exactly `agent/auxiliary_client.py` and `tests/agent/test_auxiliary_ollama_local_provider.py`
- Branch: `fix/issue-106010-ollama-aux-keyless-carry-latest`
- Final remote checks readback at update time: 5 `SUCCESS`, 3 `SKIPPED`, 0 failures; merge state `BLOCKED`
