### PR TITLE
fix(tts): preserve local paragraph pauses as explicit speech segments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2664,7 +2664,7 @@ class BasePlatformAdapter(ABC):
         job."""
         try:
             from tools.tts_text_normalize import prepare_spoken_text
-            return prepare_spoken_text(text, max_chars=None)
+            return prepare_spoken_text(text, max_chars=None, preserve_paragraphs=True)
         except Exception:
             # Keep auto-TTS best-effort if the normalizer ever fails.
             text = re.sub(r'<think[\s>].*?</think>', ' ', text, flags=re.DOTALL)

--- a/hermes_cli/cli_voice_mixin.py
+++ b/hermes_cli/cli_voice_mixin.py
@@ -310,7 +310,7 @@ class CLIVoiceMixin:
             # provider request limits and long-form chunking.
             try:
                 from tools.tts_text_normalize import prepare_spoken_text
-                tts_text = prepare_spoken_text(text, max_chars=None)
+                tts_text = prepare_spoken_text(text, max_chars=None, preserve_paragraphs=True)
             except Exception:
                 # Legacy fallback pipeline — keep voice replies best-effort.
                 tts_text = re.sub(r'```[\s\S]*?```', ' ', text)   # fenced code blocks

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1035,16 +1035,19 @@ DEFAULT_CONFIG = {
         },
         "minimax": {"model": "speech-02-hd", "voice_id": "English_expressive_narrator"},
         "kittentts": {
+            "paragraph_pause_ms": 600,  # 0 disables inter-paragraph silence
             "model": "KittenML/kitten-tts-nano-0.8-int8",  # nano 25MB; micro 41MB; mini 80MB
             "voice": "Jasper",
         },
         "neutts": {
+            "paragraph_pause_ms": 600,  # 0 disables inter-paragraph silence
             "ref_audio": "",  # path to reference voice audio (empty = bundled default)
             "ref_text": "",   # path to reference voice transcript (empty = bundled default)
             "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
             "device": "cpu",  # cpu, cuda, or mps
         },
         "piper": {
+            "paragraph_pause_ms": 600,  # 0 disables inter-paragraph silence
             # Voice name (downloaded on first use) or absolute path to a .onnx file; list:
             # github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md. Optional keys: voices_dir
             # (~/.hermes/cache/piper-voices/), use_cuda, length_scale (2.0 = twice as slow),

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -598,7 +598,7 @@ def _speak_whole_file(text: str) -> None:
     # provider request limits and long-form chunking.
     try:
         from tools.tts_text_normalize import prepare_spoken_text
-        tts_text = prepare_spoken_text(text, max_chars=None)
+        tts_text = prepare_spoken_text(text, max_chars=None, preserve_paragraphs=True)
     except Exception:
         tts_text = text
         for pattern, repl in _LEGACY_TTS_STRIP:

--- a/tests/tools/test_tts_paragraph_segments.py
+++ b/tests/tools/test_tts_paragraph_segments.py
@@ -137,7 +137,7 @@ def test_writer_rejects_empty_stream(tmp_path):
 
 
 def test_samples_are_little_endian_and_not_silently_multichannel():
-    import numpy as np
+    np = pytest.importorskip("numpy")
     block = pcm_from_samples(np.array([-2, 0, 2], dtype=np.float32), 16000)
     assert block == PCMBlock(struct.pack('<hhh', -32767, 0, 32767), 16000)
     for bad in [np.array([[1, 2]]), np.array([np.nan]), np.array([np.inf])]:
@@ -162,7 +162,7 @@ def test_cleaner_removes_multiline_nonspoken_blocks_before_segmentation():
 
 
 def test_kittentts_loads_once_and_preserves_generation_options(tmp_path, monkeypatch):
-    import numpy as np
+    np = pytest.importorskip("numpy")
     from tools import tts_tool_local as local
     calls, loads = [], []
     def generate(text, **kwargs):
@@ -264,6 +264,7 @@ class NeuTTS:
 
 
 def test_neutts_actual_subprocess_loads_model_and_reference_once(tmp_path, fake_neutts):
+    pytest.importorskip("numpy")
     from tools.tts_tool_local import _generate_neutts
     trace, config = fake_neutts
     output = tmp_path / 'neutts.wav'
@@ -278,6 +279,7 @@ def test_neutts_actual_subprocess_loads_model_and_reference_once(tmp_path, fake_
 
 
 def test_neutts_legacy_text_path_remains_supported(tmp_path, fake_neutts):
+    pytest.importorskip("numpy")
     from tools.tts_tool_local import _generate_neutts
     trace, config = fake_neutts
     output = tmp_path / 'legacy.wav'

--- a/tests/tools/test_tts_paragraph_segments.py
+++ b/tests/tools/test_tts_paragraph_segments.py
@@ -1,0 +1,301 @@
+"""Paragraph boundaries must survive cleanup, request caps and real WAV assembly."""
+import json
+import os
+import struct
+import wave
+from types import SimpleNamespace
+
+import pytest
+
+from tools.tts_tool_segments import (
+    DEFAULT_PARAGRAPH_PAUSE_MS, PCMBlock, SpeechChunk, SpeechSegment,
+    decode_segments, encode_segments, local_paragraph_pause_ms, pcm_from_samples,
+    pcm_from_wav, plan_speech_chunks, write_pcm_segments,
+)
+
+
+def read_wav(path):
+    with wave.open(str(path), 'rb') as audio:
+        return audio.getparams(), audio.readframes(audio.getnframes())
+
+
+@pytest.mark.parametrize('value', [-1, 10001, True, False, None, '600', 600.0, float('inf')])
+def test_invalid_local_pause_is_rejected(value):
+    with pytest.raises(ValueError, match='paragraph_pause_ms'):
+        local_paragraph_pause_ms('piper', {'piper': {'paragraph_pause_ms': value}})
+
+
+@pytest.mark.parametrize('provider', ['piper', 'kittentts', 'neutts'])
+def test_pause_config_defaults_and_disable(provider):
+    assert local_paragraph_pause_ms(provider, {}) == DEFAULT_PARAGRAPH_PAUSE_MS
+    assert local_paragraph_pause_ms(provider, {provider: None}) == DEFAULT_PARAGRAPH_PAUSE_MS
+    assert local_paragraph_pause_ms(provider, {provider: {'paragraph_pause_ms': 0}}) == 0
+    assert local_paragraph_pause_ms(provider, {provider: {'paragraph_pause_ms': 137}}) == 137
+    assert local_paragraph_pause_ms('openai', {'openai': {'paragraph_pause_ms': 'invalid'}}) == 0
+
+
+@pytest.mark.parametrize('cap', [1, 2, 3, 7, 13, 25, 1000])
+def test_chunk_caps_do_not_drop_text_or_paragraph_pauses(cap):
+    text = 'First paragraph is fairly long.\n\nSecond has more words.\n\nThird.'
+    chunks = plan_speech_chunks(text, cap, 137)
+    assert all(isinstance(chunk, SpeechChunk) and len(chunk.text) <= cap for chunk in chunks)
+    segments = [segment for chunk in chunks for segment in chunk.segments]
+    assert ''.join(s.text.replace(' ', '') for s in segments) == ''.join(text.split())
+    assert [s.pause_before_ms for s in segments if s.pause_before_ms] == [137, 137]
+    assert segments[0].pause_before_ms == 0
+
+
+def test_paragraph_pause_survives_exact_request_boundary():
+    chunks = plan_speech_chunks('First.\n\nNext.', len('First.'), 125)
+    assert [chunk.text for chunk in chunks] == ['First.', 'Next.']
+    assert chunks[1].segments[0].pause_before_ms == 125
+
+
+def test_single_paragraph_and_disabled_paths_keep_legacy_chunking():
+    from tools.tts_tool_delivery import _split_text_for_tts
+    for text, pause in [('One long paragraph. More words.', 600), ('First.\n\nSecond.', 0)]:
+        assert plan_speech_chunks(text, 12, pause) == _split_text_for_tts(text, 12)
+    assert plan_speech_chunks('', 12, 600) == []
+
+
+def test_literal_pilcrow_is_not_a_control_marker():
+    text = 'Literal \u200b\u00b6\u200b character.\n\nNext.'
+    chunks = plan_speech_chunks(text, 1000, 100)
+    assert len(chunks[0].segments) == 2
+    assert '\u200b\u00b6\u200b' in chunks[0].segments[0].text
+
+
+def test_segment_protocol_roundtrip():
+    segments = (SpeechSegment('Hello "world".\nПривет.'), SpeechSegment('Next.', 127))
+    assert decode_segments(encode_segments(segments)) == segments
+
+
+@pytest.mark.parametrize('payload', ['null', '{}', '[]', '[null]', '[{"text":""}]',
+                                    '[{"text":"x","pause_before_ms":true}]',
+                                    '[{"text":"x","extra":1}]'])
+def test_invalid_segment_protocol(payload):
+    with pytest.raises(ValueError):
+        decode_segments(payload)
+
+
+@pytest.mark.parametrize('rate', [8000, 22050, 24000])
+@pytest.mark.parametrize('width,channels', [(1, 1), (2, 1), (2, 2), (3, 1), (4, 2)])
+def test_writer_uses_actual_pcm_format_and_exact_silence(tmp_path, rate, width, channels):
+    frame_size = width * channels
+    first = PCMBlock(b'\x11' * (3 * frame_size), rate, width, channels)
+    second = PCMBlock(b'\x22' * (5 * frame_size), rate, width, channels)
+    output = tmp_path / 'speech.wav'
+    write_pcm_segments(str(output), [(SpeechSegment('first'), first), (SpeechSegment('second', 137), second)])
+    params, data = read_wav(output)
+    gap_frames = rate * 137 // 1000
+    assert (params.nchannels, params.sampwidth, params.framerate) == (channels, width, rate)
+    assert params.nframes == 3 + gap_frames + 5
+    silence = (b'\x80' if width == 1 else b'\x00' * width) * channels
+    assert data == first.data + silence * gap_frames + second.data
+    assert pcm_from_wav(output.read_bytes()) == PCMBlock(data, rate, width, channels)
+
+
+def test_writer_retains_pause_before_first_segment_of_later_chunk(tmp_path):
+    output = tmp_path / 'later.wav'
+    write_pcm_segments(str(output), [(SpeechSegment('later', 125), PCMBlock(b'\x01\x02', 8000))])
+    params, data = read_wav(output)
+    assert params.nframes == 1001
+    assert data == b'\x00' * 2000 + b'\x01\x02'
+
+
+@pytest.mark.parametrize('bad', [PCMBlock(b'\x01', 24000), PCMBlock(b'', 24000),
+                               PCMBlock(b'\x01\x02', 22050), PCMBlock(b'\x01\x02', 24000, channels=2)])
+def test_writer_failure_preserves_existing_output_and_removes_temporary(tmp_path, bad):
+    output = tmp_path / 'speech.wav'
+    output.write_bytes(b'existing output')
+    before = set(tmp_path.iterdir())
+    with pytest.raises(ValueError):
+        write_pcm_segments(str(output), [(SpeechSegment('first'), PCMBlock(b'\x01\x02', 24000)),
+                                        (SpeechSegment('bad', 100), bad)])
+    assert output.read_bytes() == b'existing output'
+    assert set(tmp_path.iterdir()) == before
+
+
+@pytest.mark.parametrize('after_first', [False, True])
+def test_writer_preserves_synthesis_exception_and_cleans_up(tmp_path, after_first):
+    def blocks():
+        if after_first:
+            yield SpeechSegment('first'), PCMBlock(b'\x01\x02', 24000)
+        raise RuntimeError('model failure')
+    output = tmp_path / 'speech.wav'
+    before = set(tmp_path.iterdir())
+    with pytest.raises(RuntimeError, match='model failure'):
+        write_pcm_segments(str(output), blocks())
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_writer_rejects_empty_stream(tmp_path):
+    before = set(tmp_path.iterdir())
+    with pytest.raises(ValueError, match='no audio segments'):
+        write_pcm_segments(str(tmp_path / 'speech.wav'), [])
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_samples_are_little_endian_and_not_silently_multichannel():
+    import numpy as np
+    block = pcm_from_samples(np.array([-2, 0, 2], dtype=np.float32), 16000)
+    assert block == PCMBlock(struct.pack('<hhh', -32767, 0, 32767), 16000)
+    for bad in [np.array([[1, 2]]), np.array([np.nan]), np.array([np.inf])]:
+        with pytest.raises(ValueError):
+            pcm_from_samples(bad)
+
+
+@pytest.mark.parametrize('separator', ['\n\n', '\r\n\r\n', '\n \t\n', '\n\n\n'])
+def test_cleaner_preserves_real_paragraph_boundaries(separator):
+    from tools.tts_text_normalize import prepare_spoken_text
+    raw = f'**First**.{separator}Second.'
+    assert prepare_spoken_text(raw, preserve_paragraphs=True) == 'First.\n\nSecond.'
+    assert '\n' not in prepare_spoken_text(raw)
+
+
+def test_cleaner_removes_multiline_nonspoken_blocks_before_segmentation():
+    from tools.tts_text_normalize import prepare_spoken_text
+    raw = '<think>hidden\n\nreasoning</think>First.\n\n```py\nsecret\n\ncode\n```\n\nSecond.'
+    spoken = prepare_spoken_text(raw, max_chars=None, preserve_paragraphs=True)
+    assert spoken == 'First.\n\nSecond.'
+    assert '\n\n' not in prepare_spoken_text('First\nSecond', preserve_paragraphs=True)
+
+
+def test_kittentts_loads_once_and_preserves_generation_options(tmp_path, monkeypatch):
+    import numpy as np
+    from tools import tts_tool_local as local
+    calls, loads = [], []
+    def generate(text, **kwargs):
+        calls.append((text, kwargs))
+        return np.full(4, 0.5, dtype=np.float32)
+    config = {'voice': 'voice-name', 'speed': 1.25, 'clean_text': False}
+    def load(config):
+        loads.append(config)
+        return SimpleNamespace(generate=generate), config['kittentts']
+    monkeypatch.setattr(local, '_load_kittentts_model_for_config', load)
+    segments = (SpeechSegment('First.'), SpeechSegment('Second.', 100))
+    output = tmp_path / 'kitten.wav'
+    local._generate_kittentts('First. Second.', str(output), {'kittentts': config}, segments=segments)
+    assert len(loads) == 1
+    assert calls == [(s.text, config) for s in segments]
+    assert read_wav(output)[0].nframes == 4 + 2400 + 4
+
+
+@pytest.mark.parametrize('cap,pause', [(5000, 125), (7, 125), (5000, 0)])
+def test_real_tool_config_dispatch_and_gateway_cleanup_write_correct_audio(tmp_path, monkeypatch, cap, pause):
+    from gateway.config import Platform, PlatformConfig
+    from gateway.platforms.base import BasePlatformAdapter
+    from tools import tts_tool, tts_tool_local
+
+    class Adapter(BasePlatformAdapter):
+        def __init__(self):
+            super().__init__(PlatformConfig(enabled=True, token='test'), Platform.TELEGRAM)
+        async def connect(self):
+            return True
+        async def disconnect(self):
+            pass
+        async def send(self, chat_id, content, **kwargs):
+            raise AssertionError('unused')
+        async def get_chat_info(self, chat_id):
+            return {'id': chat_id, 'type': 'dm'}
+
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    monkeypatch.setenv('HERMES_SESSION_PLATFORM', '')
+    model_path = tmp_path / 'test.onnx'
+    model_path.touch()
+    (tmp_path / 'config.yaml').write_text(
+        'tts:\n  provider: piper\n  piper:\n'
+        f'    voice: {model_path.as_posix()}\n    paragraph_pause_ms: {pause}\n    max_text_length: {cap}\n')
+    calls, loads = [], []
+
+    class Voice:
+        def synthesize_wav(self, text, output, **kwargs):
+            calls.append(text)
+            output.setparams((1, 2, 8000, 0, 'NONE', 'not compressed'))
+            output.writeframes(b'\x01\x02' * 4)
+
+    def load(path, **kwargs):
+        loads.append(path)
+        return Voice()
+    monkeypatch.setattr(tts_tool, '_import_piper', lambda: SimpleNamespace(load=load))
+    monkeypatch.setattr(tts_tool_local, '_piper_voice_cache', {})
+    raw = '**First**.\n\nSecond.'
+    prepared = Adapter().prepare_tts_text(raw)
+    assert prepared == 'First.\n\nSecond.'
+    result = json.loads(tts_tool.text_to_speech_tool(prepared, output_path=str(tmp_path / 'out.wav')))
+    assert result.get('success'), result
+    assert len(loads) == 1
+    assert calls == (['First.', 'Second.'] if pause else ['First. Second.'])
+    blocks = [read_wav(path) for path in result['file_paths']]
+    assert sum(p.nframes for p, _ in blocks) == (8 + 8000 * pause // 1000 if pause else 4)
+    assert b''.join(data for _, data in blocks) == (
+        b'\x01\x02' * 4 + b'\x00' * (2 * 8000 * pause // 1000) + b'\x01\x02' * 4
+        if pause else b'\x01\x02' * 4)
+    assert not list(tmp_path.glob('.*.wav'))
+
+
+@pytest.fixture
+def fake_neutts(tmp_path, monkeypatch):
+    trace = tmp_path / 'trace.jsonl'
+    (tmp_path / 'neutts.py').write_text('''
+import json
+import os
+import numpy as np
+TRACE = %r
+class NeuTTS:
+    def record(self, event, text=None):
+        with open(TRACE, 'a') as f:
+            f.write(json.dumps({'event': event, 'text': text, 'pid': os.getpid()}) + '\\n')
+    def __init__(self, **kwargs):
+        self.record('load')
+    def encode_reference(self, path):
+        self.record('reference')
+        return 'encoded reference'
+    def infer(self, text, reference, transcript):
+        assert reference == 'encoded reference'
+        self.record('infer', text)
+        return np.full(3, 0.5, dtype=np.float32)
+''' % str(trace))
+    monkeypatch.setenv('PYTHONPATH', str(tmp_path) + os.pathsep + os.environ.get('PYTHONPATH', ''))
+    audio, transcript = tmp_path / 'ref.wav', tmp_path / 'ref.txt'
+    audio.touch()
+    transcript.write_text('reference transcript')
+    return trace, {'neutts': {'ref_audio': str(audio), 'ref_text': str(transcript)}}
+
+
+def test_neutts_actual_subprocess_loads_model_and_reference_once(tmp_path, fake_neutts):
+    from tools.tts_tool_local import _generate_neutts
+    trace, config = fake_neutts
+    output = tmp_path / 'neutts.wav'
+    segments = (SpeechSegment('First.'), SpeechSegment('Second.', 100))
+    _generate_neutts('First. Second.', str(output), config, segments=segments)
+    events = [json.loads(line) for line in trace.read_text().splitlines()]
+    assert [event['event'] for event in events] == ['load', 'reference', 'infer', 'infer']
+    assert len({event['pid'] for event in events}) == 1
+    assert events[-2]['text'] == 'First.' and events[-1]['text'] == 'Second.'
+    assert read_wav(output)[0].nframes == 3 + 2400 + 3
+    assert not list(tmp_path.glob('.*.wav'))
+
+
+def test_neutts_legacy_text_path_remains_supported(tmp_path, fake_neutts):
+    from tools.tts_tool_local import _generate_neutts
+    trace, config = fake_neutts
+    output = tmp_path / 'legacy.wav'
+    _generate_neutts('One paragraph.', str(output), config)
+    assert read_wav(output)[0].nframes == 3
+    assert json.loads(trace.read_text().splitlines()[-1])['text'] == 'One paragraph.'
+
+
+def test_neutts_rejects_invalid_segments_before_loading_model(tmp_path, fake_neutts):
+    from tools.tts_tool_local import _generate_neutts
+    trace, config = fake_neutts
+    output = tmp_path / 'invalid.wav'
+    with pytest.raises(RuntimeError, match='non-empty list'):
+        _generate_neutts('', str(output), config, segments=())
+    assert not output.exists() and not trace.exists()
+
+
+def test_config_defaults_match_the_local_runtime_default():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    for provider in ('piper', 'kittentts', 'neutts'):
+        assert DEFAULT_CONFIG['tts'][provider]['paragraph_pause_ms'] == local_paragraph_pause_ms(provider, {})

--- a/tools/neutts_synth.py
+++ b/tools/neutts_synth.py
@@ -12,6 +12,12 @@ import struct
 import sys
 from pathlib import Path
 
+# Both `python tools/neutts_synth.py` and `python -m tools.neutts_synth` are supported.
+if __package__:
+    from .tts_tool_segments import decode_segments, pcm_from_samples, write_pcm_segments
+else:
+    from tts_tool_segments import decode_segments, pcm_from_samples, write_pcm_segments
+
 
 def _write_wav(path: str, samples, sample_rate: int = 24000) -> None:
     """Write a WAV file from float32 samples (no soundfile dependency)."""
@@ -28,7 +34,9 @@ def _write_wav(path: str, samples, sample_rate: int = 24000) -> None:
 
 def main():
     parser = argparse.ArgumentParser(description="NeuTTS synthesis helper")
-    parser.add_argument("--text", required=True, help="Text to synthesize")
+    speech = parser.add_mutually_exclusive_group(required=True)
+    speech.add_argument("--text", help="Text to synthesize")
+    speech.add_argument("--segments-stdin", action="store_true", help="Read speech/pause segments as JSON from stdin")
     parser.add_argument("--out", required=True, help="Output WAV path")
     parser.add_argument("--ref-audio", required=True, help="Reference voice audio path")
     parser.add_argument("--ref-text", required=True, help="Reference voice transcript path")
@@ -36,6 +44,12 @@ def main():
                         help="HuggingFace backbone model repo")
     parser.add_argument("--device", default="cpu", help="Device (cpu/cuda/mps)")
     args = parser.parse_args()
+    segments = None
+    if args.segments_stdin:
+        try:
+            segments = decode_segments(sys.stdin.read())
+        except (ValueError, TypeError) as exc:
+            parser.error(str(exc))
 
     ref_audio = Path(args.ref_audio).expanduser()
     ref_text_path = Path(args.ref_text).expanduser()
@@ -59,15 +73,20 @@ def main():
         backbone_device="gpu" if args.device == "cuda" else args.device,
         codec_repo="neuphonic/neucodec",
         codec_device=args.device)
-    wav = tts.infer(args.text, tts.encode_reference(str(ref_audio)), ref_text)
-
+    reference = tts.encode_reference(str(ref_audio))
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        import soundfile as sf
-        sf.write(str(out_path), wav, 24000)
-    except ImportError:
-        _write_wav(str(out_path), wav, 24000)
+    if segments is not None:
+        write_pcm_segments(str(out_path), (
+            (segment, pcm_from_samples(tts.infer(segment.text, reference, ref_text)))
+            for segment in segments))
+    else:
+        wav = tts.infer(args.text, reference, ref_text)
+        try:
+            import soundfile as sf
+            sf.write(str(out_path), wav, 24000)
+        except ImportError:
+            _write_wav(str(out_path), wav, 24000)
     print(f"OK: {out_path}", file=sys.stderr)
 
 

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -201,14 +201,24 @@ def flatten_newlines_for_payload(text: str) -> str:
     return text.strip()
 
 
-def prepare_spoken_text(text: str, max_chars: int | None = 4000) -> str:
+def prepare_spoken_text(
+    text: str, max_chars: int | None = 4000, *, preserve_paragraphs: bool = False,
+) -> str:
     """Return a TTS-friendly script from assistant text (deterministic cleanup, not a rewrite).
     Pipeline: non-spoken blocks > Markdown > symbols/units > line formatting into sentence
-    pauses > single line (for newline-sensitive providers), then ``max_chars``."""
+    pauses > single line (for newline-sensitive providers), then ``max_chars``.
+
+    Pre-synthesis callers preserve ordinary blank lines; the final provider boundary
+    decides whether to flatten them or build explicit speech/pause segments.
+    """
     spoken = text
     for step in (strip_nonspoken_blocks, strip_markdown_for_tts, normalize_symbols_for_tts,
-                 smooth_whitespace_for_tts, flatten_newlines_for_payload):
+                 smooth_whitespace_for_tts):
         spoken = step(spoken)
+    if preserve_paragraphs:
+        spoken = "\n\n".join(flatten_newlines_for_payload(p) for p in spoken.split("\n\n") if p.strip())
+    else:
+        spoken = flatten_newlines_for_payload(spoken)
     if max_chars is not None and max_chars > 0 and len(spoken) > max_chars:
         spoken = spoken[:max_chars].rstrip()
     return spoken

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -54,6 +54,8 @@ from tools.tts_tool_providers import (
     _generate_edge_tts, _generate_elevenlabs, _generate_gemini_tts, _generate_minimax_tts,
     _generate_mistral_tts, _generate_xai_tts, _resolve_minimax_tts_runtime)
 from tools.tts_tool_local import _generate_kittentts, _generate_neutts, _generate_piper_tts
+from tools.tts_tool_segments import (
+    LOCAL_TTS_PROVIDERS, SpeechChunk, SpeechSegment, local_paragraph_pause_ms, plan_speech_chunks)
 from tools.tts_tool_plugins import (
     _dispatch_to_plugin_provider, _plugin_provider_is_available,
     _plugin_provider_is_voice_compatible)
@@ -223,11 +225,18 @@ def _select_builtin_engine(provider: str) -> tuple:
         "or set up NeuTTS for local synthesis.")
 
 
-def _synthesize_builtin(engine: str, text: str, file_str: str, tts_config: Dict[str, Any], instructions: Optional[str]) -> None:
+def _synthesize_builtin(
+    engine: str, text: str, file_str: str, tts_config: Dict[str, Any], instructions: Optional[str],
+    *, segments: Optional[tuple[SpeechSegment, ...]] = None,
+) -> None:
     """Run the already-selected built-in *engine*."""
     entry = _BUILTIN_DISPATCH.get(engine)
     logger.info("Generating speech with %s...", entry[1] if entry else "Edge TTS")
-    if entry is None:
+    if segments is not None:
+        if engine not in LOCAL_TTS_PROVIDERS:
+            raise ValueError("Structured speech segments require a local TTS engine")
+        globals()[entry[2]](text, file_str, tts_config, segments=segments)
+    elif entry is None:
         _run_edge_tts(text, file_str, tts_config)
     elif engine == "openai":
         _generate_openai_tts(text, file_str, tts_config, instructions=instructions)
@@ -328,6 +337,7 @@ def _tool_failure(prefix: str, provider: str, exc: BaseException) -> str:
 def _text_to_speech_single(
     text: str, file_str: str, *, provider: str, tts_config: Dict[str, Any],
     command_provider_config: Optional[Dict[str, Any]], want_opus: bool, instructions: Optional[str],
+    segments: Optional[tuple[SpeechSegment, ...]] = None,
 ) -> str:
     """Synthesize one provider-safe chunk into *file_str*; returns the result envelope.
 
@@ -353,7 +363,10 @@ def _text_to_speech_single(
             provider, error = _select_builtin_engine(provider)
             if error:
                 return error
-            _synthesize_builtin(provider, text, file_str, tts_config, instructions)
+            if segments is None:
+                _synthesize_builtin(provider, text, file_str, tts_config, instructions)
+            else:
+                _synthesize_builtin(provider, text, file_str, tts_config, instructions, segments=segments)
         if not os.path.exists(file_str) or os.path.getsize(file_str) == 0:
             return _error_json(f"TTS generation produced no output (provider: {provider})")
 
@@ -378,7 +391,9 @@ class _ChunkFailed(Exception):
     """One chunk's synthesis returned an error envelope; message is the final tool error text."""
 
 
-def _synthesize_chunks(chunks: List[str], base_path: Path, generated_artifacts: set, **single_kwargs) -> tuple:
+def _synthesize_chunks(
+    chunks: List[str | SpeechChunk], base_path: Path, generated_artifacts: set, **single_kwargs,
+) -> tuple:
     """Synthesize chunks into ``<base>.chunkNNN<ext>`` (or ``base`` alone) -> ``(encoded_paths, results)``.
 
     Every touched path lands in *generated_artifacts* for the caller's sweep. Raises
@@ -391,7 +406,11 @@ def _synthesize_chunks(chunks: List[str], base_path: Path, generated_artifacts: 
         if len(chunks) > 1:
             chunk_path = base_path.with_name(f"{base_path.stem}.chunk{index:03d}{base_path.suffix}")
         generated_artifacts.add(str(chunk_path))
-        raw_result = _text_to_speech_single(chunk, str(chunk_path), **single_kwargs)
+        if isinstance(chunk, SpeechChunk):
+            raw_result = _text_to_speech_single(
+                chunk.text, str(chunk_path), segments=chunk.segments, **single_kwargs)
+        else:
+            raw_result = _text_to_speech_single(chunk, str(chunk_path), **single_kwargs)
         try:
             chunk_result = json.loads(raw_result)
         except (json.JSONDecodeError, TypeError):
@@ -418,17 +437,23 @@ def text_to_speech_tool(
     separate valid files and no over-limit artifact is ever returned."""
     if not text or not text.strip():
         return tool_error("Text is required", success=False)
+    tts_config, provider = _apply_call_overrides(_load_tts_config(), speed, provider)
+    try:
+        pause_ms = local_paragraph_pause_ms(provider, tts_config)
+    except ValueError as exc:
+        return _tool_failure("TTS configuration error", provider, exc)
     try:  # shared cleaner: markdown, emoji, think blocks, verifier footer, units, newlines
         from tools.tts_text_normalize import prepare_spoken_text
-        text = prepare_spoken_text(text, max_chars=None)
+        text = (prepare_spoken_text(text, max_chars=None, preserve_paragraphs=True) if pause_ms
+                else prepare_spoken_text(text, max_chars=None))
     except Exception:
         text = text.strip()
     if not text:
         return tool_error("Text is empty after TTS cleanup", success=False)
-    tts_config, provider = _apply_call_overrides(_load_tts_config(), speed, provider)
     command_provider_config = _resolve_command_provider_config(provider, tts_config)
     max_len = _resolve_max_text_length(provider, tts_config)
-    chunks = _split_text_for_tts(text, max_len)
+    chunks = (plan_speech_chunks(text, max_len, pause_ms) if pause_ms
+              else _split_text_for_tts(text, max_len))
     if not chunks:
         return tool_error("Text is required", success=False)
     if len(chunks) > 1:

--- a/tools/tts_tool_local.py
+++ b/tools/tts_tool_local.py
@@ -8,6 +8,7 @@ container. Piper and KittenTTS keep loaded models in small LRU caches registered
 
 from __future__ import annotations
 
+import io
 import logging
 import subprocess
 import sys
@@ -15,6 +16,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Tuple
 
 from tools.tts_tool_delivery import _finalize_wav_output, _origin, _section, _wav_sidecar_path
+from tools.tts_tool_segments import (
+    SpeechSegment, encode_segments, pcm_from_samples, pcm_from_wav, write_pcm_segments)
 
 logger = logging.getLogger("tools.tts_tool")
 
@@ -50,25 +53,31 @@ def _tts_cache_get_or_load(cache: Dict[str, Any], key: str, load: Callable[[], A
     return value
 
 
-def _run_helper(cmd: list, timeout: int) -> subprocess.CompletedProcess:
+def _run_helper(cmd: list, timeout: int, *, input_text: str | None = None) -> subprocess.CompletedProcess:
+    stdin_kwargs = {"stdin": subprocess.DEVNULL} if input_text is None else {"input": input_text}
     return subprocess.run(
-        cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, stdin=subprocess.DEVNULL,
+        cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
+        **stdin_kwargs,
     )
 
 
 # --- NeuTTS (subprocess via tools/neutts_synth.py so the ~500MB model exits after use) ---
-def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_neutts(
+    text: str, output_path: str, tts_config: Dict[str, Any],
+    *, segments: tuple[SpeechSegment, ...] | None = None,
+) -> str:
     neutts_config = tts_config.get("neutts") or {}
     wav_path = _wav_sidecar_path(output_path)
     cmd = [
         sys.executable, str(Path(__file__).parent / "neutts_synth.py"),
-        "--text", text,
+        *(["--segments-stdin"] if segments is not None else ["--text", text]),
         "--out", wav_path,
         "--ref-audio", neutts_config.get("ref_audio", "") or str(_NEUTTS_SAMPLES / "jo.wav"),
         "--ref-text", neutts_config.get("ref_text", "") or str(_NEUTTS_SAMPLES / "jo.txt"),
         "--model", neutts_config.get("model", "neuphonic/neutts-air-q4-gguf"),
         "--device", neutts_config.get("device", "cpu")]
-    result = _run_helper(cmd, 120)
+    result = (_run_helper(cmd, 120, input_text=encode_segments(segments)) if segments is not None
+              else _run_helper(cmd, 120))
     if result.returncode != 0:  # the synth script reports success lines as "OK:" on stderr too
         error_lines = [l for l in result.stderr.strip().splitlines() if not l.startswith("OK:")]
         raise RuntimeError(f"NeuTTS synthesis failed: {chr(10).join(error_lines) or 'unknown error'}")
@@ -137,7 +146,10 @@ def _load_piper_voice_for_config(tts_config: Dict[str, Any]) -> Tuple[Any, Dict[
 _PIPER_ADVANCED_KNOBS = ("length_scale", "noise_scale", "noise_w_scale", "volume", "normalize_audio", "speaker_id")
 
 
-def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_piper_tts(
+    text: str, output_path: str, tts_config: Dict[str, Any],
+    *, segments: tuple[SpeechSegment, ...] | None = None,
+) -> str:
     import wave
     voice, piper_config = _load_piper_voice_for_config(tts_config)
     # Bad speaker_id drops to 0 (Piper's default); bools are rejected (they'd coerce to 1/0).
@@ -159,11 +171,23 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
         except ImportError:
             logger.warning("[Piper] SynthesisConfig not available in this piper-tts version — advanced knobs ignored")
     wav_path = _wav_sidecar_path(output_path)
-    with wave.open(wav_path, "wb") as wav_file:
+    def synthesize_wav(spoken, wav_file):
         if syn_config is not None:
-            voice.synthesize_wav(text, wav_file, syn_config=syn_config)
+            voice.synthesize_wav(spoken, wav_file, syn_config=syn_config)
         else:
-            voice.synthesize_wav(text, wav_file)
+            voice.synthesize_wav(spoken, wav_file)
+
+    if segments is None:
+        with wave.open(wav_path, "wb") as wav_file:
+            synthesize_wav(text, wav_file)
+    else:
+        def audio_blocks():
+            for segment in segments:
+                buffer = io.BytesIO()
+                with wave.open(buffer, "wb") as wav_file:
+                    synthesize_wav(segment.text, wav_file)
+                yield segment, pcm_from_wav(buffer.getvalue())
+        write_pcm_segments(wav_path, audio_blocks())
     return _finalize_wav_output(wav_path, output_path)
 
 
@@ -183,12 +207,21 @@ def _load_kittentts_model_for_config(tts_config: Dict[str, Any]) -> Tuple[Any, D
     return _tts_cache_get_or_load(_kittentts_model_cache, model_name, _load_kittentts_model), kt_config
 
 
-def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_kittentts(
+    text: str, output_path: str, tts_config: Dict[str, Any],
+    *, segments: tuple[SpeechSegment, ...] | None = None,
+) -> str:
     model, kt_config = _load_kittentts_model_for_config(tts_config)
-    audio = model.generate(  # numpy array at 24kHz
-        text, voice=kt_config.get("voice", DEFAULT_KITTENTTS_VOICE),
-        speed=kt_config.get("speed", 1.0), clean_text=kt_config.get("clean_text", True))
-    import soundfile as sf
+    def generate(spoken):
+        return model.generate(  # numpy array at 24kHz
+            spoken, voice=kt_config.get("voice", DEFAULT_KITTENTTS_VOICE),
+            speed=kt_config.get("speed", 1.0), clean_text=kt_config.get("clean_text", True))
+
     wav_path = _wav_sidecar_path(output_path)
-    sf.write(wav_path, audio, 24000)
+    if segments is None:
+        import soundfile as sf
+        sf.write(wav_path, generate(text), 24000)
+    else:
+        write_pcm_segments(wav_path, (
+            (segment, pcm_from_samples(generate(segment.text))) for segment in segments))
     return _finalize_wav_output(wav_path, output_path)

--- a/tools/tts_tool_segments.py
+++ b/tools/tts_tool_segments.py
@@ -1,0 +1,175 @@
+"""Paragraph boundaries and PCM assembly for the three local TTS engines.
+
+Speech and pauses travel separately: provider text never contains control markers.
+The planner retains pauses across request caps; the writer inserts them before encoding.
+This module has no eager optional dependencies and is also used by neutts_synth.py.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+LOCAL_TTS_PROVIDERS = frozenset({"piper", "kittentts", "neutts"})
+DEFAULT_PARAGRAPH_PAUSE_MS = 600
+MAX_PARAGRAPH_PAUSE_MS = 10000
+
+
+def _validate_pause(value: object) -> int:
+    if type(value) is not int or not 0 <= value <= MAX_PARAGRAPH_PAUSE_MS:
+        raise ValueError(f"paragraph_pause_ms must be an integer from 0 to {MAX_PARAGRAPH_PAUSE_MS}")
+    return value
+
+
+def local_paragraph_pause_ms(provider: str, config: dict) -> int:
+    """Local default is 600 ms; zero keeps the legacy single-string synthesis path."""
+    if provider not in LOCAL_TTS_PROVIDERS:
+        return 0
+    section = config.get(provider)
+    section = section if isinstance(section, dict) else {}
+    return _validate_pause(section.get("paragraph_pause_ms", DEFAULT_PARAGRAPH_PAUSE_MS))
+
+
+@dataclass(frozen=True)
+class SpeechSegment:
+    text: str
+    pause_before_ms: int = 0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.text, str) or not self.text.strip():
+            raise ValueError("A speech segment must contain non-empty text")
+        _validate_pause(self.pause_before_ms)
+
+
+@dataclass(frozen=True)
+class SpeechChunk:
+    segments: tuple[SpeechSegment, ...]
+
+    @property
+    def text(self) -> str:
+        return " ".join(segment.text for segment in self.segments)
+
+
+def plan_speech_chunks(text: str, max_chars: int, pause_ms: int) -> list[SpeechChunk] | list[str]:
+    """Pack cleaned paragraphs without erasing boundaries or pausing mid-paragraph.
+
+    A pause belongs to the following segment, including at the beginning of a new
+    request. Single-paragraph and disabled inputs use the original chunker unchanged.
+    """
+    from tools.tts_tool_delivery import FALLBACK_MAX_TEXT_LENGTH, _split_text_for_tts
+
+    _validate_pause(pause_ms)
+    paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
+    if not pause_ms or len(paragraphs) < 2:
+        return _split_text_for_tts(text, max_chars)
+    if max_chars <= 0:
+        max_chars = FALLBACK_MAX_TEXT_LENGTH
+    chunks: list[SpeechChunk] = []
+    current: list[SpeechSegment] = []
+    length = 0
+    for paragraph_index, paragraph in enumerate(paragraphs):
+        for piece_index, piece in enumerate(_split_text_for_tts(paragraph, max_chars)):
+            pause = pause_ms if paragraph_index and piece_index == 0 else 0
+            if current and length + 1 + len(piece) > max_chars:
+                chunks.append(SpeechChunk(tuple(current)))
+                current, length = [], 0
+            length += len(piece) + bool(current)
+            current.append(SpeechSegment(piece, pause))
+    if current:
+        chunks.append(SpeechChunk(tuple(current)))
+    return chunks
+
+
+def encode_segments(segments: tuple[SpeechSegment, ...]) -> str:
+    return json.dumps([{"text": s.text, "pause_before_ms": s.pause_before_ms} for s in segments],
+                      ensure_ascii=False)
+
+
+def decode_segments(payload: str) -> tuple[SpeechSegment, ...]:
+    """Validate the stdin protocol before the subprocess loads a model."""
+    rows = json.loads(payload)
+    if not isinstance(rows, list) or not rows or any(not isinstance(row, dict) for row in rows):
+        raise ValueError("Expected a non-empty list of speech segments")
+    try:
+        return tuple(SpeechSegment(**row) for row in rows)
+    except TypeError as exc:
+        raise ValueError("Invalid speech segment fields") from exc
+
+
+@dataclass(frozen=True)
+class PCMBlock:
+    data: bytes
+    sample_rate: int
+    sample_width: int = 2
+    channels: int = 1
+
+
+def pcm_from_wav(data: bytes) -> PCMBlock:
+    with wave.open(io.BytesIO(data), "rb") as source:
+        return PCMBlock(source.readframes(source.getnframes()), source.getframerate(),
+                        source.getsampwidth(), source.getnchannels())
+
+
+def pcm_from_samples(samples, sample_rate: int = 24000) -> PCMBlock:
+    """Mono model output to signed little-endian PCM16 (numpy is already an engine dependency)."""
+    import numpy as np
+    samples = np.asarray(samples)
+    if samples.ndim != 1 or not np.isfinite(samples).all():
+        raise ValueError("TTS output must contain finite mono samples")
+    pcm = (np.clip(samples, -1.0, 1.0) * 32767).astype("<i2")
+    return PCMBlock(pcm.tobytes(), sample_rate)
+
+
+def write_pcm_segments(path: str, audio: Iterable[tuple[SpeechSegment, PCMBlock]]) -> None:
+    """Stream compatible PCM blocks and bounded silence to one atomically published WAV.
+
+    A failed segment or format change leaves no partial output. Only one paragraph's
+    waveform is held at a time; silence is written in bounded blocks, not a giant buffer.
+    """
+    target = Path(path)
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(prefix=f".{target.name}.", suffix=".wav",
+                                         dir=target.parent, delete=False) as temp:
+            temporary = temp.name
+        audio_format = None
+        with wave.open(temporary, "wb") as output:
+            # A generator may fail before its first block; keep close() from masking it.
+            output.setparams((1, 2, 24000, 0, "NONE", "not compressed"))
+            for segment, block in audio:
+                _validate_pause(segment.pause_before_ms)
+                fmt = (block.channels, block.sample_width, block.sample_rate)
+                if (any(type(value) is not int or value <= 0 for value in fmt)
+                        or block.sample_width > 4):
+                    raise ValueError("Invalid PCM format")
+                frame_size = block.channels * block.sample_width
+                if not block.data or len(block.data) % frame_size:
+                    raise ValueError("TTS produced empty or incomplete PCM frames")
+                if audio_format is None:
+                    audio_format = fmt
+                    output.setnchannels(block.channels)
+                    output.setsampwidth(block.sample_width)
+                    output.setframerate(block.sample_rate)
+                elif audio_format != fmt:
+                    raise ValueError("TTS segments have incompatible PCM formats")
+                frames = block.sample_rate * segment.pause_before_ms // 1000
+                zero_frame = (b"\x80" if block.sample_width == 1 else b"\x00" * block.sample_width) * block.channels
+                while frames:
+                    count = min(frames, 4096)
+                    output.writeframesraw(zero_frame * count)
+                    frames -= count
+                output.writeframesraw(block.data)
+            if audio_format is None:
+                raise ValueError("TTS produced no audio segments")
+        os.replace(temporary, target)
+    finally:
+        if temporary is not None:
+            try:
+                os.unlink(temporary)
+            except FileNotFoundError:
+                pass

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -733,3 +733,32 @@ Override these on your provider class for richer integration:
 - `get_setup_schema()` → return `{name, badge, tag, env_vars: [{key, prompt, url}]}` to power picker rows in `hermes tools` / `hermes setup` (the picker category for STT is not yet shipped — this metadata is available to plugins for forward compatibility).
 
 See `agent/transcription_provider.py` for the full ABC including docstrings.
+
+
+## Paragraph pauses for local speech
+
+Piper, KittenTTS and NeuTTS insert 600 ms of silence between paragraphs in full-response
+speech. Blank lines are retained by CLI and gateway cleanup until the TTS tool builds
+speech segments; a single newline remains an ordinary sentence break. The pause also
+survives when a paragraph starts a new provider-sized request.
+
+Configure the gap independently for each local provider:
+
+```yaml
+tts:
+  piper:
+    paragraph_pause_ms: 600
+  kittentts:
+    paragraph_pause_ms: 600
+  neutts:
+    paragraph_pause_ms: 600
+```
+
+`paragraph_pause_ms` must be an integer from 0 to 10000. Set it to `0` to keep the
+previous flattened-text behavior. Single-paragraph input retains the existing synthesis
+path. Remote and command providers still receive flattened text and are not affected.
+This setting does not add cross-call pauses to sentence-streaming playback.
+
+Pauses are inserted into PCM audio before output encoding, using the actual sample
+rate, sample width and channel count. NeuTTS loads its model and encodes the reference
+voice once per provider-sized request, not once per paragraph.


### PR DESCRIPTION
Fixes #103103

Alternative implementation to #103130. Thanks to @strangeles for the report and @kokhlo for the initial work on local paragraph pauses.

## Failure mode

Paragraph boundaries disappear before local synthesis: `prepare_spoken_text()` flattens them, CLI and gateway callers can invoke that cleanup before entering the tool, and `_split_text_for_tts()` collapses whitespace again. A local engine therefore cannot distinguish a paragraph break from an ordinary space.

## Change

Keep blank lines through pre-synthesis cleanup, then translate them into explicit `SpeechSegment(text, pause_before_ms)` records at the local-provider boundary. `SpeechChunk` packs those segments under the existing character cap. A pause belongs to the following segment, so a paragraph starting a new request keeps its gap; splitting a long paragraph does not invent additional gaps.

One PCM writer serves Piper, KittenTTS and NeuTTS. It inserts silence before output encoding, checks each segment's actual sample rate/width/channel count, writes silence in bounded blocks, and publishes the WAV atomically. Synthesis errors, empty audio and incompatible formats do not leave a partially assembled WAV.

NeuTTS receives the segment list as JSON on stdin. Each provider-sized request starts one subprocess, loads one model and encodes the reference voice once, then synthesizes its paragraphs sequentially. It does not reload the model for every paragraph.

## Behavior contract

- No paragraph sentinel or other control marker is inserted into provider text; speech and pause metadata travel separately.
- Local providers default to a 600 ms paragraph gap. `tts.<provider>.paragraph_pause_ms` accepts integers from 0 to 10000; `0` retains flattened-text behavior. Defaults and user documentation are included.
- Single-paragraph input retains the existing synthesis path. Remote, command and plugin providers retain their existing flat payloads and chunking.
- Existing provider character caps, output-format handling and delivery-size packing remain in place.
- This fixes full-response synthesis; it does not add cross-call pauses to sentence-streaming playback.

## Verification

**392 passed, 4 skipped** across 36 TTS, CLI voice and gateway test modules. [Validation run](https://github.com/Xipong/hermes-agent/actions/runs/34308800512).

```bash
python -m pytest -q --tb=short \
  tests/tools/test_tts*.py \
  tests/hermes_cli/test_voice*.py \
  tests/gateway/test*tts*.py
```

New regressions exercise paragraph boundaries at exact request caps; LF/CRLF and Markdown cleanup; exact WAV frame counts across sample formats; failure cleanup; the real configuration → gateway cleanup → tool dispatch → Piper WAV path; KittenTTS option propagation; and an actual NeuTTS subprocess with one model/reference initialization for multiple paragraphs.

The model SDK boundaries use deterministic test doubles. Real model downloads/inference and listening-quality evaluation were not performed. `git diff --check` also passes.