### PR TITLE
/review shows its reviewer subagent in the Desktop status stack

### DIFF
--- a/tests/tui_gateway/test_slash_review_owner.py
+++ b/tests/tui_gateway/test_slash_review_owner.py
@@ -1,0 +1,50 @@
+"""/review from slash.exec runs on the RPC pool, outside any turn. The reviewer it dispatches must
+still be registered under the parent Desktop/TUI session (HERMES_UI_SESSION_ID + exact steer
+authority), or `subagent.list` hides it and the Desktop status stack shows nothing for /review."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import patch
+
+from tui_gateway import server
+from tui_gateway.transport import StdioTransport
+
+
+def _live_session(agent):
+    return {
+        "agent": agent, "session_key": "review-key", "history": [{"role": "user", "content": "hi"}],
+        "history_lock": threading.Lock(), "running": False, "transport": StdioTransport(lambda: None, threading.Lock()),
+        "cwd": "", "source": "desktop",
+    }
+
+
+def test_slash_review_dispatches_under_the_parent_session_identity(monkeypatch):
+    sid = "review-sid"
+    session = _live_session(object())
+    server._sessions[sid] = session
+    seen = {}
+
+    def fake_start_review(agent, snapshot, prompt):
+        from gateway.session_context import get_session_env
+        seen["ui_session_id"] = get_session_env("HERMES_UI_SESSION_ID", "")
+        seen["authority"] = server._current_session_steer_authority(sid)
+        return {"status": "dispatched", "delegation_id": "deleg_x"}
+
+    token = server.bind_transport(session["transport"])
+    try:
+        with (
+            patch.object(server, "_session_uses_compute_host", return_value=False),
+            patch("agent.review_engine.start_review", fake_start_review),
+        ):
+            out = server._live_slash_command_output(sid, session, "review", "")
+        from gateway.session_context import get_session_env
+        assert get_session_env("HERMES_UI_SESSION_ID", "") == ""  # scope cleared after dispatch
+        assert server._current_runtime_session_record.get() is None
+    finally:
+        server.reset_transport(token)
+        server._sessions.pop(sid, None)
+
+    assert out == "Review started. Results will return here."
+    assert seen["ui_session_id"] == sid
+    assert seen["authority"] == (session["transport"], session)

--- a/tui_gateway/methods_slash.py
+++ b/tui_gateway/methods_slash.py
@@ -37,6 +37,11 @@ def _format_live_review_output(sid: str, session: Optional[dict], arg: str) -> s
     with session.get("history_lock") or contextlib.nullcontext():
         snapshot = list(session.get("history", []))
     snapshot = snapshot or list(getattr(agent, "_session_messages", None) or [])
+    # slash.exec runs on the RPC pool, not inside a turn: bind the same session identity a turn binds
+    # (HERMES_UI_SESSION_ID + steer authority), or delegate_task registers the reviewer with no owner
+    # and `subagent.list` hides it — the Desktop status stack then shows nothing for /review.
+    tokens = _set_session_context(session["session_key"], ui_session_id=sid)
+    runtime_token = _current_runtime_session_record.set(session)
     try:
         from agent.review_engine import format_dispatch_note, start_review
         result = start_review(agent, snapshot, arg or "")
@@ -44,6 +49,9 @@ def _format_live_review_output(sid: str, session: Optional[dict], arg: str) -> s
         return str(exc)
     except Exception as exc:
         return f"/review failed to start: {exc}"
+    finally:
+        _current_runtime_session_record.reset(runtime_token)
+        _clear_session_context(tokens)
     return format_dispatch_note(result, arg or "")
 
 


### PR DESCRIPTION
`/review` typed in the Desktop app (or TUI) now shows its reviewer as a live subagent card in the status stack, with steer/stop, instead of only the "Review started. Results will return here." line.

Reported on X by @b3pl33 ("Where's my /review subagent gone… I like to see what it does").

## Changes

- `tui_gateway/methods_slash.py::_format_live_review_output` binds the same session identity a turn binds (`_set_session_context(..., ui_session_id=sid)` + `_current_runtime_session_record`) around `start_review`, and clears it after.
- `tests/tui_gateway/test_slash_review_owner.py`: one invariant test — the reviewer dispatch sees `HERMES_UI_SESSION_ID == sid` and the request transport as steer authority, and the scope is cleared afterward. Red on `origin/main`, green with the fix.

## Root cause

`slash.exec` runs on the RPC pool outside any turn, so the reviewer's `delegate_task` ran with no `HERMES_UI_SESSION_ID` and no steer authority; `_register_child` stored `owner_session_id=None`, the owner-scoped `subagent.list` returned `[]` for the parent, and the Desktop status stack's 5s snapshot poll reconciled the live `subagent.start` row away.

## Validation

| Surface | Before | After |
|---|---|---|
| Registry record (live, real OpenRouter reviewer) | `owner_session_id=None`, `owner_transport=NoneType` | `owner_session_id=<parent sid>`, `owner_transport=StdioTransport`, `owner_session_record=dict` |
| `subagent.list({session_id: parent})` | `{"subagents": []}` | `[{"goal": "Review recent work", "status": "running", "accepting_steer": true, ...}]` |
| `subagent.*` events on parent sid | emitted (start/thinking/tool/complete) | unchanged |
| `scripts/run_tests.sh tests/tui_gateway/` | — | 1090 passed, 0 failed |

Not yet done: a screenshot of the Desktop card itself (verified at the RPC layer the card reads from; the renderer path is unchanged).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b61d/bbh0zox8tRDnl3Bxjq5bJ_B7XzkMHu.png)
