### PR TITLE
fix: recover from Codex image patch-limit errors (#106337)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import enum
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterator, Optional, Sequence
 
@@ -153,6 +154,13 @@ _PAYLOAD_TOO_LARGE_PATTERNS = (
 _IMAGE_TOO_LARGE_PATTERNS = (
     "image exceeds", "image too large", "image_too_large", "image size exceeds", "image dimensions exceed",
     "dimensions exceed max allowed size", "max allowed size: 8000", "media exceeds", "media too large",
+)
+
+# OpenAI Codex Responses reports image size in 32 px patches rather than
+# pixels/bytes. Keep this shape strict so unrelated patch/token limits do not
+# enter image recovery.
+_IMAGE_PATCH_LIMIT_RE = re.compile(
+    r"\bimage\b.*\brequires\s+\d+\s+patches\b.*\b(?:exceeding\s+the\s+)?limit\s+of\s+\d+\b"
 )
 
 # Undecodable image bytes → strip-and-retry, never shrink. xAI wordings
@@ -712,6 +720,8 @@ def _classify_400(c: _Ctx) -> Verdict:
     verdict = _first_match(msg, _IMAGE_TOOL_RULES)
     if verdict is not None:
         return verdict
+    if _IMAGE_PATCH_LIMIT_RE.search(msg):
+        return _V_IMAGE_TOO_LARGE
     # Invalid encrypted reasoning replay blob (OpenAI Responses); before
     # overflow because "encrypted content … could not be verified" trips it.
     if code == "invalid_encrypted_content" or "invalid_encrypted_content" in msg or (

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -10,6 +10,7 @@ mutate ``agent`` / ``messages`` / ``api_messages`` in place. Logger name stays
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time
 from dataclasses import dataclass
@@ -51,7 +52,7 @@ def _blines(agent: Any, *lines: str) -> None:
 
 
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
-    """Extract a provider-reported image dimension ceiling, if present."""
+    """Extract a provider-reported pixel or patch-derived image ceiling."""
     parts = []
     for value in (error, getattr(error, "message", None), getattr(error, "body", None)):
         if value:
@@ -60,16 +61,35 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
             except Exception:
                 pass
     text = " ".join(parts).lower()
-    if "image" not in text or "dimension" not in text or "max allowed size" not in text:
+    if "image" not in text:
         return None
-    match = re.search(r"max allowed size(?:\s+for [^:]+)?:\s*(\d{3,5})\s*pixels?", text)
-    if not match:
+
+    if "dimension" in text and "max allowed size" in text:
+        match = re.search(r"max allowed size(?:\s+for [^:]+)?:\s*(\d{3,5})\s*pixels?", text)
+        if match:
+            try:
+                max_dimension = int(match.group(1))
+            except ValueError:
+                return None
+            return max_dimension if 512 <= max_dimension <= 8000 else None
+
+    if "patches" not in text:
+        return None
+    required_match = re.search(r"\brequires\s+(\d+)\s+patches\b", text)
+    limit_match = re.search(r"\b(?:exceeding\s+the\s+)?limit\s+of\s+(\d+)\b", text)
+    if not required_match or not limit_match:
         return None
     try:
-        max_dimension = int(match.group(1))
+        required_patches = int(required_match.group(1))
+        patch_limit = int(limit_match.group(1))
     except ValueError:
         return None
-    return max_dimension if 512 <= max_dimension <= 8000 else None
+    if required_patches <= 0 or patch_limit <= 0:
+        return None
+    # Reserve one 32 px patch row below the square-root ceiling. This keeps the
+    # retry conservatively under provider-side processing/rounding boundaries
+    # (30000 patches -> (isqrt(30000) - 1) * 32 == 5504 px).
+    return max(512, min((math.isqrt(patch_limit) - 1) * 32, 8000))
 
 
 def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -40,6 +40,40 @@ class _FakeApiError(Exception):
 
 
 class TestImageTooLargeClassification:
+    def test_codex_400_patch_limit_message(self):
+        """Codex patch-budget errors must enter image shrink recovery."""
+        message = (
+            "The image you provided requires 33174 patches after processing, "
+            "exceeding the limit of 30000. Please resize the image and try again."
+        )
+        err = _FakeApiError(
+            status_code=400,
+            message=message,
+            body={
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_value",
+                    "message": message,
+                },
+            },
+        )
+
+        result = classify_api_error(err, provider="openai-codex", model="gpt-5.6-sol")
+
+        assert result.reason == FailoverReason.image_too_large
+        assert result.retryable is True
+
+    def test_patch_limit_without_image_fails_open(self):
+        """Bare patch-budget wording must not be treated as an image error."""
+        err = _FakeApiError(
+            status_code=400,
+            message="Input requires 33174 patches, exceeding the limit of 30000.",
+        )
+
+        result = classify_api_error(err, provider="openai-codex", model="gpt-5.6-sol")
+
+        assert result.reason != FailoverReason.image_too_large
+
     def test_anthropic_400_image_exceeds_message(self):
         """Anthropic's exact wording must classify as image_too_large, not context."""
         err = _FakeApiError(
@@ -155,6 +189,55 @@ def _make_agent():
 
 
 class TestShrinkImagePartsHelper:
+    def test_codex_patch_limit_derives_dimension_and_shrinks_tall_image(self, monkeypatch):
+        """Patch budget 30000 derives 5504px, shrinking a 6200px side below the old 8000 default."""
+        agent = _make_agent()
+        original_url = _big_png_data_url(100)
+        resized_url = "data:image/png;base64," + "R" * 80 * 1024
+        _install_fake_pillow(monkeypatch, (5444, 6200), shrunk_size=(4830, 5504))
+        seen = {}
+
+        def _fake_resize(path, mime_type=None, max_base64_bytes=None, max_dimension=None):
+            seen["max_dimension"] = max_dimension
+            return resized_url
+
+        monkeypatch.setattr(
+            "tools.vision_tools._resize_image_for_vision",
+            _fake_resize,
+            raising=False,
+        )
+        error = _FakeApiError(
+            status_code=400,
+            message=(
+                "The image you provided requires 33174 patches after processing, "
+                "exceeding the limit of 30000. Please resize the image and try again."
+            ),
+        )
+        max_dimension = _image_error_max_dimension(error)
+        messages = [{
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": original_url}}],
+        }]
+
+        assert max_dimension == 172 * 32
+        assert agent._try_shrink_image_parts_in_messages(
+            messages, max_dimension=max_dimension,
+        ) is True
+        assert seen["max_dimension"] == 5504
+        assert messages[0]["content"][0]["image_url"]["url"] == resized_url
+
+    def test_patch_limit_dimension_fails_open_for_missing_or_invalid_numbers(self):
+        """Patch-derived dimensions require both a positive requirement and limit."""
+        missing_required = _FakeApiError(
+            400, "The image uses patches, exceeding the limit of 30000."
+        )
+        zero_limit = _FakeApiError(
+            400, "The image requires 33174 patches, exceeding the limit of 0."
+        )
+
+        assert _image_error_max_dimension(missing_required) is None
+        assert _image_error_max_dimension(zero_limit) is None
+
     def test_no_messages_returns_false(self):
         agent = _make_agent()
         assert agent._try_shrink_image_parts_in_messages([]) is False


### PR DESCRIPTION
## Summary
- Classify OpenAI Codex Responses patch-budget 400s (`requires N patches … exceeding the limit of M`) as `image_too_large` so the existing reactive shrink/retry path runs instead of terminal `format_error`.
- Derive a conservative patch-aware `max_dimension` from the reported patch limit (`(isqrt(M) - 1) * 32`) so images under the default 8000px side still shrink when over the patch ceiling.
- Add focused regression coverage for classification, fail-open, dimension parsing, and shrink under the patch-derived cap.

Fixes #106337

## Proof
- **RED (pre-fix):** focused image-shrink suite `2 failed, 17 passed` — Codex wording classified as `format_error`; patch `max_dimension` was `None`.
- **GREEN (post-fix):** `tests/run_agent/test_image_shrink_recovery.py` — 19 passed; `tests/agent/test_error_classifier.py` — 140 passed.
- **P0 self-review:** 0 (Detection / Fail-open / Forbidden / RED evidence / Diff scope all pass).
- Base: `91433c8466253e8f58e2fb777014fcc987355eff`
- Head: `fa52796a77b09097928283ebbd5bfa847fe22c79`

## Test plan
- [x] `scripts/run_tests.sh tests/run_agent/test_image_shrink_recovery.py`
- [x] `scripts/run_tests.sh tests/agent/test_error_classifier.py`
- [ ] CI on this PR

## Risks
- Patch-limit → pixel formula is intentionally conservative (`isqrt(limit) - 1`); may over-shrink slightly vs the absolute max that still fits the budget.

Made with [Cursor](https://cursor.com)