### PR TITLE
fix(cli): keep SSL detail and add middlebox hint on Codex device-login transport errors

### DIFF
--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -212,13 +212,33 @@ def _refresh_payload_access_token(
     return payload, access
 
 
+_SSL_TROUBLE_MARKERS = ("[SSL:", "_ssl.c")
+
+
+def _ssl_interop_hint(exc: BaseException) -> str:
+    """Actionable hint for device-login transport errors that look like TLS middlebox interference.
+
+    OpenSSL 3.5+ advertises post-quantum hybrid groups (e.g. X25519MLKEM768) by default, and some
+    intercepting middleboxes reject the resulting larger TLS 1.3 ClientHello — while curl, using a
+    different TLS stack, still works, so the failure masquerades as a Codex outage (#106384).
+    """
+    if not any(marker in str(exc) for marker in _SSL_TROUBLE_MARKERS):
+        return ""
+    return (
+        " This looks like a TLS handshake failure rather than a Codex outage: some networks reject"
+        " the larger TLS 1.3 ClientHello that OpenSSL 3.5+ sends by default (post-quantum hybrid"
+        " groups). As a workaround, point OPENSSL_CONF at a config restricting Groups to classic"
+        " curves (x25519:secp256r1:secp384r1:x448) — see #106384 for details."
+    )
+
+
 def _codex_login_post(url: str, *, failure: Tuple[str, str], **kwargs: Any) -> "httpx.Response":
     """One 15s POST for the device-login flow; transport errors become ``_codex_err(*failure)``."""
     try:
         with _codex_http_client(timeout=httpx.Timeout(15.0)) as client:
             return client.post(url, **kwargs)
     except Exception as exc:
-        raise _codex_err(f"{failure[0]}: {exc}", failure[1])
+        raise _codex_err(f"{failure[0]}: {exc}{_ssl_interop_hint(exc)}", failure[1]) from exc
 
 
 def _codex_http_client(**kwargs: Any) -> "httpx.Client":
@@ -729,10 +749,15 @@ def _codex_poll_authorization_code(
         with _codex_http_client(timeout=httpx.Timeout(15.0)) as client:
             while time.monotonic() - start < max_wait:
                 time.sleep(poll_interval)
-                poll_resp = client.post(
-                    f"{issuer}/api/accounts/deviceauth/token",
-                    json={"device_auth_id": device_auth_id, "user_code": user_code},
-                    headers={"Content-Type": "application/json"})
+                try:
+                    poll_resp = client.post(
+                        f"{issuer}/api/accounts/deviceauth/token",
+                        json={"device_auth_id": device_auth_id, "user_code": user_code},
+                        headers={"Content-Type": "application/json"})
+                except Exception as exc:
+                    raise _codex_err(
+                        f"Device auth polling request failed: {exc}{_ssl_interop_hint(exc)}",
+                        "device_code_poll_error") from exc
                 if poll_resp.status_code == 200:
                     code_resp = poll_resp.json()
                     break

--- a/tests/hermes_cli/test_codex_device_login_ssl_hint.py
+++ b/tests/hermes_cli/test_codex_device_login_ssl_hint.py
@@ -1,0 +1,85 @@
+"""Regression tests: Codex device-login transport errors keep the underlying SSL detail.
+
+On networks whose middlebox rejects the larger TLS 1.3 ClientHello that OpenSSL 3.5+ sends
+(post-quantum hybrid groups), every device-login HTTP call dies with ``SSLEOFError`` /
+handshake timeouts while curl still works (#106384). Previously:
+
+* ``_codex_login_post`` swallowed the exception chain (no ``from exc``) and gave no hint;
+* the polling loop let the raw ``httpx`` error escape with no ``AuthError`` shaping at all.
+
+Both paths must keep the original SSL text, chain the cause, and append the OPENSSL_CONF
+workaround hint so the failure stops masquerading as a Codex outage.
+"""
+
+import httpx
+import pytest
+
+from hermes_cli import auth_codex
+from hermes_cli.auth import AuthError
+
+
+_SSL_EOF_MESSAGE = (
+    "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1016)")
+
+
+class _RaisingClient:
+    """Context-manager httpx.Client stand-in whose ``post`` always raises *exc*."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def post(self, url, **kwargs):
+        raise self._exc
+
+
+def _patch_client(monkeypatch, exc: BaseException) -> None:
+    monkeypatch.setattr(auth_codex, "_codex_http_client", lambda **kwargs: _RaisingClient(exc))
+
+
+def test_login_post_ssl_error_keeps_detail_and_hint(monkeypatch):
+    _patch_client(monkeypatch, httpx.ConnectError(_SSL_EOF_MESSAGE))
+
+    with pytest.raises(AuthError) as excinfo:
+        auth_codex._codex_login_post(
+            "https://auth.openai.com/api/accounts/deviceauth/usercode",
+            failure=("Failed to request device code", "device_code_request_failed"))
+
+    err = excinfo.value
+    assert err.code == "device_code_request_failed"
+    assert _SSL_EOF_MESSAGE in str(err)
+    assert "OPENSSL_CONF" in str(err)
+    assert "#106384" in str(err)
+    # ``raise ... from exc`` keeps the underlying transport error inspectable.
+    assert isinstance(err.__cause__, httpx.ConnectError)
+
+
+def test_login_post_non_ssl_error_has_no_interop_hint(monkeypatch):
+    _patch_client(monkeypatch, httpx.ConnectError("Connection refused"))
+
+    with pytest.raises(AuthError) as excinfo:
+        auth_codex._codex_login_post(
+            "https://auth.openai.com/api/accounts/deviceauth/usercode",
+            failure=("Failed to request device code", "device_code_request_failed"))
+
+    assert "Connection refused" in str(excinfo.value)
+    assert "OPENSSL_CONF" not in str(excinfo.value)
+
+
+def test_poll_authorization_code_ssl_error_surfaced_as_auth_error(monkeypatch):
+    _patch_client(monkeypatch, httpx.ConnectError(_SSL_EOF_MESSAGE))
+
+    with pytest.raises(AuthError) as excinfo:
+        auth_codex._codex_poll_authorization_code(
+            "https://auth.openai.com", device_auth_id="da", user_code="uc", poll_interval=0)
+
+    err = excinfo.value
+    assert err.code == "device_code_poll_error"
+    assert _SSL_EOF_MESSAGE in str(err)
+    assert "OPENSSL_CONF" in str(err)
+    assert isinstance(err.__cause__, httpx.ConnectError)


### PR DESCRIPTION
## What does this PR do?

On networks whose middlebox rejects the larger TLS 1.3 ClientHello that OpenSSL 3.5+ sends by default (post-quantum hybrid groups such as X25519MLKEM768), the Codex device login fails with `SSLEOFError` / handshake timeouts while curl against the same host still works — so the failure masquerades as a Codex outage and is very hard to diagnose. This PR makes both device-login transport paths preserve the underlying SSL error and point the user at the workaround:

- `_codex_login_post` (user-code request + token exchange) now re-raises with `from exc` so the exception chain is kept, and appends an interoperability hint when the transport error text looks SSL-shaped.
- `_codex_poll_authorization_code` previously let the raw `httpx` error escape with no `AuthError` shaping at all; the poll POST is now wrapped so transport failures surface as a shaped `AuthError` (`device_code_poll_error`) that carries the SSL detail and the hint.

The hint only triggers on SSL-shaped errors (`[SSL:` / `_ssl.c` markers in the message) and suggests pointing `OPENSSL_CONF` at a config restricting Groups to classic curves — the workaround verified in the issue.

## Related Issue

Fixes #106384

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth_codex.py`: added `_ssl_interop_hint()` helper (`_SSL_TROUBLE_MARKERS` detection + OPENSSL_CONF hint referencing #106384)
- `hermes_cli/auth_codex.py`: `_codex_login_post` — added `from exc` and appended the hint to the failure message
- `hermes_cli/auth_codex.py`: `_codex_poll_authorization_code` — wrapped the poll POST so transport errors become a shaped `AuthError` with the same treatment; `KeyboardInterrupt` handling is unchanged (it is a `BaseException`, not caught by the new `except Exception`)
- `tests/hermes_cli/test_codex_device_login_ssl_hint.py`: new regression tests (3)

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_codex_device_login_ssl_hint.py -q` — Observed result: 3 passed.
2. Verify the tests fail without the fix (RED receipt): stash the `hermes_cli/auth_codex.py` change and re-run — Observed result: 2 failed (the poll path raises a bare `httpx.ConnectError`, the login-post path lacks the hint/cause), 1 passed (the negative no-hint case).
3. Run the neighboring Codex auth suites: `python -m pytest tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_codex_quota_probe.py tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_auth_commands.py -q` — Observed result: 45 passed.
4. Ruff: `ruff check hermes_cli/auth_codex.py tests/hermes_cli/test_codex_device_login_ssl_hint.py` — Observed result: all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (hint text is self-contained; docstrings added on the new helper)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (error-message shaping only; no platform-specific code paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A