### PR TITLE
fix(desktop): keep runtime discovery off the main event loop

### DIFF
--- a/apps/desktop/e2e/runtime-probe-race-sitecustomize.py
+++ b/apps/desktop/e2e/runtime-probe-race-sitecustomize.py
@@ -1,0 +1,40 @@
+"""Sandbox-only gate: let the real interpreter and Hermes CLI run unchanged."""
+import atexit
+import json
+import os
+from pathlib import Path
+import sys
+import time
+
+
+def record(directory, name, **extra):
+    # Separate, atomically published records avoid partial reads/concurrent
+    # appends when Python's Windows venv redirector starts several children.
+    target = directory / name
+    target.mkdir(exist_ok=True)
+    pending = target / f"{os.getpid()}.tmp"
+    pending.write_text(
+        json.dumps({"pid": os.getpid(), "argv": sys.orig_argv, **extra}),
+        encoding="utf-8",
+    )
+    pending.replace(target / f"{os.getpid()}.json")
+
+
+directory = os.environ.get("HERMES_E2E_RUNTIME_RACE_DIR")
+if directory:
+    directory = Path(directory)
+    # Production supplies this secret only to actual backend spawns. Do not
+    # change or short-circuit their startup: the record observes a real child.
+    if os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN"):
+        record(directory, "spawned")
+    record(directory, "all")
+    if sys.orig_argv[1:] == ["-m", "hermes_cli.main", "serve", "--help"]:
+        record(directory, "entered", parent_pid=os.getppid())
+        deadline = time.monotonic() + 25
+        while not (directory / "release").exists():
+            if time.monotonic() >= deadline:
+                record(directory, "timed-out")
+                break
+            time.sleep(0.02)
+        record(directory, "released")
+        atexit.register(record, directory, "exited")

--- a/apps/desktop/e2e/runtime-probe-races.spec.ts
+++ b/apps/desktop/e2e/runtime-probe-races.spec.ts
@@ -1,0 +1,178 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { expect, test } from '@playwright/test'
+
+import { buildAppEnv, createSandbox, launchDesktop, writeEnvFile, writeMockProviderConfig } from './fixtures'
+
+const repo = path.resolve(import.meta.dirname, '../../..')
+interface ChildRecord {
+  pid: number
+  argv: string[]
+  parent_pid?: number
+}
+
+function records(directory: string, name: string): ChildRecord[] {
+  const folder = path.join(directory, name)
+
+  return fs.existsSync(folder)
+    ? fs
+        .readdirSync(folder)
+        .filter(file => file.endsWith('.json'))
+        .map(file => JSON.parse(fs.readFileSync(path.join(folder, file), 'utf8')))
+    : []
+}
+
+// Both cases use the real renderer/preload/main IPC and provisioned Python.
+// The empty namespace directory forces source-inspection fallback WITHOUT
+// modifying the real checkout or venv. Python still imports the real package.
+for (const owner of ['primary', 'pool'] as const) {
+  test(`${owner} invalidation during serve help prevents stale backend spawn`, async () => {
+    test.setTimeout(75_000)
+    const python = process.env.HERMES_DESKTOP_PYTHON
+    expect(python, 'Set HERMES_DESKTOP_PYTHON to a provisioned Hermes venv').toBeTruthy()
+    const sandbox = createSandbox(`runtime-race-${owner}`)
+    let running: Awaited<ReturnType<typeof launchDesktop>> | undefined
+    const hook = path.join(sandbox.root, 'hook')
+    fs.mkdirSync(hook)
+
+    try {
+      const prefix = execFileSync(python!, ['-c', 'import sys; print(sys.prefix)'], {
+        encoding: 'utf8',
+        env: buildAppEnv(sandbox),
+        timeout: 15_000,
+        windowsHide: true
+      }).trim()
+
+      const active = path.join(sandbox.hermesHome, 'hermes-agent')
+      fs.mkdirSync(path.join(active, 'hermes_cli'), { recursive: true })
+      fs.copyFileSync(path.join(repo, 'hermes_cli', 'main.py'), path.join(active, 'hermes_cli', 'main.py'))
+      fs.symlinkSync(prefix, path.join(active, 'venv'), process.platform === 'win32' ? 'junction' : 'dir')
+      fs.copyFileSync(
+        path.join(import.meta.dirname, 'runtime-probe-race-sitecustomize.py'),
+        path.join(hook, 'sitecustomize.py')
+      )
+      fs.mkdirSync(path.join(sandbox.hermesHome, 'profiles', 'race-pool'), { recursive: true })
+      writeMockProviderConfig(sandbox.hermesHome, 'http://127.0.0.1:1')
+      writeEnvFile(sandbox.hermesHome)
+
+      const env = buildAppEnv(sandbox, {
+        HOME: sandbox.root,
+        USERPROFILE: sandbox.root,
+        HERMES_DESKTOP_IS_PACKAGED: '1',
+        HERMES_DESKTOP_HERMES_ROOT: '',
+        HERMES_DESKTOP_HERMES: '',
+        HERMES_DESKTOP_PYTHON: '',
+        HERMES_PROBE_TIMEOUT_MS: '30000',
+        HERMES_E2E_RUNTIME_RACE_DIR: hook,
+        PYTHONPATH: [hook, repo].join(path.delimiter),
+        PYTHONDONTWRITEBYTECODE: '1',
+        NODE_OPTIONS: ''
+      })
+
+      delete env.HERMES_DESKTOP_DEV_SERVER
+      expect(env.HERMES_DASHBOARD_SESSION_TOKEN).toBeUndefined()
+
+      const imported = execFileSync(python!, ['-c', 'import hermes_cli; print(hermes_cli.__file__)'], {
+        cwd: active,
+        env,
+        encoding: 'utf8',
+        timeout: 15_000,
+        windowsHide: true
+      }).trim()
+
+      expect(path.resolve(imported)).toBe(path.join(repo, 'hermes_cli', '__init__.py'))
+      running = await launchDesktop(env)
+      // Keep preload but remove automatic UI reconnects: only the explicit
+      // bridge requests below own the test's connection attempts.
+      await running.page.goto('about:blank')
+      await running.page.waitForFunction(() => Boolean((window as any).hermesDesktop))
+
+      const pending = running.page
+        .evaluate(async scope => {
+          try {
+            await (window as any).hermesDesktop.getConnection(scope === 'pool' ? 'race-pool' : undefined)
+
+            return { status: 'resolved', error: '' }
+          } catch (error) {
+            return { status: 'rejected', error: String(error) }
+          }
+        }, owner)
+        .catch(error => ({ status: 'harness-error', error: String(error) }))
+
+      await expect.poll(() => records(hook, 'entered').length, { timeout: 20_000 }).toBeGreaterThan(0)
+      expect(records(hook, 'released')).toEqual([])
+
+      // Windows venv python.exe can be a redirector that remains the worker's
+      // immediate parent. Verify the real Electron-owned chain, not POSIX PPID.
+      const probeParents = await running.app.evaluate(() => [
+        process.pid,
+        ...(process as any)
+          ._getActiveHandles()
+          .filter(
+            (handle: any) =>
+              JSON.stringify(handle.spawnargs?.slice(1)) ===
+              JSON.stringify(['-m', 'hermes_cli.main', 'serve', '--help'])
+          )
+          .map((child: any) => child.pid)
+      ])
+
+      expect(probeParents).toContain(records(hook, 'entered')[0].parent_pid)
+
+      if (owner === 'pool') {
+        // Primary and pool share the serve-support promise. Wait for the pool's
+        // own import probe to close and its promise continuations to drain, so
+        // invalidation occurs at serve-help, not earlier runtime discovery.
+        await expect
+          .poll(
+            () =>
+              records(hook, 'all').filter(
+                record => record.argv.at(-1) === 'import yaml; import dotenv; import hermes_cli.config'
+              ).length
+          )
+          .toBe(2)
+        await running.app.evaluate(async () => {
+          const children = (process as any)
+            ._getActiveHandles()
+            .filter(
+              (handle: any) => handle.spawnargs?.at(-1) === 'import yaml; import dotenv; import hermes_cli.config'
+            )
+
+          await Promise.all(children.map((child: any) => new Promise<void>(resolve => child.once('close', resolve))))
+          await new Promise<void>(resolve => setImmediate(resolve))
+        })
+      }
+
+      const applied = await running.page.evaluate(
+        scope =>
+          (window as any).hermesDesktop.applyConnectionConfig({
+            mode: 'local',
+            ...(scope === 'pool' ? { profile: 'race-pool' } : {})
+          }),
+        owner
+      )
+
+      expect(applied.mode).toBe('local')
+      expect(records(hook, 'released')).toEqual([])
+      fs.writeFileSync(path.join(hook, 'release'), '')
+      // Rejection is the completion barrier for the actual awaiting spawn path,
+      // not an arbitrary sleep followed by an absence assertion.
+      const result = await pending
+      expect(result.status, result.error).toBe('rejected')
+      await expect.poll(() => records(hook, 'exited').length, { timeout: 15_000 }).toBeGreaterThan(0)
+      expect(records(hook, 'timed-out')).toEqual([])
+      const stale = records(hook, 'spawned').filter(record => owner === 'primary' || record.argv.includes('race-pool'))
+      expect(stale).toEqual([])
+      console.log(`${owner}: real serve-help exited; stale backend Python spawns=${stale.length}`)
+    } finally {
+      fs.writeFileSync(path.join(hook, 'release'), '')
+
+      if (running) {
+        await running.app.close()
+      }
+
+      sandbox.cleanup()
+    }
+  })
+}

--- a/apps/desktop/e2e/runtime-probe-races.spec.ts
+++ b/apps/desktop/e2e/runtime-probe-races.spec.ts
@@ -144,6 +144,29 @@ for (const owner of ['primary', 'pool'] as const) {
         })
       }
 
+      // Observe Node's actual spawn as well as Python startup. A post-spawn
+      // ownership rejection can kill Python before sitecustomize ever executes;
+      // a Python-only counter would miss that forbidden transient process.
+      await running.app.evaluate((_electron, directory) => {
+        const childProcess = process.getBuiltinModule('child_process')
+        const fs = process.getBuiltinModule('fs')
+        const path = process.getBuiltinModule('path')
+        const spawn = childProcess.spawn
+        childProcess.spawn = ((...args: Parameters<typeof spawn>) => {
+          const child = Reflect.apply(spawn, childProcess, args)
+          const options = args[2] as { env?: Record<string, string> } | undefined
+
+          if (options?.env?.HERMES_DASHBOARD_SESSION_TOKEN) {
+            const target = path.join(directory, 'spawn-attempts')
+            fs.mkdirSync(target, { recursive: true })
+            fs.writeFileSync(path.join(target, `${child.pid}.json`), JSON.stringify({ pid: child.pid, argv: args[1] }))
+          }
+
+          return child
+        }) as typeof spawn
+        process.getBuiltinModule('module').syncBuiltinESMExports()
+      }, hook)
+
       const applied = await running.page.evaluate(
         scope =>
           (window as any).hermesDesktop.applyConnectionConfig({
@@ -162,9 +185,17 @@ for (const owner of ['primary', 'pool'] as const) {
       expect(result.status, result.error).toBe('rejected')
       await expect.poll(() => records(hook, 'exited').length, { timeout: 15_000 }).toBeGreaterThan(0)
       expect(records(hook, 'timed-out')).toEqual([])
+
+      const attempts = records(hook, 'spawn-attempts').filter(
+        record => owner === 'primary' || record.argv.includes('race-pool')
+      )
+
+      expect(attempts, 'invalidated attempts must not even spawn a short-lived child').toEqual([])
       const stale = records(hook, 'spawned').filter(record => owner === 'primary' || record.argv.includes('race-pool'))
       expect(stale).toEqual([])
-      console.log(`${owner}: real serve-help exited; stale backend Python spawns=${stale.length}`)
+      console.log(
+        `${owner}: real serve-help exited; stale Node spawns=${attempts.length}, Python starts=${stale.length}`
+      )
     } finally {
       fs.writeFileSync(path.join(hook, 'release'), '')
 

--- a/apps/desktop/e2e/runtime-probe-sitecustomize.py
+++ b/apps/desktop/e2e/runtime-probe-sitecustomize.py
@@ -1,0 +1,49 @@
+"""Sandbox-only hook: require the real import probe's Electron parent to reply.
+
+Loaded by Python itself via PYTHONPATH; never replaces an interpreter or imports.
+A fatal exit is intentional: Python otherwise ignores sitecustomize exceptions.
+"""
+import json
+import os
+from pathlib import Path
+import socket
+import sys
+import time
+
+
+def _gate_runtime_probe():
+    gate = os.environ.get("HERMES_E2E_RUNTIME_PROBE_DIR")
+    argv = sys.orig_argv
+    if not gate or "-c" not in argv:
+        return
+    code = argv[argv.index("-c") + 1]
+    if "import yaml" not in code or "import hermes_cli.config" not in code:
+        return
+    root = Path(gate)
+    record = {"pid": os.getpid(), "argv": argv, "home": os.environ.get("HERMES_HOME")}
+    (root / "entered.json").write_text(json.dumps(record), encoding="utf-8")
+    deadline = time.monotonic() + 25
+    port_file = root / "port"
+    while not port_file.exists():
+        if time.monotonic() >= deadline:
+            raise TimeoutError("Electron parent never started its loopback service")
+        time.sleep(0.01)
+    with socket.create_connection(("127.0.0.1", int(port_file.read_text())), timeout=20) as connection:
+        connection.sendall(str(os.getpid()).encode("ascii"))
+        with connection.makefile("rb") as response:
+            reply = response.read(128).decode("ascii")
+        if not reply.startswith("parent:"):
+            raise RuntimeError(f"Unexpected parent response: {reply!r}")
+        record["parent_pid"] = int(reply.removeprefix("parent:"))
+    pending = root / "replied.json.tmp"
+    pending.write_text(json.dumps(record), encoding="utf-8")
+    pending.replace(root / "replied.json")
+
+
+try:
+    _gate_runtime_probe()
+except Exception as error:
+    gate = os.environ.get("HERMES_E2E_RUNTIME_PROBE_DIR")
+    if gate:
+        (Path(gate) / "failed.txt").write_text(str(error), encoding="utf-8")
+    os._exit(91)

--- a/apps/desktop/e2e/runtime-probes.spec.ts
+++ b/apps/desktop/e2e/runtime-probes.spec.ts
@@ -130,9 +130,19 @@ test('runtime import probe can complete I/O with its actual Electron parent', as
       .split('\n')
       .map(line => JSON.parse(line))
 
+    // The launch handle's PID can differ from Electron main on Windows. Use
+    // the browser process executing this callback: its I/O must stay live.
+    const main = await running.app.evaluate(() => ({
+      pid: process.pid,
+      type: (process as NodeJS.Process & { type?: string }).type,
+      electron: process.versions.electron
+    }))
+
+    expect(main.type).toBe('browser')
+    expect(main.electron).toBeTruthy()
     expect(reply.home).toBe(sandbox.hermesHome)
-    expect(reply.pid).not.toBe(running.app.process().pid)
-    expect(reply.parent_pid).toBe(running.app.process().pid)
+    expect(reply.pid).not.toBe(main.pid)
+    expect(reply.parent_pid).toBe(main.pid)
     expect(accepted).toContainEqual({ parentPid: reply.parent_pid, childPid: reply.pid })
     expect(fs.existsSync(path.join(hook, 'failed.txt'))).toBe(false)
     await waitForAppReady({ ...running, mock, mockUrl: mock.url, sandbox, cleanup: async () => {} })

--- a/apps/desktop/e2e/runtime-probes.spec.ts
+++ b/apps/desktop/e2e/runtime-probes.spec.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { expect, test } from '@playwright/test'
+
+import { startMockServer } from '../../../tests-js/scripts/mock-server'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+
+const repo = path.resolve(import.meta.dirname, '../../..')
+
+/**
+ * Real local active-install discovery, not a remote-connection reproduction.
+ * Saved remotes bypass this resolver; this does not establish AppHangB1's cause.
+ * Run after npm run build, with HERMES_DESKTOP_PYTHON set to a provisioned venv.
+ * No setup/update commands or writes through the source/venv links are needed.
+ */
+test('runtime import probe can complete I/O with its actual Electron parent', async () => {
+  test.setTimeout(90_000)
+  const python = process.env.HERMES_DESKTOP_PYTHON
+  expect(python, 'Set HERMES_DESKTOP_PYTHON to an existing Hermes test venv interpreter').toBeTruthy()
+  const sandbox = createSandbox('runtime-probe')
+  const mock = await startMockServer()
+  let running: Awaited<ReturnType<typeof launchDesktop>> | undefined
+
+  try {
+    // Link only the required source package and the actual venv (Windows needs
+    // its Scripts/python.exe redirector and pyvenv.cfg, not a copied executable).
+    const prefix = execFileSync(python!, ['-c', 'import sys; print(sys.prefix)'], {
+      encoding: 'utf8',
+      env: buildAppEnv(sandbox),
+      timeout: 15_000,
+      windowsHide: true
+    }).trim()
+
+    const active = path.join(sandbox.hermesHome, 'hermes-agent')
+    fs.mkdirSync(active)
+    const linkType = process.platform === 'win32' ? 'junction' : 'dir'
+    fs.symlinkSync(path.join(repo, 'hermes_cli'), path.join(active, 'hermes_cli'), linkType)
+    fs.symlinkSync(prefix, path.join(active, 'venv'), linkType)
+    const hook = path.join(sandbox.root, 'python-hook')
+    fs.mkdirSync(hook)
+    fs.copyFileSync(
+      path.join(import.meta.dirname, 'runtime-probe-sitecustomize.py'),
+      path.join(hook, 'sitecustomize.py')
+    )
+    writeMockProviderConfig(sandbox.hermesHome, mock.url)
+    writeEnvFile(sandbox.hermesHome)
+
+    const env = buildAppEnv(sandbox, {
+      HOME: sandbox.root,
+      USERPROFILE: sandbox.root,
+      HERMES_DESKTOP_IS_PACKAGED: '1',
+      HERMES_DESKTOP_HERMES_ROOT: '',
+      HERMES_DESKTOP_HERMES: '',
+      HERMES_DESKTOP_PYTHON: '',
+      HERMES_PROBE_TIMEOUT_MS: '15000',
+      HERMES_E2E_RUNTIME_PROBE_DIR: hook,
+      PYTHONPATH: [hook, repo].join(path.delimiter),
+      PYTHONDONTWRITEBYTECODE: '1',
+      NODE_OPTIONS: ''
+    })
+
+    delete env.HERMES_DESKTOP_DEV_SERVER
+    running = await launchDesktop(env)
+    await expect.poll(() => fs.existsSync(path.join(hook, 'entered.json')), { timeout: 20_000 }).toBe(true)
+
+    // The Python child is still waiting for a port. Exercise the existing
+    // renderer → preload → main IPC bridge before allowing that child to exit.
+    const limits = await running.page.evaluate(() =>
+      (
+        window as unknown as {
+          hermesDesktop: { getPoolLimits: () => Promise<{ maxBackends: number }> }
+        }
+      ).hermesDesktop.getPoolLimits()
+    )
+
+    expect(limits.maxBackends).toBeGreaterThan(0)
+    expect(fs.existsSync(path.join(hook, 'replied.json'))).toBe(false)
+    // This server MUST live in Electron main, not the Playwright runner. A
+    // synchronous child probe prevents main from accepting/replying and fails.
+    await running.app.evaluate(async (_electron, directory) => {
+      const net = process.getBuiltinModule('net')
+      const fs = process.getBuiltinModule('fs')
+      const path = process.getBuiltinModule('path')
+      await new Promise<void>((resolve, reject) => {
+        const server = net.createServer(socket => {
+          socket.on('error', () => undefined)
+          socket.once('data', data => {
+            fs.appendFileSync(
+              path.join(directory, 'accepted.jsonl'),
+              JSON.stringify({
+                parentPid: process.pid,
+                childPid: Number(data.toString())
+              }) + '\n'
+            )
+            socket.end(`parent:${process.pid}`)
+          })
+        })
+
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+          const address = server.address()
+
+          if (!address || typeof address === 'string') {
+            return reject(new Error('No TCP address'))
+          }
+
+          fs.writeFileSync(path.join(directory, 'port.tmp'), String(address.port))
+          fs.renameSync(path.join(directory, 'port.tmp'), path.join(directory, 'port'))
+          server.unref()
+          resolve()
+        })
+      })
+    }, hook)
+    await expect.poll(() => fs.existsSync(path.join(hook, 'replied.json')), { timeout: 20_000 }).toBe(true)
+    const reply = JSON.parse(fs.readFileSync(path.join(hook, 'replied.json'), 'utf8'))
+
+    const accepted = fs
+      .readFileSync(path.join(hook, 'accepted.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line))
+
+    expect(reply.home).toBe(sandbox.hermesHome)
+    expect(reply.pid).not.toBe(running.app.process().pid)
+    expect(reply.parent_pid).toBe(running.app.process().pid)
+    expect(accepted).toContainEqual({ parentPid: reply.parent_pid, childPid: reply.pid })
+    expect(fs.existsSync(path.join(hook, 'failed.txt'))).toBe(false)
+    await waitForAppReady({ ...running, mock, mockUrl: mock.url, sandbox, cleanup: async () => {} })
+  } finally {
+    if (running) {
+      await running.app.close()
+    }
+
+    await mock.close()
+    sandbox.cleanup()
+  }
+})

--- a/apps/desktop/electron/backend-claim-exec.test.ts
+++ b/apps/desktop/electron/backend-claim-exec.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { execText } from './backend-claim'
+
+test('execText closes noninteractive stdin and trims output after EOF', async () => {
+  const output = await execText(
+    process.execPath,
+    ['-e', "process.stdin.resume(); process.stdin.on('end', () => process.stdout.write('  eof  \\n'))"],
+    { timeout: 2000 }
+  )
+
+  assert.equal(output, 'eof')
+}, 10_000)
+
+// Windows forcibly terminates children; a graceful SIGTERM handler is POSIX-only.
+test.skipIf(process.platform === 'win32')(
+  'execText rejects timed-out output even when SIGTERM exits zero',
+  async () => {
+    await assert.rejects(
+      execText(
+        process.execPath,
+        [
+          '-e',
+          "process.on('SIGTERM', () => process.exit(0)); process.stdout.write('candidate'); setInterval(() => {}, 1000)"
+        ],
+        { timeout: 2000 }
+      ),
+      /timed out/i
+    )
+  },
+  10_000
+)

--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -26,13 +26,19 @@ import { hiddenWindowsChildOptions } from './windows-child-options'
 
 export function execText(command: string, args: string[], { timeout = 3000 } = {}): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    execFile(command, args, hiddenWindowsChildOptions({ encoding: 'utf8', timeout }), (error, stdout) => {
+    const child = execFile(command, args, hiddenWindowsChildOptions({ encoding: 'utf8', timeout }), (error, stdout) => {
       if (error) {
         reject(error)
+      } else if (timeout > 0 && child.killed) {
+        // A SIGTERM handler can exit zero after execFile's timeout fired.
+        reject(new Error(`${command} timed out after ${timeout}ms`))
       } else {
         resolve(String(stdout || '').trim())
       }
     })
+
+    // These probes are noninteractive; do not leave readers waiting for input.
+    child.stdin?.end()
   })
 }
 

--- a/apps/desktop/electron/backend-connection-state.ts
+++ b/apps/desktop/electron/backend-connection-state.ts
@@ -33,6 +33,12 @@ export function createBackendConnectionState<TProcess, TConnection>() {
       return attempt.generation === generation
     },
 
+    assertCurrentAttempt(attempt: BackendConnectionAttempt<TConnection>): void {
+      if (attempt.generation !== generation) {
+        throw new Error('Hermes backend start was superseded by a newer connection attempt.')
+      }
+    },
+
     attachProcess(
       attempt: BackendConnectionAttempt<TConnection>,
       nextProcess: TProcess

--- a/apps/desktop/electron/backend-probes.test.ts
+++ b/apps/desktop/electron/backend-probes.test.ts
@@ -7,6 +7,7 @@
 
 import assert from 'node:assert/strict'
 import fs from 'node:fs'
+import { createServer } from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -15,6 +16,7 @@ import { test } from 'vitest'
 import {
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
+  execProbe,
   hermesRuntimeImportProbe,
   PROBE_TIMEOUT_MS,
   resolveProbeTimeoutMs,
@@ -29,24 +31,53 @@ import {
 // (a tiny script we write to disk that exits 0 on --version).
 const NODE_BIN = process.execPath
 
-test('canImportHermesCli returns false when path is falsy', () => {
-  assert.equal(canImportHermesCli(''), false)
-  assert.equal(canImportHermesCli(null), false)
-  assert.equal(canImportHermesCli(undefined), false)
+test('runtime probe lets the parent service IO while its child is running', async () => {
+  let accepted = 0
+
+  const server = createServer(socket => {
+    accepted += 1
+    socket.on('error', () => {})
+    socket.end('ready')
+  })
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  assert.ok(address && typeof address !== 'string')
+
+  const script = `
+    const socket = require('node:net').connect(${address.port}, '127.0.0.1');
+    socket.on('data', () => socket.destroy());
+    socket.on('error', () => process.exit(1));
+  `
+
+  try {
+    // A synchronous probe prevents the parent from accepting this connection,
+    // so both timeout attempts fail even though the child is healthy (#103786).
+    await execProbe(NODE_BIN, ['-e', script], { stdio: 'ignore', timeout: 2000 })
+    assert.equal(accepted, 1)
+  } finally {
+    await new Promise<void>(resolve => server.close(() => resolve()))
+  }
+}, 10_000)
+
+test('canImportHermesCli returns false when path is falsy', async () => {
+  assert.equal(await canImportHermesCli(''), false)
+  assert.equal(await canImportHermesCli(null), false)
+  assert.equal(await canImportHermesCli(undefined), false)
 })
 
-test('canImportHermesCli returns false when interpreter cannot run -c', () => {
+test('canImportHermesCli returns false when interpreter cannot run -c', async () => {
   // node IS an interpreter, but `node -c "import hermes_cli"` is a
   // SyntaxError -- different exit reason from a real Python's
   // ModuleNotFoundError, but the predicate is "exit 0 or not" and
   // both land on "not", which is exactly what we want for the
   // resolver fall-through.
-  assert.equal(canImportHermesCli(NODE_BIN), false)
+  assert.equal(await canImportHermesCli(NODE_BIN), false)
 })
 
-test('canImportHermesCli returns false when binary does not exist', () => {
+test('canImportHermesCli returns false when binary does not exist', async () => {
   const ghost = path.join(os.tmpdir(), 'hermes-probes-ghost-' + Date.now() + '.exe')
-  assert.equal(canImportHermesCli(ghost), false)
+  assert.equal(await canImportHermesCli(ghost), false)
 })
 
 test('hermes runtime import probe checks config dependencies', () => {
@@ -68,18 +99,18 @@ test('empty Hermes override is not authoritative', () => {
   assert.equal(shouldTrustHermesOverride(undefined), false)
 })
 
-test('verifyHermesCli returns false when command is falsy', () => {
-  assert.equal(verifyHermesCli(''), false)
-  assert.equal(verifyHermesCli(null), false)
-  assert.equal(verifyHermesCli(undefined), false)
+test('verifyHermesCli returns false when command is falsy', async () => {
+  assert.equal(await verifyHermesCli(''), false)
+  assert.equal(await verifyHermesCli(null), false)
+  assert.equal(await verifyHermesCli(undefined), false)
 })
 
-test('verifyHermesCli returns false when binary does not exist', () => {
+test('verifyHermesCli returns false when binary does not exist', async () => {
   const ghost = path.join(os.tmpdir(), 'hermes-probes-ghost-' + Date.now() + '.exe')
-  assert.equal(verifyHermesCli(ghost), false)
+  assert.equal(await verifyHermesCli(ghost), false)
 })
 
-test('verifyHermesCli returns true when --version exits 0', () => {
+test('verifyHermesCli returns true when --version exits 0', async () => {
   // Write a tiny script that exits 0 regardless of args, then invoke
   // it through node. This stands in for a working hermes binary --
   // verifyHermesCli only cares about the exit code.
@@ -92,7 +123,7 @@ test('verifyHermesCli returns true when --version exits 0', () => {
     // execFileSync passes ['--version'] as args, which node ignores
     // gracefully (well, it prints its version and exits 0, which is
     // perfect -- exit code 0 is the only signal we read).
-    assert.equal(verifyHermesCli(NODE_BIN), true)
+    assert.equal(await verifyHermesCli(NODE_BIN), true)
   } finally {
     try {
       fs.unlinkSync(scriptPath)
@@ -102,13 +133,37 @@ test('verifyHermesCli returns true when --version exits 0', () => {
   }
 })
 
-test('verifyHermesCli swallows timeouts (does not throw)', () => {
-  // We can't easily provoke a real hang in CI without slowing the
-  // suite, but we CAN confirm that an invocation that DOES throw
-  // (because the binary is missing) returns false rather than
-  // propagating. Same code path the timeout case takes.
-  assert.equal(verifyHermesCli('/definitely/not/a/real/binary/anywhere'), false)
-})
+test('probe retries only timeouts, including a child that exits zero when terminated', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-probe-retry-'))
+
+  try {
+    for (const mode of ['recover', 'timeout', 'nonzero', 'clean-timeout']) {
+      const record = path.join(root, mode)
+
+      const script = `
+        const fs = require('node:fs');
+        fs.appendFileSync(${JSON.stringify(record)}, 'attempt\\n');
+        const count = fs.readFileSync(${JSON.stringify(record)}, 'utf8').trim().split('\\n').length;
+        if (${JSON.stringify(mode)} === 'nonzero') process.exit(1);
+        if (${JSON.stringify(mode)} === 'recover' && count === 2) process.exit(0);
+        process.on('SIGTERM', () => process.exit(${mode === 'clean-timeout' ? 0 : 1}));
+        setInterval(() => {}, 1000);
+      `
+
+      const result = execProbe(NODE_BIN, ['-e', script], { stdio: 'ignore', timeout: 2000 })
+
+      if (mode === 'recover') {
+        await result
+      } else {
+        await assert.rejects(result, undefined, mode)
+      }
+
+      assert.equal(fs.readFileSync(record, 'utf8').trim().split('\n').length, mode === 'nonzero' ? 1 : 2, mode)
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}, 20_000)
 
 test('default probe timeout is 15s (not the old 5s death-loop value)', () => {
   assert.equal(DEFAULT_PROBE_TIMEOUT_MS, 15_000)

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -33,7 +33,7 @@
  * as bootstrap-platform.ts and hardening.ts).
  */
 
-import { execFileSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 
 /** Default probe budget. 5s false-negativeed healthy Windows cold starts (#61764). */
 const DEFAULT_PROBE_TIMEOUT_MS = 15_000
@@ -85,10 +85,10 @@ function isTimeoutError(err: unknown): boolean {
 }
 
 /**
- * Run execFileSync; on timeout only, retry once before failing.
+ * Run without blocking the event loop; on timeout only, retry once before failing.
  * Non-timeout failures (ENOENT, non-zero exit) fail immediately.
  */
-function execProbeSync(
+async function execProbe(
   command: string,
   args: string[],
   options: {
@@ -99,16 +99,36 @@ function execProbeSync(
     shell?: boolean
     windowsHide?: boolean
   }
-): void {
+): Promise<void> {
+  const run = () =>
+    new Promise<void>((resolve, reject) => {
+      const child = spawn(command, args, options)
+      child.once('error', reject)
+      child.once('close', (code, signal) => {
+        // A timed-out probe may handle SIGTERM and exit zero; it is still a timeout.
+        if (code === 0 && !child.killed) {
+          resolve()
+        } else {
+          reject(
+            Object.assign(new Error(`Runtime probe failed: ${command} (${signal || code})`), {
+              code,
+              signal,
+              killed: child.killed
+            })
+          )
+        }
+      })
+    })
+
   try {
-    execFileSync(command, args, options)
+    await run()
   } catch (err) {
     if (!isTimeoutError(err)) {
       throw err
     }
 
     // One cold-cache / AV miss should not force hermes-setup --update (#61764).
-    execFileSync(command, args, options)
+    await run()
   }
 }
 
@@ -141,13 +161,13 @@ function hermesRuntimeImportProbe() {
  * @param {object} [opts.env] - Additional environment for the probe.
  * @returns {boolean}
  */
-function canImportHermesCli(pythonPath: string, opts: { env?: Record<string, string> } = {}) {
+async function canImportHermesCli(pythonPath: string, opts: { env?: Record<string, string> } = {}) {
   if (!pythonPath) {
     return false
   }
 
   try {
-    execProbeSync(pythonPath, ['-c', hermesRuntimeImportProbe()], {
+    await execProbe(pythonPath, ['-c', hermesRuntimeImportProbe()], {
       env: { ...process.env, ...(opts.env || {}) },
       stdio: 'ignore',
       timeout: PROBE_TIMEOUT_MS,
@@ -175,7 +195,7 @@ function canImportHermesCli(pythonPath: string, opts: { env?: Record<string, str
  * @param {string} hermesCommand - Resolved absolute path to a hermes
  *   executable (or an interpreter+script wrapper).
  * @param {boolean} [opts.shell] - Whether to run through a shell. For
- *   .cmd/.bat shims on Windows execFileSync needs shell:true to find
+ *   .cmd/.bat shims on Windows spawn needs shell:true to find
  *   the cmd interpreter; mirrors the same flag isCommandScript() drives
  *   in resolveHermesBackend.
  * @returns {boolean}
@@ -190,13 +210,13 @@ function shouldTrustHermesOverride(hermesOverride?: string) {
   return typeof hermesOverride === 'string' && hermesOverride.trim().length > 0
 }
 
-function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
+async function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
   if (!hermesCommand) {
     return false
   }
 
   try {
-    execProbeSync(hermesCommand, ['--version'], {
+    await execProbe(hermesCommand, ['--version'], {
       stdio: 'ignore',
       timeout: PROBE_TIMEOUT_MS,
       shell: Boolean(opts?.shell),
@@ -212,7 +232,7 @@ function verifyHermesCli(hermesCommand: string, opts?: { shell?: boolean }) {
 export {
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
-  execProbeSync,
+  execProbe,
   hermesRuntimeImportProbe,
   PROBE_TIMEOUT_MS,
   resolveProbeTimeoutMs,

--- a/apps/desktop/electron/backend-probes.windows.test.ts
+++ b/apps/desktop/electron/backend-probes.windows.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { execText } from './backend-claim'
+import { verifyHermesCli } from './backend-probes'
+
+// These exercise native Windows commands, not a mocked process.platform.
+const windowsTest = test.skipIf(process.platform !== 'win32')
+
+windowsTest(
+  'runtime discovery reads native registry and Python launcher output',
+  async () => {
+    const registry = await execText(
+      'reg.exe',
+      ['query', 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion', '/v', 'ProductName'],
+      { timeout: 15_000 }
+    )
+
+    assert.match(registry, /ProductName\s+REG_SZ\s+\S/)
+
+    const python = await execText('py.exe', ['-3', '-c', 'import sys; print(sys.executable)'], { timeout: 15_000 })
+    assert.ok(path.isAbsolute(python), 'the launcher must return a usable interpreter, not a command shim')
+    assert.ok(fs.statSync(python).isFile())
+  },
+  40_000
+)
+
+windowsTest(
+  'CLI probe preserves native cmd and bat success and failure results',
+  async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-native-cli-'))
+
+    try {
+      for (const extension of ['cmd', 'bat']) {
+        const command = path.join(root, `hermes.${extension}`)
+        fs.writeFileSync(command, '@echo off\r\nif "%~1"=="--version" (exit /b 0) else (exit /b 1)\r\n')
+        assert.equal(await verifyHermesCli(command, { shell: true }), true, extension)
+        fs.writeFileSync(command, '@echo off\r\nexit /b 1\r\n')
+        assert.equal(await verifyHermesCli(command, { shell: true }), false, extension)
+      }
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  },
+  40_000
+)

--- a/apps/desktop/electron/backend-serve-support.test.ts
+++ b/apps/desktop/electron/backend-serve-support.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import * as probes from './backend-probes'
+import { createBackendServeSupportResolver } from './backend-serve-support'
+
+test('concurrent serve checks share one pending probe and retain its negative result', async () => {
+  let fail!: (error: Error) => void
+
+  const pending = new Promise<void>((_resolve, reject) => {
+    fail = reject
+  })
+
+  const probe = vi.spyOn(probes, 'execProbe').mockReturnValue(pending)
+  const supportsServe = createBackendServeSupportResolver('/unused', () => {})
+  const backend = { command: '/unused/hermes', args: ['serve'] }
+
+  try {
+    const first = supportsServe(backend)
+    const second = supportsServe(backend)
+    const callsWhilePending = probe.mock.calls.length
+    fail(new Error('unsupported'))
+    assert.deepEqual(await Promise.all([first, second]), [false, false])
+    assert.equal(callsWhilePending, 1)
+    assert.equal(await supportsServe(backend), false)
+    assert.equal(probe.mock.calls.length, 1)
+  } finally {
+    probe.mockRestore()
+  }
+})

--- a/apps/desktop/electron/backend-serve-support.ts
+++ b/apps/desktop/electron/backend-serve-support.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { sourceDeclaresServe } from './backend-command'
+import { execProbe, PROBE_TIMEOUT_MS } from './backend-probes'
+
+interface ServeCandidate {
+  command?: string | null
+  root?: string
+  args?: string[]
+  env?: Record<string, string>
+  shell?: boolean
+  label?: string
+}
+
+// One cache per desktop runtime context; source inspection precedes a CLI probe.
+export function createBackendServeSupportResolver(hermesHome: string, rememberLog: (message: string) => void) {
+  const cache = new Map<string, Promise<boolean>>()
+
+  return async function backendSupportsServe(backend: ServeCandidate): Promise<boolean> {
+    if (!backend || !backend.command) {
+      return true
+    }
+
+    const key = `${backend.command}::${backend.root || ''}`
+
+    if (cache.has(key)) {
+      return cache.get(key)!
+    }
+
+    const pending = (async () => {
+      let supported: boolean | null = null
+
+      if (backend.root) {
+        try {
+          const src = fs.readFileSync(path.join(backend.root, 'hermes_cli', 'subcommands', 'dashboard.py'), 'utf8')
+          supported = sourceDeclaresServe(src)
+        } catch {
+          supported = null // source unreadable — fall through to the probe
+        }
+      }
+
+      if (supported === null) {
+        try {
+          const prefix = backend.args && backend.args[0] === '-m' ? backend.args.slice(0, 2) : []
+          // Same cold-Windows Python-startup class as the runtime probes
+          // (#61764/#72632/#72707): `serve --help` imports at least as much as
+          // `hermes --version` (~10.5s measured cold), and a false negative here
+          // is cached for the process lifetime, silently routing a modern
+          // runtime through the legacy `dashboard` form. Share the probe budget
+          // and its timeout-only retry instead of a thinner local bound.
+          await execProbe(backend.command, [...prefix, 'serve', '--help'], {
+            cwd: backend.root || undefined,
+            env: { ...process.env, HERMES_HOME: hermesHome, ...(backend.env || {}) },
+            timeout: PROBE_TIMEOUT_MS,
+            stdio: 'ignore',
+            // `.cmd`/`.bat` shim backends carry shell: true in their descriptor
+            // (see resolveHermesBackend step 4); execFileSync of a .cmd without
+            // shell throws EINVAL on modern Node, which the catch below would
+            // mis-cache as "serve unsupported" for the process lifetime.
+            shell: Boolean(backend.shell),
+            windowsHide: true
+          })
+          supported = true
+        } catch {
+          supported = false
+        }
+      }
+
+      rememberLog(
+        `[backend] \`serve\` ${supported ? 'supported' : 'unsupported → routing via legacy `dashboard`'} for ${backend.label || key}`
+      )
+
+      return supported
+    })()
+
+    // Publish the promise before yielding; late results never overwrite a newer entry.
+    cache.set(key, pending)
+
+    return pending
+  }
+}

--- a/apps/desktop/electron/first-run-setup-main-process.test.ts
+++ b/apps/desktop/electron/first-run-setup-main-process.test.ts
@@ -45,6 +45,7 @@ test('a first-run bootstrap-needed remote apply connects without ensuring or boo
   const prepareLocalBackend = vi.fn(async () => bootstrapBackend)
 
   const pendingConnection = runPrimaryBackendStartup({
+    assertCurrentAttempt: () => {},
     connectRemote,
     ensureLocalRuntime,
     prepareLocalBackend,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -45,7 +45,7 @@ import {
   processStartMarker,
   REAP_PROBE_TIMEOUT_MS
 } from './backend-claim'
-import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
+import { dashboardFallbackArgs } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { BackendDialClaims } from './backend-dial-claim'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -56,16 +56,11 @@ import {
   waitForHermesReady
 } from './backend-health'
 import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
-import {
-  canImportHermesCli,
-  execProbeSync,
-  PROBE_TIMEOUT_MS,
-  shouldTrustHermesOverride,
-  verifyHermesCli
-} from './backend-probes'
+import { canImportHermesCli, PROBE_TIMEOUT_MS, shouldTrustHermesOverride, verifyHermesCli } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
 import { recycleOwnedBackend } from './backend-recycle'
 import { isPidAliveWindows, waitForBackendRelease } from './backend-release-gate'
+import { createBackendServeSupportResolver } from './backend-serve-support'
 import {
   isHostKeyChangedBootFailure,
   isRetryableRemoteBootFailure,
@@ -2533,70 +2528,13 @@ function unwrapWindowsVenvHermesCommand(command, backendArgs) {
 // installs, dev checkouts, and the Windows venv). Fallback: probe the CLI once
 // (covers a bare `hermes` resolved from PATH with no known source root). Result
 // is cached per resolved runtime so we probe at most once per backend.
-const _serveSupportCache = new Map()
-
-function backendSupportsServe(backend) {
-  if (!backend || !backend.command) {
-    return true
-  }
-
-  const key = `${backend.command}::${backend.root || ''}`
-
-  if (_serveSupportCache.has(key)) {
-    return _serveSupportCache.get(key)
-  }
-
-  let supported = null
-
-  if (backend.root) {
-    try {
-      const src = fs.readFileSync(path.join(backend.root, 'hermes_cli', 'subcommands', 'dashboard.py'), 'utf8')
-      supported = sourceDeclaresServe(src)
-    } catch {
-      supported = null // source unreadable — fall through to the probe
-    }
-  }
-
-  if (supported === null) {
-    try {
-      const prefix = backend.args && backend.args[0] === '-m' ? backend.args.slice(0, 2) : []
-      // Same cold-Windows Python-startup class as the runtime probes
-      // (#61764/#72632/#72707): `serve --help` imports at least as much as
-      // `hermes --version` (~10.5s measured cold), and a false negative here
-      // is cached for the process lifetime, silently routing a modern
-      // runtime through the legacy `dashboard` form. Share the probe budget
-      // and its timeout-only retry instead of a thinner local bound.
-      execProbeSync(backend.command, [...prefix, 'serve', '--help'], {
-        cwd: backend.root || undefined,
-        env: { ...process.env, HERMES_HOME, ...(backend.env || {}) },
-        timeout: PROBE_TIMEOUT_MS,
-        stdio: 'ignore',
-        // `.cmd`/`.bat` shim backends carry shell: true in their descriptor
-        // (see resolveHermesBackend step 4); execFileSync of a .cmd without
-        // shell throws EINVAL on modern Node, which the catch below would
-        // mis-cache as "serve unsupported" for the process lifetime.
-        shell: Boolean(backend.shell),
-        windowsHide: true
-      })
-      supported = true
-    } catch {
-      supported = false
-    }
-  }
-
-  _serveSupportCache.set(key, supported)
-  rememberLog(
-    `[backend] \`serve\` ${supported ? 'supported' : 'unsupported → routing via legacy `dashboard`'} for ${backend.label || key}`
-  )
-
-  return supported
-}
+const backendSupportsServe = createBackendServeSupportResolver(HERMES_HOME, rememberLog)
 
 // Given a resolved backend whose args target `serve`, return the args the
 // runtime actually understands: unchanged when `serve` is supported, or
 // rewritten to `dashboard --no-open` for older runtimes.
-function getBackendArgsForRuntime(backend) {
-  return backendSupportsServe(backend) ? backend.args : dashboardFallbackArgs(backend.args)
+async function getBackendArgsForRuntime(backend) {
+  return (await backendSupportsServe(backend)) ? backend.args : dashboardFallbackArgs(backend.args)
 }
 
 function normalizeExecutablePathForCompare(commandPath) {
@@ -2646,7 +2584,7 @@ function isHermesSourceRoot(root) {
   return directoryExists(root) && fileExists(path.join(root, 'hermes_cli', 'main.py'))
 }
 
-function findPythonForRoot(root) {
+async function findPythonForRoot(root) {
   const override = process.env.HERMES_DESKTOP_PYTHON
 
   if (override && fileExists(override)) {
@@ -2668,7 +2606,7 @@ function findPythonForRoot(root) {
   return findSystemPython()
 }
 
-function findSystemPython() {
+async function findSystemPython() {
   if (!IS_WINDOWS) {
     // POSIX systems: PATH lookup is safe.
     for (const command of ['python3', 'python']) {
@@ -2729,13 +2667,10 @@ function findSystemPython() {
   for (const hive of ['HKLM', 'HKCU']) {
     for (const version of SUPPORTED_VERSIONS) {
       try {
-        const out = execFileSync(
+        const out = await execText(
           'reg',
           ['query', `${hive}\\SOFTWARE\\Python\\PythonCore\\${version}\\InstallPath`, '/ve', '/reg:64'],
-          // Registry reads are near-instant; the bound only exists so a
-          // pathologically wedged reg.exe can't hang the synchronous boot
-          // resolver forever (this ran unbounded before).
-          hiddenWindowsChildOptions({ encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5_000 })
+          { timeout: 5_000 }
         )
 
         // Output format: "    (Default)    REG_SZ    C:\Path\To\Python\"
@@ -2785,19 +2720,9 @@ function findSystemPython() {
   if (pyExe) {
     for (const version of SUPPORTED_VERSIONS) {
       try {
-        const out = execFileSync(
-          pyExe,
-          [`-${version}`, '-c', 'import sys; print(sys.executable)'],
-          hiddenWindowsChildOptions({
-            encoding: 'utf8',
-            stdio: ['ignore', 'pipe', 'ignore'],
-            // Bare interpreter startup — much lighter than the hermes-import
-            // probes, but still python.exe under cold cache / AV scan, so
-            // share the probe budget rather than running unbounded (this
-            // synchronous exec previously had no timeout at all).
-            timeout: PROBE_TIMEOUT_MS
-          })
-        )
+        const out = await execText(pyExe, [`-${version}`, '-c', 'import sys; print(sys.executable)'], {
+          timeout: PROBE_TIMEOUT_MS
+        })
 
         const candidate = out.trim()
 
@@ -4671,7 +4596,7 @@ function readBootstrapMarker() {
 // or a DMG launch over a prior CLI install satisfies this WITHOUT the desktop
 // ever having written the bootstrap marker -- so we must be able to recognise
 // "already installed" off the filesystem alone, not just the marker.
-function isActiveRuntimeUsable() {
+async function isActiveRuntimeUsable() {
   const venvPython = getVenvPython(VENV_ROOT)
 
   return (
@@ -4685,13 +4610,13 @@ function isActiveRuntimeUsable() {
   )
 }
 
-function activeRuntimeState() {
+async function activeRuntimeState() {
   // We DELIBERATELY do NOT verify that the checkout is currently at the
   // pinned commit -- users update via the in-app update path or `hermes
   // update`, which moves HEAD legitimately. The marker only attests "a
   // desktop-managed bootstrap ran here at least once"; runtime usability is
   // what decides whether we can actually launch.
-  return classifyActiveRuntime(readBootstrapMarker(), BOOTSTRAP_MARKER_SCHEMA_VERSION, isActiveRuntimeUsable())
+  return classifyActiveRuntime(readBootstrapMarker(), BOOTSTRAP_MARKER_SCHEMA_VERSION, await isActiveRuntimeUsable())
 }
 
 function writeBootstrapMarker(payload) {
@@ -4917,8 +4842,8 @@ function writeDefaultProjectDir(dir) {
   }
 }
 
-function createPythonBackend(root, label, backendArgs, options: any = {}) {
-  const python = findPythonForRoot(root)
+async function createPythonBackend(root, label, backendArgs, options: any = {}) {
+  const python = await findPythonForRoot(root)
 
   if (!python) {
     return null
@@ -4953,9 +4878,9 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
 // canonical install location shared with the CLI installer. The venv at
 // VENV_ROOT may not exist yet on first run; bootstrap=true tells
 // ensureRuntime() to create / refresh it before launch.
-function createActiveBackend(backendArgs) {
+async function createActiveBackend(backendArgs) {
   const venvPython = getVenvPython(VENV_ROOT)
-  const command = fileExists(venvPython) ? venvPython : findSystemPython()
+  const command = fileExists(venvPython) ? venvPython : await findSystemPython()
 
   return {
     kind: 'python',
@@ -4973,13 +4898,13 @@ function createActiveBackend(backendArgs) {
   }
 }
 
-function resolveHermesBackend(backendArgs) {
+async function resolveHermesBackend(backendArgs) {
   // 1. Explicit override -- HERMES_DESKTOP_HERMES_ROOT points at a developer
   //    checkout. Honour it as-is (no bootstrap; the user is driving).
   const overrideRoot = process.env.HERMES_DESKTOP_HERMES_ROOT && path.resolve(process.env.HERMES_DESKTOP_HERMES_ROOT)
 
   if (overrideRoot && isHermesSourceRoot(overrideRoot)) {
-    const backend = createPythonBackend(overrideRoot, `Hermes source at ${overrideRoot}`, backendArgs)
+    const backend = await createPythonBackend(overrideRoot, `Hermes source at ${overrideRoot}`, backendArgs)
 
     if (backend) {
       return backend
@@ -4991,7 +4916,7 @@ function resolveHermesBackend(backendArgs) {
   //    installed `hermes` on PATH so local Python edits are actually exercised.
   //    (In dev with no checkout, SOURCE_REPO_ROOT won't pass isHermesSourceRoot.)
   if (!IS_PACKAGED && isHermesSourceRoot(SOURCE_REPO_ROOT)) {
-    const backend = createPythonBackend(SOURCE_REPO_ROOT, `Hermes source at ${SOURCE_REPO_ROOT}`, backendArgs)
+    const backend = await createPythonBackend(SOURCE_REPO_ROOT, `Hermes source at ${SOURCE_REPO_ROOT}`, backendArgs)
 
     if (backend) {
       return backend
@@ -5006,7 +4931,7 @@ function resolveHermesBackend(backendArgs) {
   //    builds could leave a healthy install behind without the marker. If the
   //    active runtime is usable, launch it directly; only fall through to
   //    bootstrap when the runtime itself is unusable.
-  const activeRuntime = activeRuntimeState()
+  const activeRuntime = await activeRuntimeState()
 
   if (activeRuntime.shouldUseActiveRuntime && !bootstrapRepairRequested) {
     if (!activeRuntime.hasValidMarker) {
@@ -5053,7 +4978,7 @@ function resolveHermesBackend(backendArgs) {
     }
 
     if (hermesCommand) {
-      const unwrapped = unwrapWindowsVenvHermesCommand(hermesCommand, backendArgs)
+      const unwrapped = await unwrapWindowsVenvHermesCommand(hermesCommand, backendArgs)
 
       if (unwrapped) {
         return unwrapped
@@ -5072,7 +4997,10 @@ function resolveHermesBackend(backendArgs) {
       // the Nix wrapper), not a discovered PATH candidate. It must not fall
       // through to the install-script bootstrap if the optional probe times
       // out under load; the pinned backend is the only valid runtime there.
-      if (shouldTrustHermesOverride(hermesOverride) || verifyHermesCli(hermesCommand, { shell: shellForProbe })) {
+      if (
+        shouldTrustHermesOverride(hermesOverride) ||
+        (await verifyHermesCli(hermesCommand, { shell: shellForProbe }))
+      ) {
         // `unwrapped` above already answered "is this a Windows venv shim?" —
         // it was null (not a shim, or its import probe failed). Do NOT re-run
         // unwrapWindowsVenvHermesCommand here: the second call repeats the
@@ -5098,7 +5026,7 @@ function resolveHermesBackend(backendArgs) {
   // 5. Last-ditch: pip-installed hermes_cli module via system Python.
   //    Same rationale as #4 -- the user installed this; we use it but don't
   //    take ownership.
-  const python = findSystemPython()
+  const python = await findSystemPython()
 
   if (python) {
     // Same smoke-test rationale as step 4: a system Python in the
@@ -5109,7 +5037,7 @@ function resolveHermesBackend(backendArgs) {
     // Verify the import works before trusting the candidate; on
     // failure, fall through to step 6 so the bootstrap runner pulls
     // a uv-managed 3.11 into %LOCALAPPDATA%\hermes\hermes-agent\venv.
-    if (canImportHermesCli(python)) {
+    if (await canImportHermesCli(python)) {
       return {
         kind: 'python',
         label: `installed hermes_cli module via ${python}`,
@@ -5150,7 +5078,9 @@ function resolveHermesBackend(backendArgs) {
   }
 }
 
-async function ensureRuntime(backend) {
+async function ensureRuntime(backend, assertStillOwned: () => void) {
+  assertStillOwned()
+
   if (!backend.bootstrap) {
     await advanceBootProgress('runtime.external', `Using ${backend.label}`, 32)
 
@@ -5260,7 +5190,7 @@ async function ensureRuntime(backend) {
 
     // Re-resolve now that the install exists. The new resolution lands in
     // step 3 (bootstrap-complete marker) and we recurse to wire venvPython.
-    return ensureRuntime(resolveHermesBackend(backend.args))
+    return ensureRuntime(await resolveHermesBackend(backend.args), assertStillOwned)
   }
 
   // bootstrap=true with a real backend (createActiveBackend path) means we
@@ -12625,9 +12555,14 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // step 3 in hermes_cli/main.py), so the child re-homes to this profile.
   // --port 0: the OS assigns an ephemeral port; the child announces it on stdout.
   const backendArgs = ['--profile', profile, 'serve', '--host', '127.0.0.1', '--port', '0']
-  const backend = await ensureRuntime(resolveHermesBackend(backendArgs))
+
+  const backend = await ensureRuntime(await resolveHermesBackend(backendArgs), () =>
+    assertPoolEntryStillOwned(poolKey, entry)
+  )
+
   // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
-  backend.args = getBackendArgsForRuntime(backend)
+  backend.args = await getBackendArgsForRuntime(backend)
+  assertPoolEntryStillOwned(poolKey, entry)
   const hermesCwd = resolveHermesCwd()
   const webDist = resolveWebDist()
   const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
@@ -13016,8 +12951,10 @@ async function startHermes() {
     }
 
     const setup = await runPrimaryBackendStartup({
+      assertCurrentAttempt: () => backendConnectionState.assertCurrentAttempt(connectionAttempt),
       connectRemote,
-      ensureLocalRuntime: ensureRuntime,
+      ensureLocalRuntime: backend =>
+        ensureRuntime(backend, () => backendConnectionState.assertCurrentAttempt(connectionAttempt)),
       prepareLocalBackend: async () => {
         await advanceBootProgress('backend.runtime', 'Resolving Hermes runtime', 28)
 
@@ -13036,6 +12973,8 @@ async function startHermes() {
       waitForLocalStart: waitForUpdateToFinish
     })
 
+    backendConnectionState.assertCurrentAttempt(connectionAttempt)
+
     if (setup.kind === 'remote') {
       // Paths from the remote backend belong to a host the Windows desktop
       // cannot open via wsl.exe — disable WSL path bridging so native dialogs
@@ -13051,7 +12990,8 @@ async function startHermes() {
 
     const backend = setup.backend
     // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
-    backend.args = getBackendArgsForRuntime(backend)
+    backend.args = await getBackendArgsForRuntime(backend)
+    backendConnectionState.assertCurrentAttempt(connectionAttempt)
     const hermesCwd = resolveHermesCwd()
     const webDist = resolveWebDist()
     const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
@@ -13063,6 +13003,8 @@ async function startHermes() {
     const parentStartMarker = await desktopParentStartMarker()
     const backendNonce = crypto.randomBytes(16).toString('hex')
     const parentIdentityEnv = parentWatchdogEnv(process.pid, parentStartMarker, backendNonce)
+
+    backendConnectionState.assertCurrentAttempt(connectionAttempt)
 
     const hermesProcess = spawn(
       backend.command,
@@ -15091,7 +15033,7 @@ ipcMain.handle('hermes:window:openInTerminal', async (_event, sessionId, opts) =
 
   try {
     const profile = typeof opts?.profile === 'string' ? opts.profile.trim() : ''
-    const backend = resolveHermesBackend(tuiResumeArgs(sessionId.trim(), profile || undefined))
+    const backend = await resolveHermesBackend(tuiResumeArgs(sessionId.trim(), profile || undefined))
 
     if (!backend.command) {
       return { ok: false, error: 'Hermes is not installed yet' }
@@ -17829,7 +17771,7 @@ async function runDesktopUninstall(mode) {
   let pythonPath = null
 
   if (modeRemovesAgent(mode)) {
-    const sysPy = findSystemPython()
+    const sysPy = await findSystemPython()
 
     if (sysPy) {
       py = sysPy

--- a/apps/desktop/electron/primary-backend-startup.test.ts
+++ b/apps/desktop/electron/primary-backend-startup.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test, vi } from 'vitest'
 
+import { createBackendConnectionState } from './backend-connection-state'
 import { createFirstRunSetupGate } from './first-run-setup-gate'
 import {
   createPrimaryRemoteConnection,
@@ -17,6 +18,7 @@ const bootstrapBackend = {
 
 function startupOptions(overrides: Record<string, unknown> = {}) {
   return {
+    assertCurrentAttempt: () => {},
     connectRemote: vi.fn(async remote => ({ baseUrl: remote.baseUrl, mode: 'remote' as const })),
     ensureLocalRuntime: vi.fn(async backend => ({ ...backend, command: 'hermes' })),
     prepareLocalBackend: vi.fn(async () => bootstrapBackend),
@@ -159,6 +161,36 @@ test('continue local waits for update exclusion and ensures the prepared runtime
   assert.deepEqual(options.prepareLocalBackend.mock.calls, [[]])
   assert.deepEqual(options.ensureLocalRuntime.mock.calls, [[bootstrapBackend]])
   assert.deepEqual(options.resolveRemote.mock.calls, [[]])
+})
+
+test('invalidating a pending runtime discovery prevents setup and bootstrap', async () => {
+  const state = createBackendConnectionState()
+  const attempt = state.startAttempt()
+  let finish!: (backend: typeof bootstrapBackend) => void
+  let started!: () => void
+
+  const resolving = new Promise<void>(resolve => {
+    started = resolve
+  })
+
+  const options = startupOptions({
+    assertCurrentAttempt: () => state.assertCurrentAttempt(attempt),
+    prepareLocalBackend: async () => {
+      started()
+
+      return new Promise<typeof bootstrapBackend>(resolve => {
+        finish = resolve
+      })
+    }
+  })
+
+  const pending = runPrimaryBackendStartup(options)
+  await resolving
+  state.invalidate()
+  finish(bootstrapBackend)
+  await assert.rejects(pending, /superseded/)
+  assert.equal(options.waitForDecision.mock.calls.length, 0)
+  assert.equal(options.ensureLocalRuntime.mock.calls.length, 0)
 })
 
 test('reset rejects with a typed error and never enters either backend', async () => {

--- a/apps/desktop/electron/primary-backend-startup.ts
+++ b/apps/desktop/electron/primary-backend-startup.ts
@@ -1,6 +1,7 @@
 import type { FirstRunSetupDecision } from './first-run-setup-gate'
 
 export interface PrimaryBackendStartupOptions<Backend, RuntimeBackend, Remote, Connection> {
+  assertCurrentAttempt: () => void
   connectRemote: (remote: Remote) => Promise<Connection>
   ensureLocalRuntime: (backend: Backend) => Promise<RuntimeBackend>
   prepareLocalBackend: () => Backend | Promise<Backend>
@@ -75,6 +76,7 @@ export class FirstRunSetupResetError extends Error {
 // and local backend resolution happen before the setup gate, and a remote Apply
 // re-resolves persisted config without ever entering ensureRuntime/bootstrap.
 export async function runPrimaryBackendStartup<Backend, RuntimeBackend, Remote, Connection>({
+  assertCurrentAttempt,
   connectRemote,
   ensureLocalRuntime,
   prepareLocalBackend,
@@ -85,18 +87,23 @@ export async function runPrimaryBackendStartup<Backend, RuntimeBackend, Remote, 
   PrimaryBackendStartupResult<RuntimeBackend, Connection>
 > {
   const savedRemote = await resolveRemote()
+  assertCurrentAttempt()
 
   if (savedRemote) {
     return { kind: 'remote', connection: await connectRemote(savedRemote) }
   }
 
   await waitForLocalStart()
+  assertCurrentAttempt()
 
   const backend = await prepareLocalBackend()
+  assertCurrentAttempt()
   const decision = await waitForDecision(backend)
+  assertCurrentAttempt()
 
   if (decision === 'remote-applied') {
     const appliedRemote = await resolveRemote()
+    assertCurrentAttempt()
 
     if (!appliedRemote) {
       throw new Error('First-run remote setup completed without a saved remote backend.')

--- a/apps/desktop/electron/windows-hermes-path.test.ts
+++ b/apps/desktop/electron/windows-hermes-path.test.ts
@@ -90,7 +90,7 @@ function makeDeps(overrides: Partial<Parameters<typeof resolveVenvHermesCommand>
     isCommandScript: () => false,
     fileExists: () => true,
     directoryExists: () => false,
-    canImportHermesCli: () => true,
+    canImportHermesCli: async () => true,
     getVenvPython: (venvRoot: string) => `${venvRoot}/Scripts/python.exe`,
     getVenvSitePackagesEntries: () => [],
     buildDesktopBackendEnv: () => ({ FAKE_ENV: '1' }),
@@ -103,41 +103,41 @@ function makeDeps(overrides: Partial<Parameters<typeof resolveVenvHermesCommand>
   }
 }
 
-test('resolveVenvHermesCommand: returns null off Windows', () => {
+test('resolveVenvHermesCommand: returns null off Windows', async () => {
   const deps = makeDeps({ isWindows: false })
 
-  assert.equal(resolveVenvHermesCommand('/root/venv/Scripts/hermes.exe', [], deps), null)
+  assert.equal(await resolveVenvHermesCommand('/root/venv/Scripts/hermes.exe', [], deps), null)
 })
 
-test('resolveVenvHermesCommand: returns null for a .cmd/.bat script command', () => {
+test('resolveVenvHermesCommand: returns null for a .cmd/.bat script command', async () => {
   const deps = makeDeps({ isCommandScript: () => true })
 
-  assert.equal(resolveVenvHermesCommand('/root/venv/Scripts/hermes.cmd', [], deps), null)
+  assert.equal(await resolveVenvHermesCommand('/root/venv/Scripts/hermes.cmd', [], deps), null)
 })
 
-test('resolveVenvHermesCommand: returns null when the basename is not hermes/hermes.exe', () => {
+test('resolveVenvHermesCommand: returns null when the basename is not hermes/hermes.exe', async () => {
   const deps = makeDeps()
 
-  assert.equal(resolveVenvHermesCommand('/root/venv/Scripts/python.exe', [], deps), null)
+  assert.equal(await resolveVenvHermesCommand('/root/venv/Scripts/python.exe', [], deps), null)
 })
 
-test('resolveVenvHermesCommand: returns null when the parent dir is not Scripts', () => {
+test('resolveVenvHermesCommand: returns null when the parent dir is not Scripts', async () => {
   const deps = makeDeps()
 
-  assert.equal(resolveVenvHermesCommand('/root/venv/bin/hermes.exe', [], deps), null)
+  assert.equal(await resolveVenvHermesCommand('/root/venv/bin/hermes.exe', [], deps), null)
 })
 
-test('resolveVenvHermesCommand: returns null when the venv python does not exist on disk', () => {
+test('resolveVenvHermesCommand: returns null when the venv python does not exist on disk', async () => {
   const deps = makeDeps({ fileExists: () => false })
 
-  assert.equal(resolveVenvHermesCommand('/root/venv/Scripts/hermes.exe', [], deps), null)
+  assert.equal(await resolveVenvHermesCommand('/root/venv/Scripts/hermes.exe', [], deps), null)
 })
 
-test('resolveVenvHermesCommand: probes the venv python before trusting it (returns null on failed probe)', () => {
+test('resolveVenvHermesCommand: probes the venv python before trusting it (returns null on failed probe)', async () => {
   let probed = false
 
   const deps = makeDeps({
-    canImportHermesCli: (python: string) => {
+    canImportHermesCli: async (python: string) => {
       probed = true
       assert.equal(python, '/root/venv/Scripts/python.exe')
 
@@ -145,15 +145,15 @@ test('resolveVenvHermesCommand: probes the venv python before trusting it (retur
     }
   })
 
-  const result = resolveVenvHermesCommand('/root/venv/Scripts/hermes.exe', ['serve'], deps)
+  const result = await resolveVenvHermesCommand('/root/venv/Scripts/hermes.exe', ['serve'], deps)
 
   assert.equal(probed, true, 'must probe the venv interpreter; a broken venv must not be re-selected forever')
   assert.equal(result, null, 'a failed probe must fall through (return null) so the resolver reaches bootstrap')
 })
 
-test('resolveVenvHermesCommand: returns the resolved python backend descriptor when the probe passes', () => {
+test('resolveVenvHermesCommand: returns the resolved python backend descriptor when the probe passes', async () => {
   const deps = makeDeps()
-  const result = resolveVenvHermesCommand('/root/venv/Scripts/hermes.exe', ['serve', '--port', '0'], deps)
+  const result = await resolveVenvHermesCommand('/root/venv/Scripts/hermes.exe', ['serve', '--port', '0'], deps)
 
   assert.ok(result, 'a passing probe must return a backend descriptor, not null')
   assert.equal(result.command, '/root/venv/Scripts/python.exe')
@@ -164,11 +164,11 @@ test('resolveVenvHermesCommand: returns the resolved python backend descriptor w
   assert.deepEqual(result.env, { FAKE_ENV: '1' })
 })
 
-test('resolveVenvHermesCommand: is case-insensitive on hermes.exe and the Scripts dir name', () => {
+test('resolveVenvHermesCommand: is case-insensitive on hermes.exe and the Scripts dir name', async () => {
   const deps = makeDeps()
 
-  assert.ok(resolveVenvHermesCommand('/root/venv/Scripts/HERMES.EXE', [], deps))
-  assert.ok(resolveVenvHermesCommand('/root/venv/SCRIPTS/hermes.exe', [], deps))
+  assert.ok(await resolveVenvHermesCommand('/root/venv/Scripts/HERMES.EXE', [], deps))
+  assert.ok(await resolveVenvHermesCommand('/root/venv/SCRIPTS/hermes.exe', [], deps))
 })
 
 // ── getVenvSitePackagesEntries ─────────────────────────────────────────────

--- a/apps/desktop/electron/windows-hermes-path.test.ts
+++ b/apps/desktop/electron/windows-hermes-path.test.ts
@@ -194,13 +194,15 @@ test('getVenvSitePackagesEntries: returns empty on Windows when site-packages do
 })
 
 test('getVenvSitePackagesEntries: reads pyvenv.cfg version on POSIX and resolves lib/pythonX.Y/site-packages', () => {
+  const expected = path.join('/venv', 'lib', 'python3.12', 'site-packages')
+
   const result = getVenvSitePackagesEntries('/venv', {
     isWindows: false,
-    directoryExists: p => p === '/venv/lib/python3.12/site-packages',
+    directoryExists: p => p === expected,
     readFile: () => 'version_info = 3.12.1\n'
   })
 
-  assert.deepEqual(result, ['/venv/lib/python3.12/site-packages'])
+  assert.deepEqual(result, [expected])
 })
 
 test('getVenvSitePackagesEntries: returns empty on POSIX when pyvenv.cfg is missing', () => {

--- a/apps/desktop/electron/windows-hermes-path.ts
+++ b/apps/desktop/electron/windows-hermes-path.ts
@@ -171,7 +171,7 @@ export interface ResolveVenvHermesCommandDeps {
   isCommandScript: (command: string) => boolean
   fileExists: (filePath: string) => boolean
   directoryExists: (filePath: string) => boolean
-  canImportHermesCli: (python: string, opts?: { env?: Record<string, string> }) => boolean
+  canImportHermesCli: (python: string, opts?: { env?: Record<string, string> }) => Promise<boolean>
   getVenvPython: (venvRoot: string) => string
   getVenvSitePackagesEntries: (venvRoot: string) => string[]
   buildDesktopBackendEnv: (opts: {
@@ -205,11 +205,11 @@ export interface ResolveVenvHermesCommandDeps {
  * python doesn't exist, or the import probe fails. Otherwise returns the
  * resolved backend descriptor.
  */
-export function resolveVenvHermesCommand(
+export async function resolveVenvHermesCommand(
   command: string,
   backendArgs: string[],
   deps: ResolveVenvHermesCommandDeps
-): {
+): Promise<{
   label: string
   command: string
   args: string[]
@@ -218,7 +218,7 @@ export function resolveVenvHermesCommand(
   kind: 'python'
   root: string
   shell: false
-} | null {
+} | null> {
   const {
     isWindows,
     isCommandScript,
@@ -261,13 +261,13 @@ export function resolveVenvHermesCommand(
   const root = dirname(venvRoot)
 
   if (
-    !canImportHermesCli(python, {
+    !(await canImportHermesCli(python, {
       env: {
         PYTHONPATH: [...(directoryExists(root) ? [root] : []), process.env.PYTHONPATH]
           .filter((entry): entry is string => Boolean(entry))
           .join(path.delimiter)
       }
-    })
+    }))
   ) {
     rememberLog?.(
       `Ignoring venv Hermes at ${python}: runtime import probe failed (broken/partial venv); falling through to bootstrap.`

--- a/apps/desktop/src/AGENTS.md
+++ b/apps/desktop/src/AGENTS.md
@@ -15,7 +15,7 @@ The desktop has **no build/runtime dependency on the dashboard frontend**: it sp
 NOT embed `hermes --tui` — own composer, transcript, slash pipeline.
 
 **One backward-compat fallback:** `serve` is newer, so the spawn (`electron/backend-command.ts` +
-`backendSupportsServe()` in `electron/main.ts`) checks whether the resolved runtime registers `serve`
+`createBackendServeSupportResolver()` in `electron/backend-serve-support.ts`) checks whether the runtime registers `serve`
 and ONLY when it does not (older managed install / PATH `hermes` not yet updated) rewrites argv to
 legacy `dashboard --no-open`. Without it a new app against an un-upgraded runtime crashes on an
 unknown subcommand and bricks every mid-upgrade user. Keep it narrow and tested.


### PR DESCRIPTION
## Summary

Carry forward the verified runtime-responsiveness fix from [#105836](https://github.com/NousResearch/hermes-agent/pull/105836) onto the current upstream base. The change removes long-running local runtime/CLI subprocess probes from Electron's main event loop while preserving candidate order, timeout-only retry behavior, legacy-runtime fallback, and cancellation of invalidated primary/pool starts.

This PR uses `Refs #103786`, not `Closes #103786`. It fixes the demonstrated local-runtime probe blockage. The issue's complete remote AppHangB1/unread-socket causal chain is not claimed as proven or closed: the reporter later corrected the NAT/TCP-drop diagnosis, and source-pinned WER plus main/renderer stacks for a failing incident are still unavailable.

The original #105836 remains open and untouched on its author's fork. This branch is a carry-forward because that fork is not writable by the authenticated contributor account; it is not an independent duplicate implementation.

Publication snapshot after PR creation:
- PR: https://github.com/NousResearch/hermes-agent/pull/106368
- PR state: OPEN
- Base: `main` at `9e0dc4319ae2d59c60f5226b5c0af58d17755bfa`
- Head: `5d119a247a23dbb75e3fb566a787b8bdf389b779`
- Branch: `JoaoMarcos44:fix/103786-nonblocking-runtime-probes-carry`
- Local/remote ancestry: 4 commits ahead, 0 commits behind at creation

## Observed problem

- Incorrect behavior: on Windows, synchronous `execFileSync` runtime probes run from the Desktop boot/retry path. A cold registry query, Python launcher, CLI `--version`, import, or `serve --help` probe can occupy Electron's main thread long enough for Windows to report `Application Hang` / `AppHangB1` and terminate the app. A later renderer RPC can then observe a dead or unresponsive connection.
- Expected behavior: local discovery may take its existing bounded probe time, but Electron's main event loop must continue servicing renderer IPC, timers, and socket I/O while the child probe runs.
- Premise confirmation: on the clean `origin/main` baseline, `resolveHermesBackend` was synchronous and the base source contained synchronous `execFileSync` calls for the Windows registry and `py.exe` discovery path. Graphify identified the production path `startHermes() -> resolveHermesBackend() -> canImportHermesCli()` and the sibling path `spawnPoolBackend() -> resolveHermesBackend() -> canImportHermesCli()`.
- RED reproduction against `origin/main@9e0dc4319ae2d59c60f5226b5c0af58d17755bfa`: after temporarily restoring only the three resolver production files to the base, `npm run build` passed but the real Electron test `HERMES_DESKTOP_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe npx playwright test e2e/runtime-probes.spec.ts --reporter=list` failed with exit 1 after 20 seconds waiting for `entered.json`. The Python probe could not reach the point where it exchanges data with its Electron parent because the old main process was synchronously blocked. The candidate files were restored and rebuilt afterward.
- GREEN reproduction: the same real Electron/Python path passes with the asynchronous resolver and responds to the loopback exchange before the probe is released.

The issue thread also contains two separate, non-duplicate observations:
- #103803 covers a saved-direct-remote renderer WebSocket dial that fails after reload and needs a bounded renderer retry; it deliberately does not touch local runtime discovery.
- The issue's NAT correction states that the reported TCP drops were caused by a client-side network reaper in that environment. Unread socket buffers alone are therefore not treated as proof that the gateway caused the hang.

## Root cause

`apps/desktop/electron/main.ts` previously performed `resolveHermesBackend()` synchronously. Its reachable call paths included the primary `startHermes()` path, profile `spawnPoolBackend()`, `openInTerminal`, and uninstall discovery. On Windows, the resolver reached `execFileSync` for up to six registry queries and up to three `py.exe` launches, while CLI/import/serve capability checks could also run synchronously. The existing timeout values bounded child termination but did not yield Electron's event loop during the wait.

The exact line-level mechanism is now split as follows:

- `apps/desktop/electron/backend-probes.ts:91-133` defines `execProbe()` around asynchronous `spawn` child events. It preserves immediate failure for non-timeout errors and one retry only for timeout errors, including the exit-zero-after-termination case.
- `apps/desktop/electron/main.ts:2609-2744` makes system-Python discovery asynchronous; registry and Python-launcher probes use awaited child I/O.
- `apps/desktop/electron/main.ts:4901-5040` makes backend resolution asynchronous and awaits the CLI/import/venv probes.
- `apps/desktop/electron/backend-serve-support.ts:17-80` moves the fallback `serve --help` probe into an async single-flight resolver keyed by runtime identity, retaining the source-inspection fast path and legacy `dashboard --no-open` fallback.
- `apps/desktop/electron/primary-backend-startup.ts:78-120` and `backend-connection-state.ts:11-93` add generation checkpoints across every awaited boundary, so a newer attempt cannot be cleared or spawned by a stale local discovery result.
- `apps/desktop/electron/main.ts:12559-12565` and `:12953-12994` await both pool and primary resolution/capability checks before the final spawn. `openInTerminal` and uninstall discovery also await the resolver.

The issue's remote transport symptom is not used as the root-cause proof. The source-pinned proof established here is the local main-loop starvation mechanism; remote gateway recovery remains owned by #103803 and the original WER/main-stack evidence remains a limitation.

## Impact and scope

Affected:
- Windows Desktop primary local-runtime startup and retry paths.
- Windows Desktop profile/pool local-runtime startup.
- Local CLI/Python/venv discovery and serve-capability detection when those paths are reached from Desktop.
- Users whose disk, antivirus, registry, Python launcher, or runtime startup is slow enough to exceed a synchronous main-thread responsiveness window.

Not affected:
- Saved remote descriptor resolution itself; the remote renderer-dial retry is #103803.
- The messaging gateway's detached lifecycle; this PR does not re-parent or kill the gateway.
- Normal candidate ordering, the supported Python-version policy, `serve` versus legacy `dashboard --no-open` selection, or explicit Hermes command overrides.
- Secrets, configuration schema, session data, or network credentials. No `.env` or credential file was read or changed.

Operational consequence:
- A slow probe can still consume its existing child timeout and can still produce a bootstrap/fallback decision. It no longer monopolizes Electron's main event loop while waiting.
- The resolver remains sequential within each candidate ladder, so it does not add an unbounded polling loop. The serve-support cache is one pending/settled promise per runtime key and is bounded by the process lifetime of the Desktop runtime.

## Solution

1. Replace blocking probe calls with awaited child processes while preserving ignored stdio, hidden Windows children, shell handling, timeout-only retry, and non-timeout failure semantics.
2. Thread the asynchronous result through runtime validation, Windows registry/launcher discovery, primary startup, pool startup, terminal launch, uninstall discovery, and legacy serve detection.
3. Coalesce concurrent `serve --help` checks so concurrent callers do not duplicate the same capability probe.
4. Add attempt-generation checks after each asynchronous boundary and immediately before spawn. A stale primary or pool request is rejected before it can start a child or publish stale state.
5. Add deterministic unit, native Windows contract, and real Electron/Python E2E coverage. The race E2Es observe actual Node child spawns as well as Python startup, preventing a Python-only counter from missing a stale transient child.

Alternatives considered and rejected:
- Lowering the timeout alone: rejected because any synchronous probe can still exceed Windows' responsiveness threshold under cold disk/AV conditions, and it doubles the worst case when timeout retry is reached.
- Removing timeout retry: rejected because it changes the existing cold-cache recovery contract and does not remove synchronous blocking for the first attempt.
- Forcing reconnects or changing the remote RPC timeout: rejected because the remaining remote AppHangB1 causal chain is not source-pinned, and a transport workaround would not fix local main-thread starvation.
- Moving agent behavior into the renderer or re-parenting the gateway: rejected because the Desktop/backend and gateway lifecycle boundaries are existing contracts.

Complexity and resource audit:
- Candidate discovery remains `O(C + P)` child-probe attempts for `C` candidate branches and `P` sequential Windows registry/launcher probes, with the same candidate order.
- Each in-flight probe uses `O(1)` control state plus the child process; the serve resolver retains `O(K)` cache entries for `K` distinct runtime keys and does not poll.
- The fix trades main-thread blocking for event-driven child callbacks. The stress harness measured 100 probes without an unbounded memory or CPU increase and verified that all parent TCP I/O remained serviceable.

## Compatibility and residual risks

- No migration or configuration change is required.
- Existing callers that need a resolved backend now await it; TypeScript typechecking covers the signature propagation.
- Windows `.cmd`/`.bat` shims keep their shell behavior and hidden-child behavior. Explicit deployment overrides remain authoritative.
- Timeout termination still follows Node's existing child-process semantics; a child that ignores termination can keep a promise pending, but it cannot block the Electron event loop. There is no claim here of a hard process-tree deadline.
- The source-inspection fast path in `backend-serve-support.ts` remains a synchronous small file read; the long-running subprocess probe that follows it is asynchronous. No network or credential material is introduced.

## Tests and verification

### Regression, focused, and build checks

| Command/test | Objective | Result |
|---|---|---|
| Base RED: restore resolver files to `origin/main@9e0dc4319ae2d59c60f5226b5c0af58d17755bfa`; `npm run build`; `HERMES_DESKTOP_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe npx playwright test e2e/runtime-probes.spec.ts --reporter=list` | Prove the old synchronous main-loop path cannot service the probe's parent I/O | Build passed; E2E failed as expected at the 20 s `entered.json` assertion (exit 1). Candidate files were restored and rebuilt with exit 0. |
| `npx vitest run --project electron electron/backend-probes.test.ts electron/backend-claim-exec.test.ts electron/backend-serve-support.test.ts electron/primary-backend-startup.test.ts electron/backend-probes.windows.test.ts electron/windows-hermes-path.test.ts` | Probe semantics, serve coalescing, stale-attempt guards, and Windows path contracts | 49 passed, 1 skipped |
| `npm run typecheck` | Renderer, Electron, and E2E TypeScript contracts | Passed |
| `npm run build` | Production renderer/Electron bundle and staged native dependencies | Passed; `assert-dist-built` passed |
| `HERMES_DESKTOP_PYTHON=C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe npx playwright test e2e/runtime-probes.spec.ts e2e/runtime-probe-races.spec.ts --workers=1 --reporter=list` | Real Electron main/preload/renderer, Python probe I/O, and primary/pool invalidation | 3 passed; final post-red run 42.5 s |
| `HERMES_PYTHON=/c/Users/Nitro/hermes-agent/.venv/Scripts/python.exe scripts/run_tests.sh tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py -q` | Canonical Python runner smoke for the adjacent Desktop/gateway lifecycle surface | 1 file, 7 passed, 0 failed, 100% complete in 7.4 s (final post-red run) |
| `npm run lint` | Desktop lint | Exit 0; 0 errors and 139 existing warnings |
| `git diff --check origin/main...HEAD` and `git diff --check` | Patch hygiene | Passed |
| Final added-line security scan | Detect credential/token/private-key material in the diff | 0 matches for GitHub tokens, AWS keys, private keys, bearer tokens, and secret assignments |

### Three-round bottleneck battery

Each valid round ran five gates: the canonical Python runner, focused Electron Vitest, TypeScript typecheck, production build, and the real Electron E2E plus the temporary 100-probe stress harness. All gates exited 0 in three consecutive rounds after the first rebase (base `91433c8466253e8f58e2fb777014fcc987355eff`); the final rebase was followed by an additional complete gate below.

| Round | Gate result | Real E2E | Stress result |
|---|---|---|---|
| 1 | Python 7/7; Vitest 49 passed/1 skipped; typecheck/build passed | 3/3 in 45.6 s | 100/100 accepted; max event-loop gap 846 ms; RSS +6.2 MB; CPU 219 ms |
| 2 | Python 7/7; Vitest 49 passed/1 skipped; typecheck/build passed | 3/3 in 47.1 s | 100/100 accepted; max event-loop gap 182.5 ms; RSS +6.4 MB; CPU 282 ms |
| 3 | Python 7/7; Vitest 49 passed/1 skipped; typecheck/build passed | 3/3 in 1.2 min | 100/100 accepted; max event-loop gap 107 ms; RSS +6.6 MB; CPU 249 ms |
| Final after last rebase and RED/GREEN validation | Python 7/7; Vitest 49 passed/1 skipped; typecheck passed; restore build passed | 3/3 in 42.5 s | 100/100 accepted; max event-loop gap 107.4 ms; RSS +6.6 MB; CPU 218 ms |

The stress harness was temporary at `C:/Users/Nitro/AppData/Local/Temp/hermes-runtime-probe-stress.mts`; it is not part of the repository or PR. It starts five sequential batches of twenty concurrent child probes, has each child exchange data with a TCP server owned by the parent, and asserts all 100 connections plus an event-loop gap below 1 second.

### Broad-suite limitations and baseline comparison

The full Electron project was also run, but it is not green on this Windows host because the suite includes native POSIX/macOS cases and Unix permission/path expectations. The clean baseline run on `origin/main@0e9fc2cc152b4a4d9fd736f107412ace2a0c2555` produced 2,106 passed, 36 failed, 7 skipped; the candidate-tree run produced 2,114 passed, 35 failed, 8 skipped. The failures were concentrated in the same 10 environment-sensitive files (Unix permissions, macOS/Linux injected-platform cases, `/bin/sh`, POSIX remote paths, and one real-child timing assertion). No candidate-focused test failed. This limitation is reported rather than suppressed; the focused and real-path gates above are the acceptance evidence for this Desktop-only change.

The initial plain `npm ci` was rejected by the host's Node/npm engine mismatch (Node `22.16.0`, npm `11.4.1`; project requires Node `^22.22.0` and npm `<11.10.0` or `>=11.17.0`). Dependency installation and all local checks then used the documented temporary override `npm_config_engine_strict=false`; this environment limitation is not a source or test change.

## Files and documentation

Runtime production changes:
- `apps/desktop/electron/backend-probes.ts`
- `apps/desktop/electron/backend-serve-support.ts`
- `apps/desktop/electron/main.ts`
- `apps/desktop/electron/windows-hermes-path.ts`
- `apps/desktop/electron/backend-claim.ts`
- `apps/desktop/electron/backend-connection-state.ts`
- `apps/desktop/electron/primary-backend-startup.ts`

Regression and contract tests/fixtures:
- `apps/desktop/electron/backend-probes.test.ts`
- `apps/desktop/electron/backend-probes.windows.test.ts`
- `apps/desktop/electron/backend-serve-support.test.ts`
- `apps/desktop/electron/backend-claim-exec.test.ts`
- `apps/desktop/electron/primary-backend-startup.test.ts`
- `apps/desktop/electron/windows-hermes-path.test.ts`
- `apps/desktop/electron/first-run-setup-main-process.test.ts`
- `apps/desktop/e2e/runtime-probes.spec.ts`
- `apps/desktop/e2e/runtime-probe-sitecustomize.py`
- `apps/desktop/e2e/runtime-probe-races.spec.ts`
- `apps/desktop/e2e/runtime-probe-race-sitecustomize.py`

Documentation/context:
- `apps/desktop/src/AGENTS.md` now points the serve-capability contract at the extracted async resolver.
- No changelog, runtime configuration, generated bundle, diagnostic dump, environment, or credential artifact is committed.

Related work deliberately not duplicated:
- #105836: source candidate carried forward here because its head fork is not writable.
- #103803: separate renderer-side remote dial retry; not changed.
- #74050, #77638, #82680, and #59204: historical probe-budget/version/venv work preserved by this change; none owns this async main-loop conversion.

Final local branch state at publication freeze:
- Base `origin/main`: `9e0dc4319ae2d59c60f5226b5c0af58d17755bfa`
- Head: `5d119a247a23dbb75e3fb566a787b8bdf389b779`
- Remote: `fork` (`JoaoMarcos44/hermes-agent`)
- Head branch: `fix/103786-nonblocking-runtime-probes-carry`
- Remote push was verified by `git ls-remote` to the same head SHA.
- The initial hosted read-back for PR #106368 reported 26 checks: 6 `SUCCESS`, 7 `IN_PROGRESS`, 12 `SKIPPED`, 1 `NEUTRAL`, and 0 `FAILURE`. This is a historical snapshot; CI must be read again before calling the PR green.
