### PR TITLE
fix(sessions): keep pinned sessions visible in sidebar listings (#106171)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2873,8 +2873,11 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                     db.set_session_title, session_id, "" if body["title"] is None else str(body["title"]))
             except ValueError as exc:
                 return _error_response(str(exc), 400, code="invalid_title")
-        for flag, setter in (("pinned", db.set_session_pinned), ("archived", db.set_session_archived),
-                             ("hidden", db.set_session_hidden)):
+        # Pinned applies last: pinning clears hidden, so a pin in the same
+        # request always wins over an explicit hidden (same order as the
+        # dashboard's _RENAME_FLAG_SETTERS).
+        for flag, setter in (("archived", db.set_session_archived), ("hidden", db.set_session_hidden),
+                             ("pinned", db.set_session_pinned)):
             if flag in body:
                 await asyncio.to_thread(setter, session_id, body[flag])
         if "unread" in body:

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -876,8 +876,16 @@ class SessionSessionsMixin:
         return True
 
     def set_session_pinned(self, session_id: str, pinned: bool) -> bool:
-        """Pin/unpin a session and its compression lineage (pins are exempt from the auto_archive sweep)."""
-        return self._set_lineage_column("pinned", session_id, int(pinned))
+        """Pin/unpin a session and its compression lineage (pins are exempt from the auto_archive sweep).
+
+        Pinning also clears ``hidden`` across the lineage: a pin means "keep
+        visible", so a pinned session must never vanish from the sidebar
+        listing. Unpinning leaves ``hidden`` untouched.
+        """
+        ok = self._set_lineage_column("pinned", session_id, int(pinned))
+        if ok and pinned:
+            self._set_lineage_column("hidden", session_id, 0)
+        return ok
 
     def set_session_hidden(self, session_id: str, hidden: bool) -> bool:
         """Hide/unhide a session and its compression lineage from the default listing; still resumable."""
@@ -1175,15 +1183,17 @@ class SessionSessionsMixin:
     ) -> List[Dict[str, Any]]:
         """List sessions with preview and ``last_active`` in one query. ``order_by_last_active`` sorts
         by the chain TIP via a recursive CTE (the only path honouring ``id_query`` / ``search_query``);
-        ``include_pinned`` back-fills pins the page missed, still obeying the other filters."""
+        ``include_pinned`` back-fills pins the page missed, still obeying the other filters
+        (except ``hidden``: a pinned row is always listable)."""
         self.flush_token_counts()  # rows carry token/cost totals
         where_clauses, params = _session_filter_where(
             exclude_children=not include_children, source=source, sources=sources, session_key=session_key,
             exclude_sources=exclude_sources, cwd_prefix=cwd_prefix, min_message_count=min_message_count,
             archived_only=archived_only, include_archived=include_archived,
         )
+        hidden_clause = "s.hidden = 0"
         if not include_hidden:
-            where_clauses.append("s.hidden = 0")
+            where_clauses.append(hidden_clause)
         where_sql = _where_sql(where_clauses)
         base_where_params = list(params)  # pinned back-fill reuses the WHERE before LIMIT/OFFSET
         # Shared projection head of the three list queries (whitespace is part of the SQL text).
@@ -1248,7 +1258,12 @@ class SessionSessionsMixin:
         # projects to its tip like any other row.
         if include_pinned:
             seen_ids = {s["id"] for s in sessions}
-            pinned_where = f"{where_sql} AND s.pinned = 1" if where_sql else "WHERE s.pinned = 1"
+            # A pinned session is always listable: pinning means "keep visible"
+            # (set_session_pinned clears hidden on write), so the back-fill
+            # drops the hidden filter — healing rows pinned while hidden.
+            pinned_clauses = [c for c in where_clauses if c != hidden_clause]
+            pinned_sql = _where_sql(pinned_clauses)
+            pinned_where = f"{pinned_sql} AND s.pinned = 1" if pinned_sql else "WHERE s.pinned = 1"
             pinned_query = f"""
                 {select_head}COALESCE(
                         (SELECT MAX(m2.timestamp) FROM messages m2 WHERE m2.session_id = s.id),

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -872,6 +872,33 @@ async def test_patch_session_persists_pinned_and_archived(adapter, session_db):
 
 
 @pytest.mark.asyncio
+async def test_patch_session_pin_clears_hidden_and_wins(adapter, session_db):
+    """Pinning a hidden session over PATCH unhides it; a pin in the same
+    request wins over an explicit hidden (matches the dashboard order)."""
+    session_id = session_db.create_session("pin-hidden-session", "api_server")
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.patch(f"/api/sessions/{session_id}", json={"hidden": True})
+        assert resp.status == 200, await resp.text()
+
+        resp = await cli.patch(f"/api/sessions/{session_id}", json={"pinned": True})
+        assert resp.status == 200, await resp.text()
+        assert (await resp.json())["session"]["pinned"] is True
+        row = session_db.get_session(session_id)
+        assert bool(row["pinned"]) is True
+        assert bool(row["hidden"]) is False
+
+        resp = await cli.patch(
+            f"/api/sessions/{session_id}", json={"pinned": True, "hidden": True}
+        )
+        assert resp.status == 200, await resp.text()
+        row = session_db.get_session(session_id)
+        assert bool(row["pinned"]) is True
+        assert bool(row["hidden"]) is False
+
+
+@pytest.mark.asyncio
 async def test_patch_session_rejects_non_boolean_pinned(adapter, session_db):
     session_id = session_db.create_session("pin-type-session", "api_server")
     app = _create_session_app(adapter)

--- a/tests/hermes_state/test_session_hidden.py
+++ b/tests/hermes_state/test_session_hidden.py
@@ -42,3 +42,47 @@ def test_hidden_excluded_by_default_included_on_request(db):
     assert db.get_session("secret")["hidden"] == 0
     unhidden_ids = {s["id"] for s in db.list_sessions_rich(min_message_count=1)}
     assert unhidden_ids == {"visible", "secret"}
+
+
+def test_pinning_clears_hidden(db):
+    """Pinning means "keep visible": pinning a hidden session unhides it (#106171)."""
+    db.create_session("botsession", source="cli")
+    assert db.set_session_hidden("botsession", True) is True
+
+    assert db.set_session_pinned("botsession", True) is True
+
+    row = db.get_session("botsession")
+    assert row["pinned"] == 1
+    assert row["hidden"] == 0
+
+
+def test_unpinning_leaves_hidden_alone(db):
+    """Unpinning restores no visibility: the hidden flag survives an unpin."""
+    db.create_session("s", source="cli")
+    assert db.set_session_pinned("s", True) is True
+    assert db.set_session_hidden("s", True) is True
+
+    assert db.set_session_pinned("s", False) is True
+
+    row = db.get_session("s")
+    assert row["pinned"] == 0
+    assert row["hidden"] == 1
+
+
+def test_pinned_backfill_lists_hidden_pinned_rows(db):
+    """The pinned back-fill ignores the hidden filter: a pinned-but-hidden row
+    (e.g. pinned before pinning cleared hidden) stays listable via
+    ``include_pinned`` while remaining out of the default listing (#106171)."""
+    db.create_session("legacy", source="cli")
+    db.create_session("plain_hidden", source="cli")
+    assert db.set_session_pinned("legacy", True) is True
+    assert db.set_session_hidden("legacy", True) is True
+    assert db.set_session_hidden("plain_hidden", True) is True
+
+    default_ids = {s["id"] for s in db.list_sessions_rich()}
+    assert "legacy" not in default_ids
+    assert "plain_hidden" not in default_ids
+
+    pinned_ids = {s["id"] for s in db.list_sessions_rich(include_pinned=True)}
+    assert "legacy" in pinned_ids
+    assert "plain_hidden" not in pinned_ids


### PR DESCRIPTION
## What does this PR do?

Fixes pinned sessions vanishing from the sidebar. A Bot Mode session is born
with `hidden=1`; pinning it set `pinned=1` without clearing `hidden`, and the
pinned back-fill reused the `s.hidden = 0` filter — so the row was pinned yet
listed nowhere. A pinned session is now always listable:

- Write path: `set_session_pinned(true)` clears `hidden` across the
  compression lineage (covers the gateway PATCH, dashboard, and CLI pin —
  all three funnel through this setter). Unpinning leaves `hidden` untouched.
- Read path: the `include_pinned` back-fill in `list_sessions_rich` drops the
  hidden filter, healing rows pinned while hidden before this change.
- Order: the gateway PATCH applies flags `archived → hidden → pinned`, so a
  pin in the same request wins over an explicit `hidden` — same order the
  dashboard already used.

## Related Issue

Fixes #106171

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_sessions.py` — `set_session_pinned` clears `hidden` on pin;
  pinned back-fill exempts `hidden`; `list_sessions_rich` docstring updated.
- `gateway/platforms/api_server.py` — PATCH flag order `archived, hidden,
  pinned` with a comment (pin wins, matches dashboard `_RENAME_FLAG_SETTERS`).
- `tests/hermes_state/test_session_hidden.py` — 3 new tests (pin clears
  hidden, unpin preserves hidden, back-fill lists hidden+pinned rows).
- `tests/gateway/test_session_api.py` — 1 new PATCH-level test (pin over
  HTTP unhides; combined `pinned+hidden` request resolves to visible+ pinned).

## How to Test

```bash
scripts/run_tests.sh tests/hermes_state/test_session_hidden.py -q
scripts/run_tests.sh tests/gateway/test_session_api.py -k "patch_session" -q
```

Sabotage-checked: the 2 behavior tests fail on pre-fix code and pass with the
fix; the PATCH test fails with the old flag order. Wider net green:
`tests/hermes_state/` + pin/prune/hidden suites, 318 passed, 0 failed.
Note: `tests/test_hermes_state.py` has 1 failure in
`TestFTS5Search::test_search_projection_skips_context_enrichment_queries`
that reproduces on pristine `origin/main` — pre-existing, unrelated.

## Exclusions

Both halves of the issue shipped together on purpose: the write path alone
would leave already-pinned-hidden rows invisible, and the read path alone
would let the `pinned=1, hidden=1` combination be recreated. Covers the
remaining half of #106171 beyond the Option-A-only fix in #106180 (read-path
healing for rows already pinned-while-hidden, plus PATCH order parity with
the dashboard). No desktop change needed — `setSessionPinnedRemote` sends
only `pinned` and the backend now handles the unhide.

## Checklist

- [x] I have read the Contributing Guide
- [x] I have followed Conventional Commits (`fix(sessions): ...`)
- [x] I have searched for duplicate PRs (see Exclusions for #106180)
- [x] I have run tests (see How to Test)
- [x] I have added regression tests (4 new)
- [x] N/A documentation change (behavior matches the documented "pin = keep" intent)

## Platform

Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.1 (v2026.9.7), upstream facb9eb4
