### PR TITLE
ci(lint): block PRs introducing new ty invalid-method-override diagnostics (#106192)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,6 +118,93 @@ jobs:
             --output    .lint-reports/summary.md
           cat .lint-reports/summary.md >> "$GITHUB_STEP_SUMMARY"
 
+  ty-override-gate:
+    # Blocking counterpart to the advisory lint-diff above: fails the PR when
+    # the head introduces NEW `ty` diagnostics of the gated rule classes vs
+    # the merge base. Scoped to override-contract errors only — the full `ty`
+    # output carries too much pre-existing noise to gate on wholesale.
+    name: ty override gate (blocking)
+    if: inputs.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # need full history for merge-base + worktree
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
+          # raw.githubusercontent.com every job; transient fetch failures
+          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
+          version: "0.9.28"
+
+      - name: Install ruff + ty
+        uses: ./.github/actions/retry
+        with:
+          command: uv tool install ruff && uv tool install ty
+
+      - name: Determine base ref
+        id: base
+        run: |
+          # For PRs, diff against the merge base with the target branch.
+          # For pushes to main, diff against the previous commit on main.
+          if [ "${{ inputs.event_name }}" = "pull_request" ]; then
+            BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+            BASE_REF="origin/${{ github.base_ref }}"
+          else
+            BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+            BASE_REF="HEAD~1"
+          fi
+          echo "sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          echo "Base SHA: ${BASE_SHA}"
+          echo "Base ref: ${BASE_REF}"
+
+      - name: Run ruff + ty on HEAD and base
+        run: |
+          mkdir -p .lint-reports/head .lint-reports/base
+          ruff check --output-format json --exit-zero \
+            > .lint-reports/head/ruff.json || true
+          ty check --output-format gitlab --exit-zero \
+            > .lint-reports/head/ty.json || true
+          HEAD_SHA=$(git rev-parse HEAD)
+          BASE_SHA="${{ steps.base.outputs.sha }}"
+          if [ "$BASE_SHA" = "$HEAD_SHA" ]; then
+            echo "Base SHA == HEAD SHA, skipping base scan."
+            echo '[]' > .lint-reports/base/ruff.json
+            echo '[]' > .lint-reports/base/ty.json
+          else
+            git worktree add --detach /tmp/lint-base "$BASE_SHA"
+            (
+              cd /tmp/lint-base
+              ruff check --output-format json --exit-zero \
+                > "$GITHUB_WORKSPACE/.lint-reports/base/ruff.json" || true
+              ty check --output-format gitlab --exit-zero \
+                > "$GITHUB_WORKSPACE/.lint-reports/base/ty.json" || true
+            )
+            git worktree remove --force /tmp/lint-base
+          fi
+
+      - name: Fail on new override errors
+        env:
+          HEAD_REF: ${{ inputs.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+        run: |
+          # No --exit-zero, no || true. Exit code propagates to the job,
+          # which propagates to the required-check gate.
+          # Gated rule set lives here (extend with ,<rule> as needed);
+          # the flag itself accepts any ty rule names.
+          python scripts/lint_diff.py \
+            --base-ruff .lint-reports/base/ruff.json \
+            --head-ruff .lint-reports/head/ruff.json \
+            --base-ty   .lint-reports/base/ty.json \
+            --head-ty   .lint-reports/head/ty.json \
+            --base-ref  "${{ steps.base.outputs.ref }}" \
+            --head-ref  "$HEAD_REF" \
+            --fail-on-new invalid-method-override
+
   ruff-blocking:
     # Enforce the rules in pyproject.toml [tool.ruff.lint.select]. Currently
     # PLW1514 (unspecified-encoding) — catches bare ``open()`` /

--- a/scripts/lint_diff.py
+++ b/scripts/lint_diff.py
@@ -2,18 +2,24 @@
 """Diff ruff + ty diagnostic reports between two git refs.
 
 Produces a Markdown summary suitable for `$GITHUB_STEP_SUMMARY` and for PR
-comments. Compares issues by a stable key (file, rule, line) so line-only
+comments. Compares issues by a stable key (path, rule, message) so line-only
 shifts from unrelated edits are treated as the same issue.
 
 Usage:
-    lint_diff.py \\
-        --base-ruff base/ruff.json --head-ruff head/ruff.json \\
-        --base-ty   base/ty.json   --head-ty   head/ty.json \\
+    lint_diff.py \
+        --base-ruff base/ruff.json --head-ruff head/ruff.json \
+        --base-ty   base/ty.json   --head-ty   head/ty.json \
         [--base-ref origin/main] [--head-ref HEAD]
+        [--fail-on-new RULE,...]
 
 Any of the four --{base,head}-{ruff,ty} files may be missing or empty; in that
 case the tool treats it as "0 diagnostics" (e.g. if base/main doesn't have the
 config yet, or a tool crashed).
+
+With --fail-on-new, ty diagnostics whose rule is listed and that are NEW vs
+base make the tool exit 1 (for a blocking CI gate); without it the tool always
+exits 0 (advisory). When the base ty report is unavailable the gate is skipped
+(exit 0) so a missing base can never block a PR.
 """
 
 from __future__ import annotations
@@ -172,6 +178,13 @@ def main() -> int:
     ap.add_argument(
         "--output", type=Path, help="Write summary to this file instead of stdout"
     )
+    ap.add_argument(
+        "--fail-on-new",
+        default="",
+        help="Comma-separated ty rule names (e.g. invalid-method-override) that "
+        "fail the build when NEW vs base. Empty (default) keeps the advisory "
+        "behavior: always exit 0.",
+    )
     args = ap.parse_args()
 
     base_ruff_raw = _load_json(args.base_ruff)
@@ -200,7 +213,27 @@ def main() -> int:
         args.output.write_text(summary, encoding="utf-8")
     else:
         print(summary)
-    return 0
+    fail_rules = [r.strip() for r in args.fail_on_new.split(",") if r.strip()]
+    if not fail_rules:
+        return 0
+    if not base_ty_avail:
+        print(
+            "gate skipped: base ty report unavailable, "
+            "a missing base never blocks a PR",
+            file=sys.stderr,
+        )
+        return 0
+    new_ty, _, _ = _diff(base_ty, head_ty)
+    gated = [d for d in new_ty if d["rule"] in fail_rules]
+    if not gated:
+        return 0
+    print(
+        f"FAIL: {len(gated)} new {','.join(fail_rules)} diagnostic(s) vs base:",
+        file=sys.stderr,
+    )
+    for d in gated:
+        print(f"{d['path']}:{d['line']}: [{d['rule']}] {d['message']}", file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_lint_diff_gate.py
+++ b/tests/scripts/test_lint_diff_gate.py
@@ -1,0 +1,77 @@
+"""The --fail-on-new gate in scripts/lint_diff.py blocks only diagnostics the
+head introduces vs base, scoped to the listed ty rule classes.
+
+Without the flag the tool stays advisory (always exit 0); a missing base
+report skips the gate so it can never block a PR for lack of comparison data.
+Pinned here with ty-gitlab-shaped fixtures, no real ty run.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "lint_diff.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("lint_diff", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ty_entry(rule, path="a.py", line=1, message="m"):
+    return {
+        "check_name": rule,
+        "location": {"path": path, "positions": {"begin": {"line": line}}},
+        "description": message,
+    }
+
+
+def _run(monkeypatch, tmp_path, base_entries, head_entries, *extra):
+    (tmp_path / "ruff.json").write_text("[]", encoding="utf-8")
+    base_ty = tmp_path / "base-ty.json"
+    if base_entries is not None:
+        base_ty.write_text(json.dumps(base_entries), encoding="utf-8")
+    head_ty = tmp_path / "head-ty.json"
+    head_ty.write_text(json.dumps(head_entries), encoding="utf-8")
+    argv = [
+        "lint_diff.py",
+        "--base-ruff", str(tmp_path / "ruff.json"),
+        "--head-ruff", str(tmp_path / "ruff.json"),
+        "--base-ty", str(base_ty),
+        "--head-ty", str(head_ty),
+        "--output", str(tmp_path / "summary.md"),
+        *extra,
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    return _load().main()
+
+
+def test_new_gated_rule_fails(monkeypatch, tmp_path):
+    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    assert _run(monkeypatch, tmp_path, [], [entry],
+                "--fail-on-new", "invalid-method-override") == 1
+
+
+def test_preexisting_gated_rule_passes(monkeypatch, tmp_path):
+    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    assert _run(monkeypatch, tmp_path, [entry], [entry],
+                "--fail-on-new", "invalid-method-override") == 0
+
+
+def test_new_ungated_rule_passes(monkeypatch, tmp_path):
+    entry = _ty_entry("unresolved-import", path="p.py", message="no module")
+    assert _run(monkeypatch, tmp_path, [], [entry],
+                "--fail-on-new", "invalid-method-override") == 0
+
+
+def test_missing_base_skips_gate(monkeypatch, tmp_path):
+    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    assert _run(monkeypatch, tmp_path, None, [entry],
+                "--fail-on-new", "invalid-method-override") == 0
+
+
+def test_no_flag_stays_advisory(monkeypatch, tmp_path):
+    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    assert _run(monkeypatch, tmp_path, [], [entry]) == 0


### PR DESCRIPTION
## What does this PR do?

Makes the `ty` type-diff blocking for one error class: PRs that introduce NEW `invalid-method-override` diagnostics vs the merge base now fail CI. Lived case: a gateway PR widened a base method from `-> None` to `-> SendResult` with six plugin overrides still returning `None` — required checks stayed green while project-wide `ty` on the head reported new override errors, costing a full review round-trip.

The gate is scoped to override-contract errors only: the full `ty` output carries too much pre-existing noise to gate on wholesale, and a gate that blocks on noise gets ignored.

## Related Issue

Fixes #106192

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

CI/CD change (workflow gate; no template box fits — closest is Refactor, no behavior change to shipped code).

## Changes Made

- `scripts/lint_diff.py`: new `--fail-on-new RULE,...` flag — `ty` diagnostics whose rule is listed and that are NEW vs base exit 1. Without the flag the tool stays advisory (always exit 0). A missing base report skips the gate (exit 0) so it can never block for lack of comparison data.
- `.github/workflows/lint.yml`: new `ty-override-gate (blocking)` job (PRs only) — same HEAD-vs-merge-base `ty` comparison the advisory `lint-diff` job already computes, gated on `--fail-on-new invalid-method-override`. Mirrors the existing `ruff-blocking` split; the advisory reporter is untouched. Maintainers: add `ty override gate (blocking)` to the required-checks set for it to block merge.
- `tests/scripts/test_lint_diff_gate.py` (new): 5 tests pinning new-vs-pre-existing, ungated-rule, missing-base, and no-flag behavior with `ty`-gitlab-shaped fixtures.

## How to Test

1. Run: `HERMES_PYTHON=/usr/bin/python3 scripts/run_tests.sh tests/scripts/test_lint_diff_gate.py` — 5 passed.
2. Run: `uvx ruff check scripts/lint_diff.py tests/scripts/test_lint_diff_gate.py` — clean.
3. Gate proof is by fixture (new override entry → exit 1; same entry on base → 0; ungated rule → 0; missing base → 0; no flag → 0), not by a live `ty` run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.1 (v2026.9.7), upstream 72a3277cd7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
