### PR TITLE
fix(backup): verify recovery generations before quick-snapshot pruning

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1101,8 +1101,7 @@ def _copy_quick_snapshot_files(
     """Copy every quick-snapshot candidate into *staging_dir*.
 
     Returns ``(manifest {rel: size}, failed_dbs, oversized_skipped)``. The last two are snapshot
-    incompleteness (#68805): the caller must suppress pruning so the older snapshot that may hold
-    the only recoverable DB survives.
+    incompleteness (#68805): pruning still runs but must keep the latest complete recovery source.
     """
     manifest: Dict[str, int] = {}
     failed_dbs: list[str] = []
@@ -1182,18 +1181,20 @@ def _create_quick_snapshot_locked(
         json.dump(meta, f, indent=2)
     os.replace(staging_dir, root / snap_id)
     # Auto-prune (pre-update callers pass a smaller keep so state.db copies don't accumulate).
-    # Skip when a DB failed to capture OR was skipped for size (#68805): the snapshot is
-    # incomplete and the older one may hold the only recoverable database.
-    if not (failed_dbs or oversized_skipped):
-        _prune_oldest(_snapshot_dirs(root), _QUICK_DEFAULT_KEEP if keep is None else keep, shutil.rmtree, "snapshot")
-    else:
+    # When a present DB failed to capture OR was skipped for size (#68805), preserve the latest
+    # complete recovery source in addition to the retention window. Still prune stale incomplete
+    # snapshots: they contain config/auth copies too, and repeated failures must stay bounded.
+    incomplete = failed_dbs or oversized_skipped
+    retention = _QUICK_DEFAULT_KEEP if keep is None else keep
+    if incomplete:
         if oversized_skipped:
-            print("  ⚠ Skipping snapshot prune: DB file(s) skipped for size: " + ", ".join(oversized_skipped))
+            print("  ⚠ Preserving latest complete snapshot: DB file(s) skipped for size: " + ", ".join(oversized_skipped))
             logger.warning("Quick snapshot skipped oversized DB file(s): %s", ", ".join(oversized_skipped))
         logger.warning(
-            "Skipping snapshot prune because %d DB(s) failed to capture and/or %d were oversized "
-            "— preserving older snapshots as recovery source",
+            "Snapshot incomplete because %d DB(s) failed to capture and/or %d were oversized "
+            "— preserving latest complete recovery source",
             len(failed_dbs), len(oversized_skipped))
+    _prune_quick_snapshots(root, keep=retention, preserve_latest_complete=bool(incomplete))
     logger.info("quick snapshot phase=copy status=complete id=%s files=%d bytes=%d",
                 snap_id, len(manifest), sum(manifest.values()))
     return snap_id
@@ -1503,6 +1504,28 @@ def _prune_oldest(newest_first: List[Path], keep: int, remove, what: str) -> int
         except OSError as exc:
             logger.warning("Failed to prune %s %s: %s", what, p.name, exc)
     return deleted
+
+
+def _prune_quick_snapshots(
+    root: Path,
+    keep: int = _QUICK_DEFAULT_KEEP,
+    *,
+    preserve_latest_complete: bool = False,
+) -> int:
+    """Remove old snapshots, optionally retaining one complete recovery source."""
+    dirs = _snapshot_dirs(root)
+    retained = set(dirs[:keep])
+    if preserve_latest_complete:
+        for d in dirs:
+            try:
+                with open(d / "manifest.json", encoding="utf-8") as f:
+                    meta = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                continue
+            if isinstance(meta, dict) and not meta.get("failed_dbs") and not meta.get("oversized_skipped"):
+                retained.add(d)
+                break
+    return _prune_oldest([d for d in dirs if d not in retained], 0, shutil.rmtree, "snapshot")
 
 
 def prune_quick_snapshots(keep: int = _QUICK_DEFAULT_KEEP, hermes_home: Optional[Path] = None) -> int:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1101,7 +1101,7 @@ def _copy_quick_snapshot_files(
     """Copy every quick-snapshot candidate into *staging_dir*.
 
     Returns ``(manifest {rel: size}, failed_dbs, oversized_skipped)``. The last two are snapshot
-    incompleteness (#68805): pruning still runs but must keep the latest complete recovery source.
+    incompleteness (#68805): pruning still runs but must keep the newest recovery copy of each omitted DB.
     """
     manifest: Dict[str, int] = {}
     failed_dbs: list[str] = []
@@ -1181,20 +1181,21 @@ def _create_quick_snapshot_locked(
         json.dump(meta, f, indent=2)
     os.replace(staging_dir, root / snap_id)
     # Auto-prune (pre-update callers pass a smaller keep so state.db copies don't accumulate).
-    # When a present DB failed to capture OR was skipped for size (#68805), preserve the latest
-    # complete recovery source in addition to the retention window. Still prune stale incomplete
-    # snapshots: they contain config/auth copies too, and repeated failures must stay bounded.
+    # When a present DB failed to capture or was skipped for size (#68805), preserve the newest
+    # recovery copy of each omitted DB in addition to the retention window. Still prune stale
+    # partial snapshots that add no recovery coverage: they contain config/auth copies and must
+    # stay bounded.
     incomplete = failed_dbs or oversized_skipped
     retention = _QUICK_DEFAULT_KEEP if keep is None else keep
     if incomplete:
         if oversized_skipped:
-            print("  ⚠ Preserving latest complete snapshot: DB file(s) skipped for size: " + ", ".join(oversized_skipped))
+            print("  ⚠ Preserving latest recovery copy: DB file(s) skipped for size: " + ", ".join(oversized_skipped))
             logger.warning("Quick snapshot skipped oversized DB file(s): %s", ", ".join(oversized_skipped))
         logger.warning(
             "Snapshot incomplete because %d DB(s) failed to capture and/or %d were oversized "
-            "— preserving latest complete recovery source",
+            "— preserving latest recovery copy of each omitted DB",
             len(failed_dbs), len(oversized_skipped))
-    _prune_quick_snapshots(root, keep=retention, preserve_latest_complete=bool(incomplete))
+    _prune_quick_snapshots(root, keep=retention, preserve_recovery_for=set(failed_dbs) | set(oversized_skipped))
     logger.info("quick snapshot phase=copy status=complete id=%s files=%d bytes=%d",
                 snap_id, len(manifest), sum(manifest.values()))
     return snap_id
@@ -1510,21 +1511,31 @@ def _prune_quick_snapshots(
     root: Path,
     keep: int = _QUICK_DEFAULT_KEEP,
     *,
-    preserve_latest_complete: bool = False,
+    preserve_recovery_for: Optional[set[str]] = None,
 ) -> int:
-    """Remove old snapshots, optionally retaining one complete recovery source."""
+    """Remove old snapshots while retaining recovery copies for omitted DBs."""
     dirs = _snapshot_dirs(root)
     retained = set(dirs[:keep])
-    if preserve_latest_complete:
+    missing = set(preserve_recovery_for or ())
+    if missing:
         for d in dirs:
             try:
                 with open(d / "manifest.json", encoding="utf-8") as f:
                     meta = json.load(f)
-            except (OSError, json.JSONDecodeError):
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "Could not inspect snapshot %s while preserving recovery copies: %s",
+                    d.name, exc)
                 continue
-            if isinstance(meta, dict) and not meta.get("failed_dbs") and not meta.get("oversized_skipped"):
+            files = meta.get("files") if isinstance(meta, dict) else None
+            if not isinstance(files, dict):
+                continue
+            covered = missing.intersection(files)
+            if covered:
                 retained.add(d)
-                break
+                missing.difference_update(covered)
+                if not missing:
+                    break
     return _prune_oldest([d for d in dirs if d not in retained], 0, shutil.rmtree, "snapshot")
 
 

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -1195,7 +1195,15 @@ def _create_quick_snapshot_locked(
             "Snapshot incomplete because %d DB(s) failed to capture and/or %d were oversized "
             "— preserving latest recovery copy of each omitted DB",
             len(failed_dbs), len(oversized_skipped))
-    _prune_quick_snapshots(root, keep=retention, preserve_recovery_for=set(failed_dbs) | set(oversized_skipped))
+    _prune_quick_snapshots(
+        root,
+        keep=retention,
+        preserve_recovery_for=set(failed_dbs) | set(oversized_skipped),
+        namespace=_quick_snapshot_namespace(label),
+    )
+    # Damaged manifests cannot identify their original retention policy. Bound
+    # recognizable snapshot artifacts separately using the normal (not updater) window.
+    _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP, namespace="unknown")
     logger.info("quick snapshot phase=copy status=complete id=%s files=%d bytes=%d",
                 snap_id, len(manifest), sum(manifest.values()))
     return snap_id
@@ -1212,6 +1220,69 @@ def _snapshot_dirs(root: Path) -> List[Path]:
     """Published snapshot directories under *root*, newest first."""
     return _newest_first(root, lambda d: d.is_dir() and not d.name.startswith(".")
                          and not d.name.endswith(".partial"))
+
+
+def _quick_snapshot_namespace(label: Optional[str]) -> str:
+    """Keep updater safety-net snapshots separate from user-created snapshots."""
+    return "pre-update" if label == "pre-update" else "manual"
+
+
+def _snapshot_retention_namespace(directory: Path, meta: Optional[Dict[str, Any]]) -> Optional[str]:
+    if meta is not None:
+        return _quick_snapshot_namespace(meta.get("label"))
+    # Only published timestamped snapshot names are managed artifacts. Do not
+    # remove arbitrary directories placed beside them when a manifest is absent.
+    name = directory.name
+    try:
+        datetime.strptime(name[:15], "%Y%m%d-%H%M%S")
+    except ValueError:
+        return None
+    return "unknown" if len(name) == 15 or name[15:16] == "-" else None
+
+
+def _snapshot_metadata(directory: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with open(directory / "manifest.json", encoding="utf-8") as f:
+            meta = json.load(f)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        logger.warning("Could not inspect snapshot %s for retention: %s", directory.name, exc)
+        return None
+    return meta if isinstance(meta, dict) else None
+
+
+def _verified_snapshot_db(directory: Path, rel: str) -> bool:
+    """Whether *directory* has a readable SQLite recovery copy for *rel*."""
+    if not isinstance(rel, str):
+        return False
+    payload = directory / rel
+    try:
+        if not rel.endswith(".db") or not _is_within(payload, directory.resolve()):
+            return False
+    except OSError:
+        return False
+    return verify_sqlite_integrity(payload).get("valid", False)
+
+
+def _is_complete_quick_snapshot(directory: Path, meta: Dict[str, Any]) -> bool:
+    """A complete generation has no recorded omissions and every payload survives inspection."""
+    if meta.get("failed_dbs") or meta.get("oversized_skipped"):
+        return False
+    files = meta.get("files")
+    if not isinstance(files, dict) or not files:
+        return False
+    root = directory.resolve()
+    for rel, expected_size in files.items():
+        if not isinstance(rel, str):
+            return False
+        payload = directory / rel
+        try:
+            if not _is_within(payload, root) or not payload.is_file() or payload.stat().st_size != expected_size:
+                return False
+        except OSError:
+            return False
+        if rel.endswith(".db") and not _verified_snapshot_db(directory, rel):
+            return False
+    return True
 
 
 def list_quick_snapshots(limit: int = 20, hermes_home: Optional[Path] = None) -> List[Dict[str, Any]]:
@@ -1512,36 +1583,58 @@ def _prune_quick_snapshots(
     keep: int = _QUICK_DEFAULT_KEEP,
     *,
     preserve_recovery_for: Optional[set[str]] = None,
+    namespace: Optional[str] = "manual",
 ) -> int:
-    """Remove old snapshots while retaining recovery copies for omitted DBs."""
-    dirs = _snapshot_dirs(root)
+    """Bound one snapshot namespace without discarding recovery generations.
+
+    Retain the configured recent window, newest verified complete generation,
+    and the newest readable SQLite copy for each DB omitted by this run.
+    """
+    if namespace is None:
+        namespaces = {_snapshot_retention_namespace(d, _snapshot_metadata(d))
+                      for d in _snapshot_dirs(root)}
+        return sum(_prune_quick_snapshots(root, keep=keep, namespace=current)
+                   for current in namespaces if current is not None)
+    metadata = {d: _snapshot_metadata(d) for d in _snapshot_dirs(root)}
+    dirs = [d for d, meta in metadata.items()
+            if _snapshot_retention_namespace(d, meta) == namespace]
     retained = set(dirs[:keep])
-    missing = set(preserve_recovery_for or ())
-    if missing:
+    if preserve_recovery_for is None:
+        missing = set()
         for d in dirs:
-            try:
-                with open(d / "manifest.json", encoding="utf-8") as f:
-                    meta = json.load(f)
-            except (OSError, json.JSONDecodeError) as exc:
-                logger.warning(
-                    "Could not inspect snapshot %s while preserving recovery copies: %s",
-                    d.name, exc)
+            meta = _snapshot_metadata(d)
+            if meta is None:
                 continue
-            files = meta.get("files") if isinstance(meta, dict) else None
-            if not isinstance(files, dict):
-                continue
-            covered = missing.intersection(files)
-            if covered:
-                retained.add(d)
-                missing.difference_update(covered)
-                if not missing:
-                    break
+            for key in ("failed_dbs", "oversized_skipped"):
+                omissions = meta.get(key)
+                if isinstance(omissions, list):
+                    missing.update(rel for rel in omissions if isinstance(rel, str))
+    else:
+        missing = set(preserve_recovery_for)
+    for d in dirs:
+        meta = _snapshot_metadata(d)
+        if meta is None:
+            continue
+        if _is_complete_quick_snapshot(d, meta):
+            retained.add(d)
+            break
+    for d in dirs:
+        if not missing:
+            break
+        files = (metadata[d] or {}).get("files")
+        if not isinstance(files, dict):
+            continue
+        # Restore consumes manifest entries: an unlisted file is not recovery coverage.
+        covered = {rel for rel in missing if rel in files and _verified_snapshot_db(d, rel)}
+        if covered:
+            retained.add(d)
+            missing.difference_update(covered)
     return _prune_oldest([d for d in dirs if d not in retained], 0, shutil.rmtree, "snapshot")
 
 
 def prune_quick_snapshots(keep: int = _QUICK_DEFAULT_KEEP, hermes_home: Optional[Path] = None) -> int:
     """Remove oldest quick snapshots beyond the keep limit. Returns count deleted."""
-    return _prune_oldest(_snapshot_dirs(_quick_snapshot_root(hermes_home)), keep, shutil.rmtree, "snapshot")
+    return _prune_quick_snapshots(_quick_snapshot_root(hermes_home), keep=keep, namespace=None)
 
 
 def run_quick_backup(args) -> None:

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1466,10 +1466,8 @@ class TestQuickSnapshot:
 
 
 
-    def test_oversized_db_suppresses_pruning(self, hermes_home, capsys):
-        """#68805: an oversized state.db skipped for size must suppress
-        pruning so the older complete snapshot (containing the only
-        recoverable database) is preserved.
+    def test_oversized_db_preserves_latest_recovery_copy(self, hermes_home, capsys):
+        """#68805: an oversized state.db must preserve its latest recovery copy.
 
         Reproduces the reviewer's scenario: keep=1 + a state.db exceeding
         the size cap → the new snapshot omits state.db, failed_dbs stays
@@ -1498,7 +1496,7 @@ class TestQuickSnapshot:
         assert not (second_dir / "state.db").exists()
 
         # Manifest must record the oversized skip
-        with open(second_dir / "manifest.json") as f:
+        with open(second_dir / "manifest.json", encoding="utf-8") as f:
             meta = json.load(f)
         assert "state.db" in meta.get("oversized_skipped", [])
 
@@ -1513,7 +1511,44 @@ class TestQuickSnapshot:
         assert second_id in snap_ids
 
         out = capsys.readouterr().out
-        assert "skipping state.db" in out.lower() or "skipping snapshot prune" in out.lower()
+        assert "skipping state.db" in out.lower()
+
+    def test_alternating_db_failures_preserve_latest_copy_of_each_db(
+        self, hermes_home, monkeypatch
+    ):
+        """A partial snapshot may be the latest recovery source for another DB."""
+        from hermes_cli import backup
+
+        executions_db = hermes_home / "cron" / "executions.db"
+        with sqlite3.connect(executions_db) as conn:
+            conn.execute("CREATE TABLE executions (id INTEGER PRIMARY KEY)")
+
+        real_safe_copy = backup._safe_copy_db
+        failed_name = "executions.db"
+
+        def selective_safe_copy(src, dst):
+            if src.name == failed_name:
+                return False
+            return real_safe_copy(src, dst)
+
+        monkeypatch.setattr(backup, "_safe_copy_db", selective_safe_copy)
+        first_id = backup.create_quick_snapshot(
+            label="state-only", hermes_home=hermes_home, keep=10
+        )
+        assert first_id is not None
+
+        _advance_backup_clock()
+        failed_name = "state.db"
+        second_id = backup.create_quick_snapshot(
+            label="executions-only", hermes_home=hermes_home, keep=1
+        )
+        assert second_id is not None
+
+        root = hermes_home / "state-snapshots"
+        assert (root / first_id / "state.db").exists()
+        assert not (root / first_id / "cron" / "executions.db").exists()
+        assert not (root / second_id / "state.db").exists()
+        assert (root / second_id / "cron" / "executions.db").exists()
 
     @pytest.mark.parametrize("incomplete_kind", ["oversized", "failed"])
     def test_repeated_incomplete_snapshots_prune_stale_partial_copies(
@@ -1537,7 +1572,8 @@ class TestQuickSnapshot:
         for index in range(3):
             _advance_backup_clock()
             (hermes_home / ".env").write_text(
-                f"OPENROUTER_API_KEY=rotated-test-key-{index}\n"
+                f"OPENROUTER_API_KEY=rotated-test-key-{index}\n",
+                encoding="utf-8",
             )
             partial_id = backup.create_quick_snapshot(
                 label=f"partial-{index}",

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1515,6 +1515,52 @@ class TestQuickSnapshot:
         out = capsys.readouterr().out
         assert "skipping state.db" in out.lower() or "skipping snapshot prune" in out.lower()
 
+    @pytest.mark.parametrize("incomplete_kind", ["oversized", "failed"])
+    def test_repeated_incomplete_snapshots_prune_stale_partial_copies(
+        self, hermes_home, monkeypatch, incomplete_kind
+    ):
+        """Incomplete snapshots stay bounded without losing the recovery copy."""
+        from hermes_cli import backup
+
+        complete_id = backup.create_quick_snapshot(
+            label="complete", hermes_home=hermes_home, keep=1
+        )
+        assert complete_id is not None
+
+        snapshot_kwargs = {}
+        if incomplete_kind == "oversized":
+            snapshot_kwargs["max_file_size"] = 1024
+        else:
+            monkeypatch.setattr(backup, "_safe_copy_db", lambda _src, _dst: False)
+
+        partial_ids = []
+        for index in range(3):
+            _advance_backup_clock()
+            (hermes_home / ".env").write_text(
+                f"OPENROUTER_API_KEY=rotated-test-key-{index}\n"
+            )
+            partial_id = backup.create_quick_snapshot(
+                label=f"partial-{index}",
+                hermes_home=hermes_home,
+                keep=1,
+                **snapshot_kwargs,
+            )
+            assert partial_id is not None
+            partial_ids.append(partial_id)
+
+        snapshots = backup.list_quick_snapshots(limit=100, hermes_home=hermes_home)
+        assert {snapshot["id"] for snapshot in snapshots} == {
+            complete_id,
+            partial_ids[-1],
+        }
+        assert (hermes_home / "state-snapshots" / complete_id / "state.db").exists()
+        assert not (
+            hermes_home / "state-snapshots" / partial_ids[0]
+        ).exists(), "stale partial snapshot retained an old credential copy"
+        assert not (
+            hermes_home / "state-snapshots" / partial_ids[1]
+        ).exists(), "stale partial snapshot retained an old credential copy"
+
 
 class TestQuickSnapshotProjectsKanban:
     """Regression for #52889: projects.db / kanban.db must survive an upgrade.

--- a/tests/hermes_cli/test_quick_retention_repro.py
+++ b/tests/hermes_cli/test_quick_retention_repro.py
@@ -1,0 +1,119 @@
+"""Real-file recovery-retention invariants for quick snapshots."""
+import json
+import sqlite3
+
+import pytest
+
+from hermes_cli import backup
+from hermes_cli.backup import create_quick_snapshot
+
+
+_DB_CAP = 1024 ** 3
+
+
+def _make_db(path, table):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as db:
+        db.execute(f"CREATE TABLE {table} (value TEXT)")
+        db.execute(f"INSERT INTO {table} VALUES ('preserve-me')")
+
+
+@pytest.mark.parametrize("damage_manifests", [False, True])
+def test_incomplete_snapshots_with_unique_config_payloads_are_bounded(
+    tmp_path, monkeypatch, damage_manifests
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text("model: test\n")
+    _make_db(home / "state.db", "recovery")
+    complete = create_quick_snapshot(label="complete", keep=1)
+    assert complete
+    # A sparse file crosses the actual pre-update cap without allocating 1 GiB.
+    with (home / "state.db").open("r+b") as db:
+        db.truncate(_DB_CAP + 1)
+    root = home / "state-snapshots"
+    unmanaged = root / "not-a-snapshot"
+    unmanaged.mkdir()
+    monkeypatch.setattr(backup, "_QUICK_DEFAULT_KEEP", 2)
+    for index in range(5):
+        (home / "config.yaml").write_text(f"model: test-{index}\n")
+        snapshot = create_quick_snapshot(label=f"partial-{index}", keep=1, max_file_size=_DB_CAP)
+        assert snapshot
+        meta = json.loads((root / snapshot / "manifest.json").read_text())
+        assert meta["oversized_skipped"] == ["state.db"]
+        assert meta["failed_dbs"] == []
+        if damage_manifests:
+            (root / snapshot / "manifest.json").write_bytes(b"\xff")
+    assert len([p for p in root.iterdir() if p != unmanaged]) <= 4
+    backup.prune_quick_snapshots(keep=1, hermes_home=home)
+    assert unmanaged.is_dir()
+    with sqlite3.connect(root / complete / "state.db") as db:
+        assert db.execute("SELECT value FROM recovery").fetchone() == ("preserve-me",)
+    published = [p for p in root.iterdir() if p.is_dir() and p != unmanaged
+                 and not p.name.startswith(".")]
+    assert len(published) <= 2, "unique config partials accumulate beyond recovery + keep"
+
+
+@pytest.mark.parametrize("have_complete", [True, False])
+@pytest.mark.parametrize("replacement", ["healthy", "missing", "corrupt", "unlisted", "invalid-manifest"])
+def test_pruning_keeps_complete_generation_and_verified_per_db_recovery(
+    tmp_path, monkeypatch, replacement, have_complete
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: test\n")
+    _make_db(home / "state.db", "state_recovery")
+    _make_db(home / "cron" / "executions.db", "execution_recovery")
+    root = home / "state-snapshots"
+    real_copy = backup._safe_copy_db
+    failed = set() if have_complete else {"cron/executions.db"}
+
+    def selective_copy(src, dst):
+        rel = src.relative_to(home).as_posix()
+        return False if rel in failed else real_copy(src, dst)
+
+    monkeypatch.setattr(backup, "_safe_copy_db", selective_copy)
+    original = create_quick_snapshot(label="a-original", hermes_home=home, keep=10)
+    assert original
+    pre_update = create_quick_snapshot(label="pre-update", hermes_home=home, keep=1)
+    assert pre_update
+    failed = {"cron/executions.db"}
+    # Keep history until the replacement has been damaged, then trigger pruning.
+    partial = create_quick_snapshot(label="b-partial", hermes_home=home, keep=10)
+    assert partial
+    payload = root / partial / "state.db"
+    manifest = root / partial / "manifest.json"
+    if replacement == "missing":
+        payload.unlink()
+    elif replacement == "corrupt":
+        payload.write_bytes(b"not sqlite")
+    elif replacement == "unlisted":
+        meta = json.loads(manifest.read_text())
+        del meta["files"]["state.db"]
+        manifest.write_text(json.dumps(meta))
+    elif replacement == "invalid-manifest":
+        manifest.write_bytes(b"\xff")
+
+    failed = {"state.db"}
+    latest = create_quick_snapshot(label="c-partial", hermes_home=home, keep=1)
+    assert latest
+    expected_recovery = partial if replacement == "healthy" else original
+    # With no complete generation, a manifest lie must not evict the only usable
+    # partial recovery copy. With one, it survives even a healthy newer partial.
+    with sqlite3.connect(root / expected_recovery / "state.db") as db:
+        assert db.execute("SELECT value FROM state_recovery").fetchone() == ("preserve-me",)
+    with sqlite3.connect(root / latest / "cron" / "executions.db") as db:
+        assert db.execute("SELECT value FROM execution_recovery").fetchone() == ("preserve-me",)
+    if have_complete:
+        assert (root / original / "state.db").is_file()
+        assert (root / original / "cron" / "executions.db").is_file()
+    # Manual retention cannot evict an unrelated updater safety-net generation.
+    assert (root / pre_update / "state.db").is_file()
+    backup.prune_quick_snapshots(keep=1, hermes_home=home)
+    assert (root / expected_recovery / "state.db").is_file()
+    assert (root / pre_update / "state.db").is_file()
+    if have_complete:
+        assert (root / original / "state.db").is_file()
+    if replacement == "invalid-manifest":
+        assert manifest.read_bytes() == b"\xff", "unknown snapshot namespace must not be pruned"


### PR DESCRIPTION
## What does this PR do?

Hardens bounded quick-snapshot retention: preserve the newest verified complete generation and real per-database recovery coverage, not just manifest claims. Old partial configurations may age out; this is recovery retention, not an archive.

## Related Issue

Closes #106087.

Depends on and credits #97768 by @tachyon-r. The first two commits preserve the original author and commit provenance. I cannot push to that contributor's branch. This is a differentiated hardening follow-up, not a claim that the original accumulation fix is new. If #97768 lands first, only the final hardening commit needs integration. #58672 is related automatic/manual retention scope context.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/backup.py`: preserve the recent window, newest verified complete generation and readable manifest-listed recovery copies for omitted DBs. Separate manual/pre-update retention. Bound timestamped damaged-manifest artifacts separately using the normal window, without treating arbitrary directories as snapshots.
- `tests/hermes_cli/test_backup.py`: retain the source proposal's regressions.
- `tests/hermes_cli/test_quick_retention_repro.py`: real sparse SQLite, unique partial configs, alternating failures, missing/corrupt/unlisted payloads, invalid manifests, complete-generation preservation and namespace isolation.

## How to Test

Run `scripts/run_tests.sh tests/hermes_cli/test_quick_retention_repro.py tests/hermes_cli/test_backup.py tests/hermes_cli/test_backup_stability.py tests/hermes_cli/test_backup_all_profiles.py tests/hermes_cli/test_backup_path_errors.py tests/agent/test_curator_backup.py -j 4`.

The original upstream reproduction retained six snapshots instead of at most two. After salvaging #97768, the new hardening regression failed10 cases. The invalid-manifest review finding was separately reproduced red before correction. Final upstream suite: **124 passed, 0 failed, 1 skipped** across six files. Equivalent fork suite: **125 passed, 0 failed, 1 skipped** (one existing fork-only backup regression). Ruff and diff checks pass. Independent Claude Opus4.8 high-effort review found no actionable P0–P2 defects after correction. The initial preferred Claude route was unavailable and its Codex fallback found the invalid-manifest issue; the final review completed on Claude without fallback.

## Checklist

- [x] Read CONTRIBUTING.md; conventional commits and related changes only.
- [x] Searched existing issues/PRs; source dependency and author credited above.
- [x] Added real-file regressions and tested on macOS/Python3.11.15.
- [ ] Full repository test suite (not run; targeted backup suites used instead).
- [x] Updated docstrings; no new config keys, dependencies or tool schemas.
- [x] Considered cross-platform paths; no mocked OS branches introduced.

## Scope / disclosure

AI-assisted implementation and testing. Disposable homes only. No live snapshot cleanup, config change, runtime deployment/restart or external backup mutation.
