### PR TITLE
fix(compression): tolerate deleted cooldown sessions

### DIFF
--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -298,23 +298,32 @@ class SessionCompressionMixin:
         return _cooldown_row(False, None, None) if row is None else _cooldown_row(True, row[0], row[1])
 
     def restore_compression_failure_cooldown_row(self, session_id: str, snapshot: Dict[str, Any]) -> None:
-        """Restore and verify an exact cooldown-row snapshot. Unlike record/clear this
-        rollback API propagates write and verification failures: cancellation must not be
-        reported mutation-free when compensation failed."""
+        """Restore and verify an exact cooldown-row snapshot.
+
+        Propagate write and verification failures, except when a concurrently
+        deleted session no longer needs cooldown compensation.
+        """
         if not snapshot.get("session_exists", False):
             if self.get_compression_failure_cooldown_row(session_id).get("session_exists", False):
                 raise RuntimeError("cannot restore absent compression cooldown row: session now exists")
             return
         deadline = snapshot.get("cooldown_until")
         error = snapshot.get("error")
-        def _do(conn):
+        def _do(conn) -> bool:
             cursor = conn.execute(
                 "UPDATE sessions SET compression_failure_cooldown_until = ?, "
                 "compression_failure_error = ? WHERE id = ?", (deadline, error, session_id))
+            if cursor.rowcount == 0:
+                return False
             if cursor.rowcount != 1:
-                raise RuntimeError(f"compression cooldown rollback session missing: {session_id}")
-        self._execute_write(_do)
+                raise RuntimeError(f"compression cooldown rollback row count: {cursor.rowcount}")
+            return True
+        restored = self._execute_write(_do)
+        if not restored:
+            return
         actual = self.get_compression_failure_cooldown_row(session_id)
+        if not actual["session_exists"]:
+            return
         expected = _cooldown_row(True, deadline, error)
         if actual != expected:
             raise RuntimeError(

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -2253,6 +2253,49 @@ def test_force_cancel_restores_exact_expired_or_expiring_cooldown_row(
     assert db.get_compression_lock_holder(session_id) is None
 
 
+def test_exact_cooldown_restore_tolerates_a_concurrently_deleted_session(
+    tmp_path: Path,
+) -> None:
+    """A deleted session has no cooldown state left to compensate (#106271)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "COOLDOWN_ROLLBACK_DELETED_SESSION"
+    db.create_session(session_id, source="cli")
+    snapshot = db.get_compression_failure_cooldown_row(session_id)
+    assert snapshot["session_exists"] is True
+
+    assert db.delete_session(session_id) is True
+    db.restore_compression_failure_cooldown_row(session_id, snapshot)
+
+    assert db.get_compression_failure_cooldown_row(session_id) == {
+        "session_exists": False,
+        "cooldown_until": None,
+        "error": None,
+    }
+
+
+def test_exact_cooldown_restore_tolerates_deletion_before_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deletion after the compensating write is still an intentional no-op (#106271)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "COOLDOWN_ROLLBACK_DELETE_DURING_VERIFY"
+    db.create_session(session_id, source="cli")
+    snapshot = db.get_compression_failure_cooldown_row(session_id)
+    real_execute_write = db._execute_write
+
+    def _restore_then_delete(callback):
+        monkeypatch.setattr(db, "_execute_write", real_execute_write)
+        result = real_execute_write(callback)
+        assert db.delete_session(session_id) is True
+        return result
+
+    monkeypatch.setattr(db, "_execute_write", _restore_then_delete)
+    db.restore_compression_failure_cooldown_row(session_id, snapshot)
+
+    assert db.get_compression_failure_cooldown_row(session_id)["session_exists"] is False
+
+
 def test_cooldown_rollback_failure_surfaces_and_releases_lease(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## What does this PR do?

Fixes #106271. A compression rollback now treats only a zero-row cooldown update as an intentional no-op when the session was concurrently deleted. Other unexpected row counts, write errors, and mismatched surviving rows still fail loudly.

The verification read also accepts deletion after the compensating update, before it can inspect the row.

## Related Issue

Fixes #106271

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_state_compression.py`: preserve strict rollback failures while making a deleted session compensation-free.
- `tests/agent/test_compression_concurrent_fork.py`: cover deletion before the update and between update and verification using the real SQLite `SessionDB` path.

## How to Test

Base: `main@b7ac3ba1cdf89f94dfe86de27e01358b194f4053`
Candidate: `f0315ce92dffa405de3083e1cd76e49929608296`
Environment: macOS, CPython 3.11.15, locked `uv` dev environment.

1. On the base, create a `SessionDB` session, capture its cooldown snapshot, delete the session, then call `restore_compression_failure_cooldown_row`; it raises `compression cooldown rollback session missing`.
2. On this head, the same production API sequence returns normally and the session stays absent.
3. `uv run --extra dev --locked pytest -q tests/agent/test_compression_concurrent_fork.py` - 52 passed.
4. `uv run --extra dev --locked ruff check hermes_state_compression.py tests/agent/test_compression_concurrent_fork.py` and `python -m compileall -q ...` - passed.
5. `git diff --check` and exact-file `trufflehog filesystem --no-update --only-verified ...` - passed, 0 verified or unverified secrets.

## Scope Boundary

This changes only deleted-session rollback compensation. It does not change cooldown values for an existing row, connection-close recovery, compression scheduling, or session deletion.

Not run: the repository-wide test suite. `ruff format --check` would reformat extensive untouched baseline content in both owner files, so it was not applied. Direct `ty` checking of the split mixin emits existing host-relationship diagnostics outside this diff.

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs, issue timelines, symbols, error text, branches, and recent landings.
- [x] This PR contains only the rollback fix and regressions.
- [ ] I have run `pytest tests/ -q` and all tests pass; the owning file passed, full suite was not run.
- [x] I have added regression tests.
- [x] I tested on macOS.

### Documentation & Housekeeping

- [x] Documentation is N/A; the behavior is internal.
- [x] `cli-config.yaml.example` is N/A; no config changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered; the change is SQLite state compensation.
- [x] Tool descriptions and schemas are N/A.

## Screenshots / Logs

N/A. The production `SessionDB` before/after sequence and committed regression cover the behavior.