### PR TITLE
fix(skills): correct interpreter and ntn query-param syntax in maps/notion examples

### DIFF
--- a/skills/productivity/maps/SKILL.md
+++ b/skills/productivity/maps/SKILL.md
@@ -50,8 +50,8 @@ MAPS=~/.hermes/skills/maps/scripts/maps_client.py
 ### search — Geocode a place name
 
 ```bash
-python $MAPS search "Eiffel Tower"
-python $MAPS search "1600 Pennsylvania Ave, Washington DC"
+python3 $MAPS search "Eiffel Tower"
+python3 $MAPS search "1600 Pennsylvania Ave, Washington DC"
 ```
 
 Returns: lat, lon, display name, type, bounding box, importance score.
@@ -59,7 +59,7 @@ Returns: lat, lon, display name, type, bounding box, importance score.
 ### reverse — Coordinates to address
 
 ```bash
-python $MAPS reverse 48.8584 2.2945
+python3 $MAPS reverse 48.8584 2.2945
 ```
 
 Returns: full address breakdown (street, city, state, country, postcode).
@@ -68,15 +68,15 @@ Returns: full address breakdown (street, city, state, country, postcode).
 
 ```bash
 # By coordinates (from a Telegram location pin, for example)
-python $MAPS nearby 48.8584 2.2945 restaurant --limit 10
-python $MAPS nearby 40.7128 -74.0060 hospital --radius 2000
+python3 $MAPS nearby 48.8584 2.2945 restaurant --limit 10
+python3 $MAPS nearby 40.7128 -74.0060 hospital --radius 2000
 
 # By address / city / zip / landmark — --near auto-geocodes
-python $MAPS nearby --near "Times Square, New York" --category cafe
-python $MAPS nearby --near "90210" --category pharmacy
+python3 $MAPS nearby --near "Times Square, New York" --category cafe
+python3 $MAPS nearby --near "90210" --category pharmacy
 
 # Multiple categories merged into one query
-python $MAPS nearby --near "downtown austin" --category restaurant --category bar --limit 10
+python3 $MAPS nearby --near "downtown austin" --category restaurant --category bar --limit 10
 ```
 
 46 categories: restaurant, cafe, bar, hospital, pharmacy, hotel, guest_house,
@@ -95,9 +95,9 @@ directions from the search point), and promoted tags when available —
 ### distance — Travel distance and time
 
 ```bash
-python $MAPS distance "Paris" --to "Lyon"
-python $MAPS distance "New York" --to "Boston" --mode driving
-python $MAPS distance "Big Ben" --to "Tower Bridge" --mode walking
+python3 $MAPS distance "Paris" --to "Lyon"
+python3 $MAPS distance "New York" --to "Boston" --mode driving
+python3 $MAPS distance "Big Ben" --to "Tower Bridge" --mode walking
 ```
 
 Modes: driving (default), walking, cycling. Returns road distance, duration,
@@ -106,8 +106,8 @@ and straight-line distance for comparison.
 ### directions — Turn-by-turn navigation
 
 ```bash
-python $MAPS directions "Eiffel Tower" --to "Louvre Museum" --mode walking
-python $MAPS directions "JFK Airport" --to "Times Square" --mode driving
+python3 $MAPS directions "Eiffel Tower" --to "Louvre Museum" --mode walking
+python3 $MAPS directions "JFK Airport" --to "Times Square" --mode driving
 ```
 
 Returns numbered steps with instruction, distance, duration, road name, and
@@ -116,8 +116,8 @@ maneuver type (turn, depart, arrive, etc.).
 ### timezone — Timezone for coordinates
 
 ```bash
-python $MAPS timezone 48.8584 2.2945
-python $MAPS timezone 35.6762 139.6503
+python3 $MAPS timezone 48.8584 2.2945
+python3 $MAPS timezone 35.6762 139.6503
 ```
 
 Returns timezone name, UTC offset, and current local time.
@@ -125,8 +125,8 @@ Returns timezone name, UTC offset, and current local time.
 ### area — Bounding box and area for a place
 
 ```bash
-python $MAPS area "Manhattan, New York"
-python $MAPS area "London"
+python3 $MAPS area "Manhattan, New York"
+python3 $MAPS area "London"
 ```
 
 Returns bounding box coordinates, width/height in km, and approximate area.
@@ -135,7 +135,7 @@ Useful as input for the bbox command.
 ### bbox — Search within a bounding box
 
 ```bash
-python $MAPS bbox 40.75 -74.00 40.77 -73.98 restaurant --limit 20
+python3 $MAPS bbox 40.75 -74.00 40.77 -73.98 restaurant --limit 20
 ```
 
 Finds POIs within a geographic rectangle. Use `area` first to get the
@@ -148,7 +148,7 @@ When a user sends a location pin, the message contains `latitude:` and
 
 ```bash
 # User sent a pin at 36.17, -115.14 and asked "find cafes nearby"
-python $MAPS nearby 36.17 -115.14 cafe --radius 1500
+python3 $MAPS nearby 36.17 -115.14 cafe --radius 1500
 ```
 
 Present results as a numbered list with names, distances, and the

--- a/skills/productivity/notion/SKILL.md
+++ b/skills/productivity/notion/SKILL.md
@@ -82,6 +82,7 @@ Syntax notes:
 - `key=value` — string fields
 - `key[nested]=value` — nested object fields
 - `key:=value` — typed assignment (booleans, numbers, null, arrays)
+- `name==value` — query parameter (e.g. `page_size==100`); `:=` is body-only
 
 ### Search
 ```bash
@@ -100,7 +101,7 @@ ntn api v1/pages/{page_id}/markdown
 
 ### Read page content as blocks
 ```bash
-ntn api v1/blocks/{page_id}/children
+ntn api v1/blocks/{page_id}/children page_size==100
 ```
 
 ### Create page from Markdown


### PR DESCRIPTION
## What does this PR do?

Two doc-example correctness fixes in bundled skills (no behavior change, no frontmatter/structure touched):

1. **maps**: every example runs `python $MAPS`, but there is no `python` shim on macOS/minimal Linux while the script's own shebang is `#!/usr/bin/env python3` (`skills/productivity/maps/scripts/maps_client.py:1`) — the documented commands fail verbatim there. Use `python3` throughout (13 lines).
2. **notion**: the Syntax notes document `=` (string) and `:=` (typed body) but never the query-parameter form, leaving paginated reads with no correct example. `ntn api --help` → Request Input Syntax defines `name==value` as the query-parameter form (`:=` is body-only). Documents `==` and shows `page_size==100` on the block-children read.

## Related Issue

No open issue covers these doc lines (searched existing PRs for maps/notion example fixes: none). Happy to close in favor of any duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/productivity/maps/SKILL.md`: `python $MAPS` → `python3 $MAPS` (all 13 occurrences)
- `skills/productivity/notion/SKILL.md`: one `==` line in Syntax notes + `page_size==100` in the block-children example

## How to Test

1. `scripts/run_tests.sh tests/skills/test_authoring_standards.py -q` → 1190 passed, 0 failed
2. Verify against the tools themselves: `ntn api --help` (Request Input Syntax section) confirms `==` = query parameter; `head -1 skills/productivity/maps/scripts/maps_client.py` confirms the `python3` shebang
3. On a macOS host without a `python` shim, the updated maps commands run; the old ones fail with command-not-found

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(skills): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (2 files, doc examples only)
- [x] I've run the skills authoring-standards suite and all tests pass (1190 passed)
- [x] I've added tests for my changes — N/A (doc-example-only change; covered by `test_authoring_standards.py`)
- [x] I've tested on my platform: macOS (darwin, arm64)

### Documentation & Housekeeping

- [x] Relevant documentation — N/A (this PR *is* the doc fix; no frontmatter or section structure changed, HARDLINE standards suite green)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — the maps change *fixes* macOS/minimal-Linux; Linux-with-python-shim and Windows (`py` launcher unaffected — examples use `python3`, same as the shebang) keep working
- [x] Tool descriptions/schemas — N/A