### PR TITLE
fix(agent): drop partial-stream fragment on context-overflow to break the death spiral

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3248,6 +3248,23 @@ class _StreamingCall(StreamingWaitMonitor):
         error = self.result["error"]
         _partial_text = (getattr(self.agent, "_current_streamed_assistant_text", "") or "").strip() or None
         _partial_names = list(self.result.get("partial_tool_names") or [])
+        # Context-overflow / compression-exhaustion: the stream died because the
+        # prompt already filled the window. Appending the recovered fragment would
+        # make the next turn's prompt strictly larger than the one that just failed
+        # (each retry fails earlier — the death spiral in #106260). Drop the fragment
+        # so only the continuation nudge is added (the loop's empty-stub guard skips
+        # appending an empty stub); retries then run against a same-size prompt instead
+        # of a growing one, letting the existing ceiling-exit / window-exhausted paths
+        # fire instead of spiraling.
+        _ctx_overflow_dropped = 0
+        with contextlib.suppress(Exception):
+            from agent.error_classifier import classify_api_error, FailoverReason
+            if classify_api_error(
+                error, provider=str(getattr(self.agent, "provider", "") or ""),
+                model=str(getattr(self.agent, "model", "") or ""),
+            ).reason == FailoverReason.context_overflow:
+                _ctx_overflow_dropped = len(_partial_text or "")
+                _partial_text = None
         if _partial_names:
             # User-visible warning so the user and model both know what was attempted.
             _name_str = ", ".join(_partial_names[:3])
@@ -3260,6 +3277,11 @@ class _StreamingCall(StreamingWaitMonitor):
             logger.warning(
                 "Partial stream dropped tool call(s) %s after %s chars of text; surfaced warning to user: %s",
                 _partial_names, len(_partial_text or ""), error)
+        elif _ctx_overflow_dropped:
+            logger.warning(
+                "Partial stream died on context overflow; dropping %s chars of recovered content so the "
+                "next turn's prompt is not larger than the one that just failed (avoids the death spiral): %s",
+                _ctx_overflow_dropped, error)
         else:
             logger.warning(
                 "Partial stream delivered before error; returning length-truncated stub with %s chars of "

--- a/tests/agent/test_partial_stream_context_overflow_drop.py
+++ b/tests/agent/test_partial_stream_context_overflow_drop.py
@@ -1,0 +1,117 @@
+"""Regression tests for #106260: a partial-stream that dies on a context-overflow
+error must NOT append the recovered fragment to the transcript.
+
+Before the fix, ``_partial_stream_stub`` unconditionally returned the already-streamed
+text as the stub content. When the stream died because the prompt had already filled the
+window (``Context length exceeded: max compression attempts (3) reached.``), appending
+that fragment made the next turn's prompt strictly larger than the one that just failed
+— each retry failed earlier, a monotonic death spiral that compression could not save
+(short conversations sit entirely inside ``protect_last_n``).
+
+The fix classifies the stream error: when it is ``FailoverReason.context_overflow``,
+the recovered fragment is dropped (stub content ``None``) so only the continuation
+nudge is added. The loop's empty-stub guard then skips appending the stub, and retries
+run against a same-size prompt instead of a growing one.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.chat_completion_helpers import _StreamingCall
+from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+
+def _make_call(agent, error, partial_text, partial_tool_names=None):
+    """Construct a ``_StreamingCall`` without running ``__init__`` (avoids the
+    request-client/threading setup) — only ``_partial_stream_stub`` is exercised."""
+    call = _StreamingCall.__new__(_StreamingCall)
+    call.agent = agent
+    call.result = {"error": error, "partial_tool_names": partial_tool_names or []}
+    return call
+
+
+def _make_agent(*, partial_text, provider="anthropic", model="claude-sonnet-4"):
+    agent = MagicMock()
+    agent._current_streamed_assistant_text = partial_text
+    agent.provider = provider
+    agent.model = model
+    agent._fire_stream_delta = lambda text: None
+    return agent
+
+
+class TestPartialStreamContextOverflowDrop:
+    """The death-spiral fix: context-overflow errors drop the recovered fragment."""
+
+    @pytest.mark.parametrize("error", [
+        "Context length exceeded: max compression attempts (3) reached.",
+        "Context length exceeded: 51,329 tokens. Cannot compress further.",
+        "This model's maximum context length is 200000 tokens. However, your messages resulted in 201234 tokens.",
+    ])
+    def test_context_overflow_drops_partial_content(self, error):
+        agent = _make_agent(partial_text="x" * 71239)
+        call = _make_call(agent, error=error, partial_text="x" * 71239)
+        stub = call._partial_stream_stub()
+        assert stub.id == PARTIAL_STREAM_STUB_ID
+        # The 71K-char fragment must NOT be in the stub — it would grow the next prompt.
+        assert stub.choices[0].message.content is None, (
+            "context-overflow stub must drop the recovered fragment so the next turn's "
+            "prompt is not larger than the one that just failed (death spiral)"
+        )
+        assert stub.choices[0].message.tool_calls is None
+
+    def test_non_context_error_keeps_partial_content(self):
+        """A transient connection error still keeps the partial fragment — the loop
+        continues from where the stream died (the pre-fix behaviour, unchanged)."""
+        agent = _make_agent(partial_text="partial answer that was stream")
+        call = _make_call(agent, error="Connection reset by peer", partial_text="partial answer that was stream")
+        stub = call._partial_stream_stub()
+        assert stub.choices[0].message.content == "partial answer that was stream"
+
+    def test_context_overflow_with_dropped_tool_keeps_warning_only(self):
+        """When the stream dies on context overflow mid tool-call, the dropped-tool
+        warning is still surfaced (the user must know the action was not executed), but
+        the recovered text fragment is dropped — no partial-text growth."""
+        agent = _make_agent(partial_text="let me write the file: " + "y" * 50000)
+        call = _make_call(
+            agent,
+            error="Context length exceeded: max compression attempts (3) reached.",
+            partial_text="let me write the file: " + "y" * 50000,
+            partial_tool_names=["write_file"],
+        )
+        stub = call._partial_stream_stub()
+        content = stub.choices[0].message.content
+        # Warning is present (the tool call was attempted + not executed).
+        assert content is not None
+        assert "Stream stalled mid tool-call" in content
+        assert "write_file" in content
+        # The 50K-char recovered fragment must NOT be in the stub.
+        assert "y" * 100 not in content, "recovered fragment leaked into the stub despite context-overflow drop"
+
+    def test_non_context_with_dropped_tool_keeps_partial_plus_warning(self):
+        """Non-context-overflow + dropped tool: the recovered fragment stays alongside
+        the warning (unchanged pre-fix behaviour — only context-overflow drops)."""
+        agent = _make_agent(partial_text="partial preamble text")
+        call = _make_call(
+            agent,
+            error="Connection reset by peer",
+            partial_text="partial preamble text",
+            partial_tool_names=["write_file"],
+        )
+        stub = call._partial_stream_stub()
+        content = stub.choices[0].message.content
+        assert content is not None
+        assert "partial preamble text" in content  # fragment kept
+        assert "Stream stalled mid tool-call" in content  # warning kept
+
+    def test_context_overflow_empty_partial_is_noop(self):
+        """If nothing was streamed before the context overflow, dropping is a no-op
+        (the stub is already empty — the loop guard skips it)."""
+        agent = _make_agent(partial_text="")
+        call = _make_call(
+            agent,
+            error="Context length exceeded: max compression attempts (3) reached.",
+            partial_text="",
+        )
+        stub = call._partial_stream_stub()
+        assert stub.choices[0].message.content is None


### PR DESCRIPTION
## Summary

Fixes #106260.

When a streaming completion dies mid-delivery on a **context-overflow / compression-exhaustion** error (`Context length exceeded: max compression attempts (3) reached.`, `… 51,329 tokens. Cannot compress further.`, `… maximum context length is 200000 tokens …`), `agent/chat_completion_helpers._partial_stream_stub` unconditionally returned the already-streamed text as the stub content. Appending that fragment made the **next turn's prompt strictly larger than the one that just failed** — each retry failed earlier, a monotonic **death spiral** that compression could not save (short conversations sit entirely inside `protect_last_n: 20`, so all 3 compression attempts return `no_progress`; or the summary + scaffolding exceed the original → `would_grow`). The agent then sits "thinking" for 30+ minutes with an in-flight request that can never succeed.

The fix classifies the stream error before building the stub: when `classify_api_error(error).reason == FailoverReason.context_overflow`, the recovered fragment is **dropped** (stub content `None`) so only the continuation nudge is added. The conversation loop's existing empty-stub guard then skips appending the stub, and retries run against a **same-size prompt** instead of a growing one — letting the existing ceiling-exit / window-exhausted (`recover_from_truncation`) paths fire instead of spiraling.

This fits the established `#68041`-class empty-stub path (the guard already skips appending an empty stub; substituting placeholder text here was previously found to defeat that guard and leak into the stitched response). The change is surgical: only the `context_overflow` error class drops the fragment; transient errors (`Connection reset`, timeouts) keep the fragment so the loop still continues from where the stream died.

## Root cause

`_partial_stream_stub` (`chat_completion_helpers.py:3243`) builds a stub containing the full partial text recovered from the failed stream (up to ~71K chars in the report). `recover_from_truncation` (`turn_truncation.py:356`) then appends this stub to the transcript via `_continue_text` (line 250). The next turn's prompt is therefore **larger** than the failed turn → fails earlier → an even-larger stub is appended → spiral. Compression cannot help: with `protect_last_n: 20` covering a short conversation every message is inside the protected window, so all 3 attempts return `no_progress`; or the summary + scaffolding exceed the original and are rejected (`would_grow`).

## Changes

- `agent/chat_completion_helpers.py` (`_partial_stream_stub`): classify the stream error; on `FailoverReason.context_overflow`, drop the recovered fragment before the stub is built (a dedicated log line records the dropped char count + reason). The dropped-tool warning is still surfaced when a tool call was in flight — only the text fragment is dropped, so the user still learns the action was not executed.

## Tests

New `tests/agent/test_partial_stream_context_overflow_drop.py` (7 cases, all pass):
- 3 context-overflow error strings (`max compression attempts`, `Cannot compress further`, `maximum context length is …`) → stub content is `None` (fragment dropped).
- `Connection reset by peer` (transient) → stub content keeps the partial fragment (unchanged behaviour).
- context-overflow mid tool-call → stub keeps the dropped-tool warning but drops the 50K-char fragment.
- non-context mid tool-call → stub keeps fragment + warning (unchanged).
- context-overflow with empty partial → no-op (stub already empty).

Mutation-verified: removing the fix makes the 3 context-overflow tests fail (stub content = the 71K chars). No regressions in the existing partial-stream / streaming suites (the 3 pre-existing `anthropic_adapter` `ImportError` failures reproduce on clean main).

## Complementary

This is complementary to #106223 (`_window_exhausted_abort`): #106223 aborts when the window is detected as exhausted via prompt-token accounting; this PR prevents the partial fragment from growing the prompt so #106223's detection is not defeated by the death-spiral growth.
