### PR TITLE
fix(agent): bound tool-activity heartbeat so wedged calls cannot pin sessions at now

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -560,6 +560,11 @@ def _set_worker_activity_callback(agent) -> None:
 
 # Must stay far below the gateway turn-inactivity timeout (default 1800s) so a silent tool never looks idle.
 _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S = 30.0
+# Hard ceiling for mid-call stamps (#106244). Matches the default gateway inactivity budget /
+# browser_exec max timeout so a healthy long tool stays covered, but a wedged call whose own
+# timeout never surfaces (e.g. subprocess pipe drain stuck after TimeoutExpired) cannot keep
+# refreshing SessionDB ``last_activity_at`` (and the in-memory watchdog clock) forever.
+_TOOL_ACTIVITY_HEARTBEAT_MAX_DURATION_S = 1800.0
 
 
 def _run_tool_activity_heartbeat(
@@ -567,12 +572,23 @@ def _run_tool_activity_heartbeat(
     stop_event: threading.Event,
     label: str,
     interval: float = _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S,
+    max_duration: float = _TOOL_ACTIVITY_HEARTBEAT_MAX_DURATION_S,
 ) -> None:
     """Daemon thread stamping ``agent._touch_activity`` every ``interval`` seconds until
     ``stop_event`` is set, so the gateway inactivity watchdog never abandons a turn whose
-    tool runs silently. Wedged tools stay bounded by the tool layer's own timeouts."""
+    tool runs silently.
+
+    Stamps also stop once ``max_duration`` elapses even if ``fn()`` is still wedged: tool-layer
+    timeouts are supposed to bound the call, but some paths (pipe-held grandchildren after a
+    killed CLI child) never return, and an unbounded heartbeat would pin desktop sidebar
+    recency at "now" indefinitely (#106244). After the ceiling, both the DB projection and the
+    in-memory activity clock freeze so the inactivity watchdog can eventually reclaim the turn.
+    """
+    deadline = time.monotonic() + max(0.0, float(max_duration))
     try:
         while not stop_event.wait(interval):
+            if time.monotonic() >= deadline:
+                break
             agent._touch_activity(label)
     except Exception:
         pass  # a heartbeat must never break the agent loop
@@ -585,10 +601,14 @@ def _run_with_activity_heartbeat(agent, function_name: str, fn):
         # Keep the gateway turn-inactivity watchdog from abandoning a turn whose tool call runs silently for
         # longer than the inactivity timeout (#84491): stamp activity periodically while the tool is in
         # flight, not just at start/completion. Both the sequential and the concurrent paths funnel through
-        # here, so a single heartbeat covers every tool.
+        # here, so a single heartbeat covers every tool. Duration is capped (#106244) so a wedged tool
+        # cannot keep SessionDB ``last_activity_at`` fresh forever.
         target=_run_tool_activity_heartbeat,
         args=(agent, stop, f"tool running: {function_name}"),
-        kwargs={"interval": _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S},
+        kwargs={
+            "interval": _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S,
+            "max_duration": _TOOL_ACTIVITY_HEARTBEAT_MAX_DURATION_S,
+        },
         daemon=True,
         name=f"tool-activity-hb-{function_name[:24]}",
     )

--- a/tests/run_agent/test_tool_activity_heartbeat.py
+++ b/tests/run_agent/test_tool_activity_heartbeat.py
@@ -230,6 +230,52 @@ def test_heartbeat_stops_when_execute_raises(monkeypatch):
     assert len(touches) == n, "heartbeat thread kept running after execute() raised"
 
 
+def test_wedged_tool_heartbeat_stops_after_max_duration(monkeypatch):
+    """A call that never returns must not stamp activity forever (#106244).
+
+    ``browser_exec`` can wedge past its own TimeoutExpired (grandchild holds
+    stdout pipes), so the tool-layer timeout never surfaces and ``fn()`` never
+    returns. Without a wall-clock ceiling the heartbeat would keep refreshing
+    SessionDB ``last_activity_at`` and pin desktop sidebar rows at "now".
+    """
+    import agent.tool_executor as te
+
+    monkeypatch.setattr(te, "_TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S", 0.05)
+    monkeypatch.setattr(te, "_TOOL_ACTIVITY_HEARTBEAT_MAX_DURATION_S", 0.18)
+
+    agent = _make_agent(monkeypatch)
+    touches: list = []
+    agent._touch_activity = lambda desc: touches.append((time.time(), desc))
+
+    release = threading.Event()
+
+    def _wedged():
+        release.wait(timeout=2.0)
+        return {"ok": True}
+
+    result_box: list = []
+
+    def _runner():
+        result_box.append(te._run_with_activity_heartbeat(agent, "browser_exec", _wedged))
+
+    worker = threading.Thread(target=_runner, daemon=True)
+    worker.start()
+
+    # Past the ceiling: several intervals should have fired, then stopped.
+    time.sleep(0.45)
+    n = len(touches)
+    assert n >= 2, f"expected mid-call heartbeats before ceiling, got {n}"
+    assert all(desc == "tool running: browser_exec" for _, desc in touches)
+    time.sleep(0.25)
+    assert len(touches) == n, (
+        f"heartbeat kept stamping after max_duration (grew {n} -> {len(touches)})"
+    )
+
+    release.set()
+    worker.join(timeout=2.0)
+    assert result_box == [{"ok": True}]
+
+
 def test_concurrent_tool_call_heartbeat(monkeypatch):
     """Concurrent execution also stamps activity via the shared chokepoint."""
     import agent.tool_executor as te


### PR DESCRIPTION
## What does this PR do?

Addresses the session-sidebar half of #106244: when a tool call wedges so badly that its own timeout never surfaces (observed with `browser_exec` after `TimeoutExpired` leaves a grandchild holding stdout/stderr pipes), `_run_with_activity_heartbeat` previously stamped `agent._touch_activity("tool running: …")` forever. That kept SessionDB `last_activity_at` advancing and pinned finished Desktop sessions at "now".

This PR adds a wall-clock ceiling (`_TOOL_ACTIVITY_HEARTBEAT_MAX_DURATION_S = 1800`) on the shared mid-call heartbeat chokepoint. Healthy long tools stay covered for the same budget as the default gateway inactivity timeout / `browser_exec` max timeout; after the ceiling, both the DB projection and the in-memory activity clock freeze so the inactivity watchdog can eventually reclaim the turn.

Out of scope here: fixing the `browser_exec` pipe-drain wedge itself (active work on `tools/browser_use_cli.py` in #99527 / related daemon lifecycle PRs). This change is intentionally limited to `agent/tool_executor.py`.

## Related Issue

Addresses #106244

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes a bug)
- [x] ✅ Tests

## Changes Made

- `agent/tool_executor.py`: add `_TOOL_ACTIVITY_HEARTBEAT_MAX_DURATION_S`; stop mid-call stamps once the ceiling elapses even if `fn()` is still wedged; correct the docstring that claimed tool-layer timeouts alone bound wedged calls
- `tests/run_agent/test_tool_activity_heartbeat.py`: regression for a never-returning tool — heartbeats fire, then stop after the ceiling

## How to Test

```bash
# Against this head (origin/main base 990473a79c6b)
uv run pytest tests/run_agent/test_tool_activity_heartbeat.py -q
# -> 6 passed
```

Proof receipt:
- BEFORE (main): `_run_tool_activity_heartbeat` loops only on `stop_event`; a wedged `fn()` never sets it → unbounded stamps (code at `agent/tool_executor.py` on `990473a79c6b`)
- AFTER (this PR): with interval/ceiling monkeypatched short, `test_wedged_tool_heartbeat_stops_after_max_duration` shows ≥2 mid-call stamps then a frozen count while `fn()` is still blocked
- CONTROL: existing fast-tool / raise / concurrent heartbeat tests still pass (no change to in-flight refresh within the ceiling)

## Related work (not duplicates)

- #99527 / #95001 — Browser Use daemon lifecycle on `browser_use_cli.py`; complementary to the wedge root cause, does not bound the activity heartbeat
- #80832 — forces a terminal `last_activity_at` stamp when too few heartbeats persist; opposite symptom
- #102987 — ignores heartbeat-only mtime in `sessions.changed` fingerprint; does not stop `last_activity_at` advancing
- #84514 — introduced/kept silent-tool heartbeats for #84491; this PR preserves that coverage up to 1800s, then stops so a wedge cannot immortalize the turn

## Review follow-up

- Ceiling is 1800s on purpose: same order as gateway inactivity default and `browser_exec` max timeout, so legitimate long tools stay covered; only post-timeout wedges lose refresh
- Claim scope is heartbeat bounding only; sidebar can still look ~30m-fresh until the watchdog reclaims — far better than "now" for days

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run relevant tests locally (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin arm64)

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if config keys changed — N/A
- [x] I've considered cross-platform impact — pure Python wall-clock bound; no OS-specific paths
- [x] I've updated tool descriptions/schemas if tool behavior changed — N/A


Made with [Cursor](https://cursor.com)