### PR TITLE
gateway(QQBot): implement stop_typing to cancel stale typing indicator

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1628,6 +1628,28 @@ class QQAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] send_typing failed: %s", self._log_tag, exc)
 
+    async def stop_typing(self, chat_id: str) -> None:
+        """Clear the QQ "typing…" indicator immediately.
+
+        QQ's input_notify with ``input_type=1`` keeps the bubble visible for
+        ``input_second`` seconds even after the agent has replied.  Sending
+        ``input_type=0`` with the same message id cancels it right away so
+        the user doesn't see a stale "typing…" after the response lands.
+        """
+        msg_id = self._last_msg_id.get(chat_id)
+        if not self.is_connected or self._guess_chat_type(chat_id) != "c2c" or not msg_id:
+            return
+        try:
+            body = {
+                "msg_type": MSG_TYPE_INPUT_NOTIFY,
+                "msg_id": msg_id,
+                "input_notify": {"input_type": 0, "input_second": 0},
+                "msg_seq": self._next_msg_seq(chat_id)}
+            await self._api_request("POST", f"/v2/users/{chat_id}/messages", body)
+            self._typing_sent_at.pop(chat_id, None)
+        except Exception as exc:
+            logger.debug("[%s] stop_typing failed: %s", self._log_tag, exc)
+
     # ── Format / chat info / helpers ──
 
     def format_message(self, content: str) -> str:

--- a/tests/gateway/test_qqbot_stop_typing.py
+++ b/tests/gateway/test_qqbot_stop_typing.py
@@ -1,0 +1,108 @@
+"""Tests for the QQBot typing-indicator cancel (stop_typing).
+
+QQ's ``input_notify`` with ``input_type=1`` leaves a 60-second "typing…"
+bubble even after the agent has replied. ``stop_typing`` cancels it with
+``input_type=0`` so the reply doesn't sit under a stale indicator, and it
+clears the send_typing debounce so the next indicator can fire.
+"""
+
+import pytest
+
+from gateway.platforms.qqbot.adapter import QQAdapter, MSG_TYPE_INPUT_NOTIFY
+
+
+class FakeAdapter(QQAdapter):
+    """QQAdapter subclass with the network layer stubbed out."""
+
+    def __init__(self, chat_type="c2c", connected=True, msg_id="m1"):
+        if msg_id:
+            self._last_msg_id = {"u1": msg_id}
+        else:
+            self._last_msg_id = {}
+        self._typing_sent_at = {"u1": 123.0}
+        self._connection = connected
+        self._chat = chat_type
+        self.calls = []
+        self._next_seq = 0
+
+    @property
+    def is_connected(self):
+        return self._connection
+
+    @property
+    def _log_tag(self):
+        return "test"
+
+    def _guess_chat_type(self, chat_id):
+        return self._chat
+
+    def _next_msg_seq(self, chat_id):
+        self._next_seq += 1
+        return self._next_seq
+
+    async def _api_request(self, method, path, body):
+        self.calls.append((method, path, body))
+        return {}
+
+
+class TestStopTyping:
+    @pytest.mark.asyncio
+    async def test_sends_cancel_payload_and_clears_debounce(self):
+        a = FakeAdapter()
+        await a.stop_typing("u1")
+
+        assert len(a.calls) == 1, a.calls
+        method, path, body = a.calls[0]
+        assert method == "POST"
+        assert path == "/v2/users/u1/messages"
+        assert body["msg_type"] == MSG_TYPE_INPUT_NOTIFY
+        assert body["input_notify"] == {"input_type": 0, "input_second": 0}
+        assert body["msg_id"] == "m1"
+        assert body["msg_seq"] == 1
+        # The invite (debounce) must be cleared so a later send_typing fires.
+        assert "u1" not in a._typing_sent_at
+
+    @pytest.mark.asyncio
+    async def test_typing_can_fire_again_after_stop(self):
+        a = FakeAdapter()
+        await a.send_typing("u1")
+        assert len(a.calls) == 1
+        await a.stop_typing("u1")
+        await a.send_typing("u1")
+        assert len(a.calls) == 3, a.calls
+        assert a.calls[1][2]["input_notify"]["input_type"] == 0
+        assert a.calls[2][2]["input_notify"]["input_type"] == 1
+
+    @pytest.mark.asyncio
+    async def test_noop_on_non_c2c(self):
+        a = FakeAdapter(chat_type="group")
+        await a.stop_typing("u1")
+        assert a.calls == []
+
+    @pytest.mark.asyncio
+    async def test_noop_when_disconnected(self):
+        a = FakeAdapter(connected=False)
+        await a.stop_typing("u1")
+        assert a.calls == []
+
+    @pytest.mark.asyncio
+    async def test_noop_without_last_msg_id(self):
+        a = FakeAdapter(msg_id=None)
+        await a.stop_typing("u1")
+        assert a.calls == []
+
+    @pytest.mark.asyncio
+    async def test_api_failure_swallowed(self):
+        class Boom(FakeAdapter):
+            async def _api_request(self, method, path, body):
+                raise RuntimeError("boom")
+
+        a = Boom()
+        await a.stop_typing("u1")  # must not raise
+
+        class BoomSend(FakeAdapter):
+            async def _api_request(self, method, path, body):
+                raise RuntimeError("boom")
+
+        b = BoomSend()
+        await b.send_typing("u1")  # existing behavior, also silent


### PR DESCRIPTION
## Summary

The QQBot adapter's `input_notify` with `input_type=1` leaves a "typing…" bubble
visible for `input_second` (60s) even **after** the reply has been delivered.
The adapter implemented `send_typing` but not `stop_typing`, so every reply
lands under a stale indicator; in frequent conversations it looks like the bot
is permanently "typing".

## Changes

- Implement `stop_typing(chat_id)` on the QQ adapter: send `input_type=0`
  (with the same inbound `msg_id`) to cancel the bubble immediately.
- After a successful cancel, pop `_typing_sent_at[chat_id]` so the next
  `send_typing` is not suppressed by the debounce (`_TYPING_DEBOUNCE_SECONDS`).
- Guards mirror `send_typing`: no-op unless connected, C2C-only, and a
  `msg_id` is present. API errors are swallowed so a cancel failure can never
  break the reply path.

The base handler dispatches to adapter `stop_typing` via
`_stop_typing_with_metadata` after reply delivery, so this plugs into the
existing contract with no base-code changes.

## Tests

`tests/gateway/test_qqbot_stop_typing.py` — behavior-contract tests (strict
asyncio mode):

- cancel payload (`input_type=0`, `input_second=0`) + debounce state cleared
- typing indicator can fire again immediately after a stop
- no-op on non-C2C / disconnected / missing `msg_id`
- API failure swallowed (both send & stop)

All 6 pass; `test_qqbot.py` + `test_qqbot_credential_isolation.py` (70 tests)
still pass.
