### PR TITLE
fix(auth): Desktop-saved LM Studio key no longer ignored — model.key_env honored for registry providers (#106336)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -345,6 +345,25 @@ def _usable_declared_secret(provider_id: str, value: Any, source: str) -> Option
     return val
 
 
+def _model_level_key_env(provider_id: str) -> str:
+    """``model.key_env`` when config.yaml's main model targets *provider_id*, else ``""``.
+
+    The Desktop settings UI saves registry-provider keys as a credential pointer
+    (``model.key_env`` → ``$HERMES_HOME/.env``) instead of the registry's canonical env var,
+    so credential resolution must consult it (#106336).
+    """
+    try:
+        from hermes_cli.config import load_config
+        model_cfg = (load_config() or {}).get("model")
+    except Exception:
+        return ""
+    if not isinstance(model_cfg, dict):
+        return ""
+    if str(model_cfg.get("provider") or "").strip().lower() != provider_id:
+        return ""
+    return str(model_cfg.get("key_env") or model_cfg.get("api_key_env") or "").strip()
+
+
 def _resolve_api_key_provider_secret(provider_id: str, pconfig: ProviderConfig) -> tuple[str, str]:
     """Resolve an API-key provider's token and indicate where it came from."""
     if provider_id == "copilot":
@@ -364,6 +383,17 @@ def _resolve_api_key_provider_secret(provider_id: str, pconfig: ProviderConfig) 
     # Prefer ~/.hermes/.env over os.environ so a deliberate key rotation in .env isn't shadowed by
     # a stale shell export inherited from a parent process (Codex CLI, test runners, etc.).
     from hermes_cli.config import get_env_value_prefer_dotenv
+
+    # Desktop-saved credential pointer: the settings UI persists registry-provider keys as
+    # model.key_env → $HERMES_HOME/.env (e.g. HERMES_CUSTOM_LMSTUDIO_API_KEY) while keeping
+    # model.provider on the registry id, so the pointer must be honored here or the UI-saved
+    # key is silently ignored and lmstudio falls through to its no-auth placeholder (#106336).
+    key_env = _model_level_key_env(provider_id)
+    if key_env:
+        val = _usable_declared_secret(provider_id, get_env_value_prefer_dotenv(key_env), key_env)
+        if val:
+            return val, key_env
+
     for env_var in pconfig.api_key_env_vars:
         val = _usable_declared_secret(provider_id, get_env_value_prefer_dotenv(env_var), env_var)
         if val:

--- a/tests/hermes_cli/test_auth_model_key_env.py
+++ b/tests/hermes_cli/test_auth_model_key_env.py
@@ -1,0 +1,60 @@
+"""Regression tests for #106336: Desktop-saved registry-provider credentials.
+
+The Desktop settings UI persists a registry provider's API key as a credential
+pointer — ``model.key_env`` in config.yaml → the env var in ``$HERMES_HOME/.env``
+(e.g. ``HERMES_CUSTOM_LMSTUDIO_API_KEY``) — while keeping ``model.provider`` on
+the registry id. Before the fix, ``_resolve_api_key_provider_secret`` consulted
+only ``PROVIDER_REGISTRY[...].api_key_env_vars``, silently ignored the UI-saved
+key, and lmstudio fell through to its no-auth placeholder (``dummy-lm-api-key``),
+producing an opaque 401 against auth-enabled LM Studio servers.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("LM_API_KEY", raising=False)
+    monkeypatch.delenv("HERMES_CUSTOM_LMSTUDIO_API_KEY", raising=False)
+    return home
+
+
+def _write(home: Path, config: str, env: str) -> None:
+    (home / "config.yaml").write_text(config, encoding="utf-8")
+    (home / ".env").write_text(env, encoding="utf-8")
+
+
+def test_model_key_env_pointer_is_honored_for_registry_provider(hermes_home):
+    _write(
+        hermes_home,
+        "model:\n  default: some-model\n  provider: lmstudio\n"
+        "  base_url: http://127.0.0.1:1234/v1\n"
+        "  key_env: HERMES_CUSTOM_LMSTUDIO_API_KEY\n",
+        "HERMES_CUSTOM_LMSTUDIO_API_KEY=sk-lm-desktop-saved\n",
+    )
+    from hermes_cli.auth import resolve_api_key_provider_credentials
+
+    creds = resolve_api_key_provider_credentials("lmstudio")
+    assert creds["api_key"] == "sk-lm-desktop-saved"
+    assert creds["source"] == "HERMES_CUSTOM_LMSTUDIO_API_KEY"
+
+
+def test_model_key_env_does_not_leak_across_providers(hermes_home):
+    # model targets a DIFFERENT provider: its key_env must not be consulted for
+    # lmstudio, which falls back to its documented no-auth placeholder.
+    _write(
+        hermes_home,
+        "model:\n  default: gpt-x\n  provider: openai\n"
+        "  key_env: HERMES_CUSTOM_LMSTUDIO_API_KEY\n",
+        "HERMES_CUSTOM_LMSTUDIO_API_KEY=sk-lm-should-not-leak\n",
+    )
+    from hermes_cli.auth import LMSTUDIO_NOAUTH_PLACEHOLDER, resolve_api_key_provider_credentials
+
+    creds = resolve_api_key_provider_credentials("lmstudio")
+    assert creds["api_key"] == LMSTUDIO_NOAUTH_PLACEHOLDER


### PR DESCRIPTION
UI-saved LM Studio (and any registry-provider) API keys are now actually sent — the Desktop's `model.key_env` credential pointer is honored instead of silently falling back to the no-auth placeholder.

## Symptom
Save an API key for the built-in **LM Studio** provider in Hermes Desktop → Desktop writes `model.key_env: HERMES_CUSTOM_LMSTUDIO_API_KEY` + the key into `$HERMES_HOME/.env`, but the runtime resolves registry providers only from `PROVIDER_REGISTRY[...].api_key_env_vars` (`LM_API_KEY`). The saved key is ignored, the `dummy-lm-api-key` no-auth sentinel is sent, and auth-enabled LM Studio servers reject every request:

```
HTTP 401: Malformed LM Studio API token provided: dummy-lm-a******
layer: provider, provider: lmstudio, retryable: true
```

## Root cause
`hermes_cli/auth.py::_resolve_api_key_provider_secret` never consulted the model-level `key_env` pointer the Desktop save path writes (`hermes_cli/web_routers/config_env.py::_apply_main_model_assignment` carry, `web_server_config.py::_resolve_assignment_credentials`).

## Change
- New `_model_level_key_env(provider_id)`: returns `model.key_env` **only when config.yaml's main model targets the provider being resolved** (no cross-provider leak), accepting the documented `api_key_env` alias.
- `_resolve_api_key_provider_secret` consults it first, through the same `_usable_declared_secret` prefix validation (#93593 semantics preserved). Canonical env vars and credential-pool precedence unchanged.
- Fixes the class: any registry provider whose key Desktop saved via the pointer convention, not just lmstudio.

Complements #75373 (provider-level `providers.<id>.key_env`); that PR does not read the model-level pointer the Desktop actually writes (noted by @gaoanze888 on the issue).

## Validation
**Live repro:** on `origin/main` (d0df324862c), temp `HERMES_HOME` with the exact config/.env from the report → `resolve_api_key_provider_credentials("lmstudio")` returns `api_key=dummy-lm-api-key, source=default` (bug fires). After the fix, same harness → `api_key=sk-lm-…​, source=HERMES_CUSTOM_LMSTUDIO_API_KEY`; negative cases: pointer on a different provider does **not** leak (placeholder preserved), canonical `LM_API_KEY` still wins when no pointer is set.

- 2 invariant tests (`tests/hermes_cli/test_auth_model_key_env.py`), red on base.
- `scripts/run_tests.sh` over the touched-symbol test files: 250 passed, 0 failed.
- ruff, windows-footguns, compat-pointer checks clean.

Fixes #106336

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b6a0/Ik9UAFXM7nn-g6vgshO8A_SmJYflGq.png)
