### PR TITLE
fix(tools): kill the whole browser-use CLI process group on browser_exec timeout

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -14,6 +14,8 @@ Covers the three seams the integration relies on:
 import json
 import os
 import stat
+import subprocess
+import sys
 import time
 
 import pytest
@@ -1338,3 +1340,80 @@ class TestLightpandaStatusLine:
         out = self._status(monkeypatch, used=False, reason="cloud provider Browserbase is selected")
         assert "NOT in use" in out
         assert "Browserbase" in out
+
+
+class TestTimeoutProcessGroupKill:
+    """#106244: on timeout the whole CLI process group must die. A pipe-holding
+    grandchild (browser_harness daemon / Chrome helper) otherwise keeps communicate()
+    blocked forever, and the wedged call's activity heartbeat pins the session at
+    "now" in the sidebar indefinitely."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_timeout_kills_grandchild_and_returns_promptly(self, tmp_path, monkeypatch):
+        """A grandchild that outlives the direct child and holds the inherited stdout
+        pipe must not keep browser_exec blocked past the timeout (it wedged permanently
+        before the group kill)."""
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+        pid_file = tmp_path / "grandchild.pid"
+        cli = _fake_cli(tmp_path, (
+            "cat > /dev/null\n"
+            "sleep 60 &\n"
+            "echo $! > \"" + str(pid_file) + "\"\n"
+            "sleep 60\n"
+        ))
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        start = time.time()
+        result = json.loads(bu_cli.browser_exec("print(1)", timeout_s=bu_cli._MIN_TIMEOUT_S))
+        elapsed = time.time() - start
+
+        assert "timed out" in result["error"]
+        # Pre-fix, this hangs until the 60s sleeps expire — and forever with a daemon child.
+        assert elapsed < 30
+        # The pipe-holding grandchild died with the group instead of leaking.
+        pid = int(pid_file.read_text().strip())
+        time.sleep(0.5)
+        with pytest.raises(OSError):
+            os.kill(pid, 0)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_gone_group_still_surfaces_timeout(self, monkeypatch):
+        """killpg can race an already-exited group; the timeout must still surface."""
+        waits = []
+
+        class _FakeProc:
+            pid = 424242
+            returncode = None
+
+            def communicate(self, input=None, timeout=None):
+                waits.append(timeout)
+                if input is not None:
+                    raise subprocess.TimeoutExpired("browser-use", timeout)
+                return ("", "")
+
+        monkeypatch.setattr(bu_cli.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+        def _gone_group(pgid, sig):
+            raise ProcessLookupError()
+
+        monkeypatch.setattr(bu_cli.os, "killpg", _gone_group)
+        with pytest.raises(subprocess.TimeoutExpired):
+            bu_cli._run_cli_killing_process_group(["x"], "code", {}, 5)
+        # First wait is the tool timeout, second is the bounded post-kill drain.
+        assert waits == [5, bu_cli._POST_KILL_DRAIN_S]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_post_kill_drain_is_bounded(self, monkeypatch):
+        """If even the post-kill drain misses its deadline, give up instead of wedging."""
+
+        class _StuckProc:
+            pid = 424243
+            returncode = None
+
+            def communicate(self, input=None, timeout=None):
+                raise subprocess.TimeoutExpired("browser-use", timeout)
+
+        monkeypatch.setattr(bu_cli.subprocess, "Popen", lambda *a, **k: _StuckProc())
+        monkeypatch.setattr(bu_cli.os, "killpg", lambda pgid, sig: None)
+        with pytest.raises(subprocess.TimeoutExpired):
+            bu_cli._run_cli_killing_process_group(["x"], "code", {}, 5)

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -538,7 +538,8 @@ def _run_cli_killing_process_group(cmd, code, env, timeout):
         stdout, stderr = proc.communicate(input=code, timeout=timeout)
     except subprocess.TimeoutExpired:
         with contextlib.suppress(ProcessLookupError, PermissionError):
-            os.killpg(proc.pid, signal.SIGKILL)  # start_new_session=True: pgid == pid
+            # start_new_session=True: pgid == pid; POSIX-only, browser_exec gates this helper behind os.name != "nt".
+            os.killpg(proc.pid, signal.SIGKILL)  # windows-footgun: ok
         try:
             proc.communicate(timeout=_POST_KILL_DRAIN_S)
         except subprocess.TimeoutExpired:

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -516,6 +517,36 @@ def _clamp_timeout(timeout_s: Any) -> int:
         return _DEFAULT_TIMEOUT_S
 
 
+# After a whole-group SIGKILL, every pipe holder is dead, so the drain below is normally
+# instant; the deadline only guards against a process outside the group still holding a pipe.
+_POST_KILL_DRAIN_S = 10.0
+
+
+def _run_cli_killing_process_group(cmd, code, env, timeout):
+    """Run the CLI in its own session and SIGKILL the whole process group on timeout.
+
+    ``subprocess.run`` only kills the direct child on ``TimeoutExpired``; a browser_harness
+    daemon / Chrome helper grandchild inherits the stdout/stderr pipes and keeps them open,
+    so the internal ``communicate()`` blocks on pipe EOF forever and the tool call — plus its
+    activity heartbeat — wedges permanently (#106244).
+    """
+    proc = subprocess.Popen(
+        cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, env=env, start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(input=code, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(proc.pid, signal.SIGKILL)  # start_new_session=True: pgid == pid
+        try:
+            proc.communicate(timeout=_POST_KILL_DRAIN_S)
+        except subprocess.TimeoutExpired:
+            pass
+        raise
+    return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+
+
 def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT_S,
                  task_id: Optional[str] = None, local: bool = False):
     """Run Python code through the browser-use CLI, and return its output"""
@@ -561,10 +592,14 @@ def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT
     timeout = _clamp_timeout(timeout_s)
     started = time.time()
     try:
-        proc = subprocess.run(
-            cmd, input=code, capture_output=True, text=True, timeout=timeout, env=env,
-            **_windows_popen_kwargs(),
-        )
+        if os.name == "nt":
+            proc = subprocess.run(
+                cmd, input=code, capture_output=True, text=True, timeout=timeout, env=env,
+                **_windows_popen_kwargs(),
+            )
+        else:
+            # Plain run() strands the pipe-holding grandchildren above (#106244).
+            proc = _run_cli_killing_process_group(cmd, code, env, timeout)
     except subprocess.TimeoutExpired:
         return tool_error(f"browser-use exec timed out after {timeout}s. The daemon may still be working; retry "
                           f"with a larger timeout_s (max {_MAX_TIMEOUT_S}), or split the work into several calls that "


### PR DESCRIPTION
## What does this PR do?

Fixes a permanently-wedged `browser_exec` call. On timeout, `subprocess.run` only kills the direct browser-use CLI child; a browser_harness daemon / Chrome helper **grandchild** inherits the stdout/stderr pipes and keeps them open, so the internal `communicate()` blocks on pipe EOF forever:

- the tool call never returns and the worker thread stays parked in a pipe read (`sample(1)` in the issue shows threads in `_io__Buffered_read1`),
- the activity heartbeat in `agent/tool_executor.py::_run_with_activity_heartbeat` keeps stamping `last_activity_at` every 30 s for as long as the backend lives, because the `finally: stop.set()` only runs once `fn()` returns,
- so finished sessions stay pinned at "now" in the desktop sidebar until the backend is restarted.

On POSIX, the CLI now runs in its own session (`start_new_session=True`) and a timeout SIGKILLs the **whole process group**, releasing the pipes. The call then surfaces the existing timeout error, the worker thread exits, and the heartbeat stops naturally. A bounded post-kill drain guards against a process outside the group still holding a pipe. Windows keeps `subprocess.run`.

The heartbeat itself is intentionally left unchanged: with the wedge fixed, `fn()` returns and the heartbeat stops on its own, preserving the #84491 contract (a genuinely long-running tool keeps stamping until the gateway inactivity timeout).

## Related Issue

Fixes #106244

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_use_cli.py`: added `_run_cli_killing_process_group` — `Popen(start_new_session=True)`, on `TimeoutExpired` SIGKILL the process group, drain pipes under a `_POST_KILL_DRAIN_S = 10` deadline, re-raise so the existing timeout `tool_error` path is reused; `browser_exec` now uses it on POSIX (Windows branch unchanged).
- `tests/tools/test_browser_use_cli.py`: `TestTimeoutProcessGroupKill` — a real grandchild (`sleep 60 &`) holding the inherited stdout pipe is killed with the group and the call returns the timeout error promptly (this test wedges pre-fix); killpg-vs-gone-group race still surfaces the timeout; post-kill drain stays bounded.

## How to Test

1. `pytest tests/tools/test_browser_use_cli.py -q` — Observed result: 119 passed (3 of them new; the grandchild test runs ~5 s and asserts both the prompt timeout error and that the leaked `sleep` pid is gone).
2. `pytest tests/tools/test_browser_use_session_expiry.py tests/tools/test_browser_command_timeout_race.py tests/tools/test_browser_open_timeout.py -q` — Observed result: 16 passed.
3. `ruff check tools/browser_use_cli.py tests/tools/test_browser_use_cli.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring added on the new helper)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-availability) (POSIX group kill; Windows path unchanged; new tests skip on win32)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A