### PR TITLE
fix: honor pagination for Spotify playlist item reads

### DIFF
--- a/plugins/spotify/tools.py
+++ b/plugins/spotify/tools.py
@@ -222,9 +222,19 @@ def _handle_spotify_search(args: dict, **kw) -> str:
 _playlist_path = lambda args, suffix="": f"/playlists/{normalize_spotify_id(str(args.get('playlist_id') or ''), 'playlist')}{suffix}"  # noqa: E731
 
 
+def _playlist_get(client: SpotifyClient, args: dict, action: str) -> dict:
+    """Return playlist metadata with a page of items when pagination is requested."""
+    path = _playlist_path(args)
+    metadata = client.request("GET", path, params={"market": args.get("market")})
+    if "limit" not in args and not _offset(args):
+        return metadata
+    page = client.request("GET", path + "/items", params=_page_params(args))
+    return {**metadata, "tracks": page}
+
+
 _handle_spotify_playlists = _dispatcher("spotify_playlists", "list", {
     "list": lambda c, a, act: tool_result(c.request("GET", "/me/playlists", params={"limit": _limit(a), "offset": _offset(a)})),
-    "get": lambda c, a, act: tool_result(c.request("GET", _playlist_path(a), params={"market": a.get("market")})),
+    "get": lambda c, a, act: tool_result(_playlist_get(c, a, act)),
     "create": lambda c, a, act: tool_result(c.request("POST", "/me/playlists", json_body={
         "name": _nonblank(a.get("name"), "name is required for action='create'"), "public": _coerce_bool(a.get("public")),
         "collaborative": _coerce_bool(a.get("collaborative")), "description": a.get("description")})),

--- a/tests/tools/test_spotify_client.py
+++ b/tests/tools/test_spotify_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 import pytest
 
@@ -29,6 +30,35 @@ class _StubSpotifyClient:
 
     def get_currently_playing(self, *, market=None):
         return self.payload
+
+
+class _PlaylistClient:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, path, *, params=None, json_body=None):
+        self.calls.append((method, path, params))
+        if path.endswith("/items"):
+            assert params is not None
+            return {"items": [{"track": {"id": "page-2"}}], "offset": params["offset"], "total": 101}
+        return {"id": "playlist-1", "tracks": {"items": [{"track": {"id": "page-1"}}]}}
+
+
+def test_playlist_get_uses_playlist_items_endpoint_for_pagination() -> None:
+    client = _PlaylistClient()
+
+    payload = spotify_tool._playlist_get(
+        cast(spotify_mod.SpotifyClient, client),
+        {"playlist_id": "playlist-1", "limit": 50, "offset": 50},
+        "get",
+    )
+
+    assert payload["id"] == "playlist-1"
+    assert payload["tracks"]["items"][0]["track"]["id"] == "page-2"
+    assert client.calls == [
+        ("GET", "/playlists/playlist-1", {"market": None}),
+        ("GET", "/playlists/playlist-1/items", {"limit": 50, "offset": 50, "market": None}),
+    ]
 
 
 def test_spotify_client_retries_once_after_401(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes playlist pagination in the Spotify integration.

`spotify_playlists` was ignoring `limit` and `offset` when reading a playlist, so requests for later pages returned the first page again. The fix uses Spotify’s `/playlists/{playlist_id}/items` endpoint when pagination is requested.

Unlike #23536 (see related issue below), this keeps the existing playlist metadata in the response and replaces only the `tracks` field with the requested paginated page.

## Related Issue

Related PR: [#23536](https://github.com/NousResearch/hermes-agent/pull/23536)

This PR follows up on the pagination issue discussed there while preserving the existing `get` response shape, including playlist metadata.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Fixed paginated playlist reads in `plugins/spotify/tools.py`.
- Added a regression test in `tests/tools/test_spotify_client.py` to verify that a nonzero offset requests and returns the correct page.

## How to Test

1. Request a playlist page with `limit=50` and `offset=50`.
2. Confirm the response returns offset 50 rather than repeating offset 0.
3. Run: ```bash    scripts/run_tests.sh tests/tools/test_spotify_client.py```

I also verified the fix against a real Spotify playlist: the original implementation returned the first 56 tracks for offset 50, while the patched version returned the correct final 6 tracks.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping
N/A

## Screenshots / Logs

Not applicable.