### PR TITLE
feat(cron): fire cron_job_failed lifecycle hook on job failure (v2)

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -124,6 +124,21 @@ emitted by each built-in hook site.
     child_status    – exit status string (e.g. "success", "error")
     tool_call_history – redacted tool name/input summary/byte counts/status list
     duration_ms     – wall-clock time of the child run in milliseconds
+
+``cron_job_failed`` (emitted from ``cron/scheduler.py`` when a scheduled
+job fails):::
+
+    job_id          – cron job id (e.g. "abc123def456")
+    job_name        – job name, or the job id when unnamed
+    profile         – Hermes profile the job belongs to ("" when default)
+    error           – human-readable failure text
+    last_run_at     – job's last_run_at value before this run, if any
+    job             – the full job dict (schedule, prompt, script, deliver,
+                      skills, etc.) — useful for reactive self-healing
+                      scripts that need to inspect or rewrite the job
+
+The payload is delivered to the hook script on stdin as JSON (see
+``_serialize_payload``); all fields above arrive under ``extra``.
 """
 
 from __future__ import annotations

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -151,6 +151,36 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     return f"⚠️ Cron '{job_name}' failed: {cleaned}"
 
 
+def _fire_cron_job_failed_hook(job: dict, error: str | None) -> None:
+    """Fire the ``cron_job_failed`` lifecycle hook on a failed cron run.
+
+    Gives reactive consumers (shell hooks, outbound webhooks, plugins) a
+    programmatic failure signal without polling ``jobs.json`` or wrapping
+    per-job delivery paths.  Best-effort: a hook that raises must never
+    crash the scheduler or mask the original job failure — this mirrors the
+    defensive pattern used by the ``on_session_end`` hook in
+    ``agent/turn_finalizer.py``.
+
+    Fired from the worker thread that ran the job, so blocking hook scripts
+    (``subprocess.run`` inside ``agent/shell_hooks.py``) do not freeze the
+    scheduler's event loop or the main gateway loop.
+    """
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+        _invoke_hook(
+            "cron_job_failed",
+            job_id=job.get("id", ""),
+            job_name=job.get("name") or job.get("id") or "",
+            profile=job.get("profile", ""),
+            error=error or "",
+            last_run_at=job.get("last_run_at") or "",
+            job=job,
+        )
+    except Exception as exc:
+        logger.warning("cron_job_failed hook failed: %s", exc)
+
+
 class CronPromptInjectionBlocked(Exception):
     """Raised by _build_job_prompt when the fully-assembled prompt trips the
     injection scanner. Caught in run_job so the operator sees a clean
@@ -4661,6 +4691,11 @@ def run_one_job(
                 )
             else:
                 deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            # Fire the cron_job_failed hook on failure — before delivery so a
+            # broken hook (or a blocking hook script) can never suppress or
+            # delay the failure message itself; hook failures are swallowed.
+            if not success:
+                _fire_cron_job_failed_hook(job, error)
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -216,6 +216,13 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Cron job lifecycle hooks. Fired by cron/scheduler.py from the worker
+    # thread that ran the job. Observers only: return values are ignored.
+    #
+    # cron_job_failed kwargs: job_id: str, job_name: str, profile: str,
+    #   error: str, last_run_at: str, job: dict (full job spec — schedule,
+    #   prompt, script, deliver, skills — for reactive self-healing).
+    "cron_job_failed",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/cron/test_cron_job_failed_hook.py
+++ b/tests/cron/test_cron_job_failed_hook.py
@@ -1,0 +1,117 @@
+"""Tests for the ``cron_job_failed`` lifecycle hook.
+
+The hook fires from ``cron/scheduler.py::run_one_job`` when a job fails
+(error surfaced, success=False), so reactive consumers (shell hooks,
+outbound webhooks, plugins) get a programmatic failure signal without
+polling ``jobs.json``.  It must:
+
+* fire exactly once per failed run, with the full job payload
+* NOT fire on success
+* never raise into the scheduler (a broken hook cannot crash the job loop)
+"""
+
+import cron.scheduler as s
+
+
+def _patch_pipeline(monkeypatch, *, success=True, error=None):
+    """Patch the job pipeline primitives (same shape as test_run_one_job)."""
+
+    def fake_run_job(job):
+        return (success, "out", "final response", error)
+
+    def fake_save(jid, out):
+        return f"/tmp/{jid}.txt"
+
+    def fake_deliver(job, content, adapters=None, loop=None):
+        return None
+
+    def fake_mark(jid, ok, err=None, delivery_error=None):
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", fake_save)
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", fake_mark)
+
+
+def test_failed_job_fires_cron_job_failed_hook(monkeypatch):
+    """A failing job fires the hook with the job spec and error text."""
+    _patch_pipeline(monkeypatch, success=False, error="boom")
+    captured = {}
+
+    def fake_hook(job, err):
+        captured["job"] = job
+        captured["err"] = err
+
+    monkeypatch.setattr(s, "_fire_cron_job_failed_hook", fake_hook)
+
+    job = {"id": "jfail", "name": "nightly", "profile": "work"}
+    s.run_one_job(job)
+
+    assert captured["job"] is job
+    assert captured["err"] == "boom"
+
+
+def test_successful_job_does_not_fire_hook(monkeypatch):
+    """A successful job must NOT fire the failure hook."""
+    _patch_pipeline(monkeypatch, success=True)
+    fired = []
+
+    def fake_hook(job, err):
+        fired.append((job, err))
+
+    monkeypatch.setattr(s, "_fire_cron_job_failed_hook", fake_hook)
+
+    ok = s.run_one_job({"id": "jok", "name": "ok-job"})
+
+    assert ok is True
+    assert fired == []
+
+
+def test_hook_exception_does_not_crash_scheduler(monkeypatch):
+    """A raising hook is swallowed: the job still completes without raising."""
+    _patch_pipeline(monkeypatch, success=False, error="boom")
+
+    def exploding_hook(job, err):
+        raise RuntimeError("hook script exploded")
+
+    monkeypatch.setattr(s, "_fire_cron_job_failed_hook", exploding_hook)
+
+    # run_one_job must not raise even though the hook raises.
+    s.run_one_job({"id": "jboom", "name": "boom-job"})
+
+
+def test_real_hook_function_uses_plugins_invoke_hook(monkeypatch):
+    """The real _fire_cron_job_failed_hook dispatches through
+    hermes_cli.plugins.invoke_hook and swallows its own failures."""
+    import hermes_cli.plugins as plugins
+
+    calls = []
+
+    def fake_plugins_invoke_hook(name, **kwargs):
+        calls.append((name, kwargs))
+
+    monkeypatch.setattr(plugins, "invoke_hook", fake_plugins_invoke_hook)
+
+    job = {"id": "jreal", "name": "real-job", "profile": "ops", "last_run_at": "2026-08-10T00:00:00Z"}
+    s._fire_cron_job_failed_hook(job, "kaput")
+
+    assert len(calls) == 1
+    name, kwargs = calls[0]
+    assert name == "cron_job_failed"
+    assert kwargs["job_id"] == "jreal"
+    assert kwargs["error"] == "kaput"
+    assert kwargs["job"] is job
+
+
+def test_real_hook_function_swallows_exception(monkeypatch):
+    """A failure inside plugins.invoke_hook must be logged, not raised."""
+    import hermes_cli.plugins as plugins
+
+    def raising_invoke_hook(name, **kwargs):
+        raise RuntimeError("plugin dispatch failed")
+
+    monkeypatch.setattr(plugins, "invoke_hook", raising_invoke_hook)
+
+    # Must not raise.
+    s._fire_cron_job_failed_hook({"id": "jx", "name": "x"}, "err")


### PR DESCRIPTION
Retriggering CI for the cron_job_failed hook feature. Original PR #82901 had stale runs from August.