### PR TITLE
fix(responses): recover strict-relay 400 on empty assistant item after replayed reasoning (Volcengine Ark input.content)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -42,6 +42,7 @@ class FailoverReason(enum.Enum):
     content_policy_blocked = "content_policy_blocked"  # Provider safety filter rejected this prompt — don't retry unchanged
     format_error = "format_error"        # 400 bad request — abort or strip + retry
     invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
+    empty_reasoning_follow_content = "empty_reasoning_follow_content"  # Strict Responses relay rejects the empty assistant placeholder that must follow a replayed reasoning item — strip replay state and retry
     multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
     reasoning_mandatory = "reasoning_mandatory"  # Route rejects reasoning: {enabled: false} — send the disable no more this session and retry
 
@@ -349,9 +350,41 @@ _V_PAYLOAD_TOO_LARGE = _v(_R.payload_too_large, should_compress=True)
 _V_OVERLOADED, _V_SERVER_ERROR, _V_TIMEOUT, _V_UNKNOWN = map(_v, (_R.overloaded, _R.server_error, _R.timeout, _R.unknown))
 _V_IMAGE_TOO_LARGE, _V_IMAGE_CORRUPT = _v(_R.image_too_large), _v(_R.image_corrupt)
 _V_MULTIMODAL, _V_INVALID_ENCRYPTED = _v(_R.multimodal_tool_content_unsupported), _v(_R.invalid_encrypted_content)
+# Strict custom Responses relays (e.g. Volcengine Ark) reject the empty assistant
+# message Hermes emits after a replayed reasoning item with MissingParameter(input.content).
+# Same recovery as a rejected replay blob: strip replay state and retry once.
+_V_EMPTY_REASONING_FOLLOW = _v(_R.empty_reasoning_follow_content, should_compress=False, should_fallback=False)
 _V_REASONING_MANDATORY = _v(_R.reasoning_mandatory, should_compress=False, should_fallback=False)
 # A reasoning-mandatory route answering ``reasoning: {enabled: false}`` (Nous Portal + OpenRouter wording).
 _REASONING_MANDATORY_PATTERN = "reasoning is mandatory"
+
+# Strict Responses relays reject the empty assistant placeholder Hermes emits after a replayed
+# ``reasoning`` item. Volcengine Ark: code=MissingParameter, param=input.content. Match on the
+# field path AND a missing/empty signal so an unrelated ``input.content`` complaint is never caught.
+_EMPTY_REASONING_FOLLOW_CODES = frozenset({"missingparameter"})
+_EMPTY_REASONING_FOLLOW_PARAM = "input.content"
+_EMPTY_REASONING_FOLLOW_MESSAGE_PATTERNS = (
+    "missing `input.content` parameter",
+    "missing 'input.content' parameter",
+    "missing input.content parameter",
+    "input.content` parameter",
+)
+
+
+def _is_empty_reasoning_follow_content(c: "_Ctx") -> bool:
+    """True for a strict-relay 400 rejecting the empty ``{role:'assistant', content:''}`` item.
+
+    Requires the Responses field path ``input.content`` plus either the structured ``param``
+    field or a missing-parameter message/code — deliberately narrower than a bare substring hit.
+    """
+    msg = (c.msg or "").lower()
+    body = c.body if isinstance(c.body, dict) else {}
+    error_obj = body.get("error") if isinstance(body.get("error"), dict) else {}
+    param = str(error_obj.get("param") or body.get("param") or "").strip().lower()
+    param_hit = param == _EMPTY_REASONING_FOLLOW_PARAM or _EMPTY_REASONING_FOLLOW_PARAM in msg
+    message_hit = any(p in msg for p in _EMPTY_REASONING_FOLLOW_MESSAGE_PATTERNS)
+    code_hit = c.code in _EMPTY_REASONING_FOLLOW_CODES
+    return param_hit and (message_hit or code_hit)
 
 
 def _billing_hints(error_msg: str) -> Verdict:
@@ -691,6 +724,10 @@ def _classify_400(c: _Ctx) -> Verdict:
         "encrypted content for item" in msg and "could not be verified" in msg
     ) or "could not decrypt the provided encrypted_content" in msg:
         return _V_INVALID_ENCRYPTED
+    # Strict custom relay (Volcengine Ark) rejects the empty assistant placeholder that
+    # follows a replayed reasoning item — strip replay state and retry once, like a bad blob.
+    if _is_empty_reasoning_follow_content(c):
+        return _V_EMPTY_REASONING_FOLLOW
     # Reasoning-mandatory route rejecting a disable (GLM-5.3 on Nous Portal / OpenRouter). Deterministic
     # for the request shape, but the only bad field is ``reasoning: {enabled: false}`` — the loop drops
     # the disable and retries once. Must precede request-validation, which would abort as format_error.

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -374,11 +374,21 @@ def _recover_format_errors(
         )
         return True
 
-    # 400 ``invalid_encrypted_content`` on a stale ``codex_reasoning_items`` blob:
+    # 400 ``invalid_encrypted_content`` on a stale ``codex_reasoning_items`` blob,
+    # OR a strict relay's ``MissingParameter(input.content)`` on the empty assistant
+    # placeholder that must follow a replayed reasoning item. Both recover the same way:
     # disable replay for the session, strip cached items, retry once.
+    replay_rejected = classified.reason in (
+        FailoverReason.invalid_encrypted_content,
+        FailoverReason.empty_reasoning_follow_content,
+    )
+    already_retried = (
+        _retry.invalid_encrypted_content_retry_attempted
+        or _retry.empty_reasoning_follow_content_retry_attempted
+    )
     if (
-        classified.reason == FailoverReason.invalid_encrypted_content
-        and not _retry.invalid_encrypted_content_retry_attempted
+        replay_rejected
+        and not already_retried
         and agent.api_mode == "codex_responses"
         and bool(getattr(agent, "_codex_reasoning_replay_enabled", True))
         and any(
@@ -390,16 +400,25 @@ def _recover_format_errors(
         )
     ):
         _retry.invalid_encrypted_content_retry_attempted = True
+        _retry.empty_reasoning_follow_content_retry_attempted = True
         replay_stats = agent._disable_codex_reasoning_replay(messages)
+        if classified.reason == FailoverReason.empty_reasoning_follow_content:
+            user_note = (
+                "Provider rejected the empty assistant item following a replayed reasoning block "
+                "(input.content) — disabled encrypted-reasoning replay"
+            )
+            log_note = "Empty reasoning-follow-content recovery: disabled replay"
+        else:
+            user_note = "Encrypted reasoning replay was rejected by the provider — disabled replay"
+            log_note = "Invalid encrypted reasoning recovery: disabled replay"
         _vlines(
             agent,
-            f"⚠️  Encrypted reasoning replay was rejected by the provider — "
-            f"disabled replay and stripped {replay_stats['items']} item(s) from "
+            f"⚠️  {user_note} and stripped {replay_stats['items']} item(s) from "
             f"{replay_stats['messages']} message(s), retrying...",
         )
         logger.warning(
-            "%sInvalid encrypted reasoning recovery: disabled replay and stripped %d items from %d messages",
-            agent.log_prefix, replay_stats["items"], replay_stats["messages"],
+            "%s%s and stripped %d items from %d messages",
+            agent.log_prefix, log_note, replay_stats["items"], replay_stats["messages"],
         )
         return True
 

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -28,6 +28,9 @@ class TurnRetryState:
     # Format / payload recovery guards
     thinking_sig_retry_attempted: bool = False
     invalid_encrypted_content_retry_attempted: bool = False
+    # Strict Responses relay rejected the empty assistant placeholder after a replayed
+    # reasoning item (e.g. Volcengine Ark MissingParameter input.content).
+    empty_reasoning_follow_content_retry_attempted: bool = False
     native_compaction_reject_retry_attempted: bool = False
     image_shrink_retry_attempted: bool = False
     multimodal_tool_content_retry_attempted: bool = False

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -64,6 +64,7 @@ class TestFailoverReason:
             "image_corrupt",
             "model_not_found", "format_error",
             "invalid_encrypted_content",
+            "empty_reasoning_follow_content",
             "multimodal_tool_content_unsupported",
             "reasoning_mandatory",
             "provider_policy_blocked",
@@ -707,6 +708,35 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.invalid_encrypted_content
         assert result.retryable is True
         assert result.should_fallback is False
+
+    # ── Volcengine Ark: empty assistant placeholder after replayed reasoning ──
+
+    @pytest.mark.parametrize("body", [
+        # Exact Ark envelope captured from a failing codex_responses request.
+        {"error": {"code": "MissingParameter",
+                   "message": "The request failed because it is missing `input.content` parameter. Request id: x",
+                   "param": "input.content", "type": "BadRequest"}},
+        # Message-only shape: code + field path in text, no structured param.
+        {"error": {"code": "MissingParameter", "message": "HTTP 400: missing `input.content` parameter."}},
+    ], ids=["structured-param", "message-only"])
+    def test_ark_empty_reasoning_follow_content_triggers_replay_strip(self, body):
+        e = MockAPIError("Error code: 400 - bad request", status_code=400, body=body)
+        result = classify_api_error(e, provider="custom", model="ark-code-latest")
+        assert result.reason == FailoverReason.empty_reasoning_follow_content
+        assert result.retryable is True
+        assert result.should_fallback is False
+        assert result.should_compress is False
+
+    @pytest.mark.parametrize("body", [
+        # A different missing parameter must never match.
+        {"error": {"code": "MissingParameter", "message": "missing `messages` parameter.", "param": "messages"}},
+        # input.content present but rejected as an unknown parameter.
+        {"error": {"code": "UnknownParameter", "message": "unknown parameter: input.content", "param": "input.content"}},
+    ], ids=["other-param", "unknown-param"])
+    def test_ark_empty_reasoning_follow_content_negative(self, body):
+        e = MockAPIError("Error code: 400 - bad request", status_code=400, body=body)
+        result = classify_api_error(e, provider="custom", model="ark-code-latest")
+        assert result.reason != FailoverReason.empty_reasoning_follow_content
 
     # ── Codex masked encrypted-reasoning replay rejection (#92353) ──
 

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -23,6 +23,7 @@ EXPECTED_FIELDS = {
     "vertex_auth_retry_attempted",
     "thinking_sig_retry_attempted",
     "invalid_encrypted_content_retry_attempted",
+    "empty_reasoning_follow_content_retry_attempted",
     "native_compaction_reject_retry_attempted",
     "image_shrink_retry_attempted",
     "multimodal_tool_content_retry_attempted",


### PR DESCRIPTION
## What does this PR do?

Fixes an HTTP 400 from a **strict OpenAI-Responses-compatible relay** (observed with Volcengine Ark `ark-code-latest` in `codex_responses` mode) when a turn contains a replayed encrypted `reasoning` item followed only by a tool call.

To satisfy OpenAI's "a replayed `reasoning` item must be followed by another item" rule, Hermes emits a placeholder assistant item `{"role":"assistant","content":""}` (see `codex_responses_adapter.py`). OpenAI accepts the empty placeholder; strict relays reject it:

```json
HTTP 400 {"error":{"code":"MissingParameter",
  "message":"The request failed because it is missing `input.content` parameter. Request id: ...",
  "param":"input.content","type":"BadRequest"}}
```

This PR classifies that specific 400 and reuses the **existing** self-healing path already used for `invalid_encrypted_content`: disable encrypted-reasoning replay for the session, strip the cached `codex_reasoning_items`, and retry **once**. With replay off the rebuilt input is plain `user / function_call / function_call_output` with no empty assistant item, which strict relays accept.

The detector is deliberately narrow: it requires the field path `input.content` (structured `error.param` or in the message) **and** (`code=MissingParameter` or a missing-parameter message pattern), so unrelated 400s (e.g. a different missing param, or `UnknownParameter` on `input.content`) never match. No model fallback and no compression are triggered.

## Related Issue

No existing issue; happy to open one if preferred. Reproduced against the live relay and isolated with unit-level repro scripts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`
  - New `FailoverReason.empty_reasoning_follow_content` (retryable, `should_compress=False`, `should_fallback=False`).
  - New narrow matcher `_is_empty_reasoning_follow_content(_Ctx)` + constants, wired into `_classify_400` right after the existing encrypted-content branch.
- `agent/turn_retry_state.py`
  - One-shot guard `empty_reasoning_follow_content_retry_attempted`.
- `agent/turn_recovery.py`
  - Widened the existing replay-rejection recovery gate to accept both reasons and set both guards so each reason retries at most once.
  - Distinct user-facing warning and log line for the empty-follow case.
- `tests/agent/test_error_classifier.py`
  - Positive cases (structured `param`, and message-only shape) + negative cases (different missing param; `UnknownParameter` on `input.content`); enum contract updated.
- `tests/agent/test_turn_retry_state.py` — field contract updated.

## How to Test

1. `pytest tests/agent/test_error_classifier.py tests/agent/test_turn_retry_state.py tests/agent/test_codex_responses_adapter.py -q` → **170 passed**.
2. Classifier-level: a 400 body `{"error":{"code":"MissingParameter","param":"input.content", ...}}` classifies to `empty_reasoning_follow_content` (`retryable=True`, `should_fallback=False`); the two negative bodies do not.
3. End-to-end shape check: build Responses input with `replay_encrypted_reasoning=True` → contains the empty `{role:assistant,content:""}` item; after recovery (strip `codex_reasoning_items`, set the one-shot flag) and rebuild with replay disabled → no empty assistant item (`user / function_call / function_call_output` only).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the touched suites + related adapter/recovery suites; the unrelated `gateway` async failures were due to a missing local `pytest-asyncio` in my bootstrap env and pass once the plugin is present)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (new internal reason + docstrings; no user config surface)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python error-classification/recovery, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Recovered turn logs:

```
⚠️  Provider rejected the empty assistant item following a replayed reasoning block
    (input.content) — disabled encrypted-reasoning replay and stripped 1 item(s) from
    1 message(s), retrying...
WARNING ... Empty reasoning-follow-content recovery: disabled replay and stripped 1 items from 1 messages
```
