### PR TITLE
fix(ws): add send deadline to _safe_send_many so a stalled send_text latches the transport closed

### DIFF
--- a/tests/tui_gateway/test_ws_send_timeout.py
+++ b/tests/tui_gateway/test_ws_send_timeout.py
@@ -1,0 +1,93 @@
+"""A stalled ``send_text`` must not hold the writer lock forever (#106369).
+
+Without a send deadline, socket backpressure parks ``_safe_send_many`` inside
+``_send_lock`` and ``_closed`` never latches, so reconnect recovery cannot
+start. With the fix, a stalled send times out, latches the transport closed,
+and a queued second batch returns immediately instead of blocking forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import tui_gateway.ws as ws_mod
+from tui_gateway.ws import WSTransport
+
+
+class _StalledWS:
+    """``send_text`` never completes — models socket backpressure."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self._release = asyncio.Event()
+
+    async def send_text(self, line: str) -> None:
+        await self._release.wait()  # never set during the test
+        self.sent.append(line)
+
+    async def close(self, code: int = 1000) -> None:
+        self._release.set()
+
+
+class _FastWS:
+    """``send_text`` completes immediately — guards against the timeout
+    breaking the happy path."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send_text(self, line: str) -> None:
+        self.sent.append(line)
+
+
+def test_stalled_send_latches_closed() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _StalledWS()
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        orig = ws_mod._WS_WRITE_TIMEOUT_S
+        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
+        try:
+            await transport._safe_send_many(["first"])
+        finally:
+            ws_mod._WS_WRITE_TIMEOUT_S = orig
+        assert transport.closed is True, "stalled send must latch the transport closed"
+        assert ws.sent == [], "the stalled frame must not be recorded as sent"
+
+    asyncio.run(_run())
+
+
+def test_queued_batch_returns_immediately_after_timeout() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _StalledWS()
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        orig = ws_mod._WS_WRITE_TIMEOUT_S
+        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
+        try:
+            await transport._safe_send_many(["first"])
+            # _closed is now True; the second batch must not queue on _send_lock.
+            await transport._safe_send_many(["second"])
+        finally:
+            ws_mod._WS_WRITE_TIMEOUT_S = orig
+        assert transport.closed is True
+        assert ws.sent == []
+
+    asyncio.run(_run())
+
+
+def test_normal_send_completes_within_timeout() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _FastWS()
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        orig = ws_mod._WS_WRITE_TIMEOUT_S
+        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
+        try:
+            await transport._safe_send_many(["a", "b", "c"])
+        finally:
+            ws_mod._WS_WRITE_TIMEOUT_S = orig
+        assert transport.closed is False, "a fast send must not latch the transport closed"
+        assert ws.sent == ["a", "b", "c"]
+
+    asyncio.run(_run())

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -183,7 +183,15 @@ class WSTransport:
                     return
                 payload = _sanitize_ws_text(line)
                 try:
-                    await self._ws.send_text(payload)
+                    await asyncio.wait_for(self._ws.send_text(payload), timeout=_WS_WRITE_TIMEOUT_S)
+                except asyncio.TimeoutError as exc:
+                    # A stalled send_text (socket backpressure) must not hold the writer lock forever.
+                    # Unlike the loop-stall case in write(), this means the socket itself is unresponsive:
+                    # latch closed so queued batches bail and reconnect recovery can start. See #106369.
+                    self._closed = True
+                    _log.warning("ws send timed out peer=%s timeout=%ss error_type=%s error=%s",
+                                 self._peer, _WS_WRITE_TIMEOUT_S, type(exc).__name__, exc)
+                    return
                 except UnicodeEncodeError as exc:
                     # A single illegal UTF-8 frame (lone surrogate) must not tear down the socket.
                     _log.warning("ws send skipped invalid utf-8 frame peer=%s error=%s", self._peer, exc)


### PR DESCRIPTION
## Summary

`WSTransport._safe_send_many()` awaited `WebSocket.send_text()` **without a deadline** while holding the connection-wide `_send_lock`. With socket backpressure, a single pending send parks the lock indefinitely: every later batch (tool/progress events, `message.complete`, RPC responses) queues behind it, and `_closed` never latches, so reconnect recovery cannot start.

The loop itself stays responsive throughout — the existing 10 s warning in `write()` (`"ws write slow (loop stalled >10.0s)"`) covers the **loop-stall** case (the scheduled task hasn't run yet), not the **`send_text`-hang** case (the task is running but the socket write is stuck).

Fixes #106369.

## Root cause

`_safe_send_many` holds `_send_lock` across `await self._ws.send_text(payload)`:

```python
async def _safe_send_many(self, lines: list[str]) -> None:
    async with self._send_lock:          # connection-wide
        ...
        for line in lines:
            ...
            await self._ws.send_text(payload)   # ← no deadline; backpressure parks the lock
```

When `send_text` stalls (e.g. a slow consumer that never drains its receive buffer, a half-open SSH tunnel, OS socket buffer full), this `await` never returns. Because the send didn't **error** (it just hangs), the generic `except Exception` branch never fires, so `_closed` stays `False`. Later batches — including `message.complete` and RPC replies that a client is actively waiting on — block on `async with self._send_lock` forever, and reconnect teardown (`close()` → `handle_ws` finally) never observes the transport as dead.

## Fix

Wrap the send in `asyncio.wait_for(..., _WS_WRITE_TIMEOUT_S)` (reuses the existing 10 s constant) and latch the transport closed on `asyncio.TimeoutError`:

```python
try:
    await asyncio.wait_for(self._ws.send_text(payload), timeout=_WS_WRITE_TIMEOUT_S)
except asyncio.TimeoutError as exc:
    # A stalled send_text (socket backpressure) must not hold the writer lock forever.
    # Unlike the loop-stall case in write(), this means the socket itself is unresponsive:
    # latch closed so queued batches bail and reconnect recovery can start.
    self._closed = True
    _log.warning("ws send timed out peer=%s timeout=%ss error_type=%s error=%s",
                 self._peer, _WS_WRITE_TIMEOUT_S, type(exc).__name__, exc)
    return
```

Latching `_closed = True` on timeout means:

- queued batches acquire `_send_lock` (now free, since we returned), see `_closed` and bail immediately instead of parking;
- the `closed` property reports `True`, so `handle_ws` reconnect recovery can run.

This intentionally differs from the loop-stall path in `write()`, which deliberately does **not** latch on a slow future (`# Latching _closed here permanently silenced live windows after one slow write`). The loop-stall case is a transient GIL/scheduling stall where the send is still expected to complete; the `send_text`-timeout case is a dead socket.

## Verification

Reproduced with the reporter's script (mock socket whose `send_text` never completes): without the fix the second `write_async` parks forever on `_send_lock` and `transport.closed` stays `False`; with the fix the stalled send times out, latches `closed`, and the queued batch returns immediately.

New regression tests (`tests/tui_gateway/test_ws_send_timeout.py`, following the existing `test_ws_surrogate_send.py` pattern):

- `test_stalled_send_latches_closed` — a stalled `send_text` latches `transport.closed` after the timeout; the frame is not recorded as sent.
- `test_queued_batch_returns_immediately_after_timeout` — after the first send times out, a second batch returns immediately instead of parking on `_send_lock`.
- `test_normal_send_completes_within_timeout` — a fast `send_text` still completes within the deadline (regression guard: the timeout does not break the happy path).

Mutation check: without the fix, `test_stalled_send_latches_closed` hangs (the stalled send never returns, so `asyncio.run` never completes); with the fix all three pass.

Existing WebSocket transport tests remain green:

- `tests/tui_gateway/test_ws_surrogate_send.py` (4 tests — surrogate handling unchanged)
- `tests/tui_gateway/test_cold_start_gil_stall.py` (6 tests — loop-stall path unchanged)
- `tests/test_tui_gateway_ws.py` (10 tests — concurrent send serialization, cross-batch order, disconnect reap, etc.)

`ruff check` clean.

## Scope

Single-file fix (`tui_gateway/ws.py`) + new test file. No dependency, config, or protocol changes. Reuses the existing `_WS_WRITE_TIMEOUT_S` constant (no new magic number).
