### PR TITLE
fix(agent): downgrade verifier footer to neutral register on messaging surfaces (#97109)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -670,7 +670,13 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
-    return redacted
+    # Messaging surfaces get the neutral-register verifier notice, not the full
+    # developer footer (no paths/tool names/shell commands — #97109). Raw-text
+    # surfaces returned above, so reaching here means a chat surface. The
+    # neutral line carries no file paths, so the #35584 bare-path extractor
+    # structurally cannot fire on it.
+    from tools.tts_text_normalize import downgrade_verifier_footer_for_messaging
+    return downgrade_verifier_footer_for_messaging(redacted)
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1546,6 +1546,19 @@ class TurnRunner:
                 result["final_response"], result.get("messages", []), history_offset=len(agent_history),
             )
         ctx.result_holder[0] = result
+        # Messaging surfaces must never stream-finalize the full developer footer:
+        # ``finish(_final_for_stream)`` below delivers verbatim, and the reconcile
+        # basis (``_run_agent_mark_streamed_delivery``) must agree with the ledger
+        # or its stale-edit would re-leak the raw text. Downgrade the result copy
+        # (agent-side session persistence already ran inside the run) — #97109.
+        try:
+            from gateway.run import _gateway_surface_passes_raw_text
+            from tools.tts_text_normalize import downgrade_verifier_footer_for_messaging
+            if (isinstance(result, dict) and isinstance(result.get("final_response"), str)
+                    and not _gateway_surface_passes_raw_text(getattr(ctx.source, "platform", None))):
+                result["final_response"] = downgrade_verifier_footer_for_messaging(result["final_response"])
+        except Exception:
+            logger.debug("verifier footer downgrade failed", exc_info=True)
         if stream_consumer is None:
             return
         # Pass final_response as the authoritative finalize payload: it includes post-stream

--- a/tests/gateway/test_verifier_footer_register.py
+++ b/tests/gateway/test_verifier_footer_register.py
@@ -1,0 +1,94 @@
+"""Per-surface register for the file-mutation verifier footer (#97109).
+
+Messaging channels get one neutral honesty line (count preserved; no paths,
+tool names, or shell commands); developer surfaces (CLI transcript, logs, raw
+gateway surfaces) keep the full footer byte-identical. The neutral line keeps
+the ``File-mutation verifier:`` header shape so the TTS strip (#40772) still
+silences it on voice paths.
+"""
+
+import pytest
+
+from agent.turn_explainers import TurnExplainersMixin
+from gateway.config import Platform
+from gateway.run import _sanitize_gateway_final_response
+from tools.tts_text_normalize import (
+    downgrade_verifier_footer_for_messaging,
+    strip_nonspoken_blocks,
+)
+
+FAILED = {
+    "path/to/file": {"tool": "patch", "error_preview": "Could not find old_string xyz"},
+    "/etc/secret.conf": {"tool": "write_file", "error_preview": "denied"},
+}
+BODY = "Done, I updated the files as requested."
+
+
+def _full_text():
+    footer = TurnExplainersMixin._format_file_mutation_failure_footer(FAILED)
+    assert footer  # the fixture must actually carry a footer
+    return BODY + "\n\n" + footer
+
+
+class TestDowngradeHelper:
+    def test_neutral_line_keeps_count_drops_detail(self):
+        out = downgrade_verifier_footer_for_messaging(_full_text())
+        assert BODY in out
+        assert "2 file change(s) described above did not actually take effect." in out
+        for leaked in ("path/to/file", "/etc/secret.conf", "[patch]", "[write_file]",
+                        "git status", "read_file", "Could not find old_string", "\u2022"):
+            assert leaked not in out
+
+    def test_no_footer_passthrough(self):
+        assert downgrade_verifier_footer_for_messaging(BODY) == BODY
+        assert downgrade_verifier_footer_for_messaging("") == ""
+
+    def test_idempotent(self):
+        once = downgrade_verifier_footer_for_messaging(_full_text())
+        assert downgrade_verifier_footer_for_messaging(once) == once
+
+    def test_neutral_line_still_silenced_for_tts(self):
+        out = downgrade_verifier_footer_for_messaging(_full_text())
+        spoken = strip_nonspoken_blocks(out)
+        assert "File-mutation verifier" not in spoken
+        assert BODY in spoken
+
+
+class TestSanitizePerSurface:
+    @pytest.mark.parametrize("platform", ["telegram", "whatsapp", "slack", Platform.SIGNAL])
+    def test_messaging_gets_neutral_register(self, platform):
+        out = _sanitize_gateway_final_response(platform, _full_text())
+        assert "2 file change(s) described above did not actually take effect." in out
+        for leaked in ("path/to/file", "git status", "[patch]", "\u2022"):
+            assert leaked not in out
+
+    @pytest.mark.parametrize("platform", ["local", "api_server", "webhook"])
+    def test_developer_surfaces_keep_full_footer(self, platform):
+        raw = _full_text()
+        assert _sanitize_gateway_final_response(platform, raw) == raw
+
+
+class TestStreamFinalizeDowngrade:
+    def _runner_with_source(self, platform):
+        from types import SimpleNamespace
+
+        from gateway.run_turn_runner import TurnRunner
+        from gateway.turn_context import TurnContext
+
+        ctx = TurnContext()
+        ctx.source = SimpleNamespace(platform=platform)
+        return TurnRunner(SimpleNamespace(), ctx)
+
+    def test_messaging_stream_result_downgraded(self):
+        runner = self._runner_with_source(Platform.TELEGRAM)
+        result = {"final_response": _full_text(), "messages": [], "completed": True}
+        runner._finish_stream_consumer(result, [], None)
+        assert "2 file change(s) described above did not actually take effect." in result["final_response"]
+        assert "git status" not in result["final_response"]
+
+    def test_local_stream_result_untouched(self):
+        runner = self._runner_with_source(Platform.LOCAL)
+        raw = _full_text()
+        result = {"final_response": raw, "messages": [], "completed": True}
+        runner._finish_stream_consumer(result, [], None)
+        assert result["final_response"] == raw

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -176,6 +176,30 @@ _THINK_BLOCK_OPEN_RE = re.compile(r"<think[\s>].*\Z", flags=re.DOTALL | re.IGNOR
 # header line plus indented ``•`` bullets) is a UI affordance, not speech.
 _VERIFIER_FOOTER_RE = re.compile(r"^\s*⚠️?\s*File-mutation verifier:.*(?:\n[ \t]+•.*)*", flags=re.MULTILINE)
 
+_VERIFIER_FOOTER_COUNT_RE = re.compile(r"(\d+)\s*file")
+
+
+def downgrade_verifier_footer_for_messaging(text: str) -> str:
+    """Replace the full developer-register verifier footer with one neutral line (#97109).
+
+    Messaging recipients get ``<header> N file change(s) described above did not
+    actually take effect.`` — no paths, no tool names, no shell commands, so the
+    gateway's bare-path media extractor (#35584) structurally cannot fire. The
+    ``File-mutation verifier:`` header shape is kept so ``_VERIFIER_FOOTER_RE``
+    still matches for TTS stripping (#40772). Idempotent: re-applying yields the
+    same line. Non-footer text (and ``\"\"``) passes through untouched.
+    """
+    if not text or "File-mutation verifier" not in text:
+        return text
+
+    def _neutral(match: re.Match) -> str:
+        _count = _VERIFIER_FOOTER_COUNT_RE.search(match.group(0))
+        _n = _count.group(1) if _count else ""
+        _what = f"{_n} file change(s)" if _n else "a change"
+        return f"⚠️ File-mutation verifier: {_what} described above did not actually take effect."
+
+    return _VERIFIER_FOOTER_RE.sub(_neutral, text)
+
 
 def strip_nonspoken_blocks(text: str) -> str:
     """Remove ``<think>`` reasoning blocks and the file-mutation verifier footer."""


### PR DESCRIPTION
## What Problem This Solves

When the file-mutation verifier fires in a messaging session, WhatsApp/Slack/Telegram users received the full developer-register footer verbatim: warning header, per-file bullets with paths, tool names (`[patch]`), raw error previews, and `Run git status or read_file to confirm` — noise at best for a non-developer recipient. The codebase already treats the footer as a UI affordance, not user content (`_VERIFIER_FOOTER_RE` strips it before TTS, #40772), yet delivers it to messaging channels (`_neutralize_footer_paths` exists precisely because of that delivery, #35584). This PR joins the two rulings: messaging surfaces get a neutral single-line honesty notice, developer surfaces keep the full footer.

## Changes

- `tools/tts_text_normalize.py`: new `downgrade_verifier_footer_for_messaging()` reusing the existing `_VERIFIER_FOOTER_RE`. Renders `File-mutation verifier: N file change(s) described above did not actually take effect.` — count preserved, no paths/tool names/shell commands, header shape kept so the TTS strip still silences it, idempotent.
- `gateway/run.py` (`_sanitize_gateway_final_response`): apply the downgrade on chat surfaces; raw-text surfaces (`local`, `api_server`, `webhook`, `msgraph_webhook`) return before it, unchanged.
- `gateway/run_turn_runner.py` (`_finish_stream_consumer`): downgrade the result copy for messaging platforms so the streaming finalize payload and the reconcile basis agree (otherwise the stale-finalize edit would re-leak the raw footer). Agent-side session persistence already ran, so stored history keeps the full footer.

## Evidence

- Reproduced first: `_sanitize_gateway_final_response("telegram", body+footer)` returned the full footer verbatim (paths, `[patch]`, `git status`); after the fix it returns the neutral line, while `"local"` returns the input byte-identical.
- New `tests/gateway/test_verifier_footer_register.py`: 13 tests — neutral content/count, no-leak assertions, passthrough, idempotency, TTS-silence of the neutral line, per-surface sanitize matrix (telegram/whatsapp/slack/signal vs local/api_server/webhook), stream-finalize downgrade vs local untouched.
- Sabotage check: neutering the helper fails 6/13 (all messaging-path tests), restored → green.
- Regression run: 203 passed across the new file plus `test_tts_prepare_spoken`, `test_file_mutation_verifier`, `test_telegram_noise_filter`, `test_split_final_suffix_reconcile`, `test_stream_final_contract`.
- Benchmark (real measurement, 2000 runs): downgrade 7.1 us/call with footer present, 0.2 us/call fast path without — negligible per-turn cost.
- Out of scope: cron delivery uses a separate path without the sanitize chokepoint; voice behavior verified unchanged (neutral line still matches `_VERIFIER_FOOTER_RE`).

Closes #97109
