### PR TITLE
fix(cli): resolve hidden canonical Bot Chat under compression in peer dm lookup (#106165)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2763,6 +2763,29 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                     sessions = await _list()
             except Exception:
                 pass  # resolution degrades to today's no-row behavior
+        if title_filter and not sessions and include_hidden and not source:
+            # A hidden canonical Bot Chat that has rotated through compression is invisible to the
+            # rich listing above: it projects the ended root onto its live tip (replacing the title),
+            # so the exact-title filter drops it; the peer then creates a duplicate and the
+            # UNIQUE(title) guard rejects it with 400 (#106165). Fall back to the window-free
+            # exact-title lookup (the same one the local session.list path uses) and resolve the
+            # lineage to its live tip, presenting the canonical title the client matches on.
+            # Archived rows stay invisible here — the resurrection above owns that decision.
+            try:
+                direct = db.get_session_by_title(title_filter)
+                if direct and not direct.get("archived"):
+                    tip_id = direct["id"]
+                    with suppress(Exception):
+                        tip_id = db.get_compression_tip(direct["id"]) or direct["id"]
+                    row = db.get_session(tip_id) or direct
+                    if row and not row.get("archived"):
+                        row = dict(row)
+                        row["title"] = title_filter
+                        if tip_id != direct["id"]:
+                            row["_lineage_root_id"] = direct["id"]
+                        sessions = [row]
+            except Exception:
+                pass  # resolution degrades to today's no-row behavior
         # Back-filled pins arrive PAST the limit, so counting them would report
         # another page that doesn't exist. Only the recency window decides.
         windowed = sum(1 for s in sessions if not s.get("pinned"))

--- a/tests/gateway/test_peer_dm_hidden_e2e.py
+++ b/tests/gateway/test_peer_dm_hidden_e2e.py
@@ -15,6 +15,7 @@ auth check, and SQLite query in the resolution chain is the real thing.
 import asyncio
 import json
 import threading
+import urllib.parse
 from types import SimpleNamespace
 
 import pytest
@@ -141,3 +142,57 @@ def test_hidden_lookup_requires_title_filter_e2e(peer_gateway):
     ids = [s["id"] for s in listing["data"]]
     assert peer_gateway.hidden_id not in ids
     assert "ordinary_1" in ids
+
+
+@pytest.fixture()
+def peer_gateway_compressed_hidden(peer_gateway):
+    """Aged Bot Mode footprint: the hidden canonical Bot Chat has a live
+    compression tip (issue #106165). The tip is untitled and hidden via the
+    lineage; the title lives only on the ended root."""
+    db = peer_gateway.db
+    tip_id = db.create_session(
+        "botchat_tip_1", "gateway_botmode", parent_session_id=peer_gateway.hidden_id)
+    db.end_session(peer_gateway.hidden_id, "compression")
+    db.set_session_hidden(peer_gateway.hidden_id, True)  # lineage-hide root+tip
+    peer_gateway.tip_id = tip_id
+    return peer_gateway
+
+
+def test_peer_dm_reaches_compressed_hidden_bot_chat_e2e(
+        peer_gateway_compressed_hidden, monkeypatch, capsys):
+    """Hidden canonical Bot Chat under compression: the peer lookup must still
+    resolve (to the live tip) instead of missing it and colliding with
+    UNIQUE(title) on create (HTTP 400, issue #106165)."""
+    gw = peer_gateway_compressed_hidden
+    monkeypatch.setattr(peer_cmd, "_load_peers", lambda: {"spark": {"url": gw.url}})
+    monkeypatch.setattr(peer_cmd, "_peer_secret", lambda name: API_KEY)
+
+    rc = peer_cmd.cmd_peer(
+        SimpleNamespace(peer_action="dm", target="spark", message="disk status?", json=True)
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reply"] == "e2e reply to: disk status?"
+    assert payload["session_id"] == gw.tip_id
+
+    # No duplicate "Bot Chat" row was minted; the title still lives on the root.
+    assert gw.db.get_session_by_title("Bot Chat")["id"] == gw.hidden_id
+
+
+def test_compressed_hidden_lookup_resolves_live_tip_e2e(peer_gateway_compressed_hidden):
+    """GET /api/sessions?title=Bot%20Chat&include_hidden=1 surfaces the live
+    tip for a hidden canonical under compression (one row, tip id, canonical
+    title so the peer client matches it)."""
+    import urllib.request
+
+    gw = peer_gateway_compressed_hidden
+    query = urllib.parse.urlencode({"limit": 200, "title": "Bot Chat", "include_hidden": 1})
+    req = urllib.request.Request(
+        f"{gw.url}/api/sessions?{query}",
+        headers={"Authorization": f"Bearer {API_KEY}"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        listing = json.loads(resp.read().decode())
+    assert [s["id"] for s in listing["data"]] == [gw.tip_id]
+    assert listing["data"][0]["title"] == "Bot Chat"


### PR DESCRIPTION
## What Problem This Solves

`hermes peer dm <peer>` fails with HTTP 400 `Title already in use by session <id>` when the target gateway's canonical Bot Chat is **hidden and has rotated through compression** — the normal state of any aged Bot Mode chat. The #91583 fix only covered a hidden chat with no continuation:

- `GET /api/sessions?title=Bot%20Chat&include_hidden=1` goes through `list_sessions_rich`, which projects a compression-ended root onto its live tip, **replacing the title**. The handler's exact-title filter then drops the row, the lookup reports "no Bot Chat", `_ensure_bot_chat` POSTs a duplicate, and the server's UNIQUE(title) guard 400s. Same-version gateways fail; unhiding "fixes" it only because the reporter never had a compressed chat in the repro.
- The local `session.list` path never had this bug: it uses window-free `get_session_by_title` + `get_compression_tip`.

Fix (server only, create path untouched): when a title-filtered, `include_hidden` lookup with no `source` filter still finds nothing, fall back to `get_session_by_title` (hidden-aware, projection-free, window-free), skip archived rows (the #92687 resurrection above owns that decision), resolve the lineage to its live tip, and return the tip row presenting the canonical title (+ `_lineage_root_id`) so the stock peer client matches it and DMs into the live transcript. All failures degrade to today's no-row behavior. No client change: the peer already sends `title` + `include_hidden=1`.

## Evidence

Repro (real `APIServerAdapter` over loopback + real `state.db`, stock peer client, model turn stubbed): hidden `Bot Chat` root + untitled hidden compression tip → before fix, `peer dm` exits 1 with the issue's exact error (`Peer 'spark': ... (HTTP 400: Title already in use by session botchat_hidden_1)`); after fix, exits 0, reply delivered into the tip, no duplicate row minted.

Regression tests in `tests/gateway/test_peer_dm_hidden_e2e.py` (2 new: peer-dm e2e to the tip, lookup-resolves-tip; 2 pre-existing: plain-hidden e2e, no-blanket-hidden-exposure bound):

- `tests/gateway/test_peer_dm_hidden_e2e.py`: 4 passed in 1.87s
- Adjacent, unmodified behavior: `test_peer_cmd.py` + `test_session_api.py` + `test_session_list_allowed_sources.py`: 43 passed in 15.18s; `test_session_hidden.py` + gateway `test_session.py`: 66 passed in 6.69s
- Sabotage check: with the `api_server.py` hunk stashed, the 2 new tests fail (old 2 pass); with it applied, all 4 pass.

Closes #106165
