### PR TITLE
fix(desktop): auto-paginate older transcript on scroll near top (#106350)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -956,6 +956,69 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
   }, [anchorBeforePrepend, expandWindow, hiddenCount, olderAvailable, paneBudget])
 
+  // Auto-pagination on scroll near top: branched sessions immediately saturate
+  // the render budget, and a long conversation pages behind "Show earlier".
+  // Users expect wheel/trackpad scrolling up to transparently reveal earlier
+  // history (#106350) — without this, the viewport stops at scrollTop 0 with
+  // hidden turns unreachable except by explicit button click. Trigger the same
+  // showEarlier path when the user scrolls within the top threshold, coalesced
+  // per frame and gated on settled load so it doesn't fight the session-switch
+  // restore loop.
+  const showEarlierRef = useRef(showEarlier)
+  showEarlierRef.current = showEarlier
+
+  useEffect(() => {
+    const el = scrollRef.current
+
+    if (!el) {
+      return
+    }
+
+    let ticking = false
+    let cooldown = false
+    const TOP_THRESHOLD_PX = 200
+
+    const tryLoadEarlier = () => {
+      if (cooldown || !loadSettledRef.current) {
+        return
+      }
+
+      if (el.scrollTop > TOP_THRESHOLD_PX) {
+        return
+      }
+
+      const action = resolveShowEarlierAction(hiddenCount, olderAvailable)
+
+      if (!action) {
+        return
+      }
+
+      cooldown = true
+      showEarlierRef.current()
+
+      window.setTimeout(() => {
+        cooldown = false
+      }, 250)
+    }
+
+    const onScroll = () => {
+      if (ticking) {
+        return
+      }
+
+      ticking = true
+
+      requestAnimationFrame(() => {
+        ticking = false
+        tryLoadEarlier()
+      })
+    }
+
+    el.addEventListener('scroll', onScroll, { passive: true })
+
+    return () => el.removeEventListener('scroll', onScroll)
+  }, [hiddenCount, olderAvailable, scrollRef])
+
   useLayoutEffect(() => {
     const el = scrollRef.current
     const restoreFromBottom = restoreFromBottomRef.current


### PR DESCRIPTION
Fixes #106350

**Problem:** In Hermes Desktop, long conversations and branched sessions (`/branch` / "Branch in new chat") immediately saturate both the store window (`TRANSCRIPT_WINDOW_BUDGET`) and the DOM render budget (`RENDER_BUDGET`). Older turns become hidden behind the `Show earlier` button, but the scroll viewport stopped at `scrollTop: 0` with no automatic way to reach them via wheel/trackpad. Users had to discover and click the button; the transcript felt cut off.

**Root cause:** `thread/list.tsx` only expanded on explicit button click (`showEarlier`). No observer triggered pagination when the user scrolled near the top.

**Fix:** Add a passive `scroll` listener on the thread viewport that auto-invokes the same `showEarlier` path when `scrollTop` is within 200px of the top and older content exists (`hiddenCount > 0 || olderAvailable`). The handler is coalesced per `requestAnimationFrame`, has a 250ms cooldown to avoid spamming, and is gated on `loadSettledRef` so it does not fight the session-switch restore/seeking loop. The existing anchor/restore logic preserves the viewport position across the prepend.

**Verification:** Syntax check passed (`tsc --noEmit` filtered — desktop config missing external deps pre-existing). Existing desktop unit suites (`list.test.ts`, `transcript-window.test.ts`) cover the underlying budgets/windowing; the change only adds an event listener to the already-tested `showEarlier` path.
