### PR TITLE
fix(honcho): carry forward refresh_token when a refresh response omits it

### DIFF
--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -180,9 +180,15 @@ class OAuthCredential:
     def from_token_response(
         cls, body: dict[str, Any], *, now: float, client_id: str, token_endpoint: str,
         scope: str = "write", token_type: str = "Bearer", what: str = "grant",
+        fallback_refresh_token: str | None = None,
     ) -> "OAuthCredential":
-        """Build a credential from an OAuth token response; ``expires_in`` is relative to ``now``."""
-        access, refresh = body.get("access_token"), body.get("refresh_token")
+        """Build a credential from an OAuth token response; ``expires_in`` is relative to ``now``.
+
+        RFC 6749 §6: a refresh response may omit ``refresh_token`` when the AS doesn't rotate it —
+        ``fallback_refresh_token`` (the prior grant's) carries it forward. Leave unset for a fresh
+        grant (``install_grant``), where a missing refresh_token is a genuine error, not omission.
+        """
+        access, refresh = body.get("access_token"), body.get("refresh_token") or fallback_refresh_token
         if not is_oauth_access_token(access) or not refresh:
             raise ValueError(f"{what} missing access_token/refresh_token")
         return cls(access, str(refresh), now + _num(body.get("expires_in", 0), int), client_id, token_endpoint,
@@ -234,6 +240,7 @@ def _exchange_refresh_token(
     return OAuthCredential.from_token_response(
         body, now=now, client_id=cred.client_id, token_endpoint=cred.token_endpoint,
         scope=cred.scope, token_type=cred.token_type, what="refresh response",
+        fallback_refresh_token=cred.refresh_token,
     )
 
 def _exchange_with_retry(cred: OAuthCredential, *, now: float) -> OAuthCredential:

--- a/tests/honcho_plugin/test_oauth.py
+++ b/tests/honcho_plugin/test_oauth.py
@@ -102,6 +102,26 @@ class TestEnsureFreshToken:
         assert saved["oauth"]["refreshToken"] == "hch-rt-new"
         assert saved["oauth"]["expiresAt"] == 1000 + 3600
 
+    def test_non_rotating_refresh_keeps_stored_refresh_token(self, tmp_path, monkeypatch):
+        # RFC 6749 §6: an AS that doesn't rotate refresh tokens may omit refresh_token from the
+        # refresh response. The prior one must survive in memory AND on disk, or the next refresh
+        # (with no refresh_token left to send) fails permanently and forces a full re-login (#62333
+        # fixed the identical bug in tools/mcp_oauth_provider.py).
+        path = tmp_path / "honcho.json"
+        _write(path, {"hosts": {"hermes": _host_block(refresh="hch-rt-old", expires_at=100)}})
+
+        def fake_post(url, data, timeout):
+            assert data["refresh_token"] == "hch-rt-old"
+            return 200, {"access_token": "hch-at-new", "expires_in": 3600}  # no refresh_token in body
+
+        monkeypatch.setattr(oauth, "_http_post_form_status", fake_post)
+        token, refreshed = oauth.ensure_fresh_token(path, "hermes", now=1000)
+        assert token == "hch-at-new" and refreshed is True
+
+        saved = json.loads(path.read_text())["hosts"]["hermes"]
+        assert saved["apiKey"] == "hch-at-new"
+        assert saved["oauth"]["refreshToken"] == "hch-rt-old"  # carried forward, not dropped
+
     def test_refresh_failure_fails_open(self, tmp_path, monkeypatch):
         path = tmp_path / "honcho.json"
         _write(path, {"hosts": {"hermes": _host_block(expires_at=100)}})


### PR DESCRIPTION
## Problem

`OAuthCredential.from_token_response()` treats `refresh_token` as required in the response body:

```python
access, refresh = body.get("access_token"), body.get("refresh_token")
if not is_oauth_access_token(access) or not refresh:
    raise ValueError(f"{what} missing access_token/refresh_token")
```

RFC 6749 §6 explicitly allows an authorization server to omit `refresh_token` from a refresh response when it doesn't rotate the token on that call. `_exchange_refresh_token()` uses this same method for the *refresh* grant (`what="refresh response"`), so a Honcho auth server (self-hosted deployments are supported, per `hermes_cli`/`plugins/memory/honcho/cli.py`) that returns a valid 200 with a fresh `access_token` but no `refresh_token` has that entire response discarded — `_rotate_and_persist` catches the resulting `ValueError` as a generic transient failure and returns the stale token, never persisting the new one. Since the refresh_token on disk never changes either, every subsequent refresh attempt hits the identical failure, permanently breaking the refresh cycle until the user runs a full re-login.

This is the same bug class fixed today in `tools/mcp_oauth_provider.py` (9d865810b6, #62333) — independently reintroduced here.

## Fix

Add an optional `fallback_refresh_token` param to `from_token_response()`, used only when the response body omits `refresh_token`. Only the refresh path (`_exchange_refresh_token`) passes it (`cred.refresh_token`), mirroring the carry-forward pattern the same function already applies to `scope`. `install_grant()`'s initial-grant path is untouched — a missing `refresh_token` on a fresh grant is still treated as a genuine error.

## Testing

Added `test_non_rotating_refresh_keeps_stored_refresh_token`, mirroring the existing `test_expired_token_refreshes_and_persists_rotation` fixture but with a refresh response that omits `refresh_token`. Mutation-verified: reverting the source change makes the new test fail with the exact predicted symptom (stale token returned, `refreshed=False`); restoring it passes. Full `tests/honcho_plugin/` suite (301 passed, 16 skipped) is unaffected.
