### PR TITLE
fix(cli): key update-check cache on local git HEAD so manual pulls expire it

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -329,6 +329,22 @@ def _read_json(path: Path) -> Optional[dict]:
     return blob if isinstance(blob, dict) else None
 
 
+def _resolve_check_revision(embedded_rev: Optional[str], repo_dir: Optional[Path]) -> Optional[str]:
+    """The revision that keys the update-check cache (see ``check_for_updates``).
+
+    ``HERMES_REVISION`` builds key on the embedded rev directly. A git install has no
+    embedded rev, so the key is the local HEAD — the value that actually determines the
+    behind-count. Reading HEAD is a cheap local subprocess (no network), not the expensive
+    fetch the cache is designed to avoid; a manual fast-forward therefore invalidates a stale
+    "commits behind" cache (#45556).
+    """
+    if embedded_rev:
+        return embedded_rev
+    if repo_dir is None:
+        return None
+    return _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
+
+
 def check_for_updates(*, passive: bool = False) -> Optional[int]:
     """Check whether a Hermes update is available.
 
@@ -353,23 +369,27 @@ def check_for_updates(*, passive: bool = False) -> Optional[int]:
 
     if _quiet(_install_method) in {"docker", "apt"}:
         return None
-    # Cache is invalidated when the embedded rev OR installed version changed since the last check.
+    # The cache key is the revision that determines the behind-count: the embedded rev for
+    # nix/docker builds, else the local git HEAD for a checkout. The old key was the embedded
+    # rev only, so a manual fast-forward (HEAD moved, rev+version unchanged) never expired a
+    # stale "commits behind" entry (#45556).
+    repo_dir = None if embedded_rev else _resolve_repo_dir()
+    check_rev = _resolve_check_revision(embedded_rev, repo_dir)
     now = time.time()
     cached = _read_json(cache_file)
     if (cached is not None and now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-            and cached.get("rev") == embedded_rev and cached.get("ver") == VERSION):
+            and cached.get("rev") == check_rev and cached.get("ver") == VERSION):
         return cached.get("behind")
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
         # No checkout and no embedded revision — status can't be determined.
-        repo_dir = _resolve_repo_dir()
         behind = _check_via_local_git(repo_dir) if repo_dir is not None else None
     # Don't cache inconclusive results: None means the check could not run (typically a failed
     # fetch), and caching it would suppress retries for the full 6-hour window (#82166).
     if behind is not None:
         _quiet(lambda: cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION}), encoding="utf-8"))
+            json.dumps({"ts": now, "behind": behind, "rev": check_rev, "ver": VERSION}), encoding="utf-8"))
     return behind
 
 

--- a/tests/hermes_cli/test_passive_update_opt_out.py
+++ b/tests/hermes_cli/test_passive_update_opt_out.py
@@ -9,6 +9,9 @@ from hermes_constants import get_hermes_home
 def test_passive_check_obeys_config_before_using_cached_notice(monkeypatch):
     from hermes_cli import banner
 
+    # The cache key now includes the local HEAD; force a key of None so the cache below hits.
+    monkeypatch.setattr(banner, "_resolve_repo_dir", lambda: None)
+
     home = get_hermes_home()
     (home / ".update_check").write_text(json.dumps({
         "ts": time.time(), "behind": 17, "rev": None, "ver": banner.VERSION,

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -13,27 +13,30 @@ import pytest
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
+    """When cache is fresh and matches the local HEAD, return cached value without a git fetch."""
+    from hermes_cli import banner
     from hermes_cli import __version__
 
-    # Create a fake git repo and fresh cache
-    repo_dir = tmp_path / "hermes-agent"
-    repo_dir.mkdir()
-    (repo_dir / ".git").mkdir()
+    # The cache key is the local HEAD for a git install, so a cache whose rev equals HEAD
+    # must be served without an expensive network fetch.
+    fake_head = "1" * 40
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(banner, "_resolve_repo_dir", lambda: tmp_path)
+    mock_git = MagicMock(return_value=fake_head)
+    monkeypatch.setattr(banner, "_git_stdout", mock_git)
+    mock_local_git = MagicMock()
+    monkeypatch.setattr(banner, "_check_via_local_git", mock_local_git)
 
     cache_file = tmp_path / ".update_check"
     cache_file.write_text(
-        json.dumps({"ts": time.time(), "behind": 3, "ver": __version__}),
+        json.dumps({"ts": time.time(), "behind": 3, "rev": fake_head, "ver": __version__}),
         encoding="utf-8",
     )
 
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
-
-    assert result == 3
-    mock_run.assert_not_called()
+    assert banner.check_for_updates() == 3
+    # Warm cache hit reads the local HEAD exactly once and short-circuits without recomputing.
+    mock_git.assert_called_once_with(["rev-parse", "HEAD"], cwd=tmp_path)
+    mock_local_git.assert_not_called()
 
 
 
@@ -269,6 +272,37 @@ def test_check_for_updates_does_not_cache_none(tmp_path, monkeypatch):
 
     # The cache file must NOT have been written with a None result
     assert not cache_file.exists(), "None result must not be cached"
+
+
+def test_cached_behind_invalidated_when_local_head_changes(tmp_path, monkeypatch):
+    """A cache written for an earlier local HEAD must not report a stale behind count.
+
+    Regression for #45556: for a git install the update-check cache key is
+    ``HERMES_REVISION`` (unset -> None), so a manual ``git pull`` fast-forward changed
+    neither the key nor the version and left a false "N commits behind" until the 6h TTL
+    expired. The cache must key on the local git HEAD, so any local-HEAD move invalidates it.
+    """
+    from hermes_cli import banner
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cache_file = tmp_path / ".update_check"
+    # A cache written at an earlier HEAD recorded "3 behind"; a manual pull has since brought
+    # the checkout to origin/main, so the truthful answer is 0 behind.
+    old_head = "0" * 40
+    cache_file.write_text(json.dumps({
+        "ts": time.time(), "behind": 3, "rev": old_head, "ver": banner.VERSION,
+    }), encoding="utf-8")
+
+    fake_head = "1" * 40
+    monkeypatch.setattr(banner, "_resolve_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(banner, "_git_stdout", lambda args, **kw: fake_head)
+    monkeypatch.setattr(banner, "_check_via_local_git", lambda repo_dir: 0)
+
+    assert banner.check_for_updates() == 0
+    # The stale entry was invalidated and the cache rewritten for the new HEAD.
+    cached = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert cached["rev"] == fake_head
+    assert cached["behind"] == 0
 
 
 


### PR DESCRIPTION
## Summary

The startup banner / `hermes update --check` update notice reads a cache at `~/.hermes/.update_check` keyed on `HERMES_REVISION` (unset → `None`) and the installed version. For a git install, a **manual** `git pull` fast-forward moves the local `HEAD` without changing either key, so a stale "N commits behind" banner survives until the 6-hour cache TTL expires. `_invalidate_update_cache()` only runs inside `hermes update`, never on a manual `git pull`.

## Fix

Key the cache on the revision that actually determines the behind-count: the embedded `HERMES_REVISION` for nix/docker builds, else the **local git HEAD** for a checkout (new `_resolve_check_revision` helper in `hermes_cli/banner.py`). Any local-HEAD move now invalidates a stale cache. Reading `HEAD` is a cheap local subprocess (~5ms, no network) — the expensive operation the cache exists to avoid is the network fetch (0.5–3s).

Regression test `test_cached_behind_invalidated_when_local_head_changes` was confirmed RED on the base (returned the stale behind count) and GREEN after the fix.

## Notes

- Existing cache files written with `rev: None` (pre-fix) become a miss on the next check, which correctly recomputes `behind` — no migration needed.
- **Open question:** this keys on the local `HEAD` only. A remote advancing while `HEAD` is pinned (no local pull) still returns the cached behind-count until the 6h TTL — that is the existing coarseness of the cache, unchanged by this PR. Invalidating on "origin/main moved" too would require a network probe on every warm read, which is the opposite of why the cache exists.

Closes #45556
