### PR TITLE
fix(update): print explicit trailer and record receipt step on fetch failure

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -512,6 +512,8 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
 
     if fetch_result.returncode != 0:
         _print_fetch_failure(fetch_result.stderr)
+        _record_update_step("fetch", False, _classify_fetch_failure(fetch_result.stderr or ""))
+        print("✗ Update not applied — code unchanged (fetch failed).")
         sys.exit(1)
 
     # rev-list on a bogus ref exits 128 and (check=True) would traceback; verify first.
@@ -1322,6 +1324,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         fetch_result = _git_run(git_cmd, ["fetch", "origin", branch], network=True)
         if fetch_result.returncode != 0:
             _print_fetch_failure(fetch_result.stderr)
+            _record_update_step("fetch", False, _classify_fetch_failure(fetch_result.stderr or ""))
+            print("✗ Update not applied — code unchanged (fetch failed).")
             sys.exit(1)
 
         current_branch = _current_branch_name(git_cmd, check=True)

--- a/tests/hermes_cli/test_update_fetch_failure_classifier.py
+++ b/tests/hermes_cli/test_update_fetch_failure_classifier.py
@@ -6,6 +6,9 @@ generic "Failed to fetch updates from origin." — or worse, matched the
 classifier must call out rate limiting / outages explicitly, and the raw
 stderr line must always be printed alongside the diagnosis.
 """
+from pathlib import Path
+
+import pytest
 
 from hermes_cli import update_cmd
 
@@ -85,6 +88,138 @@ class TestPrintFetchFailure:
         update_cmd._print_fetch_failure("")
         out = capsys.readouterr().out.strip().splitlines()
         assert out == ["✗ Failed to fetch updates from origin."]
+
+
+def _fetch_failure_stderr():
+    return (
+        "error: RPC failed; HTTP 429 curl 22 The requested URL returned error: 429\n"
+        "fatal: expected flush after ref listing"
+    )
+
+
+class TestFetchFailureTrailerAndReceipt:
+    """When a fetch fails, the updater must print an explicit 'update not applied'
+    trailer AND record a 'fetch' step in the receipt — so the terminal state is
+    unambiguous and the receipt's steps array reflects reality."""
+
+    def _run_cmd_update_impl_with_fetch_failure(self, monkeypatch, capsys):
+        """Drive _cmd_update_impl to the fetch-failure exit with a mocked git."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        # Stub _m() so the impl can resolve helpers without a real checkout.
+        fake_main = MagicMock()
+        fake_main.PROJECT_ROOT = Path("/fake")
+        fake_main._is_windows = lambda: False
+        fake_main._resolve_update_branch = lambda *a, **k: "main"
+        monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+
+        # Stub prepare_git_command to skip the ZIP path.
+        monkeypatch.setattr(
+            update_cmd, "_prepare_git_command",
+            lambda: (False, ["git"], False),
+        )
+
+        # Stub the git lock / stash helpers imported lazily inside _cmd_update_impl.
+        # These are lazy imports inside the function body, so mock at source module.
+        import hermes_cli.gitlock as gitlock_mod
+        import hermes_cli.update_cmd_stash as stash_mod
+        monkeypatch.setattr(gitlock_mod, "clear_stale_git_locks", lambda *a: [])
+        monkeypatch.setattr(gitlock_mod, "clear_stale_tmp_packs", lambda *a: [])
+        monkeypatch.setattr(stash_mod, "_warn_orphaned_update_autostashes", lambda *a, **k: None)
+
+        # _git_run returns a failure with 429 stderr.
+        failed_result = SimpleNamespace(returncode=1, stderr=_fetch_failure_stderr(), stdout="")
+        monkeypatch.setattr(update_cmd, "_git_run", lambda *a, **k: failed_result)
+
+        # Capture the receipt step that gets recorded.
+        recorded_steps = []
+        def _spy_record(step, ok, detail=""):
+            recorded_steps.append((step, ok, detail))
+        monkeypatch.setattr(update_cmd, "_record_update_step", _spy_record)
+
+        # The impl calls _resolve_update_options; stub it.
+        monkeypatch.setattr(
+            update_cmd, "_resolve_update_options",
+            lambda *a, **k: SimpleNamespace(
+                gw_input_fn=None, assume_yes=False, switch_branch=False,
+                active_lazy_features=None, active_tool_dependencies=None,
+                discard_local_changes=False, keep_stash=False,
+            ),
+        )
+        # Stub backup/gateway helpers.
+        monkeypatch.setattr(update_cmd._m(), "_run_pre_update_backup", lambda *a: None)
+        monkeypatch.setattr(update_cmd._m(), "_pause_windows_gateways_for_update", lambda: None)
+        monkeypatch.setattr(update_cmd._m(), "_resume_windows_gateways_after_update", lambda *a: None)
+        monkeypatch.setattr(update_cmd, "_desktop_app_present", lambda *a: False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            update_cmd._cmd_update_impl(SimpleNamespace(force_venv=False), gateway_mode=False)
+        assert exc_info.value.code == 1
+
+        return capsys.readouterr().out, recorded_steps
+
+    def test_fetch_failure_prints_trailer(self, monkeypatch, capsys):
+        out, _ = self._run_cmd_update_impl_with_fetch_failure(monkeypatch, capsys)
+        assert "✗ Update not applied" in out
+        assert "code unchanged" in out
+        assert "fetch failed" in out
+
+    def test_fetch_failure_records_receipt_step(self, monkeypatch, capsys):
+        _, steps = self._run_cmd_update_impl_with_fetch_failure(monkeypatch, capsys)
+        fetch_steps = [s for s in steps if s[0] == "fetch"]
+        assert len(fetch_steps) == 1
+        step_name, step_ok, step_detail = fetch_steps[0]
+        assert step_ok is False
+        assert "rate limiting" in step_detail.lower()
+
+    def test_fetch_failure_check_prints_trailer(self, monkeypatch, capsys):
+        """_cmd_update_check also exits on fetch failure — verify trailer there too."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        fake_main = MagicMock()
+        # PROJECT_ROOT must be a MagicMock so .__truediv__ (the / operator) works.
+        fake_main.PROJECT_ROOT = MagicMock()
+        git_dir_mock = MagicMock()
+        git_dir_mock.exists.return_value = True
+        fake_main.PROJECT_ROOT.__truediv__.return_value = git_dir_mock
+        monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+
+        # Stub evaluate_update_admission (lazy import from update_contract).
+        import hermes_cli.update_contract as contract_mod
+        monkeypatch.setattr(contract_mod, "evaluate_update_admission", lambda *a: None)
+        monkeypatch.setattr(contract_mod, "record_refusal_receipt", lambda *a: None)
+
+        # Stub gitlock helpers (lazy import from gitlock).
+        import hermes_cli.gitlock as gitlock_mod
+        monkeypatch.setattr(gitlock_mod, "clear_stale_git_locks", lambda *a: [])
+        monkeypatch.setattr(gitlock_mod, "clear_stale_tmp_packs", lambda *a: [])
+
+        # Stub _base_git_cmd and _is_shallow_checkout.
+        monkeypatch.setattr(update_cmd, "_base_git_cmd", lambda: ["git"])
+        monkeypatch.setattr(update_cmd, "_is_shallow_checkout", lambda *a: False)
+
+        # _git_run returns failure for all calls (remote get-url + fetch).
+        failed_result = SimpleNamespace(returncode=1, stderr=_fetch_failure_stderr(), stdout="")
+        monkeypatch.setattr(update_cmd, "_git_run", lambda *a, **k: failed_result)
+
+        recorded_steps = []
+        def _spy_record(step, ok, detail=""):
+            recorded_steps.append((step, ok, detail))
+        monkeypatch.setattr(update_cmd, "_record_update_step", _spy_record)
+
+        with pytest.raises(SystemExit) as exc_info:
+            update_cmd._cmd_update_check("main")
+        assert exc_info.value.code == 1
+
+        out = capsys.readouterr().out
+        assert "✗ Update not applied" in out
+        assert "code unchanged" in out
+
+        fetch_steps = [s for s in recorded_steps if s[0] == "fetch"]
+        assert len(fetch_steps) == 1
+        assert fetch_steps[0][1] is False
 
 
 def test_update_network_git_calls_never_prompt_for_credentials():


### PR DESCRIPTION
## Summary

When a git fetch fails (e.g. HTTP 429 rate limit), the updater prints the classified diagnosis and calls `sys.exit(1)`. The process exits before any success banner, but there is **no closing line** saying the update was not applied — scrolled past, the terminal state is ambiguous.

This adds two lines before each `sys.exit(1)` in the fetch-failure paths:

1. `_record_update_step("fetch", False, diagnosis)` — the receipt's `steps` array now records the failed fetch with its classified detail, making post-mortems and log-based tooling reflect reality.
2. `✗ Update not applied — code unchanged (fetch failed).` — an explicit trailer so the terminal state is unambiguous even when scrolled past.

Both paths are covered: `_cmd_update_impl` (the apply path) and `_cmd_update_check` (the check/probe path).

## Test plan

- 3 new tests in `test_update_fetch_failure_classifier.py`:
  - `test_fetch_failure_prints_trailer` — verifies the trailer line prints on fetch failure in `_cmd_update_impl`
  - `test_fetch_failure_records_receipt_step` — verifies the receipt step is recorded with `ok=False` and the classified detail
  - `test_fetch_failure_check_prints_trailer` — verifies the same trailer prints in `_cmd_update_check`
- All 14 tests in the file pass (existing 11 + new 3)
- Broader `test_update_check.py` and `test_update_fleet_restart_pending.py` suites also pass

Fixes #106026
