### PR TITLE
fix(tui): a default-profile session on a named-profile backend no longer fails with `Profile '.hermes' does not exist` (#105228, #105590; salvage #105310, dup #105591)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -217,23 +217,14 @@ def profile_name_for_home(path: str | Path | None) -> str | None:
     current = Path(path).expanduser()
     try:
         default_root = get_default_hermes_root()
-        if current == default_root:
-            return "default"
-        if current.parent.name == "profiles":
-            named = named_profile_home(current)
+        for candidate in (current, current.resolve(strict=False)):
+            if candidate == default_root or candidate == default_root.resolve(strict=False):
+                return "default"
+            named = named_profile_home(candidate)
             if named is not None:
                 return named.name
-            if current.name and not current.name.startswith("."):
-                return current.name
-        if current.resolve(strict=False) == default_root.resolve(strict=False):
-            return "default"
-        named = named_profile_home(current)
     except (OSError, RuntimeError, ValueError):
         return None
-    if named is not None:
-        return named.name
-    if current.parent.name == "profiles" and current.name and not current.name.startswith("."):
-        return current.name
     return None
 
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -206,6 +206,24 @@ def named_profile_home(path: str | Path) -> Path | None:
     return None
 
 
+def profile_name_for_home(path: str | Path | None) -> str | None:
+    """Return the canonical profile id owning *path*, or ``None`` when it is not a profile home.
+
+    The default home is the Hermes root itself, so its basename is an installation detail (``.hermes``
+    on POSIX and commonly ``hermes`` on Windows), not the profile id ``default``.
+    """
+    if path is None or not str(path).strip():
+        return None
+    current = Path(path).expanduser()
+    try:
+        if current.resolve(strict=False) == get_default_hermes_root().resolve(strict=False):
+            return "default"
+        named = named_profile_home(current)
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return named.name if named is not None else None
+
+
 def profile_tombstone_path(profile_home: Path) -> Path:
     return profile_home.parent / _DELETED_PROFILES_DIR / profile_home.name
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -216,16 +216,22 @@ def profile_name_for_home(path: str | Path | None) -> str | None:
         return None
     current = Path(path).expanduser()
     try:
-        if current.resolve(strict=False) == get_default_hermes_root().resolve(strict=False):
+        default_root = get_default_hermes_root()
+        if current == default_root:
+            return "default"
+        if current.parent.name == "profiles":
+            named = named_profile_home(current)
+            if named is not None:
+                return named.name
+            if current.name and not current.name.startswith("."):
+                return current.name
+        if current.resolve(strict=False) == default_root.resolve(strict=False):
             return "default"
         named = named_profile_home(current)
     except (OSError, RuntimeError, ValueError):
         return None
     if named is not None:
         return named.name
-    # Session records already carry a validated profile home. Preserve the
-    # established basename behavior for isolated test/custom roots whose
-    # parent is the conventional profiles directory but lacks root markers.
     if current.parent.name == "profiles" and current.name and not current.name.startswith("."):
         return current.name
     return None

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -223,6 +223,10 @@ def profile_name_for_home(path: str | Path | None) -> str | None:
             named = named_profile_home(candidate)
             if named is not None:
                 return named.name
+            # A stored profile home is authoritative: its owner already resolved it, so the
+            # <root>/profiles/<name> shape names the profile even when <root> carries no markers.
+            if candidate.parent.name == "profiles" and not candidate.name.startswith("."):
+                return candidate.name
     except (OSError, RuntimeError, ValueError):
         return None
     return None

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -221,7 +221,14 @@ def profile_name_for_home(path: str | Path | None) -> str | None:
         named = named_profile_home(current)
     except (OSError, RuntimeError, ValueError):
         return None
-    return named.name if named is not None else None
+    if named is not None:
+        return named.name
+    # Session records already carry a validated profile home. Preserve the
+    # established basename behavior for isolated test/custom roots whose
+    # parent is the conventional profiles directory but lacks root markers.
+    if current.parent.name == "profiles" and current.name and not current.name.startswith("."):
+        return current.name
+    return None
 
 
 def profile_tombstone_path(profile_home: Path) -> Path:

--- a/tests/tui_gateway/test_default_profile_session_name.py
+++ b/tests/tui_gateway/test_default_profile_session_name.py
@@ -26,6 +26,9 @@ def test_default_home_aliases_are_reported_as_default(tmp_path, monkeypatch):
     for alias in (default_home.name, "hermes"):
         assert server._response_profile_name(alias) == "default"
     assert server._session_info(None, {"profile_home": str(default_home)})["profile_name"] == "default"
+    # "hermes" is a legal profile id: a REAL named profile of that name is never swallowed by the alias.
+    (default_home / "profiles" / "hermes").mkdir(parents=True)
+    assert server._response_profile_name("hermes") == "hermes"
 
 
 def test_profile_home_resolution_stamps_default_rows(tmp_path, monkeypatch):
@@ -165,4 +168,3 @@ def test_custom_default_root_real_session_db_owner_stamping(tmp_path, monkeypatc
         assert launch_db.get_session("lazy-default") is None
         assert launch_db.get_session("seeded-default") is None
         assert launch_db.get_session("branched-default") is None
-

--- a/tests/tui_gateway/test_default_profile_session_name.py
+++ b/tests/tui_gateway/test_default_profile_session_name.py
@@ -80,3 +80,89 @@ def test_profile_home_resolution_stamps_default_rows(tmp_path, monkeypatch):
                             str(default_home))
     assert captured.profile_name == "default"
     assert record["pending_title"] is None
+
+
+def test_custom_default_root_real_session_db_owner_stamping(tmp_path, monkeypatch):
+    """Custom default roots stamp real SessionDB rows as default without leaking to siblings."""
+    from hermes_constants import profile_name_for_home
+    from hermes_state import SessionDB
+    from tui_gateway import server
+
+    custom_root = tmp_path / "custom-root"
+    launch_home = custom_root / "profiles" / "worker"
+    default_home = custom_root
+    default_home.mkdir(parents=True)
+    launch_home.mkdir(parents=True)
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    # 1. Custom default root path resolution
+    assert profile_name_for_home(default_home) == "default"
+    assert profile_name_for_home(launch_home) == "worker"
+    assert server._session_info(None, {"profile_home": str(default_home)})["profile_name"] == "default"
+    assert server._session_info(None, {"profile_home": str(launch_home)})["profile_name"] == "worker"
+
+    # 2. Real SessionDB owner stamping
+    with SessionDB(default_home / "state.db") as db:
+        db.create_session("parent-default", "desktop", profile_name="default")
+    with SessionDB(launch_home / "state.db") as db:
+        pass
+
+    session = {
+        "session_key": "lazy-default",
+        "profile_home": str(default_home),
+        "cwd": str(tmp_path),
+    }
+    assert server._ensure_session_db_row(session) is True
+
+    record = {
+        "cwd": str(tmp_path),
+        "pending_title": "branch",
+        "profile_home": str(default_home),
+    }
+    server._seed_branch_row(
+        record,
+        "seeded-default",
+        "parent-default",
+        [{"role": "user", "content": "hello"}],
+        "desktop",
+        str(default_home),
+    )
+    assert record["pending_title"] is None
+
+    # Normal branch persistence path
+    with SessionDB(default_home / "state.db") as db:
+        server._persist_branch(
+            db,
+            "branched-default",
+            "parent-default",
+            "Branch Test",
+            [{"role": "user", "content": "hello"}],
+            source="desktop",
+            cwd=str(tmp_path),
+            profile_name=profile_name_for_home(str(default_home)) or server._current_profile_name(),
+        )
+
+    # Verify rows in default_home / state.db
+    with SessionDB(default_home / "state.db") as db:
+        lazy_row = db.get_session("lazy-default")
+        assert lazy_row is not None
+        assert lazy_row["profile_name"] == "default"
+
+        seeded_row = db.get_session("seeded-default")
+        assert seeded_row is not None
+        assert seeded_row["profile_name"] == "default"
+
+        branched_row = db.get_session("branched-default")
+        assert branched_row is not None
+        assert branched_row["profile_name"] == "default"
+
+    # 3. Negative assertions: default session/branch rows do not land in sibling store
+    with SessionDB(launch_home / "state.db") as launch_db:
+        assert launch_db.get_session("parent-default") is None
+        assert launch_db.get_session("lazy-default") is None
+        assert launch_db.get_session("seeded-default") is None
+        assert launch_db.get_session("branched-default") is None
+

--- a/tests/tui_gateway/test_default_profile_session_name.py
+++ b/tests/tui_gateway/test_default_profile_session_name.py
@@ -1,0 +1,82 @@
+"""Default-profile session names must be derived from the home path, not its basename."""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+
+def _profile_layout(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / ".hermes"
+    default_home = root
+    launch_home = root / "profiles" / "worker"
+    launch_home.mkdir(parents=True)
+    return default_home, launch_home
+
+
+def test_default_home_aliases_are_reported_as_default(tmp_path, monkeypatch):
+    """Legacy basename values must not be resolved as missing named profiles."""
+    from tui_gateway import server
+
+    default_home, launch_home = _profile_layout(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    for alias in (default_home.name, "hermes"):
+        assert server._response_profile_name(alias) == "default"
+    assert server._session_info(None, {"profile_home": str(default_home)})["profile_name"] == "default"
+
+
+def test_profile_home_resolution_stamps_default_rows(tmp_path, monkeypatch):
+    """Default and named homes resolve canonically, including lazy row creation."""
+    from hermes_constants import profile_name_for_home
+    from tui_gateway import server
+
+    default_home, launch_home = _profile_layout(tmp_path)
+    named_home = default_home / "profiles" / "writer"
+    named_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+
+    assert profile_name_for_home(default_home) == "default"
+    assert profile_name_for_home(named_home) == "writer"
+    assert server._session_info(None, {"profile_home": str(named_home)})["profile_name"] == "writer"
+
+    class CaptureDB:
+        profile_name = None
+
+        def create_session(self, _key, **kwargs):
+            self.profile_name = kwargs["profile_name"]
+
+        def append_messages_batch(self, _key, _messages, *, chunk_rows):
+            assert chunk_rows == 500
+
+        def get_session_title(self, _key):
+            return "branch"
+
+        def set_session_title(self, _key, _title):
+            return None
+
+    captured = CaptureDB()
+
+    @contextlib.contextmanager
+    def owner_db(_session, _failure_message=None):
+        yield captured
+
+    monkeypatch.setattr(server, "_workdir_owner_db", owner_db)
+    monkeypatch.setattr(server, "_workdir_row_model_config", lambda _session: ("test-model", {}))
+    monkeypatch.setattr(server, "_session_source", lambda _session: "desktop")
+    monkeypatch.setattr(server, "_persisted_session_cwd", lambda _session: None)
+
+    session = {"session_key": "default-row", "profile_home": str(default_home)}
+    assert server._ensure_session_db_row(session) is True
+    assert captured.profile_name == "default"
+
+    monkeypatch.setattr(server, "_session_db", owner_db)
+    record = {"cwd": str(tmp_path), "pending_title": "branch"}
+    server._seed_branch_row(record, "seeded-row", "parent-row", [{"role": "user", "content": "hi"}], "desktop",
+                            str(default_home))
+    assert captured.profile_name == "default"
+    assert record["pending_title"] is None

--- a/tests/tui_gateway/test_profile_target_unavailable.py
+++ b/tests/tui_gateway/test_profile_target_unavailable.py
@@ -35,6 +35,30 @@ def test_explicit_profile_target_never_falls_back(tmp_path, monkeypatch):
     # A real resolution I/O failure must propagate, too (no predicate patch).
     profiles = home / "profiles"
     profiles.rename(home / "saved-profiles")
-    profiles.symlink_to("profiles")
-    with pytest.raises((OSError, RuntimeError)):
-        server._profile_home("worker")
+    try:
+        profiles.symlink_to("profiles")
+    except OSError:
+        pass
+    else:
+        with pytest.raises((OSError, RuntimeError)):
+            server._profile_home("worker")
+
+
+def test_custom_root_basename_target_fails_closed_when_unavailable(tmp_path, monkeypatch):
+    """An explicit profile request matching a custom root basename fails closed."""
+    from tui_gateway import server
+
+    custom_home = tmp_path / "customer-data"
+    custom_home.mkdir()
+    (custom_home / "config.yaml").write_text("terminal:\n  cwd: /custom\n")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    monkeypatch.setattr(server, "_hermes_home", custom_home)
+
+    with pytest.raises(FileNotFoundError):
+        server._profile_home("customer-data")
+
+    with pytest.raises(FileNotFoundError):
+        with server._profile_db({"profile": "customer-data"}):
+            pass
+

--- a/tests/tui_gateway/test_profile_target_unavailable.py
+++ b/tests/tui_gateway/test_profile_target_unavailable.py
@@ -35,13 +35,9 @@ def test_explicit_profile_target_never_falls_back(tmp_path, monkeypatch):
     # A real resolution I/O failure must propagate, too (no predicate patch).
     profiles = home / "profiles"
     profiles.rename(home / "saved-profiles")
-    try:
-        profiles.symlink_to("profiles")
-    except OSError:
-        pass
-    else:
-        with pytest.raises((OSError, RuntimeError)):
-            server._profile_home("worker")
+    profiles.symlink_to("profiles")
+    with pytest.raises((OSError, RuntimeError)):
+        server._profile_home("worker")
 
 
 def test_custom_root_basename_target_fails_closed_when_unavailable(tmp_path, monkeypatch):
@@ -61,4 +57,3 @@ def test_custom_root_basename_target_fails_closed_when_unavailable(tmp_path, mon
     with pytest.raises(FileNotFoundError):
         with server._profile_db({"profile": "customer-data"}):
             pass
-

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -218,11 +218,10 @@ def _legacy_group_fence_error(rid, session, params):
         hosted = probe_hosted_room(default_db_path(), room_id=room_id)
         peer = False
         if not hosted:
-            from hermes_constants import named_profile_home
-            session_profile_home = named_profile_home(str(session.get("profile_home") or ""))
+            from hermes_constants import profile_name_for_home
             peer = probe_peer_room_reservation(
                 default_db_path(), room_id=room_id, target_profile=(
-                    (session_profile_home.name if session_profile_home is not None else "")
+                    profile_name_for_home(session.get("profile_home"))
                     or str(params.get("profile") or "").strip()
                     or str(_current_profile_name() or "default").strip()))
     except RoomProbeUnavailableError:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -268,7 +268,7 @@ def _seed_branch_row(record: dict, key: str, parent_session_id: str, history: li
                 return
             _persist_branch(db, key, parent_session_id, _branch_title(db, parent_session_id), history,
                             source=source, cwd=record["cwd"],
-                            profile_name=(Path(profile_home).name if profile_home else None), compensate=True)
+                            profile_name=profile_name_for_home(profile_home) or _current_profile_name(), compensate=True)
             record["pending_title"] = None
     except Exception:
         logger.warning("seeded-branch persistence failed for %s; falling back to lazy row creation", key,
@@ -1922,7 +1922,7 @@ def _(rid, params: dict, session: dict) -> dict:
             title = params.get("name", "") or _branch_title(db, old_key)
             home = session.get("profile_home")
             _persist_branch(db, new_key, old_key, title, history, source=source, cwd=_session_cwd(session),
-                            profile_name=Path(home).name if home else _current_profile_name(),
+                            profile_name=profile_name_for_home(home) or _current_profile_name(),
                             copy_fields=_BRANCH_COPY_FIELDS)
         except Exception as e:
             return _err(rid, 5008, f"branch failed: {e}")

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -536,7 +536,7 @@ def _resume_live_unpersisted(ctx: _Resume, live_sid: str, live: dict) -> dict:
     return _ok(ctx.rid, _attach_todo_state({
         "session_id": live_sid, "stored_session_id": str(live.get("session_key") or ""),
         "message_count": len(history), "messages": ctx.messages(history),
-        "info": {"model": _resolve_model(), "lazy": True, "profile_name": ctx.profile or ""}}, live))
+        "info": {"model": _resolve_model(), "lazy": True, "profile_name": profile_name_for_home(live.get("profile_home")) or _response_profile_name(ctx.profile)}}, live))
 
 
 def _resume_adopt_stranded(ctx: _Resume) -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -23,7 +23,8 @@ from typing import Any, Callable, NamedTuple, Optional  # noqa: F401  (Callable:
 # namespace (method_ctx.bind_module) — deleting one breaks a handler at call time, not import time.
 from agent.secret_scope import build_profile_secret_scope, reset_secret_scope, set_secret_scope  # noqa: F401
 from hermes_constants import (
-    get_hermes_home, get_hermes_home_override, reset_hermes_home_override, set_hermes_home_override)
+    get_default_hermes_root, get_hermes_home, get_hermes_home_override, profile_name_for_home,
+    reset_hermes_home_override, set_hermes_home_override)
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
@@ -444,9 +445,30 @@ def _profile_db(params: dict | None = None):
                 db.close()
 
 
+def _canonical_profile_request(name: str) -> str:
+    """Canonicalize profile basenames emitted by older session-info payloads.
+
+    ``Path(default_home).name`` was historically sent as a profile id. Those
+    basenames are installation details, while explicit unknown profile names
+    must continue to fail closed in ``_profile_home``.
+    """
+    folded = name.casefold()
+    if folded in {".hermes", "hermes"}:
+        return "default"
+    with contextlib.suppress(OSError, RuntimeError, ValueError):
+        if folded == get_default_hermes_root().name.casefold():
+            from hermes_cli import profiles as profiles_mod
+            # A custom Hermes root can share a name with a valid named profile.
+            # Prefer that real profile when it exists; otherwise this is the
+            # legacy basename of the default root.
+            if not Path(profiles_mod.get_profile_dir(name)).is_dir():
+                return "default"
+    return name
+
+
 def _response_profile_name(profile: str | None = None) -> str:
     """Profile name for session.* payloads: the requested real non-launch profile, else the launch one."""
-    name = (profile or "").strip()
+    name = _canonical_profile_request((profile or "").strip())
     return name if name and _profile_home(name) is not None else _current_profile_name()
 
 
@@ -459,7 +481,7 @@ def _db_unavailable_error(rid, *, code: int):
 # override) so config/skills/model/persistence resolve to it. Omitted/own profile → launch profile.
 def _profile_home(profile: str | None) -> Path | None:
     """Resolve a named profile's home on THIS host, or None for the launch profile."""
-    if not (name := (profile or "").strip()):
+    if not (name := _canonical_profile_request((profile or "").strip())):
         return None
     from hermes_cli import profiles as profiles_mod
     home = Path(profiles_mod.get_profile_dir(name))
@@ -2058,9 +2080,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "stored_session_id": session_key or "", "desktop_contract": DESKTOP_BACKEND_CONTRACT,
         "version": "", "release_date": "", "update_behind": None, "update_command": "",
         "usage": _session_usage_snapshot(session),
-        "profile_name": (
-            _response_profile_name(Path(session["profile_home"]).name)
-            if isinstance(session, dict) and session.get("profile_home") else _current_profile_name()),
+        "profile_name": profile_name_for_home(sess.get("profile_home")) or _current_profile_name(),
     }
     with contextlib.suppress(Exception):
         from hermes_cli import __version__, __release_date__

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -23,7 +23,7 @@ from typing import Any, Callable, NamedTuple, Optional  # noqa: F401  (Callable:
 # namespace (method_ctx.bind_module) — deleting one breaks a handler at call time, not import time.
 from agent.secret_scope import build_profile_secret_scope, reset_secret_scope, set_secret_scope  # noqa: F401
 from hermes_constants import (
-    get_default_hermes_root, get_hermes_home, get_hermes_home_override, profile_name_for_home,
+    get_hermes_home, get_hermes_home_override, profile_name_for_home,
     reset_hermes_home_override, set_hermes_home_override)
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
@@ -452,17 +452,8 @@ def _canonical_profile_request(name: str) -> str:
     basenames are installation details, while explicit unknown profile names
     must continue to fail closed in ``_profile_home``.
     """
-    folded = name.casefold()
-    if folded in {".hermes", "hermes"}:
+    if name.casefold() in {".hermes", "hermes"}:
         return "default"
-    with contextlib.suppress(OSError, RuntimeError, ValueError):
-        if folded == get_default_hermes_root().name.casefold():
-            from hermes_cli import profiles as profiles_mod
-            # A custom Hermes root can share a name with a valid named profile.
-            # Prefer that real profile when it exists; otherwise this is the
-            # legacy basename of the default root.
-            if not Path(profiles_mod.get_profile_dir(name)).is_dir():
-                return "default"
     return name
 
 
@@ -487,8 +478,12 @@ def _profile_home(profile: str | None) -> Path | None:
     home = Path(profiles_mod.get_profile_dir(name))
     if not home.is_dir():
         raise FileNotFoundError(f"Profile '{name}' does not exist.")
-    if home.resolve() == Path(_hermes_home).resolve():
+    launch = Path(_hermes_home)
+    if home == launch:
         return None  # already the launch profile (no override needed)
+    if home.name == launch.name or home.is_symlink() or launch.is_symlink():
+        if home.resolve() == launch.resolve():
+            return None
     _served_profile_homes.add(home)  # the change watcher must stat every served sibling store too
     return home
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -448,12 +448,14 @@ def _profile_db(params: dict | None = None):
 def _canonical_profile_request(name: str) -> str:
     """Canonicalize profile basenames emitted by older session-info payloads.
 
-    ``Path(default_home).name`` was historically sent as a profile id. Those
-    basenames are installation details, while explicit unknown profile names
-    must continue to fail closed in ``_profile_home``.
+    ``Path(default_home).name`` was historically sent as a profile id. Those basenames are
+    installation details — unless a real named profile of that name exists (``hermes`` is a legal
+    id), in which case it wins; other unknown names keep failing closed in ``_profile_home``.
     """
     if name.casefold() in {".hermes", "hermes"}:
-        return "default"
+        from hermes_cli import profiles as profiles_mod
+        if not Path(profiles_mod.get_profile_dir(name)).is_dir():
+            return "default"
     return name
 
 
@@ -478,12 +480,8 @@ def _profile_home(profile: str | None) -> Path | None:
     home = Path(profiles_mod.get_profile_dir(name))
     if not home.is_dir():
         raise FileNotFoundError(f"Profile '{name}' does not exist.")
-    launch = Path(_hermes_home)
-    if home == launch:
+    if home.resolve() == Path(_hermes_home).resolve():
         return None  # already the launch profile (no override needed)
-    if home.name == launch.name or home.is_symlink() or launch.is_symlink():
-        if home.resolve() == launch.resolve():
-            return None
     _served_profile_homes.add(home)  # the change watcher must stat every served sibling store too
     return home
 

--- a/tui_gateway/session_workdir.py
+++ b/tui_gateway/session_workdir.py
@@ -275,7 +275,7 @@ def _ensure_session_db_row(session: dict) -> bool:
                 # #94724 legacy-owner backfill exists to repair, and rows minted AFTER that one-shot
                 # backfill ran stayed NULL forever: profile-keyed matching then drops them from the sidebar
                 # and deep links can't resolve them (#99222).
-                profile_name=Path(profile_home).name if profile_home else _current_profile_name())
+                profile_name=profile_name_for_home(profile_home) or _current_profile_name())
             # Born hidden (session.create hidden=true, or set_hidden before the row existed): apply the deferred intent.
             if session.get("pending_hidden"):
                 try:


### PR DESCRIPTION
In a multiplexed Desktop/TUI backend launched with `--profile <name>`, a session pinned to the **default** profile crashed on init: `_session_info` labelled the home by `Path(profile_home).name` — `.hermes` (or `hermes` on Windows) — and fed that back into profile resolution, which raised `FileNotFoundError` and surfaced as `agent_init_failed` on every turn. Fixes #105228; also reported as #105590.

Salvage of #105310 by @JoaoMarcos44 (4 commits cherry-picked, authorship preserved). #105591 by @Student0S arrived later with the same approach and is credited for the custom-root-basename regression case. #105252 (aliasing in `hermes_cli/profiles.py`) was closed by its author.

- `hermes_constants.profile_name_for_home` derives the profile id from the home PATH (default root → `default`, `<root>/profiles/<name>` → `name`); the TUI writers (`methods_session.py`, `session_workdir.py`, `methods_prompt.py`) use it.
- `tui_gateway/server.py`: legacy `.hermes`/`hermes` basenames from older payloads canonicalise to `default` at the RPC boundary; unknown names still fail closed.
- Follow-up: `hermes` is a legal profile id, so the alias only applies when no real `<root>/profiles/hermes` exists; `profile_name_for_home` loses its duplicated pre/post-resolve block; `_profile_home` keeps `main`'s single `resolve()` comparison; a `try/except OSError: pass` that could silently skip an existing assertion is removed.

Validation: 5 tests green (one pre-existing cross-file ordering leak in `test_profile_target_unavailable.py` reproduces on `main` and is file-isolated by the runner); reverting `hermes_constants.py` → 3 red; removing the real-profile check → alias test red.
