### PR TITLE
feat(tts): add opt-in local speed mode

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1477,6 +1477,9 @@ platform_toolsets:
 # tts:
 #   provider: "gemini"
 #   speed: 1.0              # global speed multiplier (provider-specific overrides this)
+#   openai:
+#     speed: 1.0            # 0.25-4.0
+#     speed_mode: "forward" # "local" preserves pitch with ffmpeg instead of forwarding speed
 #   gemini:
 #     model: "gemini-3.1-flash-tts-preview"
 #     voice: "Kore"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1010,6 +1010,8 @@ DEFAULT_CONFIG = {
             # gpt-4o-mini-tts voices: alloy, ash, ballad, cedar, coral, echo, fable, marin, nova,
             # onyx, sage, shimmer, verse
             "voice": "alloy",
+            # "forward" sends speed to the endpoint; "local" uses ffmpeg atempo instead.
+            "speed_mode": "forward",
         },
         "gemini": {
             "model": "gemini-2.5-flash-preview-tts",

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -1,6 +1,8 @@
 """Tests for TTS speed configuration across providers."""
 
 import asyncio
+from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -78,6 +80,78 @@ class TestOpenaiTtsSpeed:
         create = self._run({"speed": 10.0}, tmp_path, monkeypatch)
         kwargs = create.call_args[1]
         assert kwargs["speed"] == 4.0
+
+    def test_local_mode_synthesizes_at_normal_speed_then_processes(self, tmp_path, monkeypatch):
+        """Local mode omits endpoint speed and post-processes the completed file."""
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        output = tmp_path / "out.mp3"
+        mock_response = MagicMock()
+        mock_response.stream_to_file.side_effect = lambda path: Path(path).write_bytes(b"audio")
+        mock_client = MagicMock()
+        mock_client.audio.speech.create.return_value = mock_response
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_openai_client", return_value=mock_cls), \
+             patch("tools.tts_tool_openai._resolve_openai_audio_client_config",
+                   return_value=("test-key", None, False)), \
+             patch("tools.tts_tool._apply_local_tempo", return_value=str(output)) as apply_tempo:
+            from tools.tts_tool import _generate_openai_tts
+            result = _generate_openai_tts(
+                "Hello", str(output), {"openai": {"speed": 1.5, "speed_mode": "local"}})
+
+        assert result == str(output)
+        assert "speed" not in mock_client.audio.speech.create.call_args.kwargs
+        apply_tempo.assert_called_once_with(str(output), 1.5)
+
+
+class TestLocalOpenaiTempo:
+    @pytest.mark.parametrize(
+        "speed,expected",
+        [
+            (0.25, "atempo=0.5,atempo=0.5"),
+            (0.75, "atempo=0.75"),
+            (1.5, "atempo=1.5"),
+            (2.5, "atempo=2,atempo=1.25"),
+            (4.0, "atempo=2,atempo=2"),
+        ],
+    )
+    def test_filter_stages_stay_in_portable_range(self, speed, expected):
+        from tools.tts_tool_delivery import _build_atempo_filter
+        assert _build_atempo_filter(speed) == expected
+
+    def test_atomic_replace_and_failure_cleanup(self, tmp_path):
+        from tools.tts_tool_delivery import _apply_local_tempo
+
+        output = tmp_path / "out.mp3"
+        output.write_bytes(b"original")
+
+        with patch("tools.tts_tool_delivery.shutil.which", return_value=None), \
+             pytest.raises(RuntimeError, match="requires ffmpeg"):
+            _apply_local_tempo(str(output), 1.5)
+        assert output.read_bytes() == b"original"
+
+        def successful_run(_ffmpeg, args, **_kwargs):
+            Path(args[-1]).write_bytes(b"processed")
+            return CompletedProcess(args, 0, b"", b"")
+
+        with patch("tools.tts_tool_delivery.shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("tools.tts_tool_delivery._ffmpeg_run", side_effect=successful_run):
+            assert _apply_local_tempo(str(output), 1.5) == str(output)
+        assert output.read_bytes() == b"processed"
+        assert not list(tmp_path.glob(".*.atempo.mp3"))
+
+        output.write_bytes(b"original")
+
+        def failed_run(_ffmpeg, args, **_kwargs):
+            Path(args[-1]).write_bytes(b"partial")
+            return CompletedProcess(args, 1, b"", b"encoder failed")
+
+        with patch("tools.tts_tool_delivery.shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("tools.tts_tool_delivery._ffmpeg_run", side_effect=failed_run), \
+             pytest.raises(RuntimeError, match="encoder failed"):
+            _apply_local_tempo(str(output), 1.5)
+        assert output.read_bytes() == b"original"
+        assert not list(tmp_path.glob(".*.atempo.mp3"))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -48,8 +48,8 @@ from tools.tts_command_provider import (
     _get_command_tts_output_format, _is_command_tts_voice_compatible, _resolve_command_provider_config)
 from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER
 from tools.tts_tool_delivery import (
-    _resolve_max_text_length, _build_audio_delivery_files, _convert_to_opus, _remove_quietly,
-    _repair_ogg_container, _resolve_audio_delivery_profile, _split_text_for_tts)
+    _apply_local_tempo, _resolve_max_text_length, _build_audio_delivery_files, _convert_to_opus,
+    _remove_quietly, _repair_ogg_container, _resolve_audio_delivery_profile, _split_text_for_tts)
 from tools.tts_tool_providers import (
     _generate_edge_tts, _generate_elevenlabs, _generate_gemini_tts, _generate_minimax_tts,
     _generate_mistral_tts, _generate_xai_tts, _resolve_minimax_tts_runtime)

--- a/tools/tts_tool_delivery.py
+++ b/tools/tts_tool_delivery.py
@@ -9,6 +9,7 @@ helpers ``_origin`` / ``_section`` / ``_remove_quietly``.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import shlex
@@ -222,6 +223,69 @@ def _remove_quietly(path: Optional[str]) -> None:
             os.remove(path)
         except OSError:
             pass
+
+
+def _build_atempo_filter(speed: float) -> str:
+    """Build an ffmpeg ``atempo`` chain for any positive finite multiplier.
+
+    A single ``atempo`` stage is kept within the portable 0.5-2.0 range. This
+    matters for the full OpenAI TTS speed range (0.25-4.0), whose endpoints
+    require two stages when speed is applied locally.
+    """
+    if not math.isfinite(speed) or speed <= 0:
+        raise ValueError("TTS speed must be a positive finite number")
+    factors: List[float] = []
+    remaining = float(speed)
+    while remaining < 0.5:
+        factors.append(0.5)
+        remaining /= 0.5
+    while remaining > 2.0:
+        factors.append(2.0)
+        remaining /= 2.0
+    if not math.isclose(remaining, 1.0, rel_tol=1e-9, abs_tol=1e-9) or not factors:
+        factors.append(remaining)
+    return ",".join(f"atempo={factor:.8g}" for factor in factors)
+
+
+def _apply_local_tempo(input_path: str, speed: float) -> str:
+    """Apply pitch-preserving local tempo to *input_path*, replacing it atomically.
+
+    The original provider audio remains untouched when ffmpeg is unavailable or
+    processing fails. Local mode is explicit, so those failures are surfaced to
+    the caller instead of silently falling back to endpoint-side speed.
+    """
+    if math.isclose(speed, 1.0, rel_tol=1e-9, abs_tol=1e-9):
+        return input_path
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError(
+            "tts.openai.speed_mode 'local' requires ffmpeg on PATH; "
+            "install ffmpeg or use speed_mode: forward")
+
+    source = Path(input_path)
+    output_suffix = source.suffix or ".mp3"
+    temp_output = source.with_name(
+        f".{source.stem}.{uuid.uuid4().hex}.atempo{output_suffix}")
+    codec_args = _OPUS_VOICE_ARGS if output_suffix.lower() in {".ogg", ".opus"} else []
+    try:
+        result = _ffmpeg_run(
+            ffmpeg,
+            ["-y", "-loglevel", "error", "-i", str(source), "-vn", "-filter:a",
+             _build_atempo_filter(speed), *codec_args, str(temp_output)],
+            timeout=120,
+        )
+        if result.returncode != 0 or not temp_output.exists() or temp_output.stat().st_size == 0:
+            stderr = result.stderr.decode("utf-8", errors="ignore")[:300] if result.stderr else ""
+            detail = f": {stderr}" if stderr else ""
+            raise RuntimeError(f"ffmpeg local TTS speed processing failed{detail}")
+        os.replace(temp_output, source)
+        return input_path
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("ffmpeg local TTS speed processing timed out after 120s") from exc
+    except OSError as exc:
+        raise RuntimeError(f"ffmpeg local TTS speed processing failed: {exc}") from exc
+    finally:
+        _remove_quietly(str(temp_output))
 
 
 def _wav_sidecar_path(output_path: str) -> str:

--- a/tools/tts_tool_openai.py
+++ b/tools/tts_tool_openai.py
@@ -82,7 +82,8 @@ def _has_openai_audio_backend() -> bool:
 def _generate_openai_tts(
     text: str, output_path: str, tts_config: Dict[str, Any], *, api_key: Optional[str] = None,
     base_url: Optional[str] = None, model: Optional[str] = None, voice: Optional[str] = None,
-    speed: Optional[float] = None, instructions: Optional[str] = None) -> str:
+    speed: Optional[float] = None, speed_mode: Optional[str] = None,
+    instructions: Optional[str] = None) -> str:
     """Generate audio via the OpenAI ``audio.speech.create`` SDK shape.
 
     Explicit kwargs let OpenAI-compatible backends (DeepInfra) supply credentials/model/voice
@@ -105,6 +106,11 @@ def _generate_openai_tts(
     if speed is None:
         speed_default = tts_config.get("speed", 1.0) if isinstance(tts_config, dict) else 1.0
         speed = float(oai_config.get("speed", speed_default))
+    speed = max(0.25, min(4.0, speed))
+    if speed_mode is None:
+        speed_mode = str(oai_config.get("speed_mode", "forward")).strip().lower()
+    if speed_mode not in {"forward", "local"}:
+        raise ValueError("tts.openai.speed_mode must be 'forward' or 'local'")
     # The managed gateway only proxies MANAGED_OPENAI_TTS_MODELS; coerce a direct-OpenAI
     # model (e.g. "tts-1-hd") unless the user redirected base_url to their own endpoint.
     if is_managed and not explicit_base_url and not config_base_url and model not in MANAGED_OPENAI_TTS_MODELS:
@@ -118,8 +124,8 @@ def _generate_openai_tts(
         "model": model, "voice": voice, "input": text,
         "response_format": _tts_response_format_from_path(output_path),
         "extra_headers": {"x-idempotency-key": str(uuid.uuid4())}}
-    if speed != 1.0:
-        create_kwargs["speed"] = max(0.25, min(4.0, speed))
+    if speed_mode == "forward" and speed != 1.0:
+        create_kwargs["speed"] = speed
     if instructions:
         create_kwargs["instructions"] = instructions
     if oai_config.get("language"):
@@ -127,11 +133,13 @@ def _generate_openai_tts(
     client = _origin()._import_openai_client()(api_key=api_key, base_url=base_url)
     try:
         client.audio.speech.create(**create_kwargs).stream_to_file(output_path)
-        return output_path
     finally:
         close = getattr(client, "close", None)
         if callable(close):
             close()
+    if speed_mode == "local" and speed != 1.0:
+        return _origin()._apply_local_tempo(output_path, speed)
+    return output_path
 
 
 def _generate_deepinfra_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
@@ -154,4 +162,4 @@ def _generate_deepinfra_tts(text: str, output_path: str, tts_config: Dict[str, A
     return _origin()._generate_openai_tts(
         text, output_path, tts_config, api_key=api_key, base_url=deepinfra_base_url(di_config),
         model=model, voice=di_config.get("voice", DEFAULT_DEEPINFRA_TTS_VOICE),
-        speed=float(di_config.get("speed", tts_config.get("speed", 1.0))))
+        speed=float(di_config.get("speed", tts_config.get("speed", 1.0))), speed_mode="forward")

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -57,6 +57,7 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
     speed: 1.0                  # 0.25 - 4.0
+    speed_mode: "forward"       # "local" applies pitch-preserving speed with ffmpeg
     # language: "es"            # Sent as lang_code — only for OpenAI-compatible endpoints that support it (e.g. Kokoro)
   minimax:
     region: "global"           # "global" or "cn"; see selection rules below
@@ -113,6 +114,8 @@ MiniMax TTS selects its region, endpoint, and credential together:
 - An explicitly selected region must have its matching credential. Hermes never borrows the other region's key. A `base_url` override does not change the selected credential, and an override pointing at the other region's official endpoint is rejected.
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
+
+OpenAI-compatible endpoints receive the speed value directly by default (`tts.openai.speed_mode: "forward"`). If an endpoint's own speed processing degrades audio quality, set `speed_mode: "local"`. Hermes will request normal-speed audio and apply the configured multiplier afterward with ffmpeg's pitch-preserving `atempo` filter. Local mode requires ffmpeg and reports an actionable error when processing cannot complete; it never silently falls back to endpoint-side speed.
 
 ### Gemini Persona Prompts
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in local speed mode for the whole-file OpenAI-compatible TTS path. Some compatible endpoints audibly degrade speech when their server-side `speed` parameter is above 1.0. With `tts.openai.speed_mode: "local"`, Hermes now requests normal-speed audio and applies the configured multiplier afterward with ffmpeg's pitch-preserving `atempo` filter.

The existing `forward` behavior remains the default. Local processing writes to a sibling temporary file and atomically replaces the provider output only after ffmpeg succeeds, so a failed conversion cannot destroy the original audio.

## Related Issue

Fixes #105872

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `tts.openai.speed_mode` with backward-compatible `forward` and opt-in `local` values.
- Suppress the endpoint `speed` argument in local mode, then run the completed audio through the existing cross-platform ffmpeg execution seam.
- Compose portable 0.5-2.0 `atempo` stages across the full OpenAI 0.25-4.0 speed range.
- Preserve other providers, including DeepInfra, on their existing forwarding behavior.
- Document the option in `cli-config.yaml.example` and the Voice & TTS guide.
- Cover request behavior, filter composition, missing ffmpeg, atomic replacement, failure preservation, and temporary-file cleanup.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_tts_speed.py`.
2. Run `scripts/run_tests.sh tests/tools/test_tts_openai_config.py tests/tools/test_tts_deepinfra.py tests/tools/test_tts_instructions.py`.
3. Configure an OpenAI-compatible endpoint with `speed: 1.5` and `speed_mode: "local"`; verify the request omits `speed` and the resulting file is shorter without a pitch shift.
4. Remove `speed_mode` (or set it to `forward`) and verify `speed: 1.5` is still forwarded to the endpoint.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (focused automated tests; ffmpeg was not installed for a live audio run)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — reuses the existing headless ffmpeg runner and portable file APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, this is an advanced config option and does not change the tool schema

## Screenshots / Logs

No UI change.

- `tests/tools/test_tts_speed.py`: 21 passed
- `tests/tools/test_tts_container_repair.py`: 8 passed, 1 skipped (ffmpeg unavailable)
- OpenAI config, DeepInfra isolation, and instruction forwarding: 15 passed
- Managed OpenAI audio gateway subset: 2 passed
- `ruff check` on changed Python files: passed
