### PR TITLE
fix(cli): keep npm native-binary mirrors across desktop updates

### DIFF
--- a/hermes_cli/main_tui_launch.py
+++ b/hermes_cli/main_tui_launch.py
@@ -420,13 +420,84 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
     sys.exit(1)
 
 
+def _is_regular_userconfig_file(path: Path) -> bool:
+    """True for a regular file (or symlink-to-file). Dirs and symlink-to-dir are skipped."""
+    try:
+        return path.is_file() and not path.is_dir()
+    except OSError:
+        return False
+
+
+def _hermes_home_npm_userconfig(hermes_home: str) -> str | None:
+    """Absolute ``$HERMES_HOME/npmrc`` or ``.npmrc`` path, preferring the bare name."""
+    home = Path(hermes_home)
+    for name in ("npmrc", ".npmrc"):
+        candidate = home / name
+        if _is_regular_userconfig_file(candidate):
+            return os.path.abspath(str(candidate))
+    return None
+
+
+def _windows_profile_fallback(run_env: dict[str, str]) -> str:
+    """USERPROFILE from the parent process or HOMEDRIVE+HOMEPATH; empty if unknown."""
+    for source in (os.environ, run_env):
+        value = (source.get("USERPROFILE") or "").strip()
+        if value:
+            return value
+    for source in (os.environ, run_env):
+        drive = (source.get("HOMEDRIVE") or "").strip()
+        path = (source.get("HOMEPATH") or "").strip()
+        if drive and path:
+            return f"{drive}{path}" if path.startswith(("\\", "/")) else os.path.join(drive, path)
+    return ""
+
+
+def _apply_npm_lifecycle_userconfig(
+    run_env: dict[str, str], *, windows: bool | None = None,
+) -> dict[str, str]:
+    """Pin npm userconfig + Windows profile vars so updater children still see mirrors.
+
+    ``$HERMES_HOME/npmrc`` (else ``.npmrc``) is durable across git autostash; npm's
+    default ``%USERPROFILE%\\.npmrc`` lookup needs USERPROFILE/HOME on win32.
+    Explicit ``NPM_CONFIG_USERCONFIG`` is never overwritten. Fail-open when no
+    HERMES_HOME npmrc exists.
+    """
+    if windows is None:
+        windows = sys.platform == "win32"
+    if windows:
+        if not (run_env.get("USERPROFILE") or "").strip():
+            filled = _windows_profile_fallback(run_env)
+            if filled:
+                run_env["USERPROFILE"] = filled
+        if not (run_env.get("HOME") or "").strip():
+            userprofile = (run_env.get("USERPROFILE") or "").strip()
+            if userprofile:
+                run_env["HOME"] = userprofile
+    if not (run_env.get("NPM_CONFIG_USERCONFIG") or "").strip():
+        hermes_home = (run_env.get("HERMES_HOME") or "").strip()
+        userconfig = _hermes_home_npm_userconfig(hermes_home) if hermes_home else None
+        if userconfig:
+            run_env["NPM_CONFIG_USERCONFIG"] = userconfig
+    for key, value in os.environ.items():
+        lowered = key.lower()
+        if not (
+            lowered.startswith("npm_config_")
+            and lowered.endswith("_binary_host_mirror")
+            and (value or "").strip()
+        ):
+            continue
+        if not any(k.lower() == lowered and (run_env.get(k) or "").strip() for k in run_env):
+            run_env[key] = value
+    return run_env
+
+
 def _npm_lifecycle_env(env: dict[str, str] | None = None) -> dict[str, str]:
     """Build a clean environment for the pinned UI toolchain lifecycle."""
     run_env = {**os.environ, **(env or {}), "CI": "1"}
     # esbuild treats this as an executable override. If a shell points it at a
     # different release, the pinned package's postinstall rejects that binary.
     run_env.pop("ESBUILD_BINARY_PATH", None)
-    return run_env
+    return _apply_npm_lifecycle_userconfig(run_env)
 
 
 def _tui_node_bin(bin: str) -> str:

--- a/tests/hermes_cli/test_npm_lifecycle_userconfig.py
+++ b/tests/hermes_cli/test_npm_lifecycle_userconfig.py
@@ -1,0 +1,157 @@
+"""HERMES_HOME npmrc must reach npm during desktop/TUI install (#106373).
+
+Restricted-network Windows updates fail when get-windows cannot fetch its
+GitHub Releases prebuilt. Users put ``node_get_windows_binary_host_mirror``
+in ``~/.npmrc`` or a project ``.npmrc``, but updater children miss both:
+HOME/USERPROFILE is often empty under CreateProcess, and git autostash
+strips the tracked project ``.npmrc``. Pinning ``NPM_CONFIG_USERCONFIG``
+to a durable ``$HERMES_HOME/npmrc`` (or ``.npmrc``) survives that.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from hermes_cli.main_tui_launch import _npm_lifecycle_env
+
+
+def _write_npmrc(path: Path, body: str = "node_get_windows_binary_host_mirror=https://example.test/mirror/\n") -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_hermes_home_npmrc_sets_npm_config_userconfig(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    npmrc = _write_npmrc(home / "npmrc")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+    env = _npm_lifecycle_env({})
+    assert env["NPM_CONFIG_USERCONFIG"] == os.path.abspath(str(npmrc))
+
+
+def test_hermes_home_dot_npmrc_used_when_npmrc_missing(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    npmrc = _write_npmrc(home / ".npmrc")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+    env = _npm_lifecycle_env({})
+    assert env["NPM_CONFIG_USERCONFIG"] == os.path.abspath(str(npmrc))
+
+
+def test_bare_npmrc_preferred_over_dot_npmrc(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    preferred = _write_npmrc(home / "npmrc", "registry=https://preferred.test/\n")
+    _write_npmrc(home / ".npmrc", "registry=https://dot.test/\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+    env = _npm_lifecycle_env({})
+    assert env["NPM_CONFIG_USERCONFIG"] == os.path.abspath(str(preferred))
+
+
+def test_explicit_userconfig_not_overwritten(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    _write_npmrc(home / "npmrc")
+    override = tmp_path / "explicit.npmrc"
+    _write_npmrc(override, "registry=https://explicit.test/\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("NPM_CONFIG_USERCONFIG", str(override))
+    env = _npm_lifecycle_env({})
+    assert env["NPM_CONFIG_USERCONFIG"] == str(override)
+
+
+def test_explicit_userconfig_in_env_dict_not_overwritten(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    _write_npmrc(home / "npmrc")
+    override = str(tmp_path / "from-env-dict.npmrc")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+    env = _npm_lifecycle_env({"NPM_CONFIG_USERCONFIG": override})
+    assert env["NPM_CONFIG_USERCONFIG"] == override
+
+
+def test_missing_hermes_npmrc_leaves_userconfig_unset(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+    env = _npm_lifecycle_env({})
+    assert not (env.get("NPM_CONFIG_USERCONFIG") or "").strip()
+
+
+def test_directory_npmrc_is_skipped_in_favor_of_dotfile(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    (home / "npmrc").mkdir()
+    dot = _write_npmrc(home / ".npmrc")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+    env = _npm_lifecycle_env({})
+    assert env["NPM_CONFIG_USERCONFIG"] == os.path.abspath(str(dot))
+
+
+def test_symlink_to_dir_is_not_used_as_userconfig(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    target = tmp_path / "not-a-file"
+    target.mkdir()
+    (home / "npmrc").symlink_to(target)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+    env = _npm_lifecycle_env({})
+    assert not (env.get("NPM_CONFIG_USERCONFIG") or "").strip()
+
+
+def test_binary_host_mirror_env_not_stripped(monkeypatch):
+    monkeypatch.setenv(
+        "npm_config_node_get_windows_binary_host_mirror",
+        "https://example.test/mirror/",
+    )
+    env = _npm_lifecycle_env({"SOME_OTHER": "1"})
+    assert env["npm_config_node_get_windows_binary_host_mirror"] == "https://example.test/mirror/"
+
+
+def test_windows_lifecycle_fills_empty_userprofile(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    profile = r"C:\Users\alice"
+    monkeypatch.setenv("USERPROFILE", profile)
+    env = _npm_lifecycle_env({"USERPROFILE": ""})
+    assert env["USERPROFILE"] == profile
+
+
+def test_windows_lifecycle_fills_empty_home_from_userprofile(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    profile = r"C:\Users\alice"
+    monkeypatch.setenv("USERPROFILE", profile)
+    env = _npm_lifecycle_env({"HOME": ""})
+    assert env["USERPROFILE"] == profile
+    assert env["HOME"] == profile
+
+
+def test_windows_lifecycle_does_not_overwrite_home(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("USERPROFILE", r"C:\Users\alice")
+    env = _npm_lifecycle_env({"HOME": r"D:\keep"})
+    assert env["HOME"] == r"D:\keep"
+
+
+def test_windows_lifecycle_fills_userprofile_from_homedrive(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    monkeypatch.setenv("HOMEDRIVE", "C:")
+    monkeypatch.setenv("HOMEPATH", r"\Users\alice")
+    env = _npm_lifecycle_env({"USERPROFILE": ""})
+    assert env["USERPROFILE"] == r"C:\Users\alice"
+
+
+def test_non_windows_does_not_invent_userprofile(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.delenv("USERPROFILE", raising=False)
+    env = _npm_lifecycle_env({"USERPROFILE": ""})
+    assert not (env.get("USERPROFILE") or "").strip()


### PR DESCRIPTION
## What does this PR do?

On restricted networks, Windows desktop updates fail when `get-windows`' prebuilt cannot be fetched from GitHub Releases. Users can work around this with an npm `*_binary_host_mirror`, but neither placement survives the updater:

- `%USERPROFILE%\.npmrc` is missed because handoff children often inherit an empty/wrong `USERPROFILE`/`HOME`
- a project-level `.npmrc` edit is stripped by git autostash on every update

This extends `_npm_lifecycle_env` (used by `hermes update` / desktop npm install+rebuild) so that:

1. If `$HERMES_HOME/npmrc` or `$HERMES_HOME/.npmrc` exists as a regular file, set `NPM_CONFIG_USERCONFIG` to its absolute path (prefer `npmrc`; never overwrite an explicit `NPM_CONFIG_USERCONFIG`)
2. On Windows, fill empty `USERPROFILE` from the parent env / `HOMEDRIVE`+`HOMEPATH`, and empty `HOME` from `USERPROFILE`, so a user-level npmrc can still be found when no HERMES_HOME npmrc is present
3. Ensure existing `npm_config_*_binary_host_mirror` env keys are forwarded

No default public mirror is hardcoded. Staging of `get-windows` on win32-x64 stays fail-closed.

## Related Issue

Fixes #106373

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `hermes_cli/main_tui_launch.py`: `_apply_npm_lifecycle_userconfig` helpers wired into `_npm_lifecycle_env`
- `tests/hermes_cli/test_npm_lifecycle_userconfig.py` (new): focused contract coverage (HERMES_HOME npmrc pin, fail-open, Windows profile fill, mirror forward)

## How to Test

```
HERMES_PYTHON=.venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_npm_lifecycle_userconfig.py -v
  -> 14 passed
  -> on base without fix: 7 failed, 7 passed (fail-open cases already green)
```

Manual (Windows / restricted network): put the mirror in `%HERMES_HOME%\npmrc`, then run a desktop-driven `hermes update`; `npm ci` should keep `get-windows` and the rebuild should no longer die at `stage-native-deps` solely because the mirror was lost.

## Related work (not duplicates)

- #100252 — vendor fallback inside `stage-native-deps.mjs` for offline/GFW hosts. Distinct RCA (vendored binary vs durable mirror/config). This PR does not touch that seam.
- #106024 / #82314 — broader constrained-network / GFW install proposals; not claimed here.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs (no open PR for #106373)
- [x] Only changes related to this fix
- [x] Relevant tests run locally
- [x] Tests added
- [x] Tested on: macOS (unit); Windows profile fill covered via `windows=` injection in tests

### Documentation & Housekeeping
- [x] Docs N/A (behavior is opt-in via `$HERMES_HOME/npmrc`)
- [x] cli-config.yaml.example N/A
- [x] Cross-platform: Windows profile fill gated; HERMES_HOME npmrc path works on all platforms
- [x] Tool schemas N/A


Made with [Cursor](https://cursor.com)