### PR TITLE
fix(gateway): check the system unit's own User= for linger, not the caller's

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3417,7 +3417,21 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print(f"  ⚠ Systemd unit result: {result_code}")
 
     if system:
-        print("✓ System service starts at boot without requiring systemd linger")
+        if configured_user:
+            # A system unit's own User= still needs linger — cron/Kanban workers cross
+            # `systemd-run --user`, which needs that target user's manager (#104893).
+            linger_enabled, linger_detail = get_systemd_linger_status(configured_user)
+            if linger_enabled is True:
+                print(f"✓ Systemd linger is enabled for {configured_user} (worker D-Bus available)")
+            elif linger_enabled is False:
+                print(f"⚠ Linger not enabled for {configured_user} — cron and Kanban workers cannot start (no user D-Bus)")
+                print(f"  Run: sudo loginctl enable-linger {configured_user}")
+            elif deep:
+                print(f"⚠ Could not verify systemd linger for {configured_user} ({linger_detail})")
+                print("  If you want cron and Kanban workers to reach systemd-run --user, run:")
+                print(f"  sudo loginctl enable-linger {configured_user}")
+        else:
+            print("✓ System service starts at boot without requiring systemd linger")
     else:
         linger_enabled, linger_detail = get_systemd_linger_status()
         if linger_enabled is True:

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -215,3 +215,84 @@ def test_existing_system_install_repairs_linger_for_configured_user(monkeypatch,
     gateway.systemd_install(system=True, run_as_user="alice")
 
     assert helper_calls == ["alice"]
+
+
+class TestSystemdStatusLingerMessage:
+    """``hermes gateway status --system`` must query the unit's own ``User=`` for linger, not
+    claim linger is never needed — cron/Kanban's ``systemd-run --user`` workers need that target
+    user's manager (#104893), the same fact ``_ensure_system_service_linger`` already acts on."""
+
+    def _install_common_mocks(self, monkeypatch, unit_path, configured_user):
+        monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway, "has_conflicting_systemd_units", lambda: False)
+        monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+        monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: True)
+        monkeypatch.setattr(
+            gateway, "_run_systemctl",
+            lambda *args, **kwargs: SimpleNamespace(stdout="active", stderr="", returncode=0),
+        )
+        monkeypatch.setattr(gateway, "_read_systemd_user_from_unit", lambda path: configured_user)
+        monkeypatch.setattr(gateway, "_print_runtime_health", lambda: None)
+        monkeypatch.setattr(gateway, "_read_systemd_unit_properties", lambda system=False, **kwargs: {})
+        monkeypatch.setattr(gateway.subprocess, "run", lambda *args, **kwargs: None)
+
+    def test_system_scope_with_configured_user_checks_that_users_linger(self, monkeypatch, tmp_path, capsys):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("[Service]\nUser=worker\n", encoding="utf-8")
+        self._install_common_mocks(monkeypatch, unit_path, "worker")
+        queried = []
+        monkeypatch.setattr(
+            gateway, "get_systemd_linger_status",
+            lambda username=None: (queried.append(username), (True, ""))[1],
+        )
+
+        gateway.systemd_status(system=True)
+
+        out = capsys.readouterr().out
+        assert queried == ["worker"]
+        assert "Systemd linger is enabled for worker" in out
+        assert "without requiring systemd linger" not in out
+
+    def test_system_scope_with_configured_user_and_disabled_linger_warns_for_that_user(
+        self, monkeypatch, tmp_path, capsys,
+    ):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("[Service]\nUser=worker\n", encoding="utf-8")
+        self._install_common_mocks(monkeypatch, unit_path, "worker")
+        monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda username=None: (False, ""))
+
+        gateway.systemd_status(system=True)
+
+        out = capsys.readouterr().out
+        assert "Linger not enabled for worker" in out
+        assert "sudo loginctl enable-linger worker" in out
+        assert "$USER" not in out
+
+    def test_system_scope_without_configured_user_reports_no_linger_needed(self, monkeypatch, tmp_path, capsys):
+        """A legacy/hand-edited unit with no ``User=`` runs outright as root; no target-user linger to check."""
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("[Service]\n", encoding="utf-8")
+        self._install_common_mocks(monkeypatch, unit_path, None)
+        queried = []
+        monkeypatch.setattr(
+            gateway, "get_systemd_linger_status",
+            lambda username=None: (queried.append(username), (True, ""))[1],
+        )
+
+        gateway.systemd_status(system=True)
+
+        out = capsys.readouterr().out
+        assert queried == []
+        assert "System service starts at boot without requiring systemd linger" in out
+
+    def test_system_scope_unverifiable_linger_shown_only_with_deep(self, monkeypatch, tmp_path, capsys):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("[Service]\nUser=worker\n", encoding="utf-8")
+        self._install_common_mocks(monkeypatch, unit_path, "worker")
+        monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda username=None: (None, "loginctl not found"))
+
+        gateway.systemd_status(system=True, deep=False)
+        assert "Could not verify" not in capsys.readouterr().out
+
+        gateway.systemd_status(system=True, deep=True)
+        assert "Could not verify systemd linger for worker (loginctl not found)" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- `hermes gateway status --system` unconditionally printed "System service starts at boot without requiring systemd linger" — but a system-scope unit's own `User=` still needs linger enabled so cron/Kanban's `systemd-run --user` workers can reach that target user's D-Bus (#104893). This is the exact fact `_ensure_system_service_linger`/`_ensure_linger_enabled` already act on during install/repair; the status command's own diagnostic text just never caught up.
- Fix queries `get_systemd_linger_status(configured_user)` (the function's docstring already documents this exact use case — "system-scope gateway installation runs as root but the service runs as a configured target user, so querying the caller would validate the wrong user manager") and reports on that user's real linger state, mirroring the existing wording from `_ensure_linger_enabled`/`_print_linger_enable_warning`.
- A unit with no `User=` (legacy/hand-edited, runs outright as root) keeps the original "no linger needed" message — that edge case is genuinely unaffected.

## Why this matters
Anyone running `hermes gateway status --system` to diagnose a headless install where cron/Kanban jobs are erroring (the exact symptom #104893 and its recent fix chain in this repo address) gets told linger is a non-issue for system services, even when the configured user's linger is actually disabled — actively misdirecting the diagnosis.

## Test plan
- Added `TestSystemdStatusLingerMessage` (4 new tests) to `tests/hermes_cli/test_gateway_linger.py`: configured-user + linger enabled, configured-user + linger disabled (warns for the right user, not `$USER`), no configured-user (unchanged message), and unverifiable-linger-shown-only-with-`--deep`.
- Mutation-verified: reverted the `hermes_cli/gateway.py` change only, confirmed 3 of the 4 new tests fail with the exact predicted symptom (buggy output literally prints "Configured to run as: worker" immediately followed by "starts at boot without requiring systemd linger"); restored the fix, all pass again.
- `uv run --frozen --extra dev python -m pytest tests/hermes_cli/test_gateway_linger.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_foreign_xdg_runtime.py -q` → 171 passed, 4 skipped (pre-existing, unrelated).
- `ruff check` clean on both changed files.

## Scope note
This is scoped to the `systemd_status` diagnostic message only. A separate, pre-existing gap (the `systemd_install` repair path never provisions linger for user-scope installs) is tracked by open PR #12989 and is not touched here.