### PR TITLE
fix(desktop): reuse the SSH bootstrap platform probe

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10712,6 +10712,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
     result = await lifecycle({
       ssh,
+      platform,
       profile: resolveRemoteSshDashboardProfile(sshConfig.remoteProfile, profile),
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -999,7 +999,14 @@ test('connect() spawns fresh when there is no lockfile, adopts the served token'
     [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=51999\n']
   ])
 
-  const result = await connect(connectDeps(ssh, { adoptServedToken: async () => 'the-served-token' }))
+  const result = await connect(
+    connectDeps(ssh, {
+      adoptServedToken: async () => 'the-served-token',
+      platform: { os: 'Linux', arch: 'x86_64' }
+    })
+  )
+
+  assert.equal(ssh.calls.filter(command => command === 'uname -s; uname -m').length, 0)
   assert.equal(result.reused, false)
   assert.equal(result.remotePort, 51999)
   assert.equal(result.localPort, 50001)

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1396,7 +1396,7 @@ async function connect(deps) {
   const log = msg => rememberLog(`[ssh-lifecycle] ${msg}`)
 
   assertBootstrapNotSuperseded(signal)
-  const platform = await probeRemotePlatform(ssh)
+  const platform = deps.platform ?? (await probeRemotePlatform(ssh))
   log(`remote platform ${platform.os}/${platform.arch}`)
   const hermesHome = await probeRemoteHermesHome(ssh)
   await assertRemoteInstallUpdateClear(ssh, hermesHome)


### PR DESCRIPTION
## Summary

Pass the platform detected during SSH lifecycle selection into the selected lifecycle. The POSIX lifecycle uses it when supplied and retains its existing `uname` probe for direct callers without a platform.

This does not change lifecycle selection, ownership, forwarding, reuse, cleanup, or Windows-remote behavior.

## Tests

- RED: `connect()` received a detected Linux platform but still issued one `uname -s; uname -m` command.
- GREEN: focused test passed with zero lifecycle `uname` calls.
- Full `remote-lifecycle.test.ts`: 92 passed.
- ESLint passed for `main.ts`, `remote-lifecycle.ts`, and its test.


## Verification scope
Parent inspected the production diff and reran focused tests on this branch. This is not a full Desktop responsiveness or cross-platform acceptance claim. GitHub CI must be checked separately.


Closes #106131


## Canonical local verification
Parent reran `npx vitest run electron/remote-lifecycle.test.ts --maxWorkers=1` with the repository Vitest configuration (no private test config) and `npm run typecheck`; both passed.
