### PR TITLE
fix(stream): proxy-mode and Gemini SSE loops keep the final frame and surface mid-stream drops (salvage #9834, pi#8997)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -506,24 +506,41 @@ def _make_stream_chunk(
     return _envelope(model, "chat.completion.chunk", choice, None, cls=_GeminiStreamChunk)
 
 
+_SSE_DONE = object()  # sentinel: terminal [DONE] frame
+
+
+def _parse_sse_line(line: str) -> Any:
+    """One SSE line → payload dict, ``_SSE_DONE`` for the terminal frame, or None."""
+    line = line.rstrip("\r")
+    if not line.startswith("data: "):
+        return None
+    if (data := line[6:]) == "[DONE]":
+        return _SSE_DONE
+    try:
+        payload = json.loads(data)
+    except json.JSONDecodeError:
+        logger.debug("Non-JSON Gemini SSE line: %s", data[:200])
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
 def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
     buffer = ""
     for chunk in response.iter_text():
         buffer += chunk or ""
         while "\n" in buffer:
             line, buffer = buffer.split("\n", 1)
-            line = line.rstrip("\r")
-            if not line.startswith("data: "):
-                continue
-            if (data := line[6:]) == "[DONE]":
+            payload = _parse_sse_line(line)
+            if payload is _SSE_DONE:
                 return
-            try:
-                payload = json.loads(data)
-            except json.JSONDecodeError:
-                logger.debug("Non-JSON Gemini SSE line: %s", data[:200])
-                continue
-            if isinstance(payload, dict):
+            if payload is not None:
                 yield payload
+    # The final frame may not be newline-terminated: flush the residual buffer
+    # after EOF instead of silently dropping its content (pi#8997 bug class).
+    if buffer:
+        payload = _parse_sse_line(buffer)
+        if payload is not None and payload is not _SSE_DONE:
+            yield payload
 
 
 def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices: Dict[str, Dict[str, Any]]) -> List[_GeminiStreamChunk]:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2568,8 +2568,35 @@ class GatewayTurnMixin:
 
         full_response = ""
         _start = time.time()
+        saw_done = False
+
+        def _consume_sse_line(line: str) -> bool:
+            """Parse one SSE line into full_response; True when the terminal ``[DONE]`` was seen.
+
+            Malformed frames (bad JSON, ``choices: [null]``, non-dict deltas) are skipped —
+            one bad chunk must not abort the whole stream."""
+            nonlocal full_response
+            line = line.strip()
+            if not line.startswith("data: "):
+                return False
+            data = line[6:]
+            if data.strip() == "[DONE]":
+                return True
+            try:
+                choices = json.loads(data).get("choices") or []
+                content = choices[0].get("delta", {}).get("content", "") if choices else ""
+            except (json.JSONDecodeError, TypeError, AttributeError, IndexError):
+                return False
+            if content:
+                full_response += content
+                if _stream_consumer:
+                    _stream_consumer.on_delta(content)
+            return False
+
         try:
-            _timeout = ClientTimeout(total=0, sock_read=1800)
+            # sock_connect bounds the TCP connect phase so an unreachable proxy host
+            # (DNS fail, firewall, remote down) fails fast instead of hanging on the OS default.
+            _timeout = ClientTimeout(total=0, sock_read=1800, sock_connect=30)
             async with _AioClientSession(timeout=_timeout) as session:
                 async with session.post(f"{proxy_url}/v1/chat/completions", json=body, headers=headers) as resp:
                     if resp.status != 200:
@@ -2579,28 +2606,35 @@ class GatewayTurnMixin:
 
                     buffer = ""
                     async for chunk in resp.content.iter_any():
+                        if saw_done:
+                            # A buggy upstream that holds the connection open after [DONE]
+                            # would otherwise block us for up to sock_read seconds.
+                            break
                         if not _run_still_current():
                             return _stale_result("stream")
                         buffer += chunk.decode("utf-8", errors="replace")
                         while "\n" in buffer:
                             line, buffer = buffer.split("\n", 1)
-                            line = line.strip()
-                            if not line.startswith("data: "):
-                                continue
-                            data = line[6:]
-                            if data.strip() == "[DONE]":
+                            if _consume_sse_line(line):
+                                saw_done = True
                                 break
-                            try:
-                                choices = json.loads(data).get("choices", [])
-                            except json.JSONDecodeError:
-                                continue
-                            content = choices[0].get("delta", {}).get("content", "") if choices else ""
-                            if content:
-                                full_response += content
-                                if _stream_consumer:
-                                    _stream_consumer.on_delta(content)
                         if len(buffer) > _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS:
                             raise ValueError("Proxy SSE stream exceeded max buffer size without a line boundary")
+                    # The final SSE frame may not be newline-terminated: flush the residual
+                    # buffer after EOF instead of silently dropping its content.
+                    if not saw_done and buffer:
+                        saw_done = _consume_sse_line(buffer)
+                    if not saw_done:
+                        # Clean EOF without [DONE] — the upstream dropped the response
+                        # mid-stream. Keep any partial text but say so instead of
+                        # presenting the truncation as a complete answer.
+                        logger.warning(
+                            "Proxy SSE stream from %s ended without [DONE] — response may be truncated "
+                            "(%d chars received)", proxy_url, len(full_response),
+                        )
+                        if not full_response:
+                            return self._proxy_error_result(
+                                "⚠️ Proxy connection closed before the response completed")
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -675,3 +675,39 @@ def test_text_only_tool_result_has_no_parts():
     )
     fr = request["contents"][1]["parts"][0]["functionResponse"]
     assert "parts" not in fr
+
+
+class _FakeStreamResponse:
+    """Minimal httpx.Response stand-in for _iter_sse_events: text chunks only."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def iter_text(self):
+        yield from self._chunks
+
+
+def test_iter_sse_events_flushes_residual_buffer_after_eof():
+    """A final SSE frame without a trailing newline must not be dropped (pi#8997 class)."""
+    from agent.gemini_native_adapter import _iter_sse_events
+
+    resp = _FakeStreamResponse([
+        'data: {"candidates": [1]}\n',
+        'data: {"candidates": [2]}',  # no newline, then EOF
+    ])
+    events = list(_iter_sse_events(resp))
+    assert events == [{"candidates": [1]}, {"candidates": [2]}]
+
+
+def test_iter_sse_events_stops_at_done_and_ignores_trailing_frames():
+    """[DONE] terminates iteration even when more frames follow; a residual
+    [DONE] in the leftover buffer is not yielded as data."""
+    from agent.gemini_native_adapter import _iter_sse_events
+
+    resp = _FakeStreamResponse([
+        'data: {"candidates": [1]}\ndata: [DONE]\ndata: {"candidates": [3]}\n',
+    ])
+    assert list(_iter_sse_events(resp)) == [{"candidates": [1]}]
+
+    resp = _FakeStreamResponse(['data: {"candidates": [1]}\ndata: [DONE]'])
+    assert list(_iter_sse_events(resp)) == [{"candidates": [1]}]

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -330,6 +330,68 @@ class TestStreamingResilience:
         assert result["final_response"] == "Hello"
 
     @pytest.mark.asyncio
+    async def test_residual_buffer_flushed_after_eof(self, monkeypatch):
+        """A final SSE frame without a trailing newline must not be dropped.
+
+        The line loop only consumes complete lines; if the upstream's last
+        frame lacks the newline, its content sat in ``buffer`` at EOF and
+        was silently discarded (pi#8997's bug class). The residual buffer
+        is now flushed after the read loop.
+        """
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                'data: {"choices":[{"delta":{"content":" world"}}]}',  # no newline, then EOF
+            ],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert result["final_response"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_eof_without_done_and_no_content_is_an_error(self, monkeypatch):
+        """Clean EOF with no [DONE] and no content must surface an error, not
+        an empty 'response'. With content, the partial text is kept (and the
+        truncation is logged) rather than thrown away."""
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(status=200, sse_chunks=[])
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert "closed before the response completed" in result["final_response"]
+
+    @pytest.mark.asyncio
     async def test_client_timeout_sets_sock_connect(self, monkeypatch):
         """ClientTimeout must bound the TCP connect phase.
 

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -285,6 +285,135 @@ class TestRunAgentViaProxy:
         assert messages[0]["content"] == "hello"
 
 
+class TestStreamingResilience:
+    """Tests for SSE streaming robustness — hang avoidance and malformed-chunk tolerance."""
+
+    @pytest.mark.asyncio
+    async def test_done_marker_stops_reading_trailing_chunks(self, monkeypatch):
+        """After `[DONE]`, no further SSE chunks must be processed.
+
+        A buggy upstream that holds the connection open and streams more
+        chunks after `[DONE]` should not leak those chunks into the
+        response. Regression test for the inner `break` that only exited
+        the line-parse loop, leaving the outer chunk loop to keep reading
+        until sock_read timeout.
+        """
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+
+        # Content → [DONE] → MORE content. The trailing chunk must be
+        # dropped. With the pre-fix code it would be appended to
+        # full_response, since `break` only exited the inner loop.
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                'data: [DONE]\n',
+                'data: {"choices":[{"delta":{"content":" IGNORED"}}]}\n',
+            ],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert result["final_response"] == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_client_timeout_sets_sock_connect(self, monkeypatch):
+        """ClientTimeout must bound the TCP connect phase.
+
+        Without an explicit ``sock_connect``, an unreachable proxy host
+        hangs for the OS default (minutes) before failing. The fix sets
+        a short connect cap so the gateway surfaces the error quickly.
+        """
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(status=200, sse_chunks=['data: [DONE]\n'])
+        session = _FakeSession(resp)
+
+        captured = {}
+
+        def _capture_timeout(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout", side_effect=_capture_timeout):
+                    await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert "sock_connect" in captured, (
+            "ClientTimeout should set sock_connect to bound TCP connect"
+        )
+        assert 0 < captured["sock_connect"] <= 60, (
+            f"sock_connect should be a short, reasonable cap — got {captured['sock_connect']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_chunk_is_skipped_not_fatal(self, monkeypatch):
+        """One bad SSE chunk must not abort the whole stream.
+
+        Pre-fix: `choices[0].get(...)` raised ``AttributeError`` when
+        ``choices[0]`` was ``None``, escaping the narrow
+        ``except json.JSONDecodeError`` and bubbling to the outer
+        ``except Exception`` which returned whatever partial response
+        was accumulated. All later chunks were lost.
+
+        Post-fix: type guards + broader exception handling skip the bad
+        chunk and keep parsing.
+        """
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        source = _make_source()
+
+        resp = _FakeSSEResponse(
+            status=200,
+            sse_chunks=[
+                'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                'data: {"choices":[null]}\n',
+                'data: {"choices":"wrong-type"}\n',
+                'data: {"choices":[{"delta":"wrong-type"}]}\n',
+                'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+                'data: [DONE]\n',
+            ],
+        )
+        session = _FakeSession(resp)
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="hi",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="test",
+                    )
+
+        assert result["final_response"] == "Hello world"
+
+
 class TestEnvVarRegistration:
     """Verify GATEWAY_PROXY_URL and GATEWAY_PROXY_KEY are registered."""
 


### PR DESCRIPTION
Gateway proxy mode and the Gemini native adapter no longer drop the final SSE frame or present a mid-stream connection drop as a complete answer.

Salvage of #9834 (@0xbyt4, cherry-picked with authorship intact) rebased onto current `main` and widened with the bug class from earendil-works/pi#8997 (upstream credit: Qiaochu Hu), where pi's `streamProxy` had the identical pair of defects.

## Root cause

Both SSE line loops only consume complete (`\n`-terminated) lines. A final frame without a trailing newline sits in `buffer` at EOF and is silently discarded; a clean EOF without `data: [DONE]` was returned as if the response were complete.

## Changes

- **`gateway/run_turn.py::_run_agent_via_proxy`** (salvaged from #9834, relocated — the PR predates the facade split and targeted `gateway/run.py`):
  - `[DONE]` now stops the outer chunk loop too (previously only the inner line loop; a buggy upstream holding the connection open blocked the gateway up to `sock_read=1800s`).
  - `sock_connect=30` bounds the TCP connect phase (unreachable proxy host failed on the OS default, minutes).
  - Malformed frames (`choices: [null]`, non-dict deltas) skip cleanly instead of aborting the stream.
- **Widening commit (pi#8997 class):**
  - Residual buffer is flushed after EOF, so a final non-newline-terminated frame's content is kept.
  - Clean EOF without `[DONE]` logs a truncation warning; with zero content received it returns an error result instead of "(No response from remote agent)" semantics on silence.
  - Same residual-flush fix applied to the sibling site `agent/gemini_native_adapter.py::_iter_sse_events` via a shared `_parse_sse_line` helper.

## Validation

| Check | Result |
| --- | --- |
| `tests/gateway/test_proxy_mode.py` (14) + `tests/agent/test_gemini_native_adapter.py` (31) | green |
| Sabotage: fix reverted to `origin/main` | 3 proxy tests + gemini residual-flush test go red |
| Live E2E: real `http.server` streaming a non-terminated SSE tail → real `GatewayRunner._run_agent_via_proxy` | `'Hello truncated world'` recovered (dropped before fix) |
| Live E2E: empty stream, clean EOF, no `[DONE]` | error result surfaced, not an empty "answer" |
| Live E2E: real `httpx.Client` stream → `_iter_sse_events` | final frame recovered |

**Live repro:** before — final non-newline-terminated SSE frame dropped, clean-EOF truncation returned as a complete response; after — tail recovered, truncation warned/surfaced (E2E transcript above, real sockets both surfaces).

Not run here: full CI (dispatches on this PR).

Source PR: https://github.com/NousResearch/hermes-agent/pull/9834 (will be closed with credit if this lands). Upstream reference: https://github.com/earendil-works/pi/pull/8997

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b6d7/tWdNsD9aywLbLnV9feHZl_QVurARb0.png)
