### PR TITLE
catalog: add nex-n2.5-pro:free and hy3:free to opencode-zen/openrouter

### DIFF
--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -43,7 +43,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
         "openrouter/pareto-code", "thinkingmachines/inkling:free", "thinkingmachines/inkling-small:free",
         "minimax/minimax-m3:free", "z-ai/glm-5.2:free", "poolside/laguna-s-2.1:free", "poolside/laguna-xs-2.1:free",
         "nvidia/nemotron-3-super-120b-a12b:free", "nvidia/nemotron-3-ultra-550b-a55b:free",
-        "nvidia/nemotron-3.5-lightning:free",
+        "nvidia/nemotron-3.5-lightning:free", "tencent/hy3:free", "nex-agi/nex-n2.5-pro:free",
     )
 ]
 
@@ -51,6 +51,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
 _OPENROUTER_ONLY = {
     "anthropic/claude-opus-5-fast", "anthropic/claude-opus-4.8-fast", "meta/muse-spark-1.2",
     "meta/muse-spark-1.2-contributor", "meta/muse-spark-1.3", "meta/muse-spark-1.3-contributor", "openrouter/pareto-code",
+    "tencent/hy3:free", "nex-agi/nex-n2.5-pro:free",
 }
 
 
@@ -228,7 +229,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "grok-4.6", "grok-4.5", "grok-build-0.1", "muse-spark-1.2", "minimax-m3", "minimax-m2.7", "minimax-m2.5",
         "glm-5.3", "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "kimi-k2.7-code", "deepseek-v4-pro",
         "deepseek-v4-flash", "deepseek-v4-flash-free", "qwen3.6-plus", "qwen3.5-plus", "big-pickle", "mimo-v2.5-free",
-        "hy3-free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free",
+        "hy3-free", "nex-n2.5-pro:free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free",
         "muse-spark-1.2-contributor-free", "muse-spark-1.3-contributor-free",
     ],
     # OpenCode keyless free tier — OFFLINE FLOOR only. provider_model_ids("opencode-free")


### PR DESCRIPTION
**What**
- `OPENROUTER_MODELS` 57→59: add `tencent/hy3:free`, `nex-agi/nex-n2.5-pro:free` (release 2026-09-08, models.dev verified)
- `opencode-zen` 68→69: add `nex-n2.5-pro:free` (`hy3-free` already present, live-first appends after live 70)
- `_OPENROUTER_ONLY`: mark new `:free` as not on Nous Portal

**Why**
OpenCode shows `nex-n2.5-pro:free` (live 2026-09-08) and `hy3-free` while Hermes `opencode-zen` (live-first 70, `nex 0`) and `openrouter` curated 57 did not. `opencode-zen` live `https://opencode.ai/zen/v1/models` 2026-09-09 verified 70 with `nex 0`, `hy3-free` missing from live free 7; curated must carry it. OpenRouter curated missing both.

**How verified (clone-only, origin untouched)**
- Clone at `/tmp/hermes-patch-nex-hy3` from `7f3e0bb`, patched `hermes_cli/models_catalog_static.py`
- `provider_model_ids` live-first merge `70 + curated` → `133` contains `nex-n2.5-pro:free` at tail, `hy3-free` kept; dedup ok
- `cached_provider_model_ids` with `temp HERMES_HOME` → disk cache contains `nex`, cache hit without network
- Static counts 59/69, `_OPENROUTER_ONLY` 9

**No origin file changed**, stdlib mock only, no `pip install`.

Closes stale-picker for `opencode-zen`/`openrouter` `nex`/`hy3`.