### PR TITLE
fix(desktop): serialize MCP log polling

### DIFF
--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -31,6 +31,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
+import { createSerialTask, startCompletionPoll } from '@/lib/completion-poll'
 import { compactNumber } from '@/lib/format'
 import { brandFor } from '@/lib/mcp-brands'
 import { estimateServerTokens, serverUsageCount } from '@/lib/mcp-cost'
@@ -1728,34 +1729,28 @@ function McpLogs({
   // the active profile tears down the old poll (its `cancelled` flag blocks a
   // late setLines) so profile A's logs never flash in B.
   const activeProfile = useStore($activeGatewayProfile)
+  const readLogs = useMemo(() => createSerialTask(getLogs), [])
 
   useEffect(() => {
-    let cancelled = false
+    setLines(null)
 
-    const poll = async () => {
-      try {
+    return startCompletionPoll({
+      delayMs: LOG_POLL_MS,
+      poll: async signal => {
         const response =
           source === 'stdio'
-            ? await getLogs({ file: 'mcp', lines: 500 })
-            : await getLogs({ file: 'agent', lines: 300, search: server ?? 'mcp' })
+            ? await readLogs({ file: 'mcp', lines: 500 }, signal)
+            : await readLogs({ file: 'agent', lines: 300, search: server ?? 'mcp' }, signal)
 
-        if (!cancelled) {
-          setLines(source === 'stdio' && server ? filterStdioSections(response.lines, server) : response.lines)
+        if (signal.aborted) {
+          throw new DOMException('Polling stopped', 'AbortError')
         }
-      } catch {
-        // Backend momentarily unavailable — keep the last tail.
-      }
-    }
 
-    setLines(null)
-    void poll()
-    const timer = window.setInterval(() => void poll(), LOG_POLL_MS)
-
-    return () => {
-      cancelled = true
-      window.clearInterval(timer)
-    }
-  }, [server, source, activeProfile])
+        return source === 'stdio' && server ? filterStdioSections(response.lines, server) : response.lines
+      },
+      publish: setLines
+    })
+  }, [server, source, activeProfile, readLogs])
 
   return <LogTail emptyLabel={emptyLabel} lines={lines} />
 }

--- a/apps/desktop/src/lib/completion-poll.test.ts
+++ b/apps/desktop/src/lib/completion-poll.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createSerialTask, startCompletionPoll } from './completion-poll'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+describe('startCompletionPoll', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps a slow producer single-flight and resumes cadence after completion', async () => {
+    vi.useFakeTimers()
+    const first = deferred<string>()
+    const poll = vi.fn(() => first.promise)
+    const publish = vi.fn()
+
+    const stop = startCompletionPoll({ delayMs: 2_000, poll, publish })
+    await vi.advanceTimersByTimeAsync(20_000)
+    expect(poll).toHaveBeenCalledTimes(1)
+
+    first.resolve('tail')
+    await Promise.resolve()
+    expect(publish).toHaveBeenCalledWith('tail')
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(poll).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(poll).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it('cancels stale publication and serializes a replacement lifecycle behind the active request', async () => {
+    vi.useFakeTimers()
+    const first = deferred<string>()
+    const second = deferred<string>()
+    const producer = vi.fn((profile: string) => (profile === 'A' ? first.promise : second.promise))
+    const serial = createSerialTask(producer)
+    const publishA = vi.fn()
+    const publishB = vi.fn()
+
+    const stopA = startCompletionPoll({
+      delayMs: 2_000,
+      poll: signal => serial('A', signal),
+      publish: publishA
+    })
+
+    await Promise.resolve()
+    stopA()
+
+    const stopB = startCompletionPoll({
+      delayMs: 2_000,
+      poll: signal => serial('B', signal),
+      publish: publishB
+    })
+
+    await Promise.resolve()
+    expect(producer).toHaveBeenCalledTimes(1)
+
+    first.resolve('stale')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(producer).toHaveBeenCalledTimes(2)
+    expect(publishA).not.toHaveBeenCalled()
+
+    second.resolve('fresh')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(publishB).toHaveBeenCalledWith('fresh')
+
+    stopB()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/apps/desktop/src/lib/completion-poll.ts
+++ b/apps/desktop/src/lib/completion-poll.ts
@@ -1,0 +1,61 @@
+interface CompletionPollOptions<T> {
+  delayMs: number
+  poll: (signal: AbortSignal) => Promise<T>
+  publish: (value: T) => void
+}
+
+/** Serialize a producer across effect lifecycles without publishing stale work. */
+export function createSerialTask<Args, Result>(
+  task: (args: Args) => Promise<Result>
+): (args: Args, signal: AbortSignal) => Promise<Result> {
+  let tail = Promise.resolve()
+
+  return (args, signal) => {
+    const result = tail.then(() => {
+      if (signal.aborted) {
+        throw new DOMException('Task stopped', 'AbortError')
+      }
+
+      return task(args)
+    })
+
+    tail = result.then(
+      () => undefined,
+      () => undefined
+    )
+
+    return result
+  }
+}
+
+/** Poll immediately, then wait one full cadence after each request settles. */
+export function startCompletionPoll<T>({ delayMs, poll, publish }: CompletionPollOptions<T>): () => void {
+  const controller = new AbortController()
+  let timer: number | undefined
+
+  const run = async () => {
+    try {
+      const value = await poll(controller.signal)
+
+      if (!controller.signal.aborted) {
+        publish(value)
+      }
+    } catch {
+      // A transient producer failure keeps the previous value visible.
+    }
+
+    if (!controller.signal.aborted) {
+      timer = window.setTimeout(() => void run(), delayMs)
+    }
+  }
+
+  void run()
+
+  return () => {
+    controller.abort()
+
+    if (timer !== undefined) {
+      window.clearTimeout(timer)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #106127

## Failure mode

MCP log tails were driven by `setInterval()`. If one `getLogs()` request took longer than the two-second cadence, the next interval started another request before the first settled. A profile or component change could also create a replacement effect while the old request was still alive, allowing stale work to contend with the new lifecycle and potentially publish after teardown.

## Polling model

Introduce two small primitives:

- `startCompletionPoll()` runs immediately, waits for the request to settle, then schedules the next poll after one full cadence;
- `createSerialTask()` preserves a single producer queue across React effect lifecycles and accepts an `AbortSignal` for stale-call fencing.

The MCP log view now uses both. Teardown aborts the current lifecycle, clears its timer, and prevents late publication. A replacement profile or server waits behind any already-started read rather than creating overlap.

## Behavioral contract

- At most one log request is executing at a time.
- The next cadence begins after completion, not from the previous start time.
- A stopped lifecycle cannot publish a late result.
- Transient failures preserve the last visible tail and polling resumes normally.
- Source-specific line limits and stdio section filtering are unchanged.

## Verification

- An unresolved producer remained single-flight across **20 seconds** of simulated time.
- After completion, the next read started only after the full **2,000 ms** cadence.
- A replacement lifecycle stayed serialized behind the old request, suppressed its stale result, published the fresh result, and left **zero timers** after cleanup.
- Desktop renderer typecheck passed.