### PR TITLE
fix(direnv): don't hard-fail .envrc when nix is not installed

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,4 +2,25 @@ watch_file pyproject.toml uv.lock hermes
 watch_file package-lock.json package.json web/package.json ui-tui/package.json website/package.json apps/shared/package.json apps/desktop/package.json ui-tui/packages/hermes-ink/package.json
 watch_file flake.nix flake.lock nix/devShell.nix nix/tui.nix nix/package.nix nix/python.nix nix/hermes-agent.nix nix/desktop.nix
 
-use flake
+# The nix devShell is the intended dev environment, but this checkout is also
+# used on machines with no nix installed (bootstrap/managed installs, plain
+# `pip install -e .` clones). `use flake` shells out to `nix` unconditionally,
+# so an absent nix printed two `nix: command not found` lines on every cd and
+# left the shell with NO environment at all. Guard it and fall back to the
+# local virtualenv that scripts/run_tests.sh already probes for.
+if has nix; then
+  use flake
+else
+  log_status "nix not found — skipping 'use flake'; falling back to the local venv"
+  for _venv in .venv venv; do
+    if [ -x "$PWD/$_venv/bin/python" ]; then
+      export VIRTUAL_ENV="$PWD/$_venv"
+      PATH_add "$VIRTUAL_ENV/bin"
+      break
+    fi
+  done
+  unset _venv
+fi
+
+# Machine-specific overrides (never committed).
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,8 @@ mini-swe-agent/
 
 # Nix
 .direnv/
+# Machine-specific direnv overrides sourced by .envrc
+.envrc.local
 .nix-stamps/
 result
 website/static/api/skills-index.json

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -916,6 +916,25 @@ direnv allow    # one-time
 # Subsequent entries are near-instant (stamp file skips dep install)
 ```
 
+#### Without nix installed
+
+`.envrc` only calls `use flake` when `nix` is actually on PATH. On a checkout
+without nix — a bootstrap/managed install, or a plain `pip install -e .` clone —
+it logs one status line and falls back to the checkout's virtualenv instead,
+probing `.venv` then `venv` (the same order `scripts/run_tests.sh` uses):
+
+```
+direnv: nix not found — skipping 'use flake'; falling back to the local venv
+```
+
+The fallback exports `VIRTUAL_ENV` and prepends its `bin` via `PATH_add`, so
+direnv unwinds the change on leaving the directory. If neither venv exists,
+nothing is exported — create one with `python -m venv .venv && .venv/bin/python
+-m pip install -e ".[dev]"`.
+
+`.envrc` also sources an optional `.envrc.local` (gitignored) if present, for
+machine-specific overrides.
+
 ### Flake Checks
 
 The flake includes build-time verification that runs in CI and locally:


### PR DESCRIPTION
## Problem

`.envrc` ends in an unconditional `use flake`, which shells out to `nix`. On a checkout where nix is not installed (bootstrap/managed installs, plain `pip install -e .` clones), direnv prints two `nix: command not found` lines on every `cd` into the repo and the shell ends up with **no** environment at all — not even a fallback.

```
direnv: loading ~/.hermes/hermes-agent/.envrc
direnv: using flake
/opt/homebrew/opt/bash/bin/bash:1330: nix: command not found
/opt/homebrew/opt/bash/bin/bash:1331: nix: command not found
```

## Change

Guard `use flake` behind direnv's `has nix`. When nix is absent, log one status line and fall back to the checkout's virtualenv, probing `.venv` then `venv` — the same order `scripts/run_tests.sh` already uses.

The fallback exports `VIRTUAL_ENV` and uses `PATH_add` rather than sourcing `activate`, so direnv owns the PATH mutation and unwinds it on leaving the directory (sourcing `activate` would also clobber `PS1`).

Also sources an optional `.envrc.local` for machine-specific overrides, and gitignores it.

When nix **is** installed the behaviour is byte-for-byte unchanged — `use flake` runs exactly as before.

## Verification

- With no nix installed: direnv loads cleanly, one status line, `VIRTUAL_ENV` resolves to the checkout's `.venv`, `python` resolves to `.venv/bin/python`.
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py` → 56 passed, 0 failed, 2 skipped.

Co-Authored-By: Warp <agent@warp.dev>