### PR TITLE
feat(gateway/webhook): recognize Gitea webhook deliveries

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1,5 +1,5 @@
 """Generic webhook platform adapter: aiohttp server that validates HMAC-signed POSTs (GitHub, GitLab,
-Svix, Linear, generic), renders payloads into agent prompts, and routes responses back (github_comment
+Gitea, Svix, Linear, generic), renders payloads into agent prompts, and routes responses back (github_comment
 or any gateway platform). Routes live under platforms.webhook.extra.routes: events (header filter),
 secret (REQUIRED; "INSECURE_NO_AUTH" skips validation, loopback only), prompt template, skills,
 deliver/deliver_extra, deliver_only (rendered prompt IS the message). Per-route rate limiting,
@@ -523,6 +523,7 @@ class WebhookAdapter(BasePlatformAdapter):
             return _json_error("Cannot parse body", 400)
         headers = request.headers
         event_type = (headers.get("X-GitHub-Event", "") or headers.get("X-GitLab-Event", "")
+                      or headers.get("X-Gitea-Event", "")
                       or payload.get("event_type", "") or payload.get("type", "") or "unknown")
         allowed_events = route_config.get("events", [])
         if allowed_events and event_type not in allowed_events:
@@ -549,8 +550,8 @@ class WebhookAdapter(BasePlatformAdapter):
             prompt = self._render_prompt(route_config.get("prompt", ""), payload, event_type, route_name)
             if skills := route_config.get("skills", []):
                 prompt = self._apply_skills(prompt, skills)
-        delivery_id = headers.get("X-GitHub-Delivery", headers.get("svix-id", headers.get(
-            "webhook-id", headers.get("X-Request-ID", str(int(time.time() * 1000))))))
+        delivery_id = headers.get("X-GitHub-Delivery", headers.get("X-Gitea-Delivery", headers.get("svix-id", headers.get(
+            "webhook-id", headers.get("X-Request-ID", str(int(time.time() * 1000)))))))
         now = time.time()  # idempotency: skip duplicate deliveries (webhook retries)
         if not self._record_delivery_id(delivery_id, now):
             logger.info("[webhook] Skipping duplicate delivery %s", delivery_id)
@@ -618,7 +619,7 @@ class WebhookAdapter(BasePlatformAdapter):
     # --- Signature validation ---
 
     def _validate_signature(self, request: "web.Request", body: bytes, secret: str) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, Standard Webhooks, Linear, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Gitea, Svix, Standard Webhooks, Linear, generic HMAC-SHA256)."""
         headers = request.headers
 
         def _header(name: str) -> str:
@@ -634,10 +635,13 @@ class WebhookAdapter(BasePlatformAdapter):
             svix = [_header(name) for name in ("webhook-id", "webhook-timestamp", "webhook-signature")]
         if any(svix):
             return _validate_svix_signature(body, secret, *svix)
-        # Linear (any header case): hex HMAC of the body. GitHub: sha256=<hex>. GitLab: plain token.
+        # Linear (any header case): hex HMAC of the body. GitHub: sha256=<hex>. Gitea: bare hex HMAC of
+        # the body in X-Gitea-Signature (Gitea also mirrors GitHub's X-Hub-Signature-256, but not every
+        # version/route does — commit to the Gitea header when it is the one present). GitLab: plain token.
         for provided, expected in (
                 (_header("linear-signature"), lambda: _hex_hmac(secret, body)),
                 (headers.get("X-Hub-Signature-256", ""), lambda: "sha256=" + _hex_hmac(secret, body)),
+                (headers.get("X-Gitea-Signature", ""), lambda: _hex_hmac(secret, body)),
                 (headers.get("X-Gitlab-Token", ""), lambda: secret)):
             if provided:
                 return _hmac_str_equal(provided, expected())

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -104,6 +104,11 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _gitea_signature(body: bytes, secret: str) -> str:
+    """Compute X-Gitea-Signature (bare HMAC-SHA256 hex of the body, no prefix)."""
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
 def _generic_v2_signature(body: bytes, secret: str, timestamp: str) -> str:
     """Compute X-Webhook-Signature-V2 (HMAC-SHA256 of "<timestamp>.<body>")."""
     signed_content = timestamp.encode() + b"." + body
@@ -148,6 +153,7 @@ class TestValidateSignature:
         for header in (
             "X-Hub-Signature-256",
             "X-Gitlab-Token",
+            "X-Gitea-Signature",
             "X-Webhook-Signature",
             "linear-signature",
         ):
@@ -173,6 +179,27 @@ class TestValidateSignature:
         sig = _generic_signature(body, "attacker-controlled-key")
 
         req = _mock_request(headers={"linear-signature": sig})
+
+        assert adapter._validate_signature(req, body, "real-secret") is False
+
+    def test_gitea_signature_valid_accepts(self):
+        """Gitea signs the raw body (bare hex HMAC-SHA256, no `sha256=` prefix) in X-Gitea-Signature."""
+        adapter = _make_adapter()
+        body = b'{"action": "opened", "number": 4}'
+        secret = "gitea-webhook-key"
+        sig = _gitea_signature(body, secret)
+
+        req = _mock_request(headers={"X-Gitea-Event": "issues", "X-Gitea-Signature": sig})
+
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_gitea_signature_mismatch_rejects(self):
+        """A well-formed X-Gitea-Signature computed with the wrong key fails closed."""
+        adapter = _make_adapter()
+        body = b'{"action": "opened"}'
+        sig = _gitea_signature(body, "attacker-controlled-key")
+
+        req = _mock_request(headers={"X-Gitea-Signature": sig})
 
         assert adapter._validate_signature(req, body, "real-secret") is False
 


### PR DESCRIPTION
## Problem

`gateway/platforms/webhook.py` handles GitHub, GitLab, Svix, Linear and the generic HMAC schemes, but not Gitea. Point a Gitea instance at a webhook route and delivery reaches the server, but nothing is processed:

- **Event type.** It is read from `X-GitHub-Event` / `X-GitLab-Event` only. Gitea sends `X-Gitea-Event`, so `event_type` falls through to `"unknown"` and the route's `events` filter drops every delivery — `{"status": "ignored"}` instead of `202`.
- **Signature.** `_validate_signature` checks `X-Hub-Signature-256`, `X-Gitlab-Token`, `linear-signature` and the `X-Webhook-Signature*` family. Gitea's native `X-Gitea-Signature` (bare hex HMAC-SHA256 of the raw body, no `sha256=` prefix) isn't among them. Newer Gitea also mirrors `X-Hub-Signature-256`, but not every version/route does.

## Change

- `_handle_webhook`: fall back to `X-Gitea-Event` for the event type and `X-Gitea-Delivery` for the idempotency key.
- `_validate_signature`: add an `X-Gitea-Signature` branch — bare hex HMAC-SHA256 of the body, compared through the existing hardened `_hmac_str_equal` (a hostile non-ASCII value fails closed like the other schemes). Ordered after `X-Hub-Signature-256`, so a Gitea delivery carrying both is still accepted by the GitHub branch; the new branch covers deliveries that carry only the Gitea header.

Existing providers are unaffected — the Gitea headers are consulted only when the established ones are absent.

## Tests

`tests/gateway/test_webhook_adapter.py`:
- `test_gitea_signature_valid_accepts` / `test_gitea_signature_mismatch_rejects`
- `X-Gitea-Signature` added to the non-ASCII-header rejection loop

```
$ uv run pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_signature_rate_limit.py
50 passed
$ uv run ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py
All checks passed!
```

## Reference

Gitea webhook headers — `X-Gitea-Event`, `X-Gitea-Signature` (HMAC-SHA256 hex), `X-Gitea-Delivery`: https://docs.gitea.com/next/usage/webhooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJGUnAVKcXu4gzNQXYAUMP
