### PR TITLE
fix(mcp): identify hermes-agent in the MCP handshake clientInfo (salvage #70074, Copilot CLI 1.0.84-2 parity)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2399,6 +2399,23 @@ class TestSessionKwargs:
         assert "sampling_capabilities" in kwargs
         assert kwargs["sampling_callback"] is handler
 
+    def test_session_kwargs_carry_hermes_client_identity(self):
+        """ClientSession kwargs identify hermes-agent at its shipped version, not the SDK default."""
+        from tools.mcp_tool import MCPServerTask, _ensure_mcp_sdk
+        if not _ensure_mcp_sdk():
+            pytest.skip("mcp SDK not installed")
+        from hermes_cli import __version__ as hermes_version
+        kwargs = MCPServerTask("identity_test")._session_kwargs()
+        assert kwargs["client_info"].name == "hermes-agent"
+        assert kwargs["client_info"].version == hermes_version
+
+    def test_session_kwargs_omit_client_info_without_sdk_type(self, monkeypatch):
+        """SDK builds without mcp.types.Implementation get no client_info key (no NameError)."""
+        from tools import mcp_tool_transport
+        monkeypatch.setattr(mcp_tool_transport, "_hermes_client_info", lambda: None)
+        from tools.mcp_tool import MCPServerTask
+        assert "client_info" not in MCPServerTask("no_type_test")._session_kwargs()
+
 # ---------------------------------------------------------------------------
 # 14. MCPServerTask integration
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -21,6 +21,18 @@ _PROBE_INITIALIZE_BODY = (  # JSON-RPC ``initialize`` body for the content-type 
     '"capabilities":{},"clientInfo":{"name":"hermes-probe","version":"0.1"}}}')
 
 
+def _hermes_client_info():
+    """``Implementation(name="hermes-agent", version=<shipped version>)`` for the MCP handshake, or
+    ``None`` on SDK builds without the type. Without this, servers that key behavior or logs on
+    ``clientInfo`` see the SDK default ("mcp"/"0.1.0") instead of who is actually connecting."""
+    try:
+        from mcp.types import Implementation
+    except ImportError:
+        return None
+    from hermes_cli import __version__ as hermes_version
+    return Implementation(name="hermes-agent", version=hermes_version)
+
+
 def _content_type_base(resp) -> str:
     """``content-type`` header of *resp* without parameters, lowercased."""
     return resp.headers.get("content-type", "").split(";")[0].strip().lower()
@@ -62,7 +74,7 @@ class MCPServerTransportMixin:
         return caps is None or getattr(caps, "tools", None) is not None
 
     def _session_kwargs(self) -> dict:
-        """ClientSession kwargs: sampling, elicitation, notification + logging callbacks."""
+        """ClientSession kwargs: client identity, sampling, elicitation, notification + logging callbacks."""
         kwargs = {}
         for handler in (self._sampling, self._elicitation):
             if handler:
@@ -71,6 +83,9 @@ class MCPServerTransportMixin:
             kwargs["message_handler"] = self._make_message_handler()
         if _core._MCP_LOGGING_CALLBACK_SUPPORTED:
             kwargs["logging_callback"] = self._make_logging_callback()
+        client_info = _hermes_client_info()
+        if client_info is not None and _core._client_session_accepts("client_info"):
+            kwargs["client_info"] = client_info
         return kwargs
 
     async def _negotiate_session(self, session, connect_timeout: float):


### PR DESCRIPTION
MCP servers now see **`hermes-agent/<shipped version>`** in the handshake `clientInfo` instead of the python SDK's default identity.

## What changed
- `tools/mcp_tool_transport.py`: `_session_kwargs()` — the single seam every transport (stdio, streamable HTTP, SSE) builds its `ClientSession` from — now includes `client_info=Implementation(name="hermes-agent", version=hermes_cli.__version__)`, gated on the SDK exporting the type AND `ClientSession` accepting the kwarg (older SDK builds are unaffected).
- 2 invariant tests: identity matches the shipped version; no `client_info` key (and no crash) when the SDK type is unavailable.

## Why
Server logs, policy engines, and MCP dashboards attribute sessions by `clientInfo`. Before this, every Hermes connection reported the SDK default — indistinguishable from any other python MCP client and carrying a bogus version.

Source inspiration: GitHub Copilot CLI v1.0.84-2 shipped the same fix — "MCP servers now see the same copilot-cli client identity when you add a server and when a session connects, carrying the shipped CLI version instead of 0.0.0."

## Validation
| Check | Result |
|---|---|
| Live: `MCPServerTask("x")._session_kwargs()` after SDK load | `client_info` → `hermes-agent 0.21.1` |
| `scripts/run_tests.sh` tests/tools/test_mcp_tool*.py (3 files) | 119 passed, 0 failed |
| ruff / windows-footguns / compat pointers | clean |

## Credit
Salvages #70074 by @yulunz (authorship preserved). The original targeted pre-decomposition `tools/mcp_tool.py`; this relocates the change onto the transport sibling where `ClientSession` kwargs are actually built, and adds the `_client_session_accepts("client_info")` guard for older SDKs.

Closes #70074's scope once merged (leaving the original PR for the maintainer to close with credit).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b6a0/ed9PVtwGYDp46ABeEGqMT_ZCLgZJwQ.png)
