### PR TITLE
fix(desktop): allow project creation while browsing all profiles

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
-import { $activeGatewayProfile, setShowAllProfiles } from '@/store/profile'
+import { $activeGatewayProfile, $profileScope, ALL_PROFILES, setShowAllProfiles } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
 
 import {
@@ -412,6 +412,55 @@ describe('createProject', () => {
     setSidebarAgentsGrouped(false)
     $activeProjectId.set(null)
     $projectsRpcAvailable.set(null)
+    $projects.set([])
+    $projectTree.set([])
+    $activeGatewayProfile.set('default')
+    setShowAllProfiles(false)
+  })
+
+  afterEach(() => {
+    setShowAllProfiles(false)
+    $activeGatewayProfile.set('default')
+  })
+
+  it.each(['default', 'coder'])('creates in the active %s profile without leaving All profiles', async profile => {
+    const created = { folders: [], id: 'p_new', name: 'Hermes Agent', primary_path: '/srv/hermes' }
+    const tree = { id: created.id, label: created.name, path: created.primary_path, repos: [], sessionCount: 0 }
+    const request = vi.fn().mockResolvedValue({ project: created })
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+    vi.mocked(hermes.hermesApi).mockResolvedValue({ projects: [tree], active_id: created.id })
+    $activeGatewayProfile.set(profile)
+    setShowAllProfiles(true)
+
+    await expect(createProject({ folders: ['/srv/hermes'], name: created.name, use: true })).resolves.toEqual(created)
+
+    expect(request).toHaveBeenCalledWith('projects.create', expect.objectContaining({ profile, name: created.name }))
+    expect($profileScope.get()).toBe(ALL_PROFILES)
+    expect($projects.get()).toContainEqual(created)
+    expect($projectTree.get()).toEqual(expect.arrayContaining([expect.objectContaining({ id: created.id })]))
+    expect($activeProjectId.get()).toBe(created.id)
+    expect(hermes.hermesApi).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/api/profiles/projects/tree?preview_limit=3' })
+    )
+  })
+
+  it('does not retarget a project create when the profile changes during reconnect', async () => {
+    const reconnect = deferred<never>()
+    const request = vi.fn()
+    activeGateway.mockReturnValue({ connectionState: 'closed', request } as never)
+    vi.mocked(gw.ensureActiveGatewayOpen).mockReturnValue(reconnect.promise)
+    $activeGatewayProfile.set('coder')
+    setShowAllProfiles(true)
+
+    const pending = createProject({ folders: ['/srv/hermes'], name: 'Hermes Agent' })
+    const rejection = expect(pending).rejects.toThrow('Active Hermes profile changed while connecting')
+    const otherGateway = { connectionState: 'open', request }
+    $activeGatewayProfile.set('other')
+    activeGateway.mockReturnValue(otherGateway as never)
+    reconnect.resolve(otherGateway as never)
+
+    await rejection
+    expect(request).not.toHaveBeenCalled()
   })
 
   it('creates the project and flips into the grouped view so a blank slate shows it', async () => {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -319,10 +319,8 @@ function stillOnProjectsContext(context: ActiveProjectsContext): boolean {
   return activeGateway() === context.gateway && projectProfile() === context.profile
 }
 
-async function activeProjectsContext(): Promise<ActiveProjectsContext> {
-  const profile = projectProfile()
-
-  if (!profile) {
+async function activeProjectsContext(profile = projectProfile()): Promise<ActiveProjectsContext> {
+  if (!profile || profile === ALL_PROFILES) {
     throw new Error('Projects are unavailable while viewing all profiles')
   }
 
@@ -332,7 +330,7 @@ async function activeProjectsContext(): Promise<ActiveProjectsContext> {
     gateway = await ensureActiveGatewayOpen()
   }
 
-  if (!gateway || gateway !== activeGateway() || profile !== projectProfile()) {
+  if (!gateway || gateway !== activeGateway() || profile !== normalizeProfileKey($activeGatewayProfile.get())) {
     throw new Error('Active Hermes profile changed while connecting')
   }
 
@@ -878,19 +876,27 @@ export async function createProject(input: CreateProjectInput): Promise<ProjectI
   let res: { project: ProjectInfo | null }
 
   try {
-    res = await gatewayRequest<{ project: ProjectInfo | null }>(
+    // All profiles filters the sidebar, not the owner of a new project.
+    // Capture the live route so reconnecting cannot retarget the write.
+    const context = await activeProjectsContext(normalizeProfileKey($activeGatewayProfile.get()))
+
+    res = await gatewayRequestOn<{ project: ProjectInfo | null }>(
+      context.gateway,
       'projects.create',
-      projectParams({
-        name: input.name,
-        folders: input.folders ?? [],
-        primary_path: input.primaryPath,
-        slug: input.slug,
-        description: input.description,
-        icon: input.icon,
-        color: input.color,
-        board_slug: input.boardSlug,
-        use: input.use ?? false
-      })
+      projectParams(
+        {
+          name: input.name,
+          folders: input.folders ?? [],
+          primary_path: input.primaryPath,
+          slug: input.slug,
+          description: input.description,
+          icon: input.icon,
+          color: input.color,
+          board_slug: input.boardSlug,
+          use: input.use ?? false
+        },
+        context.profile
+      )
     )
   } catch (err) {
     if (isMissingRpcMethod(err)) {


### PR DESCRIPTION
## What does this PR do?

Allows Desktop project creation while **All profiles** is selected. New projects belong to the active gateway's profile; the sidebar keeps its existing filter. Previously, the dialog accepted a name and folder but rejected Create before sending an RPC.

Creation captures the gateway/profile through the existing context helper and refuses to write if the profile changes during reconnection. Profile-scoped reads and mutations of existing projects keep their current guards.

## Related Issue

Fixes [#94430](https://github.com/NousResearch/hermes-agent/issues/94430).

Related work: [#94440](https://github.com/NousResearch/hermes-agent/pull/94440) handles the single-profile case by changing the shared read/write resolver. This change only opts creation into the active profile, works without a loaded profile roster, and covers profile changes during reconnect. [#96272](https://github.com/NousResearch/hermes-agent/pull/96272) and [#94739](https://github.com/NousResearch/hermes-agent/pull/94739) address existing-project actions and creation affordances; those surfaces are unchanged here.

## Type of Change

- [x] Bug fix

## Changes Made

- `apps/desktop/src/store/projects.ts`: let creation supply the active profile to the existing context helper and send the write on that captured gateway.
- `apps/desktop/src/store/projects.test.ts`: cover default/named profile creation without changing All profiles, cache/tree reconciliation, and a profile switch during reconnect.

## How to Test

1. Select All profiles, open New project, and enter a name and folder.
2. Click Create. The dialog should close and the project should appear under Projects, with All profiles still selected.
3. Confirm the project exists in the active profile's project store.

Verification performed:

- New regression cases failed on the original code with `Projects are unavailable while viewing all profiles`.
- `vitest run --project ui src/store/projects.test.ts src/app/chat/sidebar/project-dialog.test.tsx`: **49 passed**.
- On macOS, exercised the actual dialog and worktree renderer in an isolated Electron instance against the real Python backend. Verified project readback through RPC and SQLite, the sidebar row, preserved All profiles scope, closed dialog, and no error toast. Only the native folder-picker result was stubbed; no inference calls were needed. The probe reused the installed Electron main/preload, so this is renderer/backend verification rather than a fresh packaged-build test.
- `git diff --check`: clean.

## Checklist

- [x] Conventional commits; focused diff with regression coverage.
- [x] Searched related open PRs and documented the overlap above.
- [x] Tested the creation flow on macOS.
- [x] No new dependencies, configuration keys, tool schemas, or visual components.
- [ ] Full test suite, lint, typecheck, and packaged build were not run.

## AI assistance disclosure

Implemented and verified with Hermes Agent.
