### PR TITLE
fix(cli): `hermes -z --resume` continues the session instead of starting a fresh one (#105892; salvage #105957)

### DIFF
--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -367,7 +367,7 @@ class CLIModelSwitchMixin:
         so the session still opens (the first turn surfaces the auth error).
         """
         from cli import logger
-        if getattr(self, "_explicit_model_override", False):
+        if not (session_meta or {}).get("model") or getattr(self, "_explicit_model_override", False):
             return
         route = stored_session_route(session_meta, current_model=self.model, current_provider=self.provider)
         if route is None:

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -28,6 +28,25 @@ def _runtime_fields(cli) -> dict:
     return {key: getattr(cli, key, None) for key in _RUNTIME_FIELDS}
 
 
+def stored_session_route(session_meta, *, current_model, current_provider):
+    """The route a resumed session should run on, or ``None`` when the stored one is absent or
+    already current. Returns ``(model, provider, base_url, api_mode, provider_changed)``; the
+    canonical row reader is ``SessionDB.session_gateway_runtime`` (``model_config.gateway_runtime``,
+    else the TUI's top-level keys). Bare ``custom`` is healed because the CLI resolve path
+    hard-fails on it (the TUI gateway keeps it when a base_url exists)."""
+    stored_model = str((session_meta or {}).get("model") or "").strip()
+    if not stored_model:
+        return None
+    from hermes_state import SessionDB as _SessionDB
+    runtime = _SessionDB.session_gateway_runtime(session_meta)
+    base_url = runtime.get("base_url") or None
+    provider = _heal_bare_custom_provider(runtime.get("provider") or None, base_url=base_url, model=stored_model)
+    provider_changed = bool(provider) and provider != current_provider
+    if stored_model == current_model and not provider_changed:
+        return None
+    return stored_model, provider, base_url, (runtime.get("api_mode") or None), provider_changed
+
+
 def _heal_bare_custom_provider(provider, *, base_url, model):
     """Bare ``custom`` is a billing class, not a routable identity: persisting/restoring it makes a
     later resume hard-fail once the config default leaves the custom endpoint. Recover the durable
@@ -348,22 +367,12 @@ class CLIModelSwitchMixin:
         so the session still opens (the first turn surfaces the auth error).
         """
         from cli import logger
-        stored_model = (session_meta or {}).get("model")
-        if not stored_model or getattr(self, "_explicit_model_override", False):
+        if getattr(self, "_explicit_model_override", False):
             return
-        # Canonical row reader: model_config.gateway_runtime, else the TUI's top-level keys.
-        from hermes_state import SessionDB as _SessionDB
-        _stored_runtime = _SessionDB.session_gateway_runtime(session_meta)
-        stored_base_url = _stored_runtime.get("base_url") or None
-        stored_api_mode = _stored_runtime.get("api_mode") or None
-        # Stricter than the TUI gateway's recovery (which keeps bare "custom" when a
-        # base_url exists) — the CLI's resolve path would hard-fail on it.
-        stored_provider = _heal_bare_custom_provider(
-            _stored_runtime.get("provider") or None, base_url=stored_base_url, model=stored_model)
-        model_changed = stored_model != self.model
-        provider_changed = bool(stored_provider) and stored_provider != self.provider
-        if not model_changed and not provider_changed:
+        route = stored_session_route(session_meta, current_model=self.model, current_provider=self.provider)
+        if route is None:
             return
+        stored_model, stored_provider, stored_base_url, stored_api_mode, provider_changed = route
         self.model = stored_model
         if stored_provider:
             self.provider = stored_provider

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -152,7 +152,7 @@ def _run_and_exit_oneshot(
             toolsets=toolsets,
             skills=skills,
             usage_file=usage_file,
-            resume=resume if isinstance(resume, str) and resume.strip() else None,
+            resume=resume,
         )
     except KeyboardInterrupt:
         rc = 130

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -140,6 +140,7 @@ def _run_and_exit_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: object = None,
+    resume: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -151,6 +152,7 @@ def _run_and_exit_oneshot(
             toolsets=toolsets,
             skills=skills,
             usage_file=usage_file,
+            resume=resume if isinstance(resume, str) and resume.strip() else None,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -2879,6 +2881,10 @@ def _run_oneshot_from_args(args) -> None:
     Bypasses cli.py entirely; _run_and_exit_oneshot never returns.
     """
     _confirm_startup_expensive_model_override(args)
+    # -z honors --resume/-c/--in exactly like chat (#105892): normalize BEFORE the
+    # oneshot exit path takes over, else the flags parse fine but silently do nothing
+    # and the turn starts a fresh session (every wire request loses all history).
+    _resolve_chat_session_args(args, use_tui=False)
     _run_and_exit_oneshot(
         args.oneshot,
         model=getattr(args, "model", None),
@@ -2886,6 +2892,7 @@ def _run_oneshot_from_args(args) -> None:
         toolsets=getattr(args, "toolsets", None),
         skills=getattr(args, "skills", None),
         usage_file=getattr(args, "usage_file", None),
+        resume=getattr(args, "resume", None),
     )
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -383,36 +383,25 @@ def _load_resume_target(session_db, resume: Optional[str]) -> tuple[Optional[str
 def _apply_stored_session_runtime(
     choice: _ModelChoice, session_meta: Optional[dict], *, explicit_model: bool,
 ) -> _ModelChoice:
-    """Run a resumed one-shot on the session's stored runtime, not the ambient config.
-
-    Same contract as the interactive ``_restore_session_model`` (cli_model_switch_mixin): no
-    stored model, or an explicit ``--model``, keeps the resolved ambient choice; otherwise the
-    stored model/provider/base_url/api_mode replace it (a resumed transcript must not be sent
-    to whatever the ambient config happens to point at). A changed provider drops the resolved
-    ``api_key`` — it belongs to the ambient/alias endpoint, and api_key is never persisted to
-    the session DB, so runtime resolution re-fetches credentials for the restored provider.
-    No-op when the stored route already matches the resolved one.
-    """
-    stored_model = str((session_meta or {}).get("model") or "").strip()
-    if not stored_model or explicit_model:
+    """Run a resumed one-shot on the session's stored runtime, not the ambient config — the same
+    contract as the interactive ``_restore_session_model``, via the shared ``stored_session_route``.
+    An explicit ``--model`` keeps the ambient choice. A changed provider drops the resolved
+    ``api_key``: it belongs to the ambient endpoint and is never persisted, so runtime resolution
+    re-fetches credentials for the restored provider."""
+    if explicit_model:
         return choice
-    from hermes_state import SessionDB as _SessionDB
-    from hermes_cli.cli_model_switch_mixin import _heal_bare_custom_provider
+    from hermes_cli.cli_model_switch_mixin import stored_session_route
 
-    stored_runtime = _SessionDB.session_gateway_runtime(session_meta)
-    stored_base_url = stored_runtime.get("base_url") or None
-    # Stricter than the TUI gateway's recovery — the CLI's resolve path hard-fails on bare "custom".
-    stored_provider = _heal_bare_custom_provider(
-        stored_runtime.get("provider") or None, base_url=stored_base_url, model=stored_model)
-    if stored_model == choice.model and (not stored_provider or stored_provider == choice.provider):
+    route = stored_session_route(session_meta, current_model=choice.model, current_provider=choice.provider)
+    if route is None:
         return choice
-    choice.model = stored_model
-    if stored_provider and stored_provider != choice.provider:
+    choice.model, stored_provider, stored_base_url, stored_api_mode, provider_changed = route
+    if provider_changed:
         choice.provider = stored_provider
         choice.base_url = stored_base_url
         choice.api_key = None
-    if stored_runtime.get("api_mode"):
-        choice.api_mode = str(stored_runtime["api_mode"])
+    if stored_api_mode:
+        choice.api_mode = str(stored_api_mode)
     return choice
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -167,12 +167,14 @@ def run_oneshot(
     toolsets: object = None,
     skills: object = None,
     usage_file: Optional[str] = None,
+    resume: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
     Model/provider fall back to ``HERMES_INFERENCE_MODEL`` and config.yaml. ``usage_file`` gets a
-    JSON usage report even when the run fails. Returns the exit code; the caller owns process
-    termination.
+    JSON usage report even when the run fails. ``resume`` is a session id (already normalized by
+    the CLI layer: latest/title/--continue resolution) whose transcript is loaded and continued
+    by this turn. Returns the exit code; the caller owns process termination.
     """
     # Silence every stdlib logger: AIAgent, tools and provider adapters log to stderr through the
     # root logger. File handlers from setup_logging() keep working (level-independent).
@@ -220,6 +222,7 @@ def run_oneshot(
                 toolsets=explicit_toolsets,
                 use_config_toolsets=use_config_toolsets,
                 skills=skills,
+                resume=resume,
             )
         except BaseException as exc:  # noqa: BLE001
             # Capture anything escaping the agent (OSError from prompt_toolkit on a non-TTY pipe,
@@ -340,6 +343,28 @@ def _resolve_model_and_provider(cfg: dict, model: Optional[str], provider: Optio
     return choice
 
 
+def _load_resume_target(session_db, resume: Optional[str]) -> tuple[Optional[str], list]:
+    """Resolve ``resume`` to ``(session_id, conversation_history)`` for a oneshot turn.
+
+    Follows the same contract as the interactive CLI resume: compression-chain redirect via
+    ``resolve_resume_session_id``, safe-resume guard, model-projection history with
+    ``session_meta`` rows dropped. An unknown session raises (the user passed an explicit id;
+    silently starting a fresh session is the resume-dropped failure mode this exists to fix —
+    see #105892). An empty stored transcript keeps the turn as a fresh session.
+    """
+    if not resume:
+        return None, []
+    if session_db is None:
+        raise RuntimeError(f"cannot resume session {resume}: session store unavailable")
+    resolved = session_db.resolve_resume_session_id(resume) or resume
+    if not session_db.get_session(resolved):
+        raise RuntimeError(f"session not found: {resume}")
+    session_db.assert_resume_safe(resolved, tip_only=True)
+    restored, _display = session_db.get_resume_conversations(resolved)
+    history = [m for m in restored if m.get("role") != "session_meta"]
+    return (resolved if history else None), history
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -347,6 +372,7 @@ def _run_agent(
     toolsets: object = None,
     use_config_toolsets: bool = True,
     skills: object = None,
+    resume: Optional[str] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn, run one conversation, and return
     ``(final_response, run_result)``. Imports are local to keep CLI startup cheap."""
@@ -382,6 +408,7 @@ def _run_agent(
     skills_prompt = _build_preloaded_skills_prompt(skills)
 
     session_db = _create_session_db_for_oneshot()
+    resume_sid, conversation_history = _load_resume_target(session_db, resume)
     # The try spans agent construction (not just ``chat``) so the store is always closed, even when
     # ``AIAgent(...)`` raises — the one-shot exit path hard-exits via os._exit and skips finalizers.
     agent = None
@@ -397,6 +424,7 @@ def _run_agent(
             quiet_mode=True,
             platform="cli",
             session_db=session_db,
+            session_id=resume_sid,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=get_fallback_chain(cfg) or None,
             ephemeral_system_prompt=skills_prompt,
@@ -410,7 +438,7 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt)
+        result = agent.run_conversation(prompt, conversation_history=conversation_history or None)
         return (result.get("final_response") or "", result)
     finally:
         _close_agent(agent, session_db)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -350,7 +350,10 @@ def _load_resume_target(session_db, resume: Optional[str]) -> tuple[Optional[str
     ``resolve_resume_session_id``, safe-resume guard, model-projection history with
     ``session_meta`` rows dropped. An unknown session raises (the user passed an explicit id;
     silently starting a fresh session is the resume-dropped failure mode this exists to fix —
-    see #105892). An empty stored transcript keeps the turn as a fresh session.
+    see #105892). An empty stored transcript still returns the resolved id: the turn replays
+    nothing but is recorded under the requested session — ``hermes -z "hello" -c <title>
+    --create-if-missing`` must fill the titled session it created, not mint a fresh id
+    (same contract as the interactive /resume of an empty session).
     """
     if not resume:
         return None, []
@@ -362,7 +365,7 @@ def _load_resume_target(session_db, resume: Optional[str]) -> tuple[Optional[str
     session_db.assert_resume_safe(resolved, tip_only=True)
     restored, _display = session_db.get_resume_conversations(resolved)
     history = [m for m in restored if m.get("role") != "session_meta"]
-    return (resolved if history else None), history
+    return resolved, history
 
 
 def _run_agent(

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -281,6 +281,7 @@ class _ModelChoice:
     provider: str | None
     base_url: str | None = None
     api_key: str | None = None
+    api_mode: str | None = None
 
 
 def _configured_model(model_cfg: object) -> str:
@@ -343,8 +344,8 @@ def _resolve_model_and_provider(cfg: dict, model: Optional[str], provider: Optio
     return choice
 
 
-def _load_resume_target(session_db, resume: Optional[str]) -> tuple[Optional[str], list]:
-    """Resolve ``resume`` to ``(session_id, conversation_history)`` for a oneshot turn.
+def _load_resume_target(session_db, resume: Optional[str]) -> tuple[Optional[str], list, Optional[dict]]:
+    """Resolve ``resume`` to ``(session_id, conversation_history, session_meta)`` for a oneshot turn.
 
     Follows the same contract as the interactive CLI resume: compression-chain redirect via
     ``resolve_resume_session_id``, safe-resume guard, model-projection history with
@@ -354,18 +355,65 @@ def _load_resume_target(session_db, resume: Optional[str]) -> tuple[Optional[str
     nothing but is recorded under the requested session — ``hermes -z "hello" -c <title>
     --create-if-missing`` must fill the titled session it created, not mint a fresh id
     (same contract as the interactive /resume of an empty session).
+
+    The resolved row is also reopened (best effort): the previous run stamped ``ended_at``,
+    the existing-row upsert never clears the end fields, and ``end_session()`` only writes
+    rows whose ``ended_at`` is null — so without this step the resumed turn would be recorded
+    under a session that stays closed and its new lifecycle boundary would be lost (same
+    reason the interactive resume calls ``reopen_session()`` before continuing).
     """
     if not resume:
-        return None, []
+        return None, [], None
     if session_db is None:
         raise RuntimeError(f"cannot resume session {resume}: session store unavailable")
     resolved = session_db.resolve_resume_session_id(resume) or resume
-    if not session_db.get_session(resolved):
+    session_meta = session_db.get_session(resolved)
+    if not session_meta:
         raise RuntimeError(f"session not found: {resume}")
     session_db.assert_resume_safe(resolved, tip_only=True)
     restored, _display = session_db.get_resume_conversations(resolved)
     history = [m for m in restored if m.get("role") != "session_meta"]
-    return resolved, history
+    try:
+        session_db.reopen_session(resolved)
+    except Exception:
+        logging.debug("reopen_session failed for resumed one-shot session %s", resolved, exc_info=True)
+    return resolved, history, session_meta
+
+
+def _apply_stored_session_runtime(
+    choice: _ModelChoice, session_meta: Optional[dict], *, explicit_model: bool,
+) -> _ModelChoice:
+    """Run a resumed one-shot on the session's stored runtime, not the ambient config.
+
+    Same contract as the interactive ``_restore_session_model`` (cli_model_switch_mixin): no
+    stored model, or an explicit ``--model``, keeps the resolved ambient choice; otherwise the
+    stored model/provider/base_url/api_mode replace it (a resumed transcript must not be sent
+    to whatever the ambient config happens to point at). A changed provider drops the resolved
+    ``api_key`` — it belongs to the ambient/alias endpoint, and api_key is never persisted to
+    the session DB, so runtime resolution re-fetches credentials for the restored provider.
+    No-op when the stored route already matches the resolved one.
+    """
+    stored_model = str((session_meta or {}).get("model") or "").strip()
+    if not stored_model or explicit_model:
+        return choice
+    from hermes_state import SessionDB as _SessionDB
+    from hermes_cli.cli_model_switch_mixin import _heal_bare_custom_provider
+
+    stored_runtime = _SessionDB.session_gateway_runtime(session_meta)
+    stored_base_url = stored_runtime.get("base_url") or None
+    # Stricter than the TUI gateway's recovery — the CLI's resolve path hard-fails on bare "custom".
+    stored_provider = _heal_bare_custom_provider(
+        stored_runtime.get("provider") or None, base_url=stored_base_url, model=stored_model)
+    if stored_model == choice.model and (not stored_provider or stored_provider == choice.provider):
+        return choice
+    choice.model = stored_model
+    if stored_provider and stored_provider != choice.provider:
+        choice.provider = stored_provider
+        choice.base_url = stored_base_url
+        choice.api_key = None
+    if stored_runtime.get("api_mode"):
+        choice.api_mode = str(stored_runtime["api_mode"])
+    return choice
 
 
 def _run_agent(
@@ -386,12 +434,20 @@ def _run_agent(
 
     cfg = load_config()
     choice = _resolve_model_and_provider(cfg, model, provider)
+    # Resume resolves BEFORE the runtime provider: the session's stored model/route must
+    # replace the ambient config (see _apply_stored_session_runtime) and the ended row must
+    # be reopened before the agent can stamp a new lifecycle boundary.
+    session_db = _create_session_db_for_oneshot()
+    resume_sid, conversation_history, resume_meta = _load_resume_target(session_db, resume)
+    choice = _apply_stored_session_runtime(choice, resume_meta, explicit_model=bool((model or "").strip()))
     runtime = resolve_runtime_provider(
         requested=choice.provider,
         target_model=choice.model or None,
         explicit_base_url=choice.base_url,
         explicit_api_key=choice.api_key,
     )
+    if choice.api_mode:
+        runtime["api_mode"] = choice.api_mode
 
     # sorted() gives stable ordering for config-derived sets; explicit values preserve user order.
     toolsets_list = _normalize_toolsets(toolsets)
@@ -410,8 +466,6 @@ def _run_agent(
 
     skills_prompt = _build_preloaded_skills_prompt(skills)
 
-    session_db = _create_session_db_for_oneshot()
-    resume_sid, conversation_history = _load_resume_target(session_db, resume)
     # The try spans agent construction (not just ``chat``) so the store is always closed, even when
     # ``AIAgent(...)`` raises — the one-shot exit path hard-exits via os._exit and skips finalizers.
     agent = None

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -5,7 +5,9 @@ them: ``_run_oneshot_from_args`` ran before any session-arg normalization and ne
 forwarded ``args.resume``, so every resumed one-shot turn started a FRESH session —
 the wire carried only ``[system, current user]`` and the model "forgot" everything.
 These tests pin the loader contract (chain redirect, unknown-session error,
-session_meta filtering, empty-session fresh start) and the resume kwarg wiring.
+session_meta filtering, empty-session fresh start, ended-row reopen) and the resume
+kwarg wiring, plus the stored-runtime restore (review on #105957): a resumed one-shot
+must run on the session's stored model/provider runtime and on a reopened session row.
 """
 
 from __future__ import annotations
@@ -13,7 +15,12 @@ from __future__ import annotations
 import pytest
 
 from hermes_state import SessionDB
-from hermes_cli.oneshot import _load_resume_target, run_oneshot
+from hermes_cli.oneshot import (
+    _apply_stored_session_runtime,
+    _load_resume_target,
+    _ModelChoice,
+    run_oneshot,
+)
 
 
 def _db_with_session(tmp_path, sid, *, messages=()):
@@ -28,8 +35,8 @@ class TestLoadResumeTarget:
     def test_no_resume_is_a_noop(self, tmp_path):
         db = _db_with_session(tmp_path, "s1")
         try:
-            assert _load_resume_target(db, None) == (None, [])
-            assert _load_resume_target(db, "") == (None, [])
+            assert _load_resume_target(db, None) == (None, [], None)
+            assert _load_resume_target(db, "") == (None, [], None)
         finally:
             db.close()
 
@@ -54,10 +61,11 @@ class TestLoadResumeTarget:
                       ("assistant", "I've noted the secret word: ZEBRA42.")],
         )
         try:
-            sid, history = _load_resume_target(db, "s1")
+            sid, history, meta = _load_resume_target(db, "s1")
             assert sid == "s1"
             assert [m["role"] for m in history] == ["user", "assistant"]
             assert history[0]["content"] == "Remember the secret word ZEBRA42"
+            assert meta["id"] == "s1"
         finally:
             db.close()
 
@@ -67,7 +75,7 @@ class TestLoadResumeTarget:
             messages=[("session_meta", "model switch"), ("user", "hello")],
         )
         try:
-            sid, history = _load_resume_target(db, "s1")
+            sid, history, _meta = _load_resume_target(db, "s1")
             assert sid == "s1"
             assert [m["role"] for m in history] == ["user"]
         finally:
@@ -80,7 +88,10 @@ class TestLoadResumeTarget:
         # leaving the freshly created titled session empty (review on #105957).
         db = _db_with_session(tmp_path, "s1")
         try:
-            assert _load_resume_target(db, "s1") == ("s1", [])
+            sid, history, meta = _load_resume_target(db, "s1")
+            assert sid == "s1"
+            assert history == []
+            assert meta["id"] == "s1"
         finally:
             db.close()
 
@@ -92,7 +103,9 @@ class TestLoadResumeTarget:
         db.create_session(session_id="head", source="cli")
         db.create_session(session_id="child", source="cli", parent_session_id="head")
         try:
-            assert _load_resume_target(db, "head") == ("head", [])
+            sid, history, _meta = _load_resume_target(db, "head")
+            assert sid == "head"
+            assert history == []
         finally:
             db.close()
 
@@ -104,9 +117,199 @@ class TestLoadResumeTarget:
         db.create_session(session_id="child", source="cli", parent_session_id="parent")
         db.append_message("child", "user", content="hi")
         try:
-            sid, history = _load_resume_target(db, "parent")
+            sid, history, _meta = _load_resume_target(db, "parent")
             assert sid == "child"
             assert [m["role"] for m in history] == ["user"]
+        finally:
+            db.close()
+
+    def test_resume_reopens_ended_session_row(self, tmp_path):
+        # The previous run stamped ended_at; without reopen_session() the resumed turn is
+        # recorded under a row that stays closed and end_session() cannot stamp the new
+        # boundary (it only writes rows whose ended_at is null) — review on #105957.
+        db = _db_with_session(tmp_path, "s1", messages=[("user", "hi")])
+        db.end_session("s1", "agent_close")
+        row = db.get_session("s1")
+        assert row["ended_at"] is not None and row["end_reason"] == "agent_close"
+        try:
+            sid, _history, _meta = _load_resume_target(db, "s1")
+            assert sid == "s1"
+            reopened = db.get_session("s1")
+            assert reopened["ended_at"] is None
+            assert reopened["end_reason"] is None
+        finally:
+            db.close()
+
+    def test_reopen_failure_is_best_effort(self, tmp_path, monkeypatch):
+        db = _db_with_session(tmp_path, "s1", messages=[("user", "hi")])
+        try:
+            def _boom(_sid):
+                raise RuntimeError("reopen unavailable")
+            monkeypatch.setattr(db, "reopen_session", _boom)
+            sid, history, _meta = _load_resume_target(db, "s1")
+            assert sid == "s1"
+            assert [m["role"] for m in history] == ["user"]
+        finally:
+            db.close()
+
+
+class TestApplyStoredSessionRuntime:
+    """A resumed one-shot must run on the session's stored runtime, not the ambient
+    config (review on #105957): with ambient ``openrouter/ambient-model`` and a stored
+    ``custom:stored/stored-model`` session, the agent previously received the ambient
+    model/provider on the wire."""
+
+    _AMBIENT_KEY = object()  # sentinel: any non-None token; resume must drop it when the provider changes
+
+    @staticmethod
+    def _stored_db(tmp_path, *, model="stored-model", route=None):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="s1", source="cli")
+        if model:
+            db.update_session_model("s1", model)
+        if route is not None:
+            # Same two shapes _persist_model_switch_to_session writes (nested gateway_runtime
+            # for CLI resume, top-level keys for TUI).
+            db.patch_session_model_config("s1", {"gateway_runtime": route, **route})
+        meta = db.get_session("s1")
+        db.close()
+        return meta
+
+    def test_stored_runtime_replaces_ambient_choice(self, tmp_path):
+        meta = self._stored_db(tmp_path, route={"provider": "custom:stored", "base_url": "http://stored:9", "api_mode": "responses"})
+        choice = _apply_stored_session_runtime(
+            _ModelChoice("ambient-model", "openrouter", api_key=self._AMBIENT_KEY),
+            meta, explicit_model=False)
+        assert choice.model == "stored-model"
+        assert choice.provider == "custom:stored"
+        assert choice.base_url == "http://stored:9"
+        assert choice.api_mode == "responses"
+        # The ambient key belongs to the ambient endpoint and must not ride along.
+        assert choice.api_key is None
+
+    def test_explicit_model_flag_wins(self, tmp_path):
+        meta = self._stored_db(tmp_path, route={"provider": "custom:stored"})
+        choice = _apply_stored_session_runtime(
+            _ModelChoice("explicit-model", "openrouter", api_key=self._AMBIENT_KEY),
+            meta, explicit_model=True)
+        assert choice.model == "explicit-model"
+        assert choice.provider == "openrouter"
+        assert choice.api_key is self._AMBIENT_KEY
+
+    def test_no_stored_model_keeps_ambient_choice(self, tmp_path):
+        meta = self._stored_db(tmp_path, model=None)
+        choice = _apply_stored_session_runtime(
+            _ModelChoice("ambient-model", "openrouter", api_key=self._AMBIENT_KEY), meta, explicit_model=False)
+        assert choice.model == "ambient-model"
+        assert choice.provider == "openrouter"
+        assert choice.api_key is self._AMBIENT_KEY
+
+    def test_matching_route_is_noop_and_keeps_credentials(self, tmp_path):
+        meta = self._stored_db(tmp_path, route={"provider": "openrouter"})
+        choice = _apply_stored_session_runtime(
+            _ModelChoice("stored-model", "openrouter", base_url=None, api_key=self._AMBIENT_KEY),
+            meta, explicit_model=False)
+        assert choice.api_key is self._AMBIENT_KEY
+        assert choice.api_mode is None
+
+    def test_none_meta_is_a_noop(self):
+        choice = _ModelChoice("ambient-model", "openrouter")
+        assert _apply_stored_session_runtime(choice, None, explicit_model=False) == choice
+
+    def test_bare_custom_provider_is_healed_or_dropped(self, tmp_path):
+        # Bare "custom" persisted by older builds is not a routable identity; the CLI's
+        # resolve path would hard-fail on it, so it is healed via the base_url or dropped.
+        meta = self._stored_db(tmp_path, route={"provider": "custom"})
+        choice = _apply_stored_session_runtime(
+            _ModelChoice("ambient-model", "openrouter"), meta, explicit_model=False)
+        assert choice.model == "stored-model"
+        assert choice.provider in (None, "openrouter") or choice.provider.startswith("custom:")
+
+
+class TestRunAgentResumeRuntime:
+    """End-to-end wiring: ``_run_agent`` must hand AIAgent the session's stored runtime
+    and a reopened session row (both regressions from the review on #105957)."""
+
+    def test_run_agent_uses_stored_runtime_and_reopens_row(self, tmp_path, monkeypatch):
+        import hermes_cli.oneshot as oneshot_mod
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", "user", content="hi")
+        db.update_session_model("s1", "stored-model")
+        db.patch_session_model_config(
+            "s1", {"gateway_runtime": {"provider": "custom:stored", "base_url": "http://stored:9"},
+                   "provider": "custom:stored", "base_url": "http://stored:9"})
+        db.end_session("s1", "agent_close")
+
+        captured = {}
+
+        class _FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+            def __setattr__(self, name, _value):
+                pass
+            def run_conversation(self, _prompt, conversation_history=None):
+                captured["history"] = conversation_history
+                return {"final_response": "ok", "session_id": "s1"}
+            def close(self):
+                pass
+
+        monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: db)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {"default": "ambient-model", "provider": "openrouter"}})
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **_kw: {"api_key": "resolved", "base_url": None, "provider": "custom:stored",
+                          "requested_provider": "custom:stored", "api_mode": "chat", "credential_pool": None})
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda _cfg, _p: [])
+        monkeypatch.setattr("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build", lambda **_kw: None)
+        monkeypatch.setattr("run_agent.AIAgent", _FakeAgent)
+
+        try:
+            text, result = oneshot_mod._run_agent("hello", resume="s1")
+            assert text == "ok" and result["final_response"] == "ok"
+            assert captured["model"] == "stored-model"
+            assert captured["provider"] == "custom:stored"
+            assert captured["session_id"] == "s1"
+            assert captured["history"][0]["role"] == "user"
+            row = db.get_session("s1")
+            assert row["ended_at"] is None and row["end_reason"] is None
+        finally:
+            db.close()
+
+    def test_run_agent_explicit_model_beats_stored_runtime(self, tmp_path, monkeypatch):
+        import hermes_cli.oneshot as oneshot_mod
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="s1", source="cli")
+        db.update_session_model("s1", "stored-model")
+
+        captured = {}
+
+        class _FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+            def __setattr__(self, name, _value):
+                pass
+            def run_conversation(self, _prompt, conversation_history=None):
+                return {"final_response": "ok"}
+            def close(self):
+                pass
+
+        monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: db)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {"default": "ambient-model", "provider": "openrouter"}})
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **_kw: {"api_key": "resolved", "base_url": None, "provider": "openrouter",
+                          "requested_provider": "openrouter", "api_mode": "chat", "credential_pool": None})
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda _cfg, _p: [])
+        monkeypatch.setattr("hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build", lambda **_kw: None)
+        monkeypatch.setattr("run_agent.AIAgent", _FakeAgent)
+
+        try:
+            oneshot_mod._run_agent("hello", model="explicit-model", provider="openrouter", resume="s1")
+            assert captured["model"] == "explicit-model"
+            assert captured["provider"] == "openrouter"
         finally:
             db.close()
 

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -1,0 +1,124 @@
+"""Tests for `hermes -z --resume <session>` (#105892).
+
+The oneshot path used to accept ``--resume``/``-c`` in the parser but silently drop
+them: ``_run_oneshot_from_args`` ran before any session-arg normalization and never
+forwarded ``args.resume``, so every resumed one-shot turn started a FRESH session —
+the wire carried only ``[system, current user]`` and the model "forgot" everything.
+These tests pin the loader contract (chain redirect, unknown-session error,
+session_meta filtering, empty-session fresh start) and the resume kwarg wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_cli.oneshot import _load_resume_target, run_oneshot
+
+
+def _db_with_session(tmp_path, sid, *, messages=()):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id=sid, source="cli")
+    for role, content in messages:
+        db.append_message(sid, role, content=content)
+    return db
+
+
+class TestLoadResumeTarget:
+    def test_no_resume_is_a_noop(self, tmp_path):
+        db = _db_with_session(tmp_path, "s1")
+        try:
+            assert _load_resume_target(db, None) == (None, [])
+            assert _load_resume_target(db, "") == (None, [])
+        finally:
+            db.close()
+
+    def test_missing_store_raises_rather_than_silent_fresh(self):
+        # An explicit --resume with no session store must fail loudly; starting a
+        # fresh session here is exactly the history-dropping bug this fixes.
+        with pytest.raises(RuntimeError, match="session store unavailable"):
+            _load_resume_target(None, "s1")
+
+    def test_unknown_session_raises(self, tmp_path):
+        db = _db_with_session(tmp_path, "s1")
+        try:
+            with pytest.raises(RuntimeError, match="session not found: missing-sid"):
+                _load_resume_target(db, "missing-sid")
+        finally:
+            db.close()
+
+    def test_returns_history_for_stored_session(self, tmp_path):
+        db = _db_with_session(
+            tmp_path, "s1",
+            messages=[("user", "Remember the secret word ZEBRA42"),
+                      ("assistant", "I've noted the secret word: ZEBRA42.")],
+        )
+        try:
+            sid, history = _load_resume_target(db, "s1")
+            assert sid == "s1"
+            assert [m["role"] for m in history] == ["user", "assistant"]
+            assert history[0]["content"] == "Remember the secret word ZEBRA42"
+        finally:
+            db.close()
+
+    def test_session_meta_rows_are_dropped(self, tmp_path):
+        db = _db_with_session(
+            tmp_path, "s1",
+            messages=[("session_meta", "model switch"), ("user", "hello")],
+        )
+        try:
+            sid, history = _load_resume_target(db, "s1")
+            assert sid == "s1"
+            assert [m["role"] for m in history] == ["user"]
+        finally:
+            db.close()
+
+    def test_empty_session_starts_fresh(self, tmp_path):
+        # Chat's contract: a resumed session with no messages starts fresh (same session
+        # id, no history rows to replay) — oneshot must not crash or resurrect the id.
+        db = _db_with_session(tmp_path, "s1")
+        try:
+            assert _load_resume_target(db, "s1") == (None, [])
+        finally:
+            db.close()
+
+    def test_compression_chain_redirects_to_child_with_messages(self, tmp_path):
+        # Compression ends a session and forks a child that holds the rows; the loader
+        # must land on the child, not the empty parent (resolve_resume_session_id).
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="parent", source="cli")
+        db.create_session(session_id="child", source="cli", parent_session_id="parent")
+        db.append_message("child", "user", content="hi")
+        try:
+            sid, history = _load_resume_target(db, "parent")
+            assert sid == "child"
+            assert [m["role"] for m in history] == ["user"]
+        finally:
+            db.close()
+
+
+class TestRunOneshotForwardsResume:
+    def test_resume_kwarg_reaches_run_agent(self, monkeypatch):
+        captured = {}
+
+        def _fake_run_agent(prompt, **kwargs):
+            captured.update(kwargs, prompt=prompt)
+            return "ok", {"final_response": "ok"}
+
+        monkeypatch.setattr("hermes_cli.oneshot._run_agent", _fake_run_agent)
+        rc = run_oneshot("hello", model="m", provider="custom", resume="sess-1")
+        assert rc == 0
+        assert captured["prompt"] == "hello"
+        assert captured["resume"] == "sess-1"
+
+    def test_no_resume_forwards_none(self, monkeypatch):
+        captured = {}
+
+        def _fake_run_agent(prompt, **kwargs):
+            captured.update(kwargs)
+            return "ok", {"final_response": "ok"}
+
+        monkeypatch.setattr("hermes_cli.oneshot._run_agent", _fake_run_agent)
+        rc = run_oneshot("hello", model="m", provider="custom")
+        assert rc == 0
+        assert captured.get("resume") is None

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -69,18 +69,6 @@ class TestLoadResumeTarget:
         finally:
             db.close()
 
-    def test_session_meta_rows_are_dropped(self, tmp_path):
-        db = _db_with_session(
-            tmp_path, "s1",
-            messages=[("session_meta", "model switch"), ("user", "hello")],
-        )
-        try:
-            sid, history, _meta = _load_resume_target(db, "s1")
-            assert sid == "s1"
-            assert [m["role"] for m in history] == ["user"]
-        finally:
-            db.close()
-
     def test_empty_session_keeps_resolved_id(self, tmp_path):
         # Chat's contract: a resumed session with no messages starts fresh (no rows to
         # replay) but the turn is recorded under the SELECTED id. Dropping the id here
@@ -92,20 +80,6 @@ class TestLoadResumeTarget:
             assert sid == "s1"
             assert history == []
             assert meta["id"] == "s1"
-        finally:
-            db.close()
-
-    def test_empty_compression_head_without_rows_keeps_head_id(self, tmp_path):
-        # A chain head with no descendant rows must not fall through to a fresh id either:
-        # the turn stays anchored to the resolved head (redirect only happens when the
-        # descendant actually holds messages).
-        db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session(session_id="head", source="cli")
-        db.create_session(session_id="child", source="cli", parent_session_id="head")
-        try:
-            sid, history, _meta = _load_resume_target(db, "head")
-            assert sid == "head"
-            assert history == []
         finally:
             db.close()
 
@@ -139,19 +113,6 @@ class TestLoadResumeTarget:
             assert reopened["end_reason"] is None
         finally:
             db.close()
-
-    def test_reopen_failure_is_best_effort(self, tmp_path, monkeypatch):
-        db = _db_with_session(tmp_path, "s1", messages=[("user", "hi")])
-        try:
-            def _boom(_sid):
-                raise RuntimeError("reopen unavailable")
-            monkeypatch.setattr(db, "reopen_session", _boom)
-            sid, history, _meta = _load_resume_target(db, "s1")
-            assert sid == "s1"
-            assert [m["role"] for m in history] == ["user"]
-        finally:
-            db.close()
-
 
 class TestApplyStoredSessionRuntime:
     """A resumed one-shot must run on the session's stored runtime, not the ambient
@@ -196,14 +157,6 @@ class TestApplyStoredSessionRuntime:
         assert choice.provider == "openrouter"
         assert choice.api_key is self._AMBIENT_KEY
 
-    def test_no_stored_model_keeps_ambient_choice(self, tmp_path):
-        meta = self._stored_db(tmp_path, model=None)
-        choice = _apply_stored_session_runtime(
-            _ModelChoice("ambient-model", "openrouter", api_key=self._AMBIENT_KEY), meta, explicit_model=False)
-        assert choice.model == "ambient-model"
-        assert choice.provider == "openrouter"
-        assert choice.api_key is self._AMBIENT_KEY
-
     def test_matching_route_is_noop_and_keeps_credentials(self, tmp_path):
         meta = self._stored_db(tmp_path, route={"provider": "openrouter"})
         choice = _apply_stored_session_runtime(
@@ -211,20 +164,6 @@ class TestApplyStoredSessionRuntime:
             meta, explicit_model=False)
         assert choice.api_key is self._AMBIENT_KEY
         assert choice.api_mode is None
-
-    def test_none_meta_is_a_noop(self):
-        choice = _ModelChoice("ambient-model", "openrouter")
-        assert _apply_stored_session_runtime(choice, None, explicit_model=False) == choice
-
-    def test_bare_custom_provider_is_healed_or_dropped(self, tmp_path):
-        # Bare "custom" persisted by older builds is not a routable identity; the CLI's
-        # resolve path would hard-fail on it, so it is healed via the base_url or dropped.
-        meta = self._stored_db(tmp_path, route={"provider": "custom"})
-        choice = _apply_stored_session_runtime(
-            _ModelChoice("ambient-model", "openrouter"), meta, explicit_model=False)
-        assert choice.model == "stored-model"
-        assert choice.provider in (None, "openrouter") or choice.provider.startswith("custom:")
-
 
 class TestRunAgentResumeRuntime:
     """End-to-end wiring: ``_run_agent`` must hand AIAgent the session's stored runtime
@@ -327,15 +266,3 @@ class TestRunOneshotForwardsResume:
         assert rc == 0
         assert captured["prompt"] == "hello"
         assert captured["resume"] == "sess-1"
-
-    def test_no_resume_forwards_none(self, monkeypatch):
-        captured = {}
-
-        def _fake_run_agent(prompt, **kwargs):
-            captured.update(kwargs)
-            return "ok", {"final_response": "ok"}
-
-        monkeypatch.setattr("hermes_cli.oneshot._run_agent", _fake_run_agent)
-        rc = run_oneshot("hello", model="m", provider="custom")
-        assert rc == 0
-        assert captured.get("resume") is None

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -73,12 +73,26 @@ class TestLoadResumeTarget:
         finally:
             db.close()
 
-    def test_empty_session_starts_fresh(self, tmp_path):
-        # Chat's contract: a resumed session with no messages starts fresh (same session
-        # id, no history rows to replay) — oneshot must not crash or resurrect the id.
+    def test_empty_session_keeps_resolved_id(self, tmp_path):
+        # Chat's contract: a resumed session with no messages starts fresh (no rows to
+        # replay) but the turn is recorded under the SELECTED id. Dropping the id here
+        # re-minted a session for `hermes -z "hello" -c <title> --create-if-missing`,
+        # leaving the freshly created titled session empty (review on #105957).
         db = _db_with_session(tmp_path, "s1")
         try:
-            assert _load_resume_target(db, "s1") == (None, [])
+            assert _load_resume_target(db, "s1") == ("s1", [])
+        finally:
+            db.close()
+
+    def test_empty_compression_head_without_rows_keeps_head_id(self, tmp_path):
+        # A chain head with no descendant rows must not fall through to a fresh id either:
+        # the turn stays anchored to the resolved head (redirect only happens when the
+        # descendant actually holds messages).
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="head", source="cli")
+        db.create_session(session_id="child", source="cli", parent_session_id="head")
+        try:
+            assert _load_resume_target(db, "head") == ("head", [])
         finally:
             db.close()
 


### PR DESCRIPTION
`hermes -z` accepted `--resume`/`-c` but `_run_oneshot_from_args` never forwarded `args.resume`, so every resumed one-shot turn started a fresh session: each request carried only `[system, current user]` and the previous turn was never replayed. Fixes #105892.

Salvage of #105957 by @liuhao1024 (3 commits cherry-picked, authorship preserved).

- `hermes_cli/oneshot.py`: `_load_resume_target` resolves the session id + transcript (keeping the id for an empty `-c <title>` session) and reopens an ended row; the stored session model/provider/base_url/api_mode replace the ambient config unless `--model` was given explicitly; a changed provider drops the ambient `api_key` so credentials are re-resolved for the stored endpoint.
- Follow-up: the stored-route decision was a copy of the first half of the interactive `_restore_session_model`; both now call `cli_model_switch_mixin.stored_session_route`. `main.py` stops re-normalising `resume` (already done by `_resolve_chat_session_args`). Tests trimmed from 20 to 13 (end-to-end `_run_agent` contracts kept).

Validation: 47 tests green across oneshot/interactive resume; disabling the stored-route apply → 2 red.
