### PR TITLE
fix(model-switch): preserve provider capabilities

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1884,6 +1884,7 @@ def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_c
     agent.runtime_capabilities = resolve_native_compaction_capabilities(
         model=agent.model, base_url=agent.base_url, provider=agent.provider,
         is_codex_backend=(agent.provider or "").strip().lower() == "openai-codex",
+        provider_capabilities=agent.capabilities,
     )
     agent.max_compression_attempts = cs.max_attempts
     agent.compression_idle_compact_after_seconds = cs.idle_compact_after_seconds

--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -34,12 +34,17 @@ def is_native_compaction_model(model: Optional[str]) -> bool:
 
 def resolve_native_compaction_capabilities(
     *, model: Optional[str], base_url: Optional[str], provider: Optional[str] = None, is_codex_backend: bool = False,
+    provider_capabilities: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, bool]:
     """Resolve the native-compaction capability for a runtime destination (a resolved ``False``
     is distinct from "unresolved" and must survive model switches unchanged)."""
     direct_default = (provider or "").strip().lower() == "openai" and not base_url
+    trusted_proxy = (
+        isinstance(provider_capabilities, dict)
+        and provider_capabilities.get("openai_native_compaction") is True
+    )
     return {"native_compaction": is_native_compaction_model(model) and (
-        direct_default or is_direct_openai_route(base_url, is_codex_backend=is_codex_backend))}
+        direct_default or is_direct_openai_route(base_url, is_codex_backend=is_codex_backend) or trusted_proxy)}
 
 
 def is_direct_openai_route(base_url: Optional[str], *, is_codex_backend: bool = False) -> bool:

--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -54,6 +54,16 @@ def _model_switch_skew_guard() -> Optional[str]:
     )
 
 
+def _switch_provider_capabilities(result) -> dict[str, bool]:
+    """Return raw provider policy flags, with a safe fallback for older switch results."""
+    capabilities = getattr(result, "provider_capabilities", None)
+    if capabilities is None:
+        capabilities = getattr(result, "runtime_capabilities", None)
+    if not isinstance(capabilities, dict):
+        return {}
+    return {str(key): value for key, value in capabilities.items() if isinstance(value, bool)}
+
+
 async def _persist_model_switch_to_config(result, config_path) -> None:
     """Write-through a resolved /model switch to ``config_path`` (model.default/provider/base_url).
 
@@ -216,7 +226,7 @@ class GatewayModelCommandsMixin:
             cached_agent.switch_model(
                 new_model=result.new_model, new_provider=result.target_provider,
                 api_key=result.api_key, base_url=result.base_url, api_mode=result.api_mode,
-                capabilities=getattr(result, "runtime_capabilities", None),
+                capabilities=_switch_provider_capabilities(result),
             )
         except Exception as exc:
             logger.warning(
@@ -264,7 +274,7 @@ class GatewayModelCommandsMixin:
             "model": result.new_model, "provider": result.target_provider, "api_key": result.api_key,
             "base_url": result.base_url, "api_mode": result.api_mode,
             "request_overrides": dict(result.request_overrides or {}),
-            "capabilities": dict(result.runtime_capabilities or {}),
+            "capabilities": _switch_provider_capabilities(result),
         }
         if one_turn:
             if not hasattr(self, "_pending_one_turn_model_restores"):

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -437,6 +437,7 @@ class ModelSwitchResult:
     provider_label: str = ""
     resolved_via_alias: str = ""
     capabilities: Optional[ModelCapabilities] = None
+    provider_capabilities: Optional[dict[str, bool]] = None
     runtime_capabilities: Optional[dict[str, bool]] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
@@ -1050,6 +1051,7 @@ class _Switch:
     base_url: str = ""
     api_mode: str = ""
     validation_headers: dict = field(default_factory=dict)
+    provider_capabilities: dict[str, bool] = field(default_factory=dict)
     suppress_ollama_headers: bool = False
     validation: dict = field(default_factory=dict)
 
@@ -1072,6 +1074,12 @@ class _Switch:
         self.api_key, self.base_url = rt.get("api_key", ""), rt.get("base_url", "")
         self.api_mode = rt.get("api_mode", "")
         self.validation_headers = rt.get("extra_headers") or self.validation_headers
+        capabilities = rt.get("capabilities")
+        self.provider_capabilities = (
+            {key: value for key, value in capabilities.items()
+             if isinstance(key, str) and isinstance(value, bool)}
+            if isinstance(capabilities, dict) else {}
+        )
 
 
 def _route_explicit_provider(st: _Switch) -> Optional[ModelSwitchResult]:
@@ -1427,7 +1435,8 @@ def _build_switch_result(st: _Switch) -> ModelSwitchResult:
     from agent.native_compaction import resolve_native_compaction_capabilities
     runtime_capabilities = resolve_native_compaction_capabilities(
         model=st.new_model, base_url=st.base_url, provider=st.target_provider,
-        is_codex_backend=st.target_provider.strip().lower() == "openai-codex")
+        is_codex_backend=st.target_provider.strip().lower() == "openai-codex",
+        provider_capabilities=st.provider_capabilities)
     model_info = get_model_info(st.target_provider, st.new_model, allow_network=True)
 
     warnings = [w for w in (st.validation.get("message"), _check_hermes_model_warning(st.new_model)) if w]
@@ -1446,6 +1455,7 @@ def _build_switch_result(st: _Switch) -> ModelSwitchResult:
         provider_changed=st.provider_changed, api_key=st.api_key, base_url=st.base_url, api_mode=st.api_mode,
         request_overrides=dict(request_overrides or {}), warning_message=" | ".join(warnings) if warnings else "",
         provider_label=st.provider_label, resolved_via_alias=st.resolved_alias, capabilities=capabilities,
+        provider_capabilities=st.provider_capabilities,
         runtime_capabilities={
             k: v for k, v in runtime_capabilities.items() if isinstance(k, str) and isinstance(v, bool)},
         model_info=model_info, is_global=st.is_global)

--- a/tests/hermes_cli/test_model_switch_native_compaction_capabilities.py
+++ b/tests/hermes_cli/test_model_switch_native_compaction_capabilities.py
@@ -1,0 +1,58 @@
+"""Regression coverage for trusted native-compaction routes selected by /model."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+def test_switch_preserves_named_provider_capabilities_with_shared_base_url():
+    """The resolver identity, not the first same-URL config entry, owns capability policy."""
+    base_url = "https://proxy.example.test/v1"
+    custom_providers = [
+        {
+            "name": "generic",
+            "base_url": base_url,
+            "models": ["other-model"],
+            "capabilities": {},
+        },
+        {
+            "name": "chatgpt-tier",
+            "base_url": base_url,
+            "models": ["gpt-5.6-sol"],
+            "capabilities": {"openai_native_compaction": True},
+        },
+    ]
+    accepted = {"accepted": True, "persist": True, "recognized": True, "message": ""}
+
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.model_switch.normalize_model_for_provider",
+            side_effect=lambda model, _provider: model,
+        ),
+        patch("hermes_cli.models_validate.validate_requested_model", return_value=accepted),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "test-key",
+                "base_url": base_url,
+                "api_mode": "codex_responses",
+                "capabilities": {"openai_native_compaction": True},
+            },
+        ),
+    ):
+        result = switch_model(
+            raw_input="gpt-5.6-sol",
+            current_provider="custom",
+            current_model="gpt-5.6-terra",
+            current_base_url=base_url,
+            custom_providers=custom_providers,
+        )
+
+    assert result.success is True, result.error_message
+    assert result.provider_capabilities == {"openai_native_compaction": True}
+    assert result.runtime_capabilities == {"native_compaction": True}


### PR DESCRIPTION
## What does this PR do?

This fixes a regression in `/model` switching for named providers that explicitly support OpenAI native context compaction.

Why this matters: native compaction checkpoints are encrypted and safely retained in session state, but Hermes only sends the checkpoint replay directive when the *destination runtime* is marked native-compaction capable. After a model switch, losing that capability mark makes Hermes send the full conversation instead of the compacted checkpoint shape. The checkpoint is not lost, but it becomes inactive for subsequent requests, causing a large and unnecessary context jump.

The regression came from the `_Switch.resolve_runtime()` refactor in `hermes_cli/model_switch.py`. Before the refactor, the selected runtime's `capabilities` travelled with the switch result. The refactored path copied credentials, base URL, API mode, and headers, but dropped `capabilities`. Downstream runtime capability detection therefore treated a trusted proxy route as unsupported and disabled `context_management`.

Recovering capability policy by matching only `base_url` is not correct: several named providers can intentionally share one endpoint while having different policy. The provider selected by `resolve_runtime_provider()` is the only authoritative source for that policy.

This PR preserves the selected provider's normalized capability map through the switch, derives `native_compaction` from that map, and keeps raw provider policy distinct from the derived runtime flag in the gateway/session handoff.

## Related Issue

No existing issue: this is a regression discovered through a model-switch checkpoint-replay reproduction. A search of open and closed issues/PRs found no duplicate.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py`: retain normalized `resolve_runtime_provider()` capabilities in `_Switch` and return them as `provider_capabilities`; calculate the derived runtime flag from those exact capabilities.
- `agent/native_compaction.py` and `agent/agent_init.py`: allow a literal `openai_native_compaction=true` provider policy to authorize a trusted proxy route during startup/runtime capability resolution.
- `gateway/slash_commands_model.py`: propagate raw provider policy to the cached agent and session override instead of substituting the derived runtime map.
- `tests/hermes_cli/test_model_switch_native_compaction_capabilities.py`: add a no-network regression test where a generic provider and a native-compaction provider share one base URL; the selected provider's capability must survive the switch.

## How to Test

1. Configure two named custom providers that share a base URL, with native compaction enabled only on the provider selected for the target model.
2. Switch models through `/model` to that named provider after a native checkpoint exists.
3. Confirm the switch result contains `provider_capabilities={"openai_native_compaction": true}` and `runtime_capabilities={"native_compaction": true}`; Hermes then includes native `context_management` and can replay the existing checkpoint rather than resend full history.
4. Run:

   ```sh
   scripts/run_tests.sh tests/hermes_cli/test_model_switch*.py tests/gateway/test_model_switch*.py tests/run_agent/test_native_compaction*.py -v --tb=short
   ```

   Result: 224 passed, 0 failed on this PR branch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (focused hermetic test runner)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A; the behavior is covered by the regression test and existing capability documentation remains accurate
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- pure Python capability propagation; no platform-specific path or subprocess behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

No UI change. The regression test is a deterministic no-network reproduction of the failed capability propagation path.
