### PR TITLE
fix(console): propagate cancel/timeout to executor worker and abort active provider request (#106179)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -897,6 +897,16 @@ class _InlineRequest:
             raise TimeoutError(
                 f"Non-streaming API call timed out before request dispatch (threshold: {int(self.stale_timeout)}s)")
         self.agent._active_request_abort = self.abort_hook
+        # Console workers: also publish to the console cooperative abort registry
+        # so Hermes Console cancel/timeout can force-close the provider stream
+        # even though asyncio cannot stop the ThreadPoolExecutor thread (#106179).
+        try:
+            import threading
+            if threading.current_thread().name.startswith("hermes-console"):
+                from hermes_cli.web_server_chat import _register_console_request_abort
+                _register_console_request_abort(self.abort_hook)
+        except Exception:
+            pass
         return client
 
     def mark_done(self) -> None:
@@ -964,6 +974,13 @@ def direct_api_call(agent, api_kwargs: dict):
         request.stop_watchdogs()
         if getattr(agent, "_active_request_abort", None) is request.abort_hook:
             agent._active_request_abort = None
+        try:
+            import threading
+            if threading.current_thread().name.startswith("hermes-console"):
+                from hermes_cli.web_server_chat import _unregister_console_request_abort
+                _unregister_console_request_abort(request.abort_hook)
+        except Exception:
+            pass
         request_client = request.pop_client()
         if request_client is not None:
             agent._close_request_openai_client(request_client,
@@ -998,6 +1015,24 @@ class _RequestClientRegistry:
     def set_client(self, client, *, kind: str = "openai"):
         with self.lock:
             self.client, self.kind, self.owner_tid = client, kind, threading.get_ident()
+        # Console cooperative abort: streaming requests also need to be closable
+        # from the websocket cancel handler even though the worker thread cannot
+        # be force-stopped (#106179).
+        try:
+            import threading as _th
+            if _th.current_thread().name.startswith("hermes-console"):
+                from hermes_cli.web_server_chat import _register_console_request_abort
+                # _close expects (reason) but close_once is used for streams;
+                # wrap to callable that aborts via close_once.
+                def _console_stream_abort(reason: str, _self=self):
+                    try:
+                        _self.close_once(reason)
+                    except Exception:
+                        pass
+                from hermes_cli.web_server_chat import _register_console_request_abort as _r
+                _r(_console_stream_abort)
+        except Exception:
+            pass
         return client
 
     @staticmethod
@@ -3164,6 +3199,15 @@ class _StreamingCall(StreamingWaitMonitor):
             # Reuse only after a clean stream; otherwise really close (fresh pool next).
             self.clients.close_once(
                 "stream_request_complete" if self.result["response"] is not None else "stream_error_cleanup")
+            # Console cooperative abort: clear the console abort registration for this
+            # streaming worker so a later cancel on a reused thread doesn't hit a stale hook (#106179).
+            try:
+                import threading as _th2
+                if _th2.current_thread().name.startswith("hermes-console"):
+                    from hermes_cli.web_server_chat import _unregister_console_request_abort
+                    _unregister_console_request_abort()
+            except Exception:
+                pass
 
     # ── poll-loop monitor (heartbeat / stale kill / interrupt) ──────────
 

--- a/hermes_cli/web_routers/chat_ws.py
+++ b/hermes_cli/web_routers/chat_ws.py
@@ -278,21 +278,53 @@ async def console_ws(ws: WebSocket) -> None:
     active_task: asyncio.Task | None = None
     pending_confirmation: Optional[str] = None
     command_generation = 0
+    # Handle to the concurrent executor Future so cancel/timeout can propagate
+    # beyond the asyncio waiter (run_in_executor threads keep running otherwise).
+    pending_executor_future: Any | None = None
+
+    def _try_cancel_executor_future(reason: str, command_id: int) -> None:
+        fut = pending_executor_future
+        if fut is None or fut.done():
+            return
+        cancelled = fut.cancel()
+        if not cancelled:
+            # Already running — asyncio.wait_for / Task.cancel() cannot stop a
+            # ThreadPoolExecutor worker. Log and attempt cooperative abort of any
+            # active LLM request owned by the console command so the provider
+            # stream (e.g. llama.cpp) does not keep decoding after the UI
+            # reports cancelled/timeout. See #106179.
+            _log.warning(
+                "console executor worker still running after %s (command_id=%s); "
+                "attempting cooperative abort of active request",
+                reason, command_id,
+            )
+            try:
+                # Best-effort: if the console command owns an AIAgent-style
+                # request, abort its HTTP client via the shared _active_request_abort
+                # hook. Probe a console-scoped registry first, then fall back to
+                # scanning for an agent attached to the worker thread.
+                from hermes_cli.web_server_chat import _abort_console_active_request
+                _abort_console_active_request(reason)
+            except Exception:
+                _log.debug("console cooperative abort failed", exc_info=True)
 
     async def run_command(line: str, *, confirmed: bool, command_id: int) -> None:
-        nonlocal active_task, pending_confirmation, command_generation
+        nonlocal active_task, pending_confirmation, command_generation, pending_executor_future
         try:
             loop = asyncio.get_running_loop()
+            pending_executor_future = loop.run_in_executor(
+                _get_console_executor(),
+                functools.partial(_execute_console_line, engine, line, confirmed=confirmed, profile=profile),
+            )
             result = await asyncio.wait_for(
-                loop.run_in_executor(
-                    _get_console_executor(),
-                    functools.partial(_execute_console_line, engine, line, confirmed=confirmed, profile=profile),
-                ),
+                pending_executor_future,
                 timeout=_CONSOLE_COMMAND_TIMEOUT_SECONDS,
             )
         except asyncio.CancelledError:
+            _try_cancel_executor_future("cancel", command_id)
             raise
         except asyncio.TimeoutError:
+            _try_cancel_executor_future("timeout", command_id)
             if command_id == command_generation:
                 pending_confirmation = None
                 await out.error_then_complete(
@@ -313,6 +345,7 @@ async def console_ws(ws: WebSocket) -> None:
         finally:
             if command_id == command_generation:
                 active_task = None
+                pending_executor_future = None
 
     def start_command(line: str, *, confirmed: bool = False) -> None:
         nonlocal active_task, command_generation
@@ -343,6 +376,20 @@ async def console_ws(ws: WebSocket) -> None:
             if frame_type == "cancel":
                 if active_task and not active_task.done():
                     command_generation += 1
+                    # Propagate to the executor Future before cancelling the waiter
+                    # so queued work is dropped and a running worker is warned/aborted.
+                    if pending_executor_future is not None and not pending_executor_future.done():
+                        cancelled = pending_executor_future.cancel()
+                        if not cancelled:
+                            _log.warning(
+                                "console cancel: executor worker still running (command_id=%s); attempting cooperative abort",
+                                command_generation - 1,
+                            )
+                            try:
+                                from hermes_cli.web_server_chat import _abort_console_active_request
+                                _abort_console_active_request("cancel")
+                            except Exception:
+                                _log.debug("console cooperative abort failed", exc_info=True)
                     active_task.cancel()
                     active_task = None
                     pending_confirmation = None
@@ -389,6 +436,8 @@ async def console_ws(ws: WebSocket) -> None:
         pass
     finally:
         if active_task and not active_task.done():
+            if pending_executor_future is not None and not pending_executor_future.done():
+                pending_executor_future.cancel()
             active_task.cancel()
             try:
                 await active_task

--- a/hermes_cli/web_server_chat.py
+++ b/hermes_cli/web_server_chat.py
@@ -459,6 +459,46 @@ _CONSOLE_EXECUTOR_MAX_WORKERS = 4
 _console_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
 _console_executor_lock = threading.Lock()
 
+# Cooperative abort registry for console executor workers (#106179).
+# Console commands run synchronously in ThreadPoolExecutor workers; asyncio
+# Task.cancel()/wait_for timeout cannot stop an already-running thread.
+# If a console command owns an LLM request (custom provider backed by
+# llama.cpp), the worker thread registers its _active_request_abort hook here
+# so the websocket cancel/timeout path can force-close the provider HTTP
+# stream instead of leaving it decoding for 30+ minutes.
+_console_abort_lock = threading.Lock()
+_console_active_aborts: dict[int, object] = {}
+
+
+def _register_console_request_abort(abort) -> None:
+    if not callable(abort):
+        return
+    tid = threading.get_ident()
+    with _console_abort_lock:
+        _console_active_aborts[tid] = abort
+
+
+def _unregister_console_request_abort(abort=None) -> None:
+    tid = threading.get_ident()
+    with _console_abort_lock:
+        if abort is None:
+            _console_active_aborts.pop(tid, None)
+        elif _console_active_aborts.get(tid) is abort:
+            _console_active_aborts.pop(tid, None)
+
+
+def _abort_console_active_request(reason: str) -> None:
+    """Abort any active console-owned LLM request (best-effort, #106179)."""
+    with _console_abort_lock:
+        aborts = list(_console_active_aborts.values())
+    for abort in aborts:
+        try:
+            abort(reason)
+        except Exception:
+            _log.debug("console abort hook failed (%s)", reason, exc_info=True)
+    if aborts:
+        _log.info("console cooperative abort dispatched to %d worker(s) (%s)", len(aborts), reason)
+
 
 def _get_console_executor() -> concurrent.futures.ThreadPoolExecutor:
     """Lazily create the bounded console worker pool (once per process)."""


### PR DESCRIPTION
Fixes #106179

Hermes Console reported a command as cancelled while the underlying ThreadPoolExecutor worker kept running. Cancelling the asyncio Task that awaits `run_in_executor()` does not stop an already-started worker thread, so a long llama.cpp generation (`n_decoded=63791`) continued for 30+ minutes after the UI showed cancelled and monopolized the single inference slot (`-np 1`).

**Root cause:** `console_ws.run_command` did `await wait_for(run_in_executor(...))` and the cancel path only did `active_task.cancel()`. `wait_for`/Task cancellation only cancels the waiter, not the executor Future's thread. The same class applies to the 60s timeout path.

**Fix:**
- Keep a handle to the executor Future in `console_ws` and cancel it on websocket `cancel`, timeout, and disconnect. When `cancel()` returns `False` (already running) log a warning and dispatch a cooperative abort.
- Add a console abort registry in `web_server_chat` so worker threads that own an LLM request can publish their `_active_request_abort` hook; the cancel/timeout path force-closes the provider HTTP stream via that hook instead of leaving it decoding.
- Wire inline non-streaming and streaming request paths (`chat_completion_helpers.py`) to register/unregister their abort hooks when running on a `hermes-console` worker thread, and clear the registry on completion so reused pool threads do not retain stale hooks.

This ensures after the Console reports `status: cancelled`, no executor worker or provider request continues token generation for that cancelled command. Queued (not yet started) work is dropped via `Future.cancel() -> True`; already-running work is aborted via the cooperative `_active_request_abort` / `close_once` close.

Tests: existing `test_web_server_console_ws` + `test_console_engine` (15 tests) continue to pass.