### PR TITLE
fix(desktop): let Windows gateway drain before update

### DIFF
--- a/apps/desktop/electron/gateway-stop-before-update.test.ts
+++ b/apps/desktop/electron/gateway-stop-before-update.test.ts
@@ -79,17 +79,22 @@ test('Windows with failing CLI returns false (best-effort, never throws)', () =>
   assert.equal(ran, false)
 })
 
-test('passes a generous timeout with hidden console (taskkill window suppression)', () => {
-  let seenOptions: unknown
+test('stop timeout outlives the bounded Windows gateway drain', () => {
+  let seenOptions: { timeout?: number; windowsHide?: boolean; stdio?: string; encoding?: string } = {}
+
   stopGatewayBeforeUpdate(CLI, HOME, {
     isWindows: true,
     existsSync: () => true,
-    execFileSync: ((_c: string, _a: string[], options: unknown) => {
+    execFileSync: ((_c: string, _a: string[], options: typeof seenOptions) => {
       seenOptions = options
 
       return Buffer.from('')
     }) as never
   })
+
+  // gateway_windows._windows_stop_drain_timeout() permits a 30-second
+  // graceful drain before the command reaches its force-stop cleanup.
+  assert.ok(GATEWAY_STOP_TIMEOUT_MS > 30_000)
   assert.deepEqual(seenOptions, {
     timeout: GATEWAY_STOP_TIMEOUT_MS,
     windowsHide: true,

--- a/apps/desktop/electron/gateway-stop-before-update.ts
+++ b/apps/desktop/electron/gateway-stop-before-update.ts
@@ -34,7 +34,11 @@ export interface StopGatewayBeforeUpdateDeps {
   spy?: (command: string, args: string[]) => void
 }
 
-export const GATEWAY_STOP_TIMEOUT_MS = 20_000
+// Windows gateway stop may spend the full 30-second bounded drain before it
+// reaches Scheduled Task shutdown and force-stops remaining gateway trees.
+// Keep Desktop's synchronous wrapper above that ceiling; cutting the child off
+// early leaves gateway-owned Kanban workers alive with hermes.exe mapped.
+export const GATEWAY_STOP_TIMEOUT_MS = 45_000
 
 /**
  * Best-effort stop of all-profile messaging gateways via the CLI.


### PR DESCRIPTION
## Summary

Windows Desktop ran `hermes gateway stop --all` with a 20-second wrapper timeout even though the gateway stop path permits a 30-second graceful drain before it reaches Scheduled Task shutdown and force-stops remaining process trees. The wrapper could therefore terminate the stop command early, leaving gateway-owned Kanban workers alive with `venv\Scripts\hermes.exe` mapped and causing the subsequent 15-second shim gate to abort every update. This raises the wrapper budget to 45 seconds so the existing bounded drain and worker-tree cleanup can finish; no process matcher or kill policy is widened.

---

## Changes

- `apps/desktop/electron/gateway-stop-before-update.ts`: extend the Windows gateway lifecycle command budget beyond the bounded 30-second drain.
- `apps/desktop/electron/gateway-stop-before-update.test.ts`: assert that Desktop's wrapper timeout outlives the gateway drain ceiling while retaining hidden-process options.

## How to Test

```text
node ../../node_modules/vitest/vitest.mjs run --project electron electron/gateway-stop-before-update.test.ts
# Before fix: 1 failed, 6 passed
# After fix: 7 passed

node ../../node_modules/vitest/vitest.mjs run --project electron electron/gateway-stop-before-update.test.ts electron/backend-release-gate.test.ts electron/backend-release-gate.windows-live.test.ts
# 13 passed, 3 skipped (Windows-live tests skip on Android)

NODE_OPTIONS=--max-old-space-size=2048 npm run typecheck
# passed

node ../../node_modules/eslint/bin/eslint.js electron/gateway-stop-before-update.ts electron/gateway-stop-before-update.test.ts
# passed, 0 warnings

ruff check .
# passed
```

The full Electron project run completed 2,110 tests successfully but retained 11 unrelated host-specific failures on Android/Termux (POSIX mode assertions, Android/native-binary classification, missing Electron binary, and a loaded-runner timing test). The changed and adjacent update-gate suites pass.

## Checklist

- [x] Regression test failed before the fix and passes after it
- [x] Targeted and adjacent tests pass — 13/13, 3 Windows-live skips
- [x] TypeScript typecheck passes
- [x] ESLint passes with zero warnings
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed — behavior remains a no-op off Windows
- [x] Existing gateway identity and process-tree safety guards remain unchanged

## Risk & Impact

Low. The change only gives the existing bounded Windows shutdown path enough time to finish; it does not add process discovery, broaden tree termination, or alter gateway drain policy.

Type: Bug fix

Closes: #105950
