### PR TITLE
fix(auth): hint Codex login SSL EOF middlebox/PQ TLS

### DIFF
--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -212,13 +212,97 @@ def _refresh_payload_access_token(
     return payload, access
 
 
+# OpenSSL 3.5+ may offer PQ hybrid groups (X25519MLKEM768) that some middleboxes
+# drop. Hint-only: Hermes never rewrites OPENSSL_CONF / TLS version / Groups.
+_PQ_MIDDLEBOX_SSL_HINT = (
+    " OpenSSL 3.5+ defaults to post-quantum TLS groups (e.g. X25519MLKEM768 / ML-KEM hybrid). "
+    "Some middleboxes reject the larger TLS 1.3 ClientHello. "
+    "Workaround: set OPENSSL_CONF restricting Groups to classic curves "
+    "(x25519:secp256r1:secp384r1:x448), or diagnose with TLS 1.2. "
+    "Hermes does not auto-rewrite global TLS policy."
+)
+
+
+def _iter_exception_chain(exc: BaseException) -> Iterator[BaseException]:
+    """Yield ``exc`` then ``__cause__`` / ``__context__`` without looping."""
+    seen: set[int] = set()
+    stack: List[BaseException] = [exc]
+    while stack:
+        current = stack.pop()
+        ident = id(current)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        yield current
+        for nxt in (current.__cause__, current.__context__):
+            if nxt is not None:
+                stack.append(nxt)
+
+
+def _pq_middlebox_ssl_failure(exc: BaseException) -> bool:
+    """True when a Codex transport error matches SSL EOF / PQ-middlebox handshake timeout."""
+    import ssl as ssl_mod
+    texts: List[str] = []
+    type_names: List[str] = []
+    ssl_typed = False
+    for err in _iter_exception_chain(exc):
+        texts.append(str(err))
+        type_names.append(type(err).__name__)
+        if isinstance(err, ssl_mod.SSLError):
+            ssl_typed = True
+        lname = type(err).__name__.lower()
+        if "ssl" in lname or "tls" in lname:
+            ssl_typed = True
+    combined = " ".join(texts + type_names)
+    combined_u = combined.upper()
+    combined_l = combined.lower()
+    if "UNEXPECTED_EOF_WHILE_READING" in combined_u:
+        return True
+    if "SSLEOFERROR" in combined_u or "EOF OCCURRED IN VIOLATION OF PROTOCOL" in combined_u:
+        return True
+    if "_ssl.c:" in combined_l and "handshake operation timed out" in combined_l:
+        return True
+    ssl_context = (
+        ssl_typed or "ssl" in combined_l or "tls" in combined_l or "_ssl.c:" in combined_l)
+    return bool(ssl_context and "handshake" in combined_l and "timed out" in combined_l)
+
+
+def _pq_middlebox_ssl_hint(exc: BaseException) -> str:
+    """Return the OPENSSL_CONF / TLS 1.2 workaround hint, or empty (fail-open)."""
+    return _PQ_MIDDLEBOX_SSL_HINT if _pq_middlebox_ssl_failure(exc) else ""
+
+
+def _codex_exc_text(exc: BaseException) -> str:
+    """Keep ``str(exc)``; surface wrapped SSL cause text when httpx hid it."""
+    import ssl as ssl_mod
+    primary = str(exc).strip() or type(exc).__name__
+    for err in _iter_exception_chain(exc):
+        if err is exc:
+            continue
+        extra = str(err).strip()
+        if not extra or extra in primary:
+            continue
+        extra_l = extra.lower()
+        if (
+            isinstance(err, ssl_mod.SSLError)
+            or "ssl" in extra_l or "tls" in extra_l or "_ssl.c:" in extra_l
+        ):
+            return f"{primary} [{extra}]"
+    return primary
+
+
+def _codex_transport_error(exc: BaseException, failure: Tuple[str, str]) -> AuthError:
+    """Shape a device-login transport failure; append PQ/middlebox hint only when matched."""
+    return _codex_err(f"{failure[0]}: {_codex_exc_text(exc)}{_pq_middlebox_ssl_hint(exc)}", failure[1])
+
+
 def _codex_login_post(url: str, *, failure: Tuple[str, str], **kwargs: Any) -> "httpx.Response":
     """One 15s POST for the device-login flow; transport errors become ``_codex_err(*failure)``."""
     try:
         with _codex_http_client(timeout=httpx.Timeout(15.0)) as client:
             return client.post(url, **kwargs)
     except Exception as exc:
-        raise _codex_err(f"{failure[0]}: {exc}", failure[1])
+        raise _codex_transport_error(exc, failure) from exc
 
 
 def _codex_http_client(**kwargs: Any) -> "httpx.Client":
@@ -743,6 +827,11 @@ def _codex_poll_authorization_code(
     except KeyboardInterrupt:
         print("\nLogin cancelled.")
         raise SystemExit(130)
+    except AuthError:
+        raise
+    except Exception as exc:
+        raise _codex_transport_error(
+            exc, ("Device auth polling failed", "device_code_poll_error")) from exc
     if code_resp is None:
         raise _codex_err("Login timed out after 15 minutes.", "device_code_timeout")
     return code_resp

--- a/tests/hermes_cli/test_codex_ssl_middlebox_hint.py
+++ b/tests/hermes_cli/test_codex_ssl_middlebox_hint.py
@@ -1,0 +1,219 @@
+"""Codex device-login SSL EOF / handshake-timeout middlebox+PQ hint (#106384).
+
+OpenSSL 3.5+ may offer X25519MLKEM768; some middleboxes drop the larger TLS 1.3
+ClientHello. Hermes must preserve the underlying SSL error and append a
+workaround hint — never silently force TLS 1.2 or disable PQ globally.
+"""
+
+from __future__ import annotations
+
+import ssl
+
+import httpx
+import pytest
+
+from hermes_cli.auth_codex import (
+    _codex_login_post,
+    _codex_poll_authorization_code,
+    _pq_middlebox_ssl_hint,
+)
+from hermes_cli.auth_constants import AuthError
+
+
+_SSL_EOF_MSG = (
+    "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol "
+    "(_ssl.c:1016)"
+)
+_HANDSHAKE_TIMEOUT_SSL_C = "handshake operation timed out (_ssl.c:997)"
+_PQ_MARKERS = ("OPENSSL_CONF", "X25519MLKEM768", "ML-KEM")
+
+
+def _boom_client(exc: BaseException):
+    def factory(**kwargs):
+        class _Client:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def post(self, *a, **k):
+                raise exc
+
+        return _Client()
+
+    return factory
+
+
+def _assert_pq_hint(msg: str) -> None:
+    assert any(marker in msg for marker in _PQ_MARKERS), msg
+
+
+def _assert_no_pq_hint(msg: str) -> None:
+    assert "OPENSSL_CONF" not in msg
+    assert "X25519MLKEM768" not in msg
+    assert "ML-KEM" not in msg
+    assert "middlebox" not in msg.lower()
+
+
+def test_codex_login_post_appends_pq_middlebox_hint_on_ssl_eof(monkeypatch):
+    class Boom(ssl.SSLError):
+        pass
+
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex._codex_http_client",
+        _boom_client(Boom(1, _SSL_EOF_MSG)),
+    )
+    with pytest.raises(AuthError) as exc_info:
+        _codex_login_post(
+            "https://auth.openai.com/x",
+            failure=("Failed to request device code", "device_code_request_failed"),
+        )
+    msg = str(exc_info.value)
+    assert "UNEXPECTED_EOF_WHILE_READING" in msg
+    _assert_pq_hint(msg)
+    assert exc_info.value.code == "device_code_request_failed"
+
+
+def test_codex_login_post_no_hint_on_plain_connect_error(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex._codex_http_client",
+        _boom_client(httpx.ConnectError("Failed to resolve 'auth.openai.com'")),
+    )
+    with pytest.raises(AuthError) as exc_info:
+        _codex_login_post(
+            "https://auth.openai.com/x",
+            failure=("Failed to request device code", "device_code_request_failed"),
+        )
+    msg = str(exc_info.value)
+    assert "Failed to resolve" in msg
+    _assert_no_pq_hint(msg)
+
+
+def test_codex_login_post_hints_on_ssleoferror_message(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex._codex_http_client",
+        _boom_client(ssl.SSLEOFError(8, "EOF occurred in violation of protocol")),
+    )
+    with pytest.raises(AuthError) as exc_info:
+        _codex_login_post(
+            "https://auth.openai.com/x",
+            failure=("Token exchange failed", "token_exchange_failed"),
+        )
+    msg = str(exc_info.value)
+    assert "EOF occurred in violation of protocol" in msg
+    _assert_pq_hint(msg)
+
+
+def test_codex_login_post_hints_on_ssl_c_handshake_timeout(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex._codex_http_client",
+        _boom_client(ssl.SSLError(1, _HANDSHAKE_TIMEOUT_SSL_C)),
+    )
+    with pytest.raises(AuthError) as exc_info:
+        _codex_login_post(
+            "https://auth.openai.com/x",
+            failure=("Failed to request device code", "device_code_request_failed"),
+        )
+    msg = str(exc_info.value)
+    assert "handshake operation timed out" in msg
+    assert "_ssl.c:" in msg
+    _assert_pq_hint(msg)
+
+
+def test_codex_login_post_hints_on_wrapped_httpx_ssl_eof(monkeypatch):
+    ssl_err = ssl.SSLError(1, _SSL_EOF_MSG)
+    wrapped = httpx.ConnectError("Connection failed")
+    wrapped.__cause__ = ssl_err
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex._codex_http_client",
+        _boom_client(wrapped),
+    )
+    with pytest.raises(AuthError) as exc_info:
+        _codex_login_post(
+            "https://auth.openai.com/x",
+            failure=("Failed to request device code", "device_code_request_failed"),
+        )
+    msg = str(exc_info.value)
+    assert "UNEXPECTED_EOF_WHILE_READING" in msg or "Connection failed" in msg
+    _assert_pq_hint(msg)
+
+
+def test_codex_login_post_no_hint_on_ambiguous_timeout(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex._codex_http_client",
+        _boom_client(httpx.ConnectTimeout("timed out")),
+    )
+    with pytest.raises(AuthError) as exc_info:
+        _codex_login_post(
+            "https://auth.openai.com/x",
+            failure=("Failed to request device code", "device_code_request_failed"),
+        )
+    _assert_no_pq_hint(str(exc_info.value))
+
+
+def test_codex_poll_ssl_eof_shaped_through_transport_helper(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex._codex_http_client",
+        _boom_client(ssl.SSLError(1, _SSL_EOF_MSG)),
+    )
+    monkeypatch.setattr("hermes_cli.auth_codex.time.sleep", lambda *_a, **_k: None)
+    with pytest.raises(AuthError) as exc_info:
+        _codex_poll_authorization_code(
+            "https://auth.openai.com",
+            device_auth_id="dev",
+            user_code="CODE",
+            poll_interval=0,
+        )
+    msg = str(exc_info.value)
+    assert "UNEXPECTED_EOF_WHILE_READING" in msg
+    _assert_pq_hint(msg)
+    assert exc_info.value.code == "device_code_poll_error"
+
+
+def test_codex_poll_http_status_error_has_no_pq_hint(monkeypatch):
+    class _Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, *a, **k):
+            return httpx.Response(500, request=httpx.Request("POST", "https://auth.openai.com/x"))
+
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex._codex_http_client",
+        lambda **kwargs: _Client(),
+    )
+    monkeypatch.setattr("hermes_cli.auth_codex.time.sleep", lambda *_a, **_k: None)
+    with pytest.raises(AuthError) as exc_info:
+        _codex_poll_authorization_code(
+            "https://auth.openai.com",
+            device_auth_id="dev",
+            user_code="CODE",
+            poll_interval=0,
+        )
+    msg = str(exc_info.value)
+    assert "status 500" in msg
+    _assert_no_pq_hint(msg)
+    assert exc_info.value.code == "device_code_poll_error"
+
+
+def test_pq_hint_on_sslerror_handshake_timed_out_without_ssl_c():
+    hint = _pq_middlebox_ssl_hint(ssl.SSLError("TLS handshake timed out"))
+    assert hint
+    _assert_pq_hint(hint)
+    assert "x25519:secp256r1:secp384r1:x448" in hint
+    assert "does not auto-rewrite" in hint
+
+
+def test_pq_hint_absent_on_cert_verify_failed():
+    hint = _pq_middlebox_ssl_hint(
+        ssl.SSLCertVerificationError("CERTIFICATE_VERIFY_FAILED"))
+    assert hint == ""
+
+
+def test_pq_hint_absent_on_plain_oserror():
+    hint = _pq_middlebox_ssl_hint(OSError("[Errno 8] nodename nor servname provided"))
+    assert hint == ""

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -93,6 +93,8 @@ Don't have a subscription yet? Get one at [portal.nousresearch.com/manage-subscr
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
 
 If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add openai-codex` (or `hermes model` → **ChatGPT or Codex Subscription**) to start a fresh device-code login; the quarantine clears on the next successful exchange.
+
+Device login can fail with `[SSL: UNEXPECTED_EOF_WHILE_READING]` or a TLS handshake timeout on Python/OpenSSL 3.5+ when a middlebox rejects post-quantum groups such as X25519MLKEM768 (curl may still work). Hermes does not change default TLS policy. Point `OPENSSL_CONF` at a config that restricts `Groups` to classic curves (`x25519:secp256r1:secp384r1:x448`), or diagnose with TLS 1.2.
 :::
 
 :::warning


### PR DESCRIPTION
## What does this PR do?

Codex device login can fail with `UNEXPECTED_EOF_WHILE_READING` / SSL handshake timeout on Python/OpenSSL 3.5+ when middleboxes reject post-quantum TLS groups (e.g. `X25519MLKEM768`). Hermes already preserved the raw transport error; this PR appends an actionable OPENSSL_CONF / TLS 1.2 diagnostic hint **only** when those SSL markers match, and documents the workaround. Default TLS policy is unchanged.

## Related Issue

Fixes #106384

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `hermes_cli/auth_codex.py`: detect PQ/middlebox SSL EOF / handshake-timeout shapes on `_codex_login_post` and `_codex_poll_authorization_code`; append OPENSSL_CONF classic-Groups / TLS 1.2 hint; fail-open for non-SSL errors
- `tests/hermes_cli/test_codex_ssl_middlebox_hint.py` (new): RED/GREEN coverage for hint + fail-open cases
- `website/docs/integrations/providers.md`: Codex note documenting the middlebox/PQ interoperability failure

## How to Test

```
# focused suite (PR head)
scripts/run_tests.sh tests/hermes_cli/test_codex_ssl_middlebox_hint.py
  -> 11 passed

# adjacent suite
scripts/run_tests.sh tests/hermes_cli/test_auth_codex_provider.py
  -> 11 passed
```

Pre-fix RED (same probes without the helper): 5 failed (missing hint / raw poll SSL), 3 fail-open already green.

## Review follow-up

- Hint-only: does **not** force TLS 1.2, disable PQ groups, set `OPENSSL_CONF`, or `verify=False`.
- Independent code-review P0=0 (auth path triggered review).
- Optional `hermes doctor` dual-TLS probe from the issue was deferred; login error surfacing is the contract.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(auth): ...`)
- [x] Searched existing PRs for duplicates
- [x] Only changes related to this fix
- [x] Ran relevant tests locally
- [x] Added tests for the change
- [x] Tested on: macOS (darwin)

### Documentation & Housekeeping
- [x] Updated relevant documentation
- [x] cli-config.yaml.example — N/A
- [x] Cross-platform impact considered (hint text only)
- [x] Tool descriptions/schemas — N/A


Made with [Cursor](https://cursor.com)