### PR TITLE
fix(skills): Auto-load triggered skills in classic CLI

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -22,6 +22,7 @@ _skill_commands_home: Optional[str] = None
 _publish_lock = threading.Lock()
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_SKILL_TRIGGER_WORD = re.compile(r"^\w[\w\s-]*\w$|^\w$")
 
 # Skill-scaffolding markers. A /skill (or /bundle) turn is expanded into a
 # model-facing message embedding the full skill body; memory providers storing
@@ -147,6 +148,79 @@ def _resolve_skill_commands_home() -> str:
     """
     from hermes_constants import get_hermes_home
     return str(get_hermes_home())
+
+
+def _extract_skill_triggers(frontmatter: Dict[str, Any]) -> list[str]:
+    """Return normalized auto-trigger phrases declared in skill frontmatter."""
+    metadata = frontmatter.get("metadata")
+    hermes_meta = metadata.get("hermes") if isinstance(metadata, dict) else None
+    raw_triggers = None
+    if isinstance(hermes_meta, dict):
+        raw_triggers = hermes_meta.get("triggers")
+    if raw_triggers is None:
+        raw_triggers = frontmatter.get("triggers")
+
+    if raw_triggers is None:
+        return []
+    if not isinstance(raw_triggers, list):
+        raw_triggers = [raw_triggers]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in raw_triggers:
+        trigger = re.sub(r"\s+", " ", str(value or "").strip())
+        if not trigger:
+            continue
+        dedupe_key = trigger.casefold()
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        normalized.append(trigger)
+    return normalized
+
+
+def _compile_skill_trigger_pattern(trigger: str) -> re.Pattern[str]:
+    """Build a boundary-aware regex for a skill trigger phrase."""
+    normalized = re.sub(r"\s+", " ", trigger.strip())
+    body = r"\s+".join(re.escape(part) for part in normalized.split(" "))
+    if _SKILL_TRIGGER_WORD.fullmatch(normalized):
+        pattern = rf"\b{body}\b"
+    else:
+        pattern = rf"(?<!\w){body}(?!\w)"
+    return re.compile(pattern, re.IGNORECASE)
+
+
+def find_triggered_skill_command(
+    user_message: str,
+) -> tuple[str, Dict[str, Any], str] | None:
+    """Return the best matching skill command for a plain user message."""
+    if not isinstance(user_message, str):
+        return None
+
+    text = user_message.strip()
+    if not text or text.startswith("/"):
+        return None
+
+    best_match: tuple[int, int, str, str, Dict[str, Any]] | None = None
+    for cmd_key, skill_info in get_skill_commands().items():
+        for trigger in skill_info.get("triggers") or []:
+            if not _compile_skill_trigger_pattern(trigger).search(text):
+                continue
+            candidate = (
+                len(trigger),
+                len(skill_info.get("name") or ""),
+                cmd_key,
+                trigger,
+                skill_info,
+            )
+            if best_match is None or candidate > best_match:
+                best_match = candidate
+
+    if best_match is None:
+        return None
+
+    _, _, cmd_key, trigger, skill_info = best_match
+    return cmd_key, skill_info, trigger
 
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:
@@ -357,7 +431,8 @@ def _scan_skill_md(skill_md: Path, disabled: set, seen_names: set, commands: Dic
                        name, cmd_key, commands[cmd_key]["name"])
         return
     commands[cmd_key] = {"name": name, "description": description or f"Invoke the {name} skill",
-                         "skill_md_path": str(skill_md), "skill_dir": str(skill_md.parent)}
+                         "skill_md_path": str(skill_md), "skill_dir": str(skill_md.parent),
+                         "triggers": _extract_skill_triggers(frontmatter)}
 
 
 def scan_skill_commands() -> Dict[str, Dict[str, Any]]:

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -201,6 +201,14 @@ def find_triggered_skill_command(
     if not text or text.startswith("/"):
         return None
 
+    # Operator opt-out (`skills.auto_triggers: false`); explicit `/skill`
+    # loads bypass this function entirely and keep working.
+    try:
+        if not _load_skills_config().get("auto_triggers", True):
+            return None
+    except Exception:
+        pass
+
     best_match: tuple[int, int, str, str, Dict[str, Any]] | None = None
     for cmd_key, skill_info in get_skill_commands().items():
         for trigger in skill_info.get("triggers") or []:

--- a/contributors/emails/ultrainstinct0x@users.noreply.github.com
+++ b/contributors/emails/ultrainstinct0x@users.noreply.github.com
@@ -1,0 +1,1 @@
+UltraInstinct0x

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -290,7 +290,25 @@ class CLIChatTurnMixin:
         except Exception:
             reset_current_session_key = None  # type: ignore[assignment]
             _approval_session_token = None
-        agent_message = turn.voice_prefix + message if turn.voice_prefix else message
+        from agent.skill_commands import build_skill_invocation_message, find_triggered_skill_command
+        from cli import _cprint, _DIM, _RST
+
+        agent_message = message
+        matched = find_triggered_skill_command(message)
+        if matched:
+            cmd_key, skill_info, trigger = matched
+            expanded = build_skill_invocation_message(
+                cmd_key, user_instruction=message, task_id=self.session_id,
+                runtime_note=f'Auto-activated from skill trigger "{trigger}".',
+            )
+            if expanded:
+                agent_message = expanded
+                _cprint(
+                    f"  {_DIM}⚡ Auto-loading skill: "
+                    f"{skill_info.get('name') or cmd_key.lstrip('/')} "
+                    f"(trigger: {trigger}){_RST}"
+                )
+        agent_message = turn.voice_prefix + agent_message if turn.voice_prefix else agent_message
         # One-shot /model and /reload-skills notes; _prepend_note_to_message also handles
         # multimodal content-part lists (string concat raised TypeError with an image).
         for _note_attr in ("_pending_model_switch_note", "_pending_skills_reload_note"):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1357,6 +1357,10 @@ DEFAULT_CONFIG = {
         # curator ledger` / `rollback <entry-id>`. Never a gate — failures can't block.
         # See #79686.
         "ledger": True,
+        # Deterministic phrase triggers (`metadata.hermes.triggers`): matched plain
+        # turns auto-load the skill through the existing invocation path. false =
+        # never trigger-match; explicit `/skill` loads still work.
+        "auto_triggers": True,
     },
     # Curator — background maintenance of AGENT-CREATED skills (never hub-installed): marks
     # long-unused skills stale, archives (never deletes) obsolete ones, optionally consolidates

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -18,7 +18,10 @@ Reviewing a skill PR: check the target directory — heavy-dep or niche skills g
 `name`, `description`, `version`, `author`, `license`, `platforms` (OS gate: `[macos]`,
 `[linux, macos]`, ...), `metadata.hermes.tags`, `metadata.hermes.category`,
 `metadata.hermes.related_skills`, `metadata.hermes.config` (config.yaml settings the skill needs —
-stored under `skills.config.<key>`, prompted during setup, injected at load). Top-level `tags:` /
+stored under `skills.config.<key>`, prompted during setup, injected at load),
+`metadata.hermes.triggers` (opt-in plain-phrase auto-loading in the classic CLI;
+literal case-insensitive phrases, longest match wins, off with
+`skills.auto_triggers: false`). Top-level `tags:` /
 `category:` are accepted and mirrored from `metadata.hermes.*` by the loader.
 
 ## Authoring standards (HARDLINE — enforced by `tests/skills/test_authoring_standards.py`)

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -125,6 +125,27 @@ class TestScanSkillCommands:
                     assert matched is not None
                     assert matched[0] == winner
 
+    @pytest.mark.parametrize("skills_cfg", [{"auto_triggers": False}, {"auto_triggers": 0}])
+    def test_trigger_matching_respects_operator_opt_out(self, tmp_path, skills_cfg):
+        import agent.skill_commands as sc_mod
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "market-watch", frontmatter_extra="metadata:\n  hermes:\n    triggers: [market]\n")
+            scan_skill_commands()
+            with patch.object(sc_mod, "_load_skills_config", return_value=skills_cfg):
+                assert find_triggered_skill_command("What is the market doing today?") is None
+
+    def test_trigger_matching_defaults_to_enabled(self, tmp_path):
+        import agent.skill_commands as sc_mod
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "market-watch", frontmatter_extra="metadata:\n  hermes:\n    triggers: [market]\n")
+            scan_skill_commands()
+            with patch.object(sc_mod, "_load_skills_config", return_value={}):
+                matched = find_triggered_skill_command("What is the market doing today?")
+                assert matched is not None
+                assert matched[0] == "/market-watch"
+
     def test_loads_skill_invocation_from_symlinked_skill_dir(self, tmp_path):
         """Slash commands should load skills symlinked under the local skills dir."""
         external_root = tmp_path / "external"

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -334,7 +334,7 @@ class TestScanSkillCommands:
 
         profile_b = tmp_path / "profiles" / "b"
         _make_skill(profile_b / "skills", "b-only", body="Body of b-only.")
-        (profile_b / "config.yaml").write_text("{}\n")
+        (profile_b / "config.yaml").write_text("{}\n", encoding="utf-8")
 
         with (
             patch.object(sc_mod, "_skill_commands", {}),

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -10,6 +10,7 @@ import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    find_triggered_skill_command,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -34,7 +35,7 @@ description: Description for {name}.
 
 {body}
 """
-    (skill_dir / "SKILL.md").write_text(content)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 
 
@@ -52,11 +53,77 @@ def _symlink_category(skills_dir: Path, linked_root: Path, category: str) -> Pat
 
 class TestScanSkillCommands:
 
+    def test_reads_frontmatter_triggers(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "market-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [market, EUR/USD, market]\n"
+                ),
+            )
+            result = scan_skill_commands()
 
+        assert result["/market-watch"]["triggers"] == ["market", "EUR/USD"]
 
+    def test_finds_triggered_skill_by_word_boundary(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "market-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [market]\n"
+                ),
+            )
+            scan_skill_commands()
+            matched = find_triggered_skill_command("What is the market doing today?")
+            not_matched = find_triggered_skill_command("This supermarket is busy.")
 
+        assert matched is not None
+        assert matched[0] == "/market-watch"
+        assert matched[2] == "market"
+        assert not_matched is None
 
+    def test_finds_triggered_skill_with_punctuation_phrase(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "fx-watch",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    triggers: [EUR/USD]\n"
+                ),
+            )
+            scan_skill_commands()
+            matched = find_triggered_skill_command("What is happening with EUR/USD today?")
 
+        assert matched is not None
+        assert matched[0] == "/fx-watch"
+        assert matched[2] == "EUR/USD"
+
+    @pytest.mark.parametrize(("left", "right", "message", "winner"), [
+        (("longer-name", "market"), ("fx", "EUR/USD"), "market EUR/USD", "/fx"),
+        (("longer-name", "market"), ("fx", "market"), "market", "/longer-name"),
+        (("aa", "market"), ("zz", "market"), "market", "/zz"),
+        (("aa", "market outlook"), ("zz", "market"), "MARKET\n  outlook", "/aa"),
+    ])
+    def test_trigger_selection_is_specific_and_order_independent(self, tmp_path, left, right, message, winner):
+        import agent.skill_commands as sc_mod
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            for name, trigger in (left, right):
+                _make_skill(tmp_path, name, frontmatter_extra=f"metadata:\n  hermes:\n    triggers: ['{trigger}']\n")
+            commands = scan_skill_commands()
+            for ordered in (commands, dict(reversed(list(commands.items())))):
+                with patch.object(sc_mod, "get_skill_commands", return_value=ordered):
+                    matched = find_triggered_skill_command(message)
+                    assert matched is not None
+                    assert matched[0] == winner
 
     def test_loads_skill_invocation_from_symlinked_skill_dir(self, tmp_path):
         """Slash commands should load skills symlinked under the local skills dir."""
@@ -703,7 +770,7 @@ class TestBuildSkillInvocationMessage:
             skill_dir = _make_skill(tmp_path, "test-skill")
             references = skill_dir / "references"
             references.mkdir()
-            (references / "api.md").write_text("reference")
+            (references / "api.md").write_text("reference", encoding="utf-8")
             scan_skill_commands()
             msg = build_skill_invocation_message("/test-skill", "do stuff")
 
@@ -730,7 +797,7 @@ class TestSkillDirectoryHeader:
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = _make_skill(tmp_path, "scripted-skill")
             (skill_dir / "scripts").mkdir()
-            (skill_dir / "scripts" / "run.js").write_text("console.log('hi')")
+            (skill_dir / "scripts" / "run.js").write_text("console.log('hi')", encoding="utf-8")
             scan_skill_commands()
             msg = build_skill_invocation_message("/scripted-skill")
 

--- a/tests/cli/test_cli_auto_skill_triggers.py
+++ b/tests/cli/test_cli_auto_skill_triggers.py
@@ -1,0 +1,69 @@
+"""Classic CLI triggers use real skill loading without changing durable input."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent import skill_commands
+from hermes_cli.cli_chat_turn_mixin import CLIChatTurnMixin
+
+
+@pytest.fixture
+def trigger_turn(tmp_path, monkeypatch):
+    import tools.skills_tool as skills_tool
+
+    skills = tmp_path / "skills"
+    skill = skills / "market-watch"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: market-watch\ndescription: Market analysis.\n"
+        "metadata:\n  hermes:\n    triggers: [market, EUR/USD]\n---\n"
+        "Use verified market sources.\n", encoding="utf-8",
+    )
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills)
+    monkeypatch.setattr(skill_commands, "_skill_commands", {})
+    skill_commands.scan_skill_commands()
+    shell = SimpleNamespace(
+        session_id="trigger-test", agent=SimpleNamespace(run_conversation=MagicMock(return_value={})),
+        conversation_history=[], _sudo_password_callback=None, _approval_callback=None,
+        _secret_capture_callback=None, _flush_credit_notices=lambda: None,
+    )
+    return shell, SimpleNamespace(voice_prefix="", stream_callback=None, result=None)
+
+
+@pytest.mark.parametrize("voice_prefix", ["", "[Voice input] "])
+def test_trigger_expansion_preserves_original_turn(trigger_turn, voice_prefix):
+    shell, turn = trigger_turn
+    turn.voice_prefix = voice_prefix
+    message = "What is happening with eur/usd today?"
+    prior = {"role": "assistant", "content": "Previous response."}
+    staged = {"role": "user", "content": message}
+    shell.conversation_history = [prior, staged]
+
+    CLIChatTurnMixin._chat_run_agent(shell, turn, message)
+
+    kwargs = shell.agent.run_conversation.call_args.kwargs
+    expanded = kwargs["user_message"]
+    assert "Use verified market sources." in expanded
+    assert expanded.startswith(voice_prefix + "[IMPORTANT:")
+    assert skill_commands.extract_user_instruction_from_skill_message(
+        expanded.removeprefix(voice_prefix)
+    ) == message
+    assert kwargs["persist_user_message"] == message
+    assert kwargs["conversation_history"] == [prior]
+    assert shell.conversation_history == [prior, staged]
+
+
+@pytest.mark.parametrize("message", [
+    "Tell me a joke.", "This supermarket is busy.", "/market-watch market",
+    "", [{"type": "text", "text": "market"}],
+])
+def test_non_trigger_turns_pass_through(trigger_turn, message):
+    shell, turn = trigger_turn
+    shell.conversation_history = [{"role": "user", "content": message}]
+
+    CLIChatTurnMixin._chat_run_agent(shell, turn, message)
+
+    kwargs = shell.agent.run_conversation.call_args.kwargs
+    assert kwargs["user_message"] == message
+    assert kwargs["persist_user_message"] is None

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -27,7 +27,7 @@ from add_contributor import add_contributor, read_mapping_file  # noqa: E402
 def test_loader_reads_login_from_first_noncomment_line(tmp_path):
     d = tmp_path / "emails"
     d.mkdir()
-    (d / "jane@example.com").write_text("# salvage PR #1\njanedoe\n# trailing note\n")
+    (d / "jane@example.com").write_text("# salvage PR #1\njanedoe\n# trailing note\n", encoding="utf-8")
     mapping = release._load_contributor_dir(d)
     assert mapping == {"jane@example.com": "janedoe"}
 
@@ -66,7 +66,7 @@ def test_add_creates_mapping_file(emails_dir):
     path = emails_dir / "new@example.com"
     assert path.is_file()
     assert read_mapping_file(path) == "newperson"
-    assert "# PR #999 salvage" in path.read_text()
+    assert "# PR #999 salvage" in path.read_text(encoding="utf-8")
 
 
 
@@ -107,7 +107,7 @@ def test_cli_entrypoint_end_to_end(tmp_path):
             (SCRIPTS_DIR / name).read_text(encoding="utf-8"), encoding="utf-8"
         )
     # Minimal stub release.py so the legacy lookup import works
-    (scripts / "release.py").write_text("LEGACY_AUTHOR_MAP = {}\n")
+    (scripts / "release.py").write_text("LEGACY_AUTHOR_MAP = {}\n", encoding="utf-8")
     proc = subprocess.run(
         [sys.executable, str(scripts / "add_contributor.py"),
          "cli@example.com", "cliperson", "via subprocess"],
@@ -150,21 +150,22 @@ def test_no_case_insensitive_mapping_collisions():
 def test_add_contributor_refuses_a_case_collision(tmp_path, monkeypatch):
     d = tmp_path / "emails"
     d.mkdir()
-    (d / "agent@Example-Host.local").write_text("someone\n")
+    (d / "agent@Example-Host.local").write_text("someone\n", encoding="utf-8")
 
     import add_contributor as mod
 
     monkeypatch.setattr(mod, "EMAILS_DIR", d)
 
     assert mod.add_contributor("agent@example-host.local", "otherperson") == 1
-    assert not (d / "agent@example-host.local").exists()
+    assert [entry.name for entry in d.iterdir()] == ["agent@Example-Host.local"]
+    assert (d / "agent@Example-Host.local").read_text(encoding="utf-8") == "someone\n"
 
 
 def test_add_contributor_refuses_case_collision_even_for_same_login(emails_dir, capsys):
     # Same login, different spelling: still refused — the problem is the
     # filename pair, not the login. The exact spelling is what's "present".
     emails_dir.mkdir(parents=True)
-    (emails_dir / "Foo@Example.com").write_text("foouser\n")
+    (emails_dir / "Foo@Example.com").write_text("foouser\n", encoding="utf-8")
 
     assert add_contributor("foo@example.com", "foouser") == 1
     assert "Foo@Example.com" in capsys.readouterr().err
@@ -176,6 +177,6 @@ def test_add_contributor_refuses_case_collision_even_for_same_login(emails_dir, 
 def test_case_collision_uses_casefold(emails_dir):
     # casefold, not lower: matches how macOS/Windows fold non-ASCII (ß ~ ss).
     emails_dir.mkdir(parents=True)
-    (emails_dir / "strasse@example.com").write_text("someone\n")
+    (emails_dir / "strasse@example.com").write_text("someone\n", encoding="utf-8")
     assert add_contributor("STRASSE@example.com", "someone") == 1
     assert add_contributor("straße@example.com", "someone") == 1

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -57,6 +57,7 @@ metadata:
   hermes:
     tags: [Category, Subcategory, Keywords]
     related_skills: [other-skill-name]
+    triggers: ["my workflow"]           # Optional: classic CLI phrase activation
     requires_toolsets: [web]            # Optional — only show when these toolsets are active
     requires_tools: [web_search]        # Optional — only show when these tools are available
     fallback_for_toolsets: [browser]    # Optional — hide when these toolsets are active
@@ -96,6 +97,55 @@ Known failure modes and how to handle them.
 
 ## Verification
 How the agent confirms it worked.
+```
+
+### Deterministic trigger metadata
+
+`metadata.hermes.triggers` opts a skill into phrase-based activation in the
+**classic CLI only**. It does not wire automatic routing into the Ink TUI,
+Desktop, messaging gateway, or ACP.
+
+```yaml
+metadata:
+  hermes:
+    triggers:
+      - market outlook
+      - "EUR/USD"
+```
+
+Prefer a list of strings. A scalar is treated as a one-item list. For
+compatibility, top-level `triggers` is used when the nested value is absent
+or null; an explicit nested `[]` disables that fallback. Values are converted
+to text, stripped, whitespace-normalized, and deduplicated case-insensitively;
+empty values are dropped.
+
+Matching uses escaped literal phrases with case-insensitive regexes and
+flexible inter-word whitespace. Word-like phrases use word boundaries;
+phrases containing punctuation use negative word-character lookarounds.
+Thus `market` does not match `supermarket`, and `EUR/USD` does not match
+`xEUR/USDy`. No semantic inference or user-supplied regex execution occurs.
+
+Selection compares, in descending order: normalized trigger length, skill
+name length, slash command key, then the trigger string. The last two
+comparisons are lexicographic and case-sensitive. Exactly one registered
+skill wins; there is no multi-skill expansion or second-choice fallback if
+loading that winner fails. Avoid broad or competing phrases.
+
+`agent/skill_commands.py` extracts triggers during the existing filtered
+command scan and exposes `find_triggered_skill_command()`. The classic CLI's
+`hermes_cli/cli_chat_turn_mixin.py` resolves a string turn before adding voice
+and runtime notes, then calls `build_skill_invocation_message()` with the
+original instruction and session ID. The existing `persist_user_message`
+path keeps the original input in storage. System-prompt state and prior
+conversation messages are unchanged. Explicit slash input, empty input, and
+multimodal content-part lists bypass matching. Trigger edits take effect
+after `/reload-skills` or a fresh session.
+
+The [user guide](../user-guide/features/skills.md#automatic-triggers-classic-cli)
+includes setup and matching examples. To validate changes:
+
+```bash
+scripts/run_tests.sh tests/agent/test_skill_commands.py tests/cli/test_cli_auto_skill_triggers.py
 ```
 
 ### Platform-Specific Skills

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -139,7 +139,9 @@ original instruction and session ID. The existing `persist_user_message`
 path keeps the original input in storage. System-prompt state and prior
 conversation messages are unchanged. Explicit slash input, empty input, and
 multimodal content-part lists bypass matching. Trigger edits take effect
-after `/reload-skills` or a fresh session.
+after `/reload-skills` or a fresh session. Operators can switch all matching
+off with `skills.auto_triggers: false` (default `true`); explicit slash
+loads are unaffected.
 
 The [user guide](../user-guide/features/skills.md#automatic-triggers-classic-cli)
 includes setup and matching examples. To validate changes:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -227,7 +227,9 @@ still apply. Messages starting with `/`, empty input, and multimodal
 content-part lists are not trigger-matched.
 
 Use specific phrases to avoid accidental activation. Omit `triggers` (or set
-it to `[]`) to leave a skill without deterministic auto-loading. After editing
+it to `[]`) to leave a skill without deterministic auto-loading. Operators
+can disable all trigger matching with `skills.auto_triggers: false` in
+config.yaml; explicit `/skill` loads keep working. After editing
 frontmatter, run `/reload-skills` or start a new session to refresh the scan.
 A matching turn goes through the existing skill invocation loader; it does
 not change the system prompt or rewrite earlier messages. The original user

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -170,6 +170,7 @@ metadata:
   hermes:
     tags: [python, automation]
     category: devops
+    triggers: ["my workflow"]        # Optional: classic CLI phrase activation
     fallback_for_toolsets: [web]    # Optional — conditional activation (see below)
     requires_toolsets: [terminal]   # Optional — conditional activation (see below)
     config:                          # Optional — config.yaml settings
@@ -194,6 +195,44 @@ Trigger conditions for this skill.
 ## Verification
 How to confirm it worked.
 ```
+
+### Automatic triggers (classic CLI)
+
+A skill can opt into deterministic loading from ordinary messages with
+`metadata.hermes.triggers` in its `SKILL.md` frontmatter:
+
+```yaml
+metadata:
+  hermes:
+    triggers: [market, "EUR/USD", "market outlook"]
+```
+
+In the **classic CLI**, `What is happening with EUR/USD today?` loads that
+skill before the agent runs, without a slash command. The CLI prints an
+`Auto-loading skill` notice. This trigger routing does **not** apply to the
+Ink TUI, Desktop, messaging gateway, or ACP; their normal explicit skill
+invocation and agent-selected loading remain unchanged.
+
+Triggers are literal, case-insensitive phrases, not regular expressions or
+semantic matching. Words must have boundaries: `market` matches `market!`
+but not `supermarket`. Punctuation is literal (`EUR/USD` keeps its slash),
+and whitespace between phrase words can vary. Blank triggers are ignored
+and case-insensitive duplicates are removed.
+
+Only one skill is selected per turn: the longest matching trigger wins.
+Ties prefer the longer skill name, then the lexicographically greatest slash
+command key. Only skills registered in the current skill-command scan are
+eligible, so its disabled-skill, platform, environment, and collision filters
+still apply. Messages starting with `/`, empty input, and multimodal
+content-part lists are not trigger-matched.
+
+Use specific phrases to avoid accidental activation. Omit `triggers` (or set
+it to `[]`) to leave a skill without deterministic auto-loading. After editing
+frontmatter, run `/reload-skills` or start a new session to refresh the scan.
+A matching turn goes through the existing skill invocation loader; it does
+not change the system prompt or rewrite earlier messages. The original user
+input remains the durable transcript value. If the selected skill cannot be
+loaded, the original message is sent without trigger expansion.
 
 ### Platform-Specific Skills
 


### PR DESCRIPTION
## Summary

Continues #55674 by @konsisumer, preserving the original contributor's Git authorship. This continuation rebases the implementation onto current main, integrates it into the current classic CLI chat-turn mixin, and adds documentation and an operator opt-out. It does not close or modify #55674.

- Read `metadata.hermes.triggers` through the existing profile-aware, filtered skill-command scan.
- Match literal, case-insensitive phrases with word boundaries and flexible whitespace. Select one skill deterministically, preferring the longest matching trigger; document normalization and tie-breaking.
- Add `skills.auto_triggers` (default `true`). Setting it to `false` disables deterministic matching without disabling explicit or model-selected skill loading.
- Use the existing invocation and `persist_user_message` paths: preserve original user input in transcripts without changing the system prompt or prior messages.
- Document setup, matching, refresh behavior, opt-out, and implementation in the user/developer skill guides and `skills/AGENTS.md`.

**Scope: classic CLI only.** No Ink TUI, Desktop, messaging gateway, or ACP changes. Those integrations belong in separate PRs.

## Verification

### CI attribution follow-up, final commit

Final tested HEAD: `cd0d34c49be1ed4a33488d50df667b384c11e713`.

- Added `contributors/emails/ultrainstinct0x@users.noreply.github.com` mapping to `UltraInstinct0x`, verified against GitHub's commit-author association. Existing commit authorship is unchanged; `scripts/release.py` is untouched.
- The additional contributor tests exposed a case-sensitive-filesystem assumption, reproduced on unmodified main (`990473a79c6b0396b0a648fdd85ee8f7a5c267d3`). Corrected the test to verify the original filename and contents survive a refused collision. Added explicit UTF-8 to the touched fixture file for the Windows-footgun gate. No production behavior or workflow gates changed.
- Native macOS: `scripts/run_tests.sh tests/agent/test_skill_commands.py tests/cli/ tests/scripts/test_contributor_map.py -j 2`: **1,475 passed, 0 failed, 9 skipped**, 136 files, exit 0.
- `scripts/audit_pr_attribution.py`, Ruff on all six changed Python files, the Windows-footgun static check, and `git diff --check origin/main...HEAD`: passed.
- Live smoke and Linux/doc receipts below remain attached to their original feature SHAs; they were not rerun for these attribution-only and test-only follow-ups.

### Native macOS, original published feature commit

Tested HEAD: `0d9dd2e70bb04c39dcf3cba524f6c5b321928000`
Base: `990473a79c6b0396b0a648fdd85ee8f7a5c267d3`

macOS 27.0 (26A5425a), arm64, Python 3.12.14 in an isolated project `.venv`, installed with `uv sync --locked --extra dev --python /opt/homebrew/bin/python3.12`.

- `scripts/run_tests.sh tests/agent/test_skill_commands.py tests/cli/ -j 2`: **1,464 passed, 0 failed, 9 skipped**, 135 files, exit 0.
- `scripts/run_tests.sh tests/agent/test_skill_commands.py tests/cli/test_cli_auto_skill_triggers.py -j 2`: **47 passed, 0 failed**, exit 0.
- Ruff 0.15.10 on all five changed Python files: exit 0.
- `.venv/bin/python scripts/check-windows-footguns.py --diff origin/main`: exit 0. This is a static check, not native Windows execution.
- `git diff --check origin/main...HEAD` and `git diff --check`: both exit 0.

Automated live runs of the patched classic CLI used separate temporary homes and `gpt-6-astra` via `openai-codex`:

- `please check purple banana`: automatic-loading notice present.
- Fresh session `purple bananas`: automatic-loading notice absent.
- `skills.auto_triggers: false` with the exact matching phrase: automatic-loading notice absent.
- All three exited 0. SQLite readback confirmed exactly the original user input was persisted in each session.

The model independently called `skill_view` in all three sessions. That call and its response were not used as deterministic-loading evidence; the CLI notice was. These were automated live checks, not human-verified smoke tests. The optional tirith scanner was unavailable and reported its pattern-matching fallback.

### Oracle Linux, transferred pre-rebase commit

Fresh supplied logs for `4f51fba8e40be14040ca6b3eff0749ae29ec3f95`:

- `current-audit-tests.log`: **47 passed, 0 failed**.
- `current-audit-cli.log`: **1,465 passed, 0 failed, 8 skipped**, 135 files.
- `current-audit-docs.log`: English and Chinese static builds succeeded. The Chinese build emitted broken-link and broken-anchor warnings; their baseline status has not been established.

These Linux receipts are from before the final macOS rebase, not Linux execution of the final SHA. Upstream's intervening commit only formatted Desktop files; `git range-diff` confirmed all three feature commits were unchanged by the rebase.

**Coverage limits:** targeted skill-command and classic CLI suites, not the full repository suite. No native Windows run. Docs were not rebuilt on macOS.
