### PR TITLE
docs: clarify skill routing descriptions

### DIFF
--- a/optional-skills/mlops/chroma/SKILL.md
+++ b/optional-skills/mlops/chroma/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chroma
-description: Embedding database for RAG and semantic search.
+description: Store and search embeddings for local RAG.
 version: 1.0.0
 author: Orchestra Research
 license: MIT

--- a/optional-skills/mlops/obliteratus/SKILL.md
+++ b/optional-skills/mlops/obliteratus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obliteratus
-description: "OBLITERATUS: abliterate LLM refusals (diff-in-means)."
+description: Remove refusals from open-weight language models.
 version: 2.0.0
 author: Hermes Agent
 license: MIT

--- a/optional-skills/security/godmode/SKILL.md
+++ b/optional-skills/security/godmode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: godmode
-description: "Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN."
+description: Jailbreak API-served LLMs with prompt techniques.
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT

--- a/optional-skills/software-development/subagent-driven-development/SKILL.md
+++ b/optional-skills/software-development/subagent-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subagent-driven-development
-description: "Execute plans via delegate_task subagents (2-stage review)."
+description: Execute plans with delegate_task and two-stage review.
 version: 1.1.0
 author: Hermes Agent (adapted from obra/superpowers)
 license: MIT

--- a/skills/autonomous-ai-agents/computer-use/SKILL.md
+++ b/skills/autonomous-ai-agents/computer-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: computer-use
-description: "Drive the desktop background-first; escalate on signal."
+description: "Automate desktop apps when browser control is unsuitable."
 version: 2.0.0
 author: Francesco Bonacci (f-trycua), Hermes Agent
 license: MIT

--- a/skills/creative/popular-web-designs/SKILL.md
+++ b/skills/creative/popular-web-designs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: popular-web-designs
-description: 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS.
+description: Apply known-brand design systems to generated web UIs.
 version: 1.0.0
 author: Hermes Agent + Teknium (design systems sourced from VoltAgent/awesome-design-md)
 license: MIT

--- a/skills/email/email-inbox-triage/SKILL.md
+++ b/skills/email/email-inbox-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: email-inbox-triage
-description: "Triage an inbox: prioritize threads, draft replies safely."
+description: Triage inboxes, prioritize threads, and draft safely.
 version: 0.1.0
 author: Ben Barclay (benbarclay), Hermes Agent
 license: MIT

--- a/skills/note-taking/obsidian/SKILL.md
+++ b/skills/note-taking/obsidian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian
-description: Read, search, create, and edit notes in the Obsidian vault.
+description: Edit vault notes and wikilinks directly.
 version: 1.0.0
 author: Teknium (teknium1), Hermes Agent
 license: MIT

--- a/skills/productivity/document-to-action-items/SKILL.md
+++ b/skills/productivity/document-to-action-items/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: document-to-action-items
-description: "Extract cited obligations, deadlines, tasks from documents."
+description: "Extract cited tasks and deadlines from documents."
 version: 0.1.0
 author: Ben Barclay (benbarclay), Hermes Agent
 license: MIT

--- a/skills/productivity/docx/SKILL.md
+++ b/skills/productivity/docx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docx
-description: Create, read, edit, template, and review Word .docx files.
+description: Create, edit, review, or template Word .docx files.
 version: 1.1.0
 author: Nous Research
 license: MIT

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google-workspace
-description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python."
+description: Operate Gmail, Calendar, Drive, Docs, and Sheets.
 version: 1.2.0
 author: Nous Research
 license: MIT

--- a/skills/research/grounded-citations/SKILL.md
+++ b/skills/research/grounded-citations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grounded-citations
-description: "Ground answers and documents in cited, verifiable sources."
+description: Cite and verify external claims in deliverables.
 version: 1.2.0
 author: Hermes Agent + Teknium
 license: MIT

--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-wiki
-description: "Karpathy's LLM Wiki: build/query interlinked markdown KB."
+description: Build or query an interlinked Markdown knowledge base.
 version: 2.1.0
 author: Hermes Agent
 license: MIT

--- a/skills/software-development/requesting-code-review/SKILL.md
+++ b/skills/software-development/requesting-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: requesting-code-review
-description: "Pre-commit review: security scan, quality gates, auto-fix."
+description: "Review code pre-commit: security, quality, and auto-fix."
 version: 2.0.0
 author: Hermes Agent (adapted from obra/superpowers + MorAlekss)
 license: MIT

--- a/skills/software-development/systematic-debugging/SKILL.md
+++ b/skills/software-development/systematic-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systematic-debugging
-description: "4-phase root cause debugging: understand bugs before fixing."
+description: "Use for technical failures: reproduce, diagnose, verify."
 version: 1.1.0
 author: Hermes Agent (adapted from obra/superpowers)
 license: MIT

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -156,7 +156,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**accelerate**](/docs/user-guide/skills/optional/mlops/mlops-accelerate) | Run PyTorch training across GPUs with minimal changes. |
 | [**axolotl**](/docs/user-guide/skills/optional/mlops/mlops-training-axolotl) | Axolotl: YAML LLM fine-tuning (LoRA, DPO, GRPO). |
-| [**chroma**](/docs/user-guide/skills/optional/mlops/mlops-chroma) | Embedding database for RAG and semantic search. |
+| [**chroma**](/docs/user-guide/skills/optional/mlops/mlops-chroma) | Store and search embeddings for local RAG. |
 | [**clip**](/docs/user-guide/skills/optional/mlops/mlops-clip) | Zero-shot image classification and image-text search. |
 | [**dspy**](/docs/user-guide/skills/optional/mlops/mlops-research-dspy) | DSPy: declarative LM programs, auto-optimize prompts, RAG. |
 | [**evaluating-llms-harness**](/docs/user-guide/skills/optional/mlops/mlops-evaluation-evaluating-llms-harness) | lm-eval-harness: benchmark LLMs (MMLU, GSM8K, etc.). |
@@ -171,7 +171,7 @@ hermes skills uninstall <skill-name>
 | [**llava**](/docs/user-guide/skills/optional/mlops/mlops-llava) | Vision-language chat: VQA, captioning, image dialogue. |
 | [**modal**](/docs/user-guide/skills/optional/mlops/mlops-modal) | Serverless GPU cloud for ML jobs and model APIs. |
 | [**nemo-curator**](/docs/user-guide/skills/optional/mlops/mlops-nemo-curator) | Curate LLM training data: dedupe, filter, PII redaction. |
-| [**obliteratus**](/docs/user-guide/skills/optional/mlops/mlops-obliteratus) | OBLITERATUS: abliterate LLM refusals (diff-in-means). |
+| [**obliteratus**](/docs/user-guide/skills/optional/mlops/mlops-obliteratus) | Remove refusals from open-weight language models. |
 | [**outlines**](/docs/user-guide/skills/optional/mlops/mlops-inference-outlines) | Outlines: structured JSON/regex/Pydantic LLM generation. |
 | [**peft**](/docs/user-guide/skills/optional/mlops/mlops-peft) | Fine-tune large LLMs with LoRA on limited GPU memory. |
 | [**pinecone**](/docs/user-guide/skills/optional/mlops/mlops-pinecone) | Managed vector DB for production RAG and search. |
@@ -238,7 +238,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**1password**](/docs/user-guide/skills/optional/security/security-1password) | Set up op CLI, sign in, and read or inject secrets. |
-| [**godmode**](/docs/user-guide/skills/optional/security/security-godmode) | Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN. |
+| [**godmode**](/docs/user-guide/skills/optional/security/security-godmode) | Jailbreak API-served LLMs with prompt techniques. |
 | [**oss-forensics**](/docs/user-guide/skills/optional/security/security-oss-forensics) | GitHub supply-chain forensics: recovery, IOCs, reporting. |
 | [**sherlock**](/docs/user-guide/skills/optional/security/security-sherlock) | Find accounts for a username across 400+ platforms. |
 | [**unbroker**](/docs/user-guide/skills/optional/security/security-unbroker) | Autonomously remove your info from data-broker sites. |
@@ -264,7 +264,7 @@ hermes skills uninstall <skill-name>
 | [**code-wiki**](/docs/user-guide/skills/optional/software-development/software-development-code-wiki) | Generate wiki docs + Mermaid diagrams for any codebase. |
 | [**grill-me**](/docs/user-guide/skills/optional/software-development/software-development-grill-me) | Adversarial plan interview before implementation. |
 | [**rest-graphql-debug**](/docs/user-guide/skills/optional/software-development/software-development-rest-graphql-debug) | Debug REST/GraphQL APIs: status codes, auth, schemas, repro. |
-| [**subagent-driven-development**](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development) | Execute plans via delegate_task subagents (2-stage review). |
+| [**subagent-driven-development**](/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development) | Execute plans with delegate_task and two-stage review. |
 
 ## web-development
 

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -27,7 +27,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 |-------|-------------|------|
 | [`claude-code`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code) | Delegate coding to Claude Code CLI (features, PRs). | `autonomous-ai-agents\claude-code` |
 | [`codex`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex) | Delegate coding to OpenAI Codex CLI (features, PRs). | `autonomous-ai-agents\codex` |
-| [`computer-use`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use) | Drive the desktop background-first; escalate on signal. | `autonomous-ai-agents\computer-use` |
+| [`computer-use`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use) | Automate desktop apps when browser control is unsuitable. | `autonomous-ai-agents\computer-use` |
 | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) | Use, configure, theme, extend, and orchestrate Hermes Agent. | `autonomous-ai-agents\hermes-agent` |
 | [`merge-reconciler`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-merge-reconciler) | Neutral third-party resolution of agent merge conflicts. | `autonomous-ai-agents\merge-reconciler` |
 | [`opencode`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode) | Delegate coding to OpenCode CLI (features, PR review). | `autonomous-ai-agents\opencode` |
@@ -44,7 +44,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) | Humanize text: strip AI-isms and add real voice. | `creative\humanizer` |
 | [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video) | Manim CE animations: 3Blue1Brown math/algo videos. | `creative\manim-video` |
 | [`p5js`](/docs/user-guide/skills/bundled/creative/creative-p5js) | p5.js sketches: gen art, shaders, interactive, 3D. | `creative\p5js` |
-| [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) | 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS. | `creative\popular-web-designs` |
+| [`popular-web-designs`](/docs/user-guide/skills/bundled/creative/creative-popular-web-designs) | Apply known-brand design systems to generated web UIs. | `creative\popular-web-designs` |
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative\songwriting-and-ai-music` |
 
 ## devops
@@ -72,7 +72,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian) | Read, search, create, and edit notes in the Obsidian vault. | `note-taking\obsidian` |
+| [`obsidian`](/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian) | Edit vault notes and wikilinks directly. | `note-taking\obsidian` |
 
 ## productivity
 
@@ -80,9 +80,9 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 |-------|-------------|------|
 | [`airtable`](/docs/user-guide/skills/bundled/productivity/productivity-airtable) | Airtable REST API via curl. Records CRUD, filters, upserts. | `productivity\airtable` |
 | [`box`](/docs/user-guide/skills/bundled/productivity/productivity-box) | Box manages cloud files, sharing, search, and metadata. | `productivity\box` |
-| [`document-to-action-items`](/docs/user-guide/skills/bundled/productivity/productivity-document-to-action-items) | Extract cited obligations, deadlines, tasks from documents. | `productivity\document-to-action-items` |
-| [`docx`](/docs/user-guide/skills/bundled/productivity/productivity-docx) | Create, read, edit, template, and review Word .docx files. | `productivity\docx` |
-| [`google-workspace`](/docs/user-guide/skills/bundled/productivity/productivity-google-workspace) | Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python. | `productivity\google-workspace` |
+| [`document-to-action-items`](/docs/user-guide/skills/bundled/productivity/productivity-document-to-action-items) | Extract cited tasks and deadlines from documents. | `productivity\document-to-action-items` |
+| [`docx`](/docs/user-guide/skills/bundled/productivity/productivity-docx) | Create, edit, review, or template Word .docx files. | `productivity\docx` |
+| [`google-workspace`](/docs/user-guide/skills/bundled/productivity/productivity-google-workspace) | Operate Gmail, Calendar, Drive, Docs, and Sheets. | `productivity\google-workspace` |
 | [`maps`](/docs/user-guide/skills/bundled/productivity/productivity-maps) | Geocode, POIs, routes, timezones via OpenStreetMap/OSRM. | `productivity\maps` |
 | [`meeting-action-items`](/docs/user-guide/skills/bundled/productivity/productivity-meeting-action-items) | Turn meeting notes into cited decisions, owners, tickets. | `productivity\meeting-action-items` |
 | [`notion`](/docs/user-guide/skills/bundled/productivity/productivity-notion) | Notion API + ntn CLI: pages, databases, markdown, Workers. | `productivity\notion` |
@@ -99,8 +99,8 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 |-------|-------------|------|
 | [`arxiv`](/docs/user-guide/skills/bundled/research/research-arxiv) | Search arXiv papers by keyword, author, category, or ID. | `research\arxiv` |
 | [`competitor-news-monitor`](/docs/user-guide/skills/bundled/research/research-competitor-news-monitor) | Watch named companies for material news; cited digests. | `research\competitor-news-monitor` |
-| [`grounded-citations`](/docs/user-guide/skills/bundled/research/research-grounded-citations) | Ground answers and documents in cited, verifiable sources. | `research\grounded-citations` |
-| [`llm-wiki`](/docs/user-guide/skills/bundled/research/research-llm-wiki) | Karpathy's LLM Wiki: build/query interlinked markdown KB. | `research\llm-wiki` |
+| [`grounded-citations`](/docs/user-guide/skills/bundled/research/research-grounded-citations) | Cite and verify external claims in deliverables. | `research\grounded-citations` |
+| [`llm-wiki`](/docs/user-guide/skills/bundled/research/research-llm-wiki) | Build or query an interlinked Markdown knowledge base. | `research\llm-wiki` |
 
 ## social-media
 
@@ -119,10 +119,10 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`inspecting-hermes-desktop-dom`](/docs/user-guide/skills/bundled/software-development/software-development-inspecting-hermes-desktop-dom) | Read the live Hermes desktop DOM/CSS over CDP. | `software-development\inspecting-hermes-desktop-dom` |
 | [`node-inspect-debugger`](/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger) | Debug Node.js via --inspect + Chrome DevTools Protocol CLI. | `software-development\node-inspect-debugger` |
 | [`python-debugpy`](/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy) | Debug Python: pdb REPL + debugpy remote (DAP). | `software-development\python-debugpy` |
-| [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) | Pre-commit review: security scan, quality gates, auto-fix. | `software-development\requesting-code-review` |
+| [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review) | Review code pre-commit: security, quality, and auto-fix. | `software-development\requesting-code-review` |
 | [`simplify-code`](/docs/user-guide/skills/bundled/software-development/software-development-simplify-code) | Parallel 4-agent cleanup of recent code changes. | `software-development\simplify-code` |
 | [`spike`](/docs/user-guide/skills/bundled/software-development/software-development-spike) | Throwaway experiments to validate an idea before build. | `software-development\spike` |
-| [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) | 4-phase root cause debugging: understand bugs before fixing. | `software-development\systematic-debugging` |
+| [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) | Use for technical failures: reproduce, diagnose, verify. | `software-development\systematic-debugging` |
 | [`test-driven-development`](/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development) | TDD: enforce RED-GREEN-REFACTOR, tests before code. | `software-development\test-driven-development` |
 
 ## web

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -57,7 +57,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`email-inbox-triage`](/docs/user-guide/skills/bundled/email/email-email-inbox-triage) | Triage an inbox: prioritize threads, draft replies safely. | `email\email-inbox-triage` |
+| [`email-inbox-triage`](/docs/user-guide/skills/bundled/email/email-email-inbox-triage) | Triage inboxes, prioritize threads, and draft safely. | `email\email-inbox-triage` |
 | [`himalaya`](/docs/user-guide/skills/bundled/email/email-himalaya) | Himalaya CLI: IMAP/SMTP email from terminal. | `email\himalaya` |
 
 ## media

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-computer-use.md
@@ -1,14 +1,14 @@
 ---
-title: "Computer Use — Drive the desktop background-first; escalate on signal"
+title: "Computer Use — Automate desktop apps when browser control is unsuitable"
 sidebar_label: "Computer Use"
-description: "Drive the desktop background-first; escalate on signal"
+description: "Automate desktop apps when browser control is unsuitable"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Computer Use
 
-Drive the desktop background-first; escalate on signal.
+Automate desktop apps when browser control is unsuitable.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/creative/creative-popular-web-designs.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-popular-web-designs.md
@@ -1,14 +1,14 @@
 ---
-title: "Popular Web Designs — 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
+title: "Popular Web Designs — Apply known-brand design systems to generated web UIs"
 sidebar_label: "Popular Web Designs"
-description: "54 real design systems (Stripe, Linear, Vercel) as HTML/CSS"
+description: "Apply known-brand design systems to generated web UIs"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Popular Web Designs
 
-54 real design systems (Stripe, Linear, Vercel) as HTML/CSS.
+Apply known-brand design systems to generated web UIs.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/email/email-email-inbox-triage.md
+++ b/website/docs/user-guide/skills/bundled/email/email-email-inbox-triage.md
@@ -1,14 +1,14 @@
 ---
-title: "Email Inbox Triage — Triage an inbox: prioritize threads, draft replies safely"
+title: "Email Inbox Triage — Triage inboxes, prioritize threads, and draft safely"
 sidebar_label: "Email Inbox Triage"
-description: "Triage an inbox: prioritize threads, draft replies safely"
+description: "Triage inboxes, prioritize threads, and draft safely"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Email Inbox Triage
 
-Triage an inbox: prioritize threads, draft replies safely.
+Triage inboxes, prioritize threads, and draft safely.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
+++ b/website/docs/user-guide/skills/bundled/note-taking/note-taking-obsidian.md
@@ -1,14 +1,14 @@
 ---
-title: "Obsidian — Read, search, create, and edit notes in the Obsidian vault"
+title: "Obsidian — Edit vault notes and wikilinks directly"
 sidebar_label: "Obsidian"
-description: "Read, search, create, and edit notes in the Obsidian vault"
+description: "Edit vault notes and wikilinks directly"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Obsidian
 
-Read, search, create, and edit notes in the Obsidian vault.
+Edit vault notes and wikilinks directly.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-document-to-action-items.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-document-to-action-items.md
@@ -1,14 +1,14 @@
 ---
-title: "Document To Action Items — Extract cited obligations, deadlines, tasks from documents"
+title: "Document To Action Items — Extract cited tasks and deadlines from documents"
 sidebar_label: "Document To Action Items"
-description: "Extract cited obligations, deadlines, tasks from documents"
+description: "Extract cited tasks and deadlines from documents"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Document To Action Items
 
-Extract cited obligations, deadlines, tasks from documents.
+Extract cited tasks and deadlines from documents.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-docx.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-docx.md
@@ -1,14 +1,14 @@
 ---
-title: "Docx — Create, read, edit, template, and review Word .docx files"
+title: "Docx — Create, edit, review, or template Word .docx files"
 sidebar_label: "Docx"
-description: "Create, read, edit, template, and review Word .docx files"
+description: "Create, edit, review, or template Word .docx files"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Docx
 
-Create, read, edit, template, and review Word .docx files.
+Create, edit, review, or template Word .docx files.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
@@ -1,14 +1,14 @@
 ---
-title: "Google Workspace — Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python"
+title: "Google Workspace — Operate Gmail, Calendar, Drive, Docs, and Sheets"
 sidebar_label: "Google Workspace"
-description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python"
+description: "Operate Gmail, Calendar, Drive, Docs, and Sheets"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Google Workspace
 
-Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python.
+Operate Gmail, Calendar, Drive, Docs, and Sheets.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/research/research-grounded-citations.md
+++ b/website/docs/user-guide/skills/bundled/research/research-grounded-citations.md
@@ -1,14 +1,14 @@
 ---
-title: "Grounded Citations — Ground answers and documents in cited, verifiable sources"
+title: "Grounded Citations — Cite and verify external claims in deliverables"
 sidebar_label: "Grounded Citations"
-description: "Ground answers and documents in cited, verifiable sources"
+description: "Cite and verify external claims in deliverables"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Grounded Citations
 
-Ground answers and documents in cited, verifiable sources.
+Cite and verify external claims in deliverables.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
+++ b/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
@@ -1,14 +1,14 @@
 ---
-title: "Llm Wiki — Karpathy's LLM Wiki: build/query interlinked markdown KB"
+title: "Llm Wiki — Build or query an interlinked Markdown knowledge base"
 sidebar_label: "Llm Wiki"
-description: "Karpathy's LLM Wiki: build/query interlinked markdown KB"
+description: "Build or query an interlinked Markdown knowledge base"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Llm Wiki
 
-Karpathy's LLM Wiki: build/query interlinked markdown KB.
+Build or query an interlinked Markdown knowledge base.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review.md
@@ -1,14 +1,14 @@
 ---
-title: "Requesting Code Review — Pre-commit review: security scan, quality gates, auto-fix"
+title: "Requesting Code Review — Review code pre-commit: security, quality, and auto-fix"
 sidebar_label: "Requesting Code Review"
-description: "Pre-commit review: security scan, quality gates, auto-fix"
+description: "Review code pre-commit: security, quality, and auto-fix"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Requesting Code Review
 
-Pre-commit review: security scan, quality gates, auto-fix.
+Review code pre-commit: security, quality, and auto-fix.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging.md
@@ -1,14 +1,14 @@
 ---
-title: "Systematic Debugging — 4-phase root cause debugging: understand bugs before fixing"
+title: "Systematic Debugging — Use for technical failures: reproduce, diagnose, verify"
 sidebar_label: "Systematic Debugging"
-description: "4-phase root cause debugging: understand bugs before fixing"
+description: "Use for technical failures: reproduce, diagnose, verify"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Systematic Debugging
 
-4-phase root cause debugging: understand bugs before fixing.
+Use for technical failures: reproduce, diagnose, verify.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-chroma.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-chroma.md
@@ -1,14 +1,14 @@
 ---
-title: "Chroma — Embedding database for RAG and semantic search"
+title: "Chroma — Store and search embeddings for local RAG"
 sidebar_label: "Chroma"
-description: "Embedding database for RAG and semantic search"
+description: "Store and search embeddings for local RAG"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Chroma
 
-Embedding database for RAG and semantic search.
+Store and search embeddings for local RAG.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/mlops/mlops-obliteratus.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-obliteratus.md
@@ -1,14 +1,14 @@
 ---
-title: "Obliteratus — OBLITERATUS: abliterate LLM refusals (diff-in-means)"
+title: "Obliteratus — Remove refusals from open-weight language models"
 sidebar_label: "Obliteratus"
-description: "OBLITERATUS: abliterate LLM refusals (diff-in-means)"
+description: "Remove refusals from open-weight language models"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Obliteratus
 
-OBLITERATUS: abliterate LLM refusals (diff-in-means).
+Remove refusals from open-weight language models.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/security/security-godmode.md
+++ b/website/docs/user-guide/skills/optional/security/security-godmode.md
@@ -1,14 +1,14 @@
 ---
-title: "Godmode — Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN"
+title: "Godmode — Jailbreak API-served LLMs with prompt techniques"
 sidebar_label: "Godmode"
-description: "Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN"
+description: "Jailbreak API-served LLMs with prompt techniques"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Godmode
 
-Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN.
+Jailbreak API-served LLMs with prompt techniques.
 
 ## Skill metadata
 

--- a/website/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development.md
+++ b/website/docs/user-guide/skills/optional/software-development/software-development-subagent-driven-development.md
@@ -1,14 +1,14 @@
 ---
-title: "Subagent Driven Development — Execute plans via delegate_task subagents (2-stage review)"
+title: "Subagent Driven Development — Execute plans with delegate_task and two-stage review"
 sidebar_label: "Subagent Driven Development"
-description: "Execute plans via delegate_task subagents (2-stage review)"
+description: "Execute plans with delegate_task and two-stage review"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Subagent Driven Development
 
-Execute plans via delegate_task subagents (2-stage review).
+Execute plans with delegate_task and two-stage review.
 
 ## Skill metadata
 


### PR DESCRIPTION
## Summary
- clarify compact routing descriptions for 14 bundled and optional skills
- keep every capability self-contained within the first 57 characters
- update generated skill pages and catalog rows without unrelated generator drift
- leave every skill body and non-description frontmatter field unchanged

## Validation
- `scripts/run_tests.sh`-equivalent targeted set via the repository dev environment: 1353 passed, 0 failed
- includes `tests/skills/test_authoring_standards.py`
- 198 source skill names parse and remain unique
- final diff is limited to 14 source files, 14 generated pages, and 2 catalogs