### PR TITLE
feat(gateway): add /v1/health/detailed alias mirroring /health/detailed (#46032)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1498,6 +1498,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             ("GET", "/health", self._handle_health),
             ("GET", "/health/detailed", self._handle_health_detailed),
             ("GET", "/v1/health", self._handle_health),
+            ("GET", "/v1/health/detailed", self._handle_health_detailed),
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/api/model/options", self._handle_model_options),
             ("GET", "/v1/capabilities", self._handle_capabilities),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -307,6 +307,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
+    app.router.add_get("/v1/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_get("/api/model/options", adapter._handle_model_options)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
@@ -729,6 +730,29 @@ class TestHealthDetailedEndpoint:
                 assert data["gateway_drainable"] is True
                 assert isinstance(data["pid"], int)
                 assert "updated_at" in data
+
+    @pytest.mark.asyncio
+    async def test_v1_health_detailed_alias_matches(self, adapter):
+        """GET /v1/health/detailed is registered in the real route table and serves the identical body as /health/detailed."""
+        routes = {(method, path) for method, path, _handler in adapter._http_route_table()}
+        assert ("GET", "/v1/health/detailed") in routes
+        app = _create_app(adapter)
+        with patch("gateway.status.read_runtime_status", return_value={
+            "gateway_state": "running",
+            "platforms": {"telegram": {"state": "connected"}},
+            "active_agents": 2,
+            "exit_reason": None,
+            "updated_at": "2026-04-14T00:00:00Z",
+        }), patch("gateway.run._resolve_gateway_model", return_value="test/model"), patch(
+            "gateway.readiness.shutil.disk_usage",
+            return_value=types.SimpleNamespace(total=100, used=25, free=75),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                detailed = await cli.get("/health/detailed")
+                alias = await cli.get("/v1/health/detailed")
+                assert detailed.status == 200
+                assert alias.status == 200
+                assert await detailed.json() == await alias.json()
 
 
     @pytest.mark.asyncio

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -423,6 +423,8 @@ model, disk space, gateway/platform state, active API runs, pending process
 completions, and active delegations. The response exposes status and counts,
 not config values, credentials, paths, commands, queue payloads, or raw errors.
 
+Also available at **GET /v1/health/detailed**.
+
 The public `/health` route remains a cheap liveness probe and does not run
 readiness checks. A degraded readiness result still uses HTTP 200; inspect the
 top-level `status` and `readiness.checks` fields.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
@@ -229,6 +229,8 @@ OpenAI Responses API 格式。通过 `previous_response_id` 支持服务端对�
 
 面向监控和控制平面的已认证就绪检查。它会报告当前 profile 的配置、状态数据库、已配置模型、磁盘空间、gateway/platform 状态、活跃 API run、待处理进程完成通知和活跃 delegation 的有限状态。响应只暴露状态与计数，不包含配置值、凭据、路径、命令、队列载荷或原始错误。
 
+也可通过 **GET /v1/health/detailed** 访问。
+
 公开的 `/health` 路由仍是低开销的存活探针，不运行就绪检查。就绪状态降级时仍返回 HTTP 200；请检查顶层 `status` 和 `readiness.checks` 字段。
 
 ## Runs API（流式友好的替代方案）


### PR DESCRIPTION
## Summary

Implements the fallback option from #46032: add `GET /v1/health/detailed` mirroring the existing authenticated `GET /health/detailed`, completing the `/v1/` route family.

The issue's title option (delete `/v1/health`) was intentionally not taken: `/v1/health` was deliberately added in #3572 for OpenAI-compatible clients that expect the `/v1/` prefix and is documented as such in the API server docs (EN + zh-Hans). Deleting it would break exactly those callers. The issue author's own fallback — adding the missing detailed alias — is additive and resolves the reported inconsistency, so that's what this PR does.

## Changes

- `gateway/platforms/api_server.py`: one route row `("GET", "/v1/health/detailed", self._handle_health_detailed)` in `_http_route_table()`. The `/p/{profile}/...` multiplex mirrors derive from this table automatically; auth is inherited via the existing `@_require_auth` on `_handle_health_detailed`.
- `tests/gateway/test_api_server.py`: `_create_app()` helper registers the alias, and a new invariant test `test_v1_health_detailed_alias_matches` asserts the row exists in the real route table **and** that `GET /health/detailed` and `GET /v1/health/detailed` return 200 with identical JSON bodies.
- `website/docs/user-guide/features/api-server.md` + zh-Hans mirror: one sentence each in the existing `GET /health/detailed` section.

Closes #46032.

## Notes

- Authorship: @Alex-toughman's fork commit [74fd8d8](https://github.com/Alex-toughman/hermes-agent/commit/74fd8d8ff6edfa82c84694f45bed14ce03af58a9) proposed exactly this route row; credited via a `Co-authored-by:` trailer on the commit.
- **Open question:** alias routes (`/v1/health` and the new `/v1/health/detailed`) remain absent from `_CAPABILITY_ENDPOINTS`, consistent with `/v1/health`'s long-standing absence from that table. Happy to add them if the capabilities contract should advertise aliases.

## Test plan

```
scripts/run_tests.sh tests/gateway/test_api_server.py
# 111 passed, 0 failed (110 before + 1 new)
```

RED→GREEN verified: with the route row temporarily removed, the new test fails on the route-table assertion; with the row present, it passes and serves the identical body.
