### PR TITLE
fix(image-gen): honor the dispatched model kwarg in the OpenAI, Codex and DeepInfra providers

### DIFF
--- a/contributors/emails/kyr76789@gmail.com
+++ b/contributors/emails/kyr76789@gmail.com
@@ -1,0 +1,2 @@
+hyeonsang010716
+# contributor attribution — fix(image-gen): honor the dispatched model kwarg (openai, openai-codex, deepinfra)

--- a/plugins/image_gen/deepinfra/__init__.py
+++ b/plugins/image_gen/deepinfra/__init__.py
@@ -1,8 +1,10 @@
 """DeepInfra image generation (FLUX, Qwen-Image-Edit, …) via the OpenAI-compatible
 ``/v1/openai/images/generations`` endpoint. The catalog is fully dynamic (``image-gen``-tagged
 models from :func:`hermes_cli.models._fetch_deepinfra_models_by_tag`; no ids hardcoded).
-Selection: ``DEEPINFRA_IMAGE_MODEL`` → ``image_gen.deepinfra.model`` → first live model;
-when all are absent ``generate()`` errors rather than guessing."""
+Selection: ``model`` kwarg (the ``image_generate`` dispatcher forwards the ``hermes tools`` pick,
+``image_gen.model``; honored when the live catalog lists it or is unavailable) →
+``DEEPINFRA_IMAGE_MODEL`` → ``image_gen.deepinfra.model`` → first live model; when all are absent
+``generate()`` errors rather than guessing."""
 
 from __future__ import annotations
 
@@ -49,8 +51,15 @@ def _format_catalog_row(item: Dict[str, Any]) -> Dict[str, Any]:
     return row
 
 
-def _resolve_model(catalog: List[Dict[str, Any]], cfg: Dict[str, Any]) -> Optional[str]:
-    """env > config > first live result, else None (``cfg`` = loaded ``image_gen.deepinfra``)."""
+def _resolve_model(
+    catalog: List[Dict[str, Any]], cfg: Dict[str, Any], explicit: Optional[str] = None,
+) -> Optional[str]:
+    """caller kwarg > env > config > first live result, else None (``cfg`` = loaded
+    ``image_gen.deepinfra``). The caller's model is validated against the live catalog when one is
+    available, so a stale id left behind by another backend falls through instead of being sent."""
+    explicit = explicit.strip() if isinstance(explicit, str) else ""
+    if explicit and (not catalog or any(item.get("id") == explicit for item in catalog)):
+        return explicit
     env_override = os.environ.get("DEEPINFRA_IMAGE_MODEL", "").strip()
     if env_override:
         return env_override
@@ -104,7 +113,7 @@ class DeepInfraImageGenProvider(StaticImageGenProvider):
                 "to add the key.",
                 "auth_required")
         di_cfg = load_image_gen_config("deepinfra")
-        model_id = _resolve_model(_live_models() or [], di_cfg)
+        model_id = _resolve_model(_live_models() or [], di_cfg, kwargs.get("model"))
         if not model_id:
             return fail(
                 "No DeepInfra image-gen model available. Pin one in "

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -3,6 +3,9 @@
 Same catalog/tiers as the ``openai`` plugin (``gpt-image-2`` low/medium/high), routed
 through the Codex Responses API ``image_generation`` tool, so no ``OPENAI_API_KEY`` is
 needed. Output is PNG; source images travel as Responses ``input_image`` parts.
+Selection: ``model`` kwarg (the ``image_generate`` dispatcher forwards the ``hermes tools``
+pick, ``image_gen.model``) → ``OPENAI_IMAGE_MODEL`` → ``image_gen.openai-codex.model`` →
+``image_gen.model`` → :data:`DEFAULT_MODEL`.
 
 Do NOT reintroduce an "account capability" classifier keyed on ``Tool choice
 'image_generation' not found in 'tools' parameter``: that 400 is a request-shape
@@ -74,9 +77,10 @@ def _summarize_error_body(body: str) -> str:
     return text[:_MAX_ERROR_BODY_CHARS]
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model(explicit: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
     return resolve_static_model(
-        GPT_IMAGE_2_TIERS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex")
+        GPT_IMAGE_2_TIERS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex",
+        explicit=explicit)
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -359,7 +363,7 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             return error_factory("openai-codex", aspect)(
                 "httpx Python package not installed (pip install httpx)", "missing_dependency")
 
-        tier_id, meta = _resolve_model()
+        tier_id, meta = _resolve_model(kwargs.get("model"))
         size = size_for(aspect)
         fail = error_factory("openai-codex", aspect, model=tier_id, prompt=prompt)
         attempts = _NONFINAL_RETRIES + 1

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -1,5 +1,6 @@
 """OpenAI GPT Image 2 and 2.5 Flare/Sunburst quality tiers;
-base64 output → image cache. Selection: ``OPENAI_IMAGE_MODEL`` → ``image_gen.openai.model`` →
+base64 output → image cache. Selection: ``model`` kwarg (the ``image_generate`` dispatcher forwards
+the ``hermes tools`` pick, ``image_gen.model``) → ``OPENAI_IMAGE_MODEL`` → ``image_gen.openai.model`` →
 ``image_gen.model`` → :data:`DEFAULT_MODEL`."""
 
 from __future__ import annotations
@@ -38,9 +39,9 @@ MODELS = {
 }
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model(explicit: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
     return resolve_static_model(
-        MODELS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai")
+        MODELS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai", explicit=explicit)
 
 
 def _load_image_bytes(ref: str) -> Tuple[bytes, str]:
@@ -116,7 +117,7 @@ class OpenAIImageGenProvider(StaticImageGenProvider):
         openai, err = import_openai("openai", aspect)
         if err:
             return err
-        tier_id, meta = _resolve_model()
+        tier_id, meta = _resolve_model(kwargs.get("model"))
         size = size_for(aspect)
         sources = collect_source_images(image_url, reference_image_urls, limit=16)
         is_edit = bool(sources)

--- a/tests/plugins/image_gen/test_deepinfra_provider.py
+++ b/tests/plugins/image_gen/test_deepinfra_provider.py
@@ -104,3 +104,75 @@ def test_capabilities_advertise_text_to_image_only():
         "modalities": ["text"],
         "max_reference_images": 0,
     }
+
+
+# ── Model selection ─────────────────────────────────────────────────────────
+
+
+def _capturing_openai(captured: dict) -> MagicMock:
+    class _FakeImages:
+        def generate(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(data=[SimpleNamespace(b64_json=_b64_png(), url=None)])
+
+    class _FakeClient:
+        def __init__(self, api_key=None, base_url=None):
+            self.images = _FakeImages()
+
+    fake_openai = MagicMock()
+    fake_openai.OpenAI = _FakeClient
+    return fake_openai
+
+
+_LIVE = [{"id": "vendor/first"}, {"id": "vendor/picked"}]
+
+
+def test_resolve_model_precedence(monkeypatch):
+    """caller kwarg > env > scoped config > first live model."""
+    monkeypatch.setenv("DEEPINFRA_IMAGE_MODEL", "vendor/first")
+    assert deepinfra_plugin._resolve_model(_LIVE, {"model": "vendor/picked"}, "vendor/picked") == "vendor/picked"
+    assert deepinfra_plugin._resolve_model(_LIVE, {"model": "vendor/picked"}) == "vendor/first"
+    monkeypatch.delenv("DEEPINFRA_IMAGE_MODEL")
+    assert deepinfra_plugin._resolve_model(_LIVE, {"model": "vendor/picked"}) == "vendor/picked"
+    assert deepinfra_plugin._resolve_model(_LIVE, {}) == "vendor/first"
+    assert deepinfra_plugin._resolve_model([], {}) is None
+
+
+def test_model_kwarg_selects_live_model(monkeypatch):
+    """The `hermes tools` pick arrives as ``model`` from the image_generate dispatcher; the
+    request must use it rather than the first live catalog entry."""
+    monkeypatch.delenv("DEEPINFRA_IMAGE_MODEL", raising=False)
+    monkeypatch.setattr(deepinfra_plugin, "_live_models", lambda: list(_LIVE))
+    captured: dict = {}
+    with patch.dict("sys.modules", {"openai": _capturing_openai(captured)}):
+        result = deepinfra_plugin.DeepInfraImageGenProvider().generate(
+            prompt="a cat", aspect_ratio="square", model="vendor/picked")
+    assert result["success"] is True
+    assert result["model"] == "vendor/picked"
+    assert captured["kwargs"]["model"] == "vendor/picked"
+
+
+def test_foreign_model_kwarg_falls_back_to_first_live(monkeypatch):
+    """An id another backend left in ``image_gen.model`` is not in DeepInfra's catalog: fall
+    through to the existing selection chain instead of sending it."""
+    monkeypatch.delenv("DEEPINFRA_IMAGE_MODEL", raising=False)
+    monkeypatch.setattr(deepinfra_plugin, "_live_models", lambda: list(_LIVE))
+    captured: dict = {}
+    with patch.dict("sys.modules", {"openai": _capturing_openai(captured)}):
+        result = deepinfra_plugin.DeepInfraImageGenProvider().generate(
+            prompt="a cat", aspect_ratio="square", model="fal-ai/flux-2/klein/9b")
+    assert result["success"] is True
+    assert captured["kwargs"]["model"] == "vendor/first"
+
+
+def test_model_kwarg_honored_when_catalog_unavailable(monkeypatch):
+    """With the live catalog unreachable there is nothing to validate against; a picked model
+    still generates instead of erroring with ``no_model_available``."""
+    monkeypatch.delenv("DEEPINFRA_IMAGE_MODEL", raising=False)
+    monkeypatch.setattr(deepinfra_plugin, "_live_models", lambda: None)
+    captured: dict = {}
+    with patch.dict("sys.modules", {"openai": _capturing_openai(captured)}):
+        result = deepinfra_plugin.DeepInfraImageGenProvider().generate(
+            prompt="a cat", aspect_ratio="square", model="vendor/picked")
+    assert result["success"] is True
+    assert captured["kwargs"]["model"] == "vendor/picked"

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -162,6 +162,48 @@ class TestGenerate:
         # finals and presented as smeared/unfinished images.
         assert tool["partial_images"] == 0
 
+    def test_model_kwarg_selects_tier_over_scoped_config(self, provider, monkeypatch, tmp_path):
+        """The dispatcher forwards the `hermes tools` pick as ``model``; it beats a stale
+        ``image_gen.openai-codex.model`` and reaches the Responses tool as ``quality``."""
+        import yaml
+
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+            "image_gen": {"openai-codex": {"model": "gpt-image-2-high"}}
+        }))
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality, input_images=None):
+            captured["quality"] = quality
+            return {"b64": _b64_png(), "source": "final"}
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("a cat", model="gpt-image-2-low")
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-low"
+        assert result["quality"] == "low"
+        assert captured["quality"] == "low"
+
+    def test_unknown_model_kwarg_falls_back_to_config(self, provider, monkeypatch, tmp_path):
+        """An id from another backend left in ``image_gen.model`` is ignored, not sent."""
+        import yaml
+
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+            "image_gen": {"openai-codex": {"model": "gpt-image-2-high"}}
+        }))
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(
+            codex_plugin, "_collect_image_b64", lambda *a, **kw: {"b64": _b64_png(), "source": "final"})
+
+        result = provider.generate("a cat", model="fal-ai/flux-2/klein/9b")
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-high"
+
     def test_capabilities_advertise_image_inputs(self, provider):
         caps = provider.capabilities()
         assert caps["modalities"] == ["text", "image"]

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -104,6 +104,29 @@ class TestModelResolution:
         assert meta["quality"] == "low"
 
 
+    def test_caller_model_overrides_scoped_config(self, tmp_path, monkeypatch):
+        """The image_generate dispatcher forwards the `hermes tools` pick (``image_gen.model``) as
+        the ``model`` kwarg; it must win over a scoped ``image_gen.openai.model`` left behind."""
+        import yaml
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"model": "gpt-image-2.5-sunburst"}}})
+        )
+        model_id, meta = openai_plugin._resolve_model("gpt-image-2.5-flare")
+        assert model_id == "gpt-image-2.5-flare"
+        assert meta["api_model"] == "gpt-image-2.5-flare"
+
+    def test_unknown_caller_model_falls_back_to_config(self, tmp_path, monkeypatch):
+        """An id from another backend left in ``image_gen.model`` never reaches OpenAI."""
+        import yaml
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai": {"model": "gpt-image-2-low"}}})
+        )
+        model_id, _ = openai_plugin._resolve_model("fal-ai/flux-2/klein/9b")
+        assert model_id == "gpt-image-2-low"
+
+
 # ── Generate ────────────────────────────────────────────────────────────────
 
 
@@ -206,6 +229,53 @@ class TestGenerate:
         assert call.call_args.kwargs["model"] == api_model
         assert "response_format" not in call.call_args.kwargs
         assert Path(result["image"]).read_bytes() == bytes.fromhex(_PNG_HEX)
+
+    def test_model_kwarg_reaches_image_request(self, provider, monkeypatch, tmp_path):
+        """``generate(model=...)`` selects the tier even when a scoped config key disagrees."""
+        import yaml
+
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+            "image_gen": {"openai": {"model": "gpt-image-2.5-sunburst-high"}}
+        }))
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat", model="gpt-image-2.5-flare-low")
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2.5-flare-low"
+        call_kwargs = fake_client.images.generate.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-image-2.5-flare"
+        assert call_kwargs["quality"] == "low"
+
+    def test_tool_dispatch_pick_wins_over_scoped_config(self, provider, monkeypatch, tmp_path):
+        """End to end through ``image_generate`` dispatch: the model `hermes tools` / the Desktop
+        picker wrote to ``image_gen.model`` is the one requested, not a stale
+        ``image_gen.openai.model``."""
+        import json
+        import yaml
+        import tools.image_generation_tool as image_tool
+
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+            "image_gen": {
+                "provider": "openai",
+                "model": "gpt-image-2.5-flare",
+                "openai": {"model": "gpt-image-2.5-sunburst"},
+            }
+        }))
+        monkeypatch.setattr("agent.image_gen_registry.get_provider", lambda name: provider)
+        monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda *a, **k: None)
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = _fake_response(b64=_b64_png())
+
+        with _patched_openai(fake_client):
+            raw = image_tool._dispatch_to_plugin_provider("a cat", "square")
+
+        assert json.loads(raw)["model"] == "gpt-image-2.5-flare"
+        assert fake_client.images.generate.call_args.kwargs["model"] == "gpt-image-2.5-flare"
 
     @pytest.mark.parametrize("aspect,expected_size", [
         ("landscape", "1536x1024"),


### PR DESCRIPTION
## What does this PR do?

`hermes tools`, the Desktop settings picker and the WebUI all persist the chosen image model to `image_gen.model`, and the `image_generate` dispatcher forwards that value to `provider.generate()` as the `model` kwarg (`tools/image_generation_tool.py::_add_provider_kwargs`). The OpenRouter/Nous provider honors it since #55672 and xAI since #89890 (maintainer note there: *"the dispatcher already forwards that config value as the `model` kwarg, which the landed fix now honors"*). Three bundled providers still ignore it:

| Provider | What it did with the dispatched `model` | Effect |
|---|---|---|
| `openai` | ignored; read `image_gen.openai.model` first, then `image_gen.model` | once the scoped key exists, every later pick is shown as current but never requested |
| `openai-codex` | ignored; read `image_gen.openai-codex.model` first | same |
| `deepinfra` | ignored; read only `DEEPINFRA_IMAGE_MODEL` / `image_gen.deepinfra.model` | the model picker has **no effect at all** — the first live catalog model is always used |

The `openai` case became mainstream with GPT Image 2.5 (#105988): the new docs tell users to run `hermes config set image_gen.openai.model gpt-image-2.5-flare`. After that, switching to Sunburst (or back to GPT Image 2) in `hermes tools`, the Desktop or the WebUI writes `image_gen.model`, the UI marks the new model as *currently in use*, and every request keeps going to the scoped key's model. Reproduced on main `e7eaff6845` with the real config loader and a mocked OpenAI client:

```yaml
image_gen:
  provider: openai
  model: gpt-image-2.5-flare        # what the picker just wrote
  openai:
    model: gpt-image-2.5-sunburst   # what the 2.5 docs told the user to set earlier
```
```
request sent to OpenAI with model= gpt-image-2.5-sunburst   # main
request sent to OpenAI with model= gpt-image-2.5-flare      # this branch
```

### Fix

Pass `kwargs["model"]` into each provider's `_resolve_model()` as the `explicit` candidate that `plugins/image_gen/_common.py::resolve_static_model()` already supports (krea and meta-ai use it the same way). The three providers now share their siblings' precedence: dispatched `model` → `*_IMAGE_MODEL` env → scoped `image_gen.<plugin>.model` → top-level `image_gen.model` → default. The candidate is validated against the provider's catalog (DeepInfra: the live catalog when reachable), so an id another backend left behind in `image_gen.model` (e.g. `fal-ai/flux-2/klein/9b`) falls through instead of being sent. No config key, schema or default changes; a user with only the scoped key set sees no difference.

This also makes the three providers ready for the per-call `model` override PRs (#104744, #83478), which rely on the same kwarg reaching the provider.

## Related Issue

No open issue; found while auditing the GPT Image 2.5 selection paths added in #105988. Same defect class as #55672 / #89890 (both merged).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/image_gen/openai/__init__.py` — `_resolve_model(explicit=None)` forwards the kwarg to `resolve_static_model(..., explicit=)`; `generate()` passes `kwargs.get("model")`; selection docstring updated.
- `plugins/image_gen/openai-codex/__init__.py` — same.
- `plugins/image_gen/deepinfra/__init__.py` — `_resolve_model(catalog, cfg, explicit=None)`: caller model first, honored when the live catalog lists it or is unavailable; `generate()` passes `kwargs.get("model")`; docstring updated.
- `tests/plugins/image_gen/test_openai_provider.py` (+4), `test_openai_codex_provider.py` (+2), `test_deepinfra_provider.py` (+4) — resolver-, `generate()`- and `image_generate`-dispatch-level regressions; foreign ids fall through; DeepInfra honors a pick while its catalog is unreachable.
- `contributors/emails/kyr76789@gmail.com` — attribution mapping for the Contributor Attribution Check.

## How to Test

1. `scripts/run_tests.sh tests/plugins/image_gen/` — 245 passed on this branch (8 files).
2. Mutation check: with the three `plugins/image_gen/*/__init__.py` changes reverted and the new tests kept, 8 of the 10 new tests fail (the two that pass are the foreign-id guards, which hold on both sides); with the fix, all pass.
3. Manual: set the YAML above (any `OPENAI_API_KEY`), call `image_generate` and check the `model` in the request / the tool's `model` field — it now follows `image_gen.model`, i.e. the picker.

Also run: `tests/tools/test_image_generation.py`, `test_image_generate_schema.py`, `test_image_generation_model_override.py`, `tests/agent/pet` — green except the two `TestManagedGatewayErrorTranslation` tests, which fail identically on unmodified main in my environment (`fal-client` not installed, lazy installs disabled). `ruff check` and `scripts/check_compat_pointers.py` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — #55672 / #89890 fixed the same class for openrouter/xai; #104744 / #83478 add a per-call override on top of this kwarg and do not touch these three providers
- [x] My PR contains **only** changes related to this fix
- [x] Tests run via `scripts/run_tests.sh` (see above)
- [x] I've added tests for my changes
- [x] Tested on macOS 15 (Darwin 25.5), Python from the repo `.venv`

### Documentation & Housekeeping

- [x] Docstrings updated (selection precedence in the three providers); user docs already describe `image_gen.model` as the picker key — N/A
- [x] `cli-config.yaml.example` — N/A (no new keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure Python selection logic)
