### PR TITLE
fix(models): key the custom-endpoint catalog cache per credential

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2366,8 +2366,13 @@ def cached_fetch_api_models(
     if not normalized_url:  # nothing to key the cache on
         return None if cache_only else _live()
 
-    cache_key = f"custom:{normalized_url}"
     fp = _custom_endpoint_fingerprint(api_key, api_mode, headers)
+    # One slot per (endpoint, credential): several custom_providers entries can share a
+    # base_url with distinct keys (gateways issuing per-tenant keys). A URL-only key let the
+    # last probed credential shadow the others — the fingerprint check then failed for every
+    # other key, so GUI pickers (probe off, cache-only) saw an empty catalog and hid the
+    # providers entirely (#106184).
+    cache_key = f"custom:{normalized_url}:{fp}"
     cache = _load_provider_models_cache()
     entry = cache.get(cache_key)
     now = time.time()

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -20,6 +20,17 @@ from unittest.mock import patch
 
 import pytest
 
+GW_URL = "https://gw.example.com/v1"
+
+
+def _key(url: str = GW_URL, fp: str = "fp") -> str:
+    """Cache key for a custom endpoint under credential fingerprint *fp*.
+
+    Mirrors ``cached_fetch_api_models``: one slot per (endpoint, credential)
+    so entries sharing a base_url with distinct keys never shadow each other
+    (#106184)."""
+    return f"custom:{url}:{fp}"
+
 
 class TestCachedFetchApiModels:
     def _entry(self, models, age_seconds, fp="fp"):
@@ -28,12 +39,12 @@ class TestCachedFetchApiModels:
     def test_fresh_entry_served_without_live_fetch(self):
         import hermes_cli.models as mod
 
-        cache = {"custom:https://gw.example.com/v1": self._entry(["m1", "m2"], age_seconds=10)}
+        cache = {_key(): self._entry(["m1", "m2"], age_seconds=10)}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_save_provider_models_cache") as save, \
              patch.object(mod, "fetch_api_models") as live:
-            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+            out = mod.cached_fetch_api_models("sk-key", GW_URL)
         assert out == ["m1", "m2"]
         live.assert_not_called()
         save.assert_not_called()
@@ -44,7 +55,7 @@ class TestCachedFetchApiModels:
         slash — config.yaml entries are not guaranteed to be normalized."""
         import hermes_cli.models as mod
 
-        cache = {"custom:https://gw.example.com/v1": self._entry(["m1"], age_seconds=10)}
+        cache = {_key(): self._entry(["m1"], age_seconds=10)}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "fetch_api_models") as live:
@@ -59,19 +70,19 @@ class TestCachedFetchApiModels:
         # live fetch (within the window it stale-serves + refreshes off
         # thread — covered in TestSalvageFollowups).
         too_old = mod._PROVIDER_MODELS_STALE_SERVE_MAX + 60
-        cache = {"custom:https://gw.example.com/v1": self._entry(["old"], age_seconds=too_old)}
+        cache = {_key(): self._entry(["old"], age_seconds=too_old)}
         saved = {}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_save_provider_models_cache", side_effect=saved.update), \
              patch.object(mod, "fetch_api_models", return_value=["fresh-a", "fresh-b"]) as live:
             out = mod.cached_fetch_api_models(
-                "sk-key", "https://gw.example.com/v1", ttl_seconds=3600
+                "sk-key", GW_URL, ttl_seconds=3600
             )
         assert out == ["fresh-a", "fresh-b"]
         live.assert_called_once()
-        assert saved["custom:https://gw.example.com/v1"]["models"] == ["fresh-a", "fresh-b"]
-        assert saved["custom:https://gw.example.com/v1"]["fp"] == "fp"
+        assert saved[_key()]["models"] == ["fresh-a", "fresh-b"]
+        assert saved[_key()]["fp"] == "fp"
 
     def test_rotated_api_key_busts_cache_even_when_fresh(self):
         """A same-age entry with a DIFFERENT fingerprint (key rotated, or
@@ -79,25 +90,25 @@ class TestCachedFetchApiModels:
         credentials' catalog."""
         import hermes_cli.models as mod
 
-        cache = {"custom:https://gw.example.com/v1": self._entry(["old-key-models"], 10, fp="old-fp")}
+        cache = {_key(fp="old-fp"): self._entry(["old-key-models"], 10, fp="old-fp")}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="new-fp"), \
              patch.object(mod, "_save_provider_models_cache"), \
              patch.object(mod, "fetch_api_models", return_value=["new-key-models"]) as live:
-            out = mod.cached_fetch_api_models("sk-new-key", "https://gw.example.com/v1")
+            out = mod.cached_fetch_api_models("sk-new-key", GW_URL)
         assert out == ["new-key-models"]
         live.assert_called_once()
 
     def test_force_refresh_bypasses_fresh_cache(self):
         import hermes_cli.models as mod
 
-        cache = {"custom:https://gw.example.com/v1": self._entry(["stale-but-fresh"], age_seconds=5)}
+        cache = {_key(): self._entry(["stale-but-fresh"], age_seconds=5)}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_save_provider_models_cache"), \
              patch.object(mod, "fetch_api_models", return_value=["forced-live"]) as live:
             out = mod.cached_fetch_api_models(
-                "sk-key", "https://gw.example.com/v1", force_refresh=True
+                "sk-key", GW_URL, force_refresh=True
             )
         assert out == ["forced-live"]
         live.assert_called_once()
@@ -108,12 +119,12 @@ class TestCachedFetchApiModels:
         cached_provider_model_ids')."""
         import hermes_cli.models as mod
 
-        cache = {"custom:https://gw.example.com/v1": self._entry(["last-known-good"], age_seconds=99999, fp="fp")}
+        cache = {_key(): self._entry(["last-known-good"], age_seconds=99999, fp="fp")}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_save_provider_models_cache") as save, \
              patch.object(mod, "fetch_api_models", return_value=None):
-            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+            out = mod.cached_fetch_api_models("sk-key", GW_URL)
         assert out == ["last-known-good"]
         save.assert_not_called()  # nothing new to persist
 
@@ -124,7 +135,7 @@ class TestCachedFetchApiModels:
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_save_provider_models_cache") as save, \
              patch.object(mod, "fetch_api_models", return_value=None):
-            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+            out = mod.cached_fetch_api_models("sk-key", GW_URL)
         assert out is None
         save.assert_not_called()
 
@@ -146,7 +157,7 @@ class TestCacheOnly:
              patch.object(mod, "_spawn_swr_refresh") as swr, \
              patch.object(mod, "fetch_api_models") as live:
             out = mod.cached_fetch_api_models(
-                "sk-key", "https://gw.example.com/v1", cache_only=True, **kwargs
+                "sk-key", GW_URL, cache_only=True, **kwargs
             )
         live.assert_not_called()
         swr.assert_not_called()
@@ -154,7 +165,7 @@ class TestCacheOnly:
         return out
 
     def test_fresh_entry_is_served(self):
-        cache = {"custom:https://gw.example.com/v1": self._entry(["m1", "m2"], 10)}
+        cache = {_key(): self._entry(["m1", "m2"], 10)}
         assert self._call(cache) == ["m1", "m2"]
 
     def test_entry_past_ttl_is_still_served_within_the_stale_window(self):
@@ -164,27 +175,27 @@ class TestCacheOnly:
         import hermes_cli.models as mod
 
         age = mod._PROVIDER_MODELS_CACHE_TTL + 60
-        cache = {"custom:https://gw.example.com/v1": self._entry(["m1", "m2"], age)}
+        cache = {_key(): self._entry(["m1", "m2"], age)}
         assert self._call(cache) == ["m1", "m2"]
 
     def test_entry_beyond_the_stale_window_is_a_miss(self):
         import hermes_cli.models as mod
 
         age = mod._PROVIDER_MODELS_STALE_SERVE_MAX + 60
-        cache = {"custom:https://gw.example.com/v1": self._entry(["ancient"], age)}
+        cache = {_key(): self._entry(["ancient"], age)}
         assert self._call(cache) is None
 
     def test_empty_cache_is_a_miss(self):
         assert self._call({}) is None
 
     def test_rotated_credentials_are_a_miss(self):
-        cache = {"custom:https://gw.example.com/v1": self._entry(["old"], 10, fp="old-fp")}
+        cache = {_key(fp="old-fp"): self._entry(["old"], 10, fp="old-fp")}
         assert self._call(cache, fp="new-fp") is None
 
     def test_force_refresh_is_a_miss_rather_than_a_live_fetch(self):
         """cache_only outranks force_refresh: the caller has said no network,
         so an un-revalidatable entry is withheld instead of fetched."""
-        cache = {"custom:https://gw.example.com/v1": self._entry(["m1"], 10)}
+        cache = {_key(): self._entry(["m1"], 10)}
         assert self._call(cache, force_refresh=True) is None
 
     def test_missing_base_url_is_a_miss_rather_than_a_live_fetch(self):
@@ -204,7 +215,7 @@ class TestCacheOnly:
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_save_provider_models_cache") as save, \
              patch.object(mod, "fetch_api_models", return_value=[]):
-            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+            out = mod.cached_fetch_api_models("sk-key", GW_URL)
         assert out == []
         save.assert_not_called()
 
@@ -250,8 +261,8 @@ class TestCachedFetchApiModelsDiskRoundTrip:
 
         monkeypatch.setattr(mod, "fetch_api_models", fake_fetch)
 
-        first = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
-        second = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+        first = mod.cached_fetch_api_models("sk-key", GW_URL)
+        second = mod.cached_fetch_api_models("sk-key", GW_URL)
 
         assert first == ["disk-cached-model"]
         assert second == ["disk-cached-model"]
@@ -274,7 +285,11 @@ class TestCachedFetchApiModelsDiskRoundTrip:
         mod.cached_provider_model_ids("openrouter")
 
         cache = mod._load_provider_models_cache()
-        assert cache["custom:https://openrouter.ai/v1"]["models"] == ["custom-endpoint-model"]
+        expected_custom_key = _key(
+            "https://openrouter.ai/v1",
+            mod._custom_endpoint_fingerprint("sk-key", None, None),
+        )
+        assert cache[expected_custom_key]["models"] == ["custom-endpoint-model"]
         assert cache["openrouter"]["models"] == ["openrouter-curated-model"]
 
 
@@ -291,30 +306,30 @@ class TestSalvageFollowups:
         background refresh is spawned for the next open."""
         import hermes_cli.models as mod
 
-        cache = {"custom:https://gw.example.com/v1": self._entry(["stale-ok"], age_seconds=7200)}
+        cache = {_key(): self._entry(["stale-ok"], age_seconds=7200)}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_spawn_swr_refresh") as spawn, \
              patch.object(mod, "fetch_api_models") as live:
             out = mod.cached_fetch_api_models(
-                "sk-key", "https://gw.example.com/v1", ttl_seconds=3600
+                "sk-key", GW_URL, ttl_seconds=3600
             )
         assert out == ["stale-ok"]
         live.assert_not_called()
         spawn.assert_called_once()
-        assert spawn.call_args[0][0] == "custom:https://gw.example.com/v1"
+        assert spawn.call_args[0][0] == _key()
 
     def test_entry_beyond_stale_window_blocks_on_live_fetch(self):
         import hermes_cli.models as mod
 
         too_old = mod._PROVIDER_MODELS_STALE_SERVE_MAX + 60
-        cache = {"custom:https://gw.example.com/v1": self._entry(["ancient"], age_seconds=too_old)}
+        cache = {_key(): self._entry(["ancient"], age_seconds=too_old)}
         with patch.object(mod, "_load_provider_models_cache", return_value=cache), \
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_save_provider_models_cache"), \
              patch.object(mod, "_spawn_swr_refresh") as spawn, \
              patch.object(mod, "fetch_api_models", return_value=["fresh"]) as live:
-            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+            out = mod.cached_fetch_api_models("sk-key", GW_URL)
         assert out == ["fresh"]
         live.assert_called_once()
         spawn.assert_not_called()
@@ -336,12 +351,12 @@ class TestSalvageFollowups:
         with patch.object(mod, "_load_provider_models_cache", return_value={}), \
              patch.object(mod, "_save_provider_models_cache", side_effect=fake_save):
             mod._spawn_swr_refresh(
-                "custom:https://gw.example.com/v1",
+                _key(),
                 lambda: {"fp": "fp", "at": time.time(), "models": ["refreshed"]},
             )
             assert done.wait(timeout=5), "background refresh did not complete"
-        assert saved["custom:https://gw.example.com/v1"]["models"] == ["refreshed"]
-        assert "custom:https://gw.example.com/v1" not in mod._swr_refresh_inflight
+        assert saved[_key()]["models"] == ["refreshed"]
+        assert _key() not in mod._swr_refresh_inflight
 
     def test_corrupt_at_field_degrades_to_live_fetch_instead_of_raising(self):
         """provider_models_cache.json is user-editable; a corrupted 'at' must
@@ -349,7 +364,7 @@ class TestSalvageFollowups:
         import hermes_cli.models as mod
 
         cache = {
-            "custom:https://gw.example.com/v1": {
+            _key(): {
                 "fp": "fp", "at": "yesterday", "models": ["corrupt-row"],
             }
         }
@@ -357,6 +372,6 @@ class TestSalvageFollowups:
              patch.object(mod, "_custom_endpoint_fingerprint", return_value="fp"), \
              patch.object(mod, "_save_provider_models_cache"), \
              patch.object(mod, "fetch_api_models", return_value=["live-models"]) as live:
-            out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
+            out = mod.cached_fetch_api_models("sk-key", GW_URL)
         assert out == ["live-models"]
         live.assert_called_once()

--- a/tests/hermes_cli/test_custom_shared_url_credential_slots.py
+++ b/tests/hermes_cli/test_custom_shared_url_credential_slots.py
@@ -1,0 +1,109 @@
+"""Regression tests for #106184: ``custom_providers`` entries that share one
+base_url with distinct credentials must each keep their own cached
+``/v1/models`` catalog.
+
+The Desktop picker surfaces (chat model pill, settings auxiliary slots) request
+``model.options`` with live probing off, so section 4 of
+``list_authenticated_providers`` serves each row from
+``cached_fetch_api_models(..., cache_only=True)``. That disk cache used a
+URL-only key (``custom:<base_url>``) with the credential fingerprint stored
+inside the entry, so with several same-URL entries (gateways issuing
+per-tenant keys) only the credential that probed last could re-read its own
+catalog; every other row collapsed to an empty model list and the frontend's
+``models.length > 0`` filter hid the providers from the UI entirely.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+GW_URL = "https://gw.example.com/v1"
+
+
+class TestSharedUrlCredentialSlots:
+    def _isolate_disk(self, monkeypatch, tmp_path):
+        import hermes_cli.models as mod
+
+        cache_path = tmp_path / "provider_models_cache.json"
+        monkeypatch.setattr(mod, "_provider_models_cache_path", lambda: cache_path)
+        return mod
+
+    def test_each_credential_keeps_its_own_slot(self, monkeypatch, tmp_path):
+        """Two keys on one base_url must not evict each other: after both
+        probe, a cache-only (picker) read must still answer for each key."""
+        mod = self._isolate_disk(monkeypatch, tmp_path)
+
+        catalogs = {"sk-a": ["model-a1", "model-a2"], "sk-b": ["model-b1"]}
+
+        def fake_fetch(api_key, base_url, **kwargs):
+            return list(catalogs[api_key])
+
+        monkeypatch.setattr(mod, "fetch_api_models", fake_fetch)
+
+        # Both credentials probe (any order) — each writes a cache entry.
+        assert mod.cached_fetch_api_models("sk-a", GW_URL) == catalogs["sk-a"]
+        assert mod.cached_fetch_api_models("sk-b", GW_URL) == catalogs["sk-b"]
+
+        # Picker opens read cache-only: both must hit their own catalog.
+        # Before #106184's fix the second write shadowed the first (single
+        # URL-keyed slot), so one of these returned None.
+        assert mod.cached_fetch_api_models("sk-a", GW_URL, cache_only=True) == catalogs["sk-a"]
+        assert mod.cached_fetch_api_models("sk-b", GW_URL, cache_only=True) == catalogs["sk-b"]
+
+    def test_disk_holds_one_slot_per_credential(self, monkeypatch, tmp_path):
+        """The persisted cache must contain two distinct (url, credential)
+        keys for the shared endpoint, each with its own fingerprint."""
+        mod = self._isolate_disk(monkeypatch, tmp_path)
+
+        monkeypatch.setattr(mod, "fetch_api_models", lambda key, url, **kw: [f"m-{key}"])
+        mod.cached_fetch_api_models("sk-a", GW_URL)
+        mod.cached_fetch_api_models("sk-b", GW_URL)
+
+        cache = mod._load_provider_models_cache()
+        custom_keys = [k for k in cache if k.startswith(f"custom:{GW_URL}")]
+        assert len(custom_keys) == 2, f"expected one slot per credential, got {sorted(custom_keys)}"
+        fp_a = mod._custom_endpoint_fingerprint("sk-a", None, None)
+        fp_b = mod._custom_endpoint_fingerprint("sk-b", None, None)
+        assert fp_a != fp_b
+        assert cache[f"custom:{GW_URL}:{fp_a}"]["models"] == ["m-sk-a"]
+        assert cache[f"custom:{GW_URL}:{fp_b}"]["models"] == ["m-sk-b"]
+
+    def test_cache_only_miss_after_shadowing_is_gone(self, monkeypatch, tmp_path):
+        """Pin the exact failing shape from the report: probe with key A, then
+        key B, then open the picker twice (cache-only) — A's row must survive
+        B's write."""
+        mod = self._isolate_disk(monkeypatch, tmp_path)
+
+        state = {"calls": 0}
+
+        def fake_fetch(api_key, base_url, **kwargs):
+            state["calls"] += 1
+            return [f"catalog-{api_key}"]
+
+        monkeypatch.setattr(mod, "fetch_api_models", fake_fetch)
+
+        assert mod.cached_fetch_api_models("sk-a", GW_URL) == ["catalog-sk-a"]
+        assert mod.cached_fetch_api_models("sk-b", GW_URL) == ["catalog-sk-b"]
+        assert state["calls"] == 2
+
+        # Both picker opens are cache-only — neither may trigger a live fetch.
+        with patch.object(mod, "fetch_api_models") as live:
+            assert mod.cached_fetch_api_models("sk-a", GW_URL, cache_only=True) == ["catalog-sk-a"]
+            assert mod.cached_fetch_api_models("sk-b", GW_URL, cache_only=True) == ["catalog-sk-b"]
+            live.assert_not_called()
+        assert state["calls"] == 2
+
+    def test_stale_entry_for_other_credential_is_not_served(self, monkeypatch, tmp_path):
+        """Slots are per-credential, but the in-entry fingerprint check stays
+        authoritative: an entry whose stored fp disagrees with the caller's
+        credentials (e.g. hand-edited cache) is still a miss, never served."""
+        mod = self._isolate_disk(monkeypatch, tmp_path)
+        cache_path = tmp_path / "provider_models_cache.json"
+
+        fp_a = mod._custom_endpoint_fingerprint("sk-a", None, None)
+        stale = {"fp": "someone-else", "at": time.time(), "models": ["not-yours"]}
+        mod._save_provider_models_cache({f"custom:{GW_URL}:{fp_a}": stale})
+        assert cache_path.exists()
+
+        assert mod.cached_fetch_api_models("sk-a", GW_URL, cache_only=True) is None

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -1776,7 +1776,7 @@ def _seed_custom_model_cache(monkeypatch, models, *, age_seconds=10):
 
     fp = models_mod._custom_endpoint_fingerprint("", None, None)
     cache = {
-        f"custom:{_LOCAL_ENDPOINT}": {
+        f"custom:{_LOCAL_ENDPOINT}:{fp}": {
             "fp": fp,
             "at": time.time() - age_seconds,
             "models": list(models),
@@ -2061,7 +2061,7 @@ def test_api_mode_rows_do_not_share_a_cached_catalog(monkeypatch):
     # Only the OpenAI-mode probe (api_mode=None) is on disk.
     fp = models_mod._custom_endpoint_fingerprint("sk-shared", None, None)
     cache = {
-        f"custom:{_SHARED_PROXY_URL}": {
+        f"custom:{_SHARED_PROXY_URL}:{fp}": {
             "fp": fp,
             "at": time.time() - 10,
             "models": list(openai_catalog),


### PR DESCRIPTION
## What does this PR do?

Fixes a cache-key collision that made custom providers disappear from the Desktop model pickers when several `custom_providers` entries share one `base_url` with distinct API keys (e.g. a gateway issuing per-tenant keys — the exact setup in #106184, where 5 of 10 configured providers were invisible).

The `/v1/models` disk cache in `cached_fetch_api_models()` keyed entries by URL only (`custom:<base_url>`) and stored the credential fingerprint *inside* the entry. With multiple same-URL entries, the last credential to probe overwrote the single slot; on the next picker open every other entry failed the in-entry fingerprint check, got `None` instead of its catalog, and collapsed to an empty `models` list. The frontend picker (`model-picker.tsx`) filters rows with `models.length === 0`, so those providers vanished from the UI entirely — while a direct backend call (which probes live) showed all 10 providers, exactly as reported.

The fix keys each cache slot by `(endpoint, credential)` — `custom:<base_url>:<fingerprint>` — so each key keeps its own catalog. The in-entry fingerprint check stays authoritative for hand-edited rows. Migration cost: pre-existing URL-only cache entries miss once and are re-probed on the next live path (CLI `/model`, refresh); stale slots are wiped by the existing full-cache refresh.

## Related Issue

Fixes #106184

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` — `cached_fetch_api_models()` now computes the credential fingerprint before building the cache key and includes it in the key (`custom:<url>:<fp>`) instead of keying by URL alone.
- `tests/hermes_cli/test_cached_fetch_api_models.py` — cache-contract tests updated to the per-credential key shape (helper `_key(url, fp)`), including the dynamic real-fingerprint assertion in the disk round-trip test.
- `tests/hermes_cli/test_custom_shared_url_credential_slots.py` — new regression tests: two keys on one base_url each keep their slot (probe order irrelevant), disk holds one slot per credential, cache-only reads never re-fetch after both probes, and a fingerprint-mismatched entry is still a miss.
- `tests/hermes_cli/test_model_switch_custom_providers.py` — the two cache-seeding helpers build the per-credential key.

## How to Test

1. Configure two `custom_providers` entries with the same `base_url` but different `api_key`s (any OpenAI-compatible endpoint).
2. Run a probing surface once (e.g. `hermes model` / `/model` with refresh, or the reporter's direct `build_models_payload(..., explicit_only=True)` call) so both catalogs are probed and persisted.
3. Open the Desktop model picker (chat pill or Settings → Models auxiliary slots), which requests `model.options` with probing off (cache-only reads).
4. Observed result: both providers now list their models and stay visible. Before the fix, only the credential that probed last kept its catalog; every other same-URL row had an empty model list and was filtered out of the picker.
5. `pytest tests/hermes_cli/test_custom_shared_url_credential_slots.py tests/hermes_cli/test_cached_fetch_api_models.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_picker_prewarm.py tests/hermes_cli/test_picker_key_cmd_discovery.py tests/hermes_cli/test_model_cache_parallel_prefetch.py` — should pass (136 passed locally).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
