### PR TITLE
feat(desktop): Review pane smart file order — change-explaining files first, supporting files muted (inspired by Amp)

### DIFF
--- a/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/file-tree.tsx
@@ -50,6 +50,7 @@ import { pickRevealLabel } from '../file-actions'
 
 import {
   buildReviewFlatList,
+  buildReviewSmartList,
   buildReviewTree,
   countAllNodes,
   flattenReviewRows,
@@ -113,7 +114,11 @@ export function ReviewFileTree() {
   const loading = useStore($reviewLoading)
   const mode = useStore($reviewTreeMode)
 
-  const tree = useMemo(() => (mode === 'tree' ? buildReviewTree(files) : buildReviewFlatList(files)), [files, mode])
+  const tree = useMemo(
+    () =>
+      mode === 'tree' ? buildReviewTree(files) : mode === 'smart' ? buildReviewSmartList(files) : buildReviewFlatList(files),
+    [files, mode]
+  )
 
   // Heavy is decided by the TOTAL node count, not the top-level row count: the
   // classic blow-up is ONE folder holding tens of thousands of untracked files,
@@ -390,6 +395,9 @@ function ReviewFileRow({ node, depth }: { node: ReviewTreeNode; depth: number })
         aria-selected={selected}
         className={cn(
           'group/review-row row-hover flex h-6 select-none items-center gap-1.5 rounded-md pr-1.5 text-xs text-(--ui-text-secondary) hover:text-foreground',
+          // Smart order dims supporting files (tests, fixtures, lockfiles) so
+          // the change-explaining files read first, the way Amp mutes them.
+          node.muted && !selected && 'opacity-55',
           selected && 'bg-(--ui-row-active-background) text-foreground'
         )}
         draggable

--- a/apps/desktop/src/app/right-sidebar/review/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/index.tsx
@@ -28,6 +28,7 @@ import {
   confirmRevert,
   refreshReview,
   requestRevert,
+  type ReviewTreeMode,
   stageReviewFile,
   toggleReviewTreeMode,
   unstageReviewFile
@@ -42,6 +43,17 @@ import { ReviewShipBar } from './ship-bar'
 // Compact header/diff action buttons — micro hit targets packed tight, matching
 // the rest of the app's icon-action rows.
 const ACTION_BTN = 'size-5'
+
+// The layout button advertises the NEXT mode in the cycle (tree → list → smart).
+const NEXT_MODE: Record<ReviewTreeMode, ReviewTreeMode> = { tree: 'list', list: 'smart', smart: 'tree' }
+
+const NEXT_MODE_ICON: Record<ReviewTreeMode, string> = { tree: 'list-flat', list: 'sparkle', smart: 'list-tree' }
+
+function nextModeLabel(mode: ReviewTreeMode, c: { viewAsList: string; viewAsSmart: string; viewAsTree: string }): string {
+  const next = NEXT_MODE[mode]
+
+  return next === 'list' ? c.viewAsList : next === 'smart' ? c.viewAsSmart : c.viewAsTree
+}
 
 export function ReviewPane() {
   const { t } = useI18n()
@@ -82,16 +94,16 @@ export function ReviewPane() {
                 says "review", so the zone header hides it (styles.css). */}
             <SidebarPanelLabel data-pane-self-label="">{c.review}</SidebarPanelLabel>
           </div>
-          <Tip label={treeMode === 'tree' ? c.viewAsList : c.viewAsTree}>
+          <Tip label={nextModeLabel(treeMode, c)}>
             <Button
-              aria-label={treeMode === 'tree' ? c.viewAsList : c.viewAsTree}
+              aria-label={nextModeLabel(treeMode, c)}
               className={ACTION_BTN}
               disabled={!hasFiles}
               onClick={toggleReviewTreeMode}
               size="icon-xs"
               variant="ghost"
             >
-              <Codicon name={treeMode === 'tree' ? 'list-flat' : 'list-tree'} size="0.8125rem" />
+              <Codicon name={NEXT_MODE_ICON[treeMode]} size="0.8125rem" />
             </Button>
           </Tip>
           <Tip label={c.stageAll}>

--- a/apps/desktop/src/app/right-sidebar/review/tree-data.test.ts
+++ b/apps/desktop/src/app/right-sidebar/review/tree-data.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { HermesReviewFile } from '@/global'
 
-import { buildReviewTree, countAllNodes, flattenReviewRows } from './tree-data'
+import { buildReviewSmartList, buildReviewTree, countAllNodes, flattenReviewRows } from './tree-data'
 
 const file = (path: string, added = 1, removed = 0): HermesReviewFile => ({
   path,
@@ -104,5 +104,40 @@ describe('flattenReviewRows', () => {
     const rows = flattenReviewRows(tree, id => id !== 'a/b')
 
     expect(rows.map(r => r.node.id)).toEqual(['a', 'a/b'])
+  })
+})
+
+describe('buildReviewSmartList', () => {
+  it('orders change-explaining files by churn before supporting files, which are muted', () => {
+    const rows = buildReviewSmartList([
+      file('src/store/review.test.ts', 40, 10),
+      file('package-lock.json', 900, 900),
+      file('src/store/review.ts', 30, 5),
+      file('src/app/pane.tsx', 80, 20)
+    ])
+
+    // Source files first, biggest churn first; supporting files trail (their
+    // own group also churn-ordered), muted.
+    expect(rows.map(r => r.id)).toEqual([
+      'src/app/pane.tsx',
+      'src/store/review.ts',
+      'package-lock.json',
+      'src/store/review.test.ts'
+    ])
+    expect(rows.map(r => Boolean(r.muted))).toEqual([false, false, true, true])
+  })
+
+  it('classifies supporting paths by directory segment and filename shape', () => {
+    const rows = buildReviewSmartList([
+      file('tests/agent/test_loop.py', 5, 0),
+      file('agent/__fixtures__/sample.json', 5, 0),
+      file('agent/loop.py', 1, 0)
+    ])
+
+    expect(rows[0].id).toBe('agent/loop.py')
+    expect(rows.filter(r => r.muted).map(r => r.id).sort()).toEqual([
+      'agent/__fixtures__/sample.json',
+      'tests/agent/test_loop.py'
+    ])
   })
 })

--- a/apps/desktop/src/app/right-sidebar/review/tree-data.ts
+++ b/apps/desktop/src/app/right-sidebar/review/tree-data.ts
@@ -13,6 +13,91 @@ export interface ReviewTreeNode {
   dir?: string
   file?: HermesReviewFile
   children?: ReviewTreeNode[]
+  /** Supporting file (test/fixture/lockfile/generated) — rendered dimmed. */
+  muted?: boolean
+}
+
+// ── Importance classification (smart order) ──────────────────────────────────
+//
+// Deterministic proxy for Amp's "intelligently ordered diffs": the files that
+// best explain a change are the source files; tests, fixtures, lockfiles and
+// generated artifacts SUPPORT it. No model call — classification must be free,
+// instant, and identical on every refresh.
+
+const SUPPORTING_DIR_SEGMENTS = new Set([
+  '__fixtures__',
+  '__mocks__',
+  '__snapshots__',
+  '__tests__',
+  'fixtures',
+  'snapshots',
+  'spec',
+  'test',
+  'testdata',
+  'tests'
+])
+
+const SUPPORTING_FILENAMES = new Set([
+  'cargo.lock',
+  'composer.lock',
+  'gemfile.lock',
+  'go.sum',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'poetry.lock',
+  'uv.lock',
+  'yarn.lock'
+])
+
+// Filename shapes: foo.test.ts / foo.spec.tsx / test_foo.py / foo_test.go /
+// generated + minified + sourcemap artifacts / snapshot files.
+const SUPPORTING_FILE_RE = /(\.(test|spec)\.[^.]+$)|(^test_.+\.py$)|(_test\.(py|go|rb|ts|js)$)|(\.snap$)|(\.min\.(js|css)$)|(\.map$)|(\.generated\.[^.]+$)|(_pb2(_grpc)?\.py$)/
+
+/** True when a changed file is supporting material (test, fixture, lockfile,
+ *  generated) rather than a change-explaining source file. */
+export function isSupportingReviewPath(path: string): boolean {
+  const segments = path.split('/').filter(Boolean)
+  const name = (segments.pop() ?? path).toLowerCase()
+
+  if (SUPPORTING_FILENAMES.has(name) || SUPPORTING_FILE_RE.test(name)) {
+    return true
+  }
+
+  return segments.some(segment => SUPPORTING_DIR_SEGMENTS.has(segment.toLowerCase()))
+}
+
+// Smart flat list: change-explaining files first ordered by churn (the file
+// with the most movement usually explains the change), supporting files after,
+// dimmed. Ties break by path so the order is stable across refreshes.
+export function buildReviewSmartList(files: HermesReviewFile[]): ReviewTreeNode[] {
+  const churn = (f: HermesReviewFile) => f.added + f.removed
+
+  return [...files]
+    .sort((a, b) => {
+      const aMuted = isSupportingReviewPath(a.path)
+      const bMuted = isSupportingReviewPath(b.path)
+
+      if (aMuted !== bMuted) {
+        return aMuted ? 1 : -1
+      }
+
+      return churn(b) - churn(a) || a.path.localeCompare(b.path)
+    })
+    .map(file => {
+      const segments = file.path.split('/').filter(Boolean)
+      const name = segments.pop() ?? file.path
+
+      return {
+        id: file.path,
+        name,
+        dir: segments.join('/'),
+        isDir: false,
+        added: file.added,
+        removed: file.removed,
+        muted: isSupportingReviewPath(file.path),
+        file
+      }
+    })
 }
 
 // Flat changed-file list (VS Code's default SCM "List" view): one row per file,

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2124,6 +2124,7 @@ export const ar = defineLocale({
       stageAll: 'إدراج الكل',
       viewAsTree: 'عرض كشجرة',
       viewAsList: 'عرض كقائمة',
+      viewAsSmart: 'عرض حسب الأهمية',
       revert: 'تراجع',
       revertAll: 'التراجع عن الكل',
       revertConfirm: 'هل تريد تجاهل التغييرات على هذا الملف واستعادته إلى الحالة المُودعة؟ لا يمكن التراجع عن هذا.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2847,6 +2847,7 @@ export const en: Translations = {
       stageAll: 'Stage all',
       viewAsTree: 'View as tree',
       viewAsList: 'View as list',
+      viewAsSmart: 'View by importance',
       revert: 'Revert',
       revertAll: 'Revert all',
       revertConfirm: 'Discard changes to this file and restore it to the committed state? This cannot be undone.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2471,6 +2471,7 @@ export const ja = defineLocale({
       stageAll: 'すべてステージ',
       viewAsTree: 'ツリー表示',
       viewAsList: 'リスト表示',
+      viewAsSmart: '重要度順に表示',
       revert: '取り消し',
       revertAll: 'すべて取り消し',
       revertConfirm: 'このファイルの変更を破棄してコミット済みの状態に戻しますか？この操作は元に戻せません。',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2880,6 +2880,7 @@ export const ru = defineLocale({
       stageAll: 'Добавить всё в индекс',
       viewAsTree: 'Вид деревом',
       viewAsList: 'Вид списком',
+      viewAsSmart: 'По важности',
       revert: 'Отменить',
       revertAll: 'Отменить всё',
       revertConfirm:

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2440,6 +2440,7 @@ export interface Translations {
       stageAll: string
       viewAsTree: string
       viewAsList: string
+      viewAsSmart: string
       revert: string
       revertAll: string
       revertConfirm: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2391,6 +2391,7 @@ export const zhHant = defineLocale({
       stageAll: '全部暫存',
       viewAsTree: '樹狀檢視',
       viewAsList: '清單檢視',
+      viewAsSmart: '依重要性顯示',
       revert: '還原',
       revertAll: '全部還原',
       revertConfirm: '捨棄對此檔案的變更並將其還原至已提交狀態？此操作無法復原。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3010,6 +3010,7 @@ export const zh: Translations = {
       stageAll: '全部暂存',
       viewAsTree: '树状视图',
       viewAsList: '列表视图',
+      viewAsSmart: '按重要性显示',
       revert: '还原',
       revertAll: '全部还原',
       revertConfirm: '放弃对此文件的更改并将其恢复到已提交状态？此操作无法撤销。',

--- a/apps/desktop/src/store/review.test.ts
+++ b/apps/desktop/src/store/review.test.ts
@@ -235,10 +235,12 @@ describe('selectReviewFile / clearReviewSelection', () => {
 })
 
 describe('view state', () => {
-  it('toggleReviewTreeMode flips list <-> tree', () => {
+  it('toggleReviewTreeMode cycles tree -> list -> smart -> tree', () => {
     $reviewTreeMode.set('tree')
     toggleReviewTreeMode()
     expect($reviewTreeMode.get()).toBe('list')
+    toggleReviewTreeMode()
+    expect($reviewTreeMode.get()).toBe('smart')
     toggleReviewTreeMode()
     expect($reviewTreeMode.get()).toBe('tree')
   })

--- a/apps/desktop/src/store/review.ts
+++ b/apps/desktop/src/store/review.ts
@@ -46,16 +46,26 @@ export const $reviewCommitDefault = persistentAtom<CommitAction>(COMMIT_DEFAULT_
   encode: value => value
 })
 
-// Changed-file layout: a flat path list (VS Code's default) or a folder tree.
-export type ReviewTreeMode = 'list' | 'tree'
+// Changed-file layout: a folder tree, a flat path list (VS Code's default), or
+// a smart list — change-explaining files first, supporting files (tests,
+// fixtures, lockfiles, generated) dimmed at the bottom (Amp's intelligently
+// ordered diffs).
+export type ReviewTreeMode = 'list' | 'smart' | 'tree'
 
 export const $reviewTreeMode = persistentAtom<ReviewTreeMode>(TREE_MODE_KEY, 'tree', {
-  decode: raw => (raw === 'list' ? 'list' : 'tree'),
+  decode: raw => (raw === 'list' || raw === 'smart' ? raw : 'tree'),
   encode: value => value
 })
 
+// The header button cycles the three layouts in a fixed loop.
+const TREE_MODE_CYCLE: Record<ReviewTreeMode, ReviewTreeMode> = {
+  tree: 'list',
+  list: 'smart',
+  smart: 'tree'
+}
+
 export function toggleReviewTreeMode(): void {
-  $reviewTreeMode.set($reviewTreeMode.get() === 'tree' ? 'list' : 'tree')
+  $reviewTreeMode.set(TREE_MODE_CYCLE[$reviewTreeMode.get()])
 }
 
 export const $reviewFiles = atom<HermesReviewFile[]>([])


### PR DESCRIPTION
## Outcome

The Desktop Review pane gains a third changed-files layout, **smart order**: change-explaining source files first (biggest churn first), supporting files — tests, fixtures, snapshots, lockfiles, generated/minified artifacts — grouped after and dimmed, so the file that explains the change is the first thing a reviewer reads.

Inspired by Amp's [Intelligently Ordered Diffs](https://ampcode.com/news/intelligently-ordered-diffs) (Sep 1): "The first challenge in code review is figuring out which files to read first... Less relevant files, such as tests, fixtures, and generated code, will be shown in muted colors below the important ones."

## Their mechanism vs ours

- **Amp**: reads the diff with a model and reorders. **Hermes**: deterministic path heuristic (`isSupportingReviewPath`) + churn sort — free, instant, identical on every refresh, no API spend, no reorder-churn while the agent is still editing.
- Muted classes: `test/spec` filename shapes (`*.test.ts`, `test_*.py`, `*_test.go`, …), test/fixture/snapshot directory segments, lockfiles (`package-lock.json`, `uv.lock`, …), generated artifacts (`*.min.js`, `*.map`, `*.snap`, `*_pb2.py`, `*.generated.*`).

## Changes

- `review/tree-data.ts`: `isSupportingReviewPath()` + `buildReviewSmartList()`; `ReviewTreeNode.muted`.
- `store/review.ts`: `ReviewTreeMode` gains `'smart'`; header button cycles tree → list → smart (persisted decode falls back to `tree` for unknown values).
- `review/index.tsx`: layout button advertises the next mode (sparkle icon for smart); `review/file-tree.tsx`: muted rows render at 55% opacity.
- i18n: `viewAsSmart` in all 6 locales + types.

## Validation

| Check | Result |
|---|---|
| `vitest run` review pane + store + i18n suites | 84 passed (56 review + 28 i18n) |
| `tsc -p tsconfig.json --noEmit` | clean |
| `eslint` on touched files | clean |
| New invariant tests | 2 (smart ordering + classification), toggle test extended for 3-mode cycle |

Existing tree/list layouts and their sorting are untouched; smart is opt-in via the header toggle and persists like the other modes.

## Infographic

![Smart diff order](https://v3b.fal.media/files/b/0aa9b6d1/lsa8SFlcTCIaXmAZxEHVQ_G8JCoGaY.png)
