### PR TITLE
fix(desktop): join empty git_branch chats to live trunk lane

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -839,6 +839,46 @@ describe('overlayLiveLanes', () => {
     expect(groups.some(g => g.label === 'main' || g.id.endsWith('::branch::main'))).toBe(false)
   })
 
+  it('joins a fresh empty-git_branch session into the live master home lane', () => {
+    // session.create can INSERT cwd without git columns. liveLaneForRepo then
+    // used DEFAULT_BRANCH_LABEL ("main") and forked a second trunk next to
+    // ::branch::master. Empty git_branch must join the existing isMain lane
+    // on the same path.
+    const root = '/www/app'
+    const existing = makeCwdSession(root, { id: 'old', git_branch: 'master' })
+    const fresh = makeCwdSession(root, { id: 'fresh' })
+
+    const project = projectNode({
+      id: root,
+      repos: [
+        {
+          id: root,
+          label: 'app',
+          path: root,
+          sessionCount: 1,
+          groups: [
+            lane({
+              id: `${root}::branch::master`,
+              label: 'master',
+              isMain: true,
+              path: root,
+              sessions: [existing]
+            })
+          ]
+        }
+      ]
+    })
+
+    const overlaid = overlayLiveLanes(project, [existing, fresh])
+    const groups = overlaid.repos[0].groups
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].label).toBe('master')
+    expect(groups[0].id).toBe(`${root}::branch::master`)
+    expect(groups[0].sessions.map(s => s.id).sort()).toEqual(['fresh', 'old'])
+    expect(groups.some(g => g.label === 'main' || g.id.endsWith('::branch::main'))).toBe(false)
+  })
+
   it('joins a fresh live session into an existing non-git workspace lane (no branch id)', () => {
     const root = '/work/notes'
     const existing = makeCwdSession(root, { id: 'old' })

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -604,17 +604,13 @@ export function overlayRepoLanes(
         (placed.isMain
           ? lanes.find(g => g.isMain && g.label.toLowerCase() === placed.label.toLowerCase())
           : undefined) ??
-        // Non-git backend heuristic (`project_tree._place_by_heuristic`): one
-        // isMain lane keyed by the folder path itself (id === path, label =
-        // basename) — not `::branch::<name>`. Live placement always emits
-        // `::branch::main` / label "main", so id+label miss and used to FORK a
-        // phantom second main lane with the same sessions. Prefer the existing
-        // path-keyed main lane when present.
+        // Existing trunk on this path, any id shape: non-git heuristic (id ===
+        // path, no `::branch::`) OR a live `::branch::<HEAD>` lane. Live
+        // placement uses DEFAULT_BRANCH_LABEL ("main") when git_branch is empty,
+        // so id+label miss and used to FORK a phantom second trunk. Prefer the
+        // existing isMain lane on the same path.
         (placed.isMain && placedKey
-          ? lanes.find(
-              g =>
-                g.isMain && pathKey(g.path) === placedKey && !g.id.includes('::branch::') && !g.id.includes('::kanban')
-            )
+          ? lanes.find(g => g.isMain && pathKey(g.path) === placedKey && !g.id.includes('::kanban'))
           : undefined) ??
         (!placed.isMain && placedKey ? lanes.find(g => pathKey(g.path) === placedKey) : undefined)
 

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -225,6 +225,23 @@ def test_unrecorded_and_recorded_main_share_one_lane():
     assert len(main_lanes[0]["sessions"]) == 2
 
 
+def test_unrecorded_and_recorded_master_share_one_lane():
+    # Empty git_branch must join the recorded trunk (master), not invent a
+    # second DEFAULT_BRANCH_LABEL ("main") lane after restart.
+    resolve = _resolver({"/repo": ("/repo", "/repo")})
+    sessions = [_session("/repo", branch=""), _session("/repo", branch="master")]
+
+    tree = pt.build_tree([], sessions, [], resolve, hydrate=True)
+    project = tree["projects"][0]
+    lanes = [g for repo in project["repos"] for g in repo["groups"]]
+
+    assert len(lanes) == 1
+    assert lanes[0]["label"] == "master"
+    assert lanes[0]["id"] == "/repo::branch::master"
+    assert len(lanes[0]["sessions"]) == 2
+    assert not any(g["label"] == "main" for g in lanes)
+
+
 def test_main_checkout_detected_when_roots_differ_only_in_path_spelling():
     # The two roots come from DIFFERENT git probes: `rev-parse --show-toplevel`
     # emits forward slashes, while the `--git-common-dir` path goes through

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -242,13 +242,39 @@ def _repo_node(root: str, label: str) -> dict:
     return {"id": root, "label": label, "path": root, "groups": [], "sessionCount": 0}
 
 
+def _trunk_fallback_by_repo(sessions: list[dict], resolve: Optional[Resolve]) -> dict[str, str]:
+    """Recorded main-checkout branch per repo, so empty git_branch does not invent ``main``."""
+    votes: dict[str, dict[str, int]] = {}
+    for session in sessions:
+        branch = _field(session, "git_branch")
+        if not branch:
+            continue
+        placement = _place_session(session, resolve)
+        if not placement or not placement["is_main"]:
+            continue
+        repo = _path_key(placement["repo_key"])
+        by_branch = votes.setdefault(repo, {})
+        by_branch[branch] = by_branch.get(branch, 0) + 1
+    fallback: dict[str, str] = {}
+    for repo, by_branch in votes.items():
+        trunks = {name: count for name, count in by_branch.items() if name.lower() in _TRUNK_BRANCHES}
+        pool = trunks or by_branch
+        fallback[repo] = max(pool, key=lambda name: (pool[name], name.lower() in _TRUNK_BRANCHES, name))
+    return fallback
+
+
 def _build_repos(sessions: list[dict], resolve: Optional[Resolve], hydrate: bool) -> list[dict]:
     """Build the ``repo -> lane -> sessions`` subtree for a set of sessions."""
     lanes: dict[str, tuple[dict, dict]] = {}  # lane identity -> (group, placement)
+    trunk_fallback = _trunk_fallback_by_repo(sessions, resolve)
     for session in sessions:
         placement = _place_session(session, resolve)
         if not placement:
             continue
+        if placement["is_main"] and not _field(session, "git_branch"):
+            recorded = trunk_fallback.get(_path_key(placement["repo_key"]))
+            if recorded:
+                placement = _trunk_placement(placement["repo_key"], recorded)
         lane_identity = _lane_key(placement["lane_key"])
         if lane_identity not in lanes:
             group = dict(zip(_LANE_FIELDS, (placement[k] for k in _PLACEMENT_LANE_KEYS)))


### PR DESCRIPTION
## What does this PR do?

Stops the desktop project sidebar from forking a phantom `main` trunk when a new session has `cwd` but empty `git_branch`.

## Related Issue

N/A — found on a repo whose live HEAD is `master`. Distinct from duplicate non-git `main` lanes (#83835) and entered-project header UX (#71232).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Bug Description

`session.create` can INSERT `cwd` without git columns. `liveLaneForRepo` then labels the row `DEFAULT_BRANCH_LABEL` (`main`). Overlay matched existing trunks by id/label, then only a *non*-`::branch::` isMain lane. A live `::branch::master` (or any non-`main` HEAD) missed, so the new chat opened a second trunk.

## Root Cause

The path-keyed isMain fallback explicitly skipped `::branch::` ids. That was right for non-git folder lanes. It was wrong once a git home lane already exists as `::branch::<HEAD>`.

## Fix

Join an existing isMain lane on the same path, including `::branch::<HEAD>`. Still skip `::kanban`. Do not change `DEFAULT_BRANCH_LABEL`.

## How to Test

1. Open a git project whose current branch is not `main` (for example `master`).
2. Start a new chat in that project before git metadata is stamped.
3. The row must land under the live trunk lane, not a new `main` group.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, `npx vitest run src/app/chat/sidebar/projects/workspace-groups.test.ts` (67 passed)

### Documentation & Housekeeping

- [x] N/A for docs / config / AGENTS.md

## Test Plan

- [x] Added regression test: empty `git_branch` joins `::branch::master`
- [x] Existing `workspace-groups.test.ts` still pass (67)
- [ ] Manual verification after merge on a non-`main` default branch

## Risk Assessment

Low — overlay placement only. Non-git path-keyed trunks still match. Linked worktrees are unchanged.