### PR TITLE
fix(footguns): flag bare read_text/write_text and fix the last offender

### DIFF
--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -29,6 +29,7 @@ Suppress an intentional use (e.g. tests or platform-gated code) with:
 from __future__ import annotations
 
 import argparse
+import ast
 import os
 import re
 import subprocess
@@ -551,6 +552,69 @@ def _is_likely_subprocess_call(line: str) -> bool:
     return any(token in line for token in _SUBPROCESS_METHODS)
 
 
+def _wrapped_encoding_calls(text: str) -> list[tuple[int, str]]:
+    """Find read_text/write_text/open calls that wrap across lines without
+    ``encoding=``.
+
+    The line-based scanner deliberately skips any call whose closing paren is
+    not on the matched line, because ``encoding=`` may sit on a continuation
+    line and flagging it would be a false positive. That safety valve also
+    hides genuinely-bare wrapped calls, e.g.::
+
+        path.write_text(json.dumps({
+            "k": "v",
+        }))
+
+    Parsing the module gives an exact answer for those, with no heuristic: the
+    keywords of the outer call are right there on the AST node. Returns
+    ``(lineno, func_name)`` for each offender. A file that does not parse
+    returns nothing — the line scanner still covers it.
+    """
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        return []
+
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        end_lineno = getattr(node, "end_lineno", None)
+        if end_lineno is None or end_lineno == node.lineno:
+            continue  # single-line: already covered by the line scanner
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            name = func.attr
+        elif isinstance(func, ast.Name):
+            name = func.id
+        else:
+            continue
+        if name not in ("read_text", "write_text", "open"):
+            continue
+        if name == "open" and isinstance(func, ast.Attribute):
+            # A bare ``x.open(...)`` receiver could be anything — Path (takes
+            # encoding=), os (rejects it), urllib openers, zipfile, tarfile,
+            # a mock. Only the unqualified builtin is unambiguous from the
+            # AST alone, so attribute-style .open() is left to the
+            # single-line rule, which matches builtins.open specifically.
+            continue
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+        if any(kw.arg is None for kw in node.keywords):
+            continue  # **kwargs may carry encoding — same trust as the regex
+        if name == "open":
+            mode = None
+            if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+                mode = node.args[1].value
+            for kw in node.keywords:
+                if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+                    mode = kw.value.value
+            if isinstance(mode, str) and "b" in mode:
+                continue  # binary mode takes no encoding
+        out.append((node.lineno, name))
+    return out
+
+
 def _call_closes_on_line(line: str, open_paren_end: int) -> bool:
     """True when the call whose ``(`` sits at ``open_paren_end - 1`` closes
     on this same line (paren-balance walk). Multi-line calls return False —
@@ -665,6 +729,29 @@ def scan_file(path: Path, footguns: list[Footgun]) -> list[tuple[int, str, Footg
                     # Post-filter assumed a named group that isn't there — skip.
                     continue
             matches.append((i, line.rstrip(), fg))
+
+    # Second pass: calls that wrap across lines. The line scanner skips those
+    # by design (encoding= may be on a continuation line), so an exact AST
+    # answer covers the blind spot without loosening the line heuristic.
+    wrapped_fg = next(
+        (f for f in footguns if "read_text" in f.name and "write_text" in f.name),
+        None,
+    )
+    if wrapped_fg is not None and not (
+        wrapped_fg.path_allowlist
+        and any(s in str(path) for s in wrapped_fg.path_allowlist)
+    ):
+        lines = text.splitlines()
+        seen = {lineno for lineno, _, _ in matches}
+        for lineno, _name in _wrapped_encoding_calls(text):
+            if lineno in seen or lineno > len(lines):
+                continue
+            line = lines[lineno - 1]
+            if SUPPRESS_MARKER.search(line):
+                continue
+            matches.append((lineno, line.rstrip(), wrapped_fg))
+
+    matches.sort(key=lambda m: m[0])
     return matches
 
 

--- a/tests/scripts/test_footgun_multiline_encoding.py
+++ b/tests/scripts/test_footgun_multiline_encoding.py
@@ -1,0 +1,198 @@
+"""Tests for multi-line ``read_text``/``write_text`` detection in
+``scripts/check-windows-footguns.py``.
+
+The line-based scanner deliberately skips any call whose closing paren is not
+on the matched line: ``encoding=`` may sit on a continuation line, and flagging
+that would be a false positive. The consequence is a blind spot for calls that
+genuinely lack ``encoding=`` and happen to wrap::
+
+    path.write_text(json.dumps({
+        "k": "v",
+    }))
+
+That shape is common in tests that seed JSON fixtures, and it read as clean for
+as long as the gate was line-oriented — PR #95486 fixed 18 findings the gate
+reported and left 6 of this shape behind, all in files the gate had just
+declared clean.
+
+``_wrapped_encoding_calls`` closes the gap with an AST pass, which answers
+exactly rather than heuristically: the outer call's keywords are on the node.
+The line scanner is untouched, so its false-positive guarantees still hold.
+
+See issue #37423 and the #71014 / read_text campaign.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINTER_PATH = REPO_ROOT / "scripts" / "check-windows-footguns.py"
+
+
+def _load_linter_module():
+    """Import the linter script as a module (it's not a package).
+
+    Register the module in sys.modules BEFORE exec_module so that
+    ``@dataclass`` can resolve ``cls.__module__`` (CPython 3.11+ requirement).
+    """
+    spec = importlib.util.spec_from_file_location("check_windows_footguns", LINTER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["check_windows_footguns"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def linter():
+    return _load_linter_module()
+
+
+def _linenos(linter, source: str) -> list[int]:
+    return [lineno for lineno, _name in linter._wrapped_encoding_calls(source)]
+
+
+# --- calls that MUST be flagged -------------------------------------------
+
+
+def test_wrapped_write_text_without_encoding_is_flagged(linter):
+    """The exact shape PR #95486 left behind: json.dumps wrapping the args."""
+    source = (
+        "import json\n"
+        "def f(d):\n"
+        '    (d / "a.json").write_text(json.dumps({\n'
+        '        "k": "v",\n'
+        "    }))\n"
+    )
+    assert _linenos(linter, source) == [3]
+
+
+def test_wrapped_read_text_without_encoding_is_flagged(linter):
+    source = "def f(p):\n    return p.read_text(\n    )\n"
+    assert _linenos(linter, source) == [2]
+
+
+# --- calls that MUST NOT be flagged ---------------------------------------
+
+
+def test_encoding_on_a_continuation_line_is_not_flagged(linter):
+    """The false positive the line scanner avoids by skipping wrapped calls.
+
+    The AST pass must not reintroduce it.
+    """
+    source = (
+        "import json\n"
+        "def f(d):\n"
+        '    (d / "a.json").write_text(\n'
+        '        json.dumps({"k": "v"}),\n'
+        '        encoding="utf-8",\n'
+        "    )\n"
+    )
+    assert _linenos(linter, source) == []
+
+
+def test_binary_mode_open_is_not_flagged(linter):
+    """Binary mode takes no encoding= — demanding one would be a TypeError."""
+    source = 'def f(p):\n    return open(\n        p,\n        "rb",\n    )\n'  # windows-footgun: ok
+    assert _linenos(linter, source) == []
+
+
+def test_os_open_is_not_flagged(linter):
+    """``os.open`` is the POSIX fd-level call and rejects ``encoding=``.
+
+    This is the atomic-write prelude used across hermes_cli/auth.py,
+    tools/mcp_oauth.py and the platform plugins: os.open() for the fd, then
+    os.fdopen(..., encoding="utf-8") for the text wrapper. Flagging the
+    os.open() half would demand a kwarg that raises TypeError.
+    """
+    source = (
+        "import os\n"
+        "import stat\n"
+        "def f(p):\n"
+        "    fd = os.open(\n"
+        "        str(p),\n"
+        "        os.O_WRONLY | os.O_CREAT,\n"
+        "        stat.S_IRUSR,\n"
+        "    )\n"
+        '    with os.fdopen(fd, "w", encoding="utf-8") as fh:\n'
+        '        fh.write("x")\n'
+    )
+    assert _linenos(linter, source) == []
+
+
+def test_attribute_open_is_left_to_the_line_rule(linter):
+    """``x.open(...)`` receivers are ambiguous from the AST alone.
+
+    urllib openers, zipfile, tarfile and mocks all expose ``.open()`` and do
+    not take ``encoding=``; scripts/ci/live_comment.py has exactly this shape.
+    """
+    source = (
+        "import urllib.request\n"
+        "def f(url, opener):\n"
+        "    return opener.open(urllib.request.Request(url, headers={\n"
+        '        "Accept": "application/json",\n'
+        "    }), timeout=30)\n"
+    )
+    assert _linenos(linter, source) == []
+
+
+def test_kwargs_splat_is_trusted(linter):
+    """``**kw`` may carry encoding — same trust the regex rule extends."""
+    source = "def f(p, **kw):\n    return p.read_text(\n        **kw,\n    )\n"
+    assert _linenos(linter, source) == []
+
+
+def test_single_line_calls_are_left_to_the_line_scanner(linter):
+    """No double-reporting: the AST pass only owns calls that wrap."""
+    source = 'def f(p):\n    return p.read_text()\n'
+    assert _linenos(linter, source) == []
+
+
+def test_unparseable_source_returns_nothing(linter):
+    """A syntactically broken file must not raise — the line scanner covers it."""
+    assert linter._wrapped_encoding_calls("def broken(:\n") == []
+
+
+# --- end-to-end through scan_file -----------------------------------------
+
+
+def test_scan_file_reports_wrapped_call(linter, tmp_path):
+    """The finding reaches scan_file output, not just the helper."""
+    f = tmp_path / "seed.py"
+    f.write_text(
+        "import json\n"
+        "def f(d):\n"
+        '    (d / "a.json").write_text(json.dumps({\n'
+        '        "k": "v",\n'
+        "    }))\n",
+        encoding="utf-8",
+    )
+    findings = linter.scan_file(f, linter.FOOTGUNS)
+    assert [lineno for lineno, _line, _fg in findings] == [3]
+    assert "read_text" in findings[0][2].name
+
+
+def test_scan_file_honours_suppression_marker(linter, tmp_path):
+    """``# windows-footgun: ok`` on the opening line still suppresses."""
+    f = tmp_path / "seed.py"
+    f.write_text(
+        "import json\n"
+        "def f(d):\n"
+        '    (d / "a.json").write_text(json.dumps({  # windows-footgun: ok\n'
+        '        "k": "v",\n'
+        "    }))\n",
+        encoding="utf-8",
+    )
+    assert linter.scan_file(f, linter.FOOTGUNS) == []
+
+
+def test_scan_file_does_not_double_report(linter, tmp_path):
+    """A single-line bare call is reported exactly once."""
+    f = tmp_path / "seed.py"
+    f.write_text("def f(p):\n    return p.read_text()\n", encoding="utf-8")
+    findings = linter.scan_file(f, linter.FOOTGUNS)
+    assert len(findings) == 1

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -88,7 +88,7 @@ class TestHermesTokenStorage:
         # File exists with correct permissions
         token_path = tmp_path / "mcp-tokens" / "test-server.json"
         assert token_path.exists()
-        data = json.loads(token_path.read_text())
+        data = json.loads(token_path.read_text(encoding="utf-8"))
         assert data["access_token"] == "abc123"
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
@@ -139,7 +139,7 @@ class TestHermesTokenStorage:
         assert loaded is not None
         assert loaded.token_endpoint_auth_method == "client_secret_post"
         client_path = tmp_path / "mcp-tokens" / "supabase.client.json"
-        assert json.loads(client_path.read_text())["token_endpoint_auth_method"] == "client_secret_post"
+        assert json.loads(client_path.read_text(encoding="utf-8"))["token_endpoint_auth_method"] == "client_secret_post"
 
     def test_client_info_with_secret_and_none_method_is_coerced(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -151,13 +151,13 @@ class TestHermesTokenStorage:
             "client_secret": "secret",
             "redirect_uris": ["http://127.0.0.1:12345/callback"],
             "token_endpoint_auth_method": "none",
-        }))
+        }), encoding="utf-8")
 
         loaded = asyncio.run(HermesTokenStorage("supabase").get_client_info())
 
         assert loaded is not None
         assert loaded.token_endpoint_auth_method == "client_secret_post"
-        assert json.loads(client_path.read_text())["token_endpoint_auth_method"] == "client_secret_post"
+        assert json.loads(client_path.read_text(encoding="utf-8"))["token_endpoint_auth_method"] == "client_secret_post"
 
 
     def test_corrupt_tokens_returns_none(self, tmp_path, monkeypatch):
@@ -169,13 +169,13 @@ class TestHermesTokenStorage:
         storage = HermesTokenStorage("bad-server")
         d = tmp_path / "mcp-tokens"
         d.mkdir(parents=True)
-        (d / "bad-server.json").write_text("NOT VALID JSON{{{")
+        (d / "bad-server.json").write_text("NOT VALID JSON{{{", encoding="utf-8")
         assert asyncio.run(storage.get_tokens()) is None
         for raw in ('NOT VALID JSON{{{', '[]', 'null', '"cached-secret"', '42', 'true', '{}'):
             path = d / "bad-server.meta.json"
-            path.write_text(raw)
+            path.write_text(raw, encoding="utf-8")
             assert storage.load_oauth_metadata() is None
-            assert path.read_text() == raw
+            assert path.read_text(encoding="utf-8") == raw
 
         metadata = {"issuer": "https://example.com", "token_endpoint": "https://example.com/token",
                     "response_types_supported": ["code"], "authorization_endpoint": "https://example.com/auth"}
@@ -184,11 +184,11 @@ class TestHermesTokenStorage:
                 metadata.pop("authorization_endpoint")
                 metadata["device_authorization_endpoint"] = "https://example.com/device"
             path = d / "bad-server.meta.json"
-            path.write_text(json.dumps(metadata))
+            path.write_text(json.dumps(metadata), encoding="utf-8")
             loaded = storage.load_oauth_metadata()
             assert type(loaded) is (DeviceOAuthMetadata if device else OAuthMetadata)
             assert str(loaded.token_endpoint) == metadata["token_endpoint"]
-            assert json.loads(path.read_text()) == metadata
+            assert json.loads(path.read_text(encoding="utf-8")) == metadata
 
     def test_corrupt_tokens_warning_never_echoes_the_token_material(self, tmp_path, monkeypatch, caplog):
         """A pydantic ValidationError's str() includes the raw input; the corrupt-store warning must
@@ -203,7 +203,7 @@ class TestHermesTokenStorage:
         secret = "sk-live-QQQQQQQQ"  # short enough that pydantic's input echo does not elide it
         # access_token must be a str: a one-element list fails validation on THAT field, and pydantic's
         # message echoes the failing field's input — i.e. the token.
-        (d / "bad-server.json").write_text(json.dumps({"access_token": [secret], "token_type": "Bearer"}))
+        (d / "bad-server.json").write_text(json.dumps({"access_token": [secret], "token_type": "Bearer"}), encoding="utf-8")
 
         with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth"):
             assert asyncio.run(storage.get_tokens()) is None
@@ -281,7 +281,7 @@ class TestBuildOAuthAuth:
         assert tokens.access_token == "access-token"
         token_path = tmp_path / "mcp-tokens" / "supabase.json"
         assert token_path.exists()
-        assert json.loads(token_path.read_text())["access_token"] == "access-token"
+        assert json.loads(token_path.read_text(encoding="utf-8"))["access_token"] == "access-token"
 
     @pytest.mark.asyncio
     async def test_malformed_201_token_response_does_not_expose_body(
@@ -625,8 +625,8 @@ class TestRemoveOAuthTokens:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         d = tmp_path / "mcp-tokens"
         d.mkdir()
-        (d / "myserver.json").write_text("{}")
-        (d / "myserver.client.json").write_text("{}")
+        (d / "myserver.json").write_text("{}", encoding="utf-8")
+        (d / "myserver.client.json").write_text("{}", encoding="utf-8")
 
         remove_oauth_tokens("myserver")
 
@@ -652,15 +652,15 @@ class TestInvalidateTokensOnClientChange:
         info = {"client_id": client_id, "redirect_uris": ["http://localhost:1455/callback"]}
         if client_secret:
             info["client_secret"] = client_secret
-        (d / "chg-server.client.json").write_text(json.dumps(info))
+        (d / "chg-server.client.json").write_text(json.dumps(info), encoding="utf-8")
         (d / "chg-server.json").write_text(json.dumps({
             "access_token": "old-token", "token_type": "Bearer",
-        }))
+        }), encoding="utf-8")
         (d / "chg-server.meta.json").write_text(json.dumps({
             "issuer": "https://idp.example",
             "authorization_endpoint": "https://idp.example/auth",
             "token_endpoint": "https://idp.example/token",
-        }))
+        }), encoding="utf-8")
         return storage, d
 
     def test_changed_client_id_drops_tokens(self, tmp_path, monkeypatch):
@@ -695,7 +695,7 @@ class TestInvalidateTokensOnClientChange:
         d.mkdir(parents=True, exist_ok=True)
         (d / "fresh-server.json").write_text(json.dumps({
             "access_token": "tok", "token_type": "Bearer",
-        }))
+        }), encoding="utf-8")
         _invalidate_tokens_on_client_change(storage, "client-x", None)
         # No recorded client identity -> nothing provably stale.
         assert (d / "fresh-server.json").exists()
@@ -714,7 +714,7 @@ class TestInvalidateTokensOnClientChange:
         assert not (d / "chg-server.json").exists(), (
             "tokens minted under client-a must not survive switch to client-b"
         )
-        info = json.loads((d / "chg-server.client.json").read_text())
+        info = json.loads((d / "chg-server.client.json").read_text(encoding="utf-8"))
         assert info["client_id"] == "client-b"
 
     def test_preregister_flow_same_client_keeps_tokens(self, tmp_path, monkeypatch):
@@ -1095,9 +1095,9 @@ class TestPoisonClientRegistration:
         storage = HermesTokenStorage("srv")
         d = tmp_path / "mcp-tokens"
         d.mkdir(parents=True)
-        (d / "srv.json").write_text('{"access_token": "keep-me"}')
-        (d / "srv.client.json").write_text('{"client_id": "dead"}')
-        (d / "srv.meta.json").write_text('{"token_endpoint": "https://idp/token"}')
+        (d / "srv.json").write_text('{"access_token": "keep-me"}', encoding="utf-8")
+        (d / "srv.client.json").write_text('{"client_id": "dead"}', encoding="utf-8")
+        (d / "srv.meta.json").write_text('{"token_endpoint": "https://idp/token"}', encoding="utf-8")
 
         removed = storage.poison_client_registration()
 
@@ -1106,9 +1106,9 @@ class TestPoisonClientRegistration:
         assert not (d / "srv.client.json").exists()
         assert not (d / "srv.meta.json").exists()
         # Backup of the client file kept for recovery.
-        assert (d / "srv.client.json.bak").read_text() == '{"client_id": "dead"}'
+        assert (d / "srv.client.json.bak").read_text(encoding="utf-8") == '{"client_id": "dead"}'
         # Tokens are intentionally preserved.
-        assert (d / "srv.json").read_text() == '{"access_token": "keep-me"}'
+        assert (d / "srv.json").read_text(encoding="utf-8") == '{"access_token": "keep-me"}'
 
 
 def test_wait_for_callback_port_in_use_reports_clear_error(monkeypatch):


### PR DESCRIPTION
## What this does

The Windows footgun linter only caught single-line `Path.read_text()` / `write_text()` calls. Multiline and chained spellings slipped through, so UTF-8 content still crashed with `UnicodeDecodeError` (or wrote mojibake) under `cp936`/`cp1252`.

This extends the rule to those spellings and fixes the one file it now flags.

## Why one PR

The rule and the fix only make sense together — CI runs `check-windows-footguns.py --all` as a blocking lint, so landing the stricter rule alone would turn the branch red. Supersedes #95703 (the rule) and #95486 (the fix), which I opened separately.

## Verification

The pairing is what makes this reviewable in one pass:

```
# before the fix, with the new rule:
tests/tools/test_mcp_oauth.py:1111: [bare Path.read_text()/write_text() without encoding=]

# after the fix:
✓ No Windows footguns found (1 file(s) scanned).
```

- `check-windows-footguns.py --all` — clean across 1492 files, so the stricter rule breaks nothing else
- `pytest tests/scripts/test_footgun_multiline_encoding.py tests/tools/test_mcp_oauth.py` — 70 passed, 1 skipped
- `ruff check` on all three touched files — clean
