### PR TITLE
fix(gateway): silence expected launchctl bootout/kickstart noise on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3530,7 +3530,11 @@ def _launchctl_bootstrap(domain: str, plist_path, label: str, *, timeout: int = 
         if exc.returncode != _LAUNCHCTL_BOOTSTRAP_EIO:
             raise
         # Stale registration — bootout the leftover label and bootstrap once more.
-        subprocess.run(["launchctl", "bootout", f"{domain}/{label}"], check=False, timeout=timeout)
+        # Captured: the bootout is best-effort (a drained job may already be
+        # unloaded), so its expected 3/113/125 stderr must not leak to the terminal.
+        subprocess.run(
+            ["launchctl", "bootout", f"{domain}/{label}"],
+            check=False, timeout=timeout, **_CAPTURE_TEXT)
         subprocess.run(bootstrap, check=True, timeout=timeout)
 
 
@@ -3912,7 +3916,8 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     # Bootout/bootstrap so launchd reads the new definition; bootstrap can fail silently under load
     # during a drain, and KeepAlive can't revive an unregistered job.
-    subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
+    # Captured: best-effort (the job may already be unloaded), keep expected noise off the terminal.
+    subprocess.run(["launchctl", "bootout", target], check=False, timeout=90, **_CAPTURE_TEXT)
     _reload_budget = _launchd_reload_budget()
     # Wait out the old gateway's drain first so the budget isn't burned on guaranteed EIO ("already loaded").
     if gateway_pid is not None and not _wait_for_pid_exit(gateway_pid, _reload_budget):
@@ -3972,7 +3977,10 @@ def launchd_install(force: bool = False):
 
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{get_launchd_label()}"], check=False, timeout=90)
+    # Captured: uninstalling an already-unloaded job is fine — don't print Boot-out failed: 3.
+    subprocess.run(
+        ["launchctl", "bootout", f"{_launchd_domain()}/{get_launchd_label()}"],
+        check=False, timeout=90, **_CAPTURE_TEXT)
     if plist_path.exists():
         plist_path.unlink()
         print(f"✓ Removed {plist_path}")
@@ -4129,7 +4137,9 @@ def launchd_restart():
                 print("⚠ launchd did not revive the gateway after its graceful exit — forcing restart")
             else:
                 print(f"⚠ Gateway drain timed out after {wait_budget:.0f}s — forcing launchd restart")
-        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        # Captured: an unloaded job (3/113/125) is the expected case below, which
+        # prints its own ↻ line — and e.stderr feeds the update_cmd failure diagnostic.
+        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90, **_CAPTURE_TEXT)
         _launchd_ok("✓ Service restarted")
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
@@ -4139,7 +4149,9 @@ def launchd_restart():
         print("↻ launchd job was unloaded; reloading")
         try:
             # After a drain the job is usually still registered (bootstrap would hit EIO): boot it out first.
-            subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
+            # Captured: best-effort (the job may already be unloaded after the drain),
+            # so an expected Boot-out failed: 3 must not leak past the ↻ line below.
+            subprocess.run(["launchctl", "bootout", target], check=False, timeout=90, **_CAPTURE_TEXT)
             plist_path = str(get_launchd_plist_path())
             subprocess.run(["launchctl", "bootstrap", _launchd_domain(), plist_path], check=True, timeout=30)
             subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2463,6 +2463,73 @@ class TestLaunchctlBootstrapEioRetry:
         assert excinfo.value.returncode == 5
 
 
+class TestLaunchdExpectedNoiseIsCaptured:
+    """Expected launchctl failures must not leak stderr to the terminal.
+
+    When the job is unloaded, ``kickstart -k`` fails with 3/113/125 and the
+    recovery bootout is best-effort — both used to inherit the terminal's
+    stderr, printing ``Could not find service ...`` / ``Boot-out failed: 3``
+    around the CLI's own ``↻ launchd job was unloaded`` line.
+    """
+
+    def test_eio_recovery_bootout_captures_output(self, monkeypatch):
+        """The stale-EIO bootout in ``_launchctl_bootstrap`` is best-effort."""
+        calls = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            calls.append((cmd, kwargs))
+            if cmd[1] == "bootstrap" and len([c for c, _ in calls if c[1] == "bootstrap"]) == 1:
+                raise subprocess.CalledProcessError(5, cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli._launchctl_bootstrap("gui/501", "/tmp/ai.hermes.gateway.plist", "ai.hermes.gateway")
+
+        bootouts = [kw for cmd, kw in calls if cmd[1] == "bootout"]
+        assert len(bootouts) == 1
+        assert bootouts[0].get("capture_output") is True
+
+    def test_unloaded_restart_captures_kickstart_and_bootout(self, monkeypatch, capsys):
+        """``launchd_restart`` on an unloaded job keeps the terminal clean.
+
+        The kickstart error stays available as ``e.stderr`` for the update_cmd
+        diagnostic instead of being printed raw by launchctl.
+        """
+        run_kwargs = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: None)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: "/tmp/ai.hermes.gateway.plist")
+        monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+
+        def fake_run(cmd, **kwargs):
+            run_kwargs.append((cmd, kwargs))
+            if cmd[:2] == ["launchctl", "kickstart"] and "-k" in cmd:
+                raise subprocess.CalledProcessError(3, cmd, stderr="Could not find service")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        by_verb: dict[str, list] = {}
+        for cmd, kwargs in run_kwargs:
+            by_verb.setdefault(cmd[1], []).append((cmd, kwargs))
+        # The `-k` kickstart whose 3/113/125 failure is the handled
+        # unloaded case must capture; the post-bootstrap kickstart stays
+        # loud (its failure propagates to the domain fallback).
+        dash_k = [k for cmd, k in by_verb.get("kickstart", []) if "-k" in cmd]
+        assert dash_k, run_kwargs
+        assert all(k.get("capture_output") is True for k in dash_k)
+        assert by_verb.get("bootout"), run_kwargs
+        assert all(k.get("capture_output") is True for _, k in by_verb["bootout"])
+        out = capsys.readouterr().out
+        assert "↻ launchd job was unloaded; reloading" in out
+        assert "✓ Service restarted" in out
+
+
 class TestRetryLaunchctlBootstrapUntilRegistered:
     """`_retry_launchctl_bootstrap_until_registered` — salvage of #53277.
 


### PR DESCRIPTION
## What does this PR do?

On macOS, a restart against an **unloaded** launchd job prints raw launchctl errors around the CLI's own status lines:

```
Could not find service "ai.hermes.gateway" in domain for user gui: 501
↻ launchd job was unloaded; reloading
Boot-out failed: 3: No such process
✓ Service restarted
```

The first and third lines are launchctl's stderr leaking straight to the terminal. The best-effort `bootout` calls (`check=False`, result unused) and the handled `kickstart -k` in `launchd_restart` all inherit stderr. Exit codes 3/113/125 mean "job not loaded" — the expected case on this path, already classified by `_launchd_error_indicates_unloaded` — so the noise is cosmetic but reads as a failure.

The fix captures those calls with the existing `_CAPTURE_TEXT` idiom (same precedent as the reload helper, which already runs `bootout ... 2>/dev/null`). The kickstart error stays available as `e.stderr` for the `update_cmd` failure diagnostic instead of printing raw. The post-bootstrap `kickstart` (no `-k`) intentionally stays loud — its failure propagates to the domain-unsupported fallback, where visibility matters.

## Related Issue

Fixes #106273

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py` (+12/-5): add `**_CAPTURE_TEXT` to 5 launchctl calls — stale-EIO recovery bootout in `_launchctl_bootstrap`, in-process bootout in `refresh_launchd_plist_if_needed`, bootout in `launchd_uninstall`, `kickstart -k` + recovery bootout in `launchd_restart`. No behavior change besides captured output.
- `tests/hermes_cli/test_gateway_service.py` (+67): new `TestLaunchdExpectedNoiseIsCaptured` with 2 invariant tests (EIO-recovery bootout captures; unloaded restart captures `-k` kickstart + bootout and still prints `↻`/`✓`).

## How to Test

1. Unit (unloaded path without touching a real launchd domain):
   `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -k TestLaunchdExpectedNoiseIsCaptured`
2. Repro the original noise (macOS): `launchctl bootout gui/\$(id -u)/ai.hermes.gateway`, then `hermes gateway restart` — before: `Could not find service ...` / `Boot-out failed: 3` leak around the `↻` line; after: only `↻ launchd job was unloaded; reloading` → `✓ Service restarted`.
3. Manual end-to-end on a loaded job (this PR): `hermes gateway restart` → exit 0, gateway re-supervised by launchd under a fresh PID, no stderr leak.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (API search for bootout-stderr coverage: none; related #88848/#74973/#43842/#40831 concern supervision correctness, not this output)
- [x] My PR contains **only** changes related to this fix/feature (2 files, one logical change)
- [x] I've run `scripts/run_tests.sh` on the touched area and all tests pass (4 files: `test_gateway_service`, `test_update_launchd_unloaded_gateway`, `test_update_launchd_restart_verification`, `test_gateway_restart_loop` → 427 passed, 0 failed; new tests proven red on base)
- [x] I've added tests for my changes (2 invariant tests, red-on-base verified)
- [x] I've tested on my platform: macOS (darwin, arm64) — `hermes gateway restart` exit 0, gateway re-supervised (fresh PID)

Note: the wider `tests/hermes_cli/` run shows pre-existing failures unrelated to this change (`test_update_launchd_fleet_restart` 3, `test_update_autostash` 9, `test_web_server_cron_profiles` 23, pty-bridge files, etc.) — verified identical counts on unmodified base via a `HEAD~1` worktree.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (code comments at each call site explain the capture; no user-facing behavior/doc change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config touched)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A beyond macOS (all touched call sites are launchd/macOS-only; no shared helper signatures changed)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A