### PR TITLE
api_server: list archived sessions with ?archived_only=true

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2731,6 +2731,9 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
         source = request.query.get("source") or None
         include_children = _coerce_request_bool(request.query.get("include_children"), default=False)
+        # ``archived`` is a client-facing flag (PATCH sets it, the default list
+        # hides it); ``archived_only`` is how a client lists what it archived.
+        archived_only = _coerce_request_bool(request.query.get("archived_only"), default=False)
         # Exact-title lookup (`hermes peer dm` -> canonical "Bot Chat"). include_hidden is honored
         # ONLY with a title filter: a blanket hidden listing stays off this client surface.
         title_filter = (request.query.get("title") or "").strip() or None
@@ -2743,6 +2746,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             rows = await asyncio.to_thread(
                 db.list_sessions_rich, source=source, limit=limit, offset=offset,
                 include_children=include_children, order_by_last_active=True, include_pinned=True,
+                archived_only=archived_only,
                 search_query=title_filter, include_hidden=include_hidden)
             if title_filter:
                 rows = [s for s in rows if (s.get("title") or "").strip() == title_filter]

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -891,3 +891,29 @@ async def test_patch_session_still_rejects_unknown_fields(adapter, session_db):
         resp = await cli.patch(f"/api/sessions/{session_id}", json={"nonsense": 1})
         assert resp.status == 400, await resp.text()
         assert (await resp.json())["error"]["code"] == "unsupported_session_field"
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_archived_only_shows_the_archived_rows(adapter, session_db):
+    """``?archived_only=true`` lists what the default list hides.
+
+    ``archived`` is a client-facing flag: PATCH sets it, ``_session_response``
+    returns it, and the default list filters on it. Without a way to LIST the
+    archived rows a client can archive a chat and never see it again — no
+    "archive" or "trash" view is possible over this API. ``SessionDB`` already
+    takes ``archived_only``; this only exposes it.
+    """
+    session_db.create_session("kept", "api_server")
+    session_db.create_session("binned", "api_server")
+    session_db.set_session_archived("binned", True)
+    app = _create_session_app(adapter)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/api/sessions?archived_only=true")
+        assert resp.status == 200, await resp.text()
+        body = await resp.json()
+        assert [s["id"] for s in body["data"]] == ["binned"]
+        assert body["data"][0]["archived"] is True
+
+        resp = await cli.get("/api/sessions")
+        assert [s["id"] for s in (await resp.json())["data"]] == ["kept"]


### PR DESCRIPTION
## What

`GET /api/sessions` gains one optional query parameter, `archived_only=true`, which lists only the sessions the client archived.

## Why

`archived` is already a client-facing flag: `PATCH /api/sessions/{id}` sets it, `_session_response` returns it, and the default listing hides rows that carry it. What a client could not do was **list** what it archived, so an archive or trash view was impossible over this API: a chat archived by mistake was gone from every list.

`SessionDB.list_sessions_rich` already takes `archived_only`; this exposes it as a query parameter, parsed with `_coerce_request_bool` the same way `include_children` is. Default is `false`, so existing clients see no change.

## Test

`tests/gateway/test_session_api.py::test_list_sessions_archived_only_shows_the_archived_rows` — archives one of two sessions, asserts the default list shows the other one and `?archived_only=true` shows only the archived one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BH91MXt379P8AGqCzWpbg
