### PR TITLE
fix(desktop): select installed WSL D3D12 driver before Electron exec

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -1403,12 +1403,29 @@ def _build_desktop_app(desktop_dir: Path, *, source_mode: bool, npm: str, env: d
     return packaged_executable
 
 
+def _prefer_wsl_d3d12(env: dict, *, available: bool) -> None:
+    """Select Mesa before exec: setting this inside Electron can miss GPU initialization."""
+    overrides = ("GALLIUM_DRIVER", "MESA_LOADER_DRIVER_OVERRIDE", "LIBGL_ALWAYS_SOFTWARE", "LIBGL_DRIVERS_PATH")
+    if available and not any(key in env for key in overrides):
+        env["GALLIUM_DRIVER"] = "d3d12"
+
+
 def _desktop_launch_env(args: argparse.Namespace) -> tuple[dict, list[str]]:
     """Electron child env + config-supplied extra flags. ``desktop.*`` config is bridged to env vars
     Electron already reads; an explicit env var wins over config (and over keychain detection)."""
-    from hermes_constants import with_hermes_node_path
+    from hermes_constants import is_wsl, with_hermes_node_path
     # with_hermes_node_path() copies os.environ when called with no arg.
     env = with_hermes_node_path()
+    # /dev/dxg alone does not select hardware Mesa: Chromium may still get
+    # llvmpipe. Keep custom Mesa choices and systems without D3D12 unchanged.
+    _prefer_wsl_d3d12(env, available=is_wsl() and Path("/dev/dxg").exists() and any(
+        Path(driver).is_file() for driver in (
+            "/usr/lib/x86_64-linux-gnu/dri/d3d12_dri.so",
+            "/usr/lib/aarch64-linux-gnu/dri/d3d12_dri.so",
+            "/usr/lib64/dri/d3d12_dri.so",
+            "/usr/lib/dri/d3d12_dri.so",
+        )
+    ))
     for attr, key in (
         ("fake_boot", "HERMES_DESKTOP_BOOT_FAKE"), ("ignore_existing", "HERMES_DESKTOP_IGNORE_EXISTING")):
         if getattr(args, attr, False):

--- a/tests/hermes_cli/test_desktop_wsl_gpu.py
+++ b/tests/hermes_cli/test_desktop_wsl_gpu.py
@@ -1,0 +1,24 @@
+from hermes_cli.main_desktop import _prefer_wsl_d3d12
+
+
+def test_selects_available_wsl_driver_before_spawning_electron():
+    env = {"PATH": "/bin"}
+    _prefer_wsl_d3d12(env, available=True)
+    assert env == {"PATH": "/bin", "GALLIUM_DRIVER": "d3d12"}
+
+
+def test_missing_driver_and_explicit_mesa_choices_are_preserved():
+    overrides = [
+        {"GALLIUM_DRIVER": "llvmpipe"},
+        {"GALLIUM_DRIVER": ""},
+        {"MESA_LOADER_DRIVER_OVERRIDE": "zink"},
+        {"LIBGL_ALWAYS_SOFTWARE": "1"},
+        {"LIBGL_DRIVERS_PATH": "/custom/mesa"},
+    ]
+    for original in overrides:
+        env = dict(original)
+        _prefer_wsl_d3d12(env, available=True)
+        assert env == original
+    env = {}
+    _prefer_wsl_d3d12(env, available=False)
+    assert env == {}


### PR DESCRIPTION
Fixes #106117

## User-visible failure

On WSLg systems with `/dev/dxg` and Mesa's D3D12 driver installed, Hermes Desktop could still launch Chromium on `llvmpipe`. The GPU device was available, but the Mesa driver selection was not established early enough, so the Electron GPU process initialized against software rendering.

## Launch-boundary fix

Select `GALLIUM_DRIVER=d3d12` in the existing Python Desktop child environment **before Electron is executed**, and only when all of the following are true:

- the launcher is running under WSL;
- `/dev/dxg` exists;
- a Mesa `d3d12_dri.so` is present in a known system driver directory;
- the user has not supplied an explicit Mesa or software-rendering override.

The following variables remain authoritative, including explicitly empty values:

- `GALLIUM_DRIVER`
- `MESA_LOADER_DRIVER_OVERRIDE`
- `LIBGL_ALWAYS_SOFTWARE`
- `LIBGL_DRIVERS_PATH`

Native Linux, macOS, Windows, WSL systems without the driver, and direct Electron execution outside `hermes desktop` keep their previous environment.

## Why this boundary

The implementation follows the observed initialization order rather than adding another Electron-side switch:

| Launch experiment | WebGL renderer |
|---|---|
| Existing Hermes GPU switches | `ANGLE (Mesa, llvmpipe …)` |
| `LD_LIBRARY_PATH=/usr/lib/wsl/lib` only | `ANGLE (Mesa, llvmpipe …)` |
| Set `GALLIUM_DRIVER` inside Electron JavaScript | `ANGLE (Mesa, llvmpipe …)` |
| Set `GALLIUM_DRIVER=d3d12` before exec | `ANGLE (Microsoft Corporation, D3D12 (AMD Radeon RX 6800 XT), OpenGL 4.6)` |

Importing the patched production `_desktop_launch_env()` against a temporary `HERMES_HOME` and passing its returned environment to the same isolated Electron window selected the RX 6800 XT through D3D12. No Hermes model or backend process was started for that probe.

## Compatibility and scope

This changes only driver selection for the Hermes Python launch path. It adds no dependency, schema, persistent setting, or Electron bundle change. Nonstandard Mesa installations remain user-configurable through the existing environment variables, and the existing software/remote-display policy is untouched.

## Verification

- RED/GREEN regression: an eligible environment lacked `GALLIUM_DRIVER` before the fix and receives `d3d12` after it.
- Explicit override and missing-driver cases remain byte-for-byte unchanged.
- `scripts/run_tests.sh tests/hermes_cli/test_desktop_wsl_gpu.py tests/hermes_cli/test_desktop_exe_integrity.py` — **3 passed, 4 Windows-only skipped on Linux**.
- Focused Ruff and `git diff --check` passed.