### PR TITLE
fix(agent): pass session model as target_model in credential refresh to prevent per-turn agent rebuild

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -180,9 +180,17 @@ class CLIAgentSetupMixin:
         _primary_exc = None
         runtime = None
         try:
+            # Pass the current session model as target_model so multi-endpoint providers
+            # (e.g. OpenCode Zen/Go) re-derive api_mode from the model actually in use,
+            # not from the config default. Without this, a /model switch to a model on a
+            # different api_mode route than the default causes _ensure_runtime_credentials
+            # to overwrite self.api_mode with the default's route, which then mismatches
+            # the route signature stored at agent init — rebuilding the agent every turn.
+            # See: https://github.com/NousResearch/hermes-agent/issues/105979
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider, explicit_api_key=self._explicit_api_key,
-                explicit_base_url=self._explicit_base_url)
+                explicit_base_url=self._explicit_base_url,
+                target_model=self.model)
         except Exception as exc:
             _primary_exc = exc
         if _primary_exc is not None:

--- a/tests/hermes_cli/test_ensure_runtime_target_model.py
+++ b/tests/hermes_cli/test_ensure_runtime_target_model.py
@@ -1,0 +1,177 @@
+"""Regression test for #105979: agent rebuilt on every turn after /model switch.
+
+After a /model switch to a model on a different api_mode route than the config
+default, _ensure_runtime_credentials() must NOT overwrite self.api_mode with the
+default's route.  Without this, the route signature mismatches the one stored at
+agent init and the agent is torn down and rebuilt on every turn.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+# A minimal CLI stub that mimics a post-/model-switch state where the session
+# model is on a different api_mode route than the config default.
+class _ModelSwitchedCLI(CLIAgentSetupMixin):
+    def __init__(self, *, model: str, provider: str, api_mode: str):
+        self.model = model
+        self.requested_provider = provider
+        self.provider = provider
+        self.api_key = "test-key"
+        self.base_url = "https://opencode.ai/zen/go"
+        self.api_mode = api_mode  # set by /model switch (e.g. anthropic_messages)
+        self.acp_command = None
+        self.acp_args = []
+        self.agent = SimpleNamespace()  # simulate existing agent
+        self._fallback_model = []
+        self._explicit_api_key = None
+        self._explicit_base_url = None
+        self._credential_pool = None
+        self.service_tier = None
+        self._model_is_default = False  # post /model switch
+
+    def _normalize_model_for_provider(self, _provider: str) -> bool:
+        return False
+
+
+def _write_profile_config(hermes_home) -> None:
+    """Config where the default model uses chat_completions (glm on opencode-go)."""
+    (hermes_home / "config.yaml").write_text(
+        """
+model:
+  default: glm-5.3-flash
+  provider: opencode-go
+providers:
+  opencode-go:
+    base_url: https://opencode.ai/zen/go
+    api_key: test-key
+""",
+        encoding="utf-8",
+    )
+
+
+def test_ensure_runtime_credentials_passes_target_model(monkeypatch):
+    """_ensure_runtime_credentials must pass target_model=self.model to
+    resolve_runtime_provider so the re-resolved api_mode matches the session
+    model, not the config default."""
+    from hermes_constants import get_hermes_home
+
+    _write_profile_config(get_hermes_home())
+
+    # Simulate: session model is qwen3.7-max on opencode-go (anthropic_messages),
+    # but config default is glm-5.3-flash (chat_completions).
+    cli = _ModelSwitchedCLI(
+        model="qwen3.7-max", provider="opencode-go", api_mode="anthropic_messages"
+    )
+
+    # Track what resolve_runtime_provider was called with
+    _call_kwargs = {}
+
+    def _tracking_resolve(**kwargs):
+        _call_kwargs.update(kwargs)
+        # Return a runtime with the CORRECT api_mode for the session model
+        return {
+            "provider": "opencode-go",
+            "api_key": "test-key",
+            "base_url": "https://opencode.ai/zen/go",
+            "api_mode": "anthropic_messages",  # correct for qwen3.7-max
+            "requested_provider": "opencode-go",
+        }
+
+    # Mock at the source module since the import is lazy inside the method
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", _tracking_resolve):
+        result = cli._ensure_runtime_credentials()
+
+    assert result is True
+    # The critical assertion: target_model must be passed
+    assert "target_model" in _call_kwargs, (
+        "resolve_runtime_provider must receive target_model to avoid api_mode "
+        "mismatch after /model switch (see #105979)"
+    )
+    assert _call_kwargs["target_model"] == "qwen3.7-max"
+
+
+def test_api_mode_preserved_after_ensure_credentials(monkeypatch):
+    """After a /model switch sets api_mode=anthropic_messages,
+    _ensure_runtime_credentials must not overwrite it with chat_completions."""
+    from hermes_constants import get_hermes_home
+
+    _write_profile_config(get_hermes_home())
+
+    cli = _ModelSwitchedCLI(
+        model="qwen3.7-max", provider="opencode-go", api_mode="anthropic_messages"
+    )
+
+    def _returning_correct_mode(**kwargs):
+        return {
+            "provider": "opencode-go",
+            "api_key": "test-key",
+            "base_url": "https://opencode.ai/zen/go",
+            "api_mode": "anthropic_messages",  # correct for qwen3.7-max
+            "requested_provider": "opencode-go",
+        }
+
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", _returning_correct_mode):
+        cli._ensure_runtime_credentials()
+
+    # api_mode must still be the correct value from /model switch
+    assert cli.api_mode == "anthropic_messages", (
+        f"api_mode was overwritten to {cli.api_mode!r} after _ensure_runtime_credentials; "
+        f"expected 'anthropic_messages' (see #105979)"
+    )
+
+
+def test_route_signature_matches_after_ensure_credentials(monkeypatch):
+    """The route signature computed after _ensure_runtime_credentials must match
+    the one stored at agent init when the session model hasn't changed."""
+    from hermes_constants import get_hermes_home
+    from hermes_cli.cli_agent_setup_mixin import _route_signature
+
+    _write_profile_config(get_hermes_home())
+
+    cli = _ModelSwitchedCLI(
+        model="qwen3.7-max", provider="opencode-go", api_mode="anthropic_messages"
+    )
+
+    def _returning_correct_mode(**kwargs):
+        return {
+            "provider": "opencode-go",
+            "api_key": "test-key",
+            "base_url": "https://opencode.ai/zen/go",
+            "api_mode": "anthropic_messages",  # correct for qwen3.7-max
+            "requested_provider": "opencode-go",
+        }
+
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", _returning_correct_mode):
+        cli._ensure_runtime_credentials()
+
+    # Compute the signature the same way _resolve_turn_agent_config does
+    runtime = {
+        "api_key": cli.api_key,
+        "base_url": cli.base_url,
+        "provider": cli.provider,
+        "requested_provider": getattr(cli, "requested_provider", cli.provider),
+        "api_mode": cli.api_mode,
+        "command": cli.acp_command,
+        "args": list(cli.acp_args or []),
+        "credential_pool": getattr(cli, "_credential_pool", None),
+    }
+    current_signature = _route_signature(cli.model, runtime)
+
+    # The signature stored at agent init (simulating what _init_agent sets)
+    stored_signature = _route_signature(
+        "qwen3.7-max",
+        {"provider": "opencode-go", "requested_provider": "opencode-go",
+         "base_url": "https://opencode.ai/zen/go", "api_mode": "anthropic_messages",
+         "command": None, "args": []},
+    )
+
+    assert current_signature == stored_signature, (
+        f"Route signature mismatch after _ensure_runtime_credentials: "
+        f"current={current_signature} stored={stored_signature}. "
+        f"This would cause agent rebuild every turn (#105979)."
+    )


### PR DESCRIPTION
## What does this PR do?

When `_ensure_runtime_credentials()` re-resolves provider credentials (key rotation / token refresh), it calls `resolve_runtime_provider()` **without `target_model`**. For multi-endpoint providers (e.g. OpenCode Zen/Go where different models route through different API surfaces), this derives `api_mode` from the **config default model**, not the session model.

If a `/model` switch placed the session on a different `api_mode` route than the default (e.g. `glm-5.3-flash` → `chat_completions`, `qwen3.7-max` → `anthropic_messages`), every subsequent turn sees a route-signature mismatch and tears down + rebuilds the agent:

1. `/model` switch correctly sets `self.api_mode = "anthropic_messages"`
2. `_ensure_runtime_credentials()` calls `resolve_runtime_provider()` without `target_model`
3. Resolver derives `api_mode = "chat_completions"` from config default `glm-5.3-flash`
4. `self.api_mode` is overwritten to `chat_completions`
5. `_route_signature()` produces a different tuple than the stored `_active_agent_route_signature`
6. Agent is torn down and rebuilt. Repeat every turn.

**Fix**: Pass `target_model=self.model` so the re-resolved `api_mode` matches the session model. Backward-compatible: when no `/model` override is active, `self.model` IS the config default, so behavior is unchanged.

## Related Issue

Fixes #105979

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_agent_setup_mixin.py`:
  - `_ensure_runtime_credentials()` passes `target_model=self.model` to `resolve_runtime_provider()`
- `tests/hermes_cli/test_ensure_runtime_target_model.py`:
  - 3 regression tests verifying target_model propagation, api_mode preservation, and route signature consistency

## How to Test

1. Config: set `model.default` to a chat-routed model (e.g. `glm-5.3-flash` on opencode-go)
2. Start CLI session, `/model qwen3.7-max` (opencode-go, anthropic_messages)
3. Send two messages — previously: "Initializing agent..." on every turn. After fix: agent persists.
4. Run `pytest tests/hermes_cli/test_ensure_runtime_target_model.py -v`

## Checklist

- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(agent):`)
- [x] Searched for existing PRs (no duplicate; #101312 covers gateway rehydration path, this covers CLI per-turn path)
- [x] PR contains only this fix
- [x] Ran `pytest tests/hermes_cli/test_ensure_runtime_target_model.py tests/hermes_cli/test_cli_custom_provider_vision.py tests/agent/test_fast_mode_auto.py tests/agent/test_credential_pool_routing.py tests/hermes_cli/test_model_validation.py tests/cli/test_cli_provider_resolution.py -q`: 92 passed
- [x] Added tests for my changes
- [ ] Docs — N/A (internal fix)
