### PR TITLE
fix: reroute warn-class gateway status to home channel for group chats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -902,6 +902,32 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     return await adapter.send(chat_id, content, metadata=metadata)
 
 
+def _warn_status_reroute_target(
+    event_type: str,
+    chat_type: Optional[str],
+    current_chat_id: str,
+    home_channel,
+) -> Optional[str]:
+    """Return the chat_id a warn-class gateway status should be sent to.
+
+    warn-class statuses carry internal agent diagnostics (compression
+    overflow notices, auxiliary-model failures) meant for the operator. On
+    shared surfaces (group chats / channels) delivering them to the
+    triggering chat leaks framework internals to every participant. When the
+    platform has an explicit home channel configured, reroute warn statuses
+    there instead. DMs / 1:1 threads are left untouched (the operator is the
+    only participant). Returns the reroute target chat_id, or ``None`` when
+    the status should stay on the triggering chat.
+    """
+    if event_type != "warn" or chat_type not in ("group", "channel"):
+        return None
+    if home_channel is None or not home_channel.chat_id:
+        return None
+    if str(home_channel.chat_id) == str(current_chat_id):
+        return None
+    return home_channel.chat_id
+
+
 def _approval_send_outcome(future, timeout: float) -> str:
     """Classify an approval prompt send as ``sent`` / ``failed`` / ``ambiguous``.
 
@@ -5328,8 +5354,34 @@ class TurnRunner:
                 _redact_gateway_user_facing_secrets(str(message or ""))[:160],
             )
             return
+        _status_chat_id = ctx._status_chat_id
+        _status_thread_metadata = ctx._status_thread_metadata
+        # warn-class statuses carry internal agent diagnostics (compression
+        # overflow notices, auxiliary-model failures) meant for the operator.
+        # On shared surfaces (group chats / channels) the message would leak
+        # framework internals to every participant, so when the platform has
+        # an explicit home channel configured, reroute warn statuses there
+        # instead of the triggering chat. DMs and 1:1 threads are left
+        # untouched (the operator is the only participant there).
+        try:
+            _home = self._runner.config.get_home_channel(ctx.source.platform)
+        except Exception:
+            _home = None
+        _reroute_target = _warn_status_reroute_target(
+            event_type,
+            getattr(ctx.source, "chat_type", None),
+            _status_chat_id,
+            _home,
+        )
+        if _reroute_target is not None:
+            _status_chat_id = _reroute_target
+            # Source-thread metadata belongs to the triggering chat; the
+            # home channel is a different conversation (possibly a DM or a
+            # different topic), so drop it rather than misroute the
+            # rerouted status into the source thread.
+            _status_thread_metadata = None
         _fut = safe_schedule_threadsafe(
-            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, event_type, prepared_message, ctx._status_thread_metadata),
+            _send_or_update_status_coro(ctx._status_adapter, _status_chat_id, event_type, prepared_message, _status_thread_metadata),
             ctx._loop_for_step,
             logger=logger,
             log_message=f"status_callback ({event_type}) scheduling error",

--- a/tests/gateway/test_warn_status_home_reroute.py
+++ b/tests/gateway/test_warn_status_home_reroute.py
@@ -1,0 +1,45 @@
+"""Gateway warn-status rerouting: internal diagnostics must not leak into
+shared group chats when a home channel is configured.
+
+Regression for a guest/staff-facing profile whose compression-overflow
+warning (CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE) was delivered into the
+WhatsApp group that triggered the turn, exposing framework internals
+(token counts, /new, /compress) to every participant.
+"""
+
+import pytest
+
+from gateway.run import _warn_status_reroute_target
+
+
+class _FakeHomeChannel:
+    def __init__(self, chat_id):
+        self.chat_id = chat_id
+
+
+@pytest.mark.parametrize(
+    "event_type,chat_type,current,home,expected",
+    [
+        # warn in a group with a distinct home channel -> reroute to home
+        ("warn", "group", "120363421112864421@g.us", "140905512218873@lid", "140905512218873@lid"),
+        ("warn", "channel", "channel-1", "home-1", "home-1"),
+        # warn in a DM / 1:1 thread -> operator is the only participant, keep in place
+        ("warn", "dm", "140905512218873@lid", "140905512218873@lid", None),
+        ("warn", "private", "user-1", "home-1", None),
+        # non-warn statuses are never rerouted (lifecycle/progress stay in chat)
+        ("lifecycle", "group", "grp-1", "home-1", None),
+        ("progress", "group", "grp-1", "home-1", None),
+        # warn in a group but no home channel configured -> keep in place
+        ("warn", "group", "grp-1", None, None),
+        # warn in a group whose home channel IS the group -> keep in place
+        ("warn", "group", "home-1", "home-1", None),
+        # warn in an unclassified chat -> keep in place
+        ("warn", None, "grp-1", "home-1", None),
+    ],
+)
+def test_warn_status_reroute_target(event_type, chat_type, current, home, expected):
+    home_obj = _FakeHomeChannel(home) if home else None
+    assert (
+        _warn_status_reroute_target(event_type, chat_type, current, home_obj)
+        == expected
+    )


### PR DESCRIPTION
## Problem

`warn`-class gateway status callbacks carry internal agent diagnostics meant for the **operator** — context-overflow notices ("Context is over the compression threshold... Run /new"), auxiliary-model failures, etc. When a message arrives in a **group chat or channel**, those statuses are delivered to the triggering chat, leaking framework internals (token counts, `/new` / `/compress` guidance) to every participant.

Observed live on a guest/staff-facing WhatsApp profile: a staff-group message triggered a context-overflow warning that was posted into the group for all staff to see.

## Fix

In `TurnRunner._status_callback_sync`, when the event is `warn`-class and the source chat is a group/channel, reroute delivery to the platform's configured **home channel** when one exists and differs from the triggering chat. DMs and 1:1 threads are untouched (the operator is the only participant). Source-thread metadata is dropped on reroute so the status lands in the home conversation, not the source thread.

Behavior is fully inert when no home channel is configured — profiles without one keep current delivery.

## Implementation

- `_warn_status_reroute_target()` — pure helper deciding the reroute target (unit-testable, no adapter/loop fixtures needed)
- `_status_callback_sync()` — resolves the platform home channel and applies the reroute for warn-class events on group/channel sources
- New test file covering: group/channel reroute, DM/private untouched, non-warn untouched, no-home-channel untouched, home==trigger untouched

## Tests

- `tests/gateway/test_warn_status_home_reroute.py` — 9 new tests, all passing
- `tests/gateway/test_telegram_noise_filter.py` — 136 existing tests, all passing (warning visibility carve-outs preserved)
