### PR TITLE
fix(desktop): stop false Windows update failures (salvage #105168)

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1189,25 +1189,6 @@ $finalCode = 1
 $finalMsg = "update did not complete"
 $script:TreeSafeToFinalize = $true
 
-# -SelfTestWorkingDirectory: prove StartAssigned inherits InstallRoot --------
-if ($SelfTestWorkingDirectory) {
-    try {
-        $resolvedInstallRoot = Set-InstallRootCurrentDirectory $InstallRoot
-    } catch {
-        Write-Host "WORKING-DIRECTORY SELF-TEST: FAIL cannot enter the install root ($InstallRoot)"
-        exit 3
-    }
-    $probeExe = Join-Path $PSHOME "powershell.exe"
-    $probe = Invoke-HermesStep $probeExe @("-NoProfile", "-Command", "[Environment]::CurrentDirectory") "cwd"
-    $observed = $probe.Output.Trim()
-    if ($probe.Code -ne 0 -or -not [string]::Equals($observed, $resolvedInstallRoot, [StringComparison]::OrdinalIgnoreCase)) {
-        Write-Host "WORKING-DIRECTORY SELF-TEST: FAIL expected=$resolvedInstallRoot observed=$observed code=$($probe.Code)"
-        exit 1
-    }
-    Write-Host "WORKING-DIRECTORY SELF-TEST: PASS $observed"
-    exit 0
-}
-
 # ── -SelfTestUi: drive the shim to both terminal states, no update ─────────
 # Manual QA for the Edge shell without a checkout or a real update. Exits
 # before the marker/desktop/venv machinery — touches nothing. Off Windows
@@ -1482,6 +1463,23 @@ try {
         $finalMsg = "Update aborted: cannot enter the install root ($InstallRoot). Nothing was changed."
         Write-HandoffLog $finalMsg
         exit $finalCode
+    }
+
+    # Exercise the production cwd setup and native launcher without updating.
+    if ($SelfTestWorkingDirectory) {
+        $expectedRoot = [System.IO.Path]::GetFullPath($InstallRoot)
+        $probeExe = Join-Path $PSHOME "powershell.exe"
+        $probe = Invoke-HermesStep $probeExe @("-NoProfile", "-Command", "[Environment]::CurrentDirectory") "cwd"
+        $observed = $probe.Output.Trim()
+        if ($probe.Code -ne 0 -or -not [string]::Equals($observed, $expectedRoot, [StringComparison]::OrdinalIgnoreCase)) {
+            $finalMsg = "WORKING-DIRECTORY SELF-TEST: FAIL expected=$expectedRoot observed=$observed code=$($probe.Code)"
+            Write-Host $finalMsg
+            exit 1
+        }
+        $finalCode = 0
+        $finalMsg = "WORKING-DIRECTORY SELF-TEST: PASS $observed"
+        Write-Host $finalMsg
+        exit 0
     }
 
     # Check only the interpreter here: dependency recovery belongs to update.

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -50,7 +50,8 @@ param(
     [switch]$NoMarkerCleanup,
     [switch]$SelfTestUi,
     [switch]$SelfTestPipeDrain,
-    [switch]$SelfTestMarker
+    [switch]$SelfTestMarker,
+    [switch]$SelfTestWorkingDirectory
 )
 
 if (-not $SelfTestUi -and -not $SelfTestPipeDrain -and -not $InstallRoot) {
@@ -1178,9 +1179,34 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     return @{ Code = $code; Output = $all; TreeQuiesced = (-not $stalled -or $proc.HasExited); StartedAfterJobAssignment = $true }
 }
 
+function Set-InstallRootCurrentDirectory([string]$Root) {
+    $resolved = [System.IO.Path]::GetFullPath($Root)
+    [Environment]::CurrentDirectory = $resolved
+    return $resolved
+}
+
 $finalCode = 1
 $finalMsg = "update did not complete"
 $script:TreeSafeToFinalize = $true
+
+# -SelfTestWorkingDirectory: prove StartAssigned inherits InstallRoot --------
+if ($SelfTestWorkingDirectory) {
+    try {
+        $resolvedInstallRoot = Set-InstallRootCurrentDirectory $InstallRoot
+    } catch {
+        Write-Host "WORKING-DIRECTORY SELF-TEST: FAIL cannot enter the install root ($InstallRoot)"
+        exit 3
+    }
+    $probeExe = Join-Path $PSHOME "powershell.exe"
+    $probe = Invoke-HermesStep $probeExe @("-NoProfile", "-Command", "[Environment]::CurrentDirectory") "cwd"
+    $observed = $probe.Output.Trim()
+    if ($probe.Code -ne 0 -or -not [string]::Equals($observed, $resolvedInstallRoot, [StringComparison]::OrdinalIgnoreCase)) {
+        Write-Host "WORKING-DIRECTORY SELF-TEST: FAIL expected=$resolvedInstallRoot observed=$observed code=$($probe.Code)"
+        exit 1
+    }
+    Write-Host "WORKING-DIRECTORY SELF-TEST: PASS $observed"
+    exit 0
+}
 
 # ── -SelfTestUi: drive the shim to both terminal states, no update ─────────
 # Manual QA for the Edge shell without a checkout or a real update. Exits
@@ -1442,6 +1468,20 @@ try {
         $finalCode = 0
         $finalMsg = "marker self-test complete"
         exit 0
+    }
+
+    # StartAssigned passes a null CreateProcess currentDirectory, so children
+    # inherit the hand-off process directory rather than PowerShell's $PWD.
+    # Desktop launches us from HERMES_HOME; pin the process directory to the
+    # checkout before any update child can resolve files against the wrong tree.
+    try {
+        $resolvedInstallRoot = Set-InstallRootCurrentDirectory $InstallRoot
+        Write-HandoffLog "process cwd set to install root: $resolvedInstallRoot"
+    } catch {
+        $finalCode = 3
+        $finalMsg = "Update aborted: cannot enter the install root ($InstallRoot). Nothing was changed."
+        Write-HandoffLog $finalMsg
+        exit $finalCode
     }
 
     # Check only the interpreter here: dependency recovery belongs to update.

--- a/tests/test_desktop_update_windows_cwd.py
+++ b/tests/test_desktop_update_windows_cwd.py
@@ -1,0 +1,74 @@
+"""Native regression coverage for the Windows Desktop handoff cwd."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.windows_only
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_UPDATE_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _run_cwd_self_test(
+    install_root: Path,
+    launch_cwd: Path,
+    temp_dir: Path,
+) -> subprocess.CompletedProcess[str]:
+    powershell = shutil.which("powershell.exe")
+    assert powershell, "Windows updater tests require Windows PowerShell."
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env["TEMP"] = str(temp_dir)
+    env["TMP"] = str(temp_dir)
+    return subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(WINDOWS_UPDATE_PS1),
+            "-InstallRoot",
+            str(install_root),
+            "-SelfTestWorkingDirectory",
+            "-NoUi",
+        ],
+        cwd=launch_cwd,
+        env=env,
+        text=True,
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_handoff_children_run_from_install_root(tmp_path: Path) -> None:
+    install_root = tmp_path / "checkout"
+    launch_cwd = tmp_path / "profile-home"
+    install_root.mkdir()
+    launch_cwd.mkdir()
+
+    result = _run_cwd_self_test(install_root, launch_cwd, tmp_path / "temp")
+
+    assert result.returncode == 0, result.stdout
+    assert "WORKING-DIRECTORY SELF-TEST: PASS" in result.stdout
+
+
+def test_handoff_fails_closed_when_install_root_cannot_be_entered(tmp_path: Path) -> None:
+    install_root = tmp_path / "missing" / "checkout"
+    launch_cwd = tmp_path / "profile-home"
+    launch_cwd.mkdir()
+
+    result = _run_cwd_self_test(install_root, launch_cwd, tmp_path / "temp")
+
+    assert result.returncode == 3, result.stdout
+    assert "cannot enter the install root" in result.stdout

--- a/tests/test_desktop_update_windows_python_handoff.py
+++ b/tests/test_desktop_update_windows_python_handoff.py
@@ -50,13 +50,18 @@ def _handoff_source() -> str:
     fixture runs a synthetic PowerShell step through ``Invoke-HermesStep`` to
     prove the drain cannot deadlock (#90455) -- so they are not update steps
     and the "must drive python.exe" rule does not apply to them. Each exits
-    before any marker/venv/desktop machinery runs.
+    before any venv/desktop machinery runs.
 
     Scoped here rather than allow-listing a target, so the rule stays absolute
     for every real step. The non-greedy match ends at the first closing brace
-    in column 0; the blocks' own braces are all indented.
+    at the opening statement's indentation; inner braces are deeper.
     """
-    return re.sub(r"\nif \(\$SelfTest\w+\) \{.*?\n\}\n", "\n", _read(), flags=re.S)
+    return re.sub(
+        r"\n(?P<indent> *)if \(\$SelfTest\w+\) \{.*?\n(?P=indent)\}\n",
+        "\n",
+        _read(),
+        flags=re.S,
+    )
 
 
 def test_invoke_hermes_step_calls_drive_python_not_the_shim() -> None:


### PR DESCRIPTION
Windows Desktop updates no longer falsely report exit 8 because verification inherited the profile directory rather than the checkout.

Salvages #105168 from @fangliquanflq, preserving the original commit's authorship.

## Changes
- Establish the native process cwd at InstallRoot before updater children launch; preserve all artifact-integrity checks.
- Move the cwd self-test behind the actual production setup so removing that call breaks regression coverage.
- Adjust the existing handoff source guard to exclude indented self-test blocks, without relaxing its production target check.

Root cause: the native CreateProcess launcher inherits the handoff process cwd, while the verifier interprets Path.cwd() as the checkout.

## Validation
**Live repro:** On a real Windows runner, neutralizing only the production cwd assignment makes the native child observe profile-home instead of checkout; both new tests fail. Restoring the assignment gives 15 passed across the five related files. This is a native launcher/preflight probe, not a fresh full in-app update.

[Native Windows red/green receipt](https://github.com/NousResearch/hermes-agent/actions/runs/34293439570/job/102284786773)

Linux targeted run: 12 passed, 3 Windows-only skipped. Ruff, Windows footgun and compatibility-pointer checks passed. PR CI pending at publication.

The native probe workflow is isolated on a temporary wine2e branch and is not part of this PR. The original thread also contains contributor-reported full Windows update verification.

Fixes #105145

## Infographic
![Desktop update cwd verification](https://v3b.fal.media/files/b/0aa9a9e6/wLRWXMt4sw2sSFVcaqPPz_7biHWmvY.png)
