### PR TITLE
fix(agent): don't seed continuation stub after a context-overflow stream death (#106260)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2174,11 +2174,17 @@ def cleanup_task_resources(agent, task_id: str) -> None:
 
 
 def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, usage_obj, *,
-    dropped_tool_names=None):
+    dropped_tool_names=None, overflow_terminal=False):
     """Stub for an SSE stream that ended without ``finish_reason`` after
     delivering content. Tagged ``PARTIAL_STREAM_STUB_ID`` + ``FINISH_REASON_LENGTH``
     so the loop enters its continuation/retry path instead of accepting
-    truncated output as a complete turn (#32086)."""
+    truncated output as a complete turn (#32086).
+
+    ``overflow_terminal`` (``full_content=None``): the stream died on a
+    context-overflow error. Seeding the recovered text as a continuation stub
+    would grow every later request into the same overflow (#106260); the loop
+    treats the marker as terminal and ends the turn via the recovery contract.
+    """
     return SimpleNamespace(
         id=PARTIAL_STREAM_STUB_ID,
         model=model_name,
@@ -2190,6 +2196,7 @@ def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, u
         )],
         usage=usage_obj,
         _dropped_tool_names=dropped_tool_names or None,
+        _overflow_terminal=overflow_terminal,
     )
 
 
@@ -3267,14 +3274,33 @@ class _StreamingCall(StreamingWaitMonitor):
                 len(_partial_text or ""), error)
         # Classify content filtering (MiniMax 1027, Azure content_filter, Anthropic refusal)
         # before the error is swallowed into the stub: the loop reads the tag and falls back.
-        _stub = _build_partial_stream_stub("assistant", _partial_text, None,
-            getattr(self.agent, "model", "unknown"), None, dropped_tool_names=_partial_names)
+        _cls = None
         with contextlib.suppress(Exception):
             from agent.error_classifier import classify_api_error
             _cls = classify_api_error(
                 error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
-            if _cls.reason == FailoverReason.content_policy_blocked:
-                _stub._content_filter_terminated = True
+        # #106260: a context-overflow / payload-too-large error after partial delivery must NOT
+        # seed a continuation stub with the recovered text — the transcript already cannot fit
+        # (compression failed or protect_last_n covers it), and appending tens of KB only makes
+        # every later request larger. Return an EMPTY stub marked terminal: the loop ends the
+        # turn via the recovery contract instead of continuing into the same overflow.
+        if _cls is not None and _cls.reason in (
+            FailoverReason.context_overflow, FailoverReason.payload_too_large,
+        ):
+            logger.warning(
+                "Partial stream ended on a context-overflow error after %s chars; "
+                "NOT seeding a continuation stub (transcript is already over budget): %s",
+                len(_partial_text or ""), error,
+            )
+            _reset_stale_streak(self.agent)
+            return _build_partial_stream_stub(
+                "assistant", None, None, getattr(self.agent, "model", "unknown"), None,
+                dropped_tool_names=_partial_names, overflow_terminal=True,
+            )
+        _stub = _build_partial_stream_stub("assistant", _partial_text, None,
+            getattr(self.agent, "model", "unknown"), None, dropped_tool_names=_partial_names)
+        if _cls is not None and _cls.reason == FailoverReason.content_policy_blocked:
+            _stub._content_filter_terminated = True
         _reset_stale_streak(self.agent)  # deltas fired => provider responsive: clear the breaker
         return _stub
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3279,14 +3279,15 @@ class _StreamingCall(StreamingWaitMonitor):
             from agent.error_classifier import classify_api_error
             _cls = classify_api_error(
                 error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
-        # #106260: a context-overflow / payload-too-large error after partial delivery must NOT
-        # seed a continuation stub with the recovered text — the transcript already cannot fit
-        # (compression failed or protect_last_n covers it), and appending tens of KB only makes
-        # every later request larger. Return an EMPTY stub marked terminal: the loop ends the
-        # turn via the recovery contract instead of continuing into the same overflow.
-        if _cls is not None and _cls.reason in (
-            FailoverReason.context_overflow, FailoverReason.payload_too_large,
-        ):
+        # #106260: a context-overflow error after partial delivery must NOT seed a
+        # continuation stub with the recovered text — the transcript already cannot fit
+        # (compression failed or protect_last_n covers it), and appending tens of KB only
+        # makes every later request larger. Return an EMPTY stub marked terminal: the loop
+        # ends the turn via the recovery contract instead of continuing into the same
+        # overflow. Scope is deliberately context_overflow ONLY: payload_too_large (413)
+        # has its own byte-scored recovery owner (turn_overflow._recover_payload_too_large,
+        # #88960/#47339) that must not be bypassed (review P1, andrexibiza).
+        if _cls is not None and _cls.reason == FailoverReason.context_overflow:
             logger.warning(
                 "Partial stream ended on a context-overflow error after %s chars; "
                 "NOT seeding a continuation stub (transcript is already over budget): %s",

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -73,11 +73,12 @@ def normalize_response_for_agent(agent: Any, response: Any) -> Any:
 
 def partial_result(
     messages: List[Dict[str, Any]], api_call_count: int, final_response: str,
-    error: Optional[str] = None, *, failed: bool = False,
+    error: Optional[str] = None, *, failed: bool = False, compression_exhausted: bool = False,
 ) -> Dict[str, Any]:
     """Typed incomplete-turn result (``partial`` unless ``failed``); ``error`` defaults to
-    ``final_response``."""
-    return {
+    ``final_response``. ``compression_exhausted`` carries the #98722 typed bit the gateway
+    consumes to reset/move future input to a clean session (see run_turn.py)."""
+    result = {
         "final_response": final_response,
         "messages": messages,
         "api_calls": api_call_count,
@@ -85,6 +86,9 @@ def partial_result(
         ("failed" if failed else "partial"): True,
         "error": final_response if error is None else error,
     }
+    if compression_exhausted:
+        result["compression_exhausted"] = True
+    return result
 
 
 @dataclass
@@ -129,16 +133,20 @@ class _Trunc(TruncationVerdict):
     def end_turn(
         self, final_response: str, error: Optional[str] = None, *,
         result_messages: Optional[List[Dict[str, Any]]] = None, cleanup: bool = True,
-        failed: bool = False,
+        failed: bool = False, compression_exhausted: bool = False,
     ) -> TruncationVerdict:
-        """Persist and end the turn as partial (or ``failed``)."""
+        """Persist and end the turn as partial (or ``failed``).
+
+        ``compression_exhausted`` forwards the #98722 typed bit so the gateway can
+        move future input off a bloated session (run_turn.py consumes it).
+        """
         agent = self.agent
         if cleanup:
             agent._cleanup_task_resources(self.effective_task_id)
         agent._persist_session(self.messages, self.conversation_history)
         return self.done("return", partial_result(
             self.messages if result_messages is None else result_messages, self.api_call_count,
-            final_response, error, failed=failed,
+            final_response, error, failed=failed, compression_exhausted=compression_exhausted,
         ))
 
     @property
@@ -346,10 +354,14 @@ def recover_from_truncation(
             "budget).",
             force=True,
         )
+        # Carry the #98722 typed exhaustion bit so the gateway resets/moves future
+        # input to a clean session instead of leaving this bloated one authoritative
+        # for the next turn (review P1, andrexibiza).
         return st.end_turn(
             _CONTEXT_OVERFLOW_PARTIAL_FINAL,
             error=_CONTEXT_OVERFLOW_PARTIAL_FINAL,
             failed=True,
+            compression_exhausted=True,
         )
 
     _trunc_msg = normalize_response_for_agent(agent, response)

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -28,6 +28,14 @@ _CONTINUABLE_MODES = {"chat_completions", "bedrock_converse", "anthropic_message
 _THINK_TAG_RE = re.compile(r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>', re.IGNORECASE)
 _TRUNCATED_FINAL = "Response truncated due to output length limit"
 _FIRST_TRUNCATED_FINAL = "First response truncated due to output length limit"
+# #106260: a stream that died on a context-overflow error after partial delivery must not seed a
+# continuation — the transcript already cannot fit, and appending the partial stub grows every
+# later request into the same overflow. End the turn via the recovery contract instead.
+_CONTEXT_OVERFLOW_PARTIAL_FINAL = (
+    "The conversation exceeded the model's context window and compression could "
+    "not recover it, so the partial response was not continued. Start a new "
+    "session (or /new) to continue with a clean transcript."
+)
 
 _THINKING_EXHAUSTED = (
     "💭 Reasoning exhausted the output token budget — no visible response was produced.",
@@ -325,6 +333,24 @@ def recover_from_truncation(
         f"{agent.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens",
         force=True,
     )
+
+    # #106260: a context-overflow error after partial delivery must not seed a
+    # continuation. _partial_stream_stub marks such stubs _overflow_terminal and
+    # leaves content empty; continuing would only re-send a larger request into
+    # the same overflow (compression already failed / protect_last_n covers it).
+    if getattr(st.response, "_overflow_terminal", False):
+        agent._flush_status_buffer()
+        agent._vprint(
+            f"{agent.log_prefix}⚠️ Stream ended on a context-overflow error after "
+            "partial delivery — not continuing (the transcript is already over "
+            "budget).",
+            force=True,
+        )
+        return st.end_turn(
+            _CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            error=_CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            failed=True,
+        )
 
     _trunc_msg = normalize_response_for_agent(agent, response)
     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None

--- a/tests/run_agent/test_overflow_partial_terminal_106260.py
+++ b/tests/run_agent/test_overflow_partial_terminal_106260.py
@@ -86,6 +86,36 @@ class TestOverflowTerminalStub:
         assert response.choices[0].message.content is None
 
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_payload_too_large_partial_is_not_made_terminal(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Review P1 (andrexibiza): payload_too_large (413) has its own byte-scored
+        recovery owner and must NOT be collapsed into the context-overflow terminal
+        contract — the partial keeps its normal continuation stub."""
+        def _overflowing_stream():
+            yield _make_stream_chunk(content="some media-heavy partial output ...")
+            raise RuntimeError(
+                "Request payload too large (413): 5MB exceeds the 4MB limit"
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _overflowing_stream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._current_streamed_assistant_text = "some media-heavy partial output ..."
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert getattr(response, "_overflow_terminal", False) is False
+        # The recovered text is preserved for the normal continuation path.
+        assert response.choices[0].message.content == "some media-heavy partial output ..."
+
+
 class TestRecoverFromTruncationOverflowTerminal:
     def _mock_agent(self):
         agent = MagicMock()
@@ -127,6 +157,9 @@ class TestRecoverFromTruncationOverflowTerminal:
         result = verdict.result or {}
         assert result.get("failed") is True
         assert result.get("final_response") == _CONTEXT_OVERFLOW_PARTIAL_FINAL
+        # #98722 typed bit: the gateway consumes this to reset/move future input
+        # to a clean session instead of leaving the bloated one authoritative.
+        assert result.get("compression_exhausted") is True
         # No fragment or nudge was appended to the transcript.
         assert result.get("messages") == []
 

--- a/tests/run_agent/test_overflow_partial_terminal_106260.py
+++ b/tests/run_agent/test_overflow_partial_terminal_106260.py
@@ -1,0 +1,151 @@
+"""Regression tests for #106260: a context-overflow error after partial stream
+delivery must NOT seed a continuation stub with the recovered text.
+
+Seeding tens of KB of partial content as a length-continuation stub makes every
+later request larger, so a session whose transcript cannot fit (compression
+failed / protect_last_n covers it) loops forever growing the context. The stub
+is instead marked terminal (content empty) and the loop ends the turn via the
+recovery contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+
+
+def _make_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+def _make_stream_chunk(content=None, finish_reason=None):
+    delta = SimpleNamespace(content=content, tool_calls=None,
+                            reasoning_content=None, reasoning=None)
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=None, usage=None)
+
+
+class TestOverflowTerminalStub:
+    def test_build_stub_carries_marker_and_empty_content(self):
+        from agent.chat_completion_helpers import _build_partial_stream_stub
+
+        stub = _build_partial_stream_stub(
+            "assistant", None, None, "test/model", None, overflow_terminal=True)
+        assert stub._overflow_terminal is True
+        assert stub.id == PARTIAL_STREAM_STUB_ID
+        assert stub.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert stub.choices[0].message.content is None
+
+        normal = _build_partial_stream_stub(
+            "assistant", "some text", None, "test/model", None)
+        assert getattr(normal, "_overflow_terminal", False) is False
+        assert normal.choices[0].message.content == "some text"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_partial_stream_overflow_error_returns_terminal_stub(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """A stream that delivered text then hit the provider's
+        maximum-context-length error must return an EMPTY stub marked terminal,
+        not a continuation stub carrying the recovered text (#106260)."""
+        def _overflowing_stream():
+            yield _make_stream_chunk(content="Here's my long partial answer ...")
+            raise RuntimeError(
+                "This model's maximum context length is 128000 tokens. "
+                "However, you requested 140000 tokens."
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _overflowing_stream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._current_streamed_assistant_text = "Here's my long partial answer ..."
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert getattr(response, "_overflow_terminal", False) is True
+        # The recovered text must not be seeded for continuation.
+        assert response.choices[0].message.content is None
+
+
+class TestRecoverFromTruncationOverflowTerminal:
+    def _mock_agent(self):
+        agent = MagicMock()
+        agent._vprint = MagicMock()
+        agent._flush_status_buffer = MagicMock()
+        agent._cleanup_task_resources = MagicMock()
+        agent._persist_session = MagicMock()
+        return agent
+
+    def _response(self, overflow_terminal=True, content="recovered text"):
+        return SimpleNamespace(
+            id=PARTIAL_STREAM_STUB_ID,
+            _overflow_terminal=overflow_terminal,
+            _dropped_tool_names=None,
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(role="assistant", content=content,
+                                        tool_calls=None, reasoning_content=None),
+                finish_reason=FINISH_REASON_LENGTH,
+            )],
+        )
+
+    def test_overflow_terminal_stub_ends_turn_without_continuation(self):
+        from agent.turn_truncation import (
+            _CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            recover_from_truncation,
+        )
+
+        agent = self._mock_agent()
+        verdict = recover_from_truncation(
+            agent, self._response(), FINISH_REASON_LENGTH, MagicMock(),
+            messages=[], conversation_history=None, api_kwargs={},
+            api_call_count=0, effective_task_id=None, current_turn_user_idx=None,
+            length_continue_retries=0, truncated_response_parts=[],
+            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
+        )
+
+        assert verdict.action == "return"
+        result = verdict.result or {}
+        assert result.get("failed") is True
+        assert result.get("final_response") == _CONTEXT_OVERFLOW_PARTIAL_FINAL
+        # No fragment or nudge was appended to the transcript.
+        assert result.get("messages") == []
+
+    def test_normal_stub_is_not_treated_as_terminal(self):
+        from agent.turn_truncation import (
+            _CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            recover_from_truncation,
+        )
+
+        agent = self._mock_agent()
+        verdict = recover_from_truncation(
+            agent, self._response(overflow_terminal=False), FINISH_REASON_LENGTH,
+            MagicMock(),
+            messages=[], conversation_history=None, api_kwargs={},
+            api_call_count=0, effective_task_id=None, current_turn_user_idx=None,
+            length_continue_retries=0, truncated_response_parts=["recovered text"],
+            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
+        )
+        # Not the overflow-terminal final; the normal continuation path runs
+        # (no early return with the overflow message).
+        result = (verdict.result or {}) if verdict.action == "return" else None
+        assert result is None or result.get("final_response") != _CONTEXT_OVERFLOW_PARTIAL_FINAL


### PR DESCRIPTION
## Summary

Reference implementation for #106260 — when a stream delivered text and then died on a **context-overflow** error, the partial content (often tens of KB) was seeded as a length-continuation stub. In a session whose transcript compression cannot recover (all messages inside `protect_last_n` → `no_progress`, or the summary would itself be larger → `would_grow`), every later request is *larger* than the one that just failed — an unrecoverable loop that looks like a 30+ minute hang and can only be killed by ending the session.

## Mechanism (from the issue evidence + code)

1. Stream hits the provider context ceiling mid-delivery; `chat_completion_helpers._partial_stream_stub()` returns a stub carrying the **full recovered text** (no char cap) with `finish_reason=length`.
2. The length-continuation machinery appends the stub (tens of KB) + a nudge to the transcript, so the next request is bigger and fails earlier — the two stubs in session A alone were ~119K chars (~34K tokens) of a 64K budget.
3. Compression cannot break the loop when `protect_last_n` covers the whole (short) conversation (`no_progress`), or when the compressed result would itself grow (`would_grow`).
4. `#98722`'s "compression exhausted → clean-session recovery" contract is defeated because the stub was already appended before the overflow terminal fired.

## Fix

For exactly the `FailoverReason.context_overflow` error class (already labelled by `classify_api_error` with `should_compress=True` — no new classifier):

- `_partial_stream_stub()` returns an **EMPTY stub marked `_overflow_terminal`** (no recovered text seeded) with a WARNING.
- `recover_from_truncation()` treats `_overflow_terminal` as terminal **before** any continuation phase: the turn ends via the recovery contract with an actionable message (`… start a new session (or /new) …`), `failed=True`, **carrying the `compression_exhausted` typed bit** so the gateway's existing `_hmwa_compression_exhaustion_reset` path resets/moves future input to a clean session (the transcript is not polluted with the partial).

Scope notes (adjusted after review):

- **`payload_too_large` (HTTP 413) is deliberately NOT included** in the terminal contract — it has its own byte-scored recovery owner (`turn_overflow._recover_payload_too_large`, #88960/#47339) and keeps its normal continuation stub.
- Everything else is unchanged: network-stall partials, output-cap truncation, mid-tool-call drops and content-filter stalls still run their normal continuation/fallback paths (verified by regression: a normal stub without the marker is not treated as terminal).

## Why this error class is safe to make terminal

- The transcript already **cannot fit** — re-sending any continuation is guaranteed to re-enter the same overflow (the issue logs show `max compression attempts (3) reached` before/around each stub).
- `should_compress=True` means these errors already gate compression elsewhere; we reuse the established label.
- Fail direction is safe: worst case on a classification edge is that one overflow-doomed turn ends early with an explicit message instead of silently growing forever.

## Tests

`tests/run_agent/test_overflow_partial_terminal_106260.py`:
- stub builder carries the marker with empty content (normal stubs do not),
- a real streamed partial hitting `"This model's maximum context length is 128000 tokens…"` returns the terminal (empty) stub,
- a real streamed partial hitting a 413 payload-too-large error **keeps** its content and is **not** terminal,
- `recover_from_truncation` ends the turn (no fragment/nudge appended) on the marker with `failed=True` + `compression_exhausted=True`; a normal stub still runs the continuation path.

67 streaming/continuation regressions pass; gateway `test_35809_auto_reset_clean_context.py` covers the actual `compression_exhausted` reset body.

Open to maintainer design input — the deeper question (whether partial-content preservation vs context budget should be a configurable policy, and whether `protect_last_n` needs an overflow escape hatch) is worth a design decision; this PR removes the unbounded-growth failure mode while that is debated.
