### PR TITLE
cron: add skip_missed_runs to opt out of post-downtime catch-up firing

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2829,25 +2829,35 @@ def _reanchor_stale_cron(d: _DueJob) -> bool:
     return False
 
 
-def _fast_forward_missed_recurring(d: _DueJob, grace: int) -> None:
-    """Recurring job past its grace window: skip the accumulated misses, fire once now.
+def _fast_forward_missed_recurring(d: _DueJob, grace: int) -> bool:
+    """Recurring job past its grace window: collapse the accumulated misses.
 
-    The fast-forward is persisted immediately — NOT redundant with advance_next_run/mark_job_run:
-    it
-    protects the crash window before mark_job_run and covers the external fire_due path, which never
-    calls advance_next_run. mark_job_run re-anchors on completion, so the value is provisional.
+    Returns True when the job must NOT fire this tick (misses skipped entirely) and False when
+    it should fire now. With ``cron.skip_missed_runs`` off (default) a job past grace still
+    fires ONCE now (backlog collapsed, pre-#33315 behavior). With it on, a job more than
+    ``grace`` late is fast-forwarded to its next occurrence WITHOUT running — so a long gateway
+    outage can't burst-fire every missed agent job at once on restart and burn the whole day's
+    budget. Within-grace jobs are never skipped either way (normal late dispatch).
     """
     if (d.scan.now - d.next_run_dt).total_seconds() <= grace:
-        return
+        return False
     new_next = d.recompute_next()
     if not new_next:
-        return
+        return False
+    skip_missed = bool(_cron_config_number("skip_missed_runs", False, bool))
+    d.scan.persist(d.job["id"], next_run_at=new_next)
+    record_catch_up_occurrence()
+    if skip_missed:
+        logger.info(
+            "Job '%s' missed its scheduled time (%s, grace=%ds); "
+            "cron.skip_missed_runs is on — skipping to next run %s (no fire this tick)",
+            d.label, d.next_run, grace, new_next)
+        return True
     logger.info(
         "Job '%s' missed its scheduled time (%s, grace=%ds). "
         "Running now; next run provisionally set to: %s (re-anchored on completion)",
         d.label, d.next_run, grace, new_next)
-    d.scan.persist(d.job["id"], next_run_at=new_next)
-    record_catch_up_occurrence()
+    return False
 
 
 def _retire_expired_oneshot(d: _DueJob) -> bool:
@@ -2952,8 +2962,8 @@ def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float)
     if not manual_run and kind == "cron" and _reanchor_stale_cron(d):
         return False
     grace = _compute_grace_seconds(d.schedule)
-    if not manual_run and recurring:
-        _fast_forward_missed_recurring(d, grace)
+    if not manual_run and recurring and _fast_forward_missed_recurring(d, grace):
+        return False
     if kind == "once":
         if _retire_expired_oneshot(d) or _oneshot_dispatch_limit_reached(job, scan):
             return False

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1677,6 +1677,13 @@ DEFAULT_CONFIG = {
         # Max due jobs run in parallel per tick. None/0 = unbounded (thread count only); 1 = serial.
         # Env override: HERMES_CRON_MAX_PARALLEL.
         "max_parallel_jobs": None,
+        # After a long downtime (gateway off past the catch-up grace window), a recurring job that
+        # missed its slot would normally still fire ONCE on restart (backlog collapsed, #33315
+        # catch-up). True = instead fast-forward missed recurring jobs to their NEXT occurrence
+        # without firing — so a multi-hour outage can't burst-fire every missed agent job at once
+        # and burn a whole day's spend on return. Within-grace late jobs are unaffected. Default
+        # False preserves stock catch-up behavior. See cron.jobs._fast_forward_missed_recurring.
+        "skip_missed_runs": False,
         # save_job_output keeps the N most recent .md files per job; 0 or negative disables pruning
         # (for externally managed cleanup).
         "output_retention": 50,

--- a/tests/cron/test_skip_missed_runs.py
+++ b/tests/cron/test_skip_missed_runs.py
@@ -1,0 +1,98 @@
+"""cron.skip_missed_runs: opt-out of post-downtime catch-up firing.
+
+Stock behavior: after the gateway is off past a job's catch-up grace window, the
+due-scan collapses the missed backlog and still fires the job ONCE now — so a
+multi-hour outage restarts every missed agent job at once, in parallel, which can
+burn a whole day's budget in the first minute back. ``cron.skip_missed_runs: true``
+fast-forwards such stale recurring jobs to their NEXT occurrence without firing.
+
+Invariants asserted here:
+- default (off): a stale recurring job still fires once now (unchanged stock path);
+- on: the same stale job is excluded from the due set entirely and its next_run_at
+  advances to a future occurrence;
+- on + within grace: a merely-late job still fires (late dispatch is not affected).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cron.jobs import get_due_jobs, load_jobs, save_jobs
+
+FIXED_NOW = datetime(2026, 9, 1, 9, 31, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def cron_store(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp dir and pin the clock."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: FIXED_NOW)
+    return tmp_path
+
+
+def _daily_job(jid, next_run_dt, **extra):
+    job = {
+        "id": jid,
+        "name": jid,
+        "prompt": "x",
+        "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+        "next_run_at": next_run_dt.isoformat(),
+        "last_run_at": None,
+        "enabled": True,
+        "state": "scheduled",
+        "repeat": {"times": None, "completed": 0},
+        "deliver": "local",
+    }
+    job.update(extra)
+    return job
+
+
+class TestSkipMissedRuns:
+    def test_default_off_stale_recurring_fires_once_now(self, cron_store):
+        # 24h31m late: far beyond the 2h max grace for a daily job — stock
+        # catch-up fires it once now (backlog collapsed).
+        scheduled = FIXED_NOW - timedelta(hours=24, minutes=31)
+        save_jobs([_daily_job("daily", scheduled)])
+
+        due = get_due_jobs()
+
+        assert [d["id"] for d in due] == ["daily"]
+
+    def test_on_stale_recurring_is_skipped_and_fast_forwarded(
+        self, cron_store, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "cron.jobs._cron_config_number",
+            lambda key, default, cast: cast(True)
+            if key == "skip_missed_runs"
+            else cast(default),
+        )
+        scheduled = FIXED_NOW - timedelta(hours=24, minutes=31)
+        save_jobs([_daily_job("daily", scheduled)])
+
+        due = get_due_jobs()
+
+        # Excluded from the due set: no fire this tick.
+        assert [d["id"] for d in due] == []
+        # next_run_at fast-forwarded to a future occurrence (not left parked
+        # in the past, so the job is not stuck due forever).
+        persisted = load_jobs()[0]
+        assert datetime.fromisoformat(persisted["next_run_at"]) > FIXED_NOW
+
+    def test_on_within_grace_still_fires_late(self, cron_store, monkeypatch):
+        # 31 minutes late is within the daily 2h grace window: late dispatch,
+        # not a missed-run skip. skip_missed_runs must not suppress it.
+        monkeypatch.setattr(
+            "cron.jobs._cron_config_number",
+            lambda key, default, cast: cast(True)
+            if key == "skip_missed_runs"
+            else cast(default),
+        )
+        scheduled = FIXED_NOW - timedelta(minutes=31)
+        save_jobs([_daily_job("daily", scheduled)])
+
+        due = get_due_jobs()
+
+        assert [d["id"] for d in due] == ["daily"]


### PR DESCRIPTION
## Problem

After the gateway is off past a recurring job's catch-up grace window, the due-scan collapses the missed backlog but **still fires the job once on restart**, and the ticker runs all due jobs **in parallel** (`cron.max_parallel_jobs`). A multi-hour outage therefore burst-fires every missed agent job at once the moment power returns — e.g. a 12h outage re-ran the full day's agent crons in the first minute, burning a full day's inference spend (DIEM/API credits) before any of it could be reviewed or throttled.

Stock behavior exists to avoid the perpetual-defer loop (#33315) for jobs whose runtime exceeds interval+grace — but for spend-sensitive agent crons, "fire every missed job once, all at once" is the wrong default after a long outage.

## Change

Add `cron.skip_missed_runs` (default **False** — stock behavior completely unchanged). When **True**:

- A recurring job missed **beyond its grace window** is fast-forwarded to its **next** occurrence **without firing** (the due-scan excludes it from the tick).
- Jobs missed **within** the grace window still fire as normal late dispatch.
- One-shot grace, manual triggers, and the catch-up window itself are untouched.

This makes "machine was down for hours" cheap to recover from: missed runs quietly advance to the next scheduled occurrence instead of re-executing everything at once.

## Implementation

- `cron/jobs.py` — `_fast_forward_missed_recurring` now returns whether the missed run was skipped; `_evaluate_due_job` honors it (skip → not due this tick). Config read via the existing `_cron_config_number` helper.
- `hermes_cli/config_defaults.py` — new `cron.skip_missed_runs: False` key + rationale comment.
- `tests/cron/test_skip_missed_runs.py` — 3 invariant tests: default path still fires once, skip path excludes + fast-forwards to a future `next_run_at`, within-grace path still fires late.

## Verification

- New tests: 3/3 pass.
- Existing cron due-scan/lateness/misfire suites: 30/30 pass.
- Manually exercised all three code paths (stale+off → fires, stale+on → skips, within-grace → fires).