### PR TITLE
fix(cron): suppress permanently dead delivery targets

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1117,6 +1117,52 @@ def _warn_live_lane_failure(job: dict, msg: str, is_relay: bool) -> None:
         logger.warning("Job '%s': %s, falling back to standalone", job["id"], msg)
 
 
+def _dead_target_registry():
+    """Profile-local persistent DeadTargetRegistry shared with the gateway delivery path.
+
+    Independently constructed registries share state through the same backing file
+    (``<HERMES_HOME>/gateway/dead_targets.json``), so the cron live lane observes marks made
+    by ``DeliveryRouter.deliver()`` and vice versa — no singleton required."""
+    from gateway.dead_targets import DeadTargetRegistry
+    return DeadTargetRegistry()
+
+
+def _dead_target_identity(t: _TargetDelivery) -> tuple[str, str]:
+    """``(platform, chat_id)`` key for dead-target tracking: the LOGICAL platform, never the
+    relay transport identity — a dead ``telegram:<chat>`` reached via relay is still
+    ``telegram:<chat>`` (the same key ``DeliveryRouter.deliver()`` uses)."""
+    platform = getattr(t.platform, "value", None) or str(t.platform_name or "")
+    return str(platform).strip().lower(), str(t.chat_id)
+
+
+def _mark_dead_target(registry, platform: str, chat_id: str, error_text: str) -> Optional[str]:
+    """Record a whole-chat permanent failure; return the dead error_kind, else None.
+
+    Single classification boundary for the cron live lane — reuses ``classify_dead_error`` so
+    transient/rate-limit errors and thread/topic-level ``not_found`` never poison the chat
+    (same contract as ``deliver()``)."""
+    from gateway.dead_targets import classify_dead_error
+    dead_kind = classify_dead_error(error_text)
+    if dead_kind:
+        registry.mark_dead(platform, chat_id, reason=f"{dead_kind}: {str(error_text)[:120]}")
+    return dead_kind
+
+
+def _suppress_standalone_for_dead_target(
+    t: _TargetDelivery, target_errors: list, delivery_errors: list,
+) -> bool:
+    """True when ``t`` is confirmed-dead: a standalone retry would hit the same unreachable chat
+    with the same credential, so fail closed (record the live-lane errors) instead of
+    re-sending. Fresh registry read, so a mark flushed by the just-failed live lane applies."""
+    if not _dead_target_registry().is_dead(*_dead_target_identity(t)):
+        return False
+    if not target_errors:
+        target_errors.append(
+            f"delivery to {t.where} skipped (target previously confirmed unreachable)")
+    delivery_errors.extend(target_errors)
+    return True
+
+
 def _resolve_target_transport(
     job: dict, platform, platform_name: str, target: dict, adapters, config):
     """Resolve ``(transport, pconfig, runtime_adapter, target_adapters)`` for one target, or
@@ -1373,6 +1419,17 @@ def _deliver_via_live_adapter(
     this lane's soft failures (surfaced only if standalone also fails); ``delivery_errors`` =
     partial failures (media, thread fallback) that surface even on success."""
     job = t.job
+    dead_registry = _dead_target_registry()
+    dead_platform, dead_chat_id = _dead_target_identity(t)
+    if dead_registry.is_dead(dead_platform, dead_chat_id):
+        # Confirmed-dead (deleted group, blocked bot, deactivated user): re-sending every tick
+        # burns flood-control budget — skip the live lane; _deliver_result also skips the
+        # standalone fallback for the same reason.
+        msg = (f"live adapter send to {t.where} skipped "
+               f"(target previously confirmed unreachable)")
+        logger.info("Job '%s': %s", job["id"], msg)
+        target_errors.append(msg)
+        return False
     route_thread_id, route_metadata, media_metadata = _live_route_metadata(t)
     delivered = False
     try:
@@ -1421,12 +1478,24 @@ def _deliver_via_live_adapter(
                 route_thread_id if route_thread_id is not None else "-",
                 delivered_message_id if delivered_message_id is not None else "-")
             delivered = True
+            # Self-healing (same contract as deliver()): a send that goes through clears a stale
+            # dead flag — e.g. the bot was re-added after another instance marked the target.
+            dead_registry.clear(dead_platform, dead_chat_id)
             _seed_live_delivery_sessions(t, delivered_message_id)
     except Exception as e:
         err_msg = f"live adapter delivery to {t.where} failed: {e}"
         if not any(err_msg in err for err in target_errors):
             target_errors.append(err_msg)
-        _warn_live_lane_failure(job, err_msg, t.is_relay)
+        dead_kind = _mark_dead_target(dead_registry, dead_platform, dead_chat_id, str(e))
+        if dead_kind is not None:
+            # Permanent whole-chat failure: the standalone lane would hit the same unreachable
+            # chat — say so instead of promising a fallback that _deliver_result will skip.
+            logger.warning(
+                "Job '%s': %s — target confirmed unreachable (%s), "
+                "skipping standalone fallback",
+                job["id"], err_msg, dead_kind)
+        else:
+            _warn_live_lane_failure(job, err_msg, t.is_relay)
     return delivered
 
 
@@ -1766,7 +1835,9 @@ def _deliver_result(
             target_errors=target_errors, delivery_errors=delivery_errors,
             unverified_targets=unverified_targets,
         )
-        if not delivered:
+        if not delivered and not _suppress_standalone_for_dead_target(
+            t, target_errors, delivery_errors,
+        ):
             _deliver_standalone(
                 t, cleaned_delivery_content, media_files, target_errors, delivery_errors)
 

--- a/tests/cron/test_cron_dead_target_delivery.py
+++ b/tests/cron/test_cron_dead_target_delivery.py
@@ -1,0 +1,127 @@
+"""Cron live-lane integration with DeadTargetRegistry (deleted groups, blocked bots).
+
+The gateway's ``DeliveryRouter.deliver()`` short-circuits confirmed-dead targets, but the
+cron live lane sends through ``router._deliver_to_platform()`` directly (it needs the
+Telegram three-mode topic routing, #22773) — bypassing the registry lifecycle. These tests
+drive the REAL ``_deliver_result`` path with a REAL raising adapter (``DeliveryRouter``
+itself is never mocked; only the platform adapter and scheduler plumbing are stubbed) and
+assert the lifecycle against a temporary persistent registry:
+
+  tick 1: live send attempted -> permanent Forbidden -> target recorded dead,
+          no standalone resend to the same unreachable chat
+  tick 2: same target -> registry says dead -> no live send, no standalone resend
+
+A thread/topic-level ``not_found`` must NOT poison the whole chat (46f45104c4): the live
+lane keeps trying every tick and the standalone fallback is preserved.
+"""
+
+import asyncio
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cron.scheduler import _deliver_result
+from gateway.config import Platform, PlatformConfig
+from gateway.dead_targets import DeadTargetRegistry
+
+
+CHAT_ID = "-1001234567890"
+
+
+class RaisingAdapter:
+    """Fake Telegram adapter: records sends, always raises a fixed error."""
+
+    def __init__(self, message):
+        self.message = message
+        self.calls = []
+
+    async def send(self, chat_id, content, metadata=None):
+        self.calls.append(chat_id)
+        raise RuntimeError(self.message)
+
+
+def _job():
+    # Fresh dict per tick — the scheduler reloads the job row on every fire.
+    return {
+        "id": "dead-target-cron-test",
+        "name": "Dead Target Cron",
+        "deliver": "origin",
+        "origin": {"platform": "telegram", "chat_id": CHAT_ID},
+    }
+
+
+def _gateway_config():
+    config = MagicMock()
+    config.platforms = {Platform.TELEGRAM: PlatformConfig(enabled=True)}
+    config.get_home_channel = lambda p: None
+    return config
+
+
+@pytest.fixture
+def registry_home(tmp_path, monkeypatch):
+    """Temporary persistent registry path shared by every DeadTargetRegistry built
+    on the delivery path (mirrors tests/gateway/test_dead_targets.py::isolate)."""
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("gateway.dead_targets.get_hermes_home", lambda: tmp_path)
+    return tmp_path
+
+
+def _run_tick(job, adapter, standalone_calls):
+    """One cron tick through the real live-adapter + standalone lanes."""
+    loop = MagicMock()
+    loop.is_running.return_value = True
+
+    def fake_run_coro(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as exc:  # noqa: BLE001
+            future.set_exception(exc)
+        return future
+
+    async def fake_standalone(platform, pconfig, chat_id, text, **kwargs):
+        standalone_calls.append(chat_id)
+        return {}
+
+    with (
+        patch("gateway.config.load_gateway_config", return_value=_gateway_config()),
+        patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+        patch("tools.send_message_tool._send_to_platform", side_effect=fake_standalone),
+        patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro),
+    ):
+        return _deliver_result(job, "hello", adapters={Platform.TELEGRAM: adapter}, loop=loop)
+
+
+def test_permanent_forbidden_marks_dead_and_suppresses_resend(registry_home):
+    adapter = RaisingAdapter("Forbidden: the group chat was deleted")
+    standalone_calls = []
+
+    # Tick 1: the live lane reaches the real adapter and fails permanently.
+    error = _run_tick(_job(), adapter, standalone_calls)
+    assert adapter.calls == [CHAT_ID]
+    assert error is not None  # honestly failed, never silent success
+    # A FRESH registry instance over the same backing file sees the death.
+    assert DeadTargetRegistry().is_dead("telegram", CHAT_ID) is True
+    # The standalone lane targets the same unreachable chat — no doomed resend.
+    assert standalone_calls == []
+
+    # Tick 2: the confirmed-dead target is skipped on every lane.
+    error = _run_tick(_job(), adapter, standalone_calls)
+    assert adapter.calls == [CHAT_ID]  # no second live send
+    assert standalone_calls == []
+    assert error is not None and "unreachable" in error
+
+
+def test_thread_level_not_found_neither_marks_nor_suppresses_fallback(registry_home):
+    adapter = RaisingAdapter("Bad Request: message thread not found")
+    standalone_calls = []
+
+    for _ in range(2):
+        error = _run_tick(_job(), adapter, standalone_calls)
+        assert error is None  # standalone fallback still delivers
+
+    # Live lane retried every tick; fallback preserved; chat NOT marked dead.
+    assert adapter.calls == [CHAT_ID, CHAT_ID]
+    assert standalone_calls == [CHAT_ID, CHAT_ID]
+    assert DeadTargetRegistry().is_dead("telegram", CHAT_ID) is False


### PR DESCRIPTION
## Summary

* integrate cron live delivery with the existing `DeadTargetRegistry`
* suppress standalone retries for confirmed whole-chat dead targets
* preserve retry/fallback behavior for transient and thread-level failures

## Root cause

Cron live delivery uses `DeliveryRouter._deliver_to_platform()` directly to preserve existing Telegram topic/thread routing and cron-specific delivery behavior.

This bypasses the dead-target lifecycle implemented by `DeliveryRouter.deliver()`.

As a result, a permanently unreachable whole-chat target could:

1. be attempted by the cron live lane;
2. fail permanently;
3. fall through to standalone delivery;
4. be attempted again on subsequent cron ticks.

This defeats the existing dead-target invariant and wastes delivery/flood-control budget.

## Fix

The cron live-delivery boundary now participates in the existing `DeadTargetRegistry` lifecycle:

* skip targets already confirmed unreachable;
* classify live-send failures using the existing `classify_dead_error()`;
* persist whole-chat permanent failures;
* suppress standalone fallback for confirmed-dead targets;
* clear stale dead-target entries after confirmed successful delivery;
* continue using the logical `(platform, chat_id)` identity, including relay deliveries.

The existing `_deliver_to_platform()` path was intentionally preserved. This avoids changing Telegram topic/thread routing, timeout, confirmation, relay, media, and session behavior.

Transient failures and thread/topic-level `not_found` errors remain retryable and continue through the existing standalone fallback.

## Regression coverage

Added `tests/cron/test_cron_dead_target_delivery.py` covering:

* permanent `Forbidden` / deleted-chat failure;
* persistence of the dead-target state across cron ticks;
* suppression of both live and standalone retries;
* honest failure reporting instead of phantom delivery success;
* thread-level `not_found` remaining retryable;
* standalone fallback remaining intact for non-dead failures.

The regression was reproduced against the unmodified baseline and passes with this fix.

## Validation

- focused cron/gateway delivery suite: **82 passed**
- full `tests/cron/`: **1235 passed, 1 skipped**
- 2 unrelated deprecation/runtime warnings
- `git diff --check`: clean
- production change limited to `cron/scheduler_delivery.py`
- no changes to `DeadTargetRegistry`, gateway classification rules, or unrelated delivery behavior