### PR TITLE
fix(desktop): gate group-hold stop words on mention proximity, release first (#103893)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -620,6 +620,45 @@ describe('member holds (#93129)', () => {
     expect([...action.release]).toEqual(['impl'])
   })
 
+  it('ignores a distant German filler word when a release word is present (#103893)', async () => {
+    const { rounds } = await loadRoom()
+
+    // Explicit "go" wins over the distant filler "halt" — no sticky hold.
+    const action = rounds.classifyGroupHoldDirective('@impl go, das ist halt ein Test', ['impl'], false)
+
+    expect([...action.hold]).toEqual([])
+    expect([...action.release]).toEqual(['impl'])
+  })
+
+  it('ignores a distant German stop-word noun with no directive (#103893)', async () => {
+    const { rounds } = await loadRoom()
+
+    const action = rounds.classifyGroupHoldDirective('@impl mach mal Pause', ['impl'], false)
+
+    expect([...action.hold]).toEqual([])
+    expect([...action.release]).toEqual(['impl'])
+  })
+
+  it('still holds when the stop word sits next to the mention', async () => {
+    const { rounds } = await loadRoom()
+
+    for (const text of ['@impl stop what you are doing', 'halt @impl, now']) {
+      const action = rounds.classifyGroupHoldDirective(text, ['impl'], false)
+
+      expect([...action.hold]).toEqual(['impl'])
+      expect([...action.release]).toEqual([])
+    }
+  })
+
+  it('treats a distant English stop word as prose, not a directive', async () => {
+    const { rounds } = await loadRoom()
+
+    const action = rounds.classifyGroupHoldDirective('stop the presses, @impl what do you think?', ['impl'], false)
+
+    expect([...action.hold]).toEqual([])
+    expect([...action.release]).toEqual(['impl'])
+  })
+
   it('sets a hold on stop and clears it on resume for the same member', async () => {
     const { rounds } = await loadRoom()
     const stamp = { at: 1000, byMessageId: 'm1', thread: 't1' }

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -156,13 +156,17 @@ export function rotateGroupSpeakers(members: GroupMember[], round: number) {
 /** #93129: classify a USER room message's effect on member holds. Only user
  *  sends ever reach this (bot replies are appended by the round loop, never
  *  through sendToGroupChat), so a bot saying "stopped working on it" can
- *  never set a hold. Conservative on purpose: any standalone stop/halt/pause
- *  word next to a mention holds those members — "don't stop @x" therefore
- *  also holds, which errs toward the bot staying quiet until re-addressed
- *  (a wrongly-held bot is one mention away from release; a wrongly-running
- *  one keeps doing work it was told to stop). A non-stop direct mention
- *  releases the mentioned members — the user addressing a bot directly
- *  overrides its hold. */
+ *  never set a hold. A stop/halt/pause word holds the mentioned members only
+ *  when it reads as a directive — adjacent to a mention ("stop @x",
+ *  "@x please halt") — so a distant prose word never holds ("@x go, das ist
+ *  halt ein Test", "@x mach mal Pause", #103893). "don't stop @x" therefore
+ *  still holds: the stop word sits next to the mention, which errs toward
+ *  the bot staying quiet until re-addressed (a wrongly-held bot is one
+ *  mention away from release; a wrongly-running one keeps doing work it was
+ *  told to stop). An explicit release word (resume/continue/go/proceed) wins
+ *  over a stop word in the same message. A non-stop direct mention releases
+ *  the mentioned members — the user addressing a bot directly overrides its
+ *  hold. */
 export function classifyGroupHoldDirective(
   text: string,
   mentionedKeys: Iterable<string> | null | undefined,
@@ -170,19 +174,10 @@ export function classifyGroupHoldDirective(
 ) {
   const value = String(text || '')
   const mentioned = [...(mentionedKeys || [])]
-  const stop = /\b(stop|halt|pause)\b/i.test(value)
   const resume = /\b(resume|continue|go|proceed)\b/i.test(value)
 
-  if (stop) {
-    // "@all stop" holds every member — symmetric with "@all resume".
-    return {
-      hold: mentioned,
-      holdAll: Boolean(everyone),
-      release: [],
-      releaseAll: false
-    }
-  }
-
+  // #103893: an explicit release word wins — "@impl go, das ist halt ein
+  // Test" addresses the bot, so the distant filler "halt" must not hold it.
   if (resume) {
     return {
       hold: [],
@@ -192,12 +187,55 @@ export function classifyGroupHoldDirective(
     }
   }
 
+  const stop = /\b(stop|halt|pause)\b/i.test(value)
+
+  // "@all stop" holds every member — symmetric with "@all resume".
+  if (stop && (Boolean(everyone) || stopWordNearMention(value, mentioned))) {
+    return {
+      hold: mentioned,
+      holdAll: Boolean(everyone),
+      release: [],
+      releaseAll: false
+    }
+  }
+
   return {
     hold: [],
     holdAll: false,
     release: mentioned,
     releaseAll: false
   }
+}
+
+/** #103893: true when a stop/halt/pause token sits within two words of an
+ *  @mention of a held-candidate member. Directives keep members ("stop @x",
+ *  "@x please halt"); prose fillers don't ("@x go, das ist halt ein Test").
+ *  ponytail: fixed ≤2 window fitted to observed cases, not language-aware —
+ *  widen only with measured directive/filler pairs, never by guessing. */
+function stopWordNearMention(value: string, mentioned: string[]) {
+  const keys = new Set(mentioned.map(key => String(key).toLowerCase()))
+
+  if (!keys.size) {
+    return false
+  }
+
+  const tokens = String(value).toLowerCase().match(/@[\p{L}\p{N}_-]+|[\p{L}\p{N}_-]+/gu) || []
+  const mentionAt: number[] = []
+  const stopAt: number[] = []
+
+  tokens.forEach((token, index) => {
+    if (token.startsWith('@')) {
+      const name = token.slice(1)
+
+      if (name === 'all' || name === 'everyone' || keys.has(name)) {
+        mentionAt.push(index)
+      }
+    } else if (token === 'stop' || token === 'halt' || token === 'pause') {
+      stopAt.push(index)
+    }
+  })
+
+  return stopAt.some(stop => mentionAt.some(mention => Math.abs(stop - mention) <= 2))
 }
 
 /** What `parseGroupChatMentions` reports for one room message. */


### PR DESCRIPTION
## What Problem This Solves

`classifyGroupHoldDirective` (`apps/desktop/src/plugins/hermes-bots/group-rounds.ts`)
ran `/\b(stop|halt|pause)\b/i` over the full message and checked it before any
release word. Any everyday word overlapping the stop list — German filler
`halt`, noun `Pause` — plus an `@mention` set a sticky per-member hold: the
bot paused with "stopped by you", the turn never delivered, and resending
re-triggered it. The reported case carries an explicit release word (`go`)
that never takes effect because the stop check short-circuits first.

This PR makes two minimal changes:

1. **Release words win.** `resume|continue|go|proceed` is checked before the
   stop list, so an explicit release in the same message takes effect.
2. **Stop words need directive context.** A stop token holds only within 2
   word-tokens of an `@mention` (`stop @x`, `@x please halt` — the proximity
   the function's own comment already describes). The mention-less `@all`
   path is untouched (`everyone` flag still holds/releases all).

The `≤ 2` window is fitted to measured cases, not derived — see caveat in
`Evidence`. Behavior it preserves deliberately: `don't stop @impl` still
holds (distance 1, adjacency kept).

## Evidence

Repro from the issue, against the exported classifier (before → after):

- `classifyGroupHoldDirective('@impl go, das ist halt ein Test', ['impl'], false).hold`
  → before `['impl']`, after `[]` (with `release: ['impl']`)

Stop↔mention word distances measured on current main (matches the data in
the issue thread): intended directives `stop @impl` (1), `@impl stop` (1),
`pause @impl for now` (1), `don't stop @impl` (1), `@impl please halt` (2);
German filler cases `@impl go, das ist halt ein Test` (4),
`@impl mach mal Pause` (3) — so `≤ 2` separates every pinned directive from
every reported filler case. Caveat, stated plainly: the threshold is a
heuristic fitted to these cases, not language awareness; a genuine directive
phrased 3+ words from its mention would now miss, trading one
misclassification class for another.

Verification (all measured, worktree `fix/103893-hold-classifier`):

- `npx vitest run src/plugins/hermes-bots/group-rounds.test.ts --pool=threads`
  → **47 passed** (43 pre-existing incl. the 4 pinned directive cases +
  `don't stop @x` + `@all stop/resume`, plus 4 new regression tests)
- New tests: issue repro (`go` + `halt` → release), `@impl mach mal Pause`
  → release, near-mention stops (`@impl stop what you are doing`,
  `halt @impl, now`) → hold, distant English
  (`stop the presses, @impl what do you think?`) → release
- Sabotage check: threshold `≤ 0` fails 5 tests (4 pinned + 1 new),
  restored to `≤ 2` → all green
- `npm run typecheck --workspace apps/desktop` → clean (exit 0)

Closes #103893
