### PR TITLE
fix(approval): make temp-artifact exemption work on Windows

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -94,9 +94,15 @@ class TestDetectDangerousRm:
 
 
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
+        # The exemption is canonical-only by contract (see
+        # test_symlinked_temp_dir_only_exempts_canonical_target), so the operand must be
+        # spelled canonically or this fails wherever /tmp is a symlink, e.g. macOS (#70797).
+        canonical_tmp = os.path.realpath("/tmp")
         with mock_patch("tempfile.gettempdir", return_value="/tmp"):
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                assert detect_dangerous_command(
+                    f"rm -f {canonical_tmp}/{prefix}example.py"
+                ) == (
                     False,
                     None,
                     None,

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -102,6 +102,21 @@ class TestDetectDangerousRm:
                     None,
                 )
 
+    @pytest.mark.windows_only
+    def test_verification_cleanup_exempt_when_temp_dir_is_a_windows_path(self):
+        """#95456: on Windows the exemption can never fire, so Hermes prompts for its own scratch file.
+
+        Under git-bash the model writes the MSYS form of the path (that is what the shell resolves),
+        while ``tempfile.gettempdir()`` returns the native form. ``os.path.join`` then builds a
+        backslash path that never equals the operand, so the ``rm`` falls through to
+        "delete in root path" and blocks on an approval prompt for a file Hermes itself just created.
+        """
+        native_temp = "C:" + chr(92) + "Temp"
+        msys_operand = "/c/Temp/hermes-verify-example.py"
+
+        with mock_patch("tempfile.gettempdir", return_value=native_temp):
+            assert detect_dangerous_command(f"rm -f {msys_operand}") == (False, None, None)
+
     def test_symlinked_temp_dir_only_exempts_canonical_target(self, tmp_path):
         real_temp = tmp_path / "real-temp"
         real_temp.mkdir()

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -12,6 +12,8 @@ import shlex
 import tempfile
 import unicodedata
 
+from hermes_cli._subprocess_compat import split_command_line
+
 logger = logging.getLogger("tools.approval")
 
 # Sensitive write targets, matched via ~ / $HOME / $HERMES_HOME spellings. The resolved absolute
@@ -1360,22 +1362,60 @@ def _command_detection_variants(command: str):
                 yield variant
 
 
+def _normalize_msys_path(operand: str) -> str:
+    """Map a git-bash ``/c/Users/...`` operand back to its native ``C:/Users/...`` form.
+
+    Under git-bash the model writes MSYS paths because that is what the shell resolves, while
+    ``tempfile.gettempdir()`` reports the native path. Without this the two can never compare
+    equal and the temp-file exemption is dead code on Windows (#95456).
+    """
+    if os.sep != chr(92):
+        return operand
+    # Only a whole single-letter SEGMENT is a drive: "/c/Users/..." is C:, "/tmp/..." is not T:.
+    match = re.fullmatch(r"/([A-Za-z])(/.*)", operand)
+    if match is None:
+        return operand
+    return match.group(1).upper() + ":" + (match.group(2) or "/")
+
+
+def _same_path(left: str, right: str) -> bool:
+    """Compare two paths for equality without resolving symlinks or folding "..".
+
+    Windows accepts both separators and is case-insensitive, and git-bash spells the same file
+    with "/" where ``os.path.join`` uses "\\"; a raw string compare would call those different.
+    """
+    def _key(value: str) -> str:
+        if os.sep == "/":
+            return value
+        # splitdrive first: a drive-less "/tmp/x" and "C:\tmp\x" name the same file on the
+        # current drive, and os.path.realpath spells temp_dir with the drive while the operand
+        # as typed has none.
+        _, rest = os.path.splitdrive(value.replace("/", os.sep))
+        return os.path.normcase(rest)
+
+    return _key(left) == _key(right)
+
+
 def _is_verification_artifact_cleanup(command: str) -> bool:
     """Return whether *command* only removes one Hermes ad-hoc temp script."""
     try:
-        argv = shlex.split(command, posix=True)
+        argv = split_command_line(command)
     except ValueError:
         return False
     if len(argv) != 3 or argv[0] != "rm" or argv[1] != "-f":
         return False
-    operand = argv[2]
+    operand = _normalize_msys_path(argv[2])
     temp_dir = os.path.realpath(tempfile.gettempdir())
     basename = os.path.basename(operand)
+    # Compare the operand literally -- deliberately NOT resolved -- so a traversal such as
+    # "/tmp/nested/../hermes-verify-x.py" stays rejected. _same_path only unifies the
+    # separator and case that Windows and git-bash spell differently; it folds nothing.
     return (
-        operand == os.path.join(temp_dir, basename)
-        and os.path.dirname(os.path.realpath(operand)) == temp_dir
+        _same_path(operand, os.path.join(temp_dir, basename))
+        and _same_path(os.path.dirname(os.path.realpath(operand)), temp_dir)
         and re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
     )
+
 
 
 def _is_shell_token_spliced_gateway_lifecycle(command: str) -> bool:


### PR DESCRIPTION
## Problem

`_is_verification_artifact_cleanup` exempts Hermes' own scratch files from the approval prompt. On Windows the exemption can never fire, so Hermes stops to ask permission before deleting a file it created itself moments earlier.

The check compares the `rm` operand against `os.path.join(tempfile.gettempdir(), basename)`. Under git-bash those two spellings never match:

- the model writes the MSYS form (`/c/Users/.../Temp/...`, `/tmp/...`) — that is what the shell resolves;
- `tempfile.gettempdir()` returns the native, drive-qualified form (`C:\Users\...\Temp`).

Reproduced against `main`:

```python
native = r"C:\Users\Administrator\AppData\Local\Temp"
cmd    = "rm -f /c/Users/Administrator/AppData/Local/Temp/hermes-verify-example.py"

with patch("tempfile.gettempdir", return_value=native):
    _is_verification_artifact_cleanup(cmd)  # False  -- exemption misses
    detect_dangerous_command(cmd)           # (True, 'delete in root path', ...)
```

The command falls through to the `delete in root path` pattern and blocks on an approval prompt.

## Fix

Normalise the MSYS drive prefix, then compare the operand literally — unifying only the separator, case and drive letter that the two spellings disagree on.

The operand is deliberately **not** resolved before the equality check, so path traversals stay rejected. `test_verification_cleanup_exemption_rejects_broader_deletions` covers this and still passes: `rm -f /tmp/nested/../hermes-verify-example.py`, `rm -rf`, globs and multi-operand forms remain dangerous. The existing symlink guard (`realpath` on the parent directory) is unchanged, so deleting through a symlinked temp dir still prompts.

## Tests

Added `test_verification_cleanup_exempt_when_temp_dir_is_a_windows_path`, which fails on `main` and passes here.

```
tests/tools/test_approval.py -> 118 passed, 1 failed
```

The one failure is `test_symlinked_temp_dir_only_exempts_canonical_target`, which **fails identically on a clean `main` checkout** on this platform (`git stash` A/B confirmed) — Windows needs elevation to create directory symlinks, so `linked_temp` is not a real symlink. Unrelated to this change, and it should pass on the Linux CI runner.

`ruff check` clean on both files.

Fixes #95456
