### PR TITLE
fix(desktop): exempt private auxiliary endpoints from stale warning

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -409,6 +409,62 @@ describe('ModelSettings', () => {
     // Banner present on load, no switch required.
     expect(await screen.findByText(/still run on/)).toBeTruthy()
   })
+
+
+  it.each([
+    'http://localhost:11434/v1',
+    'http://byron.local:11434/v1',
+    'http://127.0.0.1:11434/v1',
+    'http://10.0.0.8:11434/v1',
+    'http://172.31.0.8:11434/v1',
+    'http://192.168.1.8:11434/v1',
+    'http://169.254.1.8:11434/v1',
+    'http://[::1]:11434/v1',
+    'http://[fd00::8]:11434/v1',
+    'http://[fe80::8]:11434/v1'
+  ])('does not flag a private auxiliary endpoint as stale: %s', async baseUrl => {
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'nous', model: 'hermes-4' },
+      tasks: [{ task: 'curator', provider: 'openai', model: 'llama3.2:3b', base_url: baseUrl }]
+    })
+
+    await renderModelSettings()
+    await waitFor(() => expect(getAuxiliaryModels).toHaveBeenCalled())
+
+    expect(screen.queryByText(/still run on/)).toBeNull()
+  })
+
+  it('shows a pinned auxiliary custom endpoint in its assignment row', async () => {
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'nous', model: 'hermes-4' },
+      tasks: [
+        {
+          task: 'curator',
+          provider: 'openai',
+          model: 'llama3.2:3b',
+          base_url: 'http://byron.local:11434/v1'
+        }
+      ]
+    })
+
+    await renderModelSettings()
+
+    expect(await screen.findByText(/openai · llama3\.2:3b · http:\/\/byron\.local:11434\/v1/)).toBeTruthy()
+  })
+
+  it.each(['https://api.openai.com/v1', 'not a URL'])(
+    'keeps the stale warning for a public or malformed endpoint: %s',
+    async baseUrl => {
+      getAuxiliaryModels.mockResolvedValueOnce({
+        main: { provider: 'nous', model: 'hermes-4' },
+        tasks: [{ task: 'curator', provider: 'openai', model: 'gpt-5', base_url: baseUrl }]
+      })
+
+      await renderModelSettings()
+
+      expect(await screen.findByText(/still run on/)).toBeTruthy()
+    }
+  )
 })
 
 describe('ModelSettings MoA preset editor', () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -101,6 +101,46 @@ function isProviderReady(p?: ModelOptionProvider): boolean {
   return !!p && (p.authenticated !== false || (p.models?.length ?? 0) > 0)
 }
 
+
+// A private endpoint is an intentional local auxiliary-model pin, not a stale
+// paid-provider assignment. Keep malformed or public URLs visible so the
+// warning remains conservative.
+export function isPrivateAuxiliaryEndpoint(value?: string): boolean {
+  if (!value?.trim()) {
+    return false
+  }
+
+  try {
+    const hostname = new URL(value).hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1')
+
+    if (hostname === 'localhost' || hostname.endsWith('.localhost') || hostname.endsWith('.local')) {
+      return true
+    }
+
+    if (hostname.includes(':')) {
+      return hostname === '::1' || /^f[cd]/.test(hostname) || /^fe[89ab]/.test(hostname)
+    }
+
+    const octets = hostname.split('.').map(Number)
+
+    if (octets.length !== 4 || octets.some(octet => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+      return false
+    }
+
+    const [first, second] = octets
+
+    return (
+      first === 10 ||
+      first === 127 ||
+      (first === 169 && second === 254) ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168)
+    )
+  } catch {
+    return false
+  }
+}
+
 // Mirrors `_AUX_TASK_SLOTS` in hermes_cli/web_server.py. Friendly labels and
 // hints make the assignments readable; raw task keys (vision, mcp, …) are
 // opaque to most users.
@@ -514,7 +554,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       .filter(entry => {
         const p = (entry.provider ?? '').toLowerCase()
 
-        return p && p !== 'auto' && p !== mainProvider
+        return p && p !== 'auto' && p !== mainProvider && !isPrivateAuxiliaryEndpoint(entry.base_url)
       })
       .map(entry => ({ task: entry.task, provider: entry.provider, model: entry.model }))
   }, [auxiliary, mainModel])
@@ -1068,7 +1108,9 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                   }
                   description={
                     <span className="font-mono text-[0.68rem]">
-                      {isAuto ? m.autoUseMain : `${current.provider} · ${current.model || m.providerDefault}`}
+                      {isAuto
+                        ? m.autoUseMain
+                        : `${current.provider} · ${current.model || m.providerDefault}${current.base_url ? ` · ${current.base_url}` : ''}`}
                     </span>
                   }
                   title={


### PR DESCRIPTION
Closes #106228.

## Summary
- treat loopback, RFC 1918, link-local, `.local`, and private/link-local IPv6 auxiliary endpoints as intentional local pins
- exclude those pins from the persistent paid-provider stale warning
- display a pinned auxiliary task's custom `base_url` in its assignment row
- keep malformed and public URLs conservative: they still produce the warning
- add focused UI regression coverage for local/private and public/malformed boundaries

## Validation
- `git diff --check` passed
- added 13 focused table-driven/UI cases
- all hosted CI, Docker, and Nix checks passed before the follow-up; the new commits have restarted checks
- the local checkout did not have the Desktop dependency graph installed, so Vitest could not load `vitest/config`; hosted CI is the execution gate

## Duplicate / chronology check
The initial duplicate check was clean. I claimed #106228 and opened this PR at 03:09:04 UTC. PR #106236 opened at 03:15:26 UTC, 6 minutes 22 seconds later. This follow-up addresses the row-display facet raised in review while keeping this PR focused on the desktop behavior rather than copying #106236's later backend expansion.