### PR TITLE
fix(tui-gateway): reject sessionless config.set model (#106397)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10316,6 +10316,61 @@ def test_config_set_model_once_requires_live_session(monkeypatch):
     assert "/model --once requires a live session" in resp["error"]["message"]
 
 
+def test_config_set_model_sessionless_rejected(monkeypatch):
+    """Sessionless config.set model must 4001 before _apply_model_switch.
+
+    Missing session_id and a stale session_id miss both take the sessionless
+    branch; unscoped values and legacy --global must be rejected the same way
+    so a Desktop client cannot persist model.default before session.create.
+    """
+    called = {"n": 0}
+
+    def boom(*a, **k):
+        called["n"] += 1
+        raise AssertionError("_apply_model_switch must not run")
+
+    monkeypatch.setattr(server, "_apply_model_switch", boom)
+    for value in ["some-model", "some-model --provider openai-codex --global"]:
+        resp = server.handle_request({
+            "id": "1", "method": "config.set",
+            "params": {"key": "model", "value": value},
+        })
+        assert resp["error"]["code"] == 4001
+        assert called["n"] == 0
+
+    resp = server.handle_request({
+        "id": "1", "method": "config.set",
+        "params": {"session_id": "missing-sid", "key": "model", "value": "some-model --global"},
+    })
+    assert resp["error"]["code"] == 4001
+    assert called["n"] == 0
+
+
+def test_config_set_model_live_session_still_applies_switch(monkeypatch):
+    """CONTROL: a live session still reaches _apply_model_switch, including --global."""
+    called = {"raw": []}
+
+    def fake_apply(sid, session, raw, **_kwargs):
+        called["raw"].append(raw)
+        return {"value": "some-model", "warning": "", "scope": "global"}
+
+    server._sessions["sid"] = _session()
+    monkeypatch.setattr(server, "_apply_model_switch", fake_apply)
+    try:
+        resp = server.handle_request({
+            "id": "1", "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "some-model --provider openai-codex --global",
+            },
+        })
+        assert "error" not in resp
+        assert called["raw"] == ["some-model --provider openai-codex --global"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_config_set_model_session_switch_clears_pending_once_restore(monkeypatch):
     class Agent:
         model = "temp/model"

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -140,7 +140,13 @@ def _set_model(rid, params, key, value, session):
             with _session_profile_runtime_scope(session):
                 _persist_live_session_runtime(session)
     else:
-        result = _apply_model_switch("", {"agent": None}, value, confirm_expensive_model=confirmed)
+        # --once keeps its specific 5001; other sessionless model sets 4001 so
+        # --global cannot persist profile defaults before session.create.
+        from hermes_cli.model_switch import parse_model_switch_args
+        if parse_model_switch_args(str(value)).is_once:
+            result = _apply_model_switch("", {"agent": None}, value, confirm_expensive_model=confirmed)
+        else:
+            return _err(rid, 4001, "config.set model requires a live session")
     return _kv(rid, key, result["value"], warning=result["warning"],
                confirm_required=result.get("confirm_required", False),
                confirm_message=result.get("confirm_message", ""), scope=result.get("scope", "session"))


### PR DESCRIPTION
## Summary
- Reject `config.set model` when no live TUI-gateway session resolves (error `4001`), including legacy `--global` values that previously persisted `model.default` / `model.provider` via the sessionless `_apply_model_switch` fallback.
- Preserve the existing `--once` sessionless error (`5001` + live-session message) and leave live-session `--global` / Settings `/api/model/set` unchanged.

Fixes #106397

## Proof Receipt
- **BEFORE (RED):** `test_config_set_model_sessionless_rejected` failed with `assert 5001 == 4001` on pre-fix main (`d0df324`).
- **AFTER (GREEN):** focused suite via `scripts/run_tests.sh` — 6 related tests passed (sessionless reject, live CONTROL, `--once` requires live session, live switch path, global persists, `--once` keeps env).
- **CONTROL:** live session still reaches `_apply_model_switch` (including `--global`).
- **Self-review P0:** 0 (Detection / Fail-open / Forbidden / RED proof / diff scope all PASS). Independent code-review skipped (2 files, ~62 lines, no auth/crypto/state.db).

## Test plan
- [x] `scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'sessionless_rejected or live_session_still_applies_switch or once_requires_live_session or uses_live_switch_path or global_persists or once_keeps_env'`
- [ ] CI on this PR

## Risks
- Sessionless `--once --global` still surfaces the existing once/global conflict as `5001` (does not persist). Intentional to keep `--once` specificity.


Made with [Cursor](https://cursor.com)