### PR TITLE
fix(agent): abort length-continuation when the prompt filled the context window

### DIFF
--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -52,6 +52,20 @@ _CEILING_NO_TEXT = (
     "continuation attempt — its reasoning consumed the entire budget each time.\n\nTo fix this:\n"
     "→ Lower reasoning effort: `/reasoning low` or `/reasoning none`\n→ Or raise max_tokens for this model"
 )
+_WINDOW_EXHAUSTED = (
+    "📏 Context window exhausted — the prompt left no room for generation "
+    "(continuation retries only grow it). Stopping instead of looping.",
+    "⚠️ **Context Window Exhausted**\n\nThe conversation already filled the context window, so "
+    "`finish_reason='length'` here means *no room to generate* — not a long answer that needs "
+    "stitching. Each continuation retry appends the partial fragment + a nudge, making the prompt "
+    "*longer* and the next attempt *worse*, until the window is consumed entirely.\n\nTo fix this:\n"
+    "→ Compress or shorten the conversation (e.g. `/compress`, start a new session, or trim old turns)\n"
+    "→ Raise `model.context_length` (and for Ollama `model.ollama_num_ctx`) to the real window size\n"
+    "→ Lower `model.max_tokens` if it is set above what the window can hold",
+    "Context window exhausted: prompt_tokens + max_tokens >= context_length, so "
+    "finish_reason='length' reflects window overflow, not output truncation. "
+    "Continuation would only grow the prompt.",
+)
 
 
 def normalize_response_for_agent(agent: Any, response: Any) -> Any:
@@ -150,6 +164,46 @@ def _abort_reason(agent: Any, content: Any, has_tool_calls: bool) -> Optional[tu
     visible = agent._strip_think_blocks(content) if isinstance(content, str) else content
     if visible and is_repetition_dominated(visible):
         return _REPETITION_DOMINATED
+    return None
+
+
+def _window_exhausted_abort(agent: Any, response: Any) -> Optional[tuple]:
+    """``(vprint, user response, error)`` when the prompt already consumed the context
+    window beyond the output cap: ``finish_reason='length'`` then means *no room to
+    generate*, not *a long answer that needs stitching*. Continuing appends the partial
+    fragment + a nudge — strictly more prompt — so each retry is worse (the death spiral
+    in #106120, observed live on Ollama /v1). Abort instead of looping.
+
+    Discriminator: ``prompt_tokens + max_tokens >= context_length`` — the output cap is
+    unreachable because the prompt alone leaves less than ``max_tokens`` of room, so the
+    partial fragment from one attempt already consumes what is left. Skipped when the
+    provider omits usage and no prior real count is known (best-effort, never false-aborts).
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    context_length = int(getattr(compressor, "context_length", 0) or 0) if compressor else 0
+    max_tokens = int(getattr(agent, "max_tokens", 0) or 0)
+    if not (context_length and max_tokens):
+        return None
+    prompt_tokens = 0
+    usage = getattr(response, "usage", None)
+    if usage:
+        try:
+            from agent.usage_pricing import normalize_usage
+            prompt_tokens = int(normalize_usage(
+                usage, provider=agent.provider, api_mode=agent.api_mode
+            ).prompt_tokens or 0)
+        except Exception:
+            prompt_tokens = 0
+    # last_real_prompt_tokens is folded from response.usage one phase later
+    # (turn_usage.record_response_usage), so at this point it still holds the prior
+    # call's count. Use it only when this response carries no usage (silent-clip
+    # providers like Ollama /v1 sometimes omit it).
+    if not prompt_tokens and compressor is not None:
+        prompt_tokens = int(getattr(compressor, "last_real_prompt_tokens", 0) or 0)
+    if not prompt_tokens:
+        return None
+    if prompt_tokens + max_tokens >= context_length:
+        return _WINDOW_EXHAUSTED
     return None
 
 
@@ -340,6 +394,11 @@ def recover_from_truncation(
         cf = _content_filter_fallback(st, _retry)
         if cf is not None:
             return cf
+        window_abort = _window_exhausted_abort(agent, response)
+        if window_abort is not None:
+            _wline, _wuser, _werror = window_abort
+            agent._vprint(f"{agent.log_prefix}{_wline}", force=True)
+            return st.end_turn(_wuser, _werror)
         if _trunc_msg is not None:
             if not _trunc_has_tool_calls:
                 return _continue_text(st, _retry, _trunc_msg)

--- a/tests/agent/test_turn_truncation_window_exhausted.py
+++ b/tests/agent/test_turn_truncation_window_exhausted.py
@@ -1,0 +1,199 @@
+"""Regression tests for #106120: length-continuation retries make the prompt LONGER
+when the prompt is what filled the window.
+
+When ``finish_reason='length'`` is caused by the *prompt* consuming the context
+window (not by a long answer hitting ``max_tokens``), continuing is counterproductive:
+each retry appends the partial fragment + a nudge — strictly more prompt — so every
+attempt is worse than the last (the death spiral observed live on Ollama /v1, where a
+32,638-token prompt against a 32,768 window left ~130 tokens of room and the 4 retries
+each shrank it toward zero).
+
+``_window_exhausted_abort`` detects this via ``prompt_tokens + max_tokens >=
+context_length`` (the output cap is unreachable) and aborts continuation with a clear,
+actionable message instead of looping.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.turn_truncation import (
+    _WINDOW_EXHAUSTED,
+    _window_exhausted_abort,
+    recover_from_truncation,
+)
+from agent.turn_retry_state import TurnRetryState
+
+
+def _agent(*, context_length=32768, max_tokens=8192, last_real=0, provider="openai",
+           api_mode="chat_completions"):
+    """Minimal agent with the attributes ``_window_exhausted_abort`` reads."""
+    return SimpleNamespace(
+        context_compressor=SimpleNamespace(
+            context_length=context_length,
+            last_real_prompt_tokens=last_real,
+        ),
+        max_tokens=max_tokens,
+        provider=provider,
+        api_mode=api_mode,
+    )
+
+
+def _response(*, prompt_tokens=0):
+    """A response carrying provider usage (OpenAI Chat Completions shape)."""
+    usage = SimpleNamespace(prompt_tokens=prompt_tokens) if prompt_tokens else None
+    return SimpleNamespace(id="resp_1", usage=usage)
+
+
+class TestWindowExhaustedAbort:
+    """``_window_exhausted_abort`` — the pure discriminator."""
+
+    def test_aborts_when_prompt_plus_max_tokens_reaches_context_length(self):
+        # Reporter's live case: 32,638 prompt + 8,192 max_tokens >= 32,768 context.
+        agent = _agent(context_length=32768, max_tokens=8192)
+        response = _response(prompt_tokens=32638)
+        assert _window_exhausted_abort(agent, response) is _WINDOW_EXHAUSTED
+
+    def test_no_abort_when_headroom_available(self):
+        # 1,000 prompt + 8,192 max_tokens = 9,192 < 32,768 → output cap reachable.
+        agent = _agent(context_length=32768, max_tokens=8192)
+        response = _response(prompt_tokens=1000)
+        assert _window_exhausted_abort(agent, response) is None
+
+    def test_treats_exact_boundary_as_exhausted(self):
+        # prompt_tokens + max_tokens == context_length (inclusive >=) → abort.
+        agent = _agent(context_length=10000, max_tokens=2000)
+        response = _response(prompt_tokens=8000)
+        assert _window_exhausted_abort(agent, response) is _WINDOW_EXHAUSTED
+
+    def test_one_short_of_boundary_is_not_exhausted(self):
+        # prompt_tokens + max_tokens == context_length - 1 → just enough room, continue.
+        agent = _agent(context_length=10000, max_tokens=2000)
+        response = _response(prompt_tokens=7999)
+        assert _window_exhausted_abort(agent, response) is None
+
+    def test_uses_last_real_prompt_tokens_when_response_usage_missing(self):
+        # Silent-clip providers (Ollama /v1) sometimes omit usage; fall back to the
+        # compressor's last real count.
+        agent = _agent(context_length=32768, max_tokens=8192, last_real=32638)
+        response = _response(prompt_tokens=0)  # no usage on this response
+        assert _window_exhausted_abort(agent, response) is _WINDOW_EXHAUSTED
+
+    def test_no_abort_when_usage_missing_and_no_fallback(self):
+        agent = _agent(context_length=32768, max_tokens=8192, last_real=0)
+        response = _response(prompt_tokens=0)
+        assert _window_exhausted_abort(agent, response) is None
+
+    def test_no_abort_when_no_context_length(self):
+        agent = _agent(context_length=0, max_tokens=8192)
+        response = _response(prompt_tokens=32638)
+        assert _window_exhausted_abort(agent, response) is None
+
+    def test_no_abort_when_no_max_tokens(self):
+        agent = _agent(context_length=32768, max_tokens=0)
+        response = _response(prompt_tokens=32638)
+        assert _window_exhausted_abort(agent, response) is None
+
+    def test_no_abort_when_no_context_compressor(self):
+        agent = SimpleNamespace(context_compressor=None, max_tokens=8192,
+                                provider="openai", api_mode="chat_completions")
+        response = _response(prompt_tokens=32638)
+        assert _window_exhausted_abort(agent, response) is None
+
+    def test_aborts_even_when_prompt_alone_exceeds_context(self):
+        # Pathological: prompt bigger than the window (provider accepted it anyway).
+        agent = _agent(context_length=32768, max_tokens=4096)
+        response = _response(prompt_tokens=40000)
+        assert _window_exhausted_abort(agent, response) is _WINDOW_EXHAUSTED
+
+    def test_falls_back_to_last_real_when_normalize_returns_zero(self):
+        # usage present but prompt_tokens resolves to 0 (malformed) → fallback fires.
+        agent = _agent(context_length=32768, max_tokens=8192, last_real=32638)
+        response = SimpleNamespace(id="resp_1", usage=SimpleNamespace(prompt_tokens=0))
+        assert _window_exhausted_abort(agent, response) is _WINDOW_EXHAUSTED
+
+
+class TestRecoverFromTruncationAbortsOnWindowExhaustion:
+    """End-to-end: ``recover_from_truncation`` returns the window-exhausted verdict
+    (action='return') instead of arming a continuation retry (action='break')."""
+
+    @pytest.fixture
+    def agent(self, monkeypatch):
+        # Bypass the transport-normalization layer (tested elsewhere) so the stub agent
+        # only needs the attributes recover_from_truncation actually touches.
+        monkeypatch.setattr(
+            "agent.turn_truncation.normalize_response_for_agent",
+            lambda agent, response: SimpleNamespace(content="partial", tool_calls=None),
+        )
+        ag = SimpleNamespace(
+            log_prefix="test: ",
+            api_mode="chat_completions",
+            provider="openai",
+            max_tokens=8192,
+            context_compressor=SimpleNamespace(
+                context_length=32768, last_real_prompt_tokens=32638,
+            ),
+            # _abort_reason helpers — return content unchanged so thinking/repetition
+            # aborts do NOT fire (we want to reach the window-exhaustion check).
+            _has_content_after_think_block=lambda content: False,
+            _strip_think_blocks=lambda content: content,
+            # end_turn persistence/cleanup stubs.
+            _cleanup_task_resources=lambda task_id: None,
+            _persist_session=lambda messages, history: None,
+            _session_messages=[],
+            _vprint=MagicMock(),
+            _emit_status=MagicMock(),
+            _flush_status_buffer=MagicMock(),
+            _get_messages_up_to_last_assistant=lambda messages: messages,
+            # _continue_text stubs (exercised by the headroom-available test).
+            _build_assistant_message=lambda msg, fr: {"role": "assistant", "content": getattr(msg, "content", ""), "finish_reason": fr},
+            _ephemeral_reasoning_off=False,
+        )
+        return ag
+
+    def _retry(self):
+        return TurnRetryState()
+
+    def test_returns_window_exhausted_verdict_not_continuation_retry(self, agent):
+        response = SimpleNamespace(
+            id="resp_1",
+            usage=SimpleNamespace(prompt_tokens=32638),
+        )
+        verdict = recover_from_truncation(
+            agent, response, "length", self._retry(),
+            messages=[{"role": "user", "content": "hi"}],
+            conversation_history=None, api_kwargs={}, api_call_count=1,
+            effective_task_id="t1", current_turn_user_idx=0,
+            length_continue_retries=0, truncated_response_parts=[],
+            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
+        )
+        # Aborted (return) — NOT armed for a continuation retry (break).
+        assert verdict.action == "return"
+        assert verdict.result is not None
+        assert verdict.result["error"] == _WINDOW_EXHAUSTED[2]
+        assert verdict.result["final_response"] == _WINDOW_EXHAUSTED[1]
+        # No continuation retry was armed.
+        assert not getattr(self._retry(), "restart_with_length_continuation", False)
+
+    def test_proceeds_to_continuation_when_headroom_available(self, agent):
+        # 1,000 prompt + 8,192 max_tokens < 32,768 → continuation path (break) fires.
+        agent.context_compressor.last_real_prompt_tokens = 1000
+        response = SimpleNamespace(
+            id="resp_1",
+            usage=SimpleNamespace(prompt_tokens=1000),
+        )
+        retry = self._retry()
+        verdict = recover_from_truncation(
+            agent, response, "length", retry,
+            messages=[{"role": "user", "content": "hi"}],
+            conversation_history=None, api_kwargs={}, api_call_count=1,
+            effective_task_id="t1", current_turn_user_idx=0,
+            length_continue_retries=0, truncated_response_parts=[],
+            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
+        )
+        # Continuation arms a retry (break), not an abort (return).
+        assert verdict.action == "break"
+        assert retry.restart_with_length_continuation is True


### PR DESCRIPTION
## What does this PR do?

Fixes a death spiral in the length-continuation recovery loop. When `finish_reason='length'` is caused by the **prompt** consuming the context window (not a long answer hitting `max_tokens`), each continuation retry appends the partial fragment + a nudge — strictly *more* prompt — so every attempt is worse than the last. Observed live on Ollama `/v1`: a 32,638-token prompt against a 32,768-token window left ~130 tokens of generation room; the response came back truncated and the 4 retries each shrank the remaining room toward zero, ending in an empty partial. This PR adds a `_window_exhausted_abort` guard that detects when the output cap is unreachable and aborts continuation with an actionable message instead of looping.

## Related Issue

Fixes #106120.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

Root cause: `_continue_text` (`agent/turn_truncation.py:196`) never checks whether the **prompt itself** filled the window. It assumes `finish_reason='length'` always means "the answer was long" (where stitching helps) and blindly appends more prompt.

The fix: add a `_window_exhausted_abort` guard in `recover_from_truncation`, called after `_content_filter_fallback` and before `_continue_text`/`_retry_truncated_tool_call`. It detects the condition:

```python
prompt_tokens + max_tokens >= context_length
```

i.e. the output cap is **unreachable** because the prompt alone leaves less than `max_tokens` of room. In that case `finish_reason='length'` means *no room to generate*, not *a long answer that needs stitching* — so continuation (which grows the prompt) is aborted with a clear, actionable message instead of looping.

### Signal sources
- **`prompt_tokens`**: the provider's real usage for *this* truncated call, read from `response.usage` via `normalize_usage` (the same accessor `turn_usage.record_response_usage` uses one phase later). Falls back to `compressor.last_real_prompt_tokens` when usage is absent (silent-clip providers like Ollama `/v1` sometimes omit it).
- **`context_length`**: `agent.context_compressor.context_length`.
- **`max_tokens`**: `agent.max_tokens` (the configured output cap).

### Why `prompt_tokens + max_tokens >= context_length` is the right discriminator
When the output cap is unreachable, the model can generate at most `context_length - prompt_tokens` tokens (< `max_tokens`). The continuation appends that partial (~`context_length - prompt_tokens` tokens) plus a nudge, so the next attempt's prompt is already at the window ceiling — leaving ~0 room and producing nothing. Each retry is strictly worse. This condition catches exactly the cases where continuation cannot help, and is conservative: it does **not** fire when there is genuine headroom (the existing 4-retry continuation path is preserved unchanged).

### Placement
The check runs **after** `_abort_reason` (thinking-exhaustion / repetition guards) and **after** `_content_filter_fallback` (so a content-filter stall still escalates to the fallback provider first), but **before** any continuation retry — so it covers both text continuation and truncated-tool-call retry paths.

### Behavior change
- **Before**: window-exhausted truncation → 4 continuation retries, each worse, ending in a near-empty `[response interrupted]` partial.
- **After**: window-exhausted truncation → immediate abort with an actionable message pointing the user at context overflow (compress the conversation / raise `model.context_length` / lower `model.max_tokens`).

## How to Test

New file `tests/agent/test_turn_truncation_window_exhausted.py` (13 tests):

**Unit tests for `_window_exhausted_abort`** (the pure discriminator):
- aborts at the reporter's exact live case (32,638 + 8,192 ≥ 32,768)
- aborts at the exact boundary (`prompt + max == context`)
- does **not** abort one token short of the boundary (headroom available → continue)
- does **not** abort with ample headroom (1,000 + 8,192 < 32,768)
- uses `last_real_prompt_tokens` fallback when `response.usage` is missing (Ollama)
- does **not** abort when no usage and no fallback is known (best-effort, never false-aborts)
- does **not** abort when `context_length`, `max_tokens`, or `context_compressor` is unset
- aborts when prompt alone exceeds the window (pathological)

**Integration tests via `recover_from_truncation`**:
- window-exhausted config → verdict `action='return'` with the exhaustion message (NOT `action='break'` continuation retry)
- headroom-available config → verdict `action='break'` with `restart_with_length_continuation=True` (existing continuation preserved)

**Mutation verified**: removing the `_window_exhausted_abort` call makes the integration test fail (`action` becomes `'break'` instead of `'return'`); restoring it passes.

**No regressions**: the existing truncation/continuation suite passes unchanged — `tests/run_agent/test_anthropic_truncation_continuation.py`, `tests/agent/test_repetition_guard.py`, `tests/agent/test_compressor_truncated_summary_guard.py`, `tests/agent/test_empty_response_guard.py`, `tests/agent/test_turn_retry_state.py`, `tests/agent/test_anthropic_adapter.py`, `tests/agent/test_prompt_cache_ttl_propagation.py` (111 + 59 existing tests pass; `ruff check` clean).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the truncation test suite and all tests pass (13 new + existing, `ruff check` clean)
- [x] I've added tests for my changes (13 new, mutation-verified)
- [x] The discriminator is conservative (never false-aborts; falls through to existing behavior when signals are absent)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] N/A — internal recovery-loop guard; existing continuation path preserved unchanged for genuine headroom cases; no public API or doc surface changed