### PR TITLE
fix(desktop): restore minimized sessions on focus

### DIFF
--- a/apps/desktop/src/store/pane-focus.test.ts
+++ b/apps/desktop/src/store/pane-focus.test.ts
@@ -27,6 +27,7 @@ describe('revealDesktopPane', () => {
     expect(openReview).toHaveBeenCalledOnce()
     revealDesktopPane('sessions')
     expect(setSidebarOpen).toHaveBeenCalledWith(true)
+    expect(revealTreePane).toHaveBeenCalledWith('sessions')
     revealDesktopPane('terminal')
     expect(setTerminalTakeover).toHaveBeenCalledWith(true)
   })

--- a/apps/desktop/src/store/pane-focus.ts
+++ b/apps/desktop/src/store/pane-focus.ts
@@ -15,7 +15,10 @@ const PANE_REVEALERS: Record<string, () => void> = {
   chat: () => revealTreePane('workspace'),
   files: () => setFileBrowserOpen(true),
   review: () => openReview(),
-  sessions: () => setSidebarOpen(true),
+  sessions: () => {
+    setSidebarOpen(true)
+    revealTreePane('sessions')
+  },
   terminal: () => setTerminalTakeover(true)
 }
 


### PR DESCRIPTION
Closes #106009.

## Summary
- keep the existing Sessions sidebar visibility signal when handling `focus_pane(sessions)`
- also route the explicit reveal through the `sessions` tree pane
- restore a minimized Sessions group instead of reporting success while it remains near-zero width
- add regression coverage for both reveal paths

## Validation
- `npx vitest run src/store/pane-focus.test.ts --project ui`: **3 passed**
- `npx tsc -p . --noEmit`: passed
- `git diff --check`: passed

## Duplicate check
The final check found no overlapping PR, branch, commit, assignment, or competing claim for #106009.