### PR TITLE
fix(gateway): bound reconnect replay payload bytes

### DIFF
--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -204,3 +204,14 @@ def test_truncation_detection_semantics():
     assert event_replay.is_truncated("s1", 5)
     # Unknown session: nothing evicted, nothing truncated.
     assert not event_replay.is_truncated("nope", 0)
+
+
+def test_oversized_gap_watermark_never_moves_backwards(monkeypatch):
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_MAX", 1)
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 1000)
+    event_replay._stamp_event(_frame("s"))
+    large = _frame("s")
+    large["params"]["payload"] = {"data": "x" * 2000}
+    event_replay._stamp_event(large)
+    event_replay._stamp_event(_frame("s"))
+    assert event_replay.is_truncated("s", 1)

--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -135,6 +135,58 @@ def test_concurrent_stamping_never_drops_or_duplicates_seq():
     assert replay_stats()["events"] == 8 * 200
 
 
+def test_byte_budget_evicts_payloads_and_preserves_gap_semantics(monkeypatch):
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 700)
+    monkeypatch.setattr(event_replay, "_REPLAY_PROCESS_BYTES_MAX", 5_000)
+
+    first = _frame("s1", "tool.complete")
+    first["params"]["payload"] = {"result": "x" * 400}
+    second = _frame("s1", "tool.complete")
+    second["params"]["payload"] = {"result": "y" * 400}
+    event_replay._stamp_event(first)
+    event_replay._stamp_event(second)
+
+    stats = replay_stats()
+    assert stats["bytes"] <= stats["max_bytes_per_session"]
+    assert [event["seq"] for event in events_since("s1", 0)] == [2]
+    assert event_replay.is_truncated("s1", 0)
+
+    reset_replay_state()
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 1_000)
+    monkeypatch.setattr(event_replay, "_REPLAY_PROCESS_BYTES_MAX", 700)
+    first = _frame("s1", "tool.complete")
+    first["params"]["payload"] = {"result": "x" * 400}
+    event_replay._stamp_event(first)
+    other = _frame("s2", "tool.complete")
+    other["params"]["payload"] = {"result": "y" * 400}
+    event_replay._stamp_event(other)
+
+    stats = replay_stats()
+    assert stats["bytes"] <= stats["max_bytes_process"]
+    assert events_since("s1", 0) == []
+    assert event_replay.is_truncated("s1", 0)
+    assert [event["seq"] for event in events_since("s2", 0)] == [1]
+
+
+def test_oversized_event_marks_gap_even_with_empty_buffer(monkeypatch):
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 300)
+    monkeypatch.setattr(event_replay, "_REPLAY_PROCESS_BYTES_MAX", 300)
+
+    oversized = _frame("s1", "tool.complete")
+    oversized["params"]["payload"] = {"result": "x" * 1000}
+    event_replay._stamp_event(oversized)
+
+    assert events_since("s1", 0) == []
+    assert event_replay.is_truncated("s1", 0)
+    assert not event_replay.is_truncated("s1", 1)
+
+    event_replay._stamp_event(_frame("s1"))
+    assert [event["seq"] for event in events_since("s1", 0)] == [2]
+    assert event_replay.is_truncated("s1", 0)
+    assert not event_replay.is_truncated("s1", 1)
+    assert not event_replay.is_truncated("s1", 2)
+
+
 def test_truncation_detection_semantics():
     """The RPC handler's truncated flag: gap between last_seen and buffer start."""
     # Overflow the ring so the oldest events are genuinely evicted.

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -77,14 +77,14 @@ def _stamp_event(obj: dict) -> None:
             evicted_seq, _event, evicted_size = buf.popleft()
             _replay_buffer_bytes[sid] -= evicted_size
             _replay_total_bytes -= evicted_size
-            _replay_evicted_through[sid] = evicted_seq
+            _replay_evicted_through[sid] = max(_replay_evicted_through.get(sid, 0), evicted_seq)
         while _replay_total_bytes > _REPLAY_PROCESS_BYTES_MAX:
             for evict_sid, evict_buf in _replay_buffers.items():
                 if evict_buf:
                     evicted_seq, _event, evicted_size = evict_buf.popleft()
                     _replay_buffer_bytes[evict_sid] -= evicted_size
                     _replay_total_bytes -= evicted_size
-                    _replay_evicted_through[evict_sid] = evicted_seq
+                    _replay_evicted_through[evict_sid] = max(_replay_evicted_through.get(evict_sid, 0), evicted_seq)
                     break
 
 

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -10,6 +10,7 @@ _REPLAY_BUFFER_MAX events x _REPLAY_SESSIONS_MAX sessions, oldest session evicte
 
 from __future__ import annotations
 
+import json
 import threading
 import uuid
 from collections import OrderedDict, deque
@@ -19,15 +20,18 @@ from collections import OrderedDict, deque
 # epoch lets clients detect the restart and reset their watermarks.
 _REPLAY_EPOCH = uuid.uuid4().hex
 
-# A long turn emits ~hundreds of token events; 512 covers minutes of streaming plus
-# all control events. Desktop users rarely exceed a dozen live chats.
+# Count limits protect control-frame churn; byte limits protect large tool results.
 _REPLAY_BUFFER_MAX = 512
 _REPLAY_SESSIONS_MAX = 64
+_REPLAY_BUFFER_BYTES_MAX = 4 * 1024 * 1024
+_REPLAY_PROCESS_BYTES_MAX = 64 * 1024 * 1024
 
 _replay_lock = threading.Lock()
-# sid -> deque of (seq, params dict) — the bare event (type/session_id/seq/payload),
-# the exact shape the client's dispatch path consumes.
+# sid -> deque of (seq, params dict, serialized bytes).
 _replay_buffers: "OrderedDict[str, deque]" = OrderedDict()
+_replay_buffer_bytes: dict[str, int] = {}
+_replay_evicted_through: dict[str, int] = {}
+_replay_total_bytes = 0
 _replay_next_seq: dict[str, int] = {}
 
 
@@ -48,16 +52,40 @@ def _stamp_event(obj: dict) -> None:
         # Session-less global events (skin.changed etc.) are re-fetchable via their own RPCs.
         return
     with _replay_lock:
+        global _replay_total_bytes
         seq = _replay_next_seq.get(sid, 0) + 1
         _replay_next_seq[sid] = seq
         params["seq"] = seq
+        size = len(json.dumps(params, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8", errors="surrogatepass"))
         buf = _replay_buffers.get(sid)
         if buf is None:
-            buf = _replay_buffers[sid] = deque(maxlen=_REPLAY_BUFFER_MAX)
+            buf = _replay_buffers[sid] = deque()
+            _replay_buffer_bytes[sid] = 0
             while len(_replay_buffers) > _REPLAY_SESSIONS_MAX:
-                _oldest_sid, _oldest_buf = _replay_buffers.popitem(last=False)
-                _replay_next_seq.pop(_oldest_sid, None)
-        buf.append((seq, params))
+                oldest_sid, oldest_buf = _replay_buffers.popitem(last=False)
+                _replay_total_bytes -= _replay_buffer_bytes.pop(oldest_sid, 0)
+                _replay_next_seq.pop(oldest_sid, None)
+                _replay_evicted_through.pop(oldest_sid, None)
+        if size > _REPLAY_BUFFER_BYTES_MAX or size > _REPLAY_PROCESS_BYTES_MAX:
+            _replay_evicted_through[sid] = seq
+            return
+        buf.append((seq, params, size))
+        _replay_buffer_bytes[sid] += size
+        _replay_total_bytes += size
+        while len(buf) > _REPLAY_BUFFER_MAX or _replay_buffer_bytes[sid] > _REPLAY_BUFFER_BYTES_MAX:
+            evicted_seq, _event, evicted_size = buf.popleft()
+            _replay_buffer_bytes[sid] -= evicted_size
+            _replay_total_bytes -= evicted_size
+            _replay_evicted_through[sid] = evicted_seq
+        while _replay_total_bytes > _REPLAY_PROCESS_BYTES_MAX:
+            for evict_sid, evict_buf in _replay_buffers.items():
+                if evict_buf:
+                    evicted_seq, _event, evicted_size = evict_buf.popleft()
+                    _replay_buffer_bytes[evict_sid] -= evicted_size
+                    _replay_total_bytes -= evicted_size
+                    _replay_evicted_through[evict_sid] = evicted_seq
+                    break
 
 
 def events_since(sid: str, last_seen: int) -> list[dict]:
@@ -68,15 +96,14 @@ def events_since(sid: str, last_seen: int) -> list[dict]:
     """
     with _replay_lock:
         buf = _replay_buffers.get(sid or "")
-        return [event for seq, event in buf if seq > last_seen] if buf else []
+        return [event for seq, event, _size in buf if seq > last_seen] if buf else []
 
 
 def is_truncated(sid: str, last_seen: int) -> bool:
     """True when events between *last_seen* and the ring's oldest retained seq were
     evicted — the client must refetch history instead of trusting the replay."""
     with _replay_lock:
-        buf = _replay_buffers.get(sid or "")
-        return bool(buf) and last_seen + 1 < buf[0][0]
+        return last_seen < _replay_evicted_through.get(sid or "", 0)
 
 
 def latest_seq(sid: str) -> int:
@@ -88,8 +115,12 @@ def latest_seq(sid: str) -> int:
 def reset_replay_state() -> None:
     """Test hook."""
     with _replay_lock:
+        global _replay_total_bytes
         _replay_buffers.clear()
+        _replay_buffer_bytes.clear()
+        _replay_evicted_through.clear()
         _replay_next_seq.clear()
+        _replay_total_bytes = 0
 
 
 def replay_stats() -> dict:
@@ -97,5 +128,8 @@ def replay_stats() -> dict:
     with _replay_lock:
         return {
             "sessions": len(_replay_buffers),
-            "events": sum(len(b) for b in _replay_buffers.values()),
-            "max_per_session": _REPLAY_BUFFER_MAX}
+            "events": sum(len(buffer) for buffer in _replay_buffers.values()),
+            "bytes": _replay_total_bytes,
+            "max_per_session": _REPLAY_BUFFER_MAX,
+            "max_bytes_per_session": _REPLAY_BUFFER_BYTES_MAX,
+            "max_bytes_process": _REPLAY_PROCESS_BYTES_MAX}


### PR DESCRIPTION
Fixes #106139

## Failure mode

Reconnect replay was bounded only by a 512-frame deque. A small number of large tool-result events could therefore retain far more memory than the frame count suggested, and several live sessions could multiply that cost process-wide.

Truncation also depended on the oldest frame still present in a non-empty deque. If an oversized event could not be retained—or eviction emptied the buffer—the gateway lost the evidence that a client watermark had fallen behind and could incorrectly report a complete replay.

## Replay contract

This PR keeps the existing sequence and epoch model, but adds explicit byte accounting:

- **4 MiB per session**;
- **64 MiB process-wide**;
- the existing **512-frame** and **64-session** limits remain in place.

Each retained frame records its serialized size. Admission and eviction update both session and process totals, while an independent `evicted_through` watermark records the highest sequence that is no longer replayable. Oversized events still advance the sequence and watermark even when no frame can be stored.

`events_since()` continues to return the same event shape. `is_truncated()` now compares the caller's `last_seen` value with durable in-memory eviction evidence rather than inferring a gap from current buffer contents.

## Correctness edges

- A later small event can be retained after an oversized event without erasing the earlier gap.
- The eviction watermark is monotonic even when an oversized sequence is followed by count- or byte-based eviction of an older retained frame.
- Session and process ceilings are enforced independently.

## Verification

- Coverage exercises both byte budgets, an oversized event leaving an empty buffer, a later accepted frame, and `last_seen` values before, at, and after the dropped sequence.
- A follow-up RED/GREEN regression covers the non-monotonic watermark edge.
- Full replay test file: **12 passed**.
- A boundary probe retained **63 of 512** 64 KiB frames while staying inside the configured budget and reporting truncation.