### PR TITLE
feat(desktop): add Chrome-style pane tabs and hover previews

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -116,7 +116,7 @@ fill/shadow), `ghost`, `link`, `text` (boxless quiet inline — "Cancel",
 **Sizes:** `default`, `xs`, `sm`, `lg`, `inline` (flush, zero box — for buttons
 that sit inside a heading/sentence; replaces `h-auto px-0 py-0`), `micro`
 (status-stack/table-footers), and the icon family `icon` / `icon-xs` /
-`icon-sm` / `icon-lg` / `icon-titlebar`.
+`icon-sm` / `icon-lg` / `icon-titlebar`. `icon-tab` is the compact 16px circular tab-close control.
 
 **Tooltips only when hover teaches something new.** `<Tip>` is for discovery,
 not a tax on every icon. Ask: does hover reveal something the user cannot
@@ -158,7 +158,7 @@ context-dependent (e.g. "Show" / "Hide"). Never hardcode combos; always use
 
 Notes:
 - Text buttons are square (no radius) and sized by padding + line-height (no
-  fixed heights). Only icon buttons carry the shared 4px radius.
+  fixed heights). Icon buttons carry the shared 4px radius; `icon-tab` is circular.
 - SVGs inherit `size-3.5` (`size-3` at `xs`). Don't re-set icon size.
 - Polymorph with `asChild` when the button must render as a link/Slot.
 
@@ -192,6 +192,28 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
   rows. Flat, flush-left; no per-row indentation that fights flush headers.
 - **No dividers between rows** unless the list genuinely needs them; prefer
   spacing. When you do need one, it's a single `--ui-stroke-tertiary` hairline.
+
+## Pane tabs
+
+`PaneTabStrip`, `PaneTab`, and `PaneTabLabel` own horizontal pane chrome.
+Horizontal tabs use the curved shoulders and overlapping feet of
+[chrome-tabs](https://github.com/adamschwartz/chrome-tabs), with the app's
+theme-derived gutter and chrome-surface active tab rather than a separate palette.
+These fills stay opaque under Glass so the silhouette remains visible.
+The active face joins the pane below; inactive neighbors have short separators,
+not boxed borders or an accent underline. Labels are sentence-case, 12px, and
+fade at the trailing edge. Close uses the shared ghost icon button in a reserved
+slot, so it never covers the label. Tabs shrink before the strip scrolls.
+
+Tab hover previews use the shared `Tip` / `TooltipContent` `card` variant:
+600ms initial delay, full title, optional quieter browser host/file path,
+start-aligned below the tab with viewport collision handling. No arrow, no
+focus stealing, and no pointer interception. Other tips keep the marker style.
+
+The existing pane drag/drop, multi-selection, context menus, and middle/⌘-click
+close gestures remain the interaction authority. Collapsed vertical rails retain
+their compact treatment. Geometry lives in `src/components/ui/pane-tab.css`;
+callers supply content and actions, not tab styling.
 
 ## Feedback & empty/error/loading states
 

--- a/apps/desktop/src/app/chat/pane-mirror.ts
+++ b/apps/desktop/src/app/chat/pane-mirror.ts
@@ -39,6 +39,8 @@ export interface PaneMirror<T> {
    *  as `tabLead` — a name that moves faster than re-registration (see
    *  PaneChrome.tabTitle). Falls back to `title`. */
   tabTitle?: (key: string) => ReactNode
+  /** Detail beneath the full title in the shared tab hover card. */
+  tabDescription?: (key: string) => ReactNode
   /** Mint another tile of this kind — the strip's "+" (see PaneChrome.newTab).
    *  Per tile so a mirror can offer it for some of its tabs and not others. */
   newTab?: (key: string) => (() => void) | undefined
@@ -82,6 +84,7 @@ export function paneMirror<T>(cfg: PaneMirror<T>): () => void {
         data: {
           tabLead: cfg.tabLead ? () => cfg.tabLead!(key) : undefined,
           tabTitle: cfg.tabTitle ? () => cfg.tabTitle!(key) : undefined,
+          tabDescription: cfg.tabDescription ? () => cfg.tabDescription!(key) : undefined,
           dock: {
             before: cfg.before?.(tile),
             pane: cfg.anchor?.(tile) ?? 'workspace',

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -149,6 +149,25 @@ function BrowserTabLabel({ tabId }: { tabId: string }) {
   return target ? browserTabLabel(target, pages[tabId]) : null
 }
 
+function PreviewTabDescription({ tabId }: { tabId: string }) {
+  const pages = useStore($browserPages)
+  const target = targetFor(tabId)
+
+  if (!target) {
+    return null
+  }
+
+  if (target.kind !== 'url') {
+    return target.path || target.source || null
+  }
+
+  try {
+    return new URL(pages[tabId]?.url || target.url).hostname
+  } catch {
+    return null
+  }
+}
+
 /** The tab's lead glyph — the same file/tool icon family the file tree and code
  *  fences resolve through, so a `.tsx` peek and its sidebar row agree. */
 function PreviewTabLead({ tabId }: { tabId: string }) {
@@ -262,6 +281,7 @@ const watchPreviewTileMirror = paneMirror<{ id: string }>({
   title: previewTitle,
   tabLead: tabId => <PreviewTabLead tabId={tabId} />,
   tabTitle: tabId => (targetFor(tabId)?.kind === 'url' ? <BrowserTabLabel tabId={tabId} /> : undefined),
+  tabDescription: tabId => <PreviewTabDescription tabId={tabId} />,
   // A Browser is a vessel, so there can be more of it — a file peek is one of
   // a kind and leaves the strip's "+" to whatever else the zone holds.
   newTab: tabId => (targetFor(tabId)?.kind === 'url' ? newBrowserTab : undefined),

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -111,6 +111,8 @@ interface PaneChrome extends PaneSizing {
    *  whole panes area, so the label subscribes for itself instead. Absent, or
    *  returning nothing, falls back to `title`. */
   tabTitle?: () => React.ReactNode
+  /** Optional second line in the hover preview (a browser host or file path). */
+  tabDescription?: () => React.ReactNode
 }
 
 export const paneChrome = (c: Contribution | undefined) => (c?.data ?? {}) as PaneChrome

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -492,6 +492,7 @@ export function TreeGroup({
         <ZoneMenu {...zoneMenu}>
           <PaneTabStrip
             // data-zone-tabstrip: a drop over here STACKS (drag-session reads it).
+            data-minimized={node.minimized || undefined}
             data-zone-tabstrip={node.id}
             listRef={tabsRef}
             onPointerDown={e =>
@@ -540,6 +541,8 @@ export function TreeGroup({
                   active={isActive}
                   aria-selected={isActive}
                   data-tree-tab={paneId}
+                  hoverDescription={chrome.tabDescription?.()}
+                  hoverTitle={tabLabel(paneId)}
                   key={paneId}
                   onClose={closeable ? () => closeTab(paneId) : undefined}
                   onPointerDown={e => {
@@ -627,7 +630,7 @@ export function TreeGroup({
                   style={{ cursor: 'grab' }}
                 >
                   {chrome.tabLead ? (
-                    <span className="ml-2 -mr-1 flex shrink-0 items-center">{chrome.tabLead()}</span>
+                    <span className="pane-tab-lead">{chrome.tabLead()}</span>
                   ) : null}
                   <PaneTabLabel>{tabLabel(paneId)}</PaneTabLabel>
                 </PaneTab>

--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -47,6 +47,7 @@ const buttonVariants = cva(
           "h-auto gap-0.5 px-1 py-0 text-xs leading-4 font-normal has-[>svg]:px-0.5 [&_svg:not([class*='size-'])]:size-3",
         icon: 'size-9 rounded-[4px]',
         'icon-xs': "size-6 rounded-[4px] [&_svg:not([class*='size-'])]:size-3",
+        'icon-tab': "size-4 rounded-full [&_svg:not([class*='size-'])]:size-3",
         'icon-sm': 'size-8 rounded-[4px]',
         'icon-lg': 'size-10 rounded-[4px]',
         'icon-titlebar':

--- a/apps/desktop/src/components/ui/pane-tab-preview.test.tsx
+++ b/apps/desktop/src/components/ui/pane-tab-preview.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PaneTab, PaneTabLabel } from './pane-tab'
+
+afterEach(cleanup)
+
+describe('PaneTab hover preview', () => {
+  it('dismisses before a drag handler that claims the pointer event', async () => {
+    const onPointerDown = vi.fn(event => {
+      event.preventDefault()
+      event.stopPropagation()
+    })
+
+    render(
+      <PaneTab hoverDescription="example.com" hoverTitle="Full page title" onPointerDown={onPointerDown} role="tab">
+        <PaneTabLabel>Short title</PaneTabLabel>
+      </PaneTab>
+    )
+    const tab = screen.getByRole('tab')
+    fireEvent.pointerMove(tab, { pointerType: 'mouse' })
+    const preview = await screen.findByRole('tooltip')
+    expect(within(preview).getByText('Full page title')).toBeTruthy()
+    expect(within(preview).getByText('example.com')).toBeTruthy()
+
+    fireEvent.pointerDown(tab, { button: 0, pointerType: 'mouse' })
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull())
+    expect(onPointerDown).toHaveBeenCalledOnce()
+    expect(screen.getByRole('tab')).toBe(tab)
+  })
+
+  it('closes a preview and the tab without activating the tab when its close button is pressed', async () => {
+    const onClose = vi.fn()
+    const onPointerDown = vi.fn()
+    render(
+      <PaneTab hoverTitle="Full page title" onClose={onClose} onPointerDown={onPointerDown} role="tab">
+        <PaneTabLabel>Short title</PaneTabLabel>
+      </PaneTab>
+    )
+    fireEvent.pointerMove(screen.getByRole('tab'), { pointerType: 'mouse' })
+    await screen.findByRole('tooltip')
+
+    const close = screen.getByRole('button', { name: 'Close' })
+    fireEvent.pointerDown(close, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(close)
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull())
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(onPointerDown).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/components/ui/pane-tab.css
+++ b/apps/desktop/src/components/ui/pane-tab.css
@@ -1,0 +1,219 @@
+/* Curved tab geometry adapted from https://github.com/adamschwartz/chrome-tabs.
+ * The MIT License (MIT) — Copyright (c) 2013 Adam Schwartz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+.pane-tab-strip {
+  /* Surface aliases become transparent under Glass. These solid theme seeds
+     keep the active silhouette readable without changing the window's glass. */
+  --pane-tab-active-bg: var(--ui-bg-chrome);
+  --pane-tab-strip-bg: color-mix(in srgb, var(--ui-base) 12%, var(--ui-bg-chrome));
+  --pane-tab-height: 36px;
+  height: 46px;
+  background: var(--pane-tab-strip-bg);
+  isolation: isolate;
+}
+
+:root.dark .pane-tab-strip {
+  --pane-tab-strip-bg: var(--theme-neutral-sidebar);
+}
+
+/* Minimized column tracks are still 28px; the restore handle must fit. */
+.pane-tab-strip[data-minimized] {
+  --pane-tab-height: 24px;
+  height: 28px;
+}
+
+.pane-tab-strip[data-minimized] .pane-tab-list {
+  padding-block: 4px 0;
+}
+
+.pane-tab-strip::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 0;
+  height: 4px;
+  background: var(--pane-tab-active-bg);
+  pointer-events: none;
+  z-index: 3;
+}
+
+.pane-tab-list {
+  align-items: flex-end;
+  /* Every tab overlaps, including tabs inside display:contents menu wrappers. */
+  padding: 8px 3px 2px 22px;
+}
+
+.pane-tab-horizontal {
+  --tab-bg: var(--pane-tab-active-bg, var(--ui-bg-chrome));
+  --tab-face: var(--tab-bg);
+  flex: 0 1 258px;
+  height: var(--pane-tab-height, 36px);
+  min-width: 84px;
+  max-width: 258px;
+  padding-inline: 17px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--ui-text-secondary);
+  z-index: 1;
+}
+
+.pane-tab-list .pane-tab-horizontal {
+  margin-left: -19px;
+}
+
+/* Only the body accepts input; an overlapping transparent shoulder must not
+   steal the close button or drag handle of its neighbor. */
+.pane-tab-horizontal {
+  pointer-events: none;
+}
+
+.pane-tab-horizontal::after {
+  content: '';
+  position: absolute;
+  inset: 0 9px;
+  border-radius: 8px 8px 0 0;
+  pointer-events: auto;
+}
+
+.pane-tab-horizontal > :is(.pane-tab-label, .pane-tab-lead, .pane-tab-close) {
+  pointer-events: auto;
+}
+
+.pane-tab-horizontal:hover {
+  --tab-face: color-mix(in srgb, var(--tab-bg) 65%, var(--pane-tab-strip-bg));
+  box-shadow: none;
+  z-index: 2;
+}
+
+.pane-tab-horizontal[data-active='true'] {
+  --tab-face: var(--tab-bg);
+  color: var(--ui-text-primary);
+  z-index: 3;
+}
+
+.pane-tab-horizontal[data-selected] {
+  --tab-face: color-mix(in srgb, var(--ui-accent) 14%, var(--tab-bg));
+}
+
+/* Three pieces keep the 8px shoulders and 9px feet circular at every width. */
+.pane-tab-background {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(var(--tab-face), var(--tab-face)) center / calc(100% - 32px) 100% no-repeat;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.pane-tab-background::before,
+.pane-tab-background::after {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 17px;
+  background: var(--tab-face);
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 17 36' preserveAspectRatio='none'%3E%3Cpath d='M17 0v36H0v-2c4.5 0 9-3.5 9-8V8c0-4.5 3.5-8 8-8z'/%3E%3C/svg%3E") 0 0 / 17px var(--pane-tab-height) no-repeat;
+}
+
+.pane-tab-background::after {
+  left: auto;
+  right: 0;
+  transform: scaleX(-1);
+}
+
+.pane-tab-horizontal:is([data-active='true'], [data-selected], :hover, :focus-within) > .pane-tab-background {
+  opacity: 1;
+}
+
+.pane-tab-divider {
+  position: absolute;
+  top: 9px;
+  bottom: 9px;
+  right: 9px;
+  width: 1px;
+  background: var(--ui-stroke-secondary);
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.pane-tab-horizontal:is([data-active='true'], [data-selected], :hover, :focus-within) > .pane-tab-divider,
+.pane-tab-horizontal:has(+ .pane-tab-horizontal:is([data-active='true'], [data-selected], :hover, :focus-within)) > .pane-tab-divider,
+.pane-tab-list > :has(+ .contents > .pane-tab-horizontal:is([data-active='true'], [data-selected], :hover, :focus-within)) .pane-tab-divider,
+.pane-tab-list > :nth-last-child(1 of :is(.pane-tab-horizontal, .contents)) .pane-tab-divider {
+  opacity: 0;
+}
+
+.pane-tab-lead {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 16px;
+  margin-right: 8px;
+}
+
+.pane-tab-horizontal > .pane-tab-label {
+  position: relative;
+  flex: 1;
+  padding-inline: 0;
+  z-index: 1;
+}
+
+.pane-tab-horizontal > .pane-tab-label > span {
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+  text-overflow: clip;
+  mask-image: linear-gradient(to right, black calc(100% - 12px), transparent);
+}
+
+/* Keep domain-owned lead icons above the tab face without wrapping the label:
+   drag hit-testing and context-menu refs still point at the original shell. */
+.pane-tab-horizontal > :not(.pane-tab-background, .pane-tab-divider, .pane-tab-dirty, .pane-tab-close) {
+  position: relative;
+  z-index: 1;
+}
+
+.pane-tab-close {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: 4px;
+  z-index: 1;
+}
+
+.pane-tab-horizontal:has(.pane-tab-dirty):not(:hover, :focus-within) > .pane-tab-close {
+  visibility: hidden;
+}
+
+.pane-tab-horizontal:has(.pane-tab-close):is(:hover, :focus-within) > .pane-tab-dirty {
+  visibility: hidden;
+}
+
+.pane-tab-horizontal > .pane-tab-dirty {
+  z-index: 1;
+}
+
+.pane-tab-list > :not(.pane-tab-horizontal) {
+  align-self: center;
+  flex-shrink: 0;
+}

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -1,3 +1,5 @@
+import './pane-tab.css'
+
 import * as React from 'react'
 
 import { type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
@@ -12,25 +14,15 @@ import { cn } from '@/lib/utils'
 export const PANE_TAB_STRIP_LINE_LEFT = 'shadow-[inset_1px_0_0_var(--ui-stroke-tertiary)]'
 export const PANE_TAB_STRIP_LINE_RIGHT = 'shadow-[inset_-1px_0_0_var(--ui-stroke-tertiary)]'
 
-// `--tab-face` is the tab's EFFECTIVE surface color — what actually sits under
-// the label after every wash lands. The hover close-button gradient fades into
-// it, so the fade is seamless on any theme. Idle hover repaints it below with
-// the same color-mix the darkening wash applies.
-//
-// `--tab-bg` is the base every wash mixes onto. Under Glass the surface tokens
-// are transparent and the <body> field is what shows through a tab, so the
-// base prefers `--glass-field` (styles.css sets it only under glass, on
-// `data-glass-field` declarers) and falls back to the tab's own surface token.
+// Vertical rails retain their glass-aware surface. Horizontal faces and
+// gutters are resolved together in pane-tab.css so their contrast survives Glass.
 const TAB =
   'group/tab relative flex shrink-0 items-center border-transparent bg-(--tab-bg) text-[0.6875rem] font-medium [-webkit-app-region:no-drag] [--tab-face:var(--tab-bg)] [--tab-bg:var(--glass-field,var(--tab-surface))]'
 
-// Full height: with the strip's rule removed there is no last-pixel row to
-// leave uncovered, so tabs fill the bar and no sliver of gutter shows through.
-const TAB_HORIZONTAL = 'h-full min-w-0 max-w-48 not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'
+// Horizontal tabs share Chrome's curved silhouette; vertical rails stay compact.
+const TAB_HORIZONTAL = 'pane-tab-horizontal min-w-0'
 
-// A closeable tab's floor: 8px label inset + the ~19px opaque ✕ chip, so the
-// shortest labels (FILES, REVIEW) clear the chip and pass under nothing but the
-// gradient. A floor, not padding — a tab already wider than it pays nothing.
+// Closeable tabs keep a floor; horizontal geometry reserves the close slot.
 const TAB_CLOSEABLE = 'min-w-13'
 
 const TAB_VERTICAL =
@@ -39,32 +31,22 @@ const TAB_VERTICAL =
 const TAB_ACTIVE =
   'h-full text-foreground [--tab-surface:var(--pane-tab-active-bg,var(--ui-editor-surface-background))]'
 
-// Horizontal only: the active tab is the sole seam on the strip — a
-// theme-primary underline drawn as an inset shadow in its own last pixel row,
-// so it costs no layout and can't shift the tab.
-const TAB_ACTIVE_UNDERLINE = 'shadow-[inset_0_-2px_0_var(--pane-tab-active-accent,var(--theme-primary))]'
-
-// Inactive = gutter, defaulting to the shared chrome surface so a strip that
-// sets no vars still matches the sidebar/titlebar instead of falling through to
-// the raw (unmixed) card seed. Hover DARKENS: surfaces this close in value need
-// a darkening wash to register at all. `--tab-face` tracks the wash — the same
-// mix flattened onto `--tab-bg` — so the close gradient matches what shows.
+// Vertical rails keep their existing darkening hover wash.
 const TAB_IDLE =
   'text-(--ui-text-tertiary) [--tab-surface:var(--pane-tab-strip-bg,var(--ui-sidebar-surface-background))] hover:shadow-[inset_0_0_0_100vmax_color-mix(in_srgb,#000_var(--ui-tab-hover-darken),transparent)] hover:[--tab-face:color-mix(in_srgb,#000_var(--ui-tab-hover-darken),var(--tab-bg))] hover:text-(--ui-text-secondary)'
 
-// A tab riding a multi-tab selection: an accent wash over whatever surface the
-// tab sits on. A background-image gradient (not a shadow) so it stacks cleanly
-// over `--tab-bg` without fighting the active underline / hover shadows.
-// `--tab-face` gets the same wash flattened in, keeping the close fade honest.
+// Selected rails use an accent wash; horizontal faces get the same tint in CSS.
 const TAB_SELECTED =
   '[background-image:linear-gradient(color-mix(in_srgb,var(--ui-accent)_14%,transparent),color-mix(in_srgb,var(--ui-accent)_14%,transparent))] [--tab-face:color-mix(in_srgb,var(--ui-accent)_14%,var(--tab-bg))] text-foreground'
 
 interface PaneTabProps extends React.ComponentProps<'div'> {
   active?: boolean
   dirty?: boolean
-  /** Close verb. Horizontal tabs reveal a hover ✕ on the right (a `--tab-face`
-   *  gradient fades it over the label); middle-click and ⌘-click always work,
-   *  and stay the only gestures on vertical rails (no room for a chip ✕).
+  hoverTitle?: React.ReactNode
+  hoverDescription?: React.ReactNode
+  /** Close verb. Horizontal tabs reserve a compact ✕ on the right;
+   *  middle-click and ⌘-click always work, and stay the only gestures on
+   *  vertical rails (no room for a chip ✕).
    *  There is no way to take the ✕ off a tab that HAS this verb: the chip and
    *  the pointer gestures are one affordance, so a closeable tab always says
    *  so. Omit `onClose` to make a tab uncloseable. */
@@ -89,9 +71,13 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
   {
     active = false,
     dirty = false,
+    hoverTitle,
+    hoverDescription,
     onClose,
     onMouseDown,
     onPointerDown,
+    onPointerDownCapture,
+    onContextMenuCapture,
     onPointerUp,
     onClickCapture,
     selected = false,
@@ -107,17 +93,16 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
   // that rule, and a per-tab border stacked a second translucent line over it.
   const edge = vertical ? (side === 'right' ? 'border-l' : 'border-r') : undefined
   const middle = middleClickHandlers(onClose)
+  const [previewOpen, setPreviewOpen] = React.useState(false)
 
-  return (
+  const tab = (
     <div
       className={cn(
         TAB,
         vertical ? TAB_VERTICAL : TAB_HORIZONTAL,
         !vertical && onClose && TAB_CLOSEABLE,
         edge,
-        active
-          ? cn(TAB_ACTIVE, !vertical && TAB_ACTIVE_UNDERLINE)
-          : cn(TAB_IDLE, edge && `${edge}-(--ui-stroke-tertiary)`),
+        active ? TAB_ACTIVE : cn(TAB_IDLE, edge && `${edge}-(--ui-stroke-tertiary)`),
         selected && TAB_SELECTED,
         className
       )}
@@ -136,6 +121,10 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
         }
 
         onClickCapture?.(event)
+      }}
+      onContextMenuCapture={event => {
+        setPreviewOpen(false)
+        onContextMenuCapture?.(event)
       }}
       onMouseDown={event => {
         middle.onMouseDown(event)
@@ -157,6 +146,11 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
 
         onPointerDown?.(event)
       }}
+      onPointerDownCapture={event => {
+        // Pane drag handlers prevent default before Radix can dismiss the tip.
+        setPreviewOpen(false)
+        onPointerDownCapture?.(event)
+      }}
       onPointerUp={event => {
         middle.onPointerUp(event)
         onPointerUp?.(event)
@@ -164,59 +158,70 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
       ref={ref}
       {...props}
     >
+      {!vertical && <span aria-hidden className="pane-tab-background" />}
+      {!vertical && <span aria-hidden className="pane-tab-divider" />}
       {children}
       {dirty && (
         <span
           aria-hidden
           className={cn(
             'pointer-events-none absolute grid size-4 place-items-center',
-            vertical ? 'bottom-1.5 left-1/2 -translate-x-1/2' : 'right-1.5 top-1/2 -translate-y-1/2'
+            vertical ? 'bottom-1.5 left-1/2 -translate-x-1/2' : 'pane-tab-dirty right-3 top-1/2 -translate-y-1/2'
           )}
         >
           <span className="size-2 rounded-full bg-amber-500 shadow-[0_0_0_2px_var(--tab-bg),0_1px_2px_rgba(0,0,0,0.45)] dark:bg-amber-400" />
         </span>
       )}
       {onClose && !vertical && (
-        // Hover ✕, painted OVER the label's right edge as an overlay (no
-        // layout shift, tab width never jumps on hover). The runway is a tiny
-        // transparent→`--tab-face` gradient, so the button melts into the
-        // tab's effective surface instead of hard-clipping the text under it.
-        // Short labels are kept legible by TAB_CLOSEABLE, not by padding.
-        // Rendered after the dirty dot: on hover the ✕ takes the dot's spot,
-        // VS Code-style.
-        <span className="pointer-events-none absolute inset-y-0 right-0 flex items-stretch opacity-0 transition-opacity group-hover/tab:pointer-events-auto group-hover/tab:opacity-100">
-          {/* Both pieces re-draw the active underline: they paint over the
-              tab's own last-pixel row, so without it the ✕ would bite a
-              notch out of the accent line on the active tab. */}
-          <span
-            aria-hidden
-            className="w-4 bg-linear-to-r from-transparent to-(--tab-face) group-data-[active=true]/tab:shadow-[inset_0_-2px_0_var(--pane-tab-active-accent,var(--theme-primary))]"
-          />
-          <button
+        <span className="pane-tab-close">
+          <Button
             aria-label={translateNow('common.close')}
-            className="grid cursor-pointer place-items-center bg-(--tab-face) pr-1.5 pl-0.5 text-(--ui-text-tertiary) outline-none hover:text-foreground group-data-[active=true]/tab:shadow-[inset_0_-2px_0_var(--pane-tab-active-accent,var(--theme-primary))]"
             onClick={event => {
               event.preventDefault()
               event.stopPropagation()
               onClose()
             }}
             onPointerDown={event => {
-              // Claim a plain left press so the shell can't also activate or
-              // drag the tab. Middle/⌘ presses bubble on purpose — the tab's
-              // own close gestures already route them.
+              // Closing must never also activate or start dragging the tab.
               if (event.button === 0 && !isMetaClose(event)) {
                 event.stopPropagation()
               }
             }}
+            size="icon-tab"
             tabIndex={-1}
             type="button"
+            variant="ghost"
           >
             <Codicon name="close" size="0.6875rem" />
-          </button>
+          </Button>
         </span>
       )}
     </div>
   )
+
+  return !vertical && hoverTitle ? (
+    <Tip
+      align="start"
+      alignOffset={9}
+      collisionPadding={8}
+      delayDuration={600}
+      label={
+        <>
+          <div className="text-xs font-medium leading-5 break-words">{hoverTitle}</div>
+          {hoverDescription && (
+            <div className="mt-1 text-[11px] leading-4 break-all text-(--ui-text-secondary)">{hoverDescription}</div>
+          )}
+        </>
+      }
+      onOpenChange={setPreviewOpen}
+      open={previewOpen}
+      side="bottom"
+      sideOffset={4}
+      variant="card"
+    >
+      {tab}
+    </Tip>
+  ) : tab
 })
 
 interface PaneTabLabelProps extends React.ComponentProps<'button'> {
@@ -225,10 +230,8 @@ interface PaneTabLabelProps extends React.ComponentProps<'button'> {
   as?: 'button' | 'span'
 }
 
-/** Truncating label inside a `PaneTab`. `className` merges into the text span
- *  (e.g. `normal-case tracking-normal` for filenames). On a closeable tab the
- *  text clips instead of ellipsizing, so it runs under the hover ✕ fade rather
- *  than stopping short of it with dots. */
+/** Truncating label inside a `PaneTab`. `className` merges into the text span.
+ *  Horizontal labels fade before the reserved close slot, never underneath it. */
 export const PaneTabLabel = React.forwardRef<HTMLElement, PaneTabLabelProps>(function PaneTabLabel(
   { as = 'span', className, children, ...props },
   ref
@@ -237,7 +240,7 @@ export const PaneTabLabel = React.forwardRef<HTMLElement, PaneTabLabelProps>(fun
 
   return (
     <Comp
-      className="flex h-full min-w-0 max-w-full items-center overflow-hidden px-2 text-left outline-none group-data-[vertical]/tab:h-auto group-data-[vertical]/tab:w-full group-data-[vertical]/tab:justify-center group-data-[vertical]/tab:py-2"
+      className="pane-tab-label flex h-full min-w-0 max-w-full items-center overflow-hidden px-2 text-left outline-none group-data-[vertical]/tab:h-auto group-data-[vertical]/tab:w-full group-data-[vertical]/tab:justify-center group-data-[vertical]/tab:py-2"
       ref={ref}
       {...props}
     >
@@ -277,18 +280,16 @@ export const PaneTabStrip = React.forwardRef<HTMLDivElement, PaneTabStripProps>(
 ) {
   return (
     <div
-      // Strip and active tab both sit on the sidebar surface, so the bar reads
-      // as one piece of chrome with the titlebar above it. No bottom rule — the
-      // active tab's primary underline is the only seam.
+      // The active tab flows into the pane surface; the gutter stays chrome.
       className={cn(
-        'group/pane-header relative flex h-7 shrink-0 select-none bg-(--ui-sidebar-surface-background) [-webkit-app-region:no-drag] [--pane-tab-active-bg:var(--ui-sidebar-surface-background)]',
+        'pane-tab-strip group/pane-header relative flex shrink-0 select-none bg-(--ui-sidebar-surface-background) [-webkit-app-region:no-drag]',
         className
       )}
       ref={ref}
       {...props}
     >
       <div
-        className="flex min-w-0 flex-1 overflow-x-auto overflow-y-hidden overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="pane-tab-list flex min-w-0 flex-1 overflow-x-auto overflow-y-hidden overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         ref={listRef}
         role="tablist"
       >

--- a/apps/desktop/src/components/ui/tooltip.tsx
+++ b/apps/desktop/src/components/ui/tooltip.tsx
@@ -93,12 +93,18 @@ function TooltipTrigger({ onFocus, ...props }: React.ComponentProps<typeof Toolt
   )
 }
 
+interface TooltipContentProps extends React.ComponentProps<typeof TooltipPrimitive.Content> {
+  /** Tab previews use a full surface instead of the compact marker label. */
+  variant?: 'label' | 'card'
+}
+
 function TooltipContent({
   className,
   sideOffset = 6,
   children,
+  variant = 'label',
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: TooltipContentProps) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -109,7 +115,13 @@ function TooltipContent({
         // elapses the chip appears at once.
         // pointer-events-none: the tip must never steal hover/clicks from the
         // chrome underneath (titlebar tools, adjacent tabs, etc.).
-        className={cn('pointer-events-none z-(--z-over-modal) w-fit max-w-64 select-none', className)}
+        className={cn(
+          'pointer-events-none z-(--z-over-modal) select-none',
+          variant === 'card'
+            ? 'w-64 max-w-[calc(100vw-1rem)] rounded-lg border border-(--ui-stroke-secondary) bg-(--ui-bg-elevated) p-3 text-(--ui-text-primary) shadow-md'
+            : 'w-fit max-w-64',
+          className
+        )}
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         {...props}
@@ -122,18 +134,22 @@ function TooltipContent({
             (#62022); an atomic inline child (`inline-flex`) sits on the baseline
             and hangs its extra lines below the background, dark-on-dark. Force
             direct children inline; break lines with `<br />`. */}
-        <span className="box-decoration-clone inline bg-foreground px-1.5 py-1 text-[11px] font-bold leading-normal text-background [font-family:Arial,sans-serif] [&>*]:!inline">
-          {children}
-        </span>
+        {variant === 'card' ? children : (
+          <span className="box-decoration-clone inline bg-foreground px-1.5 py-1 text-[11px] font-bold leading-normal text-background [font-family:Arial,sans-serif] [&>*]:!inline">
+            {children}
+          </span>
+        )}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )
 }
 
-interface TipProps extends Omit<React.ComponentProps<typeof TooltipPrimitive.Content>, 'content'> {
+interface TipProps extends Omit<TooltipContentProps, 'content'> {
   label: React.ReactNode
   children: React.ReactNode
   delayDuration?: number
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 // Drop-in replacement for native `title=`: wrap any single element. Instant,
@@ -155,7 +171,7 @@ interface TipProps extends Omit<React.ComponentProps<typeof TooltipPrimitive.Con
 // tried and reverted. `asChild` puts `data-slot="tooltip-trigger"` on the
 // child element itself, so arming REPLACES that node — which broke 18 tests
 // encoding that contract, and risks focus/ref identity at every call site.
-function Tip({ label, children, delayDuration = TIP_DELAY_MS, ...props }: TipProps) {
+function Tip({ label, children, delayDuration = TIP_DELAY_MS, open, onOpenChange, ...props }: TipProps) {
   // A component rendered in isolation (every unit test, and any surface
   // mounted outside the app root) has no provider above it, and Radix throws
   // "`Tooltip` must be used within `TooltipProvider`". Fall back to a local
@@ -168,7 +184,7 @@ function Tip({ label, children, delayDuration = TIP_DELAY_MS, ...props }: TipPro
   }
 
   const tip = (
-    <Tooltip delayDuration={delayDuration} disableHoverableContent>
+    <Tooltip delayDuration={delayDuration} disableHoverableContent onOpenChange={onOpenChange} open={open}>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
       <TooltipContent {...props}>{label}</TooltipContent>
     </Tooltip>


### PR DESCRIPTION

<img width="841" height="482" alt="Screenshot 2026-09-08 at 6 22 18 PM" src="https://github.com/user-attachments/assets/33dc59e9-18a0-4e38-8b53-8de2bcdd30d7" />


## What does this PR do?

Gives Desktop pane tabs the curved, overlapping shape of [adamschwartz/chrome-tabs](https://github.com/adamschwartz/chrome-tabs), using Hermes theme colors and the existing pane drag/drop controller. Hover cards show the full title and, for browser or file tabs, the hostname or path.

## Type of Change

- [x] ✨ New feature

## Changes Made

- Replace the horizontal accent underline with curved tab faces, a contrasting gutter, and the reference's bottom bar. Keep the shape visible under Glass and retain compact minimized rails.
- Reserve space for status icons, fading titles, and circular close buttons. Handle tab overlap through context-menu wrappers without covering neighboring close targets.
- Extend the shared Button and Tip primitives for tab controls and hover cards. Dismiss previews before tab activation, dragging, closing, or opening a context menu.
- Document the tab treatment and retain the upstream MIT notice with the adapted geometry. No new dependencies.

## How to Test

1. Open several session, browser, or file tabs in one pane. Check active and hovered faces in light/dark themes, including Glass.
2. Hover a long title, then click or drag the tab. The title card should appear below the strip and dismiss when acting on the tab.
3. Check close buttons, middle/Command-click, context menus, multi-tab selection, reordering, narrow strips, and minimized panes.

### Verification

- [x] Inspected the running macOS Electron/HMR surface in light and dark themes; checked overlap, close-button hit targets, hover-card placement, and dismissal on pointer-down and mouse-leave.
- [x] Focused Vitest run: **42 tests passed across 7 files**, covering tab close gestures, hover preview dismissal, tooltip focus, preview tiles, strip visibility, and overflow scrolling.
- [x] ESLint passed for all changed TypeScript files.
- [x] `git diff --check` passed.
- [ ] Full test suite, typecheck, and production build not run.

## Checklist

- [x] Read the contributing guide and checked for an existing PR.
- [x] Changes are limited to Desktop tab presentation and hover previews.
- [x] Added interaction regression tests and updated `apps/desktop/DESIGN.md`.
- [x] No config, tool schema, or dependency changes.
- [ ] Native Windows/Linux appearance not tested.
