### PR TITLE
fix(observability): attribute subagent and curator execution surfaces

### DIFF
--- a/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json
+++ b/hermes_cli/observability/schemas/hermes.shared_metrics.v2.schema.json
@@ -395,11 +395,13 @@
         "api",
         "batch",
         "cli",
+        "curator",
         "desktop",
         "gateway",
         "other",
         "python",
         "scheduled_task",
+        "subagent",
         "tui",
         "unknown"
       ]

--- a/hermes_cli/observability/shared_metrics_contract.py
+++ b/hermes_cli/observability/shared_metrics_contract.py
@@ -38,8 +38,8 @@ _METRIC_IDENTIFIER_CHARACTERS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789.
 _METRIC_IDENTIFIER_START_CHARACTERS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789")
 
 EXECUTION_SURFACES = frozenset({
-    "acp", "api", "batch", "cli", "desktop", "gateway", "python", "scheduled_task", "tui",
-    "other", "unknown",
+    "acp", "api", "batch", "cli", "curator", "desktop", "gateway", "python", "scheduled_task",
+    "subagent", "tui", "other", "unknown",
 })
 TASK_OUTCOMES = frozenset({"cancelled", "failed", "success", "timed_out", "unknown"})
 TASK_END_REASONS = frozenset({
@@ -425,6 +425,13 @@ _SURFACE_ENTRYPOINTS = {
     **dict.fromkeys(("acp", "cli", "desktop", "tui"), "interactive"),
     **{s: s for s in ("api", "batch", "python", "scheduled_task", "unknown")},
     "gateway": "gateway_message",
+    # A subagent fork always carries parent_session_id, so task_entrypoint's own
+    # parent_session_id check resolves this first in practice -- declared anyway so
+    # the surface->entrypoint mapping does not depend on that incidental rescue.
+    "subagent": "delegated",
+    # The curator fork is autonomous background curation (agent/curator.py), not a
+    # human-driven surface and not delegated from a parent turn.
+    "curator": "background",
 }
 
 

--- a/tests/hermes_cli/test_shared_metrics_surface_attribution.py
+++ b/tests/hermes_cli/test_shared_metrics_surface_attribution.py
@@ -52,7 +52,7 @@ def test_batch_runs_declare_their_surface():
 
 @pytest.mark.parametrize(
     "platform",
-    ["cli", "tui", "desktop", "batch", "acp", "api_server", "cron", "telegram"],
+    ["cli", "tui", "desktop", "batch", "acp", "api_server", "cron", "telegram", "subagent", "curator"],
 )
 def test_declared_platforms_resolve_to_a_named_surface(platform):
     """No production construction path should resolve to unknown/other.
@@ -65,6 +65,43 @@ def test_declared_platforms_resolve_to_a_named_surface(platform):
         f"platform={platform!r} resolves to {surface!r}; a real surface is being "
         "folded into the catch-all bucket"
     )
+
+
+def test_subagent_forks_get_their_own_surface():
+    """tools/delegate_tool.py builds every subagent child with platform="subagent".
+
+    If that value is not an accepted surface, every subagent delegation task run
+    is folded into "other" instead of being attributable as delegation traffic.
+    """
+    assert contract.execution_surface({"platform": "subagent"}) == "subagent"
+
+
+def test_subagent_forks_are_delegated():
+    """A subagent's task_start_fields must resolve to the "delegated" entrypoint.
+
+    delegate_tool.py always sets parent_session_id on the fork, so task_entrypoint's
+    own parent_session_id check resolves this first in practice -- this pins the
+    _SURFACE_ENTRYPOINTS mapping too, so the classification does not silently depend
+    on that incidental rescue.
+    """
+    fields = contract.task_start_fields({"platform": "subagent", "parent_session_id": "parent-1"})
+    assert fields["entrypoint"] == "delegated"
+    assert fields["execution_surface"] == "subagent"
+    # Without parent_session_id (e.g. a bare/test construction), the mapping in
+    # _SURFACE_ENTRYPOINTS is what carries the classification.
+    assert contract.task_start_fields({"platform": "subagent"})["entrypoint"] == "delegated"
+
+
+def test_curator_forks_get_their_own_surface():
+    """agent/curator.py builds its review fork with platform="curator".
+
+    curator forks carry no parent_session_id (they are not a delegated child of a
+    live turn), so an undeclared surface here folds BOTH execution_surface and
+    entrypoint into "other", losing curator activity from analytics entirely.
+    """
+    fields = contract.task_start_fields({"platform": "curator"})
+    assert fields["execution_surface"] == "curator"
+    assert fields["entrypoint"] == "background"
 
 
 def test_unattributed_runs_still_report_unknown():


### PR DESCRIPTION
## What does this PR do?

Extends the same-day fix in #106194 ("attribute ACP and batch execution surfaces") to two more construction paths with the identical declaration-gap shape: `tools/delegate_tool.py`'s subagent forks (`platform="subagent"`) and `agent/curator.py`'s curator fork (`platform="curator"`). Neither value was in the closed `EXECUTION_SURFACES` schema, so both silently folded into the `"other"` catch-all bucket instead of being attributable.

## Problem

`hermes_cli/observability/shared_metrics_contract.py::execution_surface()` normalizes an unrecognized `platform` string to `"other"`. That is correct behavior for a bounded schema, but it means a construction site that already declares a real, distinct surface still gets silently mis-attributed if the schema hasn't caught up:

1. Every subagent delegation (`tools/delegate_tool.py`) constructs its child `AIAgent` with `platform="subagent"` — `agent/turn_facade.py` even special-cases this literal by name for relay parent-session tagging — but `"subagent"` was never added to `EXECUTION_SURFACES`.
2. `agent/curator.py`'s review fork declares `platform="curator"`. Unlike a subagent, a curator fork carries no `parent_session_id`, so it isn't rescued by `task_entrypoint()`'s own delegation check either — both its `execution_surface` **and** `entrypoint` folded into `"other"`, losing curator activity from fleet telemetry entirely.

Verified empirically before the fix:
```python
>>> task_start_fields({"platform": "subagent", "parent_session_id": "abc"})
{'entrypoint': 'delegated', 'execution_surface': 'other'}
>>> task_start_fields({"platform": "curator"})
{'entrypoint': 'other', 'execution_surface': 'other'}
```

## Fix

- Add `"subagent"` and `"curator"` to `EXECUTION_SURFACES` and to the v2 wire schema enum (kept in sync by the existing `test_package_schema_matches_the_task_contract`).
- Map their entrypoints explicitly in `_SURFACE_ENTRYPOINTS`: `"subagent" -> "delegated"`, `"curator" -> "background"`. Subagent's entrypoint is already rescued by `task_entrypoint()`'s `parent_session_id` check in practice, but declaring it explicitly means the classification doesn't silently depend on that incidental path (and matches curator, which has no such rescue).

No wire-compatibility concern: the ingest service validates the envelope only and stores metric bodies verbatim, matching the precedent set by #106194.

## Testing

Extended `tests/hermes_cli/test_shared_metrics_surface_attribution.py` (the test file #106194 introduced for exactly this contract) with `subagent`/`curator` cases, mirroring its existing ACP tests.

- `uv run --frozen python -m pytest tests/hermes_cli/test_shared_metrics_surface_attribution.py tests/hermes_cli/test_relay_shared_metrics.py -q` → 125 passed
- Mutation-verified: reverting the two production files (`shared_metrics_contract.py`, the v2 schema) drops exactly 5 assertions (120 passed / 5 failed); reapplying restores green.
- `ruff check` clean on all three changed files.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
