### PR TITLE
fix(telegram): isolate turn-owned status message lifecycle

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3654,25 +3654,30 @@ class GatewayTurnMixin:
         Failed runs keep them as breadcrumbs. Only on adapters with ``delete_message``; failures swallowed."""
         from gateway.run import safe_schedule_threadsafe
         _cleanup_msg_ids, session_key = turn_ctx._cleanup_msg_ids, turn_ctx.session_key
+        delivery = turn_ctx._status_delivery
+        if delivery is not None:
+            delivery.closed = True
         if not (
             turn_ctx._cleanup_progress
             and _cleanup_adapter is not None
-            and _cleanup_msg_ids
             and session_key
             and isinstance(response, dict)
             and not response.get("failed")
             and hasattr(_cleanup_adapter, "register_post_delivery_callback")
         ):
             return
-        _ids_snapshot = list(_cleanup_msg_ids)
         _chat_id_snapshot = turn_ctx.source.chat_id
         _loop_snapshot = asyncio.get_running_loop()
 
         def _cleanup_temp_bubbles() -> None:
+            if delivery is not None:
+                delivery.cleaned = True
+            _ids_snapshot = list(dict.fromkeys(_cleanup_msg_ids))
             async def _delete_all() -> None:
                 for _mid in _ids_snapshot:
                     with suppress(Exception):
-                        await _cleanup_adapter.delete_message(_chat_id_snapshot, _mid)
+                        owner = delivery.owners.get(_mid, _cleanup_adapter) if delivery is not None else _cleanup_adapter
+                        await owner.delete_message(_chat_id_snapshot, _mid)
             with suppress(Exception):
                 safe_schedule_threadsafe(
                     _delete_all(), _loop_snapshot, logger=logger,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -51,6 +51,9 @@ class TurnRunner:
     def __init__(self, runner: "GatewayRunner", ctx: TurnContext) -> None:
         self._runner = runner
         self._ctx = ctx
+        from gateway.status_delivery import StatusDelivery
+        self._status_delivery = StatusDelivery(ctx, lambda: runner._adapter_for_source(ctx.source))
+        ctx._status_delivery = self._status_delivery
 
     # ── shared thread→loop plumbing ─────────────────────────────────────────────────────────
 
@@ -815,7 +818,7 @@ class TurnRunner:
             logger.debug("Failed to attach session title callback", exc_info=True)
 
     def _status_callback_sync(self, event_type: str, message: str) -> None:
-        from gateway.run import _prepare_gateway_status_message, _redact_gateway_user_facing_secrets, _send_or_update_status_coro
+        from gateway.run import _prepare_gateway_status_message, _redact_gateway_user_facing_secrets
         ctx = self._ctx
         if not self._status_live():
             return
@@ -827,12 +830,10 @@ class TurnRunner:
                 _redact_gateway_user_facing_secrets(str(message or ""))[:160],
             )
             return
-        fut = self._schedule(
-            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, event_type, prepared, ctx._status_thread_metadata),
+        self._schedule(
+            self._status_delivery.send(ctx._status_adapter, ctx._status_chat_id, event_type, prepared, ctx._status_thread_metadata),
             f"status_callback ({event_type}) scheduling error",
         )
-        if fut is not None and ctx._cleanup_progress:
-            fut.add_done_callback(self._track_future_cleanup_id)
 
     # ── stream consumer / interim commentary wiring ─────────────────────────────────────────
 

--- a/gateway/status_delivery.py
+++ b/gateway/status_delivery.py
@@ -1,0 +1,66 @@
+"""Turn-owned status delivery, including receipts arriving after final cleanup."""
+
+import asyncio
+import uuid
+from collections import defaultdict
+from contextlib import suppress
+
+
+class StatusDelivery:
+    """One turn, one adapter identity; never lend its status key to another turn."""
+
+    def __init__(self, ctx, current_adapter):
+        self.ctx = ctx
+        self.current_adapter = current_adapter
+        self.token = uuid.uuid4().hex
+        self.closed = False
+        self.cleaned = False
+        self.owners = {}
+        self.tasks = set()
+        self.locks = defaultdict(asyncio.Lock)
+
+    def live(self, adapter):
+        return (
+            not self.closed
+            and self.ctx._run_still_current()
+            and self.current_adapter() is adapter
+        )
+
+    def track(self, result, adapter):
+        if not self.ctx._cleanup_progress or not getattr(result, "success", False):
+            return
+        mid = getattr(result, "message_id", None)
+        if not mid:
+            return
+        mid = str(mid)
+        if self.cleaned:
+            task = asyncio.create_task(self.delete(adapter, mid))
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
+        else:
+            self.owners[mid] = adapter
+            self.ctx._cleanup_msg_ids.append(mid)
+
+    async def delete(self, adapter, mid):
+        # IDs are owned by the transport that returned them, not a replacement bot.
+        with suppress(Exception):
+            await asyncio.wait_for(
+                adapter.delete_message(self.ctx.source.chat_id, mid), 5
+            )
+
+    async def send(self, adapter, chat_id, event_type, content, metadata):
+        from gateway.run import _send_or_update_status_coro
+
+        async with self.locks[event_type]:
+            if not self.live(adapter):
+                return
+            # Recheck inside the lock: a queued callback may outlive this turn.
+            result = await _send_or_update_status_coro(
+                adapter,
+                chat_id,
+                f"{self.token}:{event_type}",
+                content,
+                dict(metadata) if metadata else None,
+            )
+            self.track(result, adapter)
+            return result

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -32,6 +32,7 @@ class TurnContext:
     long_tool_hint_fired: list = field(default_factory=lambda: [False])
     agent_holder: list = field(default_factory=lambda: [None])
     _LONG_TOOL_THRESHOLD_S: float = 30.0
+    _status_delivery: Any = None
     _cleanup_progress: bool = False
     _cleanup_msg_ids: List[str] = field(default_factory=list)
     _progress_metadata: Optional[dict] = None

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3403,19 +3403,36 @@ class TelegramAdapter(BasePlatformAdapter):
         append a fresh bubble on every call. With this method, the first call sends and the message id is
         remembered; subsequent calls with the same (chat_id, status_key) edit that same message in place.
         """
-        key = (str(chat_id), str(status_key))
+        import weakref
+        if not hasattr(self, "_status_locks"):
+            self._status_locks = weakref.WeakValueDictionary()
+        key = (str(normalize_telegram_chat_id(chat_id)), str(status_key),
+               str(self._metadata_thread_id(metadata) or ""))
+        lock = self._status_locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            return await self._send_locked_status(key, chat_id, content, metadata)
+
+    async def _send_locked_status(self, key, chat_id, content, metadata):
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
             result = await self.edit_message(chat_id, cached_id, content, finalize=True, metadata=metadata)
             if result.success:
-                if result.message_id:
+                if result.message_id and self._status_message_ids.get(key) == cached_id:
                     self._status_message_ids[key] = str(result.message_id)
                 return result
             self._status_message_ids.pop(key, None)
         result = await self.send(chat_id, content, metadata=metadata)
         if result.success and result.message_id:
             self._status_message_ids[key] = str(result.message_id)
+            while len(self._status_message_ids) > 2000:
+                self._status_message_ids.pop(next(iter(self._status_message_ids)))
         return result
+
+    def _forget_status_message_id(self, chat_id, message_id):
+        chat = str(normalize_telegram_chat_id(chat_id))
+        for key, mid in list(self._status_message_ids.items()):
+            if str(normalize_telegram_chat_id(key[0])) == chat and str(mid) == str(message_id):
+                self._status_message_ids.pop(key, None)
 
     async def _edit_text(self, chat_id: str, message_id: str, text: str, parse_mode: Any = None) -> None:
         """``editMessageText`` with normalized ids; ``parse_mode=None`` sends plain text."""
@@ -3651,8 +3668,11 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         try:
             await self._bot.delete_message(chat_id=normalize_telegram_chat_id(chat_id), message_id=int(message_id))
+            self._forget_status_message_id(chat_id, message_id)
             return True
         except Exception as e:
+            if "message to delete not found" in str(e).lower() or "message_id_invalid" in str(e).lower():
+                self._forget_status_message_id(chat_id, message_id)
             logger.debug("[%s] Failed to delete Telegram message %s: %s", self.name, message_id, _redact_telegram_error_text(e))
             return False
 

--- a/tests/gateway/test_notification_ownership.py
+++ b/tests/gateway/test_notification_ownership.py
@@ -1,0 +1,235 @@
+"""Notification ownership through actual turn wiring and Telegram transport methods.
+
+Fixture adapted from the isolated incident reproducer; only Bot API I/O is fake.
+"""
+
+import asyncio
+import queue
+from types import SimpleNamespace as NS
+import pytest
+from gateway.config import Platform, PlatformConfig
+from gateway.run import GatewayRunner
+from gateway.run_turn_runner import TurnRunner
+from gateway.turn_context import TurnContext
+from gateway.session import SessionSource
+from gateway.session_context import (
+    set_session_vars,
+    clear_session_vars,
+    get_session_env,
+)
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class Wire:
+    def __init__(self):
+        self.messages = {}
+        self.events = []
+        self.next_id = 90000
+        self.accepted = asyncio.Event()
+        self.release = asyncio.Event()
+        self.block_once = False
+
+    async def chunk(
+        self, chat, text, i, reply, metadata, thread, fallback, errors, **kw
+    ):
+        self.next_id += 1
+        mid = str(self.next_id)
+        self.messages[mid] = {"thread": str(thread), "text": text}
+        self.events.append(["send", mid, str(thread), text])
+        if self.block_once:
+            self.block_once = False
+            self.accepted.set()
+            await self.release.wait()  # server accepted; receipt delayed
+        return NS(message_id=int(mid)), fallback
+
+    async def edit(self, chat, **kw):
+        mid = str(kw["message_id"])
+        self.events.append([
+            "edit",
+            mid,
+            get_session_env("HERMES_SESSION_THREAD_ID"),
+            kw["text"],
+        ])
+        if mid not in self.messages:
+            raise ValueError("Message to edit not found")
+        self.messages[mid]["text"] = kw["text"]
+
+    async def edit_message_text(self, chat_id, **kw):
+        return await self.edit(chat_id, **kw)
+
+    async def delete_message(self, **kw):
+        mid = str(kw["message_id"])
+        self.events.append(["delete", mid])
+        if mid not in self.messages:
+            raise ValueError("Message to delete not found")
+        del self.messages[mid]
+
+
+async def noop(*a, **kw):
+    pass
+
+
+def setup():
+    wire = Wire()
+    a = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    a._bot = wire
+    a._should_attempt_rich = lambda *a, **kw: False
+    a._rich_eligible = lambda *a, **kw: False
+    a._send_chunk_with_retries = wire.chunk
+    a._edit_message_text_with_cooldown = wire.edit
+    a._retrigger_typing = noop
+    a.send_typing = noop
+    g = GatewayRunner.__new__(GatewayRunner)
+    g._adapter_for_source = lambda source: a
+    g.hooks = NS(loaded_hooks=[])
+    return wire, a, g
+
+
+def turn(g, topic):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123456",
+        chat_type="dm",
+        thread_id=topic,
+        user_id="123456",
+    )
+    ctx = TurnContext(
+        source=source,
+        session_key="agent:main:telegram:dm:123456:" + topic,
+        session_id="test-" + topic,
+        run_generation=20,
+        _run_still_current=lambda: True,
+        _cleanup_progress=True,
+        progress_queue=queue.Queue(),
+        progress_mode="all",
+        tool_progress_enabled=True,
+    )
+    tr = TurnRunner(g, ctx)
+    g._run_agent_bind_turn_wiring(ctx, tr, source, "123", False)
+    ctx.progress_callback = tr.progress_callback
+    return ctx, tr
+
+
+async def status(ctx, text):
+    tok = set_session_vars(
+        platform="telegram",
+        chat_id="123456",
+        thread_id=ctx.source.thread_id,
+        session_key=ctx.session_key,
+    )
+    try:
+        before = len(ctx._cleanup_msg_ids)
+        ctx._status_callback_sync("lifecycle", text)
+        for _ in range(100):
+            await asyncio.sleep(0.001)
+            if len(ctx._cleanup_msg_ids) > before:
+                return ctx._cleanup_msg_ids[-1]
+        raise AssertionError("callback did not complete")
+    finally:
+        clear_session_vars(tok)
+
+
+@pytest.mark.asyncio
+async def test_status_ownership_and_late_cleanup():
+    w, a, g = setup()
+    c1, t1 = turn(g, "101")
+    c2, t2 = turn(g, "202")
+    c3, t3 = turn(g, "101")  # even reused session/generation cannot reuse a turn token
+    mids = await asyncio.gather(*(status(c, "Working") for c in (c1, c2, c3)))
+    assert len(set(mids)) == 3
+    assert [w.messages[mid]["thread"] for mid in mids] == ["101", "202", "101"]
+    assert await status(c1, "Still working") == mids[0]
+    await a.delete_message(c1.source.chat_id, mids[0])
+    assert mids[0] not in a._status_message_ids.values()
+    assert await status(c1, "After deletion") != mids[0]
+    for c in (c1, c2, c3):
+        g._run_agent_schedule_bubble_cleanup({"final_response": "done"}, a, c)
+        a.pop_post_delivery_callback(c.session_key, generation=c.run_generation)()
+        await asyncio.sleep(0.01)
+    assert not w.messages
+    assert not a._status_message_ids
+
+    # First receipt arrives after callback invocation; a queued old callback must not send.
+    c, t = turn(g, "303")
+    w.block_once = True
+    pending = asyncio.create_task(
+        t._status_delivery.send(
+            a, c.source.chat_id, "lifecycle", "late", c._status_thread_metadata
+        )
+    )
+    await asyncio.wait_for(w.accepted.wait(), 5)
+    queued = asyncio.create_task(
+        t._status_delivery.send(
+            a, c.source.chat_id, "lifecycle", "stale", c._status_thread_metadata
+        )
+    )
+    g._run_agent_schedule_bubble_cleanup({"final_response": "done"}, a, c)
+    a.pop_post_delivery_callback(c.session_key, generation=c.run_generation)()
+    await asyncio.sleep(0.01)
+    _, replacement, _ = setup()
+    g._adapter_for_source = lambda source: replacement
+    w.release.set()
+    await pending
+    await queued
+    await asyncio.gather(*t._status_delivery.tasks)
+    assert not w.messages
+    assert not a._status_message_ids
+    assert not replacement._status_message_ids
+
+
+@pytest.mark.asyncio
+async def test_adapter_status_cache_serialization_and_invalidation():
+    w, a, g = setup()
+    w.block_once = True
+    first = asyncio.create_task(
+        a.send_or_update_status(
+            "123456", "owner", "first", metadata={"thread_id": "101"}
+        )
+    )
+    await asyncio.wait_for(w.accepted.wait(), 5)
+    second = asyncio.create_task(
+        a.send_or_update_status(123456, "owner", "second", metadata={"thread_id": 101})
+    )
+    w.release.set()
+    one, two = await asyncio.gather(first, second)
+    assert one.message_id == two.message_id
+    assert len([event for event in w.events if event[0] == "send"]) == 1
+    other = await a.send_or_update_status(
+        "123456", "owner", "other", metadata={"thread_id": "202"}
+    )
+    assert other.message_id != one.message_id
+    # Already-deleted messages invalidate the local cache too.
+    del w.messages[str(one.message_id)]
+    await a.delete_message("123456", one.message_id)
+    assert str(one.message_id) not in a._status_message_ids.values()
+    fresh = await a.send_or_update_status(
+        "123456", "owner", "fresh", metadata={"thread_id": "101"}
+    )
+    assert fresh.message_id != one.message_id
+    # Late successful edits must not resurrect an entry deleted while awaiting I/O.
+    entered, release = asyncio.Event(), asyncio.Event()
+    original_edit = a.edit_message
+
+    async def delayed_edit(*args, **kwargs):
+        result = await original_edit(*args, **kwargs)
+        entered.set()
+        await release.wait()
+        return result
+
+    a.edit_message = delayed_edit
+    pending = asyncio.create_task(
+        a.send_or_update_status(
+            "123456", "owner", "editing", metadata={"thread_id": "101"}
+        )
+    )
+    await asyncio.wait_for(entered.wait(), 5)
+    await a.delete_message("123456", fresh.message_id)
+    release.set()
+    await pending
+    assert str(fresh.message_id) not in a._status_message_ids.values()
+    a._status_message_ids = {("123456", f"old-{i}", "101"): str(i) for i in range(2000)}
+    latest = await a.send_or_update_status(
+        "123456", "new-owner", "bounded", metadata={"thread_id": "101"}
+    )
+    assert len(a._status_message_ids) <= 2000
+    assert latest.message_id in a._status_message_ids.values()

--- a/tests/gateway/test_telegram_status_update.py
+++ b/tests/gateway/test_telegram_status_update.py
@@ -86,7 +86,7 @@ async def test_first_call_sends_and_caches_message_id(adapter):
     assert result.message_id == "100"
     adapter.send.assert_awaited_once()
     adapter.edit_message.assert_not_awaited()
-    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "100"
+    assert "100" in adapter._status_message_ids.values()
 
 
 @pytest.mark.asyncio
@@ -102,7 +102,7 @@ async def test_distinct_status_keys_do_not_collide(adapter):
 
     assert adapter.send.await_count == 2
     adapter.edit_message.assert_not_awaited()
-    assert adapter._status_message_ids[("chat-1", "lifecycle")] == "100"
-    assert adapter._status_message_ids[("chat-1", "model-switch")] == "200"
+    assert "100" in adapter._status_message_ids.values()
+    assert "200" in adapter._status_message_ids.values()
 
 


### PR DESCRIPTION
## Summary
Keep editable lifecycle/status messages owned by one turn and Telegram destination. Repeated updates within an owner edit one message; another turn or topic starts its own message. Successful/already-gone deletion invalidates cached IDs, and late callbacks cannot revive a completed turn's status.

## Motivation
A lifecycle update can currently edit a bubble belonging to a previous turn or another topic. Cleanup can also leave a deleted ID cached or miss a receipt arriving after final delivery. This addresses the ownership and lifecycle contract reported in #92210 rather than only changing the cache key.

## Implementation
- Fresh per-turn status token, same-owner serialization, and generation/adapter checks before sending.
- Normalize chat/topic in Telegram cache keys; serialize same-key sends and bound retained IDs.
- Invalidate successful and already-gone deletions; do not reinsert an edited ID evicted during the await.
- Capture cleanup IDs at invocation and delete late receipts through the adapter that returned them.

## Prior art
This complementary implementation builds on the approaches in #92230 by @stepanov1975 and #103260 by @M-Lietz (turn-scoped keys and serialization), #103253 by @crazyief and #99905 by @seojoonkim (deletion invalidation), and #87480 by @michaelversluis (bounded caches and compare-before-reinsertion). Those proposals remain open/unmerged at the final audit. The additional owner fence and late-receipt cleanup close lifecycle gaps not covered by any single proposal; no claim of authorship over those ideas.

## Verification
- Focused status/Telegram regressions: 4 tests passed through `scripts/run_tests.sh`.
- `uvx ruff check .` and `git diff --check`: passed.
- Independent inspection covered the fork candidate and this exact upstream adaptation: no actionable P0/P1 findings (Codex subscription fallback after Claude was unavailable).
- Full gateway suite completed: 7,923 passed, 10 failed, 40 skipped (796 files). All 10 failures reproduce on untouched pinned upstream `0e9fc2cc152b4a4d9fd736f107412ace2a0c2555`: macOS path/socket-length fixtures and DNS-dependent Slack/Telegram media fixtures. This suite is explicitly not claimed green; all focused ownership regressions pass.

## Risk and exclusions
Only status ownership and invalidation are contributed here. No fork-specific progress cancellation drain, Delegating-card behavior, runtime configuration, or deployment changes. Transport tests use the real gateway/Telegram code with fake Bot API I/O; no live bot send is claimed.

Closes #92210.
