### PR TITLE
perf(desktop): index stable tool calls during streaming

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -189,6 +189,7 @@ export function useMessageStream({
   )
 
   const queuedDeltasRef = useRef<Map<string, QueuedStreamDelta[]>>(new Map())
+  const toolPartIndicesRef = useRef<Map<string, Map<string, number>>>(new Map())
   const flushHandleRef = useRef<number | null>(null)
   const lastFlushAtRef = useRef<number>(0)
   // What the previous flush cost on the main thread — drives the adaptive
@@ -480,10 +481,17 @@ export function useMessageStream({
         }
       }
 
+      let stableIndices = toolPartIndicesRef.current.get(sessionId)
+
+      if (!stableIndices) {
+        stableIndices = new Map()
+        toolPartIndicesRef.current.set(sessionId, stableIndices)
+      }
+
       mutateStream(
         sessionId,
-        parts => dedupeGeneratedImageEchoesInParts(upsertToolPart(parts, payload, phase, occurredAt)),
-        () => upsertToolPart([], payload, phase, occurredAt),
+        parts => dedupeGeneratedImageEchoesInParts(upsertToolPart(parts, payload, phase, occurredAt, stableIndices)),
+        () => upsertToolPart([], payload, phase, occurredAt, stableIndices),
         { pending: m => phase !== 'complete' || (m.pending ?? false) },
         occurredAt
       )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -189,7 +189,7 @@ export function useMessageStream({
   )
 
   const queuedDeltasRef = useRef<Map<string, QueuedStreamDelta[]>>(new Map())
-  const toolPartIndicesRef = useRef<Map<string, Map<string, number>>>(new Map())
+  const toolPartIndicesRef = useRef<WeakMap<ChatMessagePart[], Map<string, number>>>(new WeakMap())
   const flushHandleRef = useRef<number | null>(null)
   const lastFlushAtRef = useRef<number>(0)
   // What the previous flush cost on the main thread — drives the adaptive
@@ -481,17 +481,20 @@ export function useMessageStream({
         }
       }
 
-      let stableIndices = toolPartIndicesRef.current.get(sessionId)
+      const upsert = (parts: ChatMessagePart[]) => {
+        // Cache ownership follows immutable timeline arrays, not every session
+        // ever seen by this hook. Evicted arrays and their indexes can be GC'd.
+        const stableIndices = toolPartIndicesRef.current.get(parts) ?? new Map<string, number>()
+        const next = upsertToolPart(parts, payload, phase, occurredAt, stableIndices)
+        toolPartIndicesRef.current.set(next, stableIndices)
 
-      if (!stableIndices) {
-        stableIndices = new Map()
-        toolPartIndicesRef.current.set(sessionId, stableIndices)
+        return dedupeGeneratedImageEchoesInParts(next)
       }
 
       mutateStream(
         sessionId,
-        parts => dedupeGeneratedImageEchoesInParts(upsertToolPart(parts, payload, phase, occurredAt, stableIndices)),
-        () => upsertToolPart([], payload, phase, occurredAt, stableIndices),
+        upsert,
+        () => upsert([]),
         { pending: m => phase !== 'complete' || (m.pending ?? false) },
         occurredAt
       )

--- a/apps/desktop/src/app/session/hooks/use-message-stream/tool-index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/tool-index.test.tsx
@@ -1,0 +1,32 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { renderMessageStream } from './test-harness'
+
+afterEach(() => { cleanup(); vi.restoreAllMocks() })
+
+it('reuses stable indexes through the real tool event and image-dedupe producer', async () => {
+  const stream = renderMessageStream('index-session')
+  await act(async () => { await Promise.resolve() })
+  const original = Map.prototype.set
+  let indexedRows = 0
+  vi.spyOn(Map.prototype, 'set').mockImplementation(function (this: Map<unknown, unknown>, key, value) {
+    if (typeof key === 'string' && key.startsWith('index-probe-') && typeof value === 'number') {indexedRows += 1}
+
+    return original.call(this, key, value)
+  })
+  act(() => {
+    for (let i = 0; i < 160; i += 1) {
+      stream.handleEvent({ session_id: 'index-session', type: 'tool.start', payload: { name: 'read_file', tool_id: `index-probe-${i}` } })
+    }
+
+    for (let i = 0; i < 160; i += 1) {
+      stream.handleEvent({ session_id: 'index-session', type: 'tool.complete', payload: { name: 'read_file', tool_id: `index-probe-${i}`, result: 'ok' } })
+    }
+  })
+  const parts = stream.state()?.messages.at(-1)?.parts
+  expect(parts).toHaveLength(160)
+  expect(parts?.every(part => part.type === 'tool-call' && part.result !== undefined)).toBe(true)
+  expect(indexedRows).toBeGreaterThan(0)
+  expect(indexedRows).toBeLessThanOrEqual(160 * 4)
+})

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -710,6 +710,49 @@ describe('preserveLocalAssistantErrors', () => {
 })
 
 describe('upsertToolPart', () => {
+  it('retains first-match semantics after a contextual ID remap', () => {
+    const indexes = new Map<string, number>()
+    const old: ChatMessagePart[] = [toolCallPart('a'), toolCallPart('a')]
+    const remapped = upsertToolPart(old, { name: 'read_file', tool_id: 'c', context: 'path' }, 'running', 1, indexes)
+    const payload = { name: 'read_file', tool_id: 'a' }
+    expect(upsertToolPart(remapped, payload, 'running', 2, indexes)).toEqual(upsertToolPart(remapped, payload, 'running', 2))
+  })
+
+  it('matches unindexed updates across duplicate IDs, remaps and old snapshots', () => {
+    const indexes = new Map<string, number>()
+    let parts: ChatMessagePart[] = [toolCallPart('a'), toolCallPart('a'), toolCallPart('b')]
+
+    for (let step = 0; step < 40; step += 1) {
+      const payload = { name: 'read_file', tool_id: ['a', 'b', 'c'][step % 3], context: 'context', result: { step } }
+      const phase = step % 2 === 0 ? 'running' : 'complete'
+      expect(upsertToolPart(parts, payload, phase, step, indexes)).toEqual(upsertToolPart(parts, payload, phase, step))
+      parts = upsertToolPart(parts, payload, phase, step, indexes)
+
+      if (step % 3 === 0) {parts = [...parts].reverse()}
+    }
+  })
+
+  it('closes every open prose part, including non-tail restored parts', () => {
+    for (const indexes of [undefined, new Map<string, number>()]) {
+      const parts: ChatMessagePart[] = [{ type: 'text', text: 'open text' }, toolCallPart('old'), { type: 'reasoning', text: 'open thought' }]
+      const result = upsertToolPart(parts, { name: 'read_file', tool_id: 'new' }, 'running', 42, indexes)
+      expect(result[0]).toMatchObject({ completedAt: 42 })
+      expect(result[2]).toMatchObject({ completedAt: 42 })
+      expect(parts[0]).not.toHaveProperty('completedAt')
+    }
+  })
+
+  it('rebuilds stable indexes after a same-length timeline replacement', () => {
+    const indexes = new Map<string, number>()
+    const first = upsertToolPart([toolCallPart('a'), toolCallPart('b')], { name: 'read_file', tool_id: 'a' }, 'running', 1, indexes)
+    const replacement = [first[1], first[0]]
+    const updated = upsertToolPart(replacement, { name: 'read_file', tool_id: 'a' }, 'running', 2, indexes)
+    expect(updated).toHaveLength(2)
+    expect(updated[1]).toMatchObject({ toolCallId: 'a' })
+    expect(updated[0]).toBe(replacement[0])
+  })
+
+
   it('updates a stable-id row without scanning a warm tool timeline', () => {
     const raw = Array.from({ length: 2_000 }, (_, index) => toolCallPart(`call-${index}`))
 

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -710,6 +710,42 @@ describe('preserveLocalAssistantErrors', () => {
 })
 
 describe('upsertToolPart', () => {
+  it('updates a stable-id row without scanning a warm tool timeline', () => {
+    const raw = Array.from({ length: 2_000 }, (_, index) => toolCallPart(`call-${index}`))
+
+    const stableIndices = new Map<string, number>(
+      raw.map((part, index) => [part.type === 'tool-call' ? String(part.toolCallId) : '', index])
+    )
+
+    let fullPasses = 0
+
+    const parts = new Proxy(raw, {
+      get(target, property, receiver) {
+        if (property === 'map' || property === 'findIndex') {
+          return (...args: never[]) => {
+            fullPasses += 1
+
+            return Reflect.apply(target[property], target, args)
+          }
+        }
+
+        return Reflect.get(target, property, receiver)
+      }
+    })
+
+    const updated = upsertToolPart(
+      parts,
+      { name: 'read_file', result: { content: 'done' }, tool_id: 'call-1999' },
+      'complete',
+      102.875,
+      stableIndices
+    )
+
+    expect(updated).toHaveLength(raw.length)
+    expect(updated[1_999]).toMatchObject({ completedAt: 102.875, toolCallId: 'call-1999' })
+    expect(fullPasses).toBe(0)
+  })
+
   it('preserves call time through progress and records completion time', () => {
     const started = upsertToolPart([], { name: 'read_file', tool_id: 'call-1' }, 'running', 100.125)
 

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -9,7 +9,8 @@ function toolId(payload: GatewayEventPayload | undefined): string {
 }
 
 let liveToolCounter = 0
-const stableIndexLengths = new WeakMap<Map<string, number>, number>()
+const stableIndexParts = new WeakMap<Map<string, number>, WeakRef<ChatMessagePart[]>>()
+const stableOpenParts = new WeakMap<Map<string, number>, number[]>()
 
 function nextLiveToolId(name: string): string {
   liveToolCounter += 1
@@ -156,21 +157,27 @@ function hasToolMatchOverlap(left: string[], right: string[]): boolean {
 }
 
 function synchronizeStableIndices(parts: ChatMessagePart[], stableIndices: Map<string, number>): void {
-  if (stableIndexLengths.get(stableIndices) === parts.length) {
+  if (stableIndexParts.get(stableIndices)?.deref() === parts) {
     return
   }
 
   stableIndices.clear()
+  const openParts: number[] = []
 
   for (let index = 0; index < parts.length; index += 1) {
     const part = parts[index]
 
-    if (part?.type === 'tool-call' && part.toolCallId) {
+    if (part?.type === 'tool-call' && part.toolCallId && !stableIndices.has(part.toolCallId)) {
       stableIndices.set(part.toolCallId, index)
+    }
+
+    if ((part?.type === 'text' || part?.type === 'reasoning') && part.completedAt === undefined) {
+      openParts.push(index)
     }
   }
 
-  stableIndexLengths.set(stableIndices, parts.length)
+  stableOpenParts.set(stableIndices, openParts)
+  stableIndexParts.set(stableIndices, new WeakRef(parts))
 }
 
 function findToolPartIndex(
@@ -319,15 +326,6 @@ function completeOpenStreamParts(parts: ChatMessagePart[], completedAt: number):
   )
 }
 
-function completeOpenStreamTail(parts: ChatMessagePart[], completedAt: number, next: ChatMessagePart[]): void {
-  const index = parts.length - 1
-  const tail = parts[index]
-
-  if ((tail?.type === 'text' || tail?.type === 'reasoning') && tail.completedAt === undefined) {
-    next[index] = { ...tail, completedAt } as ChatMessagePart
-  }
-}
-
 export function upsertToolPart(
   parts: ChatMessagePart[],
   payload: GatewayEventPayload | undefined,
@@ -335,6 +333,10 @@ export function upsertToolPart(
   occurredAt = Date.now() / 1000,
   stableIndices?: Map<string, number>
 ): ChatMessagePart[] {
+  if (stableIndices) {
+    synchronizeStableIndices(parts, stableIndices)
+  }
+
   const stableId = toolId(payload)
   const name = payload?.name || 'tool'
   const index = findToolPartIndex(parts, name, stableId, payload, phase, stableIndices)
@@ -362,17 +364,24 @@ export function upsertToolPart(
     })
   } satisfies ChatMessagePart
 
-  const next = parts.slice()
-  // A completion can be the first tool event observed after reconnect, so it
-  // also constitutes a text/reasoning -> tool boundary when no start arrived.
-  completeOpenStreamTail(parts, occurredAt, next)
+  // Close every open text/reasoning part, including restored non-tail rows.
+  // Indexed timelines remember those rows; direct callers retain the full pass.
+  const next = stableIndices ? parts.slice() : completeOpenStreamParts(parts, occurredAt)
+
+  if (stableIndices) {
+    for (const openIndex of stableOpenParts.get(stableIndices) ?? []) {
+      next[openIndex] = { ...parts[openIndex], completedAt: occurredAt } as ChatMessagePart
+    }
+
+    stableOpenParts.set(stableIndices, [])
+  }
 
   if (index === -1) {
     stableIndices?.set(id, next.length)
     next.push(base)
 
     if (stableIndices) {
-      stableIndexLengths.set(stableIndices, next.length)
+      stableIndexParts.set(stableIndices, new WeakRef(next))
     }
 
     return next
@@ -380,6 +389,15 @@ export function upsertToolPart(
 
   next[index] = { ...parts[index], ...base }
   stableIndices?.set(id, index)
+
+  if (stableIndices) {
+    if (prev?.type === 'tool-call' && prev.toolCallId !== id) {
+      // A renamed first occurrence may reveal another row with the old ID.
+      stableIndexParts.delete(stableIndices)
+    } else {
+      stableIndexParts.set(stableIndices, new WeakRef(next))
+    }
+  }
 
   return next
 }

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -9,6 +9,7 @@ function toolId(payload: GatewayEventPayload | undefined): string {
 }
 
 let liveToolCounter = 0
+const stableIndexLengths = new WeakMap<Map<string, number>, number>()
 
 function nextLiveToolId(name: string): string {
   liveToolCounter += 1
@@ -154,20 +155,52 @@ function hasToolMatchOverlap(left: string[], right: string[]): boolean {
   return left.some(value => rightSet.has(value))
 }
 
+function synchronizeStableIndices(parts: ChatMessagePart[], stableIndices: Map<string, number>): void {
+  if (stableIndexLengths.get(stableIndices) === parts.length) {
+    return
+  }
+
+  stableIndices.clear()
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index]
+
+    if (part?.type === 'tool-call' && part.toolCallId) {
+      stableIndices.set(part.toolCallId, index)
+    }
+  }
+
+  stableIndexLengths.set(stableIndices, parts.length)
+}
+
 function findToolPartIndex(
   parts: ChatMessagePart[],
   name: string,
   stableId: string,
   payload: GatewayEventPayload | undefined,
-  phase: 'running' | 'complete'
+  phase: 'running' | 'complete',
+  stableIndices?: Map<string, number>
 ): number {
   const matchValues = toolPayloadMatchValues(payload)
   const overlaps = (index: number) => hasToolMatchOverlap(matchValues, toolPartMatchValues(parts[index]))
 
   if (stableId) {
-    const stableIndex = parts.findIndex(part => part.type === 'tool-call' && part.toolCallId === stableId)
+    if (stableIndices) {
+      synchronizeStableIndices(parts, stableIndices)
+    }
+
+    const cachedIndex = stableIndices?.get(stableId)
+    const cachedPart = cachedIndex === undefined ? undefined : parts[cachedIndex]
+
+    const stableIndex = stableIndices
+      ? cachedPart?.type === 'tool-call' && cachedPart.toolCallId === stableId
+        ? (cachedIndex as number)
+        : -1
+      : parts.findIndex(part => part.type === 'tool-call' && part.toolCallId === stableId)
 
     if (stableIndex >= 0) {
+      stableIndices?.set(stableId, stableIndex)
+
       return stableIndex
     }
 
@@ -286,21 +319,26 @@ function completeOpenStreamParts(parts: ChatMessagePart[], completedAt: number):
   )
 }
 
+function completeOpenStreamTail(parts: ChatMessagePart[], completedAt: number, next: ChatMessagePart[]): void {
+  const index = parts.length - 1
+  const tail = parts[index]
+
+  if ((tail?.type === 'text' || tail?.type === 'reasoning') && tail.completedAt === undefined) {
+    next[index] = { ...tail, completedAt } as ChatMessagePart
+  }
+}
+
 export function upsertToolPart(
   parts: ChatMessagePart[],
   payload: GatewayEventPayload | undefined,
   phase: 'running' | 'complete',
-  occurredAt = Date.now() / 1000
+  occurredAt = Date.now() / 1000,
+  stableIndices?: Map<string, number>
 ): ChatMessagePart[] {
   const stableId = toolId(payload)
   const name = payload?.name || 'tool'
-  // A completion can be the first tool event observed after reconnect, so it
-  // also constitutes a text/reasoning -> tool boundary when no start arrived.
-  const next = completeOpenStreamParts(parts, occurredAt)
-
-  const index = findToolPartIndex(next, name, stableId, payload, phase)
-
-  const prev = index >= 0 ? next[index] : null
+  const index = findToolPartIndex(parts, name, stableId, payload, phase, stableIndices)
+  const prev = index >= 0 ? parts[index] : null
   const prevArgs = prev && 'args' in prev ? prev.args : undefined
   const prevResult = prev && 'result' in prev ? prev.result : undefined
   const args = toolArgs(payload, prevArgs)
@@ -324,11 +362,24 @@ export function upsertToolPart(
     })
   } satisfies ChatMessagePart
 
+  const next = parts.slice()
+  // A completion can be the first tool event observed after reconnect, so it
+  // also constitutes a text/reasoning -> tool boundary when no start arrived.
+  completeOpenStreamTail(parts, occurredAt, next)
+
   if (index === -1) {
-    return [...next, base]
+    stableIndices?.set(id, next.length)
+    next.push(base)
+
+    if (stableIndices) {
+      stableIndexLengths.set(stableIndices, next.length)
+    }
+
+    return next
   }
 
-  next[index] = { ...next[index], ...base }
+  next[index] = { ...parts[index], ...base }
+  stableIndices?.set(id, index)
 
   return next
 }

--- a/apps/desktop/src/lib/generated-images.test.ts
+++ b/apps/desktop/src/lib/generated-images.test.ts
@@ -60,6 +60,11 @@ describe('generatedImageEchoSources', () => {
 })
 
 describe('dedupeGeneratedImageEchoesInParts', () => {
+  it('preserves unchanged timeline identity when no image echoes exist', () => {
+    const parts = [{ type: 'tool-call', toolName: 'read_file', result: {} }]
+    expect(dedupeGeneratedImageEchoesInParts(parts)).toBe(parts)
+  })
+
   it('keeps the agent prose while removing the duplicated image', () => {
     expect(
       dedupeGeneratedImageEchoesInParts([

--- a/apps/desktop/src/lib/generated-images.ts
+++ b/apps/desktop/src/lib/generated-images.ts
@@ -94,11 +94,11 @@ export function stripGeneratedImageEchoes(text: string, sources: readonly string
 
 /** Strip generated-image echoes from text parts, dropping any part left empty.
  *  The image lives in the tool slot; prose keeps the agent's actual words. */
-export function dedupeGeneratedImageEchoesInParts<T extends TextLike & ToolLike>(parts: readonly T[]): T[] {
+export function dedupeGeneratedImageEchoesInParts<T extends TextLike & ToolLike>(parts: T[]): T[] {
   const sources = generatedImageEchoSources(parts)
 
   if (!sources.length) {
-    return [...parts]
+    return parts
   }
 
   return parts


### PR DESCRIPTION
Closes #106125

## Streaming hot path

Every tool start, progress update, and completion searched the growing message-part timeline for its matching call. The update path also copied or traversed that timeline around tool boundaries, so a long turn repeated work proportional to all previously streamed parts.

An earlier index keyed validity only by timeline length. That was insufficient: a downstream transform could replace or reorder contents without changing the length, leaving a stable tool ID mapped to the wrong physical row.

## Identity-owned indexes

Index both stable tool-call IDs and open prose positions, but bind each cached index to the immutable timeline array that produced it:

- a new array identity receives a fresh index even when its length is unchanged;
- stable-ID updates use direct positions after validating that ownership;
- first-match semantics and contextual ID remaps remain intact;
- restored open text or reasoning can be closed at arbitrary positions, not only at the tail;
- immutable snapshots remain the public update contract.

Hook-side indexes are weakly owned by timeline arrays rather than stored in an unbounded session-ID map. When a timeline becomes unreachable, its index can be collected with it.

## Production-path continuity

Generated-image echo deduplication previously returned a fresh array even when it removed nothing. That no-op clone invalidated the identity-owned index on every event and made the optimization disappear in the real hook path.

The deduper now preserves input identity on a no-op. A real content change still returns a new array and therefore forces a correct index rebuild.

## Correctness contract

The indexed path preserves:

- same-length reorder safety;
- stable and contextual tool-ID matching;
- first matching row behavior;
- non-tail open text/reasoning completion;
- reconnect and completion-only continuity;
- generated-image deduplication semantics;
- immutable state publication.

The remaining unavoidable work is explicit: publishing an immutable timeline still copies its outer array, and image-source inspection still traverses the relevant content. This PR removes redundant lookup and no-op rebuild work rather than changing those contracts.

## Verification

- RED/GREEN regressions cover same-length reorder, non-tail open prose, contextual ID remapping, and index reuse through the production event path.
- A real hook fixture processes **160 starts plus 160 completions** and retains all 160 completed rows.
- Reintroducing the no-op image-dedupe clone causes **38,800 index insertions**; the final path stays within the **≤640** bound.
- Expanded stream/message/image matrix: **245 passed** before the final event-path case.
- Final focused matrix including that production-path regression: **90 passed**.
- Full Desktop typecheck, targeted ESLint, and `git diff --check` passed.