### PR TITLE
fix(cron): report unresolvable fan-out targets

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -843,12 +843,28 @@ def _delivery_lane_value(job: dict, *, for_failure: bool = False):
     return job.get("deliver", "local")
 
 
-def _resolve_delivery_targets(job: dict, *, for_failure: bool = False) -> List[dict]:
+def _is_intentional_delivery_opt_out(part: str) -> bool:
+    """True when a discarded fan-out member is an intentional no-delivery token, not a genuine
+    resolution failure. ``local`` is the structural opt-out (whole-value ``deliver: local``
+    resolves to zero targets by design); ``origin`` with no origin and no home channel is the
+    documented origin-less no-op lane (``_unresolved_delivery_outcome``, #43014) — flagging it
+    would make every CLI ``deliver=origin`` job emit a spurious error on every run."""
+    return part in ("local", "origin")
+
+
+def _resolve_delivery_targets(
+    job: dict, *, for_failure: bool = False,
+    resolution_errors: Optional[List[str]] = None,
+) -> List[dict]:
     """Resolve auto-delivery targets from comma-separated ``deliver``; ``all`` expands to every
     platform with a home channel and combines with explicit targets. Dedup by (platform, chat_id,
     thread_id). ``for_failure=True`` (failure summaries, interrupted-run notices, drift/preflight
     alerts) resolves from ``failure_deliver`` INSTEAD when the job carries one —
-    ``failure_deliver: local`` is the structural opt-out; absent, failures follow ``deliver``."""
+    ``failure_deliver: local`` is the structural opt-out; absent, failures follow ``deliver``.
+
+    When ``resolution_errors`` is a list, every fan-out member that is discarded (rather than
+    intentionally opted out) appends a human-readable entry there, so callers that deliver to the
+    surviving targets can still report the drop instead of silently succeeding."""
     deliver = _normalize_deliver_value(_delivery_lane_value(job, for_failure=for_failure))
     if deliver == "local":
         return []
@@ -863,6 +879,10 @@ def _resolve_delivery_targets(job: dict, *, for_failure: bool = False) -> List[d
     for part in parts:
         target = _resolve_single_delivery_target(job, part)
         if not target:
+            if resolution_errors is not None and not _is_intentional_delivery_opt_out(part):
+                resolution_errors.append(
+                    f"unresolvable delivery target '{part}': target skipped, "
+                    "output was not delivered there")
             continue
         key = (target["platform"].lower(), str(target["chat_id"]), target.get("thread_id"))
         kept = seen.get(key)
@@ -1657,7 +1677,9 @@ def _deliver_result(
     standalone fallback. ``for_failure=True`` routes failure-category notices through the job's
     ``failure_deliver`` override when present (NS-788). Returns None on success, else an error."""
     job.pop("_bot_chat_delivery_receipts", None)
-    targets = _resolve_delivery_targets(job, for_failure=for_failure)
+    resolution_errors: List[str] = []
+    targets = _resolve_delivery_targets(
+        job, for_failure=for_failure, resolution_errors=resolution_errors)
     if not targets:
         _record_delivery_verification(job, [])
         return _unresolved_delivery_outcome(job, for_failure)
@@ -1741,6 +1763,12 @@ def _deliver_result(
         return msg
 
     delivery_errors = []
+    # Fan-out members discarded at resolution time (unknown platform, invalid explicit
+    # target, missing home channel, deleted bot-chat profile) must fail the run's delivery
+    # accounting even when a surviving sibling delivers fine — otherwise the job records
+    # last_status=ok while a requested target never received anything.
+    for resolution_error in resolution_errors:
+        _note_target_error(job, resolution_error, delivery_errors)
     for target in targets:
         # Bot Chat owns admission; never concurrently resume a live owner's transcript.
         if target["platform"] == BOT_CHAT_PLATFORM:

--- a/tests/cron/test_fanout_resolution_errors.py
+++ b/tests/cron/test_fanout_resolution_errors.py
@@ -1,0 +1,141 @@
+"""Fan-out resolution failures must surface as delivery errors, not silent success.
+
+Regression coverage: ``_resolve_delivery_targets`` used to discard unresolvable
+fan-out members (unknown platform, missing home channel, deleted bot-chat
+profile) with no error accumulation, so ``_deliver_result`` returned ``None``
+whenever a surviving sibling delivered fine — and the job recorded
+``last_status="ok"`` while a requested target never received anything.
+"""
+
+import pytest
+
+from cron.jobs import _record_run_outcome
+from cron.scheduler import _deliver_result, _resolve_delivery_targets
+
+
+@pytest.fixture()
+def slack_sender(monkeypatch, tmp_path):
+    """Isolated HERMES_HOME with slack enabled; standalone sends recorded."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "platforms:\n  slack:\n    enabled: true\n    token: xoxb-test\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("SLACK_HOME_CHANNEL", "D0HOME")
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+
+    send_calls = []
+
+    async def fake_sender(pconfig, chat_id, message, *, thread_id=None,
+                          media_files=None, force_document=False, caption=None):
+        send_calls.append({"chat_id": chat_id, "thread_id": thread_id})
+        return {"success": True, "chat_id": chat_id, "message_id": "1.2"}
+
+    import hermes_cli.plugins as hp
+    import gateway.platform_registry as reg
+
+    entry = reg.platform_registry.get("slack")
+    if entry is None:
+        hp.discover_plugins()
+        entry = reg.platform_registry.get("slack")
+    if entry is None:
+        pytest.skip("slack platform entry not registered")
+    monkeypatch.setattr(entry, "standalone_sender_fn", fake_sender)
+    monkeypatch.setattr(hp, "discover_plugins", lambda *a, **k: None)
+    return send_calls
+
+
+def _classify(job, delivery_error):
+    recorded = dict(job)
+    _record_run_outcome(recorded, True, None, delivery_error, None, "now")
+    return recorded["last_status"]
+
+
+class TestFanoutResolutionErrors:
+    def test_valid_plus_unknown_target_returns_error(self, slack_sender):
+        job = {
+            "id": "j1", "name": "fanout",
+            "deliver": "slack:D0GOOD,nosuchplatformXYZ", "origin": None,
+        }
+        err = _deliver_result(job, "hello", adapters=None, loop=None)
+        assert err is not None, "dropped fan-out member must fail delivery accounting"
+        assert "nosuchplatformXYZ" in err
+        assert [c["chat_id"] for c in slack_sender] == ["D0GOOD"]
+        assert _classify(job, err) == "delivery_failed"
+
+    def test_single_invalid_target_still_fails_as_before(self, slack_sender):
+        job = {"id": "j2", "name": "bad", "deliver": "nosuchplatformXYZ",
+               "origin": None}
+        err = _deliver_result(job, "hello", adapters=None, loop=None)
+        assert err == "no delivery target resolved for deliver=nosuchplatformXYZ"
+        assert slack_sender == []
+        assert _classify(job, err) == "delivery_failed"
+
+    def test_local_remains_intentional_noop(self, slack_sender):
+        job = {"id": "j3", "name": "local", "deliver": "local", "origin": None}
+        errors: list = []
+        assert _resolve_delivery_targets(job, resolution_errors=errors) == []
+        assert errors == []
+        err = _deliver_result(job, "hello", adapters=None, loop=None)
+        assert err is None
+        assert slack_sender == []
+        assert _classify(job, err) == "ok"
+
+    def test_valid_fanout_unchanged(self, slack_sender):
+        job = {
+            "id": "j4", "name": "good-fanout",
+            "deliver": "slack:D0A,slack:D0B", "origin": None,
+        }
+        err = _deliver_result(job, "hello", adapters=None, loop=None)
+        assert err is None
+        assert sorted(c["chat_id"] for c in slack_sender) == ["D0A", "D0B"]
+        assert _classify(job, err) == "ok"
+
+    def test_missing_bot_chat_profile_reported(self, slack_sender):
+        job = {
+            "id": "j5", "name": "bot-chat-fanout",
+            "deliver": "slack:D0GOOD,bot-chat:deleted-profile-xyz",
+            "origin": None,
+        }
+        err = _deliver_result(job, "hello", adapters=None, loop=None)
+        assert err is not None
+        assert "deleted-profile-xyz" in err
+        assert [c["chat_id"] for c in slack_sender] == ["D0GOOD"]
+        assert _classify(job, err) == "delivery_failed"
+
+    def test_bare_platform_without_home_reported(self, slack_sender):
+        job = {
+            "id": "j6", "name": "no-home-fanout",
+            "deliver": "slack:D0GOOD,discord", "origin": None,
+        }
+        err = _deliver_result(job, "hello", adapters=None, loop=None)
+        assert err is not None
+        assert "discord" in err
+        assert [c["chat_id"] for c in slack_sender] == ["D0GOOD"]
+        assert _classify(job, err) == "delivery_failed"
+
+    def test_origin_without_origin_stays_silent(self, slack_sender, monkeypatch):
+        """Origin-less ``origin`` is the documented no-op lane (#43014), not a
+        genuine resolution failure — it must not flip a succeeding fan-out."""
+        monkeypatch.delenv("SLACK_HOME_CHANNEL")
+        job = {
+            "id": "j7", "name": "origin-fanout",
+            "deliver": "origin,slack:D0GOOD", "origin": None,
+        }
+        errors: list = []
+        targets = _resolve_delivery_targets(job, resolution_errors=errors)
+        assert [t["chat_id"] for t in targets] == ["D0GOOD"]
+        assert errors == []
+        err = _deliver_result(job, "hello", adapters=None, loop=None)
+        assert err is None
+        assert [c["chat_id"] for c in slack_sender] == ["D0GOOD"]
+
+    def test_accumulator_defaults_to_legacy_behavior(self):
+        """Existing callers pass no accumulator: list return, no error surfacing."""
+        job = {"id": "j8", "deliver": "slack:D0X,nosuchplatformXYZ",
+               "origin": None}
+        targets = _resolve_delivery_targets(job)
+        assert [(t["platform"], t["chat_id"]) for t in targets] == [
+            ("slack", "D0X")]

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -376,12 +376,14 @@ def test_worker_delivery_queue_is_keyed_by_the_delivering_jobs_own_execution(
     monkeypatch.setattr(
         scheduler,
         "_resolve_delivery_targets",
-        lambda job, for_failure=False: [{"platform": "telegram", "chat_id": "123"}],
+        lambda job, for_failure=False, resolution_errors=None: [
+            {"platform": "telegram", "chat_id": "123"}],
     )
     monkeypatch.setattr(
         scheduler_delivery,
         "_resolve_delivery_targets",
-        lambda job, for_failure=False: [{"platform": "telegram", "chat_id": "123"}],
+        lambda job, for_failure=False, resolution_errors=None: [
+            {"platform": "telegram", "chat_id": "123"}],
     )
 
     def _standalone(*_args, **_kwargs):


### PR DESCRIPTION
## Summary

Fix a cron fan-out delivery bug where an unresolvable target could be silently discarded while a sibling target succeeded.

Previously, `_resolve_delivery_targets()` treated every `None` result as a simple `continue`. For a multi-target delivery, this meant:

1. One requested target failed during resolution.
2. Another target resolved and received the output.
3. The unresolved target was silently discarded.
4. `_deliver_result()` returned `None`.
5. The cron run was recorded as `last_status="ok"`.

This could report successful delivery even though one of the requested destinations never received the output.

## What changed

* Add an opt-in `resolution_errors` accumulator to `_resolve_delivery_targets()`.
* Record genuine fan-out resolution failures instead of silently dropping them.
* Propagate those errors into `_deliver_result()` so they participate in normal delivery failure accounting.
* Preserve intentional `local` and origin-less `origin` no-op behavior.
* Keep existing callers compatible by making the accumulator optional.
* Update the affected restart-safe worker test mocks.

## Tests

Added regression coverage for:

* Valid target + unknown target
* Single invalid target (existing behavior)
* Valid fan-out
* `local` no-op
* Missing `bot-chat` profile
* Bare platform without a configured home channel
* Origin-less `origin` no-op
* Legacy behavior when no error accumulator is supplied

Validation performed:

```text
scripts/run_tests.sh tests/cron/test_fanout_resolution_errors.py
8 passed

scripts/run_tests.sh tests/cron/ tests/gateway/test_cron_shutdown_drain.py
1233 passed, 0 failed, 2 skipped

ruff
clean

git diff --check
clean
```

## Scope

This PR is intentionally limited to resolution-stage failures in cron fan-out delivery. It does not change the semantics of intentional `local` or origin-less `origin` delivery lanes.
