### PR TITLE
fix(approval): allowlist revocations stick and hand edits survive (salvage #91665 + #101840, goose#11383)

### DIFF
--- a/contributors/emails/shuwen.wu@bytedance.com
+++ b/contributors/emails/shuwen.wu@bytedance.com
@@ -1,0 +1,1 @@
+dajiaohuang

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -584,6 +584,26 @@ class TestPatternKeyUniqueness:
             assert is_approved("legacy-find", key_delete) is True
 
 
+class TestPermanentAllowlistReload:
+    def test_load_permanent_replaces_stale_entries(self):
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            load_permanent({"old-pattern"})
+            assert is_approved("reload", "old-pattern") is True
+
+            load_permanent({"new-pattern"})
+
+            assert is_approved("reload", "old-pattern") is False
+            assert is_approved("reload", "new-pattern") is True
+
+    def test_load_permanent_allowlist_clears_when_config_is_empty(self):
+        with mock_patch.object(approval_module, "_permanent_approved", {"stale-pattern"}):
+            with mock_patch("hermes_cli.config.load_config_readonly", return_value={"command_allowlist": []}):
+                assert approval_module.load_permanent_allowlist() == set()
+
+            assert approval_module._permanent_approved == set()
+            assert is_approved("reload", "stale-pattern") is False
+
+
 class TestFullCommandAlwaysShown:
     """The full command is always shown in the approval prompt (no truncation).
 

--- a/tests/tools/test_permanent_allowlist_reconcile.py
+++ b/tests/tools/test_permanent_allowlist_reconcile.py
@@ -1,0 +1,148 @@
+"""`command_allowlist` is a file the operator edits; a save must not clobber it.
+
+`load_permanent_allowlist()` runs once, at module import (tools/approval.py, the
+call at the bottom of the module), and `load_permanent()` only ever unions into
+`_permanent_approved` — nothing removes. `save_permanent_allowlist()` then wrote
+that in-memory set straight back over `config["command_allowlist"]`.
+
+So a hand edit made while a Hermes process is live was undone by the next
+`[a]lways`, in both directions at once: an entry the operator ADDED on disk was
+deleted, and an entry they REMOVED — the documented way to withdraw a standing
+approval — came back.
+
+Reconciling at write time fixes both. The file is re-read and the result is
+what is on disk now, plus what this process approved since its own baseline.
+"""
+
+import pytest
+
+import tools.approval as approval
+
+
+@pytest.fixture
+def fake_config(monkeypatch):
+    """A dict standing in for config.yaml, plus a clean module baseline."""
+    store = {"command_allowlist": []}
+
+    def _load():
+        return {"command_allowlist": list(store["command_allowlist"])}
+
+    def _save(config):
+        store["command_allowlist"] = list(config.get("command_allowlist", []))
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _load, raising=False)
+    monkeypatch.setattr("hermes_cli.config.save_config", _save, raising=False)
+
+    saved_approved = set(approval._permanent_approved)
+    saved_baseline = set(approval._permanent_baseline)
+    approval._permanent_approved.clear()
+    approval._permanent_baseline = set()
+    try:
+        yield store
+    finally:
+        approval._permanent_approved.clear()
+        approval._permanent_approved.update(saved_approved)
+        approval._permanent_baseline = saved_baseline
+
+
+def _start_process_with(store, entries):
+    """Simulate import-time load against the current file contents."""
+    store["command_allowlist"] = list(entries)
+    approval.load_permanent(set(entries))
+    approval._permanent_baseline = set(entries)
+
+
+# ── the two halves of the bug ─────────────────────────────────────────
+
+
+def test_an_entry_the_operator_added_on_disk_survives_a_save(fake_config):
+    _start_process_with(fake_config, ["git status", "ls *"])
+    fake_config["command_allowlist"] = ["git status", "ls *", "npm test"]
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert "npm test" in fake_config["command_allowlist"], (
+        "a hand-added entry was deleted by an unrelated [a]lways"
+    )
+    assert "docker *" in fake_config["command_allowlist"]
+
+
+def test_an_entry_the_operator_revoked_on_disk_is_not_resurrected(fake_config):
+    _start_process_with(fake_config, ["git status", "ls *"])
+    fake_config["command_allowlist"] = ["ls *"]          # operator revokes it
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert "git status" not in fake_config["command_allowlist"], (
+        "a revoked standing approval came back on the next save"
+    )
+    assert sorted(fake_config["command_allowlist"]) == ["docker *", "ls *"]
+
+
+def test_a_revoked_entry_stops_being_honoured_in_memory_after_the_save(fake_config):
+    _start_process_with(fake_config, ["git status", "ls *"])
+    fake_config["command_allowlist"] = ["ls *"]
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert "git status" not in approval._permanent_approved
+    assert "ls *" in approval._permanent_approved
+    assert "docker *" in approval._permanent_approved
+
+
+# ── the ordinary path must not move ───────────────────────────────────
+
+
+def test_an_untouched_file_round_trips_unchanged(fake_config):
+    _start_process_with(fake_config, ["git status", "ls *"])
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert sorted(fake_config["command_allowlist"]) == ["docker *", "git status", "ls *"]
+
+
+def test_repeated_saves_are_idempotent(fake_config):
+    _start_process_with(fake_config, ["ls *"])
+    approval.approve_permanent("docker *")
+
+    approval.save_permanent_allowlist(approval._permanent_approved)
+    first = sorted(fake_config["command_allowlist"])
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert sorted(fake_config["command_allowlist"]) == first == ["docker *", "ls *"]
+
+
+def test_a_second_process_writing_first_does_not_lose_this_ones_approval(fake_config):
+    """Two live Hermes processes. Whoever writes second must not drop the first."""
+    _start_process_with(fake_config, ["ls *"])
+    # The other process approved something and wrote it out.
+    fake_config["command_allowlist"] = ["ls *", "cargo *"]
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert sorted(fake_config["command_allowlist"]) == ["cargo *", "docker *", "ls *"]
+
+
+def test_empty_start_and_first_approval(fake_config):
+    _start_process_with(fake_config, [])
+    approval.approve_permanent("ls *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+    assert fake_config["command_allowlist"] == ["ls *"]
+
+
+def test_save_failure_is_logged_not_raised(fake_config, monkeypatch):
+    """The existing contract: a config write failure must not break approval."""
+    _start_process_with(fake_config, ["ls *"])
+
+    def _boom():
+        raise OSError("disk full")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom, raising=False)
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)   # must not raise
+    assert "docker *" in approval._permanent_approved

--- a/tests/tools/test_permanent_allowlist_reconcile.py
+++ b/tests/tools/test_permanent_allowlist_reconcile.py
@@ -14,6 +14,8 @@ Reconciling at write time fixes both. The file is re-read and the result is
 what is on disk now, plus what this process approved since its own baseline.
 """
 
+import logging
+
 import pytest
 
 import tools.approval as approval
@@ -135,7 +137,7 @@ def test_empty_start_and_first_approval(fake_config):
     assert fake_config["command_allowlist"] == ["ls *"]
 
 
-def test_save_failure_is_logged_not_raised(fake_config, monkeypatch):
+def test_save_failure_is_logged_not_raised(fake_config, monkeypatch, caplog):
     """The existing contract: a config write failure must not break approval."""
     _start_process_with(fake_config, ["ls *"])
 
@@ -144,5 +146,21 @@ def test_save_failure_is_logged_not_raised(fake_config, monkeypatch):
 
     monkeypatch.setattr("hermes_cli.config.load_config", _boom, raising=False)
     approval.approve_permanent("docker *")
-    approval.save_permanent_allowlist(approval._permanent_approved)   # must not raise
+    with caplog.at_level(logging.WARNING, logger=approval.logger.name):
+        approval.save_permanent_allowlist(approval._permanent_approved)   # must not raise
+    assert "Could not save allowlist" in caplog.text
     assert "docker *" in approval._permanent_approved
+
+
+def test_a_caller_that_passes_a_smaller_set_does_not_remove(fake_config):
+    """Documented consequence of reconciling: ``patterns`` may only add.
+
+    A future `allowlist remove` built on this function would silently no-op.
+    The docstring says so; this pins it so the next reader finds out here
+    rather than in production.
+    """
+    _start_process_with(fake_config, ["ls *", "docker *"])
+
+    approval.save_permanent_allowlist({"ls *"})          # tries to drop docker *
+
+    assert "docker *" in fake_config["command_allowlist"]

--- a/tests/tools/test_permanent_allowlist_reconcile.py
+++ b/tests/tools/test_permanent_allowlist_reconcile.py
@@ -95,29 +95,6 @@ def test_a_revoked_entry_stops_being_honoured_in_memory_after_the_save(fake_conf
     assert "docker *" in approval._permanent_approved
 
 
-# ── the ordinary path must not move ───────────────────────────────────
-
-
-def test_an_untouched_file_round_trips_unchanged(fake_config):
-    _start_process_with(fake_config, ["git status", "ls *"])
-
-    approval.approve_permanent("docker *")
-    approval.save_permanent_allowlist(approval._permanent_approved)
-
-    assert sorted(fake_config["command_allowlist"]) == ["docker *", "git status", "ls *"]
-
-
-def test_repeated_saves_are_idempotent(fake_config):
-    _start_process_with(fake_config, ["ls *"])
-    approval.approve_permanent("docker *")
-
-    approval.save_permanent_allowlist(approval._permanent_approved)
-    first = sorted(fake_config["command_allowlist"])
-    approval.save_permanent_allowlist(approval._permanent_approved)
-
-    assert sorted(fake_config["command_allowlist"]) == first == ["docker *", "ls *"]
-
-
 def test_a_second_process_writing_first_does_not_lose_this_ones_approval(fake_config):
     """Two live Hermes processes. Whoever writes second must not drop the first."""
     _start_process_with(fake_config, ["ls *"])
@@ -128,13 +105,6 @@ def test_a_second_process_writing_first_does_not_lose_this_ones_approval(fake_co
     approval.save_permanent_allowlist(approval._permanent_approved)
 
     assert sorted(fake_config["command_allowlist"]) == ["cargo *", "docker *", "ls *"]
-
-
-def test_empty_start_and_first_approval(fake_config):
-    _start_process_with(fake_config, [])
-    approval.approve_permanent("ls *")
-    approval.save_permanent_allowlist(approval._permanent_approved)
-    assert fake_config["command_allowlist"] == ["ls *"]
 
 
 def test_save_failure_is_logged_not_raised(fake_config, monkeypatch, caplog):

--- a/tests/tools/test_permanent_allowlist_reconcile.py
+++ b/tests/tools/test_permanent_allowlist_reconcile.py
@@ -36,22 +36,23 @@ def fake_config(monkeypatch):
     monkeypatch.setattr("hermes_cli.config.save_config", _save, raising=False)
 
     saved_approved = set(approval._permanent_approved)
-    saved_baseline = set(approval._permanent_baseline)
+    saved_baseline = dict(approval._permanent_baseline_by_home)
     approval._permanent_approved.clear()
-    approval._permanent_baseline = set()
+    approval._permanent_baseline_by_home.clear()
     try:
         yield store
     finally:
         approval._permanent_approved.clear()
         approval._permanent_approved.update(saved_approved)
-        approval._permanent_baseline = saved_baseline
+        approval._permanent_baseline_by_home.clear()
+        approval._permanent_baseline_by_home.update(saved_baseline)
 
 
 def _start_process_with(store, entries):
     """Simulate import-time load against the current file contents."""
     store["command_allowlist"] = list(entries)
     approval.load_permanent(set(entries))
-    approval._permanent_baseline = set(entries)
+    approval._permanent_baseline_by_home[""] = set(entries)
 
 
 # ── the two halves of the bug ─────────────────────────────────────────

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -413,6 +413,10 @@ def save_permanent_allowlist(patterns: set):
     plus ``what this process approved since its own baseline``; revoked entries are
     also dropped from the governing permanent set so ``is_approved()`` stops
     honouring them. Nothing re-reads the file on the approval hot path.
+
+    ``patterns`` may only ADD: an entry left out of it is not removed, because the
+    on-disk list wins for anything this process did not approve itself. Remove
+    entries by editing ``command_allowlist`` in config.yaml.
     """
     try:
         from hermes_cli.config import load_config, save_config

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -373,6 +373,20 @@ def _read_permanent_allowlist() -> set:
     return set(raw)
 
 
+# What ``command_allowlist`` held the last time this process synchronised with the
+# file, per profile home ("" = the unscoped launch profile). Everything in the
+# governing permanent set beyond it is an approval THIS process made, and is the
+# only thing a save is entitled to add: the difference separates "the operator
+# granted this here" from "this was on disk when we started, and may since have
+# been revoked".
+_permanent_baseline_by_home: dict[str, set] = {}
+
+
+def _baseline_key() -> str:
+    from hermes_constants import get_hermes_home_override, hermes_home_key
+    return "" if get_hermes_home_override() is None else hermes_home_key()
+
+
 def load_permanent_allowlist() -> set:
     """Load ``command_allowlist`` from config and sync it into the approval state
     so is_approved() honors 'always' choices from previous sessions."""
@@ -380,6 +394,8 @@ def load_permanent_allowlist() -> set:
         patterns = _read_permanent_allowlist()
         if patterns:
             load_permanent(patterns)
+        with _lock:
+            _permanent_baseline_by_home[_baseline_key()] = set(patterns)
         return patterns
     except Exception as e:
         logger.warning("Failed to load permanent allowlist: %s", e)
@@ -387,12 +403,31 @@ def load_permanent_allowlist() -> set:
 
 
 def save_permanent_allowlist(patterns: set):
-    """Save permanently allowed command patterns to config."""
+    """Save permanently allowed command patterns to config, reconciling with the file.
+
+    ``command_allowlist`` is a file an operator edits by hand; removing an entry
+    there is the documented way to withdraw a standing approval. This process read
+    it once at import and ``load_permanent`` only ever unions, so writing the
+    in-memory set straight back deleted entries added on disk since import and
+    resurrected the ones removed. The result written is ``what is on disk now``
+    plus ``what this process approved since its own baseline``; revoked entries are
+    also dropped from the governing permanent set so ``is_approved()`` stops
+    honouring them. Nothing re-reads the file on the approval hot path.
+    """
     try:
         from hermes_cli.config import load_config, save_config
         config = load_config()
-        config["command_allowlist"] = list(patterns)
-        save_config(config)
+        on_disk = set(config.get("command_allowlist", []) or [])
+        with _lock:
+            key = _baseline_key()
+            baseline = _permanent_baseline_by_home.get(key, set())
+            merged = on_disk | (set(patterns) - baseline)
+            config["command_allowlist"] = sorted(merged)
+            save_config(config)
+            _permanent_baseline_by_home[key] = set(merged)
+            governing = _permanent_set()
+            governing.clear()
+            governing.update(merged)
     except Exception as e:
         logger.warning("Could not save allowlist: %s", e)
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -330,7 +330,9 @@ def approve_permanent(pattern_key: str):
 def load_permanent(patterns: set):
     """Bulk-load permanent allowlist entries from config."""
     with _lock:
-        _permanent_set().update(patterns)
+        governing = _permanent_set()
+        governing.clear()
+        governing.update(patterns)
 
 
 def _persist_choice(session_key: str, choice: str, warnings: list[tuple]) -> None:
@@ -392,8 +394,7 @@ def load_permanent_allowlist() -> set:
     so is_approved() honors 'always' choices from previous sessions."""
     try:
         patterns = _read_permanent_allowlist()
-        if patterns:
-            load_permanent(patterns)
+        load_permanent(patterns)
         with _lock:
             _permanent_baseline_by_home[_baseline_key()] = set(patterns)
         return patterns

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -275,6 +275,13 @@ your configuration file.
 Use `hermes config edit` to review or remove patterns from your permanent allowlist.
 :::
 
+:::caution
+The list is read when Hermes starts. A pattern you remove while a session is
+already running stays approved in that session until it next writes the file
+(the next time you answer `always` to a prompt) or you restart Hermes. If you
+removed it for safety reasons, restart.
+:::
+
 ### Mining Approval History (`hermes approvals suggest`)
 
 Instead of answering the same prompt session after session, you can mine your


### PR DESCRIPTION
Deleting a line from `command_allowlist` in config.yaml now actually withdraws the standing approval — the next `[a]lways` no longer resurrects it, and entries the operator added by hand while a session was live survive the write.

Salvage of two open community PRs that fix complementary halves of the same bug (both cherry-picked with authorship intact), refreshed and merged onto current main:

- **#91665** (@t1mdurden) — the write side. `save_permanent_allowlist()` wrote the in-memory `_permanent_approved` set straight over `config["command_allowlist"]`. Since `load_permanent()` only ever unioned, any hand edit made while a Hermes process was live was undone by that process's next `always`: hand-added entries deleted, revoked entries resurrected. Fix: a `_permanent_baseline` records what the file held at last sync; the save re-reads the file and writes `on-disk ∪ (approved here since baseline)`, then drops revoked entries from the in-memory set too.
- **#101840** (@dajiaohuang, closes #101741) — the read side. `load_permanent()` now replaces instead of unions, and an empty `command_allowlist` clears state, so the runtime reload path (`tui_gateway/server.py` calls `load_permanent_allowlist()` on connect) picks up revocations instead of accreting forever.

The two compose: #101840's replacement semantics alone would let one save from a stale process clobber another's grants; #91665's write-time reconcile prevents exactly that (its `test_a_second_process_writing_first_does_not_lose_this_ones_approval` covers it). Conflict resolution kept main's legacy-string `command_allowlist` recovery (#101840 predates it) and made `load_permanent` run even for an empty pattern set so revoke-all works.

Prompted by aaif-goose/goose#11383 ("preserve permission revocations across managers"), the same bug class in Goose's permission store, fixed there this week.

## Root cause

The in-memory allowlist was union-only in both directions: loads never removed, saves never re-read the file.

## Validation

| Check | Result |
|---|---|
| **Live repro (before, origin/main)** | real imports + temp `HERMES_HOME`: operator revokes `git status` and hand-adds `npm test` on disk; after one `always` the file reads `['docker *', 'git status', 'ls *']` — revoked entry resurrected, hand-add lost |
| **Live repro (after, this branch)** | same script: file reads `['docker *', 'ls *', 'npm test']`; `is_approved("s", "git status")` is False; revoke-all via reload clears in-memory state |
| `scripts/run_tests.sh tests/tools/test_approval.py` | 120 passed |
| `scripts/run_tests.sh tests/tools/test_permanent_allowlist_reconcile.py` | 6 passed |
| ruff / windows-footguns / compat pointers | clean |

Trimmed the salvaged test file to the invariant cases (own commit). Docs caution added to `website/docs/user-guide/security.md` (revocation takes effect at next write or restart).

Closes #101741. Supersedes #91665 and #101840 (will cross-link on merge).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b6cf/BkvrPUFHEvnmaiTPcN202_atREvCgY.png)
