### PR TITLE
perf(state): index compacted transcript display pages

### DIFF
--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -363,7 +363,8 @@ CREATE TABLE IF NOT EXISTS messages (
     compacted INTEGER NOT NULL DEFAULT 0,
     api_content TEXT,
     display_kind TEXT,
-    display_metadata TEXT
+    display_metadata TEXT,
+    display_order INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS session_model_usage (
@@ -513,6 +514,22 @@ CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
 DEFERRED_INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
+CREATE INDEX IF NOT EXISTS idx_messages_display_page
+    ON messages(session_id, display_order, active DESC, id DESC)
+    WHERE active = 1 OR compacted = 1;
+CREATE INDEX IF NOT EXISTS idx_messages_display_backfill
+    ON messages(session_id) WHERE display_order IS NULL AND (active = 1 OR compacted = 1);
+CREATE TRIGGER IF NOT EXISTS messages_display_order_insert
+AFTER INSERT ON messages WHEN new.display_order IS NULL
+BEGIN
+    UPDATE messages SET display_order = COALESCE((
+        SELECT MIN(COALESCE(display_order, id)) FROM messages
+        WHERE session_id = new.session_id AND id <> new.id
+          AND (active = 1 OR compacted = 1)
+          AND role IS new.role AND content IS new.content AND timestamp IS new.timestamp
+          AND tool_call_id IS new.tool_call_id AND tool_calls IS new.tool_calls AND tool_name IS new.tool_name
+    ), new.id) WHERE id = new.id;
+END;
 CREATE INDEX IF NOT EXISTS idx_messages_active_null
     ON messages(active) WHERE active IS NULL;
 CREATE INDEX IF NOT EXISTS idx_sessions_session_key

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -364,6 +364,7 @@ CREATE TABLE IF NOT EXISTS messages (
     api_content TEXT,
     display_kind TEXT,
     display_metadata TEXT,
+    display_identity BLOB,
     display_order INTEGER
 );
 
@@ -518,17 +519,69 @@ CREATE INDEX IF NOT EXISTS idx_messages_display_page
     ON messages(session_id, display_order, active DESC, id DESC)
     WHERE active = 1 OR compacted = 1;
 CREATE INDEX IF NOT EXISTS idx_messages_display_backfill
-    ON messages(session_id) WHERE display_order IS NULL AND (active = 1 OR compacted = 1);
+    ON messages(session_id) WHERE (display_order IS NULL OR display_identity IS NULL)
+    AND (active = 1 OR compacted = 1);
+CREATE INDEX IF NOT EXISTS idx_messages_display_identity
+    ON messages(session_id, display_identity, display_order)
+    WHERE display_identity IS NOT NULL AND (active = 1 OR compacted = 1);
+DROP TRIGGER IF EXISTS messages_display_order_insert;
 CREATE TRIGGER IF NOT EXISTS messages_display_order_insert
 AFTER INSERT ON messages WHEN new.display_order IS NULL
 BEGIN
     UPDATE messages SET display_order = COALESCE((
-        SELECT MIN(COALESCE(display_order, id)) FROM messages
+        SELECT display_order FROM messages
         WHERE session_id = new.session_id AND id <> new.id
           AND (active = 1 OR compacted = 1)
-          AND role IS new.role AND content IS new.content AND timestamp IS new.timestamp
-          AND tool_call_id IS new.tool_call_id AND tool_calls IS new.tool_calls AND tool_name IS new.tool_name
+          AND display_identity = new.display_identity AND display_order IS NOT NULL
+        ORDER BY display_order LIMIT 1
     ), new.id) WHERE id = new.id;
+END;
+DROP TRIGGER IF EXISTS messages_display_visibility_update;
+CREATE TRIGGER IF NOT EXISTS messages_display_visibility_update
+AFTER UPDATE OF active, compacted ON messages
+WHEN (new.active = 1 OR new.compacted = 1) <> (old.active = 1 OR old.compacted = 1)
+BEGIN
+    UPDATE messages SET display_order = MIN(new.id, COALESCE((
+        SELECT display_order FROM messages
+        WHERE session_id = new.session_id AND id <> new.id
+          AND (active = 1 OR compacted = 1)
+          AND display_identity = new.display_identity AND display_order IS NOT NULL
+        ORDER BY display_order LIMIT 1
+    ), new.id)) WHERE id = new.id
+      AND (new.active = 1 OR new.compacted = 1);
+    UPDATE messages SET display_order = (SELECT display_order FROM messages WHERE id = new.id)
+    WHERE session_id = new.session_id AND id <> new.id AND (active = 1 OR compacted = 1)
+      AND display_identity = new.display_identity
+      AND (new.active = 1 OR new.compacted = 1);
+    UPDATE messages SET display_order = (
+        SELECT MIN(peer.id) FROM messages AS peer
+        WHERE peer.session_id = old.session_id AND (peer.active = 1 OR peer.compacted = 1)
+          AND peer.display_identity = old.display_identity
+    ) WHERE session_id = old.session_id AND (active = 1 OR compacted = 1)
+      AND display_identity = old.display_identity
+      AND NOT (new.active = 1 OR new.compacted = 1);
+END;
+DROP TRIGGER IF EXISTS messages_display_identity_update;
+CREATE TRIGGER IF NOT EXISTS messages_display_identity_update
+AFTER UPDATE OF role, content, timestamp, tool_call_id, tool_calls, tool_name,
+                display_kind, display_metadata ON messages
+BEGIN
+    UPDATE messages SET display_identity = NULL, display_order = NULL
+    WHERE id = new.id OR (
+        session_id = old.session_id AND display_identity = old.display_identity
+        AND (active = 1 OR compacted = 1)
+    );
+END;
+DROP TRIGGER IF EXISTS messages_display_identity_delete;
+CREATE TRIGGER IF NOT EXISTS messages_display_identity_delete
+AFTER DELETE ON messages WHEN old.active = 1 OR old.compacted = 1
+BEGIN
+    UPDATE messages SET display_order = (
+        SELECT MIN(peer.id) FROM messages AS peer
+        WHERE peer.session_id = old.session_id AND (peer.active = 1 OR peer.compacted = 1)
+          AND peer.display_identity = old.display_identity
+    ) WHERE session_id = old.session_id AND (active = 1 OR compacted = 1)
+      AND display_identity = old.display_identity;
 END;
 CREATE INDEX IF NOT EXISTS idx_messages_active_null
     ON messages(active) WHERE active IS NULL;

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -249,6 +249,23 @@ class SessionMessagesMixin:
             _str_or_none(msg.get("api_content")), _str_or_none(msg.get("display_kind")),
             self._encode_display_metadata(msg.get("display_metadata")))
 
+    def _inherit_composite_display_order(self, conn, row_id: int, session_id: str, msg: Dict[str, Any],
+                                         message_timestamp: float, tool_calls: Any) -> None:
+        handoff, live_view = split_user_originated_turn(msg)
+        if handoff is None or live_view is None:
+            return
+        encoded_content = self._encode_content(live_view.get("content"))
+        encoded_tool_calls = json.dumps(tool_calls) if tool_calls else None
+        row = conn.execute(
+            "SELECT MIN(COALESCE(display_order, id)) FROM messages "
+            "WHERE session_id = ? AND id <> ? AND (active = 1 OR compacted = 1) "
+            "AND role = 'user' AND content IS ? AND timestamp IS ? AND tool_call_id IS ? "
+            "AND tool_calls IS ? AND tool_name IS ?",
+            (session_id, row_id, encoded_content, message_timestamp, msg.get("tool_call_id"),
+             encoded_tool_calls, msg.get("tool_name"))).fetchone()
+        if row is not None and row[0] is not None:
+            conn.execute("UPDATE messages SET display_order = ? WHERE id = ?", (row[0], row_id))
+
     @staticmethod
     def _bump_session_counters(conn, session_id: str, inserted: int, tool_calls: int, *, unit: bool) -> None:
         """Bump sessions.* counters after an insert; *unit* bakes the ``+ 1`` literal into the SQL."""
@@ -278,12 +295,16 @@ class SessionMessagesMixin:
         # Encode outside the write txn (display metadata first: log-order parity).
         msg["display_metadata"] = self._encode_display_metadata(display_metadata)
         tool_calls = _parse_tool_calls(tool_calls)
+        message_timestamp = _coerce_timestamp(timestamp, time.time())
         params = self._message_row_params(
-            session_id, role, msg, tool_calls, _coerce_timestamp(timestamp, time.time()), keep_reasoning=True)
+            session_id, role, msg, tool_calls, message_timestamp, keep_reasoning=True)
         def _do(conn):
             self._check_transcript_write_guards(conn, session_id, compression_lock_holder,
                 turn_lease_holder=turn_lease_holder, turn_lease_ttl_seconds=turn_lease_ttl_seconds)
             msg_id = conn.execute(_INSERT_MESSAGE_SQL, params).lastrowid
+            if msg_id is not None:
+                self._inherit_composite_display_order(
+                    conn, int(msg_id), session_id, msg, message_timestamp, tool_calls)
             self._bump_session_counters(conn, session_id, 1, _tool_calls_count(tool_calls), unit=True)
             return msg_id
         # THE critical write (failure aborts the turn): long patience so a sibling legitimately
@@ -431,6 +452,8 @@ class SessionMessagesMixin:
                 session_id, role, msg, tool_calls, message_timestamp, keep_reasoning=role == "assistant"))
             if cur.lastrowid is not None:
                 msg["_row_id"] = cur.lastrowid
+                self._inherit_composite_display_order(
+                    conn, int(cur.lastrowid), session_id, msg, message_timestamp, tool_calls)
             inserted += 1
             tool_calls_total += _tool_calls_count(tool_calls)
             now_ts = max(now_ts, message_timestamp) + 1e-6
@@ -583,6 +606,19 @@ class SessionMessagesMixin:
             ") AND content IS ?",
             (_scrub_surrogates(api_content), session_id, self._encode_content(content)))
 
+    def _display_dedupe_key(self, row) -> Tuple[Any, ...]:
+        """Historical display identity, including normalized live content from user handoff carriers."""
+        dedupe_content = row["content"]
+        if row["role"] == "user":
+            handoff, live_view = split_user_originated_turn({
+                "role": "user", "content": self._decode_content(row["content"]),
+                "display_kind": row["display_kind"],
+                "display_metadata": self._decode_display_metadata(row["display_metadata"])})
+            if handoff is not None and live_view is not None:
+                dedupe_content = self._encode_content(live_view.get("content"))
+        return (row["role"], dedupe_content, row["timestamp"],
+                row["tool_call_id"], row["tool_calls"], row["tool_name"])
+
     def _dedupe_display_generations(self, rows):
         """Collapse compaction generations so each logical message appears once (the protected tail is copied
         into each generation: same role/content/timestamp, different ``active``/id); prefer the live row, then
@@ -590,18 +626,7 @@ class SessionMessagesMixin:
         seen: Dict[Tuple[Any, ...], Any] = {}
         first_id: Dict[Tuple[Any, ...], int] = {}
         for row in rows:
-            dedupe_content = row["content"]
-            if row["role"] == "user":
-                handoff, live_view = split_user_originated_turn({
-                    "role": "user", "content": self._decode_content(row["content"]),
-                    "display_kind": row["display_kind"],
-                    "display_metadata": self._decode_display_metadata(row["display_metadata"])})
-                if handoff is not None and live_view is not None:
-                    dedupe_content = self._encode_content(live_view.get("content"))
-            # Tool fields key too: identical tool messages collapse, distinct calls with equal
-            # role/content/timestamp never merge.
-            key = (row["role"], dedupe_content, row["timestamp"],
-                row["tool_call_id"], row["tool_calls"], row["tool_name"])
+            key = self._display_dedupe_key(row)
             cur = seen.get(key)
             if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
                 seen[key] = row
@@ -609,6 +634,36 @@ class SessionMessagesMixin:
         # Order by the logical message's FIRST row, not the chosen representative's: a protected-tail
         # copy in a newer generation has a higher id than messages emitted after the original.
         return [seen[key] for key in sorted(seen, key=first_id.__getitem__)]
+
+    def _ensure_display_order(self, session_id: str) -> bool:
+        """Backfill one legacy session once, preserving the pre-index display identity exactly."""
+        missing_sql = (
+            "SELECT 1 FROM messages WHERE session_id = ? AND (active = 1 OR compacted = 1) "
+            "AND display_order IS NULL LIMIT 1")
+        if self._read_one(missing_sql, (session_id,)) is None:
+            return True
+        if getattr(self, "read_only", False):
+            return False
+
+        def _do(conn):
+            missing = conn.execute(missing_sql, (session_id,)).fetchone()
+            if missing is None:
+                return True
+            rows = conn.execute(
+                "SELECT * FROM messages WHERE session_id = ? AND (active = 1 OR compacted = 1) ORDER BY id",
+                (session_id,)).fetchall()
+            first_id: Dict[Tuple[Any, ...], int] = {}
+            keyed_rows = []
+            for row in rows:
+                key = self._display_dedupe_key(row)
+                first_id[key] = min(first_id.get(key, row["id"]), row["id"])
+                keyed_rows.append((row["id"], key))
+            conn.executemany(
+                "UPDATE messages SET display_order = ? WHERE id = ?",
+                [(first_id[key], row_id) for row_id, key in keyed_rows])
+            return True
+
+        return bool(self._execute_write(_do))
 
     def _row_to_message_dict(self, row, *, warn_context: str, summary_flag: bool) -> Dict[str, Any]:
         """``dict(row)`` with content/tool_calls/display_metadata decoded; *summary_flag* keeps
@@ -640,8 +695,26 @@ class SessionMessagesMixin:
         if after_id is not None and include_compacted:
             raise ValueError("after_id is incompatible with include_compacted (deduped display reads use offset paging)")
         active_clause = self._active_clause(include_inactive, include_compacted)
-        if include_compacted:
-            # Full display set (the UI row cap lives in the endpoint), dedupe, then page ([:None] is a no-op).
+        if include_compacted and not include_inactive and self._ensure_display_order(session_id):
+            direction = "DESC" if latest else "ASC"
+            sql = f"""WITH page AS (
+                    SELECT display_order FROM messages
+                    WHERE session_id = ? AND (active = 1 OR compacted = 1)
+                    GROUP BY display_order ORDER BY display_order {direction}
+                    LIMIT ? OFFSET ?
+                )
+                SELECT chosen.* FROM page
+                JOIN messages AS chosen ON chosen.id = (
+                    SELECT candidate.id FROM messages AS candidate
+                    WHERE candidate.session_id = ?
+                      AND candidate.display_order = page.display_order
+                      AND (candidate.active = 1 OR candidate.compacted = 1)
+                    ORDER BY candidate.active DESC, candidate.id DESC LIMIT 1
+                )
+                ORDER BY page.display_order ASC"""
+            rows = self._read_all(sql, [session_id, -1 if limit is None else limit, offset, session_id])
+        elif include_compacted:
+            # Read-only legacy stores cannot persist display identities; retain the exact old projection.
             rows = self._dedupe_display_generations(self._read_all(
                 "SELECT * FROM messages WHERE session_id = ?" + active_clause + " ORDER BY id ASC", [session_id]))
             rows = rows[::-1][offset:][:limit][::-1] if latest else rows[offset:][:limit]

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -3,6 +3,7 @@ replayed-user dedupe. Mixin bound via the MRO, built on SessionDB's _read_ctx/_e
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import time
@@ -21,8 +22,9 @@ logger = logging.getLogger("hermes_state")  # caplog tests pin the origin module
 _INSERT_MESSAGE_SQL = """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, _compressed_summary, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+                   codex_message_items, platform_message_id, observed, _compressed_summary, active, api_content, display_kind,
+                   display_metadata, display_identity)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
 _BUMP_GENERATION_SQL = """
             INSERT INTO conversation_generations (source, session_key, generation)
             VALUES (?, ?, 1)
@@ -56,7 +58,11 @@ def _coerce_timestamp(value: Any, default: float) -> float:
     if value is None:
         return default
     try:
-        return float(value.timestamp()) if hasattr(value, "timestamp") else float(value)
+        result = float(value.timestamp()) if hasattr(value, "timestamp") else float(value)
+        # SQLite reads both signed zero spellings back as 0.0. Hash the value
+        # in that stored form so -0.0 and 0.0 retain the historical SQL/Python
+        # identity equality.
+        return 0.0 if result == 0.0 else result
     except (TypeError, ValueError):
         logger.debug("Ignoring invalid explicit message timestamp: %r", value)
         return default
@@ -238,8 +244,18 @@ class SessionMessagesMixin:
         ``message_id`` (yuanbao's message-dict convention)."""
         _str_or_none = lambda v: _scrub_surrogates(v) if isinstance(v, str) else None  # noqa: E731
         _reasoning = lambda key: msg.get(key) if keep_reasoning else None  # noqa: E731
-        return (session_id, role, self._encode_content(msg.get("content")), msg.get("tool_call_id"),
-            json.dumps(tool_calls) if tool_calls else None, _scrub_surrogates(msg.get("tool_name")),
+        encoded_content = self._encode_content(msg.get("content"))
+        encoded_tool_calls = json.dumps(tool_calls) if tool_calls else None
+        encoded_tool_name = _scrub_surrogates(msg.get("tool_name"))
+        display_metadata = self._encode_display_metadata(msg.get("display_metadata"))
+        identity_row = {
+            "role": role, "content": encoded_content, "timestamp": message_timestamp,
+            "tool_call_id": msg.get("tool_call_id"), "tool_calls": encoded_tool_calls,
+            "tool_name": encoded_tool_name, "display_kind": msg.get("display_kind"),
+            "display_metadata": display_metadata,
+        }
+        return (session_id, role, encoded_content, msg.get("tool_call_id"),
+            encoded_tool_calls, encoded_tool_name,
             msg.get("effect_disposition"), message_timestamp, msg.get("token_count"), msg.get("finish_reason"),
             _scrub_surrogates(_reasoning("reasoning")), _scrub_surrogates(_reasoning("reasoning_content")),
             *(self._reasoning_json_text(_reasoning(k))
@@ -247,24 +263,7 @@ class SessionMessagesMixin:
             msg.get("platform_message_id") or msg.get("message_id"),
             1 if msg.get("observed") else 0, 1 if msg.get("_compressed_summary") else 0, 1,
             _str_or_none(msg.get("api_content")), _str_or_none(msg.get("display_kind")),
-            self._encode_display_metadata(msg.get("display_metadata")))
-
-    def _inherit_composite_display_order(self, conn, row_id: int, session_id: str, msg: Dict[str, Any],
-                                         message_timestamp: float, tool_calls: Any) -> None:
-        handoff, live_view = split_user_originated_turn(msg)
-        if handoff is None or live_view is None:
-            return
-        encoded_content = self._encode_content(live_view.get("content"))
-        encoded_tool_calls = json.dumps(tool_calls) if tool_calls else None
-        row = conn.execute(
-            "SELECT MIN(COALESCE(display_order, id)) FROM messages "
-            "WHERE session_id = ? AND id <> ? AND (active = 1 OR compacted = 1) "
-            "AND role = 'user' AND content IS ? AND timestamp IS ? AND tool_call_id IS ? "
-            "AND tool_calls IS ? AND tool_name IS ?",
-            (session_id, row_id, encoded_content, message_timestamp, msg.get("tool_call_id"),
-             encoded_tool_calls, msg.get("tool_name"))).fetchone()
-        if row is not None and row[0] is not None:
-            conn.execute("UPDATE messages SET display_order = ? WHERE id = ?", (row[0], row_id))
+            display_metadata, self._display_identity(self._display_dedupe_key(identity_row)))
 
     @staticmethod
     def _bump_session_counters(conn, session_id: str, inserted: int, tool_calls: int, *, unit: bool) -> None:
@@ -302,9 +301,6 @@ class SessionMessagesMixin:
             self._check_transcript_write_guards(conn, session_id, compression_lock_holder,
                 turn_lease_holder=turn_lease_holder, turn_lease_ttl_seconds=turn_lease_ttl_seconds)
             msg_id = conn.execute(_INSERT_MESSAGE_SQL, params).lastrowid
-            if msg_id is not None:
-                self._inherit_composite_display_order(
-                    conn, int(msg_id), session_id, msg, message_timestamp, tool_calls)
             self._bump_session_counters(conn, session_id, 1, _tool_calls_count(tool_calls), unit=True)
             return msg_id
         # THE critical write (failure aborts the turn): long patience so a sibling legitimately
@@ -452,8 +448,6 @@ class SessionMessagesMixin:
                 session_id, role, msg, tool_calls, message_timestamp, keep_reasoning=role == "assistant"))
             if cur.lastrowid is not None:
                 msg["_row_id"] = cur.lastrowid
-                self._inherit_composite_display_order(
-                    conn, int(cur.lastrowid), session_id, msg, message_timestamp, tool_calls)
             inserted += 1
             tool_calls_total += _tool_calls_count(tool_calls)
             now_ts = max(now_ts, message_timestamp) + 1e-6
@@ -517,10 +511,13 @@ class SessionMessagesMixin:
         return [int(r["id"]) for r in rows], sum(_tool_calls_len(r["tool_calls"]) for r in rows)
 
     def _clone_message_rows(self, conn, tail_ids: List[int], *, session_id: Optional[str] = None) -> None:
-        """Pure-SQL clone of *tail_ids* as fresh live rows (new id, active=1, compacted=0, all else byte-exact;
-        FTS triggers index the clones), into *session_id* when given."""
+        """Pure-SQL clone of *tail_ids* as fresh live rows (new id/display order, active=1, compacted=0;
+        message payload columns stay byte-exact and FTS triggers index the clones), into *session_id* when given."""
         retarget = session_id is not None
-        skip = ("id", "active", "compacted") + (("session_id",) if retarget else ())
+        # A clone is a newly positioned display generation. Copy its indexed
+        # identity, but let the insert trigger assign order from rows that are
+        # still display-visible (the source may just have become rewind-only).
+        skip = ("id", "active", "compacted", "display_order") + (("session_id",) if retarget else ())
         col_list = ", ".join(c for c in self._message_column_names(conn) if c not in skip)
         conn.execute(
             f"INSERT INTO messages ({col_list}, {'session_id, ' if retarget else ''}active, compacted) "
@@ -619,6 +616,11 @@ class SessionMessagesMixin:
         return (row["role"], dedupe_content, row["timestamp"],
                 row["tool_call_id"], row["tool_calls"], row["tool_name"])
 
+    @staticmethod
+    def _display_identity(key: Tuple[Any, ...]) -> bytes:
+        """Fixed-width durable identity for indexed display-generation lookup."""
+        return hashlib.sha256(repr(key).encode("utf-8", "surrogatepass")).digest()
+
     def _dedupe_display_generations(self, rows):
         """Collapse compaction generations so each logical message appears once (the protected tail is copied
         into each generation: same role/content/timestamp, different ``active``/id); prefer the live row, then
@@ -637,9 +639,13 @@ class SessionMessagesMixin:
 
     def _ensure_display_order(self, session_id: str) -> bool:
         """Backfill one legacy session once, preserving the pre-index display identity exactly."""
+        with self._read_ctx() as conn:
+            columns = set(self._message_column_names(conn))
+        if not {"display_order", "display_identity"} <= columns:
+            return False
         missing_sql = (
             "SELECT 1 FROM messages WHERE session_id = ? AND (active = 1 OR compacted = 1) "
-            "AND display_order IS NULL LIMIT 1")
+            "AND (display_order IS NULL OR display_identity IS NULL) LIMIT 1")
         if self._read_one(missing_sql, (session_id,)) is None:
             return True
         if getattr(self, "read_only", False):
@@ -659,8 +665,8 @@ class SessionMessagesMixin:
                 first_id[key] = min(first_id.get(key, row["id"]), row["id"])
                 keyed_rows.append((row["id"], key))
             conn.executemany(
-                "UPDATE messages SET display_order = ? WHERE id = ?",
-                [(first_id[key], row_id) for row_id, key in keyed_rows])
+                "UPDATE messages SET display_order = ?, display_identity = ? WHERE id = ?",
+                [(first_id[key], self._display_identity(key), row_id) for row_id, key in keyed_rows])
             return True
 
         return bool(self._execute_write(_do))
@@ -669,6 +675,8 @@ class SessionMessagesMixin:
         """``dict(row)`` with content/tool_calls/display_metadata decoded; *summary_flag* keeps
         ``_compressed_summary`` only as ``True``."""
         msg = dict(row)
+        msg.pop("display_identity", None)
+        msg.pop("display_order", None)
         if summary_flag and msg.pop("_compressed_summary", 0):
             msg["_compressed_summary"] = True
         msg["content"] = self._decode_content(msg["content"])

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -12,6 +12,9 @@ soft-deleted Undo/Rewind rows (``active=0, compacted=0``) — that remains the
 job of ``include_inactive`` (audit / debug reads).
 """
 
+import json
+import sqlite3
+
 import pytest
 
 from agent.context_compressor import (
@@ -179,6 +182,61 @@ class TestDisplayDedupe:
         large_steps = progress_steps("large")
         assert large_steps < small_steps * 3
 
+    def test_append_display_identity_work_is_bounded_by_an_index(self, db):
+        def seed(sid, count):
+            db.create_session(sid, source="desktop")
+            db._execute_write(lambda conn: conn.executemany(
+                "INSERT INTO messages (session_id, role, content, timestamp, display_order) "
+                "VALUES (?, 'assistant', ?, ?, ?)",
+                [(sid, f"row-{index}", 100_000.0, index + 1) for index in range(count)],
+            ))
+
+        seed("write-small", 2_000)
+        seed("write-large", 20_000)
+        db._wal_active = False
+
+        def append_steps(sid):
+            callbacks = 0
+
+            def progress():
+                nonlocal callbacks
+                callbacks += 1
+                return 0
+
+            db._conn.set_progress_handler(progress, 10)
+            try:
+                db.append_message(sid, role="user", content="fresh", timestamp=100_000.0)
+            finally:
+                db._conn.set_progress_handler(None, 0)
+            return callbacks
+
+        small_steps = append_steps("write-small")
+        large_steps = append_steps("write-large")
+        assert large_steps < small_steps * 3
+
+    def test_display_identity_normalizes_sql_values_and_stays_internal(self, db, tmp_path):
+        sid = "stored-values"
+        db.create_session(sid, source="desktop")
+        db.append_message(sid, role="assistant", content="same", timestamp=-0.0)
+        newest_id = db.append_message(sid, role="assistant", content="same", timestamp=0.0)
+
+        messages = db.get_messages(sid, include_compacted=True)
+        assert [message["id"] for message in messages] == [newest_id]
+        assert "display_identity" not in messages[0]
+        assert "display_order" not in messages[0]
+        json.dumps(messages)
+
+        path = tmp_path / "current-read-only.db"
+        current = SessionDB(path)
+        current.create_session("current", source="desktop")
+        current.append_message("current", role="user", content="serializable")
+        current.close()
+        reader = SessionDB(path, read_only=True)
+        try:
+            json.dumps(reader.get_messages("current", include_compacted=True))
+        finally:
+            reader.close()
+
     def test_composite_handoff_keeps_live_turn_identity_and_first_position(self, db):
         sid = "composite"
         db.create_session(sid, source="desktop")
@@ -205,6 +263,101 @@ class TestDisplayDedupe:
         assert [message["id"] for message in messages] == [carrier_id, later_id]
         assert messages[0]["content"] == carrier
         assert original_id not in [message["id"] for message in messages]
+
+    @pytest.mark.parametrize("carrier_first", [False, True])
+    def test_composite_identity_is_symmetric_and_tracks_identity_updates(self, db, carrier_first):
+        sid = f"composite-{'carrier' if carrier_first else 'raw'}-first"
+        db.create_session(sid, source="desktop")
+        carrier = (
+            f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+            "live ask\n\n"
+            f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+        contents = [carrier, "live ask"] if carrier_first else ["live ask", carrier]
+        first_id = db.append_message(sid, role="user", content=contents[0], timestamp=100.0)
+        middle_id = db.append_message(sid, role="assistant", content="middle", timestamp=200.0)
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET active = 0, compacted = 0 WHERE id = ?", (first_id,)))
+        second_id = db.append_message(sid, role="user", content=contents[1], timestamp=100.0)
+        assert [message["id"] for message in db.get_messages(
+            sid, include_compacted=True)] == [middle_id, second_id]
+
+        # Making the first generation display-visible later must not split the
+        # identity that was assigned while it was hidden.
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET compacted = 1 WHERE id = ?", (first_id,)))
+        assert [message["id"] for message in db.get_messages(
+            sid, include_compacted=True)] == [second_id, middle_id]
+
+        # Hiding the earliest generation again must advance the group's order
+        # to its first still-visible row.
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET compacted = 0 WHERE id = ?", (first_id,)))
+        assert [message["id"] for message in db.get_messages(
+            sid, include_compacted=True)] == [middle_id, second_id]
+
+        # Identity-field updates invalidate the durable grouping; the next
+        # display read rebuilds it from the canonical key before paging.
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET role = 'assistant', content = 'middle', timestamp = 200.0 "
+            "WHERE id = ?", (second_id,)))
+        assert [message["id"] for message in db.get_messages(
+            sid, include_compacted=True)] == [second_id]
+        db._execute_write(lambda conn: conn.execute(
+            "DELETE FROM messages WHERE id = ?", (second_id,)))
+        assert [message["id"] for message in db.get_messages(
+            sid, include_compacted=True)] == [middle_id]
+
+    def test_legacy_store_is_readable_then_lazily_migrated(self, tmp_path):
+        path = tmp_path / "legacy.db"
+        writer = SessionDB(path)
+        writer.create_session("legacy", source="desktop")
+        writer.append_message("legacy", role="assistant", content="same", timestamp=1.0)
+        writer.append_message("legacy", role="assistant", content="same", timestamp=1.0)
+        new_store_missing = writer._read_one(
+            "SELECT COUNT(*) FROM messages "
+            "WHERE display_order IS NULL OR display_identity IS NULL")
+        assert new_store_missing is not None and new_store_missing[0] == 0
+        writer.close()
+
+        conn = sqlite3.connect(path)
+        conn.execute("DROP TRIGGER IF EXISTS messages_display_order_insert")
+        conn.execute("DROP TRIGGER IF EXISTS messages_display_visibility_update")
+        conn.execute("DROP TRIGGER IF EXISTS messages_display_identity_update")
+        conn.execute("DROP TRIGGER IF EXISTS messages_display_identity_delete")
+        conn.execute("DROP INDEX IF EXISTS idx_messages_display_page")
+        conn.execute("DROP INDEX IF EXISTS idx_messages_display_backfill")
+        conn.execute("DROP INDEX IF EXISTS idx_messages_display_identity")
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(messages)")}
+        for column in ("display_order", "display_identity"):
+            if column in columns:
+                conn.execute(f"ALTER TABLE messages DROP COLUMN {column}")
+        conn.commit()
+        conn.close()
+
+        reader = SessionDB(path, read_only=True)
+        try:
+            legacy_messages = reader.get_messages("legacy", include_compacted=True)
+            assert len(legacy_messages) == 1
+            json.dumps(legacy_messages)
+            assert "display_order" not in {
+                row[1] for row in reader._conn.execute("PRAGMA table_info(messages)")}
+        finally:
+            reader.close()
+
+        migrated = SessionDB(path)
+        try:
+            assert len(migrated.get_messages("legacy", include_compacted=True)) == 1
+            columns = {row[1] for row in migrated._conn.execute("PRAGMA table_info(messages)")}
+            assert {"display_order", "display_identity"} <= columns
+            assert migrated._conn.execute(
+                "SELECT COUNT(*) FROM messages "
+                "WHERE display_order IS NULL OR display_identity IS NULL").fetchone()[0] == 0
+        finally:
+            migrated.close()
 
     def test_copied_protected_tail_is_surfaced_once(self, db):
         """A message copied across compaction epochs appears exactly once."""

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -14,6 +14,13 @@ job of ``include_inactive`` (audit / debug reads).
 
 import pytest
 
+from agent.context_compressor import (
+    HISTORICAL_TASK_HEADING,
+    SUMMARY_PREFIX,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
+    _SUMMARY_END_MARKER,
+)
 from hermes_state import SessionDB
 
 
@@ -139,6 +146,65 @@ class TestDisplayDedupe:
             )
 
         db._execute_write(_do)
+
+    def test_latest_bounded_page_has_bounded_database_work(self, db):
+        for sid, count in (("small", 2_000), ("large", 20_000)):
+            db.create_session(sid, source="desktop")
+            db.append_messages_batch(
+                sid,
+                [{"role": "assistant", "content": f"row-{index}"} for index in range(count)],
+                chunk_rows=500,
+            )
+
+        db._wal_active = False
+
+        def progress_steps(sid):
+            callbacks = 0
+
+            def progress():
+                nonlocal callbacks
+                callbacks += 1
+                return 0
+
+            db._conn.set_progress_handler(progress, 100)
+            try:
+                page = db.get_messages(
+                    sid, include_compacted=True, latest=True, limit=120)
+            finally:
+                db._conn.set_progress_handler(None, 0)
+            assert len(page) == 120
+            return callbacks
+
+        small_steps = progress_steps("small")
+        large_steps = progress_steps("large")
+        assert large_steps < small_steps * 3
+
+    def test_composite_handoff_keeps_live_turn_identity_and_first_position(self, db):
+        sid = "composite"
+        db.create_session(sid, source="desktop")
+        original_id = db.append_message(sid, role="user", content="live ask", timestamp=100.0)
+        later_id = db.append_message(sid, role="assistant", content="later answer", timestamp=200.0)
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET active = 0, compacted = 1 WHERE session_id = ?", (sid,)))
+        carrier = (
+            f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+            "live ask\n\n"
+            f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+        carrier_id = db.append_message(sid, role="user", content=carrier, timestamp=100.0)
+        # Simulate rows written before display_order existed; lazy backfill must use
+        # the same normalized user-turn key as the historical Python projection.
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET display_order = NULL WHERE session_id = ?", (sid,)))
+
+        messages = db.get_messages(sid, include_compacted=True)
+
+        assert [message["id"] for message in messages] == [carrier_id, later_id]
+        assert messages[0]["content"] == carrier
+        assert original_id not in [message["id"] for message in messages]
 
     def test_copied_protected_tail_is_surfaced_once(self, db):
         """A message copied across compaction epochs appears exactly once."""


### PR DESCRIPTION
## Cause
Compacted display-history reads materialized and deduplicated the entire session before applying the requested page limit.

## Fix
Persist indexed logical display identity and ordering, preserving the canonical normalized raw/composite user identity, first-visible order and active/newest representative. Inserts use a fixed-width indexed lookup rather than a session scan. Identity changes invalidate the affected projection for lazy canonical repair; visibility changes, deletes and clones preserve ordering.

Legacy writable sessions are backfilled on demand. Read-only stores without projection columns retain their existing display read. Internal index fields never escape message JSON. Signed-zero timestamps preserve SQL/Python equality.

## Parent acceptance on 1586c466afa0c1ed06049cb3a3e684de0e91083a
- Personally inspected the final production diff.
- Canonical `scripts/run_tests.sh tests/hermes_state/`: 307 passed, 2 skipped, 0 failed.
- Independent seeded differential oracle: 100 insert/copy/archive/update/delete steps, 1600 page comparisons against canonical deduplication, all passed.
- Independently reproduced then verified repair of internal BLOB JSON failure and signed-zero duplicate rows.
- INSERT probe on 2k/20k rows: 64/63 SQLite progress callbacks (10 instructions per callback); query plan uses idx_messages_display_identity.
- Newest-120 read probe across 120/2k/10k rows: 121/120/121 callbacks (100 instructions per callback), correct page boundaries.
- git diff --check passed.

## Limits
Legacy backfill and projection repair after identity edits still scan the affected session once; this is not a claim that all history operations are constant-time. Runtime measurements used temporary databases, not a user's live state.

Closes #106137
