### PR TITLE
fix(state): only promise `hermes update` WAL repair for project-venv interpreters

### DIFF
--- a/hermes_state_wal.py
+++ b/hermes_state_wal.py
@@ -344,38 +344,59 @@ _EXTERNAL_RUNTIME_REPAIR_HINT = (
 )
 
 
-def _interpreter_in_project_venv(project_root) -> bool:
-    """True when the running interpreter lives in the install tree's own ``venv``/``.venv``.
+_HYBRID_RUNTIME_REPAIR_HINT = (
+    "the running interpreter is outside this checkout's venv — `{cmd}` rebuilds that venv with a "
+    "fixed SQLite; restart Hermes from `{venv}` to pick it up"
+)
 
-    Only that layout is rebuilt by ``hermes update``; a git checkout driven by a system Python or an
-    externally managed venv keeps its linked SQLite whatever ``hermes update`` does to the code tree.
+
+def _live_project_venv(project_root):
+    """The venv ``hermes update``'s runtime repair would cut over for this checkout.
+
+    Resolution matches ``hermes_cli.managed_uv._default_live_venv`` — interpreter-file presence,
+    managed ``venv`` winning over ``.venv`` — so an empty ``venv/`` next to a live ``.venv`` still
+    counts as repair-capable, while a bare directory without an interpreter does not (#79179).
     """
     try:
         from pathlib import Path
 
-        from hermes_constants import project_venv_dir
+        from hermes_constants import venv_python_path
 
-        venv = project_venv_dir(project_root)
-        return venv is not None and Path(sys.prefix).resolve() == venv.resolve()
+        primary, fallback = Path(project_root) / "venv", Path(project_root) / ".venv"
+        if venv_python_path(primary).is_file():
+            return primary
+        if venv_python_path(fallback).is_file():
+            return fallback
     except Exception:
-        return False
+        pass
+    return None
 
 
 def _wal_reset_repair_hint() -> str:
     """Repair hint matching what ``hermes update`` can actually do for this install type.
 
     See #75153 and #79179: ``git``/``unknown`` describe the code layout, not who owns the running
-    interpreter, so the managed-runtime wording additionally requires the project's own venv.
+    interpreter. The repair targets the checkout's live venv (``_live_project_venv``), so running
+    from it means ``hermes update`` fixes the very interpreter in use; running from outside it
+    still leaves a rebuildable venv worth pointing at; having none leaves only the
+    external-runtime wording.
     """
     try:
+        from pathlib import Path
+
+        from hermes_constants import venv_python_path
+
         from hermes_cli.config import detect_install_method, get_project_root, recommended_update_command_for_method
         root = get_project_root()
         method = detect_install_method(root)
         cmd = recommended_update_command_for_method(method)
         if method in {"git", "unknown"}:
-            if _interpreter_in_project_venv(root):
+            live = _live_project_venv(root)
+            if live is None:
+                return _EXTERNAL_RUNTIME_REPAIR_HINT
+            if Path(sys.prefix).resolve() == live.resolve():
                 return f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
-            return _EXTERNAL_RUNTIME_REPAIR_HINT
+            return _HYBRID_RUNTIME_REPAIR_HINT.format(cmd=cmd, venv=venv_python_path(live))
         return f"update the container image with `{cmd}`" if method == "docker" else cmd  # else nix/nixos
     except Exception:
         return "install a Python build bundled with SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6) and restart Hermes"

--- a/hermes_state_wal.py
+++ b/hermes_state_wal.py
@@ -338,17 +338,44 @@ def _apply_delete_for_wal_reset_bug(conn: sqlite3.Connection, *, db_label: str, 
     return "delete"
 
 
+_EXTERNAL_RUNTIME_REPAIR_HINT = (
+    "the interpreter providing SQLite is not Hermes-managed for this install — upgrade or replace it with a "
+    "Python build bundled with SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6), then restart Hermes"
+)
+
+
+def _interpreter_in_project_venv(project_root) -> bool:
+    """True when the running interpreter lives in the install tree's own ``venv``/``.venv``.
+
+    Only that layout is rebuilt by ``hermes update``; a git checkout driven by a system Python or an
+    externally managed venv keeps its linked SQLite whatever ``hermes update`` does to the code tree.
+    """
+    try:
+        from pathlib import Path
+
+        from hermes_constants import project_venv_dir
+
+        venv = project_venv_dir(project_root)
+        return venv is not None and Path(sys.prefix).resolve() == venv.resolve()
+    except Exception:
+        return False
+
+
 def _wal_reset_repair_hint() -> str:
     """Repair hint matching what ``hermes update`` can actually do for this install type.
 
-    See #75153.
+    See #75153 and #79179: ``git``/``unknown`` describe the code layout, not who owns the running
+    interpreter, so the managed-runtime wording additionally requires the project's own venv.
     """
     try:
         from hermes_cli.config import detect_install_method, get_project_root, recommended_update_command_for_method
-        method = detect_install_method(get_project_root())
+        root = get_project_root()
+        method = detect_install_method(root)
         cmd = recommended_update_command_for_method(method)
         if method in {"git", "unknown"}:
-            return f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
+            if _interpreter_in_project_venv(root):
+                return f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
+            return _EXTERNAL_RUNTIME_REPAIR_HINT
         return f"update the container image with `{cmd}`" if method == "docker" else cmd  # else nix/nixos
     except Exception:
         return "install a Python build bundled with SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6) and restart Hermes"

--- a/tests/test_wal_reset_repair_hint.py
+++ b/tests/test_wal_reset_repair_hint.py
@@ -1,0 +1,69 @@
+"""Table-driven tests for the WAL-reset repair hint's install-type wording.
+
+The hint must never promise a repair path the install cannot deliver (#79179): ``git``/``unknown``
+describe the *code layout*, not who owns the running interpreter. The ``hermes update`` wording
+additionally requires the interpreter to live in the project's own ``venv``/``.venv`` — a checkout
+driven by a system Python or an externally managed venv keeps its linked SQLite whatever
+``hermes update`` does to the code tree, and has to be told to upgrade the interpreter instead.
+"""
+
+import sys
+
+import pytest
+
+import hermes_cli.config
+from hermes_state_wal import _EXTERNAL_RUNTIME_REPAIR_HINT, _wal_reset_repair_hint
+
+
+def _hint_for_install(monkeypatch, project_root, method, *, interpreter_prefix=None):
+    """Run the hint with a faked install method, project root, and interpreter location."""
+    monkeypatch.setattr(hermes_cli.config, "detect_install_method", lambda root: method)
+    monkeypatch.setattr(hermes_cli.config, "get_project_root", lambda: project_root)
+    if interpreter_prefix is not None:
+        monkeypatch.setattr(sys, "prefix", str(interpreter_prefix))
+    return _wal_reset_repair_hint()
+
+
+@pytest.mark.parametrize("venv_name", ["venv", ".venv"])
+@pytest.mark.parametrize("method", ["git", "unknown"])
+def test_project_venv_interpreter_keeps_managed_wording(tmp_path, monkeypatch, method, venv_name):
+    venv_dir = tmp_path / venv_name
+    venv_dir.mkdir()
+    hint = _hint_for_install(monkeypatch, tmp_path, method, interpreter_prefix=venv_dir)
+    assert hint == "Hermes-managed installs can repair the embedded runtime with `hermes update`"
+
+
+@pytest.mark.parametrize("method", ["git", "unknown"])
+def test_external_interpreter_gets_runtime_upgrade_wording(tmp_path, monkeypatch, method):
+    # The project venv exists, but the interpreter runs from a venv outside the project tree:
+    # `hermes update` cannot replace the SQLite linked into it (#79179 reproduction).
+    (tmp_path / "venv").mkdir()
+    external = tmp_path.parent / "hermes-external-venv"
+    external.mkdir(exist_ok=True)
+    hint = _hint_for_install(monkeypatch, tmp_path, method, interpreter_prefix=external)
+    assert hint == _EXTERNAL_RUNTIME_REPAIR_HINT
+    assert "Hermes-managed installs" not in hint
+
+
+def test_git_checkout_without_any_venv_gets_runtime_upgrade_wording(tmp_path, monkeypatch):
+    # System-Python checkout: no project venv at all, `hermes update` has nothing to rebuild.
+    hint = _hint_for_install(monkeypatch, tmp_path, "git", interpreter_prefix=tmp_path.parent)
+    assert hint == _EXTERNAL_RUNTIME_REPAIR_HINT
+
+
+def test_docker_and_nix_wording_is_unchanged(tmp_path, monkeypatch):
+    hint = _hint_for_install(monkeypatch, tmp_path, "docker", interpreter_prefix=tmp_path)
+    assert hint == "update the container image with `docker pull nousresearch/hermes-agent:latest`"
+    hint = _hint_for_install(monkeypatch, tmp_path, "nix", interpreter_prefix=tmp_path)
+    assert hint.startswith("Update Hermes through the Nix source")
+
+
+def test_probe_failure_keeps_generic_sqlite_guidance(tmp_path, monkeypatch):
+    def _explode(root):
+        raise RuntimeError("install probe unavailable")
+
+    monkeypatch.setattr(hermes_cli.config, "detect_install_method", _explode)
+    monkeypatch.setattr(hermes_cli.config, "get_project_root", lambda: tmp_path)
+    assert _wal_reset_repair_hint() == (
+        "install a Python build bundled with SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6) and restart Hermes"
+    )

--- a/tests/test_wal_reset_repair_hint.py
+++ b/tests/test_wal_reset_repair_hint.py
@@ -1,10 +1,11 @@
 """Table-driven tests for the WAL-reset repair hint's install-type wording.
 
 The hint must never promise a repair path the install cannot deliver (#79179): ``git``/``unknown``
-describe the *code layout*, not who owns the running interpreter. The ``hermes update`` wording
-additionally requires the interpreter to live in the project's own ``venv``/``.venv`` — a checkout
-driven by a system Python or an externally managed venv keeps its linked SQLite whatever
-``hermes update`` does to the code tree, and has to be told to upgrade the interpreter instead.
+describe the *code layout*, not who owns the running interpreter. ``hermes update``'s runtime
+repair cuts over the checkout's live venv, so the gate follows the repair target's own
+resolution — interpreter-file presence with the managed ``venv`` winning over ``.venv``,
+matching ``hermes_cli.managed_uv._default_live_venv`` — rather than ``project_venv_dir``'s
+directory-presence rule.
 """
 
 import sys
@@ -12,7 +13,8 @@ import sys
 import pytest
 
 import hermes_cli.config
-from hermes_state_wal import _EXTERNAL_RUNTIME_REPAIR_HINT, _wal_reset_repair_hint
+from hermes_constants import venv_python_path
+from hermes_state_wal import _EXTERNAL_RUNTIME_REPAIR_HINT, _HYBRID_RUNTIME_REPAIR_HINT, _wal_reset_repair_hint
 
 
 def _hint_for_install(monkeypatch, project_root, method, *, interpreter_prefix=None):
@@ -24,19 +26,53 @@ def _hint_for_install(monkeypatch, project_root, method, *, interpreter_prefix=N
     return _wal_reset_repair_hint()
 
 
+def _make_live_venv(root, name):
+    """Create a venv skeleton whose interpreter file exists (platform-correct layout)."""
+    venv = root / name
+    venv.mkdir(exist_ok=True)
+    python = venv_python_path(venv)
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.touch()
+    return venv
+
+
 @pytest.mark.parametrize("venv_name", ["venv", ".venv"])
 @pytest.mark.parametrize("method", ["git", "unknown"])
 def test_project_venv_interpreter_keeps_managed_wording(tmp_path, monkeypatch, method, venv_name):
-    venv_dir = tmp_path / venv_name
-    venv_dir.mkdir()
+    venv_dir = _make_live_venv(tmp_path, venv_name)
     hint = _hint_for_install(monkeypatch, tmp_path, method, interpreter_prefix=venv_dir)
     assert hint == "Hermes-managed installs can repair the embedded runtime with `hermes update`"
 
 
 @pytest.mark.parametrize("method", ["git", "unknown"])
-def test_external_interpreter_gets_runtime_upgrade_wording(tmp_path, monkeypatch, method):
-    # The project venv exists, but the interpreter runs from a venv outside the project tree:
-    # `hermes update` cannot replace the SQLite linked into it (#79179 reproduction).
+def test_empty_venv_dir_falls_back_to_live_dot_venv(tmp_path, monkeypatch, method):
+    # Gate primitive must match the repair target: an empty `venv/` next to a live `.venv`
+    # makes `project_venv_dir` (directory presence, `venv` wins) and the repair target
+    # `_default_live_venv` (interpreter file, `venv` wins) disagree — the hint follows the
+    # repair target, so this install stays repair-capable (#79179 review).
+    (tmp_path / "venv").mkdir()
+    live = _make_live_venv(tmp_path, ".venv")
+    hint = _hint_for_install(monkeypatch, tmp_path, method, interpreter_prefix=live)
+    assert hint == "Hermes-managed installs can repair the embedded runtime with `hermes update`"
+
+
+@pytest.mark.parametrize("method", ["git", "unknown"])
+def test_hybrid_checkout_gets_rebuild_and_relaunch_wording(tmp_path, monkeypatch, method):
+    # A live project venv exists but an external interpreter runs: `hermes update` still
+    # rebuilds that venv, so the hint points at update + relaunching from it instead of
+    # foreclosing the zero-upgrade repair path (#79179 review).
+    live = _make_live_venv(tmp_path, "venv")
+    external = tmp_path.parent / "hermes-external-venv"
+    external.mkdir(exist_ok=True)
+    hint = _hint_for_install(monkeypatch, tmp_path, method, interpreter_prefix=external)
+    assert hint == _HYBRID_RUNTIME_REPAIR_HINT.format(cmd="hermes update", venv=venv_python_path(live))
+    assert "restart Hermes from" in hint
+
+
+@pytest.mark.parametrize("method", ["git", "unknown"])
+def test_venv_without_interpreter_gets_runtime_upgrade_wording(tmp_path, monkeypatch, method):
+    # A leftover venv directory with no interpreter file is not a repair target — there is
+    # nothing for `hermes update` to cut over, so the wording points at the external runtime.
     (tmp_path / "venv").mkdir()
     external = tmp_path.parent / "hermes-external-venv"
     external.mkdir(exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

The SQLite WAL-reset repair hint (`_wal_reset_repair_hint`) groups `git` and `unknown` installs under "Hermes-managed installs can repair the embedded runtime with `hermes update`". But `detect_install_method()` describes the **code layout**, not who owns the running interpreter:

- an official installer checkout (git-clone + project venv, stamped `git`) *is* repair-capable — `hermes update` performs the managed runtime repair there (`hermes_cli/managed_uv.py`);
- a plain git checkout driven by a system Python or an externally managed venv is **not** — updating Hermes code cannot replace the SQLite library linked into that interpreter, exactly the false promise #79179 reports (reproduced by two commenters, still present on current `main` in the startup WAL warning).

This PR gates the managed wording on runtime ownership: for `git`/`unknown` installs the hint keeps the `hermes update` wording only when the running interpreter lives in the project's own `venv`/`.venv` (the layout `hermes update` rebuilds, via `hermes_constants.project_venv_dir`); otherwise it tells the user to upgrade or replace the interpreter providing SQLite. Docker and nix/nixos branches and the exception fallback are unchanged.

This is the discriminating-matrix direction requested in the review of #79232 (which closed because a `runtime_repair_capability` resolver had landed — that resolver no longer exists on `main`, and the WAL-warning path this PR fixes is the sole remaining wording source, shared by the startup logger and `hermes doctor`).

## Related Issue

Fixes #79179

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_wal.py` — added `_interpreter_in_project_venv()`: True when `sys.prefix` resolves to the install tree's own `venv`/`.venv` (reusing `hermes_constants.project_venv_dir`); added `_EXTERNAL_RUNTIME_REPAIR_HINT` wording for interpreters Hermes cannot rebuild; `_wal_reset_repair_hint()` now returns the managed wording for `git`/`unknown` only under that condition.
- `tests/test_wal_reset_repair_hint.py` — new table-driven suite: `git`/`unknown` × (`venv`, `.venv`) keep the managed wording; external-interpreter and no-venv checkouts get the runtime-upgrade wording; docker/nix wording pinned; probe-failure fallback pinned.

## How to Test

1. `.venv/bin/python -m pytest tests/test_wal_reset_repair_hint.py -v` — Observed result: 9 passed.
2. `.venv/bin/python -m pytest tests/test_wal_reset_repair_hint.py tests/hermes_cli/test_doctor_journal_modes.py tests/test_hermes_state_wal_fallback.py tests/test_journal_mode_config.py tests/test_journal_mode_upgrade_warning.py tests/test_sqlite_wal_reset_gate.py tests/hermes_cli/test_update_sqlite_remediation.py tests/test_hermes_state.py` — Observed result: 388 passed, 2 skipped.
3. Manual #79179 reproduction: run `_wal_reset_repair_hint()` with `detect_install_method` patched to `git` while the interpreter runs from outside the project venv — should pass; with `sys.prefix` pointing at a `venv`/`.venv` inside the project root, the managed wording should return instead.
4. `ruff check hermes_state_wal.py tests/test_wal_reset_repair_hint.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (docstrings updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (uses `sys.prefix`, identical semantics on Windows venv layouts)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
