### PR TITLE
fix(cli): stamp cwd and git_repo_root on --create-if-missing session mints

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1327,7 +1327,25 @@ def _create_titled_session(title: str) -> Optional[str]:
 
         new_session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{_uuid.uuid4().hex[:6]}"
         db = SessionDB()
-        db.create_session(new_session_id, source="cli")
+        # Same workspace stamping as a normal new session: the mint must carry the
+        # invocation directory, otherwise the session lands in Desktop's top-level
+        # Home bucket instead of the project that owns it, and workspace-scoped
+        # lookups ("--resume latest --in <dir>") never find it. os.getcwd() is
+        # correct here: _apply_in_dir() runs before _resolve_continue_arg(), so
+        # it already reflects --in <dir>.
+        # git_repo_root parity: normal new sessions stamp the repo root so
+        # workspace grouping keys off the repo, not the leaf directory; the
+        # mint must not fragment history the same way. Fail-soft: outside a
+        # repo the column stays NULL and cwd carries the grouping.
+        try:
+            from hermes_cli.worktree_ops import _git_repo_root
+
+            _repo_root = _git_repo_root()
+        except Exception:
+            _repo_root = None
+        db.create_session(
+            new_session_id, source="cli", cwd=os.getcwd(), git_repo_root=_repo_root
+        )
         db.set_session_title(new_session_id, title)
         return new_session_id
     except Exception:

--- a/tests/hermes_cli/test_chat_c_fail_loudly.py
+++ b/tests/hermes_cli/test_chat_c_fail_loudly.py
@@ -86,6 +86,66 @@ class TestCreateTitledSession:
             db.close()
 
 
+class TestMintedSessionWorkspaceStamping:
+    """Regression for #106334: a --create-if-missing mint must record the
+    invocation directory, otherwise the session lands in Desktop's top-level
+    Home bucket (projectIdForCwd has no cwd to match) and workspace-scoped
+    lookups ("--resume latest --in <dir>") never find it."""
+
+    def test_minted_session_records_invocation_cwd(
+        self, isolated_home, tmp_path, monkeypatch
+    ):
+        work = tmp_path / "projectdir"
+        work.mkdir()
+        monkeypatch.chdir(work)
+
+        sid = _create_titled_session("my-stream")
+        assert sid
+
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            row = db.get_session(sid)
+            assert row is not None
+            assert (row.get("cwd") or "").strip(), "minted session should record cwd"
+            import os
+
+            assert os.path.realpath(row["cwd"]) == os.path.realpath(str(work))
+        finally:
+            db.close()
+
+    def test_minted_session_records_git_repo_root(
+        self, isolated_home, tmp_path, monkeypatch
+    ):
+        """Inside a git repo the mint carries git_repo_root too, so workspace
+        grouping (workspace_key prefers git_repo_root over cwd) matches a
+        normal new session created from the same directory."""
+        import subprocess
+
+        repo = tmp_path / "projrepo"
+        repo.mkdir()
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        monkeypatch.chdir(repo)
+
+        sid = _create_titled_session("my-stream")
+        assert sid
+
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            row = db.get_session(sid)
+            assert row is not None
+            import os
+
+            assert os.path.realpath(row.get("git_repo_root")) == os.path.realpath(
+                str(repo)
+            )
+        finally:
+            db.close()
+
+
 class TestChatCFailLoudlyOnStderr:
     """Behavior-level: run the real cmd_chat path and inspect channels."""
 


### PR DESCRIPTION
## Summary
- `--create-if-missing` mints (`chat -c <name> --create-if-missing`) created the session row without `cwd`/`git_repo_root`, so Desktop's project sidebar (`projectIdForCwd`) always bucketed them under Home, and workspace-scoped lookups (`--resume latest --in <dir>`) never found them (#106334).
- `_create_titled_session()` now stamps the mint like a normal new session: `cwd=os.getcwd()` (already reflects `--in <dir>` — `_apply_in_dir()` runs before `_resolve_continue_arg()`) and `git_repo_root` via the existing fail-soft `_git_repo_root()` helper, preserving `workspace_key` grouping parity.

## Testing
- Reproduced on pristine `main` (RED): fresh mint row has `cwd = NULL`, `git_repo_root = NULL`.
- With the fix (GREEN): invocation dir and repo root recorded; verified via live `_create_titled_session()` call + `SessionDB.get_session()` row inspection.
- Two regression tests in `tests/hermes_cli/test_chat_c_fail_loudly.py` (invocation cwd; `git init` repo → `git_repo_root`), both fail on unpatched main, pass with the fix.
- Mutation gate: dropping the kwargs / stamping a wrong cwd fails both tests.
- `ruff check` clean; `ruff format` drift on both files identical to main baseline (657 = 657; formatter touches only pre-existing lines).
- Full spec file: 8 passed.

Fixes #106334