### PR TITLE
feat(desktop): default glass to 29% tint on the sidebar

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -86,6 +86,15 @@ Menus and popovers use their own shared `shadow-md` +
 dashed targets and local blur. These are semantic surface classes, not licenses
 for call-site shadow or border inventions.
 
+## Window glass
+
+Glass defaults to **29% Tint, Sidebar only** in both light and dark appearances.
+Fade defaults to zero so the content column and text stay opaque. Native frost
+keeps its platform/appearance defaults. Explicitly saved settings take precedence;
+changing defaults must not overwrite a user's existing choices. The shared
+`apps/shared/src/translucency.ts` resolver owns these defaults for both the
+renderer and Electron's first window paint.
+
 ## Stroke & color tokens
 
 | Token | Use |

--- a/apps/desktop/electron/translucency.test.ts
+++ b/apps/desktop/electron/translucency.test.ts
@@ -603,9 +603,7 @@ describe('what an update actually changes natively', () => {
   })
 
   it('leaves a window alone when glass is selected but off', () => {
-    // The light default carries one point of fade. Someone who dragged the
-    // tint to zero asked for an opaque window, and that point must not follow
-    // them there — off has to mean exactly 1, not 0.9999.
+    // A saved fade must not follow the tint to zero: off means opaque.
     expect(windowOpacityFor({ ...glass(0), fade: 1 })).toBe(1)
     expect(windowOpacityFor({ ...glass(0), fade: 40 })).toBe(1)
   })
@@ -615,12 +613,7 @@ describe('what an update actually changes natively', () => {
   })
 })
 
-/**
- * The shipped defaults, per platform. These are the numbers a fresh profile
- * gets before anyone opens Settings, so they are the ones most people will
- * ever see — and they differ by platform because the lever means different
- * things behind macOS vibrancy and Windows acrylic.
- */
+/** Fresh profiles share the sidebar treatment, with native frost per platform. */
 describe('the defaults a fresh profile lands on', () => {
   const mac = (appearance: 'dark' | 'light') => defaultTranslucencyValues(appearance, false)
   const win = (appearance: 'dark' | 'light') => defaultTranslucencyValues(appearance, true)
@@ -641,21 +634,16 @@ describe('the defaults a fresh profile lands on', () => {
     expect(defaultTranslucencyState('dark', false, false).mode).toBe('clear')
   })
 
-  it('tints light more heavily than dark, on both platforms', () => {
-    // A dark field already separates from what is behind it; a bright one
-    // needs real thinning before the desktop reads as a layer underneath.
-    expect(mac('light').intensity).toBeGreaterThan(mac('dark').intensity)
-    expect(win('light').intensity).toBeGreaterThan(win('dark').intensity)
+  it('keeps tint consistent across appearances and platforms', () => {
+    for (const values of [mac('light'), mac('dark'), win('light'), win('dark')]) {
+      expect(values.intensity).toBe(mac('light').intensity)
+    }
   })
 
-  it('asks far less of Windows, which composites its own tint in DWM', () => {
-    expect(win('light').intensity).toBeLessThan(mac('light').intensity)
-    expect(win('dark').intensity).toBeLessThan(mac('dark').intensity)
-  })
-
-  it('never fades a Windows window — setOpacity dims the composited backdrop', () => {
-    expect(win('light').fade).toBe(0)
-    expect(win('dark').fade).toBe(0)
+  it('keeps the content column opaque at the native level', () => {
+    for (const values of [mac('light'), mac('dark'), win('light'), win('dark')]) {
+      expect(windowOpacityFor({ ...values, mode: 'glass' })).toBe(1)
+    }
   })
 
   it('defaults each platform onto a frost that platform can actually render', () => {
@@ -665,9 +653,9 @@ describe('the defaults a fresh profile lands on', () => {
     }
   })
 
-  it('opens the whole window, not just the sidebar rail', () => {
+  it('uses the normalized scope default for every appearance and platform', () => {
     for (const values of [mac('light'), mac('dark'), win('light'), win('dark')]) {
-      expect(values.scope).toBe('window')
+      expect(values.scope).toBe(normalizeScope(undefined))
     }
   })
 })
@@ -680,9 +668,14 @@ describe('the defaults a fresh profile lands on', () => {
 describe('resolving the book for the painted appearance', () => {
   const empty = normalizeBook(null, true)
 
-  it('falls all the way through to the platform default', () => {
-    expect(resolveTranslucency(empty, 'dark', false).intensity).toBe(defaultTranslucencyValues('dark', false).intensity)
-    expect(resolveTranslucency(empty, 'dark', true).intensity).toBe(defaultTranslucencyValues('dark', true).intensity)
+  it('agrees with the native first-window defaults in either appearance', () => {
+    for (const appearance of ['light', 'dark'] as const) {
+      for (const isWindows of [false, true]) {
+        expect(resolveTranslucency(empty, appearance, isWindows)).toEqual(
+          defaultTranslucencyState(appearance, true, isWindows)
+        )
+      }
+    }
   })
 
   it('scopes an edit to the appearance it was made in', () => {
@@ -692,14 +685,17 @@ describe('resolving the book for the painted appearance', () => {
     expect(resolveTranslucency(book, 'dark', false).intensity).toBe(defaultTranslucencyValues('dark', false).intensity)
   })
 
-  it('carries a v1 state into BOTH appearances via base', () => {
-    // Someone who tuned a window before appearances were split keeps exactly
-    // what was on screen, in either appearance, until they edit one of them.
-    const migrated = normalizeBook({ intensity: 40, mode: 'glass' }, true)
+  it('preserves a saved whole-window treatment in both appearances', () => {
+    const saved = { intensity: 40, scope: 'window', mode: 'glass' } as const
+    const migrated = normalizeBook(saved, true)
 
-    expect(migrated.base.intensity).toBe(40)
-    expect(resolveTranslucency(migrated, 'light', false).intensity).toBe(40)
-    expect(resolveTranslucency(migrated, 'dark', false).intensity).toBe(40)
+    expect(migrated.base).toEqual({ intensity: saved.intensity, scope: saved.scope })
+
+    for (const appearance of ['light', 'dark'] as const) {
+      for (const isWindows of [false, true]) {
+        expect(resolveTranslucency(migrated, appearance, isWindows)).toMatchObject(saved)
+      }
+    }
   })
 
   it('lets an appearance override base without disturbing the other', () => {

--- a/apps/desktop/src/store/translucency.win10.test.ts
+++ b/apps/desktop/src/store/translucency.win10.test.ts
@@ -10,10 +10,9 @@ import { describe, expect, it, vi } from 'vitest'
 // That is the exact shape of the bug this test guards: the $translucency
 // computed used to pass GLASS_IS_WINDOWS as the "isWindows" argument to
 // resolveTranslucency. On Win10 glass is unsupported, so GLASS_IS_WINDOWS is
-// false and the fallback defaults came from the MAC table (light intensity 66,
-// dark intensity 22) instead of the WINDOWS table (light intensity 20, dark
-// intensity 5) — an untouched profile rendered at ~70% opacity. The fix passes
-// isWindowsPlatform() instead, which is true on Win32 regardless of glass.
+// false and the fallback defaults came from the MAC table instead of the
+// WINDOWS table. The fix passes isWindowsPlatform() instead, which is true
+// on Win32 regardless of glass support.
 vi.hoisted(() => {
   Object.defineProperty(globalThis.navigator, 'platform', { configurable: true, value: 'Win32' })
   Object.defineProperty(globalThis.window, 'hermesDesktop', {
@@ -26,9 +25,7 @@ import { defaultTranslucencyValues } from '@hermes/shared/translucency'
 
 import { $translucency, $translucencyBook, GLASS_SUPPORTED, setAppearance } from './translucency'
 
-// The windows table is the one that must win on Win10. These are the numbers
-// the issue calls out: mac light 66 / mac dark 22 vs windows light 20 /
-// windows dark 5.
+// The Windows table must win on Win10, even when tint matches macOS.
 const WINDOWS_DARK = defaultTranslucencyValues('dark', true)
 const WINDOWS_LIGHT = defaultTranslucencyValues('light', true)
 
@@ -45,15 +42,12 @@ describe('Win10 translucency defaults (regression for #90824)', () => {
     // platform defaults. The store's initial appearance is dark.
     expect($translucency.get()).toEqual({ ...WINDOWS_DARK, mode: 'clear' })
 
-    // The bug's signature: mac dark intensity is 22, windows dark is 5.
-    expect($translucency.get().intensity).toBe(5)
-    expect($translucency.get().intensity).not.toBe(22)
+    expect($translucency.get().material).not.toBe(defaultTranslucencyValues('dark', false).material)
 
     // Light appearance must resolve the windows light table too.
     setAppearance('light')
     expect($translucency.get()).toEqual({ ...WINDOWS_LIGHT, mode: 'clear' })
-    expect($translucency.get().intensity).toBe(20)
-    expect($translucency.get().intensity).not.toBe(66)
+    expect($translucency.get().material).not.toBe(defaultTranslucencyValues('light', false).material)
   })
 
   it('keeps the mode clear when glass is unsupported', () => {
@@ -69,6 +63,5 @@ describe('Win10 translucency defaults (regression for #90824)', () => {
     setAppearance('dark')
 
     expect($translucency.get()).toEqual({ ...WINDOWS_DARK, mode: 'clear' })
-    expect($translucency.get().intensity).toBe(5)
   })
 })

--- a/apps/shared/src/translucency.ts
+++ b/apps/shared/src/translucency.ts
@@ -52,7 +52,7 @@ export const GLASS_SCOPES = ['window', 'sidebar'] as const
 
 export type GlassScope = (typeof GLASS_SCOPES)[number]
 
-export const DEFAULT_GLASS_SCOPE: GlassScope = 'window'
+export const DEFAULT_GLASS_SCOPE: GlassScope = 'sidebar'
 
 /**
  * Electron `setBackgroundMaterial` values. `'auto'` is deliberately absent —
@@ -125,41 +125,19 @@ export type TranslucencyValues = Omit<TranslucencyState, 'mode'>
 export type Appearance = 'light' | 'dark'
 
 /**
- * Per-appearance defaults, per platform family. Glass ships ON: it is the
- * better-looking half of the feature, and a lever that starts at zero is a
- * feature nobody finds.
- *
- * The two platforms need different numbers because the lever means different
- * things behind them. `intensity` is how much of the theme tint the renderer
- * REMOVES (see `glassSurfaceKeep`), and what shows through underneath is a
- * native material with its own weight:
- *
- * - macOS vibrancy is genuinely sheer, so the tint has to come most of the way
- *   off before the desktop reads at all. Light leans heavy — a bright desktop
- *   behind a bright window needs real thinning before the field separates —
- *   with a single point of fade so the window edge reads as glass rather than
- *   as paint. Dark takes far less: a dark field already separates, and the
- *   tint that flatters light would smother it.
- * - Windows acrylic composites its OWN tint in DWM before the page is drawn,
- *   so the renderer's tint stacks on top of a backdrop that is already doing
- *   the work. The same numbers that read as frost on a Mac read as a washed
- *   sheet here; these stay low and let DWM carry it. Fade stays at zero —
- *   `setOpacity` over a system backdrop dims the composited result rather than
- *   deepening it.
- *
- * Both sit on the frost each platform renders best: 'header' and 'titlebar'
- * are macOS-only rungs (on Windows they collapse onto mica — see
- * `glassMaterialsFor`), while 'under-window' is the acrylic rung, the live
- * blur closest to what macOS calls under-window.
+ * Glass starts at 29% tint, confined to the sidebar in both appearances.
+ * Fade stays off so the content column and text remain fully opaque.
+ * Frost keeps its platform/appearance tuning: macOS uses header/titlebar,
+ * while Windows uses under-window, the live acrylic backdrop.
  */
 const DEFAULT_VALUES: Record<'mac' | 'windows', Record<Appearance, TranslucencyValues>> = {
   mac: {
-    light: { intensity: 66, fade: 1, material: 'header', scope: 'window' },
-    dark: { intensity: 22, fade: 0, material: 'titlebar', scope: 'window' }
+    light: { intensity: 29, fade: 0, material: 'header', scope: DEFAULT_GLASS_SCOPE },
+    dark: { intensity: 29, fade: 0, material: 'titlebar', scope: DEFAULT_GLASS_SCOPE }
   },
   windows: {
-    light: { intensity: 20, fade: 0, material: 'under-window', scope: 'window' },
-    dark: { intensity: 5, fade: 0, material: 'under-window', scope: 'window' }
+    light: { intensity: 29, fade: 0, material: 'under-window', scope: DEFAULT_GLASS_SCOPE },
+    dark: { intensity: 29, fade: 0, material: 'under-window', scope: DEFAULT_GLASS_SCOPE }
   }
 }
 
@@ -274,7 +252,7 @@ export function normalizeMaterial(value: unknown): GlassMaterial {
   return GLASS_MATERIALS.includes(value as GlassMaterial) ? (value as GlassMaterial) : DEFAULT_GLASS_MATERIAL
 }
 
-/** Unknown or unsupported values fall back to whole-window glass. */
+/** Unknown or unsupported values fall back to sidebar glass. */
 export function normalizeScope(value: unknown): GlassScope {
   return GLASS_SCOPES.includes(value as GlassScope) ? (value as GlassScope) : DEFAULT_GLASS_SCOPE
 }


### PR DESCRIPTION
## What does this PR do?

Make Glass default to 29% Tint and Sidebar only in both light and dark mode. The content column stays opaque, with no native window fade. Existing saved choices still take precedence.

## Related Issue

User-requested appearance change; no linked issue.

## Type of Change

- [x] ✨ New feature (appearance defaults)

## Changes Made

- Update `apps/shared/src/translucency.ts`, the shared source for renderer defaults and Electron's first-window state. Keep the existing native frost choices for each platform and appearance.
- Update the desktop translucency tests to cover native/renderer agreement, saved whole-window settings, and Windows defaults without freezing the old tint values.
- Document the defaults in `apps/desktop/DESIGN.md`.

## How to Test

- [x] From the repository root: `node node_modules/vitest/vitest.mjs run --root apps/desktop electron/translucency.test.ts src/store/translucency.test.ts src/store/translucency.win10.test.ts` — 116 tests passed across 3 files.
- [x] Execute the shared resolver with an empty settings book for light/dark and macOS/Windows; renderer and native defaults agree at intensity 29, scope `sidebar`, fade 0.
- [x] Preview the worktree's resolved defaults through the running macOS renderer in both appearances. Confirm the 71% tint keep value, the glass seam at the sidebar edge, and the opaque content-side gradient. Capture screenshots and restore the original appearance/settings afterward.
- [ ] Native Windows visual check.

## Checklist

- [x] Conventional commits; implementation/tests and documentation are separate commits.
- [x] Searched existing PRs; no duplicate default change found.
- [x] Changes are limited to this appearance request.
- [x] Relevant tests and design documentation updated.
- [x] Tested the live macOS appearance; Windows resolver behavior covered by targeted tests.
- [ ] Full test suite, lint, typecheck, and build were not run.

## Screenshots / Logs

```text
Test Files  3 passed (3)
     Tests  116 passed (116)
```
