### PR TITLE
fix(desktop): skip WSL distro discovery for drive paths

### DIFF
--- a/apps/desktop/electron/wsl-path-bridge.test.ts
+++ b/apps/desktop/electron/wsl-path-bridge.test.ts
@@ -39,13 +39,22 @@ test('parseDefaultDistro strips the default-marker and blank lines', () => {
 
 // ── wslPosixToWindowsAccessible ──────────────────────────────────────
 
-test('wslPosixToWindowsAccessible maps a drvfs mount to its Windows drive', () => {
-  assert.equal(wslPosixToWindowsAccessible('/mnt/c/Users/alex', 'Ubuntu'), 'C:\\Users\\alex')
-  assert.equal(wslPosixToWindowsAccessible('/mnt/d', 'Ubuntu'), 'D:\\')
-})
+test('wslPosixToWindowsAccessible resolves a distro only for paths that need a UNC share', () => {
+  let distroProbes = 0
 
-test('wslPosixToWindowsAccessible maps an in-distro POSIX path to a UNC share', () => {
-  assert.equal(wslPosixToWindowsAccessible('/home/alex/proj', 'Ubuntu'), '\\\\wsl.localhost\\Ubuntu\\home\\alex\\proj')
+  const resolveDistro = () => {
+    distroProbes += 1
+
+    return 'Ubuntu'
+  }
+
+  assert.equal(wslPosixToWindowsAccessible('/mnt/c/Users/alex', undefined, resolveDistro), 'C:\\Users\\alex')
+  assert.equal(distroProbes, 0)
+  assert.equal(
+    wslPosixToWindowsAccessible('/home/alex/proj', undefined, resolveDistro),
+    '\\\\wsl.localhost\\Ubuntu\\home\\alex\\proj'
+  )
+  assert.equal(distroProbes, 1)
 })
 
 test('wslPosixToWindowsAccessible leaves non-absolute / already-Windows paths alone', () => {

--- a/apps/desktop/electron/wsl-path-bridge.ts
+++ b/apps/desktop/electron/wsl-path-bridge.ts
@@ -133,7 +133,11 @@ function wslUncBase(distro: string): string {
  * (drvfs mount), any other absolute POSIX path → `\\wsl.localhost\<distro>\...`.
  * Non-absolute or already-Windows paths pass through.
  */
-export function wslPosixToWindowsAccessible(posixPath: string, distro: string = resolveDefaultWslDistro()): string {
+export function wslPosixToWindowsAccessible(
+  posixPath: string,
+  distro?: string,
+  resolveDistro: () => string = resolveDefaultWslDistro
+): string {
   const value = String(posixPath || '').trim()
   const normalized = value.replace(/\\/g, '/')
 
@@ -151,7 +155,7 @@ export function wslPosixToWindowsAccessible(posixPath: string, distro: string = 
 
   const relative = normalized.replace(/^\/+/, '').replace(/\//g, '\\')
 
-  return `${wslUncBase(distro)}\\${relative}`
+  return `${wslUncBase(distro ?? resolveDistro())}\\${relative}`
 }
 
 /** Native folder dialog `defaultPath`: open a WSL cwd in the Windows picker. */
@@ -174,7 +178,7 @@ export function resolvePickerDefaultPath(
   const value = String(defaultPath).trim()
 
   return value.startsWith('/') && !WIN_DRIVE_RE.test(value)
-    ? wslPosixToWindowsAccessible(value, distro ?? resolveDefaultWslDistro())
+    ? wslPosixToWindowsAccessible(value, distro)
     : defaultPath
 }
 
@@ -191,6 +195,6 @@ export function resolveLocalReadPath(dirPath: string, distro?: string, profile?:
   }
 
   return IS_WINDOWS && value.startsWith('/') && !WIN_DRIVE_RE.test(value)
-    ? wslPosixToWindowsAccessible(value, distro ?? resolveDefaultWslDistro())
+    ? wslPosixToWindowsAccessible(value, distro)
     : value
 }


### PR DESCRIPTION
## Summary

Delay WSL distro resolution until `wslPosixToWindowsAccessible` has ruled out `/mnt/<drive>` paths.

Both picker defaults and local filesystem reads now pass an optional distro through without resolving it eagerly. Drive paths return directly; in-distro paths still resolve the distro and use the existing UNC selection/cache.

## Tests

- RED: `wsl-path-bridge.test.ts` used the default Ubuntu result instead of the injected resolver and recorded zero resolver calls.
- GREEN: `npx vitest run --config <evidence>/vitest-electron.config.mjs electron/wsl-path-bridge.test.ts` — 12 passed.
- `npx eslint electron/wsl-path-bridge.ts electron/wsl-path-bridge.test.ts`


## Verification scope
Parent inspected the production diff and reran focused tests on this branch. This is not a full Desktop responsiveness or cross-platform acceptance claim. GitHub CI must be checked separately.


Closes #106129


## Canonical local verification
Parent reran `npx vitest run electron/wsl-path-bridge.test.ts --maxWorkers=1` with the repository Vitest configuration (no private test config) and `npm run typecheck`; both passed.
