### PR TITLE
fix(hindsight): normalize recall_tags to a list before recall

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -760,7 +760,10 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _apply_recall_settings(self, cfg: dict) -> None:
         """Recall knobs are pure config too (``{}`` yields the defaults)."""
-        self._recall_tags = cfg.get("recall_tags") or None
+        # Config documents recall_tags as comma-separated (parity with retain_tags and
+        # recall_types below), but Hindsight's RecallRequest.tags is list[str] — passing a
+        # raw CSV string 422s the API. Normalize with the same helper retain_tags uses.
+        self._recall_tags = _normalize_retain_tags(cfg.get("recall_tags")) or None
         self._recall_tags_match = cfg.get("recall_tags_match", "any")
         self._auto_recall = cfg.get("auto_recall", True)
         self._recall_sync = bool(cfg.get("recall_sync", False))

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -224,6 +224,31 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
     ]
 
 
+def test_recall_tags_csv_config_becomes_list(provider_with_config):
+    """Documented recall_tags format is comma-separated; RecallRequest.tags is list[str]."""
+    p = provider_with_config(recall_tags="status:active, scope:user:alex")
+    assert p._recall_tags == ["status:active", "scope:user:alex"]
+
+
+def test_recall_tags_list_config_is_deduped(provider_with_config):
+    p = provider_with_config(recall_tags=["status:active", "status:active", "scope:user:alex"])
+    assert p._recall_tags == ["status:active", "scope:user:alex"]
+
+
+def test_recall_tags_unset_stays_none(provider_with_config):
+    p = provider_with_config()
+    assert p._recall_tags is None
+
+
+def test_recall_tool_sends_tags_as_list(provider_with_config):
+    """Regression: a raw CSV string here 422s Hindsight's RecallRequest.tags."""
+    p = provider_with_config(recall_tags="status:active")
+    p.handle_tool_call("hindsight_recall", {"query": "preferences"})
+    kwargs = p._client.arecall.call_args.kwargs
+    assert kwargs["tags"] == ["status:active"]
+    assert isinstance(kwargs["tags"], list)
+
+
 # ---------------------------------------------------------------------------
 # Schema tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Problem

`HindsightMemoryProvider` reads `recall_tags` straight out of config without normalizing it:

```python
self._recall_tags = cfg.get("recall_tags") or None
```

The value is then handed to the client as-is:

```python
kwargs.update(tags=self._recall_tags, tags_match=self._recall_tags_match)
```

Hindsight's `RecallRequest.tags` is `list[str]`, so a configured `recall_tags: "status:active"` is sent as a bare string and the API rejects the recall with **HTTP 422**.

This is inconsistent with the two neighbouring settings:

- `retain_tags` is normalized via `_normalize_retain_tags` (`__init__.py`, `_apply_retain_settings`).
- `recall_types` is CSV-split inline, and its comment explicitly says a comma-separated string is accepted *"for parity with recall_tags"* — but `recall_tags` itself never got that treatment.

The config schema also documents the field as comma-separated:

```python
{"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", ...}
```

So the documented format is the one that fails.

### Fix

Normalize with `_normalize_retain_tags`, the helper `retain_tags` already uses. It handles comma-separated strings, JSON-encoded lists, and real lists, and de-duplicates while preserving order:

```python
self._recall_tags = _normalize_retain_tags(cfg.get("recall_tags")) or None
```

`_normalize_retain_tags` is already imported in this module, so there is no new dependency. `or None` is preserved so the unset case still disables the tag filter rather than sending `[]`.

### Tests

Four regression tests in `tests/plugins/memory/test_hindsight_provider.py`:

- `test_recall_tags_csv_config_becomes_list` — the documented CSV format
- `test_recall_tags_list_config_is_deduped` — list input, duplicates dropped
- `test_recall_tags_unset_stays_none` — guards the disable path
- `test_recall_tool_sends_tags_as_list` — end-to-end, asserts the recall call receives a list

Verified they fail on the unpatched code (3 of 4, the unset case passing in both as intended):

```
E  AssertionError: assert 'status:active' == ['status:active']
```

Full file passes with the fix: **90 passed**.

### Notes

Found on a live install where `hindsight` is the active memory provider (`mode=local_external`). The bug is latent until `recall_tags` is actually configured, which is likely why it has gone unnoticed.
