### PR TITLE
fix(gateway): feed attachment delivery into the processing-outcome accounting

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2567,11 +2567,18 @@ class BasePlatformAdapter(ABC):
 
     async def send_multiple_images(
         self, chat_id: str, images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+        metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0) -> Optional[SendResult]:
         """Send ``(url, alt)`` images (``http(s)://`` or ``file://``) one by one (GIFs via
         ``send_animation``, local files via ``send_image_file``); override to bundle natively
-        (Signal)."""
+        (Signal). Returns an aggregate ``SendResult`` (any image delivered counts as success,
+        mirroring the ``delivery_succeeded or ...`` roll-up) for delivery-outcome accounting, or
+        ``None`` when there was nothing to send; overrides may keep returning ``None`` to opt
+        their platform out of image-delivery accounting."""
         from urllib.parse import unquote as _unquote
+        if not images:
+            return None
+        sent_any = False
         for image_url, alt_text in images:
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
@@ -2588,8 +2595,10 @@ class BasePlatformAdapter(ABC):
                     chat_id=chat_id, **url_kw, caption=alt_text or None, metadata=metadata)
                 if not img_result.success:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                sent_any = sent_any or bool(img_result.success)
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+        return SendResult(success=sent_any, error=None if sent_any else "no image delivered")
 
     async def send_image(
         self, chat_id: str, image_url: str, caption: Optional[str] = None,
@@ -3698,7 +3707,8 @@ class BasePlatformAdapter(ABC):
 
     async def _deliver_media_attachments(
         self, event: MessageEvent, media_files: list, local_files: list, *,
-        force_document_attachments: bool, human_delay: float, metadata: Dict[str, Any]) -> None:
+        force_document_attachments: bool, human_delay: float, metadata: Dict[str, Any],
+        record_delivery: Optional[Callable] = None) -> None:
         """Deliver MEDIA-tag files and detected local files by type: images batched via
         ``send_multiple_images`` unless ``[[as_document]]``; otherwise audio → send_voice (MEDIA
         tags only, never bare local files), video → send_video, else send_document. Every failure is
@@ -3711,7 +3721,8 @@ class BasePlatformAdapter(ABC):
         _image_paths += [p for p in local_files if _as_image(p)]
         if _image_paths:
             await self._send_image_batch(
-                event, [(f"file://{_quote(p)}", "") for p in _image_paths], metadata, human_delay)
+                event, [(f"file://{_quote(p)}", "") for p in _image_paths], metadata, human_delay,
+                record_delivery=record_delivery)
         chat_id = event.source.chat_id
 
         async def _send_one(path: str, *, is_voice: bool, media_tag: bool) -> None:
@@ -3726,6 +3737,8 @@ class BasePlatformAdapter(ABC):
                 result = await self.send_video(chat_id=chat_id, video_path=path, metadata=metadata)
             else:
                 result = await self.send_document(chat_id=chat_id, file_path=path, metadata=metadata)
+            if record_delivery is not None:
+                record_delivery(result)
             if not result.success:
                 logger.warning("[%s] Failed to send %s (%s): %s", self.name,
                                "media" if media_tag else "local file", ext, result.error)
@@ -3746,13 +3759,20 @@ class BasePlatformAdapter(ABC):
                     logger.error("[%s] Error sending local file %s: %s", self.name, path, err)
 
     async def _send_image_batch(
-        self, event: MessageEvent, images: list, metadata: Dict[str, Any], human_delay: float) -> None:
-        """Batch-send images; a failure is logged (never raised) so other attachments still go."""
+        self, event: MessageEvent, images: list, metadata: Dict[str, Any], human_delay: float,
+        record_delivery: Optional[Callable] = None) -> None:
+        """Batch-send images; a failure is logged (never raised) so other attachments still go.
+        Feeds the platform's aggregate result (``None`` = override opted out) to
+        ``record_delivery`` so media-only turns count as delivered (#106153)."""
         try:
-            await self.send_multiple_images(
+            batch_result = await self.send_multiple_images(
                 chat_id=event.source.chat_id, images=images, metadata=metadata, human_delay=human_delay)
+            if record_delivery is not None and batch_result is not None:
+                record_delivery(batch_result)
         except Exception as batch_err:
             logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
+            if record_delivery is not None:
+                record_delivery(SendResult(success=False, error=str(batch_err)))
 
     async def _send_final_text(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
@@ -3791,18 +3811,21 @@ class BasePlatformAdapter(ABC):
         return _thread_metadata
 
     async def _deliver_attachments(self, event: MessageEvent, extracted: "_ExtractedResponse",
-                                   metadata: Dict[str, Any], *, anything_sent: bool) -> None:
+                                   metadata: Dict[str, Any], *, anything_sent: bool,
+                                   record_delivery: Optional[Callable] = None) -> None:
         """Send extracted image URLs, MEDIA files and bare local files (human-paced),
-        then fail loudly if a non-empty response produced nothing deliverable."""
+        then fail loudly if a non-empty response produced nothing deliverable. Attachment
+        sends feed ``record_delivery`` so the processing outcome reflects them (#106153)."""
         human_delay = self._get_human_delay()
         images, media_files, local_files = extracted.images, extracted.media_files, extracted.local_files
         if images:
             logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
-            await self._send_image_batch(event, images, metadata, human_delay)
+            await self._send_image_batch(event, images, metadata, human_delay,
+                                         record_delivery=record_delivery)
         await self._deliver_media_attachments(
             event, media_files, local_files,
             force_document_attachments=extracted.force_document_attachments,
-            human_delay=human_delay, metadata=metadata)
+            human_delay=human_delay, metadata=metadata, record_delivery=record_delivery)
         if not (anything_sent or images or local_files or media_files) and extracted.pre_extract.strip():
             logger.error("[%s] response_delivery_dropped: non-empty response "
                          "(%d chars) produced no delivered message or attachment "
@@ -3960,7 +3983,8 @@ class BasePlatformAdapter(ABC):
                         is_ephemeral_response, _ephemeral_ttl, _record_delivery)
                 await self._deliver_attachments(
                     event, extracted, _final_thread_metadata,
-                    anything_sent=delivery_attempted or _tts_caption_delivered)
+                    anything_sent=delivery_attempted or _tts_caption_delivered,
+                    record_delivery=_record_delivery)
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             # Clean up the per-turn streaming-TTS flag.
             self._streaming_tts_completed_turns.discard(self._streaming_tts_turn_key(

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -781,11 +781,14 @@ class SignalAdapter(BasePlatformAdapter):
         return file_path, None, None
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
-                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+                                   metadata: Optional[Dict[str, Any]] = None,
+                                   human_delay: float = 0.0) -> Optional[SendResult]:
         """Send a batch of images via chunked Signal RPC calls. Alt texts are dropped (one shared body
-        per send); bad images are skipped with a warning; ``human_delay`` is ignored (scheduler paces)."""
+        per send); bad images are skipped with a warning; ``human_delay`` is ignored (scheduler paces).
+        Returns an aggregate ``SendResult`` (any batch delivered counts as success) for
+        delivery-outcome accounting (#106153), or ``None`` when there was nothing to send."""
         if not images:
-            return
+            return None
         scheduler = get_scheduler()
         logger.info("Signal send_multiple_images: received %d image(s) for %s — scheduler state: %s", len(images),
                     chat_id[:30], scheduler.state())
@@ -802,24 +805,32 @@ class SignalAdapter(BasePlatformAdapter):
         if not attachments:
             logger.error("Signal: no valid images in batch of %d (download=%d missing=%d oversize=%d)", len(images),
                          skipped["download"], skipped["missing"], skipped["oversize"])
-            return
+            return SendResult(success=False, error="no valid images in batch")
         logger.info("Signal send_multiple_images: %d/%d images valid, sending in chunks", len(attachments), len(images))
         base_params = await self._with_target({"account": self.account, "message": ""}, chat_id)
         per = SIGNAL_MAX_ATTACHMENTS_PER_MSG
         att_batches = [attachments[i:i + per] for i in range(0, len(attachments), per)]
         n_batches = len(att_batches)
+        sent_any, failed_batches = False, 0
         for idx, att_batch in enumerate(att_batches, start=1):
             n = len(att_batch)
             estimated = scheduler.estimate_wait(n)
             logger.debug("Signal batch %d/%d: %d attachments, estimated wait=%.1fs", idx, n_batches, n, estimated)
             if estimated >= SIGNAL_BATCH_PACING_NOTICE_THRESHOLD:
                 await self._notify_batch_pacing(chat_id, idx, n_batches, estimated)
-            await self._send_attachment_batch(scheduler, dict(base_params, attachments=att_batch), n,
-                                              f"{idx}/{n_batches}")
+            batch_ok = await self._send_attachment_batch(
+                scheduler, dict(base_params, attachments=att_batch), n, f"{idx}/{n_batches}")
+            sent_any = sent_any or batch_ok
+            failed_batches += 0 if batch_ok else 1
+        return SendResult(
+            success=sent_any,
+            error=None if not failed_batches else
+            f"{failed_batches}/{n_batches} attachment batch(es) failed")
 
-    async def _send_attachment_batch(self, scheduler, params: Dict[str, Any], n: int, label: str) -> None:
+    async def _send_attachment_batch(self, scheduler, params: Dict[str, Any], n: int, label: str) -> bool:
         """Send one attachment batch with rate-limit pacing and a single transient retry. Tokens are
-        deducted only on validated success (None = server never accepted it); 429s feed the scheduler."""
+        deducted only on validated success (None = server never accepted it); 429s feed the scheduler.
+        Returns True when the batch was validated as delivered."""
         send_timeout, max_attempts = _signal_send_timeout(n), SIGNAL_RATE_LIMIT_MAX_ATTEMPTS
         for attempt in range(1, max_attempts + 1):
             await scheduler.acquire(n)
@@ -832,7 +843,7 @@ class SignalAdapter(BasePlatformAdapter):
                 if attempt >= max_attempts:
                     logger.error("Signal: rate-limit retries exhausted on batch %s (%d attachments lost, "
                                  "server retry_after=%s)", label, n, retry_after)
-                    return
+                    return False
                 logger.warning("Signal: rate-limited on batch %s (attempt %d/%d, server retry_after=%s); "
                                "scheduler will pace the retry", label, attempt, max_attempts, retry_after)
                 continue
@@ -843,11 +854,11 @@ class SignalAdapter(BasePlatformAdapter):
                 await scheduler.report_rpc_duration(duration, n)
                 logger.info("Signal batch %s: %d attachments sent in %.1fs (attempt %d/%d)", label, n, duration,
                             attempt, max_attempts)
-                return
+                return True
             logger.error("Signal: RPC send failed for batch %s (%d attachments, attempt %d/%d, rpc_duration=%.1fs)%s",
                          label, n, attempt, max_attempts, duration, f": {err_msg}" if result is not None else "")
             if attempt >= max_attempts:
-                return
+                return False
             logger.info("Signal: retrying batch %s after %.1fs backoff", label, 2.0 ** attempt)
             await asyncio.sleep(2.0 ** attempt)
 

--- a/tests/gateway/test_media_delivery_outcome.py
+++ b/tests/gateway/test_media_delivery_outcome.py
@@ -1,0 +1,155 @@
+"""Regression tests for media-only turn delivery outcomes (#106153).
+
+Attachment sends (image batches and per-file media) must feed the
+``delivery_attempted``/``delivery_succeeded`` accounting that decides
+``ProcessingOutcome``, so a media-only reply that delivered its attachment
+reports SUCCESS instead of FAILURE.
+"""
+
+import asyncio
+from typing import Optional, Tuple, List, Dict, Any
+
+import pytest
+
+from gateway.config import PlatformConfig, Platform
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.event import MessageEvent, ProcessingOutcome
+from gateway.session import SessionSource, build_session_key
+
+
+class MediaOutcomeAdapter(BasePlatformAdapter):
+    """Minimal adapter whose attachment sends return configurable results."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.SLACK)
+        self.processing_outcomes = []
+        self.image_batch_result: Optional[SendResult] = SendResult(success=True)
+        self.document_result = SendResult(success=True)
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="m-1")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def send_document(self, chat_id, file_path, caption=None, metadata=None, **kwargs) -> SendResult:
+        return self.document_result
+
+    async def send_multiple_images(
+        self, chat_id: str, images: List[Tuple[str, str]],
+        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0,
+    ) -> Optional[SendResult]:
+        return self.image_batch_result
+
+    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        self.processing_outcomes.append(outcome)
+
+
+def _make_event() -> MessageEvent:
+    return MessageEvent(
+        text="send me the photo",
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="171717",
+            user_id="U123",
+        ),
+        message_id="m-1",
+    )
+
+
+async def _run_turn(adapter: MediaOutcomeAdapter, response: str):
+    async def _handler(_event):
+        return response
+
+    adapter.set_message_handler(_handler)
+    adapter._keep_typing = lambda *_args, **_kwargs: asyncio.Event().wait()
+    event = _make_event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+
+@pytest.mark.asyncio
+async def test_media_only_image_delivery_reports_success(tmp_path):
+    image = tmp_path / "photo.jpg"
+    image.write_bytes(b"\xff\xd8\xff\xe0")
+    adapter = MediaOutcomeAdapter()
+    adapter.image_batch_result = SendResult(success=True)
+
+    await _run_turn(adapter, f"MEDIA:{image}")
+
+    assert adapter.processing_outcomes == [ProcessingOutcome.SUCCESS]
+
+
+@pytest.mark.asyncio
+async def test_media_only_image_failure_reports_failure(tmp_path):
+    image = tmp_path / "photo.jpg"
+    image.write_bytes(b"\xff\xd8\xff\xe0")
+    adapter = MediaOutcomeAdapter()
+    adapter.image_batch_result = SendResult(success=False, error="RPC send failed")
+
+    await _run_turn(adapter, f"MEDIA:{image}")
+
+    assert adapter.processing_outcomes == [ProcessingOutcome.FAILURE]
+
+
+@pytest.mark.asyncio
+async def test_media_only_document_delivery_reports_success(tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4")
+    adapter = MediaOutcomeAdapter()
+    adapter.document_result = SendResult(success=True)
+
+    await _run_turn(adapter, f"MEDIA:{doc}")
+
+    assert adapter.processing_outcomes == [ProcessingOutcome.SUCCESS]
+
+
+@pytest.mark.asyncio
+async def test_media_only_document_failure_reports_failure(tmp_path):
+    doc = tmp_path / "report.pdf"
+    doc.write_bytes(b"%PDF-1.4")
+    adapter = MediaOutcomeAdapter()
+    adapter.document_result = SendResult(success=False, error="file too large")
+
+    await _run_turn(adapter, f"MEDIA:{doc}")
+
+    assert adapter.processing_outcomes == [ProcessingOutcome.FAILURE]
+
+
+@pytest.mark.asyncio
+async def test_platform_opted_out_of_image_accounting_keeps_old_behaviour(tmp_path):
+    # Overrides that still return None from send_multiple_images are opted out
+    # of image-delivery accounting: a media-only image turn stays FAILURE for
+    # them (pre-#106153 behaviour) rather than guessing success.
+    image = tmp_path / "photo.jpg"
+    image.write_bytes(b"\xff\xd8\xff\xe0")
+    adapter = MediaOutcomeAdapter()
+    adapter.image_batch_result = None
+
+    await _run_turn(adapter, f"MEDIA:{image}")
+
+    assert adapter.processing_outcomes == [ProcessingOutcome.FAILURE]
+
+
+@pytest.mark.asyncio
+async def test_delivered_text_outranks_failed_image_batch(tmp_path):
+    # The roll-up is ``delivery_succeeded or ...``: once the text went out, a
+    # failed image batch must not flip the turn to FAILURE.
+    image = tmp_path / "photo.jpg"
+    image.write_bytes(b"\xff\xd8\xff\xe0")
+    adapter = MediaOutcomeAdapter()
+    adapter.image_batch_result = SendResult(success=False, error="RPC send failed")
+
+    await _run_turn(adapter, f"Here is the photo.\nMEDIA:{image}")
+
+    assert adapter.processing_outcomes == [ProcessingOutcome.SUCCESS]


### PR DESCRIPTION
## What does this PR do?

On Signal, a turn whose reply is *only* media (e.g. a lone `MEDIA:<path>` tag) always ended with the ❌ reaction even when the attachment was delivered successfully. The turn outcome is computed from a `delivery_attempted`/`delivery_succeeded` pair that was only fed by `_send_final_text` and `_play_tts_file`; attachment sends (`_deliver_attachments` → `_send_image_batch` / `_deliver_media_attachments`) never recorded anything, so for a media-only reply `delivery_attempted` stayed `False` and `not bool(response)` decided the outcome as `ProcessingOutcome.FAILURE`.

This routes the attachment paths through the same accounting:

- `_deliver_attachments` / `_deliver_media_attachments` accept the `_record_delivery` callback from `_process_message_background` and pass it down.
- `_send_one` records each voice/video/document `SendResult`.
- `_send_image_batch` records the aggregate result of `send_multiple_images`.
- `send_multiple_images` now returns an aggregate `SendResult` instead of `None`: the base implementation rolls up the per-image results, and the Signal override rolls up `_send_attachment_batch` (now returning `bool`). Overrides that keep returning `None` simply opt their platform out of image-delivery accounting (behaviour unchanged for them), so the other six platform overrides are untouched.

## Related Issue

Fixes #106153

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: `send_multiple_images` returns `Optional[SendResult]` (per-image roll-up); `_send_image_batch` records the aggregate (or a failure on exception); `_deliver_media_attachments`/`_deliver_attachments` take and forward `record_delivery`; `_process_message_background` passes `_record_delivery` so attachment sends count toward the outcome.
- `gateway/platforms/signal.py`: `_send_attachment_batch` returns `bool` (validated delivery); `send_multiple_images` aggregates per-batch results into a `SendResult` (and reports `no valid images in batch` as a failure instead of silently returning).
- `tests/gateway/test_media_delivery_outcome.py`: six regression tests covering media-only image/document success & failure, the opted-out-override behaviour, and text-overrides-failed-batch roll-up.

## How to Test

1. `python -m pytest tests/gateway/test_media_delivery_outcome.py -q` → **6 passed** (media-only delivered attachment now ends the turn as `ProcessingOutcome.SUCCESS`; failures still end as `FAILURE`).
2. `python -m pytest tests/gateway/ -q` → **1098 passed, 2 skipped**; the single failure (`test_buzz_adapter.py::TestInboundMediaAuthorizationGate::test_live_media_redacts_long_path_before_bounding`) fails identically on clean upstream/main (verified via stash on a pristine worktree) — pre-existing, unrelated.
3. Related surface: `python -m pytest tests/gateway/test_signal.py tests/gateway/test_send_multiple_images.py tests/gateway/test_incomplete_gateway_turns.py tests/gateway/test_73771_media_resend_dedup.py tests/gateway/test_tts_media_routing.py tests/gateway/test_run_progress_topics.py -q` → **119 passed**.
4. Observed result: a reply consisting solely of `MEDIA:<photo>.jpg` with a successful Signal batch send now swaps the 👀 reaction for ✅ instead of ❌.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full `tests/gateway/` suite + related files green; one pre-existing unrelated failure shown to fail on clean main too)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated on every touched signature)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python accounting change, no platform-specific I/O touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (behaviour verified via the new regression tests asserting `ProcessingOutcome`).