### PR TITLE
feat(desktop): show an animated message count when scrolling up

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -277,6 +277,8 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
 
 - Visible windows keep animating when another app takes focus. Hidden/minimized
   windows and inactive panes may pause; background polling stays focus-gated.
+- Animated integer counts reuse `AnimatedInt` in `src/components/ui/diff-count.tsx`.
+  Its spring updates the DOM directly without per-frame React renders.
 - Quick, functional transitions (~100ms on controls). Respect
   `prefers-reduced-motion` for anything beyond a fade.
 - Choreographed exits (e.g. onboarding's "matrix" fade-down) stagger per-element

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
-import { onScrollToBottomRequest, resetThreadScroll, setThreadAtBottom } from '@/store/thread-scroll'
+import {
+  onScrollToBottomRequest,
+  publishThreadMessagesBelow,
+  resetThreadScroll,
+  setThreadAtBottom
+} from '@/store/thread-scroll'
 
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
 
@@ -28,11 +33,12 @@ describe('ScrollToBottomButton', () => {
     expect(screen.queryByRole('button')).toBeNull()
   })
 
-  it('is a plain jump-to-bottom control when scrolled up with no approval', () => {
+  it('shows the messages below the viewport when scrolled up with no approval', () => {
     setThreadAtBottom(false)
+    publishThreadMessagesBelow(12, { paneVisible: true })
     render(<ScrollToBottomButton sessionId={null} />)
 
-    expect(screen.getByRole('button', { name: 'Scroll to bottom' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Scroll to bottom · 12 messages' }).textContent).toBe('12 messages')
     expect(screen.queryByText('Approval needed')).toBeNull()
   })
 

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
@@ -1,12 +1,14 @@
 import { useStore } from '@nanostores/react'
+import { useReducedMotion } from 'motion/react'
 import { useRef } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
+import { AnimatedInt } from '@/components/ui/diff-count'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { cn } from '@/lib/utils'
 import { $approvalRequest } from '@/store/prompts'
-import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-scroll'
+import { $threadJumpButtonVisible, $threadMessagesBelow, requestScrollToBottom } from '@/store/thread-scroll'
 
 /**
  * Floating "jump to bottom" control. Sits centered just above the composer,
@@ -14,7 +16,8 @@ import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-
  * the thread's bottom clearance uses (`--composer-measured-height`, which
  * covers the whole dock), so it never overlaps the queue / subagent
  * / background cards. Visible only while the user has scrolled meaningfully
- * away from the bottom; clicking re-arms sticky-bottom and pins the viewport.
+ * away from the bottom, with an animated count of messages below the viewport.
+ * Clicking re-arms sticky-bottom and pins the viewport.
  *
  * When the turn is BLOCKED on an approval, this same control morphs into an
  * "Approval needed" pill — the only response surface is the inline Run/Reject
@@ -31,6 +34,8 @@ import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-
 export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }) {
   const { t } = useI18n()
   const visible = useStore($threadJumpButtonVisible)
+  const count = useStore($threadMessagesBelow)
+  const reducedMotion = useReducedMotion()
   const request = useStore($approvalRequest)
   // Scrolled away while an approval is pending → the inline Run/Reject bar is
   // below the fold. Relabel so the user knows the session needs them, not just
@@ -43,17 +48,22 @@ export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }
   }
 
   const state = visible ? 'in' : hasShownRef.current ? 'out' : 'idle'
-  const label = approval ? t.assistant.approval.jumpToApproval : t.assistant.thread.scrollToBottom
+  const countLabel = t.sidebar.messageCount(count)
+  const [beforeCount, afterCount] = countLabel.split(String(count))
+
+  const label = approval
+    ? t.assistant.approval.jumpToApproval
+    : `${t.assistant.thread.scrollToBottom} · ${countLabel}`
 
   return (
     <button
       aria-hidden={!visible}
       aria-label={label}
       className={cn(
-        'thread-jump-button absolute left-1/2 z-20 grid place-items-center backdrop-blur-[0.75rem] [-webkit-backdrop-filter:blur(0.75rem)]',
+        'thread-jump-button absolute left-1/2 z-20 flex h-8 items-center gap-1.5 rounded-full border bg-(--composer-fill) px-3 text-xs font-medium backdrop-blur-[0.75rem] [-webkit-backdrop-filter:blur(0.75rem)]',
         approval
-          ? 'h-8 grid-flow-col gap-1.5 rounded-full border border-primary/40 bg-(--composer-fill) px-3 text-primary hover:bg-primary/10'
-          : 'size-8 rounded-full border border-border/65 bg-(--composer-fill) text-muted-foreground hover:text-foreground',
+          ? 'border-primary/40 text-primary hover:bg-primary/10'
+          : 'border-border/65 text-muted-foreground hover:text-foreground',
         !visible && 'pointer-events-none'
       )}
       data-state={state}
@@ -62,13 +72,21 @@ export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }
         requestScrollToBottom(sessionId)
       }}
       style={{
-        bottom: 'calc(var(--composer-measured-height) + 0.625rem)'
+        bottom: 'calc(var(--composer-measured-height) + 1rem)'
       }}
       tabIndex={visible ? 0 : -1}
       type="button"
     >
-      <Codicon name="arrow-down" size={approval ? '0.875rem' : '1rem'} />
-      {approval && <span className="text-xs font-medium">{label}</span>}
+      <Codicon name="arrow-down" size="0.875rem" />
+      {approval ? (
+        <span>{label}</span>
+      ) : (
+        <span aria-hidden className="whitespace-nowrap tabular-nums">
+          {beforeCount}
+          {!visible || reducedMotion ? count : <AnimatedInt key={sessionId} value={count} />}
+          {afterCount}
+        </span>
+      )}
     </button>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -41,6 +41,7 @@ import { isSecondaryWindow } from '@/store/windows'
 import { MessageRenderBoundary } from '../message-render-boundary'
 
 import { resolveShowEarlierAction, useTranscriptWindow } from './transcript-window'
+import { useMessagesBelow } from './use-messages-below'
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -376,6 +377,7 @@ const TurnRow = memo(function TurnRow({ components, group, resetKey, virtualized
         'flex min-w-0 flex-col gap-(--conversation-turn-gap) pb-(--conversation-turn-gap)',
         virtualized && '[contain-intrinsic-size:auto_37.5rem] [content-visibility:auto]'
       )}
+      data-slot="aui_message-group"
     >
       <MessageRenderBoundary resetKey={resetKey}>
         {group.kind === 'turn' ? (
@@ -989,6 +991,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       )),
     [visibleGroups, components, structuralSignature, tailStart]
   )
+
+  useMessagesBelow({ contentRef, scrollRef, isAtBottom, paneVisible, rows, sessionKey })
 
   return (
     <div

--- a/apps/desktop/src/components/assistant-ui/thread/use-messages-below.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/use-messages-below.test.tsx
@@ -1,0 +1,134 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $threadMessagesBelow, resetThreadScroll } from '@/store/thread-scroll'
+
+import { countMessagesBelow, useMessagesBelow } from './use-messages-below'
+
+function rect(top: number, bottom: number): DOMRect {
+  return { top, bottom, height: bottom - top } as DOMRect
+}
+
+function transcript() {
+  const viewport = window.document.createElement('div')
+  const content = window.document.createElement('div')
+  viewport.append(content)
+  vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue(rect(0, 600))
+
+  const group = window.document.createElement('div')
+  group.dataset.slot = 'aui_message-group'
+  content.append(group)
+  vi.spyOn(group, 'getBoundingClientRect').mockReturnValue(rect(100, 900))
+
+  const user = window.document.createElement('div')
+  user.dataset.slot = 'aui_user-message-root'
+  group.append(user)
+  vi.spyOn(user, 'getBoundingClientRect').mockReturnValue(rect(100, 180))
+
+  const assistant = window.document.createElement('div')
+  assistant.dataset.slot = 'aui_assistant-message-root'
+  group.append(assistant)
+  const assistantRect = vi.spyOn(assistant, 'getBoundingClientRect').mockReturnValue(rect(200, 900))
+
+  return { viewport, content, assistantRect }
+}
+
+afterEach(() => {
+  cleanup()
+  resetThreadScroll()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('messages below the viewport', () => {
+  it('counts the clipped message plus later messages without laying out skipped turns', () => {
+    const { viewport, content, assistantRect } = transcript()
+    const skipped = window.document.createElement('div')
+    skipped.dataset.slot = 'aui_message-group'
+    content.append(skipped)
+    vi.spyOn(skipped, 'getBoundingClientRect').mockReturnValue(rect(900, 1500))
+
+    const skippedRects = ['aui_user-message-root', 'aui_assistant-message-root'].map(slot => {
+      const message = window.document.createElement('div')
+      message.dataset.slot = slot
+      skipped.append(message)
+
+      return vi.spyOn(message, 'getBoundingClientRect')
+    })
+
+    expect(countMessagesBelow(viewport, content)).toBe(3)
+
+    for (const measure of skippedRects) {
+      expect(measure).not.toHaveBeenCalled()
+    }
+
+    assistantRect.mockReturnValue(rect(200, 600))
+    expect(countMessagesBelow(viewport, content)).toBe(2)
+
+    vi.mocked(viewport.getBoundingClientRect).mockReturnValue(rect(0, 1500))
+    expect(countMessagesBelow(viewport, content)).toBe(0)
+  })
+
+  it('remeasures scroll and resize, ignores hidden panes, and clears at the bottom', () => {
+    const { viewport, content, assistantRect } = transcript()
+    let frame: FrameRequestCallback | undefined
+    let resize: ResizeObserverCallback | undefined
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frame = callback
+
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {
+      frame = undefined
+    })
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resize = callback
+        }
+
+        observe() {}
+        disconnect() {}
+      }
+    )
+
+    const flush = () => act(() => {
+      const callback = frame
+      frame = undefined
+      callback?.(0)
+    })
+
+    const options = {
+      scrollRef: { current: viewport },
+      contentRef: { current: content },
+      isAtBottom: false,
+      paneVisible: true,
+      rows: null,
+      sessionKey: 'a'
+    }
+
+    const { rerender } = renderHook(props => useMessagesBelow(props), { initialProps: options })
+    flush()
+    expect($threadMessagesBelow.get()).toBe(1)
+
+    assistantRect.mockReturnValue(rect(200, 500))
+    viewport.dispatchEvent(new Event('scroll'))
+    flush()
+    expect($threadMessagesBelow.get()).toBe(0)
+
+    assistantRect.mockReturnValue(rect(200, 900))
+    resize?.([], {} as ResizeObserver)
+    flush()
+    expect($threadMessagesBelow.get()).toBe(1)
+
+    rerender({ ...options, paneVisible: false })
+    assistantRect.mockReturnValue(rect(200, 500))
+    viewport.dispatchEvent(new Event('scroll'))
+    flush()
+    expect($threadMessagesBelow.get()).toBe(1)
+
+    rerender({ ...options, isAtBottom: true })
+    expect($threadMessagesBelow.get()).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/use-messages-below.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-messages-below.ts
@@ -1,0 +1,100 @@
+import { type ReactNode, type RefObject, useEffect } from 'react'
+
+import { publishThreadMessagesBelow } from '@/store/thread-scroll'
+
+const MESSAGE_ROOTS =
+  '[data-slot="aui_user-message-root"], [data-slot="aui_assistant-message-root"], [data-slot="aui_system-message-root"]'
+
+interface MessagesBelowOptions {
+  contentRef: RefObject<HTMLElement | null>
+  scrollRef: RefObject<HTMLElement | null>
+  isAtBottom: boolean
+  paneVisible: boolean
+  rows: ReactNode
+  sessionKey: string | null | undefined
+}
+
+/** Only measure inside the viewport's turn; leave skipped off-screen content asleep. */
+export function countMessagesBelow(viewport: HTMLElement, content: HTMLElement): number {
+  const bottom = viewport.getBoundingClientRect().bottom
+  let count = 0
+
+  for (const group of content.querySelectorAll<HTMLElement>('[data-slot="aui_message-group"]')) {
+    const rect = group.getBoundingClientRect()
+
+    if (rect.bottom <= bottom + 1) {
+      continue
+    }
+
+    const messages = group.querySelectorAll<HTMLElement>(MESSAGE_ROOTS)
+
+    if (rect.top >= bottom) {
+      count += messages.length
+
+      continue
+    }
+
+    for (const message of messages) {
+      const messageRect = message.getBoundingClientRect()
+
+      if (messageRect.height > 0 && messageRect.bottom > bottom + 1) {
+        count++
+      }
+    }
+  }
+
+  return count
+}
+
+export function useMessagesBelow({
+  contentRef,
+  scrollRef,
+  isAtBottom,
+  paneVisible,
+  rows,
+  sessionKey
+}: MessagesBelowOptions) {
+  useEffect(() => {
+    if (!paneVisible) {
+      return
+    }
+
+    if (isAtBottom) {
+      publishThreadMessagesBelow(0, { paneVisible })
+
+      return
+    }
+
+    const viewport = scrollRef.current
+    const content = contentRef.current
+
+    if (!viewport || !content) {
+      return
+    }
+
+    let frame = 0
+
+    const measure = () => {
+      frame = 0
+      publishThreadMessagesBelow(countMessagesBelow(viewport, content), { paneVisible })
+    }
+
+    const schedule = () => {
+      if (!frame) {
+        frame = requestAnimationFrame(measure)
+      }
+    }
+
+    schedule()
+    viewport.addEventListener('scroll', schedule, { passive: true })
+    const observer = new ResizeObserver(schedule)
+    observer.observe(viewport)
+    observer.observe(content)
+
+    return () => {
+      cancelAnimationFrame(frame)
+      viewport.removeEventListener('scroll', schedule)
+      observer.disconnect()
+    }
+  }, [contentRef, scrollRef, isAtBottom, paneVisible, rows, sessionKey])
+}

--- a/apps/desktop/src/components/ui/diff-count.tsx
+++ b/apps/desktop/src/components/ui/diff-count.tsx
@@ -11,7 +11,7 @@ const SPRING = { stiffness: 320, damping: 30, mass: 0.5 } as const
 // its value, so mounting/navigating shows it instantly — only a real change to
 // the number (a live edit) springs it up/down. Switching threads in the same
 // worktree (same numbers) therefore doesn't animate.
-function AnimatedInt({ value }: { value: number }) {
+export function AnimatedInt({ value }: { value: number }) {
   const spring = useSpring(value, SPRING)
   const text = useTransform(spring, latest => Math.round(latest).toString())
 

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -19,6 +19,13 @@ import { $activeProfile, normalizeProfileKey } from '@/store/profile'
 // scroll every mounted transcript.
 export const $threadScrolledUp = atom(false)
 export const $threadJumpButtonVisible = atom(false)
+export const $threadMessagesBelow = atom(0)
+
+export const publishThreadMessagesBelow = (count: number, publisher: { paneVisible: boolean }): void => {
+  if (publisher.paneVisible && $threadMessagesBelow.get() !== count) {
+    $threadMessagesBelow.set(count)
+  }
+}
 
 // Skip no-op writes so subscribers don't churn on every scroll tick.
 const setter = (target: WritableAtom<boolean>) => (value: boolean) => {
@@ -35,7 +42,10 @@ export const setThreadAtBottom = (isAtBottom: boolean) => {
   setJumpButtonVisible(!isAtBottom)
 }
 
-export const resetThreadScroll = () => setThreadAtBottom(true)
+export const resetThreadScroll = () => {
+  setThreadAtBottom(true)
+  $threadMessagesBelow.set(0)
+}
 
 export const publishThreadAtBottom = (isAtBottom: boolean, publisher: { paneVisible: boolean }): void => {
   if (!publisher.paneVisible) {


### PR DESCRIPTION
## What does this PR do?

Shows how many messages remain below the viewport in the desktop thread's jump-to-bottom control. The count animates up and down using the existing `AnimatedInt` from `diff-count.tsx`, and the pill has more room above the composer status stack.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `thread/use-messages-below.ts` counts messages below the viewport, including a partially clipped message. Scroll and resize measurements are frame-batched; off-screen turn contents are not forced through layout.
- `scroll-to-bottom-button.tsx` displays the localized count, preserves the approval label and jump action, and skips animation for reduced motion.
- The pill clears the full measured composer dock by `1rem`, including the status stack.
- Tests cover viewport boundaries, scroll/resize updates, hidden-pane isolation, and the button label. `DESIGN.md` documents reuse of `AnimatedInt`.

## How to Test

1. Open a long desktop conversation and scroll up, then down. The count should increase and decrease with the messages below the viewport.
2. Add messages while scrolled up, then click the pill. It should return to the bottom and disappear. Pending approval still shows “Approval needed”.
3. Expand the status stack and confirm the pill stays separated from it. With reduced motion enabled, the count should update without animation.

Verified on macOS:
- 21 targeted tests passed across the jump button, message counting, session scroll restoration, scroll store, and surface-variable suites.
- Renderer TypeScript check passed: `tsc -p tsconfig.json --noEmit --incremental false`.
- ESLint passed for all touched TypeScript files.
- Browser interaction probe using the real `Thread`: count decreased from 24 to 15, matched an independent DOM count, and animated through 16 to 17 after an append. Singular labels, approval, click-to-bottom, reduced motion, and session reset were exercised.
- Live desktop dock measurements retained over 18px of separation with status-stack heights of 80px, 160px, and 240px; original UI state restored afterward.

## Checklist

- [x] Read the contributing guide and searched for duplicate PRs.
- [x] Changes are limited to this feature; existing animation component reused in place.
- [x] Added behavior tests and updated relevant documentation.
- [x] Reused existing localized message-count strings.
- [x] Tested the rendered UI in light and dark mode.

The full test suite and packaged build were not run for this renderer-only change.
