### PR TITLE
fix(auth): preserve independent same-account OAuth grants

### DIFF
--- a/hermes_cli/auth_oauth_grants.py
+++ b/hermes_cli/auth_oauth_grants.py
@@ -187,9 +187,8 @@ def _find_root_counterpart(
     profile_row: Dict[str, Any], root_rows: List[Dict[str, Any]]) -> Optional[int]:
     """Index of the root OAuth row that shares a grant lineage with *profile_row*.
 
-    Fallback per the one-grant-at-root rule: same provider + same OAuth client — every Anthropic
-    ``hermes_pkce`` grant uses one client id and carries no claims, so two Anthropic OAuth rows
-    with no contrary identity are one lineage.
+    Only a copied row ID or shared token material establishes lineage. The same
+    account/client can issue multiple independent grants; identity is not proof.
     """
     from hermes_cli.auth import _nonempty_str
     candidates = [i for i, r in enumerate(root_rows) if _is_oauth_pool_payload(r)]
@@ -199,11 +198,6 @@ def _find_root_counterpart(
     for i in candidates:
         if pid and root_rows[i].get("id") == pid:
             return i
-    p_ident = _oauth_identity(profile_row)
-    for i in candidates:
-        r_ident = _oauth_identity(root_rows[i])
-        if p_ident and r_ident and p_ident == r_ident:
-            return i
     for key in ("refresh_token", "access_token"):
         p_val = profile_row.get(key)
         if not _nonempty_str(p_val):
@@ -211,14 +205,7 @@ def _find_root_counterpart(
         for i in candidates:
             if root_rows[i].get(key) == p_val:
                 return i
-    # Fallback: same provider + same client. Only a contradicting identity (both sides carry
-    # claims and they differ from every root row) blocks it.
-    if p_ident:
-        for i in candidates:
-            if not _oauth_identity(root_rows[i]):
-                return i
-        return None
-    return candidates[0]
+    return None
 
 
 def _adopt_oauth_material(target: Dict[str, Any], winner: Dict[str, Any]) -> Dict[str, Any]:
@@ -254,7 +241,7 @@ def heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str, 
     Forked copies are one credential with several owners: whichever profile rotated last holds the
     only live refresh token and every other copy (root included) is spent. Runs at profile
     ``load_pool()`` time for ``SINGLE_USE_REFRESH_POOL_PROVIDERS``: finds profile rows sharing
-    LINEAGE with a root row (same pool id, or same account identity / token material), keeps the
+    LINEAGE with a root row (same pool id or shared token material), keeps the
     freshest rotation, writes it into ROOT when root's is older, and strips the profile's copy so
     the profile borrows root from then on. Idempotent; never touches API-key rows; never deletes a
     row with no root counterpart (an independent ``hermes -p <p> auth add`` grant, or the only
@@ -290,8 +277,12 @@ def _heal_forked_provider_block(
         return {**tokens, "last_refresh": block.get("last_refresh")}
 
     p_flat, r_flat = _flat(p_block), _flat(r_block)
-    p_ident, r_ident = _oauth_identity(p_flat), _oauth_identity(r_flat)
-    if p_ident and r_ident and p_ident != r_ident:
+    # Provider blocks have no stable pool-row ID. Without a shared token pair
+    # component, a common account is insufficient evidence of a copied grant.
+    if not any(
+        p_flat.get(key) and p_flat.get(key) == r_flat.get(key)
+        for key in ("access_token", "refresh_token")
+    ):
         return None
     adopted = _oauth_freshness(p_flat) > _oauth_freshness(r_flat)
     if adopted:

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -425,6 +425,47 @@ def test_heal_never_deletes_the_only_surviving_copy(fleet):
     assert "anthropic" not in (json.loads((fleet["root"] / "auth.json").read_text())["credential_pool"])
 
 
+@pytest.mark.parametrize("shape", ["pool", "provider"])
+@pytest.mark.parametrize("claims", [True, False])
+def test_heal_preserves_independent_grants_for_same_account(fleet, shape, claims):
+    """An account can have independent device logins; identity is not lineage."""
+    import base64
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    def pair(tag):
+        payload = base64.urlsafe_b64encode(json.dumps({
+            "sub": "same-account", "exp": int(time.time()) + 3600, "jti": tag,
+        }).encode()).decode().rstrip("=")
+        return {"access_token": "h." + payload + ".s" if claims else tag,
+                "refresh_token": "independent-" + tag}
+
+    def store(tag):
+        tokens = pair(tag)
+        if shape == "provider":
+            return {"version": 1, "providers": {"openai-codex": {"tokens": tokens}}}
+        return {"version": 1, "providers": {}, "credential_pool": {"openai-codex": [{
+            "id": tag, "auth_type": "oauth", "source": "manual:device_code", **tokens,
+        }]}}
+
+    root = fleet["root"] / "auth.json"
+    kid = _profile(fleet, "independent")
+    kid.mkdir(parents=True, exist_ok=True)
+    profile = kid / "auth.json"
+    root.write_text(json.dumps(store("root-grant")))
+    profile.write_text(json.dumps(store("profile-grant")))
+    before = (root.read_bytes(), profile.read_bytes())
+    fleet["use"](kid)
+    assert heal_forked_single_use_oauth_grants("openai-codex") is None
+    assert (root.read_bytes(), profile.read_bytes()) == before
+    if claims:
+        from agent.credential_pool import load_pool
+        for _ in range(3):
+            selected = load_pool("openai-codex").select()
+            assert selected is not None
+            assert selected.refresh_token == "independent-profile-grant"
+        assert root.read_bytes() == before[0]
+
+
 def test_heal_leaves_a_different_account_alone(fleet):
     """A profile row whose JWT identity names ANOTHER account is not root's grant."""
     import base64


### PR DESCRIPTION
## Summary
Preserve independent profile OAuth logins during automatic forked-grant consolidation. An account identity identifies an account, not an OAuth grant: two device logins for the same account need not share a refresh-token chain.

- Pool-row consolidation now requires a shared row ID or shared nonempty access/refresh token material, rather than account equality or a same-provider fallback.
- Provider-block consolidation requires shared token material; matching/missing account claims alone cannot authorize deletion.
- Add a parametrized regression covering pool rows and provider blocks, with matching JWT account claims and with opaque tokens. JWT cases also exercise repeated real `load_pool().select()` calls against isolated on-disk stores.

## Reproduced failure
A profile gateway repeatedly reported provider authentication failure despite successful `hermes --profile <profile> auth add openai-codex` logins. While stopped, its new credential completed a direct inference request. Starting the gateway removed the profile credential; logs reported automatic consolidation into the root grant and subsequent `refresh_token_reused` failures.

The installed consolidation code independently reproduced the destructive behavior with synthetic independent grants: different row IDs and token pairs, same account. This PR addresses that demonstrable consolidation defect; it does not claim to reconstruct every historical token rotation.

## Validation
- New regression: **4 failures before the patch**, all passing afterward.
- **102 targeted tests passed**, rerun after applying the patch to current upstream main:
  ```sh
  scripts/run_tests.sh -j 2 \
    tests/agent/test_credential_pool_profile_oauth_fork.py \
    tests/agent/test_credential_pool.py \
    tests/hermes_cli/test_auth_codex_provider.py \
    tests/hermes_cli/test_auth_codex_self_heal.py --tb=short
  ```
- Live patched resolver repeatedly selected and retained a freshly authenticated profile credential; a request using that selection completed successfully as `gpt-5.6-sol`.
- Live Discord gateway recovery confirmed: after starting the patched gateway, it answered `pong`; operator confirmed working.
- `git diff --check` passes. Full repository suite not run locally.

## Scope / trade-off
Existing copied-row/shared-token consolidation remains enabled, and existing copied-grant tests pass. Account-only/unknown-lineage cases are now left untouched rather than destructively guessed. A provider block whose tokens have completely diverged cannot be automatically identified as a copy without additional lineage evidence. Anthropic singleton-file heuristics and other credential-refresh paths are not redesigned here.

No credentials or private conversation transcripts are included. Posted following successful live recovery at the operator's request.
