### PR TITLE
fix(whatsapp): unwrap quoted-message wrappers before extracting quote text (#106066)

### DIFF
--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -193,8 +193,15 @@ function textFromQuotedMessage(quotedMessage) {
   if (!quotedMessage) return '';
   // A quoted payload can arrive inside the same wrappers as a top-level message
   // (ephemeralMessage for disappearing-message replies, viewOnce…); normalize
-  // first so wrapped quotes keep their text (#106066).
-  const content = getMessageContent({ message: quotedMessage });
+  // first so wrapped quotes keep their text (#106066). Wrappers can nest
+  // (e.g. ephemeral around viewOnce), so keep unwrapping with an explicit
+  // bound, mirroring Baileys' own nested-envelope normalization.
+  let content = getMessageContent({ message: quotedMessage });
+  for (let depth = 0; depth < 4; depth += 1) {
+    const unwrapped = getMessageContent({ message: content });
+    if (unwrapped === content) break;
+    content = unwrapped;
+  }
   if (content.conversation) return content.conversation;
   if (content.extendedTextMessage?.text) return content.extendedTextMessage.text;
   if (content.imageMessage?.caption) return content.imageMessage.caption;

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -191,15 +191,19 @@ export function buildLocationPayload({ latitude, longitude, name, address } = {}
 
 function textFromQuotedMessage(quotedMessage) {
   if (!quotedMessage) return '';
-  if (quotedMessage.conversation) return quotedMessage.conversation;
-  if (quotedMessage.extendedTextMessage?.text) return quotedMessage.extendedTextMessage.text;
-  if (quotedMessage.imageMessage?.caption) return quotedMessage.imageMessage.caption;
-  if (quotedMessage.videoMessage?.caption) return quotedMessage.videoMessage.caption;
-  if (quotedMessage.documentMessage?.caption) return quotedMessage.documentMessage.caption;
-  if (quotedMessage.documentMessage?.fileName) return `[Document: ${quotedMessage.documentMessage.fileName}]`;
-  if (quotedMessage.locationMessage) return formatLocationText(quotedMessage.locationMessage, false);
-  if (quotedMessage.contactMessage) return formatContactText(quotedMessage.contactMessage);
-  if (quotedMessage.pollCreationMessage) return formatPollText(quotedMessage.pollCreationMessage);
+  // A quoted payload can arrive inside the same wrappers as a top-level message
+  // (ephemeralMessage for disappearing-message replies, viewOnce…); normalize
+  // first so wrapped quotes keep their text (#106066).
+  const content = getMessageContent({ message: quotedMessage });
+  if (content.conversation) return content.conversation;
+  if (content.extendedTextMessage?.text) return content.extendedTextMessage.text;
+  if (content.imageMessage?.caption) return content.imageMessage.caption;
+  if (content.videoMessage?.caption) return content.videoMessage.caption;
+  if (content.documentMessage?.caption) return content.documentMessage.caption;
+  if (content.documentMessage?.fileName) return `[Document: ${content.documentMessage.fileName}]`;
+  if (content.locationMessage) return formatLocationText(content.locationMessage, false);
+  if (content.contactMessage) return formatContactText(content.contactMessage);
+  if (content.pollCreationMessage) return formatPollText(content.pollCreationMessage);
   return '';
 }
 

--- a/scripts/whatsapp-bridge/bridge_helpers.test.mjs
+++ b/scripts/whatsapp-bridge/bridge_helpers.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractBridgeEvent } from './bridge_helpers.js';
+
+// #106066: a quoted message can arrive inside the same wrappers as a top-level
+// message (ephemeralMessage for disappearing-message replies). The quote ID and
+// flag survived, but the extractor returned empty text for wrapped payloads.
+async function quotedEvent(quotedMessage) {
+  const event = await extractBridgeEvent({
+    msg: {
+      key: { id: 'reply-id', remoteJid: 'example@g.us' },
+      message: {
+        extendedTextMessage: {
+          text: 'confirmed',
+          contextInfo: {
+            stanzaId: 'original-id',
+            participant: 'example@s.whatsapp.net',
+            quotedMessage,
+          },
+        },
+      },
+    },
+    chatId: 'example@g.us',
+    senderId: 'sender@s.whatsapp.net',
+    senderNumber: 'sender',
+    botIds: [],
+    isGroup: true,
+  });
+  assert.equal(event.quotedMessageId, 'original-id');
+  assert.equal(event.hasQuotedMessage, true);
+  return event;
+}
+
+test('plain quoted conversation keeps its text', async () => {
+  const event = await quotedEvent({ conversation: 'Example appointment at 11:40' });
+  assert.equal(event.quotedText, 'Example appointment at 11:40');
+});
+
+test('ephemeral-wrapped quoted conversation keeps its text (#106066)', async () => {
+  const event = await quotedEvent({
+    ephemeralMessage: { message: { conversation: 'Example appointment at 11:40' } },
+  });
+  assert.equal(event.quotedText, 'Example appointment at 11:40');
+});
+
+test('view-once wrapped quoted conversation keeps its text', async () => {
+  const event = await quotedEvent({
+    viewOnceMessage: { message: { conversation: 'once upon a quote' } },
+  });
+  assert.equal(event.quotedText, 'once upon a quote');
+});
+
+test('wrapped quoted media caption still resolves', async () => {
+  const event = await quotedEvent({
+    ephemeralMessage: { message: { imageMessage: { caption: 'pic caption' } } },
+  });
+  assert.equal(event.quotedText, 'pic caption');
+});

--- a/scripts/whatsapp-bridge/bridge_helpers.test.mjs
+++ b/scripts/whatsapp-bridge/bridge_helpers.test.mjs
@@ -57,3 +57,23 @@ test('wrapped quoted media caption still resolves', async () => {
   });
   assert.equal(event.quotedText, 'pic caption');
 });
+
+test('nested wrappers around a quoted conversation keep their text', async () => {
+  const event = await quotedEvent({
+    ephemeralMessage: { message: { viewOnceMessage: { message: { conversation: 'nested quote' } } } },
+  });
+  assert.equal(event.quotedText, 'nested quote');
+});
+
+test('deeply nested wrappers stay bounded and still resolve', async () => {
+  const event = await quotedEvent({
+    ephemeralMessage: {
+      message: {
+        viewOnceMessage: {
+          message: { viewOnceMessageV2: { message: { extendedTextMessage: { text: 'three deep' } } } },
+        },
+      },
+    },
+  });
+  assert.equal(event.quotedText, 'three deep');
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the WhatsApp bridge quote parser dropping the text of a quoted message that arrives inside a wrapper payload. When a reply quotes a disappearing (ephemeral) message — or any wrapper-shaped payload — `extractBridgeEvent()` reported the quote ID and `hasQuotedMessage` correctly but returned an empty `quotedText`, because `textFromQuotedMessage()` was handed `contextInfo.quotedMessage` as-is and only inspected bare fields (`conversation`, `extendedTextMessage.text`, media captions, …). The quoted payload is now routed through the existing `getMessageContent()` wrapper normalizer first, so wrapped quotes resolve through the exact same field list as bare ones — one normalization point, no new field handling.

## Related Issue

Fixes #106066

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge_helpers.js` — `textFromQuotedMessage()` normalizes the quoted payload via the existing `getMessageContent()` (same normalizer already used for top-level messages) before the field checks; all field reads switch from the raw object to the unwrapped content. No behavior change for bare payloads.
- `scripts/whatsapp-bridge/bridge_helpers.test.mjs` (new) — regression coverage following the directory's `node:test` convention: plain quoted `conversation` control, `ephemeralMessage`-wrapped conversation (the issue's reproduction), `viewOnceMessage`-wrapped conversation, and a wrapped image caption.

## How to Test

1. `cd scripts/whatsapp-bridge && node --test bridge_helpers.test.mjs` — Observed result: 4 tests, 4 pass, 0 fail on this branch; on unpatched `main` the same file fails 3 of 4 (only the bare control passes), proving the coverage captures the bug.
2. Run the reproduction from the issue (both fixtures through the real `extractBridgeEvent`): Observed result — both now print `"quotedText":"Example appointment at 11:40"`, matching the issue's Expected Behavior (unpatched main prints `""` for the ephemeral-wrapped fixture).
3. `node --test allowlist.test.mjs bridge_helpers.test.mjs outbound_ids.test.mjs owner_message_gate.test.mjs` — Observed result: 23 tests, 23 pass, 0 fail (no regressions in the dependency-free bridge suites).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this PR: the change is confined to the JavaScript WhatsApp bridge (`scripts/whatsapp-bridge/`), which no pytest suite imports; the bridge's own suites above all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0 (arm64), Node.js v24

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-function change using only Node builtins)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Reproduction output on this branch (issue's Expected Behavior):

```json
{"fixture":"plain","quotedMessageId":"original-id","hasQuotedMessage":true,"quotedText":"Example appointment at 11:40"}
{"fixture":"ephemeral-wrapped","quotedMessageId":"original-id","hasQuotedMessage":true,"quotedText":"Example appointment at 11:40"}
```
