### PR TITLE
fix(agent): surface provider error codes in API error summaries

### DIFF
--- a/agent/api_error_summary.py
+++ b/agent/api_error_summary.py
@@ -123,6 +123,26 @@ class ApiErrorSummaryMixin:
         return str(value)
 
     @staticmethod
+    def _error_code_suffix(body: dict) -> str:
+        """``[code 1305] `` prefix from a structured provider error body, else ``''``.
+
+        z.ai/Z.AI-style providers put a machine-readable numeric code (e.g. 1302 rate
+        limit, 1305 overloaded, 1316 5h usage window) next to ``error.message``. Without
+        it, every 429 renders identically and operators can't tell a concurrency cap
+        from a quota window with a ``next_flush_time``. Only surface short scalar codes
+        — never dicts/lists (Anthropic nests ``type`` objects there).
+        """
+        for source in (body.get("error") if isinstance(body.get("error"), dict) else None, body):
+            if not isinstance(source, dict):
+                continue
+            code = source.get("code")
+            if isinstance(code, (str, int)) and str(code).strip():
+                text = str(code).strip()
+                if len(text) <= 24 and not text.startswith("<"):
+                    return f"[code {text}] "
+        return ""
+
+    @staticmethod
     def _summarize_api_error(error: Exception) -> str:
         """Extract a human-readable one-liner from an API error.
 
@@ -164,10 +184,12 @@ class ApiErrorSummaryMixin:
         # JSON body errors from OpenAI/Anthropic SDKs
         body = getattr(error, "body", None)
         if isinstance(body, dict):
-            msg = body.get("error", {}).get("message") if isinstance(body.get("error"), dict) else body.get("message")
+            error_obj = body.get("error") if isinstance(body.get("error"), dict) else {}
+            msg = error_obj.get("message") if error_obj else body.get("message")
             if msg:
                 msg = ApiErrorSummaryMixin._coerce_api_error_detail(msg)
-                return ApiErrorSummaryMixin._decorate_xai_entitlement_error(f"{prefix}{msg[:300]}")
+                code = ApiErrorSummaryMixin._error_code_suffix(error_obj or body)
+                return ApiErrorSummaryMixin._decorate_xai_entitlement_error(f"{prefix}{code}{msg[:300]}")
 
         # SDK may leave body empty while httpx has the payload. Redact: the body is attacker-influenced
         # and may echo Authorization / x-api-key / request JSON.
@@ -188,9 +210,11 @@ class ApiErrorSummaryMixin:
                 if isinstance(payload, dict):
                     err = payload.get("error")
                     if isinstance(err, dict) and err.get("message"):
-                        return redact_sensitive_text(f"{prefix}{str(err['message'])[:300]}")
+                        code = ApiErrorSummaryMixin._error_code_suffix(payload)
+                        return redact_sensitive_text(f"{prefix}{code}{str(err['message'])[:300]}")
                     if payload.get("message"):
-                        return redact_sensitive_text(f"{prefix}{str(payload['message'])[:300]}")
+                        code = ApiErrorSummaryMixin._error_code_suffix(payload)
+                        return redact_sensitive_text(f"{prefix}{code}{str(payload['message'])[:300]}")
                 return redact_sensitive_text(f"{prefix}{snippet[:300]}")
 
         # Fallback: truncate the raw string but give more room than 200 chars


### PR DESCRIPTION
## Problem

Providers like Z.AI/GLM return a machine-readable numeric code next to `error.message` in 429 bodies:

- `1302` — rate limit reached for requests
- `1305` — service temporarily overloaded
- `1316`–`1321` — usage-window limits, **with a `next_flush_time` reset timestamp in the message**

`AIAgent._summarize_api_error()` extracts only `error.message`, so every 429 renders identically (`HTTP 429: The service may be temporarily overloaded`). Operators reading subagent/delegation failure summaries, halt reports, or cron tick reports cannot tell a concurrency cap (retry with backoff) from a quota window (wait until flush time) — the distinction the provider explicitly encodes in the code.

The classifier already reads `error.code` internally (`_by_error_code` in `agent/error_classifier.py`) — this just stops discarding it at the rendering step.

## Change

- New `_error_code_suffix()` helper on `ApiErrorSummaryMixin`: renders `[code NNNN] ` from structured bodies, **short scalar codes only** (≤24 chars, no `<`-prefixed HTML) so Anthropic-style nested dict `type` objects never leak into the one-liner.
- Applied in both extraction paths: the SDK `error.body` dict and the httpx `error.response.text` fallback (after `redact_sensitive_text`, same as before).

## Behavior

| Body | Before | After |
|---|---|---|
| z.ai `{error:{code:"1305",message:"…temporarily overloaded…"}}` | `HTTP 429: The service may be temporarily overloaded…` | `HTTP 429: [code 1305] The service may be temporarily overloaded…` |
| z.ai usage window (`1316`) | `HTTP 429: Usage limit reached for the past 5 hours…` | `HTTP 429: [code 1316] Usage limit reached for the past 5 hours. Resets at …` |
| OpenAI shape (no code) | unchanged | unchanged |
| Anthropic nested `code:{type:…}` | unchanged | unchanged |

## Testing

- Live-verified against real z.ai error shapes (constructor-level probes of `_summarize_api_error`).
- Existing suites pass: `tests/run_agent/test_summarize_api_error.py`, `test_nonretryable_error_html_summary.py`, `tests/agent/test_gemini_standard_key_guidance.py`, `tests/run_agent/test_codex_xai_oauth_recovery.py`, `tests/test_transform_api_error_classification_hook.py` — 46/46.
- Rebased on current `origin/main` before opening; tests re-run post-rebase.