### PR TITLE
fix(agent): stop the run-budget wrap-up notice from mutating a persisted tool row

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -127,8 +127,13 @@ def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) 
         (time.time() - started) < 0.8 * float(budget)
     ):
         return False
+    from agent.context_compressor import _DB_PERSISTED_MARKER
     for msg in reversed(messages):
         if isinstance(msg, dict) and msg.get("role") == "tool":
+            # Only the current tool-result tail is mutable; an older turn may already be
+            # cached (same contract as _maybe_inject_iteration_budget_warning).
+            if msg.get(_DB_PERSISTED_MARKER):
+                return False
             existing = msg.get("content", "")
             if isinstance(existing, str):
                 msg["content"] = existing + f"\n\n{RUN_BUDGET_WRAPUP_NOTICE}"

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -173,10 +173,12 @@ def _resolve_concurrent_tool_timeout() -> float | None:
 def _flush_session_db_after_tool_progress(agent, messages: list, *, stage: str) -> bool:
     """Flush tool-call progress to the session DB before projecting it to any UI: tool side
     effects can kill/restart the process before turn-end persistence runs."""
+    from agent.conversation_loop import _maybe_inject_run_budget_wrapup
     from agent.turn_iteration_prep import _maybe_inject_iteration_budget_warning
 
     # Persist exactly the checkpoint text the next model call will see, before stamping
     # this tool result as durable. Already-written rows must never be rewritten later.
+    _maybe_inject_run_budget_wrapup(agent, messages)
     _maybe_inject_iteration_budget_warning(agent, messages)
     try:
         persisted = agent._flush_messages_to_session_db(messages) is not False

--- a/tests/agent/test_run_budget.py
+++ b/tests/agent/test_run_budget.py
@@ -285,6 +285,23 @@ def test_wrapup_not_injected_without_turn_clock():
     assert _maybe_inject_run_budget_wrapup(agent, messages) is False
 
 
+def test_wrapup_skips_already_persisted_tool_row():
+    """An already-flushed tool row is append-only; mutating it would diverge the
+    replayed transcript from the live wire bytes and break the prompt cache (same
+    contract as _maybe_inject_iteration_budget_warning)."""
+    from agent.context_compressor import _DB_PERSISTED_MARKER
+    from agent.conversation_loop import _maybe_inject_run_budget_wrapup
+
+    agent = _StubAgent(budget=900, started=time.time() - 800)
+    messages = _tool_messages()
+    messages[-1][_DB_PERSISTED_MARKER] = True
+    snapshot = [dict(m) for m in messages]
+
+    assert _maybe_inject_run_budget_wrapup(agent, messages) is False
+    assert agent._run_budget_wrapup_injected is False
+    assert messages == snapshot
+
+
 def test_wrapup_multimodal_tool_content():
     """Content-blocks tool results get a text block appended, not clobbered."""
     from agent.conversation_loop import (
@@ -302,6 +319,32 @@ def test_wrapup_multimodal_tool_content():
     blocks = messages[-1]["content"]
     assert blocks[0] == {"type": "text", "text": "block"}
     assert blocks[-1] == {"type": "text", "text": RUN_BUDGET_WRAPUP_NOTICE}
+
+
+# ── pre-flush wiring (the notice must reach durable bytes) ─────────────────
+
+
+def test_wrapup_lands_in_the_persisted_row_via_pre_flush_hook(monkeypatch, tmp_path):
+    """The wrap-up notice must be injected BEFORE the tool row is flushed, or it
+    never reaches SQLite: prepare_iteration's own call always runs on an
+    already-persisted row (the previous iteration's flush already ran)."""
+    from hermes_state import SessionDB
+    from agent.tool_executor import _flush_session_db_after_tool_progress
+    from agent.conversation_loop import RUN_BUDGET_WRAPUP_NOTICE
+
+    session_db = SessionDB(db_path=tmp_path / "proof.db")
+    try:
+        agent = _make_agent(tmp_path, monkeypatch, session_db=session_db, run_budget_seconds=900)
+        agent._run_budget_started_at = time.time() - 800  # 89% elapsed
+        messages = _tool_messages()
+
+        assert _flush_session_db_after_tool_progress(agent, messages, stage="checkpoint")
+
+        persisted = session_db.get_messages(agent.session_id)
+        assert any(RUN_BUDGET_WRAPUP_NOTICE in str(row["content"]) for row in persisted)
+        assert agent._run_budget_wrapup_injected is True
+    finally:
+        session_db.close()
 
 
 # ── turn clock stamping ────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes `agent.conversation_loop._maybe_inject_run_budget_wrapup()` mutating an already-persisted tool row, breaking the same live/replay byte-parity contract that a sibling function (`_maybe_inject_iteration_budget_warning`) was just fixed for in this exact area.

## Problem

`_maybe_inject_run_budget_wrapup` appends the wall-clock wrap-up notice to the newest `role:"tool"` message in place, with no `_DB_PERSISTED_MARKER` check. Its sibling in `agent/turn_iteration_prep.py`, `_maybe_inject_iteration_budget_warning`, has exactly this guard, with the comment: *"Only the current tool-result tail is mutable; an older turn may already be cached."*

The reachability here isn't an edge case — it's structural. `_maybe_inject_run_budget_wrapup` is only ever called from `prepare_iteration()`, at the start of the *next* iteration. By that point, `agent/tool_executor.py`'s `_flush_session_db_after_tool_progress` has already flushed and marked the previous iteration's tool row as durable. So every successful injection was mutating a row already written to SQLite: the wire request for that turn carried the notice, but the durable transcript never did — diverging replay from the live bytes and invalidating the provider's prompt-cache prefix from that row onward.

## Fix

- Add the same `_DB_PERSISTED_MARKER` guard to `_maybe_inject_run_budget_wrapup`, scoped to the specific tool row its reversed scan lands on (it scans backward for the newest tool row rather than only checking `messages[-1]`, unlike its sibling).
- Wire `_maybe_inject_run_budget_wrapup` into `_flush_session_db_after_tool_progress` (pre-flush), mirroring exactly how `_maybe_inject_iteration_budget_warning` is wired in both places. Without this second half, the guard alone would silently stop the notice from firing in the common case — `prepare_iteration`'s call site almost always hits an already-persisted row. The pre-flush call site is what actually lets the notice land in durable bytes, same as its sibling.

## Testing

- Verified the fix's premise by reading the real call graph: all three of `tool_executor.py`'s `_flush_session_db_after_tool_progress` call sites cover every tool-completion path, confirming the guard's reachability claim.
- Added an end-to-end test (`test_wrapup_lands_in_the_persisted_row_via_pre_flush_hook`) using a real `AIAgent` + `SessionDB` that flushes and checks the actual persisted row for the notice text.
- Added a unit test (`test_wrapup_skips_already_persisted_tool_row`) for the guard itself.
- Mutation-verified: reverting the two production files drops exactly the 2 new/updated assertions (28 pass, 2 fail); reapplying restores green (30 passed).
- `uv run --frozen python -m pytest tests/agent/test_run_budget.py tests/agent/test_iteration_budget_warning.py tests/run_agent/test_steer.py -q` → 71 passed (checked the sibling function's and the `/steer` saga's suites for interaction regressions — none).
- `ruff check` clean on all three changed files.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
