### PR TITLE
fix(tui-gateway): thread custom_providers into @-context injection sizing

### DIFF
--- a/tests/tui_gateway/test_prompt_turn_context_ref_custom_providers.py
+++ b/tests/tui_gateway/test_prompt_turn_context_ref_custom_providers.py
@@ -1,0 +1,110 @@
+"""Regression test: the ``@`` context-reference expansion path in the TUI gateway's turn
+preparation must thread the agent's ``custom_providers`` into context-length resolution.
+
+Mirrors ``agent.context_compressor.ContextCompressor._resolve_context_length``'s fix
+(71516214c3, "thread custom_providers into context-length resolution", see
+``tests/agent/test_context_compressor_custom_providers.py``) — a per-model
+``context_length`` override in ``custom_providers`` was invisible to ``@file``/``@url``
+injection-limit sizing because ``_prepare_turn_input`` called ``get_model_context_length()``
+without it, so a custom-provider model's real (often larger) window was silently replaced
+by the hardcoded catalog default, needlessly truncating or refusing large ``@`` references.
+"""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tui_gateway import prompt_turn
+from tui_gateway.method_ctx import rebind
+
+
+def _noop(*_args, **_kwargs):
+    return None
+
+
+def test_context_reference_expansion_threads_agent_custom_providers():
+    custom_providers = [{"base_url": "https://custom.example.com/v1", "models": {"big-model": {"context_length": 999999}}}]
+    agent = SimpleNamespace(
+        model="big-model", base_url="https://custom.example.com/v1", api_key="", provider="custom",
+        _config_context_length=None, _custom_providers=custom_providers,
+    )
+    session = {
+        "session_key": "s1", "agent": agent, "profile_home": None,
+        "history_lock": threading.RLock(), "history": [], "history_version": 0, "cols": 80,
+    }
+    st = prompt_turn._TurnRun(agent=agent, one_turn_restore=True, terminal_callback=None, receipt_committed=False)
+
+    captured = {}
+
+    def fake_get_model_context_length(*_args, **kwargs):
+        captured.update(kwargs)
+        return 999999
+
+    prepare = rebind(prompt_turn._prepare_turn_input, {
+        "_set_session_context": lambda *a, **k: "token",
+        "_wire_callbacks": _noop,
+        "_sync_bot_capabilities": _noop,
+        "_session_cwd": lambda session: "/tmp",
+        "_register_session_cwd": _noop,
+        "make_stream_renderer": lambda cols: "streamer",
+        "_start_turn_voice": lambda: (None, False),
+        "_prepend_note": lambda msg, note: msg,
+        "_pending_reaction_notes": lambda session: "",
+        "_hud_surface_note": lambda session: "",
+    })
+
+    with (
+        patch("agent.model_metadata.get_model_context_length", side_effect=fake_get_model_context_length),
+        patch(
+            "agent.context_references.preprocess_context_references",
+            return_value=SimpleNamespace(blocked=False, message="expanded prompt", warnings=[]),
+        ),
+    ):
+        result = prepare("sid1", session, st, "@notes.txt please summarize", [])
+
+    assert result is not None
+    assert captured.get("custom_providers") == custom_providers
+
+
+def test_context_reference_expansion_defaults_custom_providers_to_none():
+    """An agent that never got ``_custom_providers`` set (e.g. a stub in another test) must
+    not raise — the call defaults to ``None``, same as every other caller of this resolver."""
+    agent = SimpleNamespace(
+        model="m", base_url="", api_key="", provider="", _config_context_length=None,
+    )
+    session = {
+        "session_key": "s1", "agent": agent, "profile_home": None,
+        "history_lock": threading.RLock(), "history": [], "history_version": 0, "cols": 80,
+    }
+    st = prompt_turn._TurnRun(agent=agent, one_turn_restore=True, terminal_callback=None, receipt_committed=False)
+
+    captured = {}
+
+    def fake_get_model_context_length(*_args, **kwargs):
+        captured.update(kwargs)
+        return 128000
+
+    prepare = rebind(prompt_turn._prepare_turn_input, {
+        "_set_session_context": lambda *a, **k: "token",
+        "_wire_callbacks": _noop,
+        "_sync_bot_capabilities": _noop,
+        "_session_cwd": lambda session: "/tmp",
+        "_register_session_cwd": _noop,
+        "make_stream_renderer": lambda cols: "streamer",
+        "_start_turn_voice": lambda: (None, False),
+        "_prepend_note": lambda msg, note: msg,
+        "_pending_reaction_notes": lambda session: "",
+        "_hud_surface_note": lambda session: "",
+    })
+
+    with (
+        patch("agent.model_metadata.get_model_context_length", side_effect=fake_get_model_context_length),
+        patch(
+            "agent.context_references.preprocess_context_references",
+            return_value=SimpleNamespace(blocked=False, message="expanded prompt", warnings=[]),
+        ),
+    ):
+        result = prepare("sid1", session, st, "@notes.txt please summarize", [])
+
+    assert result is not None
+    assert captured.get("custom_providers") is None

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -481,7 +481,8 @@ def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images
             base_url=getattr(agent, "base_url", "") or "",
             api_key=getattr(agent, "api_key", "") or "",
             provider=getattr(agent, "provider", "") or "",
-            config_context_length=getattr(agent, "_config_context_length", None))
+            config_context_length=getattr(agent, "_config_context_length", None),
+            custom_providers=getattr(agent, "_custom_providers", None))
         ctx = preprocess_context_references(
             prompt, cwd=cwd, allowed_root=cwd, context_length=ctx_len)
         if ctx.blocked:


### PR DESCRIPTION
## Summary
- `_prepare_turn_input`'s `@` branch (`tui_gateway/prompt_turn.py`) calls `get_model_context_length()` to size the hard/soft injection limits `preprocess_context_references` uses for `@file`/`@url` context references, but never passed `custom_providers`.
- Result: a model on a self-hosted/custom endpoint with a per-model `context_length` override (`custom_providers[].models.<id>.context_length`) always got the hardcoded catalog default instead of its real (often larger) window — needlessly truncating or outright refusing (`ctx.blocked` → "Context injection refused") a large `@`-reference that would actually fit the model's real context.
- `ContextCompressor._resolve_context_length` had this exact bug and was fixed the same way in `71516214c3` ("thread custom_providers into context-length resolution"). The sibling call sites in `agent/chat_completion_helpers.py` and `agent/agent_runtime_helpers.py` already use the same pattern: `custom_providers=getattr(agent, "_custom_providers", None)` — the attribute `agent_init.py` resolves once at startup. This applies the identical fix to this one remaining call site.

## Test plan
- New `tests/tui_gateway/test_prompt_turn_context_ref_custom_providers.py` (2 tests), using this file's established `rebind()` testing convention (see `tests/tui_gateway/test_bot_live_owner_delivery.py`) since `_prepare_turn_input`'s bodies are rebound onto `server.py`'s globals at install time and can't be called with its own module namespace directly:
  - `custom_providers` reaches `get_model_context_length` unchanged from `agent._custom_providers`.
  - An agent without `_custom_providers` set still works, defaulting to `None` (no regression for any existing caller shape).
- Mutation-verified: reverted `tui_gateway/prompt_turn.py` only, confirmed the first test fails with the exact predicted symptom (`captured.get("custom_providers")` is `None` instead of the configured override list); the default-`None` test correctly still passes (unaffected by the fix); restored the fix, both pass again.
- `uv run --frozen --extra dev python -m pytest tests/tui_gateway/ --ignore=tests/tui_gateway/test_hosted_room_two_gateway_scoped.py -q` → 1079 passed (3 pre-existing, unrelated test-order-pollution failures reproduced identically with the fix fully reverted — confirmed via a second full-suite run before restoring; `test_hosted_room_two_gateway_scoped.py` is excluded, a pre-existing `aiohttp` import gap in this environment, unrelated).
- `ruff check` clean on both changed files.

## Prior art / competitor note
Open PR #18844's title ("...pass custom_providers to @context path") and body describe this exact bug, but its actual current diff no longer touches this — it targets a pre-refactor file (`agent/conversation_loop.py`, which predates the `tui_gateway/prompt_turn.py` extraction) and, after being repeatedly rebased across unrelated refactors over several months, its current diff contains none of that fix (just an unrelated `context_length` result-dict field plus large unrelated `mem0` plugin changes bundled onto the same branch); it's `DIRTY`/`CONFLICTING`. So this gap is effectively unaddressed on current `main` despite that PR's title.