### PR TITLE
feat(signal): render markdown tables as monospace-aligned blocks

### DIFF
--- a/gateway/platforms/signal_format.py
+++ b/gateway/platforms/signal_format.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 
 import re
 
+from agent.markdown_tables import is_table_divider, realign_markdown_tables
+
+# Signal has no fixed-width client area; this budgets for a phone screen in the app's
+# monospace face. Tables wider than this fall back to realign_markdown_tables()'s
+# vertical Key: value rendering rather than soft-wrapping mid-cell.
+_TABLE_WIDTH = 40
+
 _CODE_BLOCK_RE = re.compile(r"```[a-zA-Z0-9_+-]*\n?(.*?)```", re.DOTALL)
 _HEADING_RE = re.compile(r"^#{1,6}\s+", re.MULTILINE)
 _INLINE_PATTERNS = [
@@ -29,6 +36,32 @@ def _normalize_bullet_markers(source: str) -> str:
                    for idx, part in enumerate(parts))
 
 
+def _realign_tables(text: str, styles: list[tuple[int, int, str]]) -> str:
+    """Detect GFM table blocks and re-align each to a fixed monospace width, recording a
+    MONOSPACE style range over the rendered block. Runs after code-block extraction, so no
+    fenced regions remain to skip."""
+    if "|" not in text:
+        return text
+    lines = text.split("\n")
+    result_lines: list[str] = []
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        if "|" in line and i + 1 < n and is_table_divider(lines[i + 1]):
+            j = i + 2
+            while j < n and "|" in lines[j] and lines[j].strip():
+                j += 1
+            rendered = realign_markdown_tables("\n".join(lines[i:j]), _TABLE_WIDTH)
+            block_start = sum(len(rl) + 1 for rl in result_lines)
+            styles.append((block_start, len(rendered), "MONOSPACE"))
+            result_lines.extend(rendered.split("\n"))
+            i = j
+            continue
+        result_lines.append(line)
+        i += 1
+    return "\n".join(result_lines)
+
+
 def markdown_to_signal(text: str) -> tuple[str, list[str]]:
     """Convert markdown to plain text + Signal textStyles list. Signal uses ``bodyRanges`` (signal-cli
     ``textStyle`` / ``textStyles`` params) as ``start:length:STYLE`` with positions in UTF-16 code units.
@@ -39,6 +72,7 @@ def markdown_to_signal(text: str) -> tuple[str, list[str]]:
         inner = match.group(1).rstrip("\n")
         styles.append((match.start(), len(inner), "MONOSPACE"))
         text = text[: match.start()] + inner + text[match.end() :]
+    text = _realign_tables(text, styles)
     new_text, last_end = "", 0
     for match in _HEADING_RE.finditer(text):
         new_text += text[last_end : match.start()]

--- a/gateway/platforms/signal_format.py
+++ b/gateway/platforms/signal_format.py
@@ -39,10 +39,23 @@ def _normalize_bullet_markers(source: str) -> str:
 def _realign_tables(text: str, styles: list[tuple[int, int, str]]) -> str:
     """Detect GFM table blocks and re-align each to a fixed monospace width, recording a
     MONOSPACE style range over the rendered block. Runs after code-block extraction, so no
-    fenced regions remain to skip."""
+    fenced regions remain to skip.
+
+    Realigning a table can change its rendered length (column padding), which shifts every
+    style range that starts after it. `styles` already holds ranges (e.g. code blocks) computed
+    against the pre-realignment `text`, so those need to be rebased in place as tables are
+    resolved. Comparisons use a frozen snapshot of the original start positions, since the
+    entries in `styles` are themselves mutated (shifted) as earlier tables are processed."""
     if "|" not in text:
         return text
     lines = text.split("\n")
+    line_starts: list[int] = []
+    offset = 0
+    for line in lines:
+        line_starts.append(offset)
+        offset += len(line) + 1
+    original_starts = [start for start, _, _ in styles]
+
     result_lines: list[str] = []
     i, n = 0, len(lines)
     while i < n:
@@ -51,9 +64,17 @@ def _realign_tables(text: str, styles: list[tuple[int, int, str]]) -> str:
             j = i + 2
             while j < n and "|" in lines[j] and lines[j].strip():
                 j += 1
-            rendered = realign_markdown_tables("\n".join(lines[i:j]), _TABLE_WIDTH)
+            original_block = "\n".join(lines[i:j])
+            rendered = realign_markdown_tables(original_block, _TABLE_WIDTH)
             block_start = sum(len(rl) + 1 for rl in result_lines)
             styles.append((block_start, len(rendered), "MONOSPACE"))
+            delta = len(rendered) - len(original_block)
+            if delta:
+                block_end = line_starts[i] + len(original_block)
+                for idx, original_start in enumerate(original_starts):
+                    if original_start >= block_end:
+                        start, length, style_type = styles[idx]
+                        styles[idx] = (start + delta, length, style_type)
             result_lines.extend(rendered.split("\n"))
             i = j
             continue

--- a/tests/gateway/test_signal_format.py
+++ b/tests/gateway/test_signal_format.py
@@ -238,6 +238,43 @@ class TestMarkdownStripPatch:
 # signal-streaming-patch: SUPPORTS_MESSAGE_EDITING and send() behavior
 # ===========================================================================
 
+class TestTableRealignment:
+    """GFM pipe tables are re-aligned to a fixed monospace width and wrapped in a
+    single MONOSPACE style range, per the Signal table-rendering feature request."""
+
+    def test_table_becomes_single_monospace_block(self):
+        md = "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |"
+        text, styles = _m2s(md)
+        mono = _find_style(styles, "MONOSPACE")
+        assert len(mono) == 1
+        start, length = (int(p) for p in mono[0].split(":")[:2])
+        block = text[start : start + length]
+        rows = block.split("\n")
+        assert len(rows) == 4
+        # Realignment pads cells so every '|' lines up across header/divider/body,
+        # even though the source rows ("Alice" vs "Bob") had different widths.
+        pipe_offsets = [i for i, ch in enumerate(rows[0]) if ch == "|"]
+        assert all([i for i, ch in enumerate(row) if ch == "|"] == pipe_offsets for row in rows[1:])
+
+    def test_non_table_pipes_left_alone(self):
+        """A lone '|' with no divider row is not a table and must not be touched."""
+        text, styles = _m2s("cost | value\nnot a table")
+        assert text == "cost | value\nnot a table"
+        assert _find_style(styles, "MONOSPACE") == []
+
+    def test_table_surrounded_by_prose_keeps_prose_out_of_monospace(self):
+        md = "Before.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nAfter."
+        text, styles = _m2s(md)
+        assert text.startswith("Before.\n\n")
+        assert text.endswith("\n\nAfter.")
+        mono = _find_style(styles, "MONOSPACE")
+        assert len(mono) == 1
+        start, length = (int(p) for p in mono[0].split(":")[:2])
+        block = text[start : start + length]
+        assert "Before" not in block and "After" not in block
+        assert block.startswith("| A")
+
+
 class TestSignalStreamingPatch:
     """Tests for signal-streaming-patch: cursor suppression and edit support.
     

--- a/tests/gateway/test_signal_format.py
+++ b/tests/gateway/test_signal_format.py
@@ -274,6 +274,19 @@ class TestTableRealignment:
         assert "Before" not in block and "After" not in block
         assert block.startswith("| A")
 
+    def test_table_before_code_block_keeps_code_block_position_correct(self):
+        """A table's realignment can change its own rendered length (column padding).
+        Any style range recorded before the table (e.g. a fenced code block) but that sits
+        *after* it in the document must be rebased by that length delta, or it ends up
+        pointing at a random substring of the table instead of the code block."""
+        md = "| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |\n\n```\ncode\n```"
+        text, styles = _m2s(md)
+        mono = _find_style(styles, "MONOSPACE")
+        assert len(mono) == 2
+        ranges = [(int(s.split(":")[0]), int(s.split(":")[1])) for s in mono]
+        code_start, code_length = max(ranges, key=lambda r: r[0])
+        assert text[code_start : code_start + code_length] == "code"
+
 
 class TestSignalStreamingPatch:
     """Tests for signal-streaming-patch: cursor suppression and edit support.


### PR DESCRIPTION
## What does this PR do?

Markdown tables emitted by the model were delivered to Signal as raw, unaligned text — Signal renders normal message bodies in a proportional font, so pipe-table columns didn't line up. `markdown_to_signal()` had no table handling at all.

This adds GFM table detection to `markdown_to_signal()`: each table block is re-aligned to a fixed monospace width via the existing `agent.markdown_tables.realign_markdown_tables()` helper (already display-width aware for CJK/wide characters, with a vertical fallback for tables too wide to align), and the whole rendered block is wrapped in a single `MONOSPACE` Signal `bodyRange` — the same style mechanism already used for fenced code blocks in this file.

## Related Issue

Fixes #106181

## Changes Made

- `gateway/platforms/signal_format.py`
  - Import `is_table_divider` / `realign_markdown_tables` from `agent.markdown_tables`.
  - Add `_TABLE_WIDTH = 40` — a fixed monospace-cell budget sized for a phone screen (Signal has no fixed-width client area).
  - Add `_realign_tables()`: scans for header+divider+body table blocks (same detection rule as `realign_markdown_tables`'s internal loop), re-renders each in isolation so its exact character span can be recorded, and appends a `(start, length, "MONOSPACE")` style range per table.
  - Wire `_realign_tables()` into `markdown_to_signal()` right after code-block extraction (mirrors how code-block styles are collected, before the heading/inline-marker passes that later shift positions via the existing `_adjust()` machinery).
  - **Fix-up (post-review):** realigning a table can change its rendered length via column padding, which shifts every style range recorded before it (e.g. a fenced code block) but positioned later in the document. `_realign_tables()` now rebases those pre-existing style start positions in place as each table is resolved, using a frozen snapshot of their original positions to decide which ones sit after the table's original span. Without this, a table followed by a code block in the same message produced a code-block `MONOSPACE` bodyRange pointing at a random substring of the table instead of the code block.
- `tests/gateway/test_signal_format.py` — new `TestTableRealignment` class:
  - `test_table_becomes_single_monospace_block` — an unaligned source table (`Alice`/`Bob` rows of different width) becomes column-aligned with one `MONOSPACE` range covering exactly the rendered block.
  - `test_non_table_pipes_left_alone` — a lone `|` with no divider row is left untouched (no false positives).
  - `test_table_surrounded_by_prose_keeps_prose_out_of_monospace` — prose before/after a table stays outside the `MONOSPACE` range.
  - `test_table_before_code_block_keeps_code_block_position_correct` — a table immediately followed by a fenced code block still yields a code-block `MONOSPACE` range that points at the code text (`"code"`), not a shifted substring of the table.

## How to Test

```
git checkout HEAD~1 -- gateway/platforms/signal_format.py
pytest tests/gateway/test_signal_format.py -q -k TableRealignment   # 3 failed, 1 passed
git checkout HEAD -- gateway/platforms/signal_format.py
pytest tests/gateway/test_signal_format.py -q -k TableRealignment   # 4 passed
```

## Verification

- `pytest tests/gateway/test_signal_format.py tests/agent/test_markdown_tables.py tests/gateway/test_signal.py tests/gateway/test_table_helpers.py -q` → **93 passed, 1 skipped**
- Full `tests/gateway/` suite (in a from-scratch venv, `pip install -e .` + messaging extras installed ad hoc): **7893 passed, 10 failed, 48 skipped, 2 xfailed**. The 10 failures are all pre-existing and unrelated to this change (Discord attachment/redirect mocks, Teams SDK availability, Telegram polling log assertion, WeCom XML parsing, session-store path) — none touch `gateway/platforms/signal_format.py` or `agent/markdown_tables.py`, and none appear in the run when only the signal/table-related test files above are selected.
- `ruff check gateway/platforms/signal_format.py tests/gateway/test_signal_format.py` → All checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(scope):`)
- [x] I searched existing issues and PRs for overlap — no open PR touches `gateway/platforms/signal_format.py` or Signal table rendering; `#103997` (pipe-table chunk-boundary preservation) is a different, non-overlapping concern
- [x] My PR contains only changes related to this fix (2 files)
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing config or docs changed
- [x] `cli-config.yaml.example` update — N/A; no config keys added

## AI assistance disclosure

This PR was written by an autonomous Claude Code agent (Claude Sonnet 5) working from issue #106181's description and the existing `agent/markdown_tables.py` / `gateway/platforms/signal_format.py` code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
