### PR TITLE
fix(agent): stop overflowing partial stream recovery (#106260)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2174,11 +2174,14 @@ def cleanup_task_resources(agent, task_id: str) -> None:
 
 
 def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, usage_obj, *,
-    dropped_tool_names=None):
+    dropped_tool_names=None, overflow_terminal=False):
     """Stub for an SSE stream that ended without ``finish_reason`` after
     delivering content. Tagged ``PARTIAL_STREAM_STUB_ID`` + ``FINISH_REASON_LENGTH``
     so the loop enters its continuation/retry path instead of accepting
-    truncated output as a complete turn (#32086)."""
+    truncated output as a complete turn (#32086). An overflow-terminal stub
+    carries no recovered content and ends the turn without continuation: adding
+    the partial fragment would make an already oversized transcript grow
+    monotonically (#106260)."""
     return SimpleNamespace(
         id=PARTIAL_STREAM_STUB_ID,
         model=model_name,
@@ -2190,6 +2193,7 @@ def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, u
         )],
         usage=usage_obj,
         _dropped_tool_names=dropped_tool_names or None,
+        _overflow_terminal=overflow_terminal,
     )
 
 
@@ -3244,10 +3248,32 @@ class _StreamingCall(StreamingWaitMonitor):
         """Tokens already reached the platform: a finish_reason="length" stub fires the
         continuation machinery; tool_calls=None blocks executing incomplete calls.
         Content may be EMPTY on purpose — the loop skips appending an empty stub and
-        only sends the nudge (placeholder text leaked into the stitched response)."""
+        only sends the nudge (placeholder text leaked into the stitched response).
+        A context/payload-overflow failure is terminal: the partial content is
+        already too large to replay safely, so it is not seeded for continuation."""
         error = self.result["error"]
         _partial_text = (getattr(self.agent, "_current_streamed_assistant_text", "") or "").strip() or None
         _partial_names = list(self.result.get("partial_tool_names") or [])
+        _classification = None
+        try:
+            from agent.error_classifier import classify_api_error
+            _classification = classify_api_error(
+                error,
+                provider=str(getattr(self.agent, "provider", "") or ""),
+                model=str(getattr(self.agent, "model", "") or ""),
+            )
+        except Exception as classification_error:
+            # Classification is advisory here; preserving the established partial
+            # recovery path is safer than turning an unclassifiable stream failure
+            # into a terminal turn.
+            logger.debug(
+                "Partial-stream error classification unavailable (%s); preserving normal recovery",
+                type(classification_error).__name__,
+            )
+        _overflow_terminal = _classification is not None and _classification.reason in (
+            FailoverReason.context_overflow,
+            FailoverReason.payload_too_large,
+        )
         if _partial_names:
             # User-visible warning so the user and model both know what was attempted.
             _name_str = ", ".join(_partial_names[:3])
@@ -3260,21 +3286,29 @@ class _StreamingCall(StreamingWaitMonitor):
             logger.warning(
                 "Partial stream dropped tool call(s) %s after %s chars of text; surfaced warning to user: %s",
                 _partial_names, len(_partial_text or ""), error)
-        else:
+        if _overflow_terminal:
+            logger.warning(
+                "Partial stream ended on a context/payload limit after %s chars; "
+                "dropping recovered content instead of seeding continuation",
+                len(_partial_text or ""),
+            )
+        elif not _partial_names:
             logger.warning(
                 "Partial stream delivered before error; returning length-truncated stub with %s chars of "
                 "recovered content so the loop can continue from where the stream died: %s",
                 len(_partial_text or ""), error)
+        if _overflow_terminal:
+            _reset_stale_streak(self.agent)
+            return _build_partial_stream_stub(
+                "assistant", None, None, getattr(self.agent, "model", "unknown"), None,
+                dropped_tool_names=_partial_names, overflow_terminal=True,
+            )
         # Classify content filtering (MiniMax 1027, Azure content_filter, Anthropic refusal)
         # before the error is swallowed into the stub: the loop reads the tag and falls back.
         _stub = _build_partial_stream_stub("assistant", _partial_text, None,
             getattr(self.agent, "model", "unknown"), None, dropped_tool_names=_partial_names)
-        with contextlib.suppress(Exception):
-            from agent.error_classifier import classify_api_error
-            _cls = classify_api_error(
-                error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
-            if _cls.reason == FailoverReason.content_policy_blocked:
-                _stub._content_filter_terminated = True
+        if _classification is not None and _classification.reason == FailoverReason.content_policy_blocked:
+            _stub._content_filter_terminated = True
         _reset_stale_streak(self.agent)  # deltas fired => provider responsive: clear the breaker
         return _stub
 

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -52,6 +52,11 @@ _CEILING_NO_TEXT = (
     "continuation attempt — its reasoning consumed the entire budget each time.\n\nTo fix this:\n"
     "→ Lower reasoning effort: `/reasoning low` or `/reasoning none`\n→ Or raise max_tokens for this model"
 )
+_CONTEXT_OVERFLOW_PARTIAL_FINAL = (
+    "The conversation exceeded the provider's context or payload limit after partial delivery, "
+    "so the partial response was not continued. Start a new session (or /new) to continue "
+    "with a clean transcript."
+)
 
 
 def normalize_response_for_agent(agent: Any, response: Any) -> Any:
@@ -325,6 +330,23 @@ def recover_from_truncation(
         f"{agent.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens",
         force=True,
     )
+
+    # A stream that died after delivery because the request was already too large
+    # cannot be safely continued: appending the recovered fragment or a nudge
+    # makes every later request larger. End through the normal persistence/recovery
+    # contract without mutating the transcript (#106260).
+    if getattr(st.response, "_overflow_terminal", False):
+        agent._flush_status_buffer()
+        agent._vprint(
+            f"{agent.log_prefix}⚠️  Stream ended on a context/payload limit after partial "
+            "delivery — not continuing the oversized transcript.",
+            force=True,
+        )
+        return st.end_turn(
+            _CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            error=_CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            failed=True,
+        )
 
     _trunc_msg = normalize_response_for_agent(agent, response)
     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None

--- a/tests/run_agent/test_overflow_partial_terminal_106260.py
+++ b/tests/run_agent/test_overflow_partial_terminal_106260.py
@@ -1,0 +1,192 @@
+"""Regression tests for #106260.
+
+A stream that delivered text and then failed because the request was already
+past a context/payload limit must not seed that text as a continuation stub.
+The stub is terminal instead, so the loop persists the unchanged transcript
+and gives the user an actionable clean-session recovery instead of growing the
+prompt on every retry.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.chat_completion_helpers import (
+    _StreamingCall,
+    _build_partial_stream_stub,
+)
+from agent.turn_retry_state import TurnRetryState
+from hermes_constants import FINISH_REASON_LENGTH, PARTIAL_STREAM_STUB_ID
+
+
+_OVERFLOW_ERRORS = (
+    "Context length exceeded: max compression attempts (3) reached.",
+    "Context length exceeded: 51,329 tokens. Cannot compress further.",
+    "This model's maximum context length is 200000 tokens. However, your messages resulted in 201234 tokens.",
+    "Request entity too large: 413",
+)
+
+
+def _make_call(error, *, partial_text="x" * 71239, partial_tool_names=None):
+    call = _StreamingCall.__new__(_StreamingCall)
+    call.agent = SimpleNamespace(
+        _current_streamed_assistant_text=partial_text,
+        provider="test-provider",
+        model="test-model",
+        _fire_stream_delta=MagicMock(),
+    )
+    call.result = {
+        "error": RuntimeError(error),
+        "partial_tool_names": partial_tool_names or [],
+    }
+    return call
+
+
+def _make_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+def _make_stream_chunk(content=None):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=None)
+    return SimpleNamespace(choices=[choice], model=None, usage=None)
+
+
+@pytest.mark.parametrize("error", _OVERFLOW_ERRORS)
+def test_overflow_partial_stub_is_terminal_and_drops_recovered_text(error):
+    call = _make_call(error)
+
+    stub = call._partial_stream_stub()
+
+    assert stub.id == PARTIAL_STREAM_STUB_ID
+    assert stub.choices[0].finish_reason == FINISH_REASON_LENGTH
+    assert stub.choices[0].message.content is None
+    assert stub._overflow_terminal is True
+
+
+def test_overflow_mid_tool_call_keeps_warning_but_not_recovered_text():
+    call = _make_call(
+        _OVERFLOW_ERRORS[0],
+        partial_text="write preamble " + "y" * 50000,
+        partial_tool_names=["write_file"],
+    )
+
+    stub = call._partial_stream_stub()
+
+    assert stub.choices[0].message.content is None
+    assert stub._overflow_terminal is True
+    warning = call.agent._fire_stream_delta.call_args.args[0]
+    assert "Stream stalled mid tool-call" in warning
+    assert "write_file" in warning
+
+
+def test_transient_partial_stub_preserves_existing_continuation_behavior():
+    call = _make_call("Connection reset by peer", partial_text="partial answer")
+
+    stub = call._partial_stream_stub()
+
+    assert stub.choices[0].message.content == "partial answer"
+    assert getattr(stub, "_overflow_terminal", False) is False
+
+
+@patch("run_agent.AIAgent._create_request_openai_client")
+@patch("run_agent.AIAgent._close_request_openai_client")
+def test_stream_path_marks_context_overflow_terminal(
+    _mock_close, mock_create, monkeypatch,
+):
+    def _overflowing_stream():
+        yield _make_stream_chunk(content="partial answer")
+        raise RuntimeError("This model's maximum context length is 128000 tokens")
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = lambda *args, **kwargs: _overflowing_stream()
+    mock_create.return_value = mock_client
+
+    agent = _make_agent()
+    agent._current_streamed_assistant_text = "partial answer"
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+    response = agent._interruptible_streaming_api_call({})
+
+    assert response.id == PARTIAL_STREAM_STUB_ID
+    assert response._overflow_terminal is True
+    assert response.choices[0].message.content is None
+
+
+def _terminal_agent():
+    return SimpleNamespace(
+        log_prefix="test: ",
+        _vprint=MagicMock(),
+        _flush_status_buffer=MagicMock(),
+        _cleanup_task_resources=MagicMock(),
+        _persist_session=MagicMock(),
+    )
+
+
+def _terminal_response():
+    return SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        _overflow_terminal=True,
+        choices=[SimpleNamespace(
+            index=0,
+            message=SimpleNamespace(
+                role="assistant",
+                content=None,
+                tool_calls=None,
+                reasoning_content=None,
+            ),
+            finish_reason=FINISH_REASON_LENGTH,
+        )],
+    )
+
+
+def test_recovery_ends_without_appending_fragment_or_nudge():
+    from agent.turn_truncation import _CONTEXT_OVERFLOW_PARTIAL_FINAL, recover_from_truncation
+
+    agent = _terminal_agent()
+    retry = TurnRetryState()
+    messages = [{"role": "user", "content": "ask"}]
+
+    verdict = recover_from_truncation(
+        agent,
+        _terminal_response(),
+        FINISH_REASON_LENGTH,
+        retry,
+        messages=messages,
+        conversation_history=None,
+        api_kwargs={},
+        api_call_count=1,
+        effective_task_id="task",
+        current_turn_user_idx=0,
+        length_continue_retries=0,
+        truncated_response_parts=[],
+        truncated_tool_call_retries=0,
+        retry_count=0,
+        compression_attempts=0,
+    )
+
+    assert verdict.action == "return"
+    assert verdict.result is not None
+    assert verdict.result["failed"] is True
+    assert verdict.result["final_response"] == _CONTEXT_OVERFLOW_PARTIAL_FINAL
+    assert verdict.result["messages"] == messages
+    assert retry.restart_with_length_continuation is False
+    agent._persist_session.assert_called_once_with(messages, None)


### PR DESCRIPTION
## Summary

Fixes #106260.

A streaming request that delivered a large partial response and then failed with a context/payload-limit error was converted into a `finish_reason="length"` continuation stub containing the entire recovered fragment. The continuation path appended that fragment to the transcript and retried, so every failed attempt made the next prompt larger. When compression had no recoverable middle (for example, a short transcript under `protect_last_n`) or refused to grow the transcript, the session could spend a long time retrying a request that could never fit.

This change makes that failure class terminal without mutating the transcript. Normal network partials keep their existing continuation behavior.

## Premise validation before the fix

The defect was reproduced on the checked-out base before any source edit:

- `_StreamingCall._partial_stream_stub()` returned a `partial-stream-stub` whose assistant content was 71,239 characters for each of these errors:
  - `Context length exceeded: max compression attempts (3) reached.`
  - `Context length exceeded: 51,329 tokens. Cannot compress further.`
  - `This model's maximum context length is 200000 tokens...`
- `Connection reset by peer` preserved the same partial content, confirming that the old behavior was not limited to a harmless transient retry.
- The line-level path was verified as `_partial_stream_stub()` -> `recover_from_truncation()` -> `_continue_text()`: the latter appends the partial assistant fragment and a continuation nudge before restarting the request.
- The current compressor already contains protected-tail pressure safeguards (`_MAX_TAIL_MESSAGE_FLOOR` and protected-tail demotion). This patch therefore addresses the stream-failure path that bypassed those safeguards instead of changing `protect_last_n` semantics globally.

Graphify navigation used the repository graph before editing:

- `graphify query '_partial_stream_stub' --context call` located the `_StreamingCall` method and its calls to `classify_api_error()` and `_build_partial_stream_stub()`.
- `graphify explain '._partial_stream_stub()'` confirmed the method's direct neighbors and the `.run()` caller.
- `graphify path '._partial_stream_stub()' 'recover_from_truncation()' --undirected` found the four-hop recovery relationship through the retry-state boundary.

Related history and work were reviewed before implementation:

- #32086 / `test_partial_stream_finish_reason.py` established that ordinary partial streams must continue.
- #68041 established the empty-stub guard; inserting placeholder content defeats that guard and poisons the transcript.
- #106223 covers prompt-filled-window `finish_reason="length"` responses, but not stream failures whose partial text is converted into a stub.
- Open PRs #106264 and #106266 were reviewed. This patch follows the terminal-marker design in #106266 while adding explicit payload-too-large coverage, classification fallback behavior, and an end-to-end recovery assertion.

## Root cause

1. `_partial_stream_stub()` unconditionally copied `_current_streamed_assistant_text` into a synthetic length-truncation response.
2. `recover_from_truncation()` treated the synthetic response like a normal output-cap truncation and `_continue_text()` persisted the fragment plus a user nudge.
3. A context-limit failure proves that replaying the same transcript is unsafe. Appending the recovered fragment makes the next request strictly larger, creating the monotonic growth/death-spiral failure.

## Implementation

- `_build_partial_stream_stub()` now supports an internal `_overflow_terminal` marker.
- `_partial_stream_stub()` reuses the existing `classify_api_error()` taxonomy:
  - `FailoverReason.context_overflow`
  - `FailoverReason.payload_too_large`
- For those reasons it returns an empty terminal stub and does not seed recovered text. A dropped mid-tool-call warning is still emitted immediately so the user is told that the action was not executed.
- `recover_from_truncation()` checks the marker before normalization, continuation, or tool-call retry. It persists the unchanged message list and returns a failed, actionable result directing the user to start a clean session with `/new`.
- Transient errors such as connection resets still produce ordinary partial stubs and continue exactly as before. Content-policy classification also remains intact.

No system prompt, toolset, credential, or persisted historical message is rewritten by the fix. The new path is O(E) for error classification plus the existing O(P) partial-text handling, where E is error-text size and P is already-streamed text; it avoids adding O(P) content to the durable transcript and keeps the new state constant-sized.

## Changed files

- `agent/chat_completion_helpers.py`
  - classify partial stream failures once;
  - mark context/payload-limit stubs terminal;
  - retain normal and content-policy behavior.
- `agent/turn_truncation.py`
  - end terminal overflow stubs before continuation logic;
  - preserve the transcript and return an actionable failed result.
- `tests/run_agent/test_overflow_partial_terminal_106260.py`
  - context-overflow and payload-too-large variants;
  - mid-tool warning preservation without recovered-text persistence;
  - transient regression coverage;
  - real mocked streaming path;
  - terminal recovery with no fragment/nudge mutation.

## Verification

Issue-specific and neighboring tests after rebasing onto `origin/main` (`b7ac3ba1cd`):

```text
HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' \
  scripts/run_tests.sh \
  tests/run_agent/test_overflow_partial_terminal_106260.py \
  tests/run_agent/test_partial_stream_finish_reason.py \
  tests/run_agent/test_streaming.py

3 files, 75 tests passed, 0 failed
```

Additional related coverage before the rebase also passed:

```text
5 files, 198 tests passed, 0 failed
```

Static validation:

```text
ruff check agent/chat_completion_helpers.py agent/turn_truncation.py \
  tests/run_agent/test_overflow_partial_terminal_106260.py
All checks passed.

git diff --check origin/main...HEAD
passed
```

A local stress harness exercised five checks per round: sequential overflow load, transient compatibility, 16-worker concurrent overflow load, terminal recovery persistence/no-mutation, and traced-memory retention. Three consecutive rounds were green:

```text
round 1: 5/5 checks, 2.898s
round 2: 5/5 checks, 2.908s
round 3: 5/5 checks, 2.967s
```

The broad `tests/agent/ tests/run_agent/` run was also attempted. It reached 7,654 discovered tests but reported 74 failures in 25 unrelated files on this Windows checkout, including existing tempfile-lock, timing, shell-hook, credential-pool, and compression-persistence failures. The changed files and issue-specific suites passed; no failure was in the new regression file or the two production files changed here. The broad-run failures were not fixed because they are outside #106260 and would require unrelated scope expansion.

`graphify update . --no-cluster` was attempted after the edit but timed out at the local 420-second tool limit before producing a graph file; no source change or generated artifact was retained from that attempt.

## Security and compatibility

- No credentials, `.env` files, or external state were read or modified.
- Error logs added by this patch contain only the classification outcome and recovered-character count, not recovered content.
- Existing continuation behavior is preserved for non-overflow stream failures.
- The terminal result is deliberately explicit: an already-over-limit transcript must be continued from a clean session rather than silently retried forever.

## Post-publication verification

After opening PR #106275, the pushed head and PR file list were read back and matched commit `5c4bddc724ec1b01b06bebfdac00708a285bb071`:

- `agent/chat_completion_helpers.py`
- `agent/turn_truncation.py`
- `tests/run_agent/test_overflow_partial_terminal_106260.py`

The required post-publication checks were repeated in three consecutive rounds. Each round ran `scripts/run_tests.sh tests/run_agent/test_overflow_partial_terminal_106260.py` plus all five stress checks:

```text
round 1: regression 8 passed in 5.5s; stress 5/5 in 4.423s
round 2: regression 8 passed in 6.6s; stress 5/5 in 2.909s
round 3: regression 8 passed in 5.4s; stress 5/5 in 2.910s
```

GitHub verification completed with no failed checks:

```text
CI Checks Summary: Passed 24, Failed 0
CI workflow: success (run 34314439837)
Docker Build, Test, and Publish: success (run 34314439216)
Nix flake check: success (run 34314439212)
```
