### PR TITLE
fix(local-runtime): don't report RAM as GPU memory on CPU-only hosts (#105389)

### DIFF
--- a/apps/desktop/src/app/settings/local-models-settings.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.tsx
@@ -530,17 +530,27 @@ export function LocalModelsSettings() {
               </span>
             )}
 
-            <span className="inline-flex items-center gap-1.5">
-              <Cpu className="size-3.5" />
-              {copy.vram(gbLabel(hardware.vram_total_bytes))}
-            </span>
+            {hardware.cpu_only ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Cpu className="size-3.5" />
+                {copy.ram(gbLabel(hardware.ram_total_bytes))}
+              </span>
+            ) : (
+              <>
+                <span className="inline-flex items-center gap-1.5">
+                  <Cpu className="size-3.5" />
+                  {copy.vram(gbLabel(hardware.vram_total_bytes))}
+                </span>
 
-            <span className="inline-flex items-center gap-1.5">
-              <Package className="size-3.5" />
-              {copy.ram(gbLabel(hardware.ram_total_bytes))}
-            </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <Package className="size-3.5" />
+                  {copy.ram(gbLabel(hardware.ram_total_bytes))}
+                </span>
+              </>
+            )}
 
-            {hardware.uma && <Pill>{copy.unifiedMemory}</Pill>}
+            {hardware.uma && !hardware.cpu_only && <Pill>{copy.unifiedMemory}</Pill>}
+            {hardware.cpu_only && <Pill>{copy.cpuOnlyMemory}</Pill>}
           </div>
         ) : (
           <p className="py-1 text-[length:var(--conversation-caption-font-size)] text-muted-foreground">

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1188,6 +1188,7 @@ export const en: Translations = {
       vram: label => `${label} GPU memory`,
       ram: label => `${label} RAM`,
       unifiedMemory: 'Unified memory',
+      cpuOnlyMemory: 'CPU only — no GPU detected',
       modelsTitle: 'Models',
       recommended: 'Recommended',
       /* The Recommended badge's tooltip, keyed by the resolver branch that

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1092,6 +1092,7 @@ export const ja = defineLocale({
       vram: label => `GPU メモリ ${label}`,
       ram: label => `RAM ${label}`,
       unifiedMemory: 'ユニファイドメモリ',
+      cpuOnlyMemory: 'CPU のみ — GPU なし',
       modelsTitle: 'モデル',
       recommended: 'おすすめ',
       recommendedReason: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1031,6 +1031,7 @@ export interface Translations {
       vram: (label: string) => string
       ram: (label: string) => string
       unifiedMemory: string
+      cpuOnlyMemory: string
       modelsTitle: string
       recommended: string
       /** Recommended-badge tooltip by resolver branch; unknown keys (newer

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1052,6 +1052,7 @@ export const zhHant = defineLocale({
       vram: label => `${label} 顯示記憶體`,
       ram: label => `${label} 記憶體`,
       unifiedMemory: '統一記憶體',
+      cpuOnlyMemory: '僅 CPU — 未偵測到 GPU',
       modelsTitle: '模型',
       recommended: '推薦',
       recommendedReason: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1387,6 +1387,7 @@ export const zh: Translations = {
       vram: label => `${label} 显存`,
       ram: label => `${label} 内存`,
       unifiedMemory: '统一内存',
+      cpuOnlyMemory: '仅 CPU — 未检测到 GPU',
       modelsTitle: '模型',
       recommended: '推荐',
       recommendedReason: {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1303,6 +1303,7 @@ export interface LocalModelsStatus {
 
 export interface LocalHardware {
   uma: boolean
+  cpu_only?: boolean
   vram_total_bytes: number
   vram_usable_bytes: number
   ram_total_bytes: number

--- a/hermes_cli/local_runtime/catalog.py
+++ b/hermes_cli/local_runtime/catalog.py
@@ -181,9 +181,15 @@ PLEASANT_FLOOR_TOK_S = 20.0
 def predicted_decode_tok_s(entry: CatalogEntry, variant: QuantVariant, budget: HardwareBudget, *,
                            spilled: bool = False) -> float:
     """Memory-bound decode prediction for ordering and floor-gating."""
-    bandwidth = (_HOST_BANDWIDTH_GB_S if spilled
-                 else _UMA_BANDWIDTH_GB_S if budget.uma
-                 else _DISCRETE_BANDWIDTH_GB_S)
+    # Pure CPU hosts (no GPU) stream from host RAM even when select_variant
+    # marks them as resident against the UMA pool — use host bandwidth so
+    # the recommendation doesn't claim GPU-like speed on a CPU (#105389).
+    if getattr(budget, "cpu_only", False):
+        bandwidth = _HOST_BANDWIDTH_GB_S
+    else:
+        bandwidth = (_HOST_BANDWIDTH_GB_S if spilled
+                     else _UMA_BANDWIDTH_GB_S if budget.uma
+                     else _DISCRETE_BANDWIDTH_GB_S)
     bytes_per_token = max(1.0, variant.size_bytes * entry.decode_fraction)
     return bandwidth * 1e9 / bytes_per_token
 

--- a/hermes_cli/local_runtime/estimator.py
+++ b/hermes_cli/local_runtime/estimator.py
@@ -71,6 +71,9 @@ class HardwareBudget:
     total_device_bytes: int
     ram_available_bytes: int
     uma: bool = False
+    # True when the budget represents a pure CPU host with no GPU — weights stream
+    # from host RAM over the system bus. Used for bandwidth-aware recommendations.
+    cpu_only: bool = False
 
 
 def profile_from_gguf(header: GGUFHeader) -> ModelProfile:

--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -250,10 +250,10 @@ def _unified_pool_bytes(smi_total: int, ram_total: int) -> int | None:
     return None
 
 
-def _uma_budget(base: int, total: int) -> HardwareBudget:
+def _uma_budget(base: int, total: int, *, cpu_only: bool = False) -> HardwareBudget:
     usable = max(0, int(base * (1 - _UMA_HEADROOM_FRACTION)))
     return HardwareBudget(usable_vram_bytes=usable, total_device_bytes=total,
-                          ram_available_bytes=0, uma=True)
+                          ram_available_bytes=0, uma=True, cpu_only=cpu_only)
 
 
 def probe_budget(*, planning: bool = False) -> HardwareBudget:
@@ -290,9 +290,30 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
         return _uma_budget(base, unified)
 
     if vram is None:
-        # No NVIDIA device visible: Metal/Vulkan/CPU paths budget from RAM as UMA (Apple
-        # Silicon) — conservative for discrete AMD until a vendor probe lands.
-        return _uma_budget(ram_total if planning else ram_avail, ram_total)
+        # No NVIDIA device visible: distinguish Apple Silicon (unified, high
+        # bandwidth) from pure CPU hosts (weights stream over host RAM).
+        # On macOS the unified pool is real GPU memory; on Windows/Linux
+        # without a GPU, treat RAM as host memory so the recommendation
+        # prices CPU inference at host bandwidth and avoids claiming
+        # "GPU memory" that doesn't exist (issue #105389).
+        if sys.platform == "darwin":
+            return _uma_budget(ram_total if planning else ram_avail, ram_total)
+        # If the allocator reports a pool (CUDA driver or engine) but without
+        # an INTEGRATED verdict, preserve the conservative RAM-as-UMA fallback
+        # tested in test_engine_fallback_without_smi_stays_conservative: a
+        # pool claim alone must not flip the verdict, and a pure CPU host has
+        # no pool at all.
+        view = _device_pool_view()
+        if view is not None:
+            return _uma_budget(ram_total if planning else ram_avail, ram_total)
+        # Pure CPU: no VRAM and no allocator pool — models spill from host
+        # RAM, priced at HOST bandwidth, and the UI will not claim GPU memory.
+        return HardwareBudget(
+            usable_vram_bytes=0,
+            total_device_bytes=0,
+            ram_available_bytes=ram_total if planning else ram_avail,
+            uma=False,
+            cpu_only=True)
 
     total, free = vram
     margin = max(_MARGIN_FLOOR, int(total * _MARGIN_FRACTION))

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -505,9 +505,16 @@ def local_models_hardware():
     """The budget as plain facts, polled by the pane and statusbar. Sync def: shells out to nvidia-smi — threadpool."""
     budget = hardware.probe_budget()
     ram_total, ram_avail = hardware._ram_bytes()
+    # CPU-only hosts have no VRAM; vram fields stay 0 so the UI doesn't claim
+    # "31GB GPU memory" on a machine with no GPU (#105389).
+    is_cpu_only = bool(getattr(budget, "cpu_only", False))
     out = {
-        "uma": budget.uma, "vram_total_bytes": budget.total_device_bytes, "vram_usable_bytes": budget.usable_vram_bytes,
-        "ram_total_bytes": ram_total, "ram_available_bytes": ram_avail, "vram_label": _human_gb(budget.total_device_bytes),
+        "uma": budget.uma,
+        "cpu_only": is_cpu_only,
+        "vram_total_bytes": 0 if is_cpu_only else budget.total_device_bytes,
+        "vram_usable_bytes": 0 if is_cpu_only else budget.usable_vram_bytes,
+        "ram_total_bytes": ram_total, "ram_available_bytes": ram_avail,
+        "vram_label": _human_gb(0 if is_cpu_only else budget.total_device_bytes),
         "gpu_name": None, "gpu_util_percent": None, "vram_used_bytes": None,
     }
     out.update(_quiet(_nvidia_smi_facts, {}))


### PR DESCRIPTION
Fixes #105389

Windows Server 2022 with no GPU reported 31.1GB 'GPU memory' (duplicating RAM) and recommended Qwen 27B which stalled for 15 minutes on CPU prompt processing.

**Root cause:** `probe_budget` on non-Darwin hosts with no NVIDIA device returned a UMA budget that treated RAM as VRAM, claiming GPU memory that doesn't exist and pricing CPU inference at unified bandwidth (210 GB/s) instead of host bandwidth (80 GB/s).

**Fix:**
- `hardware`: distinguish Apple Silicon (real unified) from pure CPU hosts; CPU-only (no VRAM, no allocator pool) returns host-RAM budget (`usable_vram=0, cpu_only=True`) so UI doesn't claim GPU memory and catalog prices at host BW
- `catalog`: use host bandwidth for `cpu_only` budgets
- `api`: expose `cpu_only` flag and zero vram fields for CPU hosts
- `desktop`: show 'RAM' only with 'CPU only — no GPU detected' pill instead of duplicate 'GPU memory + RAM' on CPU-only machines

**Testing:**
- `pytest tests/hermes_cli/test_unified_pool_quirk.py tests/hermes_cli/test_local_recommendation.py tests/hermes_cli/test_budget_source.py` — 41 passed
- Manual verification: 31GB CPU-only now recommends qwen3.6-35b-a3b (MoE, 25 tok/s predicted) over 27B (5 tok/s) and hardware panel shows single RAM entry
- OCR of issue screenshots confirms 31.1GB unified was misreported as GPU memory

Closes #105389