### PR TITLE
fix(file-ops): preserve paths and line numbers in search context

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from tests.tools.file_ops_fakes import READ_SENTINEL_RE, compound_read_output
 from tools.file_operations import ShellFileOperations
-from tools.file_operations_search import _parse_search_context_line
+from tools.file_operations_search import _parse_search_content_line
 
 
 # =========================================================================
@@ -265,7 +265,7 @@ class TestSearchContextParsing:
         with patch.object(ops, "_exec") as mock_exec:
             mock_exec.return_value = MagicMock(
                 exit_code=0,
-                stdout="./first.txt:1:foo\n./second.txt:1:bar\n",
+                stdout="./first.txt\x001:foo\n./second.txt\x001:bar\n",
             )
             result = ops._search_with_grep(
                 "foo|bar",
@@ -283,8 +283,8 @@ class TestSearchContextParsing:
         assert result.total_count == 2
         assert [match.content for match in result.matches] == ["foo", "bar"]
 
-    def test_parse_search_context_line_prefers_rightmost_numeric_separator(self):
-        parsed = _parse_search_context_line("dir/file-12-name.py-8-context here")
+    def test_parse_search_context_line_preserves_numeric_filename(self):
+        parsed = _parse_search_content_line("dir/file-12-name.py\x008-context here", context=1)
 
         assert parsed == ("dir/file-12-name.py", 8, "context here")
 
@@ -297,7 +297,7 @@ class TestSearchContextParsing:
         with patch.object(ops, "_exec") as mock_exec:
             mock_exec.return_value = MagicMock(
                 exit_code=0,
-                stdout="dir/file-12-name.py-8-context here\n",
+                stdout="dir/file-12-name.py\x008-context here\n",
             )
             result = ops._search_with_grep(
                 "needle",

--- a/tests/tools/test_search_budget_truncation.py
+++ b/tests/tools/test_search_budget_truncation.py
@@ -49,7 +49,7 @@ def test_timeout_helper_strips_only_trailing_marker():
     [
         ("files", "content", timeout_output("src/a.py", "src/b.py"), ["src/a.py", "src/b.py"]),
         ("content", "files_only", timeout_output("src/a.py", "src/b.py"), ["src/a.py", "src/b.py"]),
-        ("content", "content", timeout_output("src/a.py:10:foo", "src/b.py:20:foo"), ["src/a.py", "src/b.py"]),
+        ("content", "content", timeout_output("src/a.py\x0010:foo", "src/b.py\x0020:foo"), ["src/a.py", "src/b.py"]),
     ],
 )
 def test_rg_timeout_returns_partial_results_without_marker(ops, monkeypatch, target, output_mode, raw, expected):

--- a/tests/tools/test_search_content_framing.py
+++ b/tests/tools/test_search_content_framing.py
@@ -1,0 +1,115 @@
+"""Search locations must not be inferred from separator-shaped file content."""
+
+import json
+import shlex
+import shutil
+from unittest.mock import Mock
+
+import pytest
+
+from tools import file_operations, file_tools, terminal_tool
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ExecuteResult, ShellFileOperations
+from tools.file_operations_search import _parse_search_output
+
+
+@pytest.fixture(scope="module")
+def local_env(tmp_path_factory):
+    return LocalEnvironment(cwd=str(tmp_path_factory.mktemp("search-framing")))
+
+
+@pytest.fixture(params=["rg-default", "rg-shell", "grep",
+                        pytest.param("grep-pruned", marks=pytest.mark.macos_only)])
+def search(request, tmp_path, monkeypatch, local_env):
+    engine = "grep" if request.param.startswith("grep") else "rg"
+    executable = shutil.which(engine)
+    if executable is None:
+        pytest.skip(f"{engine} is not installed")
+    monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "1" if request.param == "rg-default" else "0")
+    monkeypatch.setattr(local_env, "cwd", str(tmp_path))
+    ops = ShellFileOperations(local_env, cwd=str(tmp_path))
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == engine)
+    if engine == "rg":
+        ops._rg_resolution_cache["rg"] = executable
+    pipeline = Mock(wraps=ops._run_search_pipeline)
+    native = Mock(wraps=ops._run_rg_native)
+    monkeypatch.setattr(ops, "_run_search_pipeline", pipeline)
+    monkeypatch.setattr(ops, "_run_rg_native", native)
+    task_id = request.node.nodeid
+    env_id = terminal_tool._resolve_container_task_id(task_id)
+    monkeypatch.setitem(terminal_tool._active_environments, env_id, local_env)
+    monkeypatch.setitem(file_tools._file_ops_cache, env_id, ops)
+    if request.param == "grep-pruned":
+        monkeypatch.setattr(file_operations, "_HOME", str(tmp_path))
+        protected = tmp_path / "Downloads"
+        protected.mkdir()
+        (protected / "ignored.txt").write_text("NEEDLE\n", encoding="utf-8")
+
+    def run(**kwargs):
+        pipeline.reset_mock()
+        native.reset_mock()
+        if request.param == "grep-pruned":
+            kwargs["path"] = str(tmp_path)
+        result = json.loads(file_tools.search_tool(task_id=task_id, **kwargs))
+        pipeline.assert_called_once()
+        argv = shlex.split(" ".join(pipeline.call_args.args[0]))
+        if request.param == "grep-pruned":
+            assert argv[0] == "find"
+            assert argv[argv.index("-exec") + 1] == "grep"
+        else:
+            assert argv[0] == ("grep" if engine == "grep" else executable)
+        assert native.called is (engine == "rg" and ops._native_read_enabled())
+        return result
+
+    return run
+
+
+@pytest.mark.parametrize("filename", ["notes.txt", "notes-12-name.txt", "sub dir/notes-12-name.txt"])
+@pytest.mark.parametrize("neighbor", ["plain context", "release-2026-final", "release-2026-final:42:status",
+                                      "", "--", "  release-2026-final  "])
+def test_context_locations_round_trip(search, tmp_path, filename, neighbor):
+    path = tmp_path / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    contents = [neighbor, "NEEDLE-123-tail:88:end", neighbor]
+    path.write_text("\n".join(contents) + "\n", encoding="utf-8")
+    original = path.read_bytes()
+
+    result = search(pattern="NEEDLE", path=str(path), context=1)
+
+    assert "error" not in result
+    assert result["total_count"] == len(contents)
+    assert result["matches"] == [
+        {"path": str(path), "line": number, "content": text}
+        for number, text in enumerate(contents, 1)
+    ]
+    without_context = search(pattern="NEEDLE", path=str(path), context=0)
+    assert "error" not in without_context, without_context
+    assert without_context["matches"] == [{"path": str(path), "line": 2, "content": contents[1]}]
+    page = search(pattern="NEEDLE", path=str(path), context=1, offset=1, limit=1)
+    assert "error" not in page, page
+    assert page["matches"] == without_context["matches"]
+    assert page["truncated"] is True
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("path", ["dir/notes-12-name.txt", r"C:\work\notes-12-name.txt",
+                                 "rg: notes-12-name.txt", "dir/notes-12-name:34: with space.txt"])
+@pytest.mark.parametrize("exit_code", [0, 2, 124, 141])
+def test_framed_records_preserve_partial_results(path, exit_code):
+    before = "release-2026-final:42:status"
+    after = "tail-17-end "
+    output = f"{path}\x001-{before}\n{path}\x002:NEEDLE\n--\n{path}\x003-{after}\n"
+    if exit_code == 2:
+        output += "grep: missing.txt: No such file or directory\n"
+    elif exit_code == 124:
+        output += "[Command timed out after 60s]\n"
+
+    result = _parse_search_output(ExecuteResult(output, exit_code), "content", 2, 1, 1)
+
+    assert result.error is None
+    assert [(m.path, m.line_number, m.content) for m in result.matches] == [
+        (path, 2, "NEEDLE"), (path, 3, after)
+    ]
+    assert result.total_count == 3
+    assert result.truncated is (exit_code == 124)
+    assert result.limit_reason == ("search_timeout" if exit_code == 124 else None)

--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -114,16 +114,28 @@ class TestSearchContentNewlineWarning:
 class TestSplitToolDiagnostics:
     """Unit coverage for the shape-based diagnostic/payload splitter."""
 
-    def test_pure_error_has_empty_payload(self):
-        out = "rg: regex parse error:\n    (?:[)\n       ^\nerror: unclosed character class\n"
+    @pytest.mark.parametrize("out", [
+        "rg: regex parse error:\n    (?:[)\n       ^\nerror: unclosed character class\n",
+        "grep: unsupported option\n--\n",
+        "clipped-12-path\x00\n",
+        "clipped-12-path\x0023\n",
+        "invalid-line\x000:payload\n",
+    ])
+    def test_pure_error_has_empty_payload(self, out):
         diagnostics, payload = _split_tool_diagnostics(out)
         assert payload.strip() == ""
-        assert "regex parse error" in diagnostics
+        assert diagnostics
+        from tools.file_operations import ExecuteResult
+        from tools.file_operations_search import _parse_search_output
+
+        result = _parse_search_output(ExecuteResult(out, 2), "content", 50, 0, 1)
+        assert result.error is not None
+        assert not result.matches
 
 
-    def test_context_lines_and_separator_are_payload(self):
-        out = "a.py:5:hit\na.py-6-after\n--\nb.py:9:hit\n"
+    def test_context_lines_are_payload_but_group_separator_is_not(self):
+        out = "a.py\x005:hit\na.py\x006-after\n--\nb.py\x009:hit\n"
         diagnostics, payload = _split_tool_diagnostics(out)
         assert diagnostics == ""
-        assert "--" in payload
-        assert "a.py-6-after" in payload
+        assert "--" not in payload
+        assert "a.py\x006-after" in payload

--- a/tests/tools/test_search_files_engine_selection.py
+++ b/tests/tools/test_search_files_engine_selection.py
@@ -317,7 +317,7 @@ class RipgrepInvocationEnvironment(RecordingEnvironment):
         if "--files" in command:
             return {"output": "/repo/a.py\n", "returncode": 0}
         if "--line-number" in command:
-            return {"output": "/repo/a.py:1:needle\n", "returncode": 0}
+            return {"output": "/repo/a.py\x001:needle\n", "returncode": 0}
         if "--count-matches" in command:
             return {"output": "", "returncode": 1}
         return {"output": "", "returncode": 1}

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -118,13 +118,13 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
-# A real rg/grep output line is a whitespace-free path token followed by ``:``
-# (match/count), ``-`` (context), or nothing (files_only); tool diagnostics
-# ("rg: ...", indented carets) never match.
+# Count/files-only output retains its text format. Content records use a NUL
+# filename boundary so punctuation in paths or source text cannot move it.
 _SEARCH_OUTPUT_RE = re.compile(r'^([A-Za-z]:)?[^\s:][^\n]*?[:\-]\d|^[^\s:][^\s]*$')
+_SEARCH_CONTENT_LINE_RE = re.compile(r'^([^\x00]+)\x00([1-9][0-9]*)([:-])(.*)$')
 
 
-def _split_tool_diagnostics(output: str) -> tuple[str, str]:
+def _split_tool_diagnostics(output: str, output_mode: str = "content") -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output → ``(diagnostics, payload)``.
     ``_exec`` merges stderr into stdout; classifying by SHAPE lets the exit-2 guard
     tell a pure failure (no payload) from a partial one (one unreadable file, others
@@ -134,28 +134,25 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     for line in output.split('\n'):
         if not line.strip():
             continue
-        # Prefix check first: a match path can contain "-<digit>" (".../pytest-686/...").
-        if line.lstrip().startswith(("rg: ", "grep: ")):
-            diagnostics.append(line)
-        elif line == "--" or _SEARCH_OUTPUT_RE.match(line):
-            payload.append(line)
+        if output_mode not in ("files_only", "count"):
+            if line == "--":
+                continue
+            is_record = _SEARCH_CONTENT_LINE_RE.match(line) is not None
         else:
+            is_record = not line.lstrip().startswith(("rg: ", "grep: ")) and bool(_SEARCH_OUTPUT_RE.match(line))
+        if not is_record:
             diagnostics.append(line)
+        else:
+            payload.append(line)
     return '\n'.join(diagnostics), '\n'.join(payload)
 
 
-def _parse_search_context_line(line: str) -> tuple[str, int, str] | None:
-    """Parse a ``path-line-content`` context line using the RIGHTMOST numeric
-    separator (filenames may contain ``-<digits>-`` segments):
-    ``dir/file-12-name.py-8-context`` → (``dir/file-12-name.py``, 8, ``context``)."""
-    if not line or line == "--":
+def _parse_search_content_line(line: str, context: int = 0) -> tuple[str, int, str] | None:
+    """Parse ``path NUL line-number [:|-] text`` without inspecting the text."""
+    match = _SEARCH_CONTENT_LINE_RE.match(line)
+    if match is None or (match.group(3) == "-" and context <= 0):
         return None
-    match = None
-    for candidate in re.finditer(r'-(\d+)-', line):
-        match = candidate
-    if match is None or match.start() == 0:
-        return None
-    return line[:match.start()], int(match.group(1)), line[match.end():]
+    return match.group(1), int(match.group(2)), match.group(4)
 
 
 _REGEX_NEWLINE_ESCAPE_RE = re.compile(r"(?<!\\)(?:\\\\)*\\n")
@@ -188,10 +185,6 @@ def _maybe_warn_line_oriented_newline_pattern(result: SearchResult, pattern: str
     return result
 
 
-# Match lines are "file:lineno:content". Windows paths carry a drive letter
-# ("C:\path"), so a naive split(":") breaks — the regex handles both.
-_MATCH_LINE_RE = re.compile(r'^([A-Za-z]:)?(.*?):(\d+):(.*)$')
-
 # Output-mode → engine flag (identical for rg and grep).
 _OUTPUT_MODE_FLAGS = {"files_only": "-l", "count": "-c"}
 
@@ -203,11 +196,11 @@ def _parse_search_output(result, output_mode: str, limit: int, offset: int,
     errors (one unreadable file), so an error is surfaced only when exit==2 AND no
     usable payload remains. ``warning`` is attached to files_only/content results."""
     stdout, limit_reason = _search_stdout_and_limit(result)
-    diagnostics, payload = _split_tool_diagnostics(stdout)
+    diagnostics, payload = _split_tool_diagnostics(stdout, output_mode)
     if result.exit_code == 2 and not payload.strip():
         error_msg = diagnostics.strip() or result.stdout.strip() or "Search error"
         return SearchResult(error=f"Search failed: {error_msg}", total_count=0)
-    lines = [ln for ln in payload.strip().split('\n') if ln]
+    lines = [ln for ln in payload.split('\n') if ln]
     if output_mode == "files_only":
         return SearchResult(
             files=lines[offset:offset + limit], total_count=len(lines),
@@ -226,19 +219,11 @@ def _parse_search_output(result, output_mode: str, limit: int, offset: int,
             truncated=bool(limit_reason), limit_reason=limit_reason)
     matches = []
     for line in lines:
-        if line == "--":
-            continue
-        m = _MATCH_LINE_RE.match(line)
-        if m:
+        parsed = _parse_search_content_line(line, context)
+        if parsed:
             matches.append(SearchMatch(
-                path=(m.group(1) or '') + m.group(2), line_number=int(m.group(3)), content=m.group(4)[:500],
+                path=parsed[0], line_number=parsed[1], content=parsed[2][:500],
             ))
-            continue
-        # Context lines only when requested, to avoid false positives on dashy paths.
-        if context > 0:
-            parsed = _parse_search_context_line(line)
-            if parsed:
-                matches.append(SearchMatch(path=parsed[0], line_number=parsed[1], content=parsed[2][:500]))
     total = len(matches)
     return SearchResult(
         matches=matches[offset:offset + limit], total_count=total,
@@ -858,7 +843,7 @@ class SearchMixin:
         # keeps a truncated prefix so the model still sees the hit. 2000 cols exceeds
         # the 500-char content clamp, so nothing previously visible is lost.
         if output_mode not in ("files_only", "count"):
-            cmd_parts.extend(["--max-columns", "2000", "--max-columns-preview"])
+            cmd_parts.extend(["--null", "--max-columns", "2000", "--max-columns-preview"])
         # A regex \n hard-errors in line-oriented mode; enable -U up front and say so.
         multiline = _pattern_has_regex_newline(pattern)
         if multiline:
@@ -889,6 +874,8 @@ class SearchMixin:
             parts.extend(["--include", self._escape_shell_arg(file_glob)])
         if output_mode in _OUTPUT_MODE_FLAGS:
             parts.append(_OUTPUT_MODE_FLAGS[output_mode])
+        else:
+            parts.append("--null")
         parts.append(self._escape_shell_arg(pattern))
         return parts
 


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect paths and line numbers in `search_files` context output (`context>0`) when neighboring text contains numeric hyphens or colons.

The context parser chooses the rightmost `-<digits>-`, while the match parser can mistake a numeric colon sequence in context text for a match header. Content searches now request NUL-delimited filenames from both ripgrep and grep, then parse the line number immediately after that boundary. This preserves the numeric-filename case fixed in #19880 without guessing where the filename ends.

## Type of Change

- [x] Bug fix

## Changes Made

- `tools/file_operations_search.py`: use `--null` for content output, share one framed match/context parser, and keep diagnostics and group separators out of results. Preserve whitespace in parsed content while retaining the existing output caps; count and files-only modes retain their current formats.
- `tests/tools/test_search_content_framing.py` and existing search tests: add real-engine round trips, pagination/partial-result checks and malformed-record coverage; update old-format fixtures.

## How to Test

Create `notes-12-name.txt` with:

```text
release-2026-final
NEEDLE
plain context
```

Call `search_files(pattern="NEEDLE", path="notes-12-name.txt", context=1)`. Before the fix, the first row points to `notes-12-name.txt-1-release` at line 2026, with only `final` as its content. It should point to the actual file at line 1 with the complete `release-2026-final` text. `context=0` must still return the hit at line 2.

Run the focused regression tests:

```bash
bash scripts/run_tests.sh -j 2 --file-retries 0 \
  tests/tools/test_search_content_framing.py -q
```

The reproduction fails on unmodified `990473a79c` and passes with the fix. All five changed test files pass in full: **182 passed, 3 Windows-only skips**.

<details>
<summary>Broader validation and limits</summary>

A broader regression run returned **608 passed, 2 failed, 11 skipped**. Both failures in `tests/tools/test_file_tools.py` also occur on the clean baseline under the same conditions:

- `TestWriteFileHandler::test_writes_content`
- `TestPatchHandler::test_replace_mode_calls_patch_replace`

Both expect `/tmp/...` while the handler resolves `/private/tmp/...` on macOS. All skips are Windows- or Linux-only cases.

Validated on macOS with Python 3.11, ripgrep 15.1.0 and Apple grep, isolated temporary homes, and retries disabled. The wider run also covers giant-line containment and multiline searches. Full-repository Ruff, Windows-footgun and compatibility-pointer checks pass. Type-check diagnostic signatures and counts match the baseline, ignoring line-number shifts. `git diff --check` passes.

One exploratory native pagination test with `limit=1` failed with `KeyError: 'matches'`. The full response was not captured; later runs passed, but the cause remains unconfirmed.

The full repository suite, native Linux/Windows execution, and remote/container backends were not run. This does not add support for newline-bearing filenames or change timeout-tail handling.

</details>

## Checklist

- [x] Read the contributing guide and checked related PRs.
- [x] Reproduced the bug on main and added behavior-level tests.
- [x] Verified real local search engines and their selected execution paths.
- [x] Ran the relevant suites and static checks; documented failures and limits.
