### PR TITLE
fix(desktop): offer Start new session on live-owner exclusivity refusals

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -32,7 +32,7 @@ import { $introSplash } from '@/store/intro-splash'
 import { $pinnedSessionIds } from '@/store/layout'
 import { $petActive } from '@/store/pet'
 import { $petOverlayActive } from '@/store/pet-overlay'
-import { $activeGatewayProfile, $gatewaySwapTarget, $hydrationSyncProfile, $profiles } from '@/store/profile'
+import { $activeGatewayProfile, $gatewaySwapTarget, $hydrationSyncProfile, $profiles, requestFreshSession } from '@/store/profile'
 import {
   $connection,
   $contextSuggestions,
@@ -46,6 +46,7 @@ import {
   resolveComposerSessionKey,
   sessionMatchesStoredId,
   sessionPinId,
+  setResumeExhaustedSessionId,
   shouldMigrateComposerScope
 } from '@/store/session'
 import { $focusedStoredSessionId, sessionTileDelegate } from '@/store/session-states'
@@ -705,7 +706,18 @@ const ChatViewContent = memo(function ChatViewContent({
                 description={t.desktop.resumeStrandedBody}
                 title={t.desktop.resumeStrandedTitle}
               >
-                <div className="grid justify-items-center">
+                <div className="flex flex-wrap items-center justify-center gap-2">
+                  <Button
+                    onClick={() => {
+                      // Clear the stranded latch before minting a draft so the
+                      // new session is not immediately covered by this overlay.
+                      setResumeExhaustedSessionId(null)
+                      requestFreshSession()
+                    }}
+                    size="sm"
+                  >
+                    {t.desktop.resumeStartNewSession}
+                  </Button>
                   <Button onClick={() => onRetryResume(routedSessionId)} size="sm" variant="outline">
                     {t.desktop.resumeRetry}
                   </Button>

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.test.tsx
@@ -6,7 +6,7 @@
 // supplied, matching how onDismissError/onRestoreToMessage already behave.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
 import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $displayTimestamps } from '@/store/display-timestamps'
 
@@ -15,6 +15,17 @@ import { stubThreadEnvironment } from '../test-utils'
 import { formatTimelineRange, formatTimelineTimestamp } from './timestamp'
 
 import { Thread } from '.'
+
+const requestFreshSession = vi.hoisted(() => vi.fn())
+
+vi.mock('@/store/profile', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/profile')>()
+
+  return {
+    ...actual,
+    requestFreshSession: () => requestFreshSession()
+  }
+})
 
 // Timeline timestamps render only when `display.timestamps` is enabled.
 $displayTimestamps.set(true)
@@ -25,6 +36,7 @@ stubThreadEnvironment()
 
 afterEach(() => {
   cleanup()
+  requestFreshSession.mockClear()
 })
 
 function userMessage(): ThreadMessage {
@@ -68,6 +80,29 @@ function assistantMessage(): ThreadMessage {
   } as unknown as ThreadMessage
 }
 
+function ownershipRefusalMessage(): ThreadMessage {
+  return {
+    id: 'assistant-error-1',
+    role: 'assistant',
+    content: [],
+    status: {
+      type: 'incomplete',
+      reason: 'error',
+      error:
+        'Session 20260909_095312_6b93f5 already has a live owner (tui, pid 32977, lease age 22m). ' +
+        'Attach through a compatible owner, or close the session in its owning surface before resuming here.'
+    },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as unknown as ThreadMessage
+}
+
 function Harness({
   assistant = assistantMessage(),
   onBranchInNewChat
@@ -104,6 +139,18 @@ describe('AssistantMessage branch button visibility (bug #2 fix)', () => {
     await screen.findByText('done')
 
     expect(screen.queryByRole('button', { name: 'Branch in new chat' })).toBeNull()
+  })
+})
+
+describe('ownership refusal recovery (#106217)', () => {
+  it('offers Start new session and suppresses Retry for live-owner refusals', async () => {
+    render(<Harness assistant={ownershipRefusalMessage()} />)
+
+    expect(await screen.findByRole('button', { name: 'Start new session' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+
+    screen.getByRole('button', { name: 'Start new session' }).click()
+    expect(requestFreshSession).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -43,11 +43,13 @@ import {
   XIcon
 } from '@/lib/icons'
 import { extractPreviewTargets } from '@/lib/preview-targets'
+import { isSessionOwnershipRefusal } from '@/lib/session-ownership-refusal'
 import { markAssistantIdSpoken } from '@/lib/spoken-reply'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notifyError } from '@/store/notifications'
+import { requestFreshSession } from '@/store/profile'
 import { requestSendDiagnostics } from '@/store/send-diagnostics'
 import { $connection, $currentModel } from '@/store/session'
 import { $voicePlayback } from '@/store/voice-playback'
@@ -511,8 +513,11 @@ const ErrorRecoveryActions: FC = () => {
 
   // Retry = assistant-ui reload (same wiring as the footer's refresh action):
   // re-runs the failed turn's prompt in place. Suppressed when the classifier
-  // says the failure is deterministic (retrying reproduces it).
-  const retryable = !surface || surface.retryable
+  // says the failure is deterministic (retrying reproduces it), and when the
+  // error is a live-owner exclusivity refusal (#106217) — Retry just hits the
+  // same 4090 again.
+  const ownershipRefusal = isSessionOwnershipRefusal(errorText)
+  const retryable = (!surface || surface.retryable) && !ownershipRefusal
 
   // Switch Provider deep-links Settings → Models for the layers where the fix
   // is provider/endpoint/auth config, not a retry.
@@ -548,8 +553,18 @@ const ErrorRecoveryActions: FC = () => {
     [errorText, model, surface]
   )
 
+  const startNewSession = useCallback(() => {
+    triggerHaptic('submit')
+    requestFreshSession()
+  }, [])
+
   return (
     <div className="flex flex-wrap items-center gap-1.5">
+      {ownershipRefusal && (
+        <button className="aui-error-action" onClick={startNewSession} type="button">
+          {copy.errorStartNewSession}
+        </button>
+      )}
       {retryable && (
         <ActionBarPrimitive.Reload asChild>
           <button className="aui-error-action" onClick={() => triggerHaptic('submit')} type="button">

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2696,6 +2696,7 @@ export const ar = defineLocale({
         streaming: 'خطأ في اتصال البث'
       },
       errorRetry: 'إعادة المحاولة',
+      errorStartNewSession: 'بدء جلسة جديدة',
       errorSwitchProvider: 'تبديل المزوّد',
       errorOpenLogs: 'فتح السجلات',
       errorOpenLogsFailed: 'تعذّر فتح مجلد السجلات',
@@ -2960,6 +2961,7 @@ export const ar = defineLocale({
     resumeStrandedBody:
       'فشل الاتصال بهذه الجلسة وتوقفت إعادة المحاولة التلقائية. تأكد من تشغيل البوابة، ثم حاول مجددا.',
     resumeRetry: 'إعادة المحاولة',
+    resumeStartNewSession: 'بدء جلسة جديدة',
     nothingToBranch: 'لا يوجد ما يمكن تفريعه',
     branchNeedsChat: 'يحتاج التفريع إلى محادثة',
     sessionBusy: 'الجلسة مشغولة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3550,6 +3550,7 @@ export const en: Translations = {
         streaming: 'Streaming connection error'
       },
       errorRetry: 'Retry',
+      errorStartNewSession: 'Start new session',
       errorSwitchProvider: 'Switch provider',
       errorOpenLogs: 'Open logs',
       errorOpenLogsFailed: 'Could not open the logs folder',
@@ -3767,6 +3768,7 @@ export const en: Translations = {
     resumeStrandedBody:
       'The connection to this session failed and automatic retries gave up. Check that the gateway is running, then try again.',
     resumeRetry: 'Retry',
+    resumeStartNewSession: 'Start new session',
     nothingToBranch: 'Nothing to branch',
     branchNeedsChat: 'Start or resume a chat before branching.',
     sessionBusy: 'Session busy',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3146,6 +3146,7 @@ export const ja = defineLocale({
         streaming: 'ストリーミング接続のエラー'
       },
       errorRetry: '再試行',
+      errorStartNewSession: '新しいセッションを開始',
       errorSwitchProvider: 'プロバイダーを切り替え',
       errorOpenLogs: 'ログを開く',
       errorOpenLogsFailed: 'ログフォルダを開けませんでした',
@@ -3359,6 +3360,7 @@ export const ja = defineLocale({
     resumeStrandedBody:
       'このセッションへの接続に失敗し、自動再試行も停止しました。ゲートウェイが実行中か確認してから、もう一度お試しください。',
     resumeRetry: '再試行',
+    resumeStartNewSession: '新しいセッションを開始',
     nothingToBranch: 'ブランチするものがありません',
     branchNeedsChat: 'ブランチする前にチャットを開始または再開してください。',
     sessionBusy: 'セッションが使用中',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3755,6 +3755,7 @@ export const ru = defineLocale({
     resumeStrandedBody:
       'Соединение с этим сеансом оборвалось, и автоматические повторные попытки исчерпаны. Проверьте, что шлюз работает, и попробуйте снова.',
     resumeRetry: 'Повторить',
+    resumeStartNewSession: 'Начать новую сессию',
     nothingToBranch: 'Нечего ветвить',
     branchNeedsChat: 'Начните или возобновите чат перед ветвлением.',
     sessionBusy: 'Сеанс занят',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3087,6 +3087,8 @@ export interface Translations {
         streaming: string
       }
       errorRetry: string
+      /** Escape hatch when Retry would only reproduce SESSION_NOT_OWNED (#106217). */
+      errorStartNewSession: string
       errorSwitchProvider: string
       errorOpenLogs: string
       errorOpenLogsFailed: string
@@ -3264,6 +3266,8 @@ export interface Translations {
     resumeStrandedTitle: string
     resumeStrandedBody: string
     resumeRetry: string
+    /** Same escape as errorStartNewSession for the full-window stranded overlay (#106217). */
+    resumeStartNewSession: string
     nothingToBranch: string
     branchNeedsChat: string
     sessionBusy: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3039,6 +3039,7 @@ export const zhHant = defineLocale({
         streaming: '串流連線錯誤'
       },
       errorRetry: '重試',
+      errorStartNewSession: '開始新工作階段',
       errorSwitchProvider: '切換服務商',
       errorOpenLogs: '開啟日誌',
       errorOpenLogsFailed: '無法開啟日誌資料夾',
@@ -3221,6 +3222,7 @@ export const zhHant = defineLocale({
     resumeStrandedTitle: '無法載入此工作階段',
     resumeStrandedBody: '與此工作階段的連線失敗，自動重試已停止。請確認閘道正在執行，然後重試。',
     resumeRetry: '重試',
+    resumeStartNewSession: '開始新工作階段',
     nothingToBranch: '沒有可分支的內容',
     branchNeedsChat: '分支前請先開始或繼續一個聊天。',
     sessionBusy: '工作階段忙碌中',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3692,6 +3692,7 @@ export const zh: Translations = {
         streaming: '流式连接错误'
       },
       errorRetry: '重试',
+      errorStartNewSession: '开始新会话',
       errorSwitchProvider: '切换服务商',
       errorOpenLogs: '打开日志',
       errorOpenLogsFailed: '无法打开日志文件夹',
@@ -3894,6 +3895,7 @@ export const zh: Translations = {
     resumeStrandedTitle: '无法加载此会话',
     resumeStrandedBody: '与此会话的连接失败，自动重试已停止。请确认网关正在运行，然后重试。',
     resumeRetry: '重试',
+    resumeStartNewSession: '开始新会话',
     nothingToBranch: '没有可分支的内容',
     branchNeedsChat: '分支前请先开始或恢复一个对话。',
     sessionBusy: '会话忙碌中',

--- a/apps/desktop/src/lib/session-ownership-refusal.test.ts
+++ b/apps/desktop/src/lib/session-ownership-refusal.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSessionOwnershipRefusal } from './session-ownership-refusal'
+
+describe('isSessionOwnershipRefusal', () => {
+  it('matches the active-session exclusivity message', () => {
+    expect(
+      isSessionOwnershipRefusal(
+        'Session 20260909_095312_6b93f5 already has a live owner (tui, pid 32977, lease age 22m). ' +
+          'Its turn activity is unknown; an open lease does not mean a turn is running. ' +
+          'Attach through a compatible owner, or close the session in its owning surface ' +
+          'before resuming here. Do not delete a live owner\'s lease to force a takeover.'
+      )
+    ).toBe(true)
+  })
+
+  it('matches the machine reason code', () => {
+    expect(isSessionOwnershipRefusal('hermes-refusal-reason: SESSION_NOT_OWNED')).toBe(true)
+  })
+
+  it('ignores unrelated turn failures', () => {
+    expect(isSessionOwnershipRefusal('rate limit exceeded')).toBe(false)
+    expect(isSessionOwnershipRefusal('')).toBe(false)
+    expect(isSessionOwnershipRefusal(null)).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/session-ownership-refusal.ts
+++ b/apps/desktop/src/lib/session-ownership-refusal.ts
@@ -1,0 +1,23 @@
+/**
+ * Detect the per-session exclusivity refusal that arrives as a Desktop turn
+ * error (gateway JSON-RPC 4090 → inline assistant error bubble).
+ *
+ * The lease/ownership guard itself is correct; Desktop must still offer an
+ * escape (start a new session) because Retry only reproduces the same refusal.
+ * Match the stable English contract from
+ * `hermes_cli.active_sessions.session_already_owned_message` plus the machine
+ * reason code when present in diagnostics text.
+ */
+export function isSessionOwnershipRefusal(text: string | null | undefined): boolean {
+  const value = (text || '').trim()
+  if (!value) {
+    return false
+  }
+
+  if (/\balready has a live owner\b/i.test(value)) {
+    return true
+  }
+
+  // Machine reason may appear in copied diagnostics or structured error dumps.
+  return /\bSESSION_NOT_OWNED\b/.test(value)
+}


### PR DESCRIPTION
## What does this PR do?

When another surface already holds a session lease, Desktop correctly refuses the turn (`prompt.submit` → JSON-RPC 4090 / `SESSION_NOT_OWNED` with `session_already_owned_message`). The lease guard stays. The bug is UX: the Turn failed card only offered Retry / logs / diagnostics, and Retry just reproduces the same refusal. The stranded-resume overlay similarly only offered Retry while hiding the composer.

This PR adds an explicit **Start new session** escape on:

1. the turn-error recovery actions when the error text is a live-owner exclusivity refusal
2. the full-window stranded-resume overlay (also clears `$resumeExhaustedSessionId` so the new draft is not immediately covered)

It does **not** delete or steal a live owner's lease (force-takeover stays out of scope).

## Related Issue

Fixes #106217

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/lib/session-ownership-refusal.ts` (new): detect live-owner refusal text / `SESSION_NOT_OWNED`
- `apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx`: show Start new session; suppress Retry for ownership refusals
- `apps/desktop/src/app/chat/index.tsx`: stranded overlay Start new session + clear exhausted latch
- i18n keys for en/zh/zh-hant/ja/ar/ru + types
- tests for the detector and the error-card escape action

## How to Test

```bash
cd apps/desktop
npm test -- --run src/lib/session-ownership-refusal.test.ts src/components/assistant-ui/thread/assistant-message.test.tsx
```

Manual:
1. Own a session in `hermes --tui`
2. Open the same session in Desktop and send a message
3. Observe Turn failed with the live-owner message
4. Confirm **Start new session** is offered (Retry is not), and it lands on a usable new draft without touching the TUI lease

## Related work (not duplicates)

- Open lease-reclaim PRs (`#105540`, `#103713`) fix dead/stale leases — different seam from Desktop escape UX
- `#101279` (needs-decision) asks to make exclusivity configurable — not this PR's scope

## Review follow-up

- Matching uses the stable English contract from `session_already_owned_message` plus the machine reason `SESSION_NOT_OWNED`
- Force-takeover / silent lease deletion is intentionally omitted

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched for existing PRs (no exact UX duplicate for #106217)
- [x] PR contains only this fix
- [x] Added focused tests
- [x] Tested reasoning against current `origin/main` (`990473a79c6b`)

### Documentation & Housekeeping
- [x] Docs N/A
- [x] Config example N/A
- [x] Cross-platform: Desktop renderer-only; lease guard unchanged
- [x] Tool schemas N/A


Made with [Cursor](https://cursor.com)