### PR TITLE
fix(desktop): cache unchanged transcript byte weights

### DIFF
--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import type { ChatMessage } from '@/lib/chat-messages'
@@ -62,6 +62,26 @@ describe('SessionStateCache', () => {
     owners.set('stored-d', 'runtime-d')
     cache.prune()
     expect(owners.get('stored-a')).toBe('runtime-new-owner')
+  })
+
+  it('does not remeasure unchanged warm transcripts on repeated stream flushes', () => {
+    const stringify = vi.spyOn(JSON, 'stringify')
+
+    const cache = new SessionStateCache(
+      { isReferenced: () => false, onEvict: () => undefined },
+      { maxBytes: Number.POSITIVE_INFINITY, maxCount: 24 }
+    )
+
+    for (let index = 0; index < 24; index += 1) {
+      cache.set(`runtime-${index}`, settled(`stored-${index}`, 'x'.repeat(4096)))
+    }
+
+    for (let flush = 0; flush < 10; flush += 1) {
+      cache.prune()
+    }
+
+    expect(stringify).toHaveBeenCalledTimes(24)
+    stringify.mockRestore()
   })
 
   it('uses transcript bytes as well as count', () => {

--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -84,6 +84,21 @@ describe('SessionStateCache', () => {
     stringify.mockRestore()
   })
 
+  it('never measures a pinned active transcript while streaming', () => {
+    const cache = new SessionStateCache({ isReferenced: () => true, onEvict: () => undefined })
+    const state = settled('active', 'stream')
+    const stringify = vi.spyOn(JSON, 'stringify')
+    try {
+      for (let flush = 0; flush < 20; flush += 1) {
+        cache.set('active', { ...state, messages: [...state.messages] })
+        cache.prune()
+      }
+      expect(stringify).not.toHaveBeenCalled()
+    } finally {
+      stringify.mockRestore()
+    }
+  })
+
   it('uses transcript bytes as well as count', () => {
     const evicted: string[] = []
 

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -68,7 +68,6 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
   override set(runtimeId: string, state: ClientSessionState): this {
     super.set(runtimeId, state)
     this.#touch(runtimeId)
-    this.#weight(state)
 
     return this
   }

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -45,6 +45,7 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
   readonly #maxBytes: number
   readonly #maxCount: number
   readonly #recency = new Map<string, number>()
+  readonly #transcriptWeights = new WeakMap<ClientSessionState['messages'], number>()
   #clock = 0
 
   constructor(callbacks: SessionStateCacheCallbacks, limits: SessionStateCacheLimits = {}) {
@@ -67,6 +68,7 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
   override set(runtimeId: string, state: ClientSessionState): this {
     super.set(runtimeId, state)
     this.#touch(runtimeId)
+    this.#weight(state)
 
     return this
   }
@@ -91,7 +93,7 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
         continue
       }
 
-      const weight = transcriptBytes(state)
+      const weight = this.#weight(state)
       candidates.push({ bytes: weight, runtimeId, state, touched: this.#recency.get(runtimeId) ?? 0 })
       bytes += weight
     }
@@ -143,6 +145,19 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
       !hasDraftOrInFlightMessage(state) &&
       !this.#callbacks.isReferenced(runtimeId, state)
     )
+  }
+
+  #weight(state: ClientSessionState): number {
+    const cached = this.#transcriptWeights.get(state.messages)
+
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const weight = transcriptBytes(state)
+    this.#transcriptWeights.set(state.messages, weight)
+
+    return weight
   }
 
   #touch(runtimeId: string): void {


### PR DESCRIPTION
Fixes #106123

## Failure mode

`SessionStateCache.prune()` measured transcript weight by serializing every eligible messages array on every pass. Stream flushing can call `set()` and `prune()` repeatedly while most cached transcripts are unchanged, turning eviction accounting into repeated JSON work over the same immutable arrays.

An initial candidate moved measurement into `set()`, but that eagerly serialized active or externally referenced transcripts that are not eligible for eviction. The final implementation rejects that trade-off.

## Cache contract

Store measured byte weights in a `WeakMap` keyed by the immutable `messages` array identity:

- an unchanged array is measured once and reuses its weight on later prunes;
- a replacement array naturally receives a fresh measurement;
- weights are initialized only when an entry reaches the eligible-candidate path;
- active and referenced entries continue to bypass measurement as well as eviction.

Weighted-LRU ordering, count limits, byte limits, runtime/stored-session ownership checks, and eviction callbacks are unchanged. The weak identity cache introduces no explicit invalidation lifecycle and cannot retain discarded transcript arrays by itself.

## Measured behavior

- Before the fix, **24 warm rows were serialized 240 times** across ten prunes.
- With identity caching, the producer/consumer probe performed **24 initial measurements and zero serializations across 30 subsequent prunes**.
- The eager-measurement regression observed **20 calls before the correction and zero after it** for a pinned active transcript.

## Verification

- The broader cache/hook matrix passed **32 targeted tests**.
- After the lazy-initialization correction, the complete focused cache file passed **17 tests**.
- Both regressions exercise the production `SessionStateCache` rather than a detached benchmark helper.