### PR TITLE
WP-2E56-DELEGATION: terminalize one-shot child state

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -104,7 +104,7 @@ _oneshot_cleanup_done = False
 # BaseException-derived errors from executor teardown; the rest are Exception.
 _ONESHOT_CLEANUPS = (
     ("tools.terminal_tool", "cleanup_all_environments", {}, Exception),
-    ("tools.async_delegation", "interrupt_all", {"reason": "oneshot shutdown"}, Exception),
+    ("tools.async_delegation", "finalize_for_oneshot_shutdown", {}, Exception),
     ("tools.browser_tool_lifecycle", "_emergency_cleanup_all_sessions", {}, Exception),
     ("tools.mcp_tool_lifecycle", "shutdown_mcp_servers", {}, BaseException),
     ("agent.auxiliary_client", "shutdown_cached_clients", {}, Exception),

--- a/tests/hermes_cli/test_oneshot_delegation_cleanup.py
+++ b/tests/hermes_cli/test_oneshot_delegation_cleanup.py
@@ -85,6 +85,10 @@ def test_oneshot_cleanup_terminalizes_prompt_child_and_grace_survivor():
         release_survivor.wait(timeout=10)
         return {"status": "completed", "summary": "late result"}
 
+    def survivor_interrupt():
+        survivor_interrupted.set()
+        time.sleep(0.08)
+
     prompt_id = _dispatch(
         goal="prompt finalizer",
         runner=prompt_runner,
@@ -93,7 +97,7 @@ def test_oneshot_cleanup_terminalizes_prompt_child_and_grace_survivor():
     survivor_id = _dispatch(
         goal="grace survivor",
         runner=survivor_runner,
-        interrupt_fn=survivor_interrupted.set,
+        interrupt_fn=survivor_interrupt,
     )
 
     try:
@@ -102,7 +106,7 @@ def test_oneshot_cleanup_terminalizes_prompt_child_and_grace_survivor():
         elapsed = time.monotonic() - started
 
         assert prompt_interrupted.is_set() and survivor_interrupted.is_set()
-        assert 0.08 <= elapsed < 0.5
+        assert elapsed == pytest.approx(0.1, abs=0.001)
         prompt_row = ad.get_durable_delegation(prompt_id)
         survivor_row = ad.get_durable_delegation(survivor_id)
         assert prompt_row["state"] == "interrupted"
@@ -128,6 +132,72 @@ def test_oneshot_cleanup_terminalizes_prompt_child_and_grace_survivor():
         time.sleep(0.02)
     assert ad.get_durable_delegation(survivor_id)["state"] == "unknown"
     assert process_registry.completion_queue.empty()
+
+
+def test_oneshot_cleanup_does_not_renew_grace_after_signal_overrun():
+    """A synchronous signal overrun skips the wait instead of restarting it."""
+    release = threading.Event()
+
+    def runner():
+        release.wait(timeout=10)
+        return {"status": "completed", "summary": "late result"}
+
+    def blocking_interrupt():
+        time.sleep(0.12)
+
+    delegation_id = _dispatch(goal="blocking signal", runner=runner, interrupt_fn=blocking_interrupt)
+    try:
+        started = time.monotonic()
+        cli_main._cleanup_oneshot_runtime()
+        assert time.monotonic() - started == pytest.approx(0.12, abs=0.001)
+        assert ad.get_durable_delegation(delegation_id)["state"] == "unknown"
+    finally:
+        release.set()
+
+
+def test_first_durable_read_preserves_live_owner_when_start_identity_unavailable(monkeypatch):
+    """Unavailable start identity cannot turn a live owner's row terminal."""
+    from gateway import status as gateway_status
+
+    release = threading.Event()
+
+    def live_runner():
+        release.wait(timeout=10)
+        return {"status": "completed", "summary": "done"}
+
+    delegation_id = _dispatch(
+        goal="live owner",
+        runner=live_runner,
+        interrupt_fn=lambda: None,
+    )
+    actual_started = gateway_status.get_process_start_time(os.getpid())
+    assert actual_started is not None
+
+    try:
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET owner_started_at=NULL WHERE delegation_id=?",
+                (delegation_id,),
+            )
+        assert ad.get_durable_delegation(delegation_id)["state"] == "running"
+
+        with ad._DB_LOCK, ad._transaction() as conn:
+            conn.execute(
+                "UPDATE async_delegations SET owner_started_at=? WHERE delegation_id=?",
+                (actual_started, delegation_id),
+            )
+        monkeypatch.setattr(gateway_status, "get_process_start_time", lambda _pid: None)
+        assert ad.get_durable_delegation(delegation_id)["state"] == "running"
+    finally:
+        release.set()
+
+    deadline = time.monotonic() + 2
+    row = ad.get_durable_delegation(delegation_id)
+    while row["state"] == "running" and time.monotonic() < deadline:
+        time.sleep(0.02)
+        row = ad.get_durable_delegation(delegation_id)
+    assert row["state"] == "completed"
+    assert row["result"]["summary"] == "done"
 
 
 def test_first_durable_read_recovers_reused_owner_pid_as_unknown(tmp_path):

--- a/tests/hermes_cli/test_oneshot_delegation_cleanup.py
+++ b/tests/hermes_cli/test_oneshot_delegation_cleanup.py
@@ -1,0 +1,199 @@
+"""One-shot async-delegation shutdown and crash-recovery invariants."""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+from hermes_cli import main as cli_main
+from tools import async_delegation as ad
+from tools.process_registry import process_registry
+
+
+_ONESHOT_UNKNOWN_REASON = (
+    "One-shot shutdown grace period elapsed before the delegation recorded a "
+    "terminal result; outcome unknown."
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_delegations(monkeypatch, tmp_path):
+    real_sleep = time.sleep
+    monotonic = 0.0
+
+    def controlled_monotonic():
+        return monotonic
+
+    def controlled_sleep(seconds):
+        nonlocal monotonic
+        monotonic += seconds
+        real_sleep(0.001)
+
+    monkeypatch.setattr(time, "monotonic", controlled_monotonic)
+    monkeypatch.setattr(time, "sleep", controlled_sleep)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+    monkeypatch.setattr(cli_main, "_oneshot_cleanup_done", False)
+    module, attr, kwargs, swallow = next(
+        step for step in cli_main._ONESHOT_CLEANUPS if step[0] == "tools.async_delegation"
+    )
+    if attr == "finalize_for_oneshot_shutdown":
+        finalizer = ad.finalize_for_oneshot_shutdown
+        monkeypatch.setattr(ad, attr, lambda: finalizer(grace_seconds=0.1))
+    async_cleanup = (module, attr, kwargs, swallow)
+    monkeypatch.setattr(cli_main, "_ONESHOT_CLEANUPS", (async_cleanup,))
+    yield
+    ad._reset_for_tests()
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+def _dispatch(*, goal, runner, interrupt_fn):
+    started = time.monotonic()
+    handle = ad.dispatch_async_delegation(
+        goal=goal,
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="",
+        runner=runner,
+        interrupt_fn=interrupt_fn,
+    )
+    assert handle["status"] == "dispatched"
+    assert time.monotonic() - started < 0.5
+    return handle["delegation_id"]
+
+
+def test_oneshot_cleanup_terminalizes_prompt_child_and_grace_survivor():
+    """One-shot cleanup waits only for unwind, then closes every durable row."""
+    prompt_interrupted = threading.Event()
+    survivor_interrupted = threading.Event()
+    release_survivor = threading.Event()
+
+    def prompt_runner():
+        assert prompt_interrupted.wait(timeout=10)
+        return {"status": "interrupted", "summary": None, "error": "cancelled"}
+
+    def survivor_runner():
+        release_survivor.wait(timeout=10)
+        return {"status": "completed", "summary": "late result"}
+
+    prompt_id = _dispatch(
+        goal="prompt finalizer",
+        runner=prompt_runner,
+        interrupt_fn=prompt_interrupted.set,
+    )
+    survivor_id = _dispatch(
+        goal="grace survivor",
+        runner=survivor_runner,
+        interrupt_fn=survivor_interrupted.set,
+    )
+
+    try:
+        started = time.monotonic()
+        cli_main._cleanup_oneshot_runtime()
+        elapsed = time.monotonic() - started
+
+        assert prompt_interrupted.is_set() and survivor_interrupted.is_set()
+        assert 0.08 <= elapsed < 0.5
+        prompt_row = ad.get_durable_delegation(prompt_id)
+        survivor_row = ad.get_durable_delegation(survivor_id)
+        assert prompt_row["state"] == "interrupted"
+        assert survivor_row["state"] == "unknown"
+        assert survivor_row["result"] == {
+            "status": "unknown",
+            "summary": None,
+            "error": _ONESHOT_UNKNOWN_REASON,
+        }
+
+        events = []
+        while not process_registry.completion_queue.empty():
+            events.append(process_registry.completion_queue.get_nowait())
+        assert {event["delegation_id"]: event["status"] for event in events} == {
+            prompt_id: "interrupted",
+            survivor_id: "unknown",
+        }
+    finally:
+        release_survivor.set()
+
+    deadline = time.monotonic() + 2
+    while ad.active_count() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert ad.get_durable_delegation(survivor_id)["state"] == "unknown"
+    assert process_registry.completion_queue.empty()
+
+
+def test_first_durable_read_recovers_reused_owner_pid_as_unknown(tmp_path):
+    """A live reused PID cannot keep a crashed owner's durable row running."""
+    repo = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    env = {**os.environ, "HERMES_HOME": str(tmp_path), "PYTHONPATH": repo}
+    producer = r'''
+import os
+import time
+from tools import async_delegation as ad
+
+handle = ad.dispatch_async_delegation(
+    goal="crash before finalization", context=None, toolsets=None, role="leaf",
+    model="m", session_key="", runner=lambda: time.sleep(600),
+)
+print(handle["delegation_id"], flush=True)
+os._exit(17)
+'''
+    first = subprocess.run(
+        [sys.executable, "-c", producer],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=15,
+    )
+    assert first.returncode == 17
+    delegation_id = first.stdout.strip().splitlines()[-1]
+
+    consumer = r'''
+import json
+import logging
+import os
+import sqlite3
+from pathlib import Path
+
+from tools import async_delegation as ad
+
+db = Path(os.environ["HERMES_HOME"]) / "state.db"
+with sqlite3.connect(db) as conn:
+    conn.execute(
+        "UPDATE async_delegations SET owner_pid=?, owner_started_at=? WHERE delegation_id=?",
+        (os.getpid(), 1, os.environ["DELEGATION_ID"]),
+    )
+
+records = []
+class Capture(logging.Handler):
+    def emit(self, record):
+        if hasattr(record, "async_delegations_recovered_total"):
+            records.append(record.async_delegations_recovered_total)
+
+ad.logger.setLevel(logging.INFO)
+ad.logger.addHandler(Capture())
+row = ad.get_durable_delegation(os.environ["DELEGATION_ID"])
+print(json.dumps({"row": row, "recovered": records}))
+'''
+    second = subprocess.run(
+        [sys.executable, "-c", consumer],
+        cwd=repo,
+        env={**env, "DELEGATION_ID": delegation_id},
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=True,
+    )
+    observed = json.loads(second.stdout.strip().splitlines()[-1])
+    assert observed["row"]["state"] == "unknown"
+    assert observed["row"]["result"]["status"] == "unknown"
+    assert observed["recovered"] == [1]

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -263,9 +263,12 @@ def recover_abandoned_delegations() -> int:
                FROM async_delegations WHERE state IN ('running','finalizing')""").fetchall()
         for row in rows:
             delegation_id, session_key, origin_ui, parent_id, dispatched_at, pid, started, task_json, origin_sid, result_json = row
-            live_started = get_process_start_time(int(pid)) if pid and _pid_exists(int(pid)) else None
-            if started is not None and live_started is not None and int(live_started) == int(started):
-                continue
+            if pid and _pid_exists(int(pid)):
+                live_started = get_process_start_time(int(pid))
+                # A mismatch proves PID reuse. Missing start identity proves
+                # nothing, so preserve a row whose owner PID is still live.
+                if started is None or live_started is None or int(live_started) == int(started):
+                    continue
             task = json.loads(task_json or "{}")
             error = "Delegation owner exited before recording a terminal result; outcome unknown."
             recovered_results = _recovered_results(task, result_json, error)
@@ -1001,7 +1004,11 @@ def interrupt_all(reason: str = "shutdown") -> int:
 
 
 def finalize_for_oneshot_shutdown(*, grace_seconds: float = 2.0) -> dict[str, int]:
-    """Terminalize live children during bounded graceful one-shot shutdown."""
+    """Signal live children, then terminalize them against one monotonic grace deadline.
+
+    Interrupt callbacks are synchronous; their elapsed time consumes the grace
+    budget. An overrun therefore skips the wait rather than renewing the budget.
+    """
     reason = (
         "One-shot shutdown grace period elapsed before the delegation recorded a "
         "terminal result; outcome unknown."
@@ -1009,6 +1016,7 @@ def finalize_for_oneshot_shutdown(*, grace_seconds: float = 2.0) -> dict[str, in
     with _records_lock:
         targets = [dict(record) for record in _records.values() if record.get("status") in _ACTIVE_STATES]
     target_ids = {str(record["delegation_id"]) for record in targets}
+    deadline = time.monotonic() + max(0.0, float(grace_seconds))
     signaled = _interrupt_records(
         targets,
         "finalize_for_oneshot_shutdown",
@@ -1016,7 +1024,6 @@ def finalize_for_oneshot_shutdown(*, grace_seconds: float = 2.0) -> dict[str, in
         "Interrupted %d async delegation(s) (%s)",
     )
 
-    deadline = time.monotonic() + max(0.0, float(grace_seconds))
     while target_ids:
         with _records_lock:
             live = {

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -263,7 +263,8 @@ def recover_abandoned_delegations() -> int:
                FROM async_delegations WHERE state IN ('running','finalizing')""").fetchall()
         for row in rows:
             delegation_id, session_key, origin_ui, parent_id, dispatched_at, pid, started, task_json, origin_sid, result_json = row
-            if pid and _pid_exists(int(pid)) and (started is None or get_process_start_time(int(pid)) == int(started)):
+            live_started = get_process_start_time(int(pid)) if pid and _pid_exists(int(pid)) else None
+            if started is not None and live_started is not None and int(live_started) == int(started):
                 continue
             task = json.loads(task_json or "{}")
             error = "Delegation owner exited before recording a terminal result; outcome unknown."
@@ -291,6 +292,17 @@ def recover_abandoned_delegations() -> int:
     return recovered
 
 
+def _recover_abandoned_with_metric() -> int:
+    """Run idempotent owner-loss recovery and retain its count in structured logs."""
+    recovered = recover_abandoned_delegations()
+    logger.info(
+        "Recovered %d abandoned async delegation(s)",
+        recovered,
+        extra={"async_delegations_recovered_total": recovered},
+    )
+    return recovered
+
+
 def restore_undelivered_completions(target_queue) -> int:
     """Enqueue durable pending completions as fresh turns after process start.
     Restored events are stamped ``restored=True`` in memory only: they came from a PREVIOUS
@@ -305,7 +317,7 @@ def restore_undelivered_completions(target_queue) -> int:
     ownership, otherwise a brand-new session adopts a dead session's delegation results seconds after boot
     (#64484).
     """
-    recover_abandoned_delegations()
+    _recover_abandoned_with_metric()
     now, restored = time.time(), 0
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute("""SELECT delegation_id, event_json, completed_at, dispatched_at
@@ -447,6 +459,10 @@ def _event_delivery(fn, evt: Dict[str, Any], claim_id: str) -> None:
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
+    # A direct status read can be the first startup touchpoint. Recover before
+    # returning so a dead owner (including a PID-reuse mismatch) is never
+    # reported as still running merely because the completion queue is idle.
+    _recover_abandoned_with_metric()
     with _DB_LOCK, _transaction() as conn:
         row = conn.execute("""SELECT origin_session, state, dispatched_at, completed_at,
                       result_json, delivery_state, delivery_attempts,
@@ -982,6 +998,74 @@ def interrupt_all(reason: str = "shutdown") -> int:
     with _records_lock:
         targets = [r for r in _records.values() if r.get("status") in _ACTIVE_STATES]
     return _interrupt_records(targets, "interrupt_all", reason, "Interrupted %d async delegation(s) (%s)")
+
+
+def finalize_for_oneshot_shutdown(*, grace_seconds: float = 2.0) -> dict[str, int]:
+    """Terminalize live children during bounded graceful one-shot shutdown."""
+    reason = (
+        "One-shot shutdown grace period elapsed before the delegation recorded a "
+        "terminal result; outcome unknown."
+    )
+    with _records_lock:
+        targets = [dict(record) for record in _records.values() if record.get("status") in _ACTIVE_STATES]
+    target_ids = {str(record["delegation_id"]) for record in targets}
+    signaled = _interrupt_records(
+        targets,
+        "finalize_for_oneshot_shutdown",
+        "oneshot shutdown",
+        "Interrupted %d async delegation(s) (%s)",
+    )
+
+    deadline = time.monotonic() + max(0.0, float(grace_seconds))
+    while target_ids:
+        with _records_lock:
+            live = {
+                delegation_id
+                for delegation_id in target_ids
+                if (_records.get(delegation_id) or {}).get("status") in _LIVE_STATES
+            }
+        if not live:
+            break
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(0.02, remaining))
+
+    survivors = []
+    with _records_lock:
+        for delegation_id in target_ids:
+            record = _records.get(delegation_id)
+            if record is None or record.get("status") not in _ACTIVE_STATES:
+                continue
+            record["status"] = "finalizing"
+            record["completed_at"] = time.time()
+            record["interrupt_fn"] = None
+            record["progress_fn"] = None
+            survivors.append(dict(record))
+
+    for record in survivors:
+        if record.get("is_batch"):
+            result = {
+                "results": [],
+                "error": reason,
+                "total_duration_seconds": round(record["completed_at"] - record["dispatched_at"], 2),
+            }
+        else:
+            result = {"status": "unknown", "summary": None, "error": reason}
+        _push_completion_event(record, result, "unknown")
+        with _records_lock:
+            current = _records.get(record["delegation_id"])
+            if current is not None and current.get("status") == "finalizing":
+                current["status"] = "unknown"
+            _prune_completed_locked()
+
+    with _records_lock:
+        statuses = [(_records.get(delegation_id) or {}).get("status") for delegation_id in target_ids]
+    return {
+        "signaled": signaled,
+        "interrupted": sum(status == "interrupted" for status in statuses),
+        "unknown": sum(status == "unknown" for status in statuses),
+    }
 
 
 def interrupt_for_session(


### PR DESCRIPTION
## Problem and result

One-shot background delegations could remain recorded as `running` after their owning CLI process exited, while shutdown cleanup could renew its grace period and first-read recovery could misclassify a live owner when process-start identity was temporarily unavailable. This change terminalizes genuinely orphaned one-shot delegations, uses one bounded shutdown deadline, preserves proven-live ambiguous owners, and keeps persistent and one-shot delivery fire-and-forget.

## Exact reviewed subject

- Head: `1bf9cd995f57901df769c6ad59e06c4acd3389ae`
- Parent: `607ae8bcc33b7c74eca9e03b588ceee8d0f0979f`
- Tree: `a7d71c529d9730098d53655cfbe841a800bb7e16`
- Base at final refresh and review: `d0df324862cb2244a40789a5ca45392165f1b950`
- Both rebased patches are range-diff identical to the previously published series; the final upstream-only commit touched `tui_gateway/methods_slash.py` and its test, outside H2.

## Verification

- RED on the original production code reproduced an unbounded callback path and false demotion when the stored start identity was unavailable: 1 passed, 2 failed.
- GREEN focused and adjacent acceptance on exact head `1bf9cd995f57901df769c6ad59e06c4acd3389ae`: 57 passed, 0 failed, 1 Linux skip; isolated adjacent timeout fixture: 1 passed (signed evidence `a29257754564e7827164d658f3ebbfc1eb55a53f0bb0ba392e73b52d0d803062`).
- Ruff passed on all three changed Python paths; `git diff --check` passed; the worktree was clean.
- Restored-bug mutation on the unchanged patch series produced 1 pass and 3 failures: both deadline regressions and the missing-start-identity regression failed as expected, while the PID-reuse mismatch control still passed. The reviewed tree was then fully restored.
- Failed predecessor review: `940655e7a6701daee11e689b498957d082ccc818802e8656c8807bd7193f6314`.
- Prior qualified exact-head PASS: `2c272280b4ebcd8f992c61f28fb35664d1b7cbe76d889ec25d53f88f87e693d7`; controlling direct-bound child PASS `eb258f04b16b224d1db88f4bea2fb9695fa1b8fe5e9587523e384d0ddaa5ab1d` under audit root `c6ad261a…f21dd`.
- Independent DeepSeek-family exact-head PASS: session `20260909_041118_076181`, signed event `59299f2806fca0edcd286e0ae4856966d3be06f7cabe47f7533d7392f96c3280`; clean before and after, targeted 4/4, Ruff 0.15.10 PASS, and diff-check PASS.

The full package is not claimed green. A broad `tests/hermes_cli tests/tools` sweep at the immediately preceding, patch-identical refreshed head produced 74 failures across 14 files; all remain inconclusive. The unrelated `TestMissedSteerRetention` fixture passes but deterministically creates `MagicMock/` cleanup debt through a bare mock path; that defect remains unfixed and outside H2.

Independent review carried two LOW follow-ups: returned cleanup counts can undercount when more than 50 targets are pruned, though production one-shot cleanup ignores the return; and durable read recovery updates row state without enqueueing until restore, a pre-existing behavior rather than an H2 regression.

## Blast radius

- `hermes_cli/main.py`
- `tests/hermes_cli/test_oneshot_delegation_cleanup.py`
- `tools/async_delegation.py`

Please run maintainer CI and merge if the repository-wide checks pass.

Dispatch-Origin: research/fcc31dda7656
