### PR TITLE
fix(toolsets): scope resolve_toolset memo by profile

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -327,6 +327,7 @@ class TestResolveToolsetMemo:
 
         registry_id = id(registry)
         generation = registry._generation
+        scope = registry.current_scope_key()
 
         first = resolve_toolset("hermes-cli")
         second = resolve_toolset("hermes-cli")
@@ -337,7 +338,7 @@ class TestResolveToolsetMemo:
             f"got {get_toolset_calls['n']} calls"
         )
         assert (
-            "hermes-cli", True, registry_id, generation
+            "hermes-cli", True, registry_id, generation, scope
         ) in toolsets_mod._resolve_toolset_memo
 
     def test_generation_bump_invalidates_memo(self, monkeypatch):
@@ -372,4 +373,36 @@ class TestResolveToolsetMemo:
         second = resolve_toolset("hermes-cli", include_registry=False)
         assert first == second
         assert first  # non-empty sanity
+
+    def test_scope_change_invalidates_memo(self, monkeypatch):
+        """Two multiplex profiles resolving the same registry-only toolset must not
+        share a cache entry (#106005 Bug 2): the memo key omitted the registry
+        scope, so a profile B resolve after profile A's could return A's tool
+        names even though B's own tools were registered under B's own scope."""
+        from tools.registry import registry
+
+        toolsets_mod._resolve_toolset_memo.clear()
+        registry.register(
+            name="__probe_scope_a_tool__", toolset="__probe_mcp_toolset__",
+            schema=_make_schema("__probe_scope_a_tool__"), handler=_dummy_handler,
+            scope="__probe_scope_a__",
+        )
+        registry.register(
+            name="__probe_scope_b_tool__", toolset="__probe_mcp_toolset__",
+            schema=_make_schema("__probe_scope_b_tool__"), handler=_dummy_handler,
+            scope="__probe_scope_b__",
+        )
+        try:
+            monkeypatch.setattr(ToolRegistry, "current_scope_key", staticmethod(lambda: "__probe_scope_a__"))
+            assert resolve_toolset("__probe_mcp_toolset__") == ["__probe_scope_a_tool__"]
+
+            monkeypatch.setattr(ToolRegistry, "current_scope_key", staticmethod(lambda: "__probe_scope_b__"))
+            b_view = resolve_toolset("__probe_mcp_toolset__")
+            assert b_view == ["__probe_scope_b_tool__"], (
+                f"profile B resolved profile A's memoized tool names: got {b_view}"
+            )
+        finally:
+            registry.deregister("__probe_scope_a_tool__", scope="__probe_scope_a__")
+            registry.deregister("__probe_scope_b_tool__", scope="__probe_scope_b__")
+            toolsets_mod._resolve_toolset_memo.clear()
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -254,9 +254,13 @@ def _registry_call(method: str, default):
         return default
 
 
-def _registry_generation() -> Tuple[int, int]:
+def _registry_generation() -> Tuple[int, int, str]:
+    """(id, generation, scope) — scope keeps the memo from serving one multiplexed
+    profile's resolution (and its registry-only MCP tool names) to another; see #106005."""
     reg = _registry()
-    return (id(reg), getattr(reg, "_generation", 0)) if reg is not None else (0, 0)
+    if reg is None:
+        return (0, 0, "")
+    return (id(reg), getattr(reg, "_generation", 0), reg.current_scope_key())
 
 
 def get_toolset(name: str, *, include_registry: bool = True) -> Optional[Dict[str, Any]]:
@@ -321,9 +325,9 @@ def bundle_non_core_tools(toolset_name: str) -> Set[str]:
     return to_remove - core
 
 
-# Memo keyed on (name, include_registry, id(registry), registry generation);
+# Memo keyed on (name, include_registry, id(registry), registry generation, scope);
 # engages only at the public entry (visited is None).
-_resolve_toolset_memo: Dict[Tuple[str, bool, int, int], List[str]] = {}
+_resolve_toolset_memo: Dict[Tuple[str, bool, int, int, str], List[str]] = {}
 
 
 def _plugin_platform_bundle(name: str) -> List[str]:


### PR DESCRIPTION
## Summary

Carry-forward of the verified scope-keyed resolver fix from #106069 onto the latest `main`.

Addresses #106005, Bug 2 only. This PR does not claim to close the entire issue: Bug 3 (`get_mcp_status()` cross-profile visibility) is already on `main`, while the remaining connection-identity/discovery lifecycle work in Bug 1 is a separate, larger change covered by the related MCP work below.

## Publication receipt

- PR: https://github.com/NousResearch/hermes-agent/pull/106377
- Head: `JoaoMarcos44:fix/issue-106005-mcp-profile-scope` at `e1116a313eb354718520b319069e0ce24228c290`
- Base: `main` at `9e0dc4319ae2d59c60f5226b5c0af58d17755bfa` when published
- Remote head read-back: `fork/fix/issue-106005-mcp-profile-scope` resolves to the exact head SHA above
- Initial CI snapshot: 33 reported checks — 18 `SUCCESS`, 4 `IN_PROGRESS`, 10 `SKIPPED`, and 1 `NEUTRAL`; merge state was `BLOCKED` while required checks were running
- Final CI snapshot read back after completion: 37 reported checks — 24 `SUCCESS`, 12 `SKIPPED`, and 1 `NEUTRAL`; 0 failed/error/cancelled checks; merge state `CLEAN`

## Reported behavior

With `GATEWAY_MULTIPLEX_PROFILES=true`, two profiles can register different MCP tools under the same toolset alias while sharing one process-wide registry generation. Resolving the alias in profile A populated `_resolve_toolset_memo`; resolving the same alias in profile B reused A's cached tool names because the memo key had no active registry scope. The registry then filtered A's names out of B's profile overlay, leaving B with an empty model-facing toolset.

The defect reproduces without a live MCP server: two scoped registry entries, one alias, unchanged registry generation, and an A -> B scope switch are sufficient.

## Root cause

`toolsets.py` built the public resolver memo key as:

```text
(name, include_registry, id(registry), registry generation)
```

The registry itself is scope-aware (`tools/registry.py::ToolRegistry.current_scope_key()`), but `_registry_generation()` did not include that identity. The memo therefore conflated profile-local views that were valid at the same registry generation.

## Fix

- Include `registry.current_scope_key()` in `_registry_generation()`.
- Keep the existing registry identity and generation components, so registry mutations still invalidate cached results.
- Keep the existing bounded memo behavior; no process-global cache flush or profile-switch ordering assumption is introduced.
- Update the memo type/documentation and add a real scoped-registry regression test with distinct profile inventories.

The change is O(1) extra key construction per public resolution and does not scan, copy, or mutate MCP connection state. Single-profile behavior keeps the same stable scope value and the same cache bound.

## Carry-forward and related work

The original implementation was published as #106069 by `chelsealong`. Its head fork is read-only to the authenticated contributor account (`pull=true`, `push=false`), and its base was 101 commits behind the current `main`. The exact verified patch was cherry-picked with `-x` onto current `main`, preserving the original commit author and linking the source commit in the history.

Related state checked before implementation:

- #104527 is merged and supplies profile-scoped MCP status behavior.
- #106314 is merged and supplies same-route shared-connection visibility/reconciliation.
- #104534 remains open with known production-shaped reload and connection-state blockers; this PR does not duplicate or partially reimplement that larger connection-identity change.
- #106069 is left open and untouched as the original candidate; this PR is its current-main carry-forward.

## Verification

### Regression proof

The new regression test was run against the old implementation by temporarily restoring only `toolsets.py` while keeping the new test:

```text
scripts/run_tests.sh tests/test_toolsets.py -k test_scope_change_invalidates_memo -q
1 failed, 26 deselected
AssertionError: profile B resolved profile A's memoized tool names
```

The source was restored, the working tree remained clean, and the fixed test passed afterward.

### Focused and adjacent checks

Using the repository runner with the verified native interpreter:

```text
HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' scripts/run_tests.sh tests/test_toolsets.py -q
27 passed, 0 failed

HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' scripts/run_tests.sh \
  tests/tools/test_mcp_dynamic_discovery.py \
  tests/gateway/test_multiplex_toolsets_profile_isolation.py \
  tests/hermes_cli/test_toolset_validation.py \
  tests/test_toolset_distributions.py -q
37 passed, 0 failed, 1 skipped

ruff check toolsets.py tests/test_toolsets.py
All checks passed
```

The broader five-file candidate command also includes `tests/tools/test_mcp_tool.py`, which currently fails during collection before running tests because `tools.mcp_tool` does not export `CreateMessageResultWithTools` (the import is at line 1911). This PR does not modify that module or test; the four adjacent files above pass independently.

### Deterministic stress check

A local, non-shipped harness interleaved two profile scopes across 16 worker threads, exercised both non-empty and empty/non-empty alias views, and performed 8,005 scoped resolutions per round. It ran five sequential contract checks plus the concurrent workload in each of three consecutive rounds:

- Round 1: 27 tests passed; 8,005 resolutions; 0.0378 s; 170,401 peak tracemalloc bytes.
- Round 2: 27 tests passed; 8,005 resolutions; 0.0344 s; 170,777 peak tracemalloc bytes.
- Round 3: 27 tests passed; 8,005 resolutions; 0.0501 s; 170,289 peak tracemalloc bytes.

All 15 stress contract checks and all three test rounds passed.

## Knowledge graph

The isolated worktree graph was updated after the final code edit with:

```text
graphify update . --no-cluster
```

The update completed successfully and reported 222,627 nodes and 489,641 edges. The run emitted four existing syntax-warning entries in unrelated non-Python/third-party files; no edited file was among those warnings. A post-update `graphify explain "resolve_toolset"` located the final implementation at `toolsets.py:353` and the regression import in `tests/test_toolsets.py`.

## Security and compatibility

The memo now distinguishes the same alias under each canonical registry scope instead of returning another profile's tool names. It does not broaden registry visibility, copy handlers between scopes, change credentials, or alter MCP connection ownership. Existing registry filtering remains the final scope boundary.

## Risk assessment

Low for non-multiplexed installations and medium for multiplexed tool resolution: the production change is limited to cache identity, but it protects a profile-isolation boundary. The regression covers divergent scoped inventories and the old implementation fails the test.

## Review checklist

- [x] Reproduced the reported memo-poisoning behavior on current `main`.
- [x] Verified the old implementation fails the new regression.
- [x] Tested the fixed path through `scripts/run_tests.sh`.
- [x] Ran adjacent MCP/toolset tests and recorded the unrelated collection blocker.
- [x] Ran lint and `git diff --check`.
- [x] Ran three consecutive deterministic stress rounds.
- [x] Preserved the original contributor's authorship in the carry-forward commit.
