### PR TITLE
fix(state): a quarantined handle no longer VACUUMs or optimizes FTS (salvage #102092, follow-up #106315)

### DIFF
--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -336,7 +336,14 @@ class SessionMaintenanceMixin:
         """VACUUM to reclaim space after large deletes (SQLite never shrinks on its own).
         Takes an exclusive lock — callers must ensure no other writers are active.  FTS5
         segments are merged first (:meth:`optimize_fts`) so their pages are reclaimed too;
-        returns the number of FTS indexes optimized (0 on merge failure / no FTS)."""
+        returns the number of FTS indexes optimized (0 on merge failure / no FTS). A quarantined
+        handle (corrupt image, replaced file, lost WAL generation) never checkpoints or rewrites
+        pages: the halt raised by ``optimize_fts`` would otherwise be swallowed below and the
+        VACUUM would proceed on the split-brain handle (#105670)."""
+        quarantine_reason = self._quarantine_reason()
+        if quarantine_reason is not None:
+            logger.warning("Skipping VACUUM for %s: this handle observed %s.", self.db_path, quarantine_reason)
+            return 0
         optimized = 0
         try:
             optimized = self.optimize_fts()  # manages its own lock

--- a/tests/hermes_state/test_deleted_wal_checkpoint_guard.py
+++ b/tests/hermes_state/test_deleted_wal_checkpoint_guard.py
@@ -62,7 +62,7 @@ def _unlink_sidecars(db_path: Path) -> None:
 
 @pytest.mark.linux_only  # deleted-WAL write halt uses Linux unlink semantics
 def test_close_after_halt_runs_no_checkpoint(tmp_path, force_wal):
-    """A writer halted by DeletedWalGenerationError must not checkpoint (periodic or close) nor run FTS repair."""
+    """A writer halted by DeletedWalGenerationError must not checkpoint (periodic, VACUUM or close) nor run FTS repair."""
     path = tmp_path / "state.db"
     db = _make_db(path, "s", "before")
     _require_wal(db)
@@ -72,11 +72,13 @@ def test_close_after_halt_runs_no_checkpoint(tmp_path, force_wal):
         db.append_message("s", role="user", content="after-unlink")
     assert db._db_wal_generation_lost is True
 
-    # Neither the periodic checkpoint, the stale-FTS retry, nor close() may touch the file now.
+    # Neither the periodic checkpoint, the stale-FTS retry, VACUUM, nor close() may touch the file now.
     with patch.object(db._conn, "execute", wraps=db._conn.execute) as mock_execute:
         db._try_wal_checkpoint()
         db._fts_stale = True
         assert db.retry_deferred_fts_recovery() is False
+        assert db.vacuum() == 0
+        assert not [c for c in mock_execute.call_args_list if "vacuum" in str(c).lower()], "VACUUM ran on a quarantined handle"
         db.close()
         # No checkpoint call should have been made.
         checkpoint_calls = [


### PR DESCRIPTION
`SessionDB.vacuum()` and `optimize_fts()` were the remaining ungated page-rewrite sites: a handle already quarantined (corrupt image, replaced file, lost WAL generation) ran `PRAGMA wal_checkpoint` → `VACUUM` → `wal_checkpoint(TRUNCATE)` and FTS5 `'optimize'` directly on `self._conn`, and the only guard `vacuum()` inherited (`optimize_fts` failing) was swallowed by its own `try/except Exception` before the rewrite. Same #105670 class as the checkpoints #106315 gated.

Salvage of #102092 by @nftpoetrist (cherry-picked onto current `main`, authorship preserved). Their `_try_wal_checkpoint` half had already landed via #106315's `_quarantine_reason()`, so this carries the two rewrite sites and their tests; the checkpoint test is dropped as covered by #106315's `linux_only` invariant. Contributor's shape kept: the typed errors (`StateDbCorruptError` / `StateDbReplacedError` / `DeletedWalGenerationError`) are raised, mirroring `_execute_write`.

Reachability is narrow (auto-vacuum after a successful prune; `hermes sessions vacuum` opens a fresh handle) — the post-merge review of #106315 surfaced it.

Validation: `tests/hermes_state` + `tests/state` — 475 passed (the 3 reds in `test_fts_runtime_rebuild.py` reproduce identically on `main`); reverting `hermes_state_maintenance.py` + `hermes_state_search.py` to `main` → 6 red (2 tests × 3 quarantine flags).
