### PR TITLE
feat(terminal): per-session Docker containers with retention lifecycle (#46041)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -392,6 +392,7 @@ def _cli_config_defaults():
             "docker_shared_container_key": "",
             "docker_container_scope": "shared",
             "docker_session_container_retention": "stop_on_session_end",
+            "docker_session_container_ttl_seconds": 3600,
         },
         "browser": {
             "inactivity_timeout": 120, "record_sessions": False, "engine": "auto",  # auto (Chrome) | lightpanda | chrome

--- a/cli.py
+++ b/cli.py
@@ -296,6 +296,7 @@ _TERMINAL_ENV_MAPPINGS = {
         "docker_shm_size", "docker_mount_cwd_to_workspace", "docker_network", "docker_run_as_host_user",
         "docker_snap_compat",
         "docker_persist_across_processes", "docker_shared_container_key", "docker_orphan_reaper",
+        "docker_container_scope", "docker_session_container_retention", "docker_session_container_ttl_seconds",
         "sandbox_dir", "persistent_shell",
     )
 }
@@ -389,6 +390,8 @@ def _cli_config_defaults():
             "modal_image": img, "daytona_image": img, "docker_volumes": [],
             "docker_mount_cwd_to_workspace": False,  # opt-in only: sandbox isolation
             "docker_shared_container_key": "",
+            "docker_container_scope": "shared",
+            "docker_session_container_retention": "stop_on_session_end",
         },
         "browser": {
             "inactivity_timeout": 120, "record_sessions": False, "engine": "auto",  # auto (Chrome) | lightpanda | chrome

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1915,6 +1915,9 @@ def _bridge_terminal_config_to_env(_terminal_cfg: dict) -> None:
         "docker_snap_compat": "TERMINAL_DOCKER_SNAP_COMPAT",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
         "docker_shared_container_key": "TERMINAL_DOCKER_SHARED_CONTAINER_KEY",
+        "docker_container_scope": "TERMINAL_DOCKER_CONTAINER_SCOPE",
+        "docker_session_container_retention": "TERMINAL_DOCKER_SESSION_CONTAINER_RETENTION",
+        "docker_session_container_ttl_seconds": "TERMINAL_DOCKER_SESSION_CONTAINER_TTL_SECONDS",
         "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         "persistent_shell": "TERMINAL_PERSISTENT_SHELL"}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2035,7 +2035,7 @@ TERMINAL_CONFIG_ENV_MAP = {
             "container_cpu", "container_memory", "container_disk", "container_persistent",
             "docker_volumes", "docker_env", "docker_mount_cwd_to_workspace", "docker_network",
             "docker_extra_args", "docker_shm_size", "docker_run_as_host_user", "docker_snap_compat",
-            "docker_persist_across_processes", "docker_shared_container_key",
+            "docker_persist_across_processes", "docker_shared_container_key", "docker_container_scope", "docker_session_container_retention", "docker_session_container_ttl_seconds",
             "docker_orphan_reaper", "sandbox_dir", "persistent_shell")}}
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -341,6 +341,12 @@ DEFAULT_CONFIG = {
         "docker_snap_compat": False,
         # Trusted profiles sharing one Docker container identity; empty = per-profile boundary.
         "docker_shared_container_key": "",
+        # shared = one container reused across all sessions (current); session = one container per chat session, resumed on reattach (#46041)
+        "docker_container_scope": "shared",
+        # stop_on_session_end (default; stopped at session close, restarted on resume) | keep_running | remove_on_session_end | idle_ttl
+        "docker_session_container_retention": "stop_on_session_end",
+        # idle_ttl retention: session container removed after this many idle seconds (0 = use terminal.lifetime_seconds)
+        "docker_session_container_ttl_seconds": 3600,
         # Keep a long-lived bash shell across execute() calls so cwd/env/shell variables survive.
         # Applies to non-local backends (SSH); local is opt-in via TERMINAL_LOCAL_PERSISTENT env.
         "persistent_shell": True,

--- a/tests/tools/test_docker_session_scope.py
+++ b/tests/tools/test_docker_session_scope.py
@@ -1,0 +1,531 @@
+"""docker_container_scope: session — persistent per-session containers (#46041).
+
+Companion to test_docker_session_isolation.py, which pins the EPHEMERAL
+per-session mode (docker + container_persistent: false). This file pins the
+PERSISTENT per-session mode: ``docker_container_scope: session`` keeps the
+persistence contract (fs state survives across turns; a stopped container is
+restarted on resume) while giving each chat session its own container, keyed
+``session:<key>`` with a retention lifecycle:
+
+* ``stop_on_session_end`` (default) — cleanup() stops WITHOUT rm; the session's
+  next use reattaches via the label probe (docker start). The orphan reaper
+  must NOT reap such stopped containers (label ``hermes-session-retention``).
+* ``keep_running`` — cleanup() is the persist no-op.
+* ``remove_on_session_end`` — stop+rm (existing ephemeral contract).
+* ``idle_ttl`` — the idle reaper force-removes after the session's own TTL.
+* ``cleanup_vm`` finds envs cached under ``session:<key>`` from close paths
+  holding a different durable id (AIAgent.close() passes session_id), via the
+  close-key registry recorded at env creation. Delegate child ids are never
+  registered, so their close() still resolves to the parent's env or no-ops.
+"""
+
+import datetime as _dt
+import subprocess
+import time
+
+import pytest
+
+from tools import terminal_tool, terminal_tool_backends
+from tools.terminal_tool_lifecycle import (
+    _cleanup_inactive_envs,
+    cleanup_vm,
+    get_active_env,
+    is_persistent_env,
+)
+from tools.environments import docker as docker_env
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    """Isolate override/alias/cwd/close-key state and pin terminal env vars."""
+    before_overrides = dict(terminal_tool._task_env_overrides)
+    terminal_tool._task_env_overrides.clear()
+    with terminal_tool._container_alias_lock:
+        before_aliases = dict(terminal_tool._container_aliases)
+        terminal_tool._container_aliases.clear()
+    with terminal_tool._session_cwd_lock:
+        before_cwd = dict(terminal_tool._session_cwd)
+        terminal_tool._session_cwd.clear()
+    with terminal_tool._session_close_keys_lock:
+        before_close_keys = dict(terminal_tool._session_close_keys)
+        terminal_tool._session_close_keys.clear()
+    # The config→env bridge is one-shot; mark it done so tests control env vars.
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+    monkeypatch.setenv("TERMINAL_DOCKER_CONTAINER_SCOPE", "shared")
+    monkeypatch.setenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "")
+    monkeypatch.setenv("HERMES_SESSION_PROFILE", "")
+    yield
+    terminal_tool._task_env_overrides.clear()
+    terminal_tool._task_env_overrides.update(before_overrides)
+    with terminal_tool._container_alias_lock:
+        terminal_tool._container_aliases.clear()
+        terminal_tool._container_aliases.update(before_aliases)
+    with terminal_tool._session_cwd_lock:
+        terminal_tool._session_cwd.clear()
+        terminal_tool._session_cwd.update(before_cwd)
+    with terminal_tool._session_close_keys_lock:
+        terminal_tool._session_close_keys.clear()
+        terminal_tool._session_close_keys.update(before_close_keys)
+
+
+def _pin_session(monkeypatch, scope="session", persistent="true", env_type="docker",
+                 session_key=None, profile=""):
+    """Pin the env vars + session-key reader the way a gateway session would."""
+    monkeypatch.setenv("TERMINAL_ENV", env_type)
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", persistent)
+    monkeypatch.setenv("TERMINAL_DOCKER_CONTAINER_SCOPE", scope)
+    monkeypatch.setenv("HERMES_SESSION_PROFILE", profile)
+    monkeypatch.setattr(terminal_tool, "_current_session_key", lambda: session_key or "")
+
+
+# --- Routing: _resolve_container_task_id ---------------------------------------
+
+
+def test_session_scope_keys_by_session(monkeypatch):
+    """docker + persistent + scope=session keys by session:<key>."""
+    _pin_session(monkeypatch, scope="session", session_key="telegram:123:456")
+    assert terminal_tool._resolve_container_task_id(None) == "session:telegram:123:456"
+
+
+def test_no_session_key_stays_default(monkeypatch):
+    """CLI (no session key) unchanged under session scope."""
+    _pin_session(monkeypatch, scope="session", session_key=None)
+    assert terminal_tool._resolve_container_task_id(None) == "default"
+
+
+def test_shared_container_key_wins_over_session_scope(monkeypatch):
+    """An explicit docker_shared_container_key beats session scope (#46041)."""
+    _pin_session(monkeypatch, scope="session", session_key="abc")
+    monkeypatch.setenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "team")
+    assert terminal_tool._resolve_container_task_id(None) == "shared:team"
+
+
+def test_scope_session_keys_session_for_non_persistent_too(monkeypatch):
+    """Non-persistent + scope=session still keys session:<key> (both branches agree)."""
+    _pin_session(monkeypatch, scope="session", persistent="false", session_key="abc")
+    assert terminal_tool._resolve_container_task_id(None) == "session:abc"
+
+
+def test_scope_shared_keeps_profile_scoping(monkeypatch):
+    """Default scope: docker+persistent still collapses to the profile branch."""
+    _pin_session(monkeypatch, scope="shared", session_key="abc", profile="work")
+    assert terminal_tool._resolve_container_task_id(None) == "profile:work"
+
+
+def test_scope_shared_default_profile_stays_literal_default(monkeypatch):
+    """Default profile + default scope keeps the shared "default" container (CLI+gateway)."""
+    _pin_session(monkeypatch, scope="shared", session_key="abc", profile="")
+    assert terminal_tool._resolve_container_task_id(None) == "default"
+
+
+def test_non_docker_backend_unchanged(monkeypatch):
+    """SSH + session scope keys session:<key> via the pre-existing branch."""
+    _pin_session(monkeypatch, scope="session", env_type="ssh", session_key="abc")
+    assert terminal_tool._resolve_container_task_id(None) == "session:abc"
+
+
+def test_docker_session_isolation_enabled_for_session_scope(monkeypatch):
+    """The isolation predicate must fire for session scope even with persistence on."""
+    _pin_session(monkeypatch, scope="session")
+    assert terminal_tool._docker_session_isolation_enabled() is True
+
+
+def test_ephemeral_isolation_still_enabled(monkeypatch):
+    """container_persistent: false keeps the existing isolation predicate."""
+    _pin_session(monkeypatch, scope="shared", persistent="false")
+    assert terminal_tool._docker_session_isolation_enabled() is True
+
+
+def test_shared_persistent_not_isolated(monkeypatch):
+    """The default mode stays non-isolated."""
+    _pin_session(monkeypatch, scope="shared", persistent="true")
+    assert terminal_tool._docker_session_isolation_enabled() is False
+
+
+def test_isolation_refuses_process_tagged_override(monkeypatch, tmp_path):
+    """Under session scope the process-global cwd must not become the mount."""
+    _pin_session(monkeypatch, scope="session", session_key="abc")
+    monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
+    terminal_tool.register_task_env_overrides(
+        "session:abc", {"cwd": str(tmp_path), "cwd_source": "process"})
+    config = {"env_type": "docker", "docker_mount_cwd_to_workspace": True, "host_cwd": "/tmp/launch"}
+    assert terminal_tool._resolve_task_host_cwd(config, "session:abc") is None
+
+
+def test_session_attached_override_mounts(monkeypatch, tmp_path):
+    """A session-tagged cwd override still mounts (unchanged from isolation mode)."""
+    _pin_session(monkeypatch, scope="session", session_key="abc")
+    monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "true")
+    terminal_tool.register_task_env_overrides(
+        "session:abc", {"cwd": str(tmp_path), "cwd_source": "session"})
+    config = {"env_type": "docker", "docker_mount_cwd_to_workspace": True, "host_cwd": None}
+    assert terminal_tool._resolve_task_host_cwd(config, "session:abc") == str(tmp_path)
+
+
+# --- Builder: _build_docker_env -------------------------------------------------
+
+
+class _RecordingDockerEnv:
+    """DockerEnvironment double: records kwargs, no docker daemon needed."""
+
+    instances: list = []
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        # Mirror the real ctor's param → attr mapping for the attrs tests assert on.
+        self._scope = kwargs.get("scope", "shared")
+        self._session_retention = kwargs.get("session_retention", "stop_on_session_end")
+        self._session_ttl_seconds = kwargs.get("session_ttl_seconds", 3600)
+        self._session_scoped = kwargs.get("scope") == "session"
+        self._persist_across_processes = kwargs.get("persist_across_processes", True)
+        _RecordingDockerEnv.instances.append(self)
+
+
+@pytest.fixture
+def recording_env(monkeypatch):
+    _RecordingDockerEnv.instances = []
+    monkeypatch.setattr(terminal_tool_backends, "_DockerEnvironment", _RecordingDockerEnv)
+    monkeypatch.setattr(terminal_tool, "_maybe_reap_docker_orphans", lambda cc: None)
+    return _RecordingDockerEnv
+
+
+def _builder_cc(**overrides):
+    config = {
+        "env_type": "docker",
+        "container_persistent": True,
+        "docker_container_scope": "session",
+        "docker_session_container_retention": "stop_on_session_end",
+        "docker_session_container_ttl_seconds": 3600,
+        "docker_persist_across_processes": True,
+    }
+    config.update(overrides)
+    return config
+
+
+def _build(cc, task_id):
+    return terminal_tool_backends._build_docker_env(
+        env_type="docker", image="i", cwd="/root", timeout=60, cc=cc,
+        task_id=task_id, ssh_config=None, host_cwd=None)
+
+
+def test_builder_session_scope_passes_retention(recording_env):
+    env = _build(_builder_cc(), "session:abc")
+    assert env._scope == "session"
+    assert env._session_retention == "stop_on_session_end"
+    assert env._session_ttl_seconds == 3600
+    assert env._session_scoped is True
+    assert env._persist_across_processes is True  # reattachable across processes
+
+
+def test_builder_remove_on_session_end_drops_persist(monkeypatch, recording_env):
+    _pin_session(monkeypatch, scope="session", persistent="true")
+    env = _build(_builder_cc(docker_session_container_retention="remove_on_session_end"), "session:abc")
+    assert env._session_retention == "remove_on_session_end"
+    assert env._persist_across_processes is False
+
+
+def test_builder_ephemeral_isolation_keeps_old_contract(monkeypatch, recording_env):
+    """container_persistent: false keeps the legacy kwargs (no scope=session leak)."""
+    _pin_session(monkeypatch, scope="shared", persistent="false")
+    env = _build(_builder_cc(container_persistent=False), "session:abc")
+    assert env._session_scoped is True  # legacy builder marker
+    assert env._scope != "session"
+    assert env._persist_across_processes is False
+
+
+def test_builder_session_scope_config_with_ephemeral_env_forces_shared(monkeypatch, recording_env):
+    """scope=session in config but container_persistent=false → ephemeral contract wins;
+    the ctor must NOT see scope=session or cleanup() would stop-only an ephemeral env."""
+    _pin_session(monkeypatch, scope="session", persistent="false")
+    env = _build(_builder_cc(container_persistent=False), "session:abc")
+    assert env._scope == "shared"
+    assert env._persist_across_processes is False
+
+
+def test_builder_shared_default_untouched(recording_env):
+    env = _build(_builder_cc(docker_container_scope="shared"), "default")
+    assert env._session_scoped is False
+    assert env._scope == "shared"
+
+
+# --- cleanup(): retention semantics ---------------------------------------------
+
+
+def _make_env(retention, *, session_scope=True):
+    """DockerEnvironment skeleton with real cleanup() logic and a fake docker exe."""
+    env = docker_env.DockerEnvironment.__new__(docker_env.DockerEnvironment)
+    env._scope = "session" if session_scope else "shared"
+    env._session_retention = retention
+    env._session_ttl_seconds = 3600
+    env._session_scoped = session_scope
+    env._persistent = True
+    env._persist_across_processes = True
+    env._container_id = "deadbeef1234567890"
+    env._docker_exe = "/usr/bin/docker"
+    env._workspace_dir = None
+    env._home_dir = None
+    env._cleanup_thread = None
+    return env
+
+
+def _verbs(calls):
+    return [c[1] for c in calls]
+
+
+def test_cleanup_stop_on_session_end_stops_without_rm(monkeypatch):
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env = _make_env("stop_on_session_end")
+    env.cleanup()
+    env.wait_for_cleanup(timeout=5)
+    assert _verbs(calls) == ["stop"], f"stop only, no rm; got {_verbs(calls)}"
+    assert env._container_id is None  # a fresh ctor re-probes labels and restarts
+
+
+def test_cleanup_keep_running_leaves_container(monkeypatch):
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env = _make_env("keep_running")
+    env.cleanup()
+    env.wait_for_cleanup(timeout=5)
+    assert calls == [], "keep_running must not touch the container"
+    assert env._container_id is None  # in-process handle dropped, container running
+
+
+def test_cleanup_remove_on_session_end_stops_and_removes(monkeypatch):
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env = _make_env("remove_on_session_end")
+    env._persist_across_processes = False  # the builder sets this for remove retention
+    env.cleanup()
+    env.wait_for_cleanup(timeout=5)
+    assert _verbs(calls) == ["stop", "rm"]
+
+
+def test_cleanup_ephemeral_isolation_still_removes(monkeypatch):
+    """Ephemeral per-session envs (scope=shared) keep the stop+rm contract."""
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env = _make_env("stop_on_session_end", session_scope=False)
+    env._persist_across_processes = False
+    env.cleanup()
+    env.wait_for_cleanup(timeout=5)
+    assert _verbs(calls) == ["stop", "rm"]
+
+
+def test_cleanup_force_remove_beats_retention(monkeypatch):
+    """User-initiated teardown (force_remove=True) removes even stop-retention containers."""
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env = _make_env("stop_on_session_end")
+    env.cleanup(force_remove=True)
+    env.wait_for_cleanup(timeout=5)
+    assert _verbs(calls) == ["stop", "rm"]
+
+
+# --- Orphan reaper: spare stopped stop-retention containers ---------------------
+
+
+def _reaper_mock(monkeypatch, ids_and_retention, finished_age=900):
+    """Fake docker: ps returns the ids; inspect answers FinishedAt then the label."""
+    old = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=finished_age)).isoformat()
+
+    def _run(cmd, **kwargs):
+        sub = cmd[1]
+        if sub == "ps":
+            return subprocess.CompletedProcess(cmd, 0, stdout="\n".join(ids_and_retention) + "\n", stderr="")
+        if sub == "inspect":
+            fmt = cmd[cmd.index("--format") + 1]
+            if "FinishedAt" in fmt:
+                return subprocess.CompletedProcess(cmd, 0, stdout=old + "\n", stderr="")
+            cid = cmd[-1]
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=(ids_and_retention.get(cid) or "") + "\n", stderr="")
+        if sub == "rm":
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+
+def test_reaper_skips_stop_on_session_end_containers(monkeypatch):
+    _reaper_mock(monkeypatch, {"cid-stop": "stop_on_session_end", "cid-plain": ""})
+    removed = docker_env.reap_orphan_containers(
+        max_age_seconds=600, profile_filter="default", docker_exe="/usr/bin/docker")
+    assert removed == 1, "only the container WITHOUT the stop-retention label may be reaped"
+
+
+def test_reaper_reaps_remove_and_idle_ttl_containers(monkeypatch):
+    _reaper_mock(monkeypatch, {"cid-rm": "remove_on_session_end", "cid-ttl": "idle_ttl"})
+    removed = docker_env.reap_orphan_containers(
+        max_age_seconds=600, profile_filter="default", docker_exe="/usr/bin/docker")
+    assert removed == 2
+
+
+def test_reaper_ignores_containers_without_label(monkeypatch):
+    """Pre-feature containers (no retention label) reap exactly as before."""
+    _reaper_mock(monkeypatch, {"cid-old": ""})
+    removed = docker_env.reap_orphan_containers(
+        max_age_seconds=600, profile_filter="default", docker_exe="/usr/bin/docker")
+    assert removed == 1
+
+
+# --- Idle reaper: idle_ttl envs expire on their own TTL -------------------------
+
+
+class _FakeSessionEnv:
+    def __init__(self, retention, ttl, scoped=True):
+        self._session_scoped = scoped
+        self._session_retention = retention
+        self._session_ttl_seconds = ttl
+
+
+def _seed_env(task_id, env, age_seconds):
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments[task_id] = env
+        terminal_tool._last_activity[task_id] = time.time() - age_seconds
+
+
+def test_idle_reaper_ttl_cutoff_for_idle_ttl(monkeypatch):
+    """idle_ttl env younger than its ttl survives; an older one is force-removed."""
+    torn_down = []
+
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        torn_down.append((task_id, force_remove))
+
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    _seed_env("session:young", _FakeSessionEnv("idle_ttl", 3600), age_seconds=400)
+    _seed_env("session:old", _FakeSessionEnv("idle_ttl", 60), age_seconds=400)
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert ("session:old", True) in torn_down
+    assert all(tid != "session:young" for tid, _ in torn_down)
+    assert get_active_env("session:young") is not None  # survived
+    assert get_active_env("session:old") is None  # reaped
+
+
+def test_idle_reaper_never_idles_stop_retention_envs(monkeypatch):
+    """stop/keep envs answer to the session, not the idle clock."""
+    torn_down = []
+
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        torn_down.append(task_id)
+
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    for retention in ("stop_on_session_end", "keep_running"):
+        _seed_env(f"session:{retention}", _FakeSessionEnv(retention, 3600), age_seconds=10_000)
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert torn_down == [], "session-retention envs must survive the idle sweep"
+    assert get_active_env("session:stop_on_session_end") is not None
+    assert get_active_env("session:keep_running") is not None
+
+
+def test_idle_reaper_non_session_envs_unchanged(monkeypatch):
+    torn_down = []
+
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        torn_down.append(task_id)
+
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    _seed_env("default", _FakeSessionEnv("stop_on_session_end", 3600, scoped=False), age_seconds=10_000)
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert torn_down == ["default"]
+
+
+# --- Close path: cleanup_vm finds envs via the close-key registry ---------------
+
+
+def test_cleanup_vm_finds_session_keyed_env_from_session_id(monkeypatch):
+    """AIAgent.close() passes the durable session_id; the env lives under session:<key>."""
+    env = _FakeSessionEnv("stop_on_session_end", 3600)
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments["session:telegram:123"] = env
+    with terminal_tool._session_close_keys_lock:
+        terminal_tool._session_close_keys["session:telegram:123"] = {
+            "session_key": "telegram:123", "session_id": "20260908_abc123"}
+    torn_down = []
+
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        torn_down.append(task_id)
+
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    cleanup_vm("20260908_abc123")  # the close path's id — NOT the cache key
+    assert torn_down == ["session:telegram:123"]
+    assert get_active_env("session:telegram:123") is None
+
+
+def test_cleanup_vm_raw_key_still_works(monkeypatch):
+    """Plain task ids keep the exact legacy behavior."""
+    env = _FakeSessionEnv("stop_on_session_end", 3600)
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments["default"] = env
+    torn_down = []
+
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        torn_down.append(task_id)
+
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    cleanup_vm("default")
+    assert torn_down == ["default"]
+
+
+def test_child_close_never_tears_down_parent_env(monkeypatch):
+    """Delegate child ids are not in the close-key registry: their close() must not
+    reach the parent's session-scoped env."""
+    env = _FakeSessionEnv("stop_on_session_end", 3600)
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments["session:parent-key"] = env
+    with terminal_tool._session_close_keys_lock:
+        terminal_tool._session_close_keys["session:parent-key"] = {
+            "session_key": "parent-key", "session_id": "parent-session-id"}
+    torn_down = []
+
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        torn_down.append(task_id)
+
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    cleanup_vm("child-session-id-xyz")
+    assert torn_down == [], "an unregistered child id must not reach the parent's env"
+    assert get_active_env("session:parent-key") is env
+
+
+def test_record_session_close_key_ignores_non_session_keys():
+    terminal_tool._record_session_close_key("default")
+    terminal_tool._record_session_close_key("profile:work")
+    terminal_tool._record_session_close_key("shared:team")
+    with terminal_tool._session_close_keys_lock:
+        assert terminal_tool._session_close_keys == {}
+
+
+def test_is_persistent_env_true_for_session_scope_env():
+    """Session-scoped containers skip per-turn teardown (their lifetime is the session)."""
+    env = _FakeSessionEnv("stop_on_session_end", 3600)
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments["session:abc"] = env
+    assert is_persistent_env("session:abc") is True

--- a/tests/tools/test_docker_session_scope.py
+++ b/tests/tools/test_docker_session_scope.py
@@ -482,6 +482,30 @@ def test_idle_reaper_never_idles_stop_retention_envs(monkeypatch):
     assert get_active_env("session:keep_running") is not None
 
 
+def test_idle_reaper_drops_session_close_key_entry(monkeypatch):
+    """Review fix (#46041): the reaper pops _active_environments/_last_activity
+    directly, so it must ALSO drop the matching _session_close_keys entry —
+    otherwise the registry retains one small dict per reaped session in a
+    long-lived gateway process. A surviving (non-stale) env keeps its entry."""
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        pass
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    _seed_env("session:reaped", _FakeSessionEnv("stop_on_session_end", 3600), age_seconds=400)
+    _seed_env("session:alive", _FakeSessionEnv("stop_on_session_end", 3600), age_seconds=100)
+    with terminal_tool._session_close_keys_lock:
+        terminal_tool._session_close_keys["session:reaped"] = {
+            "session_key": "reaped", "session_id": "20260909_a"}
+        terminal_tool._session_close_keys["session:alive"] = {
+            "session_key": "alive", "session_id": "20260909_b"}
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert get_active_env("session:reaped") is None
+    assert get_active_env("session:alive") is not None
+    with terminal_tool._session_close_keys_lock:
+        assert "session:reaped" not in terminal_tool._session_close_keys
+        assert terminal_tool._session_close_keys["session:alive"] == {
+            "session_key": "alive", "session_id": "20260909_b"}
+
+
 def test_idle_reaper_ephemeral_envs_still_reaped(monkeypatch):
     """BLOCKER regression (#46041 review): ephemeral per-session envs (_session_scoped=True,
     _scope=shared) must keep the LEGACY idle contract — reaped after lifetime_seconds."""

--- a/tests/tools/test_docker_session_scope.py
+++ b/tests/tools/test_docker_session_scope.py
@@ -210,7 +210,8 @@ def _build(cc, task_id):
         task_id=task_id, ssh_config=None, host_cwd=None)
 
 
-def test_builder_session_scope_passes_retention(recording_env):
+def test_builder_session_scope_passes_retention(monkeypatch, recording_env):
+    _pin_session(monkeypatch, scope="session", persistent="true", session_key="abc")
     env = _build(_builder_cc(), "session:abc")
     assert env._scope == "session"
     assert env._session_retention == "stop_on_session_end"
@@ -242,6 +243,25 @@ def test_builder_session_scope_config_with_ephemeral_env_forces_shared(monkeypat
     env = _build(_builder_cc(container_persistent=False), "session:abc")
     assert env._scope == "shared"
     assert env._persist_across_processes is False
+
+
+def test_builder_scope_never_leaks_to_default_container(monkeypatch, recording_env):
+    """BLOCKER regression (#46041 review): task_id=default (CLI/shared container) must get
+    scope=shared even with docker_container_scope: session in the config — the passthrough
+    table must not hand scope=session to the ctor."""
+    _pin_session(monkeypatch, scope="session", persistent="true", session_key=None)
+    env = _build(_builder_cc(), "default")
+    assert env._scope == "shared"
+    assert env._session_scoped is False
+
+
+def test_builder_scope_never_leaks_to_rl_override_sandboxes(monkeypatch, recording_env):
+    """BLOCKER regression: RL/benchmark override sandboxes keep the shared contract."""
+    _pin_session(monkeypatch, scope="session", persistent="true", session_key="abc")
+    terminal_tool.register_task_env_overrides("rl-task-1", {"docker_image": "rl-img"})
+    env = _build(_builder_cc(), "rl-task-1")
+    assert env._scope == "shared"
+    assert env._session_scoped is False
 
 
 def test_builder_shared_default_untouched(recording_env):
@@ -402,6 +422,7 @@ def test_reaper_ignores_containers_without_label(monkeypatch):
 
 class _FakeSessionEnv:
     def __init__(self, retention, ttl, scoped=True):
+        self._scope = "session" if scoped else "shared"
         self._session_scoped = scoped
         self._session_retention = retention
         self._session_ttl_seconds = ttl
@@ -430,8 +451,23 @@ def test_idle_reaper_ttl_cutoff_for_idle_ttl(monkeypatch):
     assert get_active_env("session:old") is None  # reaped
 
 
+def test_idle_reaper_stops_stop_retention_envs_after_lifetime(monkeypatch):
+    """stop-retention envs idle out after lifetime_seconds but are torn down NON-forced:
+    cleanup() applies stop-only (resumable), the registry stays bounded."""
+    torn_down = []
+
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        torn_down.append((task_id, force_remove))
+
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    _seed_env("session:stop", _FakeSessionEnv("stop_on_session_end", 3600), age_seconds=400)
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert torn_down == [("session:stop", False)], "stale stop-retention env is torn down (non-forced)"
+    assert get_active_env("session:stop") is None
+
+
 def test_idle_reaper_never_idles_stop_retention_envs(monkeypatch):
-    """stop/keep envs answer to the session, not the idle clock."""
+    """stop/keep envs inside the idle window are untouched (bg processes survive)."""
     torn_down = []
 
     def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
@@ -439,11 +475,26 @@ def test_idle_reaper_never_idles_stop_retention_envs(monkeypatch):
 
     monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
     for retention in ("stop_on_session_end", "keep_running"):
-        _seed_env(f"session:{retention}", _FakeSessionEnv(retention, 3600), age_seconds=10_000)
+        _seed_env(f"session:{retention}", _FakeSessionEnv(retention, 3600), age_seconds=100)
     _cleanup_inactive_envs(lifetime_seconds=300)
-    assert torn_down == [], "session-retention envs must survive the idle sweep"
+    assert torn_down == [], "idle-but-open session envs must survive the sweep"
     assert get_active_env("session:stop_on_session_end") is not None
     assert get_active_env("session:keep_running") is not None
+
+
+def test_idle_reaper_ephemeral_envs_still_reaped(monkeypatch):
+    """BLOCKER regression (#46041 review): ephemeral per-session envs (_session_scoped=True,
+    _scope=shared) must keep the LEGACY idle contract — reaped after lifetime_seconds."""
+    torn_down = []
+
+    def _fake_teardown(env_, task_id, *, force_remove=False, done_msg=""):
+        torn_down.append((task_id, force_remove))
+
+    monkeypatch.setattr("tools.terminal_tool_lifecycle._teardown_env", _fake_teardown)
+    _seed_env("session:ephemeral", _FakeSessionEnv("stop_on_session_end", 3600, scoped=False),
+              age_seconds=400)
+    _cleanup_inactive_envs(lifetime_seconds=300)
+    assert torn_down == [("session:ephemeral", False)], "ephemeral envs are not exempt from idling"
 
 
 def test_idle_reaper_non_session_envs_unchanged(monkeypatch):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -152,6 +152,13 @@ def reap_orphan_containers(
         age = (now - finished_at).total_seconds()
         if age < max_age_seconds:
             continue
+        if _container_session_retention(docker, cid) == "stop_on_session_end":
+            # Session-scoped container stopped at session close (#46041): its session may
+            # resume and reattach — the next use restarts it. Removal happens when the
+            # session itself removes it (remove_on_session_end) or the retention TTL is
+            # configured (idle_ttl containers carry a different label and stay reapable).
+            logger.debug("Skipping stopped session container %s (stop_on_session_end retention)", cid[:12])
+            continue
         result = _docker_query(
             [docker, "rm", "-f", cid], timeout=30, fail="orphan reaper docker rm %s failed: %s", fail_args=(cid[:12],))
         if result is None:
@@ -162,6 +169,19 @@ def reap_orphan_containers(
         else:
             logger.debug("docker rm -f %s failed: %s", cid[:12], result.stderr.strip())
     return removed
+
+
+def _container_session_retention(docker_exe: str, container_id: str) -> str:
+    """Value of the ``hermes-session-retention`` label, or ``""`` when absent/unreadable
+    (pre-feature containers and non-session containers reap exactly as before)."""
+    result = _docker_query(
+        [docker_exe, "inspect", "--format",
+         '{{index .Config.Labels "hermes-session-retention"}}', container_id],
+        timeout=10,
+        fail="orphan reaper label inspect %s failed: %s", fail_args=(container_id[:12],))
+    if result is None or result.returncode != 0:
+        return ""
+    return result.stdout.strip()
 
 
 def _container_finished_at(docker_exe: str, container_id: str):
@@ -522,9 +542,11 @@ class DockerEnvironment(BaseEnvironment):
         super().__init__(cwd=cwd, timeout=timeout)
         self._persistent = persistent_filesystem
         self._persist_across_processes = persist_across_processes
-        # Set by terminal_tool._create_environment for session-scoped containers
-        # (docker + container_persistent: false): removed at session close/idle timeout.
+        # Session-scoped containers (#46041) mark themselves here; _build_docker_env also
+        # sets it after construction for test doubles that reject ctor kwarg writes.
         self._session_scoped = False
+        if scope == "session":
+            self._session_scoped = True
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
         self._env = _normalize_env_dict(env)
@@ -565,7 +587,7 @@ class DockerEnvironment(BaseEnvironment):
         security_args = _build_security_args(
             run_as_host_user and bool(user_args), run_exec=image_uses_s6_init, snap_compat=snap_compat)
         self._snap_compat = snap_compat
-        # Config surface for #46041 session-scoped containers; consumed by session-scope routing later in this PR.
+        # Config surface for #46041 session-scoped containers.
         self._scope = scope
         self._session_retention = session_retention
         self._session_ttl_seconds = session_ttl_seconds
@@ -592,6 +614,10 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label}
+        if scope == "session":
+            # Baked at creation (immutable like the rest) so the orphan reaper can spare a
+            # STOPPED session container awaiting resume per its retention mode (#46041).
+            self._labels["hermes-session-retention"] = _sanitize_label_value(session_retention)
         # Saved for container recreation on "No such container" recovery.
         self._image = image
         self._image_uses_s6_init = image_uses_s6_init
@@ -1011,13 +1037,13 @@ class DockerEnvironment(BaseEnvironment):
         """Tear down per persist mode. Persist mode (default) leaves the container RUNNING —
         stopping it on every exit would kill background processes and add a ``docker start``
         delay per session; reclamation is ``reap_orphan_containers()`` at next startup.
-        ``persist_across_processes=False`` or ``force_remove=True`` (explicit-teardown hook,
-        unused so far) does ``docker stop`` + ``docker rm -f`` on a daemon thread that the
-        atexit hook joins via ``wait_for_cleanup`` so the work completes before exit.
-
-        Cleanup runs on a daemon thread with bounded ``subprocess.run`` calls (not the racy ``Popen(... &)``
-        pattern from before PR #33645). The atexit hook in ``tools/terminal_tool.py`` waits up to 15s for
-        the thread to finish before the interpreter exits, so ``docker stop`` / ``docker rm`` actually
+        ``persist_across_processes=False`` or ``force_remove=True`` (explicit-teardown hook)
+        does ``docker stop`` + ``docker rm -f``; a session-scoped container with
+        ``stop_on_session_end`` retention does ``docker stop`` ONLY, so a later process can
+        reattach via the label probe and restart it (#46041). Teardown runs on a daemon thread
+        with bounded ``subprocess.run`` calls (not the racy ``Popen(... &)`` pattern from before
+        PR #33645). The atexit hook in ``tools/terminal_tool.py`` waits up to 15s for the thread
+        to finish before the interpreter exits, so ``docker stop`` / ``docker rm`` actually
         completes when we do trigger it.
         """
         container_id = self._container_id
@@ -1027,19 +1053,46 @@ class DockerEnvironment(BaseEnvironment):
                 self._remove_bind_dirs()
             return
 
+        if (not force_remove and self._scope == "session"
+                and self._session_retention in ("stop_on_session_end", "idle_ttl")):
+            # Session scope, stop-family retention (#46041): stop WITHOUT rm — the session's next
+            # use reattaches via labels and restarts the container (stop_on_session_end), or the
+            # orphan reaper reclaims it once its FinishedAt ages past the sweep threshold
+            # (idle_ttl — after the env registry entry is gone at session close, the TTL clock is
+            # the reaper's age check). Filesystem state survives; in-container processes do not.
+            # Ephemeral per-session isolation (_scope left at "shared") keeps the stop+rm contract
+            # below.
+            self._spawn_teardown(
+                container_id,
+                ((["stop", "-t", "10"], "docker stop %s timed out / failed: %s"),))
+            return
+
         if not force_remove and self._persist_across_processes:
             # Drop the in-process handle so a fresh __init__ re-probes via
             # labels instead of reusing a stale Python reference.
             self._container_id = None
             return
 
+        self._spawn_teardown(
+            container_id,
+            ((["stop", "-t", "10"], "docker stop %s timed out / failed: %s"),
+             (["rm", "-f"], "docker rm -f %s failed: %s")))
+
+        # Bind-mount dirs are the container's filesystem state; only drop them
+        # once the container itself is removed.
+        if not self._persistent:
+            self._remove_bind_dirs()
+
+    def _spawn_teardown(self, container_id: str, steps) -> None:
+        """Run *steps* (argv/fail_msg pairs; the container id is appended to each argv) on a
+        daemon thread tracked for ``wait_for_all_teardowns``, then drop the in-process handle
+        so a fresh ``__init__`` re-probes via labels instead of a stale Python reference."""
         # Capture what the worker needs — the thread can outlive ``self``.
         docker_exe = self._docker_exe
         log_id = container_id[:12]
 
         def _do_cleanup() -> None:
-            for argv, fail_msg in ((["stop", "-t", "10"], "docker stop %s timed out / failed: %s"),
-                                   (["rm", "-f"], "docker rm -f %s failed: %s")):
+            for argv, fail_msg in steps:
                 try:
                     subprocess.run(
                         [docker_exe, *argv, container_id],
@@ -1053,11 +1106,6 @@ class DockerEnvironment(BaseEnvironment):
         t.start()
         self._cleanup_thread = t
         self._container_id = None
-
-        # Bind-mount dirs are the container's filesystem state; only drop them
-        # once the container itself is removed.
-        if not self._persistent:
-            self._remove_bind_dirs()
 
     @staticmethod
     def wait_for_all_teardowns(timeout: float = 15.0) -> bool:

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -513,7 +513,10 @@ class DockerEnvironment(BaseEnvironment):
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
         shared_container_key: str = "",
-        snap_compat: bool = False):
+        snap_compat: bool = False,
+        scope: str = "shared",
+        session_retention: str = "stop_on_session_end",
+        session_ttl_seconds: int = 3600):
         if cwd == "~":
             cwd = "/root"
         super().__init__(cwd=cwd, timeout=timeout)
@@ -562,6 +565,10 @@ class DockerEnvironment(BaseEnvironment):
         security_args = _build_security_args(
             run_as_host_user and bool(user_args), run_exec=image_uses_s6_init, snap_compat=snap_compat)
         self._snap_compat = snap_compat
+        # Config surface for #46041 session-scoped containers; consumed by session-scope routing later in this PR.
+        self._scope = scope
+        self._session_retention = session_retention
+        self._session_ttl_seconds = session_ttl_seconds
         if snap_compat:
             logger.warning(
                 "docker_snap_compat: running without --init and no-new-privileges (snap Docker under AppArmor)")

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -150,14 +150,25 @@ def reap_orphan_containers(
         if finished_at is None:  # unknown age — be conservative
             continue
         age = (now - finished_at).total_seconds()
-        if age < max_age_seconds:
-            continue
-        if _container_session_retention(docker, cid) == "stop_on_session_end":
-            # Session-scoped container stopped at session close (#46041): its session may
-            # resume and reattach — the next use restarts it. Removal happens when the
-            # session itself removes it (remove_on_session_end) or the retention TTL is
-            # configured (idle_ttl containers carry a different label and stay reapable).
-            logger.debug("Skipping stopped session container %s (stop_on_session_end retention)", cid[:12])
+        retention = _container_session_retention(docker, cid)
+        if retention == "stop_on_session_end":
+            if age < _STOP_RETENTION_REAP_CEILING_SECONDS:
+                # Session-scoped container stopped at session close (#46041): its session may
+                # resume and reattach — the next use restarts it. Removal happens when the
+                # session itself removes it, the retention TTL expires it, or the ceiling here
+                # declares the session abandoned.
+                logger.debug("Skipping stopped session container %s (stop_on_session_end retention)", cid[:12])
+                continue
+            logger.info("Reaping stopped session container %s (no resume for %.1f days)", cid[:12], age / 86400)
+        elif retention == "idle_ttl":
+            ttl = _container_session_ttl(docker, cid)
+            # The session's own TTL governs an idle_ttl container's lifetime — the generic
+            # 2×lifetime sweep threshold must not reap it early (#46041). No TTL label
+            # (pre-label container) falls back to the generic threshold.
+            if age < (ttl if ttl > 0 else max_age_seconds):
+                logger.debug("Skipping idle_ttl session container %s (stopped %.0fs < ttl %ds)", cid[:12], age, ttl)
+                continue
+        elif age < max_age_seconds:
             continue
         result = _docker_query(
             [docker, "rm", "-f", cid], timeout=30, fail="orphan reaper docker rm %s failed: %s", fail_args=(cid[:12],))
@@ -182,6 +193,27 @@ def _container_session_retention(docker_exe: str, container_id: str) -> str:
     if result is None or result.returncode != 0:
         return ""
     return result.stdout.strip()
+
+
+def _container_session_ttl(docker_exe: str, container_id: str) -> int:
+    """``hermes-session-ttl`` label as int seconds, or 0 when absent/unparseable."""
+    result = _docker_query(
+        [docker_exe, "inspect", "--format",
+         '{{index .Config.Labels "hermes-session-ttl"}}', container_id],
+        timeout=10,
+        fail="orphan reaper ttl inspect %s failed: %s", fail_args=(container_id[:12],))
+    if result is None or result.returncode != 0:
+        return 0
+    try:
+        return int(result.stdout.strip() or 0)
+    except ValueError:
+        return 0
+
+
+# stop_on_session_end containers awaiting a resume are spared by the orphan reaper, but not
+# forever: once a stopped one ages past this ceiling it is reclaimed (abandoned session).
+# Generous by design — 7 days of no resume is a fair proxy for "session abandoned".
+_STOP_RETENTION_REAP_CEILING_SECONDS = 7 * 24 * 3600
 
 
 def _container_finished_at(docker_exe: str, container_id: str):
@@ -615,9 +647,13 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label}
         if scope == "session":
-            # Baked at creation (immutable like the rest) so the orphan reaper can spare a
-            # STOPPED session container awaiting resume per its retention mode (#46041).
+            # Baked at creation (immutable like the rest) so the orphan reaper can apply the
+            # session's retention policy to a STOPPED container it finds (#46041): stop_on_session_end
+            # containers are spared while a resume is plausible; idle_ttl containers are removed
+            # once stopped longer than their TTL; remove_on_session_end containers never linger.
             self._labels["hermes-session-retention"] = _sanitize_label_value(session_retention)
+            if session_retention == "idle_ttl" and session_ttl_seconds > 0:
+                self._labels["hermes-session-ttl"] = str(int(session_ttl_seconds))
         # Saved for container recreation on "No such container" recovery.
         self._image = image
         self._image_uses_s6_init = image_uses_s6_init

--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -28,7 +28,8 @@ _TOOL_LEVEL_DEFAULTS: Dict[str, Any] = {
     "cwd": ".", "ssh_host": "", "ssh_user": "", "ssh_port": 22, "ssh_key": "",
     "docker_orphan_reaper": True, "docker_persist_across_processes": True,
     "sandbox_dir": "", "lifetime_seconds": 300, "docker_shared_container_key": "",
-    "home_mode": "auto",
+    "docker_container_scope": "shared", "docker_session_container_retention": "stop_on_session_end",
+    "docker_session_container_ttl_seconds": 3600, "home_mode": "auto",
 }
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -246,6 +246,42 @@ _session_cwd_lock = threading.Lock()
 _container_aliases: Dict[str, str] = {}
 _container_alias_lock = threading.Lock()
 
+# Session-close lookup: envs cached under a resolved id ("session:<key>") must be
+# reachable by close paths holding a DIFFERENT durable id — AIAgent.close() passes
+# self.session_id (the conversation id, rotates on /new) while the cache key uses
+# the session_key (stable platform-scoped chat identity). Written at env creation
+# (resolved key -> {session_id, session_key}); cleanup_vm consults it on raw-pop
+# miss. delegate_task child ids are never registered: their close() resolves via
+# the alias registry to the parent's env or falls to "default"/no-op, exactly as
+# before (#46041).
+_session_close_keys: Dict[str, Dict[str, str]] = {}
+_session_close_keys_lock = threading.Lock()
+
+
+def _record_session_close_key(cache_key: str) -> None:
+    """Remember which durable ids map to *cache_key* so session-close can find it."""
+    if not cache_key or not cache_key.startswith("session:"):
+        return
+    from gateway.session_context import get_session_env
+    entry = {
+        "session_key": _current_session_key(),
+        "session_id": get_session_env("HERMES_SESSION_ID", ""),
+    }
+    with _session_close_keys_lock:
+        _session_close_keys[cache_key] = {k: v for k, v in entry.items() if v}
+
+
+def _close_lookup_keys(task_id: str) -> list:
+    """Cache-key candidates for a close-path lookup of *task_id*: the raw id plus
+    any session-scope cache key recorded for this id at env-creation time."""
+    keys = [task_id] if task_id else []
+    with _session_close_keys_lock:
+        for cache_key, ids in _session_close_keys.items():
+            if task_id and task_id in (ids.get("session_key"), ids.get("session_id")):
+                if cache_key not in keys:
+                    keys.append(cache_key)
+    return keys
+
 
 def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
     """Record *cwd* as *session_key*'s working directory (after a completed
@@ -352,18 +388,25 @@ class _SessionScope:
       across sessions, so one shared sandbox contradicts it. Docker, plus plugin
       backends declaring ``session_isolated_when_nonpersistent`` (sandboxes resumed
       by name, where a shared deterministic name would let two ephemeral runs
-      attach one VM and delete it under each other).
+      attach one VM and delete it under each other). Docker also isolates when
+      ``docker_container_scope: session`` asks for persistent per-session
+      containers (#46041).
     * ``docker_session_isolated`` — docker-only view: the workspace mount and
       session-scoped teardown paths must not fire for other backends.
-    * ``docker_profile_scoped`` — docker + ``container_persistent: true``: ONE
-      long-lived container per profile shared by every session (CLI, gateway,
-      WebUI). The session-key fallback in :func:`_resolve_container_task_id` stops
-      cross-profile SSH reuse; ungated it fragmented persistent Docker into one
-      container per gateway session, so this restores profile scoping for exactly
-      this backend/mode.
+    * ``docker_session_scope`` — docker + ``docker_container_scope: session`` +
+      ``container_persistent: true``: ONE long-lived container per chat session,
+      reattached on resume (the persistent analogue of the ephemeral isolation
+      above).
+    * ``docker_profile_scoped`` — docker + ``container_persistent: true`` without
+      session scope: ONE long-lived container per profile shared by every session
+      (CLI, gateway, WebUI). The session-key fallback in
+      :func:`_resolve_container_task_id` stops cross-profile SSH reuse; ungated it
+      fragmented persistent Docker into one container per gateway session, so this
+      restores profile scoping for exactly this backend/mode.
     """
     env_type: str
     persistent: bool
+    docker_scope: str = "shared"
 
     @property
     def session_isolated(self) -> bool:
@@ -375,11 +418,16 @@ class _SessionScope:
 
     @property
     def docker_session_isolated(self) -> bool:
-        return self.env_type == "docker" and self.session_isolated
+        return self.env_type == "docker" and (
+            not self.persistent or self.docker_scope == "session")
+
+    @property
+    def docker_session_scope(self) -> bool:
+        return self.env_type == "docker" and self.docker_scope == "session" and self.persistent
 
     @property
     def docker_profile_scoped(self) -> bool:
-        return self.env_type == "docker" and self.persistent
+        return self.env_type == "docker" and self.persistent and self.docker_scope != "session"
 
 
 def _session_scope() -> _SessionScope:
@@ -388,6 +436,7 @@ def _session_scope() -> _SessionScope:
     return _SessionScope(
         env_type=_tenv("TERMINAL_ENV", "local"),
         persistent=_tenv_bool("TERMINAL_CONTAINER_PERSISTENT", "true"),
+        docker_scope=_tenv("TERMINAL_DOCKER_CONTAINER_SCOPE", "shared").strip() or "shared",
     )
 
 
@@ -424,19 +473,28 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     # the gateway per-message via contextvars), scope the container to it so switching profiles can't reuse
     # a previous profile's SSHEnvironment and silently run commands on the wrong remote host. Subagents
     # inherit the same session key, so they still collapse onto the parent's container (the #16177
-    # shared-container intent). CLI mode has no session key and falls through to "default", behaviour
-    # unchanged. See commit e00f940a9. This runs *after* the isolation-override and
-    # docker/container_persistent branches above: those paths already key containers per task_id, so they
-    # stay authoritative where they apply and this only covers the cases that would otherwise collapse to
-    # the shared "default" key (notably SSH).
+    # shared-container intent). With docker_container_scope: session, persistent Docker keys the same way
+    # (#46041) — one long-lived container per session, reattached on resume. CLI mode has no session key
+    # and falls through to "default", behaviour unchanged. See commit e00f940a9. This runs *after* the
+    # isolation-override and docker/container_persistent branches above: those paths already key containers
+    # per task_id, so they stay authoritative where they apply and this only covers the cases that would
+    # otherwise collapse to the shared "default" key (notably SSH).
     session_key = _current_session_key()
-    shared = _tenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip() if scope.docker_profile_scoped else ""
+    # Explicit opt-in: trusted profiles configuring the same terminal.docker_shared_container_key share
+    # ONE container/cache slot (and sandbox dir) regardless of profile name (#84671). Wins over session
+    # scope too: a configured shared identity is the more explicit statement (#46041). Docker-only key —
+    # SSH reuse must stay session/profile-keyed so a key never points at the wrong remote host.
+    shared = (_tenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip()
+              if scope.env_type == "docker" and scope.persistent else "")
     if shared:
-        # Explicit opt-in: trusted profiles configuring the same terminal.docker_shared_container_key share
-        # ONE container/cache slot (and sandbox dir) regardless of profile name (#84671).
         return f"shared:{shared}"
     if not session_key:
         return "default"
+    if scope.docker_session_scope:
+        # docker_container_scope: session + container_persistent: true — ONE long-lived container per
+        # chat session (#46041); resumed sessions reattach via labels. Subagents inherit the session
+        # key and collapse onto the parent's container, as in the non-persistent branch above.
+        return f"session:{session_key}"
     if not scope.docker_profile_scoped:
         return f"session:{session_key}"
     profile = _current_session_profile() or "default"
@@ -663,6 +721,10 @@ def _get_env_config() -> Dict[str, Any]:
         # instead of starting fresh; false = per-process isolation.
         "docker_persist_across_processes": _tenv_bool("TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"),
         "docker_shared_container_key": _tenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip(),
+        # Session-scoped containers (#46041): routing + retention surface.
+        "docker_container_scope": _tenv("TERMINAL_DOCKER_CONTAINER_SCOPE", "shared").strip() or "shared",
+        "docker_session_container_retention": _tenv("TERMINAL_DOCKER_SESSION_CONTAINER_RETENTION", "stop_on_session_end").strip() or "stop_on_session_end",
+        "docker_session_container_ttl_seconds": _parse_env_var("TERMINAL_DOCKER_SESSION_CONTAINER_TTL_SECONDS", "3600"),
         "docker_orphan_reaper": _tenv_bool("TERMINAL_DOCKER_ORPHAN_REAPER", "true"),
     }
 
@@ -1043,6 +1105,7 @@ def _acquire_env(plan: _ExecPlan, task_id: Optional[str]) -> Any:
         with _env_lock:
             _active_environments[eff] = new_env
             _last_activity[eff] = time.time()
+        _record_session_close_key(eff)
         logger.info("%s environment ready for task %s", env_type, eff[:8])
         return new_env
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1072,8 +1072,9 @@ def _acquire_env(plan: _ExecPlan, task_id: Optional[str]) -> Any:
 
     with _env_lock:
         env: Any = _lookup_active_env(eff, task_id)
-    if env is not None:
-        return env
+        if env is not None:
+            _record_session_close_key(eff)  # session_id may have rotated (/new); refresh
+            return env
 
     with _creation_locks_lock:
         task_lock = _creation_locks.setdefault(eff, threading.Lock())
@@ -1081,8 +1082,9 @@ def _acquire_env(plan: _ExecPlan, task_id: Optional[str]) -> Any:
     with task_lock:
         with _env_lock:
             env = _lookup_active_env(eff, task_id)
-        if env is not None:
-            return env
+            if env is not None:
+                _record_session_close_key(eff)  # session_id may have rotated (/new); refresh
+                return env
 
         if env_type == "singularity":
             _check_disk_usage_warning()

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -51,9 +51,6 @@ _DOCKER_KWARGS = (
     ("extra_args", "docker_extra_args", []), ("persist_across_processes", "docker_persist_across_processes", True),
     ("shared_container_key", "docker_shared_container_key", ""), ("shm_size", "docker_shm_size", "1g"),
     ("snap_compat", "docker_snap_compat", False),
-    ("scope", "docker_container_scope", "shared"),
-    ("session_retention", "docker_session_container_retention", "stop_on_session_end"),
-    ("session_ttl_seconds", "docker_session_container_ttl_seconds", 3600),
 )
 
 
@@ -121,10 +118,13 @@ def _build_docker_env(*, image, cwd, timeout, cc, task_id, host_cwd, **_):
     # persistent per-session mode: cross-process reuse stays ON for stop/keep/idle_ttl retention
     # (a stopped container must be reattachable from a later process); only remove_on_session_end
     # drops to the ephemeral contract. Ephemeral isolation (container_persistent: false) keeps the
-    # unconditional persist=False.
+    # unconditional persist=False. The scope/retention kwargs are set ONLY in the session-scope
+    # branch below — never via the passthrough — so "default"/RL-shared containers can never
+    # inherit scope="session" (which would stop-only and label them as session containers).
     session_scoped = (_docker_session_isolation_enabled() and task_id != "default"
                       and not _has_isolation_overrides(task_id))
     kwargs = {out: cc.get(key, default) for out, key, default in _DOCKER_KWARGS}
+    kwargs["scope"] = "shared"  # ctor default; only true session scope may override
     if session_scoped:
         retention = cc.get("docker_session_container_retention") or "stop_on_session_end"
         try:
@@ -143,7 +143,6 @@ def _build_docker_env(*, image, cwd, timeout, cc, task_id, host_cwd, **_):
             # Ephemeral per-session isolation: never let a cc-passed scope="session"
             # (user set scope=session but flipped container_persistent to false) flip the
             # ctor's _session_scoped marker — the ephemeral contract is stop+rm.
-            kwargs["scope"] = "shared"
             kwargs["persist_across_processes"] = False
     docker_env_obj = _DockerEnvironment(image=image, cwd=cwd, timeout=timeout, task_id=task_id, host_cwd=host_cwd,
                                         **_resources(cc), **kwargs)

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -41,6 +41,8 @@ _CONTAINER_KEYS = (
     ("docker_env", {}), ("docker_run_as_host_user", False), ("docker_extra_args", []),
     ("docker_shm_size", "1g"), ("docker_network", True), ("docker_persist_across_processes", True),
     ("docker_shared_container_key", ""), ("docker_orphan_reaper", True), ("docker_snap_compat", False),
+    ("docker_container_scope", "shared"), ("docker_session_container_retention", "stop_on_session_end"),
+    ("docker_session_container_ttl_seconds", 3600),
 )
 _DOCKER_KWARGS = (
     ("volumes", "docker_volumes", []), ("auto_mount_cwd", "docker_mount_cwd_to_workspace", False),
@@ -49,6 +51,9 @@ _DOCKER_KWARGS = (
     ("extra_args", "docker_extra_args", []), ("persist_across_processes", "docker_persist_across_processes", True),
     ("shared_container_key", "docker_shared_container_key", ""), ("shm_size", "docker_shm_size", "1g"),
     ("snap_compat", "docker_snap_compat", False),
+    ("scope", "docker_container_scope", "shared"),
+    ("session_retention", "docker_session_container_retention", "stop_on_session_end"),
+    ("session_ttl_seconds", "docker_session_container_ttl_seconds", 3600),
 )
 
 

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -117,12 +117,34 @@ def _build_docker_env(*, image, cwd, timeout, cc, task_id, host_cwd, **_):
     _maybe_reap_docker_orphans(cc)
     # A session-keyed container must not outlive its session, so cross-process reuse/persist is
     # disabled for it (cleanup_vm()/idle reaper stop+rm it). The shared "default" container and
-    # RL/benchmark override sandboxes keep their existing lifecycle.
+    # RL/benchmark override sandboxes keep their existing lifecycle. Session SCOPE (#46041) is the
+    # persistent per-session mode: cross-process reuse stays ON for stop/keep/idle_ttl retention
+    # (a stopped container must be reattachable from a later process); only remove_on_session_end
+    # drops to the ephemeral contract. Ephemeral isolation (container_persistent: false) keeps the
+    # unconditional persist=False.
     session_scoped = (_docker_session_isolation_enabled() and task_id != "default"
                       and not _has_isolation_overrides(task_id))
     kwargs = {out: cc.get(key, default) for out, key, default in _DOCKER_KWARGS}
     if session_scoped:
-        kwargs["persist_across_processes"] = False
+        retention = cc.get("docker_session_container_retention") or "stop_on_session_end"
+        try:
+            ttl = int(cc.get("docker_session_container_ttl_seconds") or 3600)
+        except (TypeError, ValueError):
+            ttl = 3600
+        is_session_scope = ((cc.get("docker_container_scope") or "shared") == "session"
+                            and cc.get("container_persistent", True))
+        if is_session_scope:
+            kwargs["scope"] = "session"
+            kwargs["session_retention"] = retention
+            kwargs["session_ttl_seconds"] = ttl
+            if retention == "remove_on_session_end":
+                kwargs["persist_across_processes"] = False
+        else:
+            # Ephemeral per-session isolation: never let a cc-passed scope="session"
+            # (user set scope=session but flipped container_persistent to false) flip the
+            # ctor's _session_scoped marker — the ephemeral contract is stop+rm.
+            kwargs["scope"] = "shared"
+            kwargs["persist_across_processes"] = False
     docker_env_obj = _DockerEnvironment(image=image, cwd=cwd, timeout=timeout, task_id=task_id, host_cwd=host_cwd,
                                         **_resources(cc), **kwargs)
     # Marker read by is_persistent_env(): a session-scoped container survives BETWEEN turns (skip

--- a/tools/terminal_tool_lifecycle.py
+++ b/tools/terminal_tool_lifecycle.py
@@ -147,7 +147,7 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     """Clean up environments that have been inactive for longer than lifetime_seconds."""
     from tools.terminal_tool import (
         _active_environments, _creation_locks, _creation_locks_lock, _env_lock,
-        _last_activity,
+        _last_activity, _session_close_keys, _session_close_keys_lock,
     )
     current_time = time.time()
 
@@ -194,6 +194,12 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
         with _creation_locks_lock:
             for t in stale:
                 _creation_locks.pop(t, None)
+        # Also drop the session-close registry entry the reaper would otherwise
+        # leave behind (bounded, but a slow leak across many sessions in a
+        # long-lived gateway process) — #46041.
+        with _session_close_keys_lock:
+            for t in stale:
+                _session_close_keys.pop(t, None)
     for task_id, env in envs_to_stop:
         if env is not None:
             _clear_file_ops_cache(task_id)

--- a/tools/terminal_tool_lifecycle.py
+++ b/tools/terminal_tool_lifecycle.py
@@ -158,9 +158,25 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
         pass
 
     # Phase 1: unregister stale entries atomically under the lock; phase 2:
-    # stop them outside it (see _unregister_env for why).
+    # stop them outside it (see _unregister_env for why). Session-scoped envs
+    # (#46041) answer to the SESSION lifecycle, not the idle clock: stop/keep
+    # retention envs are never idled out (an open session's bg processes must
+    # survive, as they do for the shared container today); idle_ttl envs expire
+    # on their own TTL and are force-removed (stop+rm).
     with _env_lock:
-        stale = [t for t, last in list(_last_activity.items()) if current_time - last > lifetime_seconds]
+        stale = []
+        for t, last in list(_last_activity.items()):
+            if current_time - last <= lifetime_seconds:
+                continue
+            env = _active_environments.get(t)
+            if env is not None and getattr(env, "_session_scoped", False):
+                retention = getattr(env, "_session_retention", "") or "stop_on_session_end"
+                if retention != "idle_ttl":
+                    continue
+                ttl = getattr(env, "_session_ttl_seconds", 0) or 0
+                if ttl > 0 and current_time - last <= ttl:
+                    continue
+            stale.append(t)
         envs_to_stop = [(t, _active_environments.pop(t, None)) for t in stale]
         for t in stale:
             _last_activity.pop(t, None)
@@ -170,7 +186,12 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     for task_id, env in envs_to_stop:
         if env is not None:
             _clear_file_ops_cache(task_id)
-            _teardown_env(env, task_id)
+            if getattr(env, "_session_scoped", False) \
+                    and (getattr(env, "_session_retention", "") or "stop_on_session_end") == "idle_ttl":
+                # idle_ttl expiry means removal (stop+rm), bypassing the retention no-op.
+                _teardown_env(env, task_id, force_remove=True)
+            else:
+                _teardown_env(env, task_id)
 
 
 def get_active_env(task_id: str):
@@ -296,13 +317,29 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     only for user-initiated teardown. The idle reaper calls ``env.cleanup()``
     directly, so persist-mode idle envs are likewise no-op'd; only the orphan
     reaper at next startup reclaims them.
+
+    Close paths may hold a different durable id than the cache key (session
+    scope #46041: AIAgent.close() passes the conversation session_id while the
+    env lives under "session:<session_key>"), so the lookup consults the
+    close-key registry recorded at env creation. Delegate children's close()
+    is unaffected: their ids resolve via the alias registry to the parent's
+    env or miss, as before.
     """
-    env = _unregister_env(task_id)
-    _clear_file_ops_cache(task_id)
+    from tools.terminal_tool import _close_lookup_keys
+    keys = _close_lookup_keys(task_id)
+    env = None
+    matched_key = task_id
+    for key in keys:
+        env = _unregister_env(key)
+        if env is not None:
+            matched_key = key
+            break
+    for key in keys:
+        _clear_file_ops_cache(key)
     if env is None:
         return
     _teardown_env(
-        env, task_id, force_remove=force_remove,
+        env, matched_key, force_remove=force_remove,
         done_msg="Manually cleaned up environment for task: %s",
     )
 

--- a/tools/terminal_tool_lifecycle.py
+++ b/tools/terminal_tool_lifecycle.py
@@ -127,16 +127,19 @@ def _unregister_env(task_id: str):
     """Pop *task_id* from the env cache, activity map and creation locks; return
     the env (or None). Callers run the (slow) teardown OUTSIDE the lock —
     Modal/Docker teardown can block 10-15s and would stall every concurrent
-    terminal/file tool call."""
+    terminal/file tool call. Also drops the session-close registry entry so the
+    map cannot grow unboundedly (#46041)."""
     from tools.terminal_tool import (
         _active_environments, _creation_locks, _creation_locks_lock, _env_lock,
-        _last_activity,
+        _last_activity, _session_close_keys, _session_close_keys_lock,
     )
     with _env_lock:
         env = _active_environments.pop(task_id, None)
         _last_activity.pop(task_id, None)
     with _creation_locks_lock:
         _creation_locks.pop(task_id, None)
+    with _session_close_keys_lock:
+        _session_close_keys.pop(task_id, None)
     return env
 
 
@@ -158,24 +161,32 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
         pass
 
     # Phase 1: unregister stale entries atomically under the lock; phase 2:
-    # stop them outside it (see _unregister_env for why). Session-scoped envs
-    # (#46041) answer to the SESSION lifecycle, not the idle clock: stop/keep
-    # retention envs are never idled out (an open session's bg processes must
-    # survive, as they do for the shared container today); idle_ttl envs expire
-    # on their own TTL and are force-removed (stop+rm).
+    # stop them outside it (see _unregister_env for why). TRUE session-scope
+    # envs (#46041, env._scope == "session") get retention-aware treatment:
+    # idle_ttl ones expire on their own TTL and are force-removed (stop+rm);
+    # stop/keep-retention ones tear down WITHOUT force after lifetime_seconds —
+    # cleanup() then applies the retention (stop-only, or persist no-op), the
+    # container stays resumable via labels, and the registry cannot grow
+    # unboundedly in a long-lived gateway process (sessions with active
+    # background processes never reach staleness — has_active_processes above).
+    # Ephemeral per-session isolation (container_persistent: false) keeps the
+    # legacy idle contract — reaped after lifetime_seconds like any sandbox.
     with _env_lock:
         stale = []
         for t, last in list(_last_activity.items()):
-            if current_time - last <= lifetime_seconds:
-                continue
+            age = current_time - last
             env = _active_environments.get(t)
-            if env is not None and getattr(env, "_session_scoped", False):
+            if env is not None and getattr(env, "_scope", "") == "session":
                 retention = getattr(env, "_session_retention", "") or "stop_on_session_end"
-                if retention != "idle_ttl":
+                window = lifetime_seconds
+                if retention == "idle_ttl":
+                    ttl = getattr(env, "_session_ttl_seconds", 0) or 0
+                    if ttl > 0:
+                        window = ttl  # the session's own TTL replaces the generic idle window
+                if age <= window:
                     continue
-                ttl = getattr(env, "_session_ttl_seconds", 0) or 0
-                if ttl > 0 and current_time - last <= ttl:
-                    continue
+            elif age <= lifetime_seconds:
+                continue
             stale.append(t)
         envs_to_stop = [(t, _active_environments.pop(t, None)) for t in stale]
         for t in stale:
@@ -186,11 +197,14 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
     for task_id, env in envs_to_stop:
         if env is not None:
             _clear_file_ops_cache(task_id)
-            if getattr(env, "_session_scoped", False) \
+            if getattr(env, "_scope", "") == "session" \
                     and (getattr(env, "_session_retention", "") or "stop_on_session_end") == "idle_ttl":
                 # idle_ttl expiry means removal (stop+rm), bypassing the retention no-op.
                 _teardown_env(env, task_id, force_remove=True)
             else:
+                # stop_on_session_end -> cleanup() stop-only (resumable);
+                # keep_running -> persist no-op (container untouched); other
+                # backends/sandboxes -> their normal teardown.
                 _teardown_env(env, task_id)
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -301,6 +301,8 @@ Runs commands inside a Docker container with security hardening (all capabilitie
 
 **Per-session isolation mode (`container_persistent: false`).** Setting `container_persistent: false` on the Docker backend switches to one container **per session**: every chat (desktop app session, gateway conversation, TUI session) gets its own fresh sandbox, created on its first terminal/file call and removed when the session closes or goes idle past `lifetime_seconds`. Nothing carries over between sessions — no filesystem state, no mounts, no background processes. With `docker_mount_cwd_to_workspace: true`, only the workspace **attached to that session** is mounted at `/workspace`; a fresh session with no attached directory gets an empty workspace instead of inheriting the previous session's mount. `delegate_task` subagents still share their parent session's container. Use this mode when the sandbox is a security boundary between conversations; keep the default `true` when you want the long-lived shared container described above.
 
+**Session-scoped containers (`docker_container_scope: session`).** Keeps the `container_persistent: true` persistence contract — filesystem state, `/root`, and installed packages survive across turns — but gives every chat session its **own** long-lived container instead of one shared per profile. Session A and Session B get separate `/workspace` trees, separate `/root`, separate caches, and separate background-process/port spaces, so two sessions can run dev servers on the same port or install conflicting packages without interfering. Resuming a session reattaches to its container (a stopped one is `docker start`ed first); containers are keyed internally by session ID + profile, never by raw user-provided strings. What happens to a session's container after the session closes is governed by `docker_session_container_retention`: `stop_on_session_end` (default) stops it — it restarts on the session's next use; `keep_running` leaves it running; `remove_on_session_end` removes it (the next use starts fresh); `idle_ttl` removes it after `docker_session_container_ttl_seconds` idle seconds (`0` falls back to `lifetime_seconds`). `container_persistent: false` still wins and gives the fully ephemeral per-session mode above. `delegate_task` subagents continue to share their parent session's container.
+
 ```yaml
 terminal:
   backend: docker
@@ -325,13 +327,16 @@ terminal:
   container_cpu: 1                 # CPU cores (0 = unlimited)
   container_memory: 5120           # MB (0 = unlimited)
   container_disk: 51200            # MB (requires overlay2 on XFS+pquota)
-  container_persistent: true       # true = persist /workspace + /root, shared container; false = fresh container per session (see below)
+  container_persistent: true       # true = persist /workspace + /root (shared container by default; per-session with docker_container_scope: session); false = fresh container per session
 
   # Cross-process container reuse (defaults match the "one long-lived
   # container shared across sessions" contract — see Container lifecycle).
   docker_persist_across_processes: true   # Reuse container across Hermes restarts
   docker_shared_container_key: ""         # Opt in trusted profiles to one identity
   docker_orphan_reaper: true              # Sweep abandoned Exited containers at startup
+  docker_container_scope: shared          # shared = one container across sessions (default); session = one container per chat session
+  docker_session_container_retention: stop_on_session_end  # session scope: stop_on_session_end | keep_running | remove_on_session_end | idle_ttl
+  docker_session_container_ttl_seconds: 3600  # session scope + idle_ttl: removed after this many idle seconds (0 = use lifetime_seconds)
 
   # Cross-backend lifecycle settings (apply to docker as well)
   timeout: 180                     # Per-command timeout in seconds


### PR DESCRIPTION
Add a Docker backend configuration option that gives each chat session its own long-lived container, while preserving the current shared-container behavior as the default.

Closes #46041

## What this adds

```yaml
terminal:
  backend: docker
  docker_container_scope: shared            # shared (default) | session
  docker_session_container_retention: stop_on_session_end  # stop_on_session_end | keep_running | remove_on_session_end | idle_ttl
  docker_session_container_ttl_seconds: 3600  # idle_ttl: removed after this many idle seconds (0 = terminal.lifetime_seconds)
```

**`docker_container_scope: session`** keeps the `container_persistent: true` persistence contract — filesystem state, `/root`, and installed packages survive across turns — but gives every chat session its **own** container instead of one shared per profile. Session A and Session B get separate `/workspace` trees, separate `/root`, separate caches, and separate background-process/port spaces. Resuming a session reattaches to its container (a stopped one is `docker start`ed first).

- Containers are keyed internally by the session key plus profile — stable platform-scoped identifiers, never raw user-provided strings.
- Terminal, file, and `execute_code` tools all resolve through the same `_resolve_container_task_id` cache key, so every tool lands in the same session container.
- `delegate_task` subagents continue to share their parent session's container (the pre-existing alias registry).
- `container_persistent: false` still wins and gives the fully ephemeral per-session mode that already exists.
- `docker_shared_container_key` still wins over session scope (an explicit shared identity is the more explicit statement).

## Retention lifecycle (`docker_session_container_retention`)

| Mode | On session close / idle | On resume |
|---|---|---|
| `stop_on_session_end` (default) | `docker stop` only — no `rm` | container restarted via the label probe |
| `keep_running` | container untouched | reattach (running) |
| `remove_on_session_end` | `docker stop` + `docker rm -f` | fresh container |
| `idle_ttl` | removed after `docker_session_container_ttl_seconds` idle seconds | fresh container |

Lifecycle safety nets:

- The orphan reaper **spares** stopped `stop_on_session_end` containers (label `hermes-session-retention`, baked at creation) so a later resume can reattach — but reaps them after 7 days of no resume (`_STOP_RETENTION_REAP_CEILING_SECONDS`), so abandoned sessions don't leak disk.
- `idle_ttl` containers honor their own TTL via a `hermes-session-ttl` label instead of the generic 2×lifetime sweep threshold.
- A stopped container is restarted through the pre-existing `_attach_existing_container` → `_start_container` path; no new reuse machinery was needed.
- Session-close (`AIAgent.close()`) passes the durable conversation `session_id`, while containers are cached under the stable `session:<key>` — a close-key registry (recorded at env creation under `_env_lock`, refreshed on cache hits to survive `/new` id rotation, popped on teardown) bridges the two. Delegate-subagent ids are never registered, so a child's `close()` cannot reach the parent's env (unchanged behavior).
- The idle reaper applies each session's own TTL for `idle_ttl` envs (force-remove) and tears stop/keep envs down non-forced after `lifetime_seconds`, so a long-lived gateway process's env registry stays bounded.

## Default unchanged

`docker_container_scope: shared` (the default) preserves every existing behavior exactly: one long-lived profile-scoped container, `container_persistent: false` ephemeral isolation, RL/benchmark override sandboxes, SSH session keying, and the `docker_shared_container_key` opt-in (which still wins over session scope when both are set).

## Testing

- New `tests/tools/test_docker_session_scope.py` (37 tests): routing/mount resolution per scope, builder kwargs per retention mode, cleanup stop-only/keep/remove semantics, orphan-reaper retention branches (skip, TTL honor, 7-day ceiling, unlabeled fallthrough), idle-reaper TTL cutoff + non-forced stop teardown, close-key registry resolution (session_id ↔ `session:<key>`, raw ids, child isolation). All daemon-free per repo convention.
- Full docker/terminal lane: **193 passed** (`test_docker_session_scope` + the 8 pre-existing docker/terminal/env-bridge files).
- One pre-existing, unrelated failure (`tests/tools/test_approval.py::TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`) reproduces on clean `main` on this machine — not touched by this change.

## Notes

**Open question:** the 7-day ceiling for abandoned `stop_on_session_end` containers is a constant (`_STOP_RETENTION_REAP_CEILING_SECONDS`), not user-configurable — happy to make it configurable if maintainers prefer.

**Open question:** `keep_running` leaves a session's container running after session close with no TTL — matching the shared container's contract (persist-mode containers run until the host reclaims them). If maintainers would rather bound it, the idle_ttl ceiling machinery here can be reused.

Ran the two-stage cross-vendor review (Gemini 3.8 Flash + GPT-OSS 120B) on the implementation diff, then a second round on the fix diff after addressing 3 BLOCKERs and 4 SHOULD-FIXes the first round found; round 2 returned APPROVED on all items from both reviewers.
