### PR TITLE
fix(cron): an off-tick "run now" no longer cancels the job's next scheduled run (#104790, #105690, #106166; salvage #105704)

### DIFF
--- a/contributors/emails/12981632+philmossman@users.noreply.github.com
+++ b/contributors/emails/12981632+philmossman@users.noreply.github.com
@@ -1,0 +1,2 @@
+philmossman
+# PR #105704 salvage

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2491,7 +2491,8 @@ def _machine_id() -> str:
 
 
 def claim_job_for_fire(
-    job_id: str, *, claim_ttl_seconds: int = FIRE_CLAIM_TTL_SECONDS, force: bool = False, return_job: bool = False,
+    job_id: str, *, claim_ttl_seconds: int = FIRE_CLAIM_TTL_SECONDS, force: bool = False,
+    manual: bool = False, return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for one external 'fire' (multi-machine at-most-once); True iff THIS
     caller won (``CronScheduler.fire_due``: exactly one of N replicas runs a job). Under the
@@ -2513,8 +2514,11 @@ def claim_job_for_fire(
             return False  # someone holds a fresh claim
         from cron.occurrences import completed_occurrence, scheduled_instant
 
-        manual = force or job.get("manual_run_at") == job.get("next_run_at")
-        instant = None if manual else scheduled_instant(job.get("next_run_at"))
+        # ``manual`` (an off-tick run-now) must NOT stamp an occurrence identity: outside a
+        # scheduler tick ``next_run_at`` is the NEXT occurrence, not the one being run, so
+        # stamping it would make completed_occurrence() skip that slot when it arrives.
+        manual_fire = force or manual or job.get("manual_run_at") == job.get("next_run_at")
+        instant = None if manual_fire else scheduled_instant(job.get("next_run_at"))
         if instant and completed_occurrence(job, instant):
             if job.get("schedule", {}).get("kind") in {"cron", "interval"}:
                 nxt = compute_next_run(job["schedule"], now.isoformat())

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2498,7 +2498,8 @@ def claim_job_for_fire(
     caller won (``CronScheduler.fire_due``: exactly one of N replicas runs a job). Under the
     fence + file lock: reject missing/terminal/paused jobs unless ``force`` (explicit manual
     fire, which also resumes the job atomically; external callbacks must leave it false so a
-    stale callback cannot resurrect a paused job). Lose if a claim younger than
+    stale callback cannot resurrect a paused job). ``manual`` = off-tick run-now without the
+    resume: no occurrence stamp, so the still-pending ``next_run_at`` slot is not skipped. Lose if a claim younger than
     ``claim_ttl_seconds`` exists (the TTL lets another fire reclaim after a crash; mark_job_run
     clears the claim). Otherwise stamp ``fire_claim`` and, for recurring jobs, advance
     ``next_run_at`` so a stale re-delivery cannot re-fire."""

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -136,16 +136,20 @@ class CronScheduler(ABC):
 
     def fire_due(
         self, job_id: str, *, adapters: Any = None, loop: Any = None, force: bool = False,
+        manual: bool = False,
     ) -> bool:
         """Run one job NOW (inbound fire webhook entry). Store CAS claim (multi-machine
         at-most-once) then shared ``run_one_job``. True if THIS caller claimed and processed the
-        attempt (even if the job failed); False if the claim was lost or the job is gone."""
-        claimed_job = self.claim_fire(job_id, force=force)
+        attempt (even if the job failed); False if the claim was lost or the job is gone.
+        ``manual`` marks an off-tick run-now (dashboard trigger): the claim must not stamp
+        ``next_run_at`` as the occurrence, or that slot is skipped when it arrives. Webhook and
+        misfire fires run the slot that is due and keep the stamp."""
+        claimed_job = self.claim_fire(job_id, force=force, manual=manual)
         if claimed_job is None:
             return False
         return self.fire_claimed(claimed_job, adapters=adapters, loop=loop)
 
-    def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
+    def claim_fire(self, job_id: str, *, force: bool = False, manual: bool = False) -> dict | None:
         """Durably claim one fire + create its audit attempt. Transports call this synchronously
         before acknowledging, then pass the exact snapshot to ``fire_claimed`` off-thread."""
         from cron.executions import create_execution, finish_execution, set_execution_occurrence
@@ -155,6 +159,8 @@ class CronScheduler(ABC):
         claim_kwargs = {"return_job": True}
         if force:
             claim_kwargs["force"] = True
+        if manual:
+            claim_kwargs["manual"] = True
         try:
             claimed_job = claim_job_for_fire(job_id, **claim_kwargs)
             if isinstance(claimed_job, dict):
@@ -189,6 +195,11 @@ class CronScheduler(ABC):
 
 def provider_supports_force_fire(provider: Any) -> bool:
     """Return whether a provider can safely receive ``fire_due(force=...)`` (signature-detected)."""
+    return provider_fire_due_accepts(provider, "force")
+
+
+def provider_fire_due_accepts(provider: Any, name: str) -> bool:
+    """Whether ``provider.fire_due`` takes keyword ``name`` (third-party providers may predate it)."""
     try:
         parameters = inspect.signature(provider.fire_due).parameters.values()
     except (TypeError, ValueError):
@@ -196,7 +207,7 @@ def provider_supports_force_fire(provider: Any) -> bool:
     return any(
         p.kind is inspect.Parameter.VAR_KEYWORD
         or (
-            p.name == "force"
+            p.name == name
             and p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
         )
         for p in parameters

--- a/hermes_cli/web_server_cron.py
+++ b/hermes_cli/web_server_cron.py
@@ -278,7 +278,7 @@ def _fire_cron_job_for_profile(profile: str, job_id: str, *, force: bool = False
     and external callers on the web_deps late-binding seam; do not add new uses.
     """
     _profile_name, home = _cron_profile_home(profile)
-    from cron.scheduler_provider import provider_supports_force_fire, resolve_cron_scheduler
+    from cron.scheduler_provider import provider_fire_due_accepts, provider_supports_force_fire, resolve_cron_scheduler
     with _cron_store_scope(home):
         provider = resolve_cron_scheduler()
         if force:
@@ -289,6 +289,10 @@ def _fire_cron_job_for_profile(profile: str, job_id: str, *, force: bool = False
                         f"Cron provider '{getattr(provider, 'name', 'custom')}' "
                         "does not support atomic forced firing of paused jobs"))
             return bool(provider.fire_due(job_id, adapters=None, loop=None, force=True))
+        # Off-tick run-now: never stamp next_run_at as the occurrence (#104790); third-party
+        # providers without the kwarg keep the legacy call.
+        if provider_fire_due_accepts(provider, "manual"):
+            return bool(provider.fire_due(job_id, adapters=None, loop=None, manual=True))
         return bool(provider.fire_due(job_id, adapters=None, loop=None))
 
 

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -294,18 +294,3 @@ def test_manual_claim_still_refuses_a_paused_job(temp_home):
 
     assert claim_job_for_fire(job["id"], manual=True) is False
     assert get_job(job["id"]).get("paused_at") is not None
-
-
-def test_scheduler_tick_claim_still_stamps_its_occurrence(temp_home):
-    """The dedupe path stays intact for ordinary (non-manual) claims: a tick fire still
-    records the occurrence it ran, so a re-delivery cannot double-fire it."""
-    from cron.jobs import create_job, claim_job_for_fire, get_job
-
-    job = create_job(prompt="x", schedule="every 5m", name="s")
-    pending = get_job(job["id"])["next_run_at"]
-
-    claimed = claim_job_for_fire(job["id"], return_job=True)
-    assert isinstance(claimed, dict)
-    assert claimed["_scheduled_instant"] is not None
-    from cron.occurrences import scheduled_instant
-    assert claimed["_scheduled_instant"] == scheduled_instant(pending)

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -263,3 +263,49 @@ def test_same_thread_fire_fence_reentrancy_preserves_ownership(temp_home):
     assert result == {"outer": True, "inner": True}
     thread.join(timeout=2)
     assert thread.is_alive() is False
+
+
+def test_manual_claim_does_not_stamp_a_future_occurrence(temp_home):
+    """An off-tick run-now must not consume the NEXT scheduled slot.
+
+    Outside a scheduler tick ``next_run_at`` is the occurrence that has NOT happened
+    yet, so stamping it as a completed occurrence makes ``_job_is_due`` skip that slot
+    when it arrives — silently, with no error and no dispatch record. ``manual=True``
+    is the caller's declaration that this is an off-tick fire.
+    """
+    from cron.jobs import create_job, claim_job_for_fire, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="m")
+    pending = get_job(job["id"])["next_run_at"]
+
+    claimed = claim_job_for_fire(job["id"], manual=True, return_job=True)
+    assert isinstance(claimed, dict)
+    assert claimed["_scheduled_instant"] is None, (
+        f"manual fire stamped the future occurrence {pending}")
+
+
+def test_manual_claim_still_refuses_a_paused_job(temp_home):
+    """``manual=True`` suppresses only the occurrence stamp — unlike ``force=True`` it
+    must not resume a paused job, which the run-now tool relies on to refuse it."""
+    from cron.jobs import create_job, claim_job_for_fire, get_job, pause_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="mp")
+    pause_job(job["id"])
+
+    assert claim_job_for_fire(job["id"], manual=True) is False
+    assert get_job(job["id"]).get("paused_at") is not None
+
+
+def test_scheduler_tick_claim_still_stamps_its_occurrence(temp_home):
+    """The dedupe path stays intact for ordinary (non-manual) claims: a tick fire still
+    records the occurrence it ran, so a re-delivery cannot double-fire it."""
+    from cron.jobs import create_job, claim_job_for_fire, get_job
+
+    job = create_job(prompt="x", schedule="every 5m", name="s")
+    pending = get_job(job["id"])["next_run_at"]
+
+    claimed = claim_job_for_fire(job["id"], return_job=True)
+    assert isinstance(claimed, dict)
+    assert claimed["_scheduled_instant"] is not None
+    from cron.occurrences import scheduled_instant
+    assert claimed["_scheduled_instant"] == scheduled_instant(pending)

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -439,6 +439,10 @@ def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
 
     assert InProcessCronScheduler().fire_due("j1", force=True) is True
     assert claims == [("j1", {"force": True, "return_job": True})]
+    # An off-tick run-now forwards ``manual`` so the claim does not stamp the next occurrence;
+    # the default (webhook / misfire) fire keeps the occurrence stamp.
+    assert InProcessCronScheduler().fire_due("j1", manual=True) is True
+    assert claims[-1] == ("j1", {"manual": True, "return_job": True})
 
 
 def test_fire_due_lost_claim_does_not_run(monkeypatch):

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -538,12 +538,13 @@ async def test_trigger_cron_job_fires_only_selected_job_and_returns_refreshed_st
     fired = []
 
     class RecordingProvider:
-        def fire_due(self, job_id, *, adapters=None, loop=None, force=False):
+        def fire_due(self, job_id, *, adapters=None, loop=None, force=False, manual=False):
             fired.append(
                 {
                     "job_id": job_id,
                     "jobs_file": cron_jobs._current_cron_store().jobs_file,
                     "force": force,
+                    "manual": manual,
                 }
             )
             cron_jobs.mark_job_run(job_id, success=True)
@@ -571,6 +572,8 @@ async def test_trigger_cron_job_fires_only_selected_job_and_returns_refreshed_st
             "job_id": selected["id"],
             "jobs_file": isolated_profiles["worker_alpha"] / "cron" / "jobs.json",
             "force": False,
+            # Off-tick run-now: the claim must not stamp next_run_at as the occurrence (#104790).
+            "manual": True,
         }
     ]
     assert triggered["last_status"] == "ok"

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -79,7 +79,7 @@ class TestBackgroundDispatch:
             assert res["claimed"] is True
             assert res["dispatched"] is True
             assert res["delegation_id"]
-            m_claim.assert_called_once_with("job-bg-01", return_job=True)
+            m_claim.assert_called_once_with("job-bg-01", manual=True, return_job=True)
             # The job actually starts on the daemon executor.
             assert run_started.wait(timeout=5.0), "job never started in background"
         finally:
@@ -326,5 +326,5 @@ class TestCronjobRunToolIntegration:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-bg-13", return_job=True)
+        m_claim.assert_called_once_with("job-bg-13", manual=True, return_job=True)
         m_run.assert_called_once()

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -39,7 +39,7 @@ class TestCronjobRunExecutesImmediately:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1", return_job=True)
+        m_claim.assert_called_once_with("job-run-1", manual=True, return_job=True)
         m_run.assert_called_once_with(claimed, adapters=None, loop=None, extra_prompt=None)
 
     def test_run_reconciles_external_provider_after_claimed_execution(self):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -184,7 +184,7 @@ def _claim_for_manual_run(job_id: str, log_label: str):
     ``(None, error_dict)`` in the ``_execute_job_now`` shape. A lost claim is labelled precisely —
     claim_job_for_fire also returns False for paused/disabled/missing jobs, not just in-flight ones."""
     try:
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        claimed_job = claim_job_for_fire(job_id, manual=True, return_job=True)
         if isinstance(claimed_job, dict):
             return claimed_job, None
         refreshed = get_job(job_id)


### PR DESCRIPTION
Running a recurring cron job manually (agent `cronjob run`, or the dashboard **Trigger** button) stamped the job's *next* `next_run_at` as the occurrence just executed. When that slot arrived, `_job_is_due` found a completed execution carrying its identity and skipped it silently; later manual runs failed with "already being fired" until the ghost execution row was deleted (#104790, #105690, confirmed independently in #106166).

Salvage of #105704 by @philmossman (cherry-picked, authorship preserved), plus the sibling site their review surfaced.

- `cron/jobs.py::claim_job_for_fire` gains `manual: bool`; an off-tick claim never stamps `_scheduled_instant`. Scheduler-tick claims are unchanged (the stamp is the CAS dedupe for late external retries).
- `tools/cronjob_tools.py` passes `manual=True` (contributor's commit).
- Follow-up: the dashboard trigger (`POST /api/cron/jobs/{id}/trigger` → `CronScheduler.fire_due` → `claim_fire`) is the same off-tick shape and had the same bug. `fire_due`/`claim_fire` forward `manual` (only when set, mirroring `force`, so third-party providers keep working); the dashboard passes it when the provider's signature accepts it. Webhook (`/api/cron/fire`) and misfire catch-up fires run the slot that is due and keep the stamp — deliberately not changed.
- Tests: 2 contributor invariants (manual claim leaves the future slot unstamped; paused job still refused) + the existing dashboard-trigger and provider tests now assert `manual`. The contributor's third, base-green tick-stamp test was dropped (already pinned by `test_scheduled_occurrence.py`).

Validation: 88 → 85 cron/tool tests green; reverting `cron/jobs.py` → 2 red; reverting `web_server_cron.py` → dashboard test red.
