### PR TITLE
fix(cron): sanitize context_from artifacts before prompt injection

### DIFF
--- a/cron/scheduler_prompt.py
+++ b/cron/scheduler_prompt.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from hermes_time import now as _hermes_now
 from typing import Optional
 
@@ -63,6 +64,25 @@ _UPSTREAM_CONTEXT_INTRO = (
 )
 
 
+def _extract_cron_context_payload(text: str) -> str:
+    """Return a cron artifact's terminal response/error without replaying its prompt."""
+    artifact = (text or "").strip()
+    if not artifact:
+        return ""
+
+    markers = list(re.finditer(r"(?m)^## (Response|Error)\s*$", artifact))
+    if not markers:
+        return artifact
+
+    marker = markers[-1]
+    payload = artifact[marker.end():].strip()
+    if not payload or payload == "(No response generated)":
+        return ""
+    if marker.group(1) == "Error":
+        return f"## Error\n\n{payload}"
+    return payload
+
+
 def _inject_context_from(job: dict, prompt: str) -> tuple[str, bool]:
     """Prepend the latest output of each ``context_from`` job; returns ``(prompt, injected)``."""
     context_from = job.get("context_from")
@@ -93,15 +113,16 @@ def _inject_context_from(job: dict, prompt: str) -> tuple[str, bool]:
             )
             latest_output = ""
             for output_file in output_files:
-                candidate = output_file.read_text(encoding="utf-8").strip()
+                artifact = output_file.read_text(encoding="utf-8").strip()
                 # Only the run header describes suppression; script/agent payloads can
                 # quote these markers. Keep error documents useful for recovery context.
-                header = candidate.split("\n---\n", 1)[0].split("\n## Prompt", 1)[0]
-                silent_audit = candidate.startswith("# Cron Job:") and any(
+                header = artifact.split("\n---\n", 1)[0].split("\n## Prompt", 1)[0]
+                silent_audit = artifact.startswith("# Cron Job:") and any(
                     line.startswith(("**Status:** no_change", "**Status:** silent",
                                      "Script gate returned `wakeAgent=false`"))
                     for line in header.splitlines()
                 )
+                candidate = _extract_cron_context_payload(artifact)
                 if candidate and not silent_audit:
                     latest_output = candidate
                     break

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -78,6 +78,40 @@ class TestBuildJobPromptContextFrom:
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
+    @pytest.mark.parametrize(
+        ("terminal_heading", "terminal_payload", "expected"),
+        [
+            ("Response", "Useful upstream answer.", "Useful upstream answer."),
+            ("Error", "RuntimeError: provider timeout", "## Error\n\nRuntimeError: provider timeout"),
+        ],
+    )
+    def test_injects_only_terminal_payload_from_cron_artifact(
+        self, cron_env, terminal_heading, terminal_payload, expected
+    ):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        upstream = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / upstream["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-09-08_16-19-01.md").write_text(
+            "# Cron Job: upstream\n\n"
+            "## Prompt\n\nUPSTREAM PROMPT MUST NOT RECURSE\n\n"
+            f"## {terminal_heading}\n\n{terminal_payload}\n",
+            encoding="utf-8",
+        )
+
+        downstream = create_job(
+            prompt="Summarize the result",
+            schedule="every 2h",
+            context_from=upstream["id"],
+        )
+
+        prompt = _build_job_prompt(downstream)
+        assert expected in prompt
+        assert "UPSTREAM PROMPT MUST NOT RECURSE" not in prompt
+        assert "## Prompt" not in prompt
+
     def test_uses_most_recent_output(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt
@@ -438,5 +472,4 @@ class TestContinuityFlag:
         prompt = _build_job_prompt(job)
         assert "Reported: story A" in prompt
         assert "previous run" in prompt.lower()
-
 


### PR DESCRIPTION
## Summary
- strip embedded upstream Prompt sections before cron context injection
- preserve terminal Response and Error payloads, plus legacy plain-text artifacts
- add regression coverage for both response and error artifacts

## Why
Today the code-improvement validation and action-queue jobs received full upstream cron artifacts, including their Prompt sections. That recursively replayed scheduler instructions and enlarged prompts. This change keeps complete artifacts on disk while limiting agent context to the terminal result.

## Validation
- tests/cron/test_cron_context_from.py: 25 passed
- tests/cron aggregate: 1213 passed, 22 skipped, 1 unrelated baseline failure
- unrelated failure: tests/cron/test_file_permissions.py::test_ensure_hermes_home_sets_0700; both the implementation and test are unchanged from origin/main
- python bytecode compilation and git diff check passed

## Safety
No broker, order-placement, kill-switch, credential, or trading-threshold code changed.