### PR TITLE
fix(desktop): SSH remote backend no longer follows the host's sticky active_profile

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -494,6 +494,17 @@ def _under_gateway_supervisor(argv: list) -> bool:
     ).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _desktop_ssh_backend(argv: list) -> bool:
+    """A Desktop-owned ``serve --ssh-session-token-file`` child has a fixed identity too.
+
+    The Desktop client names the remote profile explicitly (``--profile <name>``, or none for
+    the root home). Following the remote host's sticky ``active_profile`` instead silently
+    re-homes the backend into a profile the UI never asked for, so Settings read one
+    ``config.yaml`` and the user edits another (KC's "nothing sticks over SSH").
+    """
+    return "--ssh-session-token-file" in argv
+
+
 def _apply_profile_override() -> None:
     """Pre-parse --profile/-p and set HERMES_HOME before imports."""
     argv = sys.argv[1:]
@@ -508,7 +519,7 @@ def _apply_profile_override() -> None:
     if profile_name is None and hermes_home_env and Path(hermes_home_env).parent.name == "profiles":
         return
 
-    if profile_name is None and not _under_gateway_supervisor(argv):
+    if profile_name is None and not _under_gateway_supervisor(argv) and not _desktop_ssh_backend(argv):
         try:
             from hermes_constants import get_default_hermes_root
 

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -265,6 +265,21 @@ class TestGeneralizedSupervisorMarkers:
         )
         assert result == str(hermes_root)
 
+    def test_desktop_ssh_serve_child_skips_active_profile(self, tmp_path, monkeypatch):
+        """A Desktop-owned `serve --ssh-session-token-file` child names its profile explicitly
+        (or none for the root home); the remote host's sticky active_profile must not re-home
+        it, or Settings read one profile's config.yaml while the user edits another."""
+        hermes_root = self._root_home(tmp_path)
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=str(hermes_root),
+            active_profile="telegram_nick",
+            argv=["hermes", "serve", "--isolated", "--host", "127.0.0.1", "--port", "0",
+                  "--ssh-session-token-file", "/tmp/x/y.token"],
+        )
+        assert result == str(hermes_root)
+
     def test_generated_systemd_unit_exports_supervised_marker(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
Desktop SSH remote backends now run in the profile the app asked for instead of whatever the remote host's sticky `active_profile` file points at, so Settings changes made over SSH land in the config.yaml the UI is reading.

## Context

Desktop "Connect via SSH" spawns `hermes serve --isolated --ssh-session-token-file ... [--profile <remoteProfile>]` on the host (`apps/desktop/electron/remote-lifecycle.ts::buildSpawnCommand`). When the connection has no remote profile the flag is omitted, meaning "root home". But `hermes_cli/main.py::_apply_profile_override` treats a missing flag as "follow the sticky `active_profile` file", so a host where the user once ran `hermes profile use foo` re-homes the Desktop backend into `profiles/foo`. The UI believes it is on the root profile; every read and write goes to a different config.yaml than the one the user inspects. Community thread symptom: "everything about settings and changing models over SSH — most of it does not stick".

## Change

- `_desktop_ssh_backend(argv)`: `--ssh-session-token-file` on the command line marks a fixed-identity child, same class as supervisor-launched gateway children (#74872). The sticky-profile lookup is skipped; an explicit `--profile` still wins.
- 1 invariant test in `tests/hermes_cli/test_apply_profile_override.py`, red on `origin/main`, green here.

## Live repro

Temp `HERMES_HOME=<root>` with `active_profile=foo`, real `hermes serve` process, `/api/status.hermes_home` read back:

| Invocation | before | after |
|---|---|---|
| `serve --isolated --ssh-session-token-file …` (Desktop, root home) | `<root>/profiles/foo` | `<root>` |
| `--profile foo serve --isolated --ssh-session-token-file …` (Desktop, named remote profile) | `<root>/profiles/foo` | `<root>/profiles/foo` |
| `serve` (user CLI, no token file) | `<root>/profiles/foo` | `<root>/profiles/foo` |

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_apply_profile_override.py` — 12 passed (11 on base + new test failing on base).
- `ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`: clean.

## Infographic

![SSH backend keeps the profile you asked for](https://v3b.fal.media/files/b/0aa9b649/bsdzN_Ost9OTQoEucC4yv_rH51ObfZ.png)
