### PR TITLE
fix(gateway): delete the frozen streamed bubble once the ledger redelivers the refused final

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3768,6 +3768,24 @@ class BasePlatformAdapter(ABC):
         except Exception as batch_err:
             logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
 
+    async def _send_final_ledgered(
+        self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any], *,
+        reply_to: Optional[str], is_ephemeral_response: bool = False,
+    ) -> "Tuple[SendResult, BasePlatformAdapter, Optional[str]]":
+        """The bracket behind ``send_final_ledgered``, which also hands back the ledger row id (None
+        when the final was not ledgered). The normal lane passes that id to the post-delivery hook, so
+        a cleanup that stands down on a refused send can wait for the row's redelivery instead."""
+        delivery_adapter = self._final_delivery_adapter(event.source)
+        logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
+                    len(text_content), event.source.chat_id)
+        obligation_id = await self._record_delivery_obligation(
+            event, session_key, text_content, delivery_adapter, is_ephemeral_response)
+        result = await delivery_adapter._send_with_retry(
+            chat_id=event.source.chat_id, content=text_content, reply_to=reply_to, metadata=metadata)
+        if obligation_id is not None:
+            await self._finalize_delivery_obligation(obligation_id, result, event, delivery_adapter)
+        return result, delivery_adapter, obligation_id
+
     async def send_final_ledgered(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any], *,
         reply_to: Optional[str], is_ephemeral_response: bool = False,
@@ -3779,27 +3797,23 @@ class BasePlatformAdapter(ABC):
         supplies the source and the ledger identity (``ledger_message_id`` or ``message_id``).
         Returns the result with the adapter that sent it: that adapter owns ``result.message_id``
         (an ephemeral delete must go to the same transport)."""
-        delivery_adapter = self._final_delivery_adapter(event.source)
-        logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
-                    len(text_content), event.source.chat_id)
-        obligation_id = await self._record_delivery_obligation(
-            event, session_key, text_content, delivery_adapter, is_ephemeral_response)
-        result = await delivery_adapter._send_with_retry(
-            chat_id=event.source.chat_id, content=text_content, reply_to=reply_to, metadata=metadata)
-        if obligation_id is not None:
-            await self._finalize_delivery_obligation(obligation_id, result, event, delivery_adapter)
+        result, delivery_adapter, _obligation_id = await self._send_final_ledgered(
+            event, session_key, text_content, metadata,
+            reply_to=reply_to, is_ephemeral_response=is_ephemeral_response)
         return result, delivery_adapter
 
     async def _send_final_text(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
-        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable) -> None:
-        """Normal-lane final: the ledger bracket plus the message-id owner's ephemeral delete."""
-        result, delivery_adapter = await self.send_final_ledgered(
+        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable) -> Optional[str]:
+        """Normal-lane final: the ledger bracket plus the message-id owner's ephemeral delete. Returns
+        the ledger row id for the post-delivery hook (None when the final was not ledgered)."""
+        result, delivery_adapter, obligation_id = await self._send_final_ledgered(
             event, session_key, text_content, metadata,
             reply_to=_reply_anchor_for_event(event), is_ephemeral_response=is_ephemeral_response)
         record_delivery(result)
         if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
             delivery_adapter._schedule_ephemeral_delete(event.source.chat_id, result.message_id, ephemeral_ttl)
+        return obligation_id
 
     async def _notify_turn_error(self, event: MessageEvent, e: BaseException) -> Optional[dict]:
         """Tell the user a turn failed rather than leaving radio silence (last resort:
@@ -3896,7 +3910,8 @@ class BasePlatformAdapter(ABC):
             local_files=local_files, force_document_attachments=force_document, pre_extract=pre_extract)
 
     async def _fire_post_delivery_callback(
-            self, session_key: str, interrupt_event: asyncio.Event, *, delivered: bool = False) -> None:
+            self, session_key: str, interrupt_event: asyncio.Event, *, delivered: bool = False,
+            obligation_id: Optional[str] = None) -> None:
         """Run the one-shot post-delivery callback (bounded, errors swallowed). The generation is
         read HERE — stamped on the interrupt event DURING the handler await; an earlier snapshot
         would let stale runs fire a fresher run's callbacks.
@@ -3906,16 +3921,28 @@ class BasePlatformAdapter(ABC):
         same event first. The hook fires unconditionally
         because its lifecycle consumers (goal continuation, background review release) must run either
         way; a callback that would remove the reader's only text copy of the reply (abandoned-preview
-        cleanup) reads the stamp and stands down when the text did not land."""
+        cleanup) reads the stamp and stands down when the text did not land. Beside it, ``obligation_id``
+        (the ledger row THIS task's own final send recorded, from ``_send_final_text``) is stamped as
+        ``_hermes_final_obligation_id``, so a callback standing down may hand its work to that row's
+        redelivery. It is written here and only here, from this task's own send, and cleared again
+        afterwards: neither a queued-lane ``send_final_ledgered`` inside the handler (an earlier
+        message's reply) nor an earlier turn on this shared event can leave a row behind for a turn
+        whose own final never went out."""
         with contextlib.suppress(Exception):
             interrupt_event._hermes_final_delivered = bool(delivered)
+            interrupt_event._hermes_final_obligation_id = obligation_id or None
         _post_cb = self.pop_post_delivery_callback(
             session_key, generation=getattr(interrupt_event, "_hermes_run_generation", None))
-        if callable(_post_cb):
-            with contextlib.suppress(asyncio.TimeoutError, Exception):
-                _post_result = _post_cb()
-                if inspect.isawaitable(_post_result):
-                    await asyncio.wait_for(_post_result, timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS)
+        try:
+            if callable(_post_cb):
+                with contextlib.suppress(asyncio.TimeoutError, Exception):
+                    _post_result = _post_cb()
+                    if inspect.isawaitable(_post_result):
+                        await asyncio.wait_for(_post_result, timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS)
+        finally:
+            # Cleared even when the await above is cancelled: the row belongs to this firing alone.
+            with contextlib.suppress(Exception):
+                interrupt_event._hermes_final_obligation_id = None
 
     def _finish_session_task(self, session_key: str, interrupt_event: asyncio.Event) -> None:
         """End-of-task guard/ownership reconciliation. A late ``_pending_messages`` arrival must not
@@ -3950,6 +3977,11 @@ class BasePlatformAdapter(ABC):
         # delivered" to the post-delivery stamp.
         text_delivered = False
         post_delivery_fired = False
+        # The ledger row THIS task's own final send recorded (None when it was not ledgered or never
+        # went out). Stamped on the session event by the post-delivery hook, from here and nowhere
+        # else, so a cleanup standing down on a refused send can wait for that row's redelivery
+        # without ever picking up a row a queued-lane send or an earlier turn left behind.
+        final_obligation_id = None
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -4006,7 +4038,7 @@ class BasePlatformAdapter(ABC):
                 # _play_tts_file returns True only when the COMPLETE text rode along as the caption.
                 text_delivered = text_delivered or _tts_caption_delivered
                 if text_content and not _tts_caption_delivered:
-                    await self._send_final_text(
+                    final_obligation_id = await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
                         is_ephemeral_response, _ephemeral_ttl, _record_text_delivery)
                 await self._deliver_attachments(
@@ -4033,7 +4065,8 @@ class BasePlatformAdapter(ABC):
                 # callback popped from ``finally`` could be the NEXT turn's, fired with THIS turn's
                 # delivery outcome (a preview cleanup would then delete a reply still in flight).
                 await self._fire_post_delivery_callback(
-                    session_key, interrupt_event, delivered=text_delivered)
+                    session_key, interrupt_event, delivered=text_delivered,
+                    obligation_id=final_obligation_id)
                 post_delivery_fired = True
                 self._spawn_drain_task(pending_event, session_key)
                 return  # Drain task owns the session now.
@@ -4056,7 +4089,8 @@ class BasePlatformAdapter(ABC):
             await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
             if not post_delivery_fired:
                 await self._fire_post_delivery_callback(
-                    session_key, interrupt_event, delivered=text_delivered)
+                    session_key, interrupt_event, delivered=text_delivered,
+                    obligation_id=final_obligation_id)
             # Callback work or a late refresh may have recreated typing — one final bounded stop.
             await self._stop_typing_refresh(
                 event.source.chat_id, None, metadata=_thread_metadata, stop_attempts=1)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1569,6 +1569,10 @@ class SendResult:
     # Extra ids (send order) when a payload was split; ``message_id`` is then the LAST id so
     # later edits target the newest chunk.
     continuation_message_ids: tuple = ()
+    # True when only a PREFIX of the requested text landed (the base plain-text fallback caps at
+    # 3500 chars). ``success`` still means the reader got a reply; a consumer that needs the
+    # COMPLETE text (the post-delivery ``delivered`` stamp) must check this too.
+    truncated: bool = False
     # SEND_ERROR_KINDS member (failures only) via :func:`classify_send_error`, so consumers
     # branch without substring-matching ``error``.
     error_kind: Optional[str] = None
@@ -3236,9 +3240,14 @@ class BasePlatformAdapter(ABC):
         # rate-limited error never reaches here: it classifies as network above and the
         # loop only breaks on a non-transient, non-rate-limited error.
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
-        fallback_result = await _send(f"(Response formatting failed, plain text:)\n\n{content[:3500]}")
+        fallback_text = content[:3500]
+        fallback_result = await _send(f"(Response formatting failed, plain text:)\n\n{fallback_text}")
         if not fallback_result.success:
             logger.error("[%s] Fallback send also failed: %s", self.name, fallback_result.error)
+        elif len(fallback_text) < len(content):
+            # Only a prefix landed. Success stands (the reader got a reply), but nothing may treat
+            # this as the complete text having arrived.
+            fallback_result.truncated = True
         return fallback_result
 
     @staticmethod
@@ -3886,10 +3895,20 @@ class BasePlatformAdapter(ABC):
             text_content=text_content, images=images, media_files=media_files,
             local_files=local_files, force_document_attachments=force_document, pre_extract=pre_extract)
 
-    async def _fire_post_delivery_callback(self, session_key: str, interrupt_event: asyncio.Event) -> None:
+    async def _fire_post_delivery_callback(
+            self, session_key: str, interrupt_event: asyncio.Event, *, delivered: bool = False) -> None:
         """Run the one-shot post-delivery callback (bounded, errors swallowed). The generation is
         read HERE — stamped on the interrupt event DURING the handler await; an earlier snapshot
-        would let stale runs fire a fresher run's callbacks."""
+        would let stale runs fire a fresher run's callbacks.
+
+        ``delivered`` (the COMPLETE final text reached the user: its own send, or riding along as a
+        TTS caption; bare audio and a truncated plain-text fallback do not count) is stamped on the
+        same event first. The hook fires unconditionally
+        because its lifecycle consumers (goal continuation, background review release) must run either
+        way; a callback that would remove the reader's only text copy of the reply (abandoned-preview
+        cleanup) reads the stamp and stands down when the text did not land."""
+        with contextlib.suppress(Exception):
+            interrupt_event._hermes_final_delivered = bool(delivered)
         _post_cb = self.pop_post_delivery_callback(
             session_key, generation=getattr(interrupt_event, "_hermes_run_generation", None))
         if callable(_post_cb):
@@ -3925,12 +3944,24 @@ class BasePlatformAdapter(ABC):
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         delivery_attempted = delivery_succeeded = False  # feeds the processing-complete hook
+        # The COMPLETE final text reached the user (own send, or as a TTS caption). Kept apart from the
+        # aggregate: a voice reply can land its audio while the text send fails, and a truncated
+        # plain-text fallback is a success that carried only a prefix. Neither may read as "text
+        # delivered" to the post-delivery stamp.
+        text_delivered = False
+        post_delivery_fired = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
             if result is not None:
                 delivery_attempted = True
                 delivery_succeeded = delivery_succeeded or bool(getattr(result, "success", False))
+
+        def _record_text_delivery(result):
+            nonlocal text_delivered
+            _record_delivery(result)
+            text_delivered = text_delivered or (
+                bool(getattr(result, "success", False)) and not getattr(result, "truncated", False))
         # Reuse the interrupt event handle_message() installed; new Event only if removed externally.
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
@@ -3972,10 +4003,12 @@ class BasePlatformAdapter(ABC):
                 if not _tts_paths and _tts_requested_path is not None:
                     with contextlib.suppress(OSError):
                         os.remove(_tts_requested_path)
+                # _play_tts_file returns True only when the COMPLETE text rode along as the caption.
+                text_delivered = text_delivered or _tts_caption_delivered
                 if text_content and not _tts_caption_delivered:
                     await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
-                        is_ephemeral_response, _ephemeral_ttl, _record_delivery)
+                        is_ephemeral_response, _ephemeral_ttl, _record_text_delivery)
                 await self._deliver_attachments(
                     event, extracted, _final_thread_metadata,
                     anything_sent=delivery_attempted or _tts_caption_delivered)
@@ -3995,6 +4028,13 @@ class BasePlatformAdapter(ABC):
                 logger.debug("[%s] Processing queued follow-up message", self.name)
                 self._clear_session_guard(session_key)
                 await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
+                # Fire the post-delivery callback BEFORE handing the session over: the follow-up turn
+                # shares this interrupt Event and re-stamps its run generation as soon as it starts, so a
+                # callback popped from ``finally`` could be the NEXT turn's, fired with THIS turn's
+                # delivery outcome (a preview cleanup would then delete a reply still in flight).
+                await self._fire_post_delivery_callback(
+                    session_key, interrupt_event, delivered=text_delivered)
+                post_delivery_fired = True
                 self._spawn_drain_task(pending_event, session_key)
                 return  # Drain task owns the session now.
         except asyncio.CancelledError:
@@ -4014,7 +4054,9 @@ class BasePlatformAdapter(ABC):
             # Stop typing BEFORE the post-delivery callback: a stuck callback must not keep it
             # alive.
             await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
-            await self._fire_post_delivery_callback(session_key, interrupt_event)
+            if not post_delivery_fired:
+                await self._fire_post_delivery_callback(
+                    session_key, interrupt_event, delivered=text_delivered)
             # Callback work or a late refresh may have recreated typing — one final bounded stop.
             await self._stop_typing_refresh(
                 event.source.chat_id, None, metadata=_thread_metadata, stop_attempts=1)

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -14,6 +14,7 @@ import logging
 import os
 import signal
 import time
+from collections import deque
 from contextlib import suppress
 from datetime import datetime
 from gateway.config import Platform
@@ -30,6 +31,12 @@ from gateway.shutdown_watchdog import (
     DEFAULT_LOOP_WATCHDOG_MAX_STRIKES, DEFAULT_LOOP_WATCHDOG_TIMEOUT_S, loop_heartbeat_forever,
 )
 from typing import Any, Dict, Optional, Tuple
+
+# Follow-ups a turn hands to the ledger redelivery of its refused final (see
+# ``_register_redelivery_followup``): the registry is process-local and bounded two ways, so a row
+# that is never redelivered cannot grow it. The cutoff matches the ledger's own stale window.
+_REDELIVERY_FOLLOWUP_CAP = 64
+_REDELIVERY_FOLLOWUP_TTL_SECONDS = 24 * 3600.0
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
@@ -358,6 +365,77 @@ class GatewayStartupMixin:
         for row in await asyncio.to_thread(pending_flood_retries):
             self._schedule_flood_redelivery(row["platform"], profile=row["profile"])
 
+    def _register_redelivery_followup(self, obligation_id: str, followup: Any) -> bool:
+        """Keep ``followup`` (a plain callable) until the ledger redelivers ``obligation_id`` and that
+        send lands; ``_redeliver_claimed_obligations`` fires it then. Used by a post-delivery cleanup
+        that has to stand down because the final it watched was refused: the reply the ledger still owes
+        the reader is what makes its delete safe later. A row this process has already redelivered runs
+        the follow-up at once (the reconnect sweep redelivers inside the refused send's own
+        finalization, before the turn's callback gets to register). Process-local on purpose (the
+        consumer it acts for dies with the process, so a boot-sweep redelivery has nothing to clean up
+        for) and bounded two ways: entries older than the ledger's stale cutoff are dropped, on the
+        next registration and by a timer armed with each new row, and past the cap the oldest
+        registration goes first. Returns False when nothing was registered."""
+        if not obligation_id or not callable(followup):
+            return False
+        landed = getattr(self, "_redelivered_obligation_ids", None)
+        if landed is not None and obligation_id in landed:
+            self._run_redelivery_followup(obligation_id, followup)
+            return True
+        registry = getattr(self, "_redelivery_followups", None)
+        if registry is None:
+            registry = self._redelivery_followups = {}
+        self._prune_redelivery_followups()
+        entry = registry.get(obligation_id)
+        if entry is None:
+            while len(registry) >= _REDELIVERY_FOLLOWUP_CAP:
+                registry.pop(next(iter(registry)), None)
+            entry = registry[obligation_id] = (time.monotonic(), [])
+            # Expiry must not wait for the next registration: a row that is never redelivered (attempts
+            # exhausted, adapter gone) would otherwise keep its closure, and the consumer that closure
+            # holds, alive until the process exits.
+            with suppress(RuntimeError):
+                asyncio.get_running_loop().call_later(
+                    _REDELIVERY_FOLLOWUP_TTL_SECONDS + 1.0, self._prune_redelivery_followups)
+        entry[1].append(followup)
+        return True
+
+    def _prune_redelivery_followups(self) -> None:
+        """Drop follow-ups whose row passed the ledger's stale cutoff without a landed redelivery."""
+        registry = getattr(self, "_redelivery_followups", None)
+        if not registry:
+            return
+        now = time.monotonic()
+        for stale in [oid for oid, (registered_at, _) in registry.items()
+                      if now - registered_at > _REDELIVERY_FOLLOWUP_TTL_SECONDS]:
+            registry.pop(stale, None)
+
+    @staticmethod
+    def _run_redelivery_followup(obligation_id: str, followup: Any) -> bool:
+        try:
+            followup()
+            return True
+        except Exception:
+            logger.debug("redelivery follow-up for obligation %s failed", obligation_id, exc_info=True)
+            return False
+
+    def _fire_redelivery_followups(self, obligation_id: str) -> int:
+        """Run every follow-up registered for a redelivered row, once, each failure isolated, and
+        remember the row as landed so a follow-up that registers late runs at once. Returns how many
+        ran."""
+        if not obligation_id:
+            return 0
+        landed = getattr(self, "_redelivered_obligation_ids", None)
+        if landed is None:
+            landed = self._redelivered_obligation_ids = deque(maxlen=_REDELIVERY_FOLLOWUP_CAP)
+        if obligation_id not in landed:
+            landed.append(obligation_id)
+        registry = getattr(self, "_redelivery_followups", None)
+        entry = registry.pop(obligation_id, None) if registry else None
+        if not entry:
+            return 0
+        return sum(1 for followup in entry[1] if self._run_redelivery_followup(obligation_id, followup))
+
     async def _redeliver_claimed_obligations(self, claimed: list) -> int:
         """Redeliver final responses for claimed rows (network half of the split): runs inside the
         bounded boot-send task, so a flood-limited send can be abandoned by the restore gate without
@@ -395,6 +473,11 @@ class GatewayStartupMixin:
                         "Redelivered recovered final response to %s:%s (obligation %s, attempt %d)",
                         row["platform"], row["chat_id"], row["obligation_id"], row["attempts"],
                     )
+                    if not getattr(result, "truncated", False):
+                        # The turn that watched this final get refused may have deferred a cleanup to
+                        # its redelivery (the frozen streamed bubble the final replaces). The reader has
+                        # the complete reply now, so it may run; a truncated send is no replacement.
+                        self._fire_redelivery_followups(row["obligation_id"])
                 else:
                     await asyncio.to_thread(
                         mark_failed, row["obligation_id"], str(getattr(result, "error", "") or "send failed")

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3673,6 +3673,69 @@ class GatewayTurnMixin:
                 "possible duplicate send (see wecom ack-timeout RCA).",
                 _sk, _streamed, _previewed, _content_delivered, _transformed, len(_final),
             )
+            self._run_agent_schedule_abandoned_preview_cleanup(_sc, source, turn_ctx, _content_delivered)
+
+    def _run_agent_schedule_abandoned_preview_cleanup(
+        self, stream_consumer: Any, source: SessionSource, turn_ctx: TurnContext,
+        content_delivered: bool) -> None:
+        """Delete previews the consumer abandoned when the gateway had to send the final itself.
+
+        The consumer deletes the previews it replaces on its own fresh-final and fallback paths. This
+        branch is the one where the consumer gave up and the GATEWAY sends the replacement instead, and
+        nothing cleaned up behind it: a preview frozen mid-render, because its edits were refused inside
+        a flood window, stayed in the chat above the complete reply showing raw MarkdownV2 markers and
+        the streaming cursor.
+
+        Three guards keep this from ever removing the reader's only copy of the answer. Skipped when the
+        stream did deliver the content (those previews ARE the reply). The ids come from the consumer's
+        segment-only seam, so finalized earlier segments survive. And the delete runs from the
+        post-delivery callback, which base.py fires from ``finally`` whether or not the final send
+        succeeded: the callback reads the outcome base.py stamps on the session event and stands down
+        after a failed send, rather than deleting the preview with no replacement in the chat."""
+        from gateway.run import safe_schedule_threadsafe
+        session_key = turn_ctx.session_key
+        if content_delivered or not session_key or stream_consumer is None:
+            return
+        ids_fn = getattr(stream_consumer, "abandoned_preview_ids", None)
+        delete_fn = getattr(stream_consumer, "delete_abandoned_previews", None)
+        if not callable(ids_fn) or not callable(delete_fn):
+            return
+        cleanup_adapter = self._adapter_for_source(source)
+        if cleanup_adapter is None or not hasattr(cleanup_adapter, "register_post_delivery_callback"):
+            return
+        try:
+            stale_ids = set(ids_fn())
+        except Exception as exc:
+            logger.debug("Abandoned preview id lookup failed: %s", exc)
+            return
+        if not stale_ids:
+            return
+        _loop_snapshot = asyncio.get_running_loop()
+
+        def _cleanup_abandoned_previews() -> None:
+            # Stamped by base.py right before the hook fires. Missing or False means the replacement
+            # never reached the reader, and the frozen preview is all they have: keep it.
+            _active = getattr(cleanup_adapter, "_active_sessions", {}).get(session_key)
+            if not getattr(_active, "_hermes_final_delivered", False):
+                logger.debug(
+                    "Abandoned preview cleanup skipped for session %s: final send did not land.", session_key)
+                return
+
+            async def _delete_all() -> None:
+                with suppress(Exception):
+                    await delete_fn(stale_ids)
+            with suppress(Exception):
+                safe_schedule_threadsafe(
+                    _delete_all(), _loop_snapshot, logger=logger,
+                    log_message="Abandoned preview cleanup scheduling error",
+                )
+
+        try:
+            cleanup_adapter.register_post_delivery_callback(
+                session_key, _cleanup_abandoned_previews, generation=turn_ctx.run_generation,
+            )
+        except Exception as exc:
+            logger.debug("Abandoned preview cleanup registration failed: %s", exc)
 
     def _run_agent_schedule_bubble_cleanup(self, response: Any, _cleanup_adapter: Any, turn_ctx: TurnContext) -> None:
         """Schedule deletion of tracked temporary progress bubbles after the final response lands.

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3651,6 +3651,12 @@ class GatewayTurnMixin:
                     fail_result="Stale-finalize reconciliation edit failed for session %s (%s); sending complete response via normal final send.",
                     fail_exc="Stale-finalize reconciliation edit failed for session %s: %s; sending complete response via normal final send.",
                 )
+                if not response.get("already_sent"):
+                    # The edit that would have brought the streamed bubble up to the complete reply was
+                    # refused, so it stays frozen on the stale snapshot while the normal final send puts a
+                    # second copy below it: the same leftover as the abandoned-preview branch, cleaned up
+                    # the same way once the replacement has landed.
+                    self._run_agent_schedule_abandoned_preview_cleanup(_sc, source, turn_ctx, _content_delivered)
             else:
                 logger.info(
                     "Stale streamed finalize detected for session %s with no editable message; delivering complete response via normal final send (#71643).",
@@ -3691,7 +3697,16 @@ class GatewayTurnMixin:
         segment-only seam, so finalized earlier segments survive. And the delete runs from the
         post-delivery callback, which base.py fires from ``finally`` whether or not the final send
         succeeded: the callback reads the outcome base.py stamps on the session event and stands down
-        after a failed send, rather than deleting the preview with no replacement in the chat."""
+        after a failed send, rather than deleting the preview with no replacement in the chat.
+
+        Also reached from the stale-finalize branch when its reconciliation edit is refused: the bubble
+        then stays frozen on a stale snapshot while the normal final send puts a second copy below it.
+        And standing down on a refused send does not drop the delete when the ledger recorded that
+        final (a flood penalty over the inline cap, a dead transport): the callback hands it to the
+        row's redelivery (``_register_redelivery_followup``), and ``_redeliver_claimed_obligations``
+        fires it once the redelivered send has landed untruncated. Only the ledger row that carries
+        THIS final can fire it, and only inside this process; a redelivery after a restart finds no
+        registration and leaves the bubble."""
         from gateway.run import safe_schedule_threadsafe
         session_key = turn_ctx.session_key
         if content_delivered or not session_key or stream_consumer is None:
@@ -3712,15 +3727,7 @@ class GatewayTurnMixin:
             return
         _loop_snapshot = asyncio.get_running_loop()
 
-        def _cleanup_abandoned_previews() -> None:
-            # Stamped by base.py right before the hook fires. Missing or False means the replacement
-            # never reached the reader, and the frozen preview is all they have: keep it.
-            _active = getattr(cleanup_adapter, "_active_sessions", {}).get(session_key)
-            if not getattr(_active, "_hermes_final_delivered", False):
-                logger.debug(
-                    "Abandoned preview cleanup skipped for session %s: final send did not land.", session_key)
-                return
-
+        def _schedule_delete() -> None:
             async def _delete_all() -> None:
                 with suppress(Exception):
                     await delete_fn(stale_ids)
@@ -3729,6 +3736,27 @@ class GatewayTurnMixin:
                     _delete_all(), _loop_snapshot, logger=logger,
                     log_message="Abandoned preview cleanup scheduling error",
                 )
+
+        def _cleanup_abandoned_previews() -> None:
+            # Stamped by base.py right before the hook fires. Missing or False means the replacement
+            # never reached the reader, and the frozen preview is all they have: keep it, unless the
+            # ledger still owes the reader that reply.
+            _active = getattr(cleanup_adapter, "_active_sessions", {}).get(session_key)
+            if getattr(_active, "_hermes_final_delivered", False):
+                _schedule_delete()
+                return
+            # A refused final the ledger recorded (a flood penalty over the inline cap, a dead transport)
+            # is redelivered later, outside this turn. Hand the delete to that redelivery, which fires it
+            # once the complete reply has landed. With no row nothing will replace the bubble: it stays.
+            _obligation_id = getattr(_active, "_hermes_final_obligation_id", None)
+            _defer = getattr(self, "_register_redelivery_followup", None)
+            if _obligation_id and callable(_defer) and _defer(_obligation_id, _schedule_delete):
+                logger.debug(
+                    "Abandoned preview cleanup deferred for session %s: final send did not land; the ledger "
+                    "redelivery of obligation %s fires it.", session_key, _obligation_id)
+                return
+            logger.debug(
+                "Abandoned preview cleanup skipped for session %s: final send did not land.", session_key)
 
         try:
             cleanup_adapter.register_post_delivery_callback(

--- a/gateway/stream_consumer_transport.py
+++ b/gateway/stream_consumer_transport.py
@@ -118,6 +118,27 @@ class StreamTransportMixin:
             except Exception as e:
                 logger.debug("%s preview cleanup failed (%s): %s", label, stale_id, e)
 
+    def abandoned_preview_ids(self) -> set:
+        """Previews a GATEWAY-sent final replaces after this consumer gave up on the current segment
+        (every edit refused, so nothing here delivered the answer). Public seam for the gateway's
+        abandoned-preview cleanup.
+
+        Only the single frozen bubble of a non-split segment is handed over. Segment-only, because
+        earlier segments are finalized preambles the reader already has. Single bubble, because
+        adapters cap a long final by message count or length and still report success (Discord keeps
+        the first N-1 chunks, WeCom and others cut at their limit): one bubble holds at most one
+        platform message of the reply's prefix, which any successful final send covers, while a split
+        chain or several bubbles could hold more than a capped final delivered."""
+        if self._turn_split_delivery:
+            return set()
+        stale = {sid for sid in self._stale_preview_ids(segment_only=True) if sid}
+        return stale if len(stale) == 1 else set()
+
+    async def delete_abandoned_previews(self, stale_ids) -> None:
+        """Best-effort delete of ``abandoned_preview_ids()`` once the replacement has landed.
+        ``retry_on_false``: the flood window that stranded the preview can refuse the delete too."""
+        await self._delete_previews(set(stale_ids), label="Abandoned preview", retry_on_false=True)
+
     def _resolve_draft_streaming(self) -> bool:
         """cfg.transport "draft"/"auto" → the adapter's supports_draft_streaming probe
         ("draft" logs the downgrade); "edit"/"off" → False."""

--- a/tests/gateway/test_abandoned_preview_cleanup.py
+++ b/tests/gateway/test_abandoned_preview_cleanup.py
@@ -1,0 +1,604 @@
+"""A preview the stream consumer abandoned is deleted once the gateway's own final lands.
+
+The consumer deletes the previews it replaces on its fresh-final and fallback paths. It does not
+own the case where it gives up entirely and the GATEWAY sends the final instead, and nothing
+cleaned up behind that: on 6 Sep 2026 four preview edits were refused inside a Telegram flood
+window (9s waits against a 5s inline cap, so each failed closed), the preview froze mid-render,
+and the complete 2888-character reply arrived six seconds later as a separate message. The reader
+was left with a truncated preview above the real answer, showing raw MarkdownV2 markers and the
+streaming cursor.
+
+Three guards keep the cleanup from ever removing the reader's only copy of the answer:
+
+* skipped when the stream did deliver the content (those previews ARE the reply);
+* segment-only ids, so finalized earlier segments (delivered preambles) survive;
+* the delete runs from the post-delivery callback, which fires whether or not the final send
+  succeeded, so it reads the outcome base.py stamps on the session event (did the final TEXT land,
+  by its own send or as a TTS caption; audio alone does not count) and stands down otherwise. That
+  stamp is bound to the finishing turn: a queued follow-up shares the session event, so the hook
+  fires before the drain hand-off rather than from ``finally``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway import run as run_mod
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+
+SESSION_KEY = "agent:main:telegram:dm:5230977008"
+CHAT = "5230977008"
+FINAL = "**No, the 9 euro is admission to the whole fair, not just the one-hour lesson.**"
+
+
+@pytest.fixture
+def scheduled(monkeypatch):
+    """Capture coroutines handed to safe_schedule_threadsafe so the test awaits them deterministically."""
+    captured: list = []
+    monkeypatch.setattr(run_mod, "safe_schedule_threadsafe",
+                        lambda coro, loop, **kw: captured.append(coro))
+    return captured
+
+
+def _consumer(*, stale=("901",), delivered=False, with_seam=True):
+    consumer = SimpleNamespace(
+        final_content_delivered=delivered,
+        message_id="901",
+        adapter=MagicMock(),
+    )
+    if with_seam:
+        consumer.abandoned_preview_ids = MagicMock(return_value=set(stale))
+        consumer.delete_abandoned_previews = AsyncMock()
+    return consumer
+
+
+def _session_event(*, delivered=True, stamped=True):
+    event = asyncio.Event()
+    if stamped:
+        event._hermes_final_delivered = delivered
+    return event
+
+
+def _adapter(*, with_hook=True, session_event=None):
+    adapter = SimpleNamespace()
+    if with_hook:
+        adapter.register_post_delivery_callback = MagicMock()
+    adapter._active_sessions = {}
+    if session_event is not None:
+        adapter._active_sessions[SESSION_KEY] = session_event
+    return adapter
+
+
+def _runner(adapter, *, streamed=False):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    runner._run_agent_stream_confirmed_final_delivery = MagicMock(return_value=streamed)
+    return runner
+
+
+def _turn_ctx(consumer, session_key=SESSION_KEY):
+    return SimpleNamespace(
+        stream_consumer_holder=[consumer],
+        source=SimpleNamespace(chat_id=CHAT, thread_id=None, platform="telegram"),
+        session_key=session_key,
+        run_generation=3,
+    )
+
+
+async def _drive(runner, turn_ctx):
+    """Run the real decision function down to the abandoned-preview branch."""
+    from gateway.run import GatewayRunner
+
+    await GatewayRunner._run_agent_mark_streamed_delivery(
+        runner, {"final_response": FINAL}, turn_ctx)
+
+
+def _registered_callback(adapter):
+    adapter.register_post_delivery_callback.assert_called_once()
+    args, kwargs = adapter.register_post_delivery_callback.call_args
+    assert args[0] == SESSION_KEY
+    assert kwargs["generation"] == 3
+    return args[1]
+
+
+# ---------------------------------------------------------------------------
+# The branch registers the cleanup; a landed final lets it delete the stale previews.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_abandoned_preview_is_deleted_after_the_replacement_lands(scheduled):
+    consumer = _consumer()
+    adapter = _adapter(session_event=_session_event(delivered=True))
+    turn_ctx = _turn_ctx(consumer)
+
+    await _drive(_runner(adapter), turn_ctx)
+
+    callback = _registered_callback(adapter)
+    # Nothing is deleted until the callback fires: it fires after the final send.
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+    callback()
+    assert len(scheduled) == 1
+    await scheduled[0]
+
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_deleted_inline_before_the_final_send(scheduled):
+    """The branch runs before the normal final send, so an inline delete could leave the reader with
+    neither the preview nor a replacement."""
+    consumer = _consumer()
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    assert scheduled == []
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.parametrize("session_event", [
+    pytest.param(_session_event(delivered=False), id="final-send-failed"),
+    pytest.param(_session_event(stamped=False), id="no-stamp"),
+    pytest.param(None, id="no-active-session"),
+])
+@pytest.mark.asyncio
+async def test_a_final_that_did_not_land_keeps_the_preview(scheduled, session_event):
+    """The post-delivery hook fires from ``finally`` even when the final send failed. Without the
+    delivered stamp the frozen preview is all the reader has, so the callback must stand down."""
+    consumer = _consumer()
+    adapter = _adapter(session_event=session_event)
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+    _registered_callback(adapter)()
+
+    assert scheduled == []
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Guards.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_previews_that_hold_the_delivered_answer_are_kept():
+    """When the stream did deliver the content, those previews ARE the reply."""
+    from gateway.run import GatewayRunner
+
+    consumer = _consumer(delivered=True)
+    adapter = _adapter(session_event=_session_event(delivered=True))
+    turn_ctx = _turn_ctx(consumer)
+
+    GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+        _runner(adapter), consumer, turn_ctx.source, turn_ctx, True)
+
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_consumer_with_no_previews_registers_nothing():
+    consumer = _consumer(stale=())
+    adapter = _adapter()
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_consumer_without_the_cleanup_seam_is_ignored():
+    """Relay-style consumers without the transport mixin must not raise here."""
+    consumer = _consumer(with_seam=False)
+    adapter = _adapter()
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_an_adapter_without_the_post_delivery_hook_is_ignored():
+    consumer = _consumer()
+    adapter = _adapter(with_hook=False)
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_registration_never_breaks_the_turn():
+    consumer = _consumer()
+    adapter = _adapter()
+    adapter.register_post_delivery_callback = MagicMock(side_effect=RuntimeError("adapter gone"))
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_refused_delete_never_propagates(scheduled):
+    """The cleanup is best effort: a delete that raises must not surface from the callback."""
+    consumer = _consumer()
+    consumer.delete_abandoned_previews = AsyncMock(side_effect=RuntimeError("flood"))
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+    _registered_callback(adapter)()
+    await scheduled[0]
+
+    consumer.delete_abandoned_previews.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_stream_that_delivered_the_final_takes_the_suppression_path(scheduled):
+    """Sanity check on the branch we must NOT disturb: a confirmed streamed delivery suppresses the
+    normal send and registers no cleanup."""
+    consumer = _consumer()
+    adapter = _adapter(session_event=_session_event(delivered=True))
+    response = {"final_response": FINAL}
+
+    from gateway.run import GatewayRunner
+    await GatewayRunner._run_agent_mark_streamed_delivery(
+        _runner(adapter, streamed=True), response, _turn_ctx(consumer))
+
+    assert response.get("already_sent") is True
+    adapter.register_post_delivery_callback.assert_not_called()
+    assert scheduled == []
+
+
+# ---------------------------------------------------------------------------
+# The consumer's seam: segment-only ids, and the delete goes through the retrying helper.
+# ---------------------------------------------------------------------------
+
+def _real_consumer():
+    from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+    adapter = MagicMock(spec=BasePlatformAdapter)
+    adapter.delete_message = AsyncMock(return_value=True)
+    return GatewayStreamConsumer(adapter=adapter, chat_id=CHAT, config=StreamConsumerConfig())
+
+
+def test_finalized_earlier_segments_are_not_abandoned():
+    """A tool boundary finalizes the segment before it and resets the per-segment state, but the
+    turn-wide preview set keeps those ids. Handing that set over would delete delivered preambles
+    whose text is absent from the final answer."""
+    consumer = _real_consumer()
+
+    # Segment 1 streamed, landed and was finalized at a tool boundary.
+    consumer._message_id = "801"
+    consumer._preview_message_ids.add("801")
+    consumer._segment_preview_message_ids.add("801")
+    consumer._reset_segment_state()
+    assert consumer._message_id is None and "801" in consumer._preview_message_ids
+
+    # Segment 2 is the one the consumer gave up on.
+    consumer._message_id = "901"
+    consumer._preview_message_ids.add("901")
+    consumer._segment_preview_message_ids.add("901")
+
+    assert consumer.abandoned_preview_ids() == {"901"}
+
+
+def test_a_split_chain_is_never_handed_over():
+    """After an oversized split the sealed head chunks hold delivered text, and a long final may be
+    capped by the adapter (message count or length) while still reporting success. Nothing is deleted."""
+    consumer = _real_consumer()
+    consumer._message_id = "901"
+    consumer._preview_message_ids.add("901")
+    consumer._segment_preview_message_ids.add("901")
+    consumer._turn_split_delivery = True
+
+    assert consumer.abandoned_preview_ids() == set()
+
+
+def test_several_bubbles_in_one_segment_are_never_handed_over():
+    """Several bubbles can hold more text than a capped final delivered; only a single frozen bubble
+    is provably covered by any successful final send."""
+    consumer = _real_consumer()
+    consumer._message_id = "902"
+    for mid in ("901", "902"):
+        consumer._preview_message_ids.add(mid)
+        consumer._segment_preview_message_ids.add(mid)
+
+    assert consumer.abandoned_preview_ids() == set()
+
+
+def test_the_no_edit_sentinel_is_never_an_abandoned_preview():
+    consumer = _real_consumer()
+    consumer._message_id = "__no_edit__"
+
+    assert consumer.abandoned_preview_ids() == set()
+
+
+@pytest.mark.asyncio
+async def test_delete_abandoned_previews_requests_the_bounded_retry():
+    """Telegram reports a refused delete by returning False, and the flood window that stranded the
+    preview can refuse the delete too, so the existing bounded retry must be requested."""
+    consumer = _real_consumer()
+    consumer._delete_previews = AsyncMock()
+
+    await consumer.delete_abandoned_previews({"901", "902"})
+
+    consumer._delete_previews.assert_awaited_once_with(
+        {"901", "902"}, label="Abandoned preview", retry_on_false=True)
+
+
+# ---------------------------------------------------------------------------
+# End to end through the real background processor: the delete waits for a LANDED final.
+# ---------------------------------------------------------------------------
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+@pytest.mark.parametrize("final_landed", [True, False], ids=["final-landed", "final-refused"])
+@pytest.mark.asyncio
+async def test_end_to_end_the_delete_waits_for_a_landed_final(scheduled, final_landed):
+    from gateway.run import GatewayRunner
+
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(
+        success=final_landed, message_id="777" if final_landed else None,
+        error=None if final_landed else "Flood control exceeded. Retry in 9 seconds"))
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 3
+    adapter._active_sessions[session_key] = session_event
+
+    consumer = _consumer()
+    turn_ctx = _turn_ctx(consumer, session_key=session_key)
+    runner = _runner(adapter)
+
+    async def _handler(_event):
+        # What run_turn does on the abandoned-preview branch, BEFORE base.py sends the final.
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+            runner, consumer, source, turn_ctx, False)
+        return FINAL
+
+    adapter._message_handler = _handler
+    event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123")
+
+    await adapter._process_message_background(event, session_key)
+
+    adapter._send_with_retry.assert_awaited_once()
+    if final_landed:
+        assert len(scheduled) == 1
+        await scheduled[0]
+        consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+    else:
+        assert scheduled == []
+        consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Voice replies: only the TEXT landing counts.
+# ---------------------------------------------------------------------------
+
+async def _run_voice_turn(tmp_path, *, final_text, text_send_ok):
+    """A turn with auto-TTS on: the audio always lands; the text send outcome is the parameter."""
+    from gateway.run import GatewayRunner
+
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+    audio = tmp_path / "reply.ogg"
+    audio.write_bytes(b"ogg")
+    adapter._wants_auto_tts = MagicMock(return_value=True)
+    adapter._synthesize_auto_tts = AsyncMock(return_value=([str(audio)], None))
+    adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="a1"))
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(
+        success=text_send_ok, message_id="777" if text_send_ok else None,
+        error=None if text_send_ok else "Flood control exceeded. Retry in 9 seconds"))
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 3
+    adapter._active_sessions[session_key] = session_event
+
+    consumer = _consumer()
+    turn_ctx = _turn_ctx(consumer, session_key=session_key)
+    runner = _runner(adapter)
+
+    async def _handler(_event):
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+            runner, consumer, source, turn_ctx, False)
+        return final_text
+
+    adapter._message_handler = _handler
+    event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123")
+    await adapter._process_message_background(event, session_key)
+    return adapter, consumer
+
+
+@pytest.mark.asyncio
+async def test_audio_that_landed_without_its_text_keeps_the_preview(scheduled, tmp_path):
+    """A reply over Telegram's caption limit sends the audio bare and the text separately. If that text
+    send is refused, the audio's success must not authorise deleting the reader's only text copy."""
+    adapter, consumer = await _run_voice_turn(
+        tmp_path, final_text="x" * 1500, text_send_ok=False)
+
+    adapter.play_tts.assert_awaited_once()
+    adapter._send_with_retry.assert_awaited_once()
+    assert scheduled == []
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_delivered_tts_caption_counts_as_the_text_landing(scheduled, tmp_path):
+    """A short reply rides along as the audio's caption and the text send is skipped: the reader has
+    the text, so the abandoned preview goes."""
+    adapter, consumer = await _run_voice_turn(tmp_path, final_text=FINAL, text_send_ok=True)
+
+    adapter.play_tts.assert_awaited_once()
+    adapter._send_with_retry.assert_not_awaited()
+    assert len(scheduled) == 1
+    await scheduled[0]
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+
+
+# ---------------------------------------------------------------------------
+# Queued follow-up: the finishing turn fires ITS callback, with ITS outcome, before the hand-off.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_draining_turn_never_fires_the_next_turns_cleanup(scheduled):
+    """A follow-up queued mid-turn is drained by a new task that shares the session's interrupt Event
+    and re-stamps its run generation as soon as it starts. The finishing turn must pop and fire its own
+    callback before that hand-off; popped from ``finally`` instead, it could be the next turn's cleanup,
+    fired with this turn's delivery outcome while that turn's final send is still in flight."""
+    from gateway.run import GatewayRunner
+
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 1
+    adapter._active_sessions[session_key] = session_event
+    runner = _runner(adapter)
+
+    first_consumer, second_consumer = _consumer(stale=("901",)), _consumer(stale=("902",))
+    second_turn_started, release_second_send = asyncio.Event(), asyncio.Event()
+    event1 = MessageEvent(text="first", message_type=MessageType.TEXT, source=source, message_id="1")
+    event2 = MessageEvent(text="second", message_type=MessageType.TEXT, source=source, message_id="2")
+
+    sends: list = []
+
+    async def _send_with_retry(**kwargs):
+        sends.append(kwargs["content"])
+        if len(sends) == 1:
+            return SendResult(success=True, message_id="11")  # the first turn's final lands
+        await release_second_send.wait()  # the second turn's final stays in flight, then is refused
+        return SendResult(success=False, error="Flood control exceeded. Retry in 9 seconds")
+
+    adapter._send_with_retry = _send_with_retry
+
+    # The real typing stop awaits the platform; that yield is what lets the drain task run first.
+    real_stop = adapter._stop_typing_refresh
+
+    async def _yielding_stop(*args, **kwargs):
+        await asyncio.sleep(0)
+        return await real_stop(*args, **kwargs)
+
+    adapter._stop_typing_refresh = _yielding_stop
+
+    turns: list = []
+
+    async def _handler(event):
+        turns.append(event.message_id)
+        if len(turns) == 1:
+            adapter._pending_messages[session_key] = event2  # a follow-up arrives mid-turn
+            ctx = _turn_ctx(first_consumer, session_key=session_key)
+            ctx.run_generation = 1
+            GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+                runner, first_consumer, source, ctx, False)
+            return "first answer"
+        session_event._hermes_run_generation = 2  # what the gateway's generation binding does
+        ctx = _turn_ctx(second_consumer, session_key=session_key)
+        ctx.run_generation = 2
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+            runner, second_consumer, source, ctx, False)
+        second_turn_started.set()
+        return "second answer"
+
+    adapter._message_handler = _handler
+
+    await adapter._process_message_background(event1, session_key)
+    await asyncio.wait_for(second_turn_started.wait(), 5)
+    await asyncio.sleep(0)
+
+    # The first turn's own cleanup fired, with the first turn's outcome ...
+    assert len(scheduled) == 1
+    await scheduled[0]
+    first_consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+    # ... and the second turn's did not while its final was still in flight.
+    second_consumer.delete_abandoned_previews.assert_not_awaited()
+
+    drain_task = adapter._session_tasks.get(session_key)
+    release_second_send.set()
+    if drain_task is not None:
+        await asyncio.wait_for(drain_task, 5)
+    assert turns == ["1", "2"]
+    # The second turn's final was refused, so its preview stays.
+    assert len(scheduled) == 1
+    second_consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# The plain-text fallback in _send_with_retry: a success that carried only a prefix is not delivery.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("final_text, expect_delete", [
+    pytest.param("x" * 4933, False, id="fallback-truncated-keeps-preview"),
+    pytest.param("y" * 800, True, id="fallback-complete-deletes-preview"),
+])
+@pytest.mark.asyncio
+async def test_a_truncated_plain_text_fallback_is_not_text_delivery(scheduled, final_text, expect_delete):
+    """After a formatting failure, ``_send_with_retry`` falls back to plain text capped at 3500 chars and
+    returns the fallback's success. For a long reply that is a prefix, and the frozen preview may hold
+    text the replacement does not, so it must stay. A complete fallback is the whole reply and the
+    preview goes."""
+    from gateway.run import GatewayRunner
+
+    adapter = _StubAdapter(
+        PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+    adapter.send = AsyncMock(side_effect=[
+        SendResult(success=False, error="Bad Request: can't parse entities: unmatched '*'"),
+        SendResult(success=True, message_id="778"),
+    ])
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 3
+    adapter._active_sessions[session_key] = session_event
+
+    consumer = _consumer()
+    turn_ctx = _turn_ctx(consumer, session_key=session_key)
+    runner = _runner(adapter)
+
+    async def _handler(_event):
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(
+            runner, consumer, source, turn_ctx, False)
+        return final_text
+
+    adapter._message_handler = _handler
+    event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123")
+    await adapter._process_message_background(event, session_key)
+
+    # The real retry helper ran: the formatted send failed, the plain-text fallback landed.
+    assert adapter.send.await_count == 2
+    fallback_text = adapter.send.await_args_list[1].kwargs["content"]
+    assert fallback_text.startswith("(Response formatting failed, plain text:)")
+    assert (len(fallback_text) < len(final_text)) is (not expect_delete)
+
+    if expect_delete:
+        assert len(scheduled) == 1
+        await scheduled[0]
+        consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+    else:
+        assert scheduled == []
+        consumer.delete_abandoned_previews.assert_not_awaited()

--- a/tests/gateway/test_redelivered_final_preview_cleanup.py
+++ b/tests/gateway/test_redelivered_final_preview_cleanup.py
@@ -1,0 +1,632 @@
+"""A frozen streamed bubble is deleted after the ledger redelivers the final the platform refused.
+
+Two leftovers the abandoned-preview cleanup (the parent commit) did not reach, both seen on Telegram
+on 8 and 9 Sep 2026:
+
+* the stale-finalize branch: the consumer's finalize edit had succeeded on a stale snapshot, the
+  gateway's reconciliation edit was refused inside a flood window, and the normal final send put a
+  second copy below the frozen bubble. That branch registered no cleanup at all.
+* the redelivery path: the gateway's own final was refused too (penalties of 102 s and 269 s, both
+  over the 60 s inline cap), the ledger redelivered it minutes later, and the cleanup that WAS
+  registered had already stood down because the post-delivery stamp said the text did not land.
+  The redelivery runs outside the turn, so nothing fired it.
+
+Now the stale-finalize branch registers the same cleanup when its edit is refused, and a cleanup that
+stands down on a refused send hands its delete to the ledger row carrying the final: base.py stamps
+the obligation id on the session event beside the delivery stamp, the runner keeps a small
+process-local registry keyed by obligation id, and the redelivery loop fires the registered
+follow-ups once the redelivered send has landed untruncated. The guards are unchanged: a follow-up
+fires only for its own obligation and only on a landed redelivery; with no ledger row (the ledger
+off, a slash command, an ephemeral notice) the bubble is the reader's only copy and stays; and a
+redelivery after a restart finds an empty registry, because the consumer it would clean up for is
+gone with the old process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway import delivery_ledger as dl
+from gateway import run as run_mod
+from gateway import run_startup as run_startup_mod
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+
+SESSION_KEY = "agent:main:telegram:dm:5230977008"
+CHAT = "5230977008"
+FINAL = "**For you, I'd start with Hostelworld Social Pass and free Meetup.** Try TripBFF too."
+REFUSED = SendResult(success=False, error="flood_control:269.0")
+
+
+@pytest.fixture
+def scheduled(monkeypatch):
+    """Capture coroutines handed to safe_schedule_threadsafe so the test awaits them deterministically."""
+    captured: list = []
+    monkeypatch.setattr(run_mod, "safe_schedule_threadsafe",
+                        lambda coro, loop, **kw: captured.append(coro))
+    return captured
+
+
+def _abandoned_consumer(*, stale=("901",)):
+    """The parent commit's case: every edit refused, nothing here delivered the answer."""
+    consumer = SimpleNamespace(final_content_delivered=False, message_id="901", adapter=MagicMock())
+    consumer.abandoned_preview_ids = MagicMock(return_value=set(stale))
+    consumer.delete_abandoned_previews = AsyncMock()
+    return consumer
+
+
+def _stale_consumer(*, edit_result=REFUSED, edit_raises=None, message_id="901", split=False):
+    """The stale-finalize case: the finalize edit landed a stale snapshot, so the recorded payload does
+    not match the completed response and the gateway tries a reconciliation edit."""
+    consumer = SimpleNamespace(final_content_delivered=True, message_id=message_id, adapter=MagicMock())
+    consumer.delivered_final_matches = MagicMock(return_value=False)
+    consumer._turn_split_delivery = split
+    if edit_raises is not None:
+        consumer.adapter.edit_message = AsyncMock(side_effect=edit_raises)
+    else:
+        consumer.adapter.edit_message = AsyncMock(return_value=edit_result)
+    consumer.abandoned_preview_ids = MagicMock(return_value={"901"})
+    consumer.delete_abandoned_previews = AsyncMock()
+    return consumer
+
+
+def _session_event(*, delivered, obligation_id=None, stamp_obligation=True):
+    event = asyncio.Event()
+    event._hermes_final_delivered = delivered
+    if stamp_obligation:
+        event._hermes_final_obligation_id = obligation_id
+    return event
+
+
+def _adapter(*, session_event=None):
+    adapter = SimpleNamespace()
+    adapter.register_post_delivery_callback = MagicMock()
+    adapter._active_sessions = {}
+    if session_event is not None:
+        adapter._active_sessions[SESSION_KEY] = session_event
+    return adapter
+
+
+def _runner(adapter):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    runner._run_agent_stream_confirmed_final_delivery = MagicMock(return_value=False)
+    return runner
+
+
+def _turn_ctx(consumer, session_key=SESSION_KEY):
+    return SimpleNamespace(
+        stream_consumer_holder=[consumer],
+        source=SimpleNamespace(chat_id=CHAT, thread_id=None, platform="telegram"),
+        session_key=session_key,
+        run_generation=3,
+    )
+
+
+async def _drive(runner, turn_ctx):
+    """Run the real decision function; returns the response dict it decided on."""
+    from gateway.run import GatewayRunner
+
+    response = {"final_response": FINAL}
+    await GatewayRunner._run_agent_mark_streamed_delivery(runner, response, turn_ctx)
+    return response
+
+
+def _registered_callback(adapter):
+    adapter.register_post_delivery_callback.assert_called_once()
+    args, kwargs = adapter.register_post_delivery_callback.call_args
+    assert args[0] == SESSION_KEY
+    assert kwargs["generation"] == 3
+    return args[1]
+
+
+def _followups(runner):
+    return getattr(runner, "_redelivery_followups", {}) or {}
+
+
+# ---------------------------------------------------------------------------
+# The stale-finalize branch registers the cleanup when its reconciliation edit is refused.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_refused_reconciliation_edit_registers_the_cleanup(scheduled):
+    consumer = _stale_consumer()
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    response = await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    # The edit was tried and refused, so the normal final send is NOT suppressed.
+    consumer.adapter.edit_message.assert_awaited_once()
+    assert not response.get("already_sent")
+    callback = _registered_callback(adapter)
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+    callback()
+    assert len(scheduled) == 1
+    await scheduled[0]
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+
+
+@pytest.mark.asyncio
+async def test_a_reconciliation_edit_that_raises_registers_the_cleanup(scheduled):
+    consumer = _stale_consumer(edit_raises=RuntimeError("socket closed"))
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    response = await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    assert not response.get("already_sent")
+    _registered_callback(adapter)()
+    assert len(scheduled) == 1
+    await scheduled[0]
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+
+
+@pytest.mark.asyncio
+async def test_a_landed_reconciliation_edit_registers_nothing():
+    """The edit brought the bubble up to the complete reply: it IS the answer now."""
+    consumer = _stale_consumer(edit_result=SendResult(success=True, message_id="901"))
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    response = await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    assert response.get("already_sent") is True
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_a_stale_finalize_on_a_split_chain_registers_nothing():
+    consumer = _stale_consumer(split=True)
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    consumer.adapter.edit_message.assert_not_awaited()
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+@pytest.mark.parametrize("message_id", [None, "__no_edit__"])
+@pytest.mark.asyncio
+async def test_a_stale_finalize_without_an_editable_message_registers_nothing(message_id):
+    consumer = _stale_consumer(message_id=message_id)
+    adapter = _adapter(session_event=_session_event(delivered=True))
+
+    await _drive(_runner(adapter), _turn_ctx(consumer))
+
+    consumer.adapter.edit_message.assert_not_awaited()
+    adapter.register_post_delivery_callback.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# A cleanup that stands down on a refused send hands its delete to the ledger redelivery.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_refused_final_with_a_ledger_row_defers_the_delete_to_the_redelivery(scheduled):
+    from gateway.run import GatewayRunner
+
+    consumer = _abandoned_consumer()
+    adapter = _adapter(session_event=_session_event(delivered=False, obligation_id="ob-1"))
+    runner = _runner(adapter)
+
+    await _drive(runner, _turn_ctx(consumer))
+    _registered_callback(adapter)()
+
+    # Nothing is deleted while the reader has only the frozen bubble.
+    assert scheduled == []
+    consumer.delete_abandoned_previews.assert_not_awaited()
+    assert set(_followups(runner)) == {"ob-1"}
+
+    fired = GatewayRunner._fire_redelivery_followups(runner, "ob-1")
+
+    assert fired == 1
+    assert len(scheduled) == 1
+    await scheduled[0]
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+    # One-shot: the row is gone from the registry once fired.
+    assert _followups(runner) == {}
+
+
+@pytest.mark.parametrize("session_event", [
+    _session_event(delivered=False, obligation_id=None),
+    _session_event(delivered=False, obligation_id=""),
+    _session_event(delivered=False, stamp_obligation=False),
+], ids=["stamp-none", "stamp-empty", "stamp-absent"])
+@pytest.mark.asyncio
+async def test_a_refused_final_without_a_ledger_row_stands_down(scheduled, session_event):
+    """No row means nothing will ever replace the bubble: it is the reader's only copy and stays."""
+    consumer = _abandoned_consumer()
+    adapter = _adapter(session_event=session_event)
+    runner = _runner(adapter)
+
+    await _drive(runner, _turn_ctx(consumer))
+    _registered_callback(adapter)()
+
+    assert scheduled == []
+    assert _followups(runner) == {}
+    consumer.delete_abandoned_previews.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_follow_up_fires_only_for_its_own_obligation(scheduled):
+    from gateway.run import GatewayRunner
+
+    consumer = _abandoned_consumer()
+    adapter = _adapter(session_event=_session_event(delivered=False, obligation_id="ob-1"))
+    runner = _runner(adapter)
+    await _drive(runner, _turn_ctx(consumer))
+    _registered_callback(adapter)()
+
+    assert GatewayRunner._fire_redelivery_followups(runner, "ob-2") == 0
+    assert GatewayRunner._fire_redelivery_followups(runner, "") == 0
+
+    assert scheduled == []
+    assert set(_followups(runner)) == {"ob-1"}
+
+
+@pytest.mark.asyncio
+async def test_the_stale_finalize_branch_also_defers_on_a_refused_final(scheduled):
+    """The 8 Sep shape end to end at the decision layer: reconciliation edit refused, then the normal
+    final refused as well, then the ledger redelivers."""
+    from gateway.run import GatewayRunner
+
+    consumer = _stale_consumer()
+    adapter = _adapter(session_event=_session_event(delivered=False, obligation_id="ob-1"))
+    runner = _runner(adapter)
+
+    response = await _drive(runner, _turn_ctx(consumer))
+    assert not response.get("already_sent")
+    _registered_callback(adapter)()
+    assert scheduled == []
+
+    assert GatewayRunner._fire_redelivery_followups(runner, "ob-1") == 1
+    await scheduled[0]
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+
+
+def test_the_registry_is_bounded(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    clock = [1000.0]
+    monkeypatch.setattr(run_startup_mod.time, "monotonic", lambda: clock[0])
+    cap = run_startup_mod._REDELIVERY_FOLLOWUP_CAP
+
+    for i in range(cap + 1):
+        assert GatewayRunner._register_redelivery_followup(runner, f"ob-{i}", MagicMock()) is True
+    # Past the cap the oldest registration goes first.
+    assert len(_followups(runner)) == cap
+    assert "ob-0" not in _followups(runner)
+    assert f"ob-{cap}" in _followups(runner)
+
+    # A second follow-up for the same row joins it rather than displacing anything.
+    GatewayRunner._register_redelivery_followup(runner, f"ob-{cap}", MagicMock())
+    assert len(_followups(runner)) == cap
+    assert len(_followups(runner)[f"ob-{cap}"][1]) == 2
+
+    # Entries older than the ledger's own stale cutoff are dropped on the next registration.
+    clock[0] += run_startup_mod._REDELIVERY_FOLLOWUP_TTL_SECONDS + 1
+    GatewayRunner._register_redelivery_followup(runner, "ob-fresh", MagicMock())
+    assert set(_followups(runner)) == {"ob-fresh"}
+
+    # Nothing registers without an id or a callable.
+    assert GatewayRunner._register_redelivery_followup(runner, "", MagicMock()) is False
+    assert GatewayRunner._register_redelivery_followup(runner, "ob-x", None) is False
+
+
+def test_a_failing_follow_up_never_breaks_the_redelivery():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    ok = MagicMock()
+    GatewayRunner._register_redelivery_followup(runner, "ob-1", MagicMock(side_effect=RuntimeError("boom")))
+    GatewayRunner._register_redelivery_followup(runner, "ob-1", ok)
+
+    assert GatewayRunner._fire_redelivery_followups(runner, "ob-1") == 1
+    ok.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# The redelivery loop fires follow-ups only for a landed, untruncated redelivery.
+# ---------------------------------------------------------------------------
+
+def _redelivery_runner(adapter):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._profile_adapters = {}
+    runner._active_profile_name = lambda: "default"
+    return runner
+
+
+def _claimed_row(oid, *, content="the final answer"):
+    return {"obligation_id": oid, "session_key": SESSION_KEY, "platform": "telegram", "chat_id": CHAT,
+            "thread_id": None, "content": content, "needs_marker": True, "marker": dl.FLOOD_MARKER,
+            "attempts": 1}
+
+
+def _record(oid, *, content="the final answer"):
+    dl.record_obligation(obligation_id=oid, session_key=SESSION_KEY, platform="telegram", chat_id=CHAT,
+                         thread_id=None, content=content, adapter_profile=None)
+    dl.mark_attempting(oid)
+    dl.mark_failed(oid, "flood_control:102.0")
+
+
+@pytest.mark.parametrize("result, fires", [
+    (SendResult(success=True, message_id="55"), True),
+    (SendResult(success=False, error="flood_control:34.0"), False),
+    (SendResult(success=True, message_id="55", truncated=True), False),
+], ids=["landed", "refused-again", "landed-truncated"])
+@pytest.mark.asyncio
+async def test_the_redelivery_loop_fires_the_follow_up_only_when_the_send_landed(result, fires):
+    from gateway.run import GatewayRunner
+
+    _record("ob-1")
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=result)
+    runner = _redelivery_runner(adapter)
+    followup = MagicMock()
+    GatewayRunner._register_redelivery_followup(runner, "ob-1", followup)
+
+    redelivered = await runner._redeliver_claimed_obligations([_claimed_row("ob-1")])
+
+    assert adapter.send.call_args.kwargs["content"].startswith(dl.FLOOD_MARKER)
+    if fires:
+        assert redelivered == 1
+        followup.assert_called_once()
+        assert _followups(runner) == {}
+    else:
+        followup.assert_not_called()
+        # Still registered: a later attempt may land, and a truncated one is not a replacement.
+        assert set(_followups(runner)) == {"ob-1"}
+
+
+@pytest.mark.asyncio
+async def test_a_redelivery_with_no_follow_up_registered_is_unchanged():
+    _record("ob-1")
+    adapter = MagicMock()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="55"))
+    runner = _redelivery_runner(adapter)
+
+    assert await runner._redeliver_claimed_obligations([_claimed_row("ob-1")]) == 1
+    assert _followups(runner) == {}
+
+
+# ---------------------------------------------------------------------------
+# base.py: the ledger bracket stamps the row on the session event; the hook clears it.
+# ---------------------------------------------------------------------------
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _stub_adapter():
+    return _StubAdapter(PlatformConfig(enabled=True, token="t", typing_indicator=False), Platform.TELEGRAM)
+
+
+def _session(adapter):
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id=CHAT, chat_type="dm")
+    session_key = build_session_key(source)
+    session_event = asyncio.Event()
+    session_event._hermes_run_generation = 3
+    adapter._active_sessions[session_key] = session_event
+    return source, session_key, session_event
+
+
+@pytest.mark.parametrize("recorded", ["ob-1", None], ids=["ledgered", "not-ledgered"])
+@pytest.mark.asyncio
+async def test_the_ledger_bracket_stamps_the_row_and_the_hook_clears_it(recorded):
+    adapter = _stub_adapter()
+    adapter._record_delivery_obligation = AsyncMock(return_value=recorded)
+    adapter._finalize_delivery_obligation = AsyncMock()
+    adapter._send_with_retry = AsyncMock(return_value=REFUSED)
+    source, session_key, session_event = _session(adapter)
+    # A stale value from an earlier turn on the same event must never survive into this one.
+    session_event._hermes_final_obligation_id = "ob-stale"
+    seen = []
+    adapter.register_post_delivery_callback(
+        session_key, lambda: seen.append(getattr(session_event, "_hermes_final_obligation_id", "unset")),
+        generation=3)
+    adapter._message_handler = AsyncMock(return_value=FINAL)
+
+    await adapter._process_message_background(
+        MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123"), session_key)
+
+    assert seen == [recorded]
+    assert session_event._hermes_final_obligation_id is None
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_a_refused_final_is_cleaned_up_once_the_ledger_redelivers_it(scheduled):
+    """The 9 Sep incident in miniature, on the real ledger: the consumer gave up, the gateway's own
+    final was refused with a penalty over the inline cap, the ledger redelivered it later."""
+    from gateway.run import GatewayRunner
+
+    adapter = _stub_adapter()
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(
+        success=False, error="Flood control exceeded. Retry in 102 seconds"))
+    source, session_key, session_event = _session(adapter)
+    consumer = _abandoned_consumer()
+    turn_ctx = _turn_ctx(consumer, session_key=session_key)
+    runner = _redelivery_runner(adapter)
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+
+    async def _handler(_event):
+        GatewayRunner._run_agent_schedule_abandoned_preview_cleanup(runner, consumer, source, turn_ctx, False)
+        return FINAL
+
+    adapter._message_handler = _handler
+    event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123")
+
+    await adapter._process_message_background(event, session_key)
+
+    # Refused: the ledger holds the final as failed, the cleanup stood down and deferred to that row.
+    oid = dl.compute_obligation_id(session_key, "123", FINAL)
+    with dl._connect() as conn:
+        state = conn.execute("SELECT state FROM delivery_obligations WHERE obligation_id=?", (oid,)).fetchone()[0]
+    assert state == "failed"
+    assert scheduled == []
+    consumer.delete_abandoned_previews.assert_not_awaited()
+    assert set(_followups(runner)) == {oid}
+
+    # The penalty passes and the ledger redelivers through the runner's loop.
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="56"))
+    row = _claimed_row(oid, content=FINAL)
+    assert await runner._redeliver_claimed_obligations([row]) == 1
+
+    assert adapter.send.call_args.kwargs["content"] == dl.FLOOD_MARKER + FINAL
+    assert len(scheduled) == 1
+    await scheduled[0]
+    consumer.delete_abandoned_previews.assert_awaited_once_with({"901"})
+    assert _followups(runner) == {}
+
+
+# ---------------------------------------------------------------------------
+# The row stamp is bound to the turn's OWN final send, never inherited.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_a_turn_whose_own_final_never_went_out_reads_no_row():
+    """The stamp comes from THIS task's own final send and nowhere else. A queued-lane send inside the
+    handler (an earlier message's reply, through the public bracket) and a stale value left on the
+    shared event must not become this turn's row: the reply to message A must never be allowed to
+    delete message B's only preview when B's own final was suppressed or never produced."""
+    adapter = _stub_adapter()
+    adapter._record_delivery_obligation = AsyncMock(return_value="ob-A")
+    adapter._finalize_delivery_obligation = AsyncMock()
+    adapter._send_with_retry = AsyncMock(return_value=REFUSED)
+    source, session_key, session_event = _session(adapter)
+    session_event._hermes_final_obligation_id = "ob-stale"
+    seen = []
+    adapter.register_post_delivery_callback(
+        session_key, lambda: seen.append(getattr(session_event, "_hermes_final_obligation_id", "unset")),
+        generation=3)
+
+    async def _handler(event):
+        # The queued lane delivers an EARLIER message's reply mid-turn, and it is refused...
+        result, _sender = await adapter.send_final_ledgered(
+            event, session_key, "the reply to A", {}, reply_to=None, is_ephemeral_response=False)
+        assert result is REFUSED
+        assert adapter._record_delivery_obligation.await_count == 1
+        # ...while this turn's own final never goes out (interrupted, empty, suppressed).
+        return None
+
+    adapter._message_handler = _handler
+    await adapter._process_message_background(
+        MessageEvent(text="B", message_type=MessageType.TEXT, source=source, message_id="124"), session_key)
+
+    assert seen == [None]
+    assert session_event._hermes_final_obligation_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_hook_still_clears_the_row_stamp():
+    """A callback cancelled mid-await must not leave this firing's row on the shared event."""
+    adapter = _stub_adapter()
+    _source, session_key, session_event = _session(adapter)
+    started = asyncio.Event()
+
+    async def _hang():
+        started.set()
+        await asyncio.sleep(3600)
+
+    adapter.register_post_delivery_callback(session_key, _hang, generation=3)
+    task = asyncio.create_task(adapter._fire_post_delivery_callback(
+        session_key, session_event, delivered=False, obligation_id="ob-1"))
+    await started.wait()
+    assert session_event._hermes_final_obligation_id == "ob-1"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert session_event._hermes_final_obligation_id is None
+
+
+@pytest.mark.asyncio
+async def test_the_public_bracket_keeps_its_result_and_adapter_contract():
+    """The queued lane unpacks ``(result, adapter)`` from ``send_final_ledgered``; the row id travels
+    only on the private path the normal lane uses."""
+    adapter = _stub_adapter()
+    adapter._record_delivery_obligation = AsyncMock(return_value="ob-1")
+    adapter._finalize_delivery_obligation = AsyncMock()
+    sent = SendResult(success=True, message_id="9")
+    adapter._send_with_retry = AsyncMock(return_value=sent)
+    source, session_key, _ = _session(adapter)
+    event = MessageEvent(text="hi", message_type=MessageType.TEXT, source=source, message_id="123")
+
+    assert await adapter.send_final_ledgered(
+        event, session_key, FINAL, {}, reply_to=None, is_ephemeral_response=False) == (sent, adapter)
+    assert await adapter._send_final_text(event, session_key, FINAL, {}, False, 0, lambda _r: None) == "ob-1"
+
+
+# ---------------------------------------------------------------------------
+# Registry timing and expiry.
+# ---------------------------------------------------------------------------
+
+def test_a_follow_up_registered_after_the_row_already_landed_runs_at_once():
+    """The reconnect sweep redelivers inside the refused send's own finalization, before the turn's
+    post-delivery callback registers: by the time the follow-up arrives the row is delivered."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    assert GatewayRunner._fire_redelivery_followups(runner, "ob-1") == 0
+    late = MagicMock()
+
+    assert GatewayRunner._register_redelivery_followup(runner, "ob-1", late) is True
+
+    late.assert_called_once()
+    assert _followups(runner) == {}
+    # Another row is unaffected.
+    other = MagicMock()
+    GatewayRunner._register_redelivery_followup(runner, "ob-2", other)
+    other.assert_not_called()
+    assert set(_followups(runner)) == {"ob-2"}
+
+
+def test_expiry_releases_follow_ups_without_another_registration(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    clock = [5000.0]
+    monkeypatch.setattr(run_startup_mod.time, "monotonic", lambda: clock[0])
+    GatewayRunner._register_redelivery_followup(runner, "ob-1", MagicMock())
+    assert set(_followups(runner)) == {"ob-1"}
+
+    clock[0] += run_startup_mod._REDELIVERY_FOLLOWUP_TTL_SECONDS + 1
+    GatewayRunner._prune_redelivery_followups(runner)
+
+    assert _followups(runner) == {}
+
+
+def test_a_new_row_arms_its_own_expiry_timer(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    loop = MagicMock()
+    monkeypatch.setattr(run_startup_mod.asyncio, "get_running_loop", lambda: loop)
+    runner = object.__new__(GatewayRunner)
+
+    GatewayRunner._register_redelivery_followup(runner, "ob-1", MagicMock())
+    GatewayRunner._register_redelivery_followup(runner, "ob-1", MagicMock())  # same row: one timer
+
+    loop.call_later.assert_called_once()
+    delay, fn = loop.call_later.call_args.args[:2]
+    assert delay > run_startup_mod._REDELIVERY_FOLLOWUP_TTL_SECONDS
+    assert fn == runner._prune_redelivery_followups


### PR DESCRIPTION
Stacked on #105200 (its commit is the first one here; this PR is the second commit only). It closes the two cases that one does not reach.

## What the reader sees

Telegram, a long reply streamed by editing one preview bubble. Twice in two days (8 Sep 12:05 UTC, 9 Sep 07:26 UTC) the chat ended up with a frozen partial bubble above the complete reply:

1. **Stale finalize.** The consumer's finalize edit landed a stale snapshot, so `_run_agent_mark_streamed_delivery` tried the reconciliation edit; a flood window refused it (`Stale-finalize reconciliation edit failed ... (flood_control:269.0)`), the normal final send delivered the complete reply below, and that branch registers no cleanup at all.
2. **Ledger redelivery.** In both incidents the gateway's own final was refused as well (`retry after 102s` and `269s`, both over the 60 s inline cap), so `_finalize_delivery_obligation` marked the row failed and the flood timer redelivered it minutes later with the flood marker (`Redelivered recovered final response ... attempt 1`). The cleanup #105200 registers had already fired from the post-delivery hook with `_hermes_final_delivered=False` and stood down, correctly: at that moment the frozen bubble was the reader's only copy. Nothing fires it after the redelivery, because the redelivery runs outside the turn.

So the reader keeps a truncated copy with raw MarkdownV2 markers and the cursor, and directly under it a complete copy prefixed with "part of it may already have arrived above".

## The change

- `run_turn.py`: the stale-finalize branch schedules the same cleanup when its reconciliation edit is refused (only in the arm that actually attempted an edit; the split-chain and no-editable-message arms are untouched). The callback no longer simply stands down on a refused send: if the turn's own final was ledgered, it hands the delete to that row's redelivery.
- `platforms/base.py`: the row id comes from the turn's own final send and nowhere else. `_send_final_text` (normal lane) now returns it, through a private `_send_final_ledgered` that the public `send_final_ledgered` wraps unchanged, and `_process_message_background` passes it to `_fire_post_delivery_callback`, which stamps it on the session event (`_hermes_final_obligation_id`) right before the callback fires and clears it afterwards. A queued-lane `send_final_ledgered` inside the handler (an earlier message's reply), a turn whose final was suppressed or never produced, and a stale value from an earlier turn on the shared event therefore all read as "no row".
- `run_startup.py`: a small process-local registry on the runner, `_register_redelivery_followup` / `_fire_redelivery_followups`, keyed by obligation id (24 h cutoff to match the ledger's stale window, enforced on registration and by a timer armed with each new row; cap 64, oldest first). `_redeliver_claimed_obligations` fires the row's follow-ups after `mark_delivered`, only when the redelivered send was not truncated. Rows this process already redelivered are remembered, so a follow-up that registers late (the reconnect sweep redelivers inside the refused send's own finalization) runs at once instead of waiting forever.

## Guards

- The delete still runs only after a send that carried the complete reply landed: the inline final (existing stamp) or the ledger redelivery of the same obligation (new). A truncated redelivery does not fire it.
- A follow-up fires only for its own obligation id, once. The row id is bound to the turn's own send, so the reply to message A can never be the trigger for deleting message B's only preview.
- Process-local on purpose: a redelivery after a restart finds an empty registry and leaves the bubble. The consumer it would act for died with the old process, and that path already carries the restart marker.
- Nothing changes for the boot sweep or the reconnect sweep beyond the one extra call in the success branch, which swallows its own exceptions. The queued lane's own frozen previews are out of scope here, as before: its callbacks run outside the hook and see no row.

## Tests

`tests/gateway/test_redelivered_final_preview_cleanup.py`, 27 cases. 13 of the original 21 fail on the parent commit (stale-finalize registration, deferral, own-row-only firing, registry bounds, the redelivery loop's landed / refused / truncated outcomes, the base.py stamp lifecycle including a stale value from an earlier turn, and an end-to-end run on the real test-isolated ledger: refused final, row failed, redelivery, delete). The rest pass there as no-op guards. The six added after review cover the queued-lane-inside-the-handler ordering, a cancelled hook still clearing the stamp, the public bracket's unchanged return, a follow-up registering after its row already landed, and expiry without another registration. #105200's 24 still pass. The delivery ledger, restart-resume, post-delivery-callback, queued-final-ledger and platform base suites are unchanged.

## Relation to #105340

#105340 stops the refused preview edits from escalating the flood penalty, which is why the gateway's final ran into a 102 s and a 269 s window at all. This PR cleans up after a refusal that still happens. Independent of each other, both wanted.

## Follow-up, deliberately not here

Once the redelivery can prove that no partial copy remains above it, `FLOOD_MARKER`'s "part of it may already have arrived above" can become evidence-based instead of unconditional. Separate change.
