### PR TITLE
fix(gateway): gate restart callbacks on final text delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2998,23 +2998,10 @@ class BasePlatformAdapter(ABC):
             # Same-or-newer generation: chain so both fire in registration order.
             if callable(existing_cb) and (
                 existing_gen is None or generation is None or int(existing_gen) == int(generation)):
-                callback = self._chain_callbacks(existing_cb, callback)
+                from gateway.post_delivery import chain_post_delivery_callbacks
+                callback = chain_post_delivery_callbacks(existing_cb, callback)
         self._post_delivery_callbacks[session_key] = (
             callback if generation is None else (int(generation), callback))
-
-    @staticmethod
-    def _chain_callbacks(*callbacks: Callable) -> Callable[[], Awaitable[None]]:
-        """Async wrapper running ``callbacks`` in order with per-callback exception isolation;
-        async so coroutines returned by async hooks are awaited, not dropped."""
-        async def _chained() -> None:
-            for _cb in callbacks:
-                try:
-                    _result = _cb()
-                    if inspect.isawaitable(_result):
-                        await _result
-                except Exception:
-                    logger.debug("Post-delivery callback failed", exc_info=True)
-        return _chained
 
     def pop_post_delivery_callback(
         self, session_key: str, *, generation: int | None = None) -> Callable | None:
@@ -3634,8 +3621,9 @@ class BasePlatformAdapter(ABC):
             caption = text_content
         tts_result = await self.play_tts(
             chat_id=event.source.chat_id, audio_path=tts_path, caption=caption, metadata=metadata)
-        record_delivery(tts_result)
-        return bool(caption and getattr(tts_result, "success", False))
+        caption_delivered = bool(caption and getattr(tts_result, "success", False))
+        record_delivery(tts_result, final_text=caption_delivered)
+        return caption_delivered
 
     async def _record_delivery_obligation(
         self, event: MessageEvent, session_key: str, text_content: str,
@@ -3767,7 +3755,7 @@ class BasePlatformAdapter(ABC):
         result = await delivery_adapter._send_with_retry(
             chat_id=event.source.chat_id, content=text_content,
             reply_to=_reply_anchor_for_event(event), metadata=metadata)
-        record_delivery(result)
+        record_delivery(result, final_text=True)
         if _obligation_id is not None:
             await self._finalize_delivery_obligation(_obligation_id, result, event, delivery_adapter)
         if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
@@ -3868,15 +3856,18 @@ class BasePlatformAdapter(ABC):
             text_content=text_content, images=images, media_files=media_files,
             local_files=local_files, force_document_attachments=force_document, pre_extract=pre_extract)
 
-    async def _fire_post_delivery_callback(self, session_key: str, interrupt_event: asyncio.Event) -> None:
+    async def _fire_post_delivery_callback(
+        self, session_key: str, interrupt_event: asyncio.Event, delivery_result: Optional[SendResult],
+    ) -> None:
         """Run the one-shot post-delivery callback (bounded, errors swallowed). The generation is
         read HERE — stamped on the interrupt event DURING the handler await; an earlier snapshot
         would let stale runs fire a fresher run's callbacks."""
         _post_cb = self.pop_post_delivery_callback(
             session_key, generation=getattr(interrupt_event, "_hermes_run_generation", None))
         if callable(_post_cb):
+            from gateway.post_delivery import invoke_post_delivery_callback
             with contextlib.suppress(asyncio.TimeoutError, Exception):
-                _post_result = _post_cb()
+                _post_result = invoke_post_delivery_callback(_post_cb, delivery_result)
                 if inspect.isawaitable(_post_result):
                     await asyncio.wait_for(_post_result, timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS)
 
@@ -3907,12 +3898,15 @@ class BasePlatformAdapter(ABC):
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         delivery_attempted = delivery_succeeded = False  # feeds the processing-complete hook
+        final_text_delivery = SendResult(success=False, error="final text delivery unknown")
 
-        def _record_delivery(result):
-            nonlocal delivery_attempted, delivery_succeeded
+        def _record_delivery(result, *, final_text: bool = False):
+            nonlocal delivery_attempted, delivery_succeeded, final_text_delivery
             if result is not None:
                 delivery_attempted = True
                 delivery_succeeded = delivery_succeeded or bool(getattr(result, "success", False))
+                if final_text:
+                    final_text_delivery = result
         # Reuse the interrupt event handle_message() installed; new Event only if removed externally.
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
@@ -3996,7 +3990,12 @@ class BasePlatformAdapter(ABC):
             # Stop typing BEFORE the post-delivery callback: a stuck callback must not keep it
             # alive.
             await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
-            await self._fire_post_delivery_callback(session_key, interrupt_event)
+            if getattr(event, "_final_text_delivery_silenced", False):
+                final_text_delivery = None
+            else:
+                final_text_delivery = getattr(
+                    event, "_final_text_delivery_result", final_text_delivery)
+            await self._fire_post_delivery_callback(session_key, interrupt_event, final_text_delivery)
             # Callback work or a late refresh may have recreated typing — one final bounded stop.
             await self._stop_typing_refresh(
                 event.source.chat_id, None, metadata=_thread_metadata, stop_attempts=1)

--- a/gateway/post_delivery.py
+++ b/gateway/post_delivery.py
@@ -1,0 +1,51 @@
+"""Internal invocation contract for generation-bound post-delivery callbacks."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def callback_accepts_delivery_result(callback: Callable) -> bool:
+    """Return whether ``callback`` declares a required positional result argument.
+
+    Optional positional parameters are treated as legacy closure captures.  This preserves
+    callbacks such as ``lambda label=label: ...`` while allowing new callbacks to opt into the
+    delivery result with ``def callback(result): ...``.
+    """
+    if getattr(callback, "_hermes_accepts_delivery_result", False):
+        return True
+    try:
+        parameters = inspect.signature(callback).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+        and parameter.default is parameter.empty
+        for parameter in parameters
+    )
+
+
+def invoke_post_delivery_callback(callback: Callable, delivery_result: Any) -> Any:
+    """Invoke a result-aware callback, retaining legacy zero-argument compatibility."""
+    if callback_accepts_delivery_result(callback):
+        return callback(delivery_result)
+    return callback()
+
+
+def chain_post_delivery_callbacks(*callbacks: Callable) -> Callable[[Any], Awaitable[None]]:
+    """Run callbacks in registration order with per-callback failure isolation."""
+    async def _chained(delivery_result: Any = None) -> None:
+        for callback in callbacks:
+            try:
+                result = invoke_post_delivery_callback(callback, delivery_result)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                logger.debug("Post-delivery callback failed", exc_info=True)
+
+    _chained._hermes_accepts_delivery_result = True
+    return _chained

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -316,9 +316,15 @@ class GatewayNotificationsMixin:
         self, response: str, source: SessionSource, adapter,
         metadata: Optional[Dict[str, Any]] = None, event_message_id: Optional[str] = None,
         text_already_delivered: bool = False, deliver_media: bool = True, stream_consumer=None,
-    ) -> None:
+    ) -> "SendResult":
         """Deliver a queued response using the normal text+attachment split."""
         from gateway.run import _strip_response_attachments_for_direct_send
+        from gateway.platforms.base import SendResult
+        text_delivery_result = (
+            self._run_agent_stream_final_delivery_result(stream_consumer, response)
+            if text_already_delivered else
+            SendResult(success=False, error="queued final text delivery unknown")
+        )
         if not text_already_delivered:
             text_content = _strip_response_attachments_for_direct_send(response, adapter)
             if text_content:
@@ -337,6 +343,7 @@ class GatewayNotificationsMixin:
                         )
                         if getattr(_edit_res, "success", False):
                             _reconciled = True
+                            text_delivery_result = _edit_res
                             logger.info(
                                 "Queued-lane final reconciled by editing message %s in place (no duplicate send).",
                                 _sc_msg_id,
@@ -353,19 +360,21 @@ class GatewayNotificationsMixin:
                                     "connector's egress guard; not falling back "
                                     "to a send (the destination is not approved)."
                                 )
-                                return
+                                return _edit_res
                     except Exception as _qe:
                         logger.debug("Queued-lane reconcile edit failed (%s); falling back to send.", _qe)
                 if not _reconciled:
-                    await adapter.send(source.chat_id, text_content, metadata=metadata)
+                    text_delivery_result = await adapter.send(
+                        source.chat_id, text_content, metadata=metadata)
         # Failed turns deliver their (normalized failure) text but must not upload attachments as if
         # they succeeded — mirrors the ``not agent_result.get("failed")`` completed-turn guard.
         if not deliver_media:
-            return
+            return text_delivery_result
         await self._deliver_media_from_response(
             response, MessageEvent(text="", source=source, message_id=event_message_id), adapter,
             thread_metadata=metadata,
         )
+        return text_delivery_result
 
     def _schedule_update_notification_watch(self) -> None:
         """Ensure a background task is watching for update completion."""

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1424,8 +1424,24 @@ class GatewayShutdownMixin:
         return True
 
     def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
-        if self._restart_task_started:
+        if self._restart_task_started or (not self._running and self._shutdown_event.is_set()):
             return False
+        prior_restart_state = (
+            self._restart_requested,
+            self._restart_detached,
+            self._restart_via_service,
+            self._draining,
+        )
+
+        def _restore_restart_state() -> None:
+            (
+                self._restart_requested,
+                self._restart_detached,
+                self._restart_via_service,
+                self._draining,
+            ) = prior_restart_state
+            self._restart_task_started = False
+
         self._restart_requested = True
         self._restart_detached = detached
         self._restart_via_service = via_service
@@ -1450,7 +1466,46 @@ class GatewayShutdownMixin:
         # self._restart_task: a bare asyncio.create_task() keeps only a weak reference, so the event loop
         # may garbage-collect a still-pending task mid-flight. The cancel loop in _stop_impl explicitly
         # skips _restart_task for the same reason it skips _stop_task.
-        self._restart_task = asyncio.create_task(_run_restart())
+        restart_coro = _run_restart()
+        try:
+            self._restart_task = asyncio.create_task(restart_coro)
+        except Exception:
+            restart_coro.close()
+            self._restart_task = None
+            _restore_restart_state()
+            logger.exception("Failed to schedule gateway restart task")
+            return False
+
+        def _settle_restart_task(task: asyncio.Task) -> None:
+            if task.cancelled():
+                error = "cancelled"
+            else:
+                exc = task.exception()
+                if exc is None:
+                    return
+                error = str(exc) or type(exc).__name__
+            if self._restart_task is task:
+                self._restart_task = None
+            if self._stop_task is not None and self._stop_task.done():
+                self._stop_task = None
+            # ``_running`` is also false while startup is still connecting, so it cannot tell a
+            # pre-teardown failure from a one-way shutdown failure.  ``stop()`` resets this marker
+            # for each attempt and ``_stop_begin_teardown`` flips it at the actual phase boundary.
+            if getattr(self, "_stop_teardown_started", False):
+                # Teardown is one-way once _stop_begin_teardown clears _running.  Do not pretend
+                # the gateway is live or retry a partly completed stop; make the failed terminal
+                # state observable to wait_for_shutdown() and the process exit verdict instead.
+                self._restart_task_started = False
+                self._draining = False
+                self._exit_with_failure = True
+                self._exit_reason = self._exit_reason or f"Gateway restart teardown failed: {error}"
+                self._shutdown_event.set()
+            else:
+                # Startup may not have set ``_running`` yet, but no one-way teardown happened.
+                _restore_restart_state()
+            logger.error("Gateway restart task failed: %s", error)
+
+        self._restart_task.add_done_callback(_settle_restart_task)
         return True
 
     def _start_systemd_watchdog(self) -> bool:
@@ -1549,6 +1604,7 @@ class GatewayShutdownMixin:
         """Flag teardown, stop room worker/watchdog, notify sessions."""
         logger.info("Stopping gateway%s...", " for restart" if self._restart_requested else "")
         ctx.started_at = time.monotonic()
+        self._stop_teardown_started = True
         self._running = False
         self._clear_plugin_message_injector()
         self._draining = True
@@ -1907,6 +1963,8 @@ class GatewayShutdownMixin:
         _stop_guards = getattr(self, "_stop_loop_liveness_guards", None)
         if callable(_stop_guards):
             _stop_guards()
+        if not self._running and self._shutdown_event.is_set():
+            return
         if restart:
             self._restart_requested = True
             self._restart_detached = detached_restart
@@ -1914,6 +1972,7 @@ class GatewayShutdownMixin:
         if self._stop_task is not None:
             await self._stop_task
             return
+        self._stop_teardown_started = False
         self._stop_task = asyncio.create_task(GatewayRunner._stop_impl(self))
         await self._stop_task
 

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1716,6 +1716,7 @@ class GatewayTurnMixin:
         if _intentional_silence:
             logger.info("Suppressing intentional silence marker for session %s", session_entry.session_id)
             response = ""
+            event._final_text_delivery_silenced = True
 
         adapter = self._adapter_for_source(source)
         # Auto voice reply (TTS audio before the text) unless streaming TTS already delivered audio.
@@ -1730,6 +1731,11 @@ class GatewayTurnMixin:
         # Streamed responses still need MEDIA: files delivered (chunks carry the tags verbatim). Never
         # skip when the agent failed: the error text is new content streaming didn't show.
         if agent_result.get("already_sent") and not agent_result.get("failed"):
+            from gateway.platforms.base import SendResult
+            event._final_text_delivery_result = agent_result.get("_final_text_delivery_result")
+            if not isinstance(event._final_text_delivery_result, SendResult):
+                event._final_text_delivery_result = SendResult(
+                    success=False, error="streamed final text delivery unknown")
             if response and adapter:
                 await self._deliver_media_from_response(response, event, adapter)
             # Streaming delivered the body, but the footer was held back (`not already_sent` gate).
@@ -3056,6 +3062,36 @@ class GatewayTurnMixin:
                     return False
         return False
 
+    @staticmethod
+    def _run_agent_stream_final_delivery_result(consumer, final_text: str):
+        """Translate the stream ledger's exact-text verdict into a typed delivery result.
+
+        Suppression retains its historical ambiguity policy, but lifecycle callbacks fail closed:
+        only an affirmative ledger match is success; a missing verdict is typed as unknown.
+        """
+        from gateway.platforms.base import SendResult
+
+        if consumer is None:
+            return SendResult(success=False, error="streamed final text delivery unknown")
+        matcher = getattr(consumer, "delivered_final_matches", None)
+        if not callable(matcher):
+            return SendResult(success=False, error="streamed final text delivery unknown")
+        try:
+            verdict = matcher(final_text)
+        except Exception:
+            return SendResult(success=False, error="streamed final text delivery unknown")
+        if verdict is True:
+            message_id = getattr(consumer, "message_id", None)
+            return SendResult(
+                success=True,
+                message_id=None if message_id == "__no_edit__" else message_id,
+            )
+        return SendResult(
+            success=False,
+            error=("streamed final text delivery failed"
+                   if verdict is False else "streamed final text delivery unknown"),
+        )
+
     def _run_agent_start_turn_worker(self, turn_ctx: TurnContext, run_sync: Callable[[], Any]) -> "GatewayRunner._RunAgentWorker":
         """Schedule ``run_sync`` on the executor plus the inactivity watchdog thread.
 
@@ -3365,7 +3401,11 @@ class GatewayTurnMixin:
             _sc, first_response, previewed=bool(_delivery_result.get("response_previewed")),
         )
         # Same silence predicate as the normal path, else this branch leaks the literal marker.
+        from gateway.platforms.base import SendResult
+        _callback_delivery_result = SendResult(
+            success=False, error="queued final text delivery unknown")
         if self._is_intentional_silence(_delivery_result, first_response):
+            _callback_delivery_result = None
             logger.info(
                 "Queued follow-up for session %s: suppressing intentional silence marker before continuing.",
                 session_key or "?",
@@ -3378,7 +3418,7 @@ class GatewayTurnMixin:
                 session_key or "?",
             )
             try:
-                await self._deliver_queued_first_response(
+                _callback_delivery_result = await self._deliver_queued_first_response(
                     first_response, source=turn_ctx.source, adapter=adapter,
                     metadata=turn_ctx._status_thread_metadata, event_message_id=turn_ctx.event_message_id,
                     text_already_delivered=_already_streamed,
@@ -3386,11 +3426,14 @@ class GatewayTurnMixin:
                 )
             except Exception as e:
                 logger.warning("Failed to send first response before queued message: %s", e)
+                _callback_delivery_result = SendResult(
+                    success=False, error="queued final text delivery failed")
         # Release deferred bg-review notifications: pop (no double-fire in base.py's finally) and call.
         _bg_cb = self._pop_post_delivery_callback(adapter, session_key, turn_ctx.run_generation)
         if callable(_bg_cb):
+            from gateway.post_delivery import invoke_post_delivery_callback
             with suppress(Exception):
-                _bg_result = _bg_cb()
+                _bg_result = invoke_post_delivery_callback(_bg_cb, _callback_delivery_result)
                 if inspect.isawaitable(_bg_result):
                     await _bg_result
 
@@ -3562,6 +3605,7 @@ class GatewayTurnMixin:
             logger.warning(fail_result, _sk, getattr(_res, "error", None))
             return
         response["already_sent"] = True
+        response["_final_text_delivery_result"] = _res
         logger.info(*ok)
 
     async def _run_agent_mark_streamed_delivery(self, response: Any, turn_ctx: TurnContext) -> None:
@@ -3609,6 +3653,8 @@ class GatewayTurnMixin:
                 _sk, _streamed, _previewed, _content_delivered,
             )
             response["already_sent"] = True
+            response["_final_text_delivery_result"] = self._run_agent_stream_final_delivery_result(
+                _sc, _final)
         elif not _transformed and _stale_finalized and _sc is not None:
             # Stale finalize: edit the streamed message up to the complete response (on failure the
             # normal send delivers). Not for split delivery — message_id is only the LAST chunk.

--- a/tests/gateway/test_post_delivery_result.py
+++ b/tests/gateway/test_post_delivery_result.py
@@ -1,0 +1,179 @@
+"""Final-text delivery evidence passed to generation-bound post-delivery callbacks."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.event import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _ResultAdapter(BasePlatformAdapter):
+    def __init__(self, result: SendResult):
+        super().__init__(PlatformConfig(enabled=True), Platform.TELEGRAM)
+        self.result = result
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return self.result
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _event() -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM, chat_id="1", chat_type="dm", user_id="u1"),
+        message_id="in-1",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("send_success", [True, False])
+async def test_buffered_callback_observes_exact_final_text_send_result(send_success):
+    wire_result = SendResult(
+        success=send_success,
+        message_id="out-1" if send_success else None,
+        error=None if send_success else "connector rejected",
+    )
+    adapter = _ResultAdapter(wire_result)
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="final text"))
+    session_key = "agent:main:telegram:dm:1"
+    guard = asyncio.Event()
+    guard._hermes_run_generation = 7
+    adapter._active_sessions[session_key] = guard
+    legacy = []
+    observed = []
+    adapter.register_post_delivery_callback(
+        session_key, lambda: legacy.append("fired"), generation=7)
+    adapter.register_post_delivery_callback(
+        session_key, lambda result: observed.append(result), generation=7)
+
+    await adapter._process_message_background(_event(), session_key)
+
+    assert observed == [wire_result]
+    assert legacy == ["fired"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_auto_tts_caption_preserves_its_send_result(tmp_path):
+    wire_result = SendResult(success=True, message_id="voice-1")
+    adapter = _ResultAdapter(SendResult(success=True, message_id="unexpected-text"))
+    adapter._should_auto_tts_for_chat = lambda _chat_id: True
+    adapter.play_tts = AsyncMock(return_value=wire_result)
+    adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="final text"))
+    event = _event()
+    event.message_type = MessageType.VOICE
+    session_key = "agent:main:telegram:dm:1"
+    guard = asyncio.Event()
+    guard._hermes_run_generation = 9
+    adapter._active_sessions[session_key] = guard
+    observed = []
+    adapter.register_post_delivery_callback(
+        session_key, lambda result: observed.append(result), generation=9)
+    tts_path = tmp_path / "reply.ogg"
+    tts_path.write_text("audio", encoding="utf-8")
+
+    with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+        "tools.tts_tool.text_to_speech_tool",
+        return_value=json.dumps({"file_path": str(tts_path)}),
+    ):
+        await adapter._process_message_background(event, session_key)
+
+    assert observed == [wire_result]
+    adapter.play_tts.assert_awaited_once()
+    assert adapter.play_tts.await_args.kwargs["caption"] == "final text"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("verdict", "expected_success", "expected_error"),
+    [
+        (True, True, None),
+        (False, False, "streamed final text delivery failed"),
+        (None, False, "streamed final text delivery unknown"),
+    ],
+)
+async def test_streamed_callback_fails_closed_on_exact_text_ledger(
+    verdict, expected_success, expected_error,
+):
+    class _Consumer:
+        message_id = "stream-1"
+
+        def delivered_final_matches(self, _text):
+            return verdict
+
+    adapter = _ResultAdapter(SendResult(success=True, message_id="unused"))
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda _source: adapter
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._deliver_media_from_response = AsyncMock()
+
+    async def _handler(event):
+        agent_result = {
+            "already_sent": True,
+            "_final_text_delivery_result": (
+                GatewayRunner._run_agent_stream_final_delivery_result(
+                    _Consumer(), "final text")),
+        }
+        return await GatewayRunner._hmwa_deliver_turn_response(
+            runner, event, event.source, SimpleNamespace(session_id="session-1"),
+            "agent:main:telegram:dm:1", 8, agent_result, [], "final text", None, False,
+        )
+
+    adapter.set_message_handler(_handler)
+    session_key = "agent:main:telegram:dm:1"
+    guard = asyncio.Event()
+    guard._hermes_run_generation = 8
+    adapter._active_sessions[session_key] = guard
+    observed = []
+    adapter.register_post_delivery_callback(
+        session_key, lambda result: observed.append(result), generation=8)
+
+    await adapter._process_message_background(_event(), session_key)
+
+    assert len(observed) == 1
+    assert isinstance(observed[0], SendResult)
+    assert observed[0].success is expected_success
+    assert observed[0].error == expected_error
+    assert observed[0].message_id == ("stream-1" if expected_success else None)
+
+    async def _silent_handler(event):
+        return await GatewayRunner._hmwa_deliver_turn_response(
+            runner, event, event.source, SimpleNamespace(session_id="session-1"),
+            session_key, 10, {}, [], "[SILENT]", None, True,
+        )
+
+    adapter.set_message_handler(_silent_handler)
+    silence_guard = asyncio.Event()
+    silence_guard._hermes_run_generation = 10
+    adapter._active_sessions[session_key] = silence_guard
+    adapter.register_post_delivery_callback(
+        session_key, lambda result: observed.append(result), generation=10)
+
+    await adapter._process_message_background(_event(), session_key)
+    assert observed[-1] is None
+
+    stale_guard = asyncio.Event()
+    stale_guard._hermes_run_generation = 12
+    adapter._active_sessions[session_key] = stale_guard
+    adapter.register_post_delivery_callback(
+        session_key, lambda result: observed.append(result), generation=11)
+
+    await adapter._process_message_background(_event(), session_key)
+    assert len(observed) == 2
+    assert session_key in adapter._post_delivery_callbacks

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -160,6 +160,103 @@ async def test_request_restart_is_idempotent():
 
 
 @pytest.mark.asyncio
+async def test_request_restart_rejection_restores_live_gateway_state(monkeypatch):
+    runner, _adapter = make_restart_runner()
+
+    def _reject(_coro):
+        raise RuntimeError("task factory rejected")
+
+    monkeypatch.setattr(asyncio, "create_task", _reject)
+
+    assert runner.request_restart(detached=False, via_service=True) is False
+    assert runner._restart_task is None
+    assert runner._restart_task_started is False
+    assert runner._restart_requested is False
+    assert runner._restart_via_service is False
+    assert runner._draining is False
+
+
+@pytest.mark.asyncio
+async def test_request_restart_task_failure_before_teardown_allows_retry():
+    runner, _adapter = make_restart_runner()
+    runner.stop = AsyncMock(side_effect=RuntimeError("stop failed"))
+    runner._restart_after_turn_timeout = 0.0
+
+    assert runner.request_restart(detached=False, via_service=True) is True
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await runner._restart_task
+    await asyncio.sleep(0)
+
+    assert runner._restart_task_started is False
+    assert runner._restart_requested is False
+    assert runner._restart_via_service is False
+    assert runner._draining is False
+    runner.stop = AsyncMock()
+    assert runner.request_restart(detached=False, via_service=True) is True
+    await runner._restart_task
+
+
+@pytest.mark.asyncio
+async def test_request_restart_pre_teardown_startup_failure_allows_retry():
+    runner, _adapter = make_restart_runner()
+    runner._running = False
+    runner._shutdown_event.clear()
+    runner._exit_with_failure = False
+    runner.stop = AsyncMock(side_effect=RuntimeError("startup stop failed"))
+    runner._restart_after_turn_timeout = 0.0
+
+    assert runner.request_restart(detached=False, via_service=True) is True
+    with pytest.raises(RuntimeError, match="startup stop failed"):
+        await runner._restart_task
+    await asyncio.sleep(0)
+
+    assert runner._shutdown_event.is_set() is False
+    assert runner.should_exit_with_failure is False
+    assert runner._restart_task_started is False
+    assert runner._restart_requested is False
+    assert runner._draining is False
+    runner.stop = AsyncMock()
+    assert runner.request_restart(detached=False, via_service=True) is True
+    await runner._restart_task
+
+
+@pytest.mark.asyncio
+async def test_request_restart_failure_after_teardown_is_terminal(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    runner._restart_after_turn_timeout = 0.0
+    runner._clear_plugin_message_injector = MagicMock()
+    runner._stop_hosted_room_worker = AsyncMock(return_value=True)
+    runner._stop_systemd_watchdog = AsyncMock()
+    runner._cancel_secondary_profile_reconnect_tasks = AsyncMock()
+    runner._notify_active_sessions_of_shutdown = AsyncMock()
+    runner._launch_detached_restart_command = AsyncMock()
+
+    async def _fail_after_begin_teardown(_self, _timeout, _ctx):
+        assert runner._running is False
+        raise RuntimeError("drain failed after teardown began")
+
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner, "_stop_drain_active_work", _fail_after_begin_teardown)
+
+    assert runner.request_restart(detached=False, via_service=True) is True
+    restart_task = runner._restart_task
+    with pytest.raises(RuntimeError, match="drain failed after teardown began"):
+        await restart_task
+    await asyncio.sleep(0)
+
+    assert runner._running is False
+    assert runner._restart_task_started is False
+    assert runner._restart_task is None
+    assert runner._stop_task is None
+    assert runner._draining is False
+    assert runner.should_exit_with_failure is True
+    assert "drain failed after teardown began" in runner.exit_reason
+    await asyncio.wait_for(runner.wait_for_shutdown(), timeout=0.1)
+    assert runner.request_restart(detached=False, via_service=True) is False
+    runner._launch_detached_restart_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_request_restart_defers_stop_until_active_turn_finishes():
     """Regression for #77184: requesting turn must not enter the drain set."""
     runner, _adapter = make_restart_runner()


### PR DESCRIPTION
## Summary
- pass the exact final-text `SendResult` to generation-bound post-delivery callbacks
- fail closed for failed or unknown buffered/streamed/TTS-caption delivery while preserving intentional silence and legacy zero-argument callbacks
- settle restart scheduling and runtime failures without leaving the gateway latched; distinguish retryable pre-teardown failures from terminal post-teardown failures

## Tests
- `scripts/run_tests.sh tests/gateway/test_post_delivery_result.py tests/gateway/test_restart_drain.py` (24 passed, 2 platform skips)
- broader delivery/streaming/voice selection (128 passed, 2 platform skips)
- `python3 scripts/check_compat_pointers.py`
- `git diff --check`
- independent read-only release review: PASS

## Full gateway suite note
The macOS run exposed five host-specific existing failures (abstract UNIX socket, UNIX path length, diagnostic subprocess) and one WeCom timing flake. The WeCom file passed 27 tests three consecutive isolated runs; none of those files are changed by this PR.