### PR TITLE
fix(auth): same-account profile OAuth logins survive the forked-grant heal (salvage #106177)

### DIFF
--- a/hermes_cli/auth_oauth_grants.py
+++ b/hermes_cli/auth_oauth_grants.py
@@ -187,9 +187,8 @@ def _find_root_counterpart(
     profile_row: Dict[str, Any], root_rows: List[Dict[str, Any]]) -> Optional[int]:
     """Index of the root OAuth row that shares a grant lineage with *profile_row*.
 
-    Fallback per the one-grant-at-root rule: same provider + same OAuth client — every Anthropic
-    ``hermes_pkce`` grant uses one client id and carries no claims, so two Anthropic OAuth rows
-    with no contrary identity are one lineage.
+    Only a copied row ID or shared token material establishes lineage. The same
+    account/client can issue multiple independent grants; identity is not proof.
     """
     from hermes_cli.auth import _nonempty_str
     candidates = [i for i, r in enumerate(root_rows) if _is_oauth_pool_payload(r)]
@@ -199,11 +198,6 @@ def _find_root_counterpart(
     for i in candidates:
         if pid and root_rows[i].get("id") == pid:
             return i
-    p_ident = _oauth_identity(profile_row)
-    for i in candidates:
-        r_ident = _oauth_identity(root_rows[i])
-        if p_ident and r_ident and p_ident == r_ident:
-            return i
     for key in ("refresh_token", "access_token"):
         p_val = profile_row.get(key)
         if not _nonempty_str(p_val):
@@ -211,14 +205,7 @@ def _find_root_counterpart(
         for i in candidates:
             if root_rows[i].get(key) == p_val:
                 return i
-    # Fallback: same provider + same client. Only a contradicting identity (both sides carry
-    # claims and they differ from every root row) blocks it.
-    if p_ident:
-        for i in candidates:
-            if not _oauth_identity(root_rows[i]):
-                return i
-        return None
-    return candidates[0]
+    return None
 
 
 def _adopt_oauth_material(target: Dict[str, Any], winner: Dict[str, Any]) -> Dict[str, Any]:
@@ -254,7 +241,7 @@ def heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str, 
     Forked copies are one credential with several owners: whichever profile rotated last holds the
     only live refresh token and every other copy (root included) is spent. Runs at profile
     ``load_pool()`` time for ``SINGLE_USE_REFRESH_POOL_PROVIDERS``: finds profile rows sharing
-    LINEAGE with a root row (same pool id, or same account identity / token material), keeps the
+    LINEAGE with a root row (same pool id or shared token material), keeps the
     freshest rotation, writes it into ROOT when root's is older, and strips the profile's copy so
     the profile borrows root from then on. Idempotent; never touches API-key rows; never deletes a
     row with no root counterpart (an independent ``hermes -p <p> auth add`` grant, or the only
@@ -290,8 +277,12 @@ def _heal_forked_provider_block(
         return {**tokens, "last_refresh": block.get("last_refresh")}
 
     p_flat, r_flat = _flat(p_block), _flat(r_block)
-    p_ident, r_ident = _oauth_identity(p_flat), _oauth_identity(r_flat)
-    if p_ident and r_ident and p_ident != r_ident:
+    # Provider blocks have no stable pool-row ID. Without a shared token pair
+    # component, a common account is insufficient evidence of a copied grant.
+    if not any(
+        p_flat.get(key) and p_flat.get(key) == r_flat.get(key)
+        for key in ("access_token", "refresh_token")
+    ):
         return None
     adopted = _oauth_freshness(p_flat) > _oauth_freshness(r_flat)
     if adopted:

--- a/hermes_cli/auth_oauth_grants.py
+++ b/hermes_cli/auth_oauth_grants.py
@@ -259,8 +259,14 @@ def heal_forked_single_use_oauth_grants(provider_id: str) -> Optional[Dict[str, 
 
 
 def _heal_forked_provider_block(
-    profile_store: Dict[str, Any], root_store: Dict[str, Any], provider_id: str) -> Optional[bool]:
+    profile_store: Dict[str, Any], root_store: Dict[str, Any], provider_id: str,
+    lineage_proven: bool = False) -> Optional[bool]:
     """Consolidate a forked ``providers.<id>`` device-code block into root.
+
+    *lineage_proven* carries the pool-row verdict: a profile row that matched root by copied id
+    or shared tokens proves the fork even after both sides rotated past token equality. Root's
+    ``load_pool()`` re-seeds its ``device_code`` row FROM this block, so leaving root's block on
+    the spent pair would undo the pool-row heal on the next root load.
 
     Returns None when nothing matched, False when the profile copy was dropped (root already
     newest), True when the profile copy was fresher and was adopted into root.
@@ -278,8 +284,9 @@ def _heal_forked_provider_block(
 
     p_flat, r_flat = _flat(p_block), _flat(r_block)
     # Provider blocks have no stable pool-row ID. Without a shared token pair
-    # component, a common account is insufficient evidence of a copied grant.
-    if not any(
+    # component (or lineage proven by the pool rows), a common account is
+    # insufficient evidence of a copied grant.
+    if not lineage_proven and not any(
         p_flat.get(key) and p_flat.get(key) == r_flat.get(key)
         for key in ("access_token", "refresh_token")
     ):
@@ -321,6 +328,7 @@ class _HealPass:
         self.summary: Dict[str, Any] = {
             "adopted": False, "stripped_ids": [], "files": [], "providers_block": False}
         self.profile_changed = self.root_changed = False
+        self.lineage_proven = False  # a profile pool row matched root by copied id / shared tokens
         self.p_pool, self.p_rows = _pool_rows(profile_store, provider_id)
         self.r_pool, self.r_rows = _pool_rows(root_store, provider_id)
         self.r_oauth = [r for r in self.r_rows if _is_oauth_pool_payload(r)]
@@ -349,6 +357,7 @@ class _HealPass:
                 continue
             match_idx = _find_root_counterpart(row, self.r_rows)
             if match_idx is not None:
+                self.lineage_proven = True
                 self._adopt_root_row(match_idx, row)
             # No root pool counterpart. Root's grant may live only in its .anthropic_oauth.json
             # (the ``hermes auth`` PKCE shape); a profile hermes_pkce-family row is its copy.
@@ -371,7 +380,7 @@ class _HealPass:
         if self.provider_id not in _DEVICE_CODE_BLOCK_PROVIDERS:
             return
         block_result = _heal_forked_provider_block(
-            self.profile_store, self.root_store, self.provider_id)
+            self.profile_store, self.root_store, self.provider_id, self.lineage_proven)
         if block_result is not None:
             self.profile_changed = self.summary["providers_block"] = True
             if block_result:

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -425,6 +425,47 @@ def test_heal_never_deletes_the_only_surviving_copy(fleet):
     assert "anthropic" not in (json.loads((fleet["root"] / "auth.json").read_text())["credential_pool"])
 
 
+@pytest.mark.parametrize("shape", ["pool", "provider"])
+@pytest.mark.parametrize("claims", [True, False])
+def test_heal_preserves_independent_grants_for_same_account(fleet, shape, claims):
+    """An account can have independent device logins; identity is not lineage."""
+    import base64
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    def pair(tag):
+        payload = base64.urlsafe_b64encode(json.dumps({
+            "sub": "same-account", "exp": int(time.time()) + 3600, "jti": tag,
+        }).encode()).decode().rstrip("=")
+        return {"access_token": "h." + payload + ".s" if claims else tag,
+                "refresh_token": "independent-" + tag}
+
+    def store(tag):
+        tokens = pair(tag)
+        if shape == "provider":
+            return {"version": 1, "providers": {"openai-codex": {"tokens": tokens}}}
+        return {"version": 1, "providers": {}, "credential_pool": {"openai-codex": [{
+            "id": tag, "auth_type": "oauth", "source": "manual:device_code", **tokens,
+        }]}}
+
+    root = fleet["root"] / "auth.json"
+    kid = _profile(fleet, "independent")
+    kid.mkdir(parents=True, exist_ok=True)
+    profile = kid / "auth.json"
+    root.write_text(json.dumps(store("root-grant")))
+    profile.write_text(json.dumps(store("profile-grant")))
+    before = (root.read_bytes(), profile.read_bytes())
+    fleet["use"](kid)
+    assert heal_forked_single_use_oauth_grants("openai-codex") is None
+    assert (root.read_bytes(), profile.read_bytes()) == before
+    if claims:
+        from agent.credential_pool import load_pool
+        for _ in range(3):
+            selected = load_pool("openai-codex").select()
+            assert selected is not None
+            assert selected.refresh_token == "independent-profile-grant"
+        assert root.read_bytes() == before[0]
+
+
 def test_heal_leaves_a_different_account_alone(fleet):
     """A profile row whose JWT identity names ANOTHER account is not root's grant."""
     import base64

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -466,6 +466,40 @@ def test_heal_preserves_independent_grants_for_same_account(fleet, shape, claims
         assert root.read_bytes() == before[0]
 
 
+def test_heal_rotated_fork_moves_provider_block_with_the_pool_row(fleet):
+    """Copied pool-row id proves the fork even after both sides rotated past token equality.
+
+    Root's load_pool() re-seeds its device_code row FROM providers.<id>.tokens, so root's block
+    must carry the fresher pair too or the next root load resurrects the spent one.
+    """
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import heal_forked_single_use_oauth_grants
+
+    def store(tag, exp_off):
+        tokens = {"access_token": "at-" + tag, "refresh_token": "rt-" + tag}
+        issued = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + exp_off - 3600))
+        return {"version": 1,
+                "providers": {"openai-codex": {"tokens": tokens, "last_refresh": issued}},
+                "credential_pool": {"openai-codex": [{
+                    "id": "shared-id", "auth_type": "oauth", "source": "device_code", **tokens,
+                    "expires_at_ms": int((time.time() + exp_off) * 1000)}]}}
+
+    root = fleet["root"] / "auth.json"
+    kid = _profile(fleet, "rotated")
+    kid.mkdir(parents=True, exist_ok=True)
+    root.write_text(json.dumps(store("old", 100)))
+    (kid / "auth.json").write_text(json.dumps(store("new", 3600)))
+    fleet["use"](kid)
+    assert heal_forked_single_use_oauth_grants("openai-codex")["adopted"] is True
+    r, p = json.loads(root.read_text()), json.loads((kid / "auth.json").read_text())
+    assert r["credential_pool"]["openai-codex"][0]["refresh_token"] == "rt-new"
+    assert r["providers"]["openai-codex"]["tokens"]["refresh_token"] == "rt-new"
+    assert "openai-codex" not in p["providers"]
+    assert "openai-codex" not in p.get("credential_pool", {})
+    fleet["use"](fleet["root"])
+    assert {e.refresh_token for e in load_pool("openai-codex").entries()} == {"rt-new"}
+
+
 def test_heal_leaves_a_different_account_alone(fleet):
     """A profile row whose JWT identity names ANOTHER account is not root's grant."""
     import base64


### PR DESCRIPTION
A profile's own `hermes -p <profile> auth add openai-codex` login on the same account as root is no longer deleted by the forked-grant auto-heal, and a genuinely forked grant still heals completely (pool row **and** provider block).

Salvage of #106177 by @simpolism (cherry-picked, authorship preserved) plus one follow-up commit closing the cross-projection gap @andrexibiza raised in review.

## Changes
- `hermes_cli/auth_oauth_grants.py::_find_root_counterpart` — lineage is a copied pool-row id or shared token material only; the JWT-account and same-provider fallbacks are removed (@simpolism).
- `_heal_forked_provider_block` — requires shared token material **or** lineage already proven by the pool rows; matching account claims alone never authorize deleting a block (@simpolism + follow-up).
- `_HealPass.lineage_proven` — set when a profile pool row matched root by id/token; passed into the block heal so a historical fork whose pairs have diverged still moves root's `providers.<id>` block onto the fresh pair (follow-up).
- Tests: contributor's parametrized same-account regression (pool/provider × JWT/opaque) + one invariant for the rotated-fork shape.

## Root cause
An account identity identifies an account, not an OAuth grant; the healer treated "same `sub`/`chatgpt_account_id`" as proof the profile row was a copy of root's and deleted it, after which the profile borrowed root's already-spent refresh token (`refresh_token_reused`).

Why the follow-up: root's `load_pool()` re-seeds its `device_code` pool row FROM `providers.<id>.tokens` (`agent/credential_pool.py::_seed_tokens_singleton`). With identity matching gone and only token equality left, a fork whose pairs had diverged healed the pool row but left root's block on the spent pair, and root's next load overwrote the healed row back to the spent token.

## Validation
| Case | main | #106177 head | this PR |
|---|---|---|---|
| Independent same-account grants (pool row / provider block, JWT / opaque) | profile grant deleted | preserved | preserved |
| Historical fork, same row id, pairs diverged: root pool row after heal | fresh | fresh | fresh |
| … root `providers.openai-codex` block after heal | fresh | **spent** | fresh |
| … root `load_pool()` after heal | fresh | **spent (heal undone)** | fresh |

- New test `test_heal_rotated_fork_moves_provider_block_with_the_pool_row`: red on #106177's source, green here.
- Contributor's 4 new cases: red on `origin/main`, green here.
- 103 passed: `tests/agent/test_credential_pool_profile_oauth_fork.py`, `tests/agent/test_credential_pool.py`, `tests/hermes_cli/test_auth_codex_provider.py`, `tests/hermes_cli/test_auth_codex_self_heal.py` (real `load_pool()` I/O against a temp `HERMES_HOME`).
- Live repro (contributor): profile gateway lost its Codex credential at startup and looped on `refresh_token_reused`; with the fix the profile credential is retained and the gateway answered.

Closes #106177.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b5d4/hlNBD_1XMre9mwOlxxM7J_uDuNkVVs.png)
