### PR TITLE
fix(auxiliary): preserve Anthropic cache tokens in usage shim (salvage #71394, fixes #71242)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1675,11 +1675,29 @@ class _AnthropicCompletionsAdapter:
         _nr = get_transport("anthropic_messages").normalize_response(response, strip_tool_prefix=self._is_oauth)
         usage = None
         if hasattr(response, "usage") and response.usage:
-            prompt_tokens = getattr(response.usage, "input_tokens", 0) or 0
-            completion_tokens = getattr(response.usage, "output_tokens", 0) or 0
+            input_tokens = getattr(response.usage, "input_tokens", 0) or 0
+            output_tokens = getattr(response.usage, "output_tokens", 0) or 0
+            cache_read_input_tokens = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+            cache_creation_input_tokens = getattr(response.usage, "cache_creation_input_tokens", 0) or 0
+            inclusive_prompt = (
+                int(input_tokens)
+                + int(cache_read_input_tokens)
+                + int(cache_creation_input_tokens)
+            )
             usage = SimpleNamespace(
-                prompt_tokens=prompt_tokens, completion_tokens=completion_tokens,
-                total_tokens=getattr(response.usage, "total_tokens", 0) or (prompt_tokens + completion_tokens),
+                prompt_tokens=inclusive_prompt,
+                completion_tokens=output_tokens,
+                total_tokens=getattr(response.usage, "total_tokens", 0) or (
+                    inclusive_prompt + int(output_tokens)
+                ),
+                prompt_tokens_details=SimpleNamespace(
+                    cached_tokens=cache_read_input_tokens,
+                    cache_write_tokens=cache_creation_input_tokens,
+                ),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_input_tokens=cache_read_input_tokens,
+                cache_creation_input_tokens=cache_creation_input_tokens,
             )
         # ToolCall already duck-types as OpenAI shape via properties.
         choice = SimpleNamespace(

--- a/contributors/emails/siv.lim777@gmail.com
+++ b/contributors/emails/siv.lim777@gmail.com
@@ -1,0 +1,1 @@
+SirPranceAlot

--- a/tests/agent/test_auxiliary_client_anthropic_cache_tokens_71242.py
+++ b/tests/agent/test_auxiliary_client_anthropic_cache_tokens_71242.py
@@ -1,0 +1,109 @@
+"""Anthropic auxiliary usage carries native and OpenAI-shaped token buckets.
+
+normalize_usage() must recover the same canonical input/output/cache buckets
+from the adapted response on both the Anthropic and OpenAI-compatible paths.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "OPENAI_API_KEY", "OPENAI_BASE_URL",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_native_response(*, input_tokens=10, output_tokens=20,
+                           cache_read=0, cache_creation=0, include_cache_fields=True):
+    usage = SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
+    if include_cache_fields:
+        usage.cache_read_input_tokens = cache_read
+        usage.cache_creation_input_tokens = cache_creation
+    return SimpleNamespace(
+        content=[MagicMock()],
+        usage=usage,
+        stop_reason="end_turn",
+        model="claude-test",
+    )
+
+
+def _patch_transport():
+    fake_nr = SimpleNamespace(
+        content="hello",
+        tool_calls=None,
+        reasoning=None,
+        finish_reason="stop",
+    )
+    fake_transport = MagicMock(name="anthropic_transport")
+    fake_transport.normalize_response.return_value = fake_nr
+    return patch(
+        "agent.transports.get_transport",
+        return_value=fake_transport,
+    )
+
+
+def _patch_create_anthropic_message(response):
+    return patch(
+        "agent.anthropic_adapter.create_anthropic_message",
+        return_value=response,
+    )
+
+
+def _adapt(native):
+    from agent.auxiliary_client import _AnthropicCompletionsAdapter
+
+    adapter = _AnthropicCompletionsAdapter(
+        real_client=MagicMock(), model="claude-test", is_oauth=False,
+    )
+    with _patch_create_anthropic_message(native), _patch_transport():
+        return adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+
+@pytest.mark.parametrize(
+    ("cache_read", "cache_creation", "include_cache_fields"),
+    [(2048, 512, True), (0, 400, True), (0, 0, False)],
+)
+def test_normalize_usage_anthropic_path_preserves_cache_buckets(
+    cache_read, cache_creation, include_cache_fields
+):
+    """Native Anthropic accounting keeps fresh, read, and write buckets separate."""
+    from agent.usage_pricing import normalize_usage
+
+    result = _adapt(_make_native_response(
+        input_tokens=100, output_tokens=50,
+        cache_read=cache_read, cache_creation=cache_creation,
+        include_cache_fields=include_cache_fields,
+    ))
+    canon = normalize_usage(
+        result.usage, provider="anthropic", api_mode="anthropic_messages"
+    )
+    assert (canon.input_tokens, canon.output_tokens) == (100, 50)
+    assert (canon.cache_read_tokens, canon.cache_write_tokens) == (cache_read, cache_creation)
+
+
+@pytest.mark.parametrize(
+    ("cache_read", "cache_creation", "include_cache_fields"),
+    [(2048, 512, True), (0, 400, True), (0, 0, False)],
+)
+def test_normalize_usage_openai_path_preserves_fresh_input(
+    cache_read, cache_creation, include_cache_fields
+):
+    """Inclusive prompt totals prevent the OpenAI branch from clamping fresh input to zero."""
+    from agent.usage_pricing import normalize_usage
+
+    result = _adapt(_make_native_response(
+        input_tokens=100, output_tokens=50,
+        cache_read=cache_read, cache_creation=cache_creation,
+        include_cache_fields=include_cache_fields,
+    ))
+    canon = normalize_usage(result.usage, provider="openrouter")
+    assert (canon.input_tokens, canon.output_tokens) == (100, 50)
+    assert (canon.cache_read_tokens, canon.cache_write_tokens) == (cache_read, cache_creation)


### PR DESCRIPTION
## What does this PR do?

Salvages #71394 from @smfworks. Fixes #71242.

The Anthropic auxiliary adapter dropped cache token buckets and exposed fresh-only input as `prompt_tokens`. It now emits native Anthropic fields alongside an inclusive OpenAI-compatible prompt shape so both usage-normalization paths report correct input, output, and cache buckets.

## Related Issue

Fixes #71242.

Salvages #71394 (@smfworks); also covers the narrower cache pass-through in #71325.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: preserve native Anthropic input/output and cache fields, and expose an inclusive OpenAI-compatible `prompt_tokens` with cache details.
- `tests/agent/test_auxiliary_client_anthropic_cache_tokens_71242.py`: add adapter-to-normalizer regression coverage for Anthropic and OpenAI-compatible paths, including cache reads, cache writes, and absent fields.
- `contributors/emails/siv.lim777@gmail.com`: map the commit email to `SirPranceAlot` for contributor attribution.

## Root Cause

The adapter rebuilt native Anthropic usage with only `prompt_tokens`, `completion_tokens`, and `total_tokens`. Cache buckets were discarded. Anthropic `input_tokens` is fresh input, while the OpenAI-compatible normalizer treats `prompt_tokens` as an inclusive total before subtracting cache buckets.

## How to Test

```text
scripts/run_tests.sh tests/agent/test_auxiliary_client_anthropic_cache_tokens_71242.py tests/agent/test_auxiliary_client.py tests/agent/test_usage_pricing.py tests/run_agent/test_moa_loop_mode.py tests/hermes_state/test_aux_usage_accounting.py
uv run ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client_anthropic_cache_tokens_71242.py
```

The focused regression tests fail on `main` and pass with this change.

## Validation

- 297 affected tests passed.
- Ruff passed.
- `git diff --check` passed.
- Tests used `scripts/run_tests.sh` with isolated `HERMES_HOME`; no model calls or external credentials were used.
- Platform: macOS 26.5.1.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs; this salvages #71394
- [x] My PR contains only changes related to this fix
- [x] I've run the affected tests with the repository test runner and they pass
- [x] I've added tests for the bug fix
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A; this is an internal usage-accounting fix
- [ ] I've updated `cli-config.yaml.example` — N/A; no configuration changes
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact — no platform-specific behavior
- [ ] I've updated tool descriptions/schemas — N/A; no tool behavior changes

## Risk

Accounting and cost reporting only. Request and response semantics are unchanged, and no provider request payload is modified.

## Screenshots / Logs

N/A.
