### PR TITLE
feat(tools): per-tool spillover budgets — contain chatty tools without shrinking every budget (salvage #94679)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -499,7 +499,16 @@ DEFAULT_CONFIG = {
     # Tool-output truncation. max_bytes: terminal_tool output cap in chars (head+tail kept; 50_000 ≈
     # 12-15K tokens). max_lines: max `limit` one read_file call may request before clamping.
     # max_line_length: per-line cap in read_file's line-numbered view (chars).
-    "tool_output": {"max_bytes": 50000, "max_lines": 2000, "max_line_length": 2000},
+    # Spillover thresholds live here too: mcp_result_size_chars is the tighter per-result cap for
+    # mcp_-prefixed tools; tool_overrides maps exact tool names to lower spill thresholds so one
+    # known-chatty provider can be contained without shrinking every tool's budget.
+    "tool_output": {
+        "max_bytes": 50000,
+        "max_lines": 2000,
+        "max_line_length": 2000,
+        "mcp_result_size_chars": 50_000,
+        "tool_overrides": {},
+    },
     # Tool loop guardrails nudge models that repeat failed/non-progressing tool calls. Soft warnings
     # are always on; hard stops are opt-in so interactive sessions keep flowing.
     "tool_loop_guardrails": {

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -218,6 +218,52 @@ class TestMcpPrefixThreshold:
         # Generic tools are untouched by the MCP knob.
         assert cfg.default_result_size == DEFAULT_RESULT_SIZE_CHARS
 
+
+class TestConfiguredToolOverrides:
+    """Operators can spill a chatty named tool before the generic 100K cap."""
+
+    def test_named_override_is_loaded_from_config(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "tool_budget:\n"
+            "  tool_overrides:\n"
+            "    web_search: 20000\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = budget_for_context_window(None)
+
+        assert cfg.resolve_threshold("web_search") == 20_000
+        assert cfg.resolve_threshold("terminal") == DEFAULT_RESULT_SIZE_CHARS
+
+    def test_invalid_named_overrides_are_ignored(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "tool_budget:\n"
+            "  tool_overrides:\n"
+            "    zero: 0\n"
+            "    negative: -1\n"
+            "    boolean: true\n"
+            "    text: nope\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = budget_for_context_window(None)
+
+        assert cfg.tool_overrides == {}
+
+    def test_named_override_cannot_exceed_scaled_model_budget(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "config.yaml").write_text(
+            "tool_budget:\n"
+            "  tool_overrides:\n"
+            "    web_search: 90000\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = budget_for_context_window(65_536)
+
+        assert cfg.resolve_threshold("web_search") == cfg.default_result_size
+
     def test_config_override_survives_window_scaling(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
             "tool_budget:\n  mcp_result_size_chars: 30000\n"

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -210,7 +210,7 @@ class TestMcpPrefixThreshold:
 
     def test_config_override_via_hermes_home(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n  mcp_result_size_chars: 30000\n"
+            "tool_output:\n  mcp_result_size_chars: 30000\n"
         )
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cfg = budget_for_context_window(None)
@@ -224,7 +224,7 @@ class TestConfiguredToolOverrides:
 
     def test_named_override_is_loaded_from_config(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n"
+            "tool_output:\n"
             "  tool_overrides:\n"
             "    web_search: 20000\n"
         )
@@ -237,7 +237,7 @@ class TestConfiguredToolOverrides:
 
     def test_invalid_named_overrides_are_ignored(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n"
+            "tool_output:\n"
             "  tool_overrides:\n"
             "    zero: 0\n"
             "    negative: -1\n"
@@ -254,7 +254,7 @@ class TestConfiguredToolOverrides:
         self, tmp_path, monkeypatch
     ):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n"
+            "tool_output:\n"
             "  tool_overrides:\n"
             "    web_search: 90000\n"
         )
@@ -266,14 +266,14 @@ class TestConfiguredToolOverrides:
 
     def test_config_override_survives_window_scaling(self, tmp_path, monkeypatch):
         (tmp_path / "config.yaml").write_text(
-            "tool_budget:\n  mcp_result_size_chars: 30000\n"
+            "tool_output:\n  mcp_result_size_chars: 30000\n"
         )
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cfg = budget_for_context_window(200_000)
         assert cfg.mcp_result_size == 30_000
 
     def test_malformed_config_falls_back_to_default(self, tmp_path, monkeypatch):
-        (tmp_path / "config.yaml").write_text("tool_budget: not-a-mapping\n")
+        (tmp_path / "config.yaml").write_text("tool_output: not-a-mapping\n")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cfg = budget_for_context_window(None)
         assert cfg.resolve_threshold("mcp_x_y") == 50_000

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -278,6 +278,22 @@ class TestConfiguredToolOverrides:
         cfg = budget_for_context_window(None)
         assert cfg.resolve_threshold("mcp_x_y") == 50_000
 
+    def test_legacy_tool_budget_key_still_read_per_key(self, tmp_path, monkeypatch):
+        """tool_output ships in DEFAULT_CONFIG so the merged block always exists;
+        an explicit legacy tool_budget value must still win over merged defaults."""
+        (tmp_path / "config.yaml").write_text(
+            "tool_budget:\n"
+            "  mcp_result_size_chars: 40000\n"
+            "  tool_overrides:\n"
+            "    web_search: 15000\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        cfg = budget_for_context_window(None)
+
+        assert cfg.resolve_threshold("mcp_x_y") == 40_000
+        assert cfg.resolve_threshold("web_search") == 15_000
+
     def test_scaled_small_window_caps_mcp_threshold(self, tmp_path, monkeypatch):
         """A tiny model's scaled default_result_size caps even the MCP value."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))  # no config.yaml

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -27,6 +27,11 @@ def _configured_budget_block() -> dict:
     as a read-only compatibility fallback so existing installations do not silently
     lose their MCP threshold after upgrading. Goes through ``load_config_readonly``
     (the sanctioned path; raw config.yaml parsing outside owner modules is test-guarded).
+
+    ``tool_output`` ships in DEFAULT_CONFIG, so the loader's deep-merge means the
+    primary block always exists with default values — a whole-block "primary else
+    legacy" check would never fall back. Fall back PER KEY: a merged-in default
+    must not shadow an explicit legacy setting.
     """
     try:
         from hermes_cli.config import load_config_readonly
@@ -34,10 +39,18 @@ def _configured_budget_block() -> dict:
         if not isinstance(data, dict):
             return {}
         primary = data.get("tool_output")
-        if isinstance(primary, dict):
-            return primary
+        primary = primary if isinstance(primary, dict) else {}
         legacy = data.get("tool_budget")
-        return legacy if isinstance(legacy, dict) else {}
+        legacy = legacy if isinstance(legacy, dict) else {}
+        if not legacy:
+            return primary
+        merged = dict(primary)
+        if (merged.get("mcp_result_size_chars") == DEFAULT_MCP_RESULT_SIZE_CHARS
+                and "mcp_result_size_chars" in legacy):
+            merged["mcp_result_size_chars"] = legacy["mcp_result_size_chars"]
+        if not merged.get("tool_overrides") and "tool_overrides" in legacy:
+            merged["tool_overrides"] = legacy["tool_overrides"]
+        return merged
     except Exception:
         return {}
 

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -40,6 +40,39 @@ def _configured_mcp_result_size() -> int:
     return DEFAULT_MCP_RESULT_SIZE_CHARS
 
 
+def _configured_tool_overrides() -> Dict[str, int]:
+    """Read positive per-tool spill thresholds from ``tool_budget``.
+
+    Tool handlers and providers do not always keep their documented result
+    shape bounded. A named override lets an operator spill a known-chatty tool
+    before the generic 100K threshold without shrinking every tool or the
+    model's context window. Invalid entries are ignored fail-closed.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        data = load_config_readonly()
+        block = data.get("tool_budget") if isinstance(data, dict) else None
+        raw = block.get("tool_overrides") if isinstance(block, dict) else None
+        if not isinstance(raw, dict):
+            return {}
+        overrides: Dict[str, int] = {}
+        for name, threshold in raw.items():
+            if not isinstance(name, str) or not name.strip():
+                continue
+            if isinstance(threshold, bool):
+                continue
+            try:
+                value = int(threshold)
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                overrides[name.strip()] = value
+        return overrides
+    except Exception:
+        return {}
+
+
 @dataclass(frozen=True)
 class BudgetConfig:
     """Immutable budget constants: per-result threshold (``resolve_threshold``),
@@ -100,14 +133,26 @@ def budget_for_context_window(context_length: int | None) -> BudgetConfig:
     oversized request (#23767).
     """
     mcp_result_size = _configured_mcp_result_size()
+    tool_overrides = _configured_tool_overrides()
     if not context_length or context_length <= 0:
-        if mcp_result_size == DEFAULT_MCP_RESULT_SIZE_CHARS:
+        if (
+            mcp_result_size == DEFAULT_MCP_RESULT_SIZE_CHARS
+            and not tool_overrides
+        ):
             return DEFAULT_BUDGET
-        return BudgetConfig(mcp_result_size=mcp_result_size)
+        return BudgetConfig(
+            mcp_result_size=mcp_result_size,
+            tool_overrides=tool_overrides,
+        )
     window_chars = context_length * _CHARS_PER_TOKEN
+    per_result = max(_MIN_RESULT_SIZE_CHARS, min(int(window_chars * _PER_RESULT_WINDOW_FRACTION), DEFAULT_RESULT_SIZE_CHARS))
     return BudgetConfig(
-        default_result_size=max(_MIN_RESULT_SIZE_CHARS, min(int(window_chars * _PER_RESULT_WINDOW_FRACTION), DEFAULT_RESULT_SIZE_CHARS)),
+        default_result_size=per_result,
         turn_budget=max(_MIN_TURN_BUDGET_CHARS, min(int(window_chars * _PER_TURN_WINDOW_FRACTION), DEFAULT_TURN_BUDGET_CHARS)),
         preview_size=DEFAULT_PREVIEW_SIZE_CHARS,
         mcp_result_size=mcp_result_size,
+        tool_overrides={
+            name: min(threshold, per_result)
+            for name, threshold in tool_overrides.items()
+        },
     )

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -14,34 +14,49 @@ DEFAULT_PREVIEW_SIZE_CHARS: int = 1_500
 
 # Tighter per-result default for ``mcp_`` tools: MCP servers routinely return
 # un-paginated 20-50K payloads that sail under the generic 100K threshold; spillover
-# keeps the full payload on disk. Config: ``tool_budget.mcp_result_size_chars``.
+# keeps the full payload on disk. Config: ``tool_output.mcp_result_size_chars``.
 DEFAULT_MCP_RESULT_SIZE_CHARS: int = 50_000
 # Same prefix the untrusted-content wrapper keys on (agent/tool_dispatch_helpers.py).
 MCP_TOOL_PREFIX: str = "mcp_"
 
 
-def _configured_mcp_result_size() -> int:
-    """Read ``tool_budget.mcp_result_size_chars`` via ``load_config_readonly`` (the
-    sanctioned path; raw config.yaml parsing outside owner modules is test-guarded).
-    Any error, missing key or non-positive value returns the built-in default.
+def _configured_budget_block() -> dict:
+    """Return the spillover config block, preferring the recognized ``tool_output`` key.
 
-    The ``tool_budget:`` block name is shared with the wider configurable-caps proposal (#80508) so the two
-    can merge without a key rename.
+    ``tool_budget`` was the short-lived original spelling (shared with #80508). Keep it
+    as a read-only compatibility fallback so existing installations do not silently
+    lose their MCP threshold after upgrading. Goes through ``load_config_readonly``
+    (the sanctioned path; raw config.yaml parsing outside owner modules is test-guarded).
     """
     try:
         from hermes_cli.config import load_config_readonly
         data = load_config_readonly()
-        block = data.get("tool_budget") if isinstance(data, dict) else None
-        raw = block.get("mcp_result_size_chars") if isinstance(block, dict) else None
-        if raw is not None and int(raw) > 0:
-            return int(raw)
+        if not isinstance(data, dict):
+            return {}
+        primary = data.get("tool_output")
+        if isinstance(primary, dict):
+            return primary
+        legacy = data.get("tool_budget")
+        return legacy if isinstance(legacy, dict) else {}
+    except Exception:
+        return {}
+
+
+def _configured_mcp_result_size() -> int:
+    """Read ``tool_output.mcp_result_size_chars`` from active config."""
+    try:
+        raw = _configured_budget_block().get("mcp_result_size_chars")
+        if raw is not None and not isinstance(raw, bool):
+            value = int(raw)
+            if value > 0:
+                return value
     except Exception:
         pass
     return DEFAULT_MCP_RESULT_SIZE_CHARS
 
 
 def _configured_tool_overrides() -> Dict[str, int]:
-    """Read positive per-tool spill thresholds from ``tool_budget``.
+    """Read positive per-tool spill thresholds from ``tool_output``.
 
     Tool handlers and providers do not always keep their documented result
     shape bounded. A named override lets an operator spill a known-chatty tool
@@ -49,11 +64,7 @@ def _configured_tool_overrides() -> Dict[str, int]:
     model's context window. Invalid entries are ignored fail-closed.
     """
     try:
-        from hermes_cli.config import load_config_readonly
-
-        data = load_config_readonly()
-        block = data.get("tool_budget") if isinstance(data, dict) else None
-        raw = block.get("tool_overrides") if isinstance(block, dict) else None
+        raw = _configured_budget_block().get("tool_overrides")
         if not isinstance(raw, dict):
             return {}
         overrides: Dict[str, int] = {}

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -854,6 +854,16 @@ tool_output:
 
 Separately from truncation, oversized tool *results* are spilled to disk rather than cut: the full output is saved under `$HERMES_HOME/cache/spillover/` and the in-context content is replaced by a preview plus the saved file's path (readable with `read_file` using `offset`/`limit`, or processable with `execute_code`). The generic per-result spillover threshold is 100,000 chars, scaled down automatically for small-context models.
 
+The generic per-result threshold can be lowered for a known-chatty tool without shrinking every tool or the model context window:
+
+```yaml
+tool_budget:
+  tool_overrides:
+    web_search: 20000       # spill this named tool above 20K chars
+```
+
+Overrides must be positive integers, are keyed by the exact tool name, and are capped by the active model's context-scaled generic threshold. `read_file` remains pinned to unlimited inline output so a spill can always be paged back without creating a spill/read loop.
+
 MCP tool results (tools named `mcp_*`) spill at a tighter **50,000-char** default: MCP servers routinely return large un-paginated payloads (tool-discovery catalogs, batched executions) that would otherwise sit under the generic threshold and bloat context on every subsequent turn. Nothing is lost — the full result is preserved on disk. Override the threshold via:
 
 ```yaml

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -857,7 +857,7 @@ Separately from truncation, oversized tool *results* are spilled to disk rather 
 The generic per-result threshold can be lowered for a known-chatty tool without shrinking every tool or the model context window:
 
 ```yaml
-tool_budget:
+tool_output:
   tool_overrides:
     web_search: 20000       # spill this named tool above 20K chars
 ```
@@ -867,7 +867,7 @@ Overrides must be positive integers, are keyed by the exact tool name, and are c
 MCP tool results (tools named `mcp_*`) spill at a tighter **50,000-char** default: MCP servers routinely return large un-paginated payloads (tool-discovery catalogs, batched executions) that would otherwise sit under the generic threshold and bloat context on every subsequent turn. Nothing is lost — the full result is preserved on disk. Override the threshold via:
 
 ```yaml
-tool_budget:
+tool_output:
   mcp_result_size_chars: 50000   # per-result spillover threshold for mcp_* tools
 ```
 


### PR DESCRIPTION
## Summary

Salvage of #94679 by @zugende, rebased onto current `origin/main` with contributor authorship preserved (2 cherry-picked commits + 1 hardening commit).

Operators can now spill a **named chatty tool** to disk at a lower threshold than the generic 100K-char budget, via `config.yaml`:

```yaml
tool_output:
  tool_overrides:
    web_search: 20000   # spill this tool's results above 20K chars
```

Also folds the spillover knobs into the recognized `tool_output` config block (they previously lived under an unrecognized `tool_budget` key that `hermes config` would not validate), keeping `tool_budget` as a read-only legacy fallback.

## Why (scout context)

Weekly ChatGPT Work scout: Codex CLI 0.152.0 shipped per-tool MCP `output_token_limit` settings with consistent truncation across resumes (openai/codex#41421) and history-backend-enforced tool output budgets (#41260). Hermes already had the superior disk-spillover mechanism (full payload preserved, not truncated) but only a global threshold + one MCP-prefix knob; the per-tool granularity was the missing piece — and an open community PR (#94679) had already built exactly it against the `tool_output` seam. Salvaged rather than reimplemented.

## Changes

- `tools/budget_config.py`: `_configured_tool_overrides()` (fail-closed parsing: non-string keys, bools, non-ints, non-positives ignored) feeding the existing `BudgetConfig.tool_overrides` field; config block read moves to `tool_output` with per-key `tool_budget` legacy fallback.
- `hermes_cli/config_defaults.py`: `mcp_result_size_chars` + `tool_overrides` added to the shipped `tool_output` defaults (deep-merge; no `_config_version` bump needed).
- Resolution priority unchanged: pinned (`read_file`=inf) → named override → `mcp_` prefix → registry → default; named overrides are capped by the model's context-scaled generic budget.
- Docs: `website/docs/user-guide/configuration.md` spillover section updated in the same PR.

## Salvage hardening (commit 3)

The cherry-picked whole-block "prefer `tool_output`, else `tool_budget`" fallback could never fire: `tool_output` ships in `DEFAULT_CONFIG`, so after the loader's deep-merge the primary block always exists and a legacy `tool_budget` setting was silently lost on upgrade. Rewrote the fallback per key and added the invariant test (`test_legacy_tool_budget_key_still_read_per_key`), proven red against the cherry-picked behavior in a live E2E run.

## Validation

**Live repro:** before — `tool_output.tool_overrides.web_search: 20000` in a temp `HERMES_HOME` resolved to the generic 100,000; after — fresh-process E2E (real imports, temp `HERMES_HOME`, real disk I/O) shows a 25K-char `web_search` result spilling to `cache/spillover/` with full payload on disk and a preview in context, while the same content through `terminal` stays inline.

| Check | Result |
|---|---|
| `tests/tools/test_budget_config.py` (30 tests incl. 6 new + legacy-fallback invariant) | pass |
| `tests/hermes_cli/test_config_read_guard.py` | pass |
| Full `tests/tools/` directory | pass except 4 failures identical on unmodified `origin/main` (modal snapshot / parallel web client — pre-existing, unrelated) |
| E2E fresh-process: override honored, spill file readable, legacy `tool_budget` key honored per-key, invalid entries fail closed, no-config path returns byte-identical `DEFAULT_BUDGET` | pass |
| ruff / windows-footguns / compat-pointers / `git diff --check` | clean |

## Credit

Original implementation by @zugende in #94679 — authorship preserved via cherry-pick. Supersedes #94679 (rebase + hardening); the original will be closed with credit once this lands.

## Infographic

![Per-tool spillover budgets](https://v3b.fal.media/files/b/0aa9b6a2/n3kP5H7ONQXnp2AoxZgaT_tnXottkX.png)
