### PR TITLE
fix(compression): preserve batch clarify answers in summarize pass

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1456,7 +1456,25 @@ def _sum_clarify(name, args, content, content_len, line_count):
     # min_prune_chars guard and skips the >=200-char dedup.
     max_summary_chars = _PRUNE_MIN_CHARS - 1
     truncation_marker = "...[truncated]"
-    response = _json_dict(content).get("user_response")
+    parsed = _json_dict(content)
+    response = parsed.get("user_response")
+    # Batch clarify (``questions=[...]``) nests each answer inside ``responses[].user_response``
+    # rather than the top level; without this every batch answer was lost and the summarizer only
+    # saw "asked user a question" (#106077).
+    if response is None:
+        batch_responses = parsed.get("responses")
+        if isinstance(batch_responses, list) and batch_responses:
+            collected = []
+            for entry in batch_responses:
+                if not isinstance(entry, dict):
+                    continue
+                single = entry.get("user_response")
+                # multi_select emits a list of strings; flatten it so the summary keeps every choice.
+                if isinstance(single, str) and single:
+                    collected.append(single)
+                elif isinstance(single, list) and all(isinstance(s, str) and s for s in single):
+                    collected.extend(single)
+            response = collected if collected else None
     is_answer_shaped = (isinstance(response, str) and bool(response)) or (
         isinstance(response, list) and bool(response) and all(isinstance(s, str) and s for s in response)
     )

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -233,6 +233,51 @@ class TestSummarizeToolResultClarify:
 
             assert summary == "[clarify] asked user a question", sentinel
 
+    def test_preserves_batch_user_response_from_responses_list(self):
+        """Batch clarify (``questions=[...]``) nests answers inside ``responses[].user_response``;
+        the summarizer must surface them, not just 'asked user a question' (#106077)."""
+        content = json.dumps({
+            "responses": [
+                {
+                    "question": "May the fields be removed?",
+                    "choices_offered": None,
+                    "user_response": "Keep the fields until ratification.",
+                }
+            ]
+        })
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert summary == '[clarify] user responded: ["Keep the fields until ratification."]'
+
+    def test_preserves_batch_multi_select_and_skips_empties(self):
+        """A partially-answered batch (multi_select + a skipped question) still surfaces every real decision."""
+        content = json.dumps({
+            "responses": [
+                {"question": "Q1?", "user_response": "Answer one"},
+                {"question": "Q2?", "user_response": ["Choice A", "Choice B"]},
+                {"question": "Q3?", "user_response": ""},
+            ]
+        })
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert "Answer one" in summary
+        assert "Choice A" in summary
+        assert "Choice B" in summary
+
+    def test_batch_with_only_sentinel_falls_back_to_generic(self):
+        """A batch where every response is a timeout sentinel must not be quoted as a user answer."""
+        content = json.dumps({
+            "responses": [
+                {"question": "Q?", "user_response": "[user did not respond within 15m]"},
+            ]
+        })
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert summary == "[clarify] asked user a question"
+
 
 class TestShouldCompress:
     def test_below_threshold(self, compressor):


### PR DESCRIPTION
## What does this PR do?

Fixes loss of user answers during compression. `_sum_clarify` (the tool-result summarizer for `clarify`) only extracted the top-level `user_response` key. Batch clarify results (`questions=[...]`) nest each answer inside `responses[].user_response`, so every batch answer fell through to the generic `[clarify] asked user a question` placeholder — the summarizer model never saw the user's actual answer, permission decision, or rationale. A batch answer like "Keep the fields until ratification" was reduced to the placeholder before the summarizer saw it, losing decision/permission continuity across compression. This PR extracts `user_response` from each `responses[]` entry when the top-level key is absent.

## Related Issue

Closes #106077.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

`_sum_clarify` in `agent/context_compressor.py` previously did `response = _json_dict(content).get("user_response")` (top-level only). The single-question path (`tools/clarify_tool.py:229`) puts `user_response` at the top level (worked), but the batch path (`tools/clarify_tool.py:148-149`) returns `{"responses": [{"question": ..., "user_response": <answer>, ...}, ...]}` — `user_response` nested inside each `responses[]` entry, so `.get("user_response")` returned `None` and the summarizer emitted the generic placeholder.

The fix: when the top-level `user_response` is absent, extract `user_response` from each `responses[]` entry:
- scalar (string) answers are collected as-is
- `multi_select` (list of strings) answers are flattened so every chosen option survives
- empty/skipped answers are dropped so a partially-answered batch still surfaces real decisions
- timeout/no-user sentinels inside a batch still fall back to the generic placeholder (via `_is_clarify_non_response_sentinel`)

The single-question path is unchanged (backward-compatible).

- `agent/context_compressor.py` — extract `user_response` from `responses[]` when top-level is absent (+19/-1)
- `tests/agent/test_context_compressor.py` — 3 regression tests (+45/-0)

## How to Test

Offline reproduction (no API calls/credentials needed) against the real `_sum_clarify`:

| Format | Before (HEAD) | After (fix) |
|--------|---------------|-------------|
| Batch `{"responses":[{"user_response":"Keep the fields..."}]}` | `[clarify] asked user a question` ❌ | `[clarify] user responded: ["Keep the fields..."]` ✓ |
| Batch multi_select + skipped | `[clarify] asked user a question` ❌ | `[clarify] user responded: ["Answer one", "Choice A", "Choice B"]` ✓ |
| Single (top-level `user_response`) | `[clarify] user responded: "..."` ✓ | unchanged ✓ |
| Batch timeout sentinel | `[clarify] asked user a question` ✓ | unchanged ✓ |

Added 3 regression tests to `TestSummarizeToolResultClarify`:
1. `test_preserves_batch_user_response_from_responses_list` — the core regression
2. `test_preserves_batch_multi_select_and_skips_empties` — partial batch with multi_select
3. `test_batch_with_only_sentinel_falls_back_to_generic` — sentinel still generic

**Mutation check:** reverting the fix makes the 2 positive batch tests FAIL (answer lost) while existing tests still pass — confirming the tests exercise the fix.

**Test suite:** `tests/agent/test_context_compressor.py` — 150 passed (3 new + 147 existing).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(compression): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/agent/test_context_compressor.py -q` and all tests pass (150 passed)
- [x] I've added tests for my changes (3 new, mutation-verified)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] N/A — internal summarizer fix; single-question path unchanged (backward-compatible); no public API or doc surface changed