### PR TITLE
fix(moa): thread custom_providers into reference context-length resolution

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -359,7 +359,7 @@ def _price_reference_response(
 def _run_reference(
     slot: dict[str, Any], ref_messages: list[dict[str, Any]], *, temperature: float | None = None,
     max_tokens: int | None = None, reference_timeout: float | None = None, context_length_cache: Any = None,
-    cache_disabled: bool | None = None, cache_ttl: str | None = None,
+    cache_disabled: bool | None = None, cache_ttl: str | None = None, custom_providers: list | None = None,
 ) -> tuple[str, str, Any]:
     """Call one reference model; return ``(label, text, accounting)``. Never raises:
     a failed reference becomes a labelled ``[failed: …]`` note. Runs in a thread pool."""
@@ -378,6 +378,7 @@ def _run_reference(
         # advisory system prompt is prepended so its tokens count against the budget too.
         trimmed = _trim_messages_for_reference(
             messages, slot, runtime, reserve_output_tokens=max_tokens, context_length_cache=context_length_cache,
+            custom_providers=custom_providers,
         )
         trimmed = _maybe_apply_moa_cache_control(trimmed, _with_cache_disabled(runtime, cache_disabled), cache_ttl=cache_ttl)
 
@@ -407,7 +408,9 @@ _REFERENCE_DEFAULT_OUTPUT_RESERVE = 8192
 _REFERENCE_TRIM_SAFETY_FRACTION = 0.10
 
 
-def _reference_context_length(slot: dict[str, Any], runtime: dict[str, Any], cache: Any) -> int | None:
+def _reference_context_length(
+    slot: dict[str, Any], runtime: dict[str, Any], cache: Any, custom_providers: list | None = None,
+) -> int | None:
     """Context window for a slot, memoized in ``cache`` per (provider, model) when given.
 
     Failures are cached too so a flaky metadata source is not re-probed per reference.
@@ -423,6 +426,7 @@ def _reference_context_length(slot: dict[str, Any], runtime: dict[str, Any], cac
     try:
         context_length = get_model_context_length(
             model=model, base_url=str(runtime.get("base_url") or ""), api_key=str(runtime.get("api_key") or ""), provider=provider,
+            custom_providers=custom_providers,
         )
     except Exception:
         logger.debug("MoA reference context-length resolution failed for %s", _slot_label(slot))
@@ -435,6 +439,7 @@ def _reference_context_length(slot: dict[str, Any], runtime: dict[str, Any], cac
 def _trim_messages_for_reference(
     messages: list[dict[str, Any]], slot: dict[str, str], runtime: dict[str, Any], *,
     reserve_output_tokens: int | None = None, context_length_cache: Any = None,
+    custom_providers: list | None = None,
 ) -> list[dict[str, Any]]:
     """Trim an advisory request to fit a reference model's context window.
 
@@ -453,7 +458,7 @@ def _trim_messages_for_reference(
         return messages
     from agent.model_metadata import estimate_messages_tokens_rough
 
-    context_length = _reference_context_length(slot, runtime, context_length_cache)
+    context_length = _reference_context_length(slot, runtime, context_length_cache, custom_providers)
     if not isinstance(context_length, int) or context_length <= 0:
         return messages
     reserve = reserve_output_tokens if isinstance(reserve_output_tokens, int) and reserve_output_tokens > 0 else _REFERENCE_DEFAULT_OUTPUT_RESERVE
@@ -558,6 +563,10 @@ def _run_references_parallel(
     # Shared per-fan-out context-length cache (dict get/set is GIL-atomic).
     ctx_len_cache: dict[tuple[str, str], int | None] = {}
     cache_disabled, cache_ttl = _agent_cache_opts(agent)
+    # Same source _check_compression_model_feasibility reuses (agent_init.py); without it a
+    # per-model context_length override in custom_providers is invisible to the trim below and
+    # a reference whose real window is larger than the catalog default gets truncated for nothing.
+    custom_providers = getattr(agent, "_custom_providers", None)
     try:
         for idx, slot in enumerate(reference_models):
             if slot.get("provider") == "moa":
@@ -566,7 +575,7 @@ def _run_references_parallel(
             futures[executor.submit(
                 propagate_context_to_thread(_run_reference), slot, ref_messages, temperature=temperature,
                 max_tokens=max_tokens, reference_timeout=reference_timeout, context_length_cache=ctx_len_cache,
-                cache_disabled=cache_disabled, cache_ttl=cache_ttl,
+                cache_disabled=cache_disabled, cache_ttl=cache_ttl, custom_providers=custom_providers,
             )] = idx
 
         # Collect every reference (no early exit except a user interrupt).

--- a/tests/agent/test_moa_reference_custom_providers.py
+++ b/tests/agent/test_moa_reference_custom_providers.py
@@ -1,0 +1,123 @@
+"""Regression test: MoA's reference fan-out must thread the agent's custom_providers into
+context-length resolution.
+
+``ContextCompressor._resolve_context_length`` had this exact bug (71516214c3, "thread
+custom_providers into context-length resolution") — a per-model ``context_length`` override in
+``custom_providers`` was invisible because ``get_model_context_length()`` was called without it,
+so the hardcoded catalog default won instead. ``agent/moa_loop.py``'s
+``_reference_context_length`` (used by ``_trim_messages_for_reference`` to fit an advisor request
+into its own window, issue #60345) has the same call shape and the same gap: ``agent`` is already
+threaded down to ``_run_references_parallel`` (for cache-policy and interrupt checks), but
+``agent._custom_providers`` was never extracted or passed to the reference/trim chain below it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent import moa_loop
+
+
+class TestReferenceContextLengthCustomProviders:
+    def test_reference_context_length_passes_custom_providers_to_resolver(self):
+        captured = {}
+
+        def fake_get_model_context_length(**kwargs):
+            captured.update(kwargs)
+            return 42
+
+        custom_providers = [{"base_url": "https://custom.example.com/v1", "models": {}}]
+        with patch("agent.model_metadata.get_model_context_length", side_effect=fake_get_model_context_length):
+            result = moa_loop._reference_context_length(
+                slot={"model": "big-window-model", "provider": "custom"},
+                runtime={"base_url": "https://custom.example.com/v1", "api_key": ""},
+                cache=None,
+                custom_providers=custom_providers,
+            )
+
+        assert result == 42
+        assert captured.get("custom_providers") == custom_providers
+
+    def test_reference_context_length_defaults_custom_providers_to_none(self):
+        """Callers that never pass custom_providers (e.g. pre-existing tests) must not break."""
+        captured = {}
+
+        def fake_get_model_context_length(**kwargs):
+            captured.update(kwargs)
+            return 7
+
+        with patch("agent.model_metadata.get_model_context_length", side_effect=fake_get_model_context_length):
+            result = moa_loop._reference_context_length(
+                slot={"model": "m", "provider": "p"}, runtime={"base_url": "", "api_key": ""}, cache=None,
+            )
+
+        assert result == 7
+        assert captured.get("custom_providers") is None
+
+
+class TestTrimMessagesForReferenceCustomProviders:
+    def test_custom_provider_context_override_avoids_needless_trim(self):
+        """Without the override, the resolver would report a tiny catalog window and the advisor
+        request gets truncated; with it (the real per-model context_length the user configured),
+        the same request fits and is left untouched — reproducing issue #60345's failure mode for
+        custom-provider reference models specifically."""
+        slot = {"model": "big-window-model", "provider": "custom"}
+        runtime = {"base_url": "https://custom.example.com/v1", "api_key": ""}
+        # Several old turns plus a trailing question: fits a 999999-token window comfortably,
+        # but a 100-token window forces the oldest turns to drop (there's more than the
+        # always-kept "trailing user turn plus one preceding turn" to trim from).
+        messages = [{"role": "system", "content": "advisory system prompt"}]
+        for i in range(6):
+            role = "user" if i % 2 == 0 else "assistant"
+            messages.append({"role": role, "content": f"turn {i} " + ("word " * 500)})
+        messages.append({"role": "user", "content": "final question " + ("word " * 500)})
+
+        def fake_get_model_context_length(**kwargs):
+            # 10_000 leaves only ~800 usable tokens after the default 8192 output reserve —
+            # far below this fixture's ~4-5k estimated tokens, forcing a trim.
+            return 999999 if kwargs.get("custom_providers") else 10_000
+
+        with patch("agent.model_metadata.get_model_context_length", side_effect=fake_get_model_context_length):
+            trimmed_without_override = moa_loop._trim_messages_for_reference(
+                [dict(m) for m in messages], slot, runtime, custom_providers=None,
+            )
+            trimmed_with_override = moa_loop._trim_messages_for_reference(
+                [dict(m) for m in messages], slot, runtime,
+                custom_providers=[{"base_url": runtime["base_url"], "models": {slot["model"]: {"context_length": 999999}}}],
+            )
+
+        assert trimmed_without_override != messages, "tiny catalog window should force a trim"
+        assert trimmed_with_override == messages, "the real (large) custom-provider window must not be trimmed"
+
+
+class TestRunReferencesParallelThreadsCustomProviders:
+    def test_extracts_agent_custom_providers_and_passes_to_run_reference(self):
+        custom_providers = [{"base_url": "https://custom.example.com/v1", "models": {"m": {"context_length": 999999}}}]
+        agent = SimpleNamespace(_custom_providers=custom_providers, _cache_disabled=None, _cache_ttl=None)
+        calls = []
+
+        def fake_run_reference(slot, ref_messages, **kwargs):
+            calls.append(kwargs)
+            return (moa_loop._slot_label(slot), "text", None)
+
+        with patch.object(moa_loop, "_run_reference", side_effect=fake_run_reference):
+            moa_loop._run_references_parallel(
+                [{"provider": "custom", "model": "m"}], [{"role": "user", "content": "hi"}], agent=agent,
+            )
+
+        assert len(calls) == 1
+        assert calls[0].get("custom_providers") == custom_providers
+
+    def test_missing_agent_passes_none_without_raising(self):
+        calls = []
+
+        def fake_run_reference(slot, ref_messages, **kwargs):
+            calls.append(kwargs)
+            return (moa_loop._slot_label(slot), "text", None)
+
+        with patch.object(moa_loop, "_run_reference", side_effect=fake_run_reference):
+            moa_loop._run_references_parallel(
+                [{"provider": "custom", "model": "m"}], [{"role": "user", "content": "hi"}], agent=None,
+            )
+
+        assert len(calls) == 1
+        assert calls[0].get("custom_providers") is None


### PR DESCRIPTION
## Summary
- MoA's reference fan-out trims each advisor request to fit that reference model's own context window (`_trim_messages_for_reference`, guarding issue #60345 — without the trim, an over-budget request gets a hard HTTP 400 from the provider, which `_run_reference`'s try/except silently converts into a `[failed: …]` note, degrading the turn to fewer references).
- `_reference_context_length` resolved that window via `get_model_context_length(...)` without ever passing `custom_providers`, so a reference model on a self-hosted/custom endpoint with a per-model `context_length` override (`custom_providers[].models.<id>.context_length`) always got the hardcoded catalog default instead of its real (often larger) window — trimming a request that would have fit fine, or in the opposite direction, ~~under-estimating~~ never getting the user's actual configured value at all.
- `ContextCompressor._resolve_context_length` had this exact bug and was fixed the same way in `71516214c3` ("thread custom_providers into context-length resolution"): thread the already-resolved value through instead of letting the resolver fall back to the catalog default.
- The source here is `agent._custom_providers`, which `agent_init.py` resolves once at startup and already documents as reused elsewhere ("Reused by `_check_compression_model_feasibility`"). `_run_references_parallel` already receives `agent` (used for cache-policy and interrupt checks via `_agent_cache_opts`), so this extracts `agent._custom_providers` there and threads it down through `_run_reference` → `_trim_messages_for_reference` → `_reference_context_length` → `get_model_context_length`.

## Test plan
- New `tests/agent/test_moa_reference_custom_providers.py` (5 tests):
  - `_reference_context_length` passes `custom_providers` to the resolver (and still defaults to `None` when omitted, so no existing caller breaks).
  - `_trim_messages_for_reference`: the *same* long conversation is trimmed under a tiny catalog-default window but left untouched once the real (large) `custom_providers` override is threaded through — reproducing #60345's failure mode specifically for custom-provider reference models.
  - `_run_references_parallel` extracts `agent._custom_providers` and passes it to `_run_reference` (and passes `None` without raising when `agent` is `None`).
- Mutation-verified: reverted `agent/moa_loop.py` only, confirmed 3 of the 5 new tests fail with the exact predicted symptom (`TypeError: unexpected keyword argument 'custom_providers'` / the trim test's "without override" and "with override" outputs converging); restored the fix, all 5 pass again.
- `uv run --frozen --extra dev python -m pytest tests/agent/test_moa_reference_custom_providers.py tests/agent/test_cache_disabled_on_stubs.py tests/agent/test_moa_aggregator_cache_control.py tests/agent/test_moa_slot_api_mode.py tests/agent/test_moa_slot_max_tokens.py tests/agent/test_moa_reasoning_effort.py tests/run_agent/test_moa_loop_mode.py -q` → 66 passed.
- `ruff check` clean on both changed files.

## Prior art / competitor note
Closed (unmerged) PR #75738 covers this same conceptual gap plus several other call sites, and a maintainer review comment on it explicitly confirmed the MoA-trimming scope was still real and unaddressed by the narrower fix that did land (`71516214c3`/#83324, compressor-only). That PR's `moa_loop.py` hunk targets a pre-refactor file shape (inline in `_trim_messages_for_reference`, no `_reference_context_length` helper) and takes a different approach (reloading `custom_providers` from config fresh on every call via a new `_load_custom_providers()` helper) rather than reusing the agent's already-resolved value the way this PR and the compressor fix both do — so this is a from-scratch fix against current `main`, not a port of that diff.