### PR TITLE
fix(kanban): honor explicit scratch/project on MCP kanban_create

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -429,6 +429,43 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+@pytest.mark.parametrize("explicit", [
+    {"workspace_kind": "scratch"},
+    {"project": ""},
+])
+def test_create_explicit_scratch_ignores_ambient_board_project(
+    worker_env, tmp_path, explicit,
+):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import projects_db as pdb
+    from tools import kanban_tools as kt
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as pconn:
+        project_id = pdb.create_project(pconn, name="Ambient", primary_path=str(repo))
+
+    kb.write_board_metadata("default", project_id=project_id)
+    kb.create_board("target", name="Target", project_id="")
+
+    result = json.loads(kt._handle_create({
+        "board": "target",
+        "title": "stay scratch",
+        "assignee": "peer",
+        **explicit,
+    }))
+
+    assert result["ok"] is True
+    assert result["project_id"] is None
+    assert result["workspace_kind"] == "scratch"
+
+    with kbc.connect_closing(board="target") as conn:
+        control = kb.create_task(
+            conn, title="direct scratch", board="target", workspace_kind="scratch")
+        assert kb.get_task(conn, control).project_id is None
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     from hermes_cli import kanban_db_connect as kbc

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -816,7 +816,14 @@ def _handle_create(args: dict, **kw) -> str:
     # to inherit implicitly (the DB turns it into a fresh per-task worktree).
     workspace_kind, workspace_path = args.get("workspace_kind"), args.get("workspace_path")
     # See #67567.
-    project_id = args.get("project") or args.get("project_id")
+    project_arg_present = "project" in args or "project_id" in args
+    project_id = args["project"] if "project" in args else args.get("project_id")
+    # An explicit scratch request suppresses board project inheritance, while an
+    # explicit project may still intentionally turn scratch into a project worktree.
+    if not project_arg_present and "workspace_kind" in args and workspace_kind == "scratch":
+        project_id = ""
+    workspace_args_omitted = not any(
+        key in args for key in ("project", "project_id", "workspace_kind", "workspace_path"))
     project_source_task_id = None
     triage, skills, goal_mode = (
         _parse_bool_arg(args, "triage"), _coerce_str_list(args.get("skills"), "skills", "skill names"),
@@ -832,7 +839,7 @@ def _handle_create(args: dict, **kw) -> str:
         # The worker/API runtime may be transient; the owning task's origin is durable.
         session_id = (args.get("session_id") or (self_task.session_id if self_task else None)
                       or _current_origin_session_id() or os.environ.get("HERMES_SESSION_ID"))
-        if project_id is None and workspace_kind is None and workspace_path is None:
+        if workspace_args_omitted:
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id
         new_tid = kb.create_task(
@@ -841,6 +848,8 @@ def _handle_create(args: dict, **kw) -> str:
             priority=_opt_int(args.get("priority"), 0),
             workspace_kind=str(workspace_kind if workspace_kind is not None else "scratch"),
             workspace_path=workspace_path, project_id=project_id,
+            # Keep metadata inheritance scoped to the same board DB opened above.
+            board=args.get("board"),
             project_source_task_id=project_source_task_id, triage=triage,
             creator_task_id=self_tid,
             idempotency_key=args.get("idempotency_key"),


### PR DESCRIPTION
## What does this PR do?

`kanban_create` (MCP) was binding new cards to the session's ambient/current board `project_id` even when the caller passed an explicit target `board` plus `workspace_kind=scratch` or `project=""`. The tool opened the requested board DB but called `create_task` without `board=`, so metadata inheritance fell back to `get_current_board()`.

This fix scopes board metadata to the same board the tool opened, preserves empty `project` as an explicit clear, and lets explicit `workspace_kind=scratch` suppress board project inheritance. Dispatcher omit-all inheritance and intentional same-board project scoping remain unchanged.

## Related Issue

Fixes #106342

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/kanban_tools.py`: pass `board=` into `create_task`; preserve explicit empty project; explicit scratch suppresses board project inheritance
- `tests/tools/test_kanban_tools.py`: regression for ambient board project vs explicit scratch / empty project

## How to Test

1. `scripts/run_tests.sh tests/tools/test_kanban_tools.py::test_create_explicit_scratch_ignores_ambient_board_project`
2. `scripts/run_tests.sh tests/tools/test_kanban_tools.py`
3. `scripts/run_tests.sh tests/hermes_cli/test_kanban_board_project.py`

## Proof Receipt

- BEFORE (pre-fix): focused RED — 2 failed (`assert project_id is None`)
- AFTER: focused GREEN — 2 passed; `test_kanban_tools.py` 34 passed; `test_kanban_board_project.py` 4 passed
- Self-review P0: 0
- Independent code-review: skipped (2 modules, ~50 lines, no auth/crypto/state.db, P0=0)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run focused tests via `scripts/run_tests.sh` and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas — N/A


Made with [Cursor](https://cursor.com)