### PR TITLE
fix(tools): resolve raw @session links in session search

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -498,6 +498,73 @@ def _linked_session_id(link: str) -> str:
 
 
 class TestSessionLink:
+    @pytest.mark.parametrize("dispatch_path, embedded_profile, explicit_profile", [
+        ("registry", None, None), ("registry", "work", None),
+        ("registry", "work", "work"), ("registry", "missing", "work"),
+        ("registry", "work", ""),
+        ("inline", None, None), ("inline", "work", None),
+    ])
+    @pytest.mark.parametrize("scroll", [False, True])
+    def test_raw_session_link_resolves_like_profile_path(
+        self, db, tmp_path, monkeypatch, embedded_profile, explicit_profile, scroll,
+        dispatch_path,
+    ):
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        from agent.inline_tool_executors import INLINE_TOOL_EXECUTORS, InlineToolContext
+        from tools.registry import registry
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        target_profile = explicit_profile or embedded_profile
+        target_home = home / "profiles" / target_profile if target_profile else home
+        target_home.mkdir(parents=True, exist_ok=True)
+        target = SessionDB(target_home / "state.db") if target_profile else db
+        agent = SimpleNamespace(
+            _get_session_db_for_recall=lambda: db,
+            session_id="s_current",
+        )
+        context = InlineToolContext(effective_task_id="test-task")
+
+        def dispatch(args):
+            if dispatch_path == "registry":
+                return registry.dispatch("session_search", args, db=db)
+            return INLINE_TOOL_EXECUTORS["session_search"](agent, args, context)
+
+        try:
+            target.create_session("s_link", source="cli")
+            anchor = target.append_message("s_link", role="user", content="linked conversation")
+            # Compare with the existing profile/id path, without depending on
+            # separate profile forwarding in the inline executor (#82938).
+            path = f"{target_profile}/s_link" if target_profile else "s_link"
+            args: dict[str, object] = {"session_id": path}
+            if scroll:
+                args["around_message_id"] = anchor
+            expected_json = dispatch(args)
+            assert isinstance(expected_json, str)
+            expected = json.loads(expected_json)
+            assert expected["success"] is True
+            assert expected["messages"][0]["content"] == "linked conversation"
+
+            value = f"{embedded_profile}/s_link" if embedded_profile else "s_link"
+            args.update(session_id=f"@session:{value}", profile=explicit_profile)
+            actual_json = dispatch(args)
+            assert isinstance(actual_json, str)
+            actual = json.loads(actual_json)
+            assert actual == expected
+        finally:
+            if target is not db:
+                target.close()
+
+    @pytest.mark.parametrize("link", ["@session:", "@session: "])
+    def test_empty_raw_session_link_does_not_browse(self, db, link):
+        result = json.loads(session_search(session_id=link, db=db))
+        assert result["success"] is False
+        assert "error" in result
+
     def test_link_carries_the_named_profile(self):
         assert _session_link("s_oldest", "work") == "@session:work/s_oldest"
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -498,8 +498,12 @@ def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
               around_message_id, window, sort, profile, detail, owned_dbs) -> str:
     """Mode dispatch (see module docstring); scroll wins when an anchor is set.
     Profile DBs opened here are appended to *owned_dbs* for the caller to close."""
-    # A raw `@session:<profile>/<id>` link as session_id: ids never contain "/", so
-    # split on it and adopt the embedded profile only when none was passed.
+    # Accept raw links as well as already-split ids/profile paths.
+    if isinstance(session_id, str) and session_id.startswith("@session:"):
+        session_id = session_id.removeprefix("@session:")
+        if not session_id.strip():
+            return tool_error("Empty session id in @session: link", success=False)
+    # Ids never contain "/"; an explicit profile takes precedence over the link.
     if isinstance(session_id, str) and "/" in session_id:
         emb_profile, _, emb_id = session_id.partition("/")
         if emb_id:
@@ -567,7 +571,7 @@ SESSION_SEARCH_SCHEMA = {
         "(top-N matching sessions, top result fully hydrated); `session_id` + "
         "`around_message_id` = scroll (window of messages around an anchor); "
         "`session_id` alone = read a whole session — how you resolve an "
-        "`@session:<profile>/<id>` link (split on '/' into profile + id); no "
+        "`@session:[<profile>/]<id>` link (pass it verbatim as session_id); no "
         "args = browse recent sessions. Results are actual DB messages, no LLM. "
         "Searches conversation history ONLY — when the user gave a direct "
         "source (URL, file, contact, live system), inspect that first; never "
@@ -620,9 +624,9 @@ SESSION_SEARCH_SCHEMA = {
             "session_id": {
                 "type": "string",
                 "description": (
-                    "Scroll shape. Session to read inside. Use the session_id returned "
-                    "from a prior discovery call. Must be paired with "
-                    "around_message_id."
+                    "Read or scroll shape. Session id, <profile>/<id>, or raw "
+                    "@session:[<profile>/]<id> link. Add around_message_id to "
+                    "scroll; omit it to read the session."
                 ),
             },
             "around_message_id": {
@@ -654,9 +658,8 @@ SESSION_SEARCH_SCHEMA = {
                 "type": "string",
                 "description": (
                     "Optional. Read sessions from another Hermes profile's database "
-                    "(read-only). Use when resolving an `@session:<profile>/<id>` link: "
-                    "pass the profile segment here with session_id as the id segment. "
-                    "Omit to use the current profile."
+                    "(read-only). For a raw @session: link, pass the complete link "
+                    "as session_id; no separate profile argument is needed."
                 ),
             },
         },


### PR DESCRIPTION
## What does this PR do?

Allows `session_search` to resolve complete `@session:<id>` and `@session:<profile>/<id>` links in read and scroll modes without requiring callers to split them first.

The existing parser leaves the `@session:` prefix attached. A named-profile link is therefore parsed as an invalid profile such as `@session:work`; a no-profile link is looked up as a literal session ID and is not found.

This strips one optional leading prefix before the existing profile/ID split. Empty or whitespace-only suffixes return an error instead of accidentally entering browse mode.

No new tools, dependencies, configuration settings, database changes, or agent-executor changes.

## Related work and scope

The separate issue of the agent executor dropping an explicit `profile` argument is already addressed by [#82938](https://github.com/NousResearch/hermes-agent/pull/82938). This PR deliberately excludes that change and does not claim to fix explicit-profile forwarding through the agent.

Raw named-profile links carry their own profile inside `session_id`, so this parser fix works through the existing inline executor without depending on #82938. Existing handler-level explicit-profile precedence remains unchanged and is tested through registry dispatch.

No issue opened for the raw-link finding. Discovered through local code inspection and reproduced with temporary session databases. The pre-submission overlap search was bounded, not an exhaustive guarantee.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/session_search_tool.py`: normalize the optional `@session:` prefix, reject empty links, and describe verbatim raw-link input for read/scroll.
- `tests/tools/test_session_search.py`: 16 parametrized cases using real temporary SQLite databases and profile directories. Compare raw links with existing `profile/id` paths through registry and unchanged inline dispatch; preserve handler-level profile precedence and empty-link rejection.

## How to Test

With a temporary `work` profile containing session `s_link`, compare these exact arguments:

```python
session_search(session_id="work/s_link")
session_search(session_id="@session:work/s_link")
```

Both should return the same conversation. Add the same `around_message_id` to check scrolling. Also check a no-profile raw link and errors for `@session:` / `@session: `.

```sh
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/tools/test_session_search.py -k raw_session_link -j 4 -v
```

Broader Linux selection:

```sh
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/tools/test_session_search.py \
  tests/test_session_search_context_batch.py \
  tests/hermes_cli/test_web_server_session_search.py \
  tests/hermes_cli/test_profiles.py \
  tests/agent/test_inline_tool_executors_memory_args.py \
  tests/run_agent/test_token_persistence_non_cli.py -j 4 -q
```

## Verification — narrowed patch

- Baseline production with revised raw-link tests: **10 failed, 6 passed**. Failures show literal `@session:` IDs or invalid `@session:work` profiles. Passing cases preserve existing behavior.
- Six-file Linux selection: **132 passed, 0 failed, 2 Windows-only skipped**, on both the original base and refreshed upstream `b7ac3ba1cdf89f94dfe86de27e01358b194f4053`.
- Narrowed patch applies cleanly to refreshed upstream. Final pre-publication fetch at `0e9fc2cc152b4a4d9fd736f107412ace2a0c2555` has no changes to the two affected files since the targeted verification base; `git merge-tree` confirms a conflict-free merge. The full suite was not rerun at this later SHA. `agent/inline_tool_executors.py` has no diff.
- Ruff on both changed files and `git diff --check`: passed. `ty` still reports 33 diagnostics on both baseline and narrowed patch; type checking is not globally clean.
- Fresh full standard Linux Python suite: **46,279 passed, 10 failed, 401 skipped** across all **3,862 files**, completed in about 24 minutes (exit 1) on the original base. Command: `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 4 -q --tb=short`. All 69 session-search tests passed. The runner excludes separate integration/e2e/docker lanes by default.
- Nine failures reproduced on unchanged baseline. Rechecking the eight affected files on baseline and patch returned **383 passed, 9 failed** each, with identical failing test IDs. These are the same persistent failures seen in the prior baseline comparison.
- One additional failure, `TestDelegationCleanup::test_timed_out_child_keeps_relay_session_until_its_turn_exits`, asserted that a child had started after a 0.1-second timeout. It passed in both file-set rechecks and in **five additional isolated runs on each of baseline and patch**. Classified as an unreproduced intermittent failure, not a confirmed baseline failure or a proven root cause. No persistent patch-specific failures were observed; the original ten failures remain disclosed.
- Fresh isolated interactive CLI smoke: **four exact tool calls passed** on refreshed upstream: default raw link, named raw link, scroll, and empty-link rejection. Verified persisted tool arguments/results and final reply from actual `gpt-6-astra` / `openai-codex` inference. Synthetic data, isolated HOME/HERMES_HOME, unchanged inline executor, only session_search enabled. Test process shut down and temporary access-only credential removed. Guided arguments, not spontaneous tool selection or Desktop UI coverage.
- Fresh independent automated review: **passed, no actionable findings**. Reviewer exercised all 16 raw-link cases and the complete 69-test session-search file. Separate inline profile forwarding remains explicitly out of scope.
- Native Windows has not yet been rerun on the narrowed patch. Desktop UI and macOS have not been tested.

### Historical evidence — superseded combined patch

The earlier three-file patch also included profile forwarding. Its full Linux suite returned **46,281 passed, 9 failed, 406 skipped**, with all nine failures reproduced on baseline. Its native Windows selection returned **136 passed, 4 baseline-reproduced failures**. Its guided CLI smoke passed five checks, including explicit-profile override. These receipts are retained for development history, not claimed as execution of this revised two-file patch.

## Checklist

- [x] Contributing guide consulted; change remains a bounded bug fix.
- [x] Duplicate check refreshed; overlapping executor fix excluded and #82938 referenced.
- [x] Revised regression tests exercised against broken and fixed parser code.
- [x] Targeted Linux tests and whitespace/lint checks passed.
- [x] Full standard suite completed for final narrowed patch; failures and follow-up comparisons disclosed.
- [ ] Full suite passes — nine baseline-reproduced failures and one unreproduced intermittent failure in the full run; not all green.
- [x] Interactive CLI smoke verified for narrowed patch — four calls/results checked.
- [x] Final automated review completed — passed, no actionable findings.
- [x] Commit follows Conventional Commits: `4147afe4704afc741167db425aa1db64823d3c96`.
- [x] Relevant tool descriptions updated; config/architecture changes N/A.

## Contribution / AI assistance

Contributed by Adam (@adamjralph), with Astra, my AI assistant running in Hermes Agent. I directed the scope and supplied the test environments; Astra handled investigation, implementation, and test execution. Separate Sol-model subagents performed automated review during development. A profile-forwarding issue identified during review was excluded after the overlap audit found existing work in #82938.

A small case of Hermes helping fix Hermes — human-directed and agent-implemented, with test results and limitations disclosed above.
