### PR TITLE
ci(lint): bound the advisory public-surface step so it can't time out the blocking footguns job (#106103)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -193,6 +193,11 @@ jobs:
       - name: Public-surface diff vs base (advisory)
         if: github.event_name == 'pull_request'
         continue-on-error: true
+        # Bound the advisory step so a long deepen/fetch (e.g. a distant or missing
+        # merge-base) can't consume the blocking job's 5-minute budget and cancel it.
+        # continue-on-error already keeps a step *failure* off the job; a step-level
+        # timeout keeps a step *overrun* off the job-level timeout the same way.
+        timeout-minutes: 2
         run: |
           git fetch --no-tags --deepen=200 origin "${{ github.base_ref }}" HEAD
           for i in 1 2 3; do


### PR DESCRIPTION
## What

Bound the advisory `Public-surface diff vs base` step in the `Windows footguns (blocking)` job with a step-level `timeout-minutes: 2`.

## Why

The advisory step already carries `continue-on-error: true`, so its own *failure* never fails the job. But `continue-on-error` does **not** shield the job-level `timeout-minutes: 5`: when the merge-base is distant or missing, the `--deepen` fetch loop can run for minutes, consume the whole job budget, and the job is **cancelled at ~5m** even though:

- the blocking footgun + compat-pointer checks already passed, and
- the public-surface diff is advisory ("it never fails the job").

Observed in the issue on PR #106080, run `34285107265`, cancelled at 5m2s.

## Fix

Give the advisory step its own `timeout-minutes: 2`. A step *overrun* is then killed and — via the existing `continue-on-error: true` — kept off the job outcome exactly the way a step *failure* already is. Normal PRs (nearby merge-base) finish this step in seconds, so the bound only trips the pathological deep/absent-merge-base case, which is precisely the case that was cancelling the blocking job.

No behavior change to the blocking checks themselves; the public-surface diff remains advisory.

Fixes #106103.
