### PR TITLE
fix(agent): abort length continuation only on proven context-window exhaustion

### DIFF
--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -52,6 +52,19 @@ _CEILING_NO_TEXT = (
     "continuation attempt — its reasoning consumed the entire budget each time.\n\nTo fix this:\n"
     "→ Lower reasoning effort: `/reasoning low` or `/reasoning none`\n→ Or raise max_tokens for this model"
 )
+# When finish_reason=length is caused by context-window exhaustion (prompt + generated
+# ≈ context_length), appending a continuation nudge makes the next attempt strictly worse
+# (#106120). Abort only when usage positively proves ceiling fill; incomplete/ambiguous
+# evidence → fail open (legacy continuation). Tiny absolute slack for provider rounding.
+_CONTEXT_CEILING_EPSILON_CAP = 8
+_CONTEXT_WINDOW_EXHAUSTED = (
+    "⚠️ **Context window exhausted**\n\n"
+    "The model exhausted its context window while generating this response.\n"
+    "The prompt and generated output used approximately {used_tokens:,} of "
+    "{context_length:,} tokens.\n"
+    "Continuing would make the request larger and cannot recover this turn.\n\n"
+    "→ Reduce or compact the conversation, or increase the model context window."
+)
 
 
 def normalize_response_for_agent(agent: Any, response: Any) -> Any:
@@ -193,6 +206,103 @@ def _content_filter_fallback(st: _Trunc, _retry: TurnRetryState) -> Optional[Tru
     return None
 
 
+def _context_ceiling_epsilon(context_length: int) -> int:
+    """Tiny absolute slack for provider rounding — not a free-headroom threshold."""
+    return max(1, min(_CONTEXT_CEILING_EPSILON_CAP, context_length // 4096))
+
+
+def _agent_context_length(agent: Any) -> Optional[int]:
+    """Runtime context window from the compressor (Ollama clamp already applied)."""
+    compressor = getattr(agent, "context_compressor", None)
+    for source in (
+        getattr(compressor, "context_length", None) if compressor is not None else None,
+        getattr(agent, "context_length", None),
+    ):
+        try:
+            value = int(source or 0)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return None
+
+
+def _context_window_exhausted(agent: Any, response: Any) -> Optional[tuple[int, int, int]]:
+    """Return ``(prompt_tokens, output_tokens, context_length)`` only when usage proves
+    ``prompt + output ≈ context_length``. Incomplete or ambiguous evidence → ``None``
+    (fail open / keep legacy continuation)."""
+    usage_raw = getattr(response, "usage", None)
+    if usage_raw is None:
+        return None
+    context_length = _agent_context_length(agent)
+    if context_length is None:
+        return None
+    # Canonical buckets — do not hand-parse a single provider schema here.
+    from agent.usage_pricing import normalize_usage
+
+    canonical = normalize_usage(
+        usage_raw,
+        provider=getattr(agent, "provider", None),
+        api_mode=getattr(agent, "api_mode", None),
+    )
+    prompt_tokens = int(canonical.prompt_tokens or 0)
+    output_tokens = int(canonical.output_tokens or 0)
+    # Without a positive output count we cannot prove ceiling fill vs an output cap.
+    if prompt_tokens <= 0 or output_tokens <= 0:
+        return None
+    epsilon = _context_ceiling_epsilon(context_length)
+    if prompt_tokens + output_tokens >= context_length - epsilon:
+        return prompt_tokens, output_tokens, context_length
+    return None
+
+
+def _abort_context_window_exhausted(
+    st: _Trunc, assistant_message: Any, *,
+    prompt_tokens: int, output_tokens: int, context_length: int,
+) -> TruncationVerdict:
+    """End the turn immediately: continuation would grow an already-exhausted window (#106120)."""
+    from agent.conversation_loop import _join_truncated_parts
+
+    agent = st.agent
+    messages = st.messages
+    agent._ephemeral_reasoning_off = False
+    interim = getattr(assistant_message, "content", None)
+    if interim:
+        st.truncated_response_parts.append(interim)
+    partial = agent._strip_think_blocks(_join_truncated_parts(st.truncated_response_parts)).strip()
+    # Drop any earlier continuation trail so the next user turn starts clean.
+    idx = st.current_turn_user_idx
+    turn_start = idx + 1 if isinstance(idx, int) and idx >= 0 else 0
+    messages[turn_start:] = [
+        m for m in messages[turn_start:]
+        if not (isinstance(m, dict) and (
+            m.get("_length_continuation_fragment") or m.get("_length_continuation_nudge")
+        ))
+    ]
+    if partial:
+        append_message(messages, {
+            "role": "assistant", "content": partial, "finish_reason": "length",
+        })
+    agent._session_messages = messages
+    used_tokens = prompt_tokens + output_tokens
+    notice = _CONTEXT_WINDOW_EXHAUSTED.format(
+        used_tokens=used_tokens, context_length=context_length,
+    )
+    agent._vprint(
+        f"{agent.log_prefix}⚠️  Context window exhausted "
+        f"({used_tokens:,}/{context_length:,}; prompt={prompt_tokens:,}, "
+        f"output={output_tokens:,}) — skipping length continuation.",
+        force=True,
+    )
+    return st.end_turn(
+        f"{partial}\n\n{notice}" if partial else notice,
+        (
+            f"Context window exhausted: prompt ({prompt_tokens}) + output ({output_tokens}) "
+            f"used ~{used_tokens} of {context_length} tokens; length continuation cannot help"
+        ),
+    )
+
+
 def _continue_text(st: _Trunc, _retry: TurnRetryState, assistant_message: Any) -> TruncationVerdict:
     """Text truncation (no tool calls): append the fragment + a continuation nudge (up to
     4), then the ceiling exit that drops the fragment trail and keeps the stitched partial.
@@ -202,6 +312,15 @@ def _continue_text(st: _Trunc, _retry: TurnRetryState, assistant_message: Any) -
 
     agent = st.agent
     messages = st.messages
+    exhausted = _context_window_exhausted(agent, st.response)
+    if exhausted is not None:
+        prompt_tokens, output_tokens, context_length = exhausted
+        return _abort_context_window_exhausted(
+            st, assistant_message,
+            prompt_tokens=prompt_tokens, output_tokens=output_tokens,
+            context_length=context_length,
+        )
+
     st.length_continue_retries += 1
     n = st.length_continue_retries
     _interim_content = getattr(assistant_message, "content", None)

--- a/tests/agent/test_length_continuation_headroom.py
+++ b/tests/agent/test_length_continuation_headroom.py
@@ -1,0 +1,344 @@
+"""#106120: abort length continuation only when usage proves context-window exhaustion."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+from agent.turn_retry_state import TurnRetryState
+from agent.turn_truncation import (
+    _agent_context_length,
+    _context_ceiling_epsilon,
+    _context_window_exhausted,
+    _continue_text,
+    recover_from_truncation,
+)
+
+
+def _agent(
+    *,
+    context_length: Optional[int] = 32768,
+    api_mode: str = "chat_completions",
+    provider: str = "custom",
+) -> Any:
+    compressor = None
+    if context_length is not None:
+        compressor = SimpleNamespace(context_length=context_length)
+
+    def _build_assistant_message(msg: Any, finish_reason: str) -> Dict[str, Any]:
+        return {
+            "role": "assistant",
+            "content": getattr(msg, "content", None),
+            "finish_reason": finish_reason,
+        }
+
+    return SimpleNamespace(
+        api_mode=api_mode,
+        provider=provider,
+        log_prefix="",
+        _ephemeral_reasoning_off=False,
+        _session_messages=[],
+        context_compressor=compressor,
+        _build_assistant_message=_build_assistant_message,
+        _strip_think_blocks=lambda text: text or "",
+        _has_content_after_think_block=lambda _content: True,
+        _vprint=lambda *_a, **_k: None,
+        _emit_status=lambda *_a, **_k: None,
+        _cleanup_task_resources=lambda *_a, **_k: None,
+        _persist_session=lambda *_a, **_k: None,
+        _fallback_index=0,
+        _fallback_chain=[],
+        _try_activate_fallback=lambda: False,
+        _get_messages_up_to_last_assistant=lambda msgs: msgs,
+        _flush_status_buffer=lambda: None,
+        _buffer_vprint=lambda *_a, **_k: None,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response.choices[0].message
+        ),
+    )
+
+
+def _response(
+    *,
+    content: str | None,
+    usage: Any = None,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    finish_reason: str = "length",
+):
+    if usage is None and (prompt_tokens is not None or completion_tokens is not None):
+        usage = SimpleNamespace(
+            prompt_tokens=prompt_tokens or 0,
+            completion_tokens=completion_tokens if completion_tokens is not None else 0,
+        )
+    message = SimpleNamespace(content=content, tool_calls=None, finish_reason=finish_reason)
+    return SimpleNamespace(
+        id="chatcmpl-test",
+        choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+        usage=usage,
+    )
+
+
+def _trunc(agent: Any, response: Any, messages: List[Dict[str, Any]], *, retries: int = 0):
+    from agent.turn_truncation import _Trunc
+
+    return _Trunc(
+        agent=agent,
+        response=response,
+        finish_reason="length",
+        conversation_history=None,
+        api_call_count=1,
+        effective_task_id=None,
+        current_turn_user_idx=0,
+        messages=messages,
+        length_continue_retries=retries,
+        truncated_response_parts=[],
+        truncated_tool_call_retries=0,
+        retry_count=0,
+        compression_attempts=0,
+    )
+
+
+class TestContextCeilingHelpers:
+    def test_epsilon_is_tiny_absolute_slack(self):
+        assert _context_ceiling_epsilon(32768) == 8
+        assert _context_ceiling_epsilon(4096) == 1
+        assert _context_ceiling_epsilon(8192) == 2
+        assert _context_ceiling_epsilon(100000) == 8
+
+    def test_agent_context_length_from_compressor(self):
+        assert _agent_context_length(_agent(context_length=32768)) == 32768
+        assert _agent_context_length(_agent(context_length=None)) is None
+
+
+class TestContextWindowExhaustedPredicate:
+    def test_ceiling_confirmed(self):
+        agent = _agent(context_length=32768)
+        response = _response(content="partial", prompt_tokens=32638, completion_tokens=129)
+        assert _context_window_exhausted(agent, response) == (32638, 129, 32768)
+
+    def test_real_output_cap_fail_open(self):
+        agent = _agent(context_length=32768)
+        response = _response(content="partial", prompt_tokens=10000, completion_tokens=512)
+        assert _context_window_exhausted(agent, response) is None
+
+    def test_near_ceiling_ambiguous_fail_open(self):
+        agent = _agent(context_length=32768)
+        response = _response(content="partial", prompt_tokens=32600, completion_tokens=32)
+        assert _context_window_exhausted(agent, response) is None
+
+    def test_missing_usage_fail_open(self):
+        agent = _agent(context_length=32768)
+        response = _response(content="partial", usage=None)
+        assert _context_window_exhausted(agent, response) is None
+
+    def test_missing_context_length_fail_open(self):
+        agent = _agent(context_length=None)
+        response = _response(content="partial", prompt_tokens=32638, completion_tokens=129)
+        assert _context_window_exhausted(agent, response) is None
+
+    def test_zero_output_tokens_fail_open(self):
+        agent = _agent(context_length=32768)
+        response = _response(content="partial", prompt_tokens=32638, completion_tokens=0)
+        assert _context_window_exhausted(agent, response) is None
+
+    def test_anthropic_shaped_usage_via_normalize(self):
+        agent = _agent(context_length=32768, api_mode="anthropic_messages", provider="anthropic")
+        usage = SimpleNamespace(
+            input_tokens=30638,
+            cache_read_input_tokens=2000,
+            cache_creation_input_tokens=0,
+            output_tokens=129,
+        )
+        response = _response(content="partial", usage=usage)
+        # prompt = 30638+2000 = 32638; +129 = 32767 >= 32760
+        assert _context_window_exhausted(agent, response) == (32638, 129, 32768)
+
+    def test_dict_shaped_usage_via_normalize(self):
+        agent = _agent(context_length=32768)
+        response = _response(
+            content="partial",
+            usage={"prompt_tokens": 32638, "completion_tokens": 129},
+        )
+        assert _context_window_exhausted(agent, response) == (32638, 129, 32768)
+
+    def test_boundary_exactly_at_epsilon_aborts(self):
+        # epsilon(32768)=8 → abort when prompt+output >= 32760
+        agent = _agent(context_length=32768)
+        response = _response(content="x", prompt_tokens=32631, completion_tokens=129)
+        assert 32631 + 129 == 32760
+        assert _context_window_exhausted(agent, response) == (32631, 129, 32768)
+
+    def test_boundary_just_below_epsilon_continues(self):
+        agent = _agent(context_length=32768)
+        response = _response(content="x", prompt_tokens=32630, completion_tokens=129)
+        assert 32630 + 129 == 32759
+        assert _context_window_exhausted(agent, response) is None
+
+
+class TestContinueTextCeilingGuard:
+    def test_ceiling_confirmed_no_nudge_no_retry(self):
+        agent = _agent(context_length=32768)
+        messages = [{"role": "user", "content": "huge prompt"}]
+        response = _response(
+            content="partial answer...", prompt_tokens=32638, completion_tokens=129,
+        )
+        st = _trunc(agent, response, messages)
+        retry = TurnRetryState()
+        verdict = _continue_text(st, retry, response.choices[0].message)
+
+        assert verdict.action == "return"
+        assert retry.restart_with_length_continuation is False
+        assert st.length_continue_retries == 0
+        result = verdict.result or {}
+        assert result.get("completed") is False
+        assert result.get("partial") is True
+        final = result.get("final_response", "")
+        err = (result.get("error") or "").lower()
+        assert "partial answer..." in final
+        assert "context window" in final.lower()
+        assert "max_tokens" not in final.lower()
+        assert "output-length" not in final.lower()
+        assert "context window" in err
+        assert not any(
+            m.get("_length_continuation_nudge") for m in messages if isinstance(m, dict)
+        )
+        assert not any(
+            m.get("_length_continuation_fragment") for m in messages if isinstance(m, dict)
+        )
+
+    def test_real_output_cap_still_continues(self):
+        agent = _agent(context_length=32768)
+        messages = [{"role": "user", "content": "short"}]
+        response = _response(
+            content="partial answer cut off", prompt_tokens=10000, completion_tokens=512,
+        )
+        st = _trunc(agent, response, messages)
+        retry = TurnRetryState()
+        verdict = _continue_text(st, retry, response.choices[0].message)
+
+        assert verdict.action == "break"
+        assert retry.restart_with_length_continuation is True
+        assert st.length_continue_retries == 1
+        assert any(m.get("_length_continuation_nudge") for m in messages if isinstance(m, dict))
+
+    def test_near_ceiling_ambiguous_still_continues(self):
+        agent = _agent(context_length=32768)
+        messages = [{"role": "user", "content": "near"}]
+        response = _response(content="partial", prompt_tokens=32600, completion_tokens=32)
+        st = _trunc(agent, response, messages)
+        retry = TurnRetryState()
+        verdict = _continue_text(st, retry, response.choices[0].message)
+        assert verdict.action == "break"
+        assert retry.restart_with_length_continuation is True
+
+    def test_missing_usage_keeps_legacy(self):
+        agent = _agent(context_length=32768)
+        messages = [{"role": "user", "content": "unknown"}]
+        response = _response(content="partial", usage=None)
+        st = _trunc(agent, response, messages)
+        retry = TurnRetryState()
+        verdict = _continue_text(st, retry, response.choices[0].message)
+        assert verdict.action == "break"
+        assert retry.restart_with_length_continuation is True
+
+    def test_missing_context_length_keeps_legacy(self):
+        agent = _agent(context_length=None)
+        messages = [{"role": "user", "content": "unknown ctx"}]
+        response = _response(content="partial", prompt_tokens=32638, completion_tokens=129)
+        st = _trunc(agent, response, messages)
+        retry = TurnRetryState()
+        verdict = _continue_text(st, retry, response.choices[0].message)
+        assert verdict.action == "break"
+        assert retry.restart_with_length_continuation is True
+
+    def test_trail_cleanup_after_abort_with_prior_nudge(self):
+        agent = _agent(context_length=32768)
+        messages = [
+            {"role": "user", "content": "huge"},
+            {
+                "role": "assistant",
+                "content": "earlier fragment",
+                "_length_continuation_fragment": True,
+            },
+            {
+                "role": "user",
+                "content": "Please continue.",
+                "_length_continuation_nudge": True,
+            },
+        ]
+        response = _response(
+            content="partial answer...", prompt_tokens=32638, completion_tokens=129,
+        )
+        st = _trunc(agent, response, messages, retries=1)
+        # length_continue_retries already 1 from a prior attempt — abort must not bump further
+        retry = TurnRetryState()
+        verdict = _continue_text(st, retry, response.choices[0].message)
+        assert verdict.action == "return"
+        assert retry.restart_with_length_continuation is False
+        # Abort path must not increment retries when ceiling is proven
+        assert st.length_continue_retries == 1
+        assert not any(
+            isinstance(m, dict) and (
+                m.get("_length_continuation_nudge") or m.get("_length_continuation_fragment")
+            )
+            for m in messages
+        )
+        assert "partial answer..." in (verdict.result or {}).get("final_response", "")
+
+    def test_legacy_ceiling_exit_still_nudges_then_stops(self):
+        """Normal output truncation still nudges/retries; 4th attempt still ceiling-exits."""
+        agent = _agent(context_length=32768)
+        messages = [{"role": "user", "content": "short"}]
+        response = _response(
+            content="chunk", prompt_tokens=10000, completion_tokens=512,
+        )
+        st = _trunc(agent, response, messages, retries=3)
+        retry = TurnRetryState()
+        verdict = _continue_text(st, retry, response.choices[0].message)
+        assert verdict.action == "return"
+        assert retry.restart_with_length_continuation is False
+        assert "chunk" in (verdict.result or {}).get("final_response", "")
+        assert not any(
+            m.get("_length_continuation_nudge") for m in messages if isinstance(m, dict)
+        )
+
+
+class TestRecoverFromTruncationIntegration:
+    def test_recover_path_aborts_on_proven_ceiling(self):
+        agent = _agent(context_length=32768)
+        messages = [{"role": "user", "content": "huge"}]
+        response = _response(
+            content="tiny", prompt_tokens=32638, completion_tokens=129,
+        )
+        response.choices[0].message.tool_calls = None
+        retry = TurnRetryState()
+        verdict = recover_from_truncation(
+            agent, response, "length", retry,
+            messages=messages, conversation_history=None, api_kwargs={},
+            api_call_count=1, effective_task_id=None, current_turn_user_idx=0,
+            length_continue_retries=0, truncated_response_parts=[],
+            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
+        )
+        assert verdict.action == "return"
+        assert retry.restart_with_length_continuation is False
+        final = (verdict.result or {}).get("final_response", "")
+        assert "context window" in final.lower()
+        assert "tiny" in final
+
+    def test_recover_path_continues_on_ambiguous_near_ceiling(self):
+        """Old <256 headroom guard would abort here; usage-backed must fail open."""
+        agent = _agent(context_length=32768)
+        messages = [{"role": "user", "content": "near"}]
+        response = _response(content="tiny", prompt_tokens=32600, completion_tokens=32)
+        response.choices[0].message.tool_calls = None
+        retry = TurnRetryState()
+        verdict = recover_from_truncation(
+            agent, response, "length", retry,
+            messages=messages, conversation_history=None, api_kwargs={},
+            api_call_count=1, effective_task_id=None, current_turn_user_idx=0,
+            length_continue_retries=0, truncated_response_parts=[],
+            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
+        )
+        assert verdict.action == "break"
+        assert retry.restart_with_length_continuation is True


### PR DESCRIPTION
## What does this PR do?

`_continue_text` currently treats every text-only `finish_reason="length"` as an output-token cap and appends a continuation nudge up to 4 times. When the **prompt already filled the context window**, those retries make the next request strictly larger (observed spiral: 32638 → 32685 → 32732), which cannot recover the turn.

This PR aborts continuation **only** when provider usage **positively proves** ceiling fill:

```text
prompt_tokens + output_tokens >= context_length - EPSILON
```

where `EPSILON = max(1, min(8, context_length // 4096))` (tiny absolute slack for provider rounding — **not** a free-headroom threshold).

Evidence is taken via `agent.usage_pricing.normalize_usage` and `agent.context_compressor.context_length`. Incomplete or ambiguous evidence **fails open** and keeps legacy continuation.

On confirmed abort: preserve visible partial assistant text, strip synthetic continuation trail, `end_turn` as incomplete/partial, and surface a **context window** error (not max_tokens / output-length).

## Related Issue

Fixes #106120

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `agent/turn_truncation.py`: usage-backed ceiling-fill guard inside `_continue_text`; remove any fixed headroom threshold
- `tests/agent/test_length_continuation_headroom.py`: contract tests for confirmed abort, real output-cap continue, ambiguous fail-open, missing usage/context, provider-normalized usage, boundaries, partial preservation, trail cleanup

## How to Test

```bash
# Focused (PR head)
uv run pytest tests/agent/test_length_continuation_headroom.py -q --tb=short
# -> 21 passed

# Related truncation suite
uv run pytest tests/run_agent/test_anthropic_truncation_continuation.py \
  tests/agent/test_length_continuation_headroom.py \
  tests/run_agent/test_length_continuation_thinking_exhaustion.py -q --tb=short
# -> 37 passed

# Base main still has unconditional continuation in `_continue_text`
# (no `_context_window_exhausted` guard) — RED for the ceiling-fill case.
```

## Related work (not duplicates)

- **#106223** (open, same issue): uses `prompt_tokens + max_tokens >= context_length`. That aborts whenever the configured output cap is unreachable, which is broader than usage-proven ceiling fill and can suppress legitimate short-headroom continuations. This PR uses `prompt + generated_output ≈ context_length` and fails open without positive output evidence.
- **#105440**: disables thinking on length-continuation retry — different seam
- **#58093**: stop repeated length continuations — different policy
- **#68647**: make length continuation authoritative — different ownership/decision
- **#87992**: consult fallback when continuation exhausted — different recovery path

## Review follow-up

- Discriminator is intentionally conservative (fail open). Ollama cases that omit usage will keep legacy retries unless usage is present; that matches the “positively demonstrates” requirement.
- Abort path only runs on the text-only `_continue_text` call site; truncated tool-call retries are unchanged by design.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(agent): ...`)
- [x] Searched existing PRs / related issues (see above)
- [x] PR contains only this fix
- [x] Relevant tests run locally
- [x] Tests added for the new contract
- [x] Tested on: macOS (darwin)

### Documentation & Housekeeping
- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] Cross-platform — N/A (agent truncation path)
- [x] Tool schemas — N/A


Made with [Cursor](https://cursor.com)