### PR TITLE
fix(desktop): avoid nested npm pack invocation

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,7 +32,7 @@
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.mjs",
-    "pack": "npm run build && npm run builder -- --dir --publish never",
+    "pack": "npm run build && npm run prebuilder && cross-env NODE_OPTIONS=--max-old-space-size=16384 node scripts/run-electron-builder.mjs --dir --publish never",
     "dist": "npm run build && npm run builder",
     "dist:mac": "npm run build && npm run builder -- --mac",
     "dist:mac:dmg": "npm run build && npm run builder -- --mac dmg",


### PR DESCRIPTION
## Problem
Desktop packaging on Windows can fail when npm uses PowerShell as `script-shell`: the nested `npm run builder -- ...` invocation can expose electron-builder flags to npm instead of the builder.

## Approach
Invoke the existing builder runner directly from `pack`. The command explicitly preserves the `prebuilder` lifecycle work that `npm run builder` previously supplied, plus the existing memory limit and no-publish behavior.

## Validation
- `npm run test:desktop:platforms -- --run scripts/local-pack-publish.test.mjs`
- `npm run typecheck`
- Windows 11 isolated smoke validation with npm 12.0.2 and PowerShell 7; the fixed direct command forwarded builder arguments successfully. Temporary validation files were removed.

## Risk
Limited to the local Desktop `pack` script. `dist*` scripts continue using the existing `builder` script unchanged.

Fixes #105952
