### PR TITLE
fix(cli): keep $HERMES_HOME/npmrc npm config across updates (#106373)

### DIFF
--- a/hermes_cli/main_tui_launch.py
+++ b/hermes_cli/main_tui_launch.py
@@ -420,12 +420,37 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
     sys.exit(1)
 
 
+def _persistent_npm_userconfig() -> Optional[dict[str, str]]:
+    """``NPM_CONFIG_USERCONFIG`` for ``$HERMES_HOME/npmrc`` when it exists.
+
+    The repo-root ``.npmrc`` is git-tracked, so the updater's autostash parks
+    any mirror/proxy line added there and every update reinstalls without it
+    (restricted networks then prune optional native deps like get-windows and
+    the rebuild fails). ``$HERMES_HOME`` lives outside the git tree, survives
+    autostash/reset, and the update hand-off already carries ``HERMES_HOME``
+    down to every npm child. An explicit ``NPM_CONFIG_USERCONFIG`` wins.
+    """
+    from hermes_constants import get_hermes_home
+
+    if os.environ.get("NPM_CONFIG_USERCONFIG", "").strip():
+        return None
+    try:
+        candidate = get_hermes_home() / "npmrc"
+    except Exception:
+        return None
+    if not candidate.is_file():
+        return None
+    return {"NPM_CONFIG_USERCONFIG": str(candidate)}
+
+
 def _npm_lifecycle_env(env: dict[str, str] | None = None) -> dict[str, str]:
     """Build a clean environment for the pinned UI toolchain lifecycle."""
     run_env = {**os.environ, **(env or {}), "CI": "1"}
     # esbuild treats this as an executable override. If a shell points it at a
     # different release, the pinned package's postinstall rejects that binary.
     run_env.pop("ESBUILD_BINARY_PATH", None)
+    for key, value in (_persistent_npm_userconfig() or {}).items():
+        run_env.setdefault(key, value)
     return run_env
 
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -778,3 +778,59 @@ def test_make_tui_argv_omits_workspace_and_scrubs_esbuild_override(
     assert "ESBUILD_BINARY_PATH" not in calls[0][1]["env"]
     assert calls[1][0][0][1:] == ["run", "build"]
     assert "ESBUILD_BINARY_PATH" not in calls[1][1]["env"]
+
+
+class TestPersistentNpmUserconfig:
+    """$HERMES_HOME/npmrc must reach every npm lifecycle child process."""
+
+    def test_hermes_home_npmrc_sets_userconfig(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "npmrc").write_text(
+            "node_get_windows_binary_host_mirror=https://ghproxy.net/https://github.com/sindresorhus/get-windows/releases/download/\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+        monkeypatch.delenv("ESBUILD_BINARY_PATH", raising=False)
+
+        env = main_tui_launch._npm_lifecycle_env()
+
+        assert env["NPM_CONFIG_USERCONFIG"] == str(home / "npmrc")
+
+    def test_missing_npmrc_leaves_env_untouched(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+
+        env = main_tui_launch._npm_lifecycle_env()
+
+        assert "NPM_CONFIG_USERCONFIG" not in env
+
+    def test_explicit_userconfig_wins(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "npmrc").write_text(
+            "registry=https://example.invalid\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("NPM_CONFIG_USERCONFIG", str(tmp_path / "custom-npmrc"))
+
+        env = main_tui_launch._npm_lifecycle_env()
+
+        assert env["NPM_CONFIG_USERCONFIG"] == str(tmp_path / "custom-npmrc")
+
+    def test_caller_env_does_not_override_userconfig(self, tmp_path, monkeypatch):
+        env_in = {"NPM_CONFIG_USERCONFIG": "/from-caller/npmrc"}
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "npmrc").write_text(
+            "registry=https://example.invalid\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+
+        env = main_tui_launch._npm_lifecycle_env(env_in)
+
+        assert env["NPM_CONFIG_USERCONFIG"] == "/from-caller/npmrc"


### PR DESCRIPTION
## Problem (#106373)

On restricted networks (GitHub Releases unreachable), every Windows desktop update ends in **REBUILD FAILED**: npm prunes the `get-windows` optional dep when its `node-pre-gyp` download times out (`npm ci` still exits 0), and `stage-native-deps.mjs` only notices at rebuild time. The user's only working workaround — a `node_get_windows_binary_host_mirror` npm key — cannot survive the updater:

- `%USERPROFILE%\.npmrc`: the Windows hand-off spawns children via raw `CreateProcess(..., lpEnvironment=null)` (`HermesUpdateJob.StartAssigned`), so npm's userconfig lookup depends on the Desktop GUI process env, not the user's shell.
- repo-root `.npmrc`: git-tracked; `hermes update` autostash parks local edits (`--keep-stash`), so the mirror line is stripped on every update.

## Fix

All updater npm lifecycle spawns flow through one choke point: `_npm_lifecycle_env()` (`hermes_cli/main_tui_launch.py`), used by `_run_npm_install_deterministic` for desktop/web/TUI builds. It now exports `NPM_CONFIG_USERCONFIG=$HERMES_HOME/npmrc` when that file exists:

- `$HERMES_HOME` lives outside the git tree → survives autostash/reset/checkout rotation.
- The update chain (Desktop → windows.ps1 hand-off → `hermes update` / `desktop --force-build`) already propagates `HERMES_HOME` (main.ts sets it on the detached spawn).
- An explicit `NPM_CONFIG_USERCONFIG` (process env or caller env) always wins; a missing file changes nothing.

Users put the mirror key in `%HERMES_HOME%\npmrc` once; every subsequent update's `npm ci` resolves native prebuilts through the mirror — no more silent prune → REBUILD FAILED loop.

## Verification

- 4 new tests in `tests/hermes_cli/test_tui_npm_install.py` (`TestPersistentNpmUserconfig`): file→var mapping, missing file→untouched env, explicit env wins, caller env wins. Mutation RED confirmed (dropping the setdefault loop fails the mapping test).
- Full spec file: 34 passed. `ruff check` clean; `ruff format` drift unchanged from clean main baseline (187→187).
- Live smoke with isolated `HERMES_HOME`: var set/overridden/absent as expected.
