### PR TITLE
perf(desktop): fetch roster profiles and install identity concurrently

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -346,6 +346,7 @@ import {
 import { missingRendererAssets } from './renderer-bundle'
 import { loadRendererLoadErrorPage } from './renderer-load-error-page'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { fetchRosterSourceData } from './roster-source-fetch'
 import {
   classifyStoredSecret,
   readSecretStoragePolicy,
@@ -15726,11 +15727,13 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             )
           )
 
-          const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
+          const { body, installId } = await fetchRosterSourceData(
+            () => getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 }),
+            () => probeConnectionInstallId(connection.id, descriptor)
+          )
 
-          // Cached with a TTL, so the 5s roster poll usually pays zero extra
-          // requests for the backend-identity probe.
-          const installId = await probeConnectionInstallId(connection.id, descriptor)
+          // The install-id probe is TTL-cached, so the 5s roster poll usually
+          // pays zero extra requests; on a miss it runs beside /api/profiles.
 
           const profiles = Array.isArray(body?.profiles)
             ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)

--- a/apps/desktop/electron/roster-source-fetch.test.ts
+++ b/apps/desktop/electron/roster-source-fetch.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { fetchRosterSourceData } from './roster-source-fetch'
+
+test('roster source starts profile and install-id reads together and preserves both results', async () => {
+  let releaseProfiles!: (value: { profiles: Array<{ name: string }> }) => void
+  let releaseInstallId!: (value: string | undefined) => void
+
+  const profiles = new Promise<{ profiles: Array<{ name: string }> }>(resolve => {
+    releaseProfiles = resolve
+  })
+
+  const installId = new Promise<string | undefined>(resolve => {
+    releaseInstallId = resolve
+  })
+
+  const started: string[] = []
+
+  const pending = fetchRosterSourceData(
+    () => {
+      started.push('profiles')
+
+      return profiles
+    },
+    () => {
+      started.push('install-id')
+
+      return installId
+    }
+  )
+
+  assert.deepEqual(started, ['profiles', 'install-id'])
+  releaseInstallId('install-1')
+  releaseProfiles({ profiles: [{ name: 'default' }] })
+  assert.deepEqual(await pending, {
+    body: { profiles: [{ name: 'default' }] },
+    installId: 'install-1'
+  })
+})
+
+test('roster source preserves a profile-read failure after starting the install-id read', async () => {
+  const profilesError = new Error('profiles unavailable')
+  let installIdStarted = false
+
+  await assert.rejects(
+    fetchRosterSourceData(
+      async () => {
+        throw profilesError
+      },
+      async () => {
+        installIdStarted = true
+
+        return undefined
+      }
+    ),
+    profilesError
+  )
+  assert.equal(installIdStarted, true)
+})

--- a/apps/desktop/electron/roster-source-fetch.ts
+++ b/apps/desktop/electron/roster-source-fetch.ts
@@ -1,0 +1,8 @@
+export async function fetchRosterSourceData<T>(
+  fetchProfiles: () => Promise<T>,
+  fetchInstallId: () => Promise<string | undefined>
+): Promise<{ body: T; installId: string | undefined }> {
+  const [body, installId] = await Promise.all([fetchProfiles(), fetchInstallId()])
+
+  return { body, installId }
+}


### PR DESCRIPTION
## Summary

Start a roster source's `/api/profiles` request and cached install-id probe together, then await both. A small helper keeps the existing result and rejection contract explicit and testable.

The install-id helper still owns TTLs and absorbs status failures as before. A profile failure still rejects that source and is handled by the existing per-source isolation.

## Tests

- RED: the behavioral helper did not exist on the base revision.
- GREEN: `roster-source-fetch.test.ts` verifies both operations start before either resolves and that a profile-read error is preserved; 2 passed.
- ESLint passed for the helper, test, and `main.ts` caller.


## Verification scope
Parent inspected the production diff and reran focused tests on this branch. This is not a full Desktop responsiveness or cross-platform acceptance claim. GitHub CI must be checked separately.


Closes #106133


## Canonical local verification
Parent reran `npx vitest run electron/roster-source-fetch.test.ts --maxWorkers=1` with the repository Vitest configuration (no private test config) and `npm run typecheck`; both passed.
