### PR TITLE
fix(desktop): keep healthy gateways usable when primary sign-in expires

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -360,6 +360,170 @@ async function advanceBackoff() {
   })
 }
 
+describe('primary failure foreground isolation', () => {
+  it.each(['local', 'remote'] as const)(
+    'ordinary %s primary outage leaves the other foreground usable',
+    async primaryMode => {
+      const foregroundId = primaryMode === 'local' ? 'healthy-remote' : 'local'
+
+      const desktop = Object.assign(fakeDesktop(), {
+        getGatewayWsUrlFor: vi.fn(async () => coderConn.wsUrl),
+        getConnectionFor: vi.fn(async () => ({
+          ...coderConn,
+          connectionId: foregroundId,
+          profile: 'default',
+          mode: primaryMode === 'local' ? 'remote' : 'local',
+          remoteKind: primaryMode === 'local' ? 'cloud' : undefined,
+          authMode: primaryMode === 'local' ? 'oauth' : 'token'
+        }))
+      })
+
+      desktop.getConnection.mockResolvedValue({
+        ...primaryConn,
+        connectionId: primaryMode === 'local' ? 'local' : 'primary-vps',
+        mode: primaryMode
+      } as typeof primaryConn)
+      ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+      render(<Harness />)
+      await flushAsync()
+      let opening!: Promise<boolean>
+      act(() => {
+        opening = ensureGatewayForAgent(foregroundId, 'default')
+      })
+      await flushAsync()
+      expect(await opening).toBe(true)
+      desktop.getConnection.mockRejectedValue(new Error('ECONNREFUSED'))
+      act(() => FakeWebSocket.instances[0].drop())
+      await advanceBackoff()
+      expect(isActivePrimary()).toBe(false)
+      expect($gatewayState.get()).toBe('open')
+      await expect(requestGatewayForAgent(foregroundId, 'default', 'ping')).resolves.toEqual({ pong: true })
+      expect($desktopBoot.get().error).toBeNull()
+      expect($desktopBoot.get().visible).toBe(false)
+    }
+  )
+  it.each(['progress', 'snapshot', 'reconnect'] as const)(
+    'primary auth via %s follows the foreground, including a latched error',
+    async path => {
+      const error = 'Your remote gateway session has expired.'
+
+      const cloud = {
+        ...primaryConn,
+        mode: 'remote' as const,
+        remoteKind: 'cloud' as const,
+        authMode: 'oauth' as const
+      }
+
+      const snapshot = deferred<Awaited<ReturnType<ReturnType<typeof fakeDesktop>['getBootProgress']>>>()
+
+      const desktop = Object.assign(fakeDesktop(), {
+        getRecentLogs: vi.fn(async () => ({ lines: [] })),
+        getConnectionConfig: vi.fn(async () => ({ mode: 'cloud', remoteAuthMode: 'oauth', remoteUrl: cloud.baseUrl })),
+        getConnectionFor: vi.fn(async () => ({
+          ...coderConn,
+          connectionId: 'local',
+          profile: 'default',
+          mode: 'local',
+          baseUrl: 'http://127.0.0.1:9191',
+          wsUrl: 'ws://127.0.0.1:9191/api/ws?token=c'
+        }))
+      })
+
+      desktop.getConnection.mockResolvedValue(cloud as typeof primaryConn)
+
+      if (path === 'snapshot') {
+        desktop.getBootProgress.mockReturnValue(snapshot.promise)
+      }
+
+      ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+      const { BootFailureOverlay } = await import('@/components/boot-failure-overlay')
+
+      const overlay = render(
+        <>
+          <Harness />
+          <BootFailureOverlay />
+        </>
+      )
+
+      await flushAsync()
+      expect($desktopBoot.get().visible).toBe(false)
+
+      const selectLocal = async () => {
+        let opening!: Promise<boolean>
+        act(() => {
+          opening = ensureGatewayForAgent('local', 'default')
+        })
+        await flushAsync()
+        expect(await opening).toBe(true)
+      }
+
+      await selectLocal()
+      const foreground = activeGateway()
+
+      const progress = {
+        error,
+        fakeMode: false,
+        message: error,
+        phase: 'backend.error',
+        progress: 94,
+        retryable: false,
+        running: false,
+        timestamp: Date.now()
+      }
+
+      if (path === 'reconnect') {
+        desktop.getGatewayWsUrl.mockRejectedValue(Object.assign(new Error(error), { needsOauthLogin: true }))
+        act(() => FakeWebSocket.instances[0].drop())
+        await advanceBackoff()
+      } else {
+        act(() => (path === 'snapshot' ? snapshot.resolve(progress) : desktop.emitBootProgress(progress)))
+        await flushAsync()
+      }
+
+      expect(activeGateway()).toBe(foreground)
+      expect($connection.get()?.connectionId).toBe('local')
+      expect($gatewayState.get()).toBe('open')
+      await expect(requestGatewayForAgent('local', 'default', 'ping')).resolves.toEqual({ pong: true })
+      expect(overlay.queryByRole('heading')).toBeNull()
+      expect($desktopBoot.get().error).toBeNull()
+      expect($desktopBoot.get().visible).toBe(false)
+      expect(notifyError).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await ensureGatewayForProfile('default')
+      })
+      await flushAsync()
+      expect(isActivePrimary()).toBe(true)
+      expect($desktopBoot.get().error).toContain(error)
+      expect(overlay.getByRole('heading', { name: /sign-in required/i })).toBeTruthy()
+      expect(overlay.getByRole('button', { name: /sign in/i })).toBeTruthy()
+
+      // A now-latched foreground error must release boot readiness when leaving,
+      // but returning to its primary must retain the authentication recovery.
+      await selectLocal()
+      expect($desktopBoot.get().error).toBeNull()
+      expect($desktopBoot.get().visible).toBe(false)
+      expect(overlay.queryByRole('heading')).toBeNull()
+      await act(async () => {
+        await ensureGatewayForProfile('default')
+      })
+      expect($desktopBoot.get().error).toContain(error)
+
+      desktop.getGatewayWsUrl.mockImplementation(async conn => conn?.wsUrl ?? primaryConn.wsUrl)
+      act(() => FakeWebSocket.instances[0].drop())
+      await advanceBackoff()
+      expect($gatewayState.get()).toBe('open')
+      expect($desktopBoot.get().error).toBeNull()
+      expect(overlay.queryByRole('heading')).toBeNull()
+      await selectLocal()
+      await act(async () => {
+        await ensureGatewayForProfile('default')
+      })
+      expect($desktopBoot.get().error).toBeNull()
+    }
+  )
+})
+
 describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => {
   it('INITIAL boot against a dead VPS: getConnection hangs (waitForHermes) → app sits in the connecting combo, then fails', async () => {
     // The report's actual path: a fresh launch pointed at an unreachable VPS.

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -7,7 +7,7 @@ import {
 import { useEffect, useRef } from 'react'
 
 import { shouldApplyPostBootProgressError } from '@/components/boot-failure-reauth'
-import type { HermesConnection } from '@/global'
+import type { DesktopBootProgress, HermesConnection } from '@/global'
 import { HermesGateway } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
@@ -64,6 +64,7 @@ import {
   $activeSessionId,
   $connection,
   $currentCwd,
+  $gatewayState,
   $selectedStoredSessionId,
   $sessions,
   ensureDefaultWorkspaceCwd,
@@ -243,6 +244,21 @@ export function useGatewayBoot({
     // tick — a stale OAuth ticket fails every attempt and would otherwise stack
     // identical error toasts (and their haptics). Reset on the next clean open.
     let reauthNotified = false
+    // ponytail: only postboot primary auth belongs here; cold-start errors stay global.
+    let primaryReauthError: string | null = null
+
+    const syncPrimaryReauthError = () => {
+      if (!bootCompleted || !primaryReauthError) {
+        return
+      }
+
+      if (isActivePrimary()) {
+        failDesktopBoot(primaryReauthError)
+      } else if (activeGateway()?.connectionState === 'open' && $desktopBoot.get().error === primaryReauthError) {
+        completeDesktopBoot()
+      }
+    }
+
     // Raised once the reconnect loop has been failing for
     // RECONNECT_ESCALATE_AFTER_MS so we fire a single non-blocking toast.
     // Reset on a clean open or a manual/wake-driven reconnect.
@@ -407,10 +423,13 @@ export function useGatewayBoot({
         // through to the backoff in the finally block below — they must NOT
         // take the full-screen "couldn't start" path (locks reading/drafting).
         if (!cancelled && isGatewayReauthRequired(err) && !reauthNotified) {
-          reauthNotified = true
-          const message = err instanceof Error ? err.message : String(err)
-          failDesktopBoot(message)
-          notifyError(err, translateNow('boot.errors.gatewaySignInRequired'))
+          primaryReauthError = err instanceof Error ? err.message : String(err)
+          syncPrimaryReauthError()
+
+          if (isActivePrimary()) {
+            reauthNotified = true
+            notifyError(err, translateNow('boot.errors.gatewaySignInRequired'))
+          }
         }
       } finally {
         reconnecting = false
@@ -604,6 +623,7 @@ export function useGatewayBoot({
         reconnectFailingSince = null
         escalated = false
         reauthNotified = false
+        primaryReauthError = null
 
         gateway.close()
         // The primary mode is changing, but registered v2 sources remain
@@ -709,7 +729,11 @@ export function useGatewayBoot({
       }
     }
 
-    const offBootProgress = desktop.onBootProgress(payload => {
+    const onBootProgress = (payload: DesktopBootProgress) => {
+      if (cancelled) {
+        return
+      }
+
       // Soft switch / post-boot startHermes re-emits progress — ignore so the
       // cold-boot CONNECTING overlay stays down. Post-boot errors are gated:
       // only confirmed reauth takes the full-screen recovery surface. Transient
@@ -717,18 +741,26 @@ export function useGatewayBoot({
       // (otherwise a 1–3 min blip bricks reading/drafting behind "couldn't start").
       if ($gatewaySwitching.get() || bootCompleted) {
         if (payload.error && shouldApplyPostBootProgressError(payload.error)) {
-          applyDesktopBootProgress(payload)
+          primaryReauthError = payload.error
+
+          if (bootCompleted) {
+            syncPrimaryReauthError()
+          } else {
+            applyDesktopBootProgress(payload)
+          }
         }
 
         return
       }
 
       applyDesktopBootProgress(payload)
-    })
+    }
+
+    const offBootProgress = desktop.onBootProgress(onBootProgress)
 
     void desktop
       .getBootProgress()
-      .then(snapshot => applyDesktopBootProgress(snapshot))
+      .then(onBootProgress)
       .catch(() => undefined)
 
     setDesktopBootStep({
@@ -820,6 +852,9 @@ export function useGatewayBoot({
       }
     })
 
+    const offActiveGatewayReauth = $gateway.listen(syncPrimaryReauthError)
+    const offActiveStateReauth = $gatewayState.listen(syncPrimaryReauthError)
+
     const offState = gateway.onState(st => {
       // Mirror to the composer only while the primary is the active profile —
       // a background secondary reconnect mustn't flip the foreground state.
@@ -829,6 +864,7 @@ export function useGatewayBoot({
         reconnectAttempt = 0
         reconnectFailingSince = null
         reauthNotified = false
+        primaryReauthError = null
         escalated = false
         livenessProbeFailures = 0
         clearReconnectTimer()
@@ -1224,6 +1260,8 @@ export function useGatewayBoot({
       offConnectionApplied?.()
       offConnectionsChanged?.()
       offGatewayReconnect()
+      offActiveGatewayReauth()
+      offActiveStateReauth()
       offState()
       offEvent()
       offExit()


### PR DESCRIPTION
## What does this PR do?

An expired login on the saved primary gateway can put **“Hermes couldn't start” over the entire Desktop window even after the user has selected a healthy local gateway**. The local backend still answers requests, but the overlay prevents opening Settings or using the foreground workspace.

This change keeps post-startup authentication recovery attached to the affected primary. An already-open healthy secondary remains usable; returning to the affected primary still shows its sign-in recovery. Genuine initial-startup failures are unchanged.

**Why it matters / suggested P2:** this is failure isolation for supported multi-gateway use, not a cosmetic error-message change. Recovering the expired primary login is the existing escape; it should not be a prerequisite for using another working gateway.

## Related Issue

Related to #90149. #105139 and #102673 address connection switching/readiness and profile caches; neither changes these boot-error presentation paths. This PR is independently mergeable and does not replace those contributions.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: scope reconnect errors, progress events and delayed boot snapshots; preserve/restore primary recovery when foreground ownership changes.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx`: reproduce the blocked healthy-secondary case and retain ordinary-outage/primary-recovery controls.

## How to Test

1. Connect Desktop to a remote primary, then select a healthy local gateway.
2. Make the primary's WebSocket-ticket refresh fail with confirmed authentication expiry (401/403), while the local backend remains responsive.
3. **Before:** the global startup-error overlay intercepts Settings. **After:** local Settings opens; selecting the affected primary retains sign-in recovery.

Run against head `a8e46c6358bd4d34bcc61ee35908c49cbe8dc6a7`:

```sh
cd apps/desktop
npx --no-install vitest run src/app/gateway/hooks/use-gateway-boot.test.tsx src/components/boot-failure-reauth.test.ts
npm run typecheck
```

Published-head focused verification: **72 tests / 2 files passed**, plus all three Desktop TypeScript projects.

Additional isolated Electron evidence used the real renderer, preload, IPC, managed-local spawning and backend requests with a **synthetic** remote-auth facade: baseline 401 and 403 cases each failed the shell/Settings assertions while local ping succeeded; the unchanged reviewed fix passed **7/7 checks** in each case. Refusal and blackhole controls passed **17/17** each. The named checks cover: boot and hidden-window isolation; observing the actual ticket rejection; a successful managed-local ping; no foreground-blocking overlay; opening local Settings; and clean hidden-window completion. This is not a claim of testing the real hosted Cloud/OAuth service.

## Checklist


### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS; platform-independent renderer logic, no new native APIs

### Documentation & Housekeeping


- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline behavior comments updated; no new setup required)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

The regressions above were run against the baseline and the reviewed fix. `git diff --check` and the public-data/secret scan passed. Independent code review and isolated UI review were completed before publication. Private workspace screenshots are intentionally omitted; no user data or configuration is included.

No new dependencies, configuration keys or model-tool schemas. No Python source changes; the full Python suite was not run and its checklist item remains unchecked. macOS was executed; Windows/Linux were considered but not run locally. Live CI results are available in the PR checks rather than frozen here.
