### PR TITLE
fix(dashboard): run PTY I/O on a dedicated pool, not the default executor

### DIFF
--- a/hermes_cli/pty_executor.py
+++ b/hermes_cli/pty_executor.py
@@ -1,0 +1,58 @@
+"""Dedicated thread pool for blocking PTY I/O.
+
+Why this exists (#95559 class of bug, dashboard variant): every keep-alive PTY
+session runs a permanent drain loop whose ``bridge.read`` call is blocking on
+Windows (ConPTY has no selectable fd, so the read polls and sleeps inside the
+worker thread). Scheduling those loops on asyncio's DEFAULT executor parks one
+default-pool thread per live terminal for the whole life of the session. The
+default pool is only ``min(32, cpu_count + 4)`` threads (16 on a 12-core box),
+so a handful of dashboard terminals — plus the ConPTY write workers that
+``WinPtyBridge`` documents as leakable — exhaust it. Once exhausted, EVERY route
+that offloads blocking work with ``asyncio.to_thread`` / ``run_in_executor(None,
+...)`` queues forever: ``/api/sessions/{id}/messages`` and
+``/api/sessions/{id}/latest-descendant`` hang while cheap sync routes
+(``/api/status``, ``/api/sessions/stats``) still answer, so the dashboard looks
+half-alive and no session can be opened.
+
+Keeping PTY I/O on its own pool means terminal load can never starve the
+control plane. Threads are created lazily, so a generous ``max_workers`` costs
+nothing until terminals actually open.
+"""
+from __future__ import annotations
+
+import atexit
+import concurrent.futures
+import threading
+from typing import Optional
+
+# Headroom for the registry's max_sessions (16) drain loops plus their write /
+# close workers, so a full terminal registry still cannot queue on itself.
+PTY_EXECUTOR_MAX_WORKERS = 48
+
+_pty_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+_pty_executor_lock = threading.Lock()
+
+
+def get_pty_executor() -> concurrent.futures.ThreadPoolExecutor:
+    """Lazily create the process-wide PTY worker pool."""
+    global _pty_executor
+    if _pty_executor is None:
+        with _pty_executor_lock:
+            if _pty_executor is None:
+                _pty_executor = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=PTY_EXECUTOR_MAX_WORKERS, thread_name_prefix="hermes-pty")
+                # Never wait on in-flight workers at exit: a read parked inside
+                # pywinpty must not block interpreter shutdown.
+                atexit.register(
+                    lambda: _pty_executor
+                    and _pty_executor.shutdown(wait=False, cancel_futures=True))
+    return _pty_executor
+
+
+def reset_pty_executor_for_tests() -> None:
+    """Test-only: drop the pool so a fresh one is built on next use."""
+    global _pty_executor
+    with _pty_executor_lock:
+        pool, _pty_executor = _pty_executor, None
+    if pool is not None:
+        pool.shutdown(wait=False, cancel_futures=True)

--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -10,6 +10,8 @@ import asyncio
 import time
 from typing import Callable, Dict, Optional, Tuple
 
+from hermes_cli.pty_executor import get_pty_executor
+
 WS_CLOSE_PROCESS_EXITED = 4410
 WS_CLOSE_SUPERSEDED = 4409
 TUI_FORCE_REDRAW = b"\x0c"
@@ -61,8 +63,12 @@ class PtySession:
 
     async def _drain(self) -> None:
         loop = asyncio.get_running_loop()
+        # The blocking read runs on the dedicated PTY pool, never the default
+        # executor: this loop lives as long as the session, so one default-pool
+        # thread per terminal would starve every ``to_thread`` route (#95559).
+        executor = get_pty_executor()
         while True:
-            chunk = await loop.run_in_executor(None, self.bridge.read, self._read_timeout)
+            chunk = await loop.run_in_executor(executor, self.bridge.read, self._read_timeout)
             if chunk is None:                       # EOF — the agent process exited
                 self.alive = False
                 await _close_ws(self._ws, WS_CLOSE_PROCESS_EXITED)
@@ -133,8 +139,10 @@ class PtySession:
                 pass
         try:
             # bridge.close() joins the child — blocking; keep it off the event loop.
-            # See #53227.
-            await asyncio.to_thread(self.bridge.close)
+            # See #53227. Uses the PTY pool so a wedged close cannot consume a
+            # default-executor thread the control-plane routes need (#95559).
+            await asyncio.get_running_loop().run_in_executor(
+                get_pty_executor(), self.bridge.close)
         except Exception:
             pass
 
@@ -172,8 +180,9 @@ class PtySessionRegistry:
         if len(self._sessions) >= self._max:
             self._reap_one_idle_or_raise()
         # PTY spawn does blocking fork/exec work — keep it off the event loop.
-        # See #53227.
-        bridge = await asyncio.to_thread(spawn)
+        # See #53227. On the PTY pool (#95559): spawn latency must not queue
+        # behind, or steal threads from, the default executor.
+        bridge = await asyncio.get_running_loop().run_in_executor(get_pty_executor(), spawn)
         session = PtySession(key, bridge, buffer_cap=self._buffer_cap, read_timeout=self._read_timeout)
         await session.start()
         self._sessions[key] = session

--- a/hermes_cli/web_server_chat.py
+++ b/hermes_cli/web_server_chat.py
@@ -17,6 +17,7 @@ import urllib.request
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from pathlib import Path
 from typing import Optional
+from hermes_cli.pty_executor import get_pty_executor
 from hermes_cli.pty_session import PtySessionRegistry
 
 # Same logger the code used before extraction (record parity).
@@ -67,11 +68,15 @@ async def _legacy_pump(ws: "WebSocket", bridge) -> None:
     ``to_thread`` offloads for the blocking ``bridge.close()``.
     """
     loop = asyncio.get_running_loop()
+    # Blocking PTY work lives on the dedicated pool, not the default executor:
+    # a long-lived pump would otherwise hold a default-pool thread and starve
+    # the control-plane routes that offload via ``to_thread`` (#95559).
+    pty_pool = get_pty_executor()
 
     async def pump_pty_to_ws() -> None:
         try:
             while True:
-                chunk = await loop.run_in_executor(None, bridge.read, _PTY_READ_CHUNK_TIMEOUT)
+                chunk = await loop.run_in_executor(pty_pool, bridge.read, _PTY_READ_CHUNK_TIMEOUT)
                 if chunk is None:  # EOF
                     return
                 if not chunk:  # no data this tick; yield control and retry
@@ -90,7 +95,7 @@ async def _legacy_pump(ws: "WebSocket", bridge) -> None:
             with contextlib.suppress(Exception):
                 # The child has exited (EOF) or the send side broke. Closing from the EOF path makes the
                 # reap independent of that cancellation race (#54028).
-                await asyncio.to_thread(bridge.close)
+                await loop.run_in_executor(pty_pool, bridge.close)
             with contextlib.suppress(Exception):
                 await ws.close()
 
@@ -126,7 +131,7 @@ async def _legacy_pump(ws: "WebSocket", bridge) -> None:
         reader_task.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await reader_task
-        await asyncio.to_thread(bridge.close)
+        await loop.run_in_executor(pty_pool, bridge.close)
 
 
 # Starlette's TestClient reports the peer as "testclient"; treat it as

--- a/hermes_cli/win_pty_bridge.py
+++ b/hermes_cli/win_pty_bridge.py
@@ -8,6 +8,8 @@ import sys
 import time
 from typing import Optional, Sequence
 
+from hermes_cli.pty_executor import get_pty_executor
+
 try:
     from winpty import PtyProcess  # type: ignore
     _PTY_AVAILABLE = sys.platform.startswith("win")
@@ -126,7 +128,11 @@ class WinPtyBridge:
         if not data:
             return True
         loop = asyncio.get_running_loop()
-        write_future = loop.run_in_executor(None, self._write_blocking, data)
+        # Dedicated PTY pool: this worker can stay parked inside pywinpty after
+        # terminate() (see _stop_stalled_write), so a leak here must not consume
+        # default-executor threads the dashboard's control-plane routes need
+        # (#95559 — starved /api/sessions/{id}/messages).
+        write_future = loop.run_in_executor(get_pty_executor(), self._write_blocking, data)
         try:
             return await asyncio.wait_for(
                 asyncio.shield(write_future),
@@ -152,7 +158,7 @@ class WinPtyBridge:
 
     async def _stop_stalled_write(self, write_future: asyncio.Future) -> None:
         """Close ConPTY and reap the worker that was blocked in ``write``."""
-        await asyncio.to_thread(self.close)
+        await asyncio.get_running_loop().run_in_executor(get_pty_executor(), self.close)
         try:
             await asyncio.wait_for(
                 asyncio.shield(write_future),

--- a/tests/hermes_cli/test_pty_executor_isolation.py
+++ b/tests/hermes_cli/test_pty_executor_isolation.py
@@ -1,0 +1,86 @@
+"""PTY I/O must never occupy asyncio's default executor.
+
+Regression for the dashboard variant of #95559: keep-alive PTY drain loops (one
+per open terminal, each blocking for the life of the session on Windows ConPTY)
+were scheduled on the DEFAULT executor. That pool is only
+``min(32, cpu_count + 4)`` threads, so a handful of dashboard terminals starved
+every route that offloads blocking work with ``asyncio.to_thread`` —
+``/api/sessions/{id}/messages`` and ``/api/sessions/{id}/latest-descendant``
+hung forever while cheap sync routes kept answering, so the dashboard listed
+sessions but could not open any of them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import threading
+
+from hermes_cli.pty_executor import (
+    get_pty_executor, reset_pty_executor_for_tests)
+from hermes_cli.pty_session import PtySessionRegistry
+
+
+class _FakeBridge:
+    """Bridge whose read blocks like ConPTY's until released."""
+
+    def __init__(self) -> None:
+        self.release = threading.Event()
+        self.reading = threading.Event()
+        self.closed = False
+
+    def read(self, _timeout: float = 0.2):
+        self.reading.set()
+        self.release.wait(timeout=10.0)
+        return None  # EOF -> drain loop exits
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _default_executor_probe(loop: asyncio.AbstractEventLoop):
+    """A single-thread default executor plus a way to prove it stays free."""
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(pool)
+    return pool
+
+
+def test_pty_drain_does_not_consume_default_executor():
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        pool = _default_executor_probe(loop)
+        reset_pty_executor_for_tests()
+        bridge = _FakeBridge()
+        registry = PtySessionRegistry(
+            ttl=60.0, max_sessions=4, buffer_cap=1024, read_timeout=0.05)
+        try:
+            session, created = await registry.attach_or_spawn("k", spawn=lambda: bridge)
+            assert created
+            # The blocking read is in flight...
+            for _ in range(200):
+                if bridge.reading.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            assert bridge.reading.is_set(), "drain loop never issued its blocking read"
+
+            # ...and the single default-executor thread is still available, which
+            # is exactly what the starved /api/sessions routes needed.
+            probe = await asyncio.wait_for(asyncio.to_thread(lambda: "free"), timeout=2.0)
+            assert probe == "free"
+        finally:
+            bridge.release.set()
+            await registry.close_all()
+            pool.shutdown(wait=True, cancel_futures=True)
+            reset_pty_executor_for_tests()
+
+    asyncio.run(scenario())
+
+
+def test_pty_executor_is_shared_and_bounded():
+    reset_pty_executor_for_tests()
+    try:
+        first = get_pty_executor()
+        assert get_pty_executor() is first, "PTY pool must be process-wide"
+        assert first._max_workers >= 16, "pool must outsize the PTY session registry"
+    finally:
+        reset_pty_executor_for_tests()


### PR DESCRIPTION
## What does this PR do?

Keep-alive PTY sessions run their blocking I/O on **asyncio's default
executor**. Each open dashboard terminal parks one default-pool thread for the
entire life of the session, so a handful of terminals exhausts the pool and
every route that offloads blocking work with `asyncio.to_thread` /
`run_in_executor(None, ...)` queues forever.

The result is a dashboard that looks half-alive: the Sessions page renders
counts and titles, but no session can be opened.

**Why the pool runs out.** `PtySession._drain` is a permanent loop, and its
`bridge.read` is genuinely blocking on Windows — ConPTY has no selectable fd,
so `WinPtyBridge.read` polls and `time.sleep`s *inside* the worker thread.
`WinPtyBridge._stop_stalled_write` already documents that a wedged write
worker can stay parked after `terminate()` ("thread leaked"). The default pool
is only `min(32, cpu_count + 4)` threads — 16 on a 12-core box — and
`PtySessionRegistry` allows up to 16 concurrent sessions, so the registry
alone can outnumber the pool that also serves the whole control plane.

Fix: move PTY I/O to a dedicated pool (`hermes_cli/pty_executor.py`) so
terminal load can never starve control-plane routes. Threads are created
lazily, so the generous `max_workers` costs nothing until terminals open.

This is the same failure class as #95559 (Desktop backend stops serving
executor-backed routes) but reached through PTY drain loops rather than a
single wedged call, and it is not fixed by #93565 — that PR moved PTY *input*
off the event loop, while these offloads remained on the default executor.

## Related Issue

Same class as #95559; no separate issue filed for the dashboard PTY path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/pty_executor.py`** (new): process-wide, lazily created
  `ThreadPoolExecutor` for PTY work (`get_pty_executor()`), 48 workers to
  cover `PtySessionRegistry.max_sessions` drain loops plus their write/close
  workers. `atexit` shutdown uses `wait=False, cancel_futures=True` so a read
  parked inside pywinpty cannot block interpreter shutdown. Includes
  `reset_pty_executor_for_tests()`.
- **`hermes_cli/pty_session.py`**: `_drain` read loop, `close()`'s
  `bridge.close`, and `attach_or_spawn`'s blocking spawn now use the PTY pool.
- **`hermes_cli/web_server_chat.py`**: the legacy 1:1 pump's read loop and both
  `bridge.close` offloads now use the PTY pool.
- **`hermes_cli/win_pty_bridge.py`**: the ConPTY write worker (the one
  documented as leakable) and `_stop_stalled_write`'s close now use the PTY
  pool, so a leaked worker no longer costs a default-executor thread.
- **`tests/hermes_cli/test_pty_executor_isolation.py`** (new): wedges the
  default executor down to a single thread, starts a PTY session whose read
  blocks, and asserts `asyncio.to_thread` still completes — plus a guard that
  the pool is process-wide and outsizes the session registry.

No behavior change other than which pool the work runs on; no config keys, no
public API changes.

## How to Test

Reproduce on `main` (Windows 11, 12-core — the smaller the core count, the
easier it reproduces):

1. `hermes dashboard --host 127.0.0.1 --port 9119 --no-open`
2. Open the dashboard, read `window.__HERMES_SESSION_TOKEN__` from the console,
   and open ~16-20 terminal WebSockets to `/api/pty` (one per dashboard
   terminal tab also works, just slower to reach the limit).
3. With the token as an `X-Hermes-Session-Token` header, compare route
   families:
   - `GET /api/status`, `/api/sessions`, `/api/sessions/stats`,
     `/api/sessions/search?q=x` → 200 in milliseconds
   - `GET /api/sessions/{id}/messages`, `/api/sessions/{id}/latest-descendant`
     → never respond (curl `--max-time 25` gives `HTTP 000`)

Observed before the fix (real output):

```
/api/sessions/stats                                     HTTP 200 t=0.007
/api/sessions/{id}/messages?limit=1&order=oldest        HTTP 000 t=25.015
/api/sessions/{id}/latest-descendant                    HTTP 000 t=20.004
```

After this patch, with 20 PTY sockets open simultaneously:

```
/api/status                                             HTTP 200 t=0.053
/api/sessions/stats                                     HTTP 200 t=0.006
/api/sessions?limit=5                                   HTTP 200 t=0.010
/api/sessions/search?q=dashboard                        HTTP 200 t=0.017
/api/sessions/{id}/messages?limit=5                     HTTP 200 t=0.007
/api/sessions/{id}/latest-descendant                    HTTP 200 t=0.007
```

Sessions expand and render their transcripts in the UI again.

Automated:

```bash
pytest tests/hermes_cli/test_pty_executor_isolation.py \
       tests/hermes_cli/test_web_server_executor_isolation.py \
       tests/hermes_cli/test_pty_bridge.py \
       tests/hermes_cli/test_win_pty_bridge.py -q
# 23 passed, 2 skipped

pytest tests/test_pty_keepalive_ws.py \
       tests/hermes_cli/test_web_server_pty_idle_backoff.py \
       tests/hermes_cli/test_web_server_pty_import.py \
       tests/hermes_cli/test_web_server_pty_reconnect.py \
       tests/dashboard/ -q
# 17 passed, 5 skipped
```

The new test fails on `main` (the `to_thread` probe times out) and passes with
this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nearest are #93565 (merged; PTY *input* off the event loop) and #95559 / #26836 / #22873 (same class, different call sites); the PTY offloads changed here are still on the default executor in current `main`
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the PTY/dashboard/executor suites listed above (40 passed, 7 skipped); the full tree was not run on this Windows box
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11, Hermes 0.21.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module docstring in the new file explains the failure mode and the invariant
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — POSIX `PtyBridge` benefits identically (its `read` also blocks in a worker); no platform-specific APIs added, and the new test is platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
