### PR TITLE
fix(session_search): fall back to tool-role search when default discovery returns zero

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -1156,3 +1156,50 @@ class TestNewResetLineageBrowse:
         sids = [r["session_id"] for r in result["results"]]
         assert "s_legacy_child" in sids
 
+
+
+# =========================================================================
+# Tool-role fallback on zero results (recall blind spot, cf. #19434)
+# =========================================================================
+
+class TestToolRoleFallback:
+    """Discovery's default role filter (user/assistant) hides matches that live
+    only in tool-role output — e.g. cron pipeline ingest totals. When the
+    default search finds nothing, retry once including tool output and say so."""
+
+    def _seed_tool_only_cron(self, db):
+        now = int(time.time())
+        db.create_session("cron_ingest", source="cron")
+        db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = ?",
+                         (now - 500, "cron_ingest"))
+        db.append_message("cron_ingest", role="tool",
+                          content="ingest totals: skadefilloyalty sweep found 3 items")
+        db._conn.commit()
+
+    def test_tool_only_cron_match_surfaced_via_fallback(self, db):
+        self._seed_tool_only_cron(db)
+        result = json.loads(session_search(query="skadefilloyalty", db=db))
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "cron_ingest"
+        assert "tool-output" in result["message"]
+
+    def test_explicit_role_filter_still_returns_zero(self, db):
+        self._seed_tool_only_cron(db)
+        result = json.loads(session_search(query="skadefilloyalty", role_filter="user", db=db))
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert "No matching sessions found" in result["message"]
+        # The fallback must not fire when the caller asked for a specific filter.
+        assert "tool-output" not in result.get("message", "")
+
+    def test_user_assistant_matches_unchanged_no_fallback_note(self, db):
+        db.create_session("s_chat", source="telegram")
+        db.append_message("s_chat", role="user", content="venomous modpack discussion")
+        db.append_message("s_chat", role="assistant", content="venomous modpack notes saved")
+        db._conn.commit()
+        result = json.loads(session_search(query="venomous modpack", db=db))
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "s_chat"
+        assert result.get("message") is None

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -226,6 +226,8 @@ def _discover_payload(db, query: str, detail: str, results: list, **extra) -> st
         f"The search index is rebuilding in the background ({status['percent']}% done, "
         f"{status['indexed']:,} of {status['total']:,} messages). Results from older messages "
         f"may be incomplete until it finishes.")}}
+    if extra.get("message") is None:
+        extra.pop("message", None)
     return _ok(mode="discover", query=query, detail=detail, results=results, count=len(results), **extra, **rebuild)
 
 
@@ -269,11 +271,29 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
         fields=_DISCOVER_SEARCH_FIELDS), "FTS5 search failed: %s", "Search failed")
     if err:
         return err
+    # Recall fallback (see #19434): with the default role filter (user/assistant), a
+    # query whose only matches live in tool-role output — e.g. cron pipeline ingest
+    # totals — returns zero and the agent believes the knowledge doesn't exist. Retry
+    # once with tool output included; only the zero-result path gains behavior.
+    fallback_used = False
+    if not raw_results and not title_result and role_filter is None:
+        retry_results, retry_err = _loud(lambda: db.search_messages(
+            query=query, role_filter=["user", "assistant", "tool"],
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES), limit=_DISCOVER_SCAN_LIMIT, offset=0, sort=sort,
+            fields=_DISCOVER_SEARCH_FIELDS), "FTS5 search failed: %s", "Search failed")
+        if retry_err:
+            return retry_err
+        if retry_results:
+            raw_results = retry_results
+            fallback_used = True
     # Demote cron rows below interactive ones BEFORE dedup so a high-volume cron corpus
     # can't starve the user's own sessions out of the top `limit`; stable sort keeps BM25
     # order within each class.
     raw_results = sorted(raw_results, key=lambda r: (r.get("source") or "") in _DEMOTED_SESSION_SOURCES)
     # See #19434.
+    fallback_note = ("Note: no user/assistant matches were found, so tool-output "
+                     "matches (e.g. cron job results) were included via an automatic "
+                     "fallback role search.") if fallback_used else None
     if not raw_results and not title_result:
         return _discover_payload(db, query, detail, [], message=(
             "No matching sessions found. FTS5 ANDs all terms by default — "
@@ -318,7 +338,8 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
             results.append(entry)
     for entry in results:
         entry["link"] = _session_link(entry["session_id"], link_profile)
-    return _discover_payload(db, query, detail, results, sessions_searched=len(seen_sessions), link_hint=(
+    return _discover_payload(db, query, detail, results, sessions_searched=len(seen_sessions),
+                             message=fallback_note, link_hint=(
         "When referring the user to a session, write its `link` value "
         "verbatim inline mid-sentence (it renders as a titled link) — never "
         "as markdown, in backticks, on its own line, or next to the "


### PR DESCRIPTION
# PR: session_search — fall back to tool-role search when default discovery returns zero

**Target repo:** NousResearch/hermes-agent
**Branch (local, unpushed):** `fix/session-search-tool-role-fallback`
**Commit:** 3a33508f6c — `fix(session_search): fall back to tool-role search when default discovery returns zero`
**Diff stat:** 2 files changed, 69 insertions(+), 1 deletion(-) (`tools/session_search_tool.py` +22/−1, `tests/tools/test_session_search.py` +47)

## Problem

`session_search` discovery defaults to `role_filter=['user','assistant']` on the assumption that
"tool output is usually noise" (schema description). But scheduled pipelines (cron) keep their
*knowledge* — ingest totals, sweep results, alert bodies — in **tool-role** messages; the
user/assistant text in a cron session is boilerplate prompts. So a query whose only matches are
in tool-role output returns `No matching sessions found`, and the agent concludes the knowledge
doesn't exist anywhere in session history.

This is the same recall-blindness bug class the maintainers already track (#19434, the demotion
comment at `tools/session_search_tool.py` L21–28).

## Proven root cause (receipts)

Investigated live against a real `state.db` (read-only) — full design doc:
`~/workspace/inkorg-fix-research/session-search-fix-design.md`.

- Raw FTS5 for the failing query (`'skadefil*'`) matched **52 rows across 6 sessions**.
- The tool reported **`sessions_searched=0`**.
- Filter replication with the tool's exact predicates
  (`role IN ('user','assistant') AND s.source NOT IN ('kanban','subagent','tool') AND (active=1 OR compacted=1)`)
  showed the 4 **cron-tool hits were removed by the role filter alone** — cron is *demoted*, not
  hidden, so the source filter was not the cause for those rows.
- The remaining 31 user/assistant hits all belonged to the *current session's own lineage*, so
  the lineage-dedupe loop correctly skipped them (that content is in live context).
- Net: **0 sessions reported despite 52 FTS hits.** `_DISCOVER_SCAN_LIMIT=300`, demotion ordering,
  and `sort=newest` were all ruled out (52 ≪ 300, nothing to order).

Exact mechanism: role filter strips the only out-of-lineage (cron-tool) matches → source filter
strips subagent matches → lineage exclusion drops the only surviving (current-lineage) hits → zero.

## The fix

In `_discover` (`tools/session_search_tool.py`): when the first search returns **zero raw
results** AND **no explicit `role_filter` was passed**, retry once with
`role_filter=['user','assistant','tool']`. If the retry has hits, continue with them and prefix
the payload with:

> "Note: no user/assistant matches were found, so tool-output matches (e.g. cron job results)
> were included via an automatic fallback role search."

Behavior contract:

- **Zero change on any non-empty path** — any user/assistant hit suppresses the fallback
  (existing #19434 demotion/recall protection untouched).
- **Explicit `role_filter` never triggers the fallback** — a caller asking for `role_filter='user'`
  still gets a true zero.
- The note is omitted from the payload entirely when not used (`_discover_payload` drops a
  `message=None`).

## Tests

`TestToolRoleFallback` in `tests/tools/test_session_search.py`, following the existing
seed-temp-DB + `session_search(db=...)` pattern:

1. `test_tool_only_cron_match_surfaced_via_fallback` — tool-role-only cron match is returned via
   the fallback, with the tool-output note. **Proven red on unpatched base** (the only new test
   that fails without the fix).
2. `test_explicit_role_filter_still_returns_zero` — `role_filter="user"` returns zero, no fallback.
3. `test_user_assistant_matches_unchanged_no_fallback_note` — normal user/assistant matches
   return as before, with no fallback note.

## Test evidence

`scripts/run_tests.sh` (repo runner, CI parity):

- Full file, patched: `tests/tools/test_session_search.py` — **56/56 passed** (incl. 3 new).
- Related surface: `tests/hermes_cli/test_web_server_session_search.py` — **1/1 passed**.
- Combined run: **2 files, 57 tests passed, 0 failed**.
- Red-on-base check: with only `tools/session_search_tool.py` reverted to HEAD, the new
  fallback test **fails** (2 passed / 1 failed); restored, all green — the test pins the contract,
  not the implementation.

## Notes for Emir before pushing

- Do NOT push from the live clone at `~/.hermes/hermes-agent` (it's 612 commits behind upstream and
  carries the running gateway + local `meet_bot.py` drift). This branch lives in the worktree at
  `~/workspace/hermes-w4` and is based on the clone's current `main` (7166071fca) — rebase onto a
  fresh upstream `main` before opening the PR.
- The repo's contribution rubric (AGENTS.md) wants: reproduction on current main (done, receipts
  above), line-level account (done), 1–2 invariant tests (3 close to the bar — the third pins the
  no-note contract for non-fallback paths), behavior-contract not change-detector tests (met).