### PR TITLE
fix(desktop): keep background reports behind bounded disclosures

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/system-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.test.tsx
@@ -1,5 +1,5 @@
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { $displayTimestamps } from '@/store/display-timestamps'
@@ -14,13 +14,13 @@ $displayTimestamps.set(true)
 const timestamp = new Date('2026-05-01T00:00:00.000Z')
 stubThreadEnvironment()
 
-function Harness({ text }: { text: string }) {
+function Harness({ text, asyncResult }: { text: string; asyncResult?: string }) {
   const message = {
     id: 'system-1',
     role: 'system',
     content: [{ type: 'text', text }],
     createdAt: timestamp,
-    metadata: { custom: { timelineTimestamp: timestamp.getTime() / 1000 } }
+    metadata: { custom: { timelineTimestamp: timestamp.getTime() / 1000, asyncResult } }
   } as unknown as ThreadMessage
 
   const runtime = useExternalStoreRuntime<ThreadMessage>({
@@ -45,6 +45,26 @@ function expectTimestampSeparated(container: HTMLElement, precedingText: string)
 }
 
 afterEach(cleanup)
+
+describe('background report disclosure', () => {
+  it('keeps result bodies out of the transcript until opened and removes them when collapsed', () => {
+    const report = '{"blockers":[{"title":"Local-model readiness uses the wrong endpoint"}]}'
+    const { container, getByRole } = render(<Harness asyncResult={report} text="2 background agents finished" />)
+
+    expect(container.textContent).not.toContain('blockers')
+    expectTimestampSeparated(container, '2 background agents finished')
+    const toggle = getByRole('button', { name: '2 background agents finished' })
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    expect(container.textContent).toContain(report)
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(container.textContent).not.toContain('blockers')
+  })
+})
 
 describe('system message timestamp text separation', () => {
   it('separates an ordinary system row timestamp in accessible and copied text', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
@@ -1,10 +1,10 @@
 import { MessagePrimitive, useAuiState } from '@assistant-ui/react'
-import { type FC } from 'react'
+import { type FC, useState } from 'react'
 
 import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { messageContentText } from '@/components/assistant-ui/thread/content'
 import { MessageTimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
-import { SCAFFOLD_LABEL_CLASS } from '@/components/chat/scaffold-row'
+import { SCAFFOLD_LABEL_CLASS, ScaffoldRow } from '@/components/chat/scaffold-row'
 import { Codicon } from '@/components/ui/codicon'
 import { ToolIcon } from '@/components/ui/tool-icon'
 import { LinkifiedText } from '@/lib/external-link'
@@ -17,6 +17,7 @@ const REVIEW_NOTE_RE = /^review:(?<label>[^:\n]+):?\s*(?<detail>[\s\S]*)$/
 export const SystemMessage: FC = () => {
   const text = useAuiState(s => messageContentText(s.message.content))
   const asyncResult = useAuiState(s => s.message.metadata.custom?.asyncResult)
+  const [reportOpen, setReportOpen] = useState(false)
 
   if (!text) {
     return null
@@ -25,14 +26,29 @@ export const SystemMessage: FC = () => {
   if (typeof asyncResult === 'string' && asyncResult) {
     return (
       <MessagePrimitive.Root
-        className="flex w-full min-w-0 flex-col gap-2 self-start py-1"
+        className="flex w-full min-w-0 flex-col self-start py-1"
         data-role="system"
         data-slot="aui_system-message-root"
       >
-        <div className="text-[0.6875rem] leading-5 text-muted-foreground/55">
-          {text} <MessageTimelineTimestamp />
+        <div data-conversation-scaffold="">
+          <ScaffoldRow
+            onToggle={() => setReportOpen(!reportOpen)}
+            open={reportOpen}
+            trailing={
+              <>
+                {' '}
+                <MessageTimelineTimestamp />
+              </>
+            }
+          >
+            <span className={SCAFFOLD_LABEL_CLASS}>{text}</span>
+          </ScaffoldRow>
         </div>
-        <MarkdownTextContent isRunning={false} text={asyncResult} />
+        {reportOpen && (
+          <div className="mt-2 max-h-80 min-w-0 max-w-full overflow-auto overscroll-contain wrap-anywhere">
+            <MarkdownTextContent isRunning={false} text={asyncResult} />
+          </div>
+        )}
       </MessagePrimitive.Root>
     )
   }

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -56,7 +56,7 @@ The center of the app. You get:
 - **Reading-position memory** — returning to a session restores its saved distance from the bottom instead of always jumping to the latest message. Sessions left at the bottom continue following new output. Use **Scroll to bottom** to return to the live edge. Positions are kept in this Desktop installation's local storage; they are not synchronized through the backend.
 - **Find in page** — press **Cmd/Ctrl+F** to open a find bar that searches the rendered chat transcript. Enter / Shift+Enter (or Cmd/Ctrl+G / Cmd/Ctrl+Shift+G while the bar is open) step through matches; Esc closes it.
 
-Async cron and delegation completions keep a compact timeline label and render the result body (including job output) as Markdown. Task instructions and delivery envelopes are not shown as report content.
+Async cron and delegation completions appear as collapsed timeline disclosures. Open the completion label to read the result body (including job output) as Markdown; long reports scroll within the disclosure. Task instructions and delivery envelopes are not shown as report content.
 
 #### Status bar
 


### PR DESCRIPTION
## What does this PR do?

Keep completed background reports collapsed instead of dumping their raw JSON or Markdown into the conversation. The completion label uses the shared transcript scaffold disclosure. Opening it shows the preserved report in a bounded scroll area.

## Related work

Overlaps Benjamin Brumbaugh’s [PR #105464](https://github.com/NousResearch/hermes-agent/pull/105464), discovered during the pre-publication duplicate check. This was implemented independently and is being submitted separately at the requester’s direction. Both fix the default-expanded report; this version also bounds long report output, uses `ScaffoldRow` and its shared text/fade treatment, and tests collapse as well as expansion through the real thread renderer.

The regression was introduced by [8c10ffba55](https://github.com/NousResearch/hermes-agent/commit/8c10ffba55d8bbe6e3b658a041df113dbb87dbb2), which restored report bodies during hydration but rendered every body unconditionally.

## Type of Change

- [x] Bug fix

## Changes Made

- `system-message.tsx`: use the existing scaffold disclosure; mount report Markdown only when opened; cap the body at `max-h-80` with contained scrolling.
- `system-message.test.tsx`: verify collapsed defaults, expansion, collapse, and timestamp text separation through `Thread`.
- `website/docs/user-guide/desktop.md`: document opt-in report expansion.

No backend, stored transcript, model context, or report-parsing changes.

## How to Test

1. Open a session with completed async delegation or cron reports. Only the completion label should be visible.
2. Click the label or activate it with the keyboard. Confirm the report opens and long output scrolls to the end without expanding the entire transcript.
3. Collapse it and reload the session. Report bodies should remain unmounted until opened again.

Verified locally on macOS:

- `vitest run --project ui src/components/assistant-ui/thread/system-message.test.tsx src/lib/async-report.test.ts src/lib/chat-messages.test.ts` — 81 passed.
- Changed-file ESLint and Prettier checks — passed.
- `git diff --check` — passed.
- Replayed five real completion events containing ten reports through `toChatMessages`, `toRuntimeMessage`, and the actual `Thread` in Chromium. All started collapsed, expanded into 320px scroll areas, scrolled to the end, and collapsed again. Keyboard activation, reload, and narrow-layout screenshots checked; no renderer errors.
- The regression test failed on the original renderer because raw report text appeared immediately.

Full suite, typecheck, and production build not run locally. The private session replay and screenshots are not committed.

## Checklist

- [x] Conventional commits; only changes related to this fix.
- [x] Searched existing PRs; overlap explicitly linked above.
- [x] Added a regression test and exercised the rendered UI.
- [x] Updated relevant documentation.
- [x] No config, tool-schema, dependency, or native-platform changes.
