### PR TITLE
fix(desktop): stop failed model changes overwriting newer selections

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -10,6 +10,7 @@ import {
   $currentModel,
   $currentProvider,
   getCurrentModelSource,
+  setComposerSelectionOwner,
   setCurrentModel,
   setCurrentModelSource,
   setCurrentProvider
@@ -79,7 +80,143 @@ function Harness({
 }
 
 describe('useModelControls', () => {
+  it.each(['reject', 'confirm', 'success', 'confirmed-reject', 'confirmed-success', 'owner'])(
+    'a stale %s for A cannot repaint or finish in foreground B',
+    async outcome => {
+      const response = deferred<Record<string, unknown>>()
+      const queryClient = new QueryClient()
+      const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+      const request = vi.fn().mockReturnValue(response.promise)
+      $activeGatewayProfile.set('alpha')
+      $activeSessionId.set('runtime-a')
+      setCurrentModel('a-old')
+      setCurrentProvider('provider-a')
+
+      const { result } = renderHook(() =>
+        useModelControls({
+          cacheOwnerConnectionId: 'connection-a',
+          cacheProfile: 'alpha',
+          queryClient,
+          requestGateway: request
+        })
+      )
+
+      if (outcome.startsWith('confirmed-')) {
+        request.mockResolvedValueOnce({ confirm_required: true })
+      }
+
+      let pending!: Promise<unknown>
+      await act(async () => {
+        pending = result.current.selectModel({ model: 'a-new', provider: 'provider-a' })
+
+        if (outcome.startsWith('confirmed-')) {
+          await pending
+          pending = notify.mock.calls.at(-1)![0].action.onClick()
+        }
+      })
+      act(() => {
+        if (outcome === 'owner') {
+          setComposerSelectionOwner('connection-b', 'alpha')
+        } else {
+          $activeGatewayProfile.set('beta')
+          $activeSessionId.set('runtime-b')
+        }
+
+        // Reused ids/model values cannot make a different owner current again.
+        setCurrentModel(outcome === 'owner' ? 'a-new' : 'b-model')
+        setCurrentProvider(outcome === 'owner' ? 'provider-a' : 'provider-b')
+      })
+      notify.mockClear()
+      await act(async () => {
+        if (outcome.endsWith('reject')) {
+          response.reject(new Error('A write failed'))
+        } else {
+          response.resolve(outcome === 'confirm' ? { confirm_required: true } : {})
+        }
+
+        await pending
+      })
+      expect([$currentProvider.get(), $currentModel.get()]).toEqual(
+        outcome === 'owner' ? ['provider-a', 'a-new'] : ['provider-b', 'b-model']
+      )
+      expect(queryClient.getQueryData(modelOptionsQueryKey('alpha', 'runtime-a', 'connection-a'))).toMatchObject({
+        model: 'a-new',
+        provider: 'provider-a'
+      })
+      expect(invalidate).not.toHaveBeenCalled()
+      expect(notify).not.toHaveBeenCalled()
+      expect(notifyError).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['reject', 'confirm', 'success', 'confirmed-reject', 'confirmed-success', 'warning'])(
+    'an older %s cannot override a newer same-row pick',
+    async outcome => {
+      const response = deferred<Record<string, unknown>>()
+      const queryClient = new QueryClient()
+      const request = vi.fn().mockReturnValueOnce(response.promise).mockResolvedValue({})
+      $activeSessionId.set('runtime-a')
+      setCurrentModel('old')
+      setCurrentProvider('provider-a')
+      const { result } = renderHook(() => useModelControls({ queryClient, requestGateway: request }))
+
+      if (outcome.startsWith('confirmed-') || outcome === 'warning') {
+        request
+          .mockReset()
+          .mockResolvedValueOnce({ confirm_required: true })
+          .mockReturnValueOnce(response.promise)
+          .mockResolvedValue({})
+      }
+
+      let pending!: Promise<unknown>
+      let confirm!: () => Promise<void>
+      await act(async () => {
+        pending = result.current.selectModel({ model: 'first', provider: 'provider-a' })
+
+        if (outcome.startsWith('confirmed-') || outcome === 'warning') {
+          await pending
+          confirm = notify.mock.calls.at(-1)![0].action.onClick
+
+          if (outcome !== 'warning') {
+            pending = confirm()
+          } else {
+            request.mockReset().mockResolvedValue({})
+          }
+        }
+      })
+      const newerModel = outcome === 'warning' ? 'old' : 'first'
+      await act(async () => {
+        await result.current.selectModel({ model: newerModel, provider: 'provider-a' })
+      })
+      const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
+      notify.mockClear()
+      await act(async () => {
+        if (outcome === 'warning') {
+          await confirm()
+          expect(request).toHaveBeenCalledTimes(1)
+        } else {
+          if (outcome.endsWith('reject')) {
+            response.reject(new Error('first failed'))
+          } else {
+            response.resolve(outcome === 'confirm' ? { confirm_required: true } : {})
+          }
+
+          await pending
+        }
+      })
+      expect($currentModel.get()).toBe(newerModel)
+      expect(queryClient.getQueryData(modelOptionsQueryKey('default', 'runtime-a'))).toMatchObject({
+        model: newerModel,
+        provider: 'provider-a'
+      })
+      expect(invalidate).not.toHaveBeenCalled()
+      expect(notify).not.toHaveBeenCalled()
+      expect(notifyError).not.toHaveBeenCalled()
+    }
+  )
   beforeEach(() => {
+    vi.clearAllMocks()
+    setComposerSelectionOwner('local', 'default')
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     setCurrentModel('')
@@ -91,6 +228,7 @@ describe('useModelControls', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    setComposerSelectionOwner('local', 'default')
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     setCurrentModel('')

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -11,6 +11,7 @@ import { notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
+  $connection,
   $currentModel,
   $currentProvider,
   getComposerSelectionGeneration,
@@ -183,7 +184,8 @@ export function useModelControls({
   // Returns whether the switch was applied so callers can await it before
   // applying follow-up changes. `true` means applied (or deferred/busy-queued
   // for the next turn). `false` means NOT applied — either pending
-  // confirmation (warning with Confirm action already shown, pill rolled back)
+  // confirmation (warning with Confirm action already shown, pill rolled back),
+  // stale (a newer selection or foreground owns any follow-up),
   // or a real failure (error toast). Callers must NOT treat `false` as a
   // generic failure: for `pending` the gateway intentionally returned
   // `confirm_required` and no error should be surfaced.
@@ -211,12 +213,32 @@ export function useModelControls({
 
       const prevSource = getCurrentModelSource()
       const liveGatewayProfile = cacheProfile || $activeGatewayProfile.get()
+      const activeProfile = $activeGatewayProfile.get()
+      const connectionId = $connection.get()?.connectionId
+      let selectionGeneration = getComposerSelectionGeneration()
+      let expectedModel = selection.model
+      let expectedProvider = selection.provider
+
+      // ponytail: reuse the composer intent token; values alone miss a same-row reselect.
+      const isStale = () =>
+        touchesPrimary
+          ? $activeSessionId.get() !== primaryRuntimeId ||
+            $activeGatewayProfile.get() !== activeProfile ||
+            $connection.get()?.connectionId !== connectionId ||
+            getComposerSelectionGeneration() !== selectionGeneration ||
+            $currentModel.get() !== expectedModel ||
+            $currentProvider.get() !== expectedProvider
+          : false
 
       const paintSelection = () => {
+        expectedModel = selection.model
+        expectedProvider = selection.provider
+
         if (touchesPrimary) {
           setCurrentModel(selection.model)
           setCurrentProvider(selection.provider)
           markComposerSelectionManual()
+          selectionGeneration = getComposerSelectionGeneration()
         } else if (liveSessionId) {
           // Optimistic tile paint — session.info will confirm; rollback on error.
           sessionTileDelegate()?.updateSession(liveSessionId, state => ({
@@ -232,6 +254,13 @@ export function useModelControls({
       }
 
       const rollbackSelection = () => {
+        if (isStale()) {
+          return
+        }
+
+        expectedModel = prevModel
+        expectedProvider = prevProvider
+
         if (touchesPrimary) {
           setCurrentModel(prevModel)
           setCurrentProvider(prevProvider)
@@ -281,6 +310,10 @@ export function useModelControls({
         })
 
       const finishSwitch = (result: ModelSwitchResponse | undefined) => {
+        if (isStale()) {
+          return
+        }
+
         // A pick made DURING a turn is queued by the gateway and applied at the
         // next turn start (`deferred`). Re-fetching now would answer with the
         // model still running and repaint the old name over the user's choice —
@@ -296,6 +329,10 @@ export function useModelControls({
       try {
         const result = await requestSwitch()
 
+        if (isStale()) {
+          return false
+        }
+
         if (result?.confirm_required) {
           rollbackSelection()
           // ONE shared applier for guarded switches (#95293): the same
@@ -306,18 +343,12 @@ export function useModelControls({
             confirmMessage: result.confirm_message,
             failureMessage: copy.modelSwitchFailed,
             finish: finishSwitch,
-            // Staleness guard — the warning can linger while the user picks
-            // a different model or switches sessions. Clicking Confirm must
-            // not clobber the newer choice: bail if the live state no longer
-            // matches the snapshot this notification was created for.
             isStale: () =>
-              touchesPrimary
-                ? $activeSessionId.get() !== liveSessionId ||
-                  $currentModel.get() !== prevModel ||
-                  $currentProvider.get() !== prevProvider
-                : !liveSessionId ||
-                  $sessionStates.get()[liveSessionId]?.model !== prevModel ||
-                  $sessionStates.get()[liveSessionId]?.provider !== prevProvider,
+              isStale() ||
+              (!touchesPrimary &&
+                (!liveSessionId ||
+                  $sessionStates.get()[liveSessionId]?.model !== expectedModel ||
+                  $sessionStates.get()[liveSessionId]?.provider !== expectedProvider)),
             repaint: () => {
               paintSelection()
               cacheSelection(selection.provider, selection.model)
@@ -333,6 +364,10 @@ export function useModelControls({
 
         return true
       } catch (err) {
+        if (isStale()) {
+          return false
+        }
+
         // An OLDER gateway refuses a mid-turn switch outright (4009) instead of
         // deferring it. Don't punish the user for a backend they haven't
         // updated: keep the pick painted as the composer's selection, which is

--- a/apps/desktop/src/lib/guarded-model-switch.ts
+++ b/apps/desktop/src/lib/guarded-model-switch.ts
@@ -65,12 +65,20 @@ export function surfaceModelSwitchConfirm<T extends GuardedModelSwitchResult>(
     try {
       const result = await options.requestConfirmed()
 
+      if (options.isStale?.()) {
+        return
+      }
+
       if (result?.confirm_required) {
         throw new Error(result.confirm_message?.trim() || options.failureMessage)
       }
 
       options.finish?.(result)
     } catch (err) {
+      if (options.isStale?.()) {
+        return
+      }
+
       options.rollback?.()
       notifyError(err, options.failureMessage)
     }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1148,6 +1148,7 @@ function rescopeComposerSelection(nextScope: string | null): void {
     return
   }
 
+  composerSelectionGeneration += 1
   composerSelectionScope = nextScope
   $currentModel.set(storedComposerString(COMPOSER_MODEL_KEY) ?? '')
   $currentProvider.set(storedComposerString(COMPOSER_PROVIDER_KEY) ?? '')


### PR DESCRIPTION
## What does this PR do?

A model-change request can finish after the user has selected another model or moved to a different foreground session/gateway. Its delayed error or confirmation currently rolls back the **current** composer rather than only the original operation, so an older failed request can overwrite a newer successful selection or repaint another session's provider/model.

Use the existing composer intent generation together with captured owner/runtime identity to reject stale completion, rollback and confirmation callbacks. Changing owner invalidates the old intent; reselecting the same model is still a distinct choice.

**Why it matters / suggested P2:** this is cross-session selection-state integrity, not a cosmetic stale label. Users can work around it by waiting for outstanding changes to settle and reselecting the intended model. The fix does not change backend persistence policy, cancel already-issued backend work, or claim a data-loss/security incident.

## Related Issue

Related to #90149. #101544/#101796 cover persistence/selection state, #100518 reseeding, and #104654 runtime-to-pill synchronization. This PR targets delayed mutation completion and rollback, not those policies. The reviewed relevant patches do not guard this path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-model-controls.ts`: guard primary mutation results and rollback by captured owner/runtime/intent, including expensive-model confirmation.
- `apps/desktop/src/store/session.ts`: advance the existing intent generation when composer ownership changes.
- `apps/desktop/src/lib/guarded-model-switch.ts`: honour the supplied staleness predicate after confirmed asynchronous operations; callers without a predicate keep existing behavior.
- `apps/desktop/src/app/session/hooks/use-model-controls.test.tsx`: reproduce late failure/confirmation/success after owner changes and newer or same-row selections.

## How to Test

1. Start a model switch in session A and leave the request pending.
2. Open session B, or successfully make a newer selection in A.
3. Reject the older request (also covered: delayed confirmation/success). **Before:** the old rollback restores A's previous provider/model over the current selection. **After:** stale work cannot repaint or roll back the newer foreground intent.

Run against head `b8f3230aaff6a78d4e8c78f382519f86eea1f897`:

```sh
npm run test:ui -- src/app/session/hooks/use-model-controls.test.tsx src/app/shell/model-catalog-menu.test.tsx src/app/shell/model-catalog-menu.search-fold.test.tsx
npm run typecheck
npm run build
```

Published-head verification: **44 tests / 3 files passed**, all three Desktop TypeScript projects and the production build passed. The expanded baseline regression had **12 failing parameter rows** before the fix; the reviewed patch is unchanged after rebase.

An earlier broader UI run had two `voice-prefs.test.ts` failures reproduced on the unchanged base; no full-suite-green claim is made. Reasoning/fast-setting rollback and general overlapping secondary-tile mutation ordering are outside this primary-model fix. The shared confirmation helper applies its new post-await staleness check to every caller that supplies `isStale`, including guarded secondary confirmations. The shared confirmation helper's existing bot caller supplies no staleness predicate and retains its behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:  macOS 26.3.1 (Apple Silicon); other operating systems not executed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline behavior comments updated; no new setup required)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A



## Screenshots / Logs

The regressions above were run against the baseline and the reviewed fix. `git diff --check` and the public-data/secret scan passed. Independent code review and isolated UI review were completed before publication. Private workspace screenshots are intentionally omitted; no user data or configuration is included.

No new dependencies, configuration keys or model-tool schemas. No Python source changes; the full Python suite was not run and its checklist item remains unchecked. macOS was executed; Windows/Linux were considered but not run locally. Live CI results are available in the PR checks rather than frozen here.
