### PR TITLE
feat(tools): add service-gated dsh_task tool to run local DeepSeek Harness (dsh) agents

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -28,6 +28,47 @@ database:
   # synchronous: FULL
 
 # =============================================================================
+# DeepSeek Harness (dsh)
+# =============================================================================
+# Lets the dsh_task model tool run agent tasks on a local DeepSeek Harness
+# (https://github.com/deepseek-ai/dsh). The "dsh" toolset is OFF by default:
+# enable it by adding `dsh` to platform_toolsets.<platform> (e.g.
+# `cli: [hermes-cli, dsh]`) or via `hermes tools` -> DeepSeek Harness.
+#
+# dsh keeps its own upstream model credentials in ~/.dsh/.credentials.yaml;
+# Hermes never stores or forwards them. The dsh web process is managed
+# externally (start-harness.ps1 / scheduled task) -- nothing here launches it.
+dsh:
+  # dsh web JSON-RPC base URL, used by dsh_task action=list for session
+  # inventory. Loopback needs no auth.
+  url: "http://127.0.0.1:3080"
+  # dsh CLI launch command for action=run (one-shot headless tasks), in argv
+  # form so paths with spaces need no shell quoting. Source checkout example:
+  #   command: ["C:/Users/g/tools/node-v22.19.0-win-x64/node.exe", "--import", "tsx/esm", "D:/5.ai/deeseek harness/deepseek-harness-master/apps/cli/src/bin.ts"]
+  # npm-installed CLI example:
+  #   command: ["dsh"]
+  # Empty = action=run unavailable (action=list still works if url is up).
+  command: []
+  # dsh profile tasks run under. "headless" is the built-in one-shot profile:
+  # final assistant text on stdout, exit 0/1, no port, no interaction.
+  profile: "headless"
+  # Working directory for action=run. dsh groups its persisted sessions by
+  # cwd (~/.dsh/sessions/<cwd>), so pin this to where dsh should work.
+  # Empty = inherit Hermes' own working directory (callers may also pass a
+  # per-call cwd to the tool).
+  cwd: ""
+  # Hard deadline for action=run, in seconds. dsh headless has no internal
+  # timeout -- the process tree is killed when this expires. 900s default.
+  timeout: 900
+  # Windows only: directory whose bash.exe is the REAL Git Bash (e.g.
+  # "D:/Program Files/Git/bin"), prepended to PATH for the dsh child so it
+  # never resolves the WSL shim at C:\Windows\System32\bash.exe. Leave empty
+  # on Linux/macOS where bash is already on PATH.
+  bash_dir: ""
+
+
+
+# =============================================================================
 # Runtime Limits
 # =============================================================================
 # Long-running Hermes server processes raise their RLIMIT_NOFILE soft limit to

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -119,6 +119,7 @@ CONFIGURABLE_TOOLSETS = [
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
+    ("dsh",              "🤖 DeepSeek Harness",         "run agent tasks on the local dsh harness (dsh_task run/list)"),
     ("spotify",          "🎵 Spotify",                  "playback, search, playlists, library"),
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
@@ -156,7 +157,7 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a"}
+_DEFAULT_OFF_TOOLSETS = {"dsh", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a"}
 
 
 # Config-only capabilities: they appear in `hermes tools` for provider/API-key

--- a/tests/tools/test_dsh_tool.py
+++ b/tests/tools/test_dsh_tool.py
@@ -9,6 +9,12 @@ Covers (mocked -- no real dsh process, no model spend):
 - handler dispatch matrix via mocked client:
   run success, run missing goal, run timeout, list unreachable, unknown action
 - registry integration: toolset "dsh", async handler, schema shape
+- run_headless subprocess lifecycle (create_subprocess_exec mocked): argv/env
+  construction, launch failures (missing executable / bad cwd), timeout with
+  kill-tree + bounded drain
+- rpc()/list_sessions HTTP transport (aiohttp mocked): Typert frame shape,
+  HTTP error mapping (401/403 auth, 500), non-JSON body, connection refused,
+  compaction + limit, malformed session.list payload
 """
 
 import asyncio
@@ -333,3 +339,329 @@ def test_tool_error_code_surfaces_as_extra_field():
     out = _load_json(_err("boom", code="DSH_TIMEOUT", elapsed_s=9))
     assert out["code"] == "DSH_TIMEOUT"
     assert out["elapsed_s"] == 9
+
+
+# ---------------------------------------------------------------------------
+# run_headless(): subprocess lifecycle (create_subprocess_exec fully mocked)
+# ---------------------------------------------------------------------------
+
+def _fake_proc(returncode, stdout=b"", stderr=b"", *, first_communicate=None):
+    """Build a fake asyncio subprocess with the surface run_headless touches."""
+    state = {"communicate_calls": 0}
+
+    class _Proc:
+        pid = 4242
+
+        def __init__(self):
+            # instance attr: a class-body ``returncode = returncode`` would
+            # hit the unbound class-local (Python scoping gotcha)
+            self.returncode = returncode
+
+        async def communicate(self):
+            state["communicate_calls"] += 1
+            if first_communicate is not None and state["communicate_calls"] == 1:
+                raise first_communicate
+            return stdout, stderr
+
+        def kill(self):
+            state["killed"] = True
+
+    return _Proc(), state
+
+
+def _spawn_fake(monkeypatch, proc, *, fail=None):
+    """Monkeypatch asyncio.create_subprocess_exec; capture argv/env/cwd."""
+    from tools import dsh_client
+
+    captured = {}
+
+    async def _fake_exec(*argv, **kwargs):
+        captured["argv"] = argv
+        captured["cwd"] = kwargs.get("cwd")
+        captured["env"] = kwargs.get("env")
+        captured["start_new_session"] = kwargs.get("start_new_session")
+        if fail is not None:
+            raise fail
+        return proc
+
+    monkeypatch.setattr(dsh_client.asyncio, "create_subprocess_exec", _fake_exec)
+    return captured
+
+
+def test_run_headless_missing_command_raises_not_configured():
+    from tools.dsh_client import run_headless, DshNotConfigured
+
+    with pytest.raises(DshNotConfigured) as ei:
+        asyncio.run(run_headless("do a thing", config={}))
+    assert ei.value.code == "DSH_NOT_CONFIGURED"
+    assert "dsh.command" in ei.value.message
+
+
+def test_run_headless_nonpositive_config_timeout_raises(monkeypatch):
+    from tools.dsh_client import run_headless, DshNotConfigured
+
+    captured = {}
+
+    async def _never_called(*argv, **kwargs):
+        captured["spawned"] = True
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", _never_called)
+    with pytest.raises(DshNotConfigured):
+        asyncio.run(
+            run_headless("x", config={"command": ["dsh"], "timeout": 0})
+        )
+    assert "spawned" not in captured  # fail fast, before any process starts
+
+
+def test_run_headless_launch_file_not_found(monkeypatch):
+    from tools.dsh_client import run_headless, DshLaunchFailed
+
+    proc, _ = _fake_proc(0)
+    _spawn_fake(monkeypatch, proc, fail=FileNotFoundError(2, "no such file"))
+    with pytest.raises(DshLaunchFailed) as ei:
+        asyncio.run(run_headless("x", config={"command": ["dsh"]}))
+    assert ei.value.code == "DSH_LAUNCH_FAILED"
+    assert "executable not found" in ei.value.message
+
+
+def test_run_headless_launch_oserror_bad_cwd(monkeypatch):
+    from tools.dsh_client import run_headless, DshLaunchFailed
+
+    proc, _ = _fake_proc(0)
+    _spawn_fake(monkeypatch, proc, fail=OSError(2, "bad cwd"))
+    with pytest.raises(DshLaunchFailed) as ei:
+        asyncio.run(
+            run_headless("x", config={"command": ["dsh"]}, cwd="Z:/no/such/dir")
+        )
+    assert ei.value.code == "DSH_LAUNCH_FAILED"
+    assert "cwd" in ei.value.message
+
+
+def test_run_headless_success_builds_argv_env_and_summary(monkeypatch):
+    from tools.dsh_client import run_headless, _DEFAULT_PROFILE
+
+    proc, _ = _fake_proc(0, stdout=b"final assistant text here\n")
+    captured = _spawn_fake(monkeypatch, proc)
+    config = {
+        "command": ["node", "--import", "tsx/esm", "D:/harness/bin.ts"],
+        "profile": "headless",
+        "bash_dir": "D:/Git/bin",
+        "cwd": "F:/work",
+    }
+    result = asyncio.run(run_headless("fix the bug", config=config))
+    assert result["ok"] is True
+    assert result["status"] == "completed"
+    assert result["output"] == "final assistant text here"
+    assert result["cwd"] == "F:/work"
+
+    argv = captured["argv"]
+    assert argv == ("node", "--import", "tsx/esm", "D:/harness/bin.ts",
+                    "--profile", "headless", "fix the bug")
+    # bash_dir is prepended to PATH so the child never resolves the WSL shim.
+    assert captured["env"]["PATH"].startswith("D:/Git/bin" + __import__("os").pathsep)
+    assert captured["cwd"] == "F:/work"
+    assert captured["start_new_session"] is (__import__("sys").platform != "win32")
+    assert _DEFAULT_PROFILE == "headless"  # guard: test relies on this default
+
+
+def test_run_headless_profile_default_and_goal_arg(monkeypatch):
+    """profile/argv defaults when the config omits them."""
+    from tools.dsh_client import run_headless
+
+    proc, _ = _fake_proc(0, stdout=b"ok\n")
+    captured = _spawn_fake(monkeypatch, proc)
+    asyncio.run(run_headless("do it", config={"command": ["dsh"]}))
+    assert captured["argv"] == ("dsh", "--profile", "headless", "do it")
+
+
+def test_run_headless_timeout_kills_tree_and_raises(monkeypatch):
+    from tools import dsh_client
+    from tools.dsh_client import run_headless, DshTimeoutError
+
+    proc, state = _fake_proc(
+        1, stdout=b"partial output before the deadline\n",
+        first_communicate=asyncio.TimeoutError(),
+    )
+    _spawn_fake(monkeypatch, proc)
+    killed = []
+
+    def _spy_kill(target):
+        killed.append(target)
+
+    monkeypatch.setattr(dsh_client, "_kill_process_tree", _spy_kill)
+    with pytest.raises(DshTimeoutError) as ei:
+        asyncio.run(
+            asyncio.wait_for(
+                run_headless("slow job", config={"command": ["dsh"], "timeout": 5}),
+                timeout=15,
+            )
+        )
+    assert ei.value.code == "DSH_TIMEOUT"
+    assert "killed" in ei.value.message
+    assert killed == [proc]                      # the tree killer ran on it
+    assert state["communicate_calls"] == 2       # bounded drain after the kill
+    assert "partial output" in ei.value.extra["stdout_tail"]
+
+
+# ---------------------------------------------------------------------------
+# rpc() / list_sessions(): HTTP transport (aiohttp fully mocked)
+# ---------------------------------------------------------------------------
+
+class _FakeResp:
+    """Stand-in for an aiohttp response: status + text() + async CM."""
+
+    def __init__(self, status=200, body=""):
+        self.status = status
+        self._body = body
+
+    async def text(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _fake_aiohttp(monkeypatch, resp_factory):
+    """Inject a minimal fake aiohttp module; capture posted frames."""
+    import sys
+    import types
+
+    captured = []
+
+    class _ClientTimeout:
+        def __init__(self, **kwargs):
+            self.total = kwargs.get("total")
+
+    class _ClientConnectionError(OSError):
+        pass
+
+    class _FakeSession:
+        def __init__(self):
+            self.closed = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            self.closed = True
+            return False
+
+        def post(self, url, *, json=None, timeout=None):
+            captured.append({"url": url, "json": json, "timeout": timeout})
+            return resp_factory()
+
+    fake = types.ModuleType("aiohttp")
+    fake.ClientSession = _FakeSession
+    fake.ClientTimeout = _ClientTimeout
+    fake.ClientConnectionError = _ClientConnectionError
+    monkeypatch.setitem(sys.modules, "aiohttp", fake)
+    return captured
+
+
+def test_rpc_success_posts_typert_envelope(monkeypatch):
+    from tools.dsh_client import rpc
+
+    ok_body = json.dumps(
+        {"type": "server-response", "rpcId": "x",
+         "result": {"ok": True, "value": {"items": [1, 2]}}}
+    )
+    captured = _fake_aiohttp(monkeypatch, lambda: _FakeResp(200, ok_body))
+    value = asyncio.run(
+        rpc("session.list", {}, config={"url": "http://127.0.0.1:3080"})
+    )
+    assert value == {"items": [1, 2]}
+
+    call = captured[0]
+    assert call["url"] == "http://127.0.0.1:3080/api/session.list"
+    frame = call["json"]
+    assert frame["type"] == "client-request"
+    assert frame["method"] == "session.list"
+    assert frame["payload"] == {}
+    assert frame["rpcId"].startswith("hermes-")
+    assert call["timeout"].total == 15
+
+
+def test_rpc_http_error_mapping(monkeypatch):
+    from tools.dsh_client import rpc, DshAuthError, DshProtocolError
+
+    for status, exc_type, code in [
+        (401, DshAuthError, "DSH_AUTH_FAILED"),
+        (403, DshAuthError, "DSH_AUTH_FAILED"),
+        (500, DshProtocolError, "DSH_PROTOCOL_ERROR"),
+    ]:
+        _fake_aiohttp(monkeypatch, lambda s=status: _FakeResp(s, "boom"))
+        with pytest.raises(exc_type) as ei:
+            asyncio.run(rpc("session.list", {}, config={"url": "http://127.0.0.1:3080"}))
+        assert ei.value.code == code
+
+
+def test_rpc_non_json_body_protocol_error(monkeypatch):
+    from tools.dsh_client import rpc, DshProtocolError
+
+    _fake_aiohttp(monkeypatch, lambda: _FakeResp(200, "<html>not json</html>"))
+    with pytest.raises(DshProtocolError) as ei:
+        asyncio.run(rpc("session.list", {}, config={"url": "http://127.0.0.1:3080"}))
+    assert "non-JSON" in ei.value.message
+
+
+def test_rpc_connection_refused_unreachable(monkeypatch):
+    from tools.dsh_client import rpc, DshUnreachable
+
+    def _raising_resp():
+        fake = __import__("sys").modules["aiohttp"]
+        raise fake.ClientConnectionError("connection refused")
+
+    _fake_aiohttp(monkeypatch, _raising_resp)
+    with pytest.raises(DshUnreachable) as ei:
+        asyncio.run(rpc("session.list", {}, config={"url": "http://127.0.0.1:3080"}))
+    assert ei.value.code == "DSH_UNREACHABLE"
+    assert "not listening" in ei.value.message
+
+
+def test_rpc_missing_url_not_configured():
+    from tools.dsh_client import rpc, DshNotConfigured
+
+    with pytest.raises(DshNotConfigured):
+        asyncio.run(rpc("session.list", {}, config={"url": ""}))
+
+
+def test_list_sessions_compacts_and_limits(monkeypatch):
+    from tools import dsh_client
+    from tools.dsh_client import list_sessions
+
+    items = []
+    for i in range(10):
+        items.append({
+            "sessionId": f"s{i}",
+            "cwd": f"F:/work{i}",
+            "agentPreset": "standard",
+            "running": i % 2 == 0,
+            "updatedAt": 12345 + i,
+            "projections": {"values": {"title": f"Task {i}"}},
+        })
+
+    async def _fake_rpc(method, payload, **kw):
+        assert method == "session.list"
+        return {"items": items}
+
+    monkeypatch.setattr(dsh_client, "rpc", _fake_rpc)
+    out = asyncio.run(list_sessions(limit=3))
+    assert out["ok"] is True
+    assert out["count"] == 3
+    assert out["items"][0]["title"] == "Task 0"
+    assert out["items"][0]["sessionId"] == "s0"
+
+
+def test_list_sessions_missing_items_protocol_error(monkeypatch):
+    from tools import dsh_client
+    from tools.dsh_client import list_sessions, DshProtocolError
+
+    async def _fake_rpc(method, payload, **kw):
+        return {"unexpected": True}
+
+    monkeypatch.setattr(dsh_client, "rpc", _fake_rpc)
+    with pytest.raises(DshProtocolError):
+        asyncio.run(list_sessions())

--- a/tests/tools/test_dsh_tool.py
+++ b/tests/tools/test_dsh_tool.py
@@ -1,0 +1,335 @@
+"""Tests for the dsh integration: tools/dsh_client.py + tools/dsh_tool.py.
+
+Covers (mocked -- no real dsh process, no model spend):
+- check_fn truth table (no config -> hidden; command/url present -> visible)
+- headless outcome matrix via the pure interpret_run() classifier:
+  success / non-zero exec failure / auth-ish failure / empty stdout / truncation
+- JSON-RPC envelope parsing: ok value, server error envelope, malformed frames
+- HTTP status mapping (401/403 auth, 404 protocol)
+- handler dispatch matrix via mocked client:
+  run success, run missing goal, run timeout, list unreachable, unknown action
+- registry integration: toolset "dsh", async handler, schema shape
+"""
+
+import asyncio
+import json
+
+import pytest
+
+
+def _run_handler(args):
+    """Run the async dsh_task handler synchronously."""
+    from tools.dsh_tool import _handle_dsh_task
+
+    return asyncio.run(_handle_dsh_task(args))
+
+
+def _load_json(text):
+    return json.loads(text)
+
+
+# ---------------------------------------------------------------------------
+# Config loading & availability gate
+# ---------------------------------------------------------------------------
+
+def _config_with(block):
+    """Return a loader that makes load_config_readonly() yield a config whose
+    ``dsh`` block is *block* (or absent when block is None)."""
+    def _loader():
+        return {"dsh": block} if block is not None else {}
+    return _loader
+
+
+def test_load_config_absent_section(monkeypatch):
+    from tools import dsh_client
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _config_with(None))
+    assert dsh_client.load_config() == {}
+
+
+def test_load_config_present_section(monkeypatch):
+    from tools import dsh_client
+
+    block = {"command": ["dsh"], "url": "http://127.0.0.1:3080"}
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _config_with(block))
+    assert dsh_client.load_config() == block
+
+
+@pytest.mark.parametrize(
+    "block,expected",
+    [
+        (None, False),                      # no dsh section -> hidden
+        ({}, False),                        # empty section -> hidden
+        ({"url": "http://127.0.0.1:3080"}, True),   # list-capable
+        ({"command": ["dsh"]}, True),       # run-capable
+        ({"command": [], "url": ""}, False),
+    ],
+)
+def test_check_dsh_available_truth_table(monkeypatch, block, expected):
+    from tools import dsh_tool
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _config_with(block))
+    assert dsh_tool._check_dsh_available() is expected
+
+
+def test_check_fn_config_cache_safe(monkeypatch):
+    """check_fn must not probe the network -- config presence only."""
+    from tools import dsh_tool
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _config_with({"command": ["dsh"]}))
+    assert dsh_tool._check_dsh_available() is True
+
+
+def test_cfg_command_shapes():
+    from tools.dsh_client import _cfg_command
+
+    assert _cfg_command({"command": ["node", "--import", "tsx/esm", "bin.ts"]}) == [
+        "node", "--import", "tsx/esm", "bin.ts"
+    ]
+    assert _cfg_command({"command": "dsh --profile headless"}) == ["dsh", "--profile", "headless"]
+    assert _cfg_command({"command": []}) == []
+    assert _cfg_command({}) == []
+
+
+# ---------------------------------------------------------------------------
+# interpret_run(): headless outcome matrix
+# ---------------------------------------------------------------------------
+
+def test_interpret_run_success():
+    from tools.dsh_client import interpret_run
+
+    result = interpret_run(
+        0, "done: created hello.py\n", "",
+        elapsed_s=12.6, cwd="F:/work", sessions_dir="C:/Users/g/.dsh/sessions",
+    )
+    assert result["ok"] is True
+    assert result["status"] == "completed"
+    assert result["output"] == "done: created hello.py"
+    assert result["cwd"] == "F:/work"
+    assert result["elapsed_s"] == 13
+
+
+def test_interpret_run_truncates_long_output():
+    from tools.dsh_client import interpret_run, _OUTPUT_CAP_CHARS
+
+    result = interpret_run(
+        0, "x" * (_OUTPUT_CAP_CHARS + 5000), "",
+        elapsed_s=1, cwd=None, sessions_dir="s",
+    )
+    assert "[truncated" in result["output"]
+    assert len(result["output"]) <= _OUTPUT_CAP_CHARS + 60
+
+
+def test_interpret_run_nonzero_exit_exec_failed():
+    from tools.dsh_client import interpret_run, DshExecFailed
+
+    with pytest.raises(DshExecFailed) as ei:
+        interpret_run(1, "", "error: agent crashed", elapsed_s=3, cwd=None, sessions_dir="s")
+    assert ei.value.code == "DSH_EXEC_FAILED"
+    assert "error: agent crashed" in ei.value.message
+
+
+def test_interpret_run_auth_failure_classified():
+    from tools.dsh_client import interpret_run, DshAuthError
+
+    with pytest.raises(DshAuthError) as ei:
+        interpret_run(
+            1, "",
+            '{"code":"auth","message":"401 invalid api key"}',
+            elapsed_s=3, cwd=None, sessions_dir="s",
+        )
+    assert ei.value.code == "DSH_AUTH_FAILED"
+    assert "DEEPSEEK_API_KEY" in ei.value.message
+
+
+def test_interpret_run_empty_stdout_empty_result():
+    from tools.dsh_client import interpret_run, DshEmptyResult
+
+    with pytest.raises(DshEmptyResult) as ei:
+        interpret_run(0, "   \n", "", elapsed_s=3, cwd=None, sessions_dir="s")
+    assert ei.value.code == "DSH_EMPTY_RESULT"
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC envelope parsing & HTTP status mapping
+# ---------------------------------------------------------------------------
+
+def test_parse_envelope_ok():
+    from tools.dsh_client import _parse_envelope
+
+    value = _parse_envelope(
+        {"type": "server-response", "rpcId": "r1", "result": {"ok": True, "value": {"items": []}}}
+    )
+    assert value == {"items": []}
+
+
+def test_parse_envelope_server_error():
+    from tools.dsh_client import _parse_envelope, DshRpcError
+
+    with pytest.raises(DshRpcError) as ei:
+        _parse_envelope(
+            {
+                "type": "server-response",
+                "rpcId": "r1",
+                "result": {
+                    "ok": False,
+                    "error": {"code": "bad-request", "message": "invalid client-request message"},
+                },
+            }
+        )
+    assert ei.value.code == "DSH_RPC_ERROR"
+    assert "bad-request" in ei.value.message
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        "not-a-dict",
+        {"type": "client-request", "rpcId": "x", "method": "session.list"},
+        {"type": "server-response", "rpcId": "x", "result": {"ok": True}},  # no value
+    ],
+)
+def test_parse_envelope_protocol_errors(frame):
+    from tools.dsh_client import _parse_envelope, DshProtocolError
+
+    with pytest.raises(DshProtocolError):
+        _parse_envelope(frame)
+
+
+def test_map_http_status():
+    from tools.dsh_client import _map_http_status, DshAuthError, DshProtocolError
+
+    assert isinstance(_map_http_status(401, "nope"), DshAuthError)
+    assert isinstance(_map_http_status(403, "nope"), DshAuthError)
+    assert isinstance(_map_http_status(404, "nope"), DshProtocolError)
+    assert isinstance(_map_http_status(500, "boom"), DshProtocolError)
+
+
+# ---------------------------------------------------------------------------
+# Handler dispatch (client fully mocked)
+# ---------------------------------------------------------------------------
+
+def test_handler_run_success(monkeypatch):
+    from tools import dsh_client
+
+    async def _fake_run(task, *, cwd=None, timeout=None):
+        assert task == "write hello.py and run it"
+        assert cwd == "F:/work"
+        assert timeout == 60
+        return {"ok": True, "status": "completed", "exit_code": 0,
+                "output": "wrote and ran hello.py", "cwd": "F:/work",
+                "elapsed_s": 5}
+
+    monkeypatch.setattr(dsh_client, "run_headless", _fake_run)
+    payload = _load_json(
+        _run_handler({"action": "run", "goal": "write hello.py and run it",
+                      "cwd": "F:/work", "timeout": 60})
+    )
+    assert payload["ok"] is True
+    assert payload["status"] == "completed"
+
+
+def test_handler_run_missing_goal():
+    payload = _load_json(_run_handler({"action": "run"}))
+    assert payload["error"]
+    assert payload["code"] == "DSH_BAD_ARGUMENT"
+
+
+def test_handler_run_timeout_maps_code(monkeypatch):
+    from tools import dsh_client
+    from tools.dsh_client import DshTimeoutError
+
+    async def _fake_timeout(task, **kw):
+        raise DshTimeoutError("dsh task exceeded the 10s timeout and was killed",
+                              extra={"elapsed_s": 10})
+
+    monkeypatch.setattr(dsh_client, "run_headless", _fake_timeout)
+    payload = _load_json(_run_handler({"action": "run", "goal": "long job", "timeout": 10}))
+    assert payload["code"] == "DSH_TIMEOUT"
+    assert "killed" in payload["error"]
+
+
+def test_handler_run_not_configured(monkeypatch):
+    from tools import dsh_client
+    from tools.dsh_client import DshNotConfigured
+
+    async def _fake_not_configured(task, **kw):
+        raise DshNotConfigured("dsh.command is empty in the dsh: config block")
+
+    monkeypatch.setattr(dsh_client, "run_headless", _fake_not_configured)
+    payload = _load_json(_run_handler({"action": "run", "goal": "x"}))
+    assert payload["code"] == "DSH_NOT_CONFIGURED"
+    assert "dsh.command" in payload["error"]
+
+
+def test_handler_list_unreachable(monkeypatch):
+    from tools import dsh_client
+    from tools.dsh_client import DshUnreachable
+
+    async def _fake_list(**kw):
+        raise DshUnreachable("dsh web is not listening at http://127.0.0.1:3080")
+
+    monkeypatch.setattr(dsh_client, "list_sessions", _fake_list)
+    payload = _load_json(_run_handler({"action": "list"}))
+    assert payload["code"] == "DSH_UNREACHABLE"
+    assert "not listening" in payload["error"]
+
+
+def test_handler_list_success(monkeypatch):
+    from tools import dsh_client
+
+    async def _fake_list(**kw):
+        assert kw.get("limit") == 5
+        return {"ok": True, "count": 1,
+                "items": [{"sessionId": "s1", "cwd": "F:/work", "agentPreset": "standard"}]}
+
+    monkeypatch.setattr(dsh_client, "list_sessions", _fake_list)
+    payload = _load_json(_run_handler({"action": "list", "limit": 5}))
+    assert payload["ok"] is True
+    assert payload["items"][0]["sessionId"] == "s1"
+
+
+def test_handler_unknown_action():
+    payload = _load_json(_run_handler({"action": "steer"}))
+    assert payload["code"] == "DSH_BAD_ARGUMENT"
+    assert "Unknown action" in payload["error"]
+
+
+def test_handler_run_empty_goal_with_action_run():
+    payload = _load_json(_run_handler({"action": "run", "goal": "   "}))
+    assert payload["code"] == "DSH_BAD_ARGUMENT"
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+def test_registry_entry_registered():
+    from tools.registry import registry
+    import tools.dsh_tool  # noqa: F401 -- module-level register() call
+
+    entry = registry.get_entry("dsh_task")
+    assert entry is not None
+    assert entry.toolset == "dsh"
+    assert entry.is_async is True
+    assert entry.check_fn is tools.dsh_tool._check_dsh_available
+
+
+def test_schema_shape():
+    import tools.dsh_tool as mod
+
+    schema = mod.DSH_TASK_SCHEMA
+    assert schema["name"] == "dsh_task"
+    props = schema["parameters"]["properties"]
+    assert set(props) == {"action", "goal", "cwd", "timeout", "limit"}
+    assert props["action"]["enum"] == ["run", "list"]
+    assert props["goal"]["type"] == "string"
+
+
+def test_tool_error_code_surfaces_as_extra_field():
+    """tool_error(message, code=...) must carry the DSH_* code to the model."""
+    from tools.dsh_tool import _err
+
+    out = _load_json(_err("boom", code="DSH_TIMEOUT", elapsed_s=9))
+    assert out["code"] == "DSH_TIMEOUT"
+    assert out["elapsed_s"] == 9

--- a/tools/dsh_client.py
+++ b/tools/dsh_client.py
@@ -1,0 +1,494 @@
+"""Minimal client for the local DeepSeek Harness (dsh) agent process.
+
+Pure transport/client layer -- no registry imports, safe to import from
+tests or other tools. Mirrors what dsh 0.1.x actually exposes (see the kanban
+dsh integration spec):
+
+* ``run_headless`` -- one-shot task via ``dsh --profile headless "<task>"``:
+  a fresh agent is started, the task is submitted as a user message, the
+  final assistant text lands on stdout and the exit code (0/1) expresses
+  success/failure. No port, no interaction, no built-in timeout -- the caller
+  must kill the process tree once the deadline passes.
+* ``rpc`` / ``list_sessions`` -- read-only JSON-RPC against the dsh *web*
+  profile (``POST /api/<method>`` on ``dsh.url``, default
+  http://127.0.0.1:3080), used for session inventory. dsh exposes no
+  OpenAI-compatible endpoint, so task execution is process-level only.
+
+All failures are normalized to :class:`DshError` subclasses carrying a
+stable ``code`` (DSH_* string) that the tool layer surfaces to the model.
+Configuration is read from the ``dsh:`` block of config.yaml (see
+cli-config.yaml.example); dsh keeps its own upstream model credentials in
+~/.dsh/.credentials.yaml -- Hermes never sees or forwards them.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_OUTPUT_CAP_CHARS = 8000
+_RPC_TIMEOUT_SECONDS = 15.0
+_DEFAULT_RUN_TIMEOUT_SECONDS = 900
+_DEFAULT_PROFILE = "headless"
+_DEFAULT_URL = "http://127.0.0.1:3080"
+
+
+# ---------------------------------------------------------------------------
+# Error types -- stable DSH_* codes surfaced via tool_error(code=...)
+# ---------------------------------------------------------------------------
+
+class DshError(Exception):
+    """Base class for all dsh adapter failures."""
+
+    code = "DSH_ERROR"
+
+    def __init__(self, message: str, *, extra: Optional[dict] = None):
+        super().__init__(str(message))
+        self.message = str(message)
+        self.extra = dict(extra or {})
+
+
+class DshNotConfigured(DshError):
+    code = "DSH_NOT_CONFIGURED"
+
+
+class DshLaunchFailed(DshError):
+    code = "DSH_LAUNCH_FAILED"
+
+
+class DshUnreachable(DshError):
+    code = "DSH_UNREACHABLE"
+
+
+class DshTimeoutError(DshError):
+    code = "DSH_TIMEOUT"
+
+
+class DshAuthError(DshError):
+    code = "DSH_AUTH_FAILED"
+
+
+class DshRpcError(DshError):
+    code = "DSH_RPC_ERROR"
+
+
+class DshProtocolError(DshError):
+    code = "DSH_PROTOCOL_ERROR"
+
+
+class DshEmptyResult(DshError):
+    code = "DSH_EMPTY_RESULT"
+
+
+class DshExecFailed(DshError):
+    code = "DSH_EXEC_FAILED"
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def load_config() -> Dict[str, Any]:
+    """Return the active profile's ``dsh:`` config block (never raises).
+
+    Missing section / unreadable config yields ``{}``, which makes the
+    toolset's check_fn return False (tool hidden, no model-visible noise).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly() or {}
+        block = config.get("dsh")
+        return dict(block) if isinstance(block, dict) else {}
+    except Exception as exc:  # pragma: no cover - defensive, config is cached
+        logger.debug("dsh config unreadable: %s", exc)
+        return {}
+
+
+def _cfg_str(config: Dict[str, Any], key: str, default: str = "") -> str:
+    value = config.get(key, default)
+    return str(value).strip() if value is not None else default
+
+
+def _cfg_int(config: Dict[str, Any], key: str, default: int) -> int:
+    try:
+        return int(config.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _cfg_command(config: Dict[str, Any]) -> List[str]:
+    raw = config.get("command")
+    if isinstance(raw, str) and raw.strip():
+        # YAML users may write a bare string; split on shell whitespace.
+        return [part for part in raw.split() if part]
+    if isinstance(raw, (list, tuple)):
+        return [str(p) for p in raw if str(p).strip()]
+    return []
+
+
+def _text_cap(text: str, limit: int = _OUTPUT_CAP_CHARS) -> str:
+    """Truncate long text for model-visible summaries, never mid-surrogate."""
+    if text is None:
+        return ""
+    text = str(text)
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + f"\n...[truncated, {len(text) - limit} chars omitted]"
+
+
+# ---------------------------------------------------------------------------
+# Headless one-shot tasks (primary channel)
+# ---------------------------------------------------------------------------
+
+def interpret_run(
+    exit_code: int,
+    stdout_text: str,
+    stderr_text: str,
+    *,
+    elapsed_s: float,
+    cwd: Optional[str],
+    sessions_dir: str,
+) -> dict:
+    """Classify a finished headless process into a result dict.
+
+    Pure and synchronous so the full outcome matrix is unit-testable without
+    spawning processes. Raises :class:`DshError` subclasses for every
+    non-success outcome.
+    """
+    stdout_text = stdout_text or ""
+    stderr_text = stderr_text or ""
+
+    if exit_code != 0:
+        stderr_l = stderr_text.lower()
+        auth_hint = (
+            "401" in stderr_l
+            or "403" in stderr_l
+            or "unauthori" in stderr_l
+            or "invalid api key" in stderr_l
+            or "authentication" in stderr_l
+            or "credential" in stderr_l
+            or "api key" in stderr_l
+        )
+        if auth_hint:
+            raise DshAuthError(
+                "dsh's upstream model call failed authentication. Check that "
+                "~/.dsh/.credentials.yaml holds a valid DEEPSEEK_API_KEY and "
+                "that settings.yaml's agent-default-model provider matches it.",
+                extra={"exit_code": exit_code, "stderr": _text_cap(stderr_text, 2000)},
+            )
+        raise DshExecFailed(
+            f"dsh exited with code {exit_code} without completing the task. "
+            f"stderr: {_text_cap(stderr_text, 2000) or '(empty)'}",
+            extra={"exit_code": exit_code, "stderr": _text_cap(stderr_text, 2000)},
+        )
+
+    if not stdout_text.strip():
+        raise DshEmptyResult(
+            "dsh finished (exit 0) but produced no assistant output. "
+            "Retry with a clearer goal, or check the session log under "
+            f"{sessions_dir}.",
+            extra={"sessions_dir": sessions_dir},
+        )
+
+    return {
+        "ok": True,
+        "status": "completed",
+        "exit_code": 0,
+        "output": _text_cap(stdout_text.strip()),
+        "cwd": cwd or "(inherited)",
+        "sessions_dir": sessions_dir,
+        "elapsed_s": int(round(elapsed_s)),
+    }
+
+
+def _default_sessions_dir() -> str:
+    dsh_home = os.environ.get("DSH_HOME", "").strip() or os.path.join(
+        os.path.expanduser("~"), ".dsh"
+    )
+    return os.path.join(dsh_home, "sessions")
+
+
+def _kill_process_tree(proc: asyncio.subprocess.Process) -> None:
+    """Kill the process and its whole tree (headless spawns node -> agent)."""
+    pid = proc.pid
+    if pid is None:
+        return
+    if sys.platform == "win32":
+        # taskkill /T walks the tree; /F force-kills. Fall back to proc.kill().
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True,
+                timeout=15,
+            )
+        except Exception:
+            pass
+    else:
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)  # start_new_session=True
+            return
+        except (ProcessLookupError, PermissionError):
+            pass
+        except Exception:  # pragma: no cover - last resort on odd platforms
+            pass
+    try:
+        proc.kill()
+    except Exception:
+        pass
+
+
+async def run_headless(
+    task: str,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+    cwd: Optional[str] = None,
+    timeout: Optional[float] = None,
+) -> dict:
+    """Run one headless dsh task and wait for it to finish.
+
+    Blocks up to ``timeout`` seconds (config ``dsh.timeout``, default 900);
+    on expiry the whole process tree is killed and :class:`DshTimeoutError`
+    is raised. Returns the :func:`interpret_run` summary dict on success.
+    """
+    config = config if config is not None else load_config()
+    command = _cfg_command(config)
+    if not command:
+        raise DshNotConfigured(
+            "dsh.command is empty in the dsh: config block, so action=run "
+            "cannot launch the harness. Set it to the dsh CLI argv "
+            "(e.g. [node.exe, --import, tsx/esm, <repo>/apps/cli/src/bin.ts]) "
+            "or use action=list if you only need session inventory."
+        )
+
+    profile = _cfg_str(config, "profile", _DEFAULT_PROFILE) or _DEFAULT_PROFILE
+    bash_dir = _cfg_str(config, "bash_dir")
+    workdir = (cwd or "").strip() or _cfg_str(config, "cwd") or None
+    effective_timeout = float(
+        timeout if timeout is not None else _cfg_int(config, "timeout", _DEFAULT_RUN_TIMEOUT_SECONDS)
+    )
+    if effective_timeout <= 0:
+        raise DshNotConfigured(f"dsh.timeout must be > 0, got {effective_timeout}")
+
+    argv = list(command) + ["--profile", profile, task]
+    env = os.environ.copy()
+    if bash_dir:
+        # Windows: never let the child resolve C:\\Windows\\System32\\bash.exe
+        # (the WSL shim) when dsh spawns `bash` -- prepend the real Git Bash.
+        env["PATH"] = bash_dir + os.pathsep + env.get("PATH", "")
+
+    started = time.monotonic()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=workdir,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=(sys.platform != "win32"),
+        )
+    except FileNotFoundError as exc:
+        raise DshLaunchFailed(
+            f"Could not start dsh: executable not found ({exc}). Check the "
+            f"node/dsh path in the dsh.command config block."
+        ) from exc
+    except OSError as exc:
+        raise DshLaunchFailed(
+            f"Could not start dsh (cwd={workdir or '(inherited)'}): {exc}. "
+            f"Check that the dsh.command path exists and dsh.cwd is valid."
+        ) from exc
+
+    try:
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=effective_timeout
+            )
+        except asyncio.TimeoutError:
+            _kill_process_tree(proc)
+            # Drain whatever the killed tree already emitted (bounded).
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(), timeout=10
+                )
+            except Exception:
+                stdout_bytes, stderr_bytes = b"", b""
+            elapsed = time.monotonic() - started
+            raise DshTimeoutError(
+                f"dsh task exceeded the {int(effective_timeout)}s timeout and "
+                "was killed (process tree terminated). Re-run with a larger "
+                "timeout, or split the goal into smaller steps.",
+                extra={
+                    "elapsed_s": int(round(elapsed)),
+                    "stdout_tail": _text_cap(
+                        (stdout_bytes or b"").decode("utf-8", "replace"), 2000
+                    ),
+                },
+            ) from None
+    except DshError:
+        raise
+    except Exception as exc:
+        _kill_process_tree(proc)
+        raise DshLaunchFailed(f"dsh subprocess failed unexpectedly: {exc}") from exc
+
+    stdout_text = (stdout_bytes or b"").decode("utf-8", "replace")
+    stderr_text = (stderr_bytes or b"").decode("utf-8", "replace")
+    return interpret_run(
+        proc.returncode or 0,
+        stdout_text,
+        stderr_text,
+        elapsed_s=time.monotonic() - started,
+        cwd=workdir,
+        sessions_dir=_default_sessions_dir(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# dsh web JSON-RPC (secondary channel: read-only session management)
+# ---------------------------------------------------------------------------
+
+def _parse_envelope(data: Any) -> Any:
+    """Validate a Typert RPC response frame and return its ``value``.
+
+    Raises :class:`DshProtocolError` (malformed frame) or
+    :class:`DshRpcError` (server-reported error envelope).
+    """
+    if not isinstance(data, dict):
+        raise DshProtocolError(f"dsh RPC returned a non-object payload: {type(data).__name__}")
+    if data.get("type") != "server-response" or "result" not in data:
+        raise DshProtocolError(
+            f"dsh RPC returned an unexpected envelope: {_text_cap(json.dumps(data, ensure_ascii=False), 500)}"
+        )
+    result = data["result"]
+    if not isinstance(result, dict):
+        raise DshProtocolError("dsh RPC 'result' is not an object")
+    if result.get("ok") is False:
+        err = result.get("error") or {}
+        code = str(err.get("code") or "unknown") if isinstance(err, dict) else "unknown"
+        message = str(err.get("message") or err) if isinstance(err, dict) else str(err)
+        raise DshRpcError(f"dsh RPC error {code}: {message}")
+    if result.get("ok") is not True or "value" not in result:
+        raise DshProtocolError(
+            f"dsh RPC 'result' lacks ok/value: {_text_cap(json.dumps(result, ensure_ascii=False), 500)}"
+        )
+    return result["value"]
+
+
+def _map_http_status(status: int, body_text: str) -> DshError:
+    """Map a non-2xx HTTP response from the /api endpoint to a DshError."""
+    snippet = _text_cap(body_text or "", 500)
+    if status in (401, 403):
+        return DshAuthError(f"dsh web rejected the request (HTTP {status}): {snippet}")
+    if status == 404:
+        return DshProtocolError(
+            f"dsh web has no such API method (HTTP 404): {snippet} "
+            f"-- the running dsh version may differ from this adapter."
+        )
+    return DshProtocolError(f"dsh web returned HTTP {status}: {snippet}")
+
+
+async def rpc(
+    method: str,
+    payload: dict,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+    timeout: float = _RPC_TIMEOUT_SECONDS,
+) -> Any:
+    """POST one Typert RPC request to the dsh web profile and return value."""
+    config = config if config is not None else load_config()
+    url = _cfg_str(config, "url", _DEFAULT_URL).rstrip("/")
+    if not url:
+        raise DshNotConfigured(
+            "dsh.url is not set in the dsh: config block; this action needs "
+            "the dsh web profile (start it with start-harness.ps1)."
+        )
+
+    import aiohttp
+
+    frame = {
+        "type": "client-request",
+        "rpcId": f"hermes-{uuid.uuid4().hex[:12]}",
+        "method": method,
+        "payload": payload,
+    }
+    endpoint = f"{url}/api/{method}"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                endpoint,
+                json=frame,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                body_text = await resp.text()
+                if resp.status >= 400:
+                    raise _map_http_status(resp.status, body_text)
+                try:
+                    data = json.loads(body_text)
+                except json.JSONDecodeError as exc:
+                    raise DshProtocolError(
+                        f"dsh web returned non-JSON for {method}: "
+                        f"{_text_cap(body_text, 300)}"
+                    ) from exc
+                return _parse_envelope(data)
+    except asyncio.TimeoutError:
+        raise DshTimeoutError(
+            f"dsh web call {method} timed out after {int(timeout)}s. Is the "
+            f"web profile healthy at {url}?"
+        ) from None
+    except DshError:
+        raise
+    except (aiohttp.ClientConnectionError, OSError) as exc:
+        raise DshUnreachable(
+            f"dsh web is not listening at {url} ({exc.__class__.__name__}). "
+            f"Start it (start-harness.ps1 / scheduled task) or fix dsh.url."
+        ) from exc
+
+
+async def list_sessions(
+    *,
+    config: Optional[Dict[str, Any]] = None,
+    limit: int = 20,
+    timeout: float = _RPC_TIMEOUT_SECONDS,
+) -> dict:
+    """Return a compact session inventory from dsh web's session.list."""
+    value = await rpc("session.list", {}, config=config, timeout=timeout)
+    items = value.get("items") if isinstance(value, dict) else None
+    if not isinstance(items, list):
+        raise DshProtocolError(
+            "dsh session.list returned no 'items' array: "
+            f"{_text_cap(json.dumps(value, ensure_ascii=False), 500)}"
+        )
+    compact = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        projections = item.get("projections") or {}
+        pvalues = projections.get("values") if isinstance(projections, dict) else {}
+        title = ""
+        if isinstance(pvalues, dict):
+            title = str(pvalues.get("title") or "")
+        compact.append(
+            {
+                "sessionId": str(item.get("sessionId") or ""),
+                "cwd": str(item.get("cwd") or ""),
+                "agentPreset": str(item.get("agentPreset") or ""),
+                "running": bool(item.get("running")),
+                "updatedAt": item.get("updatedAt"),
+                "title": title,
+            }
+        )
+        if len(compact) >= limit:
+            break
+    return {
+        "ok": True,
+        "count": len(compact),
+        "items": compact,
+        "note": f"Most recent {len(compact)} sessions from dsh web (session.list).",
+    }

--- a/tools/dsh_tool.py
+++ b/tools/dsh_tool.py
@@ -1,0 +1,221 @@
+"""dsh_task -- run agent tasks on the local DeepSeek Harness (dsh).
+
+Single LLM-callable tool behind a service-gated toolset ``dsh`` that is OFF
+by default (mirrors the Home Assistant toolset pattern), so existing profiles
+and sessions are unaffected until a user enables it.
+
+Two actions:
+
+* ``run`` -- one-shot headless task via the dsh CLI
+  (``dsh --profile headless "<goal>"``): a fresh agent works on the goal and
+  the final assistant text is returned. Blocking, bounded by the ``timeout``
+  argument (config ``dsh.timeout``, default 900s); the process tree is
+  killed when the deadline passes. Only a summary comes back -- the full
+  session persists on disk under ~/.dsh/sessions/<cwd>, inspectable with
+  action=list (requires dsh web) or read directly.
+* ``list`` -- session inventory from the dsh *web* JSON-RPC endpoint
+  (config ``dsh.url``, default http://127.0.0.1:3080). The web profile is
+  managed externally (start-harness.ps1 / scheduled task); this tool never
+  launches it.
+
+dsh executes tasks with its own default agent settings (settings.yaml:
+agent-default-model, agent presets) and keeps its upstream model credentials
+in ~/.dsh/.credentials.yaml -- Hermes never sees them. Tasks can be slow and
+expensive; prefer this tool when work genuinely belongs in dsh (its own
+tool/session/preset ecosystem or per-cwd session grouping).
+"""
+
+import asyncio
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+from tools import dsh_client
+from tools.dsh_client import (
+    DshError,
+    DshNotConfigured,
+    DshUnreachable,
+)
+
+# ---------------------------------------------------------------------------
+# Action handlers
+# ---------------------------------------------------------------------------
+
+async def _do_run(args: dict) -> str:
+    goal = str(args.get("goal") or "").strip()
+    if not goal:
+        return _err(
+            "action=run requires a non-empty 'goal' describing the task for "
+            "the dsh agent.",
+            code="DSH_BAD_ARGUMENT",
+        )
+    cwd = args.get("cwd")
+    if cwd is not None and not str(cwd).strip():
+        cwd = None
+    timeout = args.get("timeout")
+    if timeout is not None:
+        try:
+            timeout = float(timeout)
+        except (TypeError, ValueError):
+            return _err(
+                f"timeout must be a number of seconds, got {timeout!r}",
+                code="DSH_BAD_ARGUMENT",
+            )
+        if timeout <= 0:
+            return _err("timeout must be > 0", code="DSH_BAD_ARGUMENT")
+
+    summary = await dsh_client.run_headless(
+        goal, cwd=str(cwd).strip() if cwd else None, timeout=timeout
+    )
+    return json.dumps(summary, ensure_ascii=False)
+
+
+async def _do_list(args: dict) -> str:
+    limit = args.get("limit")
+    if limit is not None:
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            return _err(f"limit must be an integer, got {limit!r}", code="DSH_BAD_ARGUMENT")
+        if limit <= 0 or limit > 100:
+            return _err("limit must be between 1 and 100", code="DSH_BAD_ARGUMENT")
+    payload = await dsh_client.list_sessions(limit=limit or 20)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _err(message: str, **extra) -> str:
+    """Format a tool error with a stable DSH_* code."""
+    from tools.registry import tool_error
+
+    return tool_error(message, code=extra.pop("code", "DSH_ERROR"), **extra)
+
+
+async def _handle_dsh_task(args: dict, **kw) -> str:
+    """Dispatcher for the dsh_task tool (async: headless runs can be long)."""
+    action = str(args.get("action") or "run").strip().lower()
+    try:
+        if action == "run":
+            return await _do_run(args)
+        if action == "list":
+            return await _do_list(args)
+        return _err(
+            f"Unknown action {action!r} -- expected 'run' or 'list'.",
+            code="DSH_BAD_ARGUMENT",
+        )
+    except (DshNotConfigured, DshUnreachable) as exc:
+        # Expected operational states: log at info, guidance goes to the model.
+        logger.info("dsh_task %s not usable: %s", action, exc)
+        return _err(exc.message, code=exc.code, **exc.extra)
+    except DshError as exc:
+        logger.warning("dsh_task %s failed: [%s] %s", action, exc.code, exc)
+        return _err(exc.message, code=exc.code, **exc.extra)
+    except Exception as exc:  # pragma: no cover - defensive boundary
+        logger.exception("dsh_task %s unexpected error", action)
+        return _err(f"dsh_task {action} failed: {type(exc).__name__}: {exc}", code="DSH_INTERNAL")
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def _check_dsh_available() -> bool:
+    """Tool is only visible when the user configured the dsh: block.
+
+    Config-presence gate (like HASS_TOKEN for homeassistant): the headless
+    run path needs no live port, so we deliberately do NOT probe dsh web
+    here -- an unavailable web profile is a runtime error for action=list,
+    not a reason to hide action=run.
+    """
+    config = dsh_client.load_config()
+    if not config:
+        return False
+    return bool(dsh_client._cfg_command(config)) or bool(dsh_client._cfg_str(config, "url"))
+
+
+# ---------------------------------------------------------------------------
+# Tool schema
+# ---------------------------------------------------------------------------
+
+DSH_TASK_SCHEMA = {
+    "name": "dsh_task",
+    "description": (
+        "Run an agent task on the local DeepSeek Harness (dsh) -- DeepSeek's "
+        "own agent harness with its own tools, sessions and agent presets. "
+        "action=run submits the goal to a fresh headless dsh agent and waits "
+        "(default 900s, overridable via 'timeout'); dsh picks the working "
+        "directory from 'cwd' (default: dsh.cwd / Hermes' own). Returns a "
+        "summary; the full session is stored under ~/.dsh/sessions/<cwd>. "
+        "action=list shows recent dsh sessions (requires the dsh web profile "
+        "on dsh.url). Tasks run with dsh's configured agent model (often a "
+        "high-reasoning model) and can be slow/expensive -- use for work that "
+        "genuinely belongs in dsh, not for quick lookups."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["run", "list"],
+                "description": (
+                    "Default 'run'. 'run' = execute one headless dsh task "
+                    "(blocking). 'list' = show recent dsh sessions (needs "
+                    "the dsh web profile running)."
+                ),
+            },
+            "goal": {
+                "type": "string",
+                "description": (
+                    "For action=run: the full task description, submitted "
+                    "verbatim as the user message to the dsh agent (e.g. "
+                    "'run update_all.py in this repo and report today's row "
+                    "counts')."
+                ),
+            },
+            "cwd": {
+                "type": "string",
+                "description": (
+                    "For action=run: working directory for the dsh agent. "
+                    "dsh groups its persisted sessions by cwd, so pin this to "
+                    "where the work should happen. Defaults to the dsh.cwd "
+                    "config value or Hermes' own working directory."
+                ),
+            },
+            "timeout": {
+                "type": "integer",
+                "description": (
+                    "For action=run: max seconds to wait before the dsh "
+                    "process tree is killed. Default: dsh.timeout config "
+                    "(900s). Raise for long tasks; on timeout the error "
+                    "carries a partial-output tail."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": (
+                    "For action=list: max number of sessions to return "
+                    "(default 20, max 100)."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry, tool_error  # noqa: E402
+
+registry.register(
+    name="dsh_task",
+    toolset="dsh",
+    schema=DSH_TASK_SCHEMA,
+    handler=_handle_dsh_task,
+    check_fn=_check_dsh_available,
+    is_async=True,
+    emoji="🤖",
+    max_result_size_chars=16_000,
+)

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -102,6 +102,26 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 | `search_files` | Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. Content search (target='content'): Regex search inside files. Output modes: full matches with line… | — |
 | `write_file` | Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by the write are surfaced. | — |
 
+## `dsh` toolset
+
+Runs one-shot agent tasks on a local [DeepSeek Harness (dsh)](https://github.com/deepseek-ai/dsh) — DeepSeek's own agent harness with its own tools, sessions, and agent presets. The `dsh` toolset is **off by default**: add `dsh` to the platform's toolset list (`platform_toolsets.cli: [hermes-cli, dsh]`) or enable it via `hermes tools` → DeepSeek Harness. The tool then only becomes visible once a `dsh:` block exists in config.yaml:
+
+```yaml
+dsh:
+  url: "http://127.0.0.1:3080"   # dsh web JSON-RPC base URL (action=list only)
+  command: ["dsh"]               # CLI argv for action=run; [] disables run
+  profile: "headless"            # dsh profile tasks run under
+  cwd: ""                        # working dir for dsh (sessions group by cwd)
+  timeout: 900                   # hard deadline; process tree killed on expiry
+  bash_dir: ""                   # Windows: dir containing the real Git Bash
+```
+
+`action=run` starts a fresh headless dsh agent (blocking; bounded by `dsh.timeout` or the per-call `timeout`) and returns the final assistant summary — the full session persists under `~/.dsh/sessions/<cwd>`. `action=list` reads the session inventory from the dsh *web* profile at `dsh.url`; the web process is managed externally (e.g. `start-harness.ps1`) and this tool never launches it. dsh keeps its own upstream model credentials (e.g. a `DEEPSEEK_API_KEY`) in `~/.dsh/.credentials.yaml` — Hermes never stores or forwards them; `DSH_HOME` overrides the `~/.dsh` home.
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `dsh_task` | Run an agent task on the local DeepSeek Harness: `action=run` submits `goal` to a fresh headless dsh agent and waits (default 900s, per-call `timeout` overrides; the process tree is killed on expiry); `action=list` returns the recent session inventory from the dsh web profile (`limit`, default 20). | `dsh:` block in config.yaml + `dsh` on the platform toolset list; `command` for `run`, a running dsh web at `url` for `list` |
+
 ## `homeassistant` toolset
 
 | Tool | Description | Requires environment |

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -58,6 +58,7 @@ Or in-session:
 | `coding` | composite (`file` + `terminal` + `search` + `web` + `skills` + `browser` + `todo` + `memory` + `session_search` + `clarify` + `code_execution` + `delegation` + `vision`) | Coding-focused bundle for software work: file editing, terminal, search, web docs, skills, browser, delegate, and code execution. |
 | `cronjob` | `cronjob` | Schedule and manage recurring tasks. |
 | `debugging` | composite (`file` + `terminal` + `web`) | Debug bundle — file, process/terminal, web extract/search. |
+| `dsh` | `dsh_task` | Run agent tasks on a local DeepSeek Harness (dsh) — one-shot headless runs via `action=run` plus session inventory from the dsh web profile via `action=list`. Off by default: add `dsh` to the platform's toolset list and configure a `dsh:` block in config.yaml (see [Tools Reference](tools-reference.md)). |
 | `delegation` | `delegate_task` | Spawn isolated subagent instances for parallel work. |
 | `discord` | `discord` | Core Discord text/embed/DM actions (gateway-only). Active on the `hermes-discord` toolset. |
 | `discord_admin` | `discord_admin` | Discord moderation (bans, role changes, channel management). Active on the `hermes-discord` toolset; requires the bot to hold the relevant Discord permissions. |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/tools-reference.md
@@ -90,6 +90,26 @@ description: "Hermes 内置工具权威参考，按工具集分组"
 | `search_files` | 搜索文件内容或按名称查找文件。用于替代终端中的 `grep`/`rg`/`find`/`ls`。基于 Ripgrep，比 shell 等效命令更快。内容搜索（`target='content'`）：在文件内进行正则搜索。输出模式：带行号的完整匹配… | — |
 | `write_file` | 将内容写入文件，完全替换现有内容。用于替代终端中的 `echo`/`cat heredoc`。自动创建父目录。**覆盖整个文件** —— 精准编辑请使用 `patch`。 | — |
 
+## `dsh` 工具集
+
+在本地 [DeepSeek Harness（dsh）](https://github.com/deepseek-ai/dsh) 上运行一次性 agent 任务——dsh 是 DeepSeek 自有的 agent harness，带自己的工具、会话与 agent preset。`dsh` 工具集**默认关闭**：把 `dsh` 加入平台的工具集列表（`platform_toolsets.cli: [hermes-cli, dsh]`），或通过 `hermes tools` → DeepSeek Harness 启用。之后只有当 config.yaml 中存在 `dsh:` 段时该工具才可见：
+
+```yaml
+dsh:
+  url: "http://127.0.0.1:3080"   # dsh web JSON-RPC 基础 URL（仅 action=list 使用）
+  command: ["dsh"]               # action=run 的 CLI argv；[] 表示禁用 run
+  profile: "headless"            # 任务使用的 dsh profile
+  cwd: ""                        # dsh 的工作目录（会话按 cwd 归组）
+  timeout: 900                   # 硬性截止时间；超时后杀进程树
+  bash_dir: ""                   # Windows：包含真实 Git Bash 的目录
+```
+
+`action=run` 启动一个全新的 headless dsh agent（阻塞；受 `dsh.timeout` 或每次调用的 `timeout` 限制）并返回最终助手摘要——完整会话持久化在 `~/.dsh/sessions/<cwd>`。`action=list` 从 `dsh.url` 的 dsh *web* profile 读取会话清单；web 进程由外部管理（如 `start-harness.ps1`），本工具从不自行拉起。dsh 自带的上游模型凭据（如 `DEEPSEEK_API_KEY`）存放在 `~/.dsh/.credentials.yaml`——Hermes 既不存储也不转发；`DSH_HOME` 可覆盖 `~/.dsh` 家目录。
+
+| 工具 | 描述 | 所需环境 |
+|------|------|----------|
+| `dsh_task` | 在本地 DeepSeek Harness 上运行 agent 任务：`action=run` 把 `goal` 提交给全新 headless dsh agent 并等待（默认 900s，可用每次调用的 `timeout` 覆盖；超时后杀进程树）；`action=list` 返回 dsh web profile 的近期会话清单（`limit`，默认 20）。 | config.yaml 的 `dsh:` 段 + 平台工具集列表含 `dsh`；`run` 需 `command`，`list` 需 `url` 处 dsh web 在运行 |
+
 ## `homeassistant` 工具集
 
 | 工具 | 描述 | 所需环境 |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/toolsets-reference.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/toolsets-reference.md
@@ -57,6 +57,7 @@ hermes tools                            # curses UI to enable/disable per platfo
 | `code_execution` | `execute_code` | 运行以编程方式调用 Hermes 工具的 Python 脚本。 |
 | `cronjob` | `cronjob` | 调度和管理周期性任务。 |
 | `debugging` | 复合（`file` + `terminal` + `web`） | 调试套件——文件、进程/终端、网页提取/搜索。 |
+| `dsh` | `dsh_task` | 在本地 DeepSeek Harness（dsh）上运行 agent 任务——`action=run` 执行一次性 headless 任务，`action=list` 从 dsh web profile 获取会话清单。默认关闭：需将 `dsh` 加入平台工具集列表，并在 config.yaml 配置 `dsh:` 段（见[工具参考](tools-reference.md)）。 |
 | `delegation` | `delegate_task` | 生成隔离的子 agent 实例以并行执行工作。 |
 | `discord` | `discord` | 核心 Discord 文本/嵌入/私信操作（仅限 gateway）。在 `hermes-discord` 工具集上激活。 |
 | `discord_admin` | `discord_admin` | Discord 管理操作（封禁、角色变更、频道管理）。在 `hermes-discord` 工具集上激活；需要 bot 持有相关 Discord 权限。 |


### PR DESCRIPTION
## dsh to Hermes integration: service-gated `dsh_task` tool + tests + docs

### Motivation
dsh (DeepSeek AI's open-source agent harness, @deepseek-ai/dsh 0.1.0-rc.x) is an existing independent agent ecosystem on this machine: own tools, persistent sessions grouped by cwd under `~/.dsh/sessions/`, and agent presets. This PR lets Hermes invoke dsh in a conventional way and get usable return values.

### Shape (validated against A1-A5 of the upstream research specs)
- dsh exposes **no OpenAI-compatible endpoint** -> it cannot be a Hermes model provider; the integration is process-level headless (primary) + read-only local JSON-RPC session management (secondary).
- New **service-gated `dsh_task` tool** (mirrors the Home Assistant toolset pattern):
  - `action=run`: `dsh --profile headless "<goal>"` one-shot subprocess task (default 900s timeout, external deadline kills the process tree); stdout = final assistant text, exit 0/1.
  - `action=list`: Typert JSON-RPC `session.list` against dsh web at `dsh.url` (default http://127.0.0.1:3080); returns a compact session inventory.
  - toolset `dsh` is **off by default** (`_DEFAULT_OFF_TOOLSETS` + a `CONFIGURABLE_TOOLSETS` UI row) and gated by a config-presence `check_fn` (hidden unless a `dsh:` config block exists) -> zero backward-compat risk.
- Pure client layer `tools/dsh_client.py` normalizes 8 failure classes into stable `DSH_*` codes (NOT_CONFIGURED / LAUNCH_FAILED / UNREACHABLE / TIMEOUT / AUTH_FAILED / RPC_ERROR / PROTOCOL_ERROR / EMPTY_RESULT / EXEC_FAILED), each error carrying actionable guidance.
- Secret boundary: upstream model credentials (DEEPSEEK_API_KEY) live only in dsh's `~/.dsh/.credentials.yaml`; Hermes never stores or forwards them. Config keys are url/command/profile/cwd/timeout/bash_dir -- none secret.

### Commits
- `b44186e737` feat(tools): dsh_task tool + dsh_client + tools_config wiring + `dsh:` block in cli-config.yaml.example (31 unit tests; real headless round-trip verified: 8s task completion + file on disk)
- `69c3e707a7` docs(tools): en/zh tools-reference & toolsets-reference pages (enable path, config keys, credential ownership)
- `5aa536af64` test(tools): run_headless subprocess lifecycle + rpc HTTP transport mock tests (31 -> 45, fully offline)

### Verification
- `pytest tests/tools/test_dsh_tool.py`: 45 passed (mocks cover success / timeout / auth failure / abnormal returns / malformed protocol; no real dsh process, no model spend)
- `ruff check` on all changed python files: All checks passed
- Real A2: headless task completed in 8s, agent actually wrote `dsh_smoke_test.txt`, terminal text on stdout, exit 0; 3 classes of real launch failure classified correctly
- A4 compatibility: default-off toolset + check_fn config gate; registry conflict rules; core hot paths untouched (main untouched except this branch)

### Known boundaries (YAGNI, phase 2)
- dsh web is managed externally (start-harness.ps1 / scheduled task); the tool only reads config, never probes the port or launches the process
- One-shot headless tasks have no RPC session handle -> status/stop/resume not exposed (no fake capabilities)
- action=list requires the user to start dsh web first (rc.6 plugin-layer compatibility investigation tracked separately)