### PR TITLE
agent: skip Ollama-native probe waterfall when api_mode is explicit

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1811,7 +1811,7 @@ def _compressor_max_tokens(agent):
     return None
 
 
-def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_context_length, session_db):
+def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_context_length, session_db, api_mode=None):
     _selected_engine = _select_context_engine(_agent_cfg)
     if _selected_engine is not None:
         agent.context_compressor = _selected_engine
@@ -1822,10 +1822,13 @@ def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_c
         # gpt-5.5 autoraise above) only configures the built-in ContextCompressor and never reaches the
         # plugin, so the autoraise notice would announce a change that does not apply. (#44439)
         from agent.model_metadata import get_model_context_length
+        # api_mode here is the raw, explicitly-configured value (None unless model.api_mode is set
+        # in config.yaml) — see the comment on _configure_ollama_num_ctx for why agent.api_mode
+        # (the resolved ladder value, "chat_completions" by default for most setups) would be wrong.
         _plugin_ctx_len = get_model_context_length(
             agent.model, base_url=agent.base_url, api_key=getattr(agent, "api_key", ""),
             config_context_length=_effective_context_length, provider=agent.provider,
-            custom_providers=_custom_providers,
+            custom_providers=_custom_providers, api_mode=api_mode,
         )
         # Per-model overrides BEFORE the initial update_model() so the first threshold
         # resolution already sees them.
@@ -1982,9 +1985,17 @@ def _inject_context_engine_tools(agent):
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
 
-def _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length):
+def _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length, api_mode=None):
     # Ollama defaults num_ctx to 2048, so detect the max window and send num_ctx per request.
     # model.ollama_num_ctx overrides; model.context_length caps the detected value (VRAM).
+    #
+    # ``api_mode`` here is the *raw, explicitly configured* value from config.yaml (None unless
+    # the user actually set model.api_mode) — NOT agent.api_mode, which defaults to
+    # "chat_completions" for the overwhelming majority of custom/direct-Ollama setups too and
+    # would silently disable this detection for everyone. Only a user who explicitly opted into
+    # chat_completions (hermes-agent#25629 — typically to route through a proxy like LiteLLM that
+    # works around Ollama's stream+tools hang, and that doesn't expose Ollama-native routes) skips
+    # the probe below.
     agent._ollama_num_ctx: int | None = None
     _override = _model_cfg.get("ollama_num_ctx") if isinstance(_model_cfg, dict) else None
     if _override is not None:
@@ -1992,11 +2003,14 @@ def _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length):
             agent._ollama_num_ctx = int(_override)
         except (TypeError, ValueError):
             _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _override)
-    if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url):
+    if (
+        agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url)
+        and api_mode != "chat_completions"
+    ):
         try:
             # api_key may be a callable (Entra token provider); detection needs a string.
             _key = agent.api_key if isinstance(agent.api_key, str) else ""
-            _detected = query_ollama_num_ctx(agent.model, agent.base_url, api_key=_key or "")
+            _detected = query_ollama_num_ctx(agent.model, agent.base_url, api_key=_key or "", api_mode=api_mode)
             if _detected and _detected > 0:
                 agent._ollama_num_ctx = _detected
         except Exception as exc:
@@ -2298,12 +2312,12 @@ def init_agent(
     _config_context_length, _custom_providers, _effective_context_length, _model_cfg = _resolve_context_length(
         agent, _agent_cfg, base_url
     )
-    _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_context_length, session_db)
+    _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_context_length, session_db, api_mode=api_mode)
     _enforce_minimum_context(agent)
     _warn_nonagentic_hermes_model(agent)
     _inject_context_engine_tools(agent)
     _init_usage_state(agent)
-    _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length)
+    _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length, api_mode=api_mode)
     _emit_compression_summary(agent, cs)
     _snapshot_primary_runtime(agent)
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -562,9 +562,9 @@ def _maybe_cache_local_context_length(model: str, base_url: str, length: int) ->
         save_context_length(model, base_url, length)
 
 
-def _probe_local_context_length(model: str, base_url: str, api_key: str, provider: str) -> Optional[int]:
+def _probe_local_context_length(model: str, base_url: str, api_key: str, provider: str, api_mode: Optional[str] = None) -> Optional[int]:
     """Live local probe; persists a positive result unless the provider opts out of the disk cache."""
-    local_ctx = _query_local_context_length(model, base_url, api_key=api_key)
+    local_ctx = _query_local_context_length(model, base_url, api_key=api_key, api_mode=api_mode)
     if not (local_ctx and local_ctx > 0):
         return None
     if not _skip_persistent_context_cache(base_url, provider):
@@ -572,11 +572,11 @@ def _probe_local_context_length(model: str, base_url: str, api_key: str, provide
     return local_ctx
 
 
-def _reconcile_local_cached_context_length(model: str, base_url: str, cached: int, api_key: str = "") -> int:
+def _reconcile_local_cached_context_length(model: str, base_url: str, cached: int, api_key: str = "", api_mode: Optional[str] = None) -> int:
     """*cached* unless a live local probe reports a different limit (operators restart
     vLLM/Ollama with a new --max-model-len / num_ctx under the same id). A failed
     probe keeps the disk entry; sub-minimum live windows invalidate but are not persisted."""
-    live_ctx = _query_local_context_length(model, base_url, api_key=api_key)
+    live_ctx = _query_local_context_length(model, base_url, api_key=api_key, api_mode=api_mode)
     if not (live_ctx and live_ctx > 0 and live_ctx != cached):
         return cached
     if live_ctx < MINIMUM_CONTEXT_LENGTH:
@@ -629,8 +629,16 @@ def _localhost_to_ipv4(url: str) -> str:
     return re.sub(r"^(https?://)localhost(?=[:/]|$)", r"\g<1>127.0.0.1", url, count=1)
 
 
-def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
-    """Probe known endpoints: "ollama", "lm-studio", "vllm", "llamacpp", or None (TTL-cached)."""
+def detect_local_server_type(base_url: str, api_key: str = "", *, api_mode: Optional[str] = None) -> Optional[str]:
+    """Probe known endpoints: "ollama", "lm-studio", "vllm", "llamacpp", or None (TTL-cached).
+
+    ``api_mode``: when the caller's config *explicitly* set ``api_mode: chat_completions``
+    (see hermes-agent#25629), the user has opted into plain OpenAI-compatible behavior — the
+    endpoint may be an intermediary (LiteLLM, a router) that doesn't expose any of the
+    native-fingerprint routes below and would otherwise 404 the whole waterfall on every turn.
+    Skip the probe entirely rather than let it degrade to None the slow way."""
+    if api_mode == "chat_completions":
+        return None
     import httpx
     # IPv4-resolve BEFORE deriving server/LM Studio URLs and the cache lookup, so localhost and 127.0.0.1 share a cache entry.
     normalized = _localhost_to_ipv4(_normalize_base_url(base_url))
@@ -1195,19 +1203,22 @@ def _ollama_show(server_url: str, api_key: str, bare_model: str, timeout: float 
         return None
 
 
-def _is_ollama_server(base_url: str, api_key: str) -> bool:
+def _is_ollama_server(base_url: str, api_key: str, api_mode: Optional[str] = None) -> bool:
     try:
         # Forward the API key: a remote API-keyed endpoint answers the probe waterfall with 401s without it,
         # and an unauthorized probe can never produce a positive verdict (#89863).
-        return detect_local_server_type(base_url, api_key=api_key) == "ollama"
+        return detect_local_server_type(base_url, api_key=api_key, api_mode=api_mode) == "ollama"
     except Exception:
         return False
 
 
-def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Optional[int]:
-    """Ollama ``/api/show`` context (Modelfile num_ctx, else GGUF max); the value to send as ``num_ctx``."""
+def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "", api_mode: Optional[str] = None) -> Optional[int]:
+    """Ollama ``/api/show`` context (Modelfile num_ctx, else GGUF max); the value to send as ``num_ctx``.
+
+    ``api_mode``: forwarded to :func:`_is_ollama_server` — an explicit ``chat_completions``
+    config skips the native-server fingerprint (hermes-agent#25629) and this returns None."""
     bare_model, server_url = _strip_provider_prefix(model), _server_root(base_url)
-    if not _is_ollama_server(base_url, api_key):
+    if not _is_ollama_server(base_url, api_key, api_mode=api_mode):
         return None
     _disk_key = f"{server_url}|{bare_model}"
     disk_hit = _local_probe_disk_get("ollama_num_ctx", _disk_key)
@@ -1316,9 +1327,9 @@ def _model_name_suggests_stale_32k_underreport(model: str) -> bool:
     return _model_name_suggests_kimi(model) or _model_name_suggests_minimax(model)
 
 
-def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
+def _query_local_context_length(model: str, base_url: str, api_key: str = "", api_mode: Optional[str] = None) -> Optional[int]:
     """Local-server context probe, short-TTL cached (see _LOCAL_CTX_PROBE_CACHE)."""
-    return _memo_local_probe((_strip_provider_prefix(model), base_url.rstrip("/")), lambda: _query_local_context_length_uncached(model, base_url, api_key=api_key))
+    return _memo_local_probe((_strip_provider_prefix(model), base_url.rstrip("/")), lambda: _query_local_context_length_uncached(model, base_url, api_key=api_key, api_mode=api_mode))
 
 
 def _positive_int(value: Any) -> Optional[int]:
@@ -1375,8 +1386,13 @@ def _openai_models_list_context(client, server_url: str, model: str) -> Optional
     return None
 
 
-def _query_local_context_length_uncached(model: str, base_url: str, api_key: str = "") -> Optional[int]:
-    """Query a local server for the model's context length."""
+def _query_local_context_length_uncached(model: str, base_url: str, api_key: str = "", api_mode: Optional[str] = None) -> Optional[int]:
+    """Query a local server for the model's context length.
+
+    ``api_mode``: forwarded to :func:`detect_local_server_type` so an explicit
+    ``chat_completions`` config (hermes-agent#25629) skips the native-fingerprint waterfall;
+    the generic ``/v1/models`` probes further below still run since they're plain
+    OpenAI-compatible routes, not Ollama/llama.cpp/vLLM-specific ones."""
     import httpx
     model = _strip_provider_prefix(model)
     server_url = _server_root(base_url)
@@ -1384,7 +1400,7 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
     if _endpoint_blackholed(server_url):
         return None
     try:
-        server_type = detect_local_server_type(base_url, api_key=api_key)
+        server_type = detect_local_server_type(base_url, api_key=api_key, api_mode=api_mode)
     except Exception:
         server_type = None
     def _ollama_ctx(client) -> Optional[int]:
@@ -1639,7 +1655,7 @@ def _resolve_nous_context_length(model: str, base_url: str = "", api_key: str = 
     return None, ""
 
 
-def _validate_cached_context_length(model: str, base_url: str, cached: int, is_bedrock_context: bool, *, api_key: str = "") -> Optional[int]:
+def _validate_cached_context_length(model: str, base_url: str, cached: int, is_bedrock_context: bool, *, api_key: str = "", api_mode: Optional[str] = None) -> Optional[int]:
     """Step 1 of get_model_context_length: accept, repair, or drop a persisted entry. Returns the
     value to use, or None to fall through to live resolution. Order matters: a value must be
     rejected as bogus before any provider-specific handling."""
@@ -1680,7 +1696,7 @@ def _validate_cached_context_length(model: str, base_url: str, cached: int, is_b
     # GGUF training max first which can be larger and would create a false-safe window for compression
     # (#63122). Non-local endpoints preserve the existing GGUF-first behavior.
     if is_local_endpoint(base_url):
-        return _reconcile_local_cached_context_length(model, base_url, cached, api_key=api_key)
+        return _reconcile_local_cached_context_length(model, base_url, cached, api_key=api_key, api_mode=api_mode)
     return cached
 
 
@@ -1709,14 +1725,14 @@ def _resolve_bedrock_context_length(model: str, base_url: str) -> Optional[int]:
     return ctx
 
 
-def _resolve_custom_endpoint_context_length(model: str, base_url: str, api_key: str, provider: str) -> int:
+def _resolve_custom_endpoint_context_length(model: str, base_url: str, api_key: str, provider: str, api_mode: Optional[str] = None) -> int:
     """Steps 2-3 for a truly custom endpoint: /models, local probes, Ollama /api/show, catalog, default."""
     context_length = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
     if context_length is not None:
         return context_length
     # Local endpoints: the num_ctx-aware probe first — _query_ollama_api_show is GGUF-first, which
     # can be larger and create a false-safe compression window.
-    local_ctx = _probe_local_context_length(model, base_url, api_key, provider) if is_local_endpoint(base_url) else None
+    local_ctx = _probe_local_context_length(model, base_url, api_key, provider, api_mode=api_mode) if is_local_endpoint(base_url) else None
     if local_ctx:
         return local_ctx
     # 2b. Ollama native /api/show (GGUF-first for non-local). Non-Ollama servers 404/405 quickly.
@@ -1789,7 +1805,7 @@ def _config_override_context_length(model: str, base_url: str, provider: str, cu
     return None
 
 
-def _resolve_provider_aware_context_length(model: str, base_url: str, api_key: str, provider: str, effective_provider: str) -> Optional[int]:
+def _resolve_provider_aware_context_length(model: str, base_url: str, api_key: str, provider: str, effective_provider: str, api_mode: Optional[str] = None) -> Optional[int]:
     """Step 5: provider-specific sources, tried in order; None when all miss."""
     # 5a. Copilot live /models — account-specific models (claude-opus-4.6-1m) absent from
     # models.dev, and the provider-enforced limit for the rest.
@@ -1819,8 +1835,11 @@ def _resolve_provider_aware_context_length(model: str, base_url: str, api_key: s
         if ctx is not None:
             return ctx
     # 5e. Ollama native /api/show for any base_url that is not a known non-Ollama provider (there
-    # the POST always 404s and cost ~300ms on the first turn).
-    if base_url:
+    # the POST always 404s and cost ~300ms on the first turn). Skipped outright when api_mode was
+    # explicitly configured as chat_completions (hermes-agent#25629): a plain OpenAI-compatible
+    # intermediary (LiteLLM, a router) in front of Ollama may not forward /api/show at all, and the
+    # 404 round-trip is pure overhead the user opted out of by naming the wire protocol explicitly.
+    if base_url and api_mode != "chat_completions":
         inferred = _infer_provider_from_url(base_url)
         ctx = _query_ollama_api_show(model, base_url, api_key=api_key) if inferred is None or "ollama" in inferred else None
         if ctx is not None:
@@ -1848,14 +1867,19 @@ def _resolve_provider_aware_context_length(model: str, base_url: str, api_key: s
 
 def get_model_context_length(
     model: str, base_url: str = "", api_key: str = "", config_context_length: int | None = None,
-    provider: str = "", custom_providers: list | None = None,
+    provider: str = "", custom_providers: list | None = None, api_mode: str | None = None,
 ) -> int:
     """Context length for a model. Resolution order: 0 config override / MoA aggregator /
     model_overrides / custom_providers / endpoint-scoped; 1 persistent cache (Nous, LM
     Studio, Codex OAuth bypass it) and Bedrock; 2-3 custom endpoints (/models, local
     probe, Ollama); 4 Anthropic /v1/models (API keys only); 5 provider-aware (Copilot,
     Nous, Codex OAuth, GMI, Ollama, OpenRouter live, models.dev); 6 OpenRouter for
-    unknown providers; 7 local server; 8 hardcoded defaults; 9 256K fallback."""
+    unknown providers; 7 local server; 8 hardcoded defaults; 9 256K fallback.
+
+    ``api_mode``: the *explicitly configured* wire protocol (None unless the user's config sets
+    ``model.api_mode`` literally). When it is ``"chat_completions"``, every Ollama/llama.cpp/vLLM
+    native-route probe in steps 1-7 is skipped (hermes-agent#25629) — the user opted into plain
+    OpenAI-compatible behavior, and those routes may not exist on whatever sits at base_url."""
     # 0. Explicit config override — user knows best
     if isinstance(config_context_length, int) and config_context_length > 0:
         return config_context_length
@@ -1889,7 +1913,7 @@ def get_model_context_length(
     )
     # 1. Persistent cache (LM Studio / Codex OAuth excluded — see _skip_persistent_context_cache).
     cached = get_cached_context_length(model, base_url) if base_url and not _skip_persistent_context_cache(base_url, provider) else None
-    validated = _validate_cached_context_length(model, base_url, cached, is_bedrock_context, api_key=api_key) if cached is not None else None
+    validated = _validate_cached_context_length(model, base_url, cached, is_bedrock_context, api_key=api_key, api_mode=api_mode) if cached is not None else None
     if validated is not None:
         return validated
     # 1b. AWS Bedrock. Must run BEFORE the custom-endpoint step: bedrock-runtime.* is not in
@@ -1906,7 +1930,7 @@ def get_model_context_length(
     # 2. Live /models for truly custom endpoints. Known providers skip this: their /models may
     # report a provider-imposed limit (Copilot: 128k) rather than the window.
     if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
-        return _resolve_custom_endpoint_context_length(model, base_url, api_key, provider)
+        return _resolve_custom_endpoint_context_length(model, base_url, api_key, provider, api_mode=api_mode)
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (base_url and base_url_hostname(base_url) == "api.anthropic.com"):
         ctx = _query_anthropic_context_length(model, base_url or "https://api.anthropic.com", api_key)
@@ -1917,7 +1941,7 @@ def get_model_context_length(
     effective_provider = provider
     if base_url and (not effective_provider or effective_provider in {"openrouter", "custom"}):
         effective_provider = _infer_provider_from_url(base_url) or effective_provider
-    ctx = _resolve_provider_aware_context_length(model, base_url, api_key, provider, effective_provider)
+    ctx = _resolve_provider_aware_context_length(model, base_url, api_key, provider, effective_provider, api_mode=api_mode)
     if ctx is not None:
         return ctx
     # 6. OpenRouter metadata, provider-unaware fallback — only when the provider is unknown (OR
@@ -1932,7 +1956,7 @@ def get_model_context_length(
                 return or_ctx
     # 7. Local server before hardcoded defaults — ``Hermes-3-Llama-3.1-70B`` matches ``llama``
     # (131072) even when vLLM runs at a lower ``--max-model-len``.
-    local_ctx = _probe_local_context_length(model, base_url, api_key, provider) if base_url and is_local_endpoint(base_url) else None
+    local_ctx = _probe_local_context_length(model, base_url, api_key, provider, api_mode=api_mode) if base_url and is_local_endpoint(base_url) else None
     if local_ctx:
         return local_ctx
     # 8. Hardcoded defaults: `key in model` only — the reverse would let "claude-sonnet-4" match "claude-sonnet-4-6" and return 1M.
@@ -1944,12 +1968,13 @@ def get_model_context_length(
     return DEFAULT_FALLBACK_CONTEXT
 
 
-async def get_model_context_length_async(model: str, base_url: str = "", api_key: str = "", config_context_length: int | None = None, provider: str = "", custom_providers: list | None = None) -> int:
+async def get_model_context_length_async(model: str, base_url: str = "", api_key: str = "", config_context_length: int | None = None, provider: str = "", custom_providers: list | None = None, api_mode: str | None = None) -> int:
     """get_model_context_length on a worker thread (its blocking HTTP would stall the event loop)."""
     import asyncio
     return await asyncio.to_thread(
         get_model_context_length, model, base_url=base_url, api_key=api_key,
-        config_context_length=config_context_length, provider=provider, custom_providers=custom_providers)
+        config_context_length=config_context_length, provider=provider, custom_providers=custom_providers,
+        api_mode=api_mode)
 
 
 # CJK/Hangul/Kana codepoints (~1 token each), counted in one C-level regex pass: Hangul

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -1067,3 +1067,83 @@ class TestReconcileSelfHealsPoisonedCache:
         mock_save.assert_called_once_with(
             "deepseek-v4-flash", "http://127.0.0.1:8080/v1", 1048576
         )
+
+
+class TestDetectLocalServerTypeExplicitChatCompletions:
+    """hermes-agent#25629: an explicit ``api_mode: chat_completions`` opts out of the
+    Ollama/LM-Studio/llama.cpp/vLLM native-route fingerprint waterfall entirely. Without this,
+    an intermediary that doesn't expose those routes (e.g. a LiteLLM proxy fronting Ollama to
+    dodge Ollama's stream+tools hang) 404s every leg of the waterfall on every turn before
+    Hermes ever attempts the actual chat completion."""
+
+    def test_skips_probe_entirely_when_api_mode_is_chat_completions(self):
+        from agent.model_metadata import detect_local_server_type
+
+        with patch("httpx.Client") as mock_client_cls:
+            result = detect_local_server_type(
+                "http://127.0.0.1:4000/v1", api_mode="chat_completions"
+            )
+
+        assert result is None
+        mock_client_cls.assert_not_called()
+
+    @staticmethod
+    def _ollama_only_client():
+        """A client that answers the "ollama" waterfall leg (/api/tags with a "models" body)
+        200 and everything else (lm-studio's /api/v1/models, llama.cpp's /props) 404 — mimics a
+        real Ollama server so the waterfall lands on "ollama" rather than the first, more
+        permissive lm-studio check."""
+        def get(url, *a, **k):
+            resp = MagicMock()
+            if url.endswith("/api/tags"):
+                resp.status_code = 200
+                resp.json.return_value = {"models": []}
+            else:
+                resp.status_code = 404
+            return resp
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = get
+        return client_mock
+
+    def test_still_probes_when_api_mode_is_unset(self):
+        """Regression guard: omitting api_mode (the default for existing callers/tests) must
+        preserve the pre-existing waterfall behavior."""
+        from agent.model_metadata import detect_local_server_type
+
+        client_mock = self._ollama_only_client()
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type("http://127.0.0.1:4001/v1")
+
+        assert result == "ollama"
+        assert client_mock.get.called
+
+    def test_still_probes_when_api_mode_is_something_else(self):
+        """Only the literal "chat_completions" value opts out — an unrelated api_mode
+        (e.g. anthropic_messages routed through a local proxy) must not be silently caught by
+        the same gate."""
+        from agent.model_metadata import detect_local_server_type
+
+        client_mock = self._ollama_only_client()
+        with patch("httpx.Client", return_value=client_mock):
+            result = detect_local_server_type(
+                "http://127.0.0.1:4002/v1", api_mode="anthropic_messages"
+            )
+
+        assert result == "ollama"
+        assert client_mock.get.called
+
+    def test_query_ollama_num_ctx_short_circuits_via_api_mode(self):
+        """query_ollama_num_ctx (used by agent_init._configure_ollama_num_ctx on every agent
+        init for a local endpoint) must not touch the network when api_mode is explicitly
+        chat_completions — this is the exact code path hermes-agent#25629 reported hanging."""
+        from agent.model_metadata import query_ollama_num_ctx
+
+        with patch("httpx.Client") as mock_client_cls:
+            result = query_ollama_num_ctx(
+                "llama3.1:8b", "http://127.0.0.1:4003/v1", api_mode="chat_completions"
+            )
+
+        assert result is None
+        mock_client_cls.assert_not_called()

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -187,3 +187,68 @@ class TestCompressorClampsToNumCtx:
         # num_ctx above the resolved window must not RAISE the compressor
         # window: the clamp is one-directional.
         assert agent.context_compressor.context_length == 65536
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# hermes-agent#25629 — explicit api_mode: chat_completions must skip the
+# Ollama-native pre-flight probe (agent_init._configure_ollama_num_ctx),
+# regardless of the base_url being a local/Ollama-shaped endpoint.
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestConfigureOllamaNumCtxRespectsExplicitApiMode:
+    def _build_agent(self, *, api_mode=None):
+        with (
+            patch("model_tools.get_tool_definitions", return_value=[]),
+            patch("model_tools.check_toolset_requirements", return_value={}),
+            patch("agent.process_bootstrap.OpenAI"),
+            patch("hermes_cli.config.load_config", return_value={"agent": {}, "model": {}}),
+            patch("hermes_cli.config.load_config_readonly", return_value={"agent": {}, "model": {}}),
+            patch("agent.model_metadata.get_model_context_length", return_value=131072),
+            patch("agent.context_compressor.get_model_context_length", return_value=131072),
+        ):
+            from run_agent import AIAgent
+            return AIAgent(
+                model="llama3.1:8b",
+                api_key="ollama",
+                base_url="http://127.0.0.1:11434/v1",
+                api_mode=api_mode,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    def test_explicit_chat_completions_skips_ollama_num_ctx_probe(self):
+        """Issue #25629 Option 1: a user who explicitly configures api_mode:
+        chat_completions — typically to route a local Ollama server through an
+        OpenAI-compatible intermediary (LiteLLM) that works around Ollama's
+        stream+tools hang — must not have Hermes probe Ollama-native routes
+        (/api/tags, /api/show, ...) on that intermediary. Those probes 404 on
+        an intermediary that only exposes /v1/chat_completions and previously
+        cost a full waterfall of round trips on every agent init."""
+        with patch(
+            "agent.agent_init.query_ollama_num_ctx"
+        ) as mock_query_num_ctx:
+            agent = self._build_agent(api_mode="chat_completions")
+
+        mock_query_num_ctx.assert_not_called()
+        assert agent._ollama_num_ctx is None
+        assert agent.api_mode == "chat_completions"
+
+    def test_unset_api_mode_still_probes_ollama_num_ctx(self):
+        """Regression guard: the overwhelming majority of existing direct-Ollama
+        setups never set model.api_mode at all (it resolves to "chat_completions"
+        as the ladder default in _resolve_api_mode, but that is NOT the same as
+        the user explicitly opting out) — they must keep getting num_ctx
+        auto-detection exactly as before this fix."""
+        with patch(
+            "agent.agent_init.query_ollama_num_ctx", return_value=65536
+        ) as mock_query_num_ctx:
+            agent = self._build_agent(api_mode=None)
+
+        mock_query_num_ctx.assert_called_once()
+        assert agent._ollama_num_ctx == 65536
+        # Confirms the ladder default really is "chat_completions" — proving the
+        # fix could not have simply gated on agent.api_mode without breaking
+        # this (the common) case.
+        assert agent.api_mode == "chat_completions"


### PR DESCRIPTION
## Summary

Fixes the pre-flight-detection part of #25629.

`detect_local_server_type()` (`agent/model_metadata.py`) runs an unconditional fingerprint waterfall — `/api/tags`, `/api/v1/models`, `/props`, `/v1/props`, `/version` — invoked on every `init_agent()` call via `_configure_ollama_num_ctx()` (`agent/agent_init.py`), regardless of `api_mode`. This exactly reproduces the log sequence in #25629: a user who explicitly sets `api_mode: chat_completions` to talk to an OpenAI-compatible intermediary (e.g. a proxy sitting in front of Ollama) still gets probed against Ollama-native routes the intermediary doesn't expose, gets 404s, and the agent aborts before ever attempting the real completion request.

## Change

Threads the **raw, explicitly-configured** `api_mode` — not the *resolved* `agent.api_mode`, which defaults to `"chat_completions"` for most direct-Ollama users too via the config ladder's final rung, and would have silently disabled num_ctx detection for the majority of existing users if used as the gate — through:

```
detect_local_server_type -> _is_ollama_server -> query_ollama_num_ctx -> _configure_ollama_num_ctx
```

short-circuiting the probe waterfall only when `api_mode` was **explicitly** set to `chat_completions`. Extends the same gate into the secondary `get_model_context_length` pipeline and `_build_context_engine`'s plugin-engine path. All additive `Optional[str] = None` parameters — zero behavior change for any existing caller that doesn't pass the new arg.

Deliberately did **not** wire this into `ContextCompressor` (the default, most-used compressor) — it already degrades gracefully on probe failure (try/except with fallback) rather than hanging, and changing its constructor felt too invasive on a first pass through this codebase. Flagging this as a spot a maintainer may want to extend further.

## `stream=true`

The other bug reported in #25629 (Hermes hardcoding `stream=true`) is already fixed independently — `model.streaming: false` (added in #72901, after #25629 was filed) fully disables streaming end-to-end via `_should_stream()` in `agent/turn_api_call.py`. Not touched here.

## Testing

- 6 new tests: 4 unit (`tests/agent/test_model_metadata_local_ctx.py`) covering the probe being skipped only for the literal explicit value and unaffected when unset/other, 2 integration (`tests/test_ollama_num_ctx.py`) explicitly asserting the resolved-default trap (`agent.api_mode == "chat_completions"` even when nothing was configured) that a naive gate on the resolved value would have fallen into.
- `ruff check`: clean. `ty check`: identical to baseline (3 pre-existing diagnostics, none new).
- Ran via the project's isolated per-file test runner (`scripts/run_tests.sh`) rather than bare `pytest`, per this repo's test-isolation requirements: all tests pass, and a full baseline comparison (`git stash`) against unmodified `main` confirms zero regressions.