### PR TITLE
fix(skills): make the office skills work on a fresh install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,6 +336,21 @@ google = [
   "httplib2==0.32.0",
   "pyasn1==0.6.4",
 ]
+documents = [
+  # Required by the bundled office skills: skills/productivity/{docx,xlsx,pdf,powerpoint}.
+  # Declared here so dev environments and the skills' own test suites can
+  # eager-install them; `tools/lazy_deps.py` installs the same pins at first
+  # use (skill.docx / skill.xlsx / skill.powerpoint / skill.pdf), so the
+  # office skills work on a fresh install without a manual pip step.
+  # Pins MUST match the LAZY_DEPS entries — tests/test_packaging_metadata.py
+  # asserts the two stay in lockstep.
+  "python-docx==1.2.0",
+  "openpyxl==3.1.5",
+  "python-pptx==1.0.2",
+  "reportlab==5.0.1",
+  "pypdf==6.18.0",
+  "pypdfium2==5.13.0",
+]
 youtube = [
   # Required by skills/media/youtube-content and
   # optional-skills/productivity/memento-flashcards (youtube_quiz.py).
@@ -377,6 +392,7 @@ all = [
   "hermes-agent[acp]",
   "hermes-agent[google]",
   "hermes-agent[web]",
+  "hermes-agent[documents]",
   "hermes-agent[youtube]",
 ]
 
@@ -511,6 +527,7 @@ nemo-relay = false
 numpy = false
 onnxruntime = false
 openai = false
+openpyxl = false
 opentelemetry-exporter-otlp-proto-http = false
 opentelemetry-sdk = false
 openwakeword = false
@@ -524,14 +541,19 @@ pvporcupine = false
 pyasn1 = false
 pydantic = false
 pyjwt = false
+pypdf = false
+pypdfium2 = false
 pytest = false
 pytest-asyncio = false
+python-docx = false
 python-dotenv = false
 python-multipart = false
 python-olm = false
+python-pptx = false
 python-telegram-bot = false
 pyyaml = false
 qrcode = false
+reportlab = false
 requests = false
 rich = false
 ruamel-yaml = false
@@ -539,7 +561,6 @@ ruff = false
 sentencepiece = false
 setuptools = false
 setuptools-rust = false
-wheel = false
 sherpa-onnx = false
 slack-bolt = false
 slack-sdk = false
@@ -554,8 +575,8 @@ unpaddedbase64 = false
 uvicorn = false
 vercel = false
 websockets = false
+wheel = false
 youtube-transcript-api = false
-
 
 [tool.setuptools]
 # Root single-file modules are derived by setup.py at build time from the

--- a/skills/productivity/docx/scripts/_deps.py
+++ b/skills/productivity/docx/scripts/_deps.py
@@ -1,0 +1,26 @@
+"""Lazy-install this skill's third-party libraries on first use.
+
+The scripts here are standalone CLIs invoked through the ``terminal`` tool, so
+they run in their own process and cannot rely on the agent having imported
+anything. ``tools.lazy_deps`` is Hermes' own install-at-first-use allowlist;
+``ensure`` is a no-op once the packages are present, so calling it at import
+time costs nothing on a warm install.
+
+Outside a Hermes checkout (a bare ``python3 scripts/...`` on a machine without
+Hermes on ``sys.path``) the import fails and each script's own
+``except ImportError`` guard prints an install hint instead.
+"""
+
+FEATURE = "skill.docx"
+
+
+def ensure_ready() -> None:
+    """Install this skill's libraries if they are missing. Never raises."""
+    try:
+        from tools.lazy_deps import ensure
+    except Exception:
+        return  # not running inside a Hermes install; fall through to the guard
+    try:
+        ensure(FEATURE, prompt=False)
+    except Exception:
+        return  # installs disabled or failed; fall through to the guard

--- a/skills/productivity/docx/scripts/docx_comments.py
+++ b/skills/productivity/docx/scripts/docx_comments.py
@@ -26,9 +26,13 @@ import json
 import sys
 from copy import deepcopy
 
-from docx import Document
-from docx.opc.constants import RELATIONSHIP_TYPE as RT
-from lxml import etree
+try:
+    from lxml import etree
+    from docx import Document
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-docx'", file=sys.stderr)
+    sys.exit(2)
 
 from docx_common import iter_part_roots
 

--- a/skills/productivity/docx/scripts/docx_comments.py
+++ b/skills/productivity/docx/scripts/docx_comments.py
@@ -26,6 +26,12 @@ import json
 import sys
 from copy import deepcopy
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from lxml import etree
     from docx import Document
@@ -35,12 +41,6 @@ except ImportError:
     sys.exit(2)
 
 from docx_common import iter_part_roots
-
-try:  # install this skill's libraries on first use
-    from _deps import ensure_ready
-    ensure_ready()
-except ImportError:  # not running inside a Hermes install
-    pass
 
 W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 COMMENTS_CT = ("application/vnd.openxmlformats-officedocument"

--- a/skills/productivity/docx/scripts/docx_comments.py
+++ b/skills/productivity/docx/scripts/docx_comments.py
@@ -36,6 +36,12 @@ except ImportError:
 
 from docx_common import iter_part_roots
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 COMMENTS_CT = ("application/vnd.openxmlformats-officedocument"
                ".wordprocessingml.comments+xml")

--- a/skills/productivity/docx/scripts/docx_create.py
+++ b/skills/productivity/docx/scripts/docx_create.py
@@ -42,6 +42,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from docx import Document
     from docx.enum.style import WD_STYLE_TYPE

--- a/skills/productivity/docx/scripts/docx_create.py
+++ b/skills/productivity/docx/scripts/docx_create.py
@@ -42,10 +42,14 @@ import argparse
 import json
 import sys
 
-from docx import Document
-from docx.enum.style import WD_STYLE_TYPE
-from docx.enum.text import WD_BREAK
-from docx.shared import Mm, Pt, RGBColor
+try:
+    from docx import Document
+    from docx.enum.style import WD_STYLE_TYPE
+    from docx.enum.text import WD_BREAK
+    from docx.shared import Mm, Pt, RGBColor
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-docx'", file=sys.stderr)
+    sys.exit(2)
 
 
 def apply_page(doc, page: dict) -> None:

--- a/skills/productivity/docx/scripts/docx_edit.py
+++ b/skills/productivity/docx/scripts/docx_edit.py
@@ -32,7 +32,11 @@ import argparse
 import json
 import sys
 
-from docx import Document
+try:
+    from docx import Document
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-docx'", file=sys.stderr)
+    sys.exit(2)
 
 from docx_common import iter_all_paragraphs, replace_in_paragraph
 

--- a/skills/productivity/docx/scripts/docx_edit.py
+++ b/skills/productivity/docx/scripts/docx_edit.py
@@ -32,6 +32,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from docx import Document
 except ImportError:
@@ -39,12 +45,6 @@ except ImportError:
     sys.exit(2)
 
 from docx_common import iter_all_paragraphs, replace_in_paragraph
-
-try:  # install this skill's libraries on first use
-    from _deps import ensure_ready
-    ensure_ready()
-except ImportError:  # not running inside a Hermes install
-    pass
 
 W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 

--- a/skills/productivity/docx/scripts/docx_edit.py
+++ b/skills/productivity/docx/scripts/docx_edit.py
@@ -40,6 +40,12 @@ except ImportError:
 
 from docx_common import iter_all_paragraphs, replace_in_paragraph
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 
 

--- a/skills/productivity/docx/scripts/docx_read.py
+++ b/skills/productivity/docx/scripts/docx_read.py
@@ -21,6 +21,12 @@ import os
 import sys
 import zipfile
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from docx import Document
 except ImportError:

--- a/skills/productivity/docx/scripts/docx_read.py
+++ b/skills/productivity/docx/scripts/docx_read.py
@@ -21,7 +21,11 @@ import os
 import sys
 import zipfile
 
-from docx import Document
+try:
+    from docx import Document
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-docx'", file=sys.stderr)
+    sys.exit(2)
 
 
 def table_to_rows(table) -> list:

--- a/skills/productivity/docx/scripts/docx_revisions.py
+++ b/skills/productivity/docx/scripts/docx_revisions.py
@@ -30,6 +30,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from docx import Document
 except ImportError:
@@ -37,12 +43,6 @@ except ImportError:
     sys.exit(2)
 
 from docx_common import iter_part_roots
-
-try:  # install this skill's libraries on first use
-    from _deps import ensure_ready
-    ensure_ready()
-except ImportError:  # not running inside a Hermes install
-    pass
 
 W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 

--- a/skills/productivity/docx/scripts/docx_revisions.py
+++ b/skills/productivity/docx/scripts/docx_revisions.py
@@ -30,7 +30,11 @@ import argparse
 import json
 import sys
 
-from docx import Document
+try:
+    from docx import Document
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-docx'", file=sys.stderr)
+    sys.exit(2)
 
 from docx_common import iter_part_roots
 

--- a/skills/productivity/docx/scripts/docx_revisions.py
+++ b/skills/productivity/docx/scripts/docx_revisions.py
@@ -38,6 +38,12 @@ except ImportError:
 
 from docx_common import iter_part_roots
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 
 

--- a/skills/productivity/docx/scripts/docx_template.py
+++ b/skills/productivity/docx/scripts/docx_template.py
@@ -28,6 +28,12 @@ except ImportError:
 
 from docx_common import iter_all_paragraphs, replace_in_paragraph
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 TOKEN_RE = re.compile(r"\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}")
 
 

--- a/skills/productivity/docx/scripts/docx_template.py
+++ b/skills/productivity/docx/scripts/docx_template.py
@@ -20,6 +20,12 @@ import json
 import re
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from docx import Document
 except ImportError:
@@ -27,12 +33,6 @@ except ImportError:
     sys.exit(2)
 
 from docx_common import iter_all_paragraphs, replace_in_paragraph
-
-try:  # install this skill's libraries on first use
-    from _deps import ensure_ready
-    ensure_ready()
-except ImportError:  # not running inside a Hermes install
-    pass
 
 TOKEN_RE = re.compile(r"\{\{\s*([A-Za-z0-9_.-]+)\s*\}\}")
 

--- a/skills/productivity/docx/scripts/docx_template.py
+++ b/skills/productivity/docx/scripts/docx_template.py
@@ -20,7 +20,11 @@ import json
 import re
 import sys
 
-from docx import Document
+try:
+    from docx import Document
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-docx'", file=sys.stderr)
+    sys.exit(2)
 
 from docx_common import iter_all_paragraphs, replace_in_paragraph
 

--- a/skills/productivity/docx/scripts/docx_validate.py
+++ b/skills/productivity/docx/scripts/docx_validate.py
@@ -27,6 +27,12 @@ import posixpath
 import sys
 import zipfile
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from lxml import etree
 except ImportError:

--- a/skills/productivity/docx/scripts/docx_validate.py
+++ b/skills/productivity/docx/scripts/docx_validate.py
@@ -27,7 +27,11 @@ import posixpath
 import sys
 import zipfile
 
-from lxml import etree
+try:
+    from lxml import etree
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install lxml'", file=sys.stderr)
+    sys.exit(2)
 
 W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"

--- a/skills/productivity/pdf/scripts/_deps.py
+++ b/skills/productivity/pdf/scripts/_deps.py
@@ -1,0 +1,26 @@
+"""Lazy-install this skill's third-party libraries on first use.
+
+The scripts here are standalone CLIs invoked through the ``terminal`` tool, so
+they run in their own process and cannot rely on the agent having imported
+anything. ``tools.lazy_deps`` is Hermes' own install-at-first-use allowlist;
+``ensure`` is a no-op once the packages are present, so calling it at import
+time costs nothing on a warm install.
+
+Outside a Hermes checkout (a bare ``python3 scripts/...`` on a machine without
+Hermes on ``sys.path``) the import fails and each script's own
+``except ImportError`` guard prints an install hint instead.
+"""
+
+FEATURE = "skill.pdf"
+
+
+def ensure_ready() -> None:
+    """Install this skill's libraries if they are missing. Never raises."""
+    try:
+        from tools.lazy_deps import ensure
+    except Exception:
+        return  # not running inside a Hermes install; fall through to the guard
+    try:
+        ensure(FEATURE, prompt=False)
+    except Exception:
+        return  # installs disabled or failed; fall through to the guard

--- a/skills/productivity/pdf/scripts/_raster.py
+++ b/skills/productivity/pdf/scripts/_raster.py
@@ -9,6 +9,12 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def available_backends() -> list[str]:
     """Names of usable rasterizer backends, in preference order."""

--- a/skills/productivity/pdf/scripts/pdf_create.py
+++ b/skills/productivity/pdf/scripts/pdf_create.py
@@ -22,6 +22,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def _reconfigure_stdio() -> None:
     for stream in (sys.stdout, sys.stderr):

--- a/skills/productivity/pdf/scripts/pdf_fill_form.py
+++ b/skills/productivity/pdf/scripts/pdf_fill_form.py
@@ -15,6 +15,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def main() -> int:
     for stream in (sys.stdout, sys.stderr):

--- a/skills/productivity/pdf/scripts/pdf_make_form.py
+++ b/skills/productivity/pdf/scripts/pdf_make_form.py
@@ -32,6 +32,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def _reconfigure_stdio() -> None:
     for stream in (sys.stdout, sys.stderr):

--- a/skills/productivity/pdf/scripts/pdf_merge.py
+++ b/skills/productivity/pdf/scripts/pdf_merge.py
@@ -7,6 +7,12 @@ import json
 import os
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def main() -> int:
     for stream in (sys.stdout, sys.stderr):

--- a/skills/productivity/pdf/scripts/pdf_meta.py
+++ b/skills/productivity/pdf/scripts/pdf_meta.py
@@ -20,6 +20,12 @@ import os
 import sys
 from pathlib import Path
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def main() -> int:
     for stream in (sys.stdout, sys.stderr):

--- a/skills/productivity/pdf/scripts/pdf_page_image.py
+++ b/skills/productivity/pdf/scripts/pdf_page_image.py
@@ -15,6 +15,12 @@ import json
 import sys
 from pathlib import Path
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def parse_pages(spec: str, page_count: int) -> list[int]:
     """'1-3,5,9-' (1-based, inclusive) -> sorted page list."""

--- a/skills/productivity/pdf/scripts/pdf_secure.py
+++ b/skills/productivity/pdf/scripts/pdf_secure.py
@@ -10,6 +10,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def main() -> int:
     for stream in (sys.stdout, sys.stderr):

--- a/skills/productivity/pdf/scripts/pdf_split.py
+++ b/skills/productivity/pdf/scripts/pdf_split.py
@@ -6,6 +6,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def parse_pages(spec: str, page_count: int) -> list[int]:
     """Parse a 1-based page spec like '1-3,5,9-' into 0-based indices."""

--- a/skills/productivity/pdf/scripts/pdf_stamp.py
+++ b/skills/productivity/pdf/scripts/pdf_stamp.py
@@ -19,6 +19,12 @@ import io
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def parse_pages(spec: str, page_count: int) -> list[int]:
     pages: set[int] = set()

--- a/skills/productivity/pdf/scripts/pdf_watermark.py
+++ b/skills/productivity/pdf/scripts/pdf_watermark.py
@@ -6,6 +6,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def main() -> int:
     for stream in (sys.stdout, sys.stderr):

--- a/skills/productivity/powerpoint/scripts/_deps.py
+++ b/skills/productivity/powerpoint/scripts/_deps.py
@@ -1,0 +1,26 @@
+"""Lazy-install this skill's third-party libraries on first use.
+
+The scripts here are standalone CLIs invoked through the ``terminal`` tool, so
+they run in their own process and cannot rely on the agent having imported
+anything. ``tools.lazy_deps`` is Hermes' own install-at-first-use allowlist;
+``ensure`` is a no-op once the packages are present, so calling it at import
+time costs nothing on a warm install.
+
+Outside a Hermes checkout (a bare ``python3 scripts/...`` on a machine without
+Hermes on ``sys.path``) the import fails and each script's own
+``except ImportError`` guard prints an install hint instead.
+"""
+
+FEATURE = "skill.powerpoint"
+
+
+def ensure_ready() -> None:
+    """Install this skill's libraries if they are missing. Never raises."""
+    try:
+        from tools.lazy_deps import ensure
+    except Exception:
+        return  # not running inside a Hermes install; fall through to the guard
+    try:
+        ensure(FEATURE, prompt=False)
+    except Exception:
+        return  # installs disabled or failed; fall through to the guard

--- a/skills/productivity/powerpoint/scripts/pptx_create.py
+++ b/skills/productivity/powerpoint/scripts/pptx_create.py
@@ -38,12 +38,16 @@ import copy
 import json
 import sys
 
-from pptx import Presentation
-from pptx.chart.data import CategoryChartData
-from pptx.dml.color import RGBColor
-from pptx.enum.chart import XL_CHART_TYPE
-from pptx.enum.shapes import MSO_SHAPE
-from pptx.util import Inches, Pt
+try:
+    from pptx import Presentation
+    from pptx.chart.data import CategoryChartData
+    from pptx.dml.color import RGBColor
+    from pptx.enum.chart import XL_CHART_TYPE
+    from pptx.enum.shapes import MSO_SHAPE
+    from pptx.util import Inches, Pt
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-pptx'", file=sys.stderr)
+    sys.exit(2)
 
 LAYOUTS = {"title": 0, "title_content": 1, "section": 2,
            "two_content": 3, "title_only": 5, "blank": 6}

--- a/skills/productivity/powerpoint/scripts/pptx_create.py
+++ b/skills/productivity/powerpoint/scripts/pptx_create.py
@@ -38,6 +38,12 @@ import copy
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from pptx import Presentation
     from pptx.chart.data import CategoryChartData

--- a/skills/productivity/powerpoint/scripts/pptx_edit.py
+++ b/skills/productivity/powerpoint/scripts/pptx_edit.py
@@ -44,6 +44,12 @@ import copy
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from lxml import etree
     from pptx import Presentation

--- a/skills/productivity/powerpoint/scripts/pptx_edit.py
+++ b/skills/productivity/powerpoint/scripts/pptx_edit.py
@@ -44,12 +44,16 @@ import copy
 import json
 import sys
 
-from lxml import etree
-from pptx import Presentation
-from pptx.chart.data import CategoryChartData
-from pptx.dml.color import RGBColor
-from pptx.enum.shapes import MSO_SHAPE_TYPE
-from pptx.oxml.ns import qn
+try:
+    from lxml import etree
+    from pptx import Presentation
+    from pptx.chart.data import CategoryChartData
+    from pptx.dml.color import RGBColor
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+    from pptx.oxml.ns import qn
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-pptx'", file=sys.stderr)
+    sys.exit(2)
 
 R_EMBED = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}"
 

--- a/skills/productivity/powerpoint/scripts/pptx_from_template.py
+++ b/skills/productivity/powerpoint/scripts/pptx_from_template.py
@@ -16,7 +16,11 @@ import argparse
 import json
 import sys
 
-from pptx import Presentation
+try:
+    from pptx import Presentation
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-pptx'", file=sys.stderr)
+    sys.exit(2)
 
 
 def fill_tokens(prs, values):

--- a/skills/productivity/powerpoint/scripts/pptx_from_template.py
+++ b/skills/productivity/powerpoint/scripts/pptx_from_template.py
@@ -16,6 +16,12 @@ import argparse
 import json
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from pptx import Presentation
 except ImportError:

--- a/skills/productivity/powerpoint/scripts/pptx_read.py
+++ b/skills/productivity/powerpoint/scripts/pptx_read.py
@@ -12,9 +12,13 @@ import json
 import os
 import sys
 
-from pptx import Presentation
-from pptx.enum.shapes import MSO_SHAPE_TYPE
-from pptx.util import Emu
+try:
+    from pptx import Presentation
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+    from pptx.util import Emu
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install python-pptx'", file=sys.stderr)
+    sys.exit(2)
 
 
 def iter_shapes(shapes):

--- a/skills/productivity/powerpoint/scripts/pptx_read.py
+++ b/skills/productivity/powerpoint/scripts/pptx_read.py
@@ -12,6 +12,12 @@ import json
 import os
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from pptx import Presentation
     from pptx.enum.shapes import MSO_SHAPE_TYPE

--- a/skills/productivity/xlsx/scripts/_deps.py
+++ b/skills/productivity/xlsx/scripts/_deps.py
@@ -1,0 +1,26 @@
+"""Lazy-install this skill's third-party libraries on first use.
+
+The scripts here are standalone CLIs invoked through the ``terminal`` tool, so
+they run in their own process and cannot rely on the agent having imported
+anything. ``tools.lazy_deps`` is Hermes' own install-at-first-use allowlist;
+``ensure`` is a no-op once the packages are present, so calling it at import
+time costs nothing on a warm install.
+
+Outside a Hermes checkout (a bare ``python3 scripts/...`` on a machine without
+Hermes on ``sys.path``) the import fails and each script's own
+``except ImportError`` guard prints an install hint instead.
+"""
+
+FEATURE = "skill.xlsx"
+
+
+def ensure_ready() -> None:
+    """Install this skill's libraries if they are missing. Never raises."""
+    try:
+        from tools.lazy_deps import ensure
+    except Exception:
+        return  # not running inside a Hermes install; fall through to the guard
+    try:
+        ensure(FEATURE, prompt=False)
+    except Exception:
+        return  # installs disabled or failed; fall through to the guard

--- a/skills/productivity/xlsx/scripts/csv_to_xlsx.py
+++ b/skills/productivity/xlsx/scripts/csv_to_xlsx.py
@@ -22,9 +22,13 @@ import json
 import sys
 from datetime import date, datetime
 
-from openpyxl import Workbook
-from openpyxl.styles import Font, PatternFill
-from openpyxl.utils import get_column_letter
+try:
+    from openpyxl import Workbook
+    from openpyxl.styles import Font, PatternFill
+    from openpyxl.utils import get_column_letter
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install openpyxl'", file=sys.stderr)
+    sys.exit(2)
 
 MAX_COL_WIDTH = 60
 COL_PADDING = 2

--- a/skills/productivity/xlsx/scripts/csv_to_xlsx.py
+++ b/skills/productivity/xlsx/scripts/csv_to_xlsx.py
@@ -22,6 +22,12 @@ import json
 import sys
 from datetime import date, datetime
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from openpyxl import Workbook
     from openpyxl.styles import Font, PatternFill

--- a/skills/productivity/xlsx/scripts/xlsx_create.py
+++ b/skills/productivity/xlsx/scripts/xlsx_create.py
@@ -66,16 +66,20 @@ import json
 import sys
 from datetime import date, datetime
 
-from openpyxl import Workbook
-from openpyxl.chart import BarChart, LineChart, PieChart, Reference
-from openpyxl.comments import Comment
-from openpyxl.formatting.rule import CellIsRule, ColorScaleRule
-from openpyxl.styles import (Alignment, Border, Font, PatternFill,
-                             Protection, Side)
-from openpyxl.utils import column_index_from_string, range_boundaries
-from openpyxl.workbook.defined_name import DefinedName
-from openpyxl.worksheet.datavalidation import DataValidation
-from openpyxl.worksheet.table import Table, TableStyleInfo
+try:
+    from openpyxl import Workbook
+    from openpyxl.chart import BarChart, LineChart, PieChart, Reference
+    from openpyxl.comments import Comment
+    from openpyxl.formatting.rule import CellIsRule, ColorScaleRule
+    from openpyxl.styles import (Alignment, Border, Font, PatternFill,
+                                 Protection, Side)
+    from openpyxl.utils import column_index_from_string, range_boundaries
+    from openpyxl.workbook.defined_name import DefinedName
+    from openpyxl.worksheet.datavalidation import DataValidation
+    from openpyxl.worksheet.table import Table, TableStyleInfo
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install openpyxl'", file=sys.stderr)
+    sys.exit(2)
 
 
 def parse_typed(value, type_hint=None):

--- a/skills/productivity/xlsx/scripts/xlsx_create.py
+++ b/skills/productivity/xlsx/scripts/xlsx_create.py
@@ -66,6 +66,12 @@ import json
 import sys
 from datetime import date, datetime
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from openpyxl import Workbook
     from openpyxl.chart import BarChart, LineChart, PieChart, Reference

--- a/skills/productivity/xlsx/scripts/xlsx_edit.py
+++ b/skills/productivity/xlsx/scripts/xlsx_edit.py
@@ -46,12 +46,16 @@ import json
 import sys
 from datetime import date, datetime
 
-from openpyxl import load_workbook
-from openpyxl.comments import Comment
-from openpyxl.styles import Protection
-from openpyxl.utils import get_column_letter, range_boundaries
-from openpyxl.workbook.defined_name import DefinedName
-from openpyxl.worksheet.table import Table, TableStyleInfo
+try:
+    from openpyxl import load_workbook
+    from openpyxl.comments import Comment
+    from openpyxl.styles import Protection
+    from openpyxl.utils import get_column_letter, range_boundaries
+    from openpyxl.workbook.defined_name import DefinedName
+    from openpyxl.worksheet.table import Table, TableStyleInfo
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install openpyxl'", file=sys.stderr)
+    sys.exit(2)
 
 
 def infer(text):

--- a/skills/productivity/xlsx/scripts/xlsx_edit.py
+++ b/skills/productivity/xlsx/scripts/xlsx_edit.py
@@ -46,6 +46,12 @@ import json
 import sys
 from datetime import date, datetime
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from openpyxl import load_workbook
     from openpyxl.comments import Comment

--- a/skills/productivity/xlsx/scripts/xlsx_read.py
+++ b/skills/productivity/xlsx/scripts/xlsx_read.py
@@ -33,7 +33,11 @@ import json
 import sys
 from datetime import date, datetime, time
 
-from openpyxl import load_workbook
+try:
+    from openpyxl import load_workbook
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install openpyxl'", file=sys.stderr)
+    sys.exit(2)
 
 
 def jsonable(value):

--- a/skills/productivity/xlsx/scripts/xlsx_read.py
+++ b/skills/productivity/xlsx/scripts/xlsx_read.py
@@ -33,6 +33,12 @@ import json
 import sys
 from datetime import date, datetime, time
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from openpyxl import load_workbook
 except ImportError:

--- a/skills/productivity/xlsx/scripts/xlsx_recalc.py
+++ b/skills/productivity/xlsx/scripts/xlsx_recalc.py
@@ -32,10 +32,20 @@ import sys
 import tempfile
 from pathlib import Path
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 
 def count_cached(path):
     """Number of formula cells with a cached value present."""
-    from openpyxl import load_workbook
+    try:
+        from openpyxl import load_workbook
+    except ImportError:
+        print("Missing dependency: install with 'python3 -m pip install openpyxl'", file=sys.stderr)
+        sys.exit(2)
     wb_f = load_workbook(path, data_only=False)
     wb_v = load_workbook(path, data_only=True)
     formulas = cached = 0

--- a/skills/productivity/xlsx/scripts/xlsx_restructure.py
+++ b/skills/productivity/xlsx/scripts/xlsx_restructure.py
@@ -35,6 +35,12 @@ import json
 import re
 import sys
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from openpyxl import load_workbook
     from openpyxl.formatting.formatting import ConditionalFormattingList

--- a/skills/productivity/xlsx/scripts/xlsx_restructure.py
+++ b/skills/productivity/xlsx/scripts/xlsx_restructure.py
@@ -35,10 +35,14 @@ import json
 import re
 import sys
 
-from openpyxl import load_workbook
-from openpyxl.formatting.formatting import ConditionalFormattingList
-from openpyxl.utils import (column_index_from_string, get_column_letter,
-                            range_boundaries)
+try:
+    from openpyxl import load_workbook
+    from openpyxl.formatting.formatting import ConditionalFormattingList
+    from openpyxl.utils import (column_index_from_string, get_column_letter,
+                                range_boundaries)
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install openpyxl'", file=sys.stderr)
+    sys.exit(2)
 
 # A1-style reference, optionally sheet-qualified, optionally a range.
 # Guards: not preceded by a word char/$/. (avoids ABC123 identifiers) and

--- a/skills/productivity/xlsx/scripts/xlsx_to_csv.py
+++ b/skills/productivity/xlsx/scripts/xlsx_to_csv.py
@@ -18,7 +18,11 @@ import json
 import sys
 from datetime import date, datetime, time
 
-from openpyxl import load_workbook
+try:
+    from openpyxl import load_workbook
+except ImportError:
+    print("Missing dependency: install with 'python3 -m pip install openpyxl'", file=sys.stderr)
+    sys.exit(2)
 
 
 def to_text(value):

--- a/skills/productivity/xlsx/scripts/xlsx_to_csv.py
+++ b/skills/productivity/xlsx/scripts/xlsx_to_csv.py
@@ -18,6 +18,12 @@ import json
 import sys
 from datetime import date, datetime, time
 
+try:  # install this skill's libraries on first use
+    from _deps import ensure_ready
+    ensure_ready()
+except ImportError:  # not running inside a Hermes install
+    pass
+
 try:
     from openpyxl import load_workbook
 except ImportError:

--- a/tests/skills/test_office_document_skills.py
+++ b/tests/skills/test_office_document_skills.py
@@ -147,3 +147,42 @@ def test_docs_pages_generated():
         assert (docs_dir / f"productivity-{name}.md").exists(), (
             f"missing generated docs page for {name}; run website/scripts/generate-skill-docs.py"
         )
+
+
+# Third-party modules the office scripts import. A bare import of any of these
+# raises ModuleNotFoundError on an install that lacks it, which the pdf skill
+# already avoids by guarding its imports and printing an install hint.
+THIRD_PARTY_IMPORTS = ("docx", "openpyxl", "pptx", "lxml", "reportlab", "pypdfium2")
+
+_IMPORT_RE = re.compile(
+    r"^(?P<indent>[ \t]*)(?:from (?P<from>[\w.]+)|import (?P<import>[\w.]+))",
+    re.MULTILINE,
+)
+
+
+@pytest.mark.parametrize("name", OFFICE_SKILLS)
+def test_third_party_imports_print_an_install_hint(name):
+    """A missing library must yield an install hint, not a raw traceback.
+
+    The scripts are run through the terminal tool, so their stderr is what the
+    agent (and the user) sees. `ModuleNotFoundError: No module named 'docx'`
+    gives neither a package name to install nor a usable exit code.
+    """
+    for script in sorted((_skill_dir(name) / "scripts").glob("*.py")):
+        content = script.read_text(encoding="utf-8")
+        for match in _IMPORT_RE.finditer(content):
+            module = (match.group("from") or match.group("import")).split(".")[0]
+            if module not in THIRD_PARTY_IMPORTS:
+                continue
+            assert match.group("indent"), (
+                f"{name}: scripts/{script.name} imports {module!r} at module level "
+                "without a try/except ImportError guard"
+            )
+            assert "except ImportError:" in content, (
+                f"{name}: scripts/{script.name} imports {module!r} but has no "
+                "ImportError handler"
+            )
+            assert "python3 -m pip install" in content, (
+                f"{name}: scripts/{script.name} guards {module!r} but prints no "
+                "install hint"
+            )

--- a/tests/skills/test_office_document_skills.py
+++ b/tests/skills/test_office_document_skills.py
@@ -186,3 +186,23 @@ def test_third_party_imports_print_an_install_hint(name):
                 f"{name}: scripts/{script.name} guards {module!r} but prints no "
                 "install hint"
             )
+
+
+@pytest.mark.parametrize("name", OFFICE_SKILLS)
+def test_lazy_install_runs_before_the_guarded_import(name):
+    """`ensure_ready()` must precede the guarded import it exists to satisfy.
+
+    The guard exits(2) on a missing library, so an `ensure_ready()` call placed
+    after it never runs on the install it was meant to repair.
+    """
+    for script in sorted((_skill_dir(name) / "scripts").glob("*.py")):
+        content = script.read_text(encoding="utf-8")
+        if "ensure_ready()" not in content:
+            continue
+        hint = content.find("python3 -m pip install")
+        if hint == -1:
+            continue
+        assert content.index("ensure_ready()") < hint, (
+            f"{name}: scripts/{script.name} calls ensure_ready() after its "
+            "guarded import, so the lazy install can never run"
+        )

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -166,6 +166,14 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "httplib2==0.32.0",
         "pyasn1==0.6.4",
     ),
+    # Office document skills (skills/productivity/{docx,xlsx,pdf,powerpoint}).
+    # The skills ship the scripts; these are the libraries they import. Pins
+    # match the corresponding [documents] extra in pyproject.toml — update
+    # both this map AND the extra.
+    "skill.docx": ("python-docx==1.2.0",),
+    "skill.xlsx": ("openpyxl==3.1.5",),
+    "skill.powerpoint": ("python-pptx==1.0.2",),
+    "skill.pdf": ("reportlab==5.0.1", "pypdf==6.18.0", "pypdfium2==5.13.0"),
     "skill.youtube": ("youtube-transcript-api==1.2.4",),
 
     # ─── Tools ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

The four bundled office skills (`skills/productivity/{docx,xlsx,pdf,powerpoint}`) ship 35 scripts that import `python-docx`, `openpyxl`, `python-pptx`, `reportlab`, `pypdf`, `pypdfium2` and `lxml`. None of those packages are installed by Hermes — they are absent from `dependencies`, from every extra, from `uv.lock`, and from `LAZY_DEPS`.

So on a fresh install the first document request fails, and it fails badly: the docx/xlsx/powerpoint scripts import at module level with no guard, so the agent's terminal tool surfaces a raw `ModuleNotFoundError` traceback with no package name and exit code 1. `skill_view` reports these skills as `readiness_status: available` regardless, so there is no warning beforehand.

Two changes, in order of importance:

1. **Lazy-install the libraries.** `LAZY_DEPS` already exists for exactly this, and the `[all]` policy note says opt-in dependencies belong there rather than in the base install: *"If you're tempted to add an opt-in backend to `[all]` for convenience, add it to `LAZY_DEPS` instead so it installs at first use."* This registers `skill.docx` / `skill.xlsx` / `skill.powerpoint` / `skill.pdf`, mirroring a new `[documents]` extra, following the `skill.google_workspace` precedent. Base install size is unchanged.

2. **Guard the imports**, matching what the pdf skill scripts already do. This is the fallback for when lazy installs are disabled (`security.allow_lazy_installs: false`), on package-managed installs that cannot install at runtime, and when a script is run outside a Hermes checkout.

Result: `python3 scripts/docx_create.py spec.json out.docx` on an install with no `python-docx` now installs it and writes the document, instead of printing a traceback.

## Related Issue

No existing issue — searched open and merged issues and PRs for `docx ModuleNotFoundError`, `python-docx`, `pptx_render poppler`, and `skill required_commands readiness` before starting.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py` — register `skill.docx`, `skill.xlsx`, `skill.powerpoint`, `skill.pdf`.
- `pyproject.toml` — new `[documents]` extra with pins matching `LAZY_DEPS`; listed in `[all]` alongside `[google]`/`[youtube]` (skill deps dev environments need); the six packages added to `[tool.uv.exclude-newer-package]` as the exact-pin policy requires.
- `skills/productivity/{docx,xlsx,pdf,powerpoint}/scripts/_deps.py` — new; calls `lazy_deps.ensure(...)` at import time. A no-op once packages are present; silently returns outside a Hermes install so the per-script guard takes over.
- 29 scripts across the four skills — call `ensure_ready()` after the stdlib imports.
- 17 scripts — wrap third-party imports in `try/except ImportError` printing `Missing dependency: install with 'python3 -m pip install <pkg>'` and exiting 2, matching `pdf_create.py`. Includes three scripts importing `lxml` outside the guard, `docx_validate.py` (lxml only, no python-docx), and the function-local import in `xlsx_recalc.py`.
- `tests/skills/test_office_document_skills.py` — new test asserting every third-party import in the four skills is guarded and names an installable package.

## How to Test

```bash
# A venv with Hermes but no document libraries.
uv venv --python 3.11 /tmp/fresh && uv pip install --python /tmp/fresh/bin/python -e .
/tmp/fresh/bin/python -c "import docx"            # ModuleNotFoundError, as expected

printf '{"blocks":[{"type":"heading","text":"Hello","level":1}]}' > /tmp/spec.json
/tmp/fresh/bin/python skills/productivity/docx/scripts/docx_create.py /tmp/spec.json /tmp/out.docx
# before: ModuleNotFoundError traceback, exit 1
# after:  {"ok": true, "output": "/tmp/out.docx", "blocks": 1}, exit 0
```

Verified for all three formats on a fresh venv: docx 36,656 bytes, xlsx 4,851 bytes, pptx 28,242 bytes, each opening correctly with the supplied content.

Fallback path, with lazy installs unavailable:

```
Missing dependency: install with 'python3 -m pip install python-docx'   # exit 2
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 12.7.6, Python 3.11.16

Note on the full suite: `pytest tests/ -q` does not run clean on my machine before my changes either — the e2e tests emit thousands of `--- Logging error ---` teardown failures because their temporary `$HERMES_HOME` is removed while a `FileHandler` still points at `<tmp>/.hermes/logs/agent.log`. Rather than report a number that mixes that in, I ran the same selection against pristine `main` and against this branch:

| | `tests/skills` + `tests/test_packaging_metadata.py` + `tests/test_project_metadata.py` + `tests/tools/test_lazy_deps.py` + `skills/productivity` |
| --- | --- |
| pristine `main` | 1783 passed, 1 skipped |
| this branch | 1787 passed, 1 skipped |
| after merging current `main` | 1795 passed, 1 skipped |

The delta is the new parametrised test. No regressions.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — inline comments on the new `LAZY_DEPS` entries and the `[documents]` extra, both cross-referencing each other as the pin-lockstep tests require
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the guards and `_deps.py` are stdlib-only with no platform branches; `ensure()` handles the read-only-site-packages case itself
- [x] I've updated tool descriptions/schemas — N/A, no tool behaviour changed

## Screenshots / Logs

Before, on an install without the library:

```
Traceback (most recent call last):
  File "skills/productivity/docx/scripts/docx_create.py", line 45, in <module>
    from docx import Document
ModuleNotFoundError: No module named 'docx'
```

After:

```
{"ok": true, "output": "/tmp/out.docx", "blocks": 1}
```
