### PR TITLE
fix(tools): hide console window for command-provider TTS/STT on Windows (#101585)

### DIFF
--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -141,6 +141,61 @@ class TestCommandTtsEnv:
         assert env["MY_SAFE_TTS_VAR"] == "keep"
 
 
+class TestRunCommandProviderWindowsFlags:
+    """#101585: ``shell=True`` routes through cmd.exe — the spawn must carry CREATE_NO_WINDOW.
+
+    TTS and STT share ``run_command_provider`` (imported as ``_run_command_tts`` /
+    ``_run_command_stt``), so one test covers both dispatch paths.
+    """
+
+    @staticmethod
+    def _capture_popen(monkeypatch, captured):
+        class _Stream:
+            def read(self, size):
+                return ""
+
+        class Proc:
+            returncode = 0
+            stdout = _Stream()
+            stderr = _Stream()
+
+            def wait(self, timeout=None):
+                return 0
+
+        def fake_popen(command, **kwargs):
+            captured.update(kwargs)
+            return Proc()
+
+        monkeypatch.setattr("tools.tts_command_provider.subprocess.Popen", fake_popen)
+
+    def test_windows_spawn_carries_create_no_window(self, monkeypatch):
+        from hermes_cli._subprocess_compat import windows_detach_flags_without_breakaway
+        monkeypatch.setattr(os, "name", "nt")
+        captured: dict = {}
+        self._capture_popen(monkeypatch, captured)
+
+        result = _run_command_tts("echo hi", timeout=1)
+
+        assert result.returncode == 0
+        assert captured["creationflags"] == windows_detach_flags_without_breakaway()
+        assert "start_new_session" not in captured
+        if sys.platform == "win32":
+            assert captured["creationflags"] & getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+            # Group signalling kept so the idle-timeout tree kill still works.
+            assert captured["creationflags"] & getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+
+    def test_posix_spawn_unaffected(self, monkeypatch):
+        monkeypatch.setattr(os, "name", "posix")
+        captured: dict = {}
+        self._capture_popen(monkeypatch, captured)
+
+        result = _run_command_tts("echo hi", timeout=1)
+
+        assert result.returncode == 0
+        assert captured["start_new_session"] is True
+        assert "creationflags" not in captured
+
+
 class TestGetNamedProviderConfig:
     def test_providers_block_wins(self):
         cfg = {"providers": {"voxcpm": {"command": "new"}},

--- a/tools/tts_command_provider.py
+++ b/tools/tts_command_provider.py
@@ -23,6 +23,10 @@ from functools import partial
 from pathlib import Path
 from typing import Any, Dict, FrozenSet, Optional
 
+from hermes_cli._subprocess_compat import (
+    windows_detach_flags_without_breakaway,
+    windows_hide_flags,
+)
 from utils import is_truthy_value
 
 
@@ -102,7 +106,8 @@ def terminate_command_process_tree(proc: subprocess.Popen) -> None:
     if os.name == "nt":
         try:
             subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)], stdout=subprocess.DEVNULL,
-                           stderr=subprocess.DEVNULL, timeout=5, stdin=subprocess.DEVNULL)
+                           stderr=subprocess.DEVNULL, timeout=5, stdin=subprocess.DEVNULL,
+                           creationflags=windows_hide_flags())
         except Exception:
             proc.kill()
         return
@@ -148,7 +153,10 @@ def run_command_provider(
             scrubbed[key] = value
     # Own process group so the whole tree can be signalled on idle timeout. Lossy UTF-8 decode:
     # locale-mismatched bytes must not raise in the reader threads.
-    group = ({"creationflags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)} if os.name == "nt"
+    # Windows: CREATE_NO_WINDOW is mandatory — shell=True routes through cmd.exe, which would
+    # otherwise pop a visible console on every call. No BREAKAWAY_FROM_JOB: the child must stay
+    # in the parent's job so terminate_command_process_tree() / job teardown still reap it.
+    group = ({"creationflags": windows_detach_flags_without_breakaway()} if os.name == "nt"
              else {"start_new_session": True})
     proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             text=True, encoding="utf-8", errors="replace", env=delegated_child_subprocess_env(scrubbed),


### PR DESCRIPTION
## What Problem This Solves

On Windows, every command-provider TTS/STT call (`tts.providers.<name>.command` /
`stt.providers.<name>.command`, e.g. a local Piper/whisper.cpp wrapper) flashes a black
`cmd.exe` console window. Since a refactor, both dispatch paths share one runner —
`run_command_provider()` in `tools/tts_command_provider.py` (re-exported as
`_run_command_tts` / `_run_command_stt`) — which spawned the child with `shell=True`
(routing through `cmd.exe`) and `creationflags` carrying only `CREATE_NEW_PROCESS_GROUP`
(`0x200`), not `CREATE_NO_WINDOW`.

Fix: use the existing `windows_detach_flags_without_breakaway()` helper
(`CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW`, 0 on non-Windows) for the spawn, and add
the codebase-standard `windows_hide_flags()` (`CREATE_NO_WINDOW`) to the timeout-path
`taskkill` spawn, which had the same flash. No `BREAKAWAY_FROM_JOB`: the child stays in
the parent's job so `terminate_command_process_tree()` / job teardown still reap it, and
`CREATE_NEW_PROCESS_GROUP` is kept so the idle-timeout tree kill still signals.

Note on #101722 (closed): it proposed `windows_hide_flags()` (NO_WINDOW only, dropping
the process group) and was closed on the claim that `tts_tool.py:695` /
`transcription_tools.py:212` already use it — those lines are only lazy-re-export entries
in `_PLUGIN_COMPAT_LAZY`, not the command-provider spawn. The bug was still live in
`run_command_provider()` (verified `creationflags == 0x200` pre-fix on Windows 11).

## Evidence

- Repro (mocked `Popen`, Windows 11, pre-fix): `creationflags = 0x200`,
  `HAS_CREATE_NO_WINDOW = False`; post-fix: `creationflags = 0x8000200`, True.
- New regression tests `TestRunCommandProviderWindowsFlags` (2 tests): Windows spawn
  asserts `creationflags == windows_detach_flags_without_breakaway()` incl. the
  `CREATE_NO_WINDOW` / `CREATE_NEW_PROCESS_GROUP` bits on win32, and no
  `start_new_session`; POSIX test asserts `start_new_session is True` and no
  `creationflags` (other platforms unaffected).
- Sabotage check: new Windows test fails on pre-fix code, passes with the fix.
- Live smoke on Windows 11 (real spawns): `echo` returns 0 with stdout in 0.25s;
  hanging provider raises `TimeoutExpired` in 0.80s with partial output preserved
  (taskkill path works); exit-code-3 propagates as `CalledProcessError`.
- Suites: `test_tts_command_providers` + `test_transcription_tools` — 90 passed,
  1 skipped; `test_transcription_command_providers` + `test_tts_plugin_dispatch` +
  `test_tts_speed` + `test_tts_opus_routing` — 52 passed. Total 142 passed, 1 skipped.

Closes #101585
