### PR TITLE
fix(cron): NixOS workers no longer fail the systemd scope probe (salvage #105436)

### DIFF
--- a/contributors/emails/sgarrand@gmail.com
+++ b/contributors/emails/sgarrand@gmail.com
@@ -1,0 +1,2 @@
+sgarrand
+# PR #102587 (earliest NixOS systemd probe fix; co-author credit on #105436 salvage)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1911,6 +1911,7 @@ class TestSystemdCgroupIsolation:
 
         return fake_popen, captured
 
+    @pytest.mark.linux_only
     def test_wraps_in_systemd_scope_when_supervisor_and_available(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2131,6 +2132,7 @@ class TestSystemdCgroupIsolation:
 
         assert session.systemd_unit == ""
 
+    @pytest.mark.linux_only
     def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2165,6 +2167,7 @@ class TestSystemdCgroupIsolation:
         assert stop_unit.call_args.args[0].endswith(".scope")
         killpg.assert_not_called()
 
+    @pytest.mark.linux_only
     def test_pty_spawn_is_wrapped_in_systemd_scope(self, registry, monkeypatch, _gateway_identity):
         """Interactive executors receive the same sibling-cgroup isolation."""
         from ptyprocess import PtyProcess
@@ -2196,6 +2199,7 @@ class TestSystemdCgroupIsolation:
         assert argv[-3:] == ["/bin/bash", "-lic", "set +m; codex"]
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
+    @pytest.mark.linux_only
     def test_pty_spawn_failure_reaps_scope_before_distinct_pipe_fallback(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2251,6 +2255,7 @@ class TestSystemdCgroupIsolation:
             f"hermes-worker-{session.id}-pipe-fallback.scope"
         )
 
+    @pytest.mark.linux_only
     def test_pty_spawn_failure_does_not_fallback_when_scope_reap_fails(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2345,6 +2350,7 @@ class TestSystemdCgroupIsolation:
         assert session.id in registry._finished
         assert session.id not in registry._running
 
+    @pytest.mark.linux_only
     def test_systemd_run_user_scope_available_caches_after_probe(
         self, registry, monkeypatch
     ):
@@ -2452,6 +2458,7 @@ class TestSystemdCgroupIsolation:
         assert "/bin/true" not in payload, probe_argv
         assert payload[:3] == ["/bin/sh", "-c", "exit 0"], probe_argv
 
+    @pytest.mark.linux_only
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
         """Concurrent first-use callers must wait for one definitive probe.
 
@@ -2499,6 +2506,7 @@ class TestSystemdCgroupIsolation:
         assert results == [True, True]
         assert len(probe_calls) == 1
 
+    @pytest.mark.linux_only
     def test_failed_systemd_probe_retries_after_cache_ttl(self, monkeypatch):
         import tools.process_registry as pr
 

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2430,33 +2430,29 @@ class TestSystemdCgroupIsolation:
         assert "XDG_RUNTIME_DIR" not in os.environ
         assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ
 
-    def test_probe_uses_portable_payload_not_hardcoded_bin_true(
-        self, registry, monkeypatch
-    ):
-        """The probe payload must not hardcode ``/bin/true``: NixOS has no FHS
-        ``/bin`` (only ``sh``), so an absolute ``/bin/true`` probe fails there for
-        a reason unrelated to scope availability and disables restart-safe cron
-        dispatch on every scheduled fire (#105365). The payload is
-        ``/bin/sh -c 'exit 0'``, which exists on every Linux."""
+    @pytest.mark.linux_only
+    def test_probe_succeeds_without_bin_true(self, monkeypatch):
+        """An absent ``/bin/true`` must not make a usable scope fail its probe."""
         import tools.process_registry as pr
 
         monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0, raising=False)
-        probe_calls = []
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0)
+        real_run = subprocess.run
+        executed = []
 
-        def fake_run(*args, **kwargs):
-            probe_calls.append(args)
-            return subprocess.CompletedProcess(args=args[0], returncode=0)
+        def systemd_run_on_nixos_shaped_root(argv, **kwargs):
+            # Simulate NixOS's missing executable, but run the selected replacement.
+            payload = argv[argv.index("--") + 1 :]
+            if payload[0] == "/bin/true":
+                return subprocess.CompletedProcess(payload, 127, stderr=b"No such file or directory")
+            executed.append(payload)
+            return real_run(payload, **kwargs)
 
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
-        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr("subprocess.run", systemd_run_on_nixos_shaped_root)
 
         assert pr._systemd_run_user_scope_available() is True
-        probe_argv = probe_calls[0][0]
-        sep_idx = probe_argv.index("--")
-        payload = probe_argv[sep_idx + 1 :]
-        assert "/bin/true" not in payload, probe_argv
-        assert payload[:3] == ["/bin/sh", "-c", "exit 0"], probe_argv
+        assert len(executed) == 1, "payload must really run (exit 0) on the host, not just be spelled right"
 
     @pytest.mark.linux_only
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2424,6 +2424,34 @@ class TestSystemdCgroupIsolation:
         assert "XDG_RUNTIME_DIR" not in os.environ
         assert "DBUS_SESSION_BUS_ADDRESS" not in os.environ
 
+    def test_probe_uses_portable_payload_not_hardcoded_bin_true(
+        self, registry, monkeypatch
+    ):
+        """The probe payload must not hardcode ``/bin/true``: NixOS has no FHS
+        ``/bin`` (only ``sh``), so an absolute ``/bin/true`` probe fails there for
+        a reason unrelated to scope availability and disables restart-safe cron
+        dispatch on every scheduled fire (#105365). The payload is
+        ``/bin/sh -c 'exit 0'``, which exists on every Linux."""
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0, raising=False)
+        probe_calls = []
+
+        def fake_run(*args, **kwargs):
+            probe_calls.append(args)
+            return subprocess.CompletedProcess(args=args[0], returncode=0)
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert pr._systemd_run_user_scope_available() is True
+        probe_argv = probe_calls[0][0]
+        sep_idx = probe_argv.index("--")
+        payload = probe_argv[sep_idx + 1 :]
+        assert "/bin/true" not in payload, probe_argv
+        assert payload[:3] == ["/bin/sh", "-c", "exit 0"], probe_argv
+
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
         """Concurrent first-use callers must wait for one definitive probe.
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -209,10 +209,8 @@ def _systemd_run_user_scope_available() -> bool:
     the user D-Bus bus even with the binary on PATH (every spawn would fail with
     ``Failed to connect to user bus``), so a cheap probe is run and cached.
 
-    The probe payload is ``/bin/sh -c 'exit 0'`` rather than ``/bin/true``: NixOS has
-    no FHS ``/bin`` (only ``sh``), so an absolute ``/bin/true`` probe fails there for a
-    reason unrelated to scope availability and disables restart-safe cron dispatch on
-    every scheduled fire (#105365).``"""
+    Use ``/bin/sh -c 'exit 0'``: NixOS provides ``/bin/sh`` but not ``/bin/true``
+    (#105365), regardless of the gateway service's PATH."""
     global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
     verdict = _systemd_scope_cached()
     if verdict is not None:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -207,7 +207,12 @@ def _systemd_run_user_scope_available() -> bool:
     """True if ``systemd-run --user --scope`` can create a cgroup.
     ``shutil.which`` alone is insufficient: system services and containers may lack
     the user D-Bus bus even with the binary on PATH (every spawn would fail with
-    ``Failed to connect to user bus``), so a cheap ``/bin/true`` probe is run and cached."""
+    ``Failed to connect to user bus``), so a cheap probe is run and cached.
+
+    The probe payload is ``/bin/sh -c 'exit 0'`` rather than ``/bin/true``: NixOS has
+    no FHS ``/bin`` (only ``sh``), so an absolute ``/bin/true`` probe fails there for a
+    reason unrelated to scope availability and disables restart-safe cron dispatch on
+    every scheduled fire (#105365).``"""
     global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
     verdict = _systemd_scope_cached()
     if verdict is not None:
@@ -228,7 +233,7 @@ def _systemd_run_user_scope_available() -> bool:
                     # Unique unit avoids collisions; the timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
                     result = subprocess.run(
-                        _systemd_scope_argv(binary, probe_unit, "/bin/true"),
+                        _systemd_scope_argv(binary, probe_unit, "/bin/sh", "-c", "exit 0"),
                         capture_output=True,
                         timeout=3,
                         env=systemd_user_bus_env(),


### PR DESCRIPTION
Restart-safe worker dispatch no longer fails solely because NixOS lacks `/bin/true`.

## Changes
- Probe with `/bin/sh -c 'exit 0'`, independent of the gateway's coreutils PATH. Keep current user-bus environment derivation, scope memory limits, caching and fail-closed behavior.
- Replace the argv snapshot with a regression that rejects `/bin/true` but executes the replacement payload.
- Mark the new test and eight existing systemd-only tests Linux-only; preserve native non-Linux coverage.

Root cause: the availability probe confused a missing no-op executable with an unavailable systemd scope.

## Validation
- Real NixOS 25.11 guest with systemd and a healthy lingering user manager: main probe returns false; portable-payload probe returns true. A real worker exits 0 inside `hermes-worker-pr105436-live.scope`.
- Final SHA `df2c0791349f6c928d931509834c4ae94e389922`: macOS affected suites (process registry, restart-safe cron worker, kanban restart handoff): **112 passed, 0 failed, 21 skipped**; NixOS same suites: **129 passed, 0 failed, 4 skipped**.
- Mutation check on real Linux: reverting only the payload to `/bin/true` makes the new regression fail (`False is True`); the final payload passes.
- Real NixOS final-stack checks also pass with inherited `XDG_RUNTIME_DIR`/`DBUS_SESSION_BUS_ADDRESS` absent: current bus discovery derives them and the worker runs in its scope. A controlled nonexistent bus still returns unavailable. Native macOS stays a no-op.
- Ruff, Windows-footgun, compat-pointer and subprocess-stdin checks passed. Targeted ty comparison: 47 existing diagnostics on both base and branch, no new diagnostics.
- Final-stack test, live-E2E, four-angle review and three independent simplify passes completed with no material blockers. CI finished with 24 passing and 13 skipped checks, none failed or pending. Rebase-merged at `0e9fc2cc152b4a4d9fd736f107412ace2a0c2555`; #105436, #102587, #105971 and duplicate #105321 were closed with contributor credit and responses to the existing review comments.

## Credit and scope
- Based on #105436 by @webtecnica, cherry-picked with authorship preserved (submitted September 7, 2026).
- Consolidates the earlier NixOS probe fix/report #102587 by @sgarrand (September 4, 2026). Co-author credit retained; the shell payload avoids needing the fallback-path resolver.
- Includes #105971 by @Cesar-Azeredo, cherry-picked with authorship preserved, to correct the existing macOS test failures rather than suppress failures.
- #105321 addresses the same no-op lookup; the broader resolver stack #102870 is not included and has separate remaining scope.

Fixes #105365.
