### PR TITLE
feat(desktop): configure Bot Mode group member limits

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
@@ -45,7 +45,14 @@ import { $selectedBot } from './bot-state'
 import { createCanonicalChat } from './canonical-chat'
 import { $botMeta, botHandle, botRosterKey, filterBots, ROSTER_KEY, saveBotMeta } from './data'
 import { labeled, ResizableFrame } from './dialog-parts'
-import { GROUP_CHAT_MAX_MEMBERS, mintGroupRoomId, uniqueGroupChatName, updateGroupChat } from './group-chat'
+import {
+  GROUP_CHAT_MAX_MEMBERS,
+  GROUP_CHAT_MEMBER_LIMIT_CEILING,
+  mintGroupRoomId,
+  resolveGroupChatMemberLimit,
+  uniqueGroupChatName,
+  updateGroupChat
+} from './group-chat'
 import type { GroupChatRoom } from './group-chat'
 import { GroupImageControls } from './group-chat-parts'
 import {
@@ -1132,6 +1139,7 @@ export function CreateGroupChatDialog({ open, roster, onClose, onCreated }: Crea
   const [checked, setChecked] = useState<Record<string, boolean>>({})
   const [name, setName] = useState('')
   const [image, setImage] = useState<null | string>(null)
+  const [memberLimitInput, setMemberLimitInput] = useState(String(GROUP_CHAT_MAX_MEMBERS))
 
   // Reset per open so a cancelled draft doesn't leak into the next one.
   useEffect(() => {
@@ -1140,6 +1148,7 @@ export function CreateGroupChatDialog({ open, roster, onClose, onCreated }: Crea
       setChecked({})
       setName('')
       setImage(null)
+      setMemberLimitInput(String(GROUP_CHAT_MAX_MEMBERS))
     }
   }, [open])
 
@@ -1148,18 +1157,19 @@ export function CreateGroupChatDialog({ open, roster, onClose, onCreated }: Crea
   const selectableRoster = roster.filter(bot => !bot?.ghost)
   const selected = selectableRoster.filter(bot => checked[botRosterKey(bot)])
   const visible: RosterRow[] = filterBots(selectableRoster, allMeta, query)
-  const atCap = selected.length >= GROUP_CHAT_MAX_MEMBERS
+  const memberLimit = resolveGroupChatMemberLimit(memberLimitInput)
+  const atCap = selected.length >= memberLimit
 
   const placeholder = selected.length
     ? selected.map(bot => displayName(bot, botRosterMeta(bot, allMeta))).join(', ')
     : b.group.nameLabel
 
-  const canCreate = selected.length >= 2 && Boolean(name.trim() || selected.length)
+  const canCreate = selected.length >= 2 && selected.length <= memberLimit && Boolean(name.trim() || selected.length)
 
   const create = () => {
     const base = (name.trim() || placeholder).slice(0, 64)
 
-    if (selected.length < 2 || !base) {
+    if (selected.length < 2 || selected.length > memberLimit || !base) {
       return
     }
 
@@ -1192,6 +1202,7 @@ export function CreateGroupChatDialog({ open, roster, onClose, onCreated }: Crea
     const roomMembers = durableGroupChatMembers(selected)
     updateGroupChat(groupName, (room: GroupChatRoom) => {
       room.members = roomMembers
+      room.memberLimit = memberLimit
       room.roomId = roomId
 
       if (image) {
@@ -1220,8 +1231,25 @@ export function CreateGroupChatDialog({ open, roster, onClose, onCreated }: Crea
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{b.group.newTitle}</DialogTitle>
-          <DialogDescription>{`Pick 2–${GROUP_CHAT_MAX_MEMBERS} bots. Local memberships sync through each Bot profile; cross-machine members stay scoped to this room.`}</DialogDescription>
+          <DialogDescription>{`Pick 2–${memberLimit} bots. Local memberships sync through each Bot profile; cross-machine members stay scoped to this room.`}</DialogDescription>
         </DialogHeader>
+        <label className="grid grid-cols-[1fr_5rem] items-center gap-3 text-xs text-(--ui-text-secondary)">
+          <span>
+            Maximum bots
+            <span className="block text-[0.625rem] text-(--ui-text-quaternary)">
+              Default {GROUP_CHAT_MAX_MEMBERS}, maximum {GROUP_CHAT_MEMBER_LIMIT_CEILING}
+            </span>
+          </span>
+          <Input
+            aria-label="Maximum bots"
+            max={GROUP_CHAT_MEMBER_LIMIT_CEILING}
+            min={2}
+            onBlur={() => setMemberLimitInput(String(memberLimit))}
+            onChange={event => setMemberLimitInput(event.target.value)}
+            type="number"
+            value={memberLimitInput}
+          />
+        </label>
         {/* TODO(bot-mode-types): this search box never takes focus when the dialog
             opens — SearchField accepts no `autoFocus` prop and forwards no extra
             props, so the `autoFocus` that used to sit here was inert. */}
@@ -1343,7 +1371,13 @@ export function CreateGroupChatDialog({ open, roster, onClose, onCreated }: Crea
           <Button
             disabled={!canCreate}
             onClick={create}
-            title={selected.length < 2 ? 'Pick at least 2 bots' : undefined}
+            title={
+              selected.length < 2
+                ? 'Pick at least 2 bots'
+                : selected.length > memberLimit
+                  ? `Reduce the selection to ${memberLimit} bots`
+                  : undefined
+            }
           >{`Create Group${selected.length ? ` (${selected.length})` : ''}`}</Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/desktop/src/plugins/hermes-bots/create-group-chat-dialog.picker-row-truncate.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-group-chat-dialog.picker-row-truncate.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import type * as HermesSdk from '@hermes/plugin-sdk'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { translateBots } from './i18n-test-helper'
@@ -45,6 +45,11 @@ const roster: RosterRow[] = [
   { connectionId: 'local', display_name: LONG_NAME, name: 'long-bot' },
   { connectionId: 'local', name: 'short' }
 ]
+
+const sevenBots: RosterRow[] = Array.from({ length: 7 }, (_, index) => ({
+  connectionId: 'local',
+  name: `bot-${index + 1}`
+}))
 
 beforeAll(async () => {
   // Radix Dialog reaches for APIs jsdom does not implement.
@@ -85,5 +90,34 @@ describe('CreateGroupChatDialog picker rows', () => {
     for (const row of labels) {
       expect(row!.className.split(/\s+/)).toContain('min-w-0')
     }
+  })
+
+  it('allows a seventh bot only after the room limit is raised', async () => {
+    const { CreateGroupChatDialog } = await import('./create-dialog')
+    const onCreated = vi.fn()
+
+    render(<CreateGroupChatDialog onClose={() => undefined} onCreated={onCreated} open roster={sevenBots} />)
+
+    const boxes = screen.getAllByRole('checkbox') as HTMLButtonElement[]
+
+    for (const box of boxes.slice(0, 6)) {
+      fireEvent.click(box)
+    }
+
+    expect(screen.getByText(/Pick 2–6 bots/)).toBeTruthy()
+    expect(boxes[6].disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('Maximum bots'), { target: { value: '7' } })
+    expect(screen.getByText(/Pick 2–7 bots/)).toBeTruthy()
+    expect(boxes[6].disabled).toBe(false)
+    fireEvent.click(boxes[6])
+    fireEvent.click(screen.getByRole('button', { name: 'Create Group (7)' }))
+
+    const chat = await import('./group-chat')
+    const created = Object.values(chat.$groupChats.get()).at(-1)
+
+    expect(onCreated).toHaveBeenCalledTimes(1)
+    expect(created?.members).toHaveLength(7)
+    expect(created?.memberLimit).toBe(7)
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
@@ -82,6 +82,48 @@ describe('log window', () => {
   })
 })
 
+describe('room member limit', () => {
+  it('keeps the shipped default and clamps configured values to the safety ceiling', async () => {
+    const { chat } = await loadRoom()
+
+    expect(chat.resolveGroupChatMemberLimit(undefined)).toBe(6)
+    expect(chat.resolveGroupChatMemberLimit(true)).toBe(6)
+    expect(chat.resolveGroupChatMemberLimit(1)).toBe(6)
+    expect(chat.resolveGroupChatMemberLimit('7')).toBe(7)
+    expect(chat.resolveGroupChatMemberLimit(99)).toBe(24)
+  })
+
+  it('uses the room limit for the synchronized member projection', async () => {
+    const { chat } = await loadRoom()
+    const members = Array.from({ length: 7 }, (_, index) => ({ name: `bot-${index}` }))
+
+    const room = (memberLimit?: number) => ({
+      log: [{ at: 1, from: { kind: 'user' as const, name: 'You' }, text: 'plan' }],
+      members,
+      memberLimit,
+      watermarks: {}
+    })
+
+    const defaultSnapshot = chat.groupChatSyncSnapshot({ Default: room() })
+    const configuredSnapshot = chat.groupChatSyncSnapshot({ Configured: room(7) })
+    const defaultRoom = Object.values(defaultSnapshot.rooms)[0]
+    const configuredRoom = Object.values(configuredSnapshot.rooms)[0]
+
+    expect(defaultRoom.members).toHaveLength(6)
+    expect(defaultRoom.memberLimit).toBeUndefined()
+    expect(configuredRoom.members).toHaveLength(7)
+    expect(configuredRoom.memberLimit).toBe(7)
+
+    const durable = chat.durableGroupChatRooms({ Configured: room(7) })
+    const reloaded = chat.mergeRemoteGroupChatSnapshotIntoRooms(configuredSnapshot, {})
+
+    expect(durable.Configured.members).toHaveLength(7)
+    expect(durable.Configured.memberLimit).toBe(7)
+    expect(reloaded.Configured.members).toHaveLength(7)
+    expect(reloaded.Configured.memberLimit).toBe(7)
+  })
+})
+
 describe('room naming', () => {
   it('same-name dedup reserves suffix length at the 64-char cap', async () => {
     const { chat } = await loadRoom()

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -58,6 +58,7 @@ let groupChatSyncTimer: ReturnType<typeof setTimeout> | null = null
 interface GroupChatSyncRoom {
   image?: null | string
   log: GroupMessage[]
+  memberLimit?: number
   members?: GroupMember[]
   name?: string
   revision?: number
@@ -214,6 +215,8 @@ export function groupChatSyncSnapshot(
   }
 
   for (const [name, room] of ranked) {
+    const memberLimit = resolveGroupChatMemberLimit(room.memberLimit)
+
     const log: GroupMessage[] = room.log.slice(-GROUP_CHAT_SYNC_MESSAGES).map(entry => ({
       ...(entry?.id
         ? {
@@ -247,7 +250,8 @@ export function groupChatSyncSnapshot(
         : {}),
       log,
       revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
-      members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
+      ...(durableGroupChatMemberLimit(room.memberLimit) ? { memberLimit } : {}),
+      members: (Array.isArray(room.members) ? room.members : []).slice(0, memberLimit).map(member => ({
         name: String(member?.name || '').slice(0, 128),
         ...(member?.handle
           ? {
@@ -471,6 +475,9 @@ export function mergeGroupChatSyncSnapshots(
       }),
       members,
       revision: Math.max(remoteRevision, localRevision),
+      ...(durableGroupChatMemberLimit(identity?.memberLimit)
+        ? { memberLimit: resolveGroupChatMemberLimit(identity?.memberLimit) }
+        : {}),
       ...(typeof image === 'string' && image
         ? {
             image
@@ -605,7 +612,8 @@ export function mergeRemoteGroupChatSnapshotIntoRooms(
       continue
     }
 
-    const existing = (localName ? rooms[localName] : rooms[displayName]) || {}
+    const existingRoom = localName ? rooms[localName] : rooms[displayName]
+    const existing = existingRoom || {}
     const remoteRevision = Math.max(0, Number(projected.revision || 0))
     const localRevision = Math.max(0, Number(existing.syncRevision || 0))
 
@@ -630,6 +638,12 @@ export function mergeRemoteGroupChatSnapshotIntoRooms(
     }
 
     const isPreserved = preserved.has(displayName) || (localName && preserved.has(localName))
+
+    const memberLimit = durableGroupChatMemberLimit(
+      isPreserved || remoteRevision < localRevision || (remoteRevision === localRevision && existingRoom)
+        ? existing.memberLimit
+        : projected.memberLimit
+    )
 
     if (!isPreserved) {
       if (remoteRevision > localRevision) {
@@ -670,6 +684,7 @@ export function mergeRemoteGroupChatSnapshotIntoRooms(
       sessions: existing.sessions && typeof existing.sessions === 'object' ? existing.sessions : {},
       stranded: existing.stranded && typeof existing.stranded === 'object' ? existing.stranded : {},
       members: [...members.values()],
+      ...(memberLimit ? { memberLimit } : {}),
       ...(projectedRoomId || existing.roomId
         ? {
             roomId: existing.roomId || projectedRoomId
@@ -742,6 +757,7 @@ export function durableGroupChatRooms(all: Record<string, GroupChat> = $groupCha
       sessions: room.sessions || {},
       stranded: room.stranded || {},
       members: Array.isArray(room.members) ? room.members : [],
+      memberLimit: durableGroupChatMemberLimit(room.memberLimit),
       // Immutable room identity: without this, a room merged in via the
       // remote-sync path (the only caller of this function) loses its
       // roomId on the next cold hydrate and falls back to legacy
@@ -1214,6 +1230,29 @@ export const GROUP_CHAT_MAX_MESSAGES = 10
 export const GROUP_CHAT_MAX_CONTINUATIONS = 2
 export const GROUP_CHAT_HISTORY_LIMIT = 24
 export const GROUP_CHAT_MAX_MEMBERS = 6
+export const GROUP_CHAT_MEMBER_LIMIT_CEILING = 24
+
+/** Resolve untrusted persisted/UI input to the room's bounded member cap. */
+export function resolveGroupChatMemberLimit(value: unknown): number {
+  if (typeof value === 'boolean' || value === null || value === undefined || value === '') {
+    return GROUP_CHAT_MAX_MEMBERS
+  }
+
+  const numeric = Number(value)
+
+  if (!Number.isFinite(numeric) || numeric < 2) {
+    return GROUP_CHAT_MAX_MEMBERS
+  }
+
+  return Math.min(GROUP_CHAT_MEMBER_LIMIT_CEILING, Math.floor(numeric))
+}
+
+/** Omit the default from durable/sync state so old rooms stay byte-compatible. */
+export function durableGroupChatMemberLimit(value: unknown): number | undefined {
+  const resolved = resolveGroupChatMemberLimit(value)
+
+  return resolved === GROUP_CHAT_MAX_MEMBERS ? undefined : resolved
+}
 
 /** Transcript form of a room speaker's profile name. Friendly identity wins:
  *  a Bot Mode title or a core profile display_name (e.g. default renamed to
@@ -1346,6 +1385,7 @@ export function updateGroupChat(
         // Source-qualified member descriptors keep the room whole when the
         // active connection changes and today's local members become remote.
         members: Array.isArray(room.members) ? room.members : [],
+        memberLimit: durableGroupChatMemberLimit(room.memberLimit),
         // Immutable room identity: the member-session title for new rooms.
         roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
         // Room picture (small data URL, same normalization as bot avatars).

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -47,6 +47,7 @@ import {
   $groupChats,
   $groupChatWorkspace,
   assignLegacyThreads,
+  durableGroupChatMemberLimit,
   handleSessionsGatewayTransition,
   pullGroupChatServerState,
   scheduleGroupChatServerSync,
@@ -244,6 +245,7 @@ export default {
                   // window restarts until explicitly released.
                   holds: room.holds && typeof room.holds === 'object' ? room.holds : {},
                   members: Array.isArray(room.members) ? room.members : [],
+                  memberLimit: durableGroupChatMemberLimit(room.memberLimit),
                   roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
                   image: typeof room.image === 'string' && room.image ? room.image : null,
                   rosterOrder: Number.isFinite(room.rosterOrder) ? room.rosterOrder : undefined,

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -163,6 +163,8 @@ export interface GroupChat {
   holds?: Record<string, GroupHold>
   image?: null | string
   log: GroupMessage[]
+  /** Per-room member cap. Missing keeps the shipped default. */
+  memberLimit?: number
   members?: GroupMember[]
   /** Immutable identity, so a rename doesn't fork the room. */
   roomId?: null | string

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -94,7 +94,7 @@ Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot
 
 Use the **Move up** and **Move down** arrows beside a room to choose its position among rooms. Until the first move, the existing pinned-first, recent-activity order is unchanged. After a move, room order is saved on this Desktop and survives reloads; new rooms follow the explicitly ordered rooms within their pinned or unpinned band. Moves cannot cross the pinned boundary, and filtering does not discard hidden rooms from the saved order. These controls reorder actual Group Chat rooms, not user-created Bot folders, and do not change membership or gateway ownership.
 
-**Open chat** on any group row (2–6 Bots) opens a shared room where the whole group coordinates:
+**Open chat** on any group row (2–6 Bots by default; configurable up to 24 when creating the room) opens a shared room where the whole group coordinates:
 
 - **One visible conversation.** Public messages and each member's reply stay readable in arrival order, with the speaker's name and timestamp. Starting another topic does not collapse earlier replies. **Reply in thread** continues that topic without reordering the room; **Activity** is a secondary status view, not a replacement for messages. Private Bot Chats remain separate.
 - Your message triggers up to **three serial rounds** of member turns. @-mentioned Bots respond (everyone responds when nobody is mentioned); each Bot replies briefly or passes, and the room settles when a full round stays silent.


### PR DESCRIPTION
## Summary

Bot Mode group creation hard-coded a six-member ceiling in both the picker and sync projection, so larger orchestration rooms could not be created and bypassing the UI silently dropped members. This adds a validated per-room member limit while retaining six as the default and clamping overrides to 24; the resolved value now drives creation, persistence, reload, and gateway synchronization.

---

## Changes

- `apps/desktop/src/plugins/hermes-bots/create-dialog.tsx`: add a bounded member-limit control and drive picker/create validation from it.
- `apps/desktop/src/plugins/hermes-bots/group-chat.ts`: resolve, persist, merge, and synchronize per-room limits without changing old-room defaults.
- `apps/desktop/src/plugins/hermes-bots/plugin.tsx`: hydrate the durable limit from stored room state.
- `apps/desktop/src/plugins/hermes-bots/types.ts`: model the optional per-room limit.
- `apps/desktop/src/plugins/hermes-bots/group-chat.test.ts`: cover defaults, validation, clamping, projection, persistence, and reload.
- `apps/desktop/src/plugins/hermes-bots/create-group-chat-dialog.picker-row-truncate.test.tsx`: verify creating a seven-member room after raising the limit.
- `website/docs/user-guide/bot-mode.md`: document the configurable 24-member ceiling.

## How to Test

```text
node ../../node_modules/vitest/vitest.mjs run src/plugins/hermes-bots
# 63 files passed, 587 tests passed

NODE_OPTIONS=--max-old-space-size=2048 npm run typecheck
# passed

node ../../node_modules/eslint/bin/eslint.js <changed TypeScript files>
# passed, 0 warnings

ruff check .
# passed
```

## Checklist

- [x] Tests pass — 587/587
- [x] TypeScript typecheck passes
- [x] ESLint passes with zero warnings
- [x] Follows Conventional Commits
- [x] Changes scoped to this feature only
- [x] Cross-platform impact assessed — no platform-specific APIs
- [x] Existing six-member default and turn safety caps remain unchanged

## Risk & Impact

Low. The override is per room, defaults to the existing limit, and is bounded to 24; round, message, continuation, and history caps are unchanged.

Type: New feature

Closes: #105755
