### PR TITLE
fix(agent): advance fallback chain when a candidate fails with a quota error

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3674,6 +3674,18 @@ def _quarantine_fallback_candidate(
                    "credential (%s) — skipping to next fallback", task or "call", tag, fb_label, fb_err)
 
 
+def _skip_fallback_candidate_at_capacity(
+    task: Optional[str], fb_label: str, destination: "_FallbackDestination", fb_err: Exception, *,
+    tag: str = "",
+) -> None:
+    """A fallback candidate failed with a fallback-eligible capacity/quota error. Mark it unhealthy
+    (the same key the chain selectors skip on) so the ordered walk advances to the next configured
+    entry instead of aborting the whole auxiliary call (#106367)."""
+    _mark_provider_unhealthy(destination.provider or fb_label, base_url=destination.base_url)
+    logger.warning("Auxiliary %s%s: fallback candidate %s failed with a capacity/quota "
+                   "error (%s) — skipping to next fallback", task or "call", tag, fb_label, fb_err)
+
+
 def _plan_fallback_auth_retry(
     destination: _FallbackDestination,
     rebuild: Callable[[str, Any, Optional[str]], Tuple[_FallbackDestination, Dict[str, Any]]], *,
@@ -3730,6 +3742,9 @@ def _call_fallback_candidate_sync(
         return _send(fb_client, fb_kwargs, destination)
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
+            if _is_fallback_eligible_error(fb_err):
+                _skip_fallback_candidate_at_capacity(task, fb_label, destination, fb_err)
+                return None
             raise
         fb_provider, retry = _plan_fallback_auth_retry(
             destination, rebuild, async_mode=False, failed_api_key=getattr(fb_client, "api_key", ""))
@@ -3740,6 +3755,9 @@ def _call_fallback_candidate_sync(
                 return _send(*retry)
             except Exception as retry_err:
                 if not _is_auth_error(retry_err):
+                    if _is_fallback_eligible_error(retry_err):
+                        _skip_fallback_candidate_at_capacity(task, fb_label, failed_destination, retry_err)
+                        return None
                     raise
         _quarantine_fallback_candidate(
             task, fb_label, fb_provider, fb_err, base_url=failed_destination.base_url,
@@ -3769,6 +3787,9 @@ async def _call_fallback_candidate_async(
         return await _send(fb_client, fb_kwargs, destination)
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
+            if _is_fallback_eligible_error(fb_err):
+                _skip_fallback_candidate_at_capacity(task, fb_label, destination, fb_err, tag=" (async)")
+                return None
             raise
         fb_provider, retry = _plan_fallback_auth_retry(
             destination, rebuild, async_mode=True, failed_api_key=getattr(fb_client, "api_key", ""))
@@ -3779,6 +3800,10 @@ async def _call_fallback_candidate_async(
                 return await _send(*retry)
             except Exception as retry_err:
                 if not _is_auth_error(retry_err):
+                    if _is_fallback_eligible_error(retry_err):
+                        _skip_fallback_candidate_at_capacity(
+                            task, fb_label, failed_destination, retry_err, tag=" (async)")
+                        return None
                     raise
         _quarantine_fallback_candidate(
             task, fb_label, fb_provider, fb_err,
@@ -6648,6 +6673,13 @@ _FALLBACK_REASONS: Tuple[Tuple[Callable[[Exception], bool], str], ...] = (
 )
 
 
+def _is_fallback_eligible_error(exc: Exception) -> bool:
+    """Errors that let the fallback walk advance when raised by a fallback candidate:
+    the same classes that admitted the primary failure into the chain. Anything else
+    (e.g. a request-shape ValueError) still propagates unchanged (#106367)."""
+    return any(predicate(exc) for predicate, _label in _FALLBACK_REASONS)
+
+
 def _rung(step: "_LadderStep", accept: Callable[[Exception], bool]):
     """One ladder rung: perform ``step``; yields ``(response, None)`` on success,
     ``(None, exc)`` when ``accept(exc)`` lets the next rung handle it, else re-raises."""
@@ -6832,6 +6864,28 @@ def _ladder_credential_rungs(
     return None, first_err
 
 
+def _reselect_fallback_candidate(
+    route: "_LadderRoute", task: Optional[str], resolved_provider: str, is_auto: bool, *,
+    reason: str, failed_model: Optional[str], failure_scope: Any,
+) -> Tuple[Optional[Any], Optional[str], str]:
+    """Re-run the ordered fallback selectors after a candidate proved unavailable (stale
+    credential quarantined or capacity-exhausted): configured chain → main fallback chain
+    (auto tasks) → discovery chain. Entries marked unhealthy during the current walk are
+    skipped, so each call advances to the next configured entry (#106367)."""
+    fb_client, fb_model, fb_label = _try_configured_fallback_chain(
+        task, resolved_provider or "auto", reason=reason, failed_model=failed_model,
+        failed_base_url=route.base_info, failure_scope=failure_scope)
+    if fb_client is None and is_auto:
+        fb_client, fb_model, fb_label = _try_main_fallback_chain(
+            task, resolved_provider or "auto", reason=reason, failed_model=failed_model,
+            failed_base_url=route.base_info, failure_scope=failure_scope)
+    if fb_client is None:
+        fb_client, fb_model, fb_label = _try_payment_fallback(
+            resolved_provider, task, reason=reason, failed_base_url=route.base_info,
+            failure_scope=failure_scope)
+    return fb_client, fb_model, fb_label
+
+
 def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
     """Last rung: other providers (per-task chain; then auto: main fallback chain + discovery
     chain, explicit: main-agent-model net). Returns the response or None.
@@ -6885,19 +6939,24 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
             resolved_provider, task, reason=reason, failed_model=_chain_failed_model,
             failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
     if fb_client is not None:
-        # Second pass: the candidate credential was stale and quarantined — walk the discovery
-        # chain once more (unhealthy entries are skipped).
-        for _pass in range(2):
+        # Later passes: the candidate proved unavailable (stale credential quarantined, or a
+        # capacity/quota error marked it unhealthy) — re-run the ordered selectors. Entries
+        # marked unhealthy during this walk are skipped, so each pass advances to the next
+        # configured entry instead of aborting the whole auxiliary call (#106367).
+        _attempted_labels = set()
+        for _pass in range(8):
             _record_route_info(route.route_info, _fallback_provider_from_label(fb_label), fb_model)
             fb_resp = yield _LadderStep("fallback", (fb_client, fb_model, fb_label))
             if fb_resp is not None:
                 return fb_resp
-            if _pass == 0:
-                fb_client, fb_model, fb_label = _try_payment_fallback(
-                    resolved_provider, task, reason="stale fallback credential",
-                    failed_base_url=route.base_info, failure_scope=_chain_failure_scope)
-                if fb_client is None:
-                    break
+            if fb_label in _attempted_labels:
+                break  # re-selection made no forward progress — stop
+            _attempted_labels.add(fb_label)
+            fb_client, fb_model, fb_label = _reselect_fallback_candidate(
+                route, task, resolved_provider, is_auto, reason="fallback candidate unavailable",
+                failed_model=_chain_failed_model, failure_scope=_chain_failure_scope)
+            if fb_client is None:
+                break
     # All fallback layers exhausted — one user-visible warning, then re-raise.
     logger.warning("Auxiliary %s%s: %s on %s and all fallbacks exhausted "
                    # All fallback layers exhausted — emit a single user-visible warning so the operator

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1797,7 +1797,9 @@ class TestStaleFallbackCandidateSkip:
 
         assert result.choices[0].message.content == "openrouter-serves"
         assert mock_fb.call_count == 2
-        assert mock_fb.call_args_list[1].kwargs.get("reason") == "stale fallback credential"
+        # Re-selection reason is generic: the candidate can be unavailable from either a
+        # stale credential (quarantined) or a capacity/quota error (#106367).
+        assert mock_fb.call_args_list[1].kwargs.get("reason") == "fallback candidate unavailable"
         mock_mark.assert_called_once_with(
             "anthropic", base_url="https://api.anthropic.com",
         )
@@ -1829,6 +1831,118 @@ class TestStaleFallbackCandidateSkip:
                     task="compression",
                     messages=[{"role": "user", "content": "summarize"}],
                 )
+
+
+class TestFallbackCandidateCapacityWalk:
+    """A fallback candidate that itself fails with a fallback-eligible capacity/quota error
+    must not abort the walk: the candidate is marked unhealthy and the ordered chain
+    re-selects the next configured entry (#106367)."""
+
+    def _make_429(self, msg="Rate limit exceeded, try again in 60 seconds"):
+        exc = Exception(msg)
+        exc.status_code = 429
+        return exc
+
+    def test_second_hop_quota_error_advances_to_next_configured_entry(self, monkeypatch):
+        """Primary 429 → fallback[0] 429 → fallback[1] serves (issue matrix T3)."""
+        from agent.auxiliary_client import _is_provider_unhealthy
+
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429()
+
+        lane_b = MagicMock()
+        lane_b.chat.completions.create.side_effect = self._make_429()
+        lane_c = MagicMock()
+        lane_c.chat.completions.create.return_value = _DummyResponse("third-lane-serves")
+
+        chain_walks = [
+            (lane_b, "lane-b-model", "fallback_chain[0](opencode-go)"),
+            (lane_c, "lane-c-model", "fallback_chain[1](goat-lane)"),
+        ]
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   side_effect=chain_walks) as mock_chain, \
+             patch("agent.auxiliary_client._try_main_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(None, None, "")) as mock_payment:
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result.choices[0].message.content == "third-lane-serves"
+        assert mock_chain.call_count == 2  # first selection + re-selection after lane B failed
+        assert lane_b.chat.completions.create.call_count == 1
+        assert lane_c.chat.completions.create.call_count == 1
+        assert _is_provider_unhealthy("opencode-go")  # failed lane hidden for later aux calls
+        mock_payment.assert_not_called()  # configured chain served; no discovery drift
+
+    def test_all_lanes_quota_error_exhausts_chain_and_raises_original(self, monkeypatch, caplog):
+        """Primary + every configured lane at capacity → controlled exhaustion, original
+        primary error re-raised (issue matrix T4)."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429("primary quota hit")
+
+        lane_b = MagicMock()
+        lane_b.chat.completions.create.side_effect = self._make_429()
+        lane_c = MagicMock()
+        lane_c.chat.completions.create.side_effect = self._make_429()
+
+        chain_walks = [
+            (lane_b, "lane-b-model", "fallback_chain[0](opencode-go)"),
+            (lane_c, "lane-c-model", "fallback_chain[1](goat-lane)"),
+            (None, None, ""),
+        ]
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   side_effect=chain_walks) as mock_chain, \
+             patch("agent.auxiliary_client._try_main_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(None, None, "")), \
+             caplog.at_level("WARNING", logger="agent.auxiliary_client"):
+            with pytest.raises(Exception, match="primary quota hit"):
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "summarize"}],
+                )
+
+        assert mock_chain.call_count == 3  # lanes B and C each served once, then exhausted
+        assert lane_b.chat.completions.create.call_count == 1
+        assert lane_c.chat.completions.create.call_count == 1
+        assert any("all fallbacks exhausted" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_async_candidate_quota_error_skips_instead_of_raising(self, monkeypatch):
+        """Async twin: a capacity error from the candidate returns None so the walk advances."""
+        from agent.auxiliary_client import _call_fallback_candidate_async, _is_provider_unhealthy
+
+        lane_b = MagicMock()
+        lane_b.base_url = "https://api.opencode-go.test/v1"
+        lane_b.chat.completions.create = AsyncMock(side_effect=self._make_429())
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config", lambda task: {},
+        )
+
+        result = await _call_fallback_candidate_async(
+            lane_b, "lane-b-model", "fallback_chain[0](opencode-go)",
+            task="compression", messages=[{"role": "user", "content": "hi"}],
+            temperature=None, max_tokens=None, tools=None,
+            effective_timeout=5.0, effective_extra_body={}, reasoning_config=None,
+        )
+
+        assert result is None
+        assert lane_b.chat.completions.create.call_count == 1
+        assert _is_provider_unhealthy("opencode-go")
 
 
 class TestAuxiliaryFallbackLayering:


### PR DESCRIPTION
## What does this PR do?

An auxiliary task using `provider: auto` enters the configured `fallback_providers` chain when the primary provider hits a quota/rate-limit error, but the walk was effectively **single-hop**: if the first fallback candidate itself failed with another quota/rate-limit error, the candidate exception escaped immediately (`_call_fallback_candidate_sync/async` re-raised every non-auth error) and later configured entries were never tried.

This PR makes a fallback candidate's *fallback-eligible* error (the same error classes that admitted the primary failure into the chain — quota/rate-limit/payment/capacity/transient, per `_FALLBACK_REASONS`) behave like an unavailable candidate: the candidate is marked unhealthy and control returns to the ordered walker, which re-runs the configured-chain → main-chain → discovery selectors. Entries marked unhealthy are skipped, so each pass advances to the next configured entry. This mirrors the existing stale-credential quarantine flow, which already advanced the walk for auth failures — the gap was that capacity failures aborted it.

Details:

- Non-eligible errors from a candidate (e.g. a request-shape `ValueError`) still propagate unchanged — the pre-existing `test_non_auth_fallback_error_still_raises` behavior is preserved.
- The auth refresh/retry/quarantine path is untouched; a capacity error after a credential-refresh retry also advances the walk now.
- The walk is bounded: at most 8 passes, a no-forward-progress guard (re-selecting an already-attempted label stops the walk), and the unhealthy-marking itself makes selection strictly advance.
- Re-selection reason in logs was generalized from `"stale fallback credential"` to `"fallback candidate unavailable"` since there are now two skip causes (the one assertion asserting the old string was updated accordingly).

## Related Issue

Fixes #106367

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: added `_is_fallback_eligible_error()` — the shared predicate for "this error class lets the fallback chain advance".
- `agent/auxiliary_client.py`: added `_skip_fallback_candidate_at_capacity()` — marks a capacity-failed candidate unhealthy (same key the chain selectors skip on) and logs the skip.
- `agent/auxiliary_client.py`: `_call_fallback_candidate_sync` / `_call_fallback_candidate_async` — a fallback-eligible error from the candidate (first attempt or post-refresh retry) now skips to the next fallback instead of raising.
- `agent/auxiliary_client.py`: added `_reselect_fallback_candidate()` and rewrote the pass loop in `_ladder_provider_fallback` — after a candidate is unavailable, re-run the ordered selectors (configured → main → discovery) with unhealthy entries skipped, bounded to 8 passes with a no-progress guard; previously only a single discovery-chain re-selection happened.
- `tests/agent/test_auxiliary_client.py`: new `TestFallbackCandidateCapacityWalk` covering the issue's T3/T4 matrix (sync walk advances to the next lane; all-lanes-exhausted re-raises the original error with the exhaustion warning) plus the async candidate twin; updated the one re-selection reason assertion that the generalization touches.

## How to Test

1. `pytest tests/agent/test_auxiliary_client.py::TestFallbackCandidateCapacityWalk -q` — 3 passed. Before the fix, the T3 sync case raises the first candidate's `Rate limit exceeded` error (single-hop escape) and the async case propagates the 429; after the fix the third lane serves the request and the failed lane is marked unhealthy.
2. `pytest tests/agent/test_auxiliary_client.py -q` — 207 passed (no regressions; the stale-credential refresh/quarantine tests and the non-auth-raise test all stay green).
3. `pytest tests/agent/test_compression_fallback_budget.py tests/agent/test_fast_compression_lane.py tests/agent/test_auxiliary_transient_retry.py tests/agent/test_auxiliary_main_first.py -q` — passed (adjacent fallback surfaces unchanged). Observed result: `test_fallback_dynamic_credential.py` has one failure, but it fails identically on a clean `upstream/main` checkout (pre-existing, unrelated).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
