### PR TITLE
fix(desktop): coalesce queued MCP health sweeps

### DIFF
--- a/apps/desktop/src/store/mcp-health.test.ts
+++ b/apps/desktop/src/store/mcp-health.test.ts
@@ -117,3 +117,20 @@ it('coalesces reconnects during a sweep into one fresh follow-up sweep', async (
   await flush()
   expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(2)
 })
+
+it.each(['stop', 'disconnect'])('drops the queued sweep on %s', async action => {
+  let release!: (config: Record<string, unknown>) => void
+  mocks.getHermesConfigRecord.mockReturnValueOnce(new Promise(resolve => { release = resolve })).mockResolvedValue({ mcp_servers: {} })
+  startMcpHealthChecker()
+  mocks.gatewayState.set('open')
+  mocks.gatewayState.set('closed')
+  mocks.gatewayState.set('open')
+
+  if (action === 'stop') {stopMcpHealthChecker()}
+  else {mocks.gatewayState.set('closed')}
+
+  release({ mcp_servers: {} })
+  await flush()
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(1)
+})

--- a/apps/desktop/src/store/mcp-health.test.ts
+++ b/apps/desktop/src/store/mcp-health.test.ts
@@ -1,10 +1,42 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// The store wires itself to gateway/profile atoms and the REST layer at import
-// time paths; mock the seams (same shape as updates.test.ts) so this test only
-// exercises the pure transition state machine.
+const mocks = vi.hoisted(() => {
+  const makeAtom = <T>(initial: T) => {
+    let value = initial
+    const listeners = new Set<(value: T) => void>()
+
+    return {
+      get: () => value,
+      listen(listener: (value: T) => void) {
+        listeners.add(listener)
+
+        return () => listeners.delete(listener)
+      },
+      set(next: T) {
+        value = next
+
+        for (const listener of listeners) {
+          listener(value)
+        }
+      },
+      subscribe(listener: (value: T) => void) {
+        listener(value)
+
+        return this.listen(listener)
+      }
+    }
+  }
+
+  return {
+    activeProfile: makeAtom('default'),
+    gatewayState: makeAtom<'closed' | 'open'>('closed'),
+    getHermesConfigRecord: vi.fn(),
+    notify: vi.fn()
+  }
+})
+
 vi.mock('@/hermes', () => ({
-  getHermesConfigRecord: vi.fn(),
+  getHermesConfigRecord: mocks.getHermesConfigRecord,
   testMcpServer: vi.fn()
 }))
 
@@ -13,44 +45,75 @@ vi.mock('@/i18n', () => ({
 }))
 
 vi.mock('@/store/notifications', () => ({
-  notify: vi.fn()
+  notify: mocks.notify
 }))
 
 vi.mock('@/store/profile', () => ({
-  $activeGatewayProfile: { get: () => 'default', listen: () => () => {} },
+  $activeGatewayProfile: mocks.activeProfile,
   normalizeProfileKey: (name: string | null | undefined) => (name ?? '').trim() || 'default'
 }))
 
 vi.mock('@/store/session', () => ({
-  $gatewayState: { get: () => 'closed', subscribe: () => () => {} }
+  $gatewayState: mocks.gatewayState
 }))
 
-const { shouldNotifyOnTransition } = await import('./mcp-health')
+const { shouldNotifyOnTransition, startMcpHealthChecker, stopMcpHealthChecker } = await import('./mcp-health')
 
 type Status = 'error' | 'needs-auth' | 'ok'
 
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+afterEach(() => {
+  stopMcpHealthChecker()
+  mocks.gatewayState.set('closed')
+  mocks.activeProfile.set('default')
+  mocks.getHermesConfigRecord.mockReset()
+  mocks.notify.mockReset()
+})
+
 describe('shouldNotifyOnTransition', () => {
-  // The full previous × next decision table: notify only on a TRANSITION into
-  // a bad state. Rechecks of an already-bad server stay quiet; ok never nudges.
   it.each<[previous: Status | null, next: Status, notify: boolean]>([
-    // First observation of the session (previous unknown).
     [null, 'ok', false],
     [null, 'needs-auth', true],
     [null, 'error', true],
-    // Healthy server stays healthy / breaks.
     ['ok', 'ok', false],
     ['ok', 'needs-auth', true],
     ['ok', 'error', true],
-    // Already-broken server: rechecks must NOT re-notify…
     ['needs-auth', 'needs-auth', false],
     ['error', 'error', false],
-    // …but flipping from one bad state to the other is a new transition.
     ['needs-auth', 'error', true],
     ['error', 'needs-auth', true],
-    // Recovery is silent.
     ['needs-auth', 'ok', false],
     ['error', 'ok', false]
   ])('previous=%s next=%s → notify=%s', (previous, next, expected) => {
     expect(shouldNotifyOnTransition(previous, next)).toBe(expected)
   })
+})
+
+it('coalesces reconnects during a sweep into one fresh follow-up sweep', async () => {
+  let releaseFirst!: (config: Record<string, unknown>) => void
+
+  const first = new Promise<Record<string, unknown>>(resolve => {
+    releaseFirst = resolve
+  })
+
+  mocks.getHermesConfigRecord.mockReturnValueOnce(first).mockResolvedValue({ mcp_servers: {} })
+
+  startMcpHealthChecker()
+  mocks.gatewayState.set('open')
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(1)
+
+  for (let index = 0; index < 12; index += 1) {
+    mocks.gatewayState.set('closed')
+    mocks.gatewayState.set('open')
+  }
+
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(1)
+
+  releaseFirst({ mcp_servers: {} })
+  await flush()
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(2)
 })

--- a/apps/desktop/src/store/mcp-health.ts
+++ b/apps/desktop/src/store/mcp-health.ts
@@ -175,6 +175,8 @@ function arm(): void {
 }
 
 function disarm(): void {
+  sweepQueued = false
+
   if (timer !== null) {
     clearInterval(timer)
     timer = null

--- a/apps/desktop/src/store/mcp-health.ts
+++ b/apps/desktop/src/store/mcp-health.ts
@@ -49,8 +49,10 @@ let timer: ReturnType<typeof setInterval> | null = null
 // Bumped on profile switch; in-flight sweeps compare and bail so a slow
 // profile-A probe can't record (or notify) into profile B's state.
 let sweepEpoch = 0
-// Sweeps are chained, never concurrent — sequential probes, no parallel bursts.
-let sweepChain: Promise<void> = Promise.resolve()
+// At most one sweep runs and one follow-up is remembered. Reconnect storms
+// still request a fresh pass, but cannot append an unbounded backlog.
+let sweepInFlight: Promise<void> | null = null
+let sweepQueued = false
 let offGatewayState: (() => void) | null = null
 let offProfile: (() => void) | null = null
 
@@ -143,7 +145,24 @@ async function sweep(): Promise<void> {
 }
 
 function queueSweep(): void {
-  sweepChain = sweepChain.then(sweep, sweep)
+  if (sweepInFlight) {
+    sweepQueued = true
+
+    return
+  }
+
+  sweepInFlight = sweep()
+
+  const settled = () => {
+    sweepInFlight = null
+
+    if (sweepQueued) {
+      sweepQueued = false
+      queueSweep()
+    }
+  }
+
+  sweepInFlight.then(settled, settled)
 }
 
 function arm(): void {


### PR DESCRIPTION
## Summary

Replace the unbounded MCP health promise chain with an active-plus-dirty scheduler. While a sweep is active, any number of reconnect/interval requests sets one queued-refresh bit. Settlement runs one fresh follow-up and clears the bit.

Sweeps remain non-concurrent, continue to capture profile/epoch when they actually run, and use the same success/rejection settlement path so queued refresh intent is retained.

## Tests

- RED: 12 reconnects during a held sweep produced more than the expected two config reads.
- GREEN: the same real checker lifecycle produces exactly one active and one follow-up config read; full `mcp-health.test.ts` passed 13 tests.
- ESLint passed for the store and test.


## Verification scope
Parent inspected the production diff and reran focused tests on this branch. This is not a full Desktop responsiveness or cross-platform acceptance claim. GitHub CI must be checked separately.


Closes #106135


## Additional parent acceptance
Parent RED/GREEN also covers stopping/disconnecting with a pending sweep. disarm now drops queued refresh intent. 15 MCP health tests and full Desktop typecheck passed.


## Canonical local verification
Parent reran `npx vitest run src/store/mcp-health.test.ts --maxWorkers=1` with the repository Vitest configuration (no private test config) and `npm run typecheck`; both passed.
