### PR TITLE
fix(web): move log tail reads off the event loop

### DIFF
--- a/hermes_cli/web_routers/status.py
+++ b/hermes_cli/web_routers/status.py
@@ -723,13 +723,17 @@ async def get_logs(
         if comp_prefixes is None:
             raise HTTPException(status_code=400, detail=f"Unknown component: {component}. "
                                 f"Available: {', '.join(sorted(COMPONENT_PREFIXES))}")
-    result = _read_tail(
-        log_path, min(lines, 500) if not search else 2000,
-        has_filters=bool(min_level or comp_prefixes or search),
-        min_level=min_level, component_prefixes=comp_prefixes)
-    # _read_tail doesn't support free-text search, so post-filter (case-insensitive
-    # substring) here and trim to the requested line count afterward.
-    if search:
-        needle = search.lower()
-        result = [l for l in result if needle in l.lower()][-min(lines, 500):]
+    def _load_logs():
+        result = _read_tail(
+            log_path, min(lines, 500) if not search else 2000,
+            has_filters=bool(min_level or comp_prefixes or search),
+            min_level=min_level, component_prefixes=comp_prefixes)
+        # _read_tail doesn't support free-text search, so post-filter (case-insensitive
+        # substring) here and trim to the requested line count afterward.
+        if search:
+            needle = search.lower()
+            result = [line for line in result if needle in line.lower()][-min(lines, 500):]
+        return result
+
+    result = await asyncio.to_thread(_load_logs)
     return {"file": file, "lines": result}

--- a/tests/hermes_cli/test_web_logs_async.py
+++ b/tests/hermes_cli/test_web_logs_async.py
@@ -1,0 +1,26 @@
+import asyncio
+import threading
+
+from hermes_cli.web_routers import status
+
+
+def test_get_logs_yields_while_reading_and_filtering(tmp_path, monkeypatch):
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "agent.log").write_text("fixture\n", encoding="utf-8")
+    monkeypatch.setattr(status, "get_hermes_home", lambda: tmp_path)
+
+    loop_ran = threading.Event()
+
+    def blocking_read(*args, **kwargs):
+        assert loop_ran.wait(2), "log reading blocked the event loop"
+        return ["fixture"]
+
+    import hermes_cli.logs
+    monkeypatch.setattr(hermes_cli.logs, "_read_tail", blocking_read)
+
+    async def exercise():
+        asyncio.get_running_loop().call_soon(loop_ran.set)
+        return await status.get_logs(file="agent", lines=100)
+
+    assert asyncio.run(exercise()) == {"file": "agent", "lines": ["fixture"]}


### PR DESCRIPTION
Fixes #106143

## Failure mode

`GET /api/logs` is an async route, but it ran the synchronous `_read_tail()` call—and, for text searches, filtered as many as 2,000 candidate lines—on the event-loop thread. A slow disk read or large search therefore paused unrelated route work until the handler finished.

## Change

Keep validation and result shaping in the route, but move the complete blocking unit into one `asyncio.to_thread()` call:

1. read the bounded tail with the existing level and component filters;
2. apply the existing case-insensitive text filter when requested;
3. trim the result to the existing 500-line response cap.

The file selector, unknown-component error, candidate limits, and `{file, lines}` response shape are unchanged.

## Concurrency contract

The worker thread owns both the filesystem read and the free-text scan. The event loop only awaits the finished list; it does not perform a second CPU-bound filtering pass after the thread returns.

## Verification

- The focused regression enters the real route, blocks inside `_read_tail()`, and schedules a callback on the same event loop. The previous implementation timed out because the callback could not run; this implementation lets the callback release the worker.
- A 92 MB log-route probe kept callbacks moving during three handler calls lasting 309–375 ms each.