### PR TITLE
fix(gateway): isolate global broadcasts from slow peers

### DIFF
--- a/.github/.attribution-refresh-106142
+++ b/.github/.attribution-refresh-106142
@@ -1,1 +1,0 @@
-temporary GitHub attribution refresh for PR 106142

--- a/.github/.attribution-refresh-106142
+++ b/.github/.attribution-refresh-106142
@@ -1,0 +1,1 @@
+temporary GitHub attribution refresh for PR 106142

--- a/tests/tui_gateway/test_global_coalescing.py
+++ b/tests/tui_gateway/test_global_coalescing.py
@@ -1,0 +1,70 @@
+import threading
+
+from tui_gateway.transport import FanoutTransport
+
+
+def test_global_coalescing_preserves_distinct_reclaimed_sessions():
+    entered = threading.Event()
+    release = threading.Event()
+    done = threading.Event()
+    received = []
+
+    class Peer:
+        def close(self):
+            pass
+
+        def write(self, obj: dict) -> bool:
+            frame = obj
+            if not received:
+                entered.set()
+                assert release.wait(3)
+            received.append(frame)
+            if len(received) == 3:
+                done.set()
+            return True
+
+    fanout = FanoutTransport(Peer(), coalesce_events=True)
+    try:
+        fanout.write({"method": "event", "params": {"type": "skin.changed"}})
+        assert entered.wait(3)
+        for sid in ("a", "b"):
+            fanout.write({"method": "event", "params": {"type": "session.reclaimed", "payload": {"session_id": sid}}})
+        release.set()
+        assert done.wait(3)
+        assert [frame["params"]["payload"]["session_id"] for frame in received[1:]] == ["a", "b"]
+    finally:
+        release.set()
+        fanout.close()
+
+
+def test_global_full_state_invalidations_coalesce_before_backlog_limit():
+    entered = threading.Event()
+    release = threading.Event()
+    done = threading.Event()
+    received = []
+
+    class Peer:
+        def close(self):
+            pass
+
+        def write(self, obj: dict) -> bool:
+            if not received:
+                entered.set()
+                assert release.wait(3)
+            received.append(obj)
+            if len(received) == 2:
+                done.set()
+            return True
+
+    fanout = FanoutTransport(Peer(), coalesce_events=True)
+    try:
+        fanout.write({"method": "event", "params": {"type": "skin.changed"}})
+        assert entered.wait(3)
+        for tick in range(300):
+            assert fanout.write({"method": "event", "params": {"type": "sessions.changed", "payload": {"tick": tick}}})
+        release.set()
+        assert done.wait(3)
+        assert received[1]["params"]["payload"] == {"tick": 299}
+    finally:
+        release.set()
+        fanout.close()

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -1491,6 +1491,35 @@ class _RecordingTransport:
         pass
 
 
+def test_global_broadcast_does_not_wait_for_a_blocked_peer(server):
+    entered = threading.Event()
+    release = threading.Event()
+    returned = threading.Event()
+
+    class _BlockingTransport(_RecordingTransport):
+        def write(self, obj: dict) -> bool:
+            entered.set()
+            release.wait()
+            return super().write(obj)
+
+    peer = _BlockingTransport()
+    server.register_live_transport(peer)
+
+    def broadcast():
+        server._broadcast_global_event("sessions.changed")
+        returned.set()
+
+    caller = threading.Thread(target=broadcast)
+    caller.start()
+    try:
+        assert entered.wait(2)
+        assert returned.wait(2), "the change watcher must not wait for socket progress"
+    finally:
+        release.set()
+        caller.join(timeout=2)
+        server.unregister_live_transport(peer)
+
+
 def test_unregister_live_transport_stops_delivery(capture):
     """A disconnected peer (unregistered in the ws finally block) receives nothing
     — and a stale write is never attempted against its closed socket."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -581,7 +581,7 @@ def _emit(event: str, sid: str, payload: dict | None = None):
 
 # Live WS peer transports (maintained by tui_gateway.ws): the only route for session-less background
 # events, which write_json would otherwise drop on stdio (see _broadcast_global_event).
-_live_transports: set[Transport] = set()
+_live_transports = FanoutTransport(coalesce_events=True)
 _live_transports_lock = threading.Lock()
 
 
@@ -589,28 +589,24 @@ def register_live_transport(transport: Transport | None) -> None:
     """Track a connected client transport for global broadcasts. Idempotent."""
     if transport is not None:
         with _live_transports_lock:
-            _live_transports.add(transport)
+            _live_transports.attach(transport)
 
 
 def unregister_live_transport(transport: Transport | None) -> None:
     """Stop tracking a transport (call on disconnect). Idempotent."""
-    with _live_transports_lock:
-        _live_transports.discard(transport)
+    if transport is not None:
+        with _live_transports_lock:
+            _live_transports.detach(transport)
 
 
 def _broadcast_global_event(event: str, payload: dict | None = None) -> None:
     """Fan a session-less, surface-global event (``skin.changed``) to every connected client — background
     emitters bottom out at stdio in ``write_json``'s ladder. No registered transports (stdio TUI, tests) → ``_emit``."""
     with _live_transports_lock:
-        targets = list(_live_transports)
-    if not targets:
+        has_targets = bool(_live_transports)
+    if not has_targets:
         return _emit(event, "", payload)
-    frame = _event_frame(event, "", payload)
-    for transport in targets:
-        try:
-            transport.write(frame)
-        except Exception:  # one wedged peer must not stall the rest; disconnect teardown unregisters it
-            logger.debug("global-event broadcast write failed type=%s", event, exc_info=True)
+    _live_transports.write(_event_frame(event, "", payload))
 
 
 def _approval_request_payload(data: dict | None) -> dict:

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -244,7 +244,9 @@ class FanoutTransport:
                 if self._coalesce_events:
                     params = frame.get("params") if isinstance(frame, dict) else None
                     event_type = params.get("type") if isinstance(params, dict) else None
-                    if event_type:
+                    # Only full-state invalidations may replace pending events.
+                    # In particular, distinct session.reclaimed payloads must survive.
+                    if event_type in {"sessions.changed", "skin.changed"}:
                         for index, (pending_frame, pending_size) in enumerate(peer.pending):
                             pending_params = pending_frame.get("params") if isinstance(pending_frame, dict) else None
                             if isinstance(pending_params, dict) and pending_params.get("type") == event_type:

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -138,9 +138,10 @@ class FanoutTransport:
     _MAX_PENDING_FRAMES = 256
     _MAX_PENDING_BYTES = 4 * 1024 * 1024
 
-    def __init__(self, *transports: Transport) -> None:
+    def __init__(self, *transports: Transport, coalesce_events: bool = False) -> None:
         self._lock = threading.Lock()
         self._peers: list[_FanoutPeer] = []
+        self._coalesce_events = coalesce_events
         for transport in transports:
             self.attach(transport)
 
@@ -177,9 +178,18 @@ class FanoutTransport:
                     return True
         return False
 
-    def contains(self, transport: Transport) -> bool:
+    def contains(self, transport: object) -> bool:
         with self._lock:
             return any(peer.attached and peer.transport is transport for peer in self._peers)
+
+    def __contains__(self, transport: object) -> bool:
+        return self.contains(transport)
+
+    def __bool__(self) -> bool:
+        return self.has_transports()
+
+    def clear(self) -> None:
+        self.close()
 
     def transports(self) -> list[Transport]:
         with self._lock:
@@ -231,6 +241,16 @@ class FanoutTransport:
             for peer in list(self._peers):
                 if not peer.attached:
                     continue
+                if self._coalesce_events:
+                    params = frame.get("params") if isinstance(frame, dict) else None
+                    event_type = params.get("type") if isinstance(params, dict) else None
+                    if event_type:
+                        for index, (pending_frame, pending_size) in enumerate(peer.pending):
+                            pending_params = pending_frame.get("params") if isinstance(pending_frame, dict) else None
+                            if isinstance(pending_params, dict) and pending_params.get("type") == event_type:
+                                del peer.pending[index]
+                                peer.pending_bytes -= pending_size
+                                break
                 if (len(peer.pending) >= self._MAX_PENDING_FRAMES
                         or peer.pending_bytes + size > self._MAX_PENDING_BYTES):
                     logger.warning("fanout subscriber backlog full; detaching peer")


### PR DESCRIPTION
## Cause
The global broadcaster iterated WSTransport.write serially.

## Fix
Route global peers through the existing ordered bounded FanoutTransport. Each peer has one writer, failures remain isolated, and pending events of the same global type are coalesced to the latest occurrence.

## Tests
A blocking transport proves the broadcaster returns before peer progress. Protocol, multi-client fanout, and WebSocket files: 88 passed. Eight 25-ms real WSTransports: broadcaster returned in 1.244 ms and all eight sends completed.



## Verification scope
Parent inspected the production diff and reran focused tests on this branch. This is not a full Desktop responsiveness or cross-platform acceptance claim. GitHub CI must be checked separately.


Closes #106141


## Additional parent acceptance
Parent RED/GREEN exposed loss of distinct session.reclaimed events. Coalescing is now restricted to full-state sessions.changed/skin.changed invalidations. Both reclaimed session IDs are delivered, and 300 invalidations coalesce without overflowing. The expanded protocol/fanout/WS suite passed 89 tests; final additional coalescing test file passed both tests.
