### PR TITLE
fix(agent): classify Novita 'server overload' 429 as overloaded, not rate_limit

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -125,6 +125,7 @@ _RATE_LIMIT_PATTERNS = (
 _OVERLOADED_PATTERNS = (
     "overloaded", "temporarily overloaded", "service is temporarily overloaded",
     "service may be temporarily overloaded", "server is overloaded", "server overloaded",
+    "server overload", "server_overload",
     "service overloaded", "service is overloaded", "upstream overloaded", "currently overloaded",
     "at capacity", "over capacity",
 )

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -511,6 +511,24 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_rotate_credential is False
 
+    def test_429_novita_server_overload_is_overloaded_not_rate_limit(self):
+        """Novita returns HTTP 429 with message 'server overload, please try
+        again later' and error type 'server_overload' for a genuinely busy
+        server (not a credential quota). Neither phrase was in the overload
+        tuple, so it fell through to rate_limit and would rotate the credential
+        / fall back early instead of retrying the same key. (#106205)"""
+        e = MockAPIError(
+            "server overload, please try again later",
+            status_code=429,
+            body={"error": {"message": "server overload, please try again later",
+                            "type": "server_overload"}},
+        )
+        result = classify_api_error(e, provider="custom:novita")
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_fallback is False
+        assert result.should_rotate_credential is False
+
     def test_429_normal_rate_limit_still_rotates(self):
         """Guard: a genuine 429 rate limit (no overload language) must still
         classify as rate_limit and rotate the credential. (#14038)"""

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -511,7 +511,7 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_rotate_credential is False
 
-    def test_429_novita_server_overload_is_overloaded_not_rate_limit(self):
+    def test_429_server_overload_is_overloaded_not_rate_limit(self):
         """Novita returns HTTP 429 with message 'server overload, please try
         again later' and error type 'server_overload' for a genuinely busy
         server (not a credential quota). Neither phrase was in the overload


### PR DESCRIPTION
Closes #106205

## Problem
Novita returns HTTP 429 with message `server overload, please try again later` and error
type `server_overload` when its server is genuinely busy. Hermes classified this as
`rate_limit`, setting `should_fallback=True` and `should_rotate_credential=True` — triggering
credential rotation / an early provider fallback instead of retrying on the same key. The
overload detection added for HTTP 429 (#53578) did not cover this wording.

## Root cause
`_OVERLOADED_PATTERNS` in `agent/error_classifier.py` (checked *before* rate-limit handling in
`_status_429`) recognized `"overloaded"`, `"server overloaded"`, `"server is overloaded"`,
etc., but neither `"server overload"` (the message's space form) nor `"server_overload"` (the
structured type). Novita's response fell through to `_V_RATE_LIMIT`.

## Measured evidence
Reproduced on current main (`72a3277cd7`) with the reporter's exact scenario
(`custom:novita`, model `zai-org/glm-5.3-flash`):

**RED (main):**
```
RESULT: rate_limit True True
```
**GREEN (fix):**
```
RESULT: overloaded False False
```

Regression test `test_429_novita_server_overload_is_overloaded_not_rate_limit` is RED on base
(`FailoverReason.rate_limit`) and GREEN with the fix. Full `tests/agent/test_error_classifier.py`:
`135 passed`.

## Fix
Add `"server overload"` and `"server_overload"` to `_OVERLOADED_PATTERNS`. The response now
reaches the existing `_V_OVERLOADED` verdict: retryable backoff on the same credential, no
rotation, no immediate fallback. The paired guard test `test_429_normal_rate_limit_still_rotates`
confirms a genuine per-key 429 still rotates.

2 files changed, 19 insertions. No new dependencies; no cross-platform/security surface.