### PR TITLE
fix(google-workspace): tabbed Google Docs read every tab and append to the right one (port cloudflare-os#450)

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -276,8 +276,9 @@ $GAPI sheets append SHEET_ID "Sheet1!A:C" --values '[["new","row","data"]]'
 ### Docs
 
 ```bash
-# Read
+# Read (a tabbed Doc returns a "tabs" array; single-tab and legacy Docs also return "body")
 $GAPI docs get DOC_ID
+$GAPI docs get DOC_ID --tab TAB_ID     # read one tab of a tabbed Doc
 
 # Create a new Doc (optionally seeded with body text)
 $GAPI docs create --title "Meeting Notes"
@@ -285,6 +286,7 @@ $GAPI docs create --title "Draft" --body "First paragraph..."
 
 # Append text to the end of an existing Doc
 $GAPI docs append DOC_ID --text "Additional content to append"
+$GAPI docs append DOC_ID --tab TAB_ID --text "..."   # --tab required when the Doc has multiple tabs
 ```
 
 ## Output Format

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -154,15 +154,79 @@ def _extract_message_body(msg: dict) -> str:
     return body
 
 
-def _extract_doc_text(doc: dict) -> str:
+def _extract_body_text(body: dict) -> str:
     text_parts = []
-    for element in doc.get("body", {}).get("content", []):
+    for element in body.get("content", []):
         paragraph = element.get("paragraph", {})
         for pe in paragraph.get("elements", []):
             text_run = pe.get("textRun", {})
             if text_run.get("content"):
                 text_parts.append(text_run["content"])
     return "".join(text_parts)
+
+
+def _extract_doc_text(doc: dict) -> str:
+    return _extract_body_text(doc.get("body", {}))
+
+
+def _flatten_doc_tabs(doc: dict) -> list[dict]:
+    """Flatten Google's recursive ``tabs``/``childTabs`` tree (preorder).
+
+    A tabbed Doc keeps each tab's content in its own body with an independent
+    index space; the legacy top-level ``body`` only carries the first tab, so
+    reads and writes that ignore ``tabs`` silently drop or mistarget content.
+    Returns [] for the legacy single-body response shape (no ``tabs`` field).
+    """
+    flat: list[dict] = []
+
+    def visit(tabs, level):
+        for tab in tabs or []:
+            props = tab.get("tabProperties") or {}
+            doc_tab = tab.get("documentTab") or {}
+            flat.append({
+                "tabId": props.get("tabId", ""),
+                "title": props.get("title", ""),
+                "level": level,
+                "body": doc_tab.get("body") or {},
+            })
+            visit(tab.get("childTabs"), level + 1)
+
+    visit(doc.get("tabs"), 0)
+    return flat
+
+
+def _resolve_write_tab(doc: dict, tab_arg: str | None) -> tuple[str | None, dict]:
+    """Pick exactly one tab body for a write; never merge index spaces.
+
+    Legacy docs (no ``tabs``) return (None, body) — the write carries no tabId.
+    A multi-tab doc requires an explicit --tab; an unknown ID errors instead of
+    quietly falling back to the first tab.
+    """
+    tabs = _flatten_doc_tabs(doc)
+    if not tabs:
+        return None, doc.get("body", {})
+    if tab_arg:
+        for tab in tabs:
+            if tab["tabId"] == tab_arg:
+                return tab["tabId"], tab["body"]
+        print(
+            json.dumps({
+                "error": f"unknown tab ID {tab_arg!r}",
+                "tabs": [{"tabId": t["tabId"], "title": t["title"]} for t in tabs],
+            }, indent=2, ensure_ascii=False),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if len(tabs) == 1:
+        return tabs[0]["tabId"], tabs[0]["body"]
+    print(
+        json.dumps({
+            "error": f"document has {len(tabs)} tabs; pass --tab <tabId> to pick one",
+            "tabs": [{"tabId": t["tabId"], "title": t["title"]} for t in tabs],
+        }, indent=2, ensure_ascii=False),
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 def _datetime_with_timezone(value: str) -> str:
@@ -953,23 +1017,41 @@ def sheets_create(args):
 
 
 def docs_get(args):
+    tab_arg = getattr(args, "tab", None)
+    params = {"documentId": args.doc_id, "includeTabsContent": True}
     if _gws_binary():
-        doc = _run_gws(["docs", "documents", "get"], params={"documentId": args.doc_id})
-        result = {
-            "title": doc.get("title", ""),
-            "documentId": doc.get("documentId", ""),
-            "body": _extract_doc_text(doc),
-        }
-        print(json.dumps(result, indent=2, ensure_ascii=False))
-        return
+        doc = _run_gws(["docs", "documents", "get"], params=params)
+    else:
+        service = build_service("docs", "v1")
+        doc = service.documents().get(
+            documentId=args.doc_id, includeTabsContent=True,
+        ).execute()
 
-    service = build_service("docs", "v1")
-    doc = service.documents().get(documentId=args.doc_id).execute()
     result = {
         "title": doc.get("title", ""),
         "documentId": doc.get("documentId", ""),
-        "body": _extract_doc_text(doc),
     }
+    tabs = _flatten_doc_tabs(doc)
+    if not tabs:
+        # Legacy single-body response shape.
+        result["body"] = _extract_doc_text(doc)
+    elif tab_arg:
+        _, body = _resolve_write_tab(doc, tab_arg)
+        result["tab"] = tab_arg
+        result["body"] = _extract_body_text(body)
+    else:
+        result["tabs"] = [
+            {
+                "tabId": t["tabId"],
+                "title": t["title"],
+                "level": t["level"],
+                "body": _extract_body_text(t["body"]),
+            }
+            for t in tabs
+        ]
+        # Keep "body" populated for single-tab docs so existing callers work.
+        if len(tabs) == 1:
+            result["body"] = result["tabs"][0]["body"]
     print(json.dumps(result, indent=2, ensure_ascii=False))
 
 
@@ -997,17 +1079,25 @@ def docs_create(args):
 
 
 def docs_append(args):
-    """Append text to the end of an existing Doc."""
+    """Append text to the end of an existing Doc (one tab of it, if tabbed)."""
     if _gws_binary():
-        doc = _run_gws(["docs", "documents", "get"], params={"documentId": args.doc_id})
+        doc = _run_gws(
+            ["docs", "documents", "get"],
+            params={"documentId": args.doc_id, "includeTabsContent": True},
+        )
     else:
         service = build_service("docs", "v1")
-        doc = service.documents().get(documentId=args.doc_id).execute()
+        doc = service.documents().get(
+            documentId=args.doc_id, includeTabsContent=True,
+        ).execute()
+
+    tab_id, body = _resolve_write_tab(doc, getattr(args, "tab", None))
 
     # The end-of-body index is one less than the segment endIndex of the body
     # (trailing newline is always at length-1). Docs indexes are 1-based; use
-    # endIndex - 1 to insert before the final newline.
-    content = doc.get("body", {}).get("content", [])
+    # endIndex - 1 to insert before the final newline. Each tab has its own
+    # index space, so the write location must carry the tab ID.
+    content = body.get("content", [])
     end_index = 1
     for element in content:
         ei = element.get("endIndex")
@@ -1016,21 +1106,27 @@ def docs_append(args):
     insert_index = max(end_index - 1, 1)
 
     text = args.text if args.text.endswith("\n") else args.text + "\n"
-    _docs_insert_text(args.doc_id, text, index=insert_index)
+    _docs_insert_text(args.doc_id, text, index=insert_index, tab_id=tab_id)
 
-    print(json.dumps({
+    result = {
         "status": "appended",
         "documentId": args.doc_id,
         "inserted_at": insert_index,
         "characters": len(text),
-    }, indent=2, ensure_ascii=False))
+    }
+    if tab_id:
+        result["tab"] = tab_id
+    print(json.dumps(result, indent=2, ensure_ascii=False))
 
 
-def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
+def _docs_insert_text(doc_id: str, text: str, index: int, tab_id: str | None = None) -> None:
     """Send a batchUpdate with a single insertText request."""
+    location: dict = {"index": index}
+    if tab_id:
+        location["tabId"] = tab_id
     requests = [{
         "insertText": {
-            "location": {"index": index},
+            "location": location,
             "text": text,
         }
     }]
@@ -1205,6 +1301,7 @@ def main():
 
     p = docs_sub.add_parser("get")
     p.add_argument("doc_id")
+    p.add_argument("--tab", default=None, help="Tab ID to read (tabbed Docs)")
     p.set_defaults(func=docs_get)
 
     p = docs_sub.add_parser("create")
@@ -1215,6 +1312,7 @@ def main():
     p = docs_sub.add_parser("append")
     p.add_argument("doc_id")
     p.add_argument("--text", required=True, help="Text to append to the end of the document")
+    p.add_argument("--tab", default=None, help="Tab ID to append to (required for multi-tab Docs)")
     p.set_defaults(func=docs_append)
 
     args = parser.parse_args()

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -65,7 +65,7 @@ def _write_token(path: Path, *, token="ya29.test", expiry=None, **extra):
     }
     if expiry is not None:
         data["expiry"] = expiry
-    path.write_text(json.dumps(data))
+    path.write_text(json.dumps(data), encoding="utf-8")
 
 
 def test_bridge_returns_valid_token(bridge_module, tmp_path):
@@ -191,7 +191,81 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
 
     creds = api_module.get_credentials()
 
-    saved = json.loads(token_path.read_text())
+    saved = json.loads(token_path.read_text(encoding="utf-8"))
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def _tabbed_doc():
+    """A Doc with two tabs (one nested), as the Docs API returns with includeTabsContent."""
+    def body(text):
+        return {"content": [
+            {"endIndex": len(text) + 2,
+             "paragraph": {"elements": [{"textRun": {"content": text + "\n"}}]}},
+        ]}
+    return {
+        "title": "Tabbed",
+        "documentId": "doc1",
+        "tabs": [
+            {
+                "tabProperties": {"tabId": "t.0", "title": "First"},
+                "documentTab": {"body": body("alpha")},
+                "childTabs": [
+                    {
+                        "tabProperties": {"tabId": "t.0.a", "title": "Nested"},
+                        "documentTab": {"body": body("beta")},
+                    }
+                ],
+            },
+            {
+                "tabProperties": {"tabId": "t.1", "title": "Second"},
+                "documentTab": {"body": body("gamma")},
+            },
+        ],
+    }
+
+
+def test_docs_get_returns_every_tab_of_a_tabbed_doc(api_module, monkeypatch, capsys):
+    """A multi-tab Doc must not lose tab content: reads traverse the tabs tree
+    (preorder, nested tabs included) instead of only the legacy top-level body."""
+    monkeypatch.setattr(
+        api_module, "_run_gws",
+        lambda parts, params=None, body=None: _tabbed_doc(),
+    )
+    args = types.SimpleNamespace(doc_id="doc1", tab=None)
+    api_module.docs_get(args)
+    result = json.loads(capsys.readouterr().out)
+    tabs = {t["tabId"]: t for t in result["tabs"]}
+    assert set(tabs) == {"t.0", "t.0.a", "t.1"}
+    assert tabs["t.0.a"]["body"] == "beta\n"
+    assert tabs["t.0.a"]["level"] == 1
+    # Multi-tab docs have no single merged "body" — index spaces are independent.
+    assert "body" not in result
+
+
+def test_docs_append_carries_tab_id_and_refuses_ambiguous_writes(api_module, monkeypatch, capsys):
+    """Each tab has its own index space, so a write must target exactly one tab:
+    the insert location carries the tabId, and an un-targeted write against a
+    multi-tab doc errors instead of silently landing in the first tab."""
+    monkeypatch.setattr(
+        api_module, "_run_gws",
+        lambda parts, params=None, body=None: _tabbed_doc(),
+    )
+    sent = {}
+    monkeypatch.setattr(
+        api_module, "_docs_insert_text",
+        lambda doc_id, text, index, tab_id=None: sent.update(
+            {"doc_id": doc_id, "index": index, "tab_id": tab_id}
+        ),
+    )
+
+    api_module.docs_append(types.SimpleNamespace(doc_id="doc1", text="more", tab="t.1"))
+    assert sent["tab_id"] == "t.1"
+    assert sent["index"] == len("gamma") + 1  # endIndex - 1 within THAT tab's space
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        api_module.docs_append(types.SimpleNamespace(doc_id="doc1", text="more", tab=None))
+    err = json.loads(capsys.readouterr().err)
+    assert "tabs" in err and len(err["tabs"]) == 3


### PR DESCRIPTION
## Multi-tab Google Docs no longer lose content or mistarget writes

Ported from [cloudflare/cloudflare-os#450](https://github.com/cloudflare/cloudflare-os/pull/450) (weekly OS PR scout).

**Outcome:** the google-workspace skill now reads every tab of a tabbed Google Doc and appends into exactly the tab you name — previously it silently returned only the first tab's text and could compute an append index from the wrong tab's body.

### Root cause
Google Docs holds a recursive tree of tabs, each with its own body and its **own 1-based character index space**; the legacy top-level `body` field only carries the first tab. `docs get` read only `doc["body"]`, and `docs append` derived its insert index from that body and sent the write with no `tabId`.

### Changes
- Requests pass `includeTabsContent=true` (both the `gws` CLI path and the Python SDK path)
- `docs get` returns a `tabs` array — preorder flattening of `tabs`/`childTabs`, nested tabs included, each with `tabId`, `title`, `level`, `body`; single-tab docs keep the flat `body` field so existing callers are unchanged; `--tab <tabId>` reads one tab
- `docs append` targets exactly one tab: end index computed inside that tab's body, `insertText` location carries the `tabId`, unknown `--tab` errors (no silent first-tab fallback), and a multi-tab doc without `--tab` errors with the tab list rather than guessing
- Legacy no-`tabs` responses behave exactly as before (no `tabId` sent)
- SKILL.md Docs section documents `--tab`
- Sweep: 2 pre-existing bare `read_text`/`write_text` in the touched test file gained `encoding="utf-8"`

### Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/skills/test_google_workspace_api.py` | 6 passed (2 new invariant tests: tab-tree traversal incl. nested tabs; append carries tabId + refuses ambiguous writes) |
| E2E: real subprocess CLI with a fake `gws` binary returning a tabbed doc | `get` lists both tabs; `append` without `--tab` exits 1 with the tab list; `append --tab t.1` sends `tabId` + correct in-tab index; `get --tab` returns that tab's text |
| ruff / windows-footguns / compat pointers / `git diff --check` | clean |

**Live repro:** before — on `origin/main`, the same fake-gws E2E returns only the first tab's text and `docs append` computes index 6 from tab 1's body while sending no tabId (write would land in the first tab). After — outputs above.

Adaptation note: upstream's fix is in their TypeScript `gatekeeper-google` (`listTabs()` + `tabId` on every write coordinate); here the same contract is applied to the skill's Python CLI wrapper, keeping the skill's JSON output shape backward compatible for single-tab docs.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b6aa/G1X9ZAtbdDlBBP9KfaqVA_nRLoE9fG.png)
