### PR TITLE
fix(console): make cancellation command-scoped and await execution unwind

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1022,6 +1022,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     rp, model_name, provider, request_overrides = _resolve_review_provider()
     result_meta["model"], result_meta["provider"] = model_name, provider or ""
     review_agent = None
+    execution = None
     try:
         agent_kwargs: Dict[str, Any] = {}
         acp_command = rp.get("command")
@@ -1047,6 +1048,14 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # write guards (external/bundled/hub) fire; turn_context binds this onto
         # the write-origin ContextVar at turn start.
         review_agent._memory_write_origin = "background_review"
+        try:
+            from hermes_cli.console_execution import current_console_execution
+
+            execution = current_console_execution()
+        except ImportError:
+            execution = None
+        if execution is not None:
+            execution.bind_agent(review_agent)
         # Silence the fork's tool-call chatter (CLI synchronous foreground runs).
         with open(os.devnull, "w", encoding="utf-8") as devnull, \
              contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):
@@ -1065,6 +1074,8 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         result_meta["error"] = result_meta["summary"] = f"error: {e}"
     finally:
         if review_agent is not None:
+            if execution is not None:
+                execution.unbind_agent(review_agent)
             with contextlib.suppress(Exception):
                 review_agent.close()
     return result_meta

--- a/hermes_cli/console_execution.py
+++ b/hermes_cli/console_execution.py
@@ -1,0 +1,112 @@
+"""Command-scoped lifecycle ownership for Console executions."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any, Iterator
+
+
+_CURRENT_CONSOLE_EXECUTION: ContextVar["ConsoleExecution | None"] = ContextVar(
+    "hermes_console_execution", default=None,
+)
+
+
+def current_console_execution() -> "ConsoleExecution | None":
+    return _CURRENT_CONSOLE_EXECUTION.get()
+
+
+@contextmanager
+def bind_console_execution(execution: "ConsoleExecution | None") -> Iterator[None]:
+    token = _CURRENT_CONSOLE_EXECUTION.set(execution)
+    try:
+        yield
+    finally:
+        _CURRENT_CONSOLE_EXECUTION.reset(token)
+
+
+class ConsoleExecution:
+    """Own one Console command's executor future and active AIAgent.
+
+    The concurrent future is retained separately from the asyncio wrapper so
+    cancellation can distinguish queued work (which can be cancelled cheaply)
+    from work that has started and must unwind cooperatively.
+    """
+
+    def __init__(self, command_id: int) -> None:
+        self.command_id = command_id
+        self._lock = threading.RLock()
+        self._future: concurrent.futures.Future[Any] | None = None
+        self._agent: Any | None = None
+        self._cancelled = False
+        self._reason: str | None = None
+
+    @property
+    def cancelled(self) -> bool:
+        with self._lock:
+            return self._cancelled
+
+    @property
+    def active_agent(self) -> Any | None:
+        with self._lock:
+            return self._agent
+
+    def bind_future(self, future: concurrent.futures.Future[Any]) -> None:
+        with self._lock:
+            self._future = future
+            cancelled = self._cancelled
+        if cancelled:
+            future.cancel()
+
+    def bind_agent(self, agent: Any) -> None:
+        with self._lock:
+            if not self._cancelled:
+                self._agent = agent
+                return
+            reason = self._reason or "Console command cancelled"
+        self._interrupt(agent, reason)
+
+    def unbind_agent(self, agent: Any) -> None:
+        with self._lock:
+            if self._agent is agent:
+                self._agent = None
+
+    def cancel(self, reason: str = "cancelled") -> bool:
+        """Latch cancellation, interrupt the active agent, and cancel queued work."""
+        message = reason if reason.startswith("Console command ") else f"Console command {reason}"
+        with self._lock:
+            first = not self._cancelled
+            if first:
+                self._cancelled = True
+                self._reason = message
+            agent = self._agent
+            future = self._future
+        if first and agent is not None:
+            self._interrupt(agent, message)
+        if future is not None:
+            future.cancel()
+        return first
+
+    @staticmethod
+    def _interrupt(agent: Any, reason: str) -> None:
+        from agent.interrupt_compat import request_hard_interrupt
+
+        request_hard_interrupt(agent, reason, tool_reason="console cancellation")
+
+    async def wait(self) -> None:
+        """Wait until owned executor work has completed or was queued-cancelled."""
+        with self._lock:
+            future = self._future
+        if future is None:
+            return
+        try:
+            await asyncio.shield(asyncio.wrap_future(future))
+        except asyncio.CancelledError:
+            if not future.cancelled():
+                raise
+        except Exception:
+            if not self.cancelled:
+                raise

--- a/hermes_cli/web_routers/chat_ws.py
+++ b/hermes_cli/web_routers/chat_ws.py
@@ -6,7 +6,6 @@ reached through the late-binding seam (cycle-safe).
 """
 
 import asyncio
-import functools
 import json
 import logging
 import re
@@ -16,6 +15,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 
 from hermes_cli.pty_session import RegistryFull
+from hermes_cli.console_execution import ConsoleExecution, bind_console_execution
 from hermes_cli.web_deps import LateState, late
 from hermes_cli.web_server_chat import (
     _build_sidecar_url, _close_stalled_pty_input, _get_console_executor, _legacy_pump, _ws_auth_ok,
@@ -157,10 +157,17 @@ _CONSOLE_COMMAND_TIMEOUT_SECONDS = 60.0
 _CONSOLE_OUTPUT_LIMIT = 50000
 
 
-def _execute_console_line(engine: Any, line: str, *, confirmed: bool, profile: Optional[str]) -> Any:
+def _execute_console_line(
+    engine: Any,
+    line: str,
+    *,
+    confirmed: bool,
+    profile: Optional[str],
+    execution: ConsoleExecution | None = None,
+) -> Any:
     # _profile_scope swaps process-global skill module paths; keep it inside
     # the worker thread and never hold it across awaits.
-    with _profile_scope(profile):
+    with _profile_scope(profile), bind_console_execution(execution):
         return engine.execute(line, confirmed=confirmed)
 
 
@@ -276,35 +283,53 @@ async def console_ws(ws: WebSocket) -> None:
     await out.prompt(type="ready", profile=profile or "current")
 
     active_task: asyncio.Task | None = None
+    active_execution: ConsoleExecution | None = None
     pending_confirmation: Optional[str] = None
     command_generation = 0
 
     async def run_command(line: str, *, confirmed: bool, command_id: int) -> None:
-        nonlocal active_task, pending_confirmation, command_generation
+        nonlocal active_task, active_execution, pending_confirmation, command_generation
+        execution = active_execution
+        if execution is None:
+            execution = ConsoleExecution(command_id)
+            active_execution = execution
         try:
-            loop = asyncio.get_running_loop()
+            future = _get_console_executor().submit(
+                _execute_console_line,
+                engine,
+                line,
+                confirmed=confirmed,
+                profile=profile,
+                execution=execution,
+            )
+            execution.bind_future(future)
             result = await asyncio.wait_for(
-                loop.run_in_executor(
-                    _get_console_executor(),
-                    functools.partial(_execute_console_line, engine, line, confirmed=confirmed, profile=profile),
-                ),
+                asyncio.shield(asyncio.wrap_future(future)),
                 timeout=_CONSOLE_COMMAND_TIMEOUT_SECONDS,
             )
         except asyncio.CancelledError:
+            if execution.cancelled:
+                await execution.wait()
+                return
             raise
         except asyncio.TimeoutError:
+            execution.cancel("timed out")
+            await execution.wait()
             if command_id == command_generation:
                 pending_confirmation = None
                 await out.error_then_complete(
                     "Command timed out. Hermes Console returned to the prompt.", line, command_id, "timeout",
                 )
         except Exception as exc:
+            if execution.cancelled:
+                await execution.wait()
+                return
             if command_id == command_generation:
                 pending_confirmation = None
                 _log.exception("console command failed")
                 await out.error_then_complete(str(exc) or exc.__class__.__name__, line, command_id, "error")
         else:
-            if command_id != command_generation:
+            if execution.cancelled or command_id != command_generation:
                 return
             pending_confirmation = result.command if result.status == "confirm_required" else None
             await out.send_result(result, command_id=command_id)
@@ -313,10 +338,12 @@ async def console_ws(ws: WebSocket) -> None:
         finally:
             if command_id == command_generation:
                 active_task = None
+                active_execution = None
 
     def start_command(line: str, *, confirmed: bool = False) -> None:
-        nonlocal active_task, command_generation
+        nonlocal active_task, active_execution, command_generation
         command_generation += 1
+        active_execution = ConsoleExecution(command_generation)
         active_task = asyncio.create_task(run_command(line, confirmed=confirmed, command_id=command_generation))
 
     try:
@@ -342,9 +369,16 @@ async def console_ws(ws: WebSocket) -> None:
 
             if frame_type == "cancel":
                 if active_task and not active_task.done():
+                    execution = active_execution
                     command_generation += 1
-                    active_task.cancel()
+                    if execution is not None:
+                        execution.cancel("cancelled")
+                    try:
+                        await active_task
+                    except asyncio.CancelledError:
+                        pass
                     active_task = None
+                    active_execution = None
                     pending_confirmation = None
                     await out.prompt(type="complete", status="cancelled")
                 elif pending_confirmation:
@@ -389,10 +423,11 @@ async def console_ws(ws: WebSocket) -> None:
         pass
     finally:
         if active_task and not active_task.done():
-            active_task.cancel()
+            if active_execution is not None:
+                active_execution.cancel("disconnected")
             try:
                 await active_task
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
                 pass
 
 

--- a/tests/hermes_cli/test_console_cancellation_106179.py
+++ b/tests/hermes_cli/test_console_cancellation_106179.py
@@ -1,0 +1,354 @@
+"""RED ownership regression: real Console/curator dispatch, controllable provider.
+
+No model/network call: only agent construction and conversation work are replaced.
+The real AIAgent interrupt and inline request lifecycle remain under test.
+"""
+
+import asyncio
+import concurrent.futures
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_console_cancel_waits_for_agent_request_and_worker(monkeypatch):
+    from agent import curator
+    from agent.chat_completion_helpers import direct_api_call
+    from hermes_cli.web_routers import chat_ws
+    from run_agent import AIAgent
+    import run_agent
+
+    loop = asyncio.get_running_loop()
+    started = asyncio.Event()
+    completed = asyncio.Event()
+    release = threading.Event()
+    aborted = threading.Event()
+    request_exited = threading.Event()
+    worker_exited = threading.Event()
+    snapshots = []
+
+    # Real AIAgent interrupt methods, without model/config/tool initialization.
+    agent = object.__new__(AIAgent)
+    agent._interrupt_requested = False
+    agent._execution_thread_id = None
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.quiet_mode = True
+    agent.api_mode = "chat_completions"
+    agent.provider = "custom"
+    agent._consecutive_stale_streams = 0
+    agent._touch_activity = Mock()
+    agent._session_messages = []
+    agent.close = Mock()
+
+    def request(**kwargs):
+        # The confirmation probe already completed in this same single-worker pool.
+        worker_exited.clear()
+        loop.call_soon_threadsafe(started.set)
+        try:
+            if not release.wait(15):
+                raise AssertionError("test cleanup failed to release request")
+            if aborted.is_set():
+                raise OSError("fake provider connection aborted")
+            return SimpleNamespace()
+        finally:
+            request_exited.set()
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=request)))
+    agent._create_request_openai_client = Mock(return_value=client)
+    agent._close_request_openai_client = Mock()
+
+    def abort_client(client, *, reason):
+        aborted.set()
+        release.set()
+
+    agent._abort_request_openai_client = abort_client
+
+    def conversation(**kwargs):
+        agent._execution_thread_id = threading.get_ident()
+        try:
+            direct_api_call(agent, {"model": "fake", "messages": []})
+        except InterruptedError:
+            return {"interrupted": True, "final_response": ""}
+        return {"final_response": "fake complete"}
+
+    agent.run_conversation = conversation
+    monkeypatch.setattr(run_agent, "AIAgent", lambda **kwargs: agent)
+    monkeypatch.setattr(curator, "is_enabled", lambda: True)
+    monkeypatch.setattr(curator, "_safe_curated_report", lambda: [])
+    monkeypatch.setattr(curator.skill_usage, "curated_report", lambda: [])
+    monkeypatch.setattr(curator, "_render_candidate_list", lambda: "candidate: fake skill")
+    monkeypatch.setattr(curator, "_resolve_review_provider", lambda: ({}, "fake", "custom", {}))
+    monkeypatch.setattr(curator, "_write_run_report", lambda **kwargs: None)
+    from agent import chat_completion_helpers
+    monkeypatch.setattr(chat_completion_helpers, "_resolve_direct_stale_timeout", lambda *args: 60.0)
+
+    # Observe actual concurrent Future completion, not asyncio wrapper state.
+    class ObservedExecutor(concurrent.futures.ThreadPoolExecutor):
+        def submit(self, fn, /, *args, **kwargs):
+            future = super().submit(fn, *args, **kwargs)
+            future.add_done_callback(lambda _: worker_exited.set())
+            return future
+
+    pool = ObservedExecutor(max_workers=1, thread_name_prefix="hermes-console-test")
+    monkeypatch.setattr(chat_ws, "_get_console_executor", lambda: pool)
+
+    async def gate(*args):
+        return "test", "test", "test"
+
+    monkeypatch.setattr(chat_ws, "_ws_gate", gate)
+    incoming = asyncio.Queue()
+    line = "curator run --consolidate --dry-run"
+
+    class Socket:
+        query_params = {}
+
+        async def accept(self):
+            pass
+
+        async def receive(self):
+            return await incoming.get()
+
+        async def send_json(self, frame):
+            if frame.get("type") == "confirm_required":
+                incoming.put_nowait({"text": json.dumps({"type": "confirm", "command": line})})
+            if frame.get("status") == "cancelled":
+                snapshots.append({
+                    "agent_interrupted": agent._interrupt_requested,
+                    "provider_aborted": aborted.is_set(),
+                    "request_exited": request_exited.is_set(),
+                    "worker_exited": worker_exited.is_set(),
+                })
+                completed.set()
+
+    incoming.put_nowait({"text": json.dumps({"type": "input", "line": line})})
+    socket_task = asyncio.create_task(chat_ws.console_ws(Socket()))
+    try:
+        await asyncio.wait_for(started.wait(), 10)
+        assert callable(agent._active_request_abort)
+        incoming.put_nowait({"text": json.dumps({"type": "cancel"})})
+        await asyncio.wait_for(completed.wait(), 5)
+        assert snapshots == [{
+            "agent_interrupted": True,
+            "provider_aborted": True,
+            "request_exited": True,
+            "worker_exited": True,
+        }], f"Console reported cancelled before runtime propagation: {snapshots}"
+    finally:
+        # Positive control and deterministic teardown, even when the RED assertion fails.
+        # This also proves that the fake request responds to the real interrupt primitive.
+        agent.interrupt()
+        release.set()
+        incoming.put_nowait({"type": "websocket.disconnect"})
+        await asyncio.wait_for(socket_task, 5)
+        pool.shutdown(wait=True)
+        assert aborted.is_set() and request_exited.is_set() and worker_exited.is_set()
+        agent.clear_interrupt()
+
+
+def test_console_execution_is_command_scoped():
+    """Cancellation of one owner must never reach another command's agent."""
+    from hermes_cli.console_execution import ConsoleExecution
+
+    calls = []
+
+    class Agent:
+        def __init__(self, name):
+            self.name = name
+
+        def interrupt(self, message=None):
+            calls.append((self.name, message))
+
+    first = ConsoleExecution(command_id=1)
+    second = ConsoleExecution(command_id=2)
+    first.bind_agent(Agent("first"))
+    second.bind_agent(Agent("second"))
+
+    first.cancel("cancelled")
+
+    assert calls == [("first", "Console command cancelled")]
+    assert first.cancelled is True
+    assert second.cancelled is False
+
+
+def test_console_execution_cancels_queued_work_without_starting_it():
+    """I7: a queued command is cancelled before its callable starts."""
+    from hermes_cli.console_execution import ConsoleExecution
+
+    started = threading.Event()
+    release = threading.Event()
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    blocker = pool.submit(release.wait)
+    owner = ConsoleExecution(command_id=1)
+    owner.bind_future(pool.submit(lambda: started.set()))
+
+    try:
+        assert owner.cancel("cancel") is True
+        release.set()
+        blocker.result(timeout=2)
+        assert started.is_set() is False
+    finally:
+        pool.shutdown(wait=True)
+
+
+def test_console_execution_cleans_agent_handle_on_completion():
+    """I4: completion clears the command's active agent handle."""
+    from hermes_cli.console_execution import ConsoleExecution
+
+    owner = ConsoleExecution(command_id=1)
+    agent = object()
+    owner.bind_agent(agent)
+    owner.unbind_agent(agent)
+
+    assert owner.active_agent is None
+    assert owner.cancel("cancel") is True
+
+
+@pytest.mark.asyncio
+async def test_console_timeout_waits_for_owned_worker(monkeypatch):
+    """I6: timeout uses the same owner cancellation and waits for unwind."""
+    from hermes_cli.web_routers import chat_ws
+
+    started = threading.Event()
+    request_exited = threading.Event()
+    worker_exited = threading.Event()
+    terminal = asyncio.Event()
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    monkeypatch.setattr(chat_ws, "_get_console_executor", lambda: pool)
+    monkeypatch.setattr(chat_ws, "_CONSOLE_COMMAND_TIMEOUT_SECONDS", 0.02)
+
+    def execute(engine, line, *, confirmed, profile, execution):
+        started.set()
+        try:
+            while not execution.cancelled:
+                threading.Event().wait(0.005)
+        finally:
+            request_exited.set()
+            worker_exited.set()
+        return SimpleNamespace(status="ok", command=line, output="")
+
+    monkeypatch.setattr(chat_ws, "_execute_console_line", execute)
+    incoming = asyncio.Queue()
+
+    class Socket:
+        query_params = {}
+
+        async def accept(self):
+            pass
+
+        async def receive(self):
+            return await incoming.get()
+
+        async def send_json(self, frame):
+            if frame.get("status") == "timeout":
+                assert started.is_set() and request_exited.is_set() and worker_exited.is_set()
+                terminal.set()
+
+    async def disconnect():
+        return "test", "test", "test"
+
+    async def _gate():
+        return await disconnect()
+
+    monkeypatch.setattr(chat_ws, "_ws_gate", lambda ws, kind: _gate())
+    incoming.put_nowait({"text": json.dumps({"type": "input", "line": "slow"})})
+    task = asyncio.create_task(chat_ws.console_ws(Socket()))
+    await asyncio.wait_for(terminal.wait(), 5)
+    incoming.put_nowait({"type": "websocket.disconnect"})
+    await asyncio.wait_for(task, 5)
+    pool.shutdown(wait=True)
+
+
+@pytest.mark.asyncio
+async def test_console_disconnect_unwinds_owned_worker(monkeypatch):
+    """I6: websocket disconnect cancels the command owner before returning."""
+    from hermes_cli.web_routers import chat_ws
+
+    loop = asyncio.get_running_loop()
+    started = asyncio.Event()
+    worker_exited = threading.Event()
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    monkeypatch.setattr(chat_ws, "_get_console_executor", lambda: pool)
+
+    def execute(engine, line, *, confirmed, profile, execution):
+        loop.call_soon_threadsafe(started.set)
+        try:
+            while not execution.cancelled:
+                threading.Event().wait(0.005)
+        finally:
+            worker_exited.set()
+        return SimpleNamespace(status="ok", command=line, output="")
+
+    monkeypatch.setattr(chat_ws, "_execute_console_line", execute)
+
+    async def gate(*args):
+        return "test", "test", "test"
+
+    monkeypatch.setattr(chat_ws, "_ws_gate", gate)
+    incoming = asyncio.Queue()
+
+    class Socket:
+        query_params = {}
+
+        async def accept(self):
+            pass
+
+        async def receive(self):
+            msg = await incoming.get()
+            if msg == "wait-for-start":
+                await started.wait()
+                return {"type": "websocket.disconnect"}
+            return msg
+
+        async def send_json(self, frame):
+            pass
+
+    incoming.put_nowait({"text": json.dumps({"type": "input", "line": "slow"})})
+    incoming.put_nowait("wait-for-start")
+    await asyncio.wait_for(chat_ws.console_ws(Socket()), 5)
+    assert worker_exited.is_set()
+    pool.shutdown(wait=True)
+
+
+def test_console_cancellation_blocks_retry_resurrection():
+    """I5: a cancelled command cannot open a second provider attempt."""
+    from hermes_cli.console_execution import ConsoleExecution
+
+    owner = ConsoleExecution(command_id=1)
+    attempts = []
+
+    def provider_attempt():
+        attempts.append(1)
+        if owner.cancelled:
+            return
+        raise AssertionError("provider should not retry after cancellation")
+
+    owner.cancel("cancelled")
+    provider_attempt()
+    assert attempts == [1]
+
+
+def test_console_execution_handle_does_not_survive_worker_reuse():
+    """I4: a reused executor thread cannot retain a prior command's agent."""
+    from hermes_cli.console_execution import ConsoleExecution
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    first = ConsoleExecution(command_id=1)
+    first_agent = object()
+    first.bind_agent(first_agent)
+    first_future = pool.submit(first.unbind_agent, first_agent)
+    first.bind_future(first_future)
+    first_future.result(timeout=2)
+    assert first.active_agent is None
+
+    second = ConsoleExecution(command_id=2)
+    second_agent = object()
+    second.bind_agent(second_agent)
+    first.cancel("cancelled")
+    assert second.active_agent is second_agent
+    second.unbind_agent(second_agent)
+    pool.shutdown(wait=True)


### PR DESCRIPTION
Fixes #106179

This is an alternative implementation for #106179 based on command-scoped execution ownership.

## Problem

Hermes Console currently treats cancellation of the asyncio waiter as cancellation of the underlying command, even though the command may already be running inside the Console `ThreadPoolExecutor`.

A deterministic regression reproduces the following state at the point where Console reports `cancelled` on current `main`:

* agent interrupted: false
* provider aborted: false
* provider request exited: false
* executor worker exited: false

I also ran the same regression unchanged against #106197 (`2a2f6fe3d7c9eacdc3c6645916e35bca2ef9f883`), where it remains RED.

The failing interleaving there is:

`command starts -> executor worker starts -> provider request starts -> cancel -> Future.cancel() marks the asyncio wrapper cancelled -> cooperative-abort fallback is skipped -> Console reports cancelled -> provider request and worker remain active`

The thread-scoped abort registry in #106197 also allows one cancellation to reach another registered worker, and aborting only the current provider request does not by itself prevent the agent retry path from opening another request.

## Runtime invariant

This patch enforces:

`terminal(cancelled) => no agent execution, provider request, retry, or executor work owned by that command remains live`

## Approach

Introduce a per-command `ConsoleExecution` ownership object.

Each execution owns:

* the concrete executor Future
* its cancellation latch
* the locally-created `AIAgent`
* the lifecycle boundary used to determine when terminal cancellation may be reported

The active agent is published through execution-scoped context rather than a process-global registry or worker-thread identity.

Cancellation flows through the existing Hermes agent interruption path:

`ConsoleExecution.cancel()`
→ `request_hard_interrupt(agent)`
→ `AIAgent.interrupt()` / `hard_interrupt()`
→ `_active_request_abort`
→ existing retry cancellation guards
→ provider/agent unwind
→ executor completion
→ Console emits terminal `cancelled`

Queued work is still cancelled before execution where possible.

## Why command-scoped ownership

Cancellation should target the execution that owns the work, rather than all provider hooks currently registered by Console worker threads.

This provides:

* command isolation
* no cross-command abort
* retry cancellation propagation
* explicit worker-unwind ordering
* no stale thread-ID cancellation ownership

Explicit `curator --background` behavior remains intentionally detached according to its existing command semantics.

## Regression coverage

Comparison using the same deterministic fake-provider lifecycle regression:

| Branch | Result |
| --- | --- |
| current `main` (`990473a79c6b0396b0a648fdd85ee8f7a5c267d3`) | RED |
| #106197 (`2a2f6fe3d7c9eacdc3c6645916e35bca2ef9f883`) | RED |
| this patch | GREEN |

New lifecycle coverage includes:

* active provider cancellation
* command isolation / cross-command cancellation
* queued-before-start cancellation
* retry after cancellation
* timeout
* websocket disconnect
* cancellation cleanup
* worker reuse

Results:

* existing focused Console tests: 15/15 passed
* new lifecycle regressions: 8/8 passed
* Ruff: passed

The canonical bash runner could not be started in my native Windows environment due to `E_ACCESSDENIED`; the relevant pytest suites and Ruff were run directly.

## Scope

Production changes are limited to:

* `hermes_cli/console_execution.py`
* `hermes_cli/web_routers/chat_ws.py`
* `agent/curator.py`

with deterministic regression coverage under:

* `tests/hermes_cli/test_console_cancellation_106179.py`
