### PR TITLE
fix(gateway): rebind Telegram DM topic on every session-switch surface

### DIFF
--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -248,6 +248,11 @@ class GatewayNotificationsMixin:
             "Pinned async-delegation completion to owning session %s (was %s) for routing key %s (#57498)",
             target_session_id, prior_session_id, session_entry.session_key,
         )
+        # Telegram DM topic lane: rebind (chat_id, thread_id) → owning session_id. The compression
+        # branch above (advance_compression_session) already syncs the binding; the plain
+        # switch_session path did not, leaving the topic row stale. switch_session preserves origin.
+        if not follows_compression:
+            await self._rebind_telegram_topic_after_switch(switched.origin, switched)
         return switched
 
     async def _deliver_media_from_response(

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -1491,6 +1491,10 @@ class GatewayStartupMixin:
         switched = await self.async_session_store.switch_session(session_key, cli_session_id)
         if switched is None:
             raise RuntimeError(f"could not switch session key {session_key} → {cli_session_id}")
+        # Telegram DM topic lane: rebind (chat_id, thread_id) → CLI session_id (same paired rebind
+        # /new performs) so the topic tracks the handed-off session instead of the prior one. Drove
+        # thread 34250 to 15 sessions deep on one stale row before this fix.
+        await self._rebind_telegram_topic_after_switch(dest.source, switched)
         # Evict the cached AIAgent (rebuild against the CLI session_id, like /resume) and clear stale
         # running-agent state so the synthetic turn isn't queued behind it.
         self._evict_cached_agent(session_key)

--- a/gateway/run_topics.py
+++ b/gateway/run_topics.py
@@ -200,6 +200,29 @@ class GatewayTopicThreadsMixin:
         except Exception:
             logger.debug("telegram topic binding refresh failed (%s)", reason, exc_info=True)
 
+    async def _rebind_telegram_topic_after_switch(self, source, session_entry) -> None:
+        """Pair a ``switch_session`` routing move with the durable topic rebind.
+
+        ``switch_session`` (routing) and ``bind_telegram_topic`` (the durable
+        ``telegram_dm_topic_bindings`` row) are decoupled: moving the route without
+        rebinding leaves the row pointing at the OLD session, so the next inbound
+        message switches back and the retire/archive helpers resolve the wrong topic.
+        ``/new`` already does this inline; ``/resume``, ``/branch``, the CLI-handoff
+        worker, and async-delegation completion call this after their switch.
+
+        Guarded by ``_is_telegram_topic_lane`` (no-op outside a Telegram DM topic lane)
+        and run off-loop via ``asyncio.to_thread``; best-effort like the ``/new`` path.
+        See #20470, #29712, #33414 and the switch-surface binding fix.
+        """
+        if session_entry is None or source is None:
+            return
+        if not await asyncio.to_thread(self._is_telegram_topic_lane, source):
+            return
+        try:
+            await asyncio.to_thread(self._record_telegram_topic_binding, source, session_entry)
+        except Exception:
+            logger.debug("Failed to rebind Telegram topic after session switch", exc_info=True)
+
     def _recover_telegram_topic_thread_id(self, source: SessionSource) -> Optional[str]:
         """Pin lobby-shaped topic-mode DM replies (missing ``message_thread_id`` or General) to the
         user's most-recent bound topic. Never rewrite a non-lobby, unbound thread id: a brand-new DM

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -922,6 +922,10 @@ class GatewaySessionCommandsMixin:
         # Evict so the next turn rebuilds with the right session_id — the cached AIAgent's memory
         # provider cached _session_id at initialize() and would keep writing to the wrong session.
         self._evict_cached_agent(session_key)
+        # Telegram DM topic lane: rebind (chat_id, thread_id) → resumed session_id so the next
+        # message uses the resumed session instead of switching back to the old one (same paired
+        # rebind /new performs). switch_session preserves the entry origin used for the lane guard.
+        await self._rebind_telegram_topic_after_switch(new_entry.origin or source, new_entry)
         title = await self._session_db.get_session_title(target_id) or name
         try:
             history = await self.async_session_store.load_transcript(target_id)
@@ -1070,6 +1074,9 @@ class GatewaySessionCommandsMixin:
             return t("gateway.branch.switch_failed")
         self._clear_session_boundary_security_state(session_key)
         self._evict_cached_agent(session_key)
+        # Telegram DM topic lane: rebind (chat_id, thread_id) → branched session_id (same paired
+        # rebind /new performs) so the topic follows the branch instead of the parent.
+        await self._rebind_telegram_topic_after_switch(new_entry.origin or source, new_entry)
         msg_count = len([m for m in history if m.get("role") == "user"])
         key = "gateway.branch.branched_one" if msg_count == 1 else "gateway.branch.branched_many"
         return t(key, title=branch_title, count=msg_count, parent=parent_session_id, new=new_session_id)

--- a/tests/gateway/test_telegram_topic_binding_switch_surfaces.py
+++ b/tests/gateway/test_telegram_topic_binding_switch_surfaces.py
@@ -1,0 +1,222 @@
+"""Regression: every session-switch surface must rebind the Telegram DM topic row.
+
+Topic mode persists a ``(chat_id, thread_id) -> session_id`` row in
+``telegram_dm_topic_bindings`` so reopening a topic in a fresh process resumes
+the right Hermes session, and so the retire/archive helpers resolve the correct
+topic to delete. ``/new`` already rewrites this row after resetting the session
+(``_record_telegram_topic_binding``; regression covered by
+``test_new_inside_telegram_topic_rewrites_binding_to_new_session``).
+
+But four OTHER surfaces move routing via ``SessionStore.switch_session`` WITHOUT
+the paired rebind, so the binding goes stale (keeps pointing at the old session)
+or is never written:
+
+1. ``/resume``  — ``_handle_resume_command`` (gateway/slash_commands_session.py)
+2. ``/branch``  — ``_handle_branch_command`` (gateway/slash_commands_session.py)
+3. handoff / CLI-injection worker — ``_process_handoff`` (gateway/run_startup.py)
+4. async-delegation completion — ``_resolve_async_delegation_session``
+   (gateway/run_notifications.py)
+
+A stale binding is the retire-safety hazard that drove this fix: the archiver
+resolves its delete target from the binding row, so a wrong row = deleting the
+wrong Telegram topic.
+
+Each test drives the surface against a REAL SessionStore + SessionDB (SQLite in
+tmp_path, topic mode enabled) and asserts the binding row points at the session
+the surface switched to.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.event import MessageEvent
+from gateway.session import SessionSource, SessionStore, build_session_key
+from hermes_state import AsyncSessionDB
+
+CHAT_ID = "208214988"
+THREAD_ID = "17585"
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    """Real SessionStore backed by a real SessionDB with topic mode enabled."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    config = GatewayConfig()
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    store._db.enable_telegram_topic_mode(chat_id=CHAT_ID, user_id=CHAT_ID)
+    return store
+
+
+def _make_source(thread_id: str | None = THREAD_ID) -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id=CHAT_ID,
+        chat_id=CHAT_ID,
+        chat_type="dm",
+        thread_id=thread_id,
+    )
+
+
+def _make_event(text: str, thread_id: str | None = THREAD_ID) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(thread_id), message_id="m1")
+
+
+def _binding_session_id(store: SessionStore) -> str | None:
+    row = store._db.get_telegram_topic_binding(chat_id=CHAT_ID, thread_id=THREAD_ID)
+    return row["session_id"] if row else None
+
+
+def _make_runner(store: SessionStore):
+    """Minimal GatewayRunner wired to a REAL session_store/session_db."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.config = GatewayConfig()
+    runner._background_tasks = set()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._pending_approvals = {}
+    runner._update_prompt_pending = {}
+    runner._agent_cache_lock = None
+    runner.session_store = store
+    runner._session_db = AsyncSessionDB(store._db)
+    runner._pending_skills_reload_notes = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    # Collaborators the switch handlers touch but which are irrelevant here.
+    runner._release_running_agent_state = mock.MagicMock()
+    runner._evict_cached_agent = mock.MagicMock()
+    runner._clear_conversation_scope = mock.MagicMock()
+    runner._clear_session_boundary_security_state = mock.MagicMock()
+    runner._is_user_authorized = lambda _source: True
+    runner._resume_caller_is_admin = lambda _source: True
+    return runner
+
+
+def _seed_topic_session(store: SessionStore, source: SessionSource) -> str:
+    """Create the initial topic session + its binding (the /new-established state)."""
+    entry = store.get_or_create_session(source)
+    session_key = build_session_key(source)
+    store._db.bind_telegram_topic(
+        chat_id=CHAT_ID, thread_id=THREAD_ID, user_id=CHAT_ID,
+        session_key=session_key, session_id=entry.session_id,
+    )
+    return entry.session_id
+
+
+# ---------------------------------------------------------------- /resume
+
+@pytest.mark.asyncio
+async def test_resume_rebinds_topic_to_resumed_session(store):
+    """/resume inside a topic must rebind the row to the resumed session."""
+    source = _make_source()
+    original_id = _seed_topic_session(store, source)
+
+    # A second, older session in the same topic that we will /resume back into.
+    store._db.create_session(session_id="older-session", source="telegram",
+                             user_id=CHAT_ID, chat_id=CHAT_ID, chat_type="dm",
+                             thread_id=THREAD_ID, session_key=build_session_key(source))
+    store._db.set_session_title("older-session", "Older")
+
+    runner = _make_runner(store)
+    reply = await runner._handle_resume_command(_make_event("/resume Older"))
+
+    assert _binding_session_id(store) == "older-session", (
+        f"/resume left the topic binding stale (reply={reply!r}); "
+        f"still points at {_binding_session_id(store)}, expected older-session"
+    )
+    assert original_id != "older-session"
+
+
+# ---------------------------------------------------------------- /branch
+
+@pytest.mark.asyncio
+async def test_branch_rebinds_topic_to_branched_session(store):
+    """/branch inside a topic must rebind the row to the new branched session."""
+    source = _make_source()
+    parent_id = _seed_topic_session(store, source)
+    store._db.append_message(parent_id, role="user", content="hello")
+    store._db.append_message(parent_id, role="assistant", content="world")
+
+    runner = _make_runner(store)
+    reply = await runner._handle_branch_command(_make_event("/branch"))
+
+    bound = _binding_session_id(store)
+    assert bound is not None and bound != parent_id, (
+        f"/branch left the topic binding on the parent (reply={reply!r}); "
+        f"binding={bound}, parent={parent_id}"
+    )
+    # The bound session is the live route after the branch.
+    live = store.get_or_create_session(source).session_id
+    assert bound == live, f"binding {bound} != live route {live}"
+
+
+# ---------------------------------------------------------------- handoff worker
+
+@pytest.mark.asyncio
+async def test_handoff_rebinds_topic_to_cli_session(store):
+    """The CLI-handoff worker switches routing to the CLI session; it must rebind."""
+    source = _make_source()
+    _seed_topic_session(store, source)
+
+    # The incoming CLI session that the handoff injects into this topic.
+    session_key = build_session_key(source)
+    store._db.create_session(session_id="cli-session", source="cli", user_id=CHAT_ID,
+                             chat_id=CHAT_ID, chat_type="dm", thread_id=THREAD_ID,
+                             session_key=session_key)
+
+    runner = _make_runner(store)
+
+    # _process_handoff resolves a destination, switches, then dispatches a synthetic
+    # turn. We stub the destination + the synthetic turn/send so the test isolates the
+    # switch+rebind. dest.source carries the topic SessionSource.
+    dest = mock.MagicMock()
+    dest.source = source
+    dest.platform_name = "telegram"
+    dest.home = mock.MagicMock(chat_id=CHAT_ID)
+    dest.effective_thread_id = THREAD_ID
+    runner._handoff_resolve_destination = mock.AsyncMock(return_value=dest)
+    runner._handoff_session_key = lambda _dest, _profile: session_key
+    runner._handle_message = mock.AsyncMock(return_value="")  # synthetic turn no-op
+
+    await runner._process_handoff({"id": "cli-session", "title": "CLI"})
+
+    assert _binding_session_id(store) == "cli-session", (
+        f"handoff worker left the topic binding stale; "
+        f"binding={_binding_session_id(store)}, expected cli-session"
+    )
+
+
+# ---------------------------------------------------------------- async delegation
+
+@pytest.mark.asyncio
+async def test_async_delegation_rebinds_topic_to_owning_session(store):
+    """Async-delegation completion retargets routing to the owning session; rebind."""
+    source = _make_source()
+    original_id = _seed_topic_session(store, source)
+    session_key = build_session_key(source)
+
+    # The delegation's owning ("pinned") session, distinct from the current route.
+    store._db.create_session(session_id="owning-session", source="telegram", user_id=CHAT_ID,
+                             chat_id=CHAT_ID, chat_type="dm", thread_id=THREAD_ID,
+                             session_key=session_key)
+
+    runner = _make_runner(store)
+    current_entry = store.get_or_create_session(source)
+    assert current_entry.session_id == original_id
+
+    resolved = await runner._resolve_async_delegation_session(current_entry, "owning-session")
+    assert resolved is not None and resolved.session_id == "owning-session"
+
+    assert _binding_session_id(store) == "owning-session", (
+        f"async-delegation left the topic binding stale; "
+        f"binding={_binding_session_id(store)}, expected owning-session"
+    )


### PR DESCRIPTION
## Summary

Topic mode persists a `(chat_id, thread_id) -> session_id` row in `telegram_dm_topic_bindings` so reopening a Telegram DM topic resumes the right Hermes session, and so the retire/archive helpers resolve the correct topic to delete. `/new` already pairs its `switch_session` with `_record_telegram_topic_binding` (regression: `test_new_inside_telegram_topic_rewrites_binding_to_new_session`), but **four other surfaces call `SessionStore.switch_session` WITHOUT the paired rebind**, so the binding goes stale (keeps pointing at the old session) or is never written:

1. `/resume` — `_handle_resume_command` (`gateway/slash_commands_session.py`)
2. `/branch` — `_handle_branch_command` (`gateway/slash_commands_session.py`)
3. CLI-handoff worker — `_process_handoff` (`gateway/run_startup.py`)
4. async-delegation completion — `_resolve_async_delegation_session` (`gateway/run_notifications.py`)

A stale binding is a **retire-safety hazard**: the archiver resolves its delete target from the binding row, so a wrong row means deleting the *wrong* Telegram topic. In practice it also drove one thread 15 sessions deep on a single stale row via the handoff worker.

## Fix

Add `GatewayTopicThreadsMixin._rebind_telegram_topic_after_switch(source, session_entry)` — guarded by `_is_telegram_topic_lane` (no-op outside a Telegram DM topic lane), run off-loop via `asyncio.to_thread`, best-effort like the `/new` path — and call it after `switch_session` in all four surfaces.

The async-delegation compression branch (`advance_compression_session`) already syncs the binding, so only its plain `switch_session` path is rebound. **No schema change.**

## Tests

Adds `tests/gateway/test_telegram_topic_binding_switch_surfaces.py`, which drives each of the four surfaces against a **real** `SessionStore` + `SessionDB` (SQLite in tmp_path, topic mode enabled) and asserts the binding follows the switch.

- Before the fix: all 4 fail (binding stays on the old session).
- After the fix: all 4 pass; neutering the helper flips them back to RED (load-bearing verified).
- Existing `test_telegram_topic_mode.py` + `test_branch_routing_columns.py` still green; broader `tests/gateway -k "topic or branch or resume or handoff or delegation or notification or slash"` sweep: 518 passed, 2 skipped.

## Checklist
- [x] Conventional Commit message (`fix(gateway): ...`)
- [x] PR contains only changes related to this fix
- [x] Tests added and passing (RED→GREEN, load-bearing verified)
- [x] No schema change