### PR TITLE
feat(plugins): enforce required lifecycle hooks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2179,7 +2179,7 @@ def switch_model(
 
 
 def _pre_tool_block_message(agent, function_name, function_args, effective_task_id, tool_call_id, middleware_trace):
-    """Plugin pre-tool-call hook verdict: ``(block_message, function_args)``; failures never block."""
+    """Plugin pre-tool verdict; optional failures allow, required failures propagate."""
     try:
         from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
         block_message, modified_args = _dispatch_pre_tool_call_hooks(
@@ -2190,8 +2190,24 @@ def _pre_tool_block_message(agent, function_name, function_args, effective_task_
             middleware_trace=list(middleware_trace),
         )
         return block_message, (modified_args if modified_args is not None else function_args)
-    except Exception:
+    except Exception as exc:
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+        if isinstance(exc, RequiredLifecycleError):
+            raise
         return None, function_args
+
+
+def _required_lifecycle_failure_result(exc: Exception) -> str:
+    """Return the stable settlement failure for the one typed lifecycle error."""
+    from hermes_cli.required_lifecycle import (
+        REQUIRED_LIFECYCLE_FAILURE_TEXT,
+        RequiredLifecycleError,
+    )
+
+    if not isinstance(exc, RequiredLifecycleError):
+        raise exc
+    return REQUIRED_LIFECYCLE_FAILURE_TEXT
 
 
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
@@ -2219,18 +2235,24 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     except Exception as _mw_err:
         logger.debug("tool_request middleware error: %s", _mw_err)
     block_message: Optional[str] = None
-    if not pre_tool_block_checked:
-        block_message, function_args = _pre_tool_block_message(
-            agent, function_name, function_args, effective_task_id, tool_call_id, _tool_middleware_trace
-        )
+    try:
+        if not pre_tool_block_checked:
+            block_message, function_args = _pre_tool_block_message(
+                agent, function_name, function_args, effective_task_id, tool_call_id, _tool_middleware_trace
+            )
+    except Exception as required_exc:
+        return _required_lifecycle_failure_result(required_exc)
     if block_message is not None:
         result = json.dumps({"error": block_message}, ensure_ascii=False)
-        emit_terminal_post_tool_call(
-            agent, function_name=function_name, function_args=function_args, result=result,
-            effective_task_id=effective_task_id, tool_call_id=tool_call_id, status="blocked",
-            error_type="plugin_block", error_message=block_message,
-            middleware_trace=_tool_middleware_trace,
-        )
+        try:
+            emit_terminal_post_tool_call(
+                agent, function_name=function_name, function_args=function_args, result=result,
+                effective_task_id=effective_task_id, tool_call_id=tool_call_id, status="blocked",
+                error_type="plugin_block", error_message=block_message,
+                middleware_trace=_tool_middleware_trace,
+            )
+        except Exception as required_exc:
+            return _required_lifecycle_failure_result(required_exc)
         return result
     tool_start_time = time.monotonic()
     inline_executor = resolve_invoke_tool_executor(agent, function_name)
@@ -2265,14 +2287,17 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 dispatch_kwargs["skip_tool_execution_middleware"] = True
             import model_tools
             return model_tools.handle_function_call(function_name, next_args, effective_task_id, **dispatch_kwargs)
-    if skip_tool_execution_middleware:
-        return _execute(function_args)
-    from hermes_cli.middleware import run_tool_execution_middleware
-    return run_tool_execution_middleware(
-        function_name, function_args,
-        lambda next_args: _execute(next_args if isinstance(next_args, dict) else function_args),
-        original_args=function_args, **hook_ids,
-    )
+    try:
+        if skip_tool_execution_middleware:
+            return _execute(function_args)
+        from hermes_cli.middleware import run_tool_execution_middleware
+        return run_tool_execution_middleware(
+            function_name, function_args,
+            lambda next_args: _execute(next_args if isinstance(next_args, dict) else function_args),
+            original_args=function_args, **hook_ids,
+        )
+    except Exception as required_exc:
+        return _required_lifecycle_failure_result(required_exc)
 
 
 def repair_tool_call(agent, tool_name: str) -> str | None:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1411,7 +1411,9 @@ def _dump_if_model(value):
     return _model_dump_safe(value) if hasattr(value, "model_dump") else value
 
 
-def _assistant_reasoning_text(agent, assistant_message) -> Optional[str]:
+def _assistant_reasoning_text(
+    agent, assistant_message, *, publish: bool = True
+) -> Optional[str]:
     """Structured reasoning, else inline ``<think>`` blocks embedded in content."""
     reasoning_text = agent._extract_reasoning(assistant_message)
     if not reasoning_text:
@@ -1419,13 +1421,19 @@ def _assistant_reasoning_text(agent, assistant_message) -> Optional[str]:
         think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
         if think_blocks:
             reasoning_text = "\n\n".join(b.strip() for b in think_blocks if b.strip()) or None
-    if reasoning_text and agent.verbose_logging:
+    if reasoning_text and agent.verbose_logging and publish:
         logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {reasoning_text}")
     # When streaming is active the reasoning was already displayed during the
     # stream (structured deltas or <think> tag extraction); fire only for
     # non-streaming modes (gateway, batch, quiet). Anything not shown during
     # streaming is caught by the CLI post-response fallback.
-    if reasoning_text and agent.reasoning_callback and not agent.stream_delta_callback and not agent._stream_callback:
+    if (
+        reasoning_text
+        and publish
+        and agent.reasoning_callback
+        and not agent.stream_delta_callback
+        and not agent._stream_callback
+    ):
         with contextlib.suppress(Exception):
             agent.reasoning_callback(reasoning_text)
     return _sanitize_surrogates(reasoning_text) if reasoning_text else reasoning_text
@@ -1496,9 +1504,21 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     single owner — write-time padding broke codex commentary turns and cannot
     survive ``_rows_to_conversation``."""
     assistant_tool_calls = getattr(assistant_message, "tool_calls", None)
-    reasoning_text = _assistant_reasoning_text(agent, assistant_message)
+    try:
+        from hermes_cli.plugins import requires_hook as _requires_hook
+
+        required_output_publication = _requires_hook("transform_llm_output")
+    except Exception:
+        required_output_publication = True
+    reasoning_text = _assistant_reasoning_text(
+        agent, assistant_message, publish=not required_output_publication
+    )
     msg = stamp_message_timestamp({"role": "assistant",
-        "content": _assistant_content_for_storage(agent, assistant_message), "reasoning": reasoning_text,
+        "content": (
+            "" if required_output_publication
+            else _assistant_content_for_storage(agent, assistant_message)
+        ),
+        "reasoning": None if required_output_publication else reasoning_text,
         "finish_reason": finish_reason})
 
     raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
@@ -1574,6 +1594,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     if assistant_tool_calls:
         msg["tool_calls"] = [_assistant_tool_call_dict(agent, tc, i) for i, tc in enumerate(assistant_tool_calls)]
+    if required_output_publication:
+        from hermes_cli.required_lifecycle import quarantine_required_provider_fields
+
+        quarantine_required_provider_fields(agent, msg)
     return msg
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -981,6 +981,70 @@ def _partial_turn_result(
     }
 
 
+def _apply_required_direct_result(agent, result: Any, state: Any) -> Any:
+    """Authorize a phase's direct-return result before it leaves the turn loop.
+
+    Phase helpers intentionally own several early exits.  Required output policy
+    must still be the single publication boundary for those paths.
+    """
+    if not isinstance(result, dict):
+        return result
+    from hermes_cli.required_lifecycle import (
+        REQUIRED_LIFECYCLE_FAILURE_TEXT,
+        RequiredLifecycleError,
+    )
+
+    raw = result.get("final_response")
+    raw = raw if isinstance(raw, str) else ""
+    try:
+        from hermes_cli.plugins import apply_required_lifecycle_output
+
+        required, final = apply_required_lifecycle_output(
+            raw,
+            session_id=agent.session_id or "",
+            task_id=state.effective_task_id,
+            turn_id=state.turn_id,
+            model=agent.model,
+            platform=getattr(agent, "platform", None) or "",
+        )
+    except RequiredLifecycleError as exc:
+        required, final = True, REQUIRED_LIFECYCLE_FAILURE_TEXT
+        result["failed"] = True
+        result["completed"] = False
+        result["error"] = "required_lifecycle_terminal"
+        result["failure_reason"] = exc.reason_code
+    if not required:
+        return result
+
+    result["final_response"] = final
+    result["response_transformed"] = final != raw
+    result["pre_transform_response"] = None
+    if isinstance(result.get("error"), str):
+        result["error"] = "required_lifecycle_terminal"
+    messages = result.get("messages")
+    if isinstance(messages, list):
+        replaced = False
+        for message in reversed(messages):
+            if not isinstance(message, dict):
+                continue
+            if message.get("role") == "user":
+                break
+            if message.get("role") == "assistant" and not message.get("tool_calls"):
+                message["content"] = final
+                message.pop("api_content", None)
+                replaced = True
+                break
+        if not replaced and final:
+            append_message(messages, {"role": "assistant", "content": final})
+        try:
+            agent._persist_session(messages, state.conversation_history)
+        except Exception:
+            result["failed"] = True
+            result["completed"] = False
+            result["error"] = "session_persistence_failed"
+    return result
+
+
 def _compression_deferred_result(agent, messages: List[Dict], api_call_count: int, reason: str = "lock") -> Dict[str, Any]:
     """Soft turn result for a transiently-deferred compression. Both reasons must end as
     ``compression_deferred``, never ``compression_exhausted`` — the gateway wipes the
@@ -1289,6 +1353,7 @@ class _LoopState:
     _should_review_memory: Any
     _plugin_user_context: Any
     _ext_prefetch_cache: Any
+    _required_lifecycle_failure: Any
     # Turn-scoped state (rebound by the phases).
     messages: Any
     active_system_prompt: Any
@@ -1356,6 +1421,7 @@ _CTX_FIELDS = frozenset({
     "user_message", "original_user_message", "conversation_history", "effective_task_id", "turn_id",
     "_should_review_memory", "_plugin_user_context", "_ext_prefetch_cache", "messages",
     "active_system_prompt", "current_turn_user_idx", "_preflight_compression_blocked",
+    "_required_lifecycle_failure",
 })
 # Keyword names each phase helper takes (minus ``agent``), cached per function object.
 _PHASE_PARAMS: Dict[Any, tuple] = {}
@@ -1497,23 +1563,78 @@ def _run_conversation_turn(
         max_compression_attempts=getattr(agent, "max_compression_attempts", 3),
         **{f.name: getattr(_ctx, f.name.lstrip("_")) for f in fields(_LoopState) if f.name in _CTX_FIELDS},
     )
+    if s._required_lifecycle_failure:
+        from hermes_cli.required_lifecycle import REQUIRED_LIFECYCLE_FAILURE_TEXT
+
+        s.final_response = REQUIRED_LIFECYCLE_FAILURE_TEXT
+        s.failed = True
+        s._turn_exit_reason = (
+            "required_lifecycle_blocked("
+            f"{s._required_lifecycle_failure})"
+        )
+        append_message(
+            s.messages, {"role": "assistant", "content": s.final_response}
+        )
     # Opt-in runtime: api_mode == codex_app_server hands the whole turn to the codex
     # app-server subprocess (see agent/transports/codex_app_server_session.py).
-    if agent.api_mode == "codex_app_server":
-        return agent._run_codex_app_server_turn(
-            user_message=s.user_message, original_user_message=s.original_user_message,
-            messages=s.messages, effective_task_id=s.effective_task_id,
-            should_review_memory=s._should_review_memory,
-        )
+    if not s._required_lifecycle_failure and agent.api_mode == "codex_app_server":
+        from hermes_cli.plugins import requires_hook as _requires_hook
 
-    while (s.api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        if _requires_hook("transform_llm_output"):
+            from hermes_cli.required_lifecycle import REQUIRED_LIFECYCLE_FAILURE_TEXT
+
+            s._required_lifecycle_failure = "required_lifecycle_surface_unsupported"
+            s.final_response = REQUIRED_LIFECYCLE_FAILURE_TEXT
+            s.failed = True
+            s._turn_exit_reason = (
+                "required_lifecycle_blocked(required_lifecycle_surface_unsupported)"
+            )
+            append_message(
+                s.messages, {"role": "assistant", "content": s.final_response}
+            )
+        else:
+            return agent._run_codex_app_server_turn(
+                user_message=s.user_message, original_user_message=s.original_user_message,
+                messages=s.messages, effective_task_id=s.effective_task_id,
+                should_review_memory=s._should_review_memory,
+            )
+
+    while not s._required_lifecycle_failure and (
+        (s.api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0)
+        or agent._budget_grace_call
+    ):
+        try:
+            from hermes_cli.plugins import assert_required_lifecycle_turn_healthy
+
+            assert_required_lifecycle_turn_healthy(
+                session_id=agent.session_id or "", turn_id=s.turn_id
+            )
+        except Exception as required_exc:
+            from hermes_cli.required_lifecycle import (
+                REQUIRED_LIFECYCLE_FAILURE_TEXT,
+                RequiredLifecycleError,
+            )
+
+            if not isinstance(required_exc, RequiredLifecycleError):
+                raise
+            s._required_lifecycle_failure = required_exc.reason_code
+            s.final_response = REQUIRED_LIFECYCLE_FAILURE_TEXT
+            s.failed = True
+            s._turn_exit_reason = (
+                "required_lifecycle_blocked("
+                f"{required_exc.reason_code})"
+            )
+            append_message(
+                s.messages, {"role": "assistant", "content": s.final_response}
+            )
+            break
         if _run_phase(begin_iteration, agent, s).action == "break":
             break
         _run_phase(prepare_iteration, agent, s)
         _run_phase(assemble_api_request, agent, s)
         _pg = _run_phase(run_preflight_gate, agent, s)
         if _pg.action == "return":
-            return _pg.result
+            return _apply_required_direct_result(agent, _pg.result, s)
         if _pg.action == "break":
             break
         if _pg.action == "continue":
@@ -1526,7 +1647,7 @@ def _run_conversation_turn(
 
         early_result = _run_api_retry_loop(agent, s)
         if early_result is not None:
-            return early_result
+            return _apply_required_direct_result(agent, early_result, s)
 
         _rs = _run_phase(apply_retry_restarts, agent, s)
         if _rs.action == "break":
@@ -1537,14 +1658,14 @@ def _run_conversation_turn(
         try:
             _ri = _run_phase(normalize_model_response, agent, s)
             if _ri.action == "return":
-                return _ri.result
+                return _apply_required_direct_result(agent, _ri.result, s)
             if _ri.action == "continue":
                 continue
             _v = _run_phase(
                 run_tool_round if s.assistant_message.tool_calls else finish_text_response, agent, s
             )
             if _v.action == "return":
-                return _v.result
+                return _apply_required_direct_result(agent, _v.result, s)
             if _v.action == "break":
                 break
             if _v.action == "continue":

--- a/agent/inline_tool_executors.py
+++ b/agent/inline_tool_executors.py
@@ -40,7 +40,11 @@ def emit_terminal_post_tool_call(
     error_message: Optional[str] = None,
     middleware_trace: Optional[list] = None,
 ) -> None:
-    """Emit the one terminal ``post_tool_call`` hook for a tool_call_id (best-effort)."""
+    """Emit the one terminal ``post_tool_call`` hook for a tool_call_id.
+
+    Optional observer failures remain best-effort.  A required lifecycle failure
+    must reach the tool executor before it publishes the result.
+    """
     try:
         from model_tools import _emit_post_tool_call_hook
         _emit_post_tool_call_hook(
@@ -54,7 +58,11 @@ def emit_terminal_post_tool_call(
             error_message=error_message,
             middleware_trace=list(middleware_trace or []),
         )
-    except Exception:
+    except Exception as exc:
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+        if isinstance(exc, RequiredLifecycleError):
+            raise
         pass
 
 

--- a/agent/session_persistence.py
+++ b/agent/session_persistence.py
@@ -172,7 +172,9 @@ def _db_flush_row(agent, msg: Dict, is_current_turn_user: bool) -> Dict[str, Any
     row = {
         "role": role, "content": _durable_content(content), "tool_name": msg.get("tool_name"),
         "tool_calls": msg["tool_calls"] if isinstance(msg.get("tool_calls"), list) else None,
-        "tool_call_id": msg.get("tool_call_id"), "finish_reason": msg.get("finish_reason"),
+        "tool_call_id": msg.get("tool_call_id"),
+        "effect_disposition": msg.get("effect_disposition"),
+        "finish_reason": msg.get("finish_reason"),
         **{k: msg.get(k) for k in _ROW_REASONING_KEYS},
         "_compressed_summary": bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY)),
         "timestamp": timestamp, "api_content": api_content,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1664,6 +1664,31 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     for i, tool_call in enumerate(tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
+        try:
+            from hermes_cli.plugins import assert_required_lifecycle_turn_healthy
+
+            assert_required_lifecycle_turn_healthy(
+                session_id=getattr(agent, "session_id", "") or "",
+                turn_id=getattr(agent, "_current_turn_id", "") or "",
+            )
+        except Exception as required_exc:
+            from hermes_cli.required_lifecycle import (
+                REQUIRED_LIFECYCLE_FAILURE_TEXT,
+                RequiredLifecycleError,
+            )
+
+            if not isinstance(required_exc, RequiredLifecycleError):
+                raise
+            for skipped in tool_calls[i - 1:]:
+                messages.append(
+                    make_tool_result_message(
+                        skipped.function.name,
+                        REQUIRED_LIFECYCLE_FAILURE_TEXT,
+                        skipped.id,
+                        effect_disposition="none",
+                    )
+                )
+            return
         # Check interrupt BEFORE each tool so a "stop" during the previous one skips the rest.
         if agent._interrupt_requested:
             if not _skip_remaining_sequential(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -45,6 +45,7 @@ from agent.tool_dispatch_helpers import (
     _plan_tool_batch_segments,
     make_tool_result_message,
 )
+from agent.tool_result_classification import tool_may_have_side_effect
 from tools.terminal_tool_lifecycle import get_active_env
 from tools.thread_context import propagate_context_to_thread
 from tools.tool_result_storage import (
@@ -1598,7 +1599,14 @@ def _append_invalid_arguments_result(agent, messages: list, ref: _ToolCallRef, p
     return _flush_session_db_after_tool_progress(agent, messages, stage=f"invalid tool arguments {ref.name}")
 
 
-def _settle_required_post_failure(agent, messages: list, ref: _ToolCallRef, remaining_calls) -> None:
+def _settle_required_post_failure(
+    agent,
+    messages: list,
+    ref: _ToolCallRef,
+    remaining_calls,
+    *,
+    effect_disposition: str,
+) -> None:
     """Persist only redacted rows when required terminal settlement was denied."""
     from hermes_cli.required_lifecycle import REQUIRED_LIFECYCLE_FAILURE_TEXT
 
@@ -1608,7 +1616,7 @@ def _settle_required_post_failure(agent, messages: list, ref: _ToolCallRef, rema
             ref.name,
             REQUIRED_LIFECYCLE_FAILURE_TEXT,
             ref.call_id,
-            effect_disposition="unknown",
+            effect_disposition=effect_disposition,
         )
     )
     for tool_call in remaining_calls:
@@ -1625,14 +1633,26 @@ def _settle_required_post_failure(agent, messages: list, ref: _ToolCallRef, rema
     )
 
 
-def _unsettled_sequential_calls(messages: list, calls) -> list:
-    """Return calls without a matching committed tool row, preserving model order."""
-    settled_ids = {
-        message.get("tool_call_id")
-        for message in messages
-        if isinstance(message, dict) and message.get("role") == "tool"
-    }
-    return [call for call in calls if _pairing_tool_call_id(call) not in settled_ids]
+def _unsettled_sequential_calls(messages: list, calls, *, result_start: int) -> list:
+    """Return calls without a result in this execution frame, preserving model order.
+
+    Tool-call IDs are opaque and may be reused by a later provider turn.  Historical
+    rows before ``result_start`` therefore cannot settle the current frame.  Counts,
+    rather than a set, also keep malformed duplicate IDs from hiding a missing row.
+    """
+    settled_counts: dict[str, int] = {}
+    for message in messages[result_start:]:
+        if isinstance(message, dict) and message.get("role") == "tool":
+            call_id = str(message.get("tool_call_id") or "")
+            settled_counts[call_id] = settled_counts.get(call_id, 0) + 1
+    unsettled = []
+    for call in calls:
+        call_id = _pairing_tool_call_id(call)
+        if settled_counts.get(call_id, 0):
+            settled_counts[call_id] -= 1
+        else:
+            unsettled.append(call)
+    return unsettled
 
 
 def _run_sequential_call(
@@ -1645,6 +1665,7 @@ def _run_sequential_call(
     remaining_calls,
     display_index: int,
     tool_start_time: float,
+    execution_started: threading.Event,
     defer_quiet_completion: bool = False,
 ) -> tuple[_ManagedToolResult, float]:
     """Run one sequential call with its spinner/error policy; returns ``(managed, duration)``.
@@ -1652,10 +1673,14 @@ def _run_sequential_call(
     before re-raising so the tool-call turn keeps matching results (alternation)."""
     _spinner_result = None
     try:
+        def _execute_started(args):
+            execution_started.set()
+            return dispatch.execute(args)
+
         managed = _run_sequential_tool_execution_middleware(
             agent,
             **dict(ref.middleware_kwargs(), middleware_trace=dispatch.middleware_trace_arg),
-            execute=dispatch.execute,
+            execute=_execute_started,
             scope_block=scope_block,
             display_index=display_index,
         )
@@ -1697,6 +1722,10 @@ def _run_sequential_call(
             raise _UndurableToolSettlement()
         raise
     except Exception as tool_error:
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+        if isinstance(tool_error, RequiredLifecycleError):
+            raise
         if dispatch.error_result is None:
             raise
         function_result = dispatch.error_result(tool_error)
@@ -1792,6 +1821,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     required_post_settlement = requires_hook("post_tool_call")
 
     for i, tool_call in enumerate(tool_calls, 1):
+        result_start = len(messages)
         if getattr(agent, "_incremental_persistence_failed", False):
             return
         try:
@@ -1832,6 +1862,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             [],
         )
         dispatch = None
+        execution_started = threading.Event()
         tool_start_time = time.time()
         try:
             # Check interrupt BEFORE each tool so a "stop" during the previous one skips the rest.
@@ -1862,6 +1893,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 remaining_calls=tool_calls[i - 1:],
                 display_index=i,
                 tool_start_time=tool_start_time,
+                execution_started=execution_started,
                 defer_quiet_completion=required_post_settlement,
             )
             if not _publish_sequential_result(
@@ -1876,7 +1908,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         except _UndurableToolSettlement:
             return
         except RequiredLifecycleError:
-            unsettled = _unsettled_sequential_calls(messages, tool_calls[i - 1:])
+            current_calls = tool_calls[i - 1:]
+            unsettled = _unsettled_sequential_calls(
+                messages,
+                current_calls,
+                result_start=result_start,
+            )
             failed_ref = ref
             if unsettled:
                 failed_call = unsettled[0]
@@ -1890,7 +1927,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         [],
                     )
                 _settle_required_post_failure(
-                    agent, messages, failed_ref, unsettled[1:]
+                    agent,
+                    messages,
+                    failed_ref,
+                    unsettled[1:],
+                    effect_disposition=(
+                        "unknown"
+                        if failed_call is tool_call
+                        and execution_started.is_set()
+                        and tool_may_have_side_effect(failed_ref.name)
+                        else "none"
+                    ),
                 )
             if dispatch is not None and dispatch.finish_spinner:
                 with contextlib.suppress(Exception):

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -144,6 +144,11 @@ class _BatchAbandoned(BaseException):
     so ``except Exception`` handlers in the middleware chain can't swallow it."""
 
 
+class _UndurableToolSettlement(Exception):
+    """Internal control signal: stop the batch without leaking an interrupt past
+    a tool-call settlement that could not be made canonical."""
+
+
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
     """Parse model-emitted arguments without repairing or coercing them."""
     try:
@@ -194,6 +199,25 @@ def _flush_session_db_after_tool_progress(agent, messages: list, *, stage: str) 
         agent._last_persistence_error_cause = classify_persistence_error(exc)
         logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
         return False
+
+
+def _flush_interrupted_tool_settlement(agent, messages: list) -> bool:
+    """Persist an interrupt settlement before propagating ``KeyboardInterrupt``.
+
+    One bounded retry covers a transient DB handoff.  A persistent failure is
+    stronger than the user interrupt: the caller must stop through the normal
+    persistence-failure path so turn finalization/replay recovery can run.
+    """
+    stage = "keyboard-interrupt tool settlement"
+    if _flush_session_db_after_tool_progress(agent, messages, stage=stage):
+        return True
+    if _flush_session_db_after_tool_progress(
+        agent, messages, stage=f"{stage} retry"
+    ):
+        agent._incremental_persistence_failed = False
+        agent._last_persistence_error_cause = None
+        return True
+    return False
 
 
 def _image_generate_parallel_limit() -> int:
@@ -315,12 +339,12 @@ def _append_skipped_tool_results(
     for tc in tool_calls:
         name = _tc_name(tc)
         result = content.format(name=name)
-        messages.append(make_tool_result_message(name, result, _pairing_tool_call_id(tc), effect_disposition="none"))
         if hook_error_type is not None:
             _ToolCallRef(name, {}, effective_task_id, (hook_id or _pairing_tool_call_id)(tc), []).emit_post(
                 agent, result,
                 status="cancelled", error_type=hook_error_type, error_message="Tool execution skipped due to user interrupt",
             )
+        messages.append(make_tool_result_message(name, result, _pairing_tool_call_id(tc), effect_disposition="none"))
         if flush_stage is not None:
             flushed = _flush_session_db_after_tool_progress(agent, messages, stage=f"{flush_stage} {name}")
             if not flushed and stop_on_flush_failure:
@@ -617,7 +641,7 @@ def _blocked_tool_result(agent, ref: _ToolCallRef, *, block_message: Optional[st
 
 def _pre_tool_block(agent, ref: _ToolCallRef):
     """Run ``pre_tool_call`` plugin hooks; returns ``(block_message, final_args)`` with any
-    hook-modified args applied. Hook failures never block."""
+    hook-modified args applied. Optional failures allow; required failures propagate."""
     try:
         from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
 
@@ -628,7 +652,11 @@ def _pre_tool_block(agent, ref: _ToolCallRef):
             middleware_trace=list(ref.trace),
         )
         return block_msg, (ref.args if modified_args is None else modified_args)
-    except Exception:
+    except Exception as exc:
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+        if isinstance(exc, RequiredLifecycleError):
+            raise
         return None, ref.args
 
 
@@ -1570,6 +1598,43 @@ def _append_invalid_arguments_result(agent, messages: list, ref: _ToolCallRef, p
     return _flush_session_db_after_tool_progress(agent, messages, stage=f"invalid tool arguments {ref.name}")
 
 
+def _settle_required_post_failure(agent, messages: list, ref: _ToolCallRef, remaining_calls) -> None:
+    """Persist only redacted rows when required terminal settlement was denied."""
+    from hermes_cli.required_lifecycle import REQUIRED_LIFECYCLE_FAILURE_TEXT
+
+    agent._current_tool = None
+    messages.append(
+        make_tool_result_message(
+            ref.name,
+            REQUIRED_LIFECYCLE_FAILURE_TEXT,
+            ref.call_id,
+            effect_disposition="unknown",
+        )
+    )
+    for tool_call in remaining_calls:
+        messages.append(
+            make_tool_result_message(
+                _tc_name(tool_call),
+                REQUIRED_LIFECYCLE_FAILURE_TEXT,
+                _pairing_tool_call_id(tool_call),
+                effect_disposition="none",
+            )
+        )
+    _flush_session_db_after_tool_progress(
+        agent, messages, stage=f"required post-tool settlement {ref.name}"
+    )
+
+
+def _unsettled_sequential_calls(messages: list, calls) -> list:
+    """Return calls without a matching committed tool row, preserving model order."""
+    settled_ids = {
+        message.get("tool_call_id")
+        for message in messages
+        if isinstance(message, dict) and message.get("role") == "tool"
+    }
+    return [call for call in calls if _pairing_tool_call_id(call) not in settled_ids]
+
+
 def _run_sequential_call(
     agent,
     dispatch: _SequentialDispatch,
@@ -1580,6 +1645,7 @@ def _run_sequential_call(
     remaining_calls,
     display_index: int,
     tool_start_time: float,
+    defer_quiet_completion: bool = False,
 ) -> tuple[_ManagedToolResult, float]:
     """Run one sequential call with its spinner/error policy; returns ``(managed, duration)``.
     KeyboardInterrupt (registry tools only) emits results for THIS and every remaining call
@@ -1601,10 +1667,34 @@ def _run_sequential_call(
         _spinner_result = ref.emit_cancelled(agent, tool_start_time)
         with contextlib.suppress(Exception):
             agent.interrupt("keyboard interrupt")
+        messages.append(
+            make_tool_result_message(
+                ref.name,
+                _spinner_result,
+                ref.call_id,
+                effect_disposition="unknown",
+            )
+        )
         _append_skipped_tool_results(
-            agent, messages, remaining_calls, ref.task_id,
+            agent, messages, remaining_calls[1:], ref.task_id,
             content="[Tool execution cancelled — {name} was skipped due to keyboard interrupt]",
         )
+        settlement_durable = _flush_interrupted_tool_settlement(agent, messages)
+        if defer_quiet_completion and dispatch.finish_spinner:
+            with contextlib.suppress(Exception):
+                _finish_quiet_tool_spinner(
+                    agent,
+                    dispatch.spinner,
+                    ref.name,
+                    ref.args,
+                    time.time() - tool_start_time,
+                    json.dumps(
+                        {"error": "Tool execution was interrupted."},
+                        ensure_ascii=False,
+                    ),
+                )
+        if not settlement_durable:
+            raise _UndurableToolSettlement()
         raise
     except Exception as tool_error:
         if dispatch.error_result is None:
@@ -1616,14 +1706,25 @@ def _run_sequential_call(
         if dispatch.is_delegate:
             agent._delegate_spinner = None
         tool_duration = time.time() - tool_start_time
-        if dispatch.finish_spinner and dispatch.finish_in_finally:
+        if dispatch.finish_spinner and dispatch.finish_in_finally and not defer_quiet_completion:
             _finish_quiet_tool_spinner(agent, dispatch.spinner, ref.name, ref.args, tool_duration, _spinner_result)
-    if dispatch.finish_spinner and not dispatch.finish_in_finally:
+    if dispatch.finish_spinner and not dispatch.finish_in_finally and not defer_quiet_completion:
         _finish_quiet_tool_spinner(agent, dispatch.spinner, ref.name, ref.args, tool_duration, _spinner_result)
     return managed, tool_duration
 
 
-def _publish_sequential_result(agent, messages: list, ref: _ToolCallRef, managed: _ManagedToolResult, *, tool_duration: float, index: int, budget: BudgetConfig) -> bool:
+def _publish_sequential_result(
+    agent,
+    messages: list,
+    ref: _ToolCallRef,
+    managed: _ManagedToolResult,
+    *,
+    tool_duration: float,
+    index: int,
+    budget: BudgetConfig,
+    quiet_completion_spinner=None,
+    finish_quiet_completion: bool = False,
+) -> bool:
     """Terminal hook → observe → commit → completion callbacks/print for one sequential
     result; False when the incremental flush failed (the caller must stop the batch)."""
     ref.args, ref.trace, function_result = managed.args, managed.middleware_trace, managed.result
@@ -1645,9 +1746,31 @@ def _publish_sequential_result(agent, messages: list, ref: _ToolCallRef, managed
         verbose_text=_multimodal_text_summary,
     )
     if committed is None:
+        if finish_quiet_completion:
+            with contextlib.suppress(Exception):
+                _finish_quiet_tool_spinner(
+                    agent,
+                    quiet_completion_spinner,
+                    ref.name,
+                    ref.args,
+                    tool_duration,
+                    json.dumps(
+                        {"error": "Tool result could not be saved."},
+                        ensure_ascii=False,
+                    ),
+                )
         return False
     function_result, display_function_result, risk_metadata = committed
 
+    if finish_quiet_completion:
+        _finish_quiet_tool_spinner(
+            agent,
+            quiet_completion_spinner,
+            ref.name,
+            ref.args,
+            tool_duration,
+            display_function_result,
+        )
     _emit_tool_complete_and_risk(agent, ref, display_function_result, risk_metadata, managed.blocked)
     if _tool_progress_enabled(agent):
         _print_tool_completed(agent, index, tool_duration, function_result)
@@ -1658,8 +1781,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """Execute tool calls sequentially (single calls or interactive tools). ``finalize=False``
     skips end-of-batch budget enforcement and /steer injection (the segmented dispatcher
     owns turn-end work)."""
+    from hermes_cli.plugins import requires_hook
+    from hermes_cli.required_lifecycle import (
+        REQUIRED_LIFECYCLE_FAILURE_TEXT,
+        RequiredLifecycleError,
+    )
+
     _tool_budget = _budget_for_agent(agent)  # once per turn, not per result
     tool_calls = assistant_message.tool_calls
+    required_post_settlement = requires_hook("post_tool_call")
 
     for i, tool_call in enumerate(tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
@@ -1688,39 +1818,94 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         effect_disposition="none",
                     )
                 )
-            return
-        # Check interrupt BEFORE each tool so a "stop" during the previous one skips the rest.
-        if agent._interrupt_requested:
-            if not _skip_remaining_sequential(
-                agent, messages, tool_calls[i - 1:], effective_task_id,
-                notice="tool call(s)",
-                content="[Tool execution cancelled — {name} was skipped due to user interrupt]",
-                hook_error_type="user_interrupt",
-                hook_id=lambda tc: getattr(tc, "id", "") or "",
-                flush_stage="cancelled tool result",
+            _flush_session_db_after_tool_progress(
+                agent,
+                messages,
+                stage="required lifecycle batch settlement",
+            )
+            raise
+        ref = _ToolCallRef(
+            _canonical_tool_name(_tc_name(tool_call)),
+            {},
+            effective_task_id,
+            _pairing_tool_call_id(tool_call),
+            [],
+        )
+        dispatch = None
+        tool_start_time = time.time()
+        try:
+            # Check interrupt BEFORE each tool so a "stop" during the previous one skips the rest.
+            if agent._interrupt_requested:
+                if not _skip_remaining_sequential(
+                    agent, messages, tool_calls[i - 1:], effective_task_id,
+                    notice="tool call(s)",
+                    content="[Tool execution cancelled — {name} was skipped due to user interrupt]",
+                    hook_error_type="user_interrupt",
+                    hook_id=lambda tc: getattr(tc, "id", "") or "",
+                    flush_stage="cancelled tool result",
+                ):
+                    return
+                break
+
+            pc = _parse_tool_call(agent, tool_call, flatten_probe=True)
+            ref = pc.ref(effective_task_id)
+            if pc.parse_error is not None:
+                if not _append_invalid_arguments_result(agent, messages, ref, pc.parse_error):
+                    return
+                continue
+
+            dispatch = _resolve_sequential_dispatch(agent, ref, messages)
+            managed, tool_duration = _run_sequential_call(
+                agent, dispatch, ref,
+                scope_block=pc.scope_block,
+                messages=messages,
+                remaining_calls=tool_calls[i - 1:],
+                display_index=i,
+                tool_start_time=tool_start_time,
+                defer_quiet_completion=required_post_settlement,
+            )
+            if not _publish_sequential_result(
+                agent, messages, ref, managed,
+                tool_duration=tool_duration, index=i, budget=_tool_budget,
+                quiet_completion_spinner=dispatch.spinner,
+                finish_quiet_completion=(
+                    required_post_settlement and dispatch.finish_spinner
+                ),
             ):
                 return
-            break
-
-        pc = _parse_tool_call(agent, tool_call, flatten_probe=True)
-        ref = pc.ref(effective_task_id)
-        if pc.parse_error is not None:
-            if not _append_invalid_arguments_result(agent, messages, ref, pc.parse_error):
-                return
-            continue
-
-        tool_start_time = time.time()
-        dispatch = _resolve_sequential_dispatch(agent, ref, messages)
-        managed, tool_duration = _run_sequential_call(
-            agent, dispatch, ref,
-            scope_block=pc.scope_block,
-            messages=messages,
-            remaining_calls=tool_calls[i - 1:],
-            display_index=i,
-            tool_start_time=tool_start_time,
-        )
-        if not _publish_sequential_result(agent, messages, ref, managed, tool_duration=tool_duration, index=i, budget=_tool_budget):
+        except _UndurableToolSettlement:
             return
+        except RequiredLifecycleError:
+            unsettled = _unsettled_sequential_calls(messages, tool_calls[i - 1:])
+            failed_ref = ref
+            if unsettled:
+                failed_call = unsettled[0]
+                failed_id = _pairing_tool_call_id(failed_call)
+                if failed_id != ref.call_id:
+                    failed_ref = _ToolCallRef(
+                        _canonical_tool_name(_tc_name(failed_call)),
+                        {},
+                        effective_task_id,
+                        failed_id,
+                        [],
+                    )
+                _settle_required_post_failure(
+                    agent, messages, failed_ref, unsettled[1:]
+                )
+            if dispatch is not None and dispatch.finish_spinner:
+                with contextlib.suppress(Exception):
+                    _finish_quiet_tool_spinner(
+                        agent,
+                        dispatch.spinner,
+                        failed_ref.name,
+                        failed_ref.args,
+                        time.time() - tool_start_time,
+                        json.dumps(
+                            {"error": REQUIRED_LIFECYCLE_FAILURE_TEXT},
+                            ensure_ascii=False,
+                        ),
+                    )
+            raise
 
         if agent._interrupt_requested and i < len(tool_calls):
             if not _skip_remaining_sequential(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1844,7 +1844,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     make_tool_result_message(
                         skipped.function.name,
                         REQUIRED_LIFECYCLE_FAILURE_TEXT,
-                        skipped.id,
+                        _pairing_tool_call_id(skipped),
                         effect_disposition="none",
                     )
                 )

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -393,6 +393,7 @@ class TurnContext:
     plugin_user_context: str = ""  # ``pre_llm_call`` context (appended to user message)
     ext_prefetch_cache: str = ""  # external-memory prefetch, reused across iterations
     preflight_compression_blocked: bool = False  # immediate retry proved ineffective
+    required_lifecycle_failure: str = ""  # mandatory pre-LLM failure; never call provider
 
 
 def _persist_under_lock(agent: Any, fn, failure_msg: str, pending_cli_message: Any) -> None:
@@ -460,7 +461,6 @@ def _bind_turn_identity(
 ) -> Tuple[str, str]:
     """Stage callback/persist overrides on the agent and bind this turn's task and turn
     ids. Returns ``(effective_task_id, turn_id)``."""
-    agent._stream_callback = stream_callback  # picked up by _interruptible_api_call
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = persist_user_message
     agent._persist_user_message_timestamp = persist_user_timestamp
@@ -475,6 +475,23 @@ def _bind_turn_identity(
     agent._relay_pending_turn_id = None
     agent._current_turn_id = turn_id
     agent._current_api_request_id = ""
+    # A mandatory output transform is a publication boundary.  Buffer all
+    # provider deltas until the transform has acknowledged the terminal text.
+    try:
+        from hermes_cli.plugins import requires_hook as _requires_hook
+
+        _must_buffer = _requires_hook("transform_llm_output")
+    except Exception:
+        _must_buffer = True
+    if _must_buffer:
+        agent._required_lifecycle_stream_delta_callback = agent.stream_delta_callback
+        agent.stream_delta_callback = None
+        agent._required_lifecycle_disable_streaming = bool(
+            getattr(agent, "_disable_streaming", False)
+        )
+        agent._disable_streaming = True
+        stream_callback = None
+    agent._stream_callback = stream_callback  # picked up by _interruptible_api_call
     # Tripwire: warn when this turn starts before the previous turn-end persist
     # (concurrent turns interleave transcript writes). Cleared in _persist_session.
     from agent.agent_runtime_helpers import note_turn_start
@@ -657,11 +674,12 @@ def _ensure_session_row(agent: Any, pending_cli_message: Any) -> None:
 def _collect_pre_llm_call_context(
     agent: Any, *, effective_task_id: str, turn_id: str, original_user_message: Any,
     messages: List[Any], conversation_history: Optional[List[Any]],
-) -> str:
+) -> tuple[str, str]:
     """Run ``pre_llm_call`` plugins; their context is injected into the user message
     (never the system prompt). Oversized per-hook context is spilled to disk so a
     runaway plugin can't inflate every subsequent turn's prompt."""
     try:
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
             "pre_llm_call",
@@ -703,10 +721,15 @@ def _collect_pre_llm_call_context(
                 except Exception as _spill_exc:
                     logger.warning("hook context spill failed: %s", _spill_exc)
             _ctx_parts.append(_piece)
-        return "\n\n".join(_ctx_parts)
+        return "\n\n".join(_ctx_parts), ""
+    except RequiredLifecycleError as exc:
+        logger.warning(
+            "mandatory pre_llm_call lifecycle unavailable: %s", exc.reason_code
+        )
+        return "", exc.reason_code
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
-    return ""
+    return "", ""
 
 
 def _merge_gateway_notes(
@@ -956,7 +979,7 @@ def build_turn_context(
     conversation_history = compaction.conversation_history
     current_turn_user_idx = compaction.current_turn_user_idx
 
-    plugin_user_context = _collect_pre_llm_call_context(
+    plugin_user_context, required_lifecycle_failure = _collect_pre_llm_call_context(
         agent, effective_task_id=effective_task_id, turn_id=turn_id,
         original_user_message=original_user_message, messages=messages,
         conversation_history=conversation_history,
@@ -993,6 +1016,7 @@ def build_turn_context(
         current_turn_user_idx=current_turn_user_idx, should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context, ext_prefetch_cache=ext_prefetch_cache,
         preflight_compression_blocked=compaction.blocked,
+        required_lifecycle_failure=required_lifecycle_failure,
     )
 
 
@@ -1037,6 +1061,9 @@ def build_api_messages(
         # Structural clone, NOT msg.copy(): in-place transforms below must not reach
         # persisted history via nested containers; see _clone_message_for_send.
         api_msg = _clone_message_for_send(msg)
+        from hermes_cli.required_lifecycle import restore_required_provider_fields
+
+        restore_required_provider_fields(agent, msg, api_msg)
         # api_content is bookkeeping (exact bytes sent), never a provider field — pop
         # it from EVERY outgoing copy. display_* is display-only timeline metadata
         # (strict OpenAI backends reject unknown keys); _row_id is the durable row id

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -161,6 +161,26 @@ class TurnFacadeMixin:
                 finish_task_run(**task_context, error=exc)
             raise
         finally:
+            # Direct-return and exceptional paths may bypass finalize_turn.  The
+            # cached agent must never carry publication buffering or opaque
+            # provider continuity into its next user turn.
+            with suppress(Exception):
+                from hermes_cli.required_lifecycle import scrub_required_provider_fields
+
+                scrub_required_provider_fields(self)
+            if hasattr(self, "_required_lifecycle_stream_delta_callback"):
+                self.stream_delta_callback = self._required_lifecycle_stream_delta_callback
+                del self._required_lifecycle_stream_delta_callback
+            if hasattr(self, "_required_lifecycle_disable_streaming"):
+                self._disable_streaming = self._required_lifecycle_disable_streaming
+                del self._required_lifecycle_disable_streaming
+            with suppress(Exception):
+                from hermes_cli.plugins import finish_required_lifecycle_turn
+
+                finish_required_lifecycle_turn(
+                    session_id=session_id,
+                    turn_id=str(getattr(self, "_current_turn_id", "") or relay_turn_id),
+                )
             try:
                 if relay_turn is not None:
                     relay_runtime.SESSION_COORDINATOR.end_turn(relay_turn, outcome=relay_outcome)

--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -166,7 +166,45 @@ def finish_text_response(
 
     final_response = agent._strip_think_blocks(final_response).strip()
 
+    try:
+        from hermes_cli.plugins import apply_required_lifecycle_output
+
+        raw_required_output = final_response
+        required_output, final_response = apply_required_lifecycle_output(
+            final_response,
+            session_id=agent.session_id or "",
+            task_id=getattr(agent, "_current_task_id", "") or "",
+            turn_id=getattr(agent, "_current_turn_id", "") or "",
+            model=agent.model,
+            platform=getattr(agent, "platform", None) or "",
+        )
+        if required_output:
+            agent._required_lifecycle_output_turn_id = getattr(
+                agent, "_current_turn_id", ""
+            )
+            agent._required_lifecycle_output_transformed = (
+                final_response != raw_required_output
+            )
+    except Exception as required_exc:
+        from hermes_cli.required_lifecycle import (
+            REQUIRED_LIFECYCLE_FAILURE_TEXT,
+            RequiredLifecycleError,
+        )
+
+        if not isinstance(required_exc, RequiredLifecycleError):
+            raise
+        final_response = REQUIRED_LIFECYCLE_FAILURE_TEXT
+        agent._required_lifecycle_output_turn_id = getattr(
+            agent, "_current_turn_id", ""
+        )
+        agent._required_lifecycle_output_transformed = True
+
     final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+    if getattr(agent, "_required_lifecycle_output_turn_id", "") == getattr(
+        agent, "_current_turn_id", ""
+    ):
+        final_msg["content"] = final_response
+        final_msg.pop("api_content", None)
 
     # Dropped tool-call recovery (copilot/Claude): finish_reason="tool_calls" with empty
     # tool_calls would end the turn unstarted; re-prompt (max 3 CONSECUTIVE stalls).

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -439,6 +439,25 @@ def finalize_turn(
     """Run the post-loop finalization and return the turn ``result`` dict."""
     from agent.conversation_loop import logger
 
+    from hermes_cli.required_lifecycle import (
+        REQUIRED_LIFECYCLE_FAILURE_TEXT,
+        RequiredLifecycleError,
+    )
+
+    try:
+        from hermes_cli.plugins import assert_required_lifecycle_turn_healthy
+
+        assert_required_lifecycle_turn_healthy(
+            session_id=agent.session_id or "", turn_id=turn_id
+        )
+    except RequiredLifecycleError as required_exc:
+        final_response = REQUIRED_LIFECYCLE_FAILURE_TEXT
+        failed = True
+        _turn_exit_reason = (
+            "required_lifecycle_blocked("
+            f"{required_exc.reason_code})"
+        )
+
     final_response, _turn_exit_reason, preserved_verification_fallback = _resolve_budget_fallback(
         agent, final_response=final_response, api_call_count=api_call_count,
         interrupted=interrupted, failed=failed, messages=messages,
@@ -447,6 +466,56 @@ def finalize_turn(
         _pending_verification_response_previewed=_pending_verification_response_previewed,
         logger=logger,
     )
+
+    response_transformed = False
+    pre_transform_response = None
+    required_output_hook = False
+    try:
+        from hermes_cli.plugins import apply_required_lifecycle_output, requires_hook
+
+        required_output_hook = requires_hook("transform_llm_output")
+        output_already_applied = (
+            getattr(agent, "_required_lifecycle_output_turn_id", "") == turn_id
+        )
+        if required_output_hook and output_already_applied:
+            response_transformed = bool(
+                getattr(agent, "_required_lifecycle_output_transformed", False)
+            )
+        elif required_output_hook and not interrupted:
+            raw_response = final_response if isinstance(final_response, str) else ""
+            _, final_response = apply_required_lifecycle_output(
+                raw_response,
+                session_id=agent.session_id or "",
+                task_id=effective_task_id,
+                turn_id=turn_id,
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+            response_transformed = final_response != raw_response
+    except RequiredLifecycleError as required_exc:
+        required_output_hook = True
+        final_response = REQUIRED_LIFECYCLE_FAILURE_TEXT
+        response_transformed = True
+        failed = True
+        _turn_exit_reason = (
+            "required_lifecycle_blocked("
+            f"{required_exc.reason_code})"
+        )
+
+    if required_output_hook and not interrupted:
+        replaced_terminal = False
+        for message in reversed(messages):
+            if not isinstance(message, dict):
+                continue
+            if message.get("role") == "user":
+                break
+            if message.get("role") == "assistant" and not message.get("tool_calls"):
+                message["content"] = final_response
+                message.pop("api_content", None)
+                replaced_terminal = True
+                break
+        if not replaced_terminal and final_response:
+            append_message(messages, {"role": "assistant", "content": final_response})
 
     completed = (
         final_response is not None
@@ -493,18 +562,16 @@ def finalize_turn(
     _log_turn_exit(agent, messages, final_response, api_call_count, _turn_exit_reason, interrupted, logger)
 
     # Response transforms apply only to real, uninterrupted responses.
-    if final_response and not interrupted:
+    if final_response and not interrupted and not required_output_hook:
         final_response = _append_file_mutation_footer(agent, final_response, logger)
-    if not interrupted:
+    if not interrupted and not required_output_hook:
         final_response = _explain_abnormal_exit(
             agent, final_response, _turn_exit_reason, preserved_verification_fallback, logger,
         )
 
     _platform = getattr(agent, "platform", None) or ""
-    _response_transformed = False
-    _pre_transform_response = None
-    if final_response and not interrupted:
-        final_response, _response_transformed, _pre_transform_response = _apply_output_hooks(
+    if final_response and not interrupted and not required_output_hook:
+        final_response, response_transformed, pre_transform_response = _apply_output_hooks(
             agent, final_response, logger, platform=_platform, effective_task_id=effective_task_id,
             turn_id=turn_id, original_user_message=original_user_message, messages=messages,
         )
@@ -543,8 +610,8 @@ def finalize_turn(
         "failed": failed,
         "partial": False,  # True only when stopped due to invalid tool calls
         "interrupted": interrupted,
-        "response_transformed": _response_transformed,
-        "pre_transform_response": _pre_transform_response,
+        "response_transformed": response_transformed,
+        "pre_transform_response": pre_transform_response,
         "response_previewed": getattr(agent, "_response_was_previewed", False),
         "model": agent.model,
         "provider": agent.provider,
@@ -588,6 +655,16 @@ def finalize_turn(
         result["interrupt_message"] = agent._interrupt_message
     agent.clear_interrupt()
     agent._stream_callback = None  # don't leak into future calls
+    if hasattr(agent, "_required_lifecycle_stream_delta_callback"):
+        agent.stream_delta_callback = agent._required_lifecycle_stream_delta_callback
+        del agent._required_lifecycle_stream_delta_callback
+    if hasattr(agent, "_required_lifecycle_disable_streaming"):
+        agent._disable_streaming = agent._required_lifecycle_disable_streaming
+        del agent._required_lifecycle_disable_streaming
+    if getattr(agent, "_required_lifecycle_output_turn_id", "") == turn_id:
+        del agent._required_lifecycle_output_turn_id
+        if hasattr(agent, "_required_lifecycle_output_transformed"):
+            del agent._required_lifecycle_output_transformed
 
     # Skill trigger is checked NOW — based on how many tool iterations THIS turn used.
     _should_review_skills = (
@@ -597,6 +674,10 @@ def finalize_turn(
     )
     if _should_review_skills:
         agent._iters_since_skill = 0
+
+    from hermes_cli.required_lifecycle import scrub_required_provider_fields
+
+    scrub_required_provider_fields(agent)
 
     # External memory provider: sync the completed turn + queue next prefetch.
     agent._sync_external_memory_for_turn(
@@ -637,4 +718,12 @@ def finalize_turn(
 
     agent._turn_preflight_display_snapshot = None
     agent._turn_received_provider_response = False
+    try:
+        from hermes_cli.plugins import finish_required_lifecycle_turn
+
+        finish_required_lifecycle_turn(
+            session_id=agent.session_id or "", turn_id=turn_id
+        )
+    except RequiredLifecycleError:
+        pass
     return result

--- a/agent/turn_response_intake.py
+++ b/agent/turn_response_intake.py
@@ -131,23 +131,31 @@ def normalize_model_response(
     if assistant_message.content is not None and not isinstance(assistant_message.content, str):
         assistant_message.content = _coerce_content_text(assistant_message.content)
 
+    try:
+        from hermes_cli.plugins import requires_hook as _requires_hook
+
+        required_output_publication = _requires_hook("transform_llm_output")
+    except Exception:
+        required_output_publication = True
+
     # Agent-as-provider projection: splice the provider-agent's own tool work in as
     # call/result rows before this turn's assistant message; no-op for ordinary providers.
     splice_provider_projection(agent, response, messages)
 
-    _fire_post_api_request_hook(
-        agent, response, assistant_message, finish_reason, api_messages=api_messages,
-        api_call_count=api_call_count, api_duration=api_duration, api_start_time=api_start_time,
-        api_request_id=api_request_id, effective_task_id=effective_task_id, turn_id=turn_id,
-    )
+    if not required_output_publication:
+        _fire_post_api_request_hook(
+            agent, response, assistant_message, finish_reason, api_messages=api_messages,
+            api_call_count=api_call_count, api_duration=api_duration, api_start_time=api_start_time,
+            api_request_id=api_request_id, effective_task_id=effective_task_id, turn_id=turn_id,
+        )
 
     content = assistant_message.content
-    if content and not agent.quiet_mode:
+    if content and not agent.quiet_mode and not required_output_publication:
         if agent.verbose_logging:
             agent._vprint(f"{agent.log_prefix}🤖 Assistant: {content}")
         else:
             agent._vprint(f"{agent.log_prefix}🤖 Assistant: {content[:100]}{'...' if len(content) > 100 else ''}")
-    if content and agent.tool_progress_callback:
+    if content and agent.tool_progress_callback and not required_output_publication:
         _relay_thinking(agent, content)
 
     # Incomplete <REASONING_SCRATCHPAD> (opened, never closed): the model ran out of

--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -149,7 +149,30 @@ def run_tool_round(
         with suppress(Exception):
             agent.stream_delta_callback(None)
 
-    agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+    from hermes_cli.required_lifecycle import (
+        REQUIRED_LIFECYCLE_FAILURE_TEXT,
+        RequiredLifecycleError,
+    )
+
+    try:
+        agent._execute_tool_calls(
+            assistant_message, messages, effective_task_id, api_call_count
+        )
+    except RequiredLifecycleError as required_exc:
+        failed = True
+        if getattr(agent, "_incremental_persistence_failed", False):
+            _turn_exit_reason = "session_persistence_failed"
+            final_response = ""
+        else:
+            _turn_exit_reason = (
+                "required_lifecycle_blocked("
+                f"{required_exc.reason_code})"
+            )
+            final_response = REQUIRED_LIFECYCLE_FAILURE_TEXT
+            append_message(
+                messages, {"role": "assistant", "content": final_response}
+            )
+        return _verdict("break")
 
     if getattr(agent, "_incremental_persistence_failed", False):
         # Tool result could not be made canonical: never send the in-memory result to

--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -229,7 +229,9 @@ def stage_tool_call_message(
 
     assistant_msg = agent._build_assistant_message(assistant_message, finish_reason)
 
-    turn_content = assistant_message.content or ""
+    # The provider object stays private input.  Persistence, interim delivery,
+    # and fallback narration may use only the publication-safe projection.
+    turn_content = assistant_msg.get("content") or ""
 
     # A bare bracketed token (e.g. ``[memory]``) beside a function call is protocol
     # scaffolding; persisting it lets the post-tool fallback replay it forever (#78148).

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -9,6 +9,7 @@ the final roll-back. Nothing here imports ``agent.conversation_loop`` at module 
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import re
 from dataclasses import dataclass
@@ -170,17 +171,7 @@ class _Trunc(TruncationVerdict):
         # output publication boundary.  When that boundary is configured (or
         # its policy is invalid), persisting here would durably expose raw
         # provider fragments before transform_llm_output can authorize them.
-        try:
-            from hermes_cli.plugins import requires_hook
-
-            required_output_pending = requires_hook("transform_llm_output")
-        except Exception as exc:
-            from hermes_cli.required_lifecycle import RequiredLifecycleError
-
-            if not isinstance(exc, RequiredLifecycleError):
-                raise
-            required_output_pending = True
-        if not required_output_pending:
+        if not _required_output_pending():
             agent._persist_session(self.messages, self.conversation_history)
         return self.done("return", partial_result(
             self.messages if result_messages is None else result_messages, self.api_call_count,
@@ -456,6 +447,20 @@ _CODEX_REPLAY_KEYS = (
 )
 
 
+def _required_output_pending() -> bool:
+    """Whether raw direct-return text must stay process-local until authorized."""
+    try:
+        from hermes_cli.plugins import requires_hook
+
+        return requires_hook("transform_llm_output")
+    except Exception as exc:
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+        if not isinstance(exc, RequiredLifecycleError):
+            raise
+        return True
+
+
 def continue_codex_incomplete(
     agent: Any, assistant_message: Any, finish_reason: str, *, messages: List[Dict[str, Any]],
     conversation_history: Any, api_call_count: int,
@@ -472,6 +477,9 @@ def continue_codex_incomplete(
 
     agent._codex_incomplete_retries += 1
     n = agent._codex_incomplete_retries
+    required_output_pending = _required_output_pending()
+    if n == 1 and required_output_pending:
+        agent._required_codex_incomplete_start = len(messages)
 
     interim_msg = agent._build_assistant_message(assistant_message, finish_reason)
     interim_has_content = bool((interim_msg.get("content") or "").strip())
@@ -510,7 +518,8 @@ def continue_codex_incomplete(
                     last_msg[_key] = interim_msg[_key]
         else:
             append_message(messages, interim_msg)
-            agent._emit_interim_assistant_message(interim_msg)
+            if not required_output_pending:
+                agent._emit_interim_assistant_message(interim_msg)
 
     if n < 3:
         # If the interim has nothing the Responses converter will replay, a bare retry is
@@ -545,7 +554,14 @@ def continue_codex_incomplete(
         return None
 
     agent._codex_incomplete_retries = 0
-    agent._persist_session(messages, conversation_history)
+    if required_output_pending:
+        start = getattr(agent, "_required_codex_incomplete_start", len(messages))
+        if isinstance(start, int) and not isinstance(start, bool) and 0 <= start <= len(messages):
+            del messages[start:]
+    else:
+        agent._persist_session(messages, conversation_history)
+    with contextlib.suppress(AttributeError):
+        del agent._required_codex_incomplete_start
     return partial_result(
         messages, api_call_count, "Codex response remained incomplete after 3 continuation attempts"
     )

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -166,7 +166,22 @@ class _Trunc(TruncationVerdict):
         agent = self.agent
         if cleanup:
             agent._cleanup_task_resources(self.effective_task_id)
-        agent._persist_session(self.messages, self.conversation_history)
+        # Direct truncation results pass through conversation_loop's required
+        # output publication boundary.  When that boundary is configured (or
+        # its policy is invalid), persisting here would durably expose raw
+        # provider fragments before transform_llm_output can authorize them.
+        try:
+            from hermes_cli.plugins import requires_hook
+
+            required_output_pending = requires_hook("transform_llm_output")
+        except Exception as exc:
+            from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+            if not isinstance(exc, RequiredLifecycleError):
+                raise
+            required_output_pending = True
+        if not required_output_pending:
+            agent._persist_session(self.messages, self.conversation_history)
         return self.done("return", partial_result(
             self.messages if result_messages is None else result_messages, self.api_call_count,
             final_response, error, failed=failed, compression_exhausted=compression_exhausted,
@@ -566,14 +581,22 @@ def handle_content_policy_refusal(
     if not _refusal_text:
         _refusal_text = (agent._extract_reasoning(_refusal_result) or "").strip()
 
-    agent._invoke_api_request_error_hook(
-        task_id=effective_task_id, turn_id=turn_id, api_request_id=api_request_id,
-        api_call_count=api_call_count, api_start_time=api_start_time, api_kwargs=api_kwargs,
-        error_type="ContentPolicyBlocked",
-        error_message=_refusal_text or "model declined to respond (content_filter)",
-        status_code=None, retry_count=retry_count, max_retries=max_retries, retryable=False,
-        reason=FailoverReason.content_policy_blocked.value,
-    )
+    try:
+        from hermes_cli.plugins import requires_hook as _requires_hook
+
+        required_output_publication = _requires_hook("transform_llm_output")
+    except Exception:
+        required_output_publication = True
+
+    if not required_output_publication:
+        agent._invoke_api_request_error_hook(
+            task_id=effective_task_id, turn_id=turn_id, api_request_id=api_request_id,
+            api_call_count=api_call_count, api_start_time=api_start_time, api_kwargs=api_kwargs,
+            error_type="ContentPolicyBlocked",
+            error_message=_refusal_text or "model declined to respond (content_filter)",
+            status_code=None, retry_count=retry_count, max_retries=max_retries, retryable=False,
+            reason=FailoverReason.content_policy_blocked.value,
+        )
     stop_thinking_spinner(agent, thinking_spinner)
 
     if agent._has_pending_fallback():
@@ -587,7 +610,8 @@ def handle_content_policy_refusal(
     logger.warning(
         "%sModel declined to respond (finish_reason=content_filter). model=%s provider=%s refusal=%s",
         agent.log_prefix, agent.model, agent.provider,
-        _refusal_log or "(no text)",
+        "(withheld by required output policy)"
+        if required_output_publication else _refusal_log or "(no text)",
     )
     agent._emit_status("⚠️ The model declined to respond to this request (safety refusal).")
     _refusal_detail = (

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -62,6 +62,14 @@ from hermes_cli.plugins_state import (
     PluginState, _locked_plugin_state, _nested_plugin_mapping, _nested_plugin_value,
     _plugin_relative_segments, _plugin_settings_entry,
 )
+from hermes_cli.required_lifecycle import (
+    REQUIRED_LIFECYCLE_FAILURE_TEXT,
+    REQUIRED_LIFECYCLE_HOOKS,
+    RequiredLifecycleError,
+    RequiredLifecycleLatch,
+    parse_required_lifecycle_policy,
+    required_hook_result,
+)
 
 
 def get_bundled_plugins_dir() -> Path:
@@ -890,9 +898,39 @@ class PluginContext:
         logger.debug("Plugin %s registered %d redaction pattern(s)", self.manifest.name, count)
         return count
 
-    def register_hook(self, hook_name: str, callback: Callable) -> PluginRegistration:
+    @_serialized_replacement
+    def register_hook(
+        self,
+        hook_name: str,
+        callback: Callable,
+        *,
+        registration_id: str = "",
+    ) -> PluginRegistration:
         """Register a lifecycle hook callback (unknown names warn but are still stored)."""
-        return self._track_callback("hook", hook_name, callback, self._manager._hooks, VALID_HOOKS)
+        if not callable(callback):
+            raise TypeError("Plugin hook callback must be callable")
+        if registration_id:
+            required_hook_result(registration_id)
+        if hook_name not in VALID_HOOKS:
+            logger.warning(
+                "Plugin '%s' registered unknown hook '%s' (valid: %s)",
+                self.manifest.name,
+                hook_name,
+                ", ".join(sorted(VALID_HOOKS)),
+            )
+        self._manager._hooks.setdefault(hook_name, []).append(callback)
+        handle = self._manager._track_registration(
+            self.manifest,
+            "hook",
+            hook_name,
+            lambda: self._manager._remove_callback(
+                self._manager._hooks, hook_name, callback
+            ),
+            registration_id=registration_id,
+            callback=callback,
+        )
+        logger.debug("Plugin %s registered hook: %s", self.manifest.name, hook_name)
+        return handle
 
     def register_middleware(self, kind: str, callback: Callable) -> PluginRegistration:
         """Register behavior-changing middleware (request kinds rewrite the payload, execution kinds
@@ -1169,6 +1207,12 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         # any remaining process-global slots when the symmetric force-reload lands.
         self._ownership_ledger: Dict[str, List[PluginRegistration]] = {}
         self._registration_order: List[PluginRegistration] = []
+        self._registration_generation = 0
+        self._required_lifecycle_policy: dict[
+            str, dict[str, tuple[str, ...]]
+        ] = {}
+        self._required_lifecycle_policy_error: RequiredLifecycleError | None = None
+        self._required_lifecycle_latch = RequiredLifecycleLatch()
         # Force re-discovery drains this via _evict_stale_persistent_registrations(): entries whose plugin
         # re-registered the same (kind, key) are kept (the upsert rotated them in place), the rest are
         # disposed so a disabled/removed auth plugin's provider does not outlive its plugin (#91701
@@ -1207,6 +1251,7 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
                 return
             if force:
                 self.unload()  # the ledger owns teardown of process-global registries
+            self._refresh_required_lifecycle_policy()
             if env_var_enabled("HERMES_SAFE_MODE"):
                 logger.info("HERMES_SAFE_MODE=1 — plugin discovery skipped")
                 self._discovered = True
@@ -1236,6 +1281,22 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
             except BaseException:
                 self._discovered = False
                 raise
+
+    def _refresh_required_lifecycle_policy(self) -> None:
+        """Freeze the profile's required-hook policy for this discovery sweep."""
+        self._required_lifecycle_policy = {}
+        self._required_lifecycle_policy_error = None
+        try:
+            config = load_config_readonly() or {}
+            if not isinstance(config, Mapping):
+                raise RequiredLifecycleError("required_lifecycle_policy_invalid")
+            self._required_lifecycle_policy = parse_required_lifecycle_policy(config)
+        except RequiredLifecycleError as exc:
+            self._required_lifecycle_policy_error = exc
+        except Exception:
+            self._required_lifecycle_policy_error = RequiredLifecycleError(
+                "required_lifecycle_policy_unavailable"
+            )
 
     def _re_register_config_hooks_after_force(self) -> None:
         """Restore config-owned shell hooks/outbound webhooks after a force clear; each guarded
@@ -1717,6 +1778,56 @@ def has_hook(hook_name: str) -> bool:
     return _delivery_manager().has_hook(hook_name)
 
 
+def requires_hook(hook_name: str) -> bool:
+    """Return whether the frozen profile makes this lifecycle hook mandatory."""
+    return _delivery_manager().requires_hook(hook_name)
+
+
+def assert_required_lifecycle_turn_healthy(
+    *, session_id: str, turn_id: str
+) -> None:
+    _delivery_manager().assert_required_lifecycle_turn_healthy(
+        session_id=session_id, turn_id=turn_id
+    )
+
+
+def finish_required_lifecycle_turn(*, session_id: str, turn_id: str) -> None:
+    _delivery_manager().finish_required_lifecycle_turn(
+        session_id=session_id, turn_id=turn_id
+    )
+
+
+def apply_required_lifecycle_output(
+    response_text: str,
+    *,
+    session_id: str,
+    task_id: str,
+    turn_id: str,
+    model: str,
+    platform: str,
+) -> tuple[bool, str]:
+    manager = _delivery_manager()
+    manager.assert_required_lifecycle_turn_healthy(
+        session_id=session_id, turn_id=turn_id
+    )
+    if not manager.requires_hook("transform_llm_output"):
+        return False, response_text
+    results = manager.invoke_hook(
+        "transform_llm_output",
+        response_text=response_text,
+        session_id=session_id,
+        task_id=task_id,
+        turn_id=turn_id,
+        model=model,
+        platform=platform,
+    )
+    replacement = next(
+        (result for result in results if isinstance(result, str) and result),
+        response_text,
+    )
+    return True, replacement
+
+
 def iter_hook_callbacks(hook_name: str) -> tuple[Callable, ...]:
     """Return a stable snapshot of callbacks registered for a hook."""
     return get_plugin_manager().iter_hook_callbacks(hook_name)
@@ -1782,11 +1893,16 @@ def _get_pre_tool_call_directive_details(
         fmt = getattr(_thread_tool_whitelist, "fmt", "Tool '{tool_name}' denied")
         return _PreToolCallDirective(action="block", message=fmt.format(tool_name=tool_name))
     from hermes_cli.lifecycle import invoke_hook as invoke_lifecycle_hook
-    hook_results = invoke_lifecycle_hook(
-        "pre_tool_call", tool_name=tool_name, args=args if isinstance(args, dict) else {},
-        task_id=task_id, session_id=session_id, tool_call_id=tool_call_id, turn_id=turn_id,
-        api_request_id=api_request_id, middleware_trace=list(middleware_trace or []),
-    )
+    try:
+        hook_results = invoke_lifecycle_hook(
+            "pre_tool_call", tool_name=tool_name, args=args if isinstance(args, dict) else {},
+            task_id=task_id, session_id=session_id, tool_call_id=tool_call_id, turn_id=turn_id,
+            api_request_id=api_request_id, middleware_trace=list(middleware_trace or []),
+        )
+    except RequiredLifecycleError:
+        return _PreToolCallDirective(
+            action="block", message=REQUIRED_LIFECYCLE_FAILURE_TEXT
+        )
     modified_args: Optional[Dict[str, Any]] = None
     for result in hook_results:
         if not isinstance(result, dict):

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -19,6 +19,12 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Union
 
 from hermes_cli.middleware import OBSERVER_SCHEMA_VERSION
+from hermes_cli.required_lifecycle import (
+    REQUIRED_LIFECYCLE_HOOKS,
+    RequiredHookResult,
+    RequiredLifecycleError,
+    validate_required_semantic_result,
+)
 
 logger = logging.getLogger("hermes_cli.plugins")
 
@@ -163,6 +169,89 @@ class PluginDispatchMixin:
             if name in parameters and parameters[name].kind in keyword_kinds
         })
 
+    def _required_lifecycle_snapshot(
+        self, hook_name: str, payload: Mapping[str, Any]
+    ) -> tuple[tuple[str, str, str], int, tuple[Callable, ...], dict[int, Any]] | None:
+        if hook_name not in REQUIRED_LIFECYCLE_HOOKS:
+            return None
+        configured = bool(self._required_lifecycle_policy) or (
+            self._required_lifecycle_policy_error is not None
+        )
+        try:
+            latch_key = self._required_lifecycle_latch.key(self.scope_key, payload)
+        except RequiredLifecycleError as exc:
+            if not configured:
+                return None
+            raise self._required_lifecycle_latch.fail_uncorrelated(
+                self.scope_key, exc.reason_code, hook_name
+            ) from None
+        if not configured and not self._required_lifecycle_latch.is_active(latch_key):
+            return None
+        self._required_lifecycle_latch.check(latch_key)
+        if self._required_lifecycle_policy_error is not None:
+            raise self._required_lifecycle_latch.fail(
+                latch_key, self._required_lifecycle_policy_error.reason_code, hook_name
+            )
+        with self._discovery_lock:
+            generation = self._registration_generation
+            self._required_lifecycle_latch.begin(latch_key, generation)
+            if not self._required_lifecycle_policy:
+                raise self._required_lifecycle_latch.fail(
+                    latch_key, "required_lifecycle_registration_changed", hook_name
+                )
+            callbacks = tuple(self._hooks.get(hook_name, ()))
+            required_current: dict[int, Any] = {}
+            try:
+                for plugin_key, hooks in self._required_lifecycle_policy.items():
+                    loaded = self._plugins.get(plugin_key)
+                    if loaded is None or not loaded.enabled or loaded.error is not None:
+                        raise RequiredLifecycleError(
+                            "required_lifecycle_registration_invalid", hook_name
+                        )
+                    for required_hook, registration_ids in hooks.items():
+                        hook_callbacks = tuple(self._hooks.get(required_hook, ()))
+                        for registration_id in registration_ids:
+                            matches = [
+                                registration
+                                for registration in self._ownership_ledger.get(plugin_key, ())
+                                if registration.active
+                                and registration.kind == "hook"
+                                and registration.key == required_hook
+                                and registration.registration_id == registration_id
+                                and registration.callback is not None
+                                and sum(
+                                    callback is registration.callback
+                                    for callback in hook_callbacks
+                                )
+                                == 1
+                            ]
+                            if len(matches) != 1:
+                                raise RequiredLifecycleError(
+                                    "required_lifecycle_registration_invalid", hook_name
+                                )
+                            if required_hook == hook_name:
+                                callback_key = id(matches[0].callback)
+                                if callback_key in required_current:
+                                    raise RequiredLifecycleError(
+                                        "required_lifecycle_registration_invalid", hook_name
+                                    )
+                                required_current[callback_key] = matches[0]
+            except RequiredLifecycleError as exc:
+                raise self._required_lifecycle_latch.fail(
+                    latch_key, exc.reason_code, hook_name
+                ) from None
+        return latch_key, generation, callbacks, required_current
+
+    def _required_generation_unchanged(
+        self, latch_key: tuple[str, str, str], generation: int, hook_name: str
+    ) -> None:
+        with self._discovery_lock:
+            unchanged = generation == self._registration_generation
+        if not unchanged:
+            raise self._required_lifecycle_latch.fail(
+                latch_key, "required_lifecycle_registration_changed", hook_name
+            )
+
     def invoke_hook(self, hook_name: str, **kwargs: Any) -> List[Any]:
         """Call all callbacks for *hook_name*; return their non-``None`` results.
 
@@ -177,26 +266,124 @@ class PluginDispatchMixin:
         # unrelated adapter payloads into one monolithic compatibility contract.
         if hook_name != "gateway_platform_event":
             kwargs.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
-        results: List[Any] = []
+        required_snapshot = self._required_lifecycle_snapshot(hook_name, kwargs)
+        if required_snapshot is None:
+            callbacks = tuple(self._hooks.get(hook_name, ()))
+            latch_key = None
+            generation = -1
+            required_callbacks: dict[int, Any] = {}
+        else:
+            latch_key, generation, callbacks, required_callbacks = required_snapshot
+        required_results: List[Any] = []
+        optional_results: List[Any] = []
         timeout = _resolve_hook_callback_timeout()
         use_timeout = _hook_uses_callback_timeout(hook_name, timeout)
         fail_closed = hook_name in _HOOK_TIMEOUT_FAIL_CLOSED_HOOKS
-        for cb in self._hooks.get(hook_name, []):
+        for cb in callbacks:
+            required_registration = required_callbacks.get(id(cb))
+            if required_registration is not None:
+                assert latch_key is not None
+                self._required_generation_unchanged(latch_key, generation, hook_name)
+                try:
+                    if use_timeout:
+                        acknowledged = self._run_hook_callback_bounded(
+                            hook_name, cb, kwargs, timeout
+                        )
+                        if acknowledged is _HOOK_SKIPPED:
+                            raise RequiredLifecycleError(
+                                "required_lifecycle_delivery_failed", hook_name
+                            )
+                    else:
+                        acknowledged = self._invoke_hook_callback(cb, kwargs)
+                except Exception:
+                    raise self._required_lifecycle_latch.fail(
+                        latch_key, "required_lifecycle_delivery_failed", hook_name
+                    ) from None
+                if (
+                    not isinstance(acknowledged, RequiredHookResult)
+                    or acknowledged.registration_id
+                    != required_registration.registration_id
+                    or not validate_required_semantic_result(
+                        hook_name, acknowledged.result
+                    )
+                ):
+                    raise self._required_lifecycle_latch.fail(
+                        latch_key, "required_lifecycle_delivery_failed", hook_name
+                    )
+                self._required_generation_unchanged(latch_key, generation, hook_name)
+                if acknowledged.result is not None:
+                    required_results.append(acknowledged.result)
+                continue
             try:
                 if use_timeout:
                     ret = self._run_hook_callback_bounded(hook_name, cb, kwargs, timeout)
                     if ret is _HOOK_SKIPPED:
                         if fail_closed:  # policy hook: fail closed with a block directive
-                            results.append({"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE})
+                            optional_results.append({"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE})
                         continue
                 else:
                     ret = self._invoke_hook_callback(cb, kwargs)
                 if ret is not None:
-                    results.append(ret)
+                    optional_results.append(ret)
             except Exception as exc:
                 logger.warning(
                     "Hook '%s' callback %s raised: %s", hook_name, getattr(cb, "__name__", repr(cb)), exc)
-        return results
+        if required_snapshot is not None:
+            assert latch_key is not None
+            self._required_generation_unchanged(latch_key, generation, hook_name)
+            if hook_name == "pre_tool_call":
+                compatibility = [
+                    result
+                    for result in optional_results
+                    if isinstance(result, dict)
+                    and result.get("action") in {"block", "approve"}
+                ]
+                return required_results + compatibility
+            if hook_name == "transform_llm_output":
+                return required_results
+        return required_results + optional_results
+
+    def requires_hook(self, hook_name: str) -> bool:
+        return hook_name in REQUIRED_LIFECYCLE_HOOKS and (
+            bool(self._required_lifecycle_policy)
+            or self._required_lifecycle_policy_error is not None
+        )
+
+    def assert_required_lifecycle_turn_healthy(
+        self, *, session_id: str, turn_id: str
+    ) -> None:
+        configured = bool(self._required_lifecycle_policy) or (
+            self._required_lifecycle_policy_error is not None
+        )
+        try:
+            latch_key = self._required_lifecycle_latch.key(
+                self.scope_key, {"session_id": session_id, "turn_id": turn_id}
+            )
+        except RequiredLifecycleError:
+            if not configured:
+                return
+            raise
+        self._required_lifecycle_latch.check(latch_key)
+        if not configured and not self._required_lifecycle_latch.is_active(latch_key):
+            return
+        self._required_lifecycle_latch.check_generation(
+            latch_key, self._registration_generation, "lifecycle"
+        )
+
+    def finish_required_lifecycle_turn(
+        self, *, session_id: str, turn_id: str
+    ) -> None:
+        try:
+            latch_key = self._required_lifecycle_latch.key(
+                self.scope_key, {"session_id": session_id, "turn_id": turn_id}
+            )
+        except RequiredLifecycleError:
+            if not self._required_lifecycle_policy and (
+                self._required_lifecycle_policy_error is None
+            ):
+                return
+            raise
+        self._required_lifecycle_latch.clear(latch_key)
 
     def _run_hook_callback_bounded(
         self, hook_name: str, cb: Callable, kwargs: Dict[str, Any], timeout: float
@@ -383,7 +570,7 @@ class PluginDispatchMixin:
 
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
-        return bool(self._hooks.get(hook_name))
+        return bool(self._hooks.get(hook_name)) or self.requires_hook(hook_name)
 
     def iter_hook_callbacks(self, hook_name: str) -> tuple[Callable, ...]:
         """Return a stable snapshot of callbacks registered for a hook."""

--- a/hermes_cli/plugins_ledger.py
+++ b/hermes_cli/plugins_ledger.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Unio
 from registration_lifecycle import replacement_coordinator
 from hermes_cli.plugins_loader import _plugin_home_scope
 from hermes_cli.plugins_manifest import PluginManifest, manifest_key
+from hermes_cli.required_lifecycle import RequiredLifecycleError
 
 if TYPE_CHECKING:  # pragma: no cover
     from hermes_cli.plugins import LoadedPlugin
@@ -39,8 +40,13 @@ class PluginRegistration:
     # re-discovery when the plugin no longer re-registers it.
     # See #91701.
     persistent: bool = False
+    registration_id: str = ""
+    callback: Optional[Callable] = field(default=None, repr=False)
     _disposed: bool = field(default=False, init=False, repr=False)
     _on_dispose: Optional[Callable[["PluginRegistration"], None]] = field(default=None, init=False, repr=False)
+    _dispose_under_guard: Optional[Callable[["PluginRegistration"], None]] = field(
+        default=None, init=False, repr=False
+    )
 
     @property
     def active(self) -> bool:
@@ -49,6 +55,15 @@ class PluginRegistration:
 
     def dispose(self) -> None:
         """Release this registration once; repeated disposal is harmless."""
+        if self._disposed:
+            return
+        if self._dispose_under_guard is not None:
+            self._dispose_under_guard(self)
+            return
+        self._dispose_unlocked()
+
+    def _dispose_unlocked(self) -> None:
+        """Release while the owning manager holds its mutation lock."""
         if self._disposed:
             return
         self._disposed = True
@@ -62,7 +77,7 @@ class PluginRegistration:
 class PluginLedgerMixin:
     def _track_registration(
         self, manifest: PluginManifest, kind: str, key: str, release: Callable[[], None], *,
-        persistent: bool = False,
+        persistent: bool = False, registration_id: str = "", callback: Optional[Callable] = None,
     ) -> PluginRegistration:
         """Record one registration under its canonical plugin key. ``persistent`` ones (process-global host
         infrastructure) stay in the ownership ledger for attribution but NOT in ``_registration_order``, so a
@@ -70,13 +85,29 @@ class PluginLedgerMixin:
 
         See #91701.
         """
-        registration = PluginRegistration(
-            kind=kind, key=key, release=release, plugin_key=manifest_key(manifest), persistent=persistent)
-        registration._on_dispose = lambda disposed: self._forget_registrations([disposed])
-        self._ownership_ledger.setdefault(registration.plugin_key, []).append(registration)
-        if not persistent:
-            self._registration_order.append(registration)
-        return registration
+        with self._discovery_lock:
+            self._assert_registration_mutation_allowed()
+            registration = PluginRegistration(
+                kind=kind, key=key, release=release,
+                plugin_key=manifest_key(manifest), persistent=persistent,
+                registration_id=registration_id, callback=callback,
+            )
+            registration._on_dispose = lambda disposed: self._forget_registrations([disposed])
+            registration._dispose_under_guard = self._dispose_registration_guarded
+            self._ownership_ledger.setdefault(registration.plugin_key, []).append(registration)
+            if not persistent:
+                self._registration_order.append(registration)
+            self._registration_generation += 1
+            return registration
+
+    def _assert_registration_mutation_allowed(self) -> None:
+        if self._required_lifecycle_latch.has_active():
+            raise RequiredLifecycleError("required_lifecycle_reload_deferred")
+
+    def _dispose_registration_guarded(self, registration: PluginRegistration) -> None:
+        with self._discovery_lock:
+            self._assert_registration_mutation_allowed()
+            registration._dispose_unlocked()
 
     def _track_scoped_registration(
         self, manifest: PluginManifest, kind: str, name: str, registry: Any, current: Any,
@@ -175,6 +206,7 @@ class PluginLedgerMixin:
                     ledger[plugin_key] = remaining
                 else:
                     ledger.pop(plugin_key, None)
+        self._registration_generation += 1
 
     # -- dual-kind hook ownership -------------------------------------------------------------
     # A plugin dir loaded by general discovery AND as the configured memory provider calls
@@ -222,6 +254,7 @@ class PluginLedgerMixin:
     def unload(self, plugin: Union[str, PluginManifest, LoadedPlugin, None] = None) -> bool:
         """Unload registrations while excluding discovery/deferred loading."""
         with self._discovery_lock, _plugin_home_scope(self.home_path):
+            self._assert_registration_mutation_allowed()
             return self._unload_scoped(plugin)
 
     def _unload_scoped(self, plugin: Union[str, PluginManifest, LoadedPlugin, None] = None) -> bool:

--- a/hermes_cli/plugins_loader.py
+++ b/hermes_cli/plugins_loader.py
@@ -48,6 +48,13 @@ def _serialized_replacement(method):
     """Make snapshot → write → lease attachment one atomic transaction."""
     @wraps(method)
     def wrapped(*args, **kwargs):
+        owner = args[0] if args else None
+        manager = getattr(owner, "_manager", None)
+        if manager is not None:
+            with manager._discovery_lock:
+                manager._assert_registration_mutation_allowed()
+                with replacement_coordinator.transaction():
+                    return method(*args, **kwargs)
         with replacement_coordinator.transaction():
             return method(*args, **kwargs)
 

--- a/hermes_cli/required_lifecycle.py
+++ b/hermes_cli/required_lifecycle.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 
+REQUIRED_LIFECYCLE_CAPABILITY = "required-lifecycle-hooks/v1"
 REQUIRED_LIFECYCLE_HOOKS = frozenset(
     {
         "pre_llm_call",

--- a/hermes_cli/required_lifecycle.py
+++ b/hermes_cli/required_lifecycle.py
@@ -1,0 +1,368 @@
+"""Fail-closed contract for operator-required plugin lifecycle hooks.
+
+The plugin manager remains the delivery seam.  This module owns only the
+closed policy/result types and the bounded per-turn failure latch so optional
+plugin hooks can retain their compatibility behavior.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+REQUIRED_LIFECYCLE_HOOKS = frozenset(
+    {
+        "pre_llm_call",
+        "pre_tool_call",
+        "post_tool_call",
+        "transform_llm_output",
+    }
+)
+REQUIRED_LIFECYCLE_FAILURE_TEXT = (
+    "Hermes blocked this turn because a required lifecycle guard was unavailable."
+)
+_PROVIDER_CONTINUITY_FIELDS = frozenset(
+    {
+        "reasoning_content",
+        "reasoning_details",
+        "anthropic_content_blocks",
+        "codex_reasoning_items",
+        "codex_message_items",
+    }
+)
+
+
+def _provider_continuity_key(message: Mapping[str, Any]) -> tuple[Any, ...] | None:
+    tool_calls = message.get("tool_calls")
+    if not isinstance(tool_calls, list) or not tool_calls:
+        return None
+    call_ids: list[str] = []
+    for call in tool_calls:
+        if not isinstance(call, Mapping):
+            return None
+        call_id = call.get("call_id") or call.get("id")
+        if not isinstance(call_id, str) or not call_id:
+            return None
+        call_ids.append(call_id)
+    return (
+        message.get("timestamp"),
+        message.get("finish_reason"),
+        tuple(call_ids),
+    )
+_IDENTIFIER = re.compile(r"[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?\Z")
+_MAX_PLUGINS = 16
+_MAX_REGISTRATIONS_PER_HOOK = 8
+_MAX_LATCHES = 1024
+
+
+class RequiredLifecycleError(RuntimeError):
+    """Stable, redacted failure raised by a required lifecycle guard."""
+
+    def __init__(self, reason_code: str, hook_name: str = "") -> None:
+        self.reason_code = reason_code
+        self.hook_name = hook_name
+        super().__init__(f"{reason_code}:{hook_name or 'lifecycle'}")
+
+
+@dataclass(frozen=True)
+class RequiredHookResult:
+    """Host-verifiable acknowledgement from one exact required callback."""
+
+    registration_id: str
+    result: Any = None
+
+
+def required_hook_result(registration_id: str, result: Any = None) -> RequiredHookResult:
+    """Return the acknowledgement envelope required callbacks must emit."""
+    if not isinstance(registration_id, str) or not _IDENTIFIER.fullmatch(
+        registration_id
+    ):
+        raise ValueError("required lifecycle registration id is invalid")
+    return RequiredHookResult(registration_id=registration_id, result=result)
+
+
+def quarantine_required_provider_fields(agent: Any, message: dict[str, Any]) -> None:
+    """Keep opaque continuity data in agent-owned, turn-local memory only."""
+    private = {
+        key: message.pop(key)
+        for key in _PROVIDER_CONTINUITY_FIELDS
+        if key in message
+    }
+    tool_extras: list[tuple[int, Any]] = []
+    tool_calls = message.get("tool_calls")
+    if isinstance(tool_calls, list):
+        for index, call in enumerate(tool_calls):
+            if isinstance(call, dict) and "extra_content" in call:
+                tool_extras.append((index, call.pop("extra_content")))
+    key = _provider_continuity_key(message)
+    if (private or tool_extras) and key is not None:
+        continuity = getattr(agent, "_required_provider_continuity", None)
+        if not isinstance(continuity, dict):
+            continuity = {}
+            setattr(agent, "_required_provider_continuity", continuity)
+        continuity[key] = (private, tuple(tool_extras))
+
+
+def restore_required_provider_fields(
+    agent: Any,
+    source: dict[str, Any],
+    message: dict[str, Any],
+) -> None:
+    """Restore quarantined fields only on a request-local provider clone."""
+    continuity = getattr(agent, "_required_provider_continuity", None)
+    key = _provider_continuity_key(source)
+    record = continuity.get(key) if isinstance(continuity, dict) else None
+    if not isinstance(record, tuple) or len(record) != 2:
+        return
+    private, tool_extras = record
+    if not isinstance(private, dict) or not set(private) <= _PROVIDER_CONTINUITY_FIELDS:
+        return
+    if not isinstance(tool_extras, tuple):
+        return
+    message.update(private)
+    tool_calls = message.get("tool_calls")
+    if not isinstance(tool_calls, list):
+        return
+    for item in tool_extras:
+        if (
+            not isinstance(item, tuple)
+            or len(item) != 2
+            or not isinstance(item[0], int)
+            or isinstance(item[0], bool)
+            or item[0] < 0
+            or item[0] >= len(tool_calls)
+            or not isinstance(tool_calls[item[0]], dict)
+        ):
+            return
+        tool_calls[item[0]]["extra_content"] = item[1]
+
+
+def scrub_required_provider_fields(agent: Any) -> None:
+    """Destroy all ephemeral provider continuity at terminalization."""
+    setattr(agent, "_required_provider_continuity", {})
+
+
+def parse_required_lifecycle_policy(
+    config: Mapping[str, Any],
+) -> dict[str, dict[str, tuple[str, ...]]]:
+    """Parse the closed ``plugins.required_lifecycle_hooks`` config subtree.
+
+    Absence means compatibility mode.  Presence is strict: malformed policy
+    raises so it can never silently degrade into "no requirements".
+    """
+    plugins = config.get("plugins")
+    if not isinstance(plugins, Mapping) or "required_lifecycle_hooks" not in plugins:
+        return {}
+    raw = plugins.get("required_lifecycle_hooks")
+    if not isinstance(raw, Mapping) or not raw or len(raw) > _MAX_PLUGINS:
+        raise RequiredLifecycleError("required_lifecycle_policy_invalid")
+    parsed: dict[str, dict[str, tuple[str, ...]]] = {}
+    for plugin_key, hooks in raw.items():
+        if not isinstance(plugin_key, str) or not _IDENTIFIER.fullmatch(plugin_key):
+            raise RequiredLifecycleError("required_lifecycle_policy_invalid")
+        if not isinstance(hooks, Mapping) or set(hooks) != REQUIRED_LIFECYCLE_HOOKS:
+            raise RequiredLifecycleError("required_lifecycle_policy_invalid")
+        parsed_hooks: dict[str, tuple[str, ...]] = {}
+        for hook_name in sorted(REQUIRED_LIFECYCLE_HOOKS):
+            ids = hooks.get(hook_name)
+            if (
+                not isinstance(ids, list)
+                or not ids
+                or len(ids) > _MAX_REGISTRATIONS_PER_HOOK
+                or any(
+                    not isinstance(item, str) or not _IDENTIFIER.fullmatch(item)
+                    for item in ids
+                )
+                or len(set(ids)) != len(ids)
+                or (
+                    hook_name in {"pre_tool_call", "transform_llm_output"}
+                    and len(ids) != 1
+                )
+            ):
+                raise RequiredLifecycleError("required_lifecycle_policy_invalid")
+            parsed_hooks[hook_name] = tuple(ids)
+        parsed[plugin_key] = parsed_hooks
+    for authority_hook in ("pre_tool_call", "transform_llm_output"):
+        if (
+            sum(
+                len(hooks[authority_hook])
+                for hooks in parsed.values()
+            )
+            != 1
+        ):
+            raise RequiredLifecycleError("required_lifecycle_policy_invalid")
+    return parsed
+
+
+def validate_required_semantic_result(hook_name: str, result: Any) -> bool:
+    """Return whether an acknowledged result fits the existing hook contract."""
+    if hook_name == "pre_llm_call":
+        return result is None or (
+            isinstance(result, str) and bool(result.strip())
+        ) or (
+            isinstance(result, Mapping)
+            and set(result) == {"context"}
+            and isinstance(result.get("context"), str)
+            and bool(result["context"].strip())
+        )
+    if hook_name == "post_tool_call":
+        return result is None
+    if hook_name == "transform_llm_output":
+        return result is None or (isinstance(result, str) and bool(result))
+    if hook_name == "pre_tool_call":
+        # The downstream directive consumer intentionally accepts only a
+        # concrete JSON-style object.  A custom Mapping must not be
+        # acknowledged here and then silently ignored there.
+        if not isinstance(result, dict):
+            return False
+        keys = set(result)
+        if not keys:
+            return True
+        action = result.get("action")
+        if action == "block":
+            return (
+                keys <= {"action", "message"}
+                and isinstance(result.get("message"), str)
+                and bool(result["message"])
+            )
+        if action == "approve":
+            return keys <= {"action", "message", "rule_key"} and all(
+                value is None or isinstance(value, str)
+                for key, value in result.items()
+                if key != "action"
+            )
+        if action == "modify":
+            return keys == {"action", "args"} and isinstance(
+                result.get("args"), dict
+            )
+        return False
+    return False
+
+
+class RequiredLifecycleLatch:
+    """Thread-safe bounded failure memory keyed by profile/session/turn."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._failures: OrderedDict[tuple[str, str, str], RequiredLifecycleError] = (
+            OrderedDict()
+        )
+        self._scope_failures: dict[str, RequiredLifecycleError] = {}
+        self._active_generations: OrderedDict[tuple[str, str, str], int] = (
+            OrderedDict()
+        )
+
+    @staticmethod
+    def key(scope_key: str, payload: Mapping[str, Any]) -> tuple[str, str, str]:
+        session_id = payload.get("session_id")
+        turn_id = payload.get("turn_id")
+        if not isinstance(session_id, str) or not session_id:
+            raise RequiredLifecycleError("required_lifecycle_identity_missing")
+        if not isinstance(turn_id, str) or not turn_id:
+            raise RequiredLifecycleError("required_lifecycle_identity_missing")
+        return (scope_key, session_id, turn_id)
+
+    def check(self, key: tuple[str, str, str]) -> None:
+        with self._lock:
+            scope_failure = self._scope_failures.get(key[0])
+            if scope_failure is not None:
+                raise RequiredLifecycleError(
+                    scope_failure.reason_code, scope_failure.hook_name
+                )
+            failure = self._failures.get(key)
+        if failure is not None:
+            raise RequiredLifecycleError(failure.reason_code, failure.hook_name)
+
+    def begin(self, key: tuple[str, str, str], generation: int) -> None:
+        """Bind a turn to the registration generation that admitted it."""
+        self.check(key)
+        with self._lock:
+            previous = self._active_generations.get(key)
+            if previous is None:
+                self._active_generations[key] = generation
+                self._active_generations.move_to_end(key)
+                if len(self._active_generations) > _MAX_LATCHES:
+                    self._active_generations.pop(key, None)
+                    failure = RequiredLifecycleError(
+                        "required_lifecycle_latch_capacity"
+                    )
+                    self._scope_failures[key[0]] = failure
+                    raise RequiredLifecycleError(failure.reason_code)
+                return
+        if previous != generation:
+            raise self.fail(
+                key,
+                "required_lifecycle_registration_changed",
+                "lifecycle",
+            )
+
+    def is_active(self, key: tuple[str, str, str]) -> bool:
+        with self._lock:
+            return key in self._active_generations
+
+    def has_active(self) -> bool:
+        """Return whether any turn currently owns the registration lease."""
+        with self._lock:
+            return bool(self._active_generations)
+
+    def check_generation(
+        self,
+        key: tuple[str, str, str],
+        generation: int,
+        hook_name: str,
+    ) -> None:
+        self.check(key)
+        with self._lock:
+            active_generation = self._active_generations.get(key)
+        if active_generation is not None and active_generation != generation:
+            raise self.fail(
+                key,
+                "required_lifecycle_registration_changed",
+                hook_name,
+            )
+
+    def fail(
+        self,
+        key: tuple[str, str, str],
+        reason_code: str,
+        hook_name: str,
+    ) -> RequiredLifecycleError:
+        failure = RequiredLifecycleError(reason_code, hook_name)
+        with self._lock:
+            scope_failure = self._scope_failures.get(key[0])
+            if scope_failure is not None:
+                return RequiredLifecycleError(
+                    scope_failure.reason_code, scope_failure.hook_name
+                )
+            self._failures[key] = failure
+            self._failures.move_to_end(key)
+            if len(self._failures) > _MAX_LATCHES:
+                # Evicting an active failed turn would reopen enforcement.
+                # Capacity exhaustion therefore closes this profile until its
+                # next bounded lifecycle/reload instead.
+                failure = RequiredLifecycleError(
+                    "required_lifecycle_latch_capacity", hook_name
+                )
+                self._scope_failures[key[0]] = failure
+        return failure
+
+    def fail_uncorrelated(
+        self,
+        scope_key: str,
+        reason_code: str,
+        hook_name: str,
+    ) -> RequiredLifecycleError:
+        """Close a profile when a required event lacks turn correlation."""
+        failure = RequiredLifecycleError(reason_code, hook_name)
+        with self._lock:
+            self._scope_failures[scope_key] = failure
+        return failure
+
+    def clear(self, key: tuple[str, str, str]) -> None:
+        with self._lock:
+            self._failures.pop(key, None)
+            self._active_generations.pop(key, None)

--- a/hermes_cli/required_lifecycle.py
+++ b/hermes_cli/required_lifecycle.py
@@ -31,6 +31,7 @@ _PROVIDER_CONTINUITY_FIELDS = frozenset(
         "reasoning_content",
         "reasoning_details",
         "anthropic_content_blocks",
+        "bedrock_content_blocks",
         "codex_reasoning_items",
         "codex_message_items",
     }

--- a/model_tools.py
+++ b/model_tools.py
@@ -685,6 +685,15 @@ def _dispatch_bridge_tool(function_name: str, function_args: Dict[str, Any],
     return None, (underlying_name, underlying_args)
 
 
+def _is_inline_catalog_tool(function_name: str) -> bool:
+    """Whether the bridge call is an inline catalog read, not a tool-call unwrap."""
+    try:
+        from tools import tool_search as ts
+    except Exception:
+        return False
+    return function_name in {ts.TOOL_SEARCH_NAME, ts.TOOL_DESCRIBE_NAME}
+
+
 def _apply_request_middleware(
     function_name: str, function_args: Dict[str, Any], ids: _CallIds, trace: List[Dict[str, Any]],
 ) -> Tuple[Dict[str, Any], Dict[str, Any], List[Dict[str, Any]]]:
@@ -836,10 +845,13 @@ def handle_function_call(
                                   **asdict(ids), middleware_trace=list(trace), **extra)
         return result
 
-    # Tool Search bridge: tool_search / tool_describe are catalog reads handled
-    # inline; tool_call is unwrapped so every downstream hook (pre/post, edit
-    # approval, guardrails) sees the real tool name, never the bridge.
-    bridged = _dispatch_bridge_tool(function_name, function_args, enabled_toolsets, disabled_toolsets)
+    # tool_call is unwrapped before policy so every downstream hook sees the
+    # real tool name. Inline catalog reads stay here until after pre-tool policy:
+    # direct callers must not bypass an operator-required guard.
+    inline_catalog_tool = _is_inline_catalog_tool(function_name)
+    bridged = None if inline_catalog_tool else _dispatch_bridge_tool(
+        function_name, function_args, enabled_toolsets, disabled_toolsets
+    )
     if bridged is not None:
         result, underlying = bridged
         if underlying is None:
@@ -852,7 +864,7 @@ def handle_function_call(
         )
 
     original_args = dict(function_args)
-    if not skip_tool_request_middleware:
+    if not skip_tool_request_middleware and not inline_catalog_tool:
         function_args, original_args, trace = _apply_request_middleware(function_name, function_args, ids, trace)
 
     try:
@@ -863,6 +875,17 @@ def handle_function_call(
         if blocked is not None:
             result, error_type, error_message = blocked
             return _emit(result, status="blocked", error_type=error_type, error_message=error_message)
+
+        if inline_catalog_tool:
+            bridged = _dispatch_bridge_tool(
+                function_name,
+                function_args,
+                enabled_toolsets,
+                disabled_toolsets,
+            )
+            if bridged is None or bridged[1] is not None:
+                raise RuntimeError("inline catalog bridge resolution changed during dispatch")
+            return _emit(bridged[0], duration_ms=_elapsed_ms(start))
 
         # Any non-read/search tool resets the consecutive-read-loop counter.
         if function_name not in _READ_SEARCH_TOOLS:

--- a/model_tools.py
+++ b/model_tools.py
@@ -636,6 +636,10 @@ def _emit_post_tool_call_hook(
             middleware_trace=list(middleware_trace or []),
         )
     except Exception as _hook_err:
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+        if isinstance(_hook_err, RequiredLifecycleError):
+            raise
         logger.debug("post_tool_call hook error: %s", _hook_err)
 
 
@@ -714,6 +718,10 @@ def _pre_dispatch_guards(function_name: str, function_args: Dict[str, Any], skip
             if modified_args is not None:
                 function_args = modified_args
         except Exception as _hook_err:
+            from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+            if isinstance(_hook_err, RequiredLifecycleError):
+                raise
             logger.debug("pre_tool_call hook error: %s", _hook_err)
         if block_message is not None:
             return function_args, (tool_error(block_message), "plugin_block", block_message)
@@ -873,6 +881,10 @@ def handle_function_call(
         return _apply_transform_tool_result_hook(function_name, function_args, result, duration_ms, ids)
 
     except Exception as e:
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+        if isinstance(e, RequiredLifecycleError):
+            raise
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.exception(error_msg)
         return _emit(tool_error(_sanitize_tool_error(error_msg)), duration_ms=_elapsed_ms(start),

--- a/run_agent.py
+++ b/run_agent.py
@@ -1276,6 +1276,14 @@ class AIAgent(
             if len(tool_calls) <= 1:
                 return self._execute_tool_calls_sequential(*args)
 
+            # A required post-tool observer is a serial containment boundary:
+            # do not start the next side effect before the previous result is
+            # acknowledged by the required lifecycle authority.
+            from hermes_cli.plugins import requires_hook as _requires_hook
+
+            if _requires_hook("post_tool_call"):
+                return self._execute_tool_calls_sequential(*args)
+
             from agent.tool_dispatch_helpers import _plan_tool_batch_segments
             active_env = get_active_env(effective_task_id)
             exec_cwd = Path(active_env.cwd) if active_env is not None and active_env.cwd else None

--- a/tests/hermes_cli/test_required_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_required_lifecycle_hooks.py
@@ -1,0 +1,421 @@
+"""Behavior contract for fail-closed required plugin lifecycle hooks."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from hermes_cli.plugins import (
+    PluginContext,
+    PluginManager,
+    RequiredLifecycleError,
+    get_pre_tool_call_block_message,
+    required_hook_result,
+)
+from hermes_cli.required_lifecycle import (
+    parse_required_lifecycle_policy,
+    quarantine_required_provider_fields,
+    restore_required_provider_fields,
+)
+
+
+REQUIRED = {
+    "pre_llm_call": ["behavioral.pre_llm.v1"],
+    "pre_tool_call": ["behavioral.pre_tool.v1"],
+    "post_tool_call": ["behavioral.post_tool.v1"],
+    "transform_llm_output": ["behavioral.output.v1"],
+}
+
+
+def _write_config(home: Path, requirements=REQUIRED) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {
+                    "enabled": ["atlas"],
+                    "required_lifecycle_hooks": {"atlas": requirements},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_plugin(home: Path, register_body: str) -> None:
+    root = home / "plugins" / "atlas"
+    root.mkdir(parents=True)
+    (root / "plugin.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "atlas",
+                "version": "1.0.0",
+                "description": "test plugin",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root / "__init__.py").write_text(
+        "from hermes_cli.plugins import required_hook_result\n"
+        "def register(ctx):\n"
+        + "\n".join(f"    {line}" for line in register_body.splitlines())
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _valid_register_body() -> str:
+    return "\n".join(
+        (
+            'ctx.register_hook("pre_llm_call", lambda **kw: '
+            'required_hook_result("behavioral.pre_llm.v1", None), '
+            'registration_id="behavioral.pre_llm.v1")',
+            'ctx.register_hook("pre_tool_call", lambda **kw: '
+            'required_hook_result("behavioral.pre_tool.v1", {}), '
+            'registration_id="behavioral.pre_tool.v1")',
+            'ctx.register_hook("post_tool_call", lambda **kw: '
+            'required_hook_result("behavioral.post_tool.v1", None), '
+            'registration_id="behavioral.post_tool.v1")',
+            'ctx.register_hook("transform_llm_output", lambda **kw: '
+            'required_hook_result("behavioral.output.v1", None), '
+            'registration_id="behavioral.output.v1")',
+        )
+    )
+
+
+def _manager(tmp_path: Path, monkeypatch, register_body: str) -> PluginManager:
+    home = tmp_path / "hermes"
+    _write_config(home)
+    _write_plugin(home, register_body)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+    return manager
+
+
+def _payload() -> dict[str, str]:
+    return {"session_id": "session-1", "turn_id": "turn-1"}
+
+
+def test_exact_required_registration_delivers_once_and_unwraps_result(
+    tmp_path, monkeypatch
+):
+    manager = _manager(tmp_path, monkeypatch, _valid_register_body())
+
+    assert manager.invoke_hook("pre_tool_call", **_payload()) == [{}]
+
+
+@pytest.mark.parametrize(
+    ("hook_name", "optional_result", "required_result"),
+    [
+        pytest.param(
+            "pre_tool_call",
+            '{"action": "block", "message": "legacy security block"}',
+            [{}, {"action": "block", "message": "legacy security block"}],
+            id="pre-tool-security-block",
+        ),
+        pytest.param(
+            "pre_tool_call",
+            '{"action": "modify", "args": {"command": "unsafe"}}',
+            [{}],
+            id="pre-tool-mutation",
+        ),
+        pytest.param(
+            "transform_llm_output",
+            '"unsafe replacement"',
+            [],
+            id="terminal-output-replacement",
+        ),
+    ],
+)
+def test_required_authority_ignores_optional_semantic_replacements(
+    tmp_path, monkeypatch, hook_name, optional_result, required_result
+):
+    body = _valid_register_body() + (
+        f'\nctx.register_hook("{hook_name}", lambda **kw: {optional_result})'
+    )
+    manager = _manager(tmp_path, monkeypatch, body)
+
+    payload = _payload()
+    if hook_name == "transform_llm_output":
+        payload["response_text"] = "original"
+
+    assert manager.invoke_hook(hook_name, **payload) == required_result
+
+
+@pytest.mark.parametrize(
+    "register_body",
+    [
+        pytest.param(
+            _valid_register_body().replace(
+                'registration_id="behavioral.pre_tool.v1")',
+                'registration_id="behavioral.pre_tool.v2")',
+            ),
+            id="wrong-registration-id",
+        ),
+        pytest.param(
+            _valid_register_body().replace(
+                'ctx.register_hook("pre_tool_call", lambda **kw: '
+                'required_hook_result("behavioral.pre_tool.v1", {}), '
+                'registration_id="behavioral.pre_tool.v1")\n',
+                "",
+            ),
+            id="missing-registration",
+        ),
+        pytest.param(
+            _valid_register_body()
+            + '\nctx.register_hook("pre_tool_call", lambda **kw: '
+            'required_hook_result("behavioral.pre_tool.v1", {}), '
+            'registration_id="behavioral.pre_tool.v1")',
+            id="duplicate-registration",
+        ),
+    ],
+)
+def test_required_bundle_rejects_missing_wrong_or_duplicate_registration(
+    tmp_path, monkeypatch, register_body
+):
+    manager = _manager(tmp_path, monkeypatch, register_body)
+
+    with pytest.raises(RequiredLifecycleError) as caught:
+        manager.invoke_hook("pre_tool_call", **_payload())
+
+    assert caught.value.reason_code == "required_lifecycle_registration_invalid"
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        pytest.param('(_ for _ in ()).throw(RuntimeError("secret-value"))', id="raises"),
+        pytest.param("None", id="missing-ack"),
+        pytest.param(
+            'required_hook_result("behavioral.pre_tool.v2", {})',
+            id="wrong-ack",
+        ),
+        pytest.param(
+            'required_hook_result("behavioral.pre_tool.v1", "allow")',
+            id="malformed-result",
+        ),
+    ],
+)
+def test_required_callback_failure_is_redacted_and_latched(
+    tmp_path, monkeypatch, replacement
+):
+    body = _valid_register_body().replace(
+        'required_hook_result("behavioral.pre_tool.v1", {})', replacement
+    )
+    manager = _manager(tmp_path, monkeypatch, body)
+
+    with pytest.raises(RequiredLifecycleError) as first:
+        manager.invoke_hook("pre_tool_call", **_payload())
+    with pytest.raises(RequiredLifecycleError) as latched:
+        manager.invoke_hook(
+            "transform_llm_output", response_text="raw secret", **_payload()
+        )
+
+    assert first.value.reason_code == "required_lifecycle_delivery_failed"
+    assert latched.value.reason_code == first.value.reason_code
+    assert "secret-value" not in str(first.value)
+
+
+def test_required_pre_tool_rejects_non_dict_mapping_directive(
+    tmp_path, monkeypatch
+):
+    body = _valid_register_body().replace(
+        'required_hook_result("behavioral.pre_tool.v1", {})',
+        'required_hook_result("behavioral.pre_tool.v1", '
+        '__import__("types").MappingProxyType('
+        '{"action": "block", "message": "must block"}))',
+    )
+    manager = _manager(tmp_path, monkeypatch, body)
+
+    with pytest.raises(RequiredLifecycleError) as caught:
+        manager.invoke_hook("pre_tool_call", **_payload())
+
+    assert caught.value.reason_code == "required_lifecycle_delivery_failed"
+
+
+def test_registration_generation_drift_during_required_callback_fails_closed(
+    tmp_path, monkeypatch
+):
+    body = _valid_register_body().replace(
+        'required_hook_result("behavioral.pre_tool.v1", {})',
+        '(setattr(ctx._manager, "_registration_generation", '
+        'ctx._manager._registration_generation + 1) or '
+        'required_hook_result("behavioral.pre_tool.v1", {}))',
+    )
+    manager = _manager(tmp_path, monkeypatch, body)
+
+    with pytest.raises(RequiredLifecycleError) as caught:
+        manager.invoke_hook("pre_tool_call", **_payload())
+
+    assert caught.value.reason_code == "required_lifecycle_registration_changed"
+
+
+def test_force_reload_cannot_erase_failed_active_turn_latch(tmp_path, monkeypatch):
+    body = _valid_register_body().replace(
+        'required_hook_result("behavioral.post_tool.v1", None)',
+        '(_ for _ in ()).throw(RuntimeError("post tool unavailable"))',
+    )
+    manager = _manager(tmp_path, monkeypatch, body)
+
+    with pytest.raises(RequiredLifecycleError):
+        manager.invoke_hook("post_tool_call", **_payload())
+    with pytest.raises(RequiredLifecycleError) as reload_error:
+        manager.discover_and_load(force=True)
+
+    with pytest.raises(RequiredLifecycleError) as caught:
+        manager.assert_required_lifecycle_turn_healthy(**_payload())
+
+    assert reload_error.value.reason_code == "required_lifecycle_reload_deferred"
+    assert caught.value.reason_code == "required_lifecycle_delivery_failed"
+
+
+def test_force_reload_invalidates_active_required_turn(tmp_path, monkeypatch):
+    manager = _manager(tmp_path, monkeypatch, _valid_register_body())
+    manager.invoke_hook("pre_llm_call", **_payload())
+
+    with pytest.raises(RequiredLifecycleError) as caught:
+        manager.discover_and_load(force=True)
+
+    manager.assert_required_lifecycle_turn_healthy(**_payload())
+
+    assert caught.value.reason_code == "required_lifecycle_reload_deferred"
+
+
+def test_active_turn_rejects_registration_before_live_registry_mutation(
+    tmp_path, monkeypatch
+):
+    manager = _manager(tmp_path, monkeypatch, _valid_register_body())
+    manager.invoke_hook("pre_llm_call", **_payload())
+    manifest = manager._plugins["atlas"].manifest
+    context = PluginContext(manifest, manager)
+    before = tuple(manager._hooks.get("other", ()))
+
+    with pytest.raises(RequiredLifecycleError) as caught:
+        context.register_hook("other", lambda **_kw: None)
+
+    assert caught.value.reason_code == "required_lifecycle_reload_deferred"
+    assert tuple(manager._hooks.get("other", ())) == before
+    manager.assert_required_lifecycle_turn_healthy(**_payload())
+
+
+def test_policy_rejects_multiple_pre_tool_or_output_authorities():
+    with pytest.raises(RequiredLifecycleError) as caught:
+        parse_required_lifecycle_policy(
+            {
+                "plugins": {
+                    "required_lifecycle_hooks": {
+                        "atlas": REQUIRED,
+                        "second": {
+                            hook: [identifier.replace("behavioral", "second")]
+                            for hook, (identifier,) in REQUIRED.items()
+                        },
+                    }
+                }
+            }
+        )
+
+    assert caught.value.reason_code == "required_lifecycle_policy_invalid"
+
+
+def test_provider_continuity_is_private_but_restored_on_request_clone():
+    agent = SimpleNamespace()
+    message = {
+        "role": "assistant",
+        "timestamp": 1.0,
+        "finish_reason": "tool_calls",
+        "reasoning_content": "private reasoning",
+        "tool_calls": [
+            {
+                "id": "call-1",
+                "call_id": "call-1",
+                "extra_content": {"thought_signature": "private signature"},
+            }
+        ],
+    }
+
+    quarantine_required_provider_fields(agent, message)
+    request_message = copy.deepcopy(message)
+    restore_required_provider_fields(agent, message, request_message)
+
+    assert "reasoning_content" not in message
+    assert "extra_content" not in message["tool_calls"][0]
+    assert request_message["reasoning_content"] == "private reasoning"
+    assert request_message["tool_calls"][0]["extra_content"] == {
+        "thought_signature": "private signature"
+    }
+
+
+def test_optional_hooks_keep_legacy_fail_open_behavior(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["atlas"]}}), encoding="utf-8"
+    )
+    _write_plugin(
+        home,
+        'ctx.register_hook("pre_tool_call", lambda **kw: '
+        '(_ for _ in ()).throw(RuntimeError("optional")))',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    assert manager.invoke_hook("pre_tool_call", **_payload()) == []
+
+
+def test_pre_tool_required_delivery_failure_becomes_core_owned_block(monkeypatch):
+    def unavailable(*_args, **_kwargs):
+        raise RequiredLifecycleError("required_lifecycle_delivery_failed")
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", unavailable)
+
+    assert get_pre_tool_call_block_message(
+        "terminal",
+        {"command": "true"},
+        session_id="session-1",
+        turn_id="turn-1",
+    ) == (
+        "Hermes blocked this turn because a required lifecycle guard was "
+        "unavailable."
+    )
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    [
+        pytest.param(
+            {"pre_tool_call": ["behavioral.pre_tool.v1"]},
+            id="incomplete-bundle",
+        ),
+        pytest.param(
+            {
+                **REQUIRED,
+                "pre_tool_call": [
+                    "behavioral.pre_tool.v1",
+                    "behavioral.pre_tool.v2",
+                ],
+            },
+            id="ambiguous-authority",
+        ),
+    ],
+)
+def test_malformed_required_policy_cannot_degrade_to_optional(
+    tmp_path, monkeypatch, requirements
+):
+    home = tmp_path / "hermes"
+    _write_config(home, requirements)
+    _write_plugin(home, _valid_register_body())
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    assert manager.has_hook("pre_llm_call") is True
+    with pytest.raises(RequiredLifecycleError) as caught:
+        manager.invoke_hook("pre_llm_call", **_payload())
+
+    assert caught.value.reason_code == "required_lifecycle_policy_invalid"

--- a/tests/hermes_cli/test_required_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_required_lifecycle_hooks.py
@@ -334,6 +334,7 @@ def test_provider_continuity_is_private_but_restored_on_request_clone():
         "timestamp": 1.0,
         "finish_reason": "tool_calls",
         "reasoning_content": "private reasoning",
+        "bedrock_content_blocks": [{"text": "private bedrock text"}],
         "tool_calls": [
             {
                 "id": "call-1",
@@ -348,11 +349,30 @@ def test_provider_continuity_is_private_but_restored_on_request_clone():
     restore_required_provider_fields(agent, message, request_message)
 
     assert "reasoning_content" not in message
+    assert "bedrock_content_blocks" not in message
     assert "extra_content" not in message["tool_calls"][0]
     assert request_message["reasoning_content"] == "private reasoning"
+    assert request_message["bedrock_content_blocks"] == [
+        {"text": "private bedrock text"}
+    ]
     assert request_message["tool_calls"][0]["extra_content"] == {
         "thought_signature": "private signature"
     }
+
+
+def test_required_output_discards_terminal_bedrock_raw_blocks():
+    agent = SimpleNamespace()
+    message = {
+        "role": "assistant",
+        "content": "authorized public text",
+        "finish_reason": "stop",
+        "bedrock_content_blocks": [{"text": "raw provider text"}],
+    }
+
+    quarantine_required_provider_fields(agent, message)
+
+    assert "bedrock_content_blocks" not in message
+    assert not hasattr(agent, "_required_provider_continuity")
 
 
 def test_optional_hooks_keep_legacy_fail_open_behavior(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_required_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_required_lifecycle_hooks.py
@@ -17,6 +17,7 @@ from hermes_cli.plugins import (
     required_hook_result,
 )
 from hermes_cli.required_lifecycle import (
+    REQUIRED_LIFECYCLE_CAPABILITY,
     parse_required_lifecycle_policy,
     quarantine_required_provider_fields,
     restore_required_provider_fields,
@@ -29,6 +30,10 @@ REQUIRED = {
     "post_tool_call": ["behavioral.post_tool.v1"],
     "transform_llm_output": ["behavioral.output.v1"],
 }
+
+
+def test_required_lifecycle_capability_marker_is_stable() -> None:
+    assert REQUIRED_LIFECYCLE_CAPABILITY == "required-lifecycle-hooks/v1"
 
 
 def _write_config(home: Path, requirements=REQUIRED) -> None:

--- a/tests/run_agent/test_required_lifecycle_fail_closed.py
+++ b/tests/run_agent/test_required_lifecycle_fail_closed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -260,17 +261,105 @@ def test_required_output_authorizes_length_ceiling_before_any_persistence(
         assert all(raw.strip() not in str(snapshot) for snapshot in persisted)
 
 
+@pytest.mark.parametrize(
+    ("output_expr", "expected"),
+    (
+        pytest.param(
+            'required_hook_result("behavioral.output.v1", "safe incomplete")',
+            "safe incomplete",
+            id="transformed",
+        ),
+        pytest.param(
+            '(_ for _ in ()).throw(RuntimeError("raw incomplete hook secret"))',
+            REQUIRED_LIFECYCLE_FAILURE_TEXT,
+            id="failed",
+        ),
+    ),
+)
+def test_required_output_authorizes_codex_incomplete_before_persistence(
+    tmp_path, monkeypatch, output_expr, expected
+):
+    from agent.conversation_loop import _apply_required_direct_result
+    from agent.turn_truncation import continue_codex_incomplete
+
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        output_expr,
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent._codex_incomplete_retries = 0
+    agent._current_turn_id = "turn-incomplete"
+    agent._current_api_request_id = "api-incomplete"
+    interim = MagicMock()
+    agent._emit_interim_assistant_message = interim
+    persisted = []
+    agent._persist_session = lambda messages, _history=None: persisted.append(
+        copy.deepcopy(messages)
+    )
+    messages = [{"role": "user", "content": "continue"}]
+    raw_fragments = [
+        "raw incomplete fragment one",
+        "raw incomplete fragment two",
+        "raw incomplete fragment three",
+    ]
+    result = None
+    for raw in raw_fragments:
+        result = continue_codex_incomplete(
+            agent,
+            _response(raw, finish_reason="incomplete").choices[0].message,
+            "incomplete",
+            messages=messages,
+            conversation_history=[],
+            api_call_count=1,
+        )
+
+    assert result is not None
+    assert persisted == []
+    assert interim.call_count == 0
+    state = SimpleNamespace(
+        effective_task_id="task-1",
+        turn_id="turn-incomplete",
+        conversation_history=[],
+    )
+    result = _apply_required_direct_result(agent, result, state)
+
+    assert result["final_response"] == expected
+    assert len(persisted) == 1
+    observable = str((result, persisted, interim.call_args_list))
+    assert all(raw not in observable for raw in raw_fragments)
+    assert "raw incomplete hook secret" not in observable
+
+
+@pytest.mark.parametrize(
+    "post_tool_expr",
+    [
+        pytest.param(
+            '(_ for _ in ()).throw(RuntimeError("raw post secret"))',
+            id="raises",
+        ),
+        pytest.param(
+            '(__import__("time").sleep(2.0), '
+            'required_hook_result("behavioral.post_tool.v1", None))[1]',
+            id="times-out",
+        ),
+    ],
+)
 def test_required_post_tool_failure_stops_before_next_provider_call(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, post_tool_expr
 ):
     home = tmp_path / "hermes"
     _install_required_plugin(
         home,
         'required_hook_result("behavioral.pre_llm.v1", None)',
         'required_hook_result("behavioral.output.v1", None)',
-        post_tool_expr='(_ for _ in ()).throw(RuntimeError("raw post secret"))',
+        post_tool_expr=post_tool_expr,
     )
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(plugins_mod, "_resolve_hook_callback_timeout", lambda: 0.1)
     plugins_mod._reset_plugin_managers_for_tests()
     agent = _agent()
     agent.valid_tool_names.add("web_search")
@@ -278,7 +367,9 @@ def test_required_post_tool_failure_stops_before_next_provider_call(
         SimpleNamespace(
             id=f"call-{index}",
             type="function",
-            function=SimpleNamespace(name="web_search", arguments="{}"),
+            function=SimpleNamespace(
+                name="web_search", arguments=json.dumps({"query": str(index)})
+            ),
         )
         for index in (1, 2)
     ]
@@ -295,8 +386,29 @@ def test_required_post_tool_failure_stops_before_next_provider_call(
         return next(responses)
 
     agent._interruptible_api_call = provider
+    agent.compression_enabled = True
+    agent.context_compressor.should_compress = lambda _tokens: True
+    compress = MagicMock(
+        side_effect=AssertionError("compression must not run after settlement failure")
+    )
+    agent._compress_context = compress
+    persisted = []
+    progress = []
+    completed = []
+    displayed = []
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+    agent.tool_progress_callback = lambda *parts, **kwargs: progress.append(
+        (copy.deepcopy(parts), copy.deepcopy(kwargs))
+    )
+    agent.tool_complete_callback = lambda *parts, **kwargs: completed.append(
+        (copy.deepcopy(parts), copy.deepcopy(kwargs))
+    )
+    agent._vprint = lambda message, **_kwargs: displayed.append(message)
+    raw_tool_result = "raw tool result that settlement did not authorize"
     with patch(
-        "model_tools.handle_function_call", return_value="search result"
+        "model_tools.handle_function_call", return_value=raw_tool_result
     ) as execute:
         result = agent.run_conversation(
             "search",
@@ -306,9 +418,265 @@ def test_required_post_tool_failure_stops_before_next_provider_call(
 
     assert len(calls) == 1
     assert execute.call_count == 1
+    assert compress.call_count == 0
     assert result["failed"] is True
     assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
     assert "raw post secret" not in str(result)
+    assert raw_tool_result not in str(
+        (result, persisted, progress, completed, displayed)
+    )
+    tool_results = [
+        message for message in result["messages"] if message.get("role") == "tool"
+    ]
+    assert len(tool_results) == 2
+    assert all(
+        REQUIRED_LIFECYCLE_FAILURE_TEXT in message["content"]
+        for message in tool_results
+    )
+    assert [message["effect_disposition"] for message in tool_results] == [
+        "unknown",
+        "none",
+    ]
+    assert completed == []
+    assert all("tool.completed" not in str(event) for event in progress)
+
+
+def test_batch_local_required_lifecycle_failure_stops_before_compression_or_provider(
+    monkeypatch,
+):
+    from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+    agent = _agent()
+    agent.valid_tool_names.add("web_search")
+    tool_call = SimpleNamespace(
+        id="call-batch-health",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{}"),
+    )
+    provider_calls = []
+
+    def provider(kwargs):
+        provider_calls.append(kwargs)
+        return _response("", finish_reason="tool_calls", tool_calls=[tool_call])
+
+    health_checks = 0
+
+    def health(**_kwargs):
+        nonlocal health_checks
+        health_checks += 1
+        if health_checks >= 2:
+            raise RequiredLifecycleError("required_lifecycle_generation_changed")
+
+    agent._interruptible_api_call = provider
+    agent.compression_enabled = True
+    agent.context_compressor.should_compress = lambda _tokens: True
+    compress = MagicMock(
+        side_effect=AssertionError("compression must not run after batch health failure")
+    )
+    agent._compress_context = compress
+    persisted = []
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+
+    with (
+        patch(
+            "hermes_cli.plugins.assert_required_lifecycle_turn_healthy",
+            side_effect=health,
+        ),
+        patch("model_tools.handle_function_call") as execute,
+    ):
+        result = agent.run_conversation(
+            "search", conversation_history=[], task_id="task-1"
+        )
+
+    assert len(provider_calls) == 1
+    execute.assert_not_called()
+    compress.assert_not_called()
+    assert result["failed"] is True
+    assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
+    tool_results = [
+        message for message in result["messages"] if message.get("role") == "tool"
+    ]
+    assert [message["tool_call_id"] for message in tool_results] == [
+        "call-batch-health"
+    ]
+    assert tool_results[0]["effect_disposition"] == "none"
+    assert persisted and persisted[-1] == result["messages"]
+
+
+def test_required_post_failure_quarantines_quiet_error_output(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", None)',
+        post_tool_expr='(_ for _ in ()).throw(RuntimeError("raw post secret"))',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent.platform = "cli"
+    agent.valid_tool_names.add("web_search")
+    agent.tool_progress_callback = None
+    agent._should_start_quiet_spinner = lambda: False
+    displayed = []
+    persisted = []
+    agent._vprint = lambda message, **_kwargs: displayed.append(message)
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+    tool_call = SimpleNamespace(
+        id="call-quiet",
+        type="function",
+        function=SimpleNamespace(
+            name="web_search", arguments=json.dumps({"query": "atlas"})
+        ),
+    )
+    agent._interruptible_api_call = lambda _kwargs: _response(
+        "", finish_reason="tool_calls", tool_calls=[tool_call]
+    )
+    raw_tool_result = json.dumps(
+        {"error": "raw quiet result secret"}, ensure_ascii=False
+    )
+
+    with patch("model_tools.handle_function_call", return_value=raw_tool_result):
+        result = agent.run_conversation(
+            "search", conversation_history=[], task_id="task-1"
+        )
+
+    assert result["failed"] is True
+    assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
+    assert raw_tool_result not in str((result, persisted, displayed))
+    assert "raw quiet result secret" not in str((result, persisted, displayed))
+    assert displayed
+    assert "Hermes blocked this turn" in str(displayed)
+
+
+def test_required_post_persistence_failure_stops_deferred_spinner_safely(
+    tmp_path, monkeypatch
+):
+    from agent.tool_executor import execute_tool_calls_sequential
+
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", None)',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent.platform = "cli"
+    agent.valid_tool_names.add("web_search")
+    agent._current_turn_id = "turn-persistence"
+    agent._current_api_request_id = "api-persistence"
+    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+    spinner = MagicMock()
+    tool_call = SimpleNamespace(
+        id="call-persistence",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{}"),
+    )
+    raw_tool_result = json.dumps({"error": "raw persistence secret"})
+
+    with (
+        patch(
+            "agent.tool_executor._start_quiet_tool_spinner",
+            return_value=spinner,
+        ),
+        patch(
+            "model_tools.handle_function_call", return_value=raw_tool_result
+        ),
+    ):
+        execute_tool_calls_sequential(
+            agent,
+            SimpleNamespace(tool_calls=[tool_call]),
+            [],
+            effective_task_id="task-1",
+        )
+
+    assert agent._incremental_persistence_failed is True
+    spinner.stop.assert_called_once()
+    assert "raw persistence secret" not in str(spinner.stop.call_args)
+
+
+@pytest.mark.parametrize(
+    ("scenario", "arguments", "post_tool_expr"),
+    (
+        pytest.param(
+            "invalid_arguments",
+            '{"raw invalid secret":',
+            '(_ for _ in ()).throw(RuntimeError("raw invalid post secret"))',
+            id="invalid-arguments-raises",
+        ),
+        pytest.param(
+            "interrupted",
+            "{}",
+            '(__import__("time").sleep(2.0), '
+            'required_hook_result("behavioral.post_tool.v1", None))[1]',
+            id="pre-dispatch-interrupt-times-out",
+        ),
+    ),
+)
+def test_required_post_failure_settles_preexecution_terminal_paths(
+    tmp_path, monkeypatch, scenario, arguments, post_tool_expr
+):
+    from agent.tool_executor import execute_tool_calls_sequential
+    from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", None)',
+        post_tool_expr=post_tool_expr,
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(plugins_mod, "_resolve_hook_callback_timeout", lambda: 0.1)
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent.valid_tool_names.add("web_search")
+    agent._current_turn_id = "turn-preexecution"
+    agent._current_api_request_id = "api-preexecution"
+    agent._interrupt_requested = scenario == "interrupted"
+    persisted = []
+    displayed = []
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+    agent._vprint = lambda message, **_kwargs: displayed.append(message)
+    tool_call = SimpleNamespace(
+        id="call-preexecution",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments=arguments),
+    )
+    assistant_message = SimpleNamespace(tool_calls=[tool_call])
+    messages = []
+
+    with (
+        patch("model_tools.handle_function_call") as execute,
+        pytest.raises(RequiredLifecycleError),
+    ):
+        execute_tool_calls_sequential(
+            agent,
+            assistant_message,
+            messages,
+            effective_task_id="task-1",
+        )
+
+    assert execute.call_count == 0
+    assert len(messages) == 1
+    assert messages[0]["role"] == "tool"
+    assert messages[0]["tool_call_id"] == "call-preexecution"
+    assert REQUIRED_LIFECYCLE_FAILURE_TEXT in messages[0]["content"]
+    assert messages[0]["effect_disposition"] == "unknown"
+    assert persisted and persisted[-1] == messages
+    assert "raw invalid secret" not in str((messages, persisted, displayed))
+    assert "raw invalid post secret" not in str((messages, persisted, displayed))
+    assert "Tool execution cancelled" not in str((messages, persisted))
 
 
 def test_required_pre_tool_failure_blocks_sequential_dispatch(
@@ -370,6 +738,74 @@ def test_required_pre_tool_failure_blocks_direct_invoke_tool(
     assert execute.call_count == 0
     assert REQUIRED_LIFECYCLE_FAILURE_TEXT in result
     assert "raw direct secret" not in result
+
+
+@pytest.mark.parametrize("entrypoint", ("sequential", "invoke", "registry"))
+def test_required_pre_tool_error_reaches_every_dispatch_boundary(
+    monkeypatch, entrypoint
+):
+    from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+    required_error = RequiredLifecycleError(
+        "required_lifecycle_delivery_failed", "pre_tool_call"
+    )
+    monkeypatch.setattr(
+        plugins_mod,
+        "_dispatch_pre_tool_call_hooks",
+        MagicMock(side_effect=required_error),
+    )
+    agent = SimpleNamespace(
+        session_id="required-pre-boundary",
+        _current_turn_id="turn-pre-boundary",
+        _current_api_request_id="api-pre-boundary",
+    )
+    registry_dispatch = None
+
+    if entrypoint == "sequential":
+        from agent.tool_executor import _ToolCallRef, _pre_tool_block
+
+        invoke = lambda: _pre_tool_block(  # noqa: E731
+            agent,
+            _ToolCallRef(
+                "web_search", {}, "task-1", "call-pre-boundary", []
+            ),
+        )
+    elif entrypoint == "invoke":
+        from agent.agent_runtime_helpers import _pre_tool_block_message
+
+        invoke = lambda: _pre_tool_block_message(  # noqa: E731
+            agent,
+            "web_search",
+            {},
+            "task-1",
+            "call-pre-boundary",
+            [],
+        )
+    else:
+        from model_tools import handle_function_call, registry
+
+        registry_dispatch = MagicMock(
+            side_effect=AssertionError("registry dispatch must not start")
+        )
+        monkeypatch.setattr(registry, "dispatch", registry_dispatch)
+        invoke = lambda: handle_function_call(  # noqa: E731
+            "web_search",
+            {},
+            task_id="task-1",
+            session_id="required-pre-boundary",
+            tool_call_id="call-pre-boundary",
+            turn_id="turn-pre-boundary",
+            api_request_id="api-pre-boundary",
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+
+    with pytest.raises(RequiredLifecycleError) as caught:
+        invoke()
+
+    assert caught.value is required_error
+    if registry_dispatch is not None:
+        registry_dispatch.assert_not_called()
 
 
 def test_required_output_hides_tool_narration_before_persist_and_interim_egress(

--- a/tests/run_agent/test_required_lifecycle_fail_closed.py
+++ b/tests/run_agent/test_required_lifecycle_fail_closed.py
@@ -1,0 +1,532 @@
+"""End-to-end turn containment for required plugin lifecycle hooks."""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+import hermes_cli.plugins as plugins_mod
+from hermes_cli.required_lifecycle import (
+    REQUIRED_LIFECYCLE_FAILURE_TEXT,
+    quarantine_required_provider_fields,
+)
+from run_agent import AIAgent
+
+
+REQUIRED = {
+    "pre_llm_call": ["behavioral.pre_llm.v1"],
+    "pre_tool_call": ["behavioral.pre_tool.v1"],
+    "post_tool_call": ["behavioral.post_tool.v1"],
+    "transform_llm_output": ["behavioral.output.v1"],
+}
+
+
+def _response(text: str, *, finish_reason: str = "stop", tool_calls=None):
+    message = SimpleNamespace(
+        content=text,
+        tool_calls=tool_calls,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _install_required_plugin(
+    home: Path,
+    pre_llm_expr: str,
+    output_expr: str,
+    *,
+    post_tool_expr: str = 'required_hook_result("behavioral.post_tool.v1", None)',
+    pre_tool_expr: str = 'required_hook_result("behavioral.pre_tool.v1", {})',
+) -> None:
+    plugin = home / "plugins" / "atlas"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "atlas", "version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    (plugin / "__init__.py").write_text(
+        "from hermes_cli.plugins import required_hook_result\n"
+        "def register(ctx):\n"
+        "    ctx.register_hook(\"pre_llm_call\", lambda **kw: "
+        f"{pre_llm_expr}, registration_id=\"behavioral.pre_llm.v1\")\n"
+        "    ctx.register_hook(\"pre_tool_call\", lambda **kw: "
+        f"{pre_tool_expr}, "
+        "registration_id=\"behavioral.pre_tool.v1\")\n"
+        "    ctx.register_hook(\"post_tool_call\", lambda **kw: "
+        f"{post_tool_expr}, "
+        "registration_id=\"behavioral.post_tool.v1\")\n"
+        "    ctx.register_hook(\"transform_llm_output\", lambda **kw: "
+        f"{output_expr}, registration_id=\"behavioral.output.v1\")\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {
+                    "enabled": ["atlas"],
+                    "required_lifecycle_hooks": {"atlas": REQUIRED},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _agent() -> AIAgent:
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        agent = AIAgent(
+            session_id="required-lifecycle-test",
+            api_key="test-key-1234567890",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="test/model",
+            max_iterations=2,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._fallback_chain = []
+    agent._disable_streaming = True
+    return agent
+
+
+def test_required_pre_llm_failure_stops_before_provider_call(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        '(_ for _ in ()).throw(RuntimeError("raw secret"))',
+        'required_hook_result("behavioral.output.v1", None)',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    calls = []
+    agent._interruptible_api_call = lambda kwargs: calls.append(kwargs) or _response(
+        "raw answer"
+    )
+
+    result = agent.run_conversation("do work", conversation_history=[], task_id="task-1")
+
+    assert calls == []
+    assert result["failed"] is True
+    assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
+    assert "raw secret" not in str(result)
+
+
+def test_required_output_is_buffered_transformed_then_persisted(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", "safe answer")',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    stream = []
+    deltas = []
+    delta_callback = deltas.append
+    agent.stream_delta_callback = delta_callback
+
+    def provider(_kwargs):
+        assert agent._stream_callback is None
+        assert agent.stream_delta_callback is None
+        return _response("raw answer")
+
+    agent._interruptible_api_call = provider
+    flushed = []
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        flushed.append(copy.deepcopy(messages))
+    )
+    result = agent.run_conversation(
+        "do work",
+        conversation_history=[],
+        task_id="task-1",
+        stream_callback=stream.append,
+    )
+
+    assert stream == []
+    assert deltas == []
+    assert agent.stream_delta_callback is delta_callback
+    assert result["final_response"] == "safe answer"
+    assert result["pre_transform_response"] is None
+    assert result["messages"][-1]["content"] == "safe answer"
+    assert all(message.get("content") != "raw answer" for message in result["messages"])
+    assert all(
+        message.get("content") != "raw answer"
+        for snapshot in flushed
+        for message in snapshot
+    )
+
+
+def test_required_output_failure_replaces_raw_text_before_persistence(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        '(_ for _ in ()).throw(RuntimeError("raw transform secret"))',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent._interruptible_api_call = lambda _kwargs: _response("raw answer")
+
+    result = agent.run_conversation(
+        "do work",
+        conversation_history=[],
+        task_id="task-1",
+    )
+
+    assert result["failed"] is True
+    assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
+    assert result["pre_transform_response"] is None
+    assert all(message.get("content") != "raw answer" for message in result["messages"])
+    assert "raw transform secret" not in str(result)
+
+
+@pytest.mark.parametrize(
+    ("output_expr", "expected", "failed"),
+    (
+        (
+            'required_hook_result("behavioral.output.v1", "safe partial")',
+            "safe partial",
+            False,
+        ),
+        (
+            '(_ for _ in ()).throw(RuntimeError("raw ceiling secret"))',
+            REQUIRED_LIFECYCLE_FAILURE_TEXT,
+            True,
+        ),
+    ),
+)
+def test_required_output_authorizes_length_ceiling_before_any_persistence(
+    tmp_path, monkeypatch, output_expr, expected, failed
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        output_expr,
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent.max_iterations = 6
+    fragments = [
+        "raw ceiling fragment one ",
+        "raw ceiling fragment two ",
+        "raw ceiling fragment three ",
+        "raw ceiling fragment four",
+    ]
+    responses = iter(_response(part, finish_reason="length") for part in fragments)
+    agent._interruptible_api_call = lambda _kwargs: next(responses)
+    persisted = []
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+
+    result = agent.run_conversation(
+        "write a long response", conversation_history=[], task_id="task-1"
+    )
+
+    assert result["final_response"] == expected
+    assert bool(result.get("failed")) is failed
+    assert persisted
+    for raw in fragments:
+        assert raw.strip() not in str(result)
+        assert all(raw.strip() not in str(snapshot) for snapshot in persisted)
+
+
+def test_required_post_tool_failure_stops_before_next_provider_call(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", None)',
+        post_tool_expr='(_ for _ in ()).throw(RuntimeError("raw post secret"))',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent.valid_tool_names.add("web_search")
+    tool_calls = [
+        SimpleNamespace(
+            id=f"call-{index}",
+            type="function",
+            function=SimpleNamespace(name="web_search", arguments="{}"),
+        )
+        for index in (1, 2)
+    ]
+    responses = iter(
+        (
+            _response("", finish_reason="tool_calls", tool_calls=tool_calls),
+            _response("provider must not be called again"),
+        )
+    )
+    calls = []
+
+    def provider(kwargs):
+        calls.append(kwargs)
+        return next(responses)
+
+    agent._interruptible_api_call = provider
+    with patch(
+        "model_tools.handle_function_call", return_value="search result"
+    ) as execute:
+        result = agent.run_conversation(
+            "search",
+            conversation_history=[],
+            task_id="task-1",
+        )
+
+    assert len(calls) == 1
+    assert execute.call_count == 1
+    assert result["failed"] is True
+    assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
+    assert "raw post secret" not in str(result)
+
+
+def test_required_pre_tool_failure_blocks_sequential_dispatch(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", None)',
+        pre_tool_expr='(_ for _ in ()).throw(RuntimeError("raw pre secret"))',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent.valid_tool_names.add("web_search")
+    tool_call = SimpleNamespace(
+        id="call-1",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{}"),
+    )
+    agent._interruptible_api_call = lambda _kwargs: _response(
+        "", finish_reason="tool_calls", tool_calls=[tool_call]
+    )
+
+    with patch("model_tools.handle_function_call") as execute:
+        result = agent.run_conversation(
+            "search", conversation_history=[], task_id="task-1"
+        )
+
+    assert execute.call_count == 0
+    assert result["failed"] is True
+    assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
+    assert "raw pre secret" not in str(result)
+
+
+def test_required_pre_tool_failure_blocks_direct_invoke_tool(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", None)',
+        pre_tool_expr='(_ for _ in ()).throw(RuntimeError("raw direct secret"))',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent._current_turn_id = "turn-direct"
+    agent._current_api_request_id = "api-direct"
+    agent.valid_tool_names.add("web_search")
+
+    with patch("model_tools.handle_function_call") as execute:
+        result = agent._invoke_tool(
+            "web_search", {"query": "x"}, "task-1", tool_call_id="call-1"
+        )
+
+    assert execute.call_count == 0
+    assert REQUIRED_LIFECYCLE_FAILURE_TEXT in result
+    assert "raw direct secret" not in result
+
+
+def test_required_output_hides_tool_narration_before_persist_and_interim_egress(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", "safe answer")',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    agent.valid_tool_names.add("web_search")
+    raw_text = "raw narration before tool"
+    tool_call = SimpleNamespace(
+        id="call-1",
+        type="function",
+        extra_content={"thought_signature": "private tool signature"},
+        function=SimpleNamespace(name="web_search", arguments="{}"),
+    )
+    first_response = _response(
+        raw_text,
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    first_response.choices[0].message.reasoning_content = "private continuity"
+    first_response.choices[0].message.reasoning_details = [
+        {"type": "reasoning", "text": "private chain of thought"}
+    ]
+    responses = iter((first_response, _response("raw terminal answer")))
+    provider_calls = []
+
+    def provider(kwargs):
+        provider_calls.append(copy.deepcopy(kwargs))
+        return next(responses)
+
+    agent._interruptible_api_call = provider
+    persisted = []
+    interim = []
+    progress = []
+    displayed = []
+    post_api = []
+    manager = plugins_mod._delivery_manager()
+    manager._hooks.setdefault("post_api_request", []).append(
+        lambda **payload: post_api.append(copy.deepcopy(payload))
+    )
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+    agent.interim_assistant_callback = lambda message: interim.append(
+        copy.deepcopy(message)
+    )
+    agent.tool_progress_callback = lambda *parts: progress.append(parts)
+    agent._vprint = lambda message, **_kwargs: displayed.append(message)
+
+    with patch("model_tools.handle_function_call", return_value="search result"):
+        result = agent.run_conversation(
+            "search",
+            conversation_history=[],
+            task_id="task-1",
+        )
+
+    observable = str((result, persisted, interim, progress, displayed, post_api))
+    assert result["final_response"] == "safe answer"
+    assert raw_text not in observable
+    assert "raw terminal answer" not in observable
+    assert "private continuity" not in observable
+    assert "private chain of thought" not in observable
+    assert "private tool signature" not in observable
+    assert interim == []
+    assert post_api == []
+    assert any(
+        message.get("reasoning_details")
+        == [{"type": "reasoning", "text": "private chain of thought"}]
+        for message in provider_calls[1]["messages"]
+        if isinstance(message, dict)
+    ), provider_calls[1]["messages"]
+
+
+def test_required_output_authorizes_content_filter_direct_return(
+    tmp_path, monkeypatch, caplog
+):
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", "safe refusal")',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    agent = _agent()
+    raw = "private provider refusal"
+    agent._interruptible_api_call = lambda _kwargs: _response(
+        raw, finish_reason="content_filter"
+    )
+
+    result = agent.run_conversation(
+        "do work", conversation_history=[], task_id="task-1"
+    )
+
+    assert result["final_response"] == "safe refusal"
+    assert result["pre_transform_response"] is None
+    assert raw not in str(result)
+    assert raw not in caplog.text
+
+
+def test_exceptional_turn_exit_scrubs_ephemeral_provider_continuity(monkeypatch):
+    agent = _agent()
+
+    def fail_after_quarantine(*_args, **_kwargs):
+        message = {
+            "role": "assistant",
+            "timestamp": 1.0,
+            "finish_reason": "tool_calls",
+            "reasoning_content": "private continuity",
+            "tool_calls": [{"id": "call-1", "call_id": "call-1"}],
+        }
+        quarantine_required_provider_fields(agent, message)
+        raise RuntimeError("provider failed")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fail_after_quarantine)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        agent.run_conversation("hello", conversation_history=[])
+
+    assert agent._required_provider_continuity == {}
+
+
+def test_outer_turn_scope_restores_required_stream_state_after_direct_return():
+    """A direct inner-loop return must not poison the cached agent's next turn."""
+    agent = _agent()
+    original_delta_callback = object()
+    agent.stream_delta_callback = None
+    agent._disable_streaming = True
+    agent._required_lifecycle_stream_delta_callback = original_delta_callback
+    agent._required_lifecycle_disable_streaming = False
+    agent._current_turn_id = "turn-direct-return"
+
+    with patch(
+        "agent.conversation_loop.run_conversation",
+        return_value={
+            "final_response": "bounded failure",
+            "messages": [],
+            "api_calls": 0,
+            "completed": False,
+            "failed": True,
+        },
+    ):
+        agent.run_conversation(
+            "do work",
+            conversation_history=[],
+            task_id="task-direct-return",
+        )
+
+    assert agent.stream_delta_callback is original_delta_callback
+    assert agent._disable_streaming is False
+    assert not hasattr(agent, "_required_lifecycle_stream_delta_callback")
+    assert not hasattr(agent, "_required_lifecycle_disable_streaming")

--- a/tests/run_agent/test_required_lifecycle_fail_closed.py
+++ b/tests/run_agent/test_required_lifecycle_fail_closed.py
@@ -434,7 +434,7 @@ def test_required_post_tool_failure_stops_before_next_provider_call(
         for message in tool_results
     )
     assert [message["effect_disposition"] for message in tool_results] == [
-        "unknown",
+        "none",
         "none",
     ]
     assert completed == []
@@ -672,7 +672,7 @@ def test_required_post_failure_settles_preexecution_terminal_paths(
     assert messages[0]["role"] == "tool"
     assert messages[0]["tool_call_id"] == "call-preexecution"
     assert REQUIRED_LIFECYCLE_FAILURE_TEXT in messages[0]["content"]
-    assert messages[0]["effect_disposition"] == "unknown"
+    assert messages[0]["effect_disposition"] == "none"
     assert persisted and persisted[-1] == messages
     assert "raw invalid secret" not in str((messages, persisted, displayed))
     assert "raw invalid post secret" not in str((messages, persisted, displayed))
@@ -711,6 +711,181 @@ def test_required_pre_tool_failure_blocks_sequential_dispatch(
     assert result["failed"] is True
     assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
     assert "raw pre secret" not in str(result)
+    tool_results = [
+        message for message in result["messages"] if message.get("role") == "tool"
+    ]
+    assert len(tool_results) == 1
+    assert tool_results[0]["effect_disposition"] == "none"
+
+
+@pytest.mark.parametrize("block_kind", ("scope", "guardrail"))
+def test_required_post_failure_marks_policy_block_as_no_effect(
+    monkeypatch, block_kind
+):
+    from agent.tool_executor import execute_tool_calls_sequential
+    from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+    agent = _agent()
+    agent.valid_tool_names.add("terminal")
+    agent._current_turn_id = "turn-policy-block"
+    agent._current_api_request_id = "api-policy-block"
+    persisted = []
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+    if block_kind == "scope":
+        monkeypatch.setattr(
+            "agent.tool_executor._unwrap_tool_search_call",
+            lambda *_args, **_kwargs: ("terminal", {}, "scope denied"),
+        )
+    else:
+        agent._tool_guardrails.before_call = MagicMock(
+            return_value=SimpleNamespace(
+                allows_execution=False,
+                message="guardrail denied",
+            )
+        )
+    call = SimpleNamespace(
+        id=f"call-{block_kind}",
+        type="function",
+        function=SimpleNamespace(name="terminal", arguments="{}"),
+    )
+    required_error = RequiredLifecycleError(
+        "required_lifecycle_delivery_failed", "post_tool_call"
+    )
+
+    with (
+        patch("hermes_cli.plugins.requires_hook", return_value=True),
+        patch("model_tools.handle_function_call") as execute,
+        patch(
+            "agent.tool_executor._emit_terminal_post_tool_call",
+            side_effect=required_error,
+        ),
+        pytest.raises(RequiredLifecycleError),
+    ):
+        execute_tool_calls_sequential(
+            agent,
+            SimpleNamespace(tool_calls=[call]),
+            [],
+            effective_task_id="task-policy-block",
+        )
+
+    execute.assert_not_called()
+    tool_results = [
+        message for message in persisted[-1] if message.get("role") == "tool"
+    ]
+    assert len(tool_results) == 1
+    assert tool_results[0]["effect_disposition"] == "none"
+    assert REQUIRED_LIFECYCLE_FAILURE_TEXT in tool_results[0]["content"]
+
+
+def test_required_post_failure_scopes_settlement_to_current_tool_frame(monkeypatch):
+    from agent.tool_executor import execute_tool_calls_sequential
+    from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+    agent = _agent()
+    agent.valid_tool_names.add("terminal")
+    agent._current_turn_id = "turn-current"
+    agent._current_api_request_id = "api-current"
+    persisted = []
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+    old_result = {
+        "role": "tool",
+        "tool_call_id": "reused-call-id",
+        "name": "terminal",
+        "content": "old turn result",
+    }
+    messages = [old_result]
+    current_call = SimpleNamespace(
+        id="reused-call-id",
+        type="function",
+        function=SimpleNamespace(name="terminal", arguments="{}"),
+    )
+    required_error = RequiredLifecycleError(
+        "required_lifecycle_delivery_failed", "post_tool_call"
+    )
+
+    with (
+        patch("hermes_cli.plugins.requires_hook", return_value=True),
+        patch("model_tools.handle_function_call", return_value="raw current result"),
+        patch(
+            "agent.tool_executor._emit_terminal_post_tool_call",
+            side_effect=required_error,
+        ),
+        pytest.raises(RequiredLifecycleError) as caught,
+    ):
+        execute_tool_calls_sequential(
+            agent,
+            SimpleNamespace(tool_calls=[current_call]),
+            messages,
+            effective_task_id="task-current",
+        )
+
+    assert caught.value is required_error
+    assert messages[0] == old_result
+    assert len(messages) == 2
+    assert messages[1]["tool_call_id"] == "reused-call-id"
+    assert messages[1]["effect_disposition"] == "unknown"
+    assert REQUIRED_LIFECYCLE_FAILURE_TEXT in messages[1]["content"]
+    assert "raw current result" not in str((messages, persisted))
+    assert persisted and persisted[-1] == messages
+
+
+def test_required_post_failure_does_not_hide_duplicate_current_call_id(monkeypatch):
+    from agent.tool_executor import execute_tool_calls_sequential
+    from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+    agent = _agent()
+    agent.valid_tool_names.add("terminal")
+    agent._current_turn_id = "turn-duplicate"
+    agent._current_api_request_id = "api-duplicate"
+    persisted = []
+    agent._flush_messages_to_session_db = lambda messages, _history=None: (
+        persisted.append(copy.deepcopy(messages)) or True
+    )
+    calls = [
+        SimpleNamespace(
+            id="duplicate-call-id",
+            type="function",
+            function=SimpleNamespace(name="terminal", arguments="{}"),
+        )
+        for _ in range(2)
+    ]
+    required_error = RequiredLifecycleError(
+        "required_lifecycle_delivery_failed", "post_tool_call"
+    )
+
+    with (
+        patch("hermes_cli.plugins.requires_hook", return_value=True),
+        patch(
+            "model_tools.handle_function_call",
+            side_effect=("first result", "raw second result"),
+        ) as execute,
+        patch(
+            "agent.tool_executor._emit_terminal_post_tool_call",
+            side_effect=(None, required_error),
+        ),
+        pytest.raises(RequiredLifecycleError) as caught,
+    ):
+        execute_tool_calls_sequential(
+            agent,
+            SimpleNamespace(tool_calls=calls),
+            [],
+            effective_task_id="task-duplicate",
+        )
+
+    assert caught.value is required_error
+    assert execute.call_count == 2
+    tool_results = [
+        message for message in persisted[-1] if message.get("role") == "tool"
+    ]
+    assert len(tool_results) == 2
+    assert tool_results[0]["content"] == "first result"
+    assert tool_results[1]["effect_disposition"] == "unknown"
+    assert REQUIRED_LIFECYCLE_FAILURE_TEXT in tool_results[1]["content"]
+    assert "raw second result" not in str(persisted)
 
 
 def test_required_pre_tool_failure_blocks_direct_invoke_tool(
@@ -806,6 +981,37 @@ def test_required_pre_tool_error_reaches_every_dispatch_boundary(
     assert caught.value is required_error
     if registry_dispatch is not None:
         registry_dispatch.assert_not_called()
+
+
+def test_required_pre_tool_blocks_uncorrelated_external_registry_caller(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.required_lifecycle import RequiredLifecycleError
+    from model_tools import handle_function_call, registry
+
+    home = tmp_path / "hermes"
+    _install_required_plugin(
+        home,
+        'required_hook_result("behavioral.pre_llm.v1", None)',
+        'required_hook_result("behavioral.output.v1", None)',
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    plugins_mod._reset_plugin_managers_for_tests()
+    registry_dispatch = MagicMock(
+        side_effect=AssertionError("uncorrelated external dispatch must not start")
+    )
+    monkeypatch.setattr(registry, "dispatch", registry_dispatch)
+
+    with pytest.raises(RequiredLifecycleError) as caught:
+        handle_function_call(
+            "terminal",
+            {"command": "true"},
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+
+    assert caught.value.reason_code == "required_lifecycle_identity_missing"
+    registry_dispatch.assert_not_called()
 
 
 def test_required_output_hides_tool_narration_before_persist_and_interim_egress(

--- a/tests/run_agent/test_required_lifecycle_fail_closed.py
+++ b/tests/run_agent/test_required_lifecycle_fail_closed.py
@@ -441,17 +441,40 @@ def test_required_post_tool_failure_stops_before_next_provider_call(
     assert all("tool.completed" not in str(event) for event in progress)
 
 
+@pytest.mark.parametrize(
+    ("response_id", "call_id", "expected_pairing_id"),
+    (
+        pytest.param("call-batch-health", None, "call-batch-health", id="id-only"),
+        pytest.param(None, "call-batch-health", "call-batch-health", id="call-id-only"),
+        pytest.param(
+            "call-batch-health|item-batch-health",
+            None,
+            "call-batch-health",
+            id="composite-id",
+        ),
+    ),
+)
 def test_batch_local_required_lifecycle_failure_stops_before_compression_or_provider(
-    monkeypatch,
+    monkeypatch, response_id, call_id, expected_pairing_id,
 ):
+    from agent.transports.types import NormalizedResponse, ToolCall
     from hermes_cli.required_lifecycle import RequiredLifecycleError
 
     agent = _agent()
     agent.valid_tool_names.add("web_search")
-    tool_call = SimpleNamespace(
-        id="call-batch-health",
-        type="function",
-        function=SimpleNamespace(name="web_search", arguments="{}"),
+    tool_call = ToolCall(
+        id=response_id,
+        name="web_search",
+        arguments="{}",
+        provider_data={"call_id": call_id} if call_id else None,
+    )
+    normalized = NormalizedResponse(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+    monkeypatch.setattr(
+        agent._get_transport(), "normalize_response", lambda _response: normalized
     )
     provider_calls = []
 
@@ -495,12 +518,16 @@ def test_batch_local_required_lifecycle_failure_stops_before_compression_or_prov
     compress.assert_not_called()
     assert result["failed"] is True
     assert result["final_response"] == REQUIRED_LIFECYCLE_FAILURE_TEXT
+    assistant_calls = [
+        message
+        for message in result["messages"]
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    ]
+    assert assistant_calls[-1]["tool_calls"][0]["id"] == expected_pairing_id
     tool_results = [
         message for message in result["messages"] if message.get("role") == "tool"
     ]
-    assert [message["tool_call_id"] for message in tool_results] == [
-        "call-batch-health"
-    ]
+    assert [message["tool_call_id"] for message in tool_results] == [expected_pairing_id]
     assert tool_results[0]["effect_disposition"] == "none"
     assert persisted and persisted[-1] == result["messages"]
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2318,7 +2318,8 @@ class TestConcurrentToolExecution:
         manager = SimpleNamespace(_middleware={
             "tool_request": [],
             "tool_execution": [execution_middleware],
-        })
+        }, assert_required_lifecycle_turn_healthy=lambda **_kwargs: None,
+            requires_hook=lambda _name: False)
         monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
         monkeypatch.setattr(
             "hermes_cli.lifecycle.invoke_hook",

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -387,7 +387,7 @@ def test_execute_tool_calls_sequential_flushes_each_tool_result_before_next_disp
     ]
 
 
-def test_sequential_keyboard_interrupt_emits_results_for_all_calls():
+def test_sequential_keyboard_interrupt_emits_results_for_all_calls(tmp_path):
     """A KeyboardInterrupt mid-batch must not leave dangling tool_calls.
 
     When a tool handler raises KeyboardInterrupt, the sequential executor
@@ -403,30 +403,167 @@ def test_sequential_keyboard_interrupt_emits_results_for_all_calls():
         _mock_tool_call(name="web_search", call_id="c2"),
         _mock_tool_call(name="web_search", call_id="c3"),
     ]
-    messages: list = []
+    assistant_row = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": "function",
+                "function": {
+                    "name": call.function.name,
+                    "arguments": call.function.arguments,
+                },
+            }
+            for call in tool_calls
+        ],
+    }
+    messages: list = [
+        {"role": "user", "content": "search"},
+        assistant_row,
+    ]
     assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+    db_path = tmp_path / "state.db"
+    session_id = "keyboard-interrupt-settlement"
+    db = _attach_real_session_db(agent, db_path, session_id)
+    assert agent._flush_messages_to_session_db(messages) is not False
 
     def _interrupt_dispatch(function_name, function_args, effective_task_id, **kwargs):
         # First tool raises a hard interrupt mid-batch.
         raise KeyboardInterrupt()
 
-    agent._flush_messages_to_session_db = MagicMock()
-
-    with (
-        patch("model_tools.handle_function_call", side_effect=_interrupt_dispatch),
-        patch(
-            "agent.tool_executor.maybe_persist_tool_result",
-            side_effect=lambda **kwargs: kwargs["content"],
-        ),
-        pytest.raises(KeyboardInterrupt),
-    ):
-        agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+    try:
+        with (
+            patch("model_tools.handle_function_call", side_effect=_interrupt_dispatch),
+            patch(
+                "agent.tool_executor.maybe_persist_tool_result",
+                side_effect=lambda **kwargs: kwargs["content"],
+            ),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+    finally:
+        db.close()
 
     # Every call_id has a matching tool result — alternation preserved.
     tool_results = [m for m in messages if m.get("role") == "tool"]
     assert [m["tool_call_id"] for m in tool_results] == ["c1", "c2", "c3"]
     # The results are marked as cancelled, not fabricated successes.
     assert all("cancelled" in m["content"].lower() for m in tool_results)
+    assert [m["effect_disposition"] for m in tool_results] == [
+        "unknown",
+        "none",
+        "none",
+    ]
+    durable_results = [
+        message
+        for message in _durable_messages(db_path, session_id)
+        if message.get("role") == "tool"
+    ]
+    assert [message["tool_call_id"] for message in durable_results] == [
+        "c1",
+        "c2",
+        "c3",
+    ]
+    assert [message["effect_disposition"] for message in durable_results] == [
+        "unknown",
+        "none",
+        "none",
+    ]
+
+
+def test_keyboard_interrupt_retries_settlement_before_escaping(tmp_path):
+    """A transient settlement-write failure must not expose a dangling durable turn."""
+    agent = _make_agent()
+    tool_calls = [
+        _mock_tool_call(name="web_search", call_id="c1"),
+        _mock_tool_call(name="web_search", call_id="c2"),
+    ]
+    messages = [
+        {"role": "user", "content": "search"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {
+                        "name": call.function.name,
+                        "arguments": call.function.arguments,
+                    },
+                }
+                for call in tool_calls
+            ],
+        },
+    ]
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+    db_path = tmp_path / "state.db"
+    session_id = "keyboard-interrupt-retry"
+    db = _attach_real_session_db(agent, db_path, session_id)
+    assert agent._flush_messages_to_session_db(messages) is not False
+    real_flush = agent._flush_messages_to_session_db
+    settlement_attempts = 0
+
+    def fail_once_then_persist(flush_messages, conversation_history=None):
+        nonlocal settlement_attempts
+        settlement_attempts += 1
+        if settlement_attempts == 1:
+            return False
+        return real_flush(flush_messages, conversation_history)
+
+    agent._flush_messages_to_session_db = fail_once_then_persist
+
+    try:
+        with (
+            patch("model_tools.handle_function_call", side_effect=KeyboardInterrupt()),
+            patch(
+                "agent.tool_executor.maybe_persist_tool_result",
+                side_effect=lambda **kwargs: kwargs["content"],
+            ),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            agent._execute_tool_calls_sequential(
+                assistant_message, messages, "task-1"
+            )
+    finally:
+        db.close()
+
+    assert settlement_attempts == 2
+    assert agent._incremental_persistence_failed is False
+    durable_results = [
+        message
+        for message in _durable_messages(db_path, session_id)
+        if message.get("role") == "tool"
+    ]
+    assert [message["tool_call_id"] for message in durable_results] == ["c1", "c2"]
+    assert [message["effect_disposition"] for message in durable_results] == [
+        "unknown",
+        "none",
+    ]
+
+
+def test_keyboard_interrupt_does_not_escape_when_settlement_stays_undurable():
+    agent = _make_agent()
+    tool_call = _mock_tool_call(name="web_search", call_id="c1")
+    messages = []
+    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+
+    with (
+        patch("model_tools.handle_function_call", side_effect=KeyboardInterrupt()),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=[tool_call]),
+            messages,
+            "task-1",
+        )
+
+    assert agent._flush_messages_to_session_db.call_count == 2
+    assert agent._incremental_persistence_failed is True
 
 
 @pytest.mark.parametrize("executor_mode", ["sequential", "concurrent"])
@@ -904,4 +1041,3 @@ def test_flush_concurrent_nonblank_winner_adopts_canonical_content(tmp_path):
     assert messages[-1]["content"] == "Canonical winner answer from sibling"
     assert messages[-1]["_db_persisted"] is True
     assert messages[-1]["_row_id"] == row_id
-

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -1,7 +1,9 @@
 """Tests for model_tools.py — function call dispatch, agent-loop interception, legacy toolsets."""
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 from model_tools import (
@@ -547,10 +549,85 @@ class TestBridgeDispatch:
             out = handle_function_call("tool_describe", {"names": ["nope"]})
             assert isinstance(out, str) and json.loads(out) is not None
 
+    def test_catalog_bridge_runs_pre_tool_guard_once_before_dispatch(self):
+        import tools.tool_search as ts
+
+        pre_tool = MagicMock(return_value=(None, {"queries": ["modified"]}))
+        catalog = MagicMock(return_value='{"matches": []}')
+        post_tool = MagicMock()
+        with (
+            patch("model_tools.get_tool_definitions", return_value=[]),
+            patch(
+                "hermes_cli.plugins._dispatch_pre_tool_call_hooks", pre_tool
+            ),
+            patch.object(ts, "dispatch_tool_search", catalog),
+            patch("model_tools._emit_post_tool_call_hook", post_tool),
+        ):
+            result = handle_function_call(
+                "tool_search",
+                {"queries": ["original"]},
+                task_id="task-catalog",
+                session_id="session-catalog",
+                tool_call_id="call-catalog",
+                turn_id="turn-catalog",
+                api_request_id="api-catalog",
+                skip_tool_request_middleware=True,
+            )
+
+        assert json.loads(result) == {"matches": []}
+        pre_tool.assert_called_once()
+        catalog.assert_called_once_with(
+            {"queries": ["modified"]}, current_tool_defs=[]
+        )
+        post_tool.assert_called_once()
+
     def test_tool_call_bad_args_error(self):
         with patch("model_tools.get_tool_definitions", return_value=[]):
             result = json.loads(handle_function_call("tool_call", {}))
         assert "requires a 'name'" in result["error"]
+
+    @pytest.mark.parametrize(
+        ("tool_name", "arguments", "dispatcher_name"),
+        (
+            ("tool_search", {"queries": ["anything"]}, "dispatch_tool_search"),
+            ("tool_describe", {"names": ["anything"]}, "dispatch_tool_describe"),
+        ),
+    )
+    def test_catalog_bridge_cannot_bypass_required_pre_tool_guard(
+        self, tool_name, arguments, dispatcher_name
+    ):
+        import tools.tool_search as ts
+        from hermes_cli.required_lifecycle import RequiredLifecycleError
+
+        required_error = RequiredLifecycleError(
+            "required_lifecycle_delivery_failed", "pre_tool_call"
+        )
+        dispatcher = MagicMock(
+            side_effect=AssertionError("catalog dispatch must not start")
+        )
+        with (
+            patch("model_tools.get_tool_definitions", return_value=[]),
+            patch(
+                "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+                side_effect=required_error,
+            ),
+            patch.object(ts, dispatcher_name, dispatcher),
+            pytest.raises(RequiredLifecycleError) as caught,
+        ):
+            handle_function_call(
+                tool_name,
+                arguments,
+                task_id="task-bridge",
+                session_id="session-bridge",
+                tool_call_id="call-bridge",
+                turn_id="turn-bridge",
+                api_request_id="api-bridge",
+                skip_tool_request_middleware=True,
+                skip_tool_execution_middleware=True,
+            )
+
+        assert caught.value is required_error
+        dispatcher.assert_not_called()
 
     def test_tool_call_rejects_out_of_scope_and_unwraps_in_scope(self):
         import tools.tool_search as ts

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -934,6 +934,12 @@ def register(ctx):
     ctx.register_hook("on_session_end", on_session_end)
 ```
 
+`register_hook()` also accepts a stable `registration_id=` for callbacks selected
+by the operator as mandatory lifecycle boundaries. Required callbacks must return
+`hermes_cli.plugins.required_hook_result(registration_id, result)`. See
+[Operator-required lifecycle hooks](/user-guide/features/hooks#operator-required-lifecycle-hooks)
+for the closed configuration and failure behavior.
+
 ### Hook reference
 
 Each hook is documented in full on the **[Event Hooks reference](/user-guide/features/hooks#plugin-hooks)** — callback signatures, parameter tables, exactly when each fires, and examples. Here's the summary:

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -388,6 +388,49 @@ def register(ctx):
 - Correlation fields such as `turn_id`, `api_request_id`, `task_id`, `session_id`, and `api_call_count` are hook-specific and may be absent. Treat IDs as opaque.
 - Runtime event-name validity comes from `hermes_cli.plugins.VALID_HOOKS`. `hermes hooks list` lists configured shell/outbound hooks, not every available event; `hermes hooks test <event>` reports the valid set only when an invalid event is supplied.
 
+### Operator-required lifecycle hooks
+
+Hermes normally isolates a failing plugin callback and continues. An operator can
+instead make the four turn-containment boundaries mandatory for a named plugin:
+`pre_llm_call`, `pre_tool_call`, `post_tool_call`, and
+`transform_llm_output`. When configured, a missing, replaced, timed-out, malformed,
+or failing required callback stops the turn. No later model request or tool starts,
+and untransformed provider text is not streamed or persisted.
+
+The plugin must register stable callback identities and return an acknowledgement
+created by `required_hook_result`:
+
+```python
+from hermes_cli.plugins import required_hook_result
+
+def register(ctx):
+    ctx.register_hook(
+        "pre_llm_call",
+        lambda **kw: required_hook_result("guard.pre-llm.v1", None),
+        registration_id="guard.pre-llm.v1",
+    )
+    # Register the other three required boundaries in the same way.
+```
+
+The operator-owned profile configuration must name every required identity:
+
+```yaml
+plugins:
+  enabled: [my-guard]
+  required_lifecycle_hooks:
+    my-guard:
+      pre_llm_call: [guard.pre-llm.v1]
+      pre_tool_call: [guard.pre-tool.v1]
+      post_tool_call: [guard.post-tool.v1]
+      transform_llm_output: [guard.output.v1]
+```
+
+This setting is strict by design. All four keys are required, identifiers must be
+unique and valid, and `pre_tool_call` plus `transform_llm_output` each have exactly
+one authority across the profile. A malformed policy fails closed rather than
+silently reverting to optional-hook behavior. Do not use this setting for telemetry
+plugins; it is intended for operator-selected safety and publication authorities.
+
 ### Cache-safe system prompt sections
 
 Plugins that need durable, always-on guidance can register a bounded system

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -397,6 +397,11 @@ instead make the four turn-containment boundaries mandatory for a named plugin:
 or failing required callback stops the turn. No later model request or tool starts,
 and untransformed provider text is not streamed or persisted.
 
+Installers that need to detect this host contract without importing plugin code
+can require `hermes_cli.required_lifecycle.REQUIRED_LIFECYCLE_CAPABILITY` to equal
+`"required-lifecycle-hooks/v1"`. The marker is part of the installed distribution;
+its presence does not enable the policy by itself.
+
 The plugin must register stable callback identities and return an acknowledgement
 created by `required_hook_result`:
 


### PR DESCRIPTION
## Summary

- add an opt-in, configuration-bound contract for lifecycle hooks that must acknowledge delivery
- fail closed before provider/tool execution and before output persistence when a required hook is missing, changed, malformed, timed out, or fails
- keep existing optional plugin hooks fail-open and backward compatible
- cover sequential and direct tool dispatch, pre/post-tool settlement, model output, truncation, streaming, reload, registration drift, provider-field quarantine, interruption, and persistence failure

This is a generic Hermes plugin capability. Atlas is one external consumer, but no Atlas-specific code or default policy is added to Hermes.

## Review fixes

The complete review set is fixed on `96131ef7ec585eeb222cf3d46a74c0d664d2d2a4`, rebased onto `main@b27c6f7f0d483a3f5c6bc4d5cc0c5394f356f715`:

- required post-tool acknowledgement completes before result append, database flush, progress, or UI publication
- failed settlement publishes only stable redacted status; raw tool output is quarantined
- settlement is scoped to the current execution frame, so a historical or duplicate `tool_call_id` cannot hide a missing current result
- `effect_disposition` is derived from the actual handler-start boundary: unstarted/blocked/invalid calls are `none`; only a started effect-capable call is `unknown`
- direct `tool_search` / `tool_describe` dispatch now crosses the same pre-tool authority boundary
- Bedrock's ordered raw content carrier is quarantined with the Anthropic/Codex continuity carriers and never enters the durable/public projection
- no later tool, context compression, or provider call starts after required lifecycle failure
- interrupt settlement remains durably paired before an interrupt can escape

## Verification

- affected-path suite on the recorded rebase base: **502 passed, 3 skipped**
- independent Standards review: **PASS**, no residual Critical/Important/Minor findings
- independent Spec review: **PASS**, no residual Critical/Important findings
- compatibility test with open #104763 applied on top: **136 passed**
- Python compile check and `git diff --check`: passed
- branch worktree is clean and the fork branch points to the exact head above

The three skips are existing environment/platform-conditioned cases, not failures. Hosted checks may still require maintainer authorization before GitHub Actions runs for this fork PR.

This remains complementary to #104763. The current #104763 head cherry-picks cleanly onto this exact branch head, and the joint plugin/required-lifecycle regression set is green as reported above.