### PR TITLE
docs: clarify profiles, bots, and subagents

### DIFF
--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -11,6 +11,9 @@ Bot Mode ships **built into the [desktop app](./desktop.md)** and is **on by def
 
 :::tip A Bot is a profile
 There is no new primitive to learn: a Bot **is** a Hermes profile — isolated config, memory, skills, credentials, and chat history under `~/.hermes/profiles/<name>/`. Bot Mode is a UI over that primitive, so everything you do in it is visible from the CLI too: `hermes -p <bot> chat` opens the same agent, and Bot routines appear in `hermes cron list`. No core patches, no background daemons, no extra storage.
+
+See [Profiles, agents, and bots](./profiles.md#profiles-agents-and-bots) for how
+Bot Mode relates to messaging bots and delegated subagents.
 :::
 
 ## The Bots pane

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -16,6 +16,28 @@ Never point two agent processes at the same profile (the same Hermes home). Both
 
 When you create a profile, it automatically becomes its own command. Create a profile called `coder` and you immediately have `coder chat`, `coder setup`, `coder gateway start`, etc.
 
+### Profiles, agents, and bots
+
+These terms describe different parts of Hermes:
+
+- **Profile** is the persistent home for an assistant's configuration and data.
+  It keeps the same state across conversations and restarts.
+
+- **Agent** is the running Hermes assistant that uses that configuration and
+  state. "Hermes Agent" also names the product.
+
+- **Bot Mode bot** is a profile presented as a named entry in the desktop's
+  [Bot Mode](./bot-mode.md) roster, with an avatar and a persistent Bot Chat.
+  The same profile remains accessible from the CLI.
+
+- **Messaging bot** is an account on a platform such as Telegram, Discord, or
+  Slack, connected to Hermes through the gateway. Its
+  [bot token](#different-bot-tokens) identifies that platform account.
+
+- **Subagent** is a child assistant spawned by
+  [`delegate_task`](./features/delegation.md) for a task, with a fresh
+  conversation. A separate conversation is different from a separate profile.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
Refs #89179.

Clarify profiles, agents, Bot Mode bots, messaging bots, and subagents, with links between the guides.

Passed: `npm run lint:diagrams` and `npm run build:fast`.
