### PR TITLE
fix(qqbot): force reconnect when heartbeat ACKs stop arriving (zombie connection guard)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -156,6 +156,7 @@ class QQAdapter(BasePlatformAdapter):
         self._listen_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
+        self._last_hb_ack: Optional[float] = None  # monotonic ts of last op11 ACK
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
         self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
@@ -427,6 +428,7 @@ class QQAdapter(BasePlatformAdapter):
         await asyncio.sleep(delay)
 
         self._heartbeat_interval = 30.0  # reset until Hello
+        self._last_hb_ack = None
         try:
             await self._open_gateway_ws()
             self._mark_connected()
@@ -466,6 +468,15 @@ class QQAdapter(BasePlatformAdapter):
                     await self._ws.send_json({"op": 1, "d": self._last_seq})
                 except Exception as exc:
                     logger.debug("[%s] Heartbeat failed: %s", self._log_tag, exc)
+                    continue
+                if self._last_hb_ack is not None:
+                    ack_age = time.monotonic() - self._last_hb_ack
+                    if ack_age > self._heartbeat_interval * 2.5:
+                        logger.warning(
+                            "[%s] No heartbeat ACK for %.0fs - closing WS to force reconnect",
+                            self._log_tag, ack_age)
+                        self._close_ws_soon()
+                        await asyncio.sleep(self._heartbeat_interval)
 
     async def _send_ws_auth(self, name: str, payload: Dict[str, Any], sent_msg: str, *log_args) -> bool:
         """Send an Identify/Resume payload; returns False if the send raised."""
@@ -524,6 +535,7 @@ class QQAdapter(BasePlatformAdapter):
         if op == 10:  # Hello — reply with Resume (have session) or Identify
             interval_ms = (d if isinstance(d, dict) else {}).get("heartbeat_interval", 30000)
             self._heartbeat_interval = interval_ms / 1000.0 * 0.8  # 80% of server interval
+            self._last_hb_ack = time.monotonic()
             logger.debug(
                 "[%s] Hello received, heartbeat_interval=%dms (sending every %.1fs)",
                 self._log_tag, interval_ms, self._heartbeat_interval)
@@ -543,7 +555,7 @@ class QQAdapter(BasePlatformAdapter):
             else:
                 logger.debug("[%s] Unhandled dispatch: %s", self._log_tag, t)
         elif op == 11:  # Heartbeat ACK
-            pass
+            self._last_hb_ack = time.monotonic()
         elif op == 7:  # Server Reconnect
             logger.info("[%s] Server requested reconnect (op 7)", self._log_tag)
             self._close_ws_soon()


### PR DESCRIPTION
## Problem

The QQ gateway adapter sends op1 heartbeats but handles op11 (heartbeat ACK) as a no-op:

```python
elif op == 11:  # Heartbeat ACK
    pass
```

On a silently-dead TCP connection, `send_json()` still succeeds because the payload only reaches the kernel buffer — no ACK ever comes back, but nothing tracks that. The zombie connection is only detected when the server eventually issues op7, typically ~30 minutes later. Events arriving during that window are lost, and the QQ platform does **not** redeliver group messages after the session is re-established.

## Evidence from production

Running hermes-agent 0.21.1 as a QQ group bot, gateway logs showed sessions being force-reconnected (op7, close code 4009 "Session timed out") every ~30 minutes. A user message sent ~2 minutes before one such reconnect never reached the agent (no conversation turn was logged) — silently lost while heartbeats kept "succeeding" at the TCP level.

## Fix

- record a monotonic timestamp on every op11 Heartbeat ACK (replaces the `pass`)
- baseline the timestamp on Hello (covers connections that are dead from birth) and clear it on reconnect
- in `_heartbeat_loop`, after each successful send, if no ACK has arrived for more than 2.5 heartbeat intervals, log a warning and `_close_ws_soon()` so the existing reconnect/Resume path takes over

## Effect

- silent event-loss window shrinks from ~30 minutes to roughly 90 seconds
- reconnection stays on the existing Resume path, so session continuity is preserved

## Testing

- deployed on a production bot (0.21.1): after applying, the adapter reconnects and completes Identify/READY normally
- `py_compile` passes; on healthy connections the guard is inactive (ACKs arrive every interval)
