### PR TITLE
fix(gateway): a steer/interrupt-triggered queued terminal turn gets its own ledger id

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3479,6 +3479,16 @@ class GatewayTurnMixin:
             next_inbound_id = str(pending_event.message_id) if getattr(pending_event, "message_id", None) else None
             next_channel_prompt = getattr(pending_event, "channel_prompt", None)
             next_message_type = getattr(pending_event, "message_type", None)
+        else:
+            # A steer/bare-interrupt continuation (result["pending_steer"] or a control
+            # interrupt_message) has no originating queued event, so there is no natural id to
+            # carry here — but it still needs one distinct from the chain's other turns, or an
+            # identical-text reply collides on the SAME obligation id as an earlier one (the exact
+            # bug this whole ledger fix is about, just reached from a different branch). No
+            # transport identity exists to derive one from, so mint one (same fallback shape as
+            # the keyless-turn owner id above, #60671-adjacent).
+            import uuid
+            next_inbound_id = f"steer:{uuid.uuid4().hex}"
 
         # Clear the prior turn's streaming-TTS completion marker so the recursive turn isn't suppressed.
         # See #60671.

--- a/tests/gateway/test_queued_final_ledger.py
+++ b/tests/gateway/test_queued_final_ledger.py
@@ -294,6 +294,52 @@ async def test_the_terminal_turn_of_a_chain_is_ledgered_under_its_own_inbound_id
 
 
 @pytest.mark.asyncio
+async def test_a_steer_triggered_terminal_turn_gets_its_own_inbound_id():
+    """A queued follow-up with no originating event (a leftover /steer, or a bare control
+    interrupt_message) must still carry an inbound id distinct from the chain's other turns.
+
+    Before this fix, next_inbound_id stayed None on this branch, so queued_terminal_inbound_id
+    resolved to None -- the truthiness check at the call site (agent_result.get(...) then
+    `if _terminal_inbound:`) then left event.ledger_message_id untouched, falling back to the
+    event that OPENED the chain. An identical-text reply from this branch would collide with an
+    earlier reply's obligation id exactly like the bug #106312/#106316 fixed for the
+    pending_event branch -- just reached from the one branch that saga didn't cover.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = _runner()
+    runner._MAX_INTERRUPT_DEPTH = 8
+    runner._run_agent = AsyncMock(return_value={"final_response": "done", "messages": []})
+    runner._run_agent_deliver_first_response = AsyncMock()
+    runner._adapter_for_source = MagicMock(return_value=None)
+    runner._refresh_agent_cache_message_count = AsyncMock()
+    turn_ctx = SimpleNamespace(
+        source=_source(), session_id="sid", session_key=SESSION_KEY, run_generation=1,
+        _interrupt_depth=0, history=[], _status_thread_metadata={},
+        context_prompt=None, result_holder=[None])
+
+    merged = await GatewayRunner._run_agent_queued_followup(
+        runner, turn_ctx, adapter=None, pending="leftover steer text", pending_event=None,
+        response="resp",
+        result={"interrupted": False, "messages": [], "pending_steer": "leftover steer text"},
+        stream_task=None)
+
+    inbound_id = runner._run_agent.await_args.kwargs["inbound_message_id"]
+    assert inbound_id, "must resolve to a truthy id, or the ledger override is silently skipped"
+    assert runner._run_agent.await_args.kwargs["event_message_id"] is None
+    assert merged["queued_terminal_inbound_id"] == inbound_id
+
+    # A second occurrence (another steer drain later in the same session) must not reuse the id.
+    runner._run_agent.reset_mock()
+    merged_2 = await GatewayRunner._run_agent_queued_followup(
+        runner, turn_ctx, adapter=None, pending="leftover steer text", pending_event=None,
+        response="resp",
+        result={"interrupted": False, "messages": [], "pending_steer": "leftover steer text"},
+        stream_task=None)
+    assert merged_2["queued_terminal_inbound_id"] != inbound_id
+
+
+@pytest.mark.asyncio
 async def test_a_deeper_chain_keeps_the_innermost_inbound_id():
     """Chained follow-ups nest, and the LAST message answered owns the ledger identity, so an id
     already set by a deeper recursion must not be overwritten on the way out."""


### PR DESCRIPTION
## What does this PR do?

Closes the one branch the queued-lane ledger saga (#106312/#106316, merged earlier today) didn't reach: a queued follow-up triggered by a leftover `/steer` or a bare control `interrupt_message` (no originating queued event) still collides on the same delivery-ledger obligation id as an earlier reply in the chain.

## Problem

`gateway/run_turn.py::_run_agent_queued_followup` derives `next_inbound_id` — the id that keys the follow-up's own delivery-ledger obligation — only inside the `if pending_event is not None:` branch. When the follow-up instead comes from `result["pending_steer"]` or a bare `interrupt_message` (`pending_event is None`), `next_inbound_id` stays at its `None` default.

That `None` flows into `queued_terminal_inbound_id`, which the caller in `gateway/run.py` reads back with a truthiness check:

```python
_terminal_inbound = agent_result.get("queued_terminal_inbound_id")
if _terminal_inbound:
    event.ledger_message_id = str(_terminal_inbound)
```

`None` is indistinguishable from "absent" here, so `event.ledger_message_id` is never overridden and the outer final send falls back to the id of the event that **opened** the chain. If this steer/interrupt-triggered terminal reply happens to carry the same text as an earlier reply in the same chain, both compute the identical obligation id — the earlier (possibly flood-refused) row is silently overwritten and marked delivered, and is never redelivered. This is exactly the bug the saga just fixed, reached from the one branch it didn't cover.

## Fix

When `pending_event is None`, mint a synthetic id (`uuid4`, prefixed `steer:`) distinct from any real transport id. There's no natural identity to derive one from for a synthesized continuation — this mirrors the existing keyless-turn-owner fallback already used elsewhere in the same file (`_run_agent_prepare_turn`'s `owner` id, which falls back to `uuid.uuid4()` when `event.message_id` is absent).

## Testing

- Added `test_a_steer_triggered_terminal_turn_gets_its_own_inbound_id`, mirroring the saga's own `test_a_deeper_chain_keeps_the_innermost_inbound_id` pattern: asserts the inbound id is truthy, that it feeds into `queued_terminal_inbound_id`, and that two separate occurrences get different ids (not a deterministic/reusable value).
- Mutation-verified: reverting `gateway/run_turn.py` drops exactly the new test (9 pass, 1 fail — `assert None`, reproducing the bug directly); reapplying restores green (10 passed).
- `uv run --frozen python -m pytest tests/gateway/test_queued_final_ledger.py tests/gateway/test_queued_native_image_session_key.py tests/gateway/test_multiplex_busy_input_mode.py -q` → 32 passed (checked sibling queued-lane suites for interaction regressions — none).
- `ruff check` clean on both changed files.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
