### PR TITLE
fix(desktop): coalesce pending live status refreshes

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -9,7 +9,12 @@ import { useBackgroundSync } from './use-background-sync'
 const noop = () => undefined
 const requestGateway = async () => ({ sessions: [] })
 
-function render(activeGatewayProfile: string, activeConnectionId: string, refreshSessions: () => Promise<void>) {
+function render(
+  activeGatewayProfile: string,
+  activeConnectionId: string,
+  refreshSessions: () => Promise<void>,
+  gatewayRequest = requestGateway
+) {
   return renderHook(
     ({ connectionId, profile }: { connectionId: string; profile: string }) => {
       useBackgroundSync({
@@ -26,7 +31,7 @@ function render(activeGatewayProfile: string, activeConnectionId: string, refres
         refreshHermesConfig: noop,
         refreshMessagingSessions: noop,
         refreshSessions,
-        requestGateway
+        requestGateway: gatewayRequest
       })
     },
     { initialProps: { connectionId: activeConnectionId, profile: activeGatewayProfile } }
@@ -45,6 +50,39 @@ describe('useBackgroundSync profile-scoped session refresh', () => {
   afterEach(() => {
     cleanup()
     vi.useRealTimers()
+  })
+
+  it('coalesces change ticks while the live status request is pending', async () => {
+    $changeEventsAvailable.set(true)
+    let release!: (value: { sessions: [] }) => void
+    const pending = new Promise<{ sessions: [] }>(resolve => { release = resolve })
+    const request = vi.fn(() => pending)
+    render('default', 'local', async () => undefined, request)
+    await act(async () => undefined)
+
+    for (let tick = 1; tick <= 8; tick += 1) {
+      await act(async () => { $sessionsChangeTick.set(tick) })
+    }
+
+    expect(request).toHaveBeenCalledTimes(1)
+    await act(async () => { release({ sessions: [] }) })
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('discards a queued old-connection refresh when the connection changes', async () => {
+    let rejectOld!: (reason: Error) => void
+    const oldRequest = new Promise<{ sessions: [] }>((_, reject) => { rejectOld = reject })
+    const request = vi.fn().mockReturnValueOnce(oldRequest).mockResolvedValue({ sessions: [] })
+    const hook = render('default', 'first', async () => undefined, request)
+    await act(async () => { $sessionsChangeTick.set(1) })
+    hook.rerender({ connectionId: 'second', profile: 'default' })
+    await act(async () => undefined)
+    expect(request).toHaveBeenCalledTimes(2)
+    await act(async () => { rejectOld(new Error('old connection closed')) })
+    expect(request).toHaveBeenCalledTimes(2)
+    hook.unmount()
+    await act(async () => { $sessionsChangeTick.set(2) })
+    expect(request).toHaveBeenCalledTimes(2)
   })
 
   it('refreshes the session list after the active gateway profile changes', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -575,7 +575,6 @@ export function useBackgroundSync({
 }: BackgroundSyncParams): void {
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
-  const sessionsChangeTick = useStore($sessionsChangeTick)
   const activeTranscriptBusy = useStore($busy)
   const activeTranscriptRefreshPendingRef = useRef<string | null>(null)
   // Tile reconcile state (#93942 slice 1): shared sequence guard + per-tile
@@ -682,9 +681,16 @@ export function useBackgroundSync({
 
     let cancelled = false
     let inFlight = false
+    let refreshPending = false
 
     const refreshLiveStatuses = async () => {
+      if (cancelled) {
+        return
+      }
+
       if (inFlight) {
+        refreshPending = true
+
         return
       }
 
@@ -701,8 +707,15 @@ export function useBackgroundSync({
         // still work as before; leave the current sidebar state untouched.
       } finally {
         inFlight = false
+
+        if (refreshPending && !cancelled) {
+          refreshPending = false
+          void refreshLiveStatuses()
+        }
       }
     }
+
+    const unsubscribe = $sessionsChangeTick.listen(() => void refreshLiveStatuses())
 
     const dispose = visiblePoll(
       changeEventsAvailable ? LIVE_SESSION_STATUS_BACKSTOP_INTERVAL_MS : LIVE_SESSION_STATUS_POLL_INTERVAL_MS,
@@ -713,11 +726,12 @@ export function useBackgroundSync({
 
     return () => {
       cancelled = true
+      unsubscribe()
       dispose()
     }
-    // sessionsChangeTick: each sessions.changed broadcast re-seeds immediately
-    // via the effect re-run (already coalesced to 2s server-side).
-  }, [activeGatewayProfile, changeEventsAvailable, gatewayState, requestGateway, sessionsChangeTick])
+    // Keep the in-flight guard alive across change ticks; a slow response must
+    // not create a new request (and invalidate the old result) on every tick.
+  }, [activeConnectionId, activeGatewayProfile, changeEventsAvailable, gatewayState, requestGateway])
 
   // sessions.changed also means the *stored* list may have new rows (a cron
   // run's session, an inbound messaging turn creating a thread). The full list


### PR DESCRIPTION
Fixes #106098

## Failure mode

The live-status effect subscribed to `sessionsChangeTick` through React state. Every `sessions.changed` tick therefore tore the effect down and recreated it:

1. the pending `session.active_list` response was marked stale;
2. the local `inFlight` guard was discarded;
3. a replacement request started immediately.

A burst of change events could turn one slow request into many overlapping requests while guaranteeing that earlier useful responses would be ignored.

## Ownership fix

Keep the request scheduler inside the connection-scoped effect and subscribe to `$sessionsChangeTick` directly. The effect now owns:

- one `inFlight` request;
- one `refreshPending` bit;
- one change-tick subscription;
- the periodic legacy-server backstop.

A tick during an active request marks one follow-up. Settlement starts that follow-up once; additional ticks collapse into the same pending intent. Connection changes and unmounts unsubscribe, cancel queued work, and prevent a rejected old request from restarting the old lifecycle.

`activeConnectionId` is part of the effect boundary so request ownership follows the actual backend connection, not only the profile label.

## Behavioral contract

- Change broadcasts still request an immediate status refresh.
- At most one request runs and one follow-up is queued per connection lifecycle.
- A connection replacement cannot publish or reschedule work through the retired lifecycle.
- Existing periodic polling remains the fallback for servers without change events.
- Stored-session refresh and configuration coalescing remain separate paths.

## Verification

- Mounted the production `useBackgroundSync` hook on upstream `b1f003e186`.
- With the gateway response held and eight change ticks emitted, the previous implementation made **9 requests**; the regression failed with `expected 1, got 9`.
- The fixed hook makes one active request and one coalesced follow-up.
- A connection-change case proves that rejection of the old request cannot enqueue stale work after replacement or unmount.
- Focused hook tests: **35 passed**.
- All three TypeScript project checks, focused ESLint, and `git diff --check` passed.

## Relationship to nearby work

This PR changes only live `session.active_list` scheduling. It is separate from #58109's stored-list/config coalescing and #104374's composer-focus deferral.