### PR TITLE
fix(kanban): reject unknown reviewer profiles in request_review

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3040,6 +3040,10 @@ def request_review(
                     "malformed); pass reviewer= explicitly",
                 )
         reviewer = _canonical_assignee(reviewer)
+        if reviewer is not None:
+            from hermes_cli.profiles import profile_exists
+            if not profile_exists(reviewer):
+                return _ret(False, f'unknown reviewer profile "{reviewer}"')
         assignee_sql = ", assignee = ?" if reviewer is not None else ""
         run_guard = "" if expected_run_id is None else " AND current_run_id = ?"
         params: tuple[Any, ...] = (

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -24,6 +24,9 @@ def kanban_home(tmp_path, monkeypatch):
     # test silently drops files because ``tmp_path`` isn't inside the
     # default ``MEDIA_DELIVERY_SAFE_ROOTS`` cache dirs.
     monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))
+    # Tests pass synthetic reviewer handles (e.g. "reviewer"); treat every name
+    # as a live profile so request_review's reviewer-existence guard is a no-op.
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
     kb.init_db()
     return home
 

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -38,6 +38,10 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Tests pass synthetic reviewer handles (e.g. "reviewer"); treat every name as
+    # a live profile so request_review's reviewer-existence guard is a no-op
+    # unless a test re-monkeypatches to opt back into real validation.
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
     kb.init_db()
     return home
 
@@ -115,6 +119,69 @@ def test_request_review_transitions_running_to_review(kanban_home: Path) -> None
         # No block / triage events were emitted.
         assert _events(conn, tid, kind="blocked") == []
         assert _events(conn, tid, kind="block_loop_detected") == []
+
+
+# ---------------------------------------------------------------------------
+# Reviewer-existence guard: request_review rejects an unknown reviewer profile
+# ---------------------------------------------------------------------------
+
+
+def test_request_review_rejects_unknown_reviewer(kanban_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """request_review must reject a reviewer profile that does not exist, so a
+    typo'd value (e.g. the literal string ``"reviewer"``) cannot silently park
+    the task in ``review`` with an assignee nobody can dispatch."""
+    import hermes_cli.profiles as profmod
+
+    # Only the virtual ``default`` profile is considered live here.
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: name == "default")
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="impl a feature", assignee="worker")
+        kb.claim_task(conn, tid)
+        run_id = kb.get_task(conn, tid).current_run_id
+        assert run_id is not None
+
+        ok, reason = kb.request_review(
+            conn, tid, summary="done", reviewer="zz-no-such-profile",
+            expected_run_id=run_id, with_reason=True,
+        )
+        assert ok is False
+        assert reason is not None and "unknown reviewer profile" in reason
+        assert '"zz-no-such-profile"' in reason
+
+        # The task is untouched: still running under the same claim + assignee.
+        row = _row(conn, tid)
+        assert row["status"] == "running"
+        assert row["current_run_id"] == run_id
+        assert (conn.execute("SELECT assignee FROM tasks WHERE id=?", (tid,)).fetchone())[0] == "worker"
+        # No review_requested event was emitted.
+        assert _events(conn, tid, kind="review_requested") == []
+
+
+def test_request_review_accepts_known_reviewer(kanban_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """request_review honours a reviewer profile that exists (the virtual
+    ``default`` profile always exists) and records it as the task assignee."""
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: name == "default")
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="impl a feature", assignee="worker")
+        kb.claim_task(conn, tid)
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        ok = kb.request_review(
+            conn, tid, summary="Implementation complete",
+            reviewer="default", expected_run_id=run_id,
+        )
+        assert ok is True
+
+        row = _row(conn, tid)
+        assert row["status"] == "review"
+        assignee = conn.execute("SELECT assignee FROM tasks WHERE id=?", (tid,)).fetchone()[0]
+        assert assignee == "default"
+        rr = _events(conn, tid, kind="review_requested")
+        assert len(rr) == 1 and rr[0][1]["reviewer"] == "default"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle_complete.py
@@ -23,7 +23,10 @@ from hermes_cli import kanban_diagnostics as kd
 
 
 @pytest.fixture
-def conn(tmp_path: Path):
+def conn(tmp_path: Path, monkeypatch):
+    # Tests pass synthetic reviewer handles (e.g. "reviewer"); treat every name
+    # as a live profile so request_review's reviewer-existence guard is a no-op.
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
     db = kbc.connect(tmp_path / "kanban.db")
     try:
         yield db

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -37,6 +37,9 @@ def test_review_tools_redact_handoff_and_route_changes(
 ) -> None:
     from tools import kanban_tools as tools
 
+    # Treat every assignee/reviewer name as a live profile (synthetic handles).
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
+
     secret = "ghp_" + "A" * 40
     requested = json.loads(
         tools._handle_request_review({
@@ -127,6 +130,8 @@ def test_review_cli_round_trip_preserves_handoff(
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Treat every assignee/reviewer name as a live profile (synthetic handles).
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
     kb._INITIALIZED_PATHS.clear()
     kb.init_db()
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -51,6 +51,9 @@ def kanban_home(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Tests pass synthetic reviewer/assignee handles (e.g. "reviewer"); treat
+    # every name as a live profile so request_review's reviewer guard is a no-op.
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
     kb.init_db()
     return home
 


### PR DESCRIPTION
## What does this PR do?

Fixes a silent stall: `request_review` accepted any string as the reviewer profile and parked the task in `review` status with `assignee=<typo>`. The dispatcher then had no real profile to spawn, so the review chain stalled overnight with no error signal. This PR validates the reviewer profile exists *before* the `UPDATE` runs, returning an actionable error and leaving the task in its current status.

## Related Issue

Fixes #106163.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

In `hermes_cli/kanban_db.py`, `request_review()` calls `reviewer = _canonical_assignee(reviewer)` (which only lowercases/normalizes the name) and never checked whether that reviewer corresponds to a live profile. A typo'd value (e.g. the literal string `"reviewer"` passed via the MCP tool `kanban_request_review` or `kanban request-review --reviewer <x>`) was written straight into `tasks.assignee`, the task moved to `review`, and nothing downstream could claim it.

The fix adds a profile-exists guard at the single DB-layer chokepoint, so every entry point (CLI `_cmd_request_review`, the MCP tool, and any internal caller) is covered. It reuses the lazy-import pattern already used by `_canonical_assignee` (line 1090) to avoid importing `hermes_cli.profiles` at module load:

```python
reviewer = _canonical_assignee(reviewer)
if reviewer is not None:
    from hermes_cli.profiles import profile_exists
    if not profile_exists(reviewer):
        return _ret(False, f'unknown reviewer profile "{reviewer}"')
```

If the profile does not exist, `request_review` returns `(False, 'unknown reviewer profile "<name>")` *before* the `UPDATE` runs, so the task stays in its current `running`/`ready` status under its original claim.

## How to Test

New regression tests in `tests/hermes_cli/test_kanban_review_lifecycle.py`:

- `test_request_review_rejects_unknown_reviewer` — a typo'd reviewer is rejected, the task stays `running` under its original claim/assignee, and no `review_requested` event is emitted. **Mutation-verified:** fails without the guard.
- `test_request_review_accepts_known_reviewer` — a live profile (`default`, the virtual always-on profile) is accepted, the task moves to `review`, and the reviewer is recorded on the event payload + as the new assignee.

Existing tests: synthetic reviewer handles (`"reviewer"`, `"lead-reviewer"`) are stubbed via the `hermes_cli.profiles.profile_exists` → `lambda name: True` pattern already used by adjacent tests (lines 432/485), mirroring the pre-existing `all_assignees_spawnable` fixture philosophy in `tests/hermes_cli/conftest.py`.

Verification:
- `pytest tests/hermes_cli/test_kanban_review_lifecycle.py` → 21 passed (incl. 2 new).
- Full kanban suite → **131 passed, 1 skipped**, 0 regressions.
- Mutation check: removing the 4-line guard makes `test_request_review_rejects_unknown_reviewer` fail; restoring it makes the suite green again.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(kanban): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the kanban test suite and all tests pass (131 passed, 1 skipped)
- [x] I've added tests for my changes (2 new, mutation-verified)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] N/A — internal guard reusing existing `profile_exists`; no public API or doc surface changed. Passing `reviewer=None` (re-review provenance lookup) is unaffected; the virtual `default` profile always passes `profile_exists`.