### PR TITLE
fix(gateway): resolve flush session_key to session_id at shutdown-flush recovery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5381,7 +5381,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     def _recover_pending() -> None:
         from gateway.shutdown_flush import recover_pending_to_db
-        recovered = recover_pending_to_db()
+        session_store = getattr(runner, "session_store", None)
+        resolve_session_id = None
+        if session_store is not None and hasattr(session_store, "resolve_session_id_for_key"):
+            # shutdown_flush calls the resolver as (session_key, payload); the store resolves
+            # from the key alone (it encodes the profile/platform/chat identity).
+            resolve_session_id = lambda session_key, _payload: session_store.resolve_session_id_for_key(
+                session_key)
+        recovered = recover_pending_to_db(
+            resolve_session_id=resolve_session_id, session_store=session_store)
         if recovered:
             logger.info("Recovered %d pending message(s) from shutdown flush", recovered)
 

--- a/gateway/session_recovery.py
+++ b/gateway/session_recovery.py
@@ -178,6 +178,76 @@ class SessionRecoveryMixin:
                 raise
             return None
 
+    @staticmethod
+    def _platform_from_session_key(session_key: Optional[str]) -> Optional[str]:
+        """Platform value encoded in a gateway session key (``parts[2]``), or None."""
+        if not session_key:
+            return None
+        parts = str(session_key).split(":")
+        if len(parts) < 3 or parts[0] != "agent":
+            return None
+        return parts[2] or None
+
+    @staticmethod
+    def _whatsapp_alias_session_keys(session_key: str, chat_id: Optional[str] = None) -> list:
+        """Rebuild *session_key* under every WhatsApp alias of its chat id (phone<->LID drift).
+
+        The flush key may carry the phone-form chat id while the durable row's key carries the
+        LID form (or vice versa); ``expand_whatsapp_aliases`` lets each alias resolve. Non-WhatsApp
+        keys yield no aliases. ``chat_id`` overrides the key's chat-id slot when provided.
+        """
+        parts = str(session_key).split(":")
+        if len(parts) < 5 or parts[0] != "agent" or parts[2] != Platform.WHATSAPP.value:
+            return []
+        source_id = chat_id or parts[4]
+        try:
+            from gateway.whatsapp_identity import expand_whatsapp_aliases
+            aliases = expand_whatsapp_aliases(str(source_id))
+        except Exception as exc:
+            logger.debug("WhatsApp alias expansion failed for %s: %s", source_id, exc)
+            return []
+        rebuilt = []
+        for alias in aliases:
+            alias = str(alias)
+            if alias and alias != parts[4]:
+                rebuilt.append(":".join(parts[:4] + [alias] + parts[5:]))
+        return rebuilt
+
+    def resolve_session_id_for_key(
+        self, session_key: str, *, chat_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Resolve a gateway session key to a live session_id at shutdown-flush recovery.
+
+        Recovery runs before the in-memory routing map is rebuilt, so this reads the durable row
+        directly (via the profile-aware ``_db_for_key`` and the exact-key peer finder, which keeps
+        the reset fence: rows ended only by recoverable reasons match; explicit boundaries do not).
+        WhatsApp keys are also tried under every phone<->LID alias of their chat id. Never mints a
+        session; returns None when the row is absent or unrecoverable (the caller must then preserve
+        the flush file). ``chat_id`` optionally overrides the key's chat-id slot for alias expansion.
+        """
+        if not session_key:
+            return None
+        db = self._db_for_key(session_key)
+        finder = getattr(db, "find_latest_gateway_session_for_peer", None) if db else None
+        if not callable(finder):
+            return None
+        platform = self._platform_from_session_key(session_key)
+        if not platform:
+            return None
+        candidates = [session_key]
+        for alias_key in self._whatsapp_alias_session_keys(session_key, chat_id=chat_id):
+            if alias_key and alias_key not in candidates:
+                candidates.append(alias_key)
+        for candidate in candidates:
+            try:
+                row = finder(source=platform, session_key=candidate)
+            except Exception as exc:
+                logger.debug("Session key->id resolution failed for %s: %s", candidate, exc)
+                continue
+            if isinstance(row, dict) and row.get("id"):
+                return str(row["id"])
+        return None
+
     def _recover_session_from_db(
         self, *, session_key: str, source: SessionSource, now: datetime,
         raise_on_lookup_error: bool = False) -> Optional[SessionEntry]:

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -198,11 +198,15 @@ def _serialise_value(value: Any) -> Optional[dict]:
     return {"text": str(value)}
 
 
-def recover_pending_to_db(session_db=None) -> int:
+def recover_pending_to_db(session_db=None, *, resolve_session_id=None, session_store=None) -> int:
     """Replay flush-dir ``*.json`` files via ``SessionDB.append_message``, deleting each on success.
 
     ``session_db=None`` opens (and afterwards releases) the shared default ``state.db``.
-    Returns the number of messages recovered.
+    ``resolve_session_id`` (optional ``(session_key, payload) -> Optional[str]``) maps a
+    session_key to a session_id when the payload carries only a key (plain-str pending values).
+    ``session_store`` (optional) routes the append to the profile owning the key (multiplexed
+    gateways); shutdown_flush stays decoupled — neither is imported at module level. Returns the
+    number of messages recovered.
     """
     flush_files = sorted(_get_flush_dir().glob("*.json"))
     if not flush_files:
@@ -218,7 +222,10 @@ def recover_pending_to_db(session_db=None) -> int:
             # Agent-history snapshots are for manual operator recovery, not automatic DB insertion.
             if payload.get("reason") == "shutdown-with-unpersisted-agent-history":
                 continue
-            if _recover_one_payload(session_db, path, payload):
+            if _recover_one_payload(
+                session_db, path, payload,
+                resolve_session_id=resolve_session_id, session_store=session_store,
+            ):
                 recovered += 1
                 path.unlink(missing_ok=True)
     finally:
@@ -231,8 +238,13 @@ def recover_pending_to_db(session_db=None) -> int:
     return recovered
 
 
-def _recover_one_payload(session_db, path: Path, payload: Dict[str, Any]) -> bool:
-    """Append one flush payload to ``session_db``; False (file kept) when structurally invalid."""
+def _recover_one_payload(
+    session_db, path: Path, payload: Dict[str, Any], *,
+    resolve_session_id=None, session_store=None,
+) -> bool:
+    """Append one flush payload to its owning ``session_db``; False (file kept) when structurally
+    invalid or unrecoverable. ``resolve_session_id`` maps a session_key to a session_id when the
+    payload lacks one; ``session_store`` routes the append to the profile owning the key."""
     # Cap-dropped transcript payloads carry the full message dict keyed by session_id — replay directly
     # (#78182). This handles spool files that were never drained before a restart.
     if payload.get("reason") == TRANSCRIPT_CAP_DROP_REASON:
@@ -254,15 +266,27 @@ def _recover_one_payload(session_db, path: Path, payload: Dict[str, Any]) -> boo
                        "the flush file has been preserved", path)
         return False
     # session_key is a gateway routing key (e.g. "agent:main:telegram:..."); appending a row
-    # needs the real session_id, which only the serialised data can supply at this stage.
+    # needs the real session_id, which the serialised data may lack for plain-str pending values.
     session_id = data.get("session_id", "")
+    if not session_id and resolve_session_id is not None:
+        session_id = resolve_session_id(session_key, payload)
     if not session_id:
         logger.warning("Cannot recover pending message for %s: no session_id in flush file and "
-                       "session_key-to-id resolution is not available at this recovery stage. "
+                       "session_key-to-id resolution failed. "
                        "The message text is preserved in %s", session_key, path)
         return False
-    session_db.append_message(session_id=session_id, role="user", content=text,
-                              timestamp=payload.get("ts", int(time.time())))
+    target_db: Any = session_db
+    if session_store is not None and session_key:
+        store_db = getattr(session_store, "_db_for_key", None)
+        if callable(store_db):
+            try:
+                routed = store_db(session_key)
+            except Exception:
+                routed = None
+            if routed is not None:
+                target_db = routed
+    target_db.append_message(session_id=session_id, role="user", content=text,
+                             timestamp=payload.get("ts", int(time.time())))
     return True
 
 

--- a/tests/gateway/test_session_recovery.py
+++ b/tests/gateway/test_session_recovery.py
@@ -1,0 +1,79 @@
+"""Tests for SessionRecoveryMixin.resolve_session_id_for_key — flush-recovery
+session_key → session_id resolution (profile- and WhatsApp-alias aware)."""
+
+from unittest.mock import patch
+
+from gateway.config import GatewayConfig
+from gateway.session import SessionStore
+
+
+class _FakeGatewayDB:
+    """Minimal SessionDB stand-in exposing only the peer finder the resolver uses."""
+
+    def __init__(self, rows_by_key):
+        self.rows_by_key = rows_by_key
+        self.queries = []
+
+    def find_latest_gateway_session_for_peer(self, *, source, session_key=None, **kwargs):
+        self.queries.append(session_key)
+        return self.rows_by_key.get(session_key)
+
+
+def _store(tmp_path, db):
+    config = GatewayConfig(multiplex_profiles=True)
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._loaded = True
+    store._db = db  # pin: _db_for_key returns this db for every key (no profile I/O)
+    return store
+
+
+def _no_aliases(identifier):
+    return {identifier}
+
+
+def test_resolve_exact_key_returns_row_id(tmp_path):
+    db = _FakeGatewayDB({"agent:main:telegram:dm:99": {"id": "tel-row"}})
+    store = _store(tmp_path, db)
+    assert store.resolve_session_id_for_key("agent:main:telegram:dm:99") == "tel-row"
+    assert db.queries == ["agent:main:telegram:dm:99"]
+
+
+def test_resolve_whatsapp_phone_key_to_lid_row(tmp_path, monkeypatch):
+    lid = "1234567890123456789"
+    key = f"agent:test-bot:whatsapp:dm:{lid}"
+    db = _FakeGatewayDB({key: {"id": "lid-row"}})
+    store = _store(tmp_path, db)
+    monkeypatch.setattr(
+        "gateway.whatsapp_identity.expand_whatsapp_aliases",
+        lambda ident: {"15551234567", lid} if ident == "15551234567" else {ident},
+    )
+    resolved = store.resolve_session_id_for_key(
+        "agent:test-bot:whatsapp:dm:15551234567"
+    )
+    assert resolved == "lid-row"
+    assert key in db.queries
+
+
+def test_resolve_profile_namespaced_key_does_not_adopt_main_row(tmp_path, monkeypatch):
+    """A profile-namespaced key must never resolve into the root store's
+    ``agent:main`` row: the exact-key finder only matches the namespaced key."""
+    db = _FakeGatewayDB({"agent:main:whatsapp:dm:15551234567": {"id": "main-row"}})
+    store = _store(tmp_path, db)
+    monkeypatch.setattr("gateway.whatsapp_identity.expand_whatsapp_aliases", _no_aliases)
+    assert (
+        store.resolve_session_id_for_key("agent:test-bot:whatsapp:dm:15551234567")
+        is None
+    )
+    assert db.queries and all("agent:test-bot" in q for q in db.queries)
+    assert not any(q.startswith("agent:main") for q in db.queries)
+
+
+def test_resolve_returns_none_when_no_matching_row(tmp_path, monkeypatch):
+    db = _FakeGatewayDB({})
+    store = _store(tmp_path, db)
+    monkeypatch.setattr("gateway.whatsapp_identity.expand_whatsapp_aliases", _no_aliases)
+    assert (
+        store.resolve_session_id_for_key("agent:test-bot:whatsapp:dm:15551234567")
+        is None
+    )

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -98,6 +98,78 @@ def test_recover_inserts_via_append_message_and_deletes_file(tmp_path, monkeypat
     assert not flush_file.exists()
 
 
+def test_recover_payload_without_session_id_uses_resolver_and_deletes_file(
+    tmp_path, monkeypatch
+):
+    """A str-pending payload carries session_key but no session_id; a resolver
+    maps key→id so the message replays and the file is removed."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    ts = int(time.time())
+    payload = {
+        "session_key": "agent:main:whatsapp:dm:15551234567",
+        "reason": "shutdown",
+        "ts": ts,
+        "data": {"text": "lost message"},
+    }
+    flush_file = flush_dir / "no_sid.json"
+    flush_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    mock_db = MagicMock()
+    resolver = MagicMock(return_value="sid-resolved")
+    count = recover_pending_to_db(mock_db, resolve_session_id=resolver)
+
+    assert count == 1
+    resolver.assert_called_once_with("agent:main:whatsapp:dm:15551234567", payload)
+    mock_db.append_message.assert_called_once_with(
+        session_id="sid-resolved", role="user", content="lost message", timestamp=ts
+    )
+    assert not flush_file.exists()
+
+
+def test_recover_payload_without_session_id_resolver_none_preserves_file(
+    tmp_path, monkeypatch
+):
+    """When the resolver cannot map the key, the file is preserved (never delete an
+    unrecoverable message)."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    payload = {
+        "session_key": "agent:main:whatsapp:dm:15551234567",
+        "data": {"text": "lost message"},
+    }
+    flush_file = flush_dir / "no_sid.json"
+    flush_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    mock_db = MagicMock()
+    count = recover_pending_to_db(mock_db, resolve_session_id=lambda key, payload: None)
+
+    assert count == 0
+    mock_db.append_message.assert_not_called()
+    assert flush_file.exists()
+
+
+def test_recover_payload_without_session_id_no_resolver_preserves_file(
+    tmp_path, monkeypatch
+):
+    """Existing behaviour: without a resolver, a session_id-less payload is preserved."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    payload = {
+        "session_key": "agent:main:whatsapp:dm:15551234567",
+        "data": {"text": "lost message"},
+    }
+    flush_file = flush_dir / "no_sid.json"
+    flush_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    mock_db = MagicMock()
+    count = recover_pending_to_db(mock_db)
+
+    assert count == 0
+    mock_db.append_message.assert_not_called()
+    assert flush_file.exists()
+
+
 def test_recover_closes_owned_db_when_unexpected_exception_escapes(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## What does this PR do?

When a gateway restarts, `recover_pending_to_db()` in `gateway/shutdown_flush.py` replays the files under `pending_messages/` and deletes each one it manages to deliver. Delivering needs a `session_id`. A payload flushed as a dict has one. A payload flushed as a plain string goes through the `str` branch of `_serialise_value()`, which keeps the routing `session_key` and drops the rest, so recovery has nowhere to put it. It logs

```
Cannot recover pending message for agent:<profile>:whatsapp:dm:<id>: no session_id in flush file and session_key-to-id resolution is not available at this recovery stage
```

and leaves the file where it is. The message is never delivered, and the warning comes back on the next restart and on every one after that. We hit this on a deployed multiplexed gateway, where a WhatsApp DM flushed on 2026-09-04 survived three restarts.

This PR lets recovery turn a `session_key` into the session id it belongs to.

`gateway/session_recovery.py` gains `resolve_session_id_for_key()` on the existing `SessionRecoveryMixin`. It looks the durable row up through `_db_for_key`, so a key belonging to one profile resolves against that profile's own store instead of the shared root database. The lookup keeps the reset fence intact: a session ended by an explicit boundary (`/new`, `session_reset`) never matches, while one ended by `agent_close` or `ws_orphan_reap` does. WhatsApp keys get a second chance through `expand_whatsapp_aliases`, because a flush key written before a phone-to-LID migration carries the phone-form chat id while the durable row lives under the LID form. It never creates a session, and it returns `None` when nothing matches.

`gateway/shutdown_flush.py` takes an optional `resolve_session_id` callable and an optional `session_store`. The store is what decides which database receives the append, which matters on a multiplexed gateway because a profile key's row is in `profiles/<profile>/state.db`, not in the root `state.db`. Neither is imported at module level, so `shutdown_flush` stays decoupled from the gateway.

`gateway/run.py` builds the resolver from `runner.session_store` and passes the store along.

What has not changed: a payload that already carries a `session_id` replays exactly as before, through the root store when no `session_store` is passed, so the single-profile path behaves as it always did. A payload whose key cannot be resolved is still preserved rather than deleted. Recovery never mints a session.

## Related Issue

No issue was filed for this. It came off a live gateway, and the log line above is the reproduction.

Other PRs working the same recovery walk: #87661 adds per-file error isolation and does not overlap. #75536 is an independent attempt at the same stranded-payload problem. #106907 was our earlier attempt, which routed unresolvable payloads into the Bot Chat session instead of resolving the key; it is closed in favour of this one.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session_recovery.py` (+70): `resolve_session_id_for_key()` on `SessionRecoveryMixin`, with profile-aware key resolution, the reset fence, and WhatsApp alias expansion.
- `gateway/shutdown_flush.py` (+33/-9): optional `resolve_session_id` and `session_store` arguments on `recover_pending_to_db()` and `_recover_one_payload()`.
- `gateway/run.py` (+9/-1): `_recover_pending()` wires both in from the runner.
- `tests/gateway/test_session_recovery.py` (new, 79 lines): key-to-id resolution, phone-to-LID alias expansion, the profile fence, and the no-match case.
- `tests/gateway/test_shutdown_flush.py` (+72): the resolver path deleting the file on success, and the file being preserved when resolution returns nothing.

## How to Test

1. On `main`, get a runner-level pending message flushed as a plain string, then restart the gateway. The file stays under `pending_messages/` and the warning above repeats on every restart.
2. On this branch, restart again. The message is appended to the session it was addressed to and the file is removed.
3. `pytest tests/gateway/test_shutdown_flush.py tests/gateway/test_session_recovery.py -q` gives 16 passed.

Wider run: `pytest tests/gateway/test_shutdown_flush.py tests/gateway/test_session_recovery.py tests/hermes_state/ tests/test_hermes_state.py -q` gives 571 passed, 7 skipped, 1 failed. The failure is `TestFTS5Search::test_search_projection_skips_context_enrichment_queries`, which fails the same way at the base commit `b1f003e186` in a clean worktree, so it predates this change.

I could not run the whole suite here: the `acp` package is not installed in my environment, so collection stops with 11 import errors under `tests/acp/` and `tests/acp_adapter/`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not possible in my environment; see How to Test above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python, no new file I/O, process, or terminal handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

On `main`, repeated on every restart, with the flush file left in place:

```
Cannot recover pending message for agent:<profile>:whatsapp:dm:<id>: no session_id in flush file and session_key-to-id resolution is not available at this recovery stage
```

After this change the same payload is appended to its session, the file is deleted once delivered, and the warning does not come back.
