### PR TITLE
fix(desktop): materialize timeline jump targets

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -399,8 +399,8 @@ function ChatRuntimeBoundary({
   )
 
   const transcriptWindow = useMemo(
-    () => ({ olderAvailable, expandWindow, revealMessage, timelineEntries }),
-    [expandWindow, olderAvailable, revealMessage, timelineEntries]
+    () => ({ olderAvailable, expandWindow, revealMessage, revealScope: runtimeId || storedId || '', timelineEntries }),
+    [expandWindow, olderAvailable, revealMessage, runtimeId, storedId, timelineEntries]
   )
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -79,7 +79,11 @@ import {
   mergeOlderTranscriptPage,
   transcriptBackfillAvailable
 } from './transcript-backfill'
-import { advanceSessionTranscriptWindow, type SessionWindowMemo } from './transcript-window'
+import {
+  advanceSessionTranscriptWindow,
+  type SessionWindowMemo,
+  transcriptWindowPagesToReveal
+} from './transcript-window'
 
 interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   gateway: HermesGateway | null
@@ -291,12 +295,14 @@ function ChatRuntimeBoundary({
 
   const revealMessage = useCallback(
     (messageId: string) => {
-      if (!view.$messages.get().some(message => message.id === messageId)) {
+      const neededPages = transcriptWindowPagesToReveal(view.$messages.get(), messageId)
+
+      if (neededPages == null) {
         return
       }
 
       setRevealTarget(messageId)
-      setWindowPages(pages => pages + 1)
+      setWindowPages(pages => Math.max(pages, neededPages))
     },
     [view]
   )

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -9,6 +9,7 @@ import { useLocation } from 'react-router'
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { sessionShouldHaveTranscript } from '@/app/session/hooks/use-session-actions/utils'
 import { Thread } from '@/components/assistant-ui/thread'
+import { deriveTimelineEntries } from '@/components/assistant-ui/thread/timeline-data'
 import { TranscriptWindowProvider } from '@/components/assistant-ui/thread/transcript-window'
 import { Backdrop } from '@/components/Backdrop'
 import { COMPOSER_HEART_CONFIG, HeartField } from '@/components/chat/vibe-hearts'
@@ -20,7 +21,7 @@ import { ErrorState } from '@/components/ui/error-state'
 import { TitleMenuTrigger } from '@/components/ui/title-menu-trigger'
 import { type HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
-import type { ChatMessage } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
 import { NEW_SESSION_TITLE, quickModelOptions, sessionTitle } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
@@ -259,6 +260,7 @@ function ChatRuntimeBoundary({
   // value must come from a ref rather than the stale render closure.
   const runtimeIdRef = useRef(runtimeId)
   runtimeIdRef.current = runtimeId
+  const [revealTarget, setRevealTarget] = useState<string | null>(null)
 
   // Reset the window on session swap during RENDER, so a large expand from the
   // previous chat can't leak into the next one's first paint (#55191). The
@@ -283,6 +285,46 @@ function ChatRuntimeBoundary({
   }, [messages, windowPages])
 
   const runtimeMessageRepository = useRuntimeMessageRepository(windowedMessages)
+
+  const revealMessage = useCallback(
+    (messageId: string) => {
+      if (!view.$messages.get().some(message => message.id === messageId)) {
+        return
+      }
+
+      setRevealTarget(messageId)
+      setWindowPages(pages => pages + 1)
+    },
+    [view]
+  )
+
+  useEffect(() => {
+    const target = revealTarget
+
+    if (!target) {
+      return
+    }
+
+    if (!messages.some(message => message.id === target)) {
+      setRevealTarget(null)
+
+      return
+    }
+
+    if (windowedMessages.some(message => message.id === target)) {
+      setRevealTarget(null)
+
+      return
+    }
+
+    if (windowed) {
+      setWindowPages(pages => pages + 1)
+
+      return
+    }
+
+    setRevealTarget(null)
+  }, [messages, revealTarget, windowed, windowedMessages])
 
   const storedId = useStore(view.$storedId)
   const connection = useStore($connection)
@@ -338,7 +380,28 @@ function ChatRuntimeBoundary({
 
   const olderAvailable = windowed || restBackfillAvailable
 
-  const transcriptWindow = useMemo(() => ({ olderAvailable, expandWindow }), [expandWindow, olderAvailable])
+  const timelinePromptSignature = messages
+    .filter(message => message.role === 'user')
+    .map(message => message.id)
+    .join('\n')
+
+  const timelineEntries = useMemo(
+    () =>
+      deriveTimelineEntries(
+        messages
+          .filter(message => message.role === 'user')
+          .map(message => ({ id: message.id, role: message.role, text: chatMessageText(message) }))
+      ),
+    // User prompt text is immutable for an existing id; edits create a new
+    // message id. Keep assistant streaming out of this derivation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [timelinePromptSignature]
+  )
+
+  const transcriptWindow = useMemo(
+    () => ({ olderAvailable, expandWindow, revealMessage, timelineEntries }),
+    [expandWindow, olderAvailable, revealMessage, timelineEntries]
+  )
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
     messageRepository: runtimeMessageRepository,

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -269,6 +269,7 @@ function ChatRuntimeBoundary({
   if (windowSessionKey !== runtimeId) {
     setWindowSessionKey(runtimeId)
     setWindowPages(1)
+    setRevealTarget(null)
   }
 
   const { messages: windowedMessages, windowed } = useMemo(() => {
@@ -285,6 +286,8 @@ function ChatRuntimeBoundary({
   }, [messages, windowPages])
 
   const runtimeMessageRepository = useRuntimeMessageRepository(windowedMessages)
+
+  const cancelReveal = useCallback(() => setRevealTarget(null), [])
 
   const revealMessage = useCallback(
     (messageId: string) => {
@@ -399,8 +402,15 @@ function ChatRuntimeBoundary({
   )
 
   const transcriptWindow = useMemo(
-    () => ({ olderAvailable, expandWindow, revealMessage, revealScope: runtimeId || storedId || '', timelineEntries }),
-    [expandWindow, olderAvailable, revealMessage, runtimeId, storedId, timelineEntries]
+    () => ({
+      cancelReveal,
+      olderAvailable,
+      expandWindow,
+      revealMessage,
+      revealScope: runtimeId || storedId || '',
+      timelineEntries
+    }),
+    [cancelReveal, expandWindow, olderAvailable, revealMessage, runtimeId, storedId, timelineEntries]
   )
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({

--- a/apps/desktop/src/app/chat/transcript-window.test.ts
+++ b/apps/desktop/src/app/chat/transcript-window.test.ts
@@ -11,7 +11,8 @@ import {
   selectTranscriptWindow,
   TRANSCRIPT_WINDOW_BUDGET,
   TRANSCRIPT_WINDOW_MIN_MESSAGES,
-  TRANSCRIPT_WINDOW_SLACK
+  TRANSCRIPT_WINDOW_SLACK,
+  transcriptWindowPagesToReveal
 } from './transcript-window'
 
 const message = (id: string, chars: number, branchGroupId?: string): ChatMessage => ({
@@ -94,6 +95,15 @@ describe('selectTranscriptWindow', () => {
     // Paging terminates at the full transcript — never a dead end.
     expect(window.windowed).toBe(false)
     expect(window.messages).toHaveLength(messages.length)
+  })
+
+  it('computes the page that materializes a durable target without incremental retries', () => {
+    const messages = transcript(100, RENDER_WEIGHT_CHARS * 40)
+
+    expect(transcriptWindowPagesToReveal(messages, 'm-99')).toBe(1)
+    expect(transcriptWindowPagesToReveal(messages, 'm-50')).toBe(2)
+    expect(transcriptWindowPagesToReveal(messages, 'm-0')).toBe(4)
+    expect(transcriptWindowPagesToReveal(messages, 'missing')).toBeNull()
   })
 
   it('never cuts inside a branch group, so branches keep their fork point', () => {

--- a/apps/desktop/src/app/chat/transcript-window.ts
+++ b/apps/desktop/src/app/chat/transcript-window.ts
@@ -107,6 +107,21 @@ export function selectTranscriptWindow(messages: readonly ChatMessage[], pages =
   return { messages: messages.slice(start), windowed: true }
 }
 
+/** Smallest window page count whose weight walk reaches a durable message id. */
+export function transcriptWindowPagesToReveal(messages: readonly ChatMessage[], targetId: string): number | null {
+  let weight = 0
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    weight += messageStoreWeight(messages[i].parts)
+
+    if (messages[i].id === targetId) {
+      return Math.max(1, Math.ceil(weight / TRANSCRIPT_WINDOW_BUDGET))
+    }
+  }
+
+  return null
+}
+
 /**
  * How far past the budget a window may grow before the cut moves again.
  * Half a page: each re-cut trims about this much, so streaming causes one

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -8,6 +8,8 @@ import {
   LIVE_TAIL_PARTS,
   liveTailStart,
   type MessageGroup,
+  renderBudgetToRevealGroup,
+  renderBudgetToRevealWeightedGroup,
   resolveThreadScrollTarget,
   RUN_START_SNAP_THRESHOLD_PX,
   shouldClampTranscriptBudget,
@@ -20,6 +22,27 @@ import {
 
 afterEach(() => {
   vi.restoreAllMocks()
+})
+
+describe('renderBudgetToRevealGroup', () => {
+  it('sums newest-first paint weight through the durable target id', () => {
+    const groups: MessageGroup[] = [
+      { id: 'u1', index: 0, kind: 'standalone', weight: 10 },
+      { id: 'u2', index: 1, kind: 'standalone', weight: 20 },
+      { id: 'u3', index: 2, kind: 'standalone', weight: 5 }
+    ]
+
+    expect(renderBudgetToRevealGroup(groups, 'u3')).toBe(5)
+    expect(renderBudgetToRevealGroup(groups, 'u2')).toBe(25)
+    expect(renderBudgetToRevealGroup(groups, 'u1')).toBe(35)
+    expect(renderBudgetToRevealGroup(groups, 'missing')).toBeNull()
+  })
+
+  it('uses the runtime weight signature for a heavy hidden target', () => {
+    const groups = buildGroups(['0:u1:user', '1:a1:assistant', '2:u2:user', '3:a2:assistant'].join('\n'))
+
+    expect(renderBudgetToRevealWeightedGroup(groups, '80,70,30,20', 'u1')).toBe(200)
+  })
 })
 
 describe('subscribeToThreadForeground', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -23,6 +23,7 @@ import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
 import {
   getThreadScrollPosition,
+  onRevealMessageRequest,
   onScrollToBottomRequest,
   onThreadEditClose,
   onThreadEditOpen,
@@ -120,6 +121,41 @@ export const transcriptPaneBudget = (mountedPanes: number, hidden: boolean): num
 // is a no-op. Parked panes are unmounted, so they never hit this path.
 export const shouldClampTranscriptBudget = (hidden: boolean, renderBudget: number, paneBudget: number): boolean =>
   hidden && renderBudget > paneBudget
+
+/** Paint budget required to include the group containing a durable message id. */
+export const renderBudgetToRevealGroup = (groups: readonly MessageGroup[], messageId: string): number | null => {
+  const index = groups.findIndex(group => group.id === messageId)
+
+  if (index < 0) {
+    return null
+  }
+
+  let weight = 0
+
+  for (let i = groups.length - 1; i >= index; i--) {
+    weight += groups[i].weight
+  }
+
+  return weight
+}
+
+export const weightMessageGroups = (groups: readonly MessageGroup[], weightSignature: string): MessageGroup[] => {
+  const weights = weightSignature.split(',').map(weight => Number(weight) || 1)
+
+  return groups.map(group => ({
+    ...group,
+    weight:
+      group.kind === 'turn'
+        ? group.indices.reduce((sum, index) => sum + (weights[index] ?? 1), 0)
+        : (weights[group.index] ?? 1)
+  }))
+}
+
+export const renderBudgetToRevealWeightedGroup = (
+  groups: readonly MessageGroup[],
+  weightSignature: string,
+  messageId: string
+): number | null => renderBudgetToRevealGroup(weightMessageGroups(groups, weightSignature), messageId)
 // Units the backfill adds per committed step (see the backfill effect). A
 // 60-unit step produced ~10 visible prepend frames after FIRST_PAINT_BUDGET
 // retune (#83681). 290 fills a 600-unit page in two interruptible commits —
@@ -437,7 +473,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     targetScrollTop: resolveThreadScrollTarget
   })
 
-  const { olderAvailable, expandWindow } = useTranscriptWindow()
+  const { olderAvailable, expandWindow, revealScope } = useTranscriptWindow()
 
   useEffect(() => {
     $mountedTranscriptPanes.set($mountedTranscriptPanes.get() + 1)
@@ -558,17 +594,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // Weights (part count + visible character cost) fold into the BUDGET only.
   // Group identity stays structural, so a streaming append re-runs this cheap
   // sum — not the row JSX. Settled content hits messagePaintWeight's WeakMap.
-  const weightedGroups = useMemo(() => {
-    const weights = weightSignature.split(',').map(w => Number(w) || 1)
-
-    return groups.map(group => ({
-      ...group,
-      weight:
-        group.kind === 'turn'
-          ? group.indices.reduce((sum, index) => sum + (weights[index] ?? 1), 0)
-          : (weights[group.index] ?? 1)
-    }))
-  }, [groups, weightSignature])
+  const weightedGroups = useMemo(() => weightMessageGroups(groups, weightSignature), [groups, weightSignature])
 
   // The turn floor applies to a real page only. During the first-paint budget
   // the point is a small synchronous commit; forcing 8 turns into it would put
@@ -617,6 +643,34 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   // Floating jump button (outside this subtree) → return to the bottom.
   useEffect(() => onScrollToBottomRequest(() => void scrollToBottom(), sessionId), [scrollToBottom, sessionId])
+
+  // The timeline can select a prompt present in assistant-ui but outside this
+  // list's bounded DOM page. Raise only the list that actually owns the durable
+  // id; the timeline's bounded frame retry performs the scroll after React
+  // mounts the target. Store-window expansion remains owned by ChatRuntimeBoundary.
+  const revealHandlerRef = useRef<(scope: string, id: string) => boolean>(() => false)
+
+  revealHandlerRef.current = (scope: string, id: string) => {
+    if (!revealScope || scope !== revealScope || paneLifecycle !== 'visible') {
+      return false
+    }
+
+    const neededBudget = renderBudgetToRevealWeightedGroup(groups, weightSignature, id)
+
+    if (neededBudget == null) {
+      return false
+    }
+
+    if (neededBudget > renderBudget) {
+      setRenderBudget(neededBudget)
+    }
+
+    stopScroll()
+
+    return true
+  }
+
+  useEffect(() => onRevealMessageRequest((scope, id) => revealHandlerRef.current(scope, id)), [])
 
   // Waking from display: hidden (HUD mode hides the main window; OS hide does
   // the same to any window): rAF and ResizeObserver may have been frozen, so

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
@@ -1,6 +1,8 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { onRevealMessageRequest } from '@/store/thread-scroll'
 
 import { TranscriptWindowProvider } from './transcript-window'
 
@@ -140,6 +142,7 @@ describe('ThreadTimeline with a bounded runtime window', () => {
           olderAvailable: true,
           expandWindow: vi.fn(),
           revealMessage,
+          revealScope: 'runtime-1',
           timelineEntries
         }}
       >
@@ -164,11 +167,14 @@ describe('ThreadTimeline with a bounded runtime window', () => {
 
     vi.stubGlobal('CSS', { escape: (value: string) => value })
 
+    const frames: FrameRequestCallback[] = []
     const frame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
-      callback(performance.now() + 200)
+      frames.push(callback)
 
-      return 1
+      return frames.length
     })
+    const revealDom = vi.fn(() => true)
+    const unsubscribeReveal = onRevealMessageRequest(revealDom)
 
     surface.dataset.sessionAnchor = 'timeline-test'
     viewport.dataset.slot = 'aui_thread-viewport'
@@ -192,6 +198,7 @@ describe('ThreadTimeline with a bounded runtime window', () => {
           olderAvailable: true,
           expandWindow: vi.fn(),
           revealMessage,
+          revealScope: 'runtime-1',
           timelineEntries
         }}
       >
@@ -224,6 +231,7 @@ describe('ThreadTimeline with a bounded runtime window', () => {
           olderAvailable: true,
           expandWindow: vi.fn(),
           revealMessage,
+          revealScope: 'runtime-1',
           timelineEntries
         }}
       >
@@ -231,8 +239,56 @@ describe('ThreadTimeline with a bounded runtime window', () => {
       </TranscriptWindowProvider>
     )
 
+    act(() => {
+      while (frames.length) {
+        frames.shift()?.(performance.now() + 200)
+      }
+    })
+
+    expect(revealDom).toHaveBeenCalledWith('runtime-1', 'u0')
     expect(viewport.scrollTop).toBe(92)
+    unsubscribeReveal()
     frame.mockRestore()
+  })
+
+  it('cancels a pending hidden-target jump when the runtime scope changes', () => {
+    messages = transcript(6).slice(4)
+    const timelineEntries = transcript(6).map((message, index) => ({ id: message.id, preview: `prompt ${index}` }))
+    const frames: FrameRequestCallback[] = []
+    const frame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      frames.push(callback)
+
+      return frames.length
+    })
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+    const value = (revealScope: string) => ({
+      olderAvailable: true,
+      expandWindow: vi.fn(),
+      revealMessage: vi.fn(),
+      revealScope,
+      timelineEntries
+    })
+    const { rerender } = renderTimeline(
+      <TranscriptWindowProvider value={value('runtime-1')}>
+        <ThreadTimeline />
+      </TranscriptWindowProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'prompt 0' }))
+    expect(frames).toHaveLength(1)
+    const staleFrame = frames[0]
+
+    rerender(
+      <TranscriptWindowProvider value={value('runtime-2')}>
+        <ThreadTimeline />
+      </TranscriptWindowProvider>
+    )
+
+    expect(cancelFrame).toHaveBeenCalledWith(1)
+    act(() => staleFrame(performance.now() + 200))
+    expect(frames).toHaveLength(1)
+    frame.mockRestore()
+    cancelFrame.mockRestore()
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
@@ -133,12 +133,14 @@ describe('ThreadTimeline popover', () => {
 describe('ThreadTimeline with a bounded runtime window', () => {
   it('keeps older prompts in the rail and asks the window to reveal hidden targets', () => {
     messages = transcript(2)
+    const cancelReveal = vi.fn()
     const revealMessage = vi.fn()
     const timelineEntries = transcript(6).map((message, index) => ({ id: message.id, preview: `prompt ${index}` }))
 
     renderTimeline(
       <TranscriptWindowProvider
         value={{
+          cancelReveal,
           olderAvailable: true,
           expandWindow: vi.fn(),
           revealMessage,
@@ -154,11 +156,20 @@ describe('ThreadTimeline with a bounded runtime window', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'prompt 0' }))
 
+    expect(cancelReveal).toHaveBeenCalledOnce()
     expect(revealMessage).toHaveBeenCalledWith('u0')
+    expect(cancelReveal.mock.invocationCallOrder[0]).toBeLessThan(revealMessage.mock.invocationCallOrder[0])
+
+    fireEvent.click(screen.getByRole('button', { name: 'prompt 1' }))
+
+    expect(cancelReveal).toHaveBeenCalledTimes(2)
+    expect(revealMessage).toHaveBeenNthCalledWith(2, 'u1')
+    expect(cancelReveal.mock.invocationCallOrder[1]).toBeLessThan(revealMessage.mock.invocationCallOrder[1])
   })
 
   it('scrolls to the prompt after the window materializes it', () => {
     messages = transcript(6).slice(4)
+    const cancelReveal = vi.fn()
     const revealMessage = vi.fn()
     const timelineEntries = transcript(6).map((message, index) => ({ id: message.id, preview: `prompt ${index}` }))
     const surface = globalThis.document.createElement('div')
@@ -195,6 +206,7 @@ describe('ThreadTimeline with a bounded runtime window', () => {
     const { rerender } = render(
       <TranscriptWindowProvider
         value={{
+          cancelReveal,
           olderAvailable: true,
           expandWindow: vi.fn(),
           revealMessage,
@@ -208,6 +220,7 @@ describe('ThreadTimeline with a bounded runtime window', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'prompt 0' }))
+    expect(cancelReveal).toHaveBeenCalledOnce()
     expect(revealMessage).toHaveBeenCalledWith('u0')
 
     const target = globalThis.document.createElement('div')
@@ -228,6 +241,7 @@ describe('ThreadTimeline with a bounded runtime window', () => {
     rerender(
       <TranscriptWindowProvider
         value={{
+          cancelReveal,
           olderAvailable: true,
           expandWindow: vi.fn(),
           revealMessage,
@@ -247,6 +261,11 @@ describe('ThreadTimeline with a bounded runtime window', () => {
 
     expect(revealDom).toHaveBeenCalledWith('runtime-1', 'u0')
     expect(viewport.scrollTop).toBe(92)
+
+    fireEvent.click(screen.getByRole('button', { name: 'prompt 0' }))
+
+    expect(cancelReveal).toHaveBeenCalledTimes(2)
+    expect(revealMessage).toHaveBeenCalledOnce()
     unsubscribeReveal()
     frame.mockRestore()
   })

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { TranscriptWindowProvider } from './transcript-window'
+
 /**
  * The timeline must do NO work it can't currently show. Two gates are proven
  * here by rendering the real component and counting the work it performs:
@@ -64,6 +66,9 @@ const renderTimeline = (ui: ReactNode = <ThreadTimeline />) => render(ui)
 
 afterEach(() => {
   cleanup()
+  globalThis.document.body.replaceChildren()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
   selectorCalls.mockClear()
   transcriptReads.mockClear()
   paneActive = true
@@ -120,6 +125,114 @@ describe('ThreadTimeline popover', () => {
 
     // Still mounted — the popover fades out, it does not pop out of existence.
     expect(popover?.querySelectorAll('button')).toHaveLength(6)
+  })
+})
+
+describe('ThreadTimeline with a bounded runtime window', () => {
+  it('keeps older prompts in the rail and asks the window to reveal hidden targets', () => {
+    messages = transcript(2)
+    const revealMessage = vi.fn()
+    const timelineEntries = transcript(6).map((message, index) => ({ id: message.id, preview: `prompt ${index}` }))
+
+    renderTimeline(
+      <TranscriptWindowProvider
+        value={{
+          olderAvailable: true,
+          expandWindow: vi.fn(),
+          revealMessage,
+          timelineEntries
+        }}
+      >
+        <ThreadTimeline />
+      </TranscriptWindowProvider>
+    )
+
+    expect(screen.getAllByRole('button')).toHaveLength(6)
+
+    fireEvent.click(screen.getByRole('button', { name: 'prompt 0' }))
+
+    expect(revealMessage).toHaveBeenCalledWith('u0')
+  })
+
+  it('scrolls to the prompt after the window materializes it', () => {
+    messages = transcript(6).slice(4)
+    const revealMessage = vi.fn()
+    const timelineEntries = transcript(6).map((message, index) => ({ id: message.id, preview: `prompt ${index}` }))
+    const surface = globalThis.document.createElement('div')
+    const viewport = globalThis.document.createElement('div')
+    const host = globalThis.document.createElement('div')
+
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+
+    const frame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      callback(performance.now() + 200)
+
+      return 1
+    })
+
+    surface.dataset.sessionAnchor = 'timeline-test'
+    viewport.dataset.slot = 'aui_thread-viewport'
+    viewport.getBoundingClientRect = () => ({
+      bottom: 400,
+      height: 400,
+      left: 0,
+      right: 800,
+      top: 0,
+      width: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    })
+    surface.append(viewport, host)
+    globalThis.document.body.append(surface)
+
+    const { rerender } = render(
+      <TranscriptWindowProvider
+        value={{
+          olderAvailable: true,
+          expandWindow: vi.fn(),
+          revealMessage,
+          timelineEntries
+        }}
+      >
+        <ThreadTimeline />
+      </TranscriptWindowProvider>,
+      { container: host }
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'prompt 0' }))
+    expect(revealMessage).toHaveBeenCalledWith('u0')
+
+    const target = globalThis.document.createElement('div')
+    target.dataset.messageId = 'u0'
+    target.getBoundingClientRect = () => ({
+      bottom: 200,
+      height: 100,
+      left: 0,
+      right: 700,
+      top: 100,
+      width: 700,
+      x: 0,
+      y: 100,
+      toJSON: () => ({})
+    })
+    viewport.append(target)
+    messages = [userTurn('u0', 'prompt 0'), userTurn('u1', 'prompt 1')]
+    rerender(
+      <TranscriptWindowProvider
+        value={{
+          olderAvailable: true,
+          expandWindow: vi.fn(),
+          revealMessage,
+          timelineEntries
+        }}
+      >
+        <ThreadTimeline />
+      </TranscriptWindowProvider>
+    )
+
+    expect(viewport.scrollTop).toBe(92)
+    frame.mockRestore()
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
@@ -167,6 +167,44 @@ describe('ThreadTimeline with a bounded runtime window', () => {
     expect(cancelReveal.mock.invocationCallOrder[1]).toBeLessThan(revealMessage.mock.invocationCallOrder[1])
   })
 
+  it('releases the owning scroll controller before jumping to a rendered prompt', () => {
+    messages = transcript(6)
+    const revealDom = vi.fn(() => true)
+    const unsubscribeReveal = onRevealMessageRequest(revealDom)
+    const surface = globalThis.document.createElement('div')
+    const viewport = globalThis.document.createElement('div')
+    const host = globalThis.document.createElement('div')
+    const target = globalThis.document.createElement('div')
+
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }))
+    surface.dataset.sessionAnchor = 'timeline-test'
+    viewport.dataset.slot = 'aui_thread-viewport'
+    target.dataset.messageId = 'u0'
+    viewport.append(target)
+    surface.append(viewport, host)
+    globalThis.document.body.append(surface)
+
+    render(
+      <TranscriptWindowProvider
+        value={{
+          olderAvailable: false,
+          expandWindow: vi.fn(),
+          revealScope: 'runtime-1',
+          timelineEntries: transcript(6).map((message, index) => ({ id: message.id, preview: `prompt ${index}` }))
+        }}
+      >
+        <ThreadTimeline />
+      </TranscriptWindowProvider>,
+      { container: host }
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'prompt 0' }))
+
+    expect(revealDom).toHaveBeenCalledWith('runtime-1', 'u0')
+    unsubscribeReveal()
+  })
+
   it('scrolls to the prompt after the window materializes it', () => {
     messages = transcript(6).slice(4)
     const cancelReveal = vi.fn()
@@ -179,11 +217,13 @@ describe('ThreadTimeline with a bounded runtime window', () => {
     vi.stubGlobal('CSS', { escape: (value: string) => value })
 
     const frames: FrameRequestCallback[] = []
+
     const frame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
       frames.push(callback)
 
       return frames.length
     })
+
     const revealDom = vi.fn(() => true)
     const unsubscribeReveal = onRevealMessageRequest(revealDom)
 
@@ -274,12 +314,15 @@ describe('ThreadTimeline with a bounded runtime window', () => {
     messages = transcript(6).slice(4)
     const timelineEntries = transcript(6).map((message, index) => ({ id: message.id, preview: `prompt ${index}` }))
     const frames: FrameRequestCallback[] = []
+
     const frame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
       frames.push(callback)
 
       return frames.length
     })
+
     const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+
     const value = (revealScope: string) => ({
       olderAvailable: true,
       expandWindow: vi.fn(),
@@ -287,6 +330,7 @@ describe('ThreadTimeline with a bounded runtime window', () => {
       revealScope,
       timelineEntries
     })
+
     const { rerender } = renderTimeline(
       <TranscriptWindowProvider value={value('runtime-1')}>
         <ThreadTimeline />

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { ownViewport } from './timeline'
+import { jumpScroll, ownViewport } from './timeline'
 
 /**
  * Several chat surfaces are mounted at once — side by side in a split, and
@@ -9,6 +9,21 @@ import { ownViewport } from './timeline'
 
 afterEach(() => {
   document.body.innerHTML = ''
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('jumpScroll', () => {
+  it('sets the destination immediately when reduced motion is requested', () => {
+    const viewport = document.createElement('div')
+    const frame = vi.spyOn(window, 'requestAnimationFrame')
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: true }))
+
+    jumpScroll(viewport, 120)
+
+    expect(viewport.scrollTop).toBe(120)
+    expect(frame).not.toHaveBeenCalled()
+  })
 })
 
 const surface = (id: string, hidden = false) => `

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.test.ts
@@ -24,6 +24,21 @@ describe('jumpScroll', () => {
     expect(viewport.scrollTop).toBe(120)
     expect(frame).not.toHaveBeenCalled()
   })
+
+  it('returns a cancellation handle for an animated jump', () => {
+    const viewport = document.createElement('div')
+    const frame = vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(7)
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame')
+
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }))
+
+    const cancel = jumpScroll(viewport, 120)
+
+    cancel()
+
+    expect(frame).toHaveBeenCalledOnce()
+    expect(cancelFrame).toHaveBeenCalledWith(7)
+  })
 })
 
 const surface = (id: string, hidden = false) => `

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -2,8 +2,10 @@ import { useAui, useAuiState } from '@assistant-ui/react'
 import { type FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
+import { prefersReducedMotion } from '@/hooks/use-media-query'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
+import { requestRevealMessage } from '@/store/thread-scroll'
 
 import {
   activeTimelineIndex,
@@ -78,8 +80,14 @@ const hoverProps = (index: number, paint: (index: number, on: boolean) => void) 
 // shared rAF handle cancels a prior jump so rapid tick clicks don't fight.
 let jumpRaf = 0
 
-function jumpScroll(viewport: HTMLElement, top: number, duration = 170): void {
+export function jumpScroll(viewport: HTMLElement, top: number, duration = 170): void {
   cancelAnimationFrame(jumpRaf)
+  if (prefersReducedMotion()) {
+    viewport.scrollTop = top
+
+    return
+  }
+
   const start = viewport.scrollTop
   const delta = top - start
 
@@ -154,7 +162,7 @@ export const ThreadTimeline: FC = () => {
 /** Derived prompt rail for a VISIBLE surface. Split out so the hook body — and
  *  the transcript subscription it opens — never runs for a background tab. */
 const ActiveThreadTimeline: FC = () => {
-  const { revealMessage, timelineEntries } = useTranscriptWindow()
+  const { revealMessage, revealScope, timelineEntries } = useTranscriptWindow()
 
   // Cheap in the selector, expensive only when it changes: the ids alone tell
   // us whether the RAIL changed. Prompt text is immutable once sent, and an
@@ -222,14 +230,32 @@ const ActiveThreadTimeline: FC = () => {
   const [open, setOpen] = useState(false)
   const closeTimerRef = useRef<number | undefined>(undefined)
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const jumpFrameRef = useRef(0)
+
+  const cancelPendingJump = useCallback(() => {
+    if (jumpFrameRef.current) {
+      window.cancelAnimationFrame(jumpFrameRef.current)
+      jumpFrameRef.current = 0
+    }
+
+    pendingJumpRef.current = null
+  }, [])
+  const revealScopeRef = useRef(revealScope)
+
+  useLayoutEffect(() => {
+    if (revealScopeRef.current === revealScope) {
+      return
+    }
+
+    revealScopeRef.current = revealScope
+    cancelPendingJump()
+  }, [cancelPendingJump, revealScope])
 
   const jump = useCallback(
     (id: string) => {
-      const didScroll = scrollToPrompt(rootRef.current, id)
+      cancelPendingJump()
 
-      if (didScroll) {
-        pendingJumpRef.current = null
-
+      if (scrollToPrompt(rootRef.current, id)) {
         return
       }
 
@@ -237,8 +263,44 @@ const ActiveThreadTimeline: FC = () => {
         pendingJumpRef.current = id
         revealMessage(id)
       }
+
+      let frames = 0
+
+      const retry = () => {
+        if (pendingJumpRef.current !== id) {
+          jumpFrameRef.current = 0
+
+          return
+        }
+
+        // The store window and DOM paint budget are independent. Re-requesting
+        // is harmless until the id enters assistant-ui, then raises exactly the
+        // owning list's budget. The bounded retry waits for React to mount it.
+        if (revealScope) {
+          requestRevealMessage(revealScope, id)
+        }
+
+        if (scrollToPrompt(rootRef.current, id)) {
+          pendingJumpRef.current = null
+          jumpFrameRef.current = 0
+
+          return
+        }
+
+        frames += 1
+
+        if (frames >= 45) {
+          cancelPendingJump()
+
+          return
+        }
+
+        jumpFrameRef.current = window.requestAnimationFrame(retry)
+      }
+
+      jumpFrameRef.current = window.requestAnimationFrame(retry)
     },
-    [revealMessage]
+    [cancelPendingJump, revealMessage, revealScope]
   )
 
   useLayoutEffect(() => {
@@ -248,10 +310,24 @@ const ActiveThreadTimeline: FC = () => {
       return
     }
 
-    if (scrollToPrompt(rootRef.current, pendingId)) {
-      pendingJumpRef.current = null
+    if (revealScope) {
+      requestRevealMessage(revealScope, pendingId)
     }
-  }, [promptIds, timelineEntries])
+
+    if (scrollToPrompt(rootRef.current, pendingId)) {
+      cancelPendingJump()
+    }
+  }, [cancelPendingJump, promptIds, revealScope, timelineEntries])
+
+  useEffect(() => {
+    const pendingId = pendingJumpRef.current
+
+    if (pendingId && !entries.some(entry => entry.id === pendingId)) {
+      cancelPendingJump()
+    }
+  }, [cancelPendingJump, entries])
+
+  useEffect(() => cancelPendingJump, [cancelPendingJump])
 
   // Hover sync lives on the DOM, not in React state — the tick and its popover
   // row are siblings in different subtrees, so a shared index-keyed paint() lights

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -162,7 +162,7 @@ export const ThreadTimeline: FC = () => {
 /** Derived prompt rail for a VISIBLE surface. Split out so the hook body — and
  *  the transcript subscription it opens — never runs for a background tab. */
 const ActiveThreadTimeline: FC = () => {
-  const { revealMessage, revealScope, timelineEntries } = useTranscriptWindow()
+  const { cancelReveal, revealMessage, revealScope, timelineEntries } = useTranscriptWindow()
 
   // Cheap in the selector, expensive only when it changes: the ids alone tell
   // us whether the RAIL changed. Prompt text is immutable once sent, and an
@@ -254,6 +254,7 @@ const ActiveThreadTimeline: FC = () => {
   const jump = useCallback(
     (id: string) => {
       cancelPendingJump()
+      cancelReveal?.()
 
       if (scrollToPrompt(rootRef.current, id)) {
         return
@@ -300,7 +301,7 @@ const ActiveThreadTimeline: FC = () => {
 
       jumpFrameRef.current = window.requestAnimationFrame(retry)
     },
-    [cancelPendingJump, revealMessage, revealScope]
+    [cancelPendingJump, cancelReveal, revealMessage, revealScope]
   )
 
   useLayoutEffect(() => {

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -1,5 +1,5 @@
 import { useAui, useAuiState } from '@assistant-ui/react'
-import { type FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { triggerHaptic } from '@/lib/haptics'
@@ -12,6 +12,7 @@ import {
   type TimelineEntry,
   type TimelineSourceMessage
 } from './timeline-data'
+import { useTranscriptWindow } from './transcript-window'
 
 const MIN_ENTRIES = 4
 const VIEWPORT = '[data-slot="aui_thread-viewport"]'
@@ -110,18 +111,20 @@ function jumpScroll(viewport: HTMLElement, top: number, duration = 170): void {
 export const ownViewport = (root: HTMLElement | null): HTMLElement | null =>
   (root?.closest('[data-session-anchor]') ?? document).querySelector<HTMLElement>(VIEWPORT)
 
-function scrollToPrompt(root: HTMLElement | null, id: string) {
+function scrollToPrompt(root: HTMLElement | null, id: string): boolean {
   const viewport = ownViewport(root)
   const node = viewport?.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`)
 
   if (!viewport || !node) {
-    return
+    return false
   }
 
   const top = viewport.scrollTop + (node.getBoundingClientRect().top - viewport.getBoundingClientRect().top) - 8
 
   triggerHaptic('selection')
   jumpScroll(viewport, Math.max(0, top))
+
+  return true
 }
 
 /**
@@ -151,6 +154,8 @@ export const ThreadTimeline: FC = () => {
 /** Derived prompt rail for a VISIBLE surface. Split out so the hook body — and
  *  the transcript subscription it opens — never runs for a background tab. */
 const ActiveThreadTimeline: FC = () => {
+  const { revealMessage, timelineEntries } = useTranscriptWindow()
+
   // Cheap in the selector, expensive only when it changes: the ids alone tell
   // us whether the RAIL changed. Prompt text is immutable once sent, and an
   // edit rewinds the transcript (dropping every id after it) and re-appends a
@@ -179,8 +184,13 @@ const ActiveThreadTimeline: FC = () => {
   auiRef.current = aui
 
   const previousRef = useRef<TimelineEntry[]>([])
+  const pendingJumpRef = useRef<string | null>(null)
 
   const entries = useMemo(() => {
+    if (timelineEntries) {
+      return timelineEntries
+    }
+
     const rows: TimelineSourceMessage[] = []
 
     for (const message of auiRef.current.thread().getState().messages) {
@@ -206,13 +216,42 @@ const ActiveThreadTimeline: FC = () => {
     // reads (the transcript comes off the ref) — same shape as ChatRoutesSurface's
     // gatewayState memo in app/contrib/controller.tsx.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [promptIds])
+  }, [promptIds, timelineEntries])
 
   const [activeIndex, setActiveIndex] = useState(0)
   const [open, setOpen] = useState(false)
   const closeTimerRef = useRef<number | undefined>(undefined)
   const rootRef = useRef<HTMLDivElement | null>(null)
-  const jump = useCallback((id: string) => scrollToPrompt(rootRef.current, id), [])
+
+  const jump = useCallback(
+    (id: string) => {
+      const didScroll = scrollToPrompt(rootRef.current, id)
+
+      if (didScroll) {
+        pendingJumpRef.current = null
+
+        return
+      }
+
+      if (revealMessage) {
+        pendingJumpRef.current = id
+        revealMessage(id)
+      }
+    },
+    [revealMessage]
+  )
+
+  useLayoutEffect(() => {
+    const pendingId = pendingJumpRef.current
+
+    if (!pendingId) {
+      return
+    }
+
+    if (scrollToPrompt(rootRef.current, pendingId)) {
+      pendingJumpRef.current = null
+    }
+  }, [promptIds, timelineEntries])
 
   // Hover sync lives on the DOM, not in React state — the tick and its popover
   // row are siblings in different subtrees, so a shared index-keyed paint() lights
@@ -345,7 +384,7 @@ const ActiveThreadTimeline: FC = () => {
 
 const TimelinePopover: FC<{
   activeIndex: number
-  entries: TimelineEntry[]
+  entries: readonly TimelineEntry[]
   onHover: (index: number, on: boolean) => void
   onJump: (id: string) => void
   open: boolean
@@ -391,7 +430,7 @@ const TimelinePopover: FC<{
 
 const TimelineTicks: FC<{
   activeIndex: number
-  entries: TimelineEntry[]
+  entries: readonly TimelineEntry[]
   onHover: (index: number, on: boolean) => void
   onJump: (id: string) => void
   tickRefs: React.RefObject<(HTMLSpanElement | null)[]>

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -76,17 +76,14 @@ const hoverProps = (index: number, paint: (index: number, on: boolean) => void) 
 
 // Constant-duration jump (eased), NOT native `behavior:'smooth'` — Chromium's
 // smooth scroll animates proportional to distance, so jumping across a long
-// thread crawls for seconds. A fixed ~260ms feels instant near or far. A
-// shared rAF handle cancels a prior jump so rapid tick clicks don't fight.
-let jumpRaf = 0
-
-export function jumpScroll(viewport: HTMLElement, top: number, duration = 170): void {
-  cancelAnimationFrame(jumpRaf)
-
+// thread crawls for seconds. A fixed ~260ms feels instant near or far. The
+// returned cancel function lets the owning timeline stop an in-flight jump on
+// another click, session switch, or unmount.
+export function jumpScroll(viewport: HTMLElement, top: number, duration = 170): () => void {
   if (prefersReducedMotion()) {
     viewport.scrollTop = top
 
-    return
+    return () => {}
   }
 
   const start = viewport.scrollTop
@@ -95,11 +92,12 @@ export function jumpScroll(viewport: HTMLElement, top: number, duration = 170): 
   if (Math.abs(delta) < 2) {
     viewport.scrollTop = top
 
-    return
+    return () => {}
   }
 
   const t0 = performance.now()
   const ease = (t: number) => 1 - (1 - t) ** 3 // easeOutCubic
+  let jumpRaf = 0
 
   const step = (now: number) => {
     const p = Math.min(1, (now - t0) / duration)
@@ -111,6 +109,8 @@ export function jumpScroll(viewport: HTMLElement, top: number, duration = 170): 
   }
 
   jumpRaf = requestAnimationFrame(step)
+
+  return () => cancelAnimationFrame(jumpRaf)
 }
 
 // A timeline belongs to ONE chat surface, and several are mounted at once — side
@@ -120,20 +120,19 @@ export function jumpScroll(viewport: HTMLElement, top: number, duration = 170): 
 export const ownViewport = (root: HTMLElement | null): HTMLElement | null =>
   (root?.closest('[data-session-anchor]') ?? document).querySelector<HTMLElement>(VIEWPORT)
 
-function scrollToPrompt(root: HTMLElement | null, id: string): boolean {
+function scrollToPrompt(root: HTMLElement | null, id: string): (() => void) | null {
   const viewport = ownViewport(root)
   const node = viewport?.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`)
 
   if (!viewport || !node) {
-    return false
+    return null
   }
 
   const top = viewport.scrollTop + (node.getBoundingClientRect().top - viewport.getBoundingClientRect().top) - 8
 
   triggerHaptic('selection')
-  jumpScroll(viewport, Math.max(0, top))
 
-  return true
+  return jumpScroll(viewport, Math.max(0, top))
 }
 
 /**
@@ -232,8 +231,9 @@ const ActiveThreadTimeline: FC = () => {
   const closeTimerRef = useRef<number | undefined>(undefined)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const jumpFrameRef = useRef(0)
+  const scrollCancelRef = useRef<(() => void) | null>(null)
 
-  const cancelPendingJump = useCallback(() => {
+  const cancelPendingReveal = useCallback(() => {
     if (jumpFrameRef.current) {
       window.cancelAnimationFrame(jumpFrameRef.current)
       jumpFrameRef.current = 0
@@ -241,6 +241,12 @@ const ActiveThreadTimeline: FC = () => {
 
     pendingJumpRef.current = null
   }, [])
+
+  const cancelNavigation = useCallback(() => {
+    cancelPendingReveal()
+    scrollCancelRef.current?.()
+    scrollCancelRef.current = null
+  }, [cancelPendingReveal])
 
   const revealScopeRef = useRef(revealScope)
 
@@ -250,15 +256,23 @@ const ActiveThreadTimeline: FC = () => {
     }
 
     revealScopeRef.current = revealScope
-    cancelPendingJump()
-  }, [cancelPendingJump, revealScope])
+    cancelNavigation()
+  }, [cancelNavigation, revealScope])
 
   const jump = useCallback(
     (id: string) => {
-      cancelPendingJump()
+      cancelNavigation()
       cancelReveal?.()
 
-      if (scrollToPrompt(rootRef.current, id)) {
+      if (revealScope) {
+        requestRevealMessage(revealScope, id)
+      }
+
+      const cancelScroll = scrollToPrompt(rootRef.current, id)
+
+      if (cancelScroll) {
+        scrollCancelRef.current = cancelScroll
+
         return
       }
 
@@ -283,9 +297,12 @@ const ActiveThreadTimeline: FC = () => {
           requestRevealMessage(revealScope, id)
         }
 
-        if (scrollToPrompt(rootRef.current, id)) {
+        const retryCancelScroll = scrollToPrompt(rootRef.current, id)
+
+        if (retryCancelScroll) {
           pendingJumpRef.current = null
           jumpFrameRef.current = 0
+          scrollCancelRef.current = retryCancelScroll
 
           return
         }
@@ -293,7 +310,7 @@ const ActiveThreadTimeline: FC = () => {
         frames += 1
 
         if (frames >= 45) {
-          cancelPendingJump()
+          cancelNavigation()
 
           return
         }
@@ -303,7 +320,7 @@ const ActiveThreadTimeline: FC = () => {
 
       jumpFrameRef.current = window.requestAnimationFrame(retry)
     },
-    [cancelPendingJump, cancelReveal, revealMessage, revealScope]
+    [cancelNavigation, cancelReveal, revealMessage, revealScope]
   )
 
   useLayoutEffect(() => {
@@ -317,20 +334,23 @@ const ActiveThreadTimeline: FC = () => {
       requestRevealMessage(revealScope, pendingId)
     }
 
-    if (scrollToPrompt(rootRef.current, pendingId)) {
-      cancelPendingJump()
+    const cancelScroll = scrollToPrompt(rootRef.current, pendingId)
+
+    if (cancelScroll) {
+      cancelPendingReveal()
+      scrollCancelRef.current = cancelScroll
     }
-  }, [cancelPendingJump, promptIds, revealScope, timelineEntries])
+  }, [cancelPendingReveal, promptIds, revealScope, timelineEntries])
 
   useEffect(() => {
     const pendingId = pendingJumpRef.current
 
     if (pendingId && !entries.some(entry => entry.id === pendingId)) {
-      cancelPendingJump()
+      cancelNavigation()
     }
-  }, [cancelPendingJump, entries])
+  }, [cancelNavigation, entries])
 
-  useEffect(() => cancelPendingJump, [cancelPendingJump])
+  useEffect(() => cancelNavigation, [cancelNavigation])
 
   // Hover sync lives on the DOM, not in React state — the tick and its popover
   // row are siblings in different subtrees, so a shared index-keyed paint() lights

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -82,6 +82,7 @@ let jumpRaf = 0
 
 export function jumpScroll(viewport: HTMLElement, top: number, duration = 170): void {
   cancelAnimationFrame(jumpRaf)
+
   if (prefersReducedMotion()) {
     viewport.scrollTop = top
 
@@ -240,6 +241,7 @@ const ActiveThreadTimeline: FC = () => {
 
     pendingJumpRef.current = null
   }, [])
+
   const revealScopeRef = useRef(revealScope)
 
   useLayoutEffect(() => {

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
@@ -11,6 +11,8 @@ export interface TranscriptWindowValue {
   timelineEntries?: readonly TimelineEntry[]
   /** Runtime/session identity that scopes DOM reveal requests to one pane. */
   revealScope?: string
+  /** Cancel an abandoned targeted store-window expansion. */
+  cancelReveal?: () => void
   /** Materialize a hidden prompt before the timeline scrolls to it. */
   revealMessage?: (messageId: string) => void
 }

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
@@ -9,6 +9,8 @@ export interface TranscriptWindowValue {
   expandWindow: () => void
   /** Full set of loaded user prompts, including prompts outside the runtime window. */
   timelineEntries?: readonly TimelineEntry[]
+  /** Runtime/session identity that scopes DOM reveal requests to one pane. */
+  revealScope?: string
   /** Materialize a hidden prompt before the timeline scrolls to it. */
   revealMessage?: (messageId: string) => void
 }

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
@@ -1,10 +1,16 @@
 import { createContext, type ReactNode, useContext } from 'react'
 
+import type { TimelineEntry } from './timeline-data'
+
 export interface TranscriptWindowValue {
   /** Store holds older messages the runtime window has not materialized. */
   olderAvailable: boolean
   /** Pull one more page of older messages out of the session store. */
   expandWindow: () => void
+  /** Full set of loaded user prompts, including prompts outside the runtime window. */
+  timelineEntries?: readonly TimelineEntry[]
+  /** Materialize a hidden prompt before the timeline scrolls to it. */
+  revealMessage?: (messageId: string) => void
 }
 
 const TranscriptWindowContext = createContext<TranscriptWindowValue>({

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -77,6 +77,28 @@ export const requestScrollToBottom = (sessionId: string | null = null) => {
   handlers.get(sessionId)?.forEach(handler => handler())
 }
 
+// Timeline rail → mounted transcript list. A timeline target can already be in
+// assistant-ui's repository while still sitting outside the smaller DOM paint
+// budget. Lists report whether they own the requested durable message id; only
+// that list raises its render budget, so other visible panes remain untouched.
+const revealHandlers = new Set<(scope: string, id: string) => boolean>()
+
+export const onRevealMessageRequest = (handler: (scope: string, id: string) => boolean) => {
+  revealHandlers.add(handler)
+
+  return () => void revealHandlers.delete(handler)
+}
+
+export const requestRevealMessage = (scope: string, id: string): boolean => {
+  let handled = false
+
+  revealHandlers.forEach(handler => {
+    handled = handler(scope, id) || handled
+  })
+
+  return handled
+}
+
 // Inline edit grows a sticky human bubble. Fire on pointerdown so the viewport
 // escapes stick-to-bottom before focus/layout; close clears the edit flag when
 // the inline composer unmounts.


### PR DESCRIPTION
## Summary
- keep the timeline sourced from the full loaded transcript even when assistant-ui is windowed
- materialize hidden runtime and DOM targets before completing a jump
- release sticky-bottom ownership before every jump so it cannot snap the viewport back
- compute the required transcript page directly for very deep targets
- scope and cancel pending reveal/scroll work across session changes

## Verification
- `npm run test:ui -- src/app/chat/transcript-window.test.ts src/components/assistant-ui/thread/timeline-idle.test.tsx src/components/assistant-ui/thread/timeline.test.ts src/components/assistant-ui/thread/list.test.ts` (77 passed)
- `npm run typecheck`
- `npm run build`
- focused ESLint on all changed production/test files (no errors; one pre-existing `tailProfile` exhaustive-deps warning in `src/app/chat/index.tsx`)

## Full-suite note
`npm run test:ui` reached 7,370 passing tests and failed only the two existing `src/store/voice-prefs.test.ts` localStorage expectations. That file is unchanged by this PR; the same two failures reproduce when run alone.