### PR TITLE
fix(desktop-update): Windows verify resolves checkout root from module path, not cwd

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1644,7 +1644,13 @@ try {
 
     # A zero-exit update is not proof that the runtime survived the update.
     if ($res.Code -eq 0 -and -not $desktopBuildFailed) {
-        $verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path.cwd())"
+        # The Desktop spawns this script with cwd=HERMES_HOME (see main.ts
+        # spawnUpdaterProcess), NOT the checkout, so Path.cwd() is the wrong
+        # project_root and verify fails "executable is missing" on every
+        # desktop-driven update. Derive the checkout from the imported
+        # module's own location instead (hermes_cli/ -> repo root), which is
+        # correct regardless of cwd.
+        $verifyCode = "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path(hermes_cli.main.__file__).resolve().parents[1])"
         $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
         if ($verify.Code -ne 0) {
             $finalCode = 8


### PR DESCRIPTION
## Problem

Every desktop-driven update on Windows **git installs** ends in "update did not finish" even though the update itself succeeds (exit 0, code pulled to latest `main`).

The post-update verification in `scripts/desktop-update/windows.ps1` fails with:

```
RuntimeError: The updated Desktop executable is missing
```

…while `Hermes.exe` is present at `apps/desktop/release/win-unpacked/Hermes.exe` the whole time.

## Root cause

The Desktop app spawns the update script with `cwd = HERMES_HOME` (`spawnUpdaterProcess` in `apps/desktop/electron/main.ts`), **not** the checkout directory, and `windows.ps1` never changes location. The verify step therefore passed `Path.cwd()` as the `project_root` to `verify_windows_desktop_update()`, which then looked for the packaged executable under

```
<HERMES_HOME>\apps\desktop\release\win-unpacked\Hermes.exe   (wrong — always missing)
```

instead of

```
<HERMES_HOME>\hermes-agent\apps\desktop\release\win-unpacked\Hermes.exe   (real)
```

Manual `hermes update` from a terminal works because the shell cwd happens to be the checkout, which is why the CLI path never trips this.

## Repro (before fix)

```powershell
# simulate the Desktop spawn: cwd = HERMES_HOME
cd $env:LOCALAPPDATA\hermes
python -c "import hermes_cli.main; from pathlib import Path; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update(Path.cwd())"
# -> RuntimeError: The updated Desktop executable is missing

# same snippet from the checkout root
cd <checkout>   # <HERMES_HOME>\hermes-agent
# -> exits 0
```

Confirmed identical failure in 4 consecutive desktop-driven update runs (hand-off log), each with the code actually updated and `Hermes.exe` present.

## Fix

Derive the checkout root from the imported module's own location instead of `cwd`:

```python
verify_windows_desktop_update(Path(hermes_cli.main.__file__).resolve().parents[1])
```

`hermes_cli` is imported from the checkout (venv editable install), so `parents[1]` is the repo root regardless of the process cwd. Also avoids string-literal path quoting issues in the embedded `-c` payload.

## Verification (after fix)

- Same snippet from `cwd = HERMES_HOME` (the previously failing environment) → exits 0
- `windows.ps1` parses clean (PowerShell `Parser::ParseFile`)

## Notes

- Only affects **git installs** on Windows updating from the **Desktop UI** (the script exists only in the git checkout, and CLI updates aren't cwd-dependent).
- Impact is cosmetic-but-confusing: the runtime is fully updated; the UI just reports failure. Fixing the verify lets the hand-off report success and stop showing the error on every relaunch.
