### PR TITLE
fix(loop): the current-turn index is re-anchored after the alternation repair merges rows (webui #7461; salvage #105694)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1407,7 +1407,7 @@ def _run_api_retry_loop(agent, s: _LoopState) -> Optional[Dict[str, Any]]:
     return None
 
 
-def run_conversation(
+def _run_conversation_turn(
     agent,
     user_message: Any,
     system_message: str = None,
@@ -1553,6 +1553,46 @@ def run_conversation(
         # future input can move to a clean session (#98722).
         result.update(error=_COMPRESSION_TIMEOUT_FINAL_RESPONSE, partial=True, compression_exhausted=True)
     return result
+
+
+def run_conversation(
+    agent,
+    user_message: Any,
+    system_message: str = None,
+    conversation_history: List[Dict[str, Any]] = None,
+    task_id: str = None,
+    stream_callback: Optional[callable] = None,
+    persist_user_message: Optional[Any] = None,
+    persist_user_timestamp: Optional[float] = None,
+    persist_user_display_kind: Optional[str] = None,
+    persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+    persist_user_platform_id: Optional[str] = None,
+    moa_config: Optional[dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run one turn (see ``_run_conversation_turn``) and export the current-turn boundary.
+
+    Every envelope that leaves the loop — success, partial/error, interrupt, retry-exhausted,
+    tool-limit, preflight timeout, codex runtime — passes through here, so the
+    ``{turn_id, current_turn_user_idx}`` pair is stamped beside the exact ``messages`` it
+    addresses, after every history rewrite including post-turn micro-compaction.
+    """
+    from agent.turn_context import export_current_turn_boundary
+
+    result = _run_conversation_turn(
+        agent,
+        user_message,
+        system_message=system_message,
+        conversation_history=conversation_history,
+        task_id=task_id,
+        stream_callback=stream_callback,
+        persist_user_message=persist_user_message,
+        persist_user_timestamp=persist_user_timestamp,
+        persist_user_display_kind=persist_user_display_kind,
+        persist_user_display_metadata=persist_user_display_metadata,
+        persist_user_platform_id=persist_user_platform_id,
+        moa_config=moa_config,
+    )
+    return export_current_turn_boundary(agent, result, user_message)
 
 
 __all__ = ["run_conversation"]

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -244,6 +244,44 @@ def reanchor_current_turn_user_idx(messages: List[Any], user_message: Any) -> in
     return fallback
 
 
+def export_current_turn_boundary(agent: Any, result: Any, user_message: Any) -> Any:
+    """Stamp ``{turn_id, current_turn_user_idx}`` on a result envelope, proven against the
+    exact ``result["messages"]`` projection it travels with.
+
+    Hosts that settle their own transcript by index (hermes-webui) must never guess which
+    row is the current user turn after this loop rewrote history (alternation repair,
+    compaction, post-turn micro-compaction): a guessed index or a text match can relabel an
+    identical historical prompt and claim its old answer as this turn's. So the producer
+    exports the coordinate, computed on the final list, only when the addressed row is this
+    turn's user message verbatim. Otherwise the keys are omitted and hosts fail closed.
+    Also mirrors the final index into ``_persist_user_message_idx`` so the persist override
+    targets the surviving row after post-turn micro-compaction.
+    """
+    if not isinstance(result, dict):
+        return result
+    messages = result.get("messages")
+    turn_id = str(getattr(agent, "_current_turn_id", "") or "")
+    if not isinstance(messages, list) or not turn_id or user_message is None:
+        return result
+    idx = reanchor_current_turn_user_idx(messages, user_message)
+    if idx < 0 or idx >= len(messages):
+        return result
+    row = messages[idx]
+    if not (isinstance(row, dict) and row.get("role") == "user"):
+        return result
+    from agent.context_compressor import user_originated_turn_view
+
+    live_view = user_originated_turn_view(row)
+    if row.get("content") != user_message and not (
+        isinstance(live_view, dict) and live_view.get("content") == user_message
+    ):
+        return result  # rewritten (merge-into-tail) row: not a proven boundary
+    result["turn_id"] = turn_id
+    result["current_turn_user_idx"] = idx
+    agent._persist_user_message_idx = idx
+    return result
+
+
 def compression_made_progress(
     orig_len: int, new_len: int, orig_tokens: int, new_tokens: int
 ) -> bool:

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -89,9 +89,12 @@ class IterationPrep:
     action: str
     messages: Any
     request_logger: Any
+    current_turn_user_idx: Any
 
 
-def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> IterationPrep:
+def prepare_iteration(
+    agent: Any, *, messages: Any, api_call_count: Any, user_message: Any = None, current_turn_user_idx: Any = None,
+) -> IterationPrep:
     """Prepare ``messages`` for this iteration in the original order. Every mutation here is
     cache-safe by construction: steer text lands in the newest tool result, the ghost-row
     filter only drops hidden scaffold placeholders, and repair runs BEFORE the request build."""
@@ -182,7 +185,31 @@ def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> Itera
             repaired_seq,
             agent.session_id or "-",
         )
-    return IterationPrep(action="fallthrough", messages=messages, request_logger=request_logger)
+        # The repair merges adjacent user rows in place (after a compaction the role=user
+        # summary sits next to the protected first user message), so the list shrinks and
+        # the index recorded at turn start points past this turn's user row. Re-anchor it
+        # like the compression restart path does, and mirror the value into
+        # _persist_user_message_idx, which hosts read when the result carries no index:
+        # a stale anchor injects prefetch into a historical row and makes hosts that settle
+        # their transcript by this index (hermes-webui) write the current turn to the FRONT
+        # of the context, rewriting the prompt's leading messages every turn.
+        _reanchored_idx = (
+            reanchor_current_turn_user_idx(messages, user_message) if user_message is not None
+            else current_turn_user_idx
+        )
+        if _reanchored_idx != current_turn_user_idx:
+            request_logger.info(
+                "Re-anchored current_turn_user_idx %s -> %s after alternation repair (session=%s)",
+                current_turn_user_idx,
+                _reanchored_idx,
+                agent.session_id or "-",
+            )
+            current_turn_user_idx = _reanchored_idx
+            agent._persist_user_message_idx = _reanchored_idx
+    return IterationPrep(
+        action="fallthrough", messages=messages, request_logger=request_logger,
+        current_turn_user_idx=current_turn_user_idx,
+    )
 
 
 def _previous_tool_round(messages: Any) -> list:

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -193,6 +193,11 @@ def prepare_iteration(
         # a stale anchor injects prefetch into a historical row and makes hosts that settle
         # their transcript by this index (hermes-webui) write the current turn to the FRONT
         # of the context, rewriting the prompt's leading messages every turn.
+        # reanchor_current_turn_user_idx scans from the tail: with two identical user
+        # rows it resolves to the LAST one, i.e. this turn, never the historical copy.
+        # Without the message text the index cannot be re-derived; leave it (an
+        # out-of-range index is detectably stale, a clamped one would silently target
+        # a wrong row).
         _reanchored_idx = (
             reanchor_current_turn_user_idx(messages, user_message) if user_message is not None
             else current_turn_user_idx

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 from agent.display import KawaiiSpinner
-from agent.turn_context import reanchor_current_turn_user_idx
+from agent.turn_context_compaction import _reanchor
 
 logger = logging.getLogger("agent.conversation_loop")
 
@@ -185,32 +185,19 @@ def prepare_iteration(
             repaired_seq,
             agent.session_id or "-",
         )
-        # The repair merges adjacent user rows in place (after a compaction the role=user
-        # summary sits next to the protected first user message), so the list shrinks and
-        # the index recorded at turn start points past this turn's user row. Re-anchor it
-        # like the compression restart path does, and mirror the value into
-        # _persist_user_message_idx, which hosts read when the result carries no index:
-        # a stale anchor injects prefetch into a historical row and makes hosts that settle
-        # their transcript by this index (hermes-webui) write the current turn to the FRONT
-        # of the context, rewriting the prompt's leading messages every turn.
-        # reanchor_current_turn_user_idx scans from the tail: with two identical user
-        # rows it resolves to the LAST one, i.e. this turn, never the historical copy.
-        # Without the message text the index cannot be re-derived; leave it (an
-        # out-of-range index is detectably stale, a clamped one would silently target
-        # a wrong row).
-        _reanchored_idx = (
-            reanchor_current_turn_user_idx(messages, user_message) if user_message is not None
-            else current_turn_user_idx
-        )
-        if _reanchored_idx != current_turn_user_idx:
-            request_logger.info(
-                "Re-anchored current_turn_user_idx %s -> %s after alternation repair (session=%s)",
-                current_turn_user_idx,
-                _reanchored_idx,
-                agent.session_id or "-",
-            )
-            current_turn_user_idx = _reanchored_idx
-            agent._persist_user_message_idx = _reanchored_idx
+        # The merge shrank the list, so the index recorded at turn start can point past this
+        # turn's user row: prefetch would inject into a historical row and index-settling hosts
+        # (hermes-webui) would write the current turn to the FRONT of the context. Re-anchor as
+        # the compression-restart path does (last verbatim row wins, never a historical copy);
+        # without the text the index cannot be re-derived and is left detectably stale.
+        if user_message is not None:
+            _reanchored_idx = _reanchor(agent, messages, user_message)
+            if _reanchored_idx != current_turn_user_idx:
+                request_logger.info(
+                    "Re-anchored current_turn_user_idx %s -> %s after alternation repair (session=%s)",
+                    current_turn_user_idx, _reanchored_idx, agent.session_id or "-",
+                )
+                current_turn_user_idx = _reanchored_idx
     return IterationPrep(
         action="fallthrough", messages=messages, request_logger=request_logger,
         current_turn_user_idx=current_turn_user_idx,
@@ -470,8 +457,7 @@ def apply_retry_restarts(
         # In-loop compression rebuilt `messages`; re-anchor the current-turn index
         # like the prologue, AFTER the handoff guard (it may re-append this turn's
         # ask). A stale anchor injects prefetch into a historical row.
-        current_turn_user_idx = reanchor_current_turn_user_idx(messages, user_message)
-        agent._persist_user_message_idx = current_turn_user_idx
+        current_turn_user_idx = _reanchor(agent, messages, user_message)
         return _verdict("continue")
 
     if _retry.restart_with_rebuilt_messages:

--- a/contributors/emails/portavales@gmail.com
+++ b/contributors/emails/portavales@gmail.com
@@ -1,0 +1,2 @@
+portavales
+# PR #105694 salvage

--- a/tests/run_agent/test_export_current_turn_boundary.py
+++ b/tests/run_agent/test_export_current_turn_boundary.py
@@ -1,0 +1,131 @@
+"""The loop exports ``{turn_id, current_turn_user_idx}`` beside the exact ``messages`` it
+addresses, and only when that row is this turn's user message verbatim.
+
+Hosts that settle a transcript by index (hermes-webui) must not guess the current-turn
+row after the loop rewrote history (alternation repair, compaction, post-turn
+micro-compaction): with a repeated prompt a guessed index or a text match relabels the
+historical copy and claims its old answer. The producer therefore proves the coordinate on
+the final list; when it cannot, the keys are omitted and hosts fail closed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.turn_context import export_current_turn_boundary
+
+
+class _Agent:
+    def __init__(self, turn_id="session:task:abcd1234"):
+        self._current_turn_id = turn_id
+        self._persist_user_message_idx = None
+
+
+def test_repeated_prompt_resolves_to_the_last_verbatim_row():
+    messages = [
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "new answer"},
+    ]
+    agent = _Agent()
+    result = export_current_turn_boundary(agent, {"messages": messages}, "same question")
+    assert result["current_turn_user_idx"] == 2
+    assert result["turn_id"] == agent._current_turn_id
+    assert agent._persist_user_message_idx == 2
+
+
+def test_missing_current_row_exports_nothing():
+    messages = [
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    agent = _Agent()
+    result = export_current_turn_boundary(agent, {"messages": messages}, "another question")
+    assert "current_turn_user_idx" not in result and "turn_id" not in result
+    assert agent._persist_user_message_idx is None
+
+
+def test_rewritten_row_is_not_a_proven_boundary():
+    # merge-into-tail rewrote the surviving row's content: reanchor would fall back to it,
+    # but the export refuses to claim a row that is not the verbatim message.
+    messages = [
+        {"role": "user", "content": "summary\n\nsame question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    result = export_current_turn_boundary(_Agent(), {"messages": messages}, "same question")
+    assert "current_turn_user_idx" not in result
+
+
+def test_multimodal_content_is_matched_verbatim():
+    content = [{"type": "text", "text": "look"}, {"type": "image_url", "image_url": {"url": "data:x"}}]
+    messages = [{"role": "user", "content": content}, {"role": "assistant", "content": "ok"}]
+    result = export_current_turn_boundary(_Agent(), {"messages": messages}, content)
+    assert result["current_turn_user_idx"] == 0
+
+
+def test_no_turn_id_or_non_dict_result_is_left_alone():
+    assert export_current_turn_boundary(_Agent(turn_id=""), {"messages": [{"role": "user", "content": "q"}]}, "q") == {
+        "messages": [{"role": "user", "content": "q"}]
+    }
+    assert export_current_turn_boundary(_Agent(), None, "q") is None
+
+
+@pytest.fixture()
+def loop_agent():
+    from run_agent import AIAgent
+
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+def _stub(content, finish_reason="stop"):
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+
+    return SimpleNamespace(
+        id="chatcmpl-test",
+        model="test/model",
+        choices=[SimpleNamespace(index=0, message=_mock_assistant_msg(content=content), finish_reason=finish_reason)],
+        usage=None,
+    )
+
+
+def test_run_conversation_exports_the_pair_on_a_success_envelope(loop_agent):
+    loop_agent.client.chat.completions.create.side_effect = [_stub("new answer")]
+    history = [
+        {"role": "user", "content": "same question"},
+        {"role": "assistant", "content": "old answer"},
+    ]
+    with (
+        patch.object(loop_agent, "_persist_session"),
+        patch.object(loop_agent, "_save_trajectory"),
+        patch.object(loop_agent, "_cleanup_task_resources"),
+    ):
+        result = loop_agent.run_conversation("same question", conversation_history=history)
+
+    assert result["completed"] is True
+    idx = result["current_turn_user_idx"]
+    assert result["messages"][idx]["role"] == "user"
+    assert result["messages"][idx]["content"] == "same question"
+    assert idx > 0  # the historical identical prompt at index 0 is never the export
+    assert result["turn_id"] == loop_agent._current_turn_id
+    assert result["messages"][-1]["content"] == "new answer"

--- a/tests/run_agent/test_export_current_turn_boundary.py
+++ b/tests/run_agent/test_export_current_turn_boundary.py
@@ -24,54 +24,31 @@ class _Agent:
         self._persist_user_message_idx = None
 
 
-def test_repeated_prompt_resolves_to_the_last_verbatim_row():
-    messages = [
-        {"role": "user", "content": "same question"},
-        {"role": "assistant", "content": "old answer"},
-        {"role": "user", "content": "same question"},
-        {"role": "assistant", "content": "new answer"},
-    ]
+@pytest.mark.parametrize("user_message, messages, expected_idx", [
+    # a repeated prompt resolves to the LAST verbatim row, never the historical copy
+    ("same question", [
+        {"role": "user", "content": "same question"}, {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "same question"}, {"role": "assistant", "content": "new answer"},
+    ], 2),
+    # multimodal content matches by structural equality
+    ([{"type": "text", "text": "look"}, {"type": "image_url", "image_url": {"url": "data:x"}}],
+     [{"role": "user", "content": [{"type": "text", "text": "look"}, {"type": "image_url", "image_url": {"url": "data:x"}}]},
+      {"role": "assistant", "content": "ok"}], 0),
+    # a row the repair rewrote (merge-into-tail) is not a proven boundary: export nothing
+    ("same question", [{"role": "user", "content": "summary\n\nsame question"}, {"role": "assistant", "content": "answer"}], None),
+    # no current row at all: export nothing, persist override untouched
+    ("another question", [{"role": "user", "content": "same question"}, {"role": "assistant", "content": "old answer"}], None),
+])
+def test_boundary_is_exported_only_for_the_verbatim_current_row(user_message, messages, expected_idx):
     agent = _Agent()
-    result = export_current_turn_boundary(agent, {"messages": messages}, "same question")
-    assert result["current_turn_user_idx"] == 2
-    assert result["turn_id"] == agent._current_turn_id
-    assert agent._persist_user_message_idx == 2
-
-
-def test_missing_current_row_exports_nothing():
-    messages = [
-        {"role": "user", "content": "same question"},
-        {"role": "assistant", "content": "old answer"},
-    ]
-    agent = _Agent()
-    result = export_current_turn_boundary(agent, {"messages": messages}, "another question")
-    assert "current_turn_user_idx" not in result and "turn_id" not in result
-    assert agent._persist_user_message_idx is None
-
-
-def test_rewritten_row_is_not_a_proven_boundary():
-    # merge-into-tail rewrote the surviving row's content: reanchor would fall back to it,
-    # but the export refuses to claim a row that is not the verbatim message.
-    messages = [
-        {"role": "user", "content": "summary\n\nsame question"},
-        {"role": "assistant", "content": "answer"},
-    ]
-    result = export_current_turn_boundary(_Agent(), {"messages": messages}, "same question")
-    assert "current_turn_user_idx" not in result
-
-
-def test_multimodal_content_is_matched_verbatim():
-    content = [{"type": "text", "text": "look"}, {"type": "image_url", "image_url": {"url": "data:x"}}]
-    messages = [{"role": "user", "content": content}, {"role": "assistant", "content": "ok"}]
-    result = export_current_turn_boundary(_Agent(), {"messages": messages}, content)
-    assert result["current_turn_user_idx"] == 0
-
-
-def test_no_turn_id_or_non_dict_result_is_left_alone():
-    assert export_current_turn_boundary(_Agent(turn_id=""), {"messages": [{"role": "user", "content": "q"}]}, "q") == {
-        "messages": [{"role": "user", "content": "q"}]
-    }
-    assert export_current_turn_boundary(_Agent(), None, "q") is None
+    result = export_current_turn_boundary(agent, {"messages": messages}, user_message)
+    if expected_idx is None:
+        assert "current_turn_user_idx" not in result and "turn_id" not in result
+        assert agent._persist_user_message_idx is None
+    else:
+        assert result["current_turn_user_idx"] == expected_idx
+        assert result["turn_id"] == agent._current_turn_id
+        assert agent._persist_user_message_idx == expected_idx
 
 
 @pytest.fixture()

--- a/tests/run_agent/test_repair_reanchors_current_turn_user_idx.py
+++ b/tests/run_agent/test_repair_reanchors_current_turn_user_idx.py
@@ -1,0 +1,50 @@
+"""Regression: ``repair_message_sequence`` merges adjacent rows *before* the current
+turn's user message (a role=user compaction summary next to the protected first
+user message), so the index recorded at turn start drifts past the current row.
+Hosts that settle the transcript by that index (WebUI) then write the current
+user turn to the FRONT of the context. ``run_conversation`` must re-anchor the
+index after a repair that changed the list.
+"""
+from agent.agent_runtime_helpers import repair_message_sequence
+from agent.turn_context import reanchor_current_turn_user_idx
+
+
+class _Agent:
+    session_id = "s"
+
+
+def _history_with_adjacent_users():
+    return [
+        {"role": "assistant", "content": "**Context snapshot**"},
+        {"role": "user", "content": "compaction summary written as a user row"},
+        {"role": "user", "content": "first protected user message"},
+        {"role": "assistant", "content": "ok",
+         "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "out"},
+        {"role": "user", "content": "NEW question"},
+    ]
+
+
+def test_repair_shifts_recorded_index_and_reanchor_recovers_it():
+    messages = _history_with_adjacent_users()
+    recorded_idx = len(messages) - 1  # what run_conversation records at turn start
+    assert messages[recorded_idx]["content"] == "NEW question"
+    repairs = repair_message_sequence(_Agent(), messages)
+    assert repairs >= 1
+    # the recorded index no longer addresses the current user row
+    assert recorded_idx >= len(messages) or messages[recorded_idx]["content"] != "NEW question"
+    reanchored = reanchor_current_turn_user_idx(messages, "NEW question")
+    assert messages[reanchored]["role"] == "user"
+    assert messages[reanchored]["content"] == "NEW question"
+    assert reanchored == len(messages) - 1
+
+
+def test_repair_without_changes_keeps_index():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "NEW question"},
+    ]
+    recorded_idx = len(messages) - 1
+    assert repair_message_sequence(_Agent(), messages) == 0
+    assert reanchor_current_turn_user_idx(messages, "NEW question") == recorded_idx

--- a/tests/run_agent/test_repair_reanchors_current_turn_user_idx.py
+++ b/tests/run_agent/test_repair_reanchors_current_turn_user_idx.py
@@ -1,50 +1,45 @@
-"""Regression: ``repair_message_sequence`` merges adjacent rows *before* the current
-turn's user message (a role=user compaction summary next to the protected first
-user message), so the index recorded at turn start drifts past the current row.
-Hosts that settle the transcript by that index (WebUI) then write the current
-user turn to the FRONT of the context. ``run_conversation`` must re-anchor the
-index after a repair that changed the list.
-"""
-from agent.agent_runtime_helpers import repair_message_sequence
-from agent.turn_context import reanchor_current_turn_user_idx
+"""``prepare_iteration`` runs the alternation repair, which merges adjacent user rows in place
+(after a compaction the role=user summary sits next to the protected first user message). The
+index recorded at turn start then points past this turn's user row; hosts that settle the
+transcript by that index (WebUI) write the current turn to the FRONT of the context. The
+iteration prep must hand back a re-anchored index and mirror it into the persist override."""
 
 
-class _Agent:
-    session_id = "s"
+def _agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from run_agent import AIAgent
+    from hermes_state import SessionDB
+
+    return AIAgent(session_db=SessionDB(db_path=tmp_path / "proof.db"),
+                   model="test-model", provider="openai-compat", api_key="test",
+                   base_url="http://127.0.0.1:1/v1", max_iterations=4,
+                   quiet_mode=True, skip_context_files=True, skip_memory=True)
 
 
-def _history_with_adjacent_users():
-    return [
-        {"role": "assistant", "content": "**Context snapshot**"},
-        {"role": "user", "content": "compaction summary written as a user row"},
-        {"role": "user", "content": "first protected user message"},
-        {"role": "assistant", "content": "ok",
-         "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}}]},
-        {"role": "tool", "tool_call_id": "c1", "content": "out"},
-        {"role": "user", "content": "NEW question"},
-    ]
+def test_prepare_iteration_reanchors_after_the_repair_merges_rows(tmp_path, monkeypatch):
+    from agent.turn_context import _reset_per_turn_agent_state
+    from agent.turn_iteration_prep import prepare_iteration
 
-
-def test_repair_shifts_recorded_index_and_reanchor_recovers_it():
-    messages = _history_with_adjacent_users()
-    recorded_idx = len(messages) - 1  # what run_conversation records at turn start
-    assert messages[recorded_idx]["content"] == "NEW question"
-    repairs = repair_message_sequence(_Agent(), messages)
-    assert repairs >= 1
-    # the recorded index no longer addresses the current user row
-    assert recorded_idx >= len(messages) or messages[recorded_idx]["content"] != "NEW question"
-    reanchored = reanchor_current_turn_user_idx(messages, "NEW question")
-    assert messages[reanchored]["role"] == "user"
-    assert messages[reanchored]["content"] == "NEW question"
-    assert reanchored == len(messages) - 1
-
-
-def test_repair_without_changes_keeps_index():
-    messages = [
-        {"role": "user", "content": "hello"},
-        {"role": "assistant", "content": "hi"},
-        {"role": "user", "content": "NEW question"},
-    ]
-    recorded_idx = len(messages) - 1
-    assert repair_message_sequence(_Agent(), messages) == 0
-    assert reanchor_current_turn_user_idx(messages, "NEW question") == recorded_idx
+    agent = _agent(tmp_path, monkeypatch)
+    try:
+        _reset_per_turn_agent_state(agent)
+        messages = [
+            {"role": "assistant", "content": "**Context snapshot**"},
+            {"role": "user", "content": "compaction summary written as a user row"},
+            {"role": "user", "content": "first protected user message"},
+            {"role": "assistant", "content": "ok",
+             "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "out"},
+            {"role": "user", "content": "NEW question"},
+        ]
+        recorded_idx = len(messages) - 1  # what run_conversation records at turn start
+        prep = prepare_iteration(
+            agent, messages=messages, api_call_count=1,
+            user_message="NEW question", current_turn_user_idx=recorded_idx,
+        )
+        assert prep.action == "fallthrough"
+        assert len(prep.messages) < len(messages) + 1 and recorded_idx >= len(prep.messages)
+        assert prep.messages[prep.current_turn_user_idx]["content"] == "NEW question"
+        assert agent._persist_user_message_idx == prep.current_turn_user_idx
+    finally:
+        agent._session_db.close()


### PR DESCRIPTION
`prepare_iteration` runs the alternation repair, which merges adjacent user rows in place — after a compaction the `role=user` summary sits next to the protected first user message. The list shrinks and `current_turn_user_idx` (recorded at turn start) points past this turn's user row: per-turn context injection targets the wrong row, and hosts that settle the transcript by this index (hermes-webui) write the current user turn to the **front** of the context, rewriting the prompt's leading messages every turn (0% prefix-cache hits at 200K tokens).

Salvage of #105694 by @portavales (2 commits cherry-picked, authorship preserved).

- Commit 1: after a repair that changed the list, re-anchor via the same `_reanchor` the compression-restart path uses (last verbatim user row wins, never a historical copy) and return the index through `IterationPrep`.
- Commit 2: every `run_conversation` result envelope carries `{turn_id, current_turn_user_idx}` computed on the final `messages`, exported only when the addressed row is this turn's message verbatim. The consumer is hermes-webui (stated in the PR); in-tree nothing reads it yet.
- Follow-up: the contributor's regression test exercised only pre-existing helpers (reverting the fix left it green); it now drives `prepare_iteration` on a real `AIAgent` and is red without the re-anchor. Both re-anchor sites share `_reanchor`; the export tests fold into one parametrized invariant + the envelope test.

Validation: 26 tests green; removing the re-anchor → `IndexError` in the new test.
