### PR TITLE
fix(state): preserve summary boundaries in live replay

### DIFF
--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -784,14 +784,16 @@ class SessionMessagesMixin:
         """Load messages in OpenAI format. ``include_compacted`` (deduped display history) is for DISPLAY reads
         only: the model-fed restore must not regrow what compaction summarized away. ``repair_alternation``
         repairs the loaded list for LIVE REPLAY callers (a durable ``user;user`` pair would re-trigger the
-        per-request repair forever); the stored transcript is never mutated."""
+        per-request repair forever), preserving summary markers before repair so derivative context
+        cannot merge with an original user turn; the stored transcript is never mutated."""
         rows = self._fetch_conversation_rows(
             self._resume_lineage_ids(session_id) if include_ancestors else [session_id],
             self._active_clause(include_inactive, include_compacted), with_session_id=False)
         if include_compacted:
             rows = self._dedupe_display_generations(rows)
         return self._rows_to_conversation(rows, session_id=session_id, include_ancestors=include_ancestors,
-            repair_alternation=repair_alternation, include_row_ids=include_row_ids)
+            repair_alternation=repair_alternation, include_row_ids=include_row_ids,
+            include_summary_markers=repair_alternation)
 
     def _dedupe_replayed_user(self, messages, msg, exact_user_clones) -> Tuple[bool, Any]:
         """Ancestor-lineage dedupe of one decoded user *msg* -> ``(skip, exact_clone_key)``. Rotation

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -327,6 +327,34 @@ def test_compressed_summary_marker_survives_restart_via_resume_history(tmp_path)
     assert all("_compressed_summary" not in m for m in plain)
 
 
+def test_live_replay_preserves_summary_boundary_without_changing_display(tmp_path):
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    db.create_session("summary-replay", source="telegram")
+    db.append_message("summary-replay", "user", "Derivative context", _compressed_summary=True)
+    db.append_message("summary-replay", "user", "Original request")
+    db.append_message("summary-replay", "assistant", "Original answer")
+    db.create_session("plain-replay", source="telegram")
+    db.append_message("plain-replay", "user", "First request")
+    db.append_message("plain-replay", "user", "Second request")
+
+    reopened = SessionDB(db_path)
+    display_before = reopened.get_messages_as_conversation("summary-replay")
+    replay = reopened.get_messages_as_conversation("summary-replay", repair_alternation=True)
+    assert [m["content"] for m in replay] == [
+        "Derivative context", "Original request", "Original answer"
+    ]
+    assert replay[0].get("_compressed_summary") is True
+    assert all("_compressed_summary" not in m for m in replay[1:])
+    assert reopened.get_messages_as_conversation("summary-replay") == display_before
+    assert all("_compressed_summary" not in m for m in display_before)
+    plain = reopened.get_messages_as_conversation("plain-replay", repair_alternation=True)
+    assert [m["content"] for m in plain] == ["First request\n\nSecond request"]
+    assert all("_compressed_summary" not in m for m in plain)
+
+
 def test_compressed_summary_column_is_added_to_legacy_databases(tmp_path):
     """Pre-upgrade databases gain the marker column via declarative reconcile.
 


### PR DESCRIPTION
## What does this PR do?

Preserve persisted summary-carrier metadata before repairing live replay history. Otherwise a user-role compression summary can merge with the next original user request when `get_messages_as_conversation(..., repair_alternation=True)` reloads it.

## Related Issue

Fixes #106352.

## Changes Made

- Pass the existing `include_summary_markers=repair_alternation` option to `_rows_to_conversation`.
- Add one SessionDB restart regression covering the summary boundary, unchanged marker-free display reads, and unchanged merging of genuine consecutive user turns.

The existing decoder and repair logic handle the marker. No schema, storage ownership, provider, or replay-matching changes are introduced.

## How to Test

`scripts/run_tests.sh tests/agent/test_pre_compress_checkpoint_contract.py -q`

The new regression failed on unmodified `6e2b8e070d28b1a3381a3fb290b6b8d6cce13cef`; the complete named file passed with the fix (23 tests, macOS). An independent semantic review passed that exact source/test delta. This branch transfers it unchanged onto upstream `9e0dc4319ae2d59c60f5226b5c0af58d17755bfa`; current-base validation and installed acceptance remain pending. No full-suite pass is claimed.

## Checklist

- [x] Bug fix with one focused behavioral regression
- [x] Existing issues and PRs searched; related replay-canonicalization PR #105308 changes a separate cleanup surface
- [x] Conventional commit; only related changes
- [x] Relevant getter docstring updated
- [ ] Current-base CI complete
- [ ] Installed acceptance complete
