### PR TITLE
fix(cli): re-sync PROVIDER_REGISTRY after provider discovery completes (#102123)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -281,11 +281,34 @@ def _register_plugin_provider(pp: Any) -> None:
         PROVIDER_REGISTRY.setdefault(alias, pconfig)
 
 
-try:
-    from providers import list_providers as _list_providers_for_registry
-    for _pp in _list_providers_for_registry():
-        if _pp.name not in PROVIDER_REGISTRY:
+def sync_plugin_providers_to_registry() -> int:
+    """Mirror ``providers/`` plugin profiles into ``PROVIDER_REGISTRY`` (idempotent).
+
+    Only adds names that are missing — never overwrites hand-declared entries.
+    Runs once at import below, and is called back by ``providers`` when dynamic
+    discovery completes: an ``import hermes_cli.auth`` that happens mid-discovery
+    (e.g. from an entry-point plugin) would otherwise snapshot a partial provider
+    list that never refreshes. See #102123.
+    """
+    added = 0
+    try:
+        from providers import list_providers as _list_sync_providers
+    except Exception:
+        return 0
+    try:
+        for _pp in _list_sync_providers():
+            if _pp.name in PROVIDER_REGISTRY:
+                continue
             _register_plugin_provider(_pp)
+            if _pp.name in PROVIDER_REGISTRY:
+                added += 1
+    except Exception:
+        pass
+    return added
+
+
+try:
+    sync_plugin_providers_to_registry()
 except Exception:
     pass
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -65,6 +65,26 @@ def register_provider(profile: ProviderProfile) -> None:
     for alias in profile.aliases:
         _ALIASES[alias] = profile.name
     _PROVIDER_LIST_CACHE = None
+    _sync_auth_registry()
+
+
+def _sync_auth_registry() -> None:
+    """Best-effort re-sync of ``hermes_cli.auth.PROVIDER_REGISTRY`` (#102123).
+
+    Called when discovery completes and on every registration so an
+    ``import hermes_cli.auth`` that happened mid-discovery (partial import-time
+    snapshot) is reconciled once the full provider set is known. Looks the auth
+    module up through ``sys.modules`` and never imports it — importing here
+    would run its top-level code mid-scan and risks a circular import. Never
+    raises: provider registration must not fail because of an auth mirror.
+    """
+    try:
+        auth_mod = sys.modules.get("hermes_cli.auth")
+        sync = getattr(auth_mod, "sync_plugin_providers_to_registry", None)
+        if sync is not None:
+            sync()
+    except Exception:
+        pass
 
 
 def get_provider_profile(name: str) -> ProviderProfile | None:
@@ -413,6 +433,12 @@ def _discover_providers() -> None:
                 )
     except Exception:
         pass
+
+    # Reconcile hermes_cli.auth.PROVIDER_REGISTRY when a full scan completes:
+    # an auth import that happened mid-scan snapshotted a partial provider set
+    # (the _discovered flag is set before the scan). No-op unless auth was
+    # already imported. See #102123.
+    _sync_auth_registry()
 
     # (Pip entry-point providers are discovered in step 0, before the
     # filesystem plugins, so first-party profiles always win on name

--- a/tests/providers/test_auth_registry_mid_discovery.py
+++ b/tests/providers/test_auth_registry_mid_discovery.py
@@ -1,0 +1,124 @@
+"""Regression test for #102123.
+
+``hermes_cli.auth.PROVIDER_REGISTRY`` used to be a one-shot snapshot taken at
+import time. When ``hermes_cli.auth`` was first imported mid-discovery (e.g. by
+an entry-point plugin), the snapshot only saw the providers registered up to
+that moment and stayed incomplete forever — late providers were present in
+``providers._REGISTRY`` but absent from ``PROVIDER_REGISTRY``.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+import providers
+import hermes_cli.auth as auth_mod
+from providers.base import ProviderProfile
+
+
+EARLY = "probe-102123-early"
+LATE = "probe-102123-late"
+LATE_ALIAS = "probe-102123-late-alias"
+
+
+@pytest.fixture()
+def _isolated_registries():
+    """Snapshot both registries; restore on teardown so nothing leaks."""
+    saved_registry = dict(providers._REGISTRY)
+    saved_aliases = dict(providers._ALIASES)
+    saved_discovered = providers._discovered
+    saved_auth_keys = set(auth_mod.PROVIDER_REGISTRY)
+    saved_plugin_modules = {
+        m for m in sys.modules if m.startswith("plugins.model_providers")
+    }
+    providers._REGISTRY.clear()
+    providers._ALIASES.clear()
+    providers._PROVIDER_LIST_CACHE = None
+    providers._discovered = False
+    yield
+    for key in set(auth_mod.PROVIDER_REGISTRY) - saved_auth_keys:
+        del auth_mod.PROVIDER_REGISTRY[key]
+    for mod in [
+        m
+        for m in sys.modules
+        if m.startswith("plugins.model_providers")
+        and m not in saved_plugin_modules
+    ]:
+        del sys.modules[mod]
+    providers._REGISTRY.clear()
+    providers._REGISTRY.update(saved_registry)
+    providers._ALIASES.clear()
+    providers._ALIASES.update(saved_aliases)
+    providers._PROVIDER_LIST_CACHE = None
+    providers._discovered = saved_discovered
+
+
+def test_mid_discovery_auth_import_reconciled(
+    _isolated_registries, monkeypatch, tmp_path
+):
+    """Mid-discovery auth snapshot + late provider -> REGISTRY finally complete."""
+
+    def fake_entry_point_step():
+        # Reproduce a mid-discovery `import hermes_cli.auth`: its module
+        # top-level snapshots list_providers() exactly like this. Only EARLY
+        # is registered at this point on the way in (actually nothing yet —
+        # EARLY registers just below), so the snapshot is partial by design.
+        for pp in providers.list_providers():
+            if pp.name not in auth_mod.PROVIDER_REGISTRY:
+                auth_mod._register_plugin_provider(pp)
+        providers.register_provider(
+            ProviderProfile(
+                name=EARLY,
+                display_name="Early",
+                base_url="https://early.example/v1",
+                env_vars=("PROBE_102123_EARLY_KEY",),
+            )
+        )
+        # The snapshot above could only see EARLY-or-nothing: prove the hazard
+        # setup is real before discovery continues.
+        assert LATE not in auth_mod.PROVIDER_REGISTRY
+
+    late_plugin = tmp_path / "zzz_probe_102123"
+    late_plugin.mkdir()
+    (late_plugin / "__init__.py").write_text(
+        "from providers import register_provider\n"
+        "from providers.base import ProviderProfile\n"
+        "register_provider(ProviderProfile(\n"
+        f"    name={LATE!r}, display_name='Late',\n"
+        "    base_url='https://late.example/v1',\n"
+        f"    env_vars=('PROBE_102123_LATE_KEY',), aliases=({LATE_ALIAS!r},)))\n",
+        encoding="utf-8",
+    )
+    sys.modules.pop("plugins.model_providers.zzz_probe_102123", None)
+    monkeypatch.setattr(
+        providers, "_discover_entry_point_providers", fake_entry_point_step
+    )
+    monkeypatch.setattr(providers, "_BUNDLED_PLUGINS_DIR", tmp_path)
+    monkeypatch.setattr(providers, "_user_plugins_dir", lambda: None)
+    monkeypatch.setattr(providers, "_installed_plugins_dir", lambda: None)
+
+    providers._discover_providers()
+
+    assert providers.get_provider_profile(LATE) is not None
+    assert LATE in auth_mod.PROVIDER_REGISTRY
+    assert LATE_ALIAS in auth_mod.PROVIDER_REGISTRY
+    assert EARLY in auth_mod.PROVIDER_REGISTRY
+
+
+def test_sync_idempotent_and_no_clobber(_isolated_registries):
+    """Repeated syncs add nothing new and never replace existing entries."""
+    snapshot = dict(auth_mod.PROVIDER_REGISTRY)
+    auth_mod.sync_plugin_providers_to_registry()
+    for key, config in snapshot.items():
+        assert auth_mod.PROVIDER_REGISTRY[key] is config
+    after = dict(auth_mod.PROVIDER_REGISTRY)
+    assert auth_mod.sync_plugin_providers_to_registry() == 0
+    assert dict(auth_mod.PROVIDER_REGISTRY) == after
+
+
+def test_sync_noop_when_auth_never_imported(monkeypatch):
+    """The providers-side hook must not import hermes_cli.auth by itself."""
+    monkeypatch.delitem(sys.modules, "hermes_cli.auth", raising=False)
+    providers._sync_auth_registry()
+    assert "hermes_cli.auth" not in sys.modules


### PR DESCRIPTION
## What Problem This Solves

`hermes_cli.auth.PROVIDER_REGISTRY` can stay permanently incomplete when
`hermes_cli.auth` is first imported while `providers._discover_providers()`
is still mid-scan (e.g. an entry-point plugin transitively importing auth).
`_discovered` is set before the scan, so the import-time `list_providers()`
snapshot sees only the subset registered so far, and nothing ever refreshes
it: a provider ends up present in `providers._REGISTRY` but absent from
`PROVIDER_REGISTRY`, dropping out of `/api/model/options?explicit_only=1`
and failing `is_provider_explicitly_configured()` purely based on plugin
discovery order.

Fix (issue's suggested directions 1+4, minimal):

- `hermes_cli/auth.py`: the import-time snapshot block becomes idempotent
  `sync_plugin_providers_to_registry() -> int` (adds only missing names,
  never overwrites hand-declared entries, same skip/alias mapping). Still
  runs once at import — normal-path behavior unchanged.
- `providers/__init__.py`: new `_sync_auth_registry()` (looks auth up via
  `sys.modules`, never imports it — no circular-import risk; never raises)
  called when a full `_discover_providers()` scan completes and on every
  `register_provider()` so post-discovery registrations mirror too.

Deliberately not included: per-resolver on-miss re-sync (touches every
`PROVIDER_REGISTRY.get` call site and adds per-request overhead). Keeping
the dict itself correct at the two choke points fixes all direct readers
at once. Related prior work: #101768 (open, broader approach, does not
reference this issue); #102234/#102235 (closed as dupes of #101768).

## Evidence

New `tests/providers/test_auth_registry_mid_discovery.py` (3 tests) drives
the real `_discover_providers()`: a fake entry-point step takes the partial
import-time snapshot, an early provider registers, a late provider arrives
via a fake bundled plugin dir, then asserts both + alias land in
`PROVIDER_REGISTRY`; plus sync idempotency/no-clobber and the
never-imports-auth guard.

- Red on base (`git stash` of the fix): 3 failed.
- Green with fix: 3 passed.
- Neighbors: `test_entry_point_discovery.py` 6 passed,
  `test_provider_registry.py` 2 passed, `test_plugin_discovery.py`
  3 passed. `ruff check` clean on all changed files.
- Overhead (measured, Windows 11): cold discovery 238.7 ms for
  48 providers; steady-state sync 0.028 ms (repeat 0.009 ms), adds 0 —
  sync runs only at import / discovery end / registration, never per request.

Closes #102123
