### PR TITLE
fix(desktop): anchor Windows update handoff cwd

### DIFF
--- a/apps/desktop/electron/update-handoff-marker.test.ts
+++ b/apps/desktop/electron/update-handoff-marker.test.ts
@@ -66,6 +66,17 @@ function runWindows(installRoot: string, startedAt?: string) {
   )
 }
 
+test('Windows hand-off anchors verification to the installation root', () => {
+  const source = fs.readFileSync(WINDOWS_SCRIPT, 'utf8')
+  const markerTest = source.indexOf('if ($SelfTestMarker)')
+  const anchor = source.indexOf('Set-Location -LiteralPath $InstallRoot')
+  const python = source.indexOf('$pythonExe = Join-Path $InstallRoot')
+
+  assert.ok(markerTest >= 0, 'marker self-test guard should exist')
+  assert.ok(anchor > markerTest, 'the hand-off must anchor its cwd after self-tests')
+  assert.ok(anchor < python, 'the hand-off must anchor its cwd before running Python')
+})
+
 function assertScriptHandoff(run: (installRoot: string, startedAt?: string) => ReturnType<typeof spawnSync>) {
   const preserved = sandbox('preserved')
   const acquiredAt = Math.floor(Date.now() / 1000) - 300

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1444,6 +1444,12 @@ try {
         exit 0
     }
 
+    # A detached `cmd /c start` hand-off inherits Electron's launch directory,
+    # which may be the packaged app rather than this checkout. The post-update
+    # verifier receives `Path.cwd()`, so anchor every following step to the
+    # installation root before it inspects the rebuilt Desktop artifacts.
+    Set-Location -LiteralPath $InstallRoot
+
     # Check only the interpreter here: dependency recovery belongs to update.
     $pythonExe = Join-Path $InstallRoot "venv\Scripts\python.exe"
     if (-not (Test-Path -LiteralPath $pythonExe -PathType Leaf)) {


### PR DESCRIPTION
## Summary
- set the Windows Desktop hand-off working directory to `InstallRoot` before running the updater and post-update verifier
- prevent `verify_windows_desktop_update(Path.cwd())` from searching below the packaged Electron directory and falsely reporting `Hermes.exe` missing
- add a regression check for the hand-off cwd anchor

## Validation
- `npm --workspace apps/desktop test -- electron/update-handoff-marker.test.ts`
- PowerShell script parse check

Observed on Windows: the Desktop update completed and relaunched successfully, but the detached updater inherited a non-checkout working directory, causing a false verification failure.