### PR TITLE
fix(state): reconcile NOT NULL columns via a per-column legacy backfill

### DIFF
--- a/hermes_cli/web_server_sessions.py
+++ b/hermes_cli/web_server_sessions.py
@@ -84,9 +84,11 @@ def _session_db_read_probe_statements() -> tuple:
 
 
 # Stores where a heal WRITABLE OPEN SUCCEEDED but the read probe still failed:
-# one reconciliation cannot fix them (e.g. a NOT-NULL-without-default column),
-# so they fall back to the raw read-only open until restart instead of paying
-# a writable init per poll. A FAILED writable open (transient lock) is NOT
+# one reconciliation cannot fix them (e.g. a NOT-NULL-without-DEFAULT column
+# with no SessionSchemaMixin._NOT_NULL_BACKFILL entry, which SQLite refuses to
+# ADD), so they fall back to the raw read-only open until restart instead of
+# paying a writable init per poll. A FAILED writable open (transient lock, or
+# an executescript(SCHEMA_SQL) error before the reconciler runs) is NOT
 # recorded — the next poll retries the heal.
 _session_db_heal_exhausted: set = set()
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -487,8 +487,6 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     delivery_claimed_at REAL
 );
 
-CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
-CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
@@ -510,7 +508,11 @@ CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
 """
 
 # Indexes on later-added columns must run AFTER _reconcile_columns(), or executescript fails on legacy DBs.
+# That includes every column SessionSchemaMixin._NOT_NULL_BACKFILL can ADD: an index on it in
+# SCHEMA_SQL would fail with "no such column" before the reconciler gets to heal the column.
 DEFERRED_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
+CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_messages_session_active
     ON messages(session_id, active, timestamp);
 CREATE INDEX IF NOT EXISTS idx_messages_active_null

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -14,7 +14,7 @@ import sqlite3
 import tempfile
 import time
 import uuid
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 
 from hermes_constants import get_hermes_home
@@ -658,6 +658,39 @@ class SessionSchemaMixin:
                 os.replace(tmp, cache_path)
         return table_columns
 
+    # Legacy-row literals for NOT NULL columns SCHEMA_SQL declares without a DEFAULT. SQLite refuses
+    # ``ADD COLUMN x TEXT NOT NULL`` outright ("Cannot add a NOT NULL column with default value
+    # NULL"), so a table that predates such a column can only be reconciled when a domain-valid
+    # value for rows written before the column existed is declared HERE, per column. Nothing is
+    # derived from the SQL type: '' / 0 are not valid history for timestamps, heartbeat liveness,
+    # lease holders/expiry, routing JSON or message roles, and a value SQLite accepts is no
+    # evidence the row is semantically right (#101409). A column without an entry stays
+    # unreconciled and the WARNING in _reconcile_columns fires (fail closed).
+    #
+    # sessions.source: 'unknown' is ensure_session's default for an unrecorded origin and is
+    # deliberately absent from SessionDB._AUTO_PRUNE_STALE_OPEN_SOURCES (#60609), so legacy rows
+    # stay outside state-owned stale-open reaping instead of being promoted to a lifecycle owner
+    # such as 'cli'. Any index on an allowlisted column belongs in DEFERRED_INDEX_SQL, not
+    # SCHEMA_SQL, or executescript fails on the legacy store before this code runs.
+    _NOT_NULL_BACKFILL: Dict[Tuple[str, str], str] = {
+        ("sessions", "source"): "'unknown'",
+    }
+
+    @classmethod
+    def _addable_column_ddl(cls, table: str, column: str, col_type: str) -> str:
+        """*col_type* as reconstructed by ``_parse_schema_columns`` (``TEXT NOT NULL``), made
+        ADDable when a legacy value is declared: a NOT NULL column without a DEFAULT that has a
+        ``_NOT_NULL_BACKFILL`` entry gets ``DEFAULT <literal>`` so SQLite accepts the ALTER and
+        backfills existing rows in the same statement. Nullable columns, columns that already
+        carry a DEFAULT, and NOT NULL columns with no declared backfill are returned unchanged
+        (the latter still fail the ALTER, which _reconcile_columns reports)."""
+        if "NOT NULL" not in col_type or "DEFAULT" in col_type:
+            return col_type
+        literal = cls._NOT_NULL_BACKFILL.get((table, column))
+        if literal is None:
+            return col_type
+        return f"{col_type} DEFAULT {literal}"
+
     def _reconcile_columns(self, cursor: sqlite3.Cursor) -> None:
         """ADD every SCHEMA_SQL column missing from the live tables (SCHEMA_SQL is the single
         source of truth; column additions need no version-gated migration)."""
@@ -672,8 +705,9 @@ class SessionSchemaMixin:
             for col_name, col_type in declared_cols.items():
                 if col_name in live_cols:
                     continue
+                col_ddl = self._addable_column_ddl(table_name, col_name, col_type)
                 try:
-                    cursor.execute(f'ALTER TABLE "{table_name}" ADD COLUMN {_q(col_name)} {col_type}')
+                    cursor.execute(f'ALTER TABLE "{table_name}" ADD COLUMN {_q(col_name)} {col_ddl}')
                 except sqlite3.OperationalError as exc:
                     message = str(exc).lower()
                     if "duplicate column" in message:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1967,6 +1967,200 @@ class TestReconcileColumnsErrorHandling:
         assert "last_read_at" in cols
 
 
+class TestReconcileNotNullWithoutDefault:
+    """A NOT NULL column SCHEMA_SQL declares without a DEFAULT is ADDable only by policy.
+
+    SQLite rejects ``ALTER TABLE ... ADD COLUMN x TEXT NOT NULL`` outright
+    ("Cannot add a NOT NULL column with default value NULL"), so a store whose
+    table predates such a column could never be reconciled: the reconciler
+    warned on every open and the store stayed behind SCHEMA_SQL. The fix is
+    explicit per column (``_NOT_NULL_BACKFILL``): a column with a declared,
+    domain-valid legacy value is ADDed with that value as DEFAULT so existing
+    rows are filled in the same DDL; a column without one stays unreconciled
+    and keeps the loud WARNING (fail closed, no value is manufactured from the
+    SQL type).
+    """
+
+    # NOT NULL / no-DEFAULT columns that predate this policy. None has a declared legacy value: a
+    # store missing one stays behind SCHEMA_SQL with the WARNING rather than receiving a made-up
+    # timestamp, heartbeat, holder, role or state. Adding a NOT NULL column to SCHEMA_SQL without a
+    # DEFAULT must either declare its backfill in _NOT_NULL_BACKFILL or be added here knowingly.
+    _FAIL_CLOSED = frozenset({
+        ("schema_version", "version"),
+        ("system_prompts", "prompt"),
+        ("sessions", "started_at"),
+        ("messages", "session_id"), ("messages", "role"), ("messages", "timestamp"),
+        ("gateway_routing", "entry_json"), ("gateway_routing", "updated_at"),
+        ("gateway_heartbeats", "pid"), ("gateway_heartbeats", "started_at"),
+        ("gateway_heartbeats", "last_heartbeat"),
+        ("compression_locks", "holder"), ("compression_locks", "acquired_at"),
+        ("compression_locks", "expires_at"),
+        ("session_turn_leases", "holder"), ("session_turn_leases", "acquired_at"),
+        ("session_turn_leases", "expires_at"),
+        ("async_delegations", "origin_session"), ("async_delegations", "state"),
+        ("async_delegations", "dispatched_at"), ("async_delegations", "updated_at"),
+    })
+
+    @staticmethod
+    def _strip_column(db_path, table, column):
+        """Rebuild *table* without *column* (DROP COLUMN refuses indexed columns).
+
+        legacy_alter_table keeps views/triggers pointing at the original table
+        name, mirroring a store whose CREATE TABLE simply predates the column.
+        Indexes on the column go with the old table, as on such a store.
+        """
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("PRAGMA foreign_keys=OFF")
+            conn.execute("PRAGMA legacy_alter_table=ON")
+            keep = [
+                r[1] for r in conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+                if r[1] != column
+            ]
+            ddl = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()[0]
+            legacy_ddl = "\n".join(
+                line for line in ddl.splitlines()
+                if not line.strip().startswith(f"{column} ")
+            )
+            cols = ", ".join(f'"{c}"' for c in keep)
+            conn.execute(f'ALTER TABLE "{table}" RENAME TO "{table}_legacy"')
+            conn.execute(legacy_ddl)
+            conn.execute(f'INSERT INTO "{table}" ({cols}) SELECT {cols} FROM "{table}_legacy"')
+            conn.execute(f'DROP TABLE "{table}_legacy"')
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _column_info(conn, table, column):
+        for row in conn.execute(f'PRAGMA table_info("{table}")').fetchall():
+            if row[1] == column:
+                return row  # (cid, name, type, notnull, dflt_value, pk)
+        return None
+
+    def test_store_lacking_sessions_source_heals_on_open_as_unknown(self, tmp_path, caplog):
+        """The allowlisted column, end to end through the public open path.
+
+        On base the plain ``SessionDB(db_path)`` open of such a store never
+        reaches the reconciler: ``executescript(SCHEMA_SQL)`` fails first on
+        ``idx_sessions_source`` ("no such column: source"). Those indexes now
+        live in DEFERRED_INDEX_SQL, the column is re-ADDed NOT NULL with
+        ``'unknown'`` for every legacy row, and the negative control shows
+        those rows stay outside state-owned stale-open reaping (they are
+        unrecorded provenance, not a promoted lifecycle owner).
+        """
+        import logging
+
+        from hermes_state_schema import schema_read_probe_statements
+
+        db_path = tmp_path / "state.db"
+        seed = SessionDB(db_path=db_path)
+        seed.create_session("legacy-cli", source="cli")
+        seed.create_session("legacy-telegram", source="telegram")
+        seed._conn.execute("UPDATE sessions SET started_at = 1.0, last_activity_at = 1.0")
+        seed._conn.commit()
+        seed.close()
+        self._strip_column(db_path, "sessions", "source")
+        probe = sqlite3.connect(str(db_path))
+        try:
+            assert self._column_info(probe, "sessions", "source") is None
+        finally:
+            probe.close()
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            healed = SessionDB(db_path=db_path)
+        try:
+            conn = healed._conn
+            info = self._column_info(conn, "sessions", "source")
+            assert info is not None, "sessions.source must be ADDed by the open"
+            assert info[3] == 1, "sessions.source must stay NOT NULL"
+            assert {r[0] for r in conn.execute("SELECT source FROM sessions")} == {"unknown"}
+            # The deferred indexes on the healed column exist, and the read probe passes.
+            live_indexes = {
+                r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")
+            }
+            assert {"idx_sessions_source", "idx_sessions_source_id"} <= live_indexes
+            for statement in schema_read_probe_statements():
+                conn.execute(statement).fetchone()
+
+            # Negative control: legacy rows are old enough to reap, but 'unknown' is not a
+            # state-owned source, so the automatic sweep leaves them open while it closes a
+            # genuinely CLI-owned row of the same age.
+            assert "unknown" not in SessionDB._AUTO_PRUNE_STALE_OPEN_SOURCES
+            healed.create_session("owned-cli", source="cli")
+            conn.execute(
+                "UPDATE sessions SET started_at = 1.0, last_activity_at = 1.0 WHERE id = 'owned-cli'"
+            )
+            conn.commit()
+            closed = healed.sweep_orphaned_sessions(
+                max_idle_seconds=60.0, sources=SessionDB._AUTO_PRUNE_STALE_OPEN_SOURCES,
+                exclude_pinned=True, respect_gateway_heartbeats=False,
+            )
+            assert closed == ["owned-cli"]
+            assert healed.get_session("legacy-telegram")["ended_at"] is None
+            assert healed.get_session("legacy-cli")["ended_at"] is None
+        finally:
+            healed.close()
+        assert not [
+            r for r in caplog.records
+            if r.levelno >= logging.WARNING and "reconcile" in r.getMessage()
+        ], "an allowlisted NOT NULL column must heal without a WARNING"
+
+    def test_not_null_columns_without_default_need_a_declared_policy(self):
+        """Census of SCHEMA_SQL: every NOT NULL/no-DEFAULT column is either allowlisted or
+        knowingly fail-closed; a new one with neither fails here instead of silently
+        inheriting a manufactured value.
+
+        Allowlisted entries must be real SCHEMA_SQL columns of that shape and must
+        produce DDL SQLite accepts on a populated table, backfilling exactly the
+        declared literal. Fail-closed entries pass through unchanged, and SQLite
+        rejects that ALTER, which is what routes them to the reconciler's WARNING.
+        """
+        expected = SessionDB._parse_schema_columns(SCHEMA_SQL)
+        not_null_no_default = {
+            (table, col): col_type
+            for table, cols in expected.items()
+            for col, col_type in cols.items()
+            if "NOT NULL" in col_type and "DEFAULT" not in col_type
+        }
+        allowlist = SessionDB._NOT_NULL_BACKFILL
+        stale = set(allowlist) - set(not_null_no_default)
+        assert not stale, f"_NOT_NULL_BACKFILL names columns that are not NOT NULL/no-DEFAULT: {stale}"
+        undeclared = set(not_null_no_default) - set(allowlist) - self._FAIL_CLOSED
+        assert not undeclared, (
+            f"{sorted(undeclared)}: NOT NULL without DEFAULT in SCHEMA_SQL but no policy. Give it a "
+            "DEFAULT in SCHEMA_SQL, declare a domain-valid legacy value in _NOT_NULL_BACKFILL, or add "
+            "it to _FAIL_CLOSED knowing a store that lacks it will stay unreconciled."
+        )
+        assert set(allowlist) == {("sessions", "source")}
+        assert not (set(allowlist) & self._FAIL_CLOSED)
+
+        for (table, col), col_type in sorted(not_null_no_default.items()):
+            ddl = SessionDB._addable_column_ddl(table, col, col_type)
+            ref = sqlite3.connect(":memory:")
+            try:
+                ref.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+                ref.execute("INSERT INTO t DEFAULT VALUES")
+                if (table, col) in allowlist:
+                    literal = allowlist[(table, col)]
+                    assert ddl == f"{col_type} DEFAULT {literal}", (table, col, ddl)
+                    ref.execute(f'ALTER TABLE t ADD COLUMN "{col}" {ddl}')
+                    assert ref.execute(f'SELECT "{col}" FROM t').fetchone()[0] == literal.strip("'")
+                else:
+                    assert ddl == col_type, f"{table}.{col}: no policy, must pass through unchanged"
+                    with pytest.raises(sqlite3.OperationalError, match="NOT NULL"):
+                        ref.execute(f'ALTER TABLE t ADD COLUMN "{col}" {ddl}')
+            finally:
+                ref.close()
+
+        # Columns the policy does not concern are never rewritten.
+        assert SessionDB._addable_column_ddl("sessions", "title", "TEXT") == "TEXT"
+        assert SessionDB._addable_column_ddl(
+            "messages", "active", "INTEGER NOT NULL DEFAULT 1") == "INTEGER NOT NULL DEFAULT 1"
+
+
 class TestFtsRebuildLoopWithoutTrigram:
     """A trigram-less SQLite build must not re-index the store on every open.
 


### PR DESCRIPTION
## What does this PR do?

Defensive fix for a gap in the column reconciler. `_reconcile_columns()` (`hermes_state_schema.py`) ADDs a missing `SCHEMA_SQL` column with `ALTER TABLE ... ADD COLUMN <name> <type>` verbatim, and SQLite refuses that for a `NOT NULL` column with no `DEFAULT` ("Cannot add a NOT NULL column with default value NULL"). The `OperationalError` is neither a duplicate-column race nor lock contention, so the reconciler logs its catch-all WARNING and moves on; the next open retries and fails identically.

`sessions.source` (`TEXT NOT NULL`, `hermes_state_common.py`) is the column this PR reproduces the gap with; it has been `NOT NULL` since the first `CREATE TABLE sessions` (440c244ca), so a store lacking it is a foreign or partial writer or manual surgery, not a hermes-agent upgrade path. On such a store the open never even reached the reconciler: `SCHEMA_SQL` created `idx_sessions_source` / `idx_sessions_source_id` before `_reconcile_columns()` ran, so `executescript` failed with `no such column: source`.

This was reproduced synthetically (seed a `SessionDB`, rebuild `sessions` without `source`, open it again). No field report is behind this change; an earlier revision of this PR attributed it to an operator incident, which on inspection was a different condition (a bare `state.db` with no `sessions` table at all, which the base code heals on any writable open).

**Fix, in two parts.**

1. `SessionSchemaMixin._NOT_NULL_BACKFILL` is an explicit allowlist of domain-valid legacy values, and `_addable_column_ddl()` appends `DEFAULT <literal>` only for a listed column, so SQLite accepts the ALTER and backfills existing rows in the same statement. Nothing is derived from the SQL type: `''` / `0` are not valid history for timestamps, heartbeat liveness, lease holders or message roles (#101409), so an unlisted `NOT NULL`/no-`DEFAULT` column passes through unchanged, the ALTER still fails, and the existing WARNING is the outcome (fail closed). The only entry is `("sessions", "source") -> 'unknown'`: `ensure_session`'s default for an unrecorded origin, absent from `_AUTO_PRUNE_STALE_OPEN_SOURCES` (#60609), so legacy rows stay outside state-owned stale-open reaping rather than being promoted to a lifecycle owner such as `cli`.
2. `idx_sessions_source` and `idx_sessions_source_id` move from `SCHEMA_SQL` to `DEFERRED_INDEX_SQL`, which `_init_schema()` already runs after the reconciler, so the heal is reachable through the public `SessionDB(db_path)` open. Fresh stores end up with the same indexes; only creation order changes.

`_parse_schema_columns()` and its on-disk `schema_columns.json` cache are not modified. `_rebuild_table()` exists but is used for PRIMARY KEY repairs only; rebuilding `sessions` (FK target of `messages`) for a column addition would be far riskier than an ADD with a declared DEFAULT.

## Related Issue

None filed. Prior art searched (open PRs): `reconcile NOT NULL`, `source column state.db`, `_reconcile_columns`. Closest: #94701 (declares `origin_session_id TEXT NOT NULL DEFAULT ''` in `SCHEMA_SQL` and relies on the reconciler; works because that column carries a DEFAULT, which is the same policy this PR applies per column for those that do not), #60609 (`unknown` sources fail closed in stale-open reconciliation; the reason for the `'unknown'` backfill), #101409 (structural integrity does not certify semantic reconstruction; the reason there is no type-derived fallback).

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state_schema.py`: `SessionSchemaMixin._NOT_NULL_BACKFILL` (explicit per-column legacy literals; one entry, `sessions.source -> 'unknown'`) and `_addable_column_ddl()`, which appends the DEFAULT for allowlisted columns only and returns everything else unchanged; `_reconcile_columns()` passes the declared type through it before the ALTER. `Tuple` added to the `typing` import.
- `hermes_state_common.py`: `idx_sessions_source` and `idx_sessions_source_id` move from `SCHEMA_SQL` to `DEFERRED_INDEX_SQL` (same statements, later in `_init_schema()`), with a note that any index on an allowlisted column must live there.
- `tests/test_hermes_state.py`: `TestReconcileNotNullWithoutDefault` (2 tests, below).
- `hermes_cli/web_server_sessions.py`: comment-only. The `_session_db_heal_exhausted` note names the case that stays unhealable (a `NOT NULL` column with no `_NOT_NULL_BACKFILL` entry) and that an `executescript(SCHEMA_SQL)` failure before the reconciler is a failed writable open, which that set does not record.

## How to Test

1. Reproduce on `main`: seed a `SessionDB`, rebuild `sessions` without `source` (the test's `_strip_column` helper does this), open `SessionDB(db_path)` again: `sqlite3.OperationalError: no such column: source` from `executescript(SCHEMA_SQL)`. Calling `_reconcile_columns()` directly on such a store instead logs `reconcile sessions.source failed; store remains behind SCHEMA_SQL: Cannot add a NOT NULL column with default value NULL`.
2. `scripts/run_tests.sh tests/test_hermes_state.py -k TestReconcileNotNullWithoutDefault -q`:
   - `test_store_lacking_sessions_source_heals_on_open_as_unknown`: a store with a `cli` and a `telegram` row is rebuilt without `source` and opened via `SessionDB(db_path)`. `source` is re-ADDed `NOT NULL`, every legacy row reads `'unknown'`, both deferred indexes exist, the read probe passes, no reconcile WARNING is logged. Negative control: `sweep_orphaned_sessions(sources=_AUTO_PRUNE_STALE_OPEN_SOURCES, ...)` closes an equally aged `cli` row and leaves both healed rows open. Fails on base with `no such column: source`; fails with the index move alone reverted (verified).
   - `test_not_null_columns_without_default_need_a_declared_policy`: censuses `SCHEMA_SQL`. Every `NOT NULL`/no-`DEFAULT` column must be in `_NOT_NULL_BACKFILL` or in the test's explicit fail-closed ledger of pre-existing columns; a new one with neither fails the test. Allowlisted entries must be real columns of that shape and their DDL must be accepted by SQLite on a populated table with exactly the declared literal; unlisted ones must pass through unchanged and be rejected by SQLite (the WARNING path). Nullable and DEFAULT-carrying columns are never rewritten.
3. Regression: `tests/test_hermes_state.py -q` (261 passed, 2 failed: `TestFTS5Search::test_search_projection_skips_context_enrichment_queries` and `TestConnectionLifecycle::test_failed_read_only_open_does_not_leak_tracked_connection`; both fail identically on pristine `upstream/main` with the same interpreter (Python 3.13.15, SQLite 3.53.4), and `hermes_state*.py` plus this test file are byte-identical between the PR base and that checkout, so neither is caused by this PR). `tests/test_schema_read_probe.py -q` (5 passed).

Not changed: no `UPDATE ... WHERE col IS NULL` pass (the `ADD COLUMN ... NOT NULL DEFAULT` backfills existing rows itself); no other `SCHEMA_SQL` index moves (no other allowlisted column exists, and indexes on the fail-closed columns would fail the same way the ALTER does, which is the intended outcome for those).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Darwin 25.6), Python venv, SQLite bundled with CPython

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (synthetic store rebuilt without `sessions.source`, `SessionDB(db_path)` open):

```
sqlite3.OperationalError: no such column: source        # executescript(SCHEMA_SQL), idx_sessions_source
```

and, when `_reconcile_columns()` is reached directly:

```
WARNING hermes_state:hermes_state_schema.py reconcile sessions.source failed; store remains behind SCHEMA_SQL: Cannot add a NOT NULL column with default value NULL
```

After: the open succeeds with no reconcile WARNING; `PRAGMA table_info(sessions)` shows `source TEXT NOT NULL DEFAULT 'unknown'`, every pre-existing row reads `'unknown'`, and `idx_sessions_source` / `idx_sessions_source_id` exist.
