### PR TITLE
feat(delegate): add delegation.suppress_memory_notify to skip parent memory-provider on_delegation

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1260,6 +1260,9 @@ DEFAULT_CONFIG = {
         # Orchestrator role controls. Depth floored at 1, no ceiling; each level multiplies cost.
         "max_spawn_depth": 1,  # 1 = flat, 2 = orchestrator→leaf, 3+ = deeper
         "orchestrator_enabled": True,  # kill switch for role="orchestrator"
+        # When true, skip parent memory-provider on_delegation notifications for child results
+        # (children are ephemeral workers; providers that persist delegation observations opt out).
+        "suppress_memory_notify": False,
         # Subagent threads ALWAYS resolve approvals non-interactively (the parent TUI owns stdin;
         # input() from a worker would deadlock). false = auto-deny, true = auto-approve "once"; both
         # log a warning audit line. true only for trusted batch work.

--- a/tests/tools/test_delegate_memory_notify.py
+++ b/tests/tools/test_delegate_memory_notify.py
@@ -75,11 +75,14 @@ def test_missing_delegation_key_still_notifies():
 
 
 def test_notify_loop_isolates_raising_provider():
-    """A provider raising inside on_delegation must not break result processing."""
+    """A provider raising inside on_delegation must not break result processing,
+    and the hook is still invoked (isolation, not skipping)."""
     parent = _make_parent()
     parent._memory_manager.on_delegation.side_effect = RuntimeError("provider down")
 
     _notify_with_config(parent, [_make_result(0)], {})
+
+    parent._memory_manager.on_delegation.assert_called_once()
 
 
 def test_malformed_config_fails_open():

--- a/tests/tools/test_delegate_memory_notify.py
+++ b/tests/tools/test_delegate_memory_notify.py
@@ -1,0 +1,91 @@
+"""Tests for ``delegation.suppress_memory_notify``: gating the parent memory-provider
+``on_delegation`` notifications that ``_notify_memory_manager`` fires for delegate_task
+child results. Default must keep firing (the hook is a deliberate provider contract);
+a truthy flag opts the parent out. Malformed config fails OPEN (children still notify).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.delegate_tool_results import _notify_memory_manager
+
+
+def _make_parent():
+    parent = MagicMock()
+    parent._memory_manager = MagicMock()
+    return parent
+
+
+def _make_result(task_index=0, summary="did the work"):
+    return {"task_index": task_index, "summary": summary, "status": "completed"}
+
+
+def _notify_with_config(parent, results, cfg, *, load_error=None):
+    """Run _notify_memory_manager with ``tools.delegate_tool._load_config`` patched —
+    the seam production reads (function-local import)."""
+    task_list = [{"goal": f"goal-{i}"} for i in range(len(results))]
+    children = {i: MagicMock(session_id=f"child-{i}") for i in range(len(results))}
+    target = {"return_value": cfg} if load_error is None else {"side_effect": load_error}
+    with patch("tools.delegate_tool._load_config", **target):
+        _notify_memory_manager(results, task_list, children, parent)
+
+
+def test_on_delegation_fires_per_entry_by_default():
+    """No flag configured: every child result still reaches the parent's provider with
+    task text, summary text, and the child's session id (hook contract invariant)."""
+    parent = _make_parent()
+    results = [_make_result(0, "alpha done"), _make_result(1, "beta done")]
+
+    _notify_with_config(parent, results, {})
+
+    calls = parent._memory_manager.on_delegation.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs == {"task": "goal-0", "result": "alpha done", "child_session_id": "child-0"}
+    assert calls[1].kwargs == {"task": "goal-1", "result": "beta done", "child_session_id": "child-1"}
+
+
+@pytest.mark.parametrize("flag_value", [True, "true", "yes", "1"])
+def test_suppress_flag_truthy_skips_on_delegation(flag_value):
+    """A truthy delegation.suppress_memory_notify short-circuits before any per-entry work."""
+    parent = _make_parent()
+
+    _notify_with_config(parent, [_make_result(0)], {"suppress_memory_notify": flag_value})
+
+    parent._memory_manager.on_delegation.assert_not_called()
+
+
+@pytest.mark.parametrize("flag_value", [False, "false", "no", "off", 0, None])
+def test_suppress_flag_falsy_still_notifies(flag_value):
+    """Falsy values (including explicit false and unknown strings) keep the notify contract."""
+    parent = _make_parent()
+
+    _notify_with_config(parent, [_make_result(0)], {"suppress_memory_notify": flag_value})
+
+    parent._memory_manager.on_delegation.assert_called_once()
+
+
+def test_missing_delegation_key_still_notifies():
+    """Absent flag in a populated delegation section: notify (default-on contract)."""
+    parent = _make_parent()
+
+    _notify_with_config(parent, [_make_result(0)], {"max_summary_chars": 24000})
+
+    parent._memory_manager.on_delegation.assert_called_once()
+
+
+def test_notify_loop_isolates_raising_provider():
+    """A provider raising inside on_delegation must not break result processing."""
+    parent = _make_parent()
+    parent._memory_manager.on_delegation.side_effect = RuntimeError("provider down")
+
+    _notify_with_config(parent, [_make_result(0)], {})
+
+
+def test_malformed_config_fails_open():
+    """A raising _load_config must not crash finalization: children still notify."""
+    parent = _make_parent()
+
+    _notify_with_config(parent, [_make_result(0)], None, load_error=TypeError("bad config"))
+
+    parent._memory_manager.on_delegation.assert_called_once()

--- a/tools/delegate_tool_results.py
+++ b/tools/delegate_tool_results.py
@@ -330,15 +330,15 @@ def _parent_finalization_lock(parent_agent) -> threading.RLock:
     return lock
 
 def _notify_memory_manager(results, task_list, child_by_index, parent_agent) -> None:
+    memory = getattr(parent_agent, "_memory_manager", None) if parent_agent else None
+    if not memory:
+        return
     from tools.delegate_tool import _load_config
     try:
         if is_truthy_value(_load_config().get("suppress_memory_notify")):
             return  # delegation.suppress_memory_notify: ephemeral child results opted out of provider persistence
     except (TypeError, ValueError):
         pass
-    memory = getattr(parent_agent, "_memory_manager", None) if parent_agent else None
-    if not memory:
-        return
     for entry in results:
         try:
             task_index = entry.get("task_index", -1)

--- a/tools/delegate_tool_results.py
+++ b/tools/delegate_tool_results.py
@@ -8,6 +8,8 @@ import threading
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
+from utils import is_truthy_value
+
 logger = logging.getLogger("tools.delegate_tool")  # log-record parity with the origin module
 
 def _stringify_tool_content(content: Any) -> str:
@@ -328,6 +330,12 @@ def _parent_finalization_lock(parent_agent) -> threading.RLock:
     return lock
 
 def _notify_memory_manager(results, task_list, child_by_index, parent_agent) -> None:
+    from tools.delegate_tool import _load_config
+    try:
+        if is_truthy_value(_load_config().get("suppress_memory_notify")):
+            return  # delegation.suppress_memory_notify: ephemeral child results opted out of provider persistence
+    except (TypeError, ValueError):
+        pass
     memory = getattr(parent_agent, "_memory_manager", None) if parent_agent else None
     if not memory:
         return


### PR DESCRIPTION
# PR body draft

## Summary

Implements the one remaining open item from #46027 (delegate-task sub-agent hygiene): a config flag to suppress parent memory-provider notifications for child delegation results.

`_notify_memory_manager` (`tools/delegate_tool_results.py`) currently calls `memory.on_delegation(...)` on the parent's memory manager for every completed child, unconditionally. Providers that persist delegation observations (or any third-party provider hooking `on_delegation`) previously had no way to opt out for ephemeral child results.

With `delegation.suppress_memory_notify: true`, the notification loop is short-circuited before any per-entry work. Default remains `false`, preserving the existing provider contract (see Open question).

**Verification:** 14 new tests in `tests/tools/test_delegate_memory_notify.py` (default per-entry notify contract, parametrized truthy/falsy flag values, raising-provider isolation, malformed-config fail-open). Regression lane `tests/tools/test_delegate.py` + new file: 80 passed + 14 passed; the single failure (`test_child_dedicated_db_follows_parents_db_path`) reproduces identically on clean `main` (pre-existing macOS `/private/tmp` symlink-resolution issue, unrelated).

## What was already shipped (verified against `main` before implementing)

The issue's other three recommendations are addressed on current `main` and out of scope here:

- **Per-agent tool blocking (#46027 item 2):** `DELEGATE_BLOCKED_TOOLS` frozenset + per-child `disabled_toolsets` (`tools/delegate_tool_toolsets.py`); the literal per-tool `blocked_tools` proposal is explicitly rejected by the public plugin launch API (`agent/subagent_lifecycle.py`).
- **Summary cap (item 3):** `delegation.max_summary_chars` (default 24000) + dynamic headroom budget + spill-to-disk (`_apply_summary_budget`).
- **Interrupted children (item 4):** structured `status="interrupted"` results; cooperative interrupt runs the child's `finally` path.

## Changes

- `tools/delegate_tool_results.py` — gate `_notify_memory_manager` on the new flag (checked once before the notification loop, after the existing memory-manager presence check; `is_truthy_value` semantics matching `delegation.subagent_auto_approve`).
- `hermes_cli/config_defaults.py` — `delegation.suppress_memory_notify: False` with a why-comment.
- `tests/tools/test_delegate_memory_notify.py` — new: default-on behavior invariant (hook fires per result entry), flag-on suppression, truthy-string handling, and raising-provider isolation.

## Open question

The issue proposed `suppress_memory_notify` default `true` ("child agents are ephemeral workers; their work should not be persisted into the parent's long-term memory"). This PR defaults it to `false`: `on_delegation` is an explicit parent-side observation API added deliberately in April 2026 (`agent/memory_provider.py`), no in-tree provider persists child results today, and a default-on flip would silently change behavior for any provider relying on the hook. Happy to flip the default if maintainers prefer the issue's semantics.

Closes #46027
