### PR TITLE
fix(vision): recover from image patch-limit rejections

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -153,6 +153,7 @@ _PAYLOAD_TOO_LARGE_PATTERNS = (
 _IMAGE_TOO_LARGE_PATTERNS = (
     "image exceeds", "image too large", "image_too_large", "image size exceeds", "image dimensions exceed",
     "dimensions exceed max allowed size", "max allowed size: 8000", "media exceeds", "media too large",
+    "patches after processing, exceeding the limit of",
 )
 
 # Undecodable image bytes → strip-and-retry, never shrink. xAI wordings

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -10,6 +10,7 @@ mutate ``agent`` / ``messages`` / ``api_messages`` in place. Logger name stays
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time
 from dataclasses import dataclass
@@ -51,7 +52,7 @@ def _blines(agent: Any, *lines: str) -> None:
 
 
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
-    """Extract a provider-reported image dimension ceiling, if present."""
+    """Extract a dimension ceiling, including OpenAI's 32px-patch budget."""
     parts = []
     for value in (error, getattr(error, "message", None), getattr(error, "body", None)):
         if value:
@@ -60,6 +61,14 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
             except Exception:
                 pass
     text = " ".join(parts).lower()
+    patch_limit = re.search(
+        r"image .*?requires \d+ patches after processing, exceeding the limit of (\d+)", text
+    )
+    if patch_limit and (limit := int(patch_limit.group(1))) > 0:
+        # A byte-small image can still exceed the patch budget. Bounding both
+        # sides to whole 32px patches guarantees ceil(w/32)*ceil(h/32) <= limit;
+        # the existing resizer preserves aspect ratio and only edits the request.
+        return min(8000, 32 * math.isqrt(limit))
     if "image" not in text or "dimension" not in text or "max allowed size" not in text:
         return None
     match = re.search(r"max allowed size(?:\s+for [^:]+)?:\s*(\d{3,5})\s*pixels?", text)

--- a/tests/agent/test_image_patch_limit_recovery.py
+++ b/tests/agent/test_image_patch_limit_recovery.py
@@ -1,0 +1,93 @@
+"""A patch-budget rejection must resize request copies before model failover."""
+
+import base64
+import copy
+import io
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from agent.conversation_compression import try_shrink_image_parts_in_messages
+from agent.error_classifier import FailoverReason, classify_api_error
+from agent.turn_recovery import _image_error_max_dimension, recover_after_classification
+from agent.turn_retry_state import TurnRetryState
+
+
+def _patch_error(required=35721, limit=30000):
+    message = (
+        f"The image you provided requires {required} patches after processing, "
+        f"exceeding the limit of {limit}. Please resize the image and try again."
+    )
+    error = RuntimeError(message)
+    error.status_code = 400
+    error.body = {"error": {"message": message, "param": "input", "code": "invalid_value"}}
+    return error
+
+
+@pytest.mark.parametrize("part_type", ["image_url", "input_image", "image"])
+def test_patch_rejection_recovers_request_and_preserves_source(tmp_path, part_type):
+    # Highly compressible pixels reproduce the patch limit below the byte-size
+    # threshold: re-encoding a JPEG without reducing dimensions cannot fix it.
+    source = tmp_path / "avatar.png"
+    with Image.new("RGB", (6048, 6048), "navy") as picture:
+        picture.save(source)
+    original = source.read_bytes()
+    encoded = base64.b64encode(original).decode("ascii")
+    url = f"data:image/png;base64,{encoded}"
+    if part_type == "image":
+        part = {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": encoded}}
+    else:
+        part = {"type": part_type, "image_url": {"url": url} if part_type == "image_url" else url}
+    history = [{"role": "user", "content": [{"type": "text", "text": "Use my avatar."}, part]}]
+    original_history = copy.deepcopy(history)
+    notices = []
+    agent = SimpleNamespace(
+        provider="openai-codex", model="test-vision-model", log_prefix="",
+        _recover_with_credential_pool=lambda **kwargs: (False, False),
+        _try_shrink_image_parts_in_messages=try_shrink_image_parts_in_messages,
+        _vprint=lambda message, **kwargs: notices.append(message),
+    )
+    error = _patch_error()
+    classified = classify_api_error(error, provider=agent.provider, model=agent.model)
+    assert classified.reason == FailoverReason.image_too_large
+    assert not classified.should_compress
+    assert not classified.should_fallback
+
+    # A later user turn reconstructs its request from the same original history.
+    # Both attempts must be recoverable without modifying that history or file.
+    for _ in range(2):
+        request = [dict(message) for message in history]
+        retry = TurnRetryState()
+        recovered, _ = recover_after_classification(
+            agent, error, classified, retry, status_code=400, error_context={},
+            messages=history, api_messages=request,
+        )
+        assert recovered and retry.image_shrink_retry_attempted
+        resized = request[0]["content"][1]
+        if part_type == "image":
+            payload = resized["source"]["data"]
+        else:
+            image_url = resized["image_url"]
+            payload = (image_url["url"] if isinstance(image_url, dict) else image_url).split(",", 1)[1]
+        with Image.open(io.BytesIO(base64.b64decode(payload))) as picture:
+            width, height = picture.size
+            assert ((width + 31) // 32) * ((height + 31) // 32) <= 30000
+            assert width == height  # preserve the avatar's aspect ratio
+        assert request[0]["content"][0] == history[0]["content"][0]
+        assert history == original_history
+        assert source.read_bytes() == original
+    assert notices
+    assert agent.provider == "openai-codex" and agent.model == "test-vision-model"
+
+
+@pytest.mark.parametrize("limit", [1024, 10000, 30000])
+def test_patch_ceiling_uses_provider_budget_from_error_body(limit):
+    error = _patch_error(required=limit + 1, limit=limit)
+    # SDK wrappers may keep the useful provider message only in the body.
+    error.args = ("HTTP 400",)
+    ceiling = _image_error_max_dimension(error)
+    assert ceiling is not None
+    assert ((ceiling + 31) // 32) ** 2 <= limit
+    assert ((ceiling + 32) // 32) ** 2 > limit
+    assert _image_error_max_dimension(RuntimeError("input token limit exceeded")) is None


### PR DESCRIPTION
## What does this PR do?

Recognize OpenAI's per-image patch-limit rejection and route it through the existing request-copy resize/retry path before provider failover.

A routine avatar attachment exposed this with a 6048×6048 PNG:

> The image you provided requires 35721 patches after processing, exceeding the limit of 30000. Please resize the image and try again.

On current `main`, this is classified as `format_error` with `should_fallback=True`. In the observed session, the selected vision model failed over to a text-only model; repeated vision-tool results then reduced to the native-vision success placeholder, and later turns kept replaying the oversized original. This PR addresses the initial patch-limit recovery gap. The separate fallback/tool-vision mismatch is already covered by the open proposal #83150.

## Related Issue

No existing issue/PR found for the exact patch-limit error. Related: #83150 (vision after text-only failover), #76525 (Qwen pixel-budget rejection; different provider wording).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Classify `patches after processing, exceeding the limit of` as `image_too_large`.
- Derive a conservative per-side ceiling from the reported 32-pixel patch budget: `32 * isqrt(limit)`, bounded by the existing 8000px maximum. For 30000 patches, that is 5504px, ensuring `ceil(width/32) * ceil(height/32) <= 30000` after the existing aspect-preserving resizer succeeds. This also handles pixel-large but byte-small images that the byte threshold alone would miss.
- Reuse the existing one-shot resize/retry and status notice. Original files and canonical conversation history remain unchanged; this adds no consent dialog, configuration, or proactive resizing policy. A request reconstructed from the original history on a later turn can recover again.

## How to Test

Two invariant tests, parameterized into six cases, use synthetic pixels only. They exercise the real classifier, post-classification recovery handler, data-URL rewriting, and Pillow resizer under the canonical runner's temporary `HERMES_HOME`; they make no provider calls. Cases cover Chat Completions, Responses, and Anthropic image-part shapes, repeated reconstruction from retained history, unchanged source/history, and limits supplied only in an SDK error body.

1. Base `c32e0acb0ec59d53ac964007c75630e098bcd045`: all six regression cases fail (`format_error` instead of `image_too_large`; no dimension ceiling).
2. With this change:

   ```sh
   scripts/run_tests.sh tests/agent/test_image_patch_limit_recovery.py tests/agent/test_error_classifier.py tests/run_agent/test_image_shrink_recovery.py tests/run_agent/test_image_rejection_fallback.py --file-retries 0 -j 4
   ```

   **168 passed, 0 failed.** After strengthening the source/history preservation assertion, the six new cases were rerun and passed.
3. Ruff on all three changed Python files and `git diff --check`: passed.

The local runner used the existing development Python via `HERMES_PYTHON`; no dependency or live-install changes were needed. Validation is local recovery-path validation, not a live OpenAI replay.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] Full test suite run — targeted suite above passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant helper docstring updated
- [x] Config keys: N/A
- [x] Architecture/workflow changes: N/A
- [x] Cross-platform impact considered: existing Pillow/tempfile path, no OS-specific changes
- [x] Tool schemas/descriptions: N/A

## Scope boundary

Remote image URLs still follow the existing recovery limitations, and an unsuccessful resize retains the existing terminal/fallback handling. This does not repair the independent native-vision placeholder bug after other reasons for text-only failover. No private image, transcript, request dump, credential, or user-specific path is included.
