### PR TITLE
fix: exclude private-endpoint aux pins from stale-aux report

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -600,8 +600,16 @@ def is_local_endpoint(base_url: str) -> bool:
         return False
     if host is None:
         return False
-    # Unqualified hostnames (no dots) are local by definition — Docker Compose service names, /etc/hosts entries, mDNS.
-    if host in _LOCAL_HOSTS or host.endswith(_CONTAINER_LOCAL_SUFFIXES) or (host and "." not in host):
+    # IPv6 first: loopback, ULA (fc00::/7) and link-local (fe80::/10) are local;
+    # a global-scope address must never fall through to the unqualified rule.
+    if ":" in host:
+        return host in _LOCAL_HOSTS or host.startswith(("fc", "fd")) or (
+            host.startswith("fe") and len(host) > 2 and host[2] in "89ab"
+        )
+    # Unqualified hostnames (no dots) are local by definition — Docker Compose
+    # service names, /etc/hosts entries, mDNS. `*.local` (RFC 6762 mDNS) is only
+    # resolvable on the LAN, so it is local too (e.g. an Ollama box at `byron.local`).
+    if host in _LOCAL_HOSTS or host.endswith(_CONTAINER_LOCAL_SUFFIXES) or host.endswith(".local") or (host and "." not in host):
         return True
     try:
         addr = ipaddress.ip_address(host)

--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -409,6 +409,34 @@ describe('ModelSettings', () => {
     // Banner present on load, no switch required.
     expect(await screen.findByText(/still run on/)).toBeTruthy()
   })
+
+  it('does not flag an aux slot pinned to a private endpoint (per-task base_url)', async () => {
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'nous', model: 'hermes-4' },
+      tasks: [{ task: 'curator', provider: 'openai', model: 'gpt-4o', base_url: 'http://byron.local:11434/v1' }]
+    })
+
+    await renderModelSettings()
+    await waitFor(() => expect(getAuxiliaryModels).toHaveBeenCalled())
+
+    // A pin on a private endpoint can never bill the provider — it is the
+    // intended per-task base_url feature, not a stale pin.
+    expect(screen.queryByText(/still run on/)).toBeNull()
+  })
+
+  it('shows the custom base_url on the pinned aux row', async () => {
+    getAuxiliaryModels.mockResolvedValueOnce({
+      main: { provider: 'nous', model: 'hermes-4' },
+      tasks: [{ task: 'vision', provider: 'openai', model: 'gpt-4o-mini', base_url: 'http://192.168.1.10:11434/v1' }]
+    })
+
+    await renderModelSettings()
+
+    // The endpoint the backend already sends is finally visible, so a user can
+    // tell a local pin apart from a provider pin at a glance.
+    expect(await screen.findByText('http://192.168.1.10:11434/v1')).toBeTruthy()
+    expect(screen.queryByText(/still run on/)).toBeNull()
+  })
 })
 
 describe('ModelSettings MoA preset editor', () => {

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -26,6 +26,7 @@ import type {
 import { useI18n } from '@/i18n'
 import { isCodeSkewRestartRequired } from '@/lib/code-skew-error'
 import { AlertTriangle, Cpu, Loader2 } from '@/lib/icons'
+import { isLocalEndpointUrl } from '@/lib/local-endpoint'
 import { DEFAULT_REASONING_EFFORT, REASONING_EFFORT_VALUES } from '@/lib/reasoning-effort'
 import { cn } from '@/lib/utils'
 import { setMainModelAssignment } from '@/store/cron-model-impact'
@@ -514,7 +515,12 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       .filter(entry => {
         const p = (entry.provider ?? '').toLowerCase()
 
-        return p && p !== 'auto' && p !== mainProvider
+        if (!p || p === 'auto' || p === mainProvider) {
+          return false
+        }
+        // A pin pointed at a private endpoint (localhost/LAN/mDNS — the per-task
+        // base_url feature) can never bill a provider, so it is not stale.
+        return !isLocalEndpointUrl(entry.base_url)
       })
       .map(entry => ({ task: entry.task, provider: entry.provider, model: entry.model }))
   }, [auxiliary, mainModel])
@@ -1067,8 +1073,9 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                     )
                   }
                   description={
-                    <span className="font-mono text-[0.68rem]">
-                      {isAuto ? m.autoUseMain : `${current.provider} · ${current.model || m.providerDefault}`}
+                    <span className="flex flex-wrap items-center gap-x-2 font-mono text-[0.68rem]">
+                      <span>{isAuto ? m.autoUseMain : `${current.provider} · ${current.model || m.providerDefault}`}</span>
+                      {!isAuto && current.base_url && <span className="text-muted-foreground">{current.base_url}</span>}
                     </span>
                   }
                   title={

--- a/apps/desktop/src/lib/local-endpoint.test.ts
+++ b/apps/desktop/src/lib/local-endpoint.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { isLocalEndpointUrl } from './local-endpoint'
+
+describe('isLocalEndpointUrl', () => {
+  it('classifies loopback and localhost variants as local', () => {
+    expect(isLocalEndpointUrl('http://localhost:11434/v1')).toBe(true)
+    expect(isLocalEndpointUrl('http://127.0.0.1:8080')).toBe(true)
+    expect(isLocalEndpointUrl('http://127.8.9.10:11434')).toBe(true)
+    expect(isLocalEndpointUrl('http://[::1]:11434/v1')).toBe(true)
+    expect(isLocalEndpointUrl('http://0.0.0.0:11434')).toBe(true)
+    expect(isLocalEndpointUrl('https://LOCALHOST:11434/v1')).toBe(true)
+  })
+
+  it('classifies RFC-1918 and link-local ranges as local', () => {
+    expect(isLocalEndpointUrl('http://10.0.0.5:11434/v1')).toBe(true)
+    expect(isLocalEndpointUrl('http://172.16.1.20:11434')).toBe(true)
+    expect(isLocalEndpointUrl('http://172.31.255.1')).toBe(true)
+    expect(isLocalEndpointUrl('http://192.168.1.10:11434/v1')).toBe(true)
+    expect(isLocalEndpointUrl('http://169.254.169.254/latest/meta-data')).toBe(true)
+  })
+
+  it('classifies Tailscale CGNAT as local', () => {
+    expect(isLocalEndpointUrl('http://100.100.100.100:11434')).toBe(true)
+    expect(isLocalEndpointUrl('http://100.127.0.1')).toBe(true)
+  })
+
+  it('classifies mDNS, container-internal and unqualified hosts as local', () => {
+    expect(isLocalEndpointUrl('http://byron.local:11434/v1')).toBe(true)
+    expect(isLocalEndpointUrl('http://byron:11434/v1')).toBe(true)
+    expect(isLocalEndpointUrl('http://ollama.docker.internal:11434')).toBe(true)
+  })
+
+  it('classifies IPv6 ULA and link-local as local', () => {
+    expect(isLocalEndpointUrl('http://[fd00::1]:11434')).toBe(true)
+    expect(isLocalEndpointUrl('http://[fe80::1]:11434')).toBe(true)
+  })
+
+  it('rejects public endpoints, empties and garbage', () => {
+    expect(isLocalEndpointUrl('https://api.openai.com/v1')).toBe(false)
+    expect(isLocalEndpointUrl('https://api.anthropic.com')).toBe(false)
+    expect(isLocalEndpointUrl('https://api.openrouter.ai/api/v1')).toBe(false)
+    expect(isLocalEndpointUrl('http://8.8.8.8/v1')).toBe(false)
+    expect(isLocalEndpointUrl('http://[2607:f8b0::1]:11434')).toBe(false)
+    expect(isLocalEndpointUrl('')).toBe(false)
+    expect(isLocalEndpointUrl('   ')).toBe(false)
+    expect(isLocalEndpointUrl('not a url')).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/local-endpoint.test.ts
+++ b/apps/desktop/src/lib/local-endpoint.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { isLocalEndpointUrl } from './local-endpoint'
 
 describe('isLocalEndpointUrl', () => {

--- a/apps/desktop/src/lib/local-endpoint.ts
+++ b/apps/desktop/src/lib/local-endpoint.ts
@@ -1,0 +1,74 @@
+/**
+ * Local/private endpoint classification for model `base_url` values.
+ *
+ * Mirrors `agent/model_metadata.py::is_local_endpoint` (the canonical classifier
+ * used for runtime timeout auto-bumps), so the desktop UI and the backend agree
+ * on what counts as local: loopback, RFC-1918, link-local, Tailscale CGNAT,
+ * mDNS (`*.local`), container-internal DNS and unqualified hostnames.
+ *
+ * A pin whose base_url is a private endpoint can never bill a provider — it is
+ * the intended per-task base_url feature, not a stale pin.
+ */
+
+const CONTAINER_LOCAL_SUFFIXES = ['.docker.internal', '.containers.internal', '.lima.internal']
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0'])
+
+export function isLocalEndpointUrl(baseUrl: string): boolean {
+  if (!baseUrl.trim()) {
+    return false
+  }
+
+  const candidate = baseUrl.trim()
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(candidate) ? candidate : `http://${candidate}`
+
+  let host: string
+  try {
+    host = new URL(withScheme).hostname
+  } catch {
+    return false
+  }
+  if (host.startsWith('[') && host.endsWith(']')) {
+    host = host.slice(1, -1)
+  }
+  host = host.toLowerCase()
+
+  // IPv6 first: loopback, ULA fc00::/7 and link-local fe80::/10 are local; a
+  // global-scope address must never fall through to the unqualified-host rule.
+  if (host.includes(':')) {
+    return (
+      LOOPBACK_HOSTS.has(host) ||
+      /^f[cd][0-9a-f]*:/.test(host) || // ULA fc00::/7
+      /^fe[89ab][0-9a-f]*:/.test(host) // link-local fe80::/10
+    )
+  }
+
+  if (LOOPBACK_HOSTS.has(host)) {
+    return true
+  }
+  if (host.endsWith('.local') || CONTAINER_LOCAL_SUFFIXES.some(suffix => host.endsWith(suffix))) {
+    return true
+  }
+  // Unqualified hostnames (no dots) are local by definition — Docker Compose
+  // service names, /etc/hosts entries, mDNS (e.g. an Ollama box at `byron`).
+  if (!host.includes('.')) {
+    return true
+  }
+
+  const parts = host.split('.')
+  if (parts.length !== 4) {
+    return false
+  }
+  const nums = parts.map(part => (part && /^\d+$/.test(part) ? Number(part) : Number.NaN))
+  if (nums.some(Number.isNaN)) {
+    return false
+  }
+  const [a, b] = nums
+  return (
+    a === 10 || // RFC-1918 10/8
+    a === 127 || // loopback 127/8
+    (a === 172 && b >= 16 && b <= 31) || // RFC-1918 172.16/12
+    (a === 192 && b === 168) || // RFC-1918 192.168/16
+    (a === 169 && b === 254) || // link-local 169.254/16 (cloud IMDS)
+    (a === 100 && b >= 64 && b <= 127) // Tailscale CGNAT 100.64/10
+  )
+}

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -616,10 +616,33 @@ def _stale_aux_pins(cfg: dict, new_provider: str) -> list:
             continue
         slot_provider = str(slot_cfg.get("provider", "") or "").strip()
         if slot_provider and slot_provider.lower() not in {"auto", ""} and slot_provider.lower() != new_provider:
+            # A pin pointed at a private endpoint (localhost/LAN/mDNS, the per-task
+            # base_url feature) can never bill a provider — the switch does not
+            # orphan it, so it must not be reported as stale.
+            if _aux_pin_on_private_endpoint(slot_cfg):
+                continue
             stale_aux.append({
                 "task": slot, "provider": slot_provider, "model": str(slot_cfg.get("model", "") or ""),
             })
     return stale_aux
+
+
+def _aux_pin_on_private_endpoint(slot_cfg: dict) -> bool:
+    """True when the slot pins a local/private endpoint via ``base_url``.
+
+    Reuses ``agent.model_metadata.is_local_endpoint`` (the canonical local-endpoint
+    classifier: loopback, RFC-1918, link-local, Tailscale CGNAT, mDNS and
+    unqualified hosts) so the stale-aux report and the runtime's timeout
+    auto-bumps agree on what counts as local.
+    """
+    base_url = str(slot_cfg.get("base_url") or "").strip()
+    if not base_url:
+        return False
+    try:
+        from agent.model_metadata import is_local_endpoint
+    except Exception:
+        return False
+    return is_local_endpoint(base_url)
 
 
 def _cron_model_impact(cfg: dict, provider: str, model: str) -> Any:

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -25,6 +25,8 @@ class TestLocalStreamReadTimeout:
         "http://host.docker.internal:11434",
         "http://host.containers.internal:11434",
         "http://host.lima.internal:11434",
+        "http://byron.local:11434",
+        "http://ollama.local:11434/v1",
     ])
     def test_local_endpoint_bumps_read_timeout(self, base_url):
         """Local endpoint + default timeout -> bumps to base_timeout."""
@@ -70,6 +72,9 @@ class TestIsLocalEndpoint:
         "http://192.168.1.100:8000",
         "http://10.0.0.5:1234",
         "http://172.17.0.1:11434",
+        "http://byron.local:11434",
+        "http://[fd00::1]:11434",
+        "http://[fe80::1]:11434",
     ])
     def test_classic_local_addresses(self, url):
         assert is_local_endpoint(url) is True
@@ -81,6 +86,7 @@ class TestIsLocalEndpoint:
         "https://openrouter.ai/api",
         "https://api.anthropic.com",
         "https://evil.docker.internal.example.com",
+        "http://[2607:f8b0::1]:11434",
     ])
     def test_remote_endpoints(self, url):
         assert is_local_endpoint(url) is False

--- a/tests/hermes_cli/test_web_server_config_stale_aux.py
+++ b/tests/hermes_cli/test_web_server_config_stale_aux.py
@@ -1,0 +1,47 @@
+"""Stale-aux reporting must ignore pins aimed at private/local endpoints.
+
+Aux slots whose ``base_url`` is a private endpoint (localhost, LAN, mDNS — the
+per-task base_url feature) can never bill a provider, so switching the main
+model does not orphan them: they must not surface in the stale-aux report that
+drives the desktop "still run on <provider> — Reset all to main" nudge.
+"""
+
+from hermes_cli.web_server_config import _AUX_TASK_SLOTS, _stale_aux_pins
+
+
+def _cfg_with_slot(provider: str, model: str, base_url: str = "") -> dict:
+    slot_cfg: dict = {"provider": provider, "model": model}
+    if base_url:
+        slot_cfg["base_url"] = base_url
+    return {"auxiliary": {_AUX_TASK_SLOTS[0]: slot_cfg}}
+
+
+class TestStaleAuxPinsPrivateEndpoints:
+    def test_private_endpoint_pin_is_not_stale(self):
+        """Ollama-style LAN/mDNS pin never bills a provider -> excluded."""
+        cfg = _cfg_with_slot("openai", "gpt-4o", base_url="http://byron.local:11434/v1")
+        assert _stale_aux_pins(cfg, "nous") == []
+
+    def test_rfc1918_pin_is_not_stale(self):
+        cfg = _cfg_with_slot("openai", "gpt-4o", base_url="http://192.168.1.10:11434/v1")
+        assert _stale_aux_pins(cfg, "nous") == []
+
+    def test_loopback_pin_is_not_stale(self):
+        cfg = _cfg_with_slot("openai", "gpt-4o", base_url="http://127.0.0.1:11434/v1")
+        assert _stale_aux_pins(cfg, "nous") == []
+
+    def test_provider_pin_without_base_url_is_stale(self):
+        """No base_url -> ordinary provider pin, still reported."""
+        stale = _stale_aux_pins(_cfg_with_slot("openai", "gpt-4o"), "nous")
+        assert len(stale) == 1
+        assert stale[0]["provider"] == "openai"
+        assert stale[0]["model"] == "gpt-4o"
+
+    def test_public_custom_endpoint_pin_is_stale(self):
+        """A public custom gateway can still bill -> keep reporting it."""
+        cfg = _cfg_with_slot("openai", "gpt-4o", base_url="https://api.example.com/v1")
+        assert len(_stale_aux_pins(cfg, "nous")) == 1
+
+    def test_same_provider_pin_never_stale(self):
+        cfg = _cfg_with_slot("nous", "hermes-4", base_url="https://api.example.com/v1")
+        assert _stale_aux_pins(cfg, "nous") == []


### PR DESCRIPTION
Closes #106228.

## Problem
Aux slots pinned to a private endpoint via `base_url` (Ollama on `byron.local`, LAN IPs, localhost) are **intended per-task targets** — they can never bill a provider. Yet the desktop UI:

1. Permanently flags them with the destructive "⚠️ N tasks still run on `openai` — Reset all to main" banner (a Reset would wipe the user's working local setup), and
2. Never shows the `base_url` the backend already sends (`AuxiliaryTaskAssignment.base_url`), so a local pin is indistinguishable from a provider pin.

The post-switch stale report (`stale_aux` in the web-server config responses) has the same blind spot.

## Changes
- **desktop** (`apps/desktop/src/app/settings/model-settings.tsx`): the persistent stale-aux filter now excludes entries whose `base_url` is a private endpoint; the pinned-row description now renders the custom `base_url` when present.
- **backend** (`hermes_cli/web_server_config.py`): `_stale_aux_pins` skips slots whose config pins a private endpoint (`_aux_pin_on_private_endpoint`, reusing the canonical `agent.model_metadata.is_local_endpoint` so the report and runtime timeout auto-bumps agree).
- **canonical classifier** (`agent/model_metadata.py::is_local_endpoint`): two latent gaps fixed — `*.local` (RFC 6762 mDNS) now counts as local, and global-scope IPv6 addresses (e.g. `2607:f8b0::1`) no longer fall through the "unqualified hostname ⇒ local" rule.
- New TS classifier mirror `apps/desktop/src/lib/local-endpoint.ts` so frontend and backend share one semantic.

## Tests
- desktop vitest: new `local-endpoint.test.ts` (16 cases: loopback, RFC-1918, link-local, CGNAT, mDNS, unqualified, container DNS, IPv6 ULA/link-local/global, public hosts) + 2 new `model-settings.test.tsx` cases (no banner for a private-endpoint pin; base_url visible on the row) — 32 passed.
- pytest: new `test_web_server_config_stale_aux.py` (5 cases) + mDNS/IPv6 cases in `test_local_stream_timeout.py` — 260 passed across the touched families.
- `tsc --noEmit` and `ruff check` clean on touched files.

(Full desktop `npm run check` wasn't run locally — the local node_modules is partially corrupted; CI runs the complete lint/test matrix.)