### PR TITLE
fix(agent): a /steer row counts as human input everywhere (follow-up #106317)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -25,6 +25,7 @@ from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.context_compressor_summary import SummaryDispatchMixin
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.micro_compaction import MicroCompactionMixin
+from agent.prompt_builder import STEER_DISPLAY_KIND
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH, get_model_context_length, estimate_messages_tokens_rough, estimate_tokens_rough,
     strip_opaque_replay_items,
@@ -3644,7 +3645,9 @@ Write only the summary body. Do not include any preamble or prefix."""
             return False
         # display_kind rows (internal notifications, hidden scaffolding) are not human input
         # and must not anchor the tail or seed auto-focus. Mirrors is_user_originated_turn.
-        if message.get("display_kind") or cls._is_context_summary_message(message):
+        # A /steer row is typed for the renderer and the alternation repair, but it IS human input.
+        display_kind = message.get("display_kind")
+        if (display_kind and display_kind != STEER_DISPLAY_KIND) or cls._is_context_summary_message(message):
             return False
         return not cls._is_blank_user_turn(message)
 
@@ -4777,10 +4780,10 @@ def split_user_originated_turn(message: Any) -> tuple[Optional[Dict[str, Any]], 
         candidate = None if display_kind and display_kind != "hidden" else ContextCompressor._strip_context_summary_handoff_message(message)
         if candidate is None:
             return handoff, None
-    elif message.get("display_kind"):
+    elif message.get("display_kind") and message.get("display_kind") != STEER_DISPLAY_KIND:
         return None, None
     else:
-        candidate = message.copy()
+        candidate = message.copy()  # includes a typed /steer row: full user authority
 
     for key in (
         COMPRESSED_SUMMARY_METADATA_KEY, COMPRESSED_SUMMARY_HAS_USER_TURN_KEY, MICRO_COMPACT_MARKER_KEY,

--- a/agent/interrupt_control.py
+++ b/agent/interrupt_control.py
@@ -215,8 +215,8 @@ class InterruptControlMixin:
         return True
 
     def steer(self, text: str) -> bool:
-        """Append user text to the LAST tool result once the batch finishes (no interrupt); multiple calls
-        concatenate with newlines. Returns False for empty text."""
+        """Queue user text for delivery as its own user row after the current tool batch finishes (no
+        interrupt); multiple calls concatenate with newlines. Returns False for empty text."""
         if not text or not text.strip():
             return False
         cleaned = text.strip()

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -239,16 +239,8 @@ def _inject_steer_after_newest_tool_result(agent: Any, messages: Any, steer_text
             messages.insert(_si + 1, steer_user_row(steer_text))
             logger.debug("Pre-API-call steer drain: appended user row after tool msg at index %d", _si)
             return
-    _lock = getattr(agent, "_pending_steer_lock", None)
-    if _lock is not None:
-        with _lock:
-            if agent._pending_steer:
-                agent._pending_steer = agent._pending_steer + "\n" + steer_text
-            else:
-                agent._pending_steer = steer_text
-    else:
-        existing = getattr(agent, "_pending_steer", None)
-        agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
+    from agent.agent_runtime_helpers import _requeue_pending_steer
+    _requeue_pending_steer(agent, steer_text)
 
 
 @dataclass

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -730,7 +730,9 @@ class SessionSearchMixin:
         decode loop; otherwise ``/undo N`` pairs an in-memory count that excludes handoffs
         with a DB pick that includes them."""
         active_clause = "" if include_inactive else " AND active = 1"
-        display_clause = " AND (display_kind IS NULL OR display_kind = '')"
+        # A /steer row is typed for the renderer but is human input: keep it so the DB pick agrees
+        # with the in-memory user_originated_turn_view count.
+        display_clause = " AND (display_kind IS NULL OR display_kind = '' OR display_kind = 'steer')"
         with self._read_ctx() as conn:
             rows = conn.execute(
                 "SELECT id, timestamp, content FROM messages WHERE session_id = ? AND role = 'user'"

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -721,6 +721,33 @@ class TestSteerMarkerContract:
         assert "User guidance:" not in format_steer_marker("hi")
 
 
+class TestSteerRowIsHumanInput:
+    def test_steer_row_counts_as_a_user_originated_turn(self, tmp_path):
+        """The steer row is typed (renderer label, alternation-repair guard) but it carries full user
+        authority: every "is this human input" predicate — in memory and the DB pick /undo uses — must
+        agree with the anchor-restoration predicate that already accepts it."""
+        from agent.context_compressor import ContextCompressor, is_user_originated_turn
+        from agent.conversation_compression import _is_real_user_message
+        from agent.prompt_builder import steer_user_row
+        from hermes_state import SessionDB
+
+        row = steer_user_row("focus on the error handling")
+        assert _is_real_user_message(row)
+        assert is_user_originated_turn(row)
+        assert ContextCompressor._is_actionable_user_turn(row)
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="first question")
+            db.append_message("s1", role="assistant", content="first answer")
+            db.append_message("s1", role="user", content=row["content"], display_kind=row["display_kind"])
+            recents = db.list_recent_user_messages("s1", limit=5)
+            assert [r["preview"][:5] for r in recents] == ["[OUT-", "first"]
+        finally:
+            db.close()
+
+
 class TestSteerCommandRegistry:
     def test_steer_in_command_registry(self):
         """The /steer slash command must be registered so it reaches all

--- a/tui_gateway/session_history.py
+++ b/tui_gateway/session_history.py
@@ -4,6 +4,7 @@ turn tracking and turn-failure detail. Bodies are rebound onto server.py's globa
 from __future__ import annotations
 
 from .method_ctx import bind_module
+from agent.prompt_builder import STEER_DISPLAY_KIND
 
 
 def _active_image_routing_identity(agent: Any) -> tuple[str, str]:
@@ -202,7 +203,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
-        if role == "user" and m.get("display_kind") == "steer":
+        if role == "user" and m.get("display_kind") == STEER_DISPLAY_KIND:
             # Mid-turn /steer: show the user's own words, not the model-facing marker wrapper.
             from agent.conversation_compression import _extract_steer_text_from_message
             content_text = _extract_steer_text_from_message(m) or content_text


### PR DESCRIPTION
Follow-up to #106317 (salvage of #104444); surfaced in the post-merge review pass (both reviewers converged on it).

Typing the steer row (`display_kind="steer"`) for the history renderer and the alternation-repair guard collided with the codebase convention that *any* `display_kind` on a user row means scaffolding. Probe on `main`: `is_user_originated_turn(steer_user_row(..)) == False`, `_is_actionable_user_turn == False`, `_is_real_user_message == True` — the two predicate families disagreed on the same row. Consequences: the steer was not tail-protected as the newest human intent, not counted in resume/dispatcher user-turn views, and `list_recent_user_messages` (`/undo`, `/rewind`) skipped it in SQL. A steer carries full user authority; the steer kind is whitelisted in `_is_actionable_user_turn`, `split_user_originated_turn` and the `/undo` pick.

Cleanups from the same pass: the pre-API drain's requeue tail calls `_requeue_pending_steer` instead of a verbatim copy; `tui_gateway/session_history.py` compares against `STEER_DISPLAY_KIND` rather than a literal; `steer()`'s docstring no longer says "append to the LAST tool result".

Validation: 2574 tests green across `tests/run_agent`, compression, hermes_state, TUI history; new `test_steer_row_counts_as_a_user_originated_turn` fails on `main` (3 predicates + the DB pick).
