### PR TITLE
fix(hermes_cli): drop delisted ox-alpha-free from opencode-go curated floor

### DIFF
--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -240,15 +240,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free",
         "muse-spark-1.3-contributor-free",
     ],
-    # Synced against opencode.ai/docs/go + live GET /zen/go/v1/models. "ox-alpha-free" is the
-    # Go-subscription twin of Zen's keyless Ox Alpha (NOT keyless — the Go relay requires a Go key).
+    # Synced against opencode.ai/docs/go + live GET /zen/go/v1/models. Known-delisted models are
+    # REMOVED (the live-first merge would otherwise keep offering a model that 401s): "ox-alpha-free"
+    # — the Go-subscription twin of Zen's keyless Ox Alpha — was delisted 2026-09-09.
     "opencode-go": [
         "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5", "gpt-5.6-luna", "grok-4.5", "glm-5.3",
         "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro",
         "mimo-v2-omni", "minimax-m3", "minimax-m2.7", "minimax-m2.5", "deepseek-v4-pro",
         "deepseek-v4-flash", "qwen3.8-max", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",
         "qwen3.5-plus", "hy3", "hy3-preview", "muse-spark-1.2-contributor", "muse-spark-1.3-contributor",
-        "ox-alpha-free",
     ],
     "kilocode": [
         "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4",

--- a/tests/hermes_cli/test_provider_live_curated_merge.py
+++ b/tests/hermes_cli/test_provider_live_curated_merge.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from hermes_cli.models import (
     _LIVE_FIRST_PICKER_PROVIDERS,
+    _PROVIDER_MODELS,
     provider_model_ids,
 )
 
@@ -85,4 +86,29 @@ class TestGenericProviderLiveCuratedMerge:
         ):
             zen_result = set(provider_model_ids("opencode-zen"))
         assert {"a", "b", "c"} <= zen_result
+
+    def test_opencode_go_merge_does_not_resurrect_delisted_model(self):
+        """#95914 bug class, end-to-end through provider_model_ids with the REAL curated floor:
+        the Go relay (GET /zen/go/v1/models) delisted ox-alpha-free 2026-09-09. The live-first
+        merge must not resurrect it from the curated floor, or the picker keeps offering a model
+        that now 401s (REVERT-PROOF: a stale floor re-adds it and this fails)."""
+        assert "opencode-go" in _LIVE_FIRST_PICKER_PROVIDERS
+        live = ["deepseek-v4-flash", "kimi-k3", "omen-alpha"]  # current Go relay (no ox-alpha-free)
+
+        with (
+            patch("providers.get_provider_profile", return_value=self._make_profile(live)),
+            patch(
+                "hermes_cli.auth.resolve_api_key_provider_credentials",
+                return_value={"api_key": "k", "base_url": ""},
+            ),
+        ):
+            result = provider_model_ids("opencode-go")
+
+        assert "ox-alpha-free" not in result
+        assert {"deepseek-v4-flash", "kimi-k3", "omen-alpha"} <= set(result)
+
+    def test_opencode_go_curated_floor_excludes_delisted_ox_alpha_free(self):
+        """The static floor must not carry a known-delisted Go model (offline fallback must
+        not offer a model that 401s — same policy as opencode-free/x-preview-f-free)."""
+        assert "ox-alpha-free" not in _PROVIDER_MODELS["opencode-go"]
 


### PR DESCRIPTION
## Problem

The opencode-go relay (`GET /zen/go/v1/models`) delisted `ox-alpha-free` (2026-09-09), but `_PROVIDER_MODELS["opencode-go"]` in `hermes_cli/models_catalog_static.py` still carried it. `_profile_live_catalog` merges the curated floor into the live list (live-first for opencode-go), so the model picker kept offering a model that now 401s — the same failure class as #95914 (opencode-free / x-preview-f-free).

Verified against the live relay: 35 models, no `ox-alpha-free`; the loaded module merged floor made it 36.

## Fix

- Remove `ox-alpha-free` from the opencode-go curated floor; document the delisting policy in the adjacent comment.
- Regression tests in `tests/hermes_cli/test_provider_live_curated_merge.py`:
  - `test_opencode_go_merge_does_not_resurrect_delisted_model` — end-to-end through `provider_model_ids` with the real floor (fails if a stale floor resurrects it).
  - `test_opencode_go_curated_floor_excludes_delisted_ox_alpha_free` — floor pin.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_provider_live_curated_merge.py` → 4/4 pass
- Related: `test_opencode_free_live_catalog.py`, `test_opencode_go_in_model_list.py`, `test_opencode_go_profile.py` → 40/40 pass
- Live end-to-end: `provider_model_ids("opencode-go", force_refresh=True)` and `list_authenticated_providers` both return 35 models with no `ox-alpha-free` (pre-fix: 36 incl. it).