### PR TITLE
fix(cron): attribute cron deliveries with the job's pinned model (#105244)

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -162,8 +162,19 @@ def _inchannel_seed_allowed(*, is_dm: bool, user_id: Optional[str]) -> bool:
     return bool(is_dm or user_id)
 
 
+def _cron_job_model_label(job: dict) -> str:
+    """Pinned-model attribution for delivery/mirror provenance ('' when unpinned)."""
+    if not isinstance(job, dict):
+        return ""
+    return str(job.get("model") or "").strip()
+
+
 def _cron_mirror_message(job: dict, text: str) -> str:
-    return f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}"
+    label = f"{job.get('name') or job.get('id', 'cron')}"
+    model = _cron_job_model_label(job)
+    if model:
+        label += f" (model: {model})"
+    return f"[Cron delivery: {label}]\n{text}"
 
 
 def _maybe_mirror_cron_delivery(
@@ -1695,9 +1706,16 @@ def _deliver_result(
     unverified_targets: list = []
     if wrap_response:
         task_name = job.get("name", job["id"])
+        task_model = _cron_job_model_label(job)
+        origin_line = f"(job_id: {job.get('id', '')}"
+        if task_model:
+            # Pinned-model attribution (#105244): a job running on a model other
+            # than the profile default must not read as the agent's own voice.
+            origin_line += f", model: {task_model}"
+        origin_line += ")"
         delivery_content = (
             f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job.get('id', '')})\n"
+            f"{origin_line}\n"
             f"-------------\n\n"
             f"{content}\n\n"
             "To stop or manage this job, send me a new message "

--- a/tests/cron/test_105244_cron_delivery_identity.py
+++ b/tests/cron/test_105244_cron_delivery_identity.py
@@ -1,0 +1,83 @@
+"""Regression tests for #105244 mechanism B.
+
+A cron job pinned to a model different from the profile default delivers its
+output into the user's chat. The delivery must carry the *job's* identity
+(including the pinned model) so neither the user nor the agent mistakes the
+job's model for the agent's own runtime model.
+
+Old behavior preserved: an unpinned job's header/mirror bytes are unchanged,
+and a pinned job still RUNS with its pin (pin precedence untouched).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cron.scheduler import _deliver_result, _load_cron_job_config
+from cron.scheduler_delivery import _cron_mirror_message
+
+
+def _run_delivery(job, content="Here is today's summary."):
+    from gateway.config import Platform
+
+    pconfig = MagicMock()
+    pconfig.enabled = True
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+    with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+         patch("tools.send_message_tool._send_to_platform",
+               new=AsyncMock(return_value={"success": True})) as send_mock:
+        _deliver_result(job, content)
+    send_mock.assert_called_once()
+    return send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+
+
+class TestPinnedModelAttribution:
+    def test_delivery_header_names_pinned_model(self):
+        sent = _run_delivery({
+            "id": "test-job",
+            "name": "weekly-research",
+            "model": "qwen3.5:397b",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        })
+        assert "Cronjob Response: weekly-research" in sent
+        assert "(job_id: test-job" in sent
+        assert "qwen3.5:397b" in sent
+
+    def test_mirror_prefix_names_pinned_model(self):
+        text = _cron_mirror_message(
+            {"id": "abc123", "name": "weekly-research", "model": "qwen3.5:397b"},
+            "payload",
+        )
+        assert text.startswith("[Cron delivery: weekly-research")
+        assert "qwen3.5:397b" in text.split("\n", 1)[0]
+        assert text.endswith("payload")
+
+
+class TestUnpinnedBytesUnchanged:
+    def test_delivery_header_without_pin_has_no_model(self):
+        sent = _run_delivery({
+            "id": "test-job",
+            "name": "daily-report",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        })
+        assert "(job_id: test-job)" in sent
+        assert "model:" not in sent
+
+    def test_mirror_prefix_without_pin_unchanged(self):
+        assert _cron_mirror_message(
+            {"id": "abc123", "name": "daily-report"}, "payload"
+        ) == "[Cron delivery: daily-report]\npayload"
+
+
+class TestPinStillEffective:
+    def test_job_pin_wins_over_env_and_missing_config(self, monkeypatch, tmp_path):
+        """Old behavior: the pin itself still decides the run's model."""
+        monkeypatch.setenv("HERMES_MODEL", "deepseek-v4-pro:0813")
+        # Point the home at an empty dir so no config.yaml can override the pin.
+        import cron.scheduler as sched
+
+        monkeypatch.setattr(sched, "_get_hermes_home", lambda: tmp_path)
+        resolved = _load_cron_job_config(
+            {"id": "j", "model": "qwen3.5:397b"}, "j", "weekly-research")
+        assert resolved.model == "qwen3.5:397b"


### PR DESCRIPTION
## What Problem This Solves

#105244 mechanism B: a cron job pinned to a model different from the profile
default (e.g. profile `deepseek-v4-pro:0813`, job pin `qwen3.5:397b`) executes
with the override and delivers its output into the user's chat. The delivery
wrapper identified the *job* (`Cronjob Response: <name>`, `(job_id: <id>)`)
but never the *model that produced it*, so every weekly run spoke as "Qwen"
with no provenance — and the agent later answered "what model are you
running" with the cron job's model. The session-mirror prefix
(`[Cron delivery: <name>]`) had the same gap.

This change attributes both surfaces with the job's pinned model:
- wrapped delivery header: `(job_id: <id>, model: <pin>)` when a pin exists;
  unpinned jobs render byte-identical headers (no `model:` fragment).
- session-mirror prefix: `[Cron delivery: <name> (model: <pin>)]`; unpinned
  mirrors are byte-identical to before.

Pin precedence is untouched — the fix is provenance-only, no session-state
or resolution change (deliberately avoiding the `sweeper:risk-session-state`
surface).

Scope note: mechanism A (live-session pin re-point path, related #102658)
is left as follow-up; this PR covers mechanism B only.

Related to #105244

## Evidence

TDD red→green→sabotage, measured in `D:/code/wt-105244` (branch
`fix/105244-model-identity`, base `origin/main=9e0dc4319a`):

- RED (before fix): 2 new attribution tests failed with the exact symptom —
  delivered content contained `(job_id: test-job)` with no model, mirror
  prefix was bare `[Cron delivery: weekly-research]`.
- GREEN (after fix): `tests/cron/test_105244_cron_delivery_identity.py` —
  5 passed in 0.70s (2 pinned-attribution + 2 unpinned-bytes-unchanged +
  1 pin-still-wins-over-`HERMES_MODEL`-and-missing-config).
- Sabotage check: blanking the mirror attribution re-fails exactly 1 test
  (`test_mirror_prefix_names_pinned_model`), then restored to green.
- Neighbors: `tests/cron/test_scheduler.py` + new file — 109 passed in
  14.90s. `test_run_one_job` + `test_mirror_origin_fallback` +
  `test_cron_failure_deliver` + `test_media_delivery_parity` — 56 passed,
  1 failed in `TestMediaPolicyEnvBridge` (Windows path-escape assertion);
  verified the same test fails on the clean `origin/main` checkout, so it
  is pre-existing and unrelated.

## Test Plan

- [x] `pytest tests/cron/test_105244_cron_delivery_identity.py -q` — 5 passed
- [x] `pytest tests/cron/test_scheduler.py tests/cron/test_105244_cron_delivery_identity.py -q` — 109 passed
- [x] Neighbor cron suites — 56 passed, 1 pre-existing env failure (confirmed on clean main)
