### PR TITLE
fix(cli): a failed `hermes -z --resume` no longer leaks the session store (follow-up #106313)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -396,9 +396,13 @@ def _apply_stored_session_runtime(
     if route is None:
         return choice
     choice.model, stored_provider, stored_base_url, stored_api_mode, provider_changed = route
-    if provider_changed:
+    # Same application order as _restore_session_model: a stored provider carries its base_url
+    # even when it matches the ambient provider (a custom endpoint whose config URL moved).
+    if stored_provider:
         choice.provider = stored_provider
-        choice.base_url = stored_base_url
+        if stored_base_url:
+            choice.base_url = stored_base_url
+    if provider_changed:
         choice.api_key = None
     if stored_api_mode:
         choice.api_mode = str(stored_api_mode)
@@ -427,38 +431,39 @@ def _run_agent(
     # replace the ambient config (see _apply_stored_session_runtime) and the ended row must
     # be reopened before the agent can stamp a new lifecycle boundary.
     session_db = _create_session_db_for_oneshot()
-    resume_sid, conversation_history, resume_meta = _load_resume_target(session_db, resume)
-    choice = _apply_stored_session_runtime(choice, resume_meta, explicit_model=bool((model or "").strip()))
-    runtime = resolve_runtime_provider(
-        requested=choice.provider,
-        target_model=choice.model or None,
-        explicit_base_url=choice.base_url,
-        explicit_api_key=choice.api_key,
-    )
-    if choice.api_mode:
-        runtime["api_mode"] = choice.api_mode
-
-    # sorted() gives stable ordering for config-derived sets; explicit values preserve user order.
-    toolsets_list = _normalize_toolsets(toolsets)
-    if toolsets_list is None and use_config_toolsets:
-        toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
-
-    # Oneshot builds AIAgent directly, bypassing cli.py's MCP background discovery and
-    # _init_agent's wait, so the construction-time tool snapshot would miss late MCP servers.
-    # Idempotent start + bounded wait with the single-query bound (there is no later turn).
-    # Ensure MCP tools are discovered before building the agent. This helper starts discovery if needed
-    # (idempotent) and bounded-waits with the larger single-query bound (default 15s) because there is only
-    # ONE turn and no between-turns late-binding refresh (#38448).
-    from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
-
-    ensure_mcp_discovery_before_agent_build(logger=logging.getLogger(__name__), single_query=True)
-
-    skills_prompt = _build_preloaded_skills_prompt(skills)
-
-    # The try spans agent construction (not just ``chat``) so the store is always closed, even when
-    # ``AIAgent(...)`` raises — the one-shot exit path hard-exits via os._exit and skips finalizers.
+    # The try spans everything from store creation through ``chat`` so the store is always
+    # closed: resume resolution, provider resolution and ``AIAgent(...)`` can all raise, and the
+    # one-shot exit path hard-exits via os._exit and skips finalizers.
     agent = None
     try:
+        resume_sid, conversation_history, resume_meta = _load_resume_target(session_db, resume)
+        choice = _apply_stored_session_runtime(choice, resume_meta, explicit_model=bool((model or "").strip()))
+        runtime = resolve_runtime_provider(
+            requested=choice.provider,
+            target_model=choice.model or None,
+            explicit_base_url=choice.base_url,
+            explicit_api_key=choice.api_key,
+        )
+        if choice.api_mode:
+            runtime["api_mode"] = choice.api_mode
+
+        # sorted() gives stable ordering for config-derived sets; explicit values preserve user order.
+        toolsets_list = _normalize_toolsets(toolsets)
+        if toolsets_list is None and use_config_toolsets:
+            toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
+
+        # Oneshot builds AIAgent directly, bypassing cli.py's MCP background discovery and
+        # _init_agent's wait, so the construction-time tool snapshot would miss late MCP servers.
+        # Idempotent start + bounded wait with the single-query bound (there is no later turn).
+        # Ensure MCP tools are discovered before building the agent. This helper starts discovery if needed
+        # (idempotent) and bounded-waits with the larger single-query bound (default 15s) because there is only
+        # ONE turn and no between-turns late-binding refresh (#38448).
+        from hermes_cli.mcp_startup import ensure_mcp_discovery_before_agent_build
+
+        ensure_mcp_discovery_before_agent_build(logger=logging.getLogger(__name__), single_query=True)
+
+        skills_prompt = _build_preloaded_skills_prompt(skills)
+
         agent = AIAgent(
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),

--- a/tests/hermes_cli/test_oneshot_resume.py
+++ b/tests/hermes_cli/test_oneshot_resume.py
@@ -216,6 +216,26 @@ class TestRunAgentResumeRuntime:
         finally:
             db.close()
 
+    def test_run_agent_closes_store_when_resume_target_is_unknown(self, tmp_path, monkeypatch):
+        """A failed resume must not leak the SessionDB: the one-shot exit is os._exit, so nothing
+        else ever closes it."""
+        import hermes_cli.oneshot as oneshot_mod
+
+        closed = []
+
+        class _Store(SessionDB):
+            def close(self):
+                closed.append(True)
+                super().close()
+
+        db = _Store(db_path=tmp_path / "state.db")
+        monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: db)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {"default": "m", "provider": "openrouter"}})
+
+        with pytest.raises(RuntimeError, match="session not found"):
+            oneshot_mod._run_agent("hello", resume="missing-sid")
+        assert closed, "SessionDB left open after the resume failure"
+
     def test_run_agent_explicit_model_beats_stored_runtime(self, tmp_path, monkeypatch):
         import hermes_cli.oneshot as oneshot_mod
 


### PR DESCRIPTION
Follow-up to #106313 (salvage of #105957); both items surfaced in the post-merge review pass.

- `hermes_cli/oneshot.py::_run_agent`: `_create_session_db_for_oneshot()` had moved ahead of the `try/finally` that closes it, so an unknown `--resume` target (or a provider-resolution error) left the SQLite handle open — and the one-shot exit is `os._exit`, so nothing else ever closed it. The `try` now spans from store creation through `chat`.
- `_apply_stored_session_runtime` applied the stored `base_url` only when the provider changed; the interactive `_restore_session_model` applies it whenever a provider is stored (a `custom:x` endpoint whose config URL moved). Both paths now apply the route in the same order.

Validation: 42 tests green (oneshot/resume/model-restore); new invariant `test_run_agent_closes_store_when_resume_target_is_unknown` fails on `main`'s `oneshot.py`.
