### PR TITLE
fix(docx): validate comment style references

### DIFF
--- a/skills/productivity/docx/scripts/docx_validate.py
+++ b/skills/productivity/docx/scripts/docx_validate.py
@@ -13,8 +13,9 @@ Checks (health-check tier, NOT full XSD schema validation):
   - r:embed / r:id references in document.xml resolve to relationships
   - embedded images are non-empty and start with known magic bytes
     (PNG/JPEG/GIF/BMP/TIFF/EMF/WMF/SVG); no PIL required
-  - paragraph and run style ids referenced by the document exist in
-    styles.xml
+  - paragraph, run, and table style ids referenced by document.xml and
+    optional comments.xml exist in styles.xml; malformed comments XML is
+    reported without stopping the remaining checks
 
 Output: {"ok": bool, "issues": [{"severity": "error"|"warning", ...}]}
 Exit code 1 when any error-severity issue is found (warnings exit 0).
@@ -122,14 +123,25 @@ def validate(path: str) -> dict:
         styles_root = etree.fromstring(zf.read("word/styles.xml"))
         defined = {s.get(f"{{{W}}}styleId")
                    for s in styles_root.iter(f"{{{W}}}style")}
-    for tag, attr in ((f"{{{W}}}pStyle", f"{{{W}}}val"),
-                      (f"{{{W}}}rStyle", f"{{{W}}}val"),
-                      (f"{{{W}}}tblStyle", f"{{{W}}}val")):
-        for el in doc_root.iter(tag):
-            sid = el.get(attr)
-            if sid and sid not in defined:
-                _issue(issues, "error", "missing-style",
-                       f"style id referenced but not defined: {sid}")
+    style_roots = [("word/document.xml", doc_root)]
+    if "word/comments.xml" in names:
+        try:
+            comments_root = etree.fromstring(zf.read("word/comments.xml"))
+        except etree.XMLSyntaxError as exc:
+            _issue(issues, "error", "bad-comments-xml", f"word/comments.xml: {exc}")
+        else:
+            style_roots.append(("word/comments.xml", comments_root))
+    for part_name, style_root in style_roots:
+        for tag, attr in ((f"{{{W}}}pStyle", f"{{{W}}}val"),
+                          (f"{{{W}}}rStyle", f"{{{W}}}val"),
+                          (f"{{{W}}}tblStyle", f"{{{W}}}val")):
+            for el in style_root.iter(tag):
+                sid = el.get(attr)
+                if sid and sid not in defined:
+                    detail = f"style id referenced but not defined: {sid}"
+                    if part_name == "word/comments.xml":
+                        detail = f"{part_name}: {detail}"
+                    _issue(issues, "error", "missing-style", detail)
 
     # --- python-docx can open it ------------------------------------------
     try:

--- a/tests/skills/test_docx_skill.py
+++ b/tests/skills/test_docx_skill.py
@@ -1,0 +1,208 @@
+"""Behavioral unit tests for DOCX style-reference health checks.
+
+ZIP and XML parsing are real. Optional dependency adapters isolate this
+unit from python-docx opening and lxml-specific parsing behavior; these
+are not full package integration tests.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+from unittest.mock import Mock, patch
+import xml.etree.ElementTree as ET
+import zipfile
+
+import pytest
+
+
+W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PR = "http://schemas.openxmlformats.org/package/2006/relationships"
+CT = "http://schemas.openxmlformats.org/package/2006/content-types"
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/docx/scripts/docx_validate.py"
+)
+
+
+@pytest.fixture
+def validator():
+    class XMLSyntaxError(Exception):
+        pass
+
+    def fromstring(data):
+        try:
+            return ET.fromstring(data)
+        except ET.ParseError as exc:
+            raise XMLSyntaxError(str(exc)) from exc
+
+    etree = types.ModuleType("lxml.etree")
+    etree.fromstring = fromstring
+    etree.XMLSyntaxError = XMLSyntaxError
+    lxml = types.ModuleType("lxml")
+    lxml.etree = etree
+    docx = types.ModuleType("docx")
+    docx.Document = Mock()
+    with patch.dict(sys.modules, {"lxml": lxml, "lxml.etree": etree, "docx": docx}):
+        spec = importlib.util.spec_from_file_location("docx_validator_unit", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        yield module, docx.Document
+
+
+def _content(tag=None, sid=None):
+    text = "<w:r><w:t>Probe</w:t></w:r>"
+    if tag == "pStyle":
+        return f'<w:p><w:pPr><w:pStyle w:val="{sid}"/></w:pPr>{text}</w:p>'
+    if tag == "rStyle":
+        return (
+            f'<w:p><w:r><w:rPr><w:rStyle w:val="{sid}"/></w:rPr>'
+            "<w:t>Probe</w:t></w:r></w:p>"
+        )
+    if tag == "tblStyle":
+        return (
+            f'<w:tbl><w:tblPr><w:tblStyle w:val="{sid}"/></w:tblPr>'
+            '<w:tblGrid><w:gridCol w:w="1000"/></w:tblGrid>'
+            f"<w:tr><w:tc><w:p>{text}</w:p></w:tc></w:tr></w:tbl>"
+        )
+    return f"<w:p>{text}</w:p>"
+
+
+def _package(tmp_path, *, body=(None, None), comments=None, defined=()):
+    """Construct coherent relationships; missing styles are deliberate."""
+    path = tmp_path / "probe.docx"
+    body_xml = _content(*body)
+    if comments is not None:
+        body_xml += (
+            '<w:p><w:commentRangeStart w:id="0"/><w:r><w:t>Anchor</w:t></w:r>'
+            '<w:commentRangeEnd w:id="0"/>'
+            '<w:r><w:commentReference w:id="0"/></w:r></w:p>'
+        )
+    overrides = "".join(
+        f'<Override PartName="/word/{part}.xml" '
+        f'ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.{kind}+xml"/>'
+        for part, kind in [("document", "document.main"), ("styles", "styles")]
+        + ([("comments", "comments")] if comments is not None else [])
+    )
+    rels = f'<Relationship Id="rStyles" Type="{R}/styles" Target="styles.xml"/>'
+    if comments is not None:
+        rels += f'<Relationship Id="rComments" Type="{R}/comments" Target="comments.xml"/>'
+    styles = "".join(
+        f'<w:style w:type="paragraph" w:styleId="{sid}"><w:name w:val="{sid}"/></w:style>'
+        for sid in defined
+    )
+    parts = {
+        "[Content_Types].xml": (
+            f'<Types xmlns="{CT}"><Default Extension="rels" '
+            'ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+            f'<Default Extension="xml" ContentType="application/xml"/>{overrides}</Types>'
+        ),
+        "_rels/.rels": (
+            f'<Relationships xmlns="{PR}"><Relationship Id="rDoc" '
+            f'Type="{R}/officeDocument" Target="word/document.xml"/></Relationships>'
+        ),
+        "word/document.xml": f'<w:document xmlns:w="{W}"><w:body>{body_xml}<w:sectPr/></w:body></w:document>',
+        "word/_rels/document.xml.rels": f'<Relationships xmlns="{PR}">{rels}</Relationships>',
+        "word/styles.xml": f'<w:styles xmlns:w="{W}">{styles}</w:styles>',
+    }
+    if comments is not None:
+        parts["word/comments.xml"] = comments
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, xml in parts.items():
+            zf.writestr(name, xml.encode("utf-8"))
+    return path
+
+
+def _comments(tag=None, sid=None):
+    return (
+        f'<w:comments xmlns:w="{W}"><w:comment w:id="0" w:author="Tester">'
+        f"{_content(tag, sid)}</w:comment></w:comments>"
+    )
+
+
+def _run(validator, path, capsys):
+    module, document_open = validator
+    before = path.read_bytes()
+    with patch.object(sys, "argv", [str(SCRIPT), str(path)]):
+        rc = module.main()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    report = json.loads(captured.out)
+    document_open.assert_called_once_with(str(path))
+    assert path.read_bytes() == before
+    return rc, report
+
+
+@pytest.mark.parametrize(
+    "part,tag,defined",
+    [
+        pytest.param(None, None, False, id="A-no-comments"),
+        pytest.param("comments", "pStyle", True, id="B-defined-comment-pStyle"),
+        pytest.param("comments", "pStyle", False, id="C-missing-comment-pStyle"),
+        pytest.param("comments", "rStyle", False, id="D-missing-comment-rStyle"),
+        pytest.param("comments", "tblStyle", False, id="E-missing-comment-tblStyle"),
+        pytest.param("body", "pStyle", False, id="F-missing-body-pStyle"),
+        pytest.param("body", "rStyle", False, id="G-missing-body-rStyle"),
+        pytest.param("body", "tblStyle", False, id="H-missing-body-tblStyle"),
+    ],
+)
+def test_style_references_in_optional_comments_and_body(
+    tmp_path, capsys, validator, part, tag, defined
+):
+    sid = "ProbeStyle"
+    comments = _comments(tag, sid) if part == "comments" else None
+    path = _package(
+        tmp_path,
+        body=(tag, sid) if part == "body" else (None, None),
+        comments=comments,
+        defined=(sid,) if defined else (),
+    )
+    rc, report = _run(validator, path, capsys)
+    if part is None or defined:
+        assert rc == 0
+        assert report == {"ok": True, "issues": []}
+    else:
+        assert rc == 1
+        assert report["ok"] is False
+        assert any(
+            issue["severity"] == "error"
+            and issue["code"] == "missing-style"
+            and sid in issue["detail"]
+            and (part != "comments" or "comments.xml" in issue["detail"])
+            for issue in report["issues"]
+        )
+    if part is None:
+        with zipfile.ZipFile(path) as zf:
+            assert "word/comments.xml" not in zf.namelist()
+            assert b"comments" not in zf.read("word/_rels/document.xml.rels")
+            assert b"comments" not in zf.read("[Content_Types].xml")
+
+
+@pytest.mark.parametrize(
+    "missing_body", [pytest.param(False, id="I-malformed-comments"),
+                     pytest.param(True, id="J-malformed-comments-continue-body")]
+)
+def test_malformed_comments_report_and_continue(tmp_path, capsys, validator, missing_body):
+    path = _package(
+        tmp_path,
+        body=("pStyle", "GhostBodyStyle") if missing_body else (None, None),
+        comments=f'<w:comments xmlns:w="{W}"><w:comment>',
+    )
+    rc, report = _run(validator, path, capsys)
+    assert rc == 1
+    assert report["ok"] is False
+    assert any(
+        issue["severity"] == "error"
+        and issue["code"] == "bad-comments-xml"
+        and "word/comments.xml" in issue["detail"]
+        for issue in report["issues"]
+    )
+    if missing_body:
+        assert any(
+            issue["severity"] == "error"
+            and issue["code"] == "missing-style"
+            and "GhostBodyStyle" in issue["detail"]
+            for issue in report["issues"]
+        )


### PR DESCRIPTION
## What does this PR do?

`docx_validate.py` currently checks `pStyle`, `rStyle`, and `tblStyle` references from `word/document.xml` against `word/styles.xml`, but does not apply the same health-check to style references in `word/comments.xml`.

This change makes `comments.xml` style references checked consistently with `document.xml` while keeping the validator's existing health-check scope. It does not turn the helper into full DOCX or XSD validation.

## Related Issue

No exact pre-existing issue was found in the bounded search for this `comments.xml` style-reference gap. The repository issue route is available, but this PR does not invent or link an unrelated issue and makes no `Fixes #` claim.

Related work: PR #102236 is open and concerns footnote-ID validation in the same validator file. Its scope is footnotes rather than `comments.xml` `pStyle` / `rStyle` / `tblStyle` coverage, so it is treated as partial same-file overlap rather than an equivalent fix or owner of this change.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/productivity/docx/scripts/docx_validate.py`
  - extends the existing style-reference health-check to optional `word/comments.xml`;
  - checks comment `pStyle`, `rStyle`, and `tblStyle` references against the same defined-style set used for `document.xml`;
  - reports malformed `comments.xml` while preserving body-style checks.
- `tests/skills/test_docx_skill.py`
  - adds focused regression coverage for valid and missing comment/body style references and malformed-comments behavior.

Only these two files are in scope.

## How to Test

Evidence completed for this candidate:

1. **Synthetic reproduction on the unpatched validator** — macOS 13.7.8 x86_64, `python-docx 1.2.0`, `lxml 6.1.2`:
   - a missing custom style referenced only from `comments.xml` passed silently;
   - the equivalent missing style in `document.xml` produced `missing-style`.
2. **RED regression run** — 10 cases collected; 5 passed and the 5 expected pre-fix cases failed (`C`, `D`, `E`, `I`, `J`), with no import/collection/environment failure.
3. **Focused GREEN** — `scripts/run_tests.sh tests/skills/test_docx_skill.py -q` completed with 10/10 passing.
4. **Real CLI integration A–J** — 10 real `docx_validate.py` CLI invocations on Linux x86_64 with Python 3.11.15, `python-docx 1.2.0`, and `lxml 6.1.3`; all ten produced the expected exit code and JSON diagnostics, with no retries, unexpected stderr, or traceback.
5. **Static evidence** — diff check, Python compile, Ruff, Windows-footgun scan, and compatibility-pointer check passed.
6. **Type-check advisory** — `ty` returned 9 diagnostics. They were preserved and adjudicated rather than hidden or fixed in this candidate; this PR does not claim a clean `ty` result.

Validation status is intentionally explicit:

- `HISTORICAL_FULL_SUITE=NON-GREEN` — 46,153 tests passed, 12 failed, 443 skipped, and one file had collection/setup errors in the repository-wide validation run.
- `FULL_SUITE_RECLASSIFIED_AS_PASS=NO` — the historical full-suite result is not presented as passing.
- `ALL_TESTS_PASS_CHECKBOX=UNCHECKED` — the all-tests-pass checklist item below remains unchecked.
- `PATCH_CAUSAL_EXCLUSION=COMPLETE_FOR_OBSERVED_FINAL_FAILURE_SET` — matched candidate/pristine comparisons reproduced the observed final failure set and collection failure on pristine; this does not claim a green full suite.

No GitHub CI result is claimed here. The canonical repository-wide suite was not rerun for this publication.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not claimed**; the historical canonical full repository suite was non-green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64 for real CLI A–J; macOS 13.7.8 x86_64 for the original synthetic reproduction. Native Windows runtime execution was not performed; the Windows-footgun static check passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the validator health-check docstring was updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture/workflow rule changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure ZIP/XML validator path; native Windows runtime was not claimed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-tool schema changed

## Screenshots / Logs

No screenshots. The validation results above summarize the focused RED/GREEN runs, static checks, and real CLI A–J results. The historical repository-wide validation result remains explicitly non-green, and no all-tests-pass claim is made.
