### PR TITLE
fix(desktop): keep visible animations running when unfocused

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -275,6 +275,8 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
 
 ## Motion
 
+- Visible windows keep animating when another app takes focus. Hidden/minimized
+  windows and inactive panes may pause; background polling stays focus-gated.
 - Quick, functional transitions (~100ms on controls). Respect
   `prefers-reduced-motion` for anything beyond a fade.
 - Choreographed exits (e.g. onboarding's "matrix" fade-down) stagger per-element

--- a/apps/desktop/e2e/glyph-spinner.spec.ts
+++ b/apps/desktop/e2e/glyph-spinner.spec.ts
@@ -173,11 +173,9 @@ test.describe('GlyphSpinner (compositor animation)', () => {
     expect(parked.playState).toBe('paused')
     expect(parked.willChange).toBe('auto')
 
-    // 2. The global gate: window blur / minimize / document-hidden, which
-    //    main.tsx drives by arming this attribute on the root. The strip must
-    //    be named in that rule, or every spinner keeps animating behind an
-    //    inactive window — the CPU burn the original ticker's pause
-    //    controller existed to avoid.
+    // 2. The global gate: window minimize / document-hidden, which
+    //    main.tsx drives by arming this attribute on the root. Visible windows
+    //    keep animating even when another app has focus.
     const globallyPaused = await page.evaluate(strip => {
       const root = document.documentElement
       const had = root.hasAttribute('data-renderer-animations-paused')

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -210,7 +210,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
             scheduleMeasure('ancestor-mutation')
           })
 
-    pauseController = createRendererLoopPauseController(handleVisibilityChange)
+    pauseController = createRendererLoopPauseController(handleVisibilityChange, { pauseWhenUnfocused: true })
 
     if (measure('initial')) {
       scheduleMeasure('settle')

--- a/apps/desktop/src/app/starmap/star-map.tsx
+++ b/apps/desktop/src/app/starmap/star-map.tsx
@@ -3,6 +3,7 @@ import { atom, type WritableAtom } from 'nanostores'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useThemeEpoch } from '@/hooks/use-theme-epoch'
+import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 import { createDoubleTapDetector, isSmartZoomWheel } from '@/lib/trackpad-gestures'
 import type { StarmapGraph } from '@/types/hermes'
 
@@ -496,7 +497,7 @@ export function StarMap({
   }, [invalidate, themeEpoch])
 
   // Render loop. The core scramble animates continuously, so the loop runs while
-  // the window is focused — but each frame is cheap (live scramble + a blit of the
+  // the window is visible — but each frame is cheap (live scramble + a blit of the
   // cached static layer). The expensive scene only re-renders when invalidate()
   // marks it dirty. Capped to ~30fps; interaction (force) bypasses the cap.
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
@@ -506,16 +507,8 @@ export function StarMap({
     let lastAnimTs = 0
     let force = true
 
-    // The scramble keeps the loop perpetually "animating", so a fully-built,
-    // untouched map still repaints 30×/s for as long as the panel is open. That's
-    // wasted CPU/GPU (WindowServer compositing) when the window isn't even the one
-    // you're looking at. Freeze the loop while the window is hidden or unfocused;
-    // a frozen core next to other work is fine, and it resumes instantly on focus.
-    const isPaused = () =>
-      (typeof document !== 'undefined' && document.hidden) ||
-      (typeof document.hasFocus === 'function' && !document.hasFocus())
-
-    let paused = isPaused()
+    let paused = false
+    let pauseController: ReturnType<typeof createRendererLoopPauseController>
 
     const schedule = () => {
       if (!paused && !raf) {
@@ -641,10 +634,10 @@ export function StarMap({
       schedule()
     }
 
-    // Suspend the loop when the window drops out of view/focus; wake + force a
+    // Suspend the loop when the window drops out of view; wake + force a
     // fresh frame the moment it returns so the resume is seamless.
     const onActivity = () => {
-      const next = isPaused()
+      const next = pauseController.isPaused()
 
       if (next === paused) {
         return
@@ -664,17 +657,14 @@ export function StarMap({
       }
     }
 
-    document.addEventListener('visibilitychange', onActivity)
-    window.addEventListener('blur', onActivity)
-    window.addEventListener('focus', onActivity)
+    pauseController = createRendererLoopPauseController(onActivity)
+    paused = pauseController.isPaused()
 
     schedule()
 
     return () => {
       cancelAnimationFrame(raf)
-      document.removeEventListener('visibilitychange', onActivity)
-      window.removeEventListener('blur', onActivity)
-      window.removeEventListener('focus', onActivity)
+      pauseController.dispose()
 
       invalidateRef.current = () => {}
     }

--- a/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
+++ b/apps/desktop/src/components/chat/image-generation-placeholder.test.tsx
@@ -83,7 +83,7 @@ describe('DiffusionCanvas scheduling', () => {
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
   })
 
-  it('cancels its loop while inactive and resumes only when the window is observable', () => {
+  it('keeps animating while unfocused but cancels its loop while minimized', () => {
     const raf = installRaf()
 
     render()
@@ -93,7 +93,7 @@ describe('DiffusionCanvas scheduling', () => {
     act(() => {
       window.dispatchEvent(new Event('blur'))
     })
-    expect(raf.pending()).toBe(0)
+    expect(raf.pending()).toBe(1)
 
     act(() => {
       window.dispatchEvent(new Event('focus'))

--- a/apps/desktop/src/components/pet/pet-sprite.test.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.test.tsx
@@ -172,13 +172,13 @@ describe('PetSprite RAF scheduling', () => {
     expect(raf.request).toHaveBeenCalledTimes(2)
   })
 
-  it('suspends while unfocused, resumes on focus, and leaves no work after unmount', () => {
+  it('keeps animating while unfocused and leaves no work after unmount', () => {
     const raf = installRaf()
 
     mount.render(<PetSprite info={INFO} />)
 
     act(() => window.dispatchEvent(new Event('blur')))
-    expect(raf.pending()).toBe(0)
+    expect(raf.pending()).toBe(1)
 
     act(() => window.dispatchEvent(new Event('focus')))
     expect(raf.pending()).toBe(1)

--- a/apps/desktop/src/components/pet/pet-sprite.tsx
+++ b/apps/desktop/src/components/pet/pet-sprite.tsx
@@ -133,7 +133,7 @@ export function roamWalkRow(dir: -1 | 0 | 1, stateRows?: string[]): { row?: stri
 
 interface PetSpriteProps {
   info: PetInfo
-  /** Keep animating in a deliberately non-activating visible window, such as the pop-out pet overlay. */
+  /** Opt in to pausing on blur; visible pets animate by default. */
   pauseWhenUnfocused?: boolean
   /** On-screen scale multiplier applied on top of the pet's native scale. */
   zoom?: number
@@ -158,7 +158,7 @@ interface PetSpriteProps {
  * with `memo`, this component effectively never re-renders after mount until
  * the pet itself changes.
  */
-function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUnfocused = true }: PetSpriteProps) {
+function PetSpriteImpl({ info, zoom = 1, stateOverride, rowOverride, pauseWhenUnfocused = false }: PetSpriteProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const stateRef = useRef<PetState>($petState.get())
   const overrideRef = useRef<PetState | undefined>(stateOverride)

--- a/apps/desktop/src/components/pet/use-pet-roam.test.tsx
+++ b/apps/desktop/src/components/pet/use-pet-roam.test.tsx
@@ -98,14 +98,14 @@ describe('usePetRoam RAF scheduling', () => {
     expect(vi.getTimerCount()).toBe(1)
   })
 
-  it('suspends idle movement while unfocused and cleans up its wake timer on unmount', () => {
+  it('keeps idle movement scheduled while unfocused and cleans up on unmount', () => {
     const raf = installRaf()
 
     mount.render(<RoamHarness />)
     expect(vi.getTimerCount()).toBe(1)
 
     act(() => window.dispatchEvent(new Event('blur')))
-    expect(vi.getTimerCount()).toBe(0)
+    expect(vi.getTimerCount()).toBe(1)
 
     act(() => window.dispatchEvent(new Event('focus')))
     expect(vi.getTimerCount()).toBe(1)

--- a/apps/desktop/src/components/ui/glyph-spinner.tsx
+++ b/apps/desktop/src/components/ui/glyph-spinner.tsx
@@ -77,7 +77,7 @@ export function GlyphSpinner({
 }: GlyphSpinnerProps) {
   const spin = FRAMES_BY_NAME[spinner] ?? FRAMES_BY_NAME.braille!
   // Pause when this surface is a hidden (kept-alive) tab: N mounted tabs each
-  // animating burns CPU for pixels nobody can see. Window blur / minimize /
+  // animating burns CPU for pixels nobody can see. Window minimize /
   // document-hidden are handled globally instead, by the
   // `:root[data-renderer-animations-paused]` rule in styles.css that
   // main.tsx's installRendererAnimationPauseState() drives — the same

--- a/apps/desktop/src/lib/budgeted-loop.test.ts
+++ b/apps/desktop/src/lib/budgeted-loop.test.ts
@@ -71,7 +71,7 @@ describe('createBudgetedLoop', () => {
     loop.dispose()
   })
 
-  it('pauses while the window is not observable and resumes when it is', () => {
+  it('keeps drawing while unfocused but pauses while minimized', () => {
     const raf = installRaf()
     const draw = vi.fn()
     const loop = createBudgetedLoop(draw)
@@ -79,7 +79,9 @@ describe('createBudgetedLoop', () => {
     expect(raf.pending()).toBe(1)
 
     window.dispatchEvent(new Event('blur'))
-    expect(raf.pending()).toBe(0)
+    expect(raf.pending()).toBe(1)
+    raf.runNext(1000)
+    expect(draw).toHaveBeenCalledTimes(1)
 
     window.dispatchEvent(new Event('focus'))
     expect(raf.pending()).toBe(1)

--- a/apps/desktop/src/lib/budgeted-loop.ts
+++ b/apps/desktop/src/lib/budgeted-loop.ts
@@ -9,8 +9,8 @@
  *  - **fps budget** — paints are skipped until `1000 / fps` elapsed; the loop
  *    still rides rAF so Chromium can align and pause it natively.
  *  - **observability pause** — wired to `createRendererLoopPauseController`:
- *    the loop cancels while the window is hidden, minimized, or unfocused and
- *    resumes when observable.
+ *    the loop cancels while the window is hidden or minimized and resumes
+ *    when visible, even if another window has focus.
  *  - **idle dormancy** — when `idleWhen()` returns true after a draw, the loop
  *    parks (zero pending frames, zero timers) until `wake()` is called. This
  *    is the piece every hand-rolled loop forgot: "nothing visible to animate"
@@ -43,7 +43,7 @@ export interface BudgetedLoopOptions {
    *  animation finished). Checked after every draw; when true the loop parks
    *  until `wake()`. Omit for loops that should run whenever observable. */
   idleWhen?: () => boolean
-  /** Forwarded to the pause controller. Default true (pause on blur). */
+  /** Forwarded to the pause controller. Default false (animate while visible). */
   pauseWhenUnfocused?: boolean
 }
 
@@ -60,7 +60,7 @@ export interface BudgetedLoop {
 
 export function createBudgetedLoop(
   draw: (now: number) => void,
-  { fps = 15, idleWhen, pauseWhenUnfocused = true }: BudgetedLoopOptions = {}
+  { fps = 15, idleWhen, pauseWhenUnfocused = false }: BudgetedLoopOptions = {}
 ): BudgetedLoop {
   const frameInterval = 1000 / fps
   let frame = 0

--- a/apps/desktop/src/lib/renderer-loop-pause.test.ts
+++ b/apps/desktop/src/lib/renderer-loop-pause.test.ts
@@ -8,7 +8,7 @@ describe('installRendererAnimationPauseState', () => {
     vi.restoreAllMocks()
   })
 
-  it('pauses on blur, resumes on focus, and cleans up its root state', () => {
+  it('keeps visible animations running across blur and focus, and cleans up its root state', () => {
     let focused = true
     vi.spyOn(document, 'hasFocus').mockImplementation(() => focused)
 
@@ -17,7 +17,7 @@ describe('installRendererAnimationPauseState', () => {
 
     focused = false
     window.dispatchEvent(new Event('blur'))
-    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(true)
+    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(false)
 
     focused = true
     window.dispatchEvent(new Event('focus'))

--- a/apps/desktop/src/lib/renderer-loop-pause.ts
+++ b/apps/desktop/src/lib/renderer-loop-pause.ts
@@ -5,7 +5,7 @@ interface WindowStatePayload {
 
 export const RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE = 'data-renderer-animations-paused'
 
-export function createRendererLoopPauseController(onChange: () => void, { pauseWhenUnfocused = true } = {}) {
+export function createRendererLoopPauseController(onChange: () => void, { pauseWhenUnfocused = false } = {}) {
   let windowPaused = false
   let windowFocused = document.hasFocus()
 
@@ -37,8 +37,10 @@ export function createRendererLoopPauseController(onChange: () => void, { pauseW
   })
 
   document.addEventListener('visibilitychange', onVisibilityChange)
-  window.addEventListener('blur', onBlur)
-  window.addEventListener('focus', onFocus)
+  if (pauseWhenUnfocused) {
+    window.addEventListener('blur', onBlur)
+    window.addEventListener('focus', onFocus)
+  }
 
   return {
     dispose: () => {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -59,7 +59,7 @@ if (winParam === 'overlay') {
   void import('./app/wake-indicator/wake-indicator-root').then(({ mountWakeIndicator }) => mountWakeIndicator())
 } else {
   // CSS animations do not inherit Chromium's JS-loop pause policy. Mirror the
-  // main window's focus/visibility state to :root so decorative infinite
+  // main window's visibility state to :root so decorative infinite
   // animations stop producing frames when nobody can see them.
   installRendererAnimationPauseState()
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -32,9 +32,9 @@
   }
 }
 
-/* Continuous decorative animations otherwise keep Chromium's renderer awake
-   behind another app. main.tsx owns this attribute only for the primary
-   window; wake/pet overlays retain their purpose-built visibility behavior. */
+/* Pause continuous animations only when the window is hidden/minimized, not
+   merely unfocused. main.tsx owns this attribute for the primary window;
+   wake/pet overlays retain their purpose-built visibility behavior. */
 :root[data-renderer-animations-paused]
   :is(
     .shimmer,


### PR DESCRIPTION
## What does this PR do?

Keep desktop animations running when another app takes focus and Hermes remains visible. Previously, blur paused the shared CSS animation gate and renderer loops. Hidden/minimized windows can still pause.

## Related Issue

User-reported behavior; no linked issue.

## Type of Change

- [x] Bug fix

## Changes Made

- Make focus-based pausing opt-in in `renderer-loop-pause.ts` and `budgeted-loop.ts`, without restarting animation callbacks on blur/focus.
- Keep pet sprites and roaming animated without focus; use the shared visibility controller for `star-map.tsx`.
- Preserve hidden/minimized and inactive-pane pauses, reduced-motion behavior, and existing frame budgets. Terminal geometry measurement and background polling remain focus-gated.
- Update the motion contract in `apps/desktop/DESIGN.md` and existing blur regression tests.

## How to Test

From `apps/desktop`:

```sh
npx vitest run --project ui src/lib/renderer-loop-pause.test.ts src/lib/budgeted-loop.test.ts src/components/pet/pet-sprite.test.tsx src/components/pet/use-pet-roam.test.tsx src/components/ui/status-pulse.test.tsx src/components/chat/image-generation-placeholder.test.tsx src/app/right-sidebar/terminal/persistent.test.tsx src/app/shell/hooks/use-status-snapshot.test.ts
```

36 tests passed across 8 files. Before the fix, updated blur expectations failed in the root animation gate, budgeted loop, and pet sprite tests.

Manual verification still needed: leave Hermes visible beside another app, switch focus, and check the spinner/pet/starmap continue animating. Minimize and restore Hermes to check pause/resume. Live visual verification has not been performed.

## Checklist

- [x] Conventional commits; only changes related to this fix.
- [x] Updated existing behavior tests and motion documentation.
- [x] Targeted Vitest tests passed on macOS.
- [ ] Live desktop visual verification.
- [ ] Full checks; not run for this handoff.
