### PR TITLE
fix(desktop): honour the last profile pick during an in-flight switch

### DIFF
--- a/apps/desktop/src/store/profile-last-intent.test.ts
+++ b/apps/desktop/src/store/profile-last-intent.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+import { deferred } from '../test/deferred'
+
+const { connect } = vi.hoisted(() => ({ connect: vi.fn() }))
+
+// Keep the real profile/gateway stores; only the transport and view effects are inert.
+vi.mock('@/hermes', () => ({
+  setApiRequestProfile: vi.fn(),
+  setApiRequestConnection: vi.fn(),
+  HermesGateway: class {
+    connectionState = 'closed'
+    connect = async (url: string) => {
+      await connect(url)
+      this.connectionState = 'open'
+    }
+    close = () => { this.connectionState = 'closed' }
+    onEvent = () => () => {}
+    onState = () => () => {}
+  }
+}))
+vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
+vi.mock('@/store/starmap', () => ({ resetStarmapGraph: vi.fn() }))
+
+const gateway = await import('./gateway')
+const { $activeGatewayProfile, ensureGatewayProfile } = await import('./profile')
+const { $connection } = await import('./session')
+
+const descriptor = (profile: string): HermesConnection => ({
+  authMode: 'token',
+  isFullscreen: false,
+  nativeOverlayWidth: 0,
+  logs: [],
+  windowButtonPosition: null,
+  baseUrl: `https://${profile}.invalid`,
+  mode: 'remote',
+  profile,
+  token: 'test-token',
+  wsUrl: `wss://${profile}.invalid/ws`
+})
+
+afterEach(() => {
+  gateway.closeSecondaryGateways()
+  vi.unstubAllGlobals()
+})
+
+it('returns to A when A is requested while B is still dialing', async () => {
+  const dial = deferred<void>()
+  connect.mockImplementationOnce(() => dial.promise)
+  const primary = { connectionState: 'open' }
+  gateway.configureGatewayRegistry({
+    onEvent: vi.fn(),
+    onActiveRouteChanged: profile => $activeGatewayProfile.set(profile)
+  })
+  gateway.setPrimaryGateway(primary as never, 'default')
+  await gateway.ensureGatewayForProfile('default')
+  $activeGatewayProfile.set('default')
+  const getConnection = vi.fn(async (profile: string) => descriptor(profile))
+  vi.stubGlobal('window', { hermesDesktop: { getConnection } })
+
+  const b = ensureGatewayProfile('work')
+  await vi.waitFor(() => expect(connect).toHaveBeenCalledOnce())
+  const a = ensureGatewayProfile('default')
+  dial.resolve()
+  await Promise.all([b, a])
+
+  expect($activeGatewayProfile.get()).toBe('default')
+  expect($connection.get()?.profile).toBe('default')
+  expect(gateway.activeGateway()).toBe(primary)
+  const calls = getConnection.mock.calls.length
+  await ensureGatewayProfile('default')
+  expect(getConnection).toHaveBeenCalledTimes(calls) // The post-mutex no-op still avoids redialing.
+})

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -547,10 +547,6 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     )
   }
 
-  if (routeAgrees()) {
-    return
-  }
-
   // Serialize concurrent activations so rapid session switches cannot race the
   // active pointer. Re-acquire after every wake: multiple waiters can observe
   // the same settled switch, and the first one starts the next switch before


### PR DESCRIPTION
## What does this PR do?

If profile A is active, the user starts switching to B, then selects A again before B finishes connecting, **Desktop can end on B despite the user's final selection being A**. The “already active” fast path runs before the pending-switch mutex, so the final A request is discarded.

Delete that redundant pre-mutex check. The existing check after the mutex still avoids unnecessary work once earlier activation has settled. Production code changes by four deleted lines; no new state or coordinator is introduced.

**Why it matters / suggested P2:** this is a reproducible wrong-profile activation race, not cosmetic flicker. The workaround is to wait for B to finish and select A again. It affects the legacy profile activation path; this PR does not claim universal registry-switch ordering or failure-reporting coverage.

## Related Issue

Related to #90149. The current patches for #105139 and #102673 do not change this pre-mutex early return. This is a separate, independently mergeable legacy activation-ordering fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/profile.ts`: remove the four-line early return before waiting for an in-flight switch.
- `apps/desktop/src/store/profile-last-intent.test.ts`: drive A → pending B → A through real profile/gateway/session stores; assert final profile, connection and socket identity, and the settled no-op behavior.

## How to Test

1. Start with profile A connected; hold B's connection completion.
2. Request B, then request A before releasing B.
3. Release B. **Before:** the regression finishes on `work` (B), not `default` (A). **After:** the final A request waits and then wins; a subsequent settled A request remains a no-op.

Run against head `4ce4d4fa1769faa55eeecbe37929e584213a7a0e`:

```sh
npm run test:ui -- src/store/profile-last-intent.test.ts src/store/profile.test.ts src/store/profile-switch-failure.test.ts src/store/profile-agent-activation.test.ts
npm run typecheck
```

Final-head verification: **35 tests / 4 files passed**, plus all three Desktop TypeScript projects and `git diff --check`. The new behavioral regression was independently run against the unchanged base and failed with `work` instead of `default`.

Transport/UI effects are synthetic; profile, gateway and session stores are real. Production build was not rerun for this store-only patch. Failed legacy dials retain their existing rejection behavior; unrelated registry disposal/supersession behavior is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:  macOS 26.3.1 (Apple Silicon); other operating systems not executed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline behavior comments updated; no new setup required)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A



## Screenshots / Logs

The regressions above were run against the baseline and the reviewed fix. `git diff --check` and the public-data/secret scan passed. Independent code review and isolated UI review were completed before publication. Private workspace screenshots are intentionally omitted; no user data or configuration is included.

No new dependencies, configuration keys or model-tool schemas. No Python source changes; the full Python suite was not run and its checklist item remains unchecked. macOS was executed; Windows/Linux were considered but not run locally. Live CI results are available in the PR checks rather than frozen here.

