### PR TITLE
feat(providers): opt-in body metadata.session_id for custom OpenAI-compatible providers (#106113)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -290,6 +290,39 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
+def _custom_provider_send_session_metadata(
+    *, provider: str, model: str, base_url: str, custom_providers: List[Dict[str, Any]]
+) -> bool:
+    provider_norm = (provider or "").strip().lower()
+    if provider_norm != "custom" and not provider_norm.startswith("custom:"):
+        return False
+    provider_key_filter = provider_norm.partition(":")[2].strip()
+    target_url = _normalized_custom_base_url(base_url)
+    if not target_url:
+        return False
+    fallback = False
+    for entry in custom_providers or []:
+        if (
+            not isinstance(entry, dict)
+            or entry.get("send_session_metadata") is not True
+        ):
+            continue
+        entry_keys = {
+            str(entry.get("provider_key", "") or "").strip().lower(),
+            str(entry.get("name", "") or "").strip().lower(),
+        }
+        if provider_key_filter and provider_key_filter not in entry_keys:
+            continue
+        if _normalized_custom_base_url(entry.get("base_url")) != target_url:
+            continue
+        if str(entry.get("model", "") or "").strip():
+            if _custom_provider_model_matches(model, entry):
+                return True
+        elif not fallback:
+            fallback = True
+    return fallback
+
+
 def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
     extra_body = _custom_provider_extra_body_for_agent(
         provider=agent.provider, model=agent.model, base_url=agent.base_url,
@@ -1715,6 +1748,12 @@ def _resolve_context_length(agent, _agent_cfg, base_url):
 
     # Reused by _check_compression_model_feasibility (aux compression model detection).
     agent._custom_providers = _custom_providers
+    agent._send_session_metadata = _custom_provider_send_session_metadata(
+        provider=agent.provider,
+        model=agent.model,
+        base_url=agent.base_url,
+        custom_providers=_custom_providers,
+    )
     _merge_custom_provider_extra_body(agent, _custom_providers)
 
     if _config_context_length is None and _custom_providers:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1329,6 +1329,7 @@ def _build_chat_completions_kwargs(agent, api_messages, tools_for_api, reasoning
         max_tokens_param_fn=agent._max_tokens_param, reasoning_config=reasoning_config,
         request_overrides=request_overrides, session_id=getattr(agent, "session_id", None),
         cache_scope_id=cache_scope_id, ollama_num_ctx=agent._ollama_num_ctx,
+        send_session_metadata=bool(getattr(agent, "_send_session_metadata", False)),
         provider_preferences=_prefs or None, openrouter_min_coding_score=agent.openrouter_min_coding_score,
         supports_reasoning=agent._supports_reasoning_extra_body(),
         qwen_session_metadata=_qwen_meta)

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -109,6 +109,39 @@ def _add_prompt_cache_key(
         api_kwargs["prompt_cache_key"] = cache_key
 
 
+def _add_session_metadata(
+    api_kwargs: dict[str, Any],
+    *,
+    send_session_metadata: bool,
+    session_id: str | None = None,
+    cache_scope_id: str | None = None,
+) -> None:
+    """Merge a per-conversation ``metadata.session_id`` when the endpoint opts in.
+
+    Load-balancing gateways (LiteLLM session affinity, matching pools of identical
+    vLLM/llama.cpp backends) pin requests that carry a body ``metadata.session_id``
+    to one deployment for a TTL, turning per-turn cold prefills into prefix-cache
+    hits. Static config cannot express this: concurrent conversations would share
+    one affinity bucket. The value is normalized exactly like ``prompt_cache_key``
+    — ``cache_scope_id`` (compression-lineage root) beats the physical
+    ``session_id`` so affinity survives context-compression session rotation.
+    """
+    if not send_session_metadata:
+        return
+    from agent.transports.codex import _cache_scope_from_session_id
+
+    affinity_id = _cache_scope_from_session_id(cache_scope_id or session_id)
+    if not affinity_id:
+        return
+    metadata = api_kwargs.get("metadata")
+    if metadata is None:
+        api_kwargs["metadata"] = {"session_id": affinity_id}
+    elif isinstance(metadata, dict):
+        # Fill only the free key: Qwen portal metadata and user request_overrides
+        # keep every key they set (promptId and friends).
+        metadata.setdefault("session_id", affinity_id)
+
+
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
     """Clamp Hermes' extended effort set (``ultra``) to the OpenAI-compat wire vocabulary.
 
@@ -284,11 +317,19 @@ def _base_kwargs(model: str, sanitized: list, tools: Any, params: dict, profile:
     return api_kwargs
 
 
-def _finish_kwargs(api_kwargs: dict[str, Any], sanitized: list, params: dict, *, supports_prompt_cache_key: bool) -> dict[str, Any]:
-    """Tail shared by both build paths: content-addressed prompt_cache_key, then return."""
+def _finish_kwargs(
+    api_kwargs: dict[str, Any], sanitized: list, params: dict, *, supports_prompt_cache_key: bool
+) -> dict[str, Any]:
+    """Tail shared by both build paths: content-addressed prompt_cache_key, session-affinity metadata, then return."""
     _add_prompt_cache_key(
         api_kwargs, messages=sanitized, tools=api_kwargs.get("tools"), supports_prompt_cache_key=supports_prompt_cache_key,
         session_id=params.get("session_id"), cache_scope_id=params.get("cache_scope_id"),
+    )
+    _add_session_metadata(
+        api_kwargs,
+        send_session_metadata=bool(params.get("send_session_metadata")),
+        session_id=params.get("session_id"),
+        cache_scope_id=params.get("cache_scope_id"),
     )
     return api_kwargs
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1075,6 +1075,7 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
+    "send_session_metadata",
     "ssl_ca_cert", "ssl_verify", "key_env"}
 
 # Fields that look like they should be inside custom_providers, not at root

--- a/hermes_cli/config_providers.py
+++ b/hermes_cli/config_providers.py
@@ -117,7 +117,8 @@ _KNOWN_PROVIDER_KEYS = {
     "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env", "key_cmd",
     "api_mode", "transport", "model", "default_model", "models", "models_discovered",
     "context_length", "rate_limit_delay", "request_timeout_seconds", "stale_timeout_seconds",
-    "discover_models", "extra_body", "extra_headers", "capabilities", "ssl_ca_cert", "ssl_verify"}
+    "discover_models", "extra_body", "extra_headers", "capabilities", "ssl_ca_cert", "ssl_verify",
+    "send_session_metadata"}
 
 
 def _pick_provider_base_url(entry: Dict[str, Any], provider_key: str) -> str:
@@ -260,6 +261,8 @@ def _normalize_custom_provider_entry(
             normalized[field] = entry[field]
     if isinstance(entry.get("extra_body"), dict):
         normalized["extra_body"] = dict(entry["extra_body"])
+    if entry.get("send_session_metadata") is True:
+        normalized["send_session_metadata"] = True
 
     # Per-provider extra HTTP headers may carry credentials — never log them downstream.
     _put("extra_headers", normalize_extra_headers(entry.get("extra_headers")))
@@ -285,7 +288,7 @@ def _custom_provider_entry_to_provider_config(
     for field in (
         "name", "api_key", "key_env", "key_cmd", "models", "models_discovered", "context_length",
         "rate_limit_delay", "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify"):
+        "ssl_ca_cert", "ssl_verify", "send_session_metadata"):
         if field in normalized:
             provider_entry[field] = normalized[field]
     if "model" in normalized:

--- a/tests/agent/test_custom_provider_extra_body.py
+++ b/tests/agent/test_custom_provider_extra_body.py
@@ -71,3 +71,78 @@ def test_named_custom_provider_extra_body_matches_provider_key():
     )
 
     assert agent.request_overrides == {"extra_body": {"enable_thinking": False}}
+
+
+def test_send_session_metadata_resolves_for_matching_url():
+    from agent.agent_init import _custom_provider_send_session_metadata
+
+    assert _custom_provider_send_session_metadata(
+        provider="custom",
+        model="qwen3.8",
+        base_url="https://gateway.internal.example.com/v1",
+        custom_providers=[
+            {
+                "name": "my-gateway",
+                "base_url": "https://gateway.internal.example.com/v1",
+                "send_session_metadata": True,
+            }
+        ],
+    ) is True
+
+
+def test_send_session_metadata_off_for_other_url():
+    from agent.agent_init import _custom_provider_send_session_metadata
+
+    assert _custom_provider_send_session_metadata(
+        provider="custom",
+        model="qwen3.8",
+        base_url="https://other.internal.example.com/v1",
+        custom_providers=[
+            {
+                "name": "my-gateway",
+                "base_url": "https://gateway.internal.example.com/v1",
+                "send_session_metadata": True,
+            }
+        ],
+    ) is False
+
+
+def test_send_session_metadata_off_for_non_custom_provider():
+    from agent.agent_init import _custom_provider_send_session_metadata
+
+    assert _custom_provider_send_session_metadata(
+        provider="openai",
+        model="gpt-4o",
+        base_url="https://gateway.internal.example.com/v1",
+        custom_providers=[
+            {
+                "name": "my-gateway",
+                "base_url": "https://gateway.internal.example.com/v1",
+                "send_session_metadata": True,
+            }
+        ],
+    ) is False
+
+
+def test_send_session_metadata_named_provider_key_scopes_match():
+    from agent.agent_init import _custom_provider_send_session_metadata
+
+    assert _custom_provider_send_session_metadata(
+        provider="custom:my-gateway",
+        model="qwen3.8",
+        base_url="https://gateway.internal.example.com/v1",
+        custom_providers=[
+            {
+                "provider_key": "other-provider",
+                "name": "Other Provider",
+                "base_url": "https://gateway.internal.example.com/v1",
+                "send_session_metadata": True,
+            },
+            {
+                "provider_key": "my-gateway",
+                "name": "My Gateway",
+                "base_url": "https://gateway.internal.example.com/v1",
+                "send_session_metadata": True,
+            },
+        ],
+    ) is True

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1036,3 +1036,71 @@ class TestPromptCacheKeyCapability:
             request_overrides={"prompt_cache_key": "   "},
         )
         assert "prompt_cache_key" not in kwargs
+
+
+class TestSessionMetadataAffinity:
+    """Opt-in body ``metadata.session_id`` for deployment-affinity gateways (#106113)."""
+
+    @staticmethod
+    def _messages():
+        return [
+            {"role": "system", "content": "You are stable."},
+            {"role": "user", "content": "hello"},
+        ]
+
+    def test_flag_off_leaves_body_untouched(self, transport):
+        kwargs = transport.build_kwargs(
+            model="gateway-model", messages=self._messages(),
+            session_id="session_alice_1",
+        )
+        assert "metadata" not in kwargs
+
+    def test_flag_on_emits_session_id(self, transport):
+        kwargs = transport.build_kwargs(
+            model="gateway-model", messages=self._messages(),
+            session_id="session_alice_1", send_session_metadata=True,
+        )
+        assert kwargs["metadata"] == {"session_id": "session_alice_1"}
+
+    def test_cache_scope_id_beats_physical_session_id(self, transport):
+        """Affinity survives compression rotation: the lineage root wins."""
+        kwargs = transport.build_kwargs(
+            model="gateway-model", messages=self._messages(),
+            session_id="session_rotated_2", cache_scope_id="session_root_1",
+            send_session_metadata=True,
+        )
+        assert kwargs["metadata"] == {"session_id": "session_root_1"}
+
+    def test_cron_suffix_is_normalized_away(self, transport):
+        kwargs = transport.build_kwargs(
+            model="gateway-model", messages=self._messages(),
+            session_id="cron_job_20260715_100000", send_session_metadata=True,
+        )
+        assert kwargs["metadata"] == {"session_id": "cron_job"}
+
+    def test_existing_metadata_keys_are_preserved(self, transport):
+        kwargs = transport.build_kwargs(
+            model="gateway-model", messages=self._messages(),
+            session_id="session_alice_1", send_session_metadata=True,
+            request_overrides={"metadata": {"promptId": "caller-set"}},
+        )
+        assert kwargs["metadata"]["promptId"] == "caller-set"
+        assert kwargs["metadata"]["session_id"] == "session_alice_1"
+
+    def test_blank_ids_emit_no_metadata(self, transport):
+        kwargs = transport.build_kwargs(
+            model="gateway-model", messages=self._messages(),
+            send_session_metadata=True,
+        )
+        assert "metadata" not in kwargs
+
+    def test_flag_on_via_provider_profile_path(self, transport):
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="affinity-gateway")
+        kwargs = transport.build_kwargs(
+            model="gateway-model", messages=self._messages(),
+            session_id="session_alice_1", send_session_metadata=True,
+            provider_profile=profile,
+        )
+        assert kwargs["metadata"] == {"session_id": "session_alice_1"}

--- a/tests/hermes_cli/test_custom_provider_extra_headers.py
+++ b/tests/hermes_cli/test_custom_provider_extra_headers.py
@@ -244,3 +244,28 @@ def test_fetch_api_models_sends_extra_headers_to_models_probe(monkeypatch):
     assert captured["headers"]["authorization"] == "Bearer proxy-key"
     assert captured["headers"]["sleeve-harness"] == "hermes"
     assert captured["headers"]["sleeve-base-url"] == "http://localhost:8081/v1"
+
+
+def test_normalize_entry_keeps_send_session_metadata_true():
+    normalized = _normalize_custom_provider_entry(
+        {
+            "name": "my-gateway",
+            "base_url": "https://gateway.internal.example.com/v1",
+            "send_session_metadata": True,
+        }
+    )
+    assert normalized is not None
+    assert normalized["send_session_metadata"] is True
+
+
+def test_normalize_entry_defaults_send_session_metadata_off():
+    for absent in (None, False, "true", 1):
+        normalized = _normalize_custom_provider_entry(
+            {
+                "name": "my-gateway",
+                "base_url": "https://gateway.internal.example.com/v1",
+                "send_session_metadata": absent,
+            }
+        )
+        assert normalized is not None
+        assert "send_session_metadata" not in normalized


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible providers behind a load-balancing gateway (LiteLLM `session_affinity`, pools of identical vLLM/llama.cpp backends) can now opt into per-conversation deployment affinity:

```yaml
custom_providers:
  - name: my-gateway
    base_url: https://gateway.internal/v1
    send_session_metadata: true
```

When set, the chat-completions transport merges a dynamic per-conversation identifier into the request body `metadata.session_id`.

Closes #106113.

## Implementation

- `_add_session_metadata` (new, `agent/transports/chat_completions.py`): called from `_finish_kwargs`, the tail shared by both build paths (profile + legacy). The value reuses the `prompt_cache_key` normalization — `_cache_scope_from_session_id(cache_scope_id or session_id)` — so the affinity key survives context-compression session rotation (#79017) and recurring cron fires of one job share one bucket. Existing `metadata` (Qwen portal top-level, caller `request_overrides`) is never overwritten: only the free `session_id` key is filled via `setdefault`.
- `send_session_metadata` accepted as a custom-provider entry field (`hermes_cli/config_providers.py` `_KNOWN_PROVIDER_KEYS`, normalized as strict `is True`; carried through the legacy → v12 `providers:` translation) and in `_VALID_CUSTOM_PROVIDER_FIELDS` (`hermes_cli/config.py`).
- `_custom_provider_send_session_metadata` (`agent/agent_init.py`): resolves the flag for the active provider/model/base_url using the same entry matching as the existing static `extra_body` merge (named `custom:<key>` scoping, model-scoped vs fallback entries), stored on the agent as `_send_session_metadata`.
- `_build_chat_completions_kwargs` (`agent/chat_completion_helpers.py`) passes the flag into the transport params for both build paths.

Static `extra_body` cannot express this: a static value collapses concurrent conversations into one affinity bucket. Opt-in keeps strict hosts (which 400 on unknown body fields) untouched.

## Tests

- `TestSessionMetadataAffinity` (7 tests, transport): flag off leaves body untouched; flag on emits the id; `cache_scope_id` beats physical `session_id`; cron suffix normalized away; pre-existing `metadata` keys preserved; blank ids emit nothing; profile build path covered.
- Resolver tests (4, `tests/agent/test_custom_provider_extra_body.py`): URL match, other-URL off, non-custom provider off, named `custom:<key>` scoping.
- Config normalization tests (2, `tests/hermes_cli/test_custom_provider_extra_headers.py`): strict-bool keep, non-true values dropped.

All new tests verified red under mutations (flag ignored / metadata clobbered / resolver skips all / normalizer drops the flag).