### PR TITLE
feat(plugins): authenticated saved side runs (ABI convergence draft)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1233,6 +1233,11 @@ def _consume_ephemeral_max_output(agent):
     ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
     if ephemeral_out is not None:
         agent._ephemeral_max_output_tokens = None
+        # Host-owned bounded runs may recover from truncation, but must not
+        # silently enlarge their explicitly authorized per-request output limit.
+        ceiling = getattr(agent, "_max_output_tokens_ceiling", None)
+        if ceiling is not None:
+            ephemeral_out = min(ephemeral_out, ceiling)
     return ephemeral_out
 
 
@@ -1369,7 +1374,18 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     """
     from agent.opencode_affinity import merge_opencode_session_headers
 
+    # Capture the one-shot bound before the transport consumes it. Provider
+    # thinking transforms may enlarge even a clamped retry (or the first call).
+    from agent.output_ceiling import validate_output_ceiling
+    output_limit = getattr(agent, "_max_output_tokens_ceiling", None)
+    if output_limit is not None:
+        requested = getattr(agent, "_ephemeral_max_output_tokens", None)
+        if requested is None:
+            requested = agent.max_tokens
+        if requested is not None:
+            output_limit = min(output_limit, requested)
     kwargs = _build_api_kwargs_for_mode(agent, api_messages, tools_for_api)
+    validate_output_ceiling(agent, kwargs, output_limit)
     return merge_opencode_session_headers(
         kwargs,
         getattr(agent, "provider", None),

--- a/agent/output_ceiling.py
+++ b/agent/output_ceiling.py
@@ -1,0 +1,57 @@
+"""Opt-in host limits checked after provider request transformations.
+
+Reject incompatible assembly rather than changing configured reasoning semantics.
+An omitted cap is not evidence of a bounded request (notably on Codex subscriptions).
+"""
+
+
+def validate_output_ceiling(agent, kwargs: dict, limit: int | None) -> None:
+    if limit is None:
+        return
+
+    mode = agent.api_mode
+    extra = kwargs.get("extra_body") or {}
+    if not isinstance(extra, dict):
+        raise ValueError("Host output limit cannot validate a non-object extra_body")
+    # SDK extra_body fields override the typed request fields at serialization.
+    body = {**kwargs, **extra}
+    if mode == "bedrock_converse":
+        values = [("inferenceConfig.maxTokens", (body.get("inferenceConfig") or {}).get("maxTokens"))]
+    elif mode == "anthropic_messages":
+        values = [("max_tokens", body.get("max_tokens"))]
+    elif mode == "codex_responses":
+        values = [("max_output_tokens", body.get("max_output_tokens"))]
+    elif mode == "chat_completions":
+        values = [(key, body[key]) for key in ("max_tokens", "max_completion_tokens") if key in body]
+    else:
+        raise ValueError(f"Host output limit is not supported by transport {mode!r}")
+
+    if not values:
+        raise ValueError(f"Host output limit {limit} requires an explicit wire cap; transport {mode!r} omitted it")
+    for key, value in values:
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError(
+                f"Host output limit {limit} requires an explicit positive integer wire cap; "
+                f"transport {mode!r} omitted or invalidated it"
+            )
+        if value > limit:
+            raise ValueError(
+                f"Host output limit {limit} is incompatible with provider thinking/output assembly: "
+                f"{key} requires {value}. Increase the configured limit or choose compatible reasoning; "
+                "the request was not sent and the reasoning budget was not reduced."
+            )
+
+    # GeminiNativeClient performs another conversion inside chat.completions.create.
+    # Check that same output calculation before handing the request to the client.
+    if mode == "chat_completions":
+        from agent.gemini_native_adapter import is_native_gemini_base_url, _effective_gemini_max_output_tokens
+
+        if is_native_gemini_base_url(getattr(agent, "base_url", None) or ""):
+            thinking = extra.get("thinking_config") or extra.get("thinkingConfig")
+            native_limit = _effective_gemini_max_output_tokens(kwargs.get("max_tokens"), thinking)
+            if native_limit > limit:
+                raise ValueError(
+                    f"Host output limit {limit} is incompatible with native Gemini thinking/output assembly: "
+                    f"maxOutputTokens requires {native_limit}. Increase the configured limit or choose "
+                    "compatible reasoning; the request was not sent."
+                )

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1218,6 +1218,10 @@ agent:
 # Gateway Lifecycle
 # =============================================================================
 gateway:
+  # Capacity for authenticated plugin side runs; excess work is rejected, not queued.
+  # side_runs:
+  #   max_concurrent: 3  # 1–10
+
   # Post-interrupt grace for running agents during an unexpected SIGTERM.
   # Adapter, bridge, and database teardown starts after this many seconds even
   # if an agent has not unwound. Keep it below the service-manager stop budget.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3516,7 +3516,7 @@ class BasePlatformAdapter(ABC):
         # runner. Without this, they are queued as pending messages and either: See #4926.
         cmd = event.get_command()
         from hermes_cli.commands import (is_interrupt_then_dispatch, should_bypass_active_session)
-        if should_bypass_active_session(cmd):
+        if should_bypass_active_session(cmd, profile=self._session_key_profile(event.source)):
             try:
                 # /stop, /new, /reset: cancel + response + drain; other bypasses don't cancel.
                 if cmd and is_interrupt_then_dispatch(cmd):

--- a/gateway/plugin_commands.py
+++ b/gateway/plugin_commands.py
@@ -1,0 +1,79 @@
+"""Authenticated gateway command context. Constructed only at the slash dispatch sink."""
+from dataclasses import dataclass
+import inspect
+
+
+@dataclass(frozen=True)
+class PluginCommandContext:
+    _runner: object
+    _event: object
+    plugin_id: str
+    _registration_context: object
+    _command_name: str
+    _command_entry: dict
+
+    @property
+    def source(self):
+        from copy import deepcopy
+        return deepcopy(self._event.source)
+
+    def start_side_run(self, prompt, config):
+        from hermes_cli.plugin_side_runs import SideRunConfig
+        options = SideRunConfig.from_mapping(config)
+        manager = self._registration_context._manager
+        # An async handler can resume after unload/reload. Lease validation and acquiring its
+        # cleanup registration must be atomic with that teardown, not just checked at dispatch.
+        with manager._discovery_lock:
+            if manager._plugin_commands.get(self._command_name) is not self._command_entry:
+                raise ValueError("Plugin command is no longer active")
+            return self._service().start(self._event, self.plugin_id, prompt, options,
+                                         registration_context=self._registration_context)
+
+    def cancel_side_run(self, session_id):
+        return self._service().cancel(self._event.source, session_id, plugin_id=self.plugin_id)
+
+    def _service(self):
+        from gateway.side_runs import SideRunService
+        service = getattr(self._runner, "_plugin_side_runs", None)
+        if service is None:
+            service = SideRunService(self._runner)
+            self._runner._plugin_side_runs = service
+        return service
+
+
+def accepts_context(handler):
+    try:
+        parameter = inspect.signature(handler).parameters.get("context")
+    except (TypeError, ValueError):
+        # Opaque builtins retain the original one-argument command contract.
+        return False
+    return parameter is not None and parameter.kind in {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY,
+    }
+
+
+async def dispatch_plugin_command(runner, event, source, command):
+    if not command:
+        return False, None
+    from hermes_cli.plugins import get_plugin_commands, get_plugin_command_handler
+    name = command.replace("_", "-")
+    handler = get_plugin_command_handler(name)
+    if handler is None:
+        return False, None
+    entry = get_plugin_commands().get(name)
+    denied = runner._check_slash_access(source, name)
+    if denied is not None:
+        return True, denied
+    if not event.allow_gateway_control or event.internal:
+        return True, "Plugin command requires an authenticated user command."
+    try:
+        kwargs = {}
+        if accepts_context(handler):
+            kwargs["context"] = PluginCommandContext(runner, event, entry["plugin_key"], entry["context"], name, entry)
+        result = handler(event.get_command_args().strip(), **kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+        return True, str(result) if result is not None else None
+    except Exception:
+        # Plugin/provider exceptions can contain credentials and must never become model prompts.
+        return True, "Plugin command failed. Check its configuration and host compatibility."

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -516,6 +516,16 @@ class GatewayInboundMixin:
             # interrupt_then_dispatch / reject). Unrecognized commands and plain text fall through.
             return True, await self._dispatch_busy_slash_command(event, _cmd_def_inner, _quick_key, source)
 
+        from hermes_cli.plugins import get_plugin_commands
+        entry = get_plugin_commands().get((_evt_cmd or "").replace("_", "-"))
+        if entry is not None and entry.get("busy_policy") is not None:
+            if entry.get("busy_policy") != "noninterrupting":
+                return True, "This plugin command is unavailable while the session is busy."
+            if self._draining:
+                return True, "Gateway is draining and cannot accept side runs."
+            from gateway.plugin_commands import dispatch_plugin_command
+            return await dispatch_plugin_command(self, event, source, _evt_cmd)
+
         # Telegram photo bursts arrive as near-simultaneous updates — never interrupt for a
         # photo-only follow-up; adapter-level batching absorbs them.
         if event.message_type == MessageType.PHOTO:
@@ -977,20 +987,9 @@ class GatewayInboundMixin:
                 return True, f"Quick command '/{command}' has no target defined.", command
             command = new_command  # Fall through to normal command dispatch below
 
-        # Plugin-registered slash commands. Underscores normalize to hyphens so Telegram's
-        # underscored autocomplete form matches plugin commands registered with hyphens.
-        if command:
-            try:
-                from hermes_cli.plugins import get_plugin_command_handler
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
-                if plugin_handler:
-                    result = plugin_handler(event.get_command_args().strip())
-                    if asyncio.iscoroutine(result):
-                        result = await result
-                    return True, str(result) if result else None, command
-            except Exception as e:
-                logger.warning("Plugin command dispatch failed: %s", e)
-        return False, None, command
+        from gateway.plugin_commands import dispatch_plugin_command
+        handled, result = await dispatch_plugin_command(self, event, source, command)
+        return handled, result, command
 
     def _hm_bundle_slash_rewrite(
         self, event: "MessageEvent", source: SessionSource, _quick_key: str, command: str
@@ -1122,6 +1121,13 @@ class GatewayInboundMixin:
         Only events that may control the gateway (``allow_gateway_control``) can answer them."""
         if not event.allow_gateway_control:
             return None
+        side_runs = getattr(self, "_plugin_side_runs", None)
+        if side_runs is not None:
+            reply = side_runs.approval_reply(event)
+            if reply is not None:
+                return reply
+        if event.get_command() in {"approve", "deny"} and event.get_command_args().strip().startswith("side:"):
+            return "Approval request has expired or is unavailable."
         _reply = self._hm_update_prompt_reply(event, _quick_key)
         if _reply is None:
             _reply = await self._hm_clarify_reply(event, source, _quick_key)

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -272,6 +272,8 @@ class GatewayShutdownMixin:
         PERMANENT supervised watchers (_hermes_supervised_watcher, incl. the scale-to-zero watcher
         itself) are excluded, else this would be True forever and the gateway could never go dormant.
         """
+        if self._active_deferred_agent_worker_count():
+            return True
         if any(
             not t.done() and not getattr(t, "_hermes_supervised_watcher", False)
             for t in self._background_tasks
@@ -1551,6 +1553,8 @@ class GatewayShutdownMixin:
         ctx.started_at = time.monotonic()
         self._running = False
         self._clear_plugin_message_injector()
+        if (side_runs := getattr(self, "_plugin_side_runs", None)) is not None:
+            side_runs.shutdown()
         self._draining = True
         # getattr-guards: shutdown-path test doubles may lack the room worker / systemd watchdog.
         stop_room_worker = getattr(self, "_stop_hosted_room_worker", None)

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -74,11 +74,28 @@ def _runtime_cwd(func: str, *args: Any) -> None:
         pass
 
 
+_isolated_session = ContextVar("isolated_session", default=False)
+
+
+@contextmanager
+def isolated_session_context(session_id):
+    """Fresh same-process agent: no process identity writes or inherited approval bypass."""
+    from tools.approval_context import require_manual_approval
+    token = _isolated_session.set(True)
+    try:
+        with scoped_current_session_id(session_id), require_manual_approval():
+            yield
+    finally:
+        _isolated_session.reset(token)
+
+
 def set_current_session_id(session_id: str) -> None:
     """Synchronize ``HERMES_SESSION_ID`` across ContextVar and ``os.environ`` (tools read it
     with an os.environ fallback).  Delegated subagent children (built in the parent process)
     get ONLY the task-local write, or they would clobber the parent's id."""
     _SESSION_ID.set(session_id)
+    if _isolated_session.get():
+        return
     try:
         from agent.delegation_context import is_delegated_child_context
         if is_delegated_child_context():

--- a/gateway/side_runs.py
+++ b/gateway/side_runs.py
@@ -1,0 +1,327 @@
+"""Gateway-owned fresh plugin conversations. Never enters the parent turn/cache path."""
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from dataclasses import dataclass, field
+import json
+import threading
+import uuid
+
+from gateway.session import SessionContext
+from hermes_cli.plugin_side_runs import SideRunConfig, bounded_number
+
+
+def owner_identity(source):
+    """A shared room is not shared authority for a privately initiated child."""
+    fields = ("chat_id", "chat_type", "thread_id", "user_id", "user_id_alt", "scope_id", "profile")
+    return {"platform": source.platform.value, **{k: str(getattr(source, k, None) or "") for k in fields}}
+
+
+def owns_side_run(source, model_config):
+    if isinstance(model_config, str):
+        model_config = json.loads(model_config)
+    side = (model_config or {}).get("side_run")
+    if side is None:
+        return None
+    return bool(source.user_id and isinstance(side, dict) and side.get("owner") == owner_identity(source))
+
+
+@dataclass
+class SideRun:
+    session_id: str
+    key: str
+    event: object
+    plugin_id: str
+    config: SideRunConfig
+    parent_id: str | None
+    adapter: object
+    db: object
+    listing_key: str
+    cancelled: threading.Event = field(default_factory=threading.Event)
+    agent: object = None
+    task: asyncio.Task | None = None
+    registration: object = None
+
+    def interrupt(self, reason="Side run cancelled", *, hard_cancel=True):
+        from tools.approval import unregister_gateway_notify
+        self.cancelled.set()
+        unregister_gateway_notify(self.key)
+        if self.agent is not None:
+            self.agent.interrupt(reason, hard_cancel=hard_cancel)
+
+
+class SideRunService:
+    def __init__(self, runner, *, max_concurrent=None):
+        from hermes_cli.config import load_config
+        if max_concurrent is None:
+            max_concurrent = (load_config().get("gateway", {}).get("side_runs", {}) or {}).get("max_concurrent", 3)
+        self.max_concurrent = bounded_number(max_concurrent, "side run concurrency", 1, 10, integer=True)
+        self.runner = runner
+        self.loop = asyncio.get_running_loop()
+        self.runs: dict[str, SideRun] = {}
+        self.closing = False
+
+    def start(self, event, plugin_id, prompt, config, *, registration_context=None):
+        if self.closing or self.runner._draining:
+            raise ValueError("Side runs are unavailable while the gateway is draining")
+        if len(self.runs) >= self.max_concurrent:
+            raise ValueError("Side-run capacity reached; wait or cancel an existing run")
+        if not isinstance(prompt, str) or not prompt.strip() or len(prompt) > 100000:
+            raise ValueError("Side-run prompt must contain 1 to 100000 characters")
+        # Revalidate even programmatically constructed dataclasses at the host boundary.
+        config = SideRunConfig.from_mapping(config.to_dict())
+        source = event.source
+        if not event.allow_gateway_control or not source.user_id:
+            raise ValueError("Side runs require an authenticated owner")
+        adapter = self.runner._adapter_for_source(source)
+        if adapter is None or not callable(getattr(adapter, "send", None)):
+            raise ValueError("Side runs require a reply transport")
+        with self.runner._profile_scope_for_source(source):
+            session_db = getattr(self.runner, "_session_db", None)
+            if session_db is None:
+                raise ValueError("Side runs require a durable session database")
+            db = session_db._db
+            parent_key = self.runner._session_key_for_source(source)
+            parent = self.runner.session_store._entries.get(parent_key)
+        sid = "side-" + uuid.uuid4().hex
+        run = SideRun(sid, "plugin-side:" + sid, deepcopy(event), plugin_id, config,
+                      getattr(parent, "session_id", None), adapter, db, parent_key)
+        self.runs[sid] = run
+        if registration_context is not None:
+            def cancel_on_unload():
+                run.cancelled.set()
+                self.loop.call_soon_threadsafe(self._cancel_run, run)
+            run.registration = registration_context.on_unload(cancel_on_unload)
+        run.task = self.loop.create_task(self._execute(run, prompt.strip()), name=f"plugin-side:{sid}")
+        # Reuse the host's detached-work drain/interrupt ledger, including admission
+        # before construction and final delivery after the synchronous worker exits.
+        self.runner._track_deferred_agent_worker(run.task, run)
+        return sid
+
+    def cancel(self, source, session_id, *, plugin_id=None):
+        run = self.runs.get(session_id)
+        if run is None or owner_identity(source) != owner_identity(run.event.source):
+            return False
+        if plugin_id is not None and plugin_id != run.plugin_id:
+            return False
+        self._cancel_run(run)
+        return True
+
+    def _cancel_run(self, run):
+        if self.runs.get(run.session_id) is not run:
+            return
+        run.interrupt()
+
+    def shutdown(self):
+        self.closing = True
+        for run in list(self.runs.values()):
+            self._cancel_run(run)
+
+    async def wait(self):
+        tasks = [run.task for run in self.runs.values() if run.task is not None]
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    async def _send(self, run, text):
+        from gateway.run import _redact_gateway_user_facing_secrets
+        source = run.event.source
+        metadata = dict(self.runner._thread_metadata_for_source(
+            source, self.runner._reply_anchor_for_event(run.event)) or {})
+        # This is an independent message beside the parent's native stream; never seal that stream.
+        metadata["_interim_send"] = True
+        result = await run.adapter.send(
+            source.chat_id, _redact_gateway_user_facing_secrets(text),
+            reply_to=self.runner._reply_anchor_for_event(run.event),
+            metadata=metadata,
+        )
+        if result is not None and getattr(result, "success", True) is False:
+            raise RuntimeError("Side-run delivery failed")
+
+    async def _execute(self, run, prompt):
+        # The executor Future is shielded: cancelling an asyncio waiter cannot kill a sync worker.
+        # Capacity and callbacks stay owned until that worker's finally/close has actually completed.
+        timer = self.loop.call_later(run.config.run_budget_seconds, self._cancel_run, run)
+        worker = None
+        try:
+            source = run.event.source
+            with self.runner._profile_scope_for_source(source):
+                tokens = self.runner._set_session_env(SessionContext(source, [], {}, session_key=run.key, session_id=run.session_id))
+                try:
+                    worker = asyncio.create_task(self.runner._run_in_executor_with_context(self._work, run, prompt))
+                finally:
+                    self.runner._clear_session_env(tokens)
+            while True:
+                try:
+                    answer = await asyncio.shield(worker)
+                    break
+                except asyncio.CancelledError:
+                    self._cancel_run(run)
+                    if self.closing:
+                        # The host has already budgeted drain/settle. Its executor
+                        # quiesce policy retains DB handles for live sync workers.
+                        raise
+                    if worker.cancelled():
+                        raise RuntimeError("Side-run worker was cancelled before execution") from None
+            timer.cancel()
+            text = f"Side run {run.session_id} cancelled." if run.cancelled.is_set() else answer
+            await self._send(run, text)
+        except Exception:
+            # Never return/log raw constructor, provider or tool exceptions (often contain secrets).
+            try:
+                await self._send(run, f"Side run {run.session_id} failed. Check the route configuration or provider availability.")
+            except Exception:
+                # Session transcript/outcome remains available when delivery is unavailable.
+                pass
+        finally:
+            timer.cancel()
+            if worker is not None and not worker.done() and not self.closing:
+                self._cancel_run(run)
+                await asyncio.shield(worker)
+            self.runs.pop(run.session_id, None)
+            if run.registration is not None:
+                run.registration.dispose()
+
+    def _work(self, run, prompt):
+        from run_agent import AIAgent
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        from tools.approval import register_gateway_notify, unregister_gateway_notify
+        from tools.approval_context import set_current_session_key, reset_current_session_key
+        from gateway.session_context import isolated_session_context
+        source, config = run.event.source, run.config
+        token = set_current_session_key(run.key)
+        agent = None
+        status = "failed"
+        try:
+            with isolated_session_context(run.session_id):
+                db = run.db
+                # Independent, user-visible branch with an empty transcript: reuse the durable
+                # branch marker so parent compression/resume never treats this as a continuation.
+                saved = {"_branched_from": run.parent_id,
+                         "side_run": {"owner": owner_identity(source), "plugin": run.plugin_id,
+                                     "effective_config": config.to_dict()},
+                         "gateway_runtime": {"provider": config.provider, "model": config.model},
+                         "max_iterations": config.max_iterations, "max_tokens": config.max_tokens,
+                         "reasoning_config": config.reasoning,
+                         "codex_app_server_auto_compaction": "off"}
+                db.create_session(run.session_id, source.platform.value, model=config.model,
+                                  model_config=saved, user_id=source.user_id, chat_id=source.chat_id,
+                                  chat_type=source.chat_type, thread_id=source.thread_id, session_key=run.listing_key,
+                                  parent_session_id=run.parent_id, origin_json=json.dumps(source.to_dict()))
+                if run.cancelled.is_set():
+                    return "Cancelled"
+                runtime = resolve_runtime_provider(requested=config.provider, target_model=config.model, strict=True)
+                from hermes_cli.runtime_provider_strict import validate_explicit_runtime
+                validate_explicit_runtime(config.provider, config.model, runtime)
+                if (runtime.get("command") or runtime.get("acp_command")
+                        or str(runtime.get("base_url", "")).startswith(("acp:", "moa:"))
+                        or runtime.get("api_mode") == "codex_app_server"):
+                    raise ValueError("External agent/virtual transports do not support isolated host tool approvals")
+                saved["side_run"]["runtime"] = {key: runtime[key] for key in ("provider", "api_mode") if key in runtime}
+                db.update_session_meta(run.session_id, json.dumps(saved), model=config.model)
+                if config.tools is not None:
+                    from toolsets import get_all_toolsets
+                    if set(config.tools) - set(get_all_toolsets()):
+                        raise ValueError("Unknown toolset in side-run configuration")
+                kwargs = {key: runtime[key] for key in (
+                    "provider", "api_key", "base_url", "api_mode", "credential_pool", "request_overrides", "capabilities",
+                ) if key in runtime}
+                overrides = dict(kwargs.get("request_overrides") or {})
+                # SDK transports merge provider overrides after request assembly. A preset's
+                # empty history, selected tools and output/reasoning limits must remain authoritative.
+                reserved = {"messages", "input", "system", "instructions", "tools", "tool_choice",
+                            "max_tokens", "max_completion_tokens", "max_output_tokens",
+                            "reasoning", "reasoning_effort", "thinking"}
+                for body in (overrides, overrides.get("extra_body") or {}):
+                    if not isinstance(body, dict) or reserved.intersection(body):
+                        raise ValueError("Provider overrides conflict with isolated side-run configuration")
+                if runtime.get("extra_headers"):
+                    overrides["extra_headers"] = runtime["extra_headers"]
+                kwargs["request_overrides"] = overrides
+                agent = AIAgent(
+                    **kwargs, model=config.model, requested_provider=config.provider,
+                    session_id=run.session_id, session_db=db, parent_session_id=run.parent_id,
+                    platform=source.platform.value, user_id=source.user_id, user_id_alt=source.user_id_alt,
+                    user_name=source.user_name, chat_id=source.chat_id, chat_name=source.chat_name,
+                    chat_type=source.chat_type, thread_id=source.thread_id, gateway_session_key=run.key,
+                    enabled_toolsets=None if config.tools is None else list(config.tools),
+                    reasoning_config=deepcopy(config.reasoning), max_iterations=config.max_iterations,
+                    max_tokens=config.max_tokens, run_budget_seconds=config.run_budget_seconds,
+                    fallback_model=[], skip_memory=True, skip_context_files=True, skip_background_review=True,
+                    quiet_mode=True,
+                )
+                run.agent = agent
+                agent._max_output_tokens_ceiling = config.max_tokens
+                # Native app-server promotion would replace Hermes' tool/approval loop mid-run.
+                agent.codex_app_server_auto_compaction = "off"
+                if getattr(agent, "api_mode", None) == "codex_app_server":
+                    raise ValueError("App-server transport cannot enforce host side-run boundaries")
+                if agent.model != config.model or agent.provider != runtime["provider"]:
+                    raise ValueError("Agent changed explicit primary route")
+                if run.cancelled.is_set():
+                    agent.interrupt("Side run cancelled", hard_cancel=True)
+                    return "Cancelled"
+                register_gateway_notify(run.key, lambda data: self._notify(run, data))
+                if run.cancelled.is_set():
+                    unregister_gateway_notify(run.key)
+                    return "Cancelled"
+                result = agent.run_conversation(user_message=prompt, conversation_history=None, task_id=run.session_id)
+                if result.get("failed") or result.get("error"):
+                    raise RuntimeError("Side run failed")
+                answer = result.get("final_response")
+                if not isinstance(answer, str) or not answer.strip():
+                    raise RuntimeError("Side run returned no answer")
+                status = "completed"
+                return answer
+        finally:
+            unregister_gateway_notify(run.key)
+            from tools.approval import clear_session
+            try:
+                clear_session(run.key)
+                if run.db.get_session(run.session_id):
+                    # SessionDB preserves the first end reason. Stamp the host outcome before
+                    # AIAgent.close() writes its generic agent_close marker.
+                    run.db.end_session(run.session_id, "side_run_" + ("cancelled" if run.cancelled.is_set() else status))
+            finally:
+                try:
+                    if agent is not None:
+                        agent.close()
+                finally:
+                    reset_current_session_key(token)
+
+    def _notify(self, run, data):
+        from gateway.run import _redact_approval_command
+        request_id = data["request_id"]
+        if run.cancelled.is_set() or self.closing:
+            raise RuntimeError("Side run cancelled")
+        text = (f"Side run {run.session_id} requests approval:\n"
+                f"{_redact_approval_command(data.get('command', ''))}\n"
+                f"/approve side:{request_id}\n/deny side:{request_id}")
+        future = asyncio.run_coroutine_threadsafe(self._send(run, text), self.loop)
+        try:
+            future.result(timeout=30)
+        except BaseException:
+            future.cancel()
+            raise RuntimeError("Approval transport unavailable") from None
+
+    def approval_reply(self, event):
+        command = event.get_command()
+        if command not in {"approve", "deny"}:
+            return None
+        argument = event.get_command_args().strip()
+        if not argument.startswith("side:"):
+            return None
+        request_id = argument[5:]
+        from tools.approval import list_gateway_approvals, resolve_gateway_approval
+        for run in list(self.runs.values()):
+            if any(p.get("request_id") == request_id for p in list_gateway_approvals(run.key)):
+                denied = self.runner._check_slash_access(event.source, command)
+                if denied is not None:
+                    return denied
+                if not event.allow_gateway_control or owner_identity(event.source) != owner_identity(run.event.source):
+                    return "Approval request is unavailable for this sender."
+                if run.cancelled.is_set():
+                    return "Approval request has expired."
+                count = resolve_gateway_approval(run.key, "once" if command == "approve" else "deny", request_id=request_id)
+                return "Side-run approval recorded." if count else "Approval request has expired."
+        return "Approval request has expired or is unavailable."

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -314,6 +314,13 @@ class GatewaySessionCommandsMixin:
         Rows once stored only source + user_id, so the persisted chat/thread origin is compared too
         and legacy NULL rows fail closed.  The table has no user_id_alt column, so an alt-keyed
         (Signal/Feishu) caller is never proven by user_id alone (CWE-639)."""
+        from gateway.side_runs import owns_side_run
+        try:
+            side_owner = owns_side_run(source, row.get("model_config"))
+        except (ValueError, TypeError, AttributeError):
+            return False
+        if side_owner is not None:
+            return side_owner
         caller_src = source.platform.value if source.platform else None
         row_src = row.get("source")
         caller_uid = _sattr(source, "user_id")
@@ -348,6 +355,14 @@ class GatewaySessionCommandsMixin:
         """Whether *source* may resume session *target_id* (IDOR guard for every adapter).  The live
         origin decides when the target is active; otherwise the DB row must PROVE ownership or fail
         closed.  Admin ``--all`` bypasses."""
+        try:
+            row = await self._session_db.get_session(target_id) or {}
+            from gateway.side_runs import owns_side_run
+            side_owner = owns_side_run(source, row.get("model_config"))
+        except (ValueError, TypeError, AttributeError):
+            return False
+        if side_owner is not None:
+            return side_owner
         if allow_override and self._resume_caller_is_admin(source):
             return True
         # Only a real SessionSource origin decides; unresolvable/error falls through to DB scoping.
@@ -366,6 +381,13 @@ class GatewaySessionCommandsMixin:
     async def _resume_row_visible(self, source: SessionSource, row: dict, allow_all: bool) -> bool:
         """Whether a listing *row* belongs to the caller's origin (blocks cross-origin enumeration of
         ids/previews); Matrix is room-scoped, ``--all`` needs a configured admin everywhere."""
+        from gateway.side_runs import owns_side_run
+        try:
+            side_owner = owns_side_run(source, row.get("model_config"))
+        except (ValueError, TypeError, AttributeError):
+            return False
+        if side_owner is not None:
+            return side_owner
         if allow_all and self._resume_caller_is_admin(source):
             return True
         sid = str(row.get("id") or "")
@@ -867,6 +889,19 @@ class GatewaySessionCommandsMixin:
                                           allow_cross_room: bool) -> Optional[str]:
         """IDOR guard: a session id/title is a routing handle, not authority — bind /resume to the
         caller's own room (Matrix) or platform/user/chat (other adapters)."""
+        from gateway.side_runs import owns_side_run
+        try:
+            row = await self._session_db.get_session(target_id) or {}
+            side_owner = owns_side_run(source, row.get("model_config"))
+        except (ValueError, TypeError, AttributeError):
+            return t("gateway.resume.blocked_not_owner", name=name)
+        if side_owner is not None:
+            if not side_owner:
+                return t("gateway.resume.blocked_not_owner", name=name)
+            service = getattr(self, "_plugin_side_runs", None)
+            if service is not None and target_id in service.runs:
+                return "Wait for the side run to finish before resuming its session."
+            return None
         if source.platform == Platform.MATRIX:
             target_origin = self._gateway_session_origin_for_id(target_id)
             if self._same_matrix_room(source, target_origin) or allow_cross_room:
@@ -998,8 +1033,7 @@ class GatewaySessionCommandsMixin:
             search_query=search_query,
             # Search filters in SQL: over-fetch so origin-invisible matches don't consume the page.
             limit=50 if search_query else 10, exclude_sources=["tool"])
-        if not cross_origin:
-            rows = [row for row in rows if await self._resume_row_visible(source, row, allow_all=False)]
+        rows = [row for row in rows if await self._resume_row_visible(source, row, allow_all=cross_origin)]
         rows = rows[:10]
         if search_query:
             title = f"Sessions matching “{search_query}”"

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -400,7 +400,7 @@ def is_interrupt_then_dispatch(command_name: str | None) -> bool:
     return cmd is not None and cmd.busy_policy == "interrupt_then_dispatch"
 
 
-def should_bypass_active_session(command_name: str | None) -> bool:
+def should_bypass_active_session(command_name: str | None, *, profile: str | None = None) -> bool:
     """True for any resolvable slash command: every recognized command is dispatched mid-run
     (Guard-2 handler or the "busy" catch-all), never queued — gateway.run's safety net discards
     command text reaching the pending queue, so a queued mid-run /model (or /reasoning, /voice,
@@ -411,7 +411,19 @@ def should_bypass_active_session(command_name: str | None) -> bool:
 
     See #10370, #4665, #5057, #6252.
     """
-    return resolve_command(command_name) is not None if command_name else False
+    if not command_name:
+        return False
+    if resolve_command(command_name) is not None:
+        return True
+    from hermes_cli.plugins import get_plugin_commands
+    from hermes_cli.plugins_loader import _plugin_home_scope
+    from hermes_cli.profiles import get_profile_dir
+    from contextlib import nullcontext
+    # Adapter Guard 1 runs before its profile-scoped message handler. This only classifies
+    # commands; authenticated dispatch still resolves the handler in the source's own profile.
+    with _plugin_home_scope(get_profile_dir(profile)) if profile else nullcontext():
+        entry = get_plugin_commands().get(command_name.replace("_", "-"))
+        return bool(entry and entry.get("busy_policy") in {"reject", "noninterrupting"})
 
 
 def _resolve_config_gates() -> set[str]:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1883,6 +1883,7 @@ DEFAULT_CONFIG = {
         "export": {"otlp": {"enabled": False, "endpoint": "", "headers_env": {}}},
     },
     "gateway": {  # Gateway settings (messaging platforms: Telegram, Discord, Slack, ...).
+        "side_runs": {"max_concurrent": 3},
         # Named-profile allowlist for multiplex mode. None = serve all; [] = default only.
         "multiplex_profile_allowlist": None,
         # Seconds to let a SIGTERM-interrupted gateway agent unwind before adapter/database

--- a/hermes_cli/plugin_side_runs.py
+++ b/hermes_cli/plugin_side_runs.py
@@ -1,0 +1,72 @@
+"""Validated configuration for the optional native plugin side-run capability."""
+from dataclasses import asdict, dataclass
+import math
+import re
+from typing import Any
+
+
+def bounded_number(value, name, low, high, *, integer=False):
+    if (isinstance(value, bool) or not isinstance(value, (int, float))
+            or not low <= value <= high or not math.isfinite(value)
+            or (integer and not isinstance(value, int))):
+        raise ValueError(f"{name} must be {'an integer' if integer else 'a finite number'} between {low} and {high}")
+    return value
+
+
+@dataclass(frozen=True)
+class SideRunConfig:
+    provider: str
+    model: str
+    tools: tuple[str, ...] | None = ()
+    reasoning: dict | None = None
+    max_iterations: int = 20
+    max_tokens: int = 4096
+    run_budget_seconds: float = 300
+
+    @classmethod
+    def from_mapping(cls, value: Any):
+        if not isinstance(value, dict) or set(value) - set(cls.__dataclass_fields__):
+            raise ValueError("Side-run configuration contains unsupported fields")
+        data = dict(value)
+        for name in ("provider", "model"):
+            v = data.get(name)
+            if (not isinstance(v, str) or not v or v != v.strip()
+                    or len(v) > 256 or any(ord(c) < 32 for c in v)):
+                raise ValueError(f"{name} must be an explicit nonempty identifier without surrounding whitespace")
+            data[name] = v
+        if data["provider"] in {"auto", "default"} or not re.fullmatch(r"[a-z0-9][a-z0-9_.:@-]*", data["provider"]):
+            raise ValueError("provider must be explicit")
+        tools = data.get("tools", [])
+        if tools is not None:
+            if not isinstance(tools, (list, tuple)) or len(tools) > 64 or any(
+                not isinstance(t, str) or not re.fullmatch(r"[a-zA-Z0-9_.:-]+", t) for t in tools
+            ):
+                raise ValueError("tools must be null or a list of toolset names")
+            data["tools"] = tuple(dict.fromkeys(tools))
+        reasoning = data.get("reasoning")
+        if reasoning is not None:
+            if not isinstance(reasoning, dict) or set(reasoning) - {"enabled", "effort", "max_tokens"}:
+                raise ValueError("reasoning supports enabled, effort and max_tokens")
+            if "enabled" in reasoning and type(reasoning["enabled"]) is not bool:
+                raise ValueError("reasoning.enabled must be boolean")
+            if "effort" in reasoning and (
+                not isinstance(reasoning["effort"], str)
+                or reasoning["effort"] not in {"none", "minimal", "low", "medium", "high", "xhigh"}
+            ):
+                raise ValueError("Unsupported reasoning effort")
+            if "max_tokens" in reasoning:
+                bounded_number(reasoning["max_tokens"], "reasoning.max_tokens", 1, 131072, integer=True)
+            data["reasoning"] = dict(reasoning)
+        for name, low, high, integer in (
+            ("max_iterations", 1, 500, True), ("max_tokens", 1, 131072, True),
+            ("run_budget_seconds", 1, 3600, False),
+        ):
+            if name in data:
+                bounded_number(data[name], name, low, high, integer=integer)
+        return cls(**data)
+
+    def to_dict(self):
+        data = asdict(self)
+        if self.tools is not None:
+            data["tools"] = list(self.tools)
+        return data

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -651,11 +651,16 @@ class PluginContext:
     @_serialized_replacement
     def register_command(
         self, name: str, handler: Callable, description: str = "", args_hint: str = "",
-        argument_mode: str | None = None,
+        argument_mode: str | None = None, *, busy_policy: str | None = None,
     ) -> Optional[PluginRegistration]:
         """Register an in-session slash command (``/name``); handler ``fn(raw_args: str) -> str | None``
         (sync or async). ``args_hint`` (e.g. ``"<file>"``) lets adapters like Discord surface an argument
-        field; without it the command registers parameterless there but still accepts trailing text."""
+        field; without it the command registers parameterless there but still accepts trailing text.
+        Gateway handlers may declare an optional keyword ``context``; it is supplied only after
+        source/slash authorization. ``busy_policy="noninterrupting"`` opts into both busy guards;
+        its handler must not mutate or interrupt the parent conversation."""
+        if busy_policy not in {None, "reject", "noninterrupting"}:
+            raise ValueError("Plugin busy_policy must be None, reject or noninterrupting")
         clean = name.lower().strip().lstrip("/").replace(" ", "-")
         if not clean:
             logger.warning("Plugin '%s' tried to register a command with an empty name.", self.manifest.name)
@@ -669,12 +674,21 @@ class PluginContext:
         hint = (args_hint or "").strip()
         entry = {
             "handler": handler, "description": description or "Plugin command",
+            "busy_policy": busy_policy, "context": self,
             "plugin": self.manifest.name, "plugin_key": self.plugin_id, "args_hint": hint,
             "argument_mode": argument_mode if argument_mode in {"options", "text", "mixed"}
             else ("text" if hint else None),
         }
         return self._register_entry("command", clean, self._manager._plugin_commands, entry,
                                     "Plugin %s registered command: /%s", clean)
+
+    @property
+    def supports_side_runs(self) -> bool:
+        """Host implements authenticated command context and isolated gateway side runs.
+
+        A live transport is still required; use the invocation context's start_side_run.
+        """
+        return True
 
     def dispatch_tool(self, tool_name: str, args: dict, **kwargs) -> str:
         """Dispatch a tool call through the registry with the parent agent (when available)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -811,7 +811,8 @@ def _opencode_free_runtime(provider, requested_provider, model_cfg, target_model
 
 
 def resolve_runtime_provider(*, requested: Optional[str] = None, explicit_api_key: Optional[str] = None,
-                             explicit_base_url: Optional[str] = None, target_model: Optional[str] = None) -> Dict[str, Any]:
+                             explicit_base_url: Optional[str] = None, target_model: Optional[str] = None,
+                             strict: bool = False) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution. Ladder (order is behavior — each
     rung returns or raises, else falls to the next):
       1. disabled-provider guard (``providers.<name>.enabled: false``)
@@ -825,9 +826,15 @@ def resolve_runtime_provider(*, requested: Optional[str] = None, explicit_api_ke
       8. OpenRouter / bare-custom fallback
     target_model overrides model_cfg["default"] when computing provider-specific api_mode (e.g.
     OpenCode Zen/Go where different models route through different API surfaces)."""
+    if strict and (not requested or requested.strip().lower() in {"auto", "default"} or not target_model):
+        raise ValueError("Strict resolution requires explicit provider and model")
     requested_provider = resolve_requested_provider(requested)
     _raise_if_provider_disabled(requested_provider)
-    return next(r for r in _ladder_rungs(requested_provider, explicit_api_key, explicit_base_url, target_model) if r)
+    runtime = next(r for r in _ladder_rungs(requested_provider, explicit_api_key, explicit_base_url, target_model) if r)
+    if strict:
+        from hermes_cli.runtime_provider_strict import validate_explicit_runtime
+        validate_explicit_runtime(requested_provider, target_model, runtime)
+    return runtime
 
 
 def _ladder_rungs(requested_provider, explicit_api_key, explicit_base_url, target_model):

--- a/hermes_cli/runtime_provider_strict.py
+++ b/hermes_cli/runtime_provider_strict.py
@@ -1,0 +1,17 @@
+"""Explicit primary-route validation; auxiliary routing remains independently configured."""
+
+
+def validate_explicit_runtime(requested, model, runtime):
+    actual = runtime.get("provider")
+    matches = actual == requested
+    if actual == "custom" and requested != "custom":
+        from hermes_cli.runtime_provider_custom import _get_named_custom_provider
+        entry = _get_named_custom_provider(requested)
+        matches = bool(entry and entry.get("base_url", "").rstrip("/") == runtime.get("base_url", "").rstrip("/"))
+    if not matches or runtime.get("model", model) != model:
+        raise ValueError("Explicit provider/model could not be resolved without changing route")
+    overrides = runtime.get("request_overrides") or {}
+    for payload in (overrides, overrides.get("extra_body") or {}):
+        if any(key in payload for key in ("model", "provider", "fallback", "fallbacks", "models")):
+            raise ValueError("Provider request overrides cannot change a strict primary route")
+    return runtime

--- a/run_agent.py
+++ b/run_agent.py
@@ -215,6 +215,9 @@ class AIAgent(
 ):
     """AI Agent with tool calling capabilities."""
 
+    # Optional host-owned ceiling for retry/continuation output boosts.
+    _max_output_tokens_ceiling: int | None = None
+
     _TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER = (
         "[hermes-agent: tool call arguments were corrupted in this session and "
         "have been dropped to keep the conversation alive. See issue #15236.]"

--- a/tests/agent/test_host_output_ceiling.py
+++ b/tests/agent/test_host_output_ceiling.py
@@ -1,0 +1,14 @@
+"""Bounded hosts keep retry boosts below their preset without disabling recovery."""
+from types import SimpleNamespace
+
+import pytest
+
+from agent.chat_completion_helpers import _consume_ephemeral_max_output
+
+
+@pytest.mark.parametrize("requested,ceiling,expected", [(256, 128, 128), (64, 128, 64), (256, None, 256)])
+def test_retry_output_cap_preserves_host_ceiling_and_smaller_overflow_limits(requested, ceiling, expected):
+    agent = SimpleNamespace(_ephemeral_max_output_tokens=requested, _max_output_tokens_ceiling=ceiling)
+    assert _consume_ephemeral_max_output(agent) == expected
+    assert agent._ephemeral_max_output_tokens is None
+    assert _consume_ephemeral_max_output(agent) is None

--- a/tests/agent/test_host_output_ceiling_transforms.py
+++ b/tests/agent/test_host_output_ceiling_transforms.py
@@ -1,0 +1,105 @@
+"""Real provider assembly must retain a bounded host's per-request limit."""
+from copy import deepcopy
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from agent.chat_completion_helpers import build_api_kwargs
+from agent.transports.anthropic import AnthropicTransport
+
+
+@pytest.mark.parametrize("model,reasoning,limit,ephemeral,ceiling,rejected", [
+    ("claude-sonnet-4-20250514", {"enabled": True, "effort": "medium"}, 128, None, 128, True),
+    ("claude-sonnet-4-20250514", {"enabled": True, "effort": "medium"}, 128, 256, 128, True),
+    ("claude-sonnet-4-20250514", {"enabled": True, "effort": "medium"}, 16384, 64, 16384, True),
+    ("claude-sonnet-4-20250514", {"enabled": True, "effort": "medium"}, 16384, None, 16384, False),
+    ("claude-sonnet-4-20250514", {"enabled": False}, 128, 64, 128, False),
+    ("claude-sonnet-4-6", {"enabled": True, "effort": "medium"}, 128, 256, 128, False),
+    ("claude-haiku-4-5", {"enabled": True, "effort": "medium"}, 128, None, 128, False),
+    ("claude-sonnet-4-20250514", {"enabled": True, "effort": "medium"}, 128, None, None, False),
+    ("claude-sonnet-4-20250514", {"enabled": True, "effort": "medium"}, 128, 256, None, False),
+])
+def test_anthropic_assembly_rejects_incompatible_thinking_before_sdk_dispatch(
+    model, reasoning, limit, ephemeral, ceiling, rejected,
+):
+    from anthropic import Anthropic
+
+    transport = AnthropicTransport()
+    agent = SimpleNamespace(
+        model=model, api_mode="anthropic_messages", provider="anthropic",
+        base_url="https://api.anthropic.com", session_id="bounded-fixture",
+        max_tokens=limit, reasoning_config=deepcopy(reasoning), tools=[],
+        _max_output_tokens_ceiling=ceiling, _ephemeral_max_output_tokens=ephemeral,
+        _is_anthropic_oauth=False, _get_transport=lambda: transport,
+        _prepare_anthropic_messages_for_api=deepcopy, _anthropic_preserve_dots=lambda: False,
+    )
+    messages = [{"role": "user", "content": "Reply briefly."}]
+    original = deepcopy(messages)
+    requests = []
+
+    def capture(request):
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json={
+            "id": "msg_fixture", "type": "message", "role": "assistant", "model": model,
+            "content": [{"type": "text", "text": "OK"}], "stop_reason": "end_turn",
+            "stop_sequence": None, "usage": {"input_tokens": 3, "output_tokens": 1},
+        })
+
+    with Anthropic(api_key="fixture-only", max_retries=0,
+                   http_client=httpx.Client(transport=httpx.MockTransport(capture))) as client:
+        if rejected:
+            with pytest.raises(ValueError, match="output limit.*thinking"):
+                client.messages.create(**build_api_kwargs(agent, messages))
+            assert requests == []
+        else:
+            client.messages.create(**build_api_kwargs(agent, messages))
+            assert len(requests) == 1
+            if ceiling is not None:
+                assert requests[0]["max_tokens"] <= min(ceiling, ephemeral or limit)
+            else:
+                assert requests[0]["max_tokens"] > limit  # ordinary manual-thinking headroom
+    assert agent.reasoning_config == reasoning
+    assert messages == original
+    assert agent._ephemeral_max_output_tokens is None
+
+
+@pytest.mark.parametrize("kind", ["gemini", "gemini-native", "responses", "codex", "bedrock", "extra-body"])
+def test_other_provider_transforms_cannot_erase_or_expand_output_limit(kind):
+    from agent.output_ceiling import validate_output_ceiling
+    from agent.transports.chat_completions import ChatCompletionsTransport
+    from agent.transports.codex import ResponsesApiTransport
+    from agent.transports.bedrock import BedrockTransport
+
+    messages = [{"role": "user", "content": "Reply briefly."}]
+    agent = SimpleNamespace(api_mode="chat_completions", base_url="https://example.invalid/v1")
+    rejected = kind not in {"responses", "bedrock"}
+    if kind in {"gemini", "gemini-native", "extra-body"}:
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="google/gemini-3-flash" if kind == "gemini" else "fixture-model",
+            messages=messages, tools=[], max_tokens=128,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+            reasoning_config={"enabled": True, "effort": "medium"} if kind == "gemini" else None,
+            request_overrides={"extra_body": {"max_tokens": 256}} if kind == "extra-body" else {},
+        )
+        if kind == "gemini-native":
+            agent.base_url = "https://generativelanguage.googleapis.com/v1beta"
+            kwargs["extra_body"] = {"thinking_config": {"includeThoughts": True}}
+    elif kind in {"responses", "codex"}:
+        agent.api_mode = "codex_responses"
+        kwargs = ResponsesApiTransport().build_kwargs(
+            model="gpt-5", messages=messages, tools=[], max_tokens=128,
+            is_codex_backend=kind == "codex", base_url="https://example.invalid/v1",
+        )
+    else:
+        agent.api_mode = "bedrock_converse"
+        kwargs = BedrockTransport().build_kwargs(model="fixture-model", messages=messages, max_tokens=128)
+    original = deepcopy(kwargs)
+    if rejected:
+        with pytest.raises(ValueError, match="output limit"):
+            validate_output_ceiling(agent, kwargs, 128)
+    else:
+        validate_output_ceiling(agent, kwargs, 128)
+    assert kwargs == original  # reject rather than silently rewriting reasoning or requests
+    validate_output_ceiling(agent, kwargs, None)  # ordinary-agent compatibility

--- a/tests/gateway/test_plugin_side_run_boundaries.py
+++ b/tests/gateway/test_plugin_side_run_boundaries.py
@@ -1,0 +1,194 @@
+"""Real adapter/runner dispatch and human approval boundaries for isolated plugin work."""
+import asyncio
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter, PlatformConfig
+from gateway.platforms.event import MessageEvent
+from gateway.platforms.base import SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from tests.gateway.test_slash_access_dispatch import _make_runner
+
+
+class Adapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.DISCORD)
+        self.sent = []
+    async def connect(self, *, is_reconnect=False):
+        return True
+    async def disconnect(self):
+        self._mark_disconnected()
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append((chat_id, content, reply_to, metadata))
+        return SendResult(success=True, message_id="sent")
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "group"}
+
+
+@pytest.mark.asyncio
+async def test_auth_and_both_busy_guards_preserve_parent_and_legacy_handlers(monkeypatch):
+    manager = PluginManager()
+    ctx = PluginContext(PluginManifest(name="boundary", source="user"), manager)
+    invocations = []
+    def contextual(raw_args, *, context=None):
+        invocations.append((raw_args, context.source))
+        return "handled"
+    ctx.register_command("side-probe", contextual, busy_policy="noninterrupting")
+    ctx.register_command("legacy-probe", lambda args: "legacy:" + args)
+    ctx.register_command("builtin-probe", str)
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda: manager)
+    runner = _make_runner(platform_extra={"group_allow_admin_from": ["admin"], "group_user_allowed_commands": ["side-probe"]})
+    runner._draining = False
+    runner._hm_quick_commands = lambda: {}
+    runner._is_user_authorized = GatewayRunner._is_user_authorized.__get__(runner)
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "owner,denied")
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "false")
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "false")
+    runner._get_unauthorized_dm_behavior = lambda *args, **kwargs: "ignore"
+    runner._is_session_running = lambda key: True
+    runner._hm_evict_idle_stale_agent = lambda key: None
+    runner._hm_evict_reaped_agent = lambda key: None
+    parent = Mock()
+    source = SessionSource(Platform.DISCORD, "chat", user_id="owner", thread_id="topic", chat_type="group")
+    key = runner._session_key_for_source(source)
+    runner._running_agents[key] = parent
+    runner._hm_pending_reply_intercepts = AsyncMock(return_value=None)
+    adapter = Adapter()
+    runner.adapters = {Platform.DISCORD: adapter}
+    adapter.set_message_handler(runner._handle_message)
+    adapter._active_sessions[key] = asyncio.Event()
+    pending = MessageEvent(text="parent queued", source=source)
+    adapter._pending_messages[key] = pending
+    for user in ("outsider", "denied", "owner"):
+        runner.config.platforms[Platform.DISCORD].extra["group_user_allowed_commands"] = [] if user == "denied" else ["side-probe"]
+        event = MessageEvent(text="/side_probe prompt", source=replace(source, user_id=user), message_id="trigger")
+        await adapter._handle_message_while_active(event, key)
+    assert [args for args, _ in invocations] == ["prompt"]
+    assert invocations[0][1].user_id == "owner"
+    parent.interrupt.assert_not_called()
+    assert adapter._pending_messages[key] is pending
+    assert key in adapter._active_sessions
+    assert adapter.sent[-1][1] == "handled"
+    runner._is_session_running = lambda key: False
+    runner._check_slash_access = lambda *args: None
+    handled, result, _ = await runner._hm_dispatch_quick_and_plugin_commands(
+        MessageEvent(text="/legacy-probe text", source=source), source, "legacy-probe")
+    assert handled and result == "legacy:text"
+    handled, result, _ = await runner._hm_dispatch_quick_and_plugin_commands(
+        MessageEvent(text="/builtin-probe opaque", source=source), source, "builtin-probe")
+    assert handled and result == "opaque"
+    manager.unload()
+
+
+@pytest.mark.asyncio
+async def test_approval_request_id_owner_races_and_cancellation(tmp_path, monkeypatch):
+    from gateway.side_runs import SideRunService
+    from hermes_cli.plugin_side_runs import SideRunConfig
+    from hermes_state import SessionDB
+    from tools import approval
+    from tools.approval_context import get_current_session_key, manual_approval_required
+    from tools.approval_gateway_wait import _await_gateway_decision
+
+    db = SessionDB(tmp_path / "state.db")
+    decisions = []
+    class Agent:
+        def __init__(self, **kwargs):
+            self.model, self.provider = kwargs["model"], kwargs["provider"]
+        def run_conversation(self, **kwargs):
+            assert manual_approval_required()
+            assert not approval.is_approval_bypass_active()
+            key = get_current_session_key()
+            result = _await_gateway_decision(key, approval._gateway_notify_cb(key), {
+                "command": "rm example.txt", "description": "delete example", "pattern_key": "example"})
+            decisions.append(result)
+            return {"final_response": "approved" if result["choice"] == "once" else "denied"}
+        def interrupt(self, *args, **kwargs):
+            pass
+        def close(self):
+            pass
+    monkeypatch.setattr("run_agent.AIAgent", Agent)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kwargs: {"provider": "openai"})
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", True)
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = SimpleNamespace(_db=db)
+    runner.session_store = SimpleNamespace(_entries={})
+    runner._draining = False
+    runner._session_key_for_source = lambda source: "parent"
+    runner._reply_anchor_for_event = lambda event: "trigger"
+    runner._thread_metadata_for_source = lambda *args: {"thread_id": "topic"}
+    source = SessionSource(Platform.TELEGRAM, "chat", user_id="owner", thread_id="topic", chat_type="group")
+    notices = asyncio.Queue()
+    async def send(*args, **kwargs):
+        await notices.put(args[1])
+        return SendResult(success=True)
+    adapter = SimpleNamespace(send=send)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._adapter_for_source = lambda source: adapter
+    runner._check_slash_access = lambda *args: None
+    service = SideRunService(runner, max_concurrent=2)
+    runner._plugin_side_runs = service
+    config = SideRunConfig.from_mapping({"provider": "openai", "model": "model", "tools": []})
+    parent_cb = Mock()
+    approval.register_gateway_notify("parent", parent_cb)
+    manager = PluginManager()
+    registration_context = PluginContext(PluginManifest(name="test", source="user"), manager)
+    ids = [service.start(MessageEvent(text="/side", source=source), "test", "prompt", config, registration_context=registration_context) for _ in range(2)]
+    try:
+        prompts = [await asyncio.wait_for(notices.get(), 10) for _ in ids]
+        assert all("/approve side:" in text for text in prompts)
+        runs = list(service.runs.values())
+        requests = [approval.list_gateway_approvals(run.key)[0]["request_id"] for run in runs]
+        assert len(set(requests)) == len(requests)
+        intruder = MessageEvent(text=f"/approve side:{requests[0]}", source=replace(source, user_id="other"))
+        assert "unavailable" in service.approval_reply(intruder)
+        assert approval.list_gateway_approvals(runs[0].key)
+        allowed = replace(intruder, source=source)
+        assert "recorded" in service.approval_reply(allowed)
+        assert "expired" in service.approval_reply(allowed)
+        assert approval.list_gateway_approvals(runs[1].key)
+        manager.unload()
+        await asyncio.sleep(0)
+        assert runs[1].cancelled.is_set()
+        await asyncio.wait_for(service.wait(), 10)
+        assert sorted(d["choice"] or "deny" for d in decisions) == ["deny", "once"]
+        assert approval._gateway_notify_cb("parent") is parent_cb
+        # After unload/restart, a stale child id must never approve the parent's FIFO head.
+        runner._plugin_side_runs = None
+        runner._hm_update_prompt_reply = Mock(side_effect=AssertionError("fell through to parent"))
+        assert "expired" in await runner._hm_pending_reply_intercepts(allowed, source, "parent")
+    finally:
+        service.shutdown()
+        await asyncio.wait_for(service.wait(), 10)
+        runner._shutdown_executor()
+        approval.unregister_gateway_notify("parent")
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_unloaded_async_handler_cannot_launch_with_stale_context(monkeypatch):
+    manager = PluginManager()
+    registration = PluginContext(PluginManifest(name="delayed", source="user"), manager)
+    entered, release = asyncio.Event(), asyncio.Event()
+    async def delayed(args, *, context=None):
+        entered.set()
+        await release.wait()
+        return context.start_side_run(args, {"provider": "openai", "model": "fixture"})
+    registration.register_command("delayed-side", delayed, busy_policy="noninterrupting")
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda: manager)
+    from gateway.plugin_commands import dispatch_plugin_command
+    service = SimpleNamespace(start=Mock(return_value="should-not-launch"))
+    runner = SimpleNamespace(_check_slash_access=lambda *args: None, _plugin_side_runs=service)
+    source = SessionSource(Platform.TELEGRAM, "chat", user_id="owner")
+    task = asyncio.create_task(dispatch_plugin_command(runner, MessageEvent(text="/delayed-side prompt", source=source), source, "delayed-side"))
+    await entered.wait()
+    manager.unload()
+    release.set()
+    handled, result = await task
+    assert handled and "failed" in result.lower()
+    service.start.assert_not_called()

--- a/tests/gateway/test_plugin_side_run_compat.py
+++ b/tests/gateway/test_plugin_side_run_compat.py
@@ -1,0 +1,44 @@
+"""Opt-in side-run commands must not change legacy command busy semantics."""
+from unittest.mock import Mock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli.commands import should_bypass_active_session
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+@pytest.mark.asyncio
+async def test_legacy_busy_commands_keep_existing_queue_or_steer_path(monkeypatch):
+    manager = PluginManager()
+    ctx = PluginContext(PluginManifest(name="legacy", source="user"), manager)
+    handler = Mock(return_value="legacy")
+    ctx.register_command("legacy-probe", handler)
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda: manager)
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(Platform.TELEGRAM, "room", user_id="owner")
+    event = MessageEvent(text="/legacy-probe argument", source=source)
+    assert not should_bypass_active_session("legacy-probe")
+    assert await runner._hm_busy_slash_or_photo(event, source, "parent") == (False, None)
+    handler.assert_not_called()
+    manager.unload()
+
+
+@pytest.mark.asyncio
+async def test_explicit_reject_is_inline_and_never_executes_handler(monkeypatch):
+    manager = PluginManager()
+    ctx = PluginContext(PluginManifest(name="rejecting", source="user"), manager)
+    handler = Mock(return_value="must not execute")
+    ctx.register_command("reject-probe", handler, busy_policy="reject")
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda: manager)
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(Platform.TELEGRAM, "room", user_id="owner")
+    event = MessageEvent(text="/reject-probe argument", source=source)
+    assert should_bypass_active_session("reject-probe")
+    handled, response = await runner._hm_busy_slash_or_photo(event, source, "parent")
+    assert handled and "busy" in response
+    handler.assert_not_called()
+    manager.unload()

--- a/tests/gateway/test_plugin_side_run_failures.py
+++ b/tests/gateway/test_plugin_side_run_failures.py
@@ -1,0 +1,112 @@
+"""Side-run failure paths must preserve ownership and fail closed without leaking errors."""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import SendResult
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from gateway.side_runs import SideRunService
+from hermes_cli.plugin_side_runs import SideRunConfig
+from hermes_state import SessionDB
+
+
+def fixture_runner(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = SimpleNamespace(_db=db)
+    runner._draining = False
+    runner.session_store = SimpleNamespace(_entries={})
+    runner._session_key_for_source = lambda source: "parent"
+    runner._reply_anchor_for_event = lambda event: "trigger"
+    runner._thread_metadata_for_source = lambda *args: {}
+    adapter = SimpleNamespace(send=AsyncMock(return_value=SendResult(success=True)))
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._adapter_for_source = lambda source: adapter
+    source = SessionSource(Platform.TELEGRAM, "room", user_id="owner")
+    return runner, db, adapter, MessageEvent(text="/run prompt", source=source)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["resolver", "identity", "transport", "constructor", "conversation"])
+async def test_failed_run_is_saved_owned_and_error_is_sanitized(tmp_path, monkeypatch, stage):
+    runner, db, adapter, event = fixture_runner(tmp_path)
+    constructed, called, closed = [], [], []
+    secret = "private-provider-credential-do-not-display"
+    def resolve(**kwargs):
+        if stage == "resolver":
+            raise ValueError(secret)
+        if stage == "transport":
+            return {"provider": "openai", "command": "external-agent", "base_url": "acp://fixture"}
+        return {"provider": "openrouter" if stage == "identity" else "openai"}
+    class Agent:
+        def __init__(self, **kwargs):
+            constructed.append(True)
+            if stage == "constructor":
+                raise RuntimeError(secret)
+            self.model, self.provider = kwargs["model"], kwargs["provider"]
+        def run_conversation(self, **kwargs):
+            called.append(True)
+            raise RuntimeError(secret)
+        def close(self):
+            closed.append(True)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", resolve)
+    monkeypatch.setattr("run_agent.AIAgent", Agent)
+    service = SideRunService(runner)
+    sid = service.start(event, "test", "prompt", SideRunConfig.from_mapping({"provider": "openai", "model": "fixture"}))
+    try:
+        await asyncio.wait_for(service.wait(), 10)
+        row = db.get_session(sid)
+        assert row["user_id"] == "owner"
+        assert row["end_reason"] == "side_run_failed"
+        assert secret not in str(row)
+        assert "failed" in adapter.send.await_args.args[1]
+        assert secret not in str(adapter.send.await_args)
+        assert not service.runs
+        assert bool(constructed) == (stage in {"constructor", "conversation"})
+        assert bool(called) == (stage == "conversation")
+        assert bool(closed) == (stage == "conversation")
+    finally:
+        runner._shutdown_executor()
+        db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["transport", "timeout"])
+async def test_approval_missing_transport_or_timeout_denies_and_cleans_up(tmp_path, monkeypatch, failure):
+    from tools import approval
+    from tools.approval_context import get_current_session_key
+    from tools.approval_gateway_wait import _await_gateway_decision
+    runner, db, adapter, event = fixture_runner(tmp_path)
+    outcomes = []
+    class Agent:
+        def __init__(self, **kwargs):
+            self.provider, self.model = kwargs["provider"], kwargs["model"]
+        def run_conversation(self, **kwargs):
+            key = get_current_session_key()
+            outcomes.append(_await_gateway_decision(key, approval._gateway_notify_cb(key), {"command": "rm fixture", "pattern_key": "fixture"}))
+            return {"final_response": "denied"}
+        def close(self):
+            pass
+    monkeypatch.setattr("run_agent.AIAgent", Agent)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kwargs: {"provider": "openai"})
+    if failure == "transport":
+        adapter.send.return_value = SendResult(success=False)
+    else:
+        monkeypatch.setattr("tools.approval_context._get_approval_timeout", lambda: 0)
+    service = SideRunService(runner)
+    sid = service.start(event, "test", "prompt", SideRunConfig.from_mapping({"provider": "openai", "model": "fixture"}))
+    key = service.runs[sid].key
+    try:
+        await asyncio.wait_for(service.wait(), 10)
+        assert outcomes and outcomes[0]["resolved"] is False and outcomes[0]["choice"] is None
+        assert not approval.list_gateway_approvals(key)
+        assert approval._gateway_notify_cb(key) is None
+        assert not service.runs
+    finally:
+        runner._shutdown_executor()
+        db.close()

--- a/tests/gateway/test_plugin_side_run_lifecycle.py
+++ b/tests/gateway/test_plugin_side_run_lifecycle.py
@@ -1,0 +1,87 @@
+"""Saved side work participates in existing drain accounting and owner listing."""
+import asyncio
+import threading
+
+import pytest
+
+from gateway.side_runs import SideRunService
+from hermes_cli.plugin_side_runs import SideRunConfig
+from hermes_cli.session_listing import query_session_listing
+from tests.gateway.test_plugin_side_run_failures import fixture_runner
+
+
+@pytest.mark.asyncio
+async def test_child_is_listable_but_execution_approval_key_is_independent(tmp_path, monkeypatch):
+    runner, db, _, event = fixture_runner(tmp_path)
+    approval_keys = []
+
+    class Agent:
+        def __init__(self, **kwargs):
+            self.provider, self.model = kwargs["provider"], kwargs["model"]
+            approval_keys.append(kwargs["gateway_session_key"])
+        def run_conversation(self, **kwargs):
+            return {"final_response": "answer"}
+        def close(self):
+            pass
+
+    monkeypatch.setattr("run_agent.AIAgent", Agent)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kw: {"provider": "openai"})
+    service = SideRunService(runner)
+    sid = service.start(event, "fixture", "prompt", SideRunConfig.from_mapping({"provider": "openai", "model": "fixture"}))
+    try:
+        await service.wait()
+        rows = query_session_listing(db, source="telegram", session_key="parent", include_unnamed=True)
+        assert sid in {row["id"] for row in rows}
+        assert approval_keys == ["plugin-side:" + sid]
+    finally:
+        runner._shutdown_executor()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_accounts_for_child_and_does_not_wait_forever_on_supervisor(tmp_path, monkeypatch):
+    runner, db, _, event = fixture_runner(tmp_path)
+    runner._running_agents = {}
+    runner._running_agent_count = lambda: 0
+    runner._snapshot_running_agents = lambda: {}
+    runner._active_cron_job_count = lambda: 0
+    runner._active_api_run_count = lambda: 0
+    runner._update_runtime_status = lambda *args: None
+    entered, release, closed = threading.Event(), threading.Event(), threading.Event()
+
+    class Agent:
+        def __init__(self, **kwargs):
+            self.provider, self.model = kwargs["provider"], kwargs["model"]
+        def run_conversation(self, **kwargs):
+            entered.set()
+            assert release.wait(10)
+            return {"final_response": "answer"}
+        def interrupt(self, *args, **kwargs):
+            pass
+        def close(self):
+            closed.set()
+
+    monkeypatch.setattr("run_agent.AIAgent", Agent)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kw: {"provider": "openai"})
+    service = SideRunService(runner)
+    sid = service.start(event, "fixture", "prompt", SideRunConfig.from_mapping({"provider": "openai", "model": "fixture"}))
+    run = service.runs[sid]
+    try:
+        assert await asyncio.to_thread(entered.wait, 5)
+        assert runner._active_work_count() == 1
+        _, timed_out = await runner._drain_active_agents(0)
+        assert timed_out
+        assert runner._interrupt_deferred_agent_workers("shutdown") == 1
+        assert run.cancelled.is_set()
+        service.shutdown()
+        run.task.cancel()
+        done, _ = await asyncio.wait([run.task], timeout=2)
+        assert run.task in done, "shutdown supervisor blocked on an uninterruptible worker"
+        assert run.task.cancelled()
+        assert not closed.is_set(), "the worker should still be unwinding independently"
+    finally:
+        release.set()
+        await asyncio.to_thread(closed.wait, 5)
+        await asyncio.gather(run.task, return_exceptions=True)
+        runner._shutdown_executor()
+        db.close()

--- a/tests/gateway/test_plugin_side_run_overrides.py
+++ b/tests/gateway/test_plugin_side_run_overrides.py
@@ -1,0 +1,50 @@
+"""Provider overrides cannot replace isolated input, tools, or per-preset output limits."""
+import asyncio
+
+import pytest
+
+from gateway.side_runs import SideRunService
+from hermes_cli.plugin_side_runs import SideRunConfig
+from tests.gateway.test_plugin_side_run_failures import fixture_runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [
+    ("tools", [{"type": "function", "function": {"name": "unselected_tool"}}]),
+    ("messages", [{"role": "user", "content": "injected history"}]),
+    ("input", "injected history"),
+    ("max_tokens", 99999),
+    ("max_completion_tokens", 99999),
+    ("max_output_tokens", 99999),
+    ("reasoning", {"effort": "high"}),
+])
+@pytest.mark.parametrize("nested", [False, True])
+async def test_provider_override_cannot_escape_preset(tmp_path, monkeypatch, field, value, nested):
+    runner, db, _, event = fixture_runner(tmp_path)
+    constructed = []
+
+    class Agent:
+        def __init__(self, **kwargs):
+            constructed.append(True)
+            self.model, self.provider = kwargs["model"], kwargs["provider"]
+        def run_conversation(self, **kwargs):
+            return {"final_response": "unsafe success"}
+        def close(self):
+            pass
+
+    override = {field: value}
+    if nested:
+        override = {"extra_body": override}
+    monkeypatch.setattr("run_agent.AIAgent", Agent)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kwargs: {
+        "provider": "openai", "request_overrides": override})
+    service = SideRunService(runner)
+    sid = service.start(event, "test", "prompt", SideRunConfig.from_mapping({
+        "provider": "openai", "model": "fixture", "tools": [], "max_tokens": 80}))
+    try:
+        await asyncio.wait_for(service.wait(), 10)
+        assert not constructed
+        assert db.get_session(sid)["end_reason"] == "side_run_failed"
+    finally:
+        runner._shutdown_executor()
+        db.close()

--- a/tests/gateway/test_plugin_side_run_profile.py
+++ b/tests/gateway/test_plugin_side_run_profile.py
@@ -1,0 +1,95 @@
+"""Same-profile credentials, persistence and adapter busy policy without touching real profiles."""
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner, _SESSION_DB_UNPINNED, _profile_runtime_scope
+from gateway.session import SessionSource
+from hermes_constants import get_hermes_home
+from hermes_state import SessionDB
+
+
+@pytest.mark.asyncio
+async def test_secondary_profile_busy_policy_credentials_and_database(tmp_path, monkeypatch):
+    from hermes_cli.commands import should_bypass_active_session
+    from hermes_cli.plugins import get_plugin_manager
+    from hermes_cli.plugin_side_runs import SideRunConfig
+    from gateway.side_runs import SideRunService
+    from gateway.session_context import get_session_env
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    secondary = root / "profiles" / "secondary"
+    secondary.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    (root / "config.yaml").write_text("plugins:\n  enabled: []\n")
+    (secondary / "config.yaml").write_text(yaml.safe_dump({
+        "plugins": {"enabled": ["fixture"]},
+        "providers": {"fixture": {"base_url": "http://route.invalid/v1", "key_env": "FIXTURE_ROUTE_KEY"}},
+    }))
+    (secondary / ".env").write_text("FIXTURE_ROUTE_KEY=secondary-fixture\n")
+    plugin_dir = secondary / "plugins" / "fixture"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text("name: fixture\nversion: 0.1.0\n")
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n    ctx.register_command('side-secondary', lambda args: 'ok', busy_policy='noninterrupting')\n")
+    with _profile_runtime_scope(secondary):
+        manager = get_plugin_manager()
+        manager.discover_and_load()
+    assert not should_bypass_active_session("side-secondary")
+    assert should_bypass_active_session("side-secondary", profile="secondary")
+    assert get_hermes_home() == root
+    primary_db = SessionDB(root / "state.db")
+    secondary_db = SessionDB(secondary / "state.db")
+    observed = []
+    class Agent:
+        def __init__(self, **kwargs):
+            self.provider, self.model = kwargs["provider"], kwargs["model"]
+            observed.append((get_hermes_home(), kwargs["api_key"], get_session_env("HERMES_SESSION_PROFILE")))
+        def run_conversation(self, **kwargs):
+            return {"final_response": "secondary answer"}
+        def close(self):
+            pass
+        def interrupt(self, *args, **kwargs):
+            pass
+    monkeypatch.setattr("run_agent.AIAgent", Agent)
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+    def open_profile_db():
+        assert get_hermes_home() == secondary, "side-run admission opened the primary profile DB"
+        return SimpleNamespace(_db=secondary_db)
+    runner._open_session_db_for_active_scope = open_profile_db
+    runner._resolve_profile_home_for_source = lambda source: secondary
+    runner._draining = False
+    runner.session_store = SimpleNamespace(_entries={})
+    runner._session_key_for_source = lambda source: "secondary-parent"
+    runner._reply_anchor_for_event = lambda event: "trigger"
+    runner._thread_metadata_for_source = lambda source, *args: {"hermes_profile": source.profile}
+    secondary_adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: SimpleNamespace(send=AsyncMock())}
+    runner._adapter_for_source = lambda source: secondary_adapter
+    service = SideRunService(runner)
+    source = SessionSource(Platform.TELEGRAM, "chat", user_id="owner", profile="secondary")
+    sid = service.start(MessageEvent(text="/side-secondary prompt", source=source), "fixture", "prompt",
+                        SideRunConfig.from_mapping({"provider": "custom:fixture", "model": "fixture-model"}))
+    try:
+        await asyncio.wait_for(service.wait(), 10)
+        assert observed == [(secondary, "secondary-fixture", "secondary")]
+        assert primary_db.get_session(sid) is None
+        assert secondary_db.get_session(sid)["end_reason"] == "side_run_completed"
+        assert secondary_adapter.send.await_args.kwargs["metadata"]["hermes_profile"] == "secondary"
+        runner.adapters[Platform.TELEGRAM].send.assert_not_awaited()
+    finally:
+        service.shutdown()
+        await service.wait()
+        runner._shutdown_executor()
+        manager.unload()
+        secondary_db.close()
+        primary_db.close()

--- a/tests/gateway/test_plugin_side_run_real_agent.py
+++ b/tests/gateway/test_plugin_side_run_real_agent.py
@@ -1,0 +1,157 @@
+"""Real AIAgent/SDK/resolver/SQLite path with an in-memory HTTP transport."""
+import asyncio
+from copy import deepcopy
+import json
+import threading
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.platforms.base import SendResult
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionContext, SessionSource
+from hermes_state import SessionDB
+
+
+@pytest.mark.asyncio
+async def test_real_parent_and_child_keep_separate_prompts_routes_and_transcripts(tmp_path, monkeypatch):
+    from run_agent import AIAgent
+    from gateway.side_runs import SideRunService
+    from gateway.session_context import isolated_session_context
+    from hermes_cli.plugin_side_runs import SideRunConfig
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+        "model": {"provider": "custom:fixture", "default": "forbidden-default"},
+        "providers": {"fixture": {"base_url": "http://route.invalid/v1", "api_key": "fixture-only"}},
+        "compression": {"enabled": False},
+    }))
+    db = SessionDB(tmp_path / "state.db")
+    parent_entered = threading.Event()
+    parent_release = threading.Event()
+    requests = []
+
+    def capture(request):
+        assert request.url.host == "route.invalid"
+        assert request.url.path == "/v1/chat/completions"
+        payload = json.loads(request.content)
+        requests.append(payload)
+        assert payload["model"] in {"parent-model", "child-model"}
+        if payload["model"] == "parent-model":
+            parent_entered.set()
+            assert parent_release.wait(20)
+        if payload.get("stream"):
+            chunk = {"id": "fixture", "object": "chat.completion.chunk", "created": 1,
+                     "model": payload["model"], "choices": [{"index": 0, "finish_reason": "stop",
+                     "delta": {"role": "assistant", "content": payload["model"] + " answer"}}],
+                     "usage": {"prompt_tokens": 5, "completion_tokens": 4, "total_tokens": 9}}
+            return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                                  content="data: " + json.dumps(chunk) + "\n\ndata: [DONE]\n\n")
+        return httpx.Response(200, json={"id": "fixture-completion", "object": "chat.completion", "created": 1,
+            "model": payload["model"], "choices": [{"index": 0, "finish_reason": "stop", "message": {
+                "role": "assistant", "content": payload["model"] + " answer"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 4, "total_tokens": 9}})
+
+    monkeypatch.setattr(AIAgent, "_build_keepalive_http_client",
+                        staticmethod(lambda *args, **kwargs: httpx.Client(transport=httpx.MockTransport(capture))))
+    runtime = resolve_runtime_provider(requested="custom:fixture", target_model="parent-model", strict=True)
+    source = SessionSource(Platform.TELEGRAM, "chat", user_id="owner", thread_id="topic")
+    parent = AIAgent(model="parent-model", provider=runtime["provider"], api_key=runtime["api_key"],
+                     base_url=runtime["base_url"], api_mode=runtime["api_mode"],
+                     requested_provider="custom:fixture", session_id="parent", session_db=db,
+                     platform="telegram", enabled_toolsets=["todo"], fallback_model=[], max_iterations=2,
+                     skip_memory=True, skip_context_files=True, skip_background_review=True, quiet_mode=True)
+    runner = object.__new__(GatewayRunner)
+    runner._draining = False
+    runner._session_db = SimpleNamespace(_db=db)
+    entry = SimpleNamespace(session_id="parent")
+    runner.session_store = SimpleNamespace(_entries={"parent-key": entry})
+    runner._session_key_for_source = lambda source: "parent-key"
+    delivered = []
+    async def send(chat_id, content, **kwargs):
+        delivered.append((chat_id, content, kwargs))
+        return SendResult(success=True)
+    adapter = SimpleNamespace(send=send)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._adapter_for_source = lambda source: adapter
+    service = SideRunService(runner)
+    def run_parent():
+        tokens = runner._set_session_env(SessionContext(source, [], {}, session_key="parent-key", session_id="parent"))
+        try:
+            with isolated_session_context("parent"):
+                return parent.run_conversation(user_message="parent prompt", conversation_history=None, task_id="parent")
+        finally:
+            runner._clear_session_env(tokens)
+    parent_task = asyncio.create_task(asyncio.to_thread(run_parent))
+    try:
+        assert await asyncio.to_thread(parent_entered.wait, 10)
+        parent_prompt = parent._cached_system_prompt
+        parent_tools = deepcopy(parent.tools)
+        assert parent_tools
+        parent_row = db.get_session("parent")
+        parent_messages = db.get_messages("parent")
+        child_id = service.start(MessageEvent(text="/route child prompt", source=source, message_id="trigger"),
+                                 "fixture", "child prompt", SideRunConfig.from_mapping({
+                                     "provider": "custom:fixture", "model": "child-model", "tools": [],
+                                     "max_iterations": 2, "max_tokens": 80, "run_budget_seconds": 15}))
+        await asyncio.wait_for(service.wait(), 15)
+        expected_metadata = {**runner._thread_metadata_for_source(source, "trigger"), "_interim_send": True}
+        assert delivered == [("chat", "child-model answer", {"reply_to": "trigger", "metadata": expected_metadata})]
+        assert parent._cached_system_prompt == parent_prompt
+        assert parent.tools == parent_tools
+        assert parent.model == "parent-model"
+        assert db.get_session("parent") == parent_row
+        assert db.get_messages("parent") == parent_messages
+        assert runner.session_store._entries["parent-key"] is entry
+        child = db.get_session(child_id)
+        assert child["end_reason"] == "side_run_completed"
+        assert json.loads(child["model_config"])["side_run"]["owner"]["user_id"] == source.user_id
+        assert child["model"] == "child-model"
+        assert child["system_prompt"] or child.get("system_prompt_hash")
+        assert [m["content"] for m in db.get_messages(child_id) if m["role"] in {"user", "assistant"}] == ["child prompt", "child-model answer"]
+        assert sorted(r["model"] for r in requests) == ["child-model", "parent-model"]
+        child_payload = next(r for r in requests if r["model"] == "child-model")
+        assert all("parent prompt" not in str(m) for m in child_payload["messages"])
+        assert not child_payload.get("tools")
+    finally:
+        parent_release.set()
+        service.shutdown()
+        await asyncio.wait_for(service.wait(), 15)
+        await asyncio.wait_for(parent_task, 15)
+        parent.close()
+        runner._shutdown_executor()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_side_delivery_does_not_seal_parent_native_stream():
+    from gateway.side_runs import SideRunService
+    from tests.gateway.relay.test_relay_live_cards import _connected_adapter
+    adapter, _ = _connected_adapter(supported_ops=("send", "edit", "typing", "draft"))
+    class Transport:
+        def __init__(self):
+            self.ops = []
+        async def send_outbound(self, payload, platform=None):
+            self.ops.append(dict(payload))
+            return {"success": True, "message_id": "111.222"}
+    transport = Transport()
+    adapter._transport = transport
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(Platform.SLACK, "C1", user_id="owner", thread_id="1700.42", scope_id="workspace")
+    event = MessageEvent(text="/side prompt", source=source, message_id="1700.43")
+    metadata = runner._thread_metadata_for_source(source, event.message_id)
+    await adapter.send_draft("C1", 5, "parent streaming", metadata=metadata)
+    key = adapter._draft_key("C1", metadata)
+    service = SideRunService(runner, max_concurrent=1)
+    await service._send(SimpleNamespace(adapter=adapter, event=event), "child final")
+    assert adapter._open_draft_by_chat[key] == 5
+    sent = [op for op in transport.ops if op["op"] == "send"]
+    assert len(sent) == 1
+    assert sent[0]["metadata"]["scope_id"] == source.scope_id
+    assert sent[0]["metadata"]["user_id"] == source.user_id
+    assert not any(op.get("final") for op in transport.ops)

--- a/tests/gateway/test_plugin_side_run_validation.py
+++ b/tests/gateway/test_plugin_side_run_validation.py
@@ -1,0 +1,18 @@
+"""Explicit route identities are validated, never silently repaired."""
+import pytest
+
+from hermes_cli.plugin_side_runs import SideRunConfig
+
+
+@pytest.mark.parametrize("patch", [
+    {"provider": " openai"},
+    {"provider": "openai "},
+    {"provider": "OpenAI"},
+    {"model": " model"},
+    {"model": "model "},
+    {"reasoning": {"effort": []}},
+    {"reasoning": {"effort": {}}},
+])
+def test_invalid_identity_or_reasoning_is_rejected_without_normalization(patch):
+    with pytest.raises(ValueError):
+        SideRunConfig.from_mapping({"provider": "openai", "model": "model", **patch})

--- a/tests/gateway/test_plugin_side_runs.py
+++ b/tests/gateway/test_plugin_side_runs.py
@@ -1,0 +1,178 @@
+"""Side runs exercise the real gateway boundary and durable child sessions, without model I/O."""
+import asyncio
+import json
+import threading
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+@pytest.mark.asyncio
+async def test_plugin_dispatch_authorizes_and_consumes_errors(monkeypatch):
+    manager = PluginManager()
+    ctx = PluginContext(PluginManifest(name="test-side", source="user"), manager)
+    calls = []
+
+    def broken(args):
+        calls.append(args)
+        raise RuntimeError("secret-provider-token")
+
+    ctx.register_command("probe-side", broken)
+    monkeypatch.setattr("hermes_cli.plugins._ensure_plugins_discovered", lambda: manager)
+    runner = object.__new__(GatewayRunner)
+    runner._draining = False
+    runner._hm_quick_commands = lambda: {}
+    runner._check_slash_access = Mock(return_value="Denied")
+    source = SessionSource(Platform.TELEGRAM, "chat", user_id="owner")
+    event = MessageEvent(text="/probe-side payload", source=source)
+    result = await runner._hm_dispatch_quick_and_plugin_commands(event, source, "probe-side")
+    assert result[:2] == (True, "Denied")
+    assert calls == []
+    runner._check_slash_access.return_value = None
+    handled, message, _ = await runner._hm_dispatch_quick_and_plugin_commands(event, source, "probe-side")
+    assert handled and "failed" in message.lower()
+    assert "secret-provider-token" not in message
+    assert calls == ["payload"]
+
+
+@pytest.mark.asyncio
+async def test_children_isolated_cancel_retains_capacity_and_owner(tmp_path, monkeypatch):
+    from gateway.side_runs import SideRunService
+    from hermes_cli.plugin_side_runs import SideRunConfig
+    from hermes_state import SessionDB
+
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("parent", "telegram", model="parent-model")
+    db.append_message("parent", "user", "untouched")
+    snapshot = db.get_session("parent")
+    messages = db.get_messages("parent")
+    started, release, interrupted = threading.Event(), threading.Event(), threading.Event()
+    agents = []
+
+    class Agent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.model = kwargs["model"]
+            self.provider = kwargs["provider"]
+            self.interrupted = False
+            agents.append(self)
+        def run_conversation(self, user_message, conversation_history, task_id):
+            assert conversation_history is None
+            self.kwargs["session_db"].append_message(task_id, "user", user_message)
+            started.set()
+            assert release.wait(10)
+            self.kwargs["session_db"].append_message(task_id, "assistant", "child answer")
+            return {"final_response": "child answer"}
+        def interrupt(self, *args, **kwargs):
+            self.interrupted = True
+            interrupted.set()
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr("run_agent.AIAgent", Agent)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kw: {
+        "provider": kw["requested"], "api_key": "fake", "base_url": "https://invalid.example/v1",
+        "api_mode": "chat_completions"})
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = SimpleNamespace(_db=db)
+    runner._draining = False
+    runner.session_store = SimpleNamespace(_entries={"parent-key": SimpleNamespace(session_id="parent")})
+    runner._session_key_for_source = lambda source: "parent-key"
+    runner._reply_anchor_for_event = lambda event: "reply"
+    runner._thread_metadata_for_source = lambda source, *args: {"thread_id": source.thread_id}
+    adapter = SimpleNamespace(send=AsyncMock(return_value=SimpleNamespace(success=True)))
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._adapter_for_source = lambda source: adapter
+    source = SessionSource(Platform.TELEGRAM, "chat", user_id="owner", thread_id="topic", chat_type="group")
+    event = MessageEvent(text="/probe prompt", source=source)
+    service = SideRunService(runner, max_concurrent=1)
+    config = SideRunConfig.from_mapping({"provider": "openai", "model": "child-model", "tools": [], "run_budget_seconds": 1})
+    child_id = service.start(event, "plugin", "prompt", config)
+    try:
+        assert await asyncio.to_thread(started.wait, 10)
+        row = db.get_session(child_id)
+        assert row["parent_session_id"] == "parent"
+        assert row["session_key"] == "parent-key"  # discoverable in the owner's chat listing
+        assert agents[0].kwargs["gateway_session_key"] != "parent-key"
+        assert json.loads(row["model_config"])["side_run"]["owner"]["user_id"] == "owner"
+        assert agents[0].kwargs["fallback_model"] == []
+        assert agents[0].kwargs["enabled_toolsets"] == []
+        assert not service.cancel(replace(source, user_id="intruder"), child_id)
+        assert await asyncio.to_thread(interrupted.wait, 5)
+        assert service.cancel(source, child_id)
+        assert agents[0].interrupted
+        service.runs[child_id].task.cancel()
+        await asyncio.sleep(0)
+        with pytest.raises(ValueError, match="capacity"):
+            service.start(event, "plugin", "another", config)
+        assert db.get_session("parent") == snapshot
+        assert db.get_messages("parent") == messages
+    finally:
+        release.set()
+        await asyncio.wait_for(service.wait(), 10)
+        runner._shutdown_executor()
+    assert agents[0].closed
+    assert not service.runs
+    assert "cancel" in adapter.send.await_args.args[1].lower()
+    assert adapter.send.await_args.kwargs["metadata"] == {"thread_id": "topic", "_interim_send": True}
+    assert adapter.send.await_args.kwargs["reply_to"] == "reply"
+    assert all(m["content"] != "untouched" for m in db.get_messages_as_conversation(child_id, include_ancestors=True))
+    db.end_session("parent", "compression")
+    assert db.resolve_resume_session_id("parent") == "parent"
+    db.close()
+
+
+def test_config_and_strict_resolution_fail_closed(tmp_path, monkeypatch):
+    from hermes_cli.plugin_side_runs import SideRunConfig
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    import yaml
+    for patch in ({"max_iterations": True}, {"max_tokens": False}, {"run_budget_seconds": float("nan")},
+                  {"run_budget_seconds": float("inf")}, {"max_iterations": 501}, {"provider": "auto"},
+                  {"tools": "all"}, {"reasoning": {"enabled": 1}}, {"fallback_model": "other"}):
+        with pytest.raises(ValueError):
+            SideRunConfig.from_mapping({"provider": "openai", "model": "test-model", **patch})
+    # Real profile config + real resolver; transport is local/config-only, no credential lookup mocks.
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+        "model": {"provider": "openrouter", "default": "primary-model"},
+        "providers": {"test-route": {"base_url": "http://127.0.0.1:9999/v1", "api_key": "test-only"}},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    runtime = resolve_runtime_provider(requested="custom:test-route", target_model="explicit-model", strict=True)
+    assert runtime["provider"] == "custom"
+    assert runtime["base_url"] == "http://127.0.0.1:9999/v1"
+    with pytest.raises(ValueError):
+        resolve_runtime_provider(requested="auto", target_model="test", strict=True)
+    with pytest.raises(Exception):
+        resolve_runtime_provider(requested="missing-route", target_model="test", strict=True)
+
+
+@pytest.mark.asyncio
+async def test_side_run_owner_cannot_be_bypassed_by_shared_group_or_admin(tmp_path):
+    from gateway.side_runs import owner_identity
+    from hermes_state import SessionDB
+    db = SessionDB(tmp_path / "state.db")
+    source = SessionSource(Platform.TELEGRAM, "chat", user_id="owner", chat_type="group", scope_id="scope")
+    db.create_session("child", "telegram", model_config={"side_run": {"owner": owner_identity(source)}},
+                      user_id="owner", chat_id="chat", chat_type="group")
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = SimpleNamespace(get_session=AsyncMock(side_effect=db.get_session))
+    runner._resume_caller_is_admin = lambda source: True
+    runner._gateway_session_origin_for_id = lambda sid: None
+    runner._is_shared_session_source = lambda source: True
+    assert await runner._resume_target_allowed(source, "child")
+    assert not await runner._resume_target_allowed(replace(source, user_id="other"), "child", allow_override=True)
+    assert not await runner._resume_target_allowed(replace(source, scope_id="elsewhere"), "child", allow_override=True)
+    assert not await runner._resume_row_visible(replace(source, user_id="other"), db.get_session("child"), allow_all=True)
+    matrix = replace(source, platform=Platform.MATRIX)
+    db.create_session("matrix-child", "matrix", model_config={"side_run": {"owner": owner_identity(matrix)}})
+    runner._same_matrix_room = lambda *args: True
+    assert await runner._resume_access_denied_reply(replace(matrix, user_id="other"), "matrix-child", "child", True, True)
+    db.close()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -285,7 +285,7 @@ def is_current_session_yolo_enabled() -> bool:
 def _yolo_active() -> bool:
     """CLI ``--yolo`` (process-scoped, frozen at import) or gateway ``/yolo``
     (session-scoped). Hardline / deny-rule floors run BEFORE this everywhere."""
-    return _YOLO_MODE_FROZEN or is_current_session_yolo_enabled()
+    return not approval_context.manual_approval_required() and (_YOLO_MODE_FROZEN or is_current_session_yolo_enabled())
 
 
 def is_approved(session_key: str, pattern_key: str) -> bool:
@@ -372,7 +372,8 @@ def is_approval_bypass_active_for_session(session_key: str) -> bool:
     """Canonical three-source bypass check: process ``--yolo`` (frozen at import), the
     session-scoped gateway ``/yolo`` toggle, ``approvals.mode: off``. Pure bypass
     sub-expression only — hardline blocklist / permanent allowlist are the caller's job."""
-    return (_YOLO_MODE_FROZEN or is_session_yolo_enabled(session_key) or approval_context._get_approval_mode() == "off")
+    return not approval_context.manual_approval_required() and (
+        _YOLO_MODE_FROZEN or is_session_yolo_enabled(session_key) or approval_context._get_approval_mode() == "off")
 
 
 def is_approval_bypass_active() -> bool:

--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -6,6 +6,7 @@ gate in :mod:`tools.approval`.
 """
 
 import contextvars
+from contextlib import contextmanager
 import logging
 import os
 from hermes_cli.config import cfg_get
@@ -225,8 +226,27 @@ def _get_approval_config() -> dict:
         return {}
 
 
+_require_manual_approval = contextvars.ContextVar("require_manual_approval", default=False)
+
+
+def manual_approval_required():
+    return _require_manual_approval.get()
+
+
+@contextmanager
+def require_manual_approval():
+    """Isolated host work never inherits process YOLO or an automatic guardian decision."""
+    token = _require_manual_approval.set(True)
+    try:
+        yield
+    finally:
+        _require_manual_approval.reset(token)
+
+
 def _get_approval_mode() -> str:
     """Return 'manual', 'smart', or 'off' (a hosted-room policy overrides config)."""
+    if manual_approval_required():
+        return "manual"
     try:
         from gateway.hosted_room_execution_policy import current_room_execution_policy
         if (room_policy := current_room_execution_policy()) is not None:

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1172,13 +1172,20 @@ def register(ctx):
 
 After registration, users can type `/mystatus` in any session. The command appears in autocomplete, `/help` output, and the Telegram bot menu.
 
-**Signature:** `ctx.register_command(name: str, handler: Callable, description: str = "", args_hint: str = "")`
+**Signature:** `ctx.register_command(name, handler, description="", args_hint="", argument_mode=None, *, busy_policy=None)`
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | `str` | Command name without the leading slash (e.g. `"lcm"`, `"mystatus"`) |
 | `handler` | `Callable[[str], str \| None]` | Called with the raw argument string. May also be `async`. |
 | `description` | `str` | Shown in `/help`, autocomplete, and Telegram bot menu |
+
+Gateway handlers may declare `context=None` as a named optional parameter. It receives
+an authenticated invocation context after source and slash authorization. Legacy
+one-argument handlers remain supported. `busy_policy="noninterrupting"` opts into
+inline execution through both busy guards without interrupting the parent. See
+[Authenticated plugin side runs](./side-runs.md) for fresh saved conversations,
+explicit routing, ownership, cancellation, and approval semantics.
 
 **Key differences from `register_cli_command()`:**
 

--- a/website/docs/developer-guide/plugins/side-runs.md
+++ b/website/docs/developer-guide/plugins/side-runs.md
@@ -1,0 +1,138 @@
+---
+title: Authenticated plugin side runs
+---
+
+# Authenticated plugin side runs
+
+The gateway can run a fresh, saved conversation on behalf of an authenticated plugin
+slash command. The host owns execution, delivery, cancellation, and approval routing.
+A concrete consumer is the standalone configurable model-routes plugin; no model-route
+presets or third-party integration are built into the host.
+
+Feature-detect `ctx.supports_side_runs is True` before registering handlers that require
+this capability. Older hosts must receive ordinary one-argument handlers which explain
+that the capability is unavailable. There is no release-number or global plugin-API
+version check.
+
+```python
+def register(ctx):
+    if getattr(ctx, "supports_side_runs", False) is not True:
+        ctx.register_command("example-run", lambda args: "A compatible host is required.")
+        return
+
+    def run(args, *, context=None):
+        if context is None:
+            return "Use an authenticated gateway chat."
+        config = ctx.get_config("route", {})
+        session_id = context.start_side_run(args, config)
+        return f"Started {session_id}"
+
+    ctx.register_command("example-run", run, args_hint="<prompt>",
+                         argument_mode="text", busy_policy="noninterrupting")
+```
+
+`register_command` adds an optional keyword-only `busy_policy`. The default `None`
+preserves the existing busy-input queue/steer behavior. Explicit `reject` declines inline;
+`noninterrupting` passes both adapter and runner busy guards inline,
+without interrupting or claiming the parent session. The adapter reads policy in the
+owning/routed profile before handing the event to its authenticated message handler.
+A noninterrupting handler must not change the parent's model, history, or cached prompt.
+
+The optional named `context` parameter is signature-inspected. Legacy one-argument
+handlers are still called with only `raw_args`; CLI/TUI handlers without a gateway
+context should decline side-run launch. Context is created only after source admission
+and slash authorization; internal synthetic events cannot launch contextual commands.
+Plugin handler failures are consumed as sanitized command errors, never model prompts.
+Do not launch from `pre_gateway_dispatch`, which runs before authentication.
+
+## Invocation context
+
+- `context.source`: a copy of the full trusted `SessionSource`, including transport
+  metadata. It is not reconstructed from plugin-supplied IDs.
+- `context.start_side_run(prompt, config) -> session_id`: admits bounded work, registers
+  host cleanup with the plugin's unload ledger, and returns its fresh session ID.
+- `context.cancel_side_run(session_id) -> bool`: requests interruption only when the
+  invocation's owner and plugin match the active child. A task ID is not authority.
+
+Config requires explicit `provider` and `model`. Optional fields are `tools`, `reasoning`,
+`max_iterations`, `max_tokens`, and `run_budget_seconds`. See
+`hermes_cli/plugin_side_runs.py::SideRunConfig` for the validated bounds. Unknown fields
+are rejected. Canonical identifiers are validated without trimming or case normalization.
+`tools=[]` means no tools; `tools=None` requests all available toolsets.
+Toolset selection is not a security boundary. The gateway service caps concurrent runs
+with `gateway.side_runs.max_concurrent` (default 3, 1–10), rejecting excess work.
+
+The host uses `resolve_runtime_provider(..., strict=True)`, verifies the resolved
+provider/model and constructor identities, and supplies `fallback_model=[]`. Canonical
+provider names or configured custom identities are required; an alias resolving to a
+different identity fails closed. Provider request overrides that can replace the primary
+model/route, isolated history/input, selected tools, output limits, or reasoning are rejected
+at either the top level or in `extra_body`. External-agent command/ACP transports, virtual MoA routes,
+and Codex app-server are refused because their tool/approval loops are not host-owned.
+Native app-server promotion is disabled on the child. No parent route resolver or smart
+classifier is called.
+
+## Isolation, approvals, and persistence
+
+Each worker receives its source profile's config and secret ContextVars, a new session
+ID and gateway tool/approval key, and `conversation_history=None`. The parent ID is
+provenance. The durable independent-branch marker prevents parent compression/resume
+from selecting a child, and prevents resume from loading parent history. Child ownership
+and effective configuration are stored in the real SessionDB. Runtime fallback is empty;
+context files, memory loading, and background review are skipped.
+
+The durable listing key remains the initiating chat's key, separate from the child-only
+execution/approval key, so `/sessions` can discover the child. Unnamed children follow
+the existing `include_unnamed` listing option; ownership filtering still precedes display.
+
+Gateway resume/listing checks compare the child's initiating owner, platform, profile,
+chat/thread, and scope before shared-room or administrator exceptions, including Matrix.
+An active child cannot be resumed until it ends. Explicitly resuming a finished child
+changes the caller's active session by request; later turns use ordinary gateway policies.
+
+Every child registers its own approval callback. Plain-text prompts route
+`/approve side:<request-id>` and `/deny side:<request-id>` to the exact pending request,
+after source/slash authorization and ownership checks. A stale ID never falls through
+to a parent's FIFO approval. Hosts restricting slash commands must grant the owner
+`approve` and `deny` as well as the initiating plugin command; owning a child does not
+override an administrator's slash policy. Missing permission fails closed.
+Missing delivery, timeout, cancellation, and unload deny
+pending work. Isolated execution forces manual approval and masks process/session YOLO;
+existing explicit permanent approvals remain host policy.
+
+Cancellation sets the agent's cooperative interrupt flag. The asyncio supervisor shields
+the synchronous executor worker and retains capacity until its cleanup actually ends.
+Timeout/unload/shutdown request cancellation; none claims to forcibly kill a blocked OS
+or provider operation. Worker-side SQLite finalization precedes executor completion, so
+normal shutdown's executor-quiesce/skip-close policy also protects child writes.
+Side supervisors join the existing detached-worker ledger for active-work reporting,
+drain, interruption and idle/suspend checks. During host shutdown a cancelled supervisor
+may stop waiting after the host's bounded drain/settle windows; a still-running sync
+worker owns its final cleanup and the host retains its database handle.
+
+The final answer is sent directly with the source's reply anchor and adapter metadata.
+`_interim_send=True` keeps this independent message from sealing a simultaneous parent
+native stream. Delivery is best-effort; transcripts remain available when transport fails.
+The host does not automatically resume interrupted work after a restart.
+
+## Limits
+
+The explicit route guarantee applies to the primary model. Auxiliary compression,
+vision, tool-internal LLM calls, and other auxiliary tasks use their own configuration.
+A runtime deadline and per-request output limit are not monetary or total-spend limits.
+The host checks the assembled primary request after provider transformations, including
+thinking/headroom expansion and retry boosts. Incompatible reasoning/output settings
+are rejected rather than silently changing reasoning or sending an enlarged cap.
+Transports that omit the explicit wire cap (including Codex subscription Responses)
+cannot serve bounded side runs; ordinary unbounded agents are unchanged. Native Gemini's
+later thinking expansion is also checked. Trusted request middleware can still mutate
+requests after assembly: this is not a sandbox against arbitrary installed plugin code.
+Tools use the same bot/service/profile credentials and filesystem permissions.
+
+The parent's actual cached prompt and tool schemas are retained. The legacy process-global
+`model_tools._last_resolved_tool_names` can change when any new agent selects tools;
+this capability does not promise immutable process-global diagnostics/defaults.
+
+Tests cover real discovery, adapter/runner authentication and busy dispatch, SQLite
+lineage/ownership, fake-transport AIAgent concurrency, profile secrets, approval request
+ownership, and cooperative cancellation. All tests use the canonical `scripts/run_tests.sh`.


### PR DESCRIPTION
## Summary

Adds a generic, gateway-owned saved side-run capability for authenticated native plugin commands. The concrete consumer is a standalone configurable model-routes plugin: launch a fresh conversation on an explicit primary provider/model alongside an active parent without changing the parent's history, route, tool schemas, or cached prompt. Route presets and the consumer plugin remain outside the core repository; this adds no model tool or third-party integration.

- Construct command context after source admission and slash authorization; preserve one-argument handlers and legacy busy queue/steer behavior (`busy_policy=None`). Explicit noninterrupting commands pass both busy guards without claiming the parent.
- Own child execution, per-profile configuration/credentials, independent SQLite lineage and owner-scoped listing/resume, direct transport delivery, cancellation, unload cleanup, and shutdown/drain accounting in the host.
- Enforce explicit primary routes without fallback, validate conflicting request overrides, and clamp/reject assembled primary requests that cannot honor output ceilings. Isolate approvals from parent/session YOLO and route request-specific approve/deny commands through existing slash policy plus child ownership.
- Document feature detection, fail-closed unsupported hosts/transports, cooperative cancellation, auxiliary-model exclusions, and the distinction between runtime/output bounds and monetary limits.

## Draft gate: converge the upstream plugin ABI

**This is a draft proposal, not merge-ready or released plugin support.** Please converge the authenticated command context and busy policy with the existing work before accepting a new ABI:

- #104590 — centralized authenticated plugin command dispatch
- #51596 — gateway context for plugin slash commands
- #97707 — busy-safe controls during active turns

All three were open when checked for this submission. This contribution addresses saved, explicitly routed, independently owned child runs beyond those overlapping dispatch surfaces; the overlap is a coordination dependency, not a claim that those APIs have shipped. Happy to adapt this implementation to the agreed context/policy surface rather than introduce parallel contracts. No fork pinning or automatic core-patch reapplication is proposed.

## Validation

Base tested: `990473a79c6b0396b0a648fdd85ee8f7a5c267d3`.

All Python runs used `scripts/run_tests.sh` with an isolated HOME, credential-stripped environment, and per-file subprocess isolation. No live gateway install/restart or external provider call was used for this submission.

- Focused host and separate consumer suite: **64 passed, 0 failed** across 13 files (60 host tests and 4 separate consumer tests). Includes real native discovery, authenticated adapter/runner dispatch, AIAgent/SDK using an in-memory HTTP transport, SQLite persistence, concurrent parent/child invariants, ownership, lifecycle, approval and compatibility contracts. The consumer tests are not included in this PR.
- Full final candidate discovery: **3,874/3,874 test files covered; 46,476 passed, 38 failed, 360 skipped.** The original runner was interrupted after 3,497 completed file results. Only the remaining 377 files were run to completion, then the disjoint file inventories and per-file results were reconciled. These are combined results, not a claim that a single uninterrupted run passed.
- **37 of the 38 failing test IDs also reproduced on the unchanged upstream base**, using focused baseline runs. They span session recovery/update/provider enumeration, Hindsight, state search, launcher, browser/kernel/Daytona, execution flags, lazy dependencies and web configuration. The remaining candidate-only failure was `tests/state/test_append_message_after_close_94736.py::TestAppendAfterClose::test_concurrent_close_during_flush_loses_no_writes`; its complete file passed on both a candidate rerun and baseline run. It remains a non-reproduced concurrency failure, not silently classified as fixed.
- Candidate rerun of the state-close and remote-kernel files: **18 passed, 0 failed**. Baseline run of the same two files: **17 passed, 1 failed** (the remote-kernel eviction test). The earlier full candidate run was also non-green. **No blanket full-suite or CI-green claim.**
- Read-only independent review found lifecycle/drain and durable listing gaps; the final review confirmed their fixes and legacy busy compatibility. Existing slash authorization for approvals was deliberately retained rather than bypassed. The remaining review gate is ABI convergence above.
- `git diff --check` and the recorded Ruff check passed. Gitleaks scanned all 32 publication candidate files with no findings; introduced-line privacy review found no private paths, personal data or credentials. Test logs and operator artifacts are not committed.

## Limitations / maintainer decisions

Cancellation is cooperative: it does not forcibly terminate a blocked provider/OS operation. Capacity stays owned through ordinary worker cleanup, and shutdown uses the existing executor-quiesce/database-retention policy. Auxiliary model calls and tool-internal calls have their own configuration. Tool selection is not a sandbox against installed code. Transports that cannot honor the host-owned tool/approval loop or explicit wire output cap fail closed. There is no automatic restart recovery or automatic session switch.
