### PR TITLE
fix(agent): a mid-turn /steer is persisted as its own user row instead of rewriting a tool result (#58599, #104442; salvage #104444)

### DIFF
--- a/agent/AGENTS.md
+++ b/agent/AGENTS.md
@@ -59,7 +59,10 @@ Adding one: register in that table (no `if name == ...` chain); `tools/todo_tool
   commands (`agent/skill_commands.py`) inject as a user message; subdirectory `AGENTS.md` hints
   (`agent/subdirectory_hints.py`) append to the tool result (head+tail truncated past `_MAX_HINT_CHARS = 32_000`, with a warning).
 - **Strict role alternation.** Never two same-role messages in a row; never a synthetic user
-  message injected mid-loop. Cron deliveries live in their own session for this reason.
+  message injected mid-loop. The one exception is `/steer`, delivered as a standalone user row
+  after a tool result (`assistant(tool_calls) → tool → user` is legal on every provider path) —
+  never smeared onto the already-persisted tool row, which append-only persistence would leave
+  divergent from the live request. Cron deliveries live in their own session for this reason.
 - **Context files** (`agent/prompt_builder.py`) load from the CWD only at startup and are capped
   (`CONTEXT_FILE_MAX_CHARS` / dynamic cap from the context window / `context_file_max_chars`).
   Never load an install-tree `AGENTS.md` as project context (PR #64611); subdirectory hints reject

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -19,7 +19,7 @@ from hermes_cli.timeouts import get_provider_request_timeout
 from agent.message_sanitization import (
     _FULL_ARGS_LOG_BOUND, coalesce_tool_call_id, tool_call_id_variants, tool_result_id_variants
 )
-from agent.prompt_builder import format_steer_marker
+from agent.prompt_builder import STEER_DISPLAY_KIND, steer_user_row
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import (
@@ -533,6 +533,9 @@ def _merge_consecutive_users(messages: List[Dict]) -> Tuple[List[Dict], int]:
             # A summary carrier followed by a new user row is a deliberate durable shape after
             # retry/rewind; never mutate the persisted carrier (sanitizers merge copies later).
             and split_user_originated_turn(prev)[0] is None
+            # A /steer row that ended the previous run is already persisted; merging the next
+            # prompt into it would rewrite it in place and re-break replay parity.
+            and prev.get("display_kind") != STEER_DISPLAY_KIND
             # Only merge plain-text content; leave multimodal (list) content alone.
             and isinstance(prev.get("content", ""), str) and isinstance(msg.get("content", ""), str)
         ):
@@ -3180,10 +3183,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
         # user message (which persists like any other user turn).
         _requeue_pending_steer(agent, steer_text)
         return
-    marker = format_steer_marker(steer_text)
-    # Append a standalone user message instead of rewriting the persisted
-    # tool row's content.
-    messages.append({"role": "user", "content": marker})
+    messages.append(steer_user_row(steer_text))
     _ra().logger.info(
         "Delivered /steer to agent after tool batch (%d chars) as new user message: %s", len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3147,9 +3147,25 @@ def _requeue_pending_steer(agent, steer_text: str) -> None:
 
 
 def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
-    """Append pending /steer text to the last ``role:"tool"`` message of this batch (bounded by
-    ``num_tool_msgs``), marked as user-origin. Modifies existing content only, so role
-    alternation is preserved."""
+    """Persist any pending /steer text as a standalone user message.
+
+    Called at the end of a tool-call batch, before the next API call.
+
+    The steer is emitted as a NEW ``role:"user"`` message appended after the
+    last tool result (marker text included), so:
+
+    - the model still sees the self-describing out-of-band marker (same text,
+      same provenance semantics);
+    - message-role alternation stays legal — ``assistant(tool_calls) → tool →
+      user`` is the documented "user jumped in mid-run" pattern that
+      ``repair_message_sequence`` deliberately keeps;
+    - the appended dict carries no ``_DB_PERSISTED_MARKER`` yet, so the next
+      ``_flush_messages_to_session_db`` writes it to the session store — the
+      steer text finally becomes part of the durable transcript instead of
+      being smeared onto an already-persisted tool row that append-only
+      persistence never rewrites (replayed histories then diverge from the
+      live request bytes and break the provider prompt cache).
+    """
     if num_tool_msgs <= 0 or not messages:
         return
     steer_text = agent._drain_pending_steer()
@@ -3159,22 +3175,17 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     tail = range(len(messages) - 1, max(len(messages) - num_tool_msgs - 1, -1), -1)
     target = next((messages[j] for j in tail if isinstance(messages[j], dict) and messages[j].get("role") == "tool"), None)
     if target is None:
-        # No tool result in this batch (e.g. all skipped by interrupt).
+        # No tool result in this batch (e.g. all skipped by interrupt);
+        # requeue so the fallback path delivers it as a normal next-turn
+        # user message (which persists like any other user turn).
         _requeue_pending_steer(agent, steer_text)
         return
     marker = format_steer_marker(steer_text)
-    existing_content = target.get("content", "")
-    if isinstance(existing_content, str):
-        target["content"] = existing_content + marker
-    else:
-        # Anthropic multimodal content blocks: preserve them and append a text block.
-        try:
-            target["content"] = [*(existing_content or []), {"type": "text", "text": marker.lstrip()}]
-        except Exception:
-            # Fall back to string replacement if content shape is unexpected.
-            target["content"] = f"{existing_content}{marker}"
+    # Append a standalone user message instead of rewriting the persisted
+    # tool row's content.
+    messages.append({"role": "user", "content": marker})
     _ra().logger.info(
-        "Delivered /steer to agent after tool batch (%d chars): %s", len(steer_text),
+        "Delivered /steer to agent after tool batch (%d chars) as new user message: %s", len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),
     )
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1934,8 +1934,8 @@ def _steer_markers() -> Tuple[str, str]:
 
 def _message_contains_busy_steer(message: Any) -> bool:
     """Return whether *message* carries a busy-steer marker.
-    Steer follow-ups live as markers inside ``role=tool`` results, so they carry user intent that
-    ``_is_real_user_message`` alone would miss."""
+    Steer follow-ups are now their own ``role=user`` rows (caught by ``_is_real_user_message``); in
+    transcripts persisted before that they ride inside ``role=tool`` results, so those still count."""
     text = _message_text(message)
     if not text:
         return False

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -13,7 +13,7 @@ import sys
 import threading
 from collections import OrderedDict
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from hermes_constants import (
     get_hermes_home, get_skills_dir, is_wsl, reset_hermes_home_override, set_hermes_home_override,
@@ -512,8 +512,20 @@ STEER_MARKER_CLOSE = "[/OUT-OF-BAND USER MESSAGE]"
 
 
 def format_steer_marker(steer_text: str) -> str:
-    """Wrap a mid-turn steer for appending to a tool result (see note above)."""
+    """Wrap a mid-turn steer in the self-describing marker (see note above)."""
     return f"\n\n{STEER_MARKER_OPEN}\n{steer_text}\n{STEER_MARKER_CLOSE}"
+
+
+STEER_DISPLAY_KIND = "steer"
+
+
+def steer_user_row(steer_text: str) -> Dict[str, Any]:
+    """The standalone ``role:user`` row a mid-turn /steer is delivered as (after the newest tool
+    result). Its own row — never smeared onto the already-persisted tool row, which append-only
+    persistence would leave divergent from the live request — and typed so the alternation repair
+    never merges the next real prompt into it and history renderers can label it."""
+    return {"role": "user", "content": format_steer_marker(steer_text).lstrip(),
+            "display_kind": STEER_DISPLAY_KIND}
 
 
 STEER_CHANNEL_NOTE = (

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -1,7 +1,7 @@
 """Outer-iteration bookkeeping for the conversation turn loop, in call order:
 ``begin_iteration`` (pending redirect, interrupt / review-budget / iteration-budget exits),
-``prepare_iteration`` (``agent:step`` callback, skill-nudge counter, pre-API ``/steer`` drain
-into the newest tool result — never a user message —, run-budget wrap-up notice, tool_call
+``prepare_iteration`` (``agent:step`` callback, skill-nudge counter, pre-API ``/steer`` drain as a
+standalone user row after the newest tool result, run-budget wrap-up notice, tool_call
 argument sanitization, interrupt-scaffold ghost-row drop, role-alternation repair),
 ``announce_api_call`` (verbose summary / quiet spinner) and, after the retry loop,
 ``apply_retry_restarts`` (consumes the ``TurnRetryState`` restart flags). Nothing here
@@ -93,7 +93,7 @@ class IterationPrep:
 
 def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> IterationPrep:
     """Prepare ``messages`` for this iteration in the original order. Every mutation here is
-    cache-safe by construction: steer text lands in the newest tool result, the ghost-row
+    cache-safe by construction: steer text is appended as a new (not yet persisted) user row, the ghost-row
     filter only drops hidden scaffold placeholders, and repair runs BEFORE the request build."""
     from agent.conversation_loop import (
         _INTERRUPT_SCAFFOLD_MARKER, _maybe_inject_run_budget_wrapup
@@ -125,18 +125,20 @@ def prepare_iteration(agent: Any,*, messages: Any, api_call_count: Any) -> Itera
     except Exception:
         logger.debug("Nous key pre-expiry adoption failed", exc_info=True)
 
-    # Drain a /steer sent during the last API call into the newest tool message so
-    # it lands THIS iteration. Never put in a user message (breaks alternation).
+    # Drain a /steer sent during the last API call so it lands THIS iteration. Delivered as a
+    # standalone user row after the newest tool result (never smeared onto the tool row: that
+    # row is already persisted append-only, so replay would diverge from the live request and
+    # break the prompt cache — same contract as apply_pending_steer_to_tool_results).
     _pre_api_steer = agent._drain_pending_steer()
     if _pre_api_steer:
-        _inject_steer_into_newest_tool_result(agent, messages, _pre_api_steer)
+        _inject_steer_after_newest_tool_result(agent, messages, _pre_api_steer)
 
-    # One-shot run-budget wrap-up notice at 80% of agent.run_budget_seconds, via the
-    # same cache-safe channel as /steer (newest tool result); off with no budget.
+    # One-shot run-budget wrap-up notice at 80% of agent.run_budget_seconds, appended to the
+    # newest tool result; off with no budget.
     if getattr(agent, "run_budget_seconds", None):
         _maybe_inject_run_budget_wrapup(agent, messages)
 
-    # Use the same cache-safe channel as /steer; never add a synthetic user/system row.
+    # Appended to the newest tool result; never a synthetic user/system row.
     _maybe_inject_iteration_budget_warning(agent, messages)
 
     request_logger = getattr(agent, "logger", None) or logger  # same name as the origin module
@@ -208,26 +210,15 @@ def _previous_tool_round(messages: Any) -> list:
     return []
 
 
-def _inject_steer_into_newest_tool_result(agent: Any, messages: Any, steer_text: str) -> None:
-    """Append the steer marker to the newest tool message; with no tool message, put the
-    text back so the post-tool-execution drain delivers it later."""
+def _inject_steer_after_newest_tool_result(agent: Any, messages: Any, steer_text: str) -> None:
+    """Append the steer marker as a standalone user row after the newest tool message; with no
+    tool message, put the text back so the post-tool-execution drain delivers it later."""
     for _si in range(len(messages) - 1, -1, -1):
         _sm = messages[_si]
         if isinstance(_sm, dict) and _sm.get("role") == "tool":
             from agent.prompt_builder import format_steer_marker
-            marker = format_steer_marker(steer_text)
-            existing = _sm.get("content", "")
-            if isinstance(existing, str):
-                _sm["content"] = existing + marker
-            else:
-                # Multimodal content blocks — append a text block.
-                with suppress(Exception):
-                    blocks = list(existing) if existing else []
-                    blocks.append({"type": "text", "text": marker})
-                    _sm["content"] = blocks
-            logger.debug(
-                "Pre-API-call steer drain: injected into tool msg at index %d", _si
-            )
+            messages.insert(_si + 1, {"role": "user", "content": format_steer_marker(steer_text)})
+            logger.debug("Pre-API-call steer drain: appended user row after tool msg at index %d", _si)
             return
     _lock = getattr(agent, "_pending_steer_lock", None)
     if _lock is not None:

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -216,8 +216,8 @@ def _inject_steer_after_newest_tool_result(agent: Any, messages: Any, steer_text
     for _si in range(len(messages) - 1, -1, -1):
         _sm = messages[_si]
         if isinstance(_sm, dict) and _sm.get("role") == "tool":
-            from agent.prompt_builder import format_steer_marker
-            messages.insert(_si + 1, {"role": "user", "content": format_steer_marker(steer_text)})
+            from agent.prompt_builder import steer_user_row
+            messages.insert(_si + 1, steer_user_row(steer_text))
             logger.debug("Pre-API-call steer drain: appended user row after tool msg at index %d", _si)
             return
     _lock = getattr(agent, "_pending_steer_lock", None)

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -603,7 +603,7 @@ export interface SessionMessage {
   reasoning_content?: null | string
   reasoning_details?: unknown
   display_kind?:
-    'async_delegation_complete' | 'auto_continue' | 'hidden' | 'model_switch' | 'personality_switch' | string
+    'async_delegation_complete' | 'auto_continue' | 'hidden' | 'model_switch' | 'personality_switch' | 'steer' | string
   /**
    * A backend older than this app can still serve this as unparsed JSON text,
    * so readers must narrow before indexing into it.

--- a/contributors/emails/57474+albert748@users.noreply.github.com
+++ b/contributors/emails/57474+albert748@users.noreply.github.com
@@ -1,0 +1,2 @@
+albert748
+# PR #104444 salvage

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -486,7 +486,7 @@ class TestEmptyHiddenAssistantRehealRegression:
 
 
 class TestSteerInjection:
-    def test_appends_to_last_tool_result(self):
+    def test_appends_standalone_user_message_after_tool_results(self):
         agent = _bare_agent()
         agent.steer("please also check auth.log")
         messages = [
@@ -496,13 +496,33 @@ class TestSteerInjection:
             {"role": "tool", "content": "ls output B", "tool_call_id": "b"},
         ]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=2)
-        # The LAST tool result is modified; earlier ones are untouched.
+        # Existing tool rows are untouched (append-only persistence contract);
+        # the steer becomes a NEW user message at the tail.
         assert messages[2]["content"] == "ls output A"
-        assert "ls output B" in messages[3]["content"]
-        assert STEER_MARKER_OPEN in messages[3]["content"]
-        assert "please also check auth.log" in messages[3]["content"]
+        assert messages[3]["content"] == "ls output B"
+        assert messages[-1]["role"] == "user"
+        assert STEER_MARKER_OPEN in messages[-1]["content"]
+        assert "please also check auth.log" in messages[-1]["content"]
+        # Role-alternation pattern: assistant(tool_calls) → tool → user is
+        # the documented legal "user jumped in mid-run" shape.
         # And pending_steer is consumed.
         assert agent._pending_steer is None
+
+    def test_appended_user_message_is_persistable(self):
+        """The appended user dict carries no _DB_PERSISTED_MARKER yet, so the
+        next _flush_messages_to_session_db writes it to state.db — the steer
+        text lands in the durable transcript (messages.content, role=user)."""
+        from agent.context_compressor import _DB_PERSISTED_MARKER
+
+        agent = _bare_agent()
+        agent.steer("remember this decision")
+        messages = [
+            {"role": "assistant", "tool_calls": [{"id": "a"}]},
+            {"role": "tool", "content": "output", "tool_call_id": "a"},
+        ]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        assert messages[-1]["role"] == "user"
+        assert _DB_PERSISTED_MARKER not in messages[-1]
 
     def test_no_op_when_no_steer_pending(self):
         agent = _bare_agent()
@@ -518,20 +538,25 @@ class TestSteerInjection:
         """The injection marker must attribute the appended text to the user
         via the explicit out-of-band marker (which the system prompt tells the
         model to trust) — otherwise the model reads it as untrusted tool output
-        and refuses it as suspected prompt injection.  Cache-safe: it only
-        rewrites existing tool content, never the message-role sequence.
+        and refuses it as suspected prompt injection.  Cache-safe: the marker
+        is delivered as a NEW user message, never by rewriting existing tool
+        content, so the persisted transcript matches the wire bytes.
         """
         agent = _bare_agent()
         agent.steer("stop after next step")
         messages = [{"role": "tool", "content": "x", "tool_call_id": "1"}]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        assert messages[-1]["role"] == "user"
         content = messages[-1]["content"]
         assert STEER_MARKER_OPEN in content
         assert "stop after next step" in content
+        # The tool row itself is untouched.
+        assert messages[0]["content"] == "x"
 
     def test_multimodal_content_list_preserved(self):
-        """Anthropic-style list content should be preserved, with the steer
-        appended as a text block."""
+        """Anthropic-style list content on tool results is left untouched —
+        the steer is appended as a standalone user message instead of being
+        merged into the content blocks."""
         agent = _bare_agent()
         agent.steer("extra note")
         original_blocks = [{"type": "text", "text": "existing output"}]
@@ -539,12 +564,9 @@ class TestSteerInjection:
             {"role": "tool", "content": list(original_blocks), "tool_call_id": "1"}
         ]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
-        new_content = messages[-1]["content"]
-        assert isinstance(new_content, list)
-        assert len(new_content) == 2
-        assert new_content[0] == {"type": "text", "text": "existing output"}
-        assert new_content[1]["type"] == "text"
-        assert "extra note" in new_content[1]["text"]
+        assert messages[0]["content"] == original_blocks       # untouched
+        assert messages[-1]["role"] == "user"
+        assert "extra note" in messages[-1]["content"]
 
 
 
@@ -728,9 +750,9 @@ class TestLegacyHiddenPlaceholderWireSubstitution:
         from run_agent import AIAgent
 
         with (
-            patch("model_tools.get_tool_definitions", return_value=[]),
-            patch("model_tools.check_toolset_requirements", return_value={}),
-            patch("agent.process_bootstrap.OpenAI"),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -553,7 +553,22 @@ class TestSteerInjection:
         # The tool row itself is untouched.
         assert messages[0]["content"] == "x"
 
-    def test_multimodal_content_list_preserved(self):
+    def test_persisted_steer_row_is_never_merged_with_the_next_prompt(self):
+        """A run that ends right after a steered batch leaves user(steer) as the persisted tail.
+        The next real prompt makes two consecutive user rows; the alternation repair must leave
+        the steer row byte-identical (append-only persistence cannot follow an in-place merge)."""
+        from agent.agent_runtime_helpers import _merge_consecutive_users
+        from agent.prompt_builder import steer_user_row
+
+        steer = steer_user_row("focus on error handling")
+        before = dict(steer)
+        merged, repairs = _merge_consecutive_users([steer, {"role": "user", "content": "next question"}])
+        assert steer == before
+        assert repairs == 0
+        assert [m["role"] for m in merged] == ["user", "user"]
+        assert merged[-1]["content"] == "next question"
+
+    def test_multimodal_tool_content_untouched_steer_lands_as_user_row(self):
         """Anthropic-style list content on tool results is left untouched —
         the steer is appended as a standalone user message instead of being
         merged into the content blocks."""

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -750,9 +750,9 @@ class TestLegacyHiddenPlaceholderWireSubstitution:
         from run_agent import AIAgent
 
         with (
-            patch("run_agent.get_tool_definitions", return_value=[]),
-            patch("run_agent.check_toolset_requirements", return_value={}),
-            patch("run_agent.OpenAI"),
+            patch("model_tools.get_tool_definitions", return_value=[]),
+            patch("model_tools.check_toolset_requirements", return_value={}),
+            patch("agent.process_bootstrap.OpenAI"),
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -621,29 +621,27 @@ class TestPreApiCallSteerDrain:
     fix for the scenario where /steer sent during model thinking only lands
     after the agent is completely done."""
 
-    def test_pre_api_drain_injects_into_last_tool_result(self):
-        """If a steer is pending when the main loop starts building
-        api_messages, it should be injected into the last tool result
-        in the messages list."""
+    def test_pre_api_drain_appends_user_row_and_leaves_tool_row_untouched(self):
+        """A steer pending when the loop builds api_messages lands THIS iteration as a
+        standalone user row after the newest tool result; the (already persisted, append-only)
+        tool row is byte-identical afterwards so replay cannot diverge from the live request."""
+        from agent.turn_iteration_prep import _inject_steer_after_newest_tool_result
+
         agent = _bare_agent()
-        # Simulate messages after a tool batch completed
+        tool_row = {"role": "tool", "content": "output here", "tool_call_id": "tc1"}
+        before = dict(tool_row)
         messages = [
             {"role": "user", "content": "do something"},
             {"role": "assistant", "content": "ok", "tool_calls": [
                 {"id": "tc1", "function": {"name": "terminal", "arguments": "{}"}}
             ]},
-            {"role": "tool", "content": "output here", "tool_call_id": "tc1"},
+            tool_row,
         ]
-        # Steer arrives during API call (set after tool execution)
         agent.steer("focus on error handling")
-        # Simulate what the pre-API-call drain does:
-        _pre_api_steer = agent._drain_pending_steer()
-        assert _pre_api_steer == "focus on error handling"
-        # Inject into last tool msg (mirrors the new code in run_conversation)
-        for _si in range(len(messages) - 1, -1, -1):
-            if messages[_si].get("role") == "tool":
-                messages[_si]["content"] += format_steer_marker(_pre_api_steer)
-                break
+        _inject_steer_after_newest_tool_result(agent, messages, agent._drain_pending_steer())
+        assert tool_row == before
+        assert messages[-2] is tool_row
+        assert messages[-1]["role"] == "user"
         assert STEER_MARKER_OPEN in messages[-1]["content"]
         assert "focus on error handling" in messages[-1]["content"]
         assert agent._pending_steer is None

--- a/tests/run_agent/test_tool_batch_segmentation.py
+++ b/tests/run_agent/test_tool_batch_segmentation.py
@@ -635,10 +635,12 @@ class TestSegmentedDispatchIntegration:
         with patch("agent.tool_executor._budget_for_agent", return_value=budget):
             agent._execute_tool_calls(msg, messages, "task-1")
 
-        assert len(messages) == 1
+        assert len(messages) == 2
         _assert_budget_replaced(messages[0]["content"])
-        assert messages[0]["content"].count(STEER_MARKER_OPEN) == 1
-        assert "preserve malformed-call steer after budget enforcement" in messages[0]["content"]
+        assert STEER_MARKER_OPEN not in messages[0]["content"]   # tool row untouched
+        assert messages[1]["role"] == "user"                      # steer = new user msg
+        assert messages[1]["content"].count(STEER_MARKER_OPEN) == 1
+        assert "preserve malformed-call steer after budget enforcement" in messages[1]["content"]
 
 
 class TestPathCanonicalization:

--- a/tui_gateway/session_history.py
+++ b/tui_gateway/session_history.py
@@ -202,6 +202,10 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
+        if role == "user" and m.get("display_kind") == "steer":
+            # Mid-turn /steer: show the user's own words, not the model-facing marker wrapper.
+            from agent.conversation_compression import _extract_steer_text_from_message
+            content_text = _extract_steer_text_from_message(m) or content_text
         if role == "tool":
             tc_name, tc_args = tool_call_args.get(m.get("tool_call_id") or "", (None, None))
             name = tc_name or m.get("tool_name") or "tool"


### PR DESCRIPTION
`/steer` text was smeared onto the last `role:tool` message's content. That row had already been flushed append-only (`_DB_PERSISTED_MARKER`), so the durable transcript never contained the steer and replayed history diverged from the live request at the injection point — a 75–85% prompt-cache miss on the next surface switch or restart. Canonical issue #58599 (#104442 closed as a duplicate of it).

Salvage of #104444 by @albert748 (cherry-picked, authorship preserved), widened to the whole bug class.

- `apply_pending_steer_to_tool_results`: the steer becomes a standalone `role:user` row after the last tool result (`assistant(tool_calls) → tool → user` is legal on every provider path; the Anthropic converter folds it into the tool_result user message).
- Same class, second site: the pre-API-call drain (`turn_iteration_prep`) smeared the marker onto the newest persisted tool row for any `/steer` that landed during an API call; it now inserts the same row.
- Both sites build the row via `prompt_builder.steer_user_row` (`display_kind="steer"`, no leading blank lines). The alternation repair skips a steer-typed row, so a run that ended right after a steered batch does not get the next prompt merged *into* the persisted steer row (which would have re-broken parity). TUI/Desktop history shows the user's words, not the marker wrapper; `agent/AGENTS.md`'s alternation rule documents the exception.
- The contributor's unrelated hunk repointing test patch targets to PLUGIN-COMPAT pointers (off limits in-tree) is dropped.
- Still out of scope (same class, separate follow-up): the run-budget and iteration-budget notices still append to the newest tool row.

Validation: 79 tests green under `-W error::HermesPluginCompatWarning`; reverting `agent_runtime_helpers.py` → 5 red; reverting the pre-API drain → 1 red; removing the merge guard → 1 red.
