### PR TITLE
fix(cli): refresh TERMINAL_CWD when --in re-homes the session

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1430,6 +1430,15 @@ def _apply_in_dir(args) -> None:
     except OSError as e:
         print(f"Error: cannot enter --in directory {in_dir}: {e}")
         sys.exit(1)
+    # Every cwd consumer (resolve_agent_cwd -> Codex app-server thread cwd, the
+    # terminal tool, context-file discovery) prefers TERMINAL_CWD over the process
+    # cwd, so a value inherited from a parent surface, the shell or .env outlives
+    # this chdir and re-homes the session in the old directory (#106220). Refresh
+    # it. An unset variable stays unset: the backends then derive from the new
+    # process cwd (local exports it at cli import, docker mounts it, ssh and
+    # container backends keep their own remote/sandbox default).
+    if os.environ.get("TERMINAL_CWD", "").strip():
+        os.environ["TERMINAL_CWD"] = _target_dir
     args.no_restore_cwd = True
 
 

--- a/tests/hermes_cli/test_resume_latest_and_in_dir.py
+++ b/tests/hermes_cli/test_resume_latest_and_in_dir.py
@@ -229,3 +229,51 @@ def test_in_dir_expands_user_home(main_mod, launched, monkeypatch, tmp_path):
         assert os.getcwd() == str((home / "proj").resolve())
     finally:
         os.chdir(start)
+
+
+# ---------------------------------------------------------------------------
+# --in must win over an inherited TERMINAL_CWD (#106220)
+# ---------------------------------------------------------------------------
+
+
+def test_in_dir_replaces_inherited_terminal_cwd(main_mod, monkeypatch, tmp_path):
+    """A parent Hermes surface, the shell or .env can export TERMINAL_CWD before
+    the CLI starts. Every cwd consumer prefers that variable over the process
+    cwd, so a bare chdir left the Codex app-server thread, the terminal tool and
+    context-file discovery in the inherited directory."""
+    import os
+    from pathlib import Path
+
+    from agent.runtime_cwd import resolve_agent_cwd
+
+    inherited = tmp_path / "inherited"
+    target = tmp_path / "target"
+    inherited.mkdir()
+    target.mkdir()
+    monkeypatch.chdir(inherited)
+    monkeypatch.setenv("TERMINAL_CWD", str(inherited))
+
+    args = _args(in_dir=str(target))
+    main_mod._apply_in_dir(args)
+
+    assert Path.cwd().resolve() == target.resolve()
+    assert Path(os.environ["TERMINAL_CWD"]).resolve() == target.resolve()
+    assert resolve_agent_cwd().resolve() == target.resolve()
+    assert args.no_restore_cwd is True
+
+
+def test_in_dir_leaves_unset_terminal_cwd_unset(main_mod, monkeypatch, tmp_path):
+    """Without an inherited value the backends already derive from the process
+    cwd (local exports os.getcwd() at cli import, docker mounts it, the TUI
+    child inherits the chdir). Pre-seeding a host path here would leak it into
+    ssh/container backends that must keep their own default."""
+    import os
+
+    target = tmp_path / "target"
+    target.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    main_mod._apply_in_dir(_args(in_dir=str(target)))
+
+    assert "TERMINAL_CWD" not in os.environ


### PR DESCRIPTION
## What does this PR do?

`--in DIR` only `chdir`'d (`hermes_cli/main.py::_apply_in_dir`). Every cwd consumer prefers `TERMINAL_CWD` over the process cwd: `agent/runtime_cwd.py::resolve_agent_cwd()` (which is what `agent/codex_runtime.py::_ensure_codex_session` passes as the app-server thread cwd), the terminal tool (`agent/tool_executor.py`), and context-file discovery. So a `TERMINAL_CWD` inherited from a parent Hermes surface, the shell or `.env` survived the chdir and the session kept running in the old directory, exactly the mismatch in #106220.

Why it only bites some setups:

- **local backend**: `cli.py::_mirror_config_to_env` force-exports `TERMINAL_CWD = os.getcwd()` when `cli.py` is imported, and `cmd_chat` imports it after the chdir, so the stale value is overwritten by accident.
- **docker / ssh backends**: a placeholder `terminal.cwd` is popped and nothing is exported, so the inherited value stays.
- **TUI launch path**: `_launch_tui` runs before `cli.py` is ever imported and passes the inherited value to the child; `tui_gateway/session_workdir.py` then prefers `TERMINAL_CWD` over `os.getcwd()` for the new session, on every backend.

The fix refreshes `TERMINAL_CWD` to the `--in` target **when it is already set**. An unset variable stays unset: the backends then derive from the new process cwd (local exports it at `cli` import, docker's cwd passthrough mounts `os.getcwd()`, ssh/container backends keep their own remote/sandbox default), so no host path is pre-seeded into a backend that must not receive one. This mirrors what the worktree join already does (`cli.py`, `os.environ["TERMINAL_CWD"] = info["path"]`) and what the Desktop does for its backend child.

Precedence stays as today for the rest: an explicit non-placeholder `terminal.cwd` in `config.yaml` is still re-bridged over the environment at `cli` import (and by `apply_terminal_config_to_env` for the TUI child), so config continues to win over `--in` on non-local backends. Changing that is a policy decision I left out of this PR.

## Related Issue

Fixes #106220

Related, not duplicates: #87501 / #98009 make one-shot (`-z`) runs honor `--in` at all (the one-shot dispatchers never reach `cmd_chat`); #87501 additionally pins `TERMINAL_CWD` for the local backend inside the one-shot path. This PR covers the interactive/TUI path and the inherited-variable case, and touches only the existing `_apply_in_dir` body, so it composes with either.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — `_apply_in_dir`: after the chdir, overwrite an already-set `TERMINAL_CWD` with the validated target directory (comment explains why unset stays unset).
- `tests/hermes_cli/test_resume_latest_and_in_dir.py` — two regressions: an inherited `TERMINAL_CWD` is replaced and `resolve_agent_cwd()` reports the `--in` directory; an unset `TERMINAL_CWD` is left unset.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_resume_latest_and_in_dir.py tests/hermes_cli/test_in_dir_msys_paths.py tests/hermes_cli/test_deprecated_cwd_warning.py tests/agent/test_runtime_cwd.py tests/cli/test_cwd_env_respect.py tests/tools/test_terminal_env_bridge.py tests/gateway/test_cwd_placeholder.py` → 49 passed, 0 failed (macOS arm64, CPython 3.11.15).
2. Mutation check: with the `hermes_cli/main.py` hunk reverted, `test_in_dir_replaces_inherited_terminal_cwd` fails on the `TERMINAL_CWD` assertion (still points at the inherited directory); with the hunk applied it passes.
3. End-to-end probe of the reporter's scenario (two temp dirs A and B, `TERMINAL_CWD=A` exported, `HERMES_HOME` pointed at a temp home whose `config.yaml` selects the backend), reproducing the startup order of `cmd_chat`: `_apply_in_dir(--in B)` → `import cli` → `resolve_agent_cwd()`:

   | backend | before (main) | after |
   | --- | --- | --- |
   | local | B (rescued by the `cli` import force-export) | B |
   | docker | **A** | B |
   | ssh | **A** | B |

   ```python
   os.environ["TERMINAL_CWD"] = str(A); os.chdir(A)
   from hermes_cli import main as m
   m._apply_in_dir(argparse.Namespace(in_dir=str(B)))
   import cli
   from agent.runtime_cwd import resolve_agent_cwd
   assert resolve_agent_cwd() == B
   ```

Known limit, unchanged by this PR: a `TERMINAL_CWD` set in `~/.hermes/.env` is reloaded with override when `cli.py` is imported, so on non-local backends it still wins over `--in`. That key is already deprecated (`hermes_cli` warns about it at startup).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the seven cwd-related files above through `scripts/run_tests.sh`, not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64), CPython 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing surface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the value written is the already-validated, MSYS-translated absolute path `_apply_in_dir` chdirs into
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

