### PR TITLE
fix(kanban): enforce pre_tool_call hooks on CLI complete (#106292)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -871,15 +871,48 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     fail_msg: dict[str, str] = {}
     with kbc.connect_closing() as conn:
         def op(tid):
+            summary_local = summary
+            result_local = getattr(args, "result", None)
+            metadata_local = metadata
+            # CLI parity with agent tool path: enforce pre_tool_call hooks (Issue #106292).
+            # The agent's kanban_complete goes through model_tools._pre_dispatch_guards ->
+            # _dispatch_pre_tool_call_hooks before the DB write; the CLI previously skipped it,
+            # so an external lifecycle policy bound to pre_tool_call could be bypassed from the shell.
+            try:
+                from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
+
+                hook_args = {
+                    "task_id": tid,
+                    "summary": summary_local,
+                    "result": result_local,
+                    "metadata": metadata_local,
+                }
+                block_msg, modified = _dispatch_pre_tool_call_hooks(
+                    "kanban_complete", hook_args, task_id=tid
+                )
+                if block_msg:
+                    fail_msg[tid] = block_msg
+                    return False
+                if isinstance(modified, dict):
+                    if "summary" in modified:
+                        summary_local = modified["summary"]
+                    if "result" in modified:
+                        result_local = modified["result"]
+                    if "metadata" in modified:
+                        metadata_local = modified["metadata"]
+            except Exception:
+                # Hook dispatch already fails closed for timeouts/bounded hooks;
+                # unexpected import/dispatch errors should not block CLI completion.
+                pass
             gate_err = _goal_gate_error(
-                conn, tid, (summary or args.result or "").strip(), "completion",
+                conn, tid, (summary_local or result_local or "").strip(), "completion",
                 "Re-scope with kanban edit, or record the block with kanban block instead of completing.",
                 "Provide evidence matching the task's acceptance criteria.")
             if gate_err:
                 fail_msg[tid] = gate_err
                 return False
             fail_msg[tid] = f"cannot complete {tid} (unknown id or terminal state)"
-            return kb.complete_task(conn, tid, result=args.result, summary=summary, metadata=metadata,
+            return kb.complete_task(conn, tid, result=result_local, summary=summary_local, metadata=metadata_local,
                                     expected_run_id=_worker_run_id_for(tid))
 
         return _bulk_apply(ids, op, lambda tid: f"Completed {tid}", fail_msg.__getitem__)


### PR DESCRIPTION
Fixes #106292.

### Problem
`hermes kanban complete` wrote directly to the Kanban kernel (`kb.complete_task`) without invoking `pre_tool_call` hooks. The structured agent tool path (`kanban_complete` via `model_tools.handle_function_call` → `_dispatch_pre_tool_call_hooks`) correctly enforces lifecycle policies registered as `pre_tool_call` shell/plugin hooks, but the equivalent CLI (and shell) surface could bypass them. In a bounded multi-task workflow this allowed premature root completion and worktree cleanup while children/vault-qc were still pending.

### Root cause
`_cmd_complete` in `hermes_cli/kanban.py` called the DB mutator directly with no hook gating. It was also out of parity with the agent path's goal-judge gate ordering — hooks must run first so a policy can reject before any other guard.

### Fix
Route each CLI completion through `hermes_cli.plugins._dispatch_pre_tool_call_hooks` for `kanban_complete` (parity with `model_tools._pre_dispatch_guards`):

- Construct hook args `{task_id, summary, result, metadata}` per `tid` and call `_dispatch_pre_tool_call_hooks("kanban_complete", args, task_id=tid)`
- If the hook returns a block message, set `fail_msg[tid]` and return `False` so `_bulk_apply` reports the block and never touches the DB
- If the hook returns `modified` args, honor `summary`/`result`/`metadata` overrides (shell hook `modify` dialect)
- Honors timeout fail-closed semantics already inside `_dispatch_pre_tool_call_hooks`; unexpected errors fail open for the CLI

### Tests
- Existing suite green: `test_kanban_goal_mode` (5) + `test_kanban_review_lifecycle` (19)
- Manual hook-parity checks: block → no DB write, allow → DB write, modify → handoff reflects hook output
- No workflow files modified.