### PR TITLE
fix(tools): bound tool-activity heartbeats and real-profile launch serialization (#106244)

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -108,6 +108,10 @@ _MAX_TOOL_WORKERS = 8  # concurrent worker threads per batch
 _DEFAULT_IMAGE_PARALLEL_REQUESTS = 4
 # Generous: slow-but-valid tool work must never be preempted by the batch guard.
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
+# Heartbeat stamps stop after the longest possible tool deadline plus margin (#106244): the gateway
+# watchdog gives a turn 30 idle minutes, so a call abandoned past this bound is wedged beyond
+# saving, and stamping forever pins the session's ``last_activity_at`` at "now" (sidebar sort + age).
+_TOOL_ACTIVITY_HEARTBEAT_MAX_S = 1800.0 + 120.0
 # Long enough for an approval round-trip, short enough that one wedged dispatch can't starve the batch.
 _START_ORDER_GATE_TIMEOUT_S = 120.0
 # Fallback only; the effective bound derives from approvals.timeout (_authorization_gate_lock_timeout).
@@ -567,12 +571,20 @@ def _run_tool_activity_heartbeat(
     stop_event: threading.Event,
     label: str,
     interval: float = _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S,
+    max_duration: float = _TOOL_ACTIVITY_HEARTBEAT_MAX_S,
 ) -> None:
     """Daemon thread stamping ``agent._touch_activity`` every ``interval`` seconds until
-    ``stop_event`` is set, so the gateway inactivity watchdog never abandons a turn whose
-    tool runs silently. Wedged tools stay bounded by the tool layer's own timeouts."""
+    ``stop_event`` is set or ``max_duration`` elapses, so the gateway inactivity watchdog never
+    abandons a turn whose tool runs silently. The duration bound is the wedge backstop: a tool
+    call abandoned past every tool-layer deadline keeps its worker thread (daemon executors never
+    join it), and an unbounded heartbeat would keep stamping ``last_activity_at`` "now" for days,
+    pinning the session at the top of every recency-sorted surface (#106244). Past the bound the
+    watchdog may eventually reclaim the turn — correct for a call that overstayed every deadline."""
+    started = time.monotonic()
     try:
         while not stop_event.wait(interval):
+            if time.monotonic() - started >= max_duration:
+                break
             agent._touch_activity(label)
     except Exception:
         pass  # a heartbeat must never break the agent loop

--- a/tests/run_agent/test_tool_activity_heartbeat.py
+++ b/tests/run_agent/test_tool_activity_heartbeat.py
@@ -268,3 +268,41 @@ def test_concurrent_tool_call_heartbeat(monkeypatch):
     agent._execute_tool_calls_concurrent(msg, messages, "task")
 
     assert len(touches) >= 3, f"expected mid-call heartbeats, got {len(touches)}"
+
+
+def test_heartbeat_stops_after_max_duration(monkeypatch):
+    """A wedged tool call must not keep stamping last_activity_at forever (#106244).
+
+    The sequential runner abandons a wedged worker without joining it (daemon executor), so
+    the worker thread — and its heartbeat — can outlive the turn by days. Past
+    ``_TOOL_ACTIVITY_HEARTBEAT_MAX_S`` the heartbeat must stop: the gateway watchdog reclaims
+    an idle turn, and the session's age label returns to real time.
+
+    Red on base: the loop had no duration bound, so touches continued past the window.
+    """
+    import agent.tool_executor as te
+
+    touches: list = []
+    stop = threading.Event()
+
+    class _Agent:
+        def _touch_activity(self, desc):
+            touches.append(time.time())
+
+    thread = threading.Thread(
+        target=te._run_tool_activity_heartbeat,
+        args=(_Agent(), stop, "tool running: browser_exec"),
+        kwargs={"interval": 0.02, "max_duration": 0.1},
+        daemon=True,
+    )
+    thread.start()
+    time.sleep(0.4)
+    n = len(touches)
+    assert n >= 2, f"expected periodic touches before the bound, got {n}"
+    time.sleep(0.2)
+    assert len(touches) == n, (
+        f"heartbeat kept stamping past max_duration: {n} -> {len(touches)}"
+    )
+    stop.set()
+    thread.join(timeout=1.0)
+    assert not thread.is_alive()

--- a/tests/tools/test_real_profile_lock_scope.py
+++ b/tests/tools/test_real_profile_lock_scope.py
@@ -1,0 +1,158 @@
+"""Real-profile CDP resolution must not serialize unrelated browser calls on the launch lock (#106244).
+
+Two failures shipped together:
+1. ``_real_profile_cdp`` held ``_real_profile_cdp_lock`` across snapshot + launch + attach
+   (minutes-scale, unbounded when a file op wedges inside the snapshot). Every other session's
+   ``browser_exec`` blocked on that lock for the whole hold — each with its own 30s activity
+   heartbeat stamping ``last_activity_at`` "now", pinning old sessions at the top of the sidebar
+   for days. The fix scopes the lock to cache reads/publishes; the snapshot+launch runs under a
+   separate launch lock whose waiters poll with a hard bound instead of parking forever.
+2. ``_run_tool_activity_heartbeat`` (tested in tests/run_agent/) stamped ``last_activity_at``
+   every 30s for as long as a wedged tool call lived — the pinned-at-"now" symptom itself.
+"""
+
+import threading
+import time
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir(exist_ok=True)
+
+
+def _make_module(monkeypatch, *, snapshot_fn):
+    """Import the real module with browser-layer globals stubbed through ``_bt``/locals."""
+    import tools.browser_tool_real_profile as rp
+    import tools.browser_tool as bt
+    import hermes_cli.browser_connect as bc
+
+    monkeypatch.setattr(bt, "_real_profile_launch_lock", threading.Lock())
+    monkeypatch.setattr(bt, "_real_profile_cdp_cache", {})
+
+    monkeypatch.setattr(rp._cloud, "_use_real_profile", lambda: True)
+    monkeypatch.setattr(rp._lp, "_using_lightpanda_engine", lambda: False)
+    monkeypatch.setattr(rp, "_real_profile_unsupported_reason", lambda browser: None)
+    monkeypatch.setattr(rp, "_cdp_http_ready", lambda cdp: True)
+    monkeypatch.setattr(rp, "_surviving_chrome_cdp", lambda copy_dir: None)
+    monkeypatch.setattr(rp, "_agent_browser_get_cdp", lambda session: None)
+    monkeypatch.setattr(bc, "detect_default_chromium", lambda: "chrome", raising=False)
+    monkeypatch.setattr(rp, "_real_profile_snapshot_error", lambda err: f"snapshot error: {err}")
+    monkeypatch.setattr(rp, "_launch_real_profile_chrome", lambda b, d: (9223, None), raising=False)
+    monkeypatch.setattr(rp, "_attach_agent_browser_to_real_profile",
+                        lambda port, d: ("http://127.0.0.1:9223", None), raising=False)
+    monkeypatch.setattr(bc, "chromium_executable", lambda browser: "/usr/bin/chrome", raising=False)
+    monkeypatch.setattr(bc, "snapshot_real_profile", snapshot_fn, raising=False)
+    monkeypatch.setattr(rp._session, "_prepare_session_socket_dir", lambda name: None)
+    return rp, bt
+
+
+def test_waiter_bounded_when_holder_errors(monkeypatch):
+    """Holder's snapshot fails → it releases the launch lock without publishing; the waiter
+    must take over and succeed, NOT park on the cache for the full 15-minute bound.
+
+    Red on the pre-fix code differently: the waiter parked on ``_real_profile_cdp_lock``
+    held across the holder's whole (failing) launch path.
+    """
+    calls = {"n": 0}
+    started = threading.Event()
+
+    def flaky_snapshot(browser, src=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            started.set()
+            time.sleep(0.3)
+            return None, "db locked"
+        return "/tmp/fake-copy", None
+
+    rp, bt = _make_module(monkeypatch, snapshot_fn=flaky_snapshot)
+    monkeypatch.setattr(rp, "_REAL_PROFILE_LAUNCH_WAIT_POLLS", 50)
+    monkeypatch.setattr(rp, "_REAL_PROFILE_LAUNCH_WAIT_POLL_S", 0.05)
+
+    out = {}
+    t1 = threading.Thread(target=lambda: out.__setitem__("first", rp._real_profile_cdp()))
+    t1.start()
+    assert started.wait(5), "first caller never reached the snapshot"
+    time.sleep(0.05)
+    t2 = threading.Thread(target=lambda: out.__setitem__("second", rp._real_profile_cdp()))
+    t2.start()
+    t1.join(15)
+    t2.join(15)
+    assert not t1.is_alive() and not t2.is_alive(), "a caller parked past the bound"
+
+    first_cdp, first_err = out["first"]
+    second_cdp, second_err = out["second"]
+    assert first_cdp is None and "db locked" in (first_err or "")
+    assert second_cdp == "http://127.0.0.1:9223", f"waiter should take over and succeed: {second_err!r}"
+    assert calls["n"] == 2
+
+
+def test_concurrent_callers_launch_once(monkeypatch):
+    """Two racing callers: one snapshot+launch, the waiter reuses the published cache."""
+    started = threading.Event()
+
+    def slow_snapshot(browser, src=None):
+        started.set()
+        time.sleep(0.3)
+        return "/tmp/fake-copy", None
+
+    rp, bt = _make_module(monkeypatch, snapshot_fn=slow_snapshot)
+    launches = []
+    real_launch = rp._launch_real_profile_chrome
+
+    def counting_launch(browser, copy_dir):
+        launches.append(copy_dir)
+        return real_launch(browser, copy_dir)
+
+    monkeypatch.setattr(rp, "_launch_real_profile_chrome", counting_launch, raising=False)
+
+    out = []
+    threads = [threading.Thread(target=lambda: out.append(rp._real_profile_cdp())) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(15)
+        assert not t.is_alive(), "racing caller parked past the bound"
+
+    assert len(out) == 2
+    for cdp, err in out:
+        assert cdp == "http://127.0.0.1:9223", f"both callers succeed: {err!r}"
+    assert len(launches) == 1, f"racing callers launched {len(launches)} browsers"
+
+
+def test_second_caller_not_blocked_while_first_snapshots(monkeypatch):
+    """The lock must guard cache reads/publishes only: a caller entering the snapshot must not
+    block a second caller from PROGRESSING (reaching its own bounded wait), which is what
+    pinned unrelated sessions at "now" pre-fix."""
+    started = threading.Event()
+
+    def slow_snapshot(browser, src=None):
+        started.set()
+        time.sleep(1.5)
+        return "/tmp/fake-copy", None
+
+    rp, bt = _make_module(monkeypatch, snapshot_fn=slow_snapshot)
+    monkeypatch.setattr(rp, "_REAL_PROFILE_LAUNCH_WAIT_POLLS", 3)
+    monkeypatch.setattr(rp, "_REAL_PROFILE_LAUNCH_WAIT_POLL_S", 0.05)
+
+    out = {}
+    t1 = threading.Thread(target=lambda: out.__setitem__("first", rp._real_profile_cdp()))
+    t1.start()
+    assert started.wait(5), "first caller never reached the snapshot"
+
+    t0 = time.monotonic()
+    t2 = threading.Thread(target=lambda: out.__setitem__("second", rp._real_profile_cdp()))
+    t2.start()
+    t2.join(10)
+    elapsed = time.monotonic() - t0
+
+    assert not t2.is_alive(), "second caller blocked on the launch lock while the first snapshots"
+    second_cdp, second_err = out["second"]
+    assert second_cdp is None and "not finished in time" in (second_err or ""), \
+        f"second caller should fail on its bounded wait: {second_cdp!r} {second_err!r}"
+    assert elapsed < 1.0, f"second caller took {elapsed:.2f}s (should be bounded by the poll window)"
+    t1.join(15)
+    first_cdp, first_err = out["first"]
+    assert first_cdp == "http://127.0.0.1:9223", f"first caller should still succeed: {first_err!r}"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -232,6 +232,7 @@ from tools import browser_tool_lightpanda_fallback as _lp
 # instead of each launching a rival Chromium on the same copied user-data-dir.
 _REAL_PROFILE_SESSION = "hermes-real-profile"
 _real_profile_cdp_lock = threading.Lock()
+_real_profile_launch_lock = threading.Lock()  # one snapshot+launch at a time; losers poll the cache (#106244)
 _real_profile_cdp_cache: dict = {}
 _real_profile_chrome_procs: list = []  # Popen handles of directly-launched real browsers
 

--- a/tools/browser_tool_real_profile.py
+++ b/tools/browser_tool_real_profile.py
@@ -248,6 +248,10 @@ def _real_profile_cdp() -> tuple:
     from hermes_cli.browser_connect import (chromium_executable, detect_default_chromium,
                                             real_profile_copy_dir, snapshot_real_profile)
 
+    # The lock guards cache reads/publishes ONLY — never the snapshot or launch: those run
+    # minutes-scale with no bound that covers a wedged file op, and holding the lock across
+    # them queued every other browser_exec in every session behind one slow/wedged copy, each
+    # still running its own activity heartbeat — sessions pinned at "now" for days (#106244).
     with _bt._real_profile_cdp_lock:
         cached = _bt._real_profile_cdp_cache.get("cdp")
         if cached and _cdp_http_ready(cached):
@@ -257,33 +261,66 @@ def _real_profile_cdp() -> tuple:
             return cached, None
         _bt._real_profile_cdp_cache.pop("cdp", None)
 
-        browser = detect_default_chromium()
-        unsupported = _real_profile_unsupported_reason(browser)
-        if unsupported:
-            return None, unsupported
+    browser = detect_default_chromium()
+    unsupported = _real_profile_unsupported_reason(browser)
+    if unsupported:
+        return None, unsupported
+    if browser is None:
+        return None, _RP + "no default Chromium-family browser could be detected. Install Chrome (or set browser.engine), or turn the toggle off."
 
-        # Reuse BEFORE writing anything. CRITICAL: the snapshot overlay (truncates/rewrites
-        # Cookies / Login Data) must NOT run while a live copy-browser (maybe from a previous
-        # hermes process) holds the user-data-dir open — that corrupts the databases.
-        copy_dir = real_profile_copy_dir(browser)
-        existing = _agent_browser_get_cdp(_bt._REAL_PROFILE_SESSION)
-        if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
+    # Reuse BEFORE writing anything. CRITICAL: the snapshot overlay (truncates/rewrites
+    # Cookies / Login Data) must NOT run while a live copy-browser (maybe from a previous
+    # hermes process) holds the user-data-dir open — that corrupts the databases.
+    copy_dir = real_profile_copy_dir(browser)
+    existing = _agent_browser_get_cdp(_bt._REAL_PROFILE_SESSION)
+    if existing and _cdp_http_ready(existing) and _cdp_on_data_dir(existing, copy_dir):
+        with _bt._real_profile_cdp_lock:
             _bt._real_profile_cdp_cache["cdp"] = existing
-            return existing, None
-        if existing:  # stale/wrong-dir session: close it so nothing holds the dir open
-            _agent_browser_close_session(_bt._REAL_PROFILE_SESSION)
-        # A Chrome from an earlier hermes process can still hold the copy dir after its attach
-        # daemon was reaped (that owner died). Re-attach to it rather than overlay a live profile;
-        # if the daemon cannot attach, fail closed — never snapshot over an open profile. Not ours
-        # to terminate (no Popen handle): it lives until the user closes it, by design.
-        surviving = _surviving_chrome_cdp(copy_dir)
-        if surviving:
-            cdp, err = _attach_agent_browser_to_real_profile(int(surviving.rsplit(":", 1)[1]), copy_dir)
-            if not cdp:
-                return None, err
+        return existing, None
+    if existing:  # stale/wrong-dir session: close it so nothing holds the dir open
+        _agent_browser_close_session(_bt._REAL_PROFILE_SESSION)
+    # A Chrome from an earlier hermes process can still hold the copy dir after its attach
+    # daemon was reaped (that owner died). Re-attach to it rather than overlay a live profile;
+    # if the daemon cannot attach, fail closed — never snapshot over an open profile. Not ours
+    # to terminate (no Popen handle): it lives until the user closes it, by design.
+    surviving = _surviving_chrome_cdp(copy_dir)
+    if surviving:
+        cdp, err = _attach_agent_browser_to_real_profile(int(surviving.rsplit(":", 1)[1]), copy_dir)
+        if not cdp:
+            return None, err
+        with _bt._real_profile_cdp_lock:
             _bt._real_profile_cdp_cache["cdp"] = cdp
-            _bt.logger.info("real-profile: re-attached to surviving Chrome at %s (%s)", cdp, copy_dir)
-            return cdp, None
+        _bt.logger.info("real-profile: re-attached to surviving Chrome at %s (%s)", cdp, copy_dir)
+        return cdp, None
+
+    # Two calls can pass the cache check together; only one may snapshot+launch, or two racing
+    # callers would overlay the SAME copy dir concurrently (corrupts the profile) and
+    # double-launch Chrome. The loser polls the cache — the winner publishes there — with a
+    # bound: the full path completes in minutes, so a waiter past it means the holder wedged
+    # and this caller fails instead of parking its turn (and heartbeat) forever (#106244).
+    acquired_now = _bt._real_profile_launch_lock.acquire(blocking=False)
+    if not acquired_now:
+        for _ in range(_REAL_PROFILE_LAUNCH_WAIT_POLLS):
+            time.sleep(_REAL_PROFILE_LAUNCH_WAIT_POLL_S)
+            with _bt._real_profile_cdp_lock:
+                cached = _bt._real_profile_cdp_cache.get("cdp")
+                if cached and _cdp_http_ready(cached):
+                    return cached, None
+            # The holder finished without publishing (error path) or died: take over the
+            # launch instead of waiting out the full bound for nothing.
+            if _bt._real_profile_launch_lock.acquire(blocking=False):
+                acquired_now = True
+                break
+        if not acquired_now:
+            return None, (_RP + "another call is already starting the real-profile browser and has "
+                          "not finished in time. Retry.")
+    try:
+        # Re-check the cache under the launch lock: the previous holder may have published
+        # between our cache check and this acquire.
+        with _bt._real_profile_cdp_lock:
+            cached = _bt._real_profile_cdp_cache.get("cdp")
+            if cached and _cdp_http_ready(cached):
+                return cached, None
 
         copy_dir, err = snapshot_real_profile(browser)
         if err or not copy_dir:
@@ -297,6 +334,13 @@ def _real_profile_cdp() -> tuple:
         cdp, err = _attach_agent_browser_to_real_profile(port, copy_dir)
         if not cdp:
             return None, err
-        _bt._real_profile_cdp_cache["cdp"] = cdp
+        with _bt._real_profile_cdp_lock:
+            _bt._real_profile_cdp_cache["cdp"] = cdp
         _bt.logger.info("real-profile browser ready for %s at %s (%s)", browser, cdp, copy_dir)
         return cdp, None
+    finally:
+        _bt._real_profile_launch_lock.release()
+
+
+_REAL_PROFILE_LAUNCH_WAIT_POLL_S = 1.0
+_REAL_PROFILE_LAUNCH_WAIT_POLLS = 900  # 15 min: snapshot + cold Chrome launch + attach, with margin


### PR DESCRIPTION
## What does this PR do?

Two compounding gaps let a single wedged `browser_exec` call pin unrelated desktop sessions at "now" in the sidebar for days (#106244):

1. **The tool-activity heartbeat is unbounded.** `_run_tool_activity_heartbeat` stamped `agent._touch_activity("tool running: <tool>")` every 30s for as long as its tool call lived. Its docstring assumed "wedged tools stay bounded by the tool layer's own timeouts," but that assumption breaks for *abandoned* workers: when the sequential runner hits its 420s deadline (or `/stop` fires), it emits the terminal result and returns without joining the worker (daemon executor, `shutdown(wait=False)`), so the worker thread — and its heartbeat — can outlive the turn indefinitely. Each stamp writes `sessions.last_activity_at`, so every affected session's age read "now" and it sorted to the top of every recency-sorted surface until a backend restart. Verified live on v0.21.0: four sessions with no messages since Sep 5–8 kept advancing `last_activity_at` while `last_activity_description` stayed `"tool running: browser_exec"`; the timestamps froze the moment the backend process was killed.

2. **`_real_profile_cdp` held `_real_profile_cdp_lock` across the whole snapshot + Chrome launch + attach path** (minutes-scale, and unbounded when a file op wedges inside the profile snapshot — reproduced locally: a live-Chrome cookie-DB copy blocked a worker thread for 75s+ before the *test* gave up; the code had no bound at all). Every other `browser_exec` call in every session queued on that lock, each still running its own heartbeat, which is how multiple unrelated sessions wedged at once.

### The fix

- **Heartbeat bound (generic, all tools):** the loop stops after `_TOOL_ACTIVITY_HEARTBEAT_MAX_S` (1800s deadline cap + 120s margin). The watchdog-facing purpose is preserved: a genuinely running tool stamps each interval; a call abandoned past every tool deadline loses its heartbeat and the gateway inactivity watchdog may reclaim the turn — correct for a call that overstayed everything.
- **Real-profile lock scope:** `_real_profile_cdp_lock` now guards only cache reads/publishes. The snapshot + launch runs under a separate `_real_profile_launch_lock` (new, in `tools/browser_tool.py`) so racing callers still can't double-launch Chrome on the same copy dir; a loser polls the published cache with a hard 15-minute bound and *takes over the launch* if the holder exits without publishing, so a wedged holder can no longer park unrelated turns forever.

Note: the sqlite-backup hang inside `snapshot_real_profile` itself was already bounded on `main` (progress-callback deadline, introduced in fb3446a281); the user's installed v0.21.0 predates it, which is why the wedged copy never finished there. This PR fixes the two gaps that remain on `main`.

## Related Issue

Fixes #106244

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_executor.py`
  - `_run_tool_activity_heartbeat`: new `max_duration` parameter (default `_TOOL_ACTIVITY_HEARTBEAT_MAX_S = 1800 + 120`); the stamp loop breaks when the bound elapses.
- `tools/browser_tool.py`
  - New `_real_profile_launch_lock` (one snapshot+launch at a time; waiters poll the cache instead of blocking the old shared lock).
- `tools/browser_tool_real_profile.py`
  - `_real_profile_cdp`: lock scope reduced to cache reads/publishes; detect/snapshot/launch/attach runs outside it; racing callers poll the cache with `_REAL_PROFILE_LAUNCH_WAIT_POLLS` (15 min) and take over the launch when the holder releases without publishing.
- Tests (both proven red on base, green with the fix):
  - `tests/run_agent/test_tool_activity_heartbeat.py::test_heartbeat_stops_after_max_duration`
  - `tests/tools/test_real_profile_lock_scope.py` (3 tests: bounded waiter on holder error, launch-exactly-once under race, second caller never blocked while the first snapshots)

## How to Test

Reproduction of the symptom (pre-fix v0.21.0):

1. Enable `browser.use_real_profile: true` with Chrome running; run any `browser_exec` in two desktop sessions.
2. Let one call wedge inside the profile snapshot/launch path (e.g. a live-Chrome cookie DB lock) and let the runner abandon it.
3. Observe `sqlite3 ~/.hermes/state.db "SELECT id, last_activity_at FROM sessions WHERE ..."` advancing ~30s while no new messages are written; the sidebar pins those sessions at "now".
4. Restart the backend → timestamps freeze and ages return to real time.

With this PR:

1. `scripts/run_tests.sh tests/run_agent/test_tool_activity_heartbeat.py tests/tools/test_real_profile_lock_scope.py -q` — all green.
2. Red-on-base proof: `git stash` the three source files and re-run — the 4 new tests fail (heartbeat keeps stamping past the bound; racing/failed-holder callers park on the locks).
3. Also ran: `tests/tools/ -k "real_profile or browser_use"` (218 passed), `tests/run_agent/ -k "tool or heartbeat or activity or interrupt"` (467 passed; the 1 failure is a pre-existing missing-`anthropic`-package env issue, verified failing on a pristine checkout too), and `scripts/check-windows-footguns.py` on all touched files (clean).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites above; full suite run by CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A (behavior documented in updated docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — verified with `scripts/check-windows-footguns.py`; the new locks are plain `threading.Lock` (portable), and the `browser_exec` subprocess path is untouched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema changes)

## Screenshots / Logs

Live evidence from the wedged backend (v0.21.0, pre-fix):

- 4 sessions' `last_activity_at` advancing ~60s across a 32s sleep while `messages` had no new rows; `last_activity_description = "tool running: browser_exec"`.
- `sample(1)` on the backend pid: worker threads matching the wedged sessions; after backend restart, timestamps froze and the sidebar returned to normal.
- Debug report links (from the issue): https://dpaste.com/6F78G4K56 · https://dpaste.com/9RSJM94DH