### PR TITLE
fix(cli): stop dpaste.com fallback from leaking debug logs for 7 days

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -116,6 +116,10 @@ upload, but the following personal data is NOT redacted and will be public:
 The resulting URL is public to anyone who has the link. Pastes auto-delete
 after 6 hours, but may be archived by third parties in the meantime.
 
+If paste.rs is unreachable, uploads fall back to dpaste.com: those pastes
+stay public for the --expire window (default: 1 day) and CANNOT be deleted
+with `hermes debug delete`.
+
 Use --local to view the report without uploading.
 """
 
@@ -124,7 +128,8 @@ _GATEWAY_PRIVACY_NOTICE = (
     "(may contain conversation fragments) to a public paste service. "
     "Full logs are NOT included from the gateway — use `hermes debug share` "
     "from the CLI for full log uploads.\n"
-    "Pastes auto-delete after 6 hours.")
+    "Pastes auto-delete after 6 hours (dpaste.com fallback pastes: kept for "
+    "1 day, cannot be deleted).")
 
 
 def _extract_paste_id(url: str) -> Optional[str]:
@@ -136,10 +141,19 @@ def _extract_paste_id(url: str) -> Optional[str]:
     return None
 
 
+def _is_dpaste_url(url: str) -> bool:
+    """Whether *url* is a dpaste.com paste (no unauthenticated delete exists for those)."""
+    return url.strip().startswith(("https://dpaste.com/", "http://dpaste.com/"))
+
+
 def delete_paste(url: str) -> bool:
     """Delete a paste.rs paste (the only service with unauthenticated DELETE). True on success."""
     paste_id = _extract_paste_id(url)
     if not paste_id:
+        if _is_dpaste_url(url):
+            raise ValueError(
+                "Cannot delete: dpaste.com pastes cannot be deleted (anonymous "
+                "uploads have no owner token); they expire on their own.  Got: " + url)
         raise ValueError(f"Cannot delete: only paste.rs URLs are supported.  Got: {url}")
     req = urllib.request.Request(f"{_PASTE_RS_URL}{paste_id}", method="DELETE",
                                  headers={"User-Agent": _USER_AGENT})
@@ -175,7 +189,7 @@ def _upload_paste_rs(content: str) -> str:
     return _post_paste("paste.rs", _PASTE_RS_URL, content.encode("utf-8"), "text/plain; charset=utf-8")
 
 
-def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
+def _upload_dpaste_com(content: str, expiry_days: int = 1) -> str:
     boundary = "----HermesDebugBoundary9f3c"
     fields = (("content", content), ("syntax", "text"), ("expiry_days", str(expiry_days)))
     body = ("".join(f'--{boundary}\r\nContent-Disposition: form-data; name="{n}"\r\n\r\n{v}\r\n'
@@ -184,8 +198,13 @@ def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
                        f"multipart/form-data; boundary={boundary}")
 
 
-def upload_to_pastebin(content: str, expiry_days: int = 7) -> str:
-    """Upload *content* to a paste service, trying paste.rs then dpaste.com."""
+def upload_to_pastebin(content: str, expiry_days: int = 1) -> str:
+    """Upload *content* to a paste service, trying paste.rs then dpaste.com.
+
+    ``expiry_days`` applies only to the dpaste.com fallback (paste.rs pastes are
+    swept after 6h); dpaste.com's minimum is 1 day and anonymous pastes cannot
+    be deleted afterwards, so callers must not promise a shorter retention.
+    """
     errors: list[str] = []
     for service, upload in (
         ("paste.rs", lambda: _upload_paste_rs(content)),
@@ -406,12 +425,13 @@ class DebugShareResult:
     urls: dict  # label -> paste URL (e.g. {"Report": "...", "agent.log": "..."})
     failures: list  # human-readable "label: error" strings for optional uploads
     redacted: bool  # whether force-mode redaction was applied before upload
-    auto_delete_seconds: int  # how long until the pastes auto-delete
+    auto_delete_seconds: int  # how long until the pastes auto-delete (paste.rs only;
+    # dpaste.com fallbacks outlive this and cannot be deleted)
     report: str = ""  # the summary report text (kept for local fallback)
 
 
 def build_debug_share(
-    *, log_lines: int = 200, expiry: int = 7, redact: bool = True) -> DebugShareResult:
+        *, log_lines: int = 200, expiry: int = 1, redact: bool = True) -> DebugShareResult:
     """Collect the debug report + full logs, upload each, return the URLs.
 
     Shared by ``hermes debug share`` and the dashboard ``POST /api/ops/debug-share``. Blocking
@@ -460,7 +480,7 @@ def _confirm_upload(args) -> bool:
 def run_debug_share(args):
     """Collect debug report + full logs, upload each, print URLs."""
     log_lines = getattr(args, "lines", 200)
-    expiry = getattr(args, "expire", 7)
+    expiry = getattr(args, "expire", 1)
     redact = not getattr(args, "no_redact", False)
 
     if getattr(args, "local", False):
@@ -492,9 +512,18 @@ def run_debug_share(args):
         print(f"  {label:<{label_width}}  {url}")
     if result.failures:
         print(f"\n  (failed to upload: {', '.join(result.failures)})")
-    print(f"\n⏱  Pastes will auto-delete in {result.auto_delete_seconds // 3600} hours.\n"
-          "To delete now:  hermes debug delete <url>\n"
-          "\nShare these links with the Hermes team for support.")
+    dpaste_urls = [u for u in result.urls.values() if _is_dpaste_url(u)]
+    if dpaste_urls:
+        print(f"\n⏱  paste.rs pastes will auto-delete in "
+              f"{result.auto_delete_seconds // 3600} hours.")
+        print(f"⚠️  {len(dpaste_urls)} of {len(result.urls)} upload(s) fell back to "
+              f"dpaste.com: those pastes stay public for {expiry} day(s) and CANNOT be "
+              "deleted with `hermes debug delete`.\n"
+              "\nShare these links with the Hermes team for support.")
+    else:
+        print(f"\n⏱  Pastes will auto-delete in {result.auto_delete_seconds // 3600} hours.\n"
+              "To delete now:  hermes debug delete <url>\n"
+              "\nShare these links with the Hermes team for support.")
 
 
 _NOUS_PRIVACY_NOTICE = """\
@@ -588,7 +617,7 @@ Commands:
 
 Options (share):
   --lines N    Number of log lines to include (default: 200)
-  --expire N   Paste expiry in days (default: 7)
+  --expire N   dpaste.com fallback retention in days (default: 1)
   --local      Print report locally instead of uploading
   --nous       Upload to Nous-internal storage (private, staff-only,
                auto-deletes in 14 days) instead of a public paste

--- a/hermes_cli/subcommands/debug.py
+++ b/hermes_cli/subcommands/debug.py
@@ -19,7 +19,7 @@ Examples:
     hermes debug share              Upload debug report (asks for confirmation)
     hermes debug share --yes        Skip confirmation (for scripts/CI)
     hermes debug share --lines 500  Include more log lines
-    hermes debug share --expire 30  Keep paste for 30 days
+    hermes debug share --expire 30  Keep dpaste.com fallback pastes for 30 days
     hermes debug share --local      Print report locally (no upload)
     hermes debug share --no-redact  Disable upload-time secret redaction
     hermes debug share --nous       Upload to Nous-internal storage (private)
@@ -32,7 +32,11 @@ Examples:
         "--lines", type=int, default=200,
         help="Number of log lines to include per log file (default: 200)")
     share_parser.add_argument(
-        "--expire", type=int, default=7, help="Paste expiry in days (default: 7)")
+        "--expire", type=int, default=1,
+        help="dpaste.com fallback retention in days (minimum 1; default: 1). "
+            "paste.rs pastes are always deleted after 6 hours, but if the "
+            "upload falls back to dpaste.com the pastes live for this many "
+            "days and cannot be deleted.")
     share_parser.add_argument(
         "--local", action="store_true", help="Print the report locally instead of uploading")
     share_parser.add_argument(

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -101,6 +101,30 @@ class TestUploadToPastebin:
             with pytest.raises(RuntimeError, match="Failed to upload"):
                 upload_to_pastebin("content")
 
+    def test_fallback_defaults_to_one_day_retention(self):
+        """dpaste.com's minimum retention is 1 day and anonymous pastes cannot be
+        deleted, so the fallback must never default to a longer window (#106164)."""
+        from hermes_cli.debug import upload_to_pastebin
+
+        with patch("hermes_cli.debug._upload_paste_rs",
+                    side_effect=Exception("down")), \
+             patch("hermes_cli.debug._upload_dpaste_com",
+                    return_value="https://dpaste.com/TEST") as dp:
+            upload_to_pastebin("content")
+
+        dp.assert_called_once_with("content", expiry_days=1)
+
+    def test_explicit_expiry_is_passed_through(self):
+        from hermes_cli.debug import upload_to_pastebin
+
+        with patch("hermes_cli.debug._upload_paste_rs",
+                    side_effect=Exception("down")), \
+             patch("hermes_cli.debug._upload_dpaste_com",
+                    return_value="https://dpaste.com/TEST") as dp:
+            upload_to_pastebin("content", expiry_days=30)
+
+        dp.assert_called_once_with("content", expiry_days=30)
+
 
 # ---------------------------------------------------------------------------
 # Log reading
@@ -632,6 +656,14 @@ class TestDeletePaste:
         assert req.method == "DELETE"
         assert "paste.rs/abc123" in req.full_url
 
+    def test_dpaste_url_error_explains_no_delete(self):
+        """dpaste.com pastes have no owner token, so the user must be told the
+        paste cannot be deleted and will expire on its own (#106164)."""
+        from hermes_cli.debug import delete_paste
+
+        with pytest.raises(ValueError, match="cannot be deleted.*expire on their own"):
+            delete_paste("https://dpaste.com/ABC123")
+
 
 class TestScheduleAutoDelete:
     """``_schedule_auto_delete`` used to spawn a detached Python subprocess
@@ -814,6 +846,66 @@ class TestShareIncludesAutoDelete:
         assert "PUBLIC paste service" in out
         assert "NOT redacted" in out
 
+    def test_privacy_notice_mentions_dpaste_fallback(self, hermes_home, capsys):
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.local = False
+        args.nous = False
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://paste.rs/test"), \
+             patch("hermes_cli.debug._schedule_auto_delete"):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "fall back to dpaste.com" in out
+        assert "CANNOT be deleted" in out
+
+    def test_share_output_warns_on_dpaste_fallback(self, hermes_home, capsys):
+        """With dpaste.com URLs the output must not promise 6-hour auto-delete
+        or a working `hermes debug delete` (#106164)."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 1
+        args.local = False
+        args.nous = False
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://dpaste.com/TEST"), \
+             patch("hermes_cli.debug._schedule_auto_delete"):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "fell back to dpaste.com" in out
+        assert "CANNOT be deleted" in out
+        assert "To delete now" not in out
+        assert "paste.rs pastes will auto-delete in 6 hours" in out
+
+    def test_share_output_keeps_delete_hint_for_paste_rs(self, hermes_home, capsys):
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.local = False
+        args.nous = False
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://paste.rs/test"), \
+             patch("hermes_cli.debug._schedule_auto_delete"):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "Pastes will auto-delete in 6 hours" in out
+        assert "To delete now:  hermes debug delete <url>" in out
+        assert "fell back to dpaste.com" not in out
+
 
 # ---------------------------------------------------------------------------
 # build_debug_share — structured core used by the dashboard endpoint
@@ -873,6 +965,20 @@ class TestBuildDebugShare:
         assert "Report" in result.urls
         assert len(result.failures) == 1
         assert "paste service hiccup" in result.failures[0]
+
+    def test_defaults_to_one_day_fallback_expiry(self, hermes_home):
+        """The dashboard endpoint calls build_debug_share() with no expiry; the
+        default must stay at dpaste.com's 1-day minimum (#106164)."""
+        from hermes_cli.debug import build_debug_share
+
+        with patch("hermes_cli.dump.run_dump"), patch(
+            "hermes_cli.debug.upload_to_pastebin",
+            return_value="https://paste.rs/x"
+        ) as up, patch("hermes_cli.debug._schedule_auto_delete"):
+            build_debug_share(log_lines=50)
+
+        for call in up.call_args_list:
+            assert call.kwargs.get("expiry_days") == 1
 
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes debug share` promises "Pastes auto-delete in 6 hours" and offers `hermes debug delete <url>`, but when paste.rs is unreachable and the upload falls back to dpaste.com, both promises are false:

- the paste lives for `expiry_days` days (default **7**, not 6 hours) — confirmed against dpaste's API in #106164
- it can never be deleted (`hermes debug delete` rejects dpaste URLs; anonymous dpaste pastes have no owner token, so the API returns 401 for DELETE)
- the pending-paste sweep only tracks paste.rs URLs, so nothing ever acts on dpaste pastes

Net effect: sensitive logs (message content, per the privacy notice) stay publicly reachable for a week with no tool-supported remedy, while the user was told the leak self-heals in 6 hours.

This PR shrinks the exposure window and stops the output from lying:

1. **Default the dpaste.com fallback retention to 1 day** (dpaste's minimum — verified via the API: `expiry_days=1` yields a 24h expiry) across `--expire`, `upload_to_pastebin()`, and `build_debug_share()`, so the dashboard endpoint (`POST /api/ops/debug-share`, which passes no expiry) benefits too. Explicit `--expire N` still wins.
2. **Print an accurate warning when uploads fell back to dpaste.com** — real retention window, and that `hermes debug delete` cannot delete them — instead of the unconditional 6-hour promise.
3. **Disclose the fallback in both privacy notices before the user consents** (CLI + gateway `/debug`).
4. **Explain in `hermes debug delete` errors** why dpaste.com pastes cannot be deleted and that they expire on their own.

## Related Issue

Fixes #106164

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_cli/debug.py`: default `expiry_days`/`expiry` to 1 in `_upload_dpaste_com()`, `upload_to_pastebin()`, `build_debug_share()`, and `run_debug_share()`; dpaste-aware fallback warning in the share output; fallback disclosure in `_PRIVACY_NOTICE` and `_GATEWAY_PRIVACY_NOTICE`; dpaste-specific `delete_paste()` error; `_DEBUG_USAGE` text
- `hermes_cli/subcommands/debug.py`: `--expire` default 7 → 1 with accurate help text
- `tests/hermes_cli/test_debug.py`: 7 new regression tests

## How to Test

1. `python -m pytest tests/hermes_cli/test_debug.py tests/gateway/test_debug_command.py tests/hermes_cli/test_dashboard_admin_endpoints.py -q` → **Observed result: 101 passed** (58 + 1 + 42).
2. Fallback default: with `_upload_paste_rs` failing and `_upload_dpaste_com` mocked, `upload_to_pastebin("content")` calls the fallback with `expiry_days=1`; explicit `expiry_days=30` is still passed through. Covered by `test_fallback_defaults_to_one_day_retention` / `test_explicit_expiry_is_passed_through`.
3. Honest output: `run_debug_share` with dpaste URLs prints "fell back to dpaste.com … CANNOT be deleted" and drops the `To delete now` hint (paste.rs-only runs keep the original wording). Covered by `test_share_output_warns_on_dpaste_fallback` / `test_share_output_keeps_delete_hint_for_paste_rs`.
4. Live API check performed for this PR: `curl -X POST https://dpaste.com/api/v2/ -F content=probe -F syntax=text -F expiry_days=1` returns 201 with `item_detail` showing a 24h expiry.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — targeted suites: `tests/hermes_cli/` + `tests/gateway/test_debug_command.py` all green for this change's surface; the wider `tests/hermes_cli/` directory has pre-existing order-dependent failures on this machine (single-file runs pass, incl. all files touched here)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (CLI `--help` text updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python CLI text/defaults, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A