### PR TITLE
fix(desktop): honor effective project profile scope

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
 import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
-import { $activeGatewayProfile, $profileScope, ALL_PROFILES, setShowAllProfiles } from '@/store/profile'
+import { $activeGatewayProfile, $profiles, $profileScope, ALL_PROFILES, setShowAllProfiles } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
 
 import {
@@ -144,6 +144,7 @@ describe('projects RPC profile forwarding', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     $activeGatewayProfile.set('default')
+    $profiles.set([{ is_default: true, name: 'default' } as never])
     $activeProjectId.set(null)
     $projectTree.set([])
     setShowAllProfiles(false)
@@ -173,6 +174,7 @@ describe('projects RPC profile forwarding', () => {
     const gateway = { connectionState: 'open', request }
     activeGateway.mockReturnValue(gateway as never)
     gatewayAtom.set(gateway as never)
+    $profiles.set([{ is_default: true, name: 'default' } as never, { is_default: false, name: 'work' } as never])
     setShowAllProfiles(true)
 
     await refreshProjects()
@@ -180,6 +182,32 @@ describe('projects RPC profile forwarding', () => {
     await fetchProjectSessions('p_123')
 
     expect(request).not.toHaveBeenCalled()
+    setShowAllProfiles(false)
+  })
+
+  it('uses the active profile when a persisted all-profiles preference is hidden for one profile', async () => {
+    const project = { id: 'p_123' } as SidebarProjectTree
+
+    const request = vi.fn(async (method: string) =>
+      method === 'projects.project_sessions' ? { project } : { active_id: null, projects: [], scoped_session_ids: [] }
+    )
+
+    const gateway = { connectionState: 'open', request }
+
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+    setShowAllProfiles(true)
+
+    await refreshProjects()
+    await refreshProjectTree()
+    await expect(fetchProjectSessions('p_123')).resolves.toBe(project)
+
+    expect(request).toHaveBeenNthCalledWith(1, 'projects.list', { profile: 'default' })
+    expect(request).toHaveBeenNthCalledWith(2, 'projects.tree', { preview_limit: 3, profile: 'default' })
+    expect(request).toHaveBeenNthCalledWith(3, 'projects.project_sessions', {
+      profile: 'default',
+      project_id: 'p_123'
+    })
     setShowAllProfiles(false)
   })
 })
@@ -415,6 +443,7 @@ describe('createProject', () => {
     $projects.set([])
     $projectTree.set([])
     $activeGatewayProfile.set('default')
+    $profiles.set([{ is_default: true, name: 'default' } as never, { is_default: false, name: 'work' } as never])
     setShowAllProfiles(false)
   })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -19,6 +19,7 @@ import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import {
   $activeGatewayProfile,
+  $profiles,
   $profileScope,
   ALL_PROFILES,
   normalizeProfileKey,
@@ -279,10 +280,14 @@ async function gatewayRequest<T>(method: string, params: Record<string, unknown>
   return gateway.request<T>(method, params)
 }
 
+function viewingAllProfiles(): boolean {
+  return $profileScope.get() === ALL_PROFILES && $profiles.get().length > 1
+}
+
 export function projectProfile(): null | string {
   const profile = normalizeProfileKey($activeGatewayProfile.get())
 
-  return $profileScope.get() === ALL_PROFILES || profile === ALL_PROFILES ? null : profile
+  return viewingAllProfiles() || profile === ALL_PROFILES ? null : profile
 }
 
 function projectParams(
@@ -460,7 +465,7 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
 // sessions + the scoped-session-id set). Best-effort: a failure leaves the
 // cached tree intact so the sidebar doesn't flicker.
 export async function refreshProjectTree(): Promise<void> {
-  if ($profileScope.get() === ALL_PROFILES) {
+  if (viewingAllProfiles()) {
     await refreshProjectTreeAcrossProfiles()
 
     return
@@ -489,7 +494,7 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
 
     // A profile switch mid-flight leaves this payload describing the wrong
     // scope; the newer refresh owns the tree.
-    if (generation !== projectTreeRefreshGeneration || $profileScope.get() !== ALL_PROFILES) {
+    if (generation !== projectTreeRefreshGeneration || !viewingAllProfiles()) {
       return
     }
 


### PR DESCRIPTION
## What does this PR do?

Project requests now use the active profile when `ALL_PROFILES` is only a persisted preference and the window has one profile.

The sidebar already hides the all-profiles view unless at least two profiles exist. The project store did not apply that same rule. It could load the overview through the cross-profile endpoint, then skip `projects.project_sessions` during drill-in because it still saw the hidden `ALL_PROFILES` sentinel. The entered project then showed `No sessions yet` even when its overview count was positive.

This change gives project routing one effective all-profiles predicate and uses it for profile selection, tree refresh, and stale-response checks.

## Related Issue

Fixes #106003

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Treat `ALL_PROFILES` as the effective project scope only when more than one profile exists.
- Keep single-profile project RPCs on the active gateway when an old all-profiles preference remains persisted.
- Add a regression test for list, tree, and project drill-in routing in that state.
- Make existing all-profile fixtures model a real two-profile window.

## How to Test

1. Persist the all-profiles preference, then expose only the default profile.
2. Refresh the project list and tree, then fetch one project's sessions.
3. Confirm all three RPCs use `profile: 'default'` and the drill-in returns the project.

Commands run:

```text
npm run test:ui -- src/store/projects.test.ts src/app/chat/sidebar/profile-scope.test.ts src/app/chat/sidebar/use-entered-project-sessions.test.ts src/store/layout-sidebar-view.test.ts
npm run typecheck
npx eslint src/store/projects.ts src/store/projects.test.ts
npx prettier --check src/store/projects.ts src/store/projects.test.ts
git diff --check
```

The focused suites pass with 56 tests. The full UI run completed with 7,369 passing tests and two existing failures in `src/store/voice-prefs.test.ts`. Running that file alone reproduces the same two failures without loading these changes. The final upstream rebase changed only Python observability files, and the focused suites and static checks were rerun afterward.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

`pytest tests/ -q` was not run because this change only affects the Desktop TypeScript package. The relevant Desktop tests and checks are listed above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## Screenshots / Logs

Not applicable. This changes project RPC routing and has an automated regression test.
