### PR TITLE
fix(auth): preserve SSL error + PQ-hint in Codex device-login failures

### DIFF
--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -20,9 +20,18 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
 from hermes_cli.auth_constants import (
-    _decode_jwt_claims, AUTH_LOCK_TIMEOUT_SECONDS, AuthError,
-    CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS, CODEX_OAUTH_CLIENT_ID, CODEX_OAUTH_TOKEN_URL,
-    CODEX_OAUTH_USER_AGENT, CODEX_RATE_LIMITED_CODE, DEFAULT_CODEX_BASE_URL, _codex_err, httpx)
+    _decode_jwt_claims,
+    AUTH_LOCK_TIMEOUT_SECONDS,
+    AuthError,
+    CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    CODEX_OAUTH_CLIENT_ID,
+    CODEX_OAUTH_TOKEN_URL,
+    CODEX_OAUTH_USER_AGENT,
+    CODEX_RATE_LIMITED_CODE,
+    DEFAULT_CODEX_BASE_URL,
+    _codex_err,
+    httpx,
+)
 from utils import env_float
 
 if TYPE_CHECKING:  # annotation-only; the runtime import would be a cycle
@@ -32,15 +41,18 @@ if TYPE_CHECKING:  # annotation-only; the runtime import would be a cycle
 logger = logging.getLogger("hermes_cli.auth")
 
 _MISSING_ACCESS_TOKEN_MSG = (
-    "Codex auth is missing access_token. Run `hermes auth` to re-authenticate.")
+    "Codex auth is missing access_token. Run `hermes auth` to re-authenticate."
+)
 _MISSING_REFRESH_TOKEN_MSG = (
-    "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.")
+    "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate."
+)
 _NO_CREDENTIALS_MSG = "No Codex credentials stored. Run `hermes auth` to authenticate."
 
 
 def _parse_retry_after_seconds(headers: Any) -> Optional[int]:
     """Best-effort parse of a ``Retry-After`` header into whole seconds."""
     from agent.retry_utils import parse_retry_after_seconds
+
     seconds = parse_retry_after_seconds(headers)
     return None if seconds is None else int(seconds)
 
@@ -52,29 +64,42 @@ def _stripped(value: Any) -> str:
 def _clear_pool_entry_status(entry: Dict[str, Any]) -> None:
     """Reset a pool entry's cooldown / last-error metadata to healthy."""
     from hermes_cli.auth import _POOL_STATUS_FIELDS
+
     for status_field in _POOL_STATUS_FIELDS:
         entry[status_field] = None
 
 
 def _codex_access_token_is_expiring(access_token: Any, skew_seconds: int) -> bool:
     exp = _decode_jwt_claims(access_token).get("exp")
-    return isinstance(exp, (int, float)) and float(exp) <= (time.time() + max(0, int(skew_seconds)))
+    return isinstance(exp, (int, float)) and float(exp) <= (
+        time.time() + max(0, int(skew_seconds))
+    )
 
 
 def _codex_base_url() -> str:
-    return os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
+    return (
+        os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        or DEFAULT_CODEX_BASE_URL
+    )
 
 
 def _codex_runtime_result(
-    api_key: str, *, source: str, last_refresh: Optional[str]) -> Dict[str, Any]:
+    api_key: str, *, source: str, last_refresh: Optional[str]
+) -> Dict[str, Any]:
     return {
-        "provider": "openai-codex", "base_url": _codex_base_url(), "api_key": api_key,
-        "source": source, "last_refresh": last_refresh, "auth_mode": "chatgpt"}
+        "provider": "openai-codex",
+        "base_url": _codex_base_url(),
+        "api_key": api_key,
+        "source": source,
+        "last_refresh": last_refresh,
+        "auth_mode": "chatgpt",
+    }
 
 
 def _load_auth_store_maybe_locked(lock: bool) -> Dict[str, Any]:
     """Load the auth store, taking the cross-process lock unless the caller already holds it."""
     from hermes_cli.auth import _auth_store_lock, _load_auth_store
+
     if lock:
         with _auth_store_lock():
             return _load_auth_store()
@@ -84,6 +109,7 @@ def _load_auth_store_maybe_locked(lock: bool) -> Dict[str, Any]:
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json)."""
     from hermes_cli.auth import _load_provider_state, _nonempty_str
+
     auth_store = _load_auth_store_maybe_locked(_lock)
     state = _load_provider_state(auth_store, "openai-codex")
     if not state:
@@ -92,18 +118,26 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     if not isinstance(tokens, dict):
         raise _codex_err(
             "Codex auth state is missing tokens. Run `hermes auth` to re-authenticate.",
-            "codex_auth_invalid_shape", relogin=True)
+            "codex_auth_invalid_shape",
+            relogin=True,
+        )
     if not _nonempty_str(tokens.get("access_token")):
-        raise _codex_err(_MISSING_ACCESS_TOKEN_MSG, "codex_auth_missing_access_token", relogin=True)
+        raise _codex_err(
+            _MISSING_ACCESS_TOKEN_MSG, "codex_auth_missing_access_token", relogin=True
+        )
     if not _nonempty_str(tokens.get("refresh_token")):
         raise _codex_err(
-            _MISSING_REFRESH_TOKEN_MSG, "codex_auth_missing_refresh_token", relogin=True)
+            _MISSING_REFRESH_TOKEN_MSG, "codex_auth_missing_refresh_token", relogin=True
+        )
     return {"tokens": tokens, "last_refresh": state.get("last_refresh")}
 
 
 def _sync_codex_pool_entries(
-    auth_store: Dict[str, Any], tokens: Dict[str, str], last_refresh: Optional[str],
-    previous_singleton_tokens: Optional[Dict[str, str]] = None) -> None:
+    auth_store: Dict[str, Any],
+    tokens: Dict[str, str],
+    last_refresh: Optional[str],
+    previous_singleton_tokens: Optional[Dict[str, str]] = None,
+) -> None:
     """Mirror a fresh Codex re-auth into the credential_pool OAuth entries.
 
     ``device_code`` (the singleton-seeded entry from ``hermes setup`` / the model picker) is always
@@ -131,7 +165,8 @@ def _sync_codex_pool_entries(
     for entry in _codex_pool_dicts(entries):
         source = entry.get("source")
         is_alias = source == "manual:device_code" and bool(
-            prev_at and entry.get("access_token") == prev_at)
+            prev_at and entry.get("access_token") == prev_at
+        )
         if not (source == "device_code" or is_alias):
             continue
         entry["access_token"] = access_token
@@ -142,11 +177,19 @@ def _sync_codex_pool_entries(
         _clear_pool_entry_status(entry)
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
+def _save_codex_tokens(
+    tokens: Dict[str, str], last_refresh: str = None, label: str = None
+) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     from hermes_cli.auth import (
-        _auth_store_lock, _load_auth_store, _load_provider_state, _save_auth_store,
-        _save_provider_state, _utc_now_z)
+        _auth_store_lock,
+        _load_auth_store,
+        _load_provider_state,
+        _save_auth_store,
+        _save_provider_state,
+        _utc_now_z,
+    )
+
     if last_refresh is None:
         last_refresh = _utc_now_z()
     with _auth_store_lock():
@@ -155,24 +198,33 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
         # Capture the previous singleton tokens BEFORE overwriting: the pool sync uses them to
         # tell legacy singleton-aliases (refresh) from independent ``auth add`` accounts (keep).
         previous_singleton_tokens = (
-            state.get("tokens") if isinstance(state.get("tokens"), dict) else None)
+            state.get("tokens") if isinstance(state.get("tokens"), dict) else None
+        )
         state.update(tokens=tokens, last_refresh=last_refresh, auth_mode="chatgpt")
         if label and str(label).strip():
             state["label"] = str(label).strip()
         _save_provider_state(auth_store, "openai-codex", state)
         _sync_codex_pool_entries(
-            auth_store, tokens, last_refresh, previous_singleton_tokens=previous_singleton_tokens)
+            auth_store,
+            tokens,
+            last_refresh,
+            previous_singleton_tokens=previous_singleton_tokens,
+        )
         _save_auth_store(auth_store)
 
 
 def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
     """Adopt a valid Codex CLI token pair into Hermes auth, if available."""
     from hermes_cli.auth import _import_codex_cli_tokens, _save_codex_tokens
+
     imported = _import_codex_cli_tokens()
     # Require BOTH tokens before adopting: persisting a payload without a usable refresh_token
     # would only break the next refresh cycle.
-    if not (imported and _stripped(imported.get("access_token"))
-            and _stripped(imported.get("refresh_token"))):
+    if not (
+        imported
+        and _stripped(imported.get("access_token"))
+        and _stripped(imported.get("refresh_token"))
+    ):
         return None
     logger.info("Codex auth recovered from Codex CLI auth.json (%s).", reason)
     _save_codex_tokens(imported)
@@ -180,23 +232,34 @@ def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
 
 
 def _refresh_payload_access_token(
-    response: "httpx.Response", *, provider: str, invalid_json: Tuple[str, str],
-    invalid_response: Optional[Tuple[str, str]], missing_access: Tuple[str, str],
-    relogin_required: bool = True, invalid_json_relogin: Optional[bool] = None,
-    strict_str: bool = True) -> Tuple[Dict[str, Any], str]:
+    response: "httpx.Response",
+    *,
+    provider: str,
+    invalid_json: Tuple[str, str],
+    invalid_response: Optional[Tuple[str, str]],
+    missing_access: Tuple[str, str],
+    relogin_required: bool = True,
+    invalid_json_relogin: Optional[bool] = None,
+    strict_str: bool = True,
+) -> Tuple[Dict[str, Any], str]:
     """Parse a 200 token-refresh response; return ``(payload, stripped access_token)``.
 
     Each ``(message, code)`` pair keeps the provider's historical wording; ``{exc}`` in
     *invalid_json*'s message is formatted with the JSON error. *strict_str* rejects non-string
     access tokens; otherwise they are ``str()``-coerced.
     """
+
     def _err(message: str, code: str, relogin: bool = relogin_required) -> AuthError:
-        return AuthError(message, provider=provider, code=code, relogin_required=relogin)
+        return AuthError(
+            message, provider=provider, code=code, relogin_required=relogin
+        )
 
     try:
         payload = response.json()
     except Exception as exc:
-        relogin = relogin_required if invalid_json_relogin is None else invalid_json_relogin
+        relogin = (
+            relogin_required if invalid_json_relogin is None else invalid_json_relogin
+        )
         raise _err(invalid_json[0].format(exc=exc), invalid_json[1], relogin) from exc
     if not isinstance(payload, dict):
         if invalid_response is not None:
@@ -212,13 +275,21 @@ def _refresh_payload_access_token(
     return payload, access
 
 
-def _codex_login_post(url: str, *, failure: Tuple[str, str], **kwargs: Any) -> "httpx.Response":
+def _codex_login_post(
+    url: str, *, failure: Tuple[str, str], **kwargs: Any
+) -> "httpx.Response":
     """One 15s POST for the device-login flow; transport errors become ``_codex_err(*failure)``."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
     try:
         with _codex_http_client(timeout=httpx.Timeout(15.0)) as client:
             return client.post(url, **kwargs)
     except Exception as exc:
-        raise _codex_err(f"{failure[0]}: {exc}", failure[1])
+        msg = f"{failure[0]}: {exc}"
+        hint = _ssl_tls_middlebox_hint(exc)
+        if hint:
+            msg += hint
+        raise _codex_err(msg, failure[1])
 
 
 def _codex_http_client(**kwargs: Any) -> "httpx.Client":
@@ -236,6 +307,7 @@ def _codex_http_client(**kwargs: Any) -> "httpx.Client":
     client = httpx.Client(**kwargs)
     with suppress(Exception):
         from agent.process_bootstrap import enable_happy_eyeballs_on_client
+
         enable_happy_eyeballs_on_client(client)
     return client
 
@@ -244,15 +316,17 @@ def _codex_quota_exhausted_error(retry_after: Optional[int]) -> AuthError:
     message = (
         f"Codex provider quota exhausted (429); retry after {retry_after}s. "
         "Credentials are still valid."
-        if retry_after is not None else
-        "Codex provider quota exhausted (429). Credentials are still valid; "
-        "retry after the usage limit resets.")
+        if retry_after is not None
+        else "Codex provider quota exhausted (429). Credentials are still valid; "
+        "retry after the usage limit resets."
+    )
     return _codex_err(message, CODEX_RATE_LIMITED_CODE, relogin=False)
 
 
 def _codex_refresh_failure_error(response: "httpx.Response") -> AuthError:
     """Decode a non-200 Codex token-refresh response into a shaped AuthError."""
     from hermes_cli.auth import _nonempty_str
+
     code = "codex_refresh_failed"
     message = f"Codex token refresh failed with status {response.status_code}."
     try:
@@ -280,60 +354,89 @@ def _codex_refresh_failure_error(response: "httpx.Response") -> AuthError:
             "Codex refresh token was already consumed by another client "
             "(e.g. Codex CLI or VS Code extension). "
             "Run `codex` in your terminal to generate fresh tokens, "
-            "then run `hermes auth` to re-authenticate.")
+            "then run `hermes auth` to re-authenticate."
+        )
     # A 401/403 from the token endpoint always means the refresh token is invalid/expired —
     # force relogin even if the body error code wasn't one of the known strings.
-    relogin_required = (
-        code in {"invalid_grant", "invalid_token", "invalid_request", "refresh_token_reused"}
-        or response.status_code in {401, 403})
+    relogin_required = code in {
+        "invalid_grant",
+        "invalid_token",
+        "invalid_request",
+        "refresh_token_reused",
+    } or response.status_code in {401, 403}
     return _codex_err(message, code, relogin=relogin_required)
 
 
 def refresh_codex_oauth_pure(
-    access_token: str, refresh_token: str, *, timeout_seconds: float = 20.0) -> Dict[str, Any]:
+    access_token: str, refresh_token: str, *, timeout_seconds: float = 20.0
+) -> Dict[str, Any]:
     """Refresh Codex OAuth tokens without mutating Hermes auth state."""
     from hermes_cli.auth import _nonempty_str, _utc_now_z
-    del access_token  # Access token is only used by callers to decide whether to refresh.
+
+    del (
+        access_token
+    )  # Access token is only used by callers to decide whether to refresh.
     if not _nonempty_str(refresh_token):
         raise _codex_err(
-            _MISSING_REFRESH_TOKEN_MSG, "codex_auth_missing_refresh_token", relogin=True)
+            _MISSING_REFRESH_TOKEN_MSG, "codex_auth_missing_refresh_token", relogin=True
+        )
     with _codex_http_client(
         timeout=httpx.Timeout(max(5.0, float(timeout_seconds))),
-        headers={"Accept": "application/json", "User-Agent": CODEX_OAUTH_USER_AGENT}) as client:
+        headers={"Accept": "application/json", "User-Agent": CODEX_OAUTH_USER_AGENT},
+    ) as client:
         response = client.post(
-            CODEX_OAUTH_TOKEN_URL, headers={"Content-Type": "application/x-www-form-urlencoded"},
+            CODEX_OAUTH_TOKEN_URL,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={
-                "grant_type": "refresh_token", "refresh_token": refresh_token,
-                "client_id": CODEX_OAUTH_CLIENT_ID})
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": CODEX_OAUTH_CLIENT_ID,
+            },
+        )
     if response.status_code == 429:
         # Quota exhaustion on the token endpoint: the refresh token is still valid and re-auth
         # cannot lift a quota cap, so classify distinctly from auth failures ("retry later").
         raise _codex_quota_exhausted_error(
-            _parse_retry_after_seconds(getattr(response, "headers", None)))
+            _parse_retry_after_seconds(getattr(response, "headers", None))
+        )
     if response.status_code != 200:
         raise _codex_refresh_failure_error(response)
     refresh_payload, refreshed_access = _refresh_payload_access_token(
-        response, provider="openai-codex", invalid_response=None,
-        invalid_json=("Codex token refresh returned invalid JSON.", "codex_refresh_invalid_json"),
+        response,
+        provider="openai-codex",
+        invalid_response=None,
+        invalid_json=(
+            "Codex token refresh returned invalid JSON.",
+            "codex_refresh_invalid_json",
+        ),
         missing_access=(
             "Codex token refresh response was missing access_token.",
-            "codex_refresh_missing_access_token"))
+            "codex_refresh_missing_access_token",
+        ),
+    )
     updated = {
-        "access_token": refreshed_access, "refresh_token": refresh_token.strip(),
-        "last_refresh": _utc_now_z()}
+        "access_token": refreshed_access,
+        "refresh_token": refresh_token.strip(),
+        "last_refresh": _utc_now_z(),
+    }
     next_refresh = refresh_payload.get("refresh_token")
     if _nonempty_str(next_refresh):
         updated["refresh_token"] = next_refresh.strip()
     return updated
 
 
-def _refresh_codex_auth_tokens(tokens: Dict[str, str], timeout_seconds: float) -> Dict[str, str]:
+def _refresh_codex_auth_tokens(
+    tokens: Dict[str, str], timeout_seconds: float
+) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token."""
     from hermes_cli.auth import _save_codex_tokens, refresh_codex_oauth_pure
+
     try:
         refreshed = refresh_codex_oauth_pure(
-            str(tokens.get("access_token", "") or ""), str(tokens.get("refresh_token", "") or ""),
-            timeout_seconds=timeout_seconds)
+            str(tokens.get("access_token", "") or ""),
+            str(tokens.get("refresh_token", "") or ""),
+            timeout_seconds=timeout_seconds,
+        )
     except AuthError as exc:
         # Self-heal cross-store rotation: refresh_tokens are single-use, so when the Codex CLI (or
         # another Hermes process) rotates the shared token this frozen copy fails with a
@@ -343,13 +446,16 @@ def _refresh_codex_auth_tokens(tokens: Dict[str, str], timeout_seconds: float) -
         if not getattr(exc, "relogin_required", False):
             raise
         imported = _recover_codex_tokens_from_cli(
-            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}")
+            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
+        )
         if not imported:
             raise
         return imported
     updated_tokens = {
-        **tokens, "access_token": refreshed["access_token"],
-        "refresh_token": refreshed["refresh_token"]}
+        **tokens,
+        "access_token": refreshed["access_token"],
+        "refresh_token": refreshed["refresh_token"],
+    }
     _save_codex_tokens(updated_tokens)
     return updated_tokens
 
@@ -357,19 +463,25 @@ def _refresh_codex_auth_tokens(tokens: Dict[str, str], timeout_seconds: float) -
 def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     """Read ~/.codex/auth.json (Codex CLI file) tokens if valid and not expired; never writes."""
     from hermes_cli.auth import _codex_access_token_is_expiring
+
     codex_home = os.getenv("CODEX_HOME", "").strip() or str(Path.home() / ".codex")
     auth_path = Path(codex_home).expanduser() / "auth.json"
     if not auth_path.is_file():
         return None
     try:
         tokens = json.loads(auth_path.read_text(encoding="utf-8-sig")).get("tokens")
-        if not (isinstance(tokens, dict) and tokens.get("access_token")
-                and tokens.get("refresh_token")):
+        if not (
+            isinstance(tokens, dict)
+            and tokens.get("access_token")
+            and tokens.get("refresh_token")
+        ):
             return None
         # Importing stale tokens that can't be refreshed would leave the user with
         # "Login successful!" but no working credentials.
         if _codex_access_token_is_expiring(tokens["access_token"], 0):
-            logger.debug("Codex CLI tokens at %s are expired — skipping import.", auth_path)
+            logger.debug(
+                "Codex CLI tokens at %s are expired — skipping import.", auth_path
+            )
             return None
         return dict(tokens)
     except Exception:
@@ -377,8 +489,11 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
 
 
 def resolve_codex_runtime_credentials(
-    *, force_refresh: bool = False, refresh_if_expiring: bool = True,
-    refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS) -> Dict[str, Any]:
+    *,
+    force_refresh: bool = False,
+    refresh_if_expiring: bool = True,
+    refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+) -> Dict[str, Any]:
     """Resolve runtime credentials from Hermes's own Codex token store.
 
     Falls back to the credential pool when the singleton (``providers.openai-codex.tokens``) has no
@@ -391,8 +506,12 @@ def resolve_codex_runtime_credentials(
     credential. See issue #32992.
     """
     from hermes_cli.auth import (
-        _auth_store_lock, _codex_access_token_is_expiring, _probe_codex_quota_restored,
-        _read_codex_tokens)
+        _auth_store_lock,
+        _codex_access_token_is_expiring,
+        _probe_codex_quota_restored,
+        _read_codex_tokens,
+    )
+
     read_error: Optional[AuthError] = None
     data = None
     try:
@@ -400,15 +519,22 @@ def resolve_codex_runtime_credentials(
     except AuthError as exc:
         read_error = exc
         if exc.relogin_required and exc.code in {
-            "codex_auth_missing_access_token", "codex_auth_missing_refresh_token",
-            "codex_auth_invalid_shape"}:
+            "codex_auth_missing_access_token",
+            "codex_auth_missing_refresh_token",
+            "codex_auth_invalid_shape",
+        }:
             imported = _recover_codex_tokens_from_cli(str(exc.code or "auth_error"))
             if imported:
-                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
+                data = {
+                    "tokens": imported,
+                    "last_refresh": imported.get("last_refresh"),
+                }
     if data is None:
         pool_token = _pool_codex_access_token()
         if pool_token:
-            return _codex_runtime_result(pool_token, source="credential_pool", last_refresh=None)
+            return _codex_runtime_result(
+                pool_token, source="credential_pool", last_refresh=None
+            )
         pool_rate_limit = _codex_pool_rate_limit_status()
         if pool_rate_limit:
             # Before surfacing the persisted cooldown, ask the usage endpoint whether the quota
@@ -416,16 +542,22 @@ def resolve_codex_runtime_credentials(
             # days in the future while the account is already usable again.
             stale_token = _stripped(pool_rate_limit.get("access_token"))
             if stale_token and _probe_codex_quota_restored(
-                stale_token, base_url=pool_rate_limit.get("base_url")):
-                logger.info("Codex quota restored upstream — clearing stale pool cooldown(s).")
+                stale_token, base_url=pool_rate_limit.get("base_url")
+            ):
+                logger.info(
+                    "Codex quota restored upstream — clearing stale pool cooldown(s)."
+                )
                 clear_codex_pool_quota_cooldowns()
                 pool_token = _pool_codex_access_token()
                 if pool_token:
                     return _codex_runtime_result(
-                        pool_token, source="credential_pool", last_refresh=None)
+                        pool_token, source="credential_pool", last_refresh=None
+                    )
             reset_at = pool_rate_limit.get("reset_at")
             in_future = isinstance(reset_at, (int, float)) and reset_at > time.time()
-            raise _codex_quota_exhausted_error(int(reset_at - time.time()) if in_future else None)
+            raise _codex_quota_exhausted_error(
+                int(reset_at - time.time()) if in_future else None
+            )
         if read_error is not None:
             raise read_error
         raise _codex_err(_NO_CREDENTIALS_MSG, "codex_auth_missing", relogin=True)
@@ -435,11 +567,15 @@ def resolve_codex_runtime_credentials(
 
     def _should_refresh(token: str) -> bool:
         return bool(force_refresh) or (
-            refresh_if_expiring and _codex_access_token_is_expiring(token, refresh_skew_seconds))
+            refresh_if_expiring
+            and _codex_access_token_is_expiring(token, refresh_skew_seconds)
+        )
 
     if _should_refresh(access_token):
         # Re-read under lock to avoid racing with other Hermes processes
-        lock_timeout = max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)
+        lock_timeout = max(
+            float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0
+        )
         with _auth_store_lock(timeout_seconds=lock_timeout):
             data = _read_codex_tokens(_lock=False)
             tokens = dict(data["tokens"])
@@ -447,7 +583,8 @@ def resolve_codex_runtime_credentials(
                 tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
             access_token = _stripped(tokens.get("access_token"))
     return _codex_runtime_result(
-        access_token, source="hermes-auth-store", last_refresh=data.get("last_refresh"))
+        access_token, source="hermes-auth-store", last_refresh=data.get("last_refresh")
+    )
 
 
 def _is_codex_rate_limit_shaped(code: Any, reason: Any, message: Any) -> bool:
@@ -456,14 +593,17 @@ def _is_codex_rate_limit_shaped(code: Any, reason: Any, message: Any) -> bool:
     return (
         code == 429
         or any(k in reason_l for k in ("rate_limit", "usage_limit", "quota"))
-        or any(k in message_l for k in ("rate limit", "usage limit", "quota")))
+        or any(k in message_l for k in ("rate limit", "usage limit", "quota"))
+    )
 
 
 def _entry_is_rate_limit_exhausted(entry: Dict[str, Any]) -> bool:
     """Pool entry frozen by a 429/quota stop (as opposed to an auth failure)."""
     return entry.get("last_status") == "exhausted" and _is_codex_rate_limit_shaped(
-        entry.get("last_error_code"), entry.get("last_error_reason"),
-        entry.get("last_error_message"))
+        entry.get("last_error_code"),
+        entry.get("last_error_reason"),
+        entry.get("last_error_message"),
+    )
 
 
 # Throttle for the live Codex quota probe. It runs on the hot credential-selection path while the
@@ -488,14 +628,18 @@ def _codex_usage_probe_url(base_url: Optional[str]) -> str:
 
 
 def _probe_codex_quota_restored(
-    access_token: Any, *, base_url: Optional[str] = None,
-    min_interval_seconds: float = CODEX_QUOTA_PROBE_MIN_INTERVAL_SECONDS) -> Optional[bool]:
+    access_token: Any,
+    *,
+    base_url: Optional[str] = None,
+    min_interval_seconds: float = CODEX_QUOTA_PROBE_MIN_INTERVAL_SECONDS,
+) -> Optional[bool]:
     """Ask the Codex usage endpoint whether this account's quota is usable again.
 
     Probes are throttled per access token (module-local cache) so the hot selection path can fire
     this freely.
     """
     from hermes_cli.auth import _codex_quota_probe_cache, _nonempty_str
+
     token = _stripped(access_token)
     # Real Codex access tokens are JWTs. Refusing to probe non-JWT tokens avoids pointless
     # network calls for corrupt/placeholder entries (and keeps hermetic test fixtures offline).
@@ -512,12 +656,17 @@ def _probe_codex_quota_restored(
     result: Optional[bool] = None
     try:
         headers = {
-            "Authorization": f"Bearer {token}", "Accept": "application/json",
-            "User-Agent": "codex-cli"}
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "User-Agent": "codex-cli",
+        }
         # Best-effort ChatGPT-Account-Id from the JWT (required for some account shapes).
         auth_claims = _decode_jwt_claims(token).get("https://api.openai.com/auth")
         account_id = (
-            auth_claims.get("chatgpt_account_id") if isinstance(auth_claims, dict) else None)
+            auth_claims.get("chatgpt_account_id")
+            if isinstance(auth_claims, dict)
+            else None
+        )
         if _nonempty_str(account_id):
             headers["ChatGPT-Account-Id"] = account_id.strip()
         with _codex_http_client(timeout=10.0) as client:
@@ -551,6 +700,7 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
     entry just re-freezes with fresh metadata on its next 429).
     """
     from hermes_cli.auth import _auth_store_lock, _load_auth_store, _save_auth_store
+
     cleared = 0
     try:
         with _auth_store_lock():
@@ -559,7 +709,10 @@ def clear_codex_pool_quota_cooldowns(access_token: Optional[str] = None) -> int:
             if entries is None:
                 return 0
             for entry in _codex_pool_dicts(entries):
-                if access_token and str(entry.get("access_token") or "") != access_token:
+                if (
+                    access_token
+                    and str(entry.get("access_token") or "") != access_token
+                ):
                     continue
                 if _entry_is_rate_limit_exhausted(entry):
                     _clear_pool_entry_status(entry)
@@ -580,6 +733,7 @@ def _codex_pool_dicts(entries: Optional[List[Any]]) -> Iterator[Dict[str, Any]]:
 def _read_codex_pool_entries() -> Optional[List[Any]]:
     """Locked read of ``credential_pool.openai-codex`` from auth.json (None when absent)."""
     from hermes_cli.auth import _auth_store_lock, _load_auth_store
+
     with _auth_store_lock():
         auth_store = _load_auth_store()
     return _pool_entries(auth_store, "openai-codex")
@@ -589,6 +743,7 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
     """Return metadata for a pool-only Codex credential in quota cooldown."""
     from hermes_cli.auth import _nonempty_str
     from agent.credential_pool import _parse_absolute_timestamp
+
     try:
         now = time.time()
         for entry in _codex_pool_dicts(_read_codex_pool_entries()):
@@ -598,10 +753,14 @@ def _codex_pool_rate_limit_status() -> Optional[Dict[str, Any]]:
             reset_at = _parse_absolute_timestamp(entry.get("last_error_reset_at"))
             if reset_at is None or reset_at > now:
                 return {
-                    "label": entry.get("label"), "last_refresh": entry.get("last_refresh"),
-                    "reset_at": reset_at, "reason": entry.get("last_error_reason"),
-                    "message": entry.get("last_error_message"), "access_token": token.strip(),
-                    "base_url": entry.get("base_url")}
+                    "label": entry.get("label"),
+                    "last_refresh": entry.get("last_refresh"),
+                    "reset_at": reset_at,
+                    "reason": entry.get("last_error_reason"),
+                    "message": entry.get("last_error_message"),
+                    "access_token": token.strip(),
+                    "base_url": entry.get("base_url"),
+                }
     except Exception:
         logger.debug("Codex pool rate-limit lookup failed", exc_info=True)
     return None
@@ -620,9 +779,13 @@ def _pool_codex_access_token() -> str:
     Fallback for ``resolve_codex_runtime_credentials`` when the singleton has no creds.
     """
     from hermes_cli.auth import _nonempty_str
+
     try:
         for entry in _codex_pool_dicts(_read_codex_pool_entries()):
-            token, reset_at = entry.get("access_token"), entry.get("last_error_reset_at")
+            token, reset_at = (
+                entry.get("access_token"),
+                entry.get("last_error_reset_at"),
+            )
             in_cooldown = isinstance(reset_at, (int, float)) and reset_at > time.time()
             if _nonempty_str(token) and not in_cooldown:
                 return token.strip()
@@ -631,28 +794,47 @@ def _pool_codex_access_token() -> str:
     return ""
 
 
-def _login_openai_codex(args, pconfig: ProviderConfig, *, force_new_login: bool = False) -> None:
+def _login_openai_codex(
+    args, pconfig: ProviderConfig, *, force_new_login: bool = False
+) -> None:
     """OpenAI Codex login via device code flow. Tokens stored in ~/.hermes/auth.json."""
     from hermes_cli.auth import (
-        _codex_access_token_is_expiring, _codex_device_code_login, _import_codex_cli_tokens,
-        _offer_existing_oauth_credentials, _print_login_success, _prompt_yes_no, _save_codex_tokens,
-        _update_config_for_provider, resolve_codex_runtime_credentials)
+        _codex_access_token_is_expiring,
+        _codex_device_code_login,
+        _import_codex_cli_tokens,
+        _offer_existing_oauth_credentials,
+        _print_login_success,
+        _prompt_yes_no,
+        _save_codex_tokens,
+        _update_config_for_provider,
+        resolve_codex_runtime_credentials,
+    )
+
     del args, pconfig  # kept for parity with other provider login helpers
     if not force_new_login:
         if _offer_existing_oauth_credentials(
-            "openai-codex", resolve=resolve_codex_runtime_credentials,
-            is_expiring=_codex_access_token_is_expiring, display_name="Codex",
+            "openai-codex",
+            resolve=resolve_codex_runtime_credentials,
+            is_expiring=_codex_access_token_is_expiring,
+            display_name="Codex",
             default_base_url=DEFAULT_CODEX_BASE_URL,
-            expired_notice="Existing Codex credentials are expired. Starting fresh login..."):
+            expired_notice="Existing Codex credentials are expired. Starting fresh login...",
+        ):
             return
         cli_tokens = _import_codex_cli_tokens()
         if cli_tokens:
             print("Found existing Codex CLI credentials at ~/.codex/auth.json")
-            print("Hermes will create its own session to avoid conflicts with Codex CLI / VS Code.")
+            print(
+                "Hermes will create its own session to avoid conflicts with Codex CLI / VS Code."
+            )
             if _prompt_yes_no(
-                "Import these credentials? (a separate login is recommended) [y/N]: ", default="n"):
+                "Import these credentials? (a separate login is recommended) [y/N]: ",
+                default="n",
+            ):
                 _save_codex_tokens(cli_tokens)
-                config_path = _update_config_for_provider("openai-codex", _codex_base_url())
+                config_path = _update_config_for_provider(
+                    "openai-codex", _codex_base_url()
+                )
                 print()
                 print("Credentials imported. Note: if Codex CLI refreshes its token,")
                 print("Hermes will keep working independently with its own session.")
@@ -667,11 +849,14 @@ def _login_openai_codex(args, pconfig: ProviderConfig, *, force_new_login: bool 
     creds = _codex_device_code_login()
     _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
     config_path = _update_config_for_provider(
-        "openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL))
+        "openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL)
+    )
     _print_login_success("openai-codex", config_path, show_auth_state=True)
 
 
-def _codex_login_rate_limited_error(response: "httpx.Response", *, during: str = "") -> AuthError:
+def _codex_login_rate_limited_error(
+    response: "httpx.Response", *, during: str = ""
+) -> AuthError:
     """AuthError for a 429 from OpenAI's device-auth endpoints (throttle, not credential fault)."""
     # Upstream rate-limit / usage-quota exhaustion on the token endpoint. The stored refresh token is still
     # valid here — re-authenticating cannot lift a quota cap. Classify distinctly from auth failures so
@@ -679,12 +864,15 @@ def _codex_login_rate_limited_error(response: "httpx.Response", *, during: str =
     # #32790).
     retry_after = _parse_retry_after_seconds(getattr(response, "headers", None))
     wait_hint = (
-        f" Try again in about {retry_after}s." if retry_after is not None
-        else " Wait a minute and run the login again.")
+        f" Try again in about {retry_after}s."
+        if retry_after is not None
+        else " Wait a minute and run the login again."
+    )
     return _codex_err(
         f"OpenAI is rate-limiting Codex login requests (HTTP 429){during}. "
         f"This is a temporary throttle on OpenAI's side, not a credential problem.{wait_hint}",
-        CODEX_RATE_LIMITED_CODE)
+        CODEX_RATE_LIMITED_CODE,
+    )
 
 
 def _codex_request_device_code(issuer: str, client_id: str) -> Dict[str, Any]:
@@ -696,32 +884,47 @@ def _codex_request_device_code(issuer: str, client_id: str) -> Dict[str, Any]:
     max_attempts = 4
     for attempt in range(1, max_attempts + 1):
         resp = _codex_login_post(
-            f"{issuer}/api/accounts/deviceauth/usercode", json={"client_id": client_id},
+            f"{issuer}/api/accounts/deviceauth/usercode",
+            json={"client_id": client_id},
             headers={"Content-Type": "application/json"},
-            failure=("Failed to request device code", "device_code_request_failed"))
+            failure=("Failed to request device code", "device_code_request_failed"),
+        )
         if resp.status_code != 429:
             break
         if attempt < max_attempts:
             # Exponential backoff (2s, 4s, 8s) capped, preferring the server's Retry-After.
             retry_after = _parse_retry_after_seconds(getattr(resp, "headers", None))
-            delay = max(1, min(int(retry_after if retry_after is not None else 2 ** attempt), 60))
-            print(f"OpenAI is rate-limiting login requests (429); retrying in {delay}s...")
+            delay = max(
+                1, min(int(retry_after if retry_after is not None else 2**attempt), 60)
+            )
+            print(
+                f"OpenAI is rate-limiting login requests (429); retrying in {delay}s..."
+            )
             time.sleep(delay)
     if resp.status_code == 429:
         raise _codex_login_rate_limited_error(resp)
     if resp.status_code != 200:
         raise _codex_err(
-            f"Device code request returned status {resp.status_code}.", "device_code_request_error")
+            f"Device code request returned status {resp.status_code}.",
+            "device_code_request_error",
+        )
     device_data = resp.json()
     device_data["interval"] = max(3, int(device_data.get("interval", "5")))
-    if not device_data.get("user_code", "") or not device_data.get("device_auth_id", ""):
-        raise _codex_err("Device code response missing required fields.", "device_code_incomplete")
+    if not device_data.get("user_code", "") or not device_data.get(
+        "device_auth_id", ""
+    ):
+        raise _codex_err(
+            "Device code response missing required fields.", "device_code_incomplete"
+        )
     return device_data
 
 
 def _codex_poll_authorization_code(
-    issuer: str, *, device_auth_id: str, user_code: str, poll_interval: int) -> Dict[str, Any]:
+    issuer: str, *, device_auth_id: str, user_code: str, poll_interval: int
+) -> Dict[str, Any]:
     """Step 3 of the Codex device flow: poll until sign-in completes (403/404 = still pending)."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
     max_wait = 15 * 60  # 15 minutes
     start = time.monotonic()
     code_resp = None
@@ -729,17 +932,35 @@ def _codex_poll_authorization_code(
         with _codex_http_client(timeout=httpx.Timeout(15.0)) as client:
             while time.monotonic() - start < max_wait:
                 time.sleep(poll_interval)
-                poll_resp = client.post(
-                    f"{issuer}/api/accounts/deviceauth/token",
-                    json={"device_auth_id": device_auth_id, "user_code": user_code},
-                    headers={"Content-Type": "application/json"})
+                try:
+                    poll_resp = client.post(
+                        f"{issuer}/api/accounts/deviceauth/token",
+                        json={"device_auth_id": device_auth_id, "user_code": user_code},
+                        headers={"Content-Type": "application/json"},
+                    )
+                except Exception as transport_exc:
+                    hint = _ssl_tls_middlebox_hint(transport_exc)
+                    if hint:
+                        raise _codex_err(
+                            f"Device auth poll transport failure: {transport_exc}{hint}",
+                            "device_code_poll_error",
+                        )
+                    raise _codex_err(
+                        f"Device auth poll transport failure: {transport_exc}",
+                        "device_code_poll_error",
+                    )
+
                 if poll_resp.status_code == 200:
                     code_resp = poll_resp.json()
                     break
-                if poll_resp.status_code not in {403, 404}:  # 403/404 = user hasn't finished yet
+                if poll_resp.status_code not in {
+                    403,
+                    404,
+                }:  # 403/404 = user hasn't finished yet
                     raise _codex_err(
                         f"Device auth polling returned status {poll_resp.status_code}.",
-                        "device_code_poll_error")
+                        "device_code_poll_error",
+                    )
     except KeyboardInterrupt:
         print("\nLogin cancelled.")
         raise SystemExit(130)
@@ -749,37 +970,50 @@ def _codex_poll_authorization_code(
 
 
 def _codex_exchange_authorization_code(
-    issuer: str, client_id: str, code_resp: Dict[str, Any]) -> Dict[str, Any]:
+    issuer: str, client_id: str, code_resp: Dict[str, Any]
+) -> Dict[str, Any]:
     """Step 4 of the Codex device flow: swap the authorization code for tokens."""
     authorization_code = code_resp.get("authorization_code", "")
     code_verifier = code_resp.get("code_verifier", "")
     if not authorization_code or not code_verifier:
         raise _codex_err(
             "Device auth response missing authorization_code or code_verifier.",
-            "device_code_incomplete_exchange")
+            "device_code_incomplete_exchange",
+        )
     token_resp = _codex_login_post(
         CODEX_OAUTH_TOKEN_URL,
         data={
-            "grant_type": "authorization_code", "code": authorization_code,
-            "redirect_uri": f"{issuer}/deviceauth/callback", "client_id": client_id,
-            "code_verifier": code_verifier},
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": f"{issuer}/deviceauth/callback",
+            "client_id": client_id,
+            "code_verifier": code_verifier,
+        },
         headers={"Content-Type": "application/x-www-form-urlencoded"},
-        failure=("Token exchange failed", "token_exchange_failed"))
+        failure=("Token exchange failed", "token_exchange_failed"),
+    )
     if token_resp.status_code == 429:
-        raise _codex_login_rate_limited_error(token_resp, during=" during token exchange")
+        raise _codex_login_rate_limited_error(
+            token_resp, during=" during token exchange"
+        )
     if token_resp.status_code != 200:
         raise _codex_err(
-            f"Token exchange returned status {token_resp.status_code}.", "token_exchange_error")
+            f"Token exchange returned status {token_resp.status_code}.",
+            "token_exchange_error",
+        )
     tokens = token_resp.json()
     if not tokens.get("access_token", ""):
         raise _codex_err(
-            "Token exchange did not return an access_token.", "token_exchange_no_access_token")
+            "Token exchange did not return an access_token.",
+            "token_exchange_no_access_token",
+        )
     return tokens
 
 
 def _codex_device_code_login() -> Dict[str, Any]:
     """Run the OpenAI device code login flow and return credentials dict."""
     from hermes_cli.auth import _utc_now_z
+
     issuer, client_id = "https://auth.openai.com", CODEX_OAUTH_CLIENT_ID
     device_data = _codex_request_device_code(issuer, client_id)
     user_code = device_data["user_code"]
@@ -792,13 +1026,20 @@ def _codex_device_code_login() -> Dict[str, Any]:
     print(f"     \033[94m{user_code}\033[0m\n")
     print("Waiting for sign-in... (press Ctrl+C to cancel)")
     code_resp = _codex_poll_authorization_code(
-        issuer, device_auth_id=device_data["device_auth_id"], user_code=user_code,
-        poll_interval=device_data["interval"])
+        issuer,
+        device_auth_id=device_data["device_auth_id"],
+        user_code=user_code,
+        poll_interval=device_data["interval"],
+    )
     tokens = _codex_exchange_authorization_code(issuer, client_id, code_resp)
     # Return tokens for the caller to persist (never writes to ~/.codex/)
     return {
         "tokens": {
             "access_token": tokens.get("access_token", ""),
-            "refresh_token": tokens.get("refresh_token", "")},
-        "base_url": _codex_base_url(), "last_refresh": _utc_now_z(), "auth_mode": "chatgpt",
-        "source": "device-code"}
+            "refresh_token": tokens.get("refresh_token", ""),
+        },
+        "base_url": _codex_base_url(),
+        "last_refresh": _utc_now_z(),
+        "auth_mode": "chatgpt",
+        "source": "device-code",
+    }

--- a/hermes_cli/auth_codex_ssl_helper.py
+++ b/hermes_cli/auth_codex_ssl_helper.py
@@ -1,0 +1,80 @@
+"""Detect SSL/TLS failure patterns during Codex device login and produce a user-facing hint.
+
+Codex device-code login can fail with SSL errors on Python/OpenSSL 3.5 when a middlebox rejects
+a TLS 1.3 handshake containing post-quantum hybrid groups (e.g. X25519MLKEM768 in ClientHello
+`key_share`/`supported_groups`). The resulting transport error is indistinguishable from a genuine
+network outage, but its fix is a client-side OpenSSL configuration that restricts offered groups
+to classic elliptic curves. See issue #106384, PR #44392.
+"""
+
+from __future__ import annotations
+
+import ssl
+from typing import Any
+
+_DOCS_URL = (
+    "https://hermes-agent.nousresearch.com/docs/guides/codex-device-login-tls-failure"
+)
+
+
+def _ssl_tls_middlebox_hint(exc: Any) -> str | None:
+    """Detect SSL/TLS-flavored transport failures and return a hint, or None for unrelated errors.
+
+    Recognized patterns:
+    - ssl.SSLError subclasses (SSLEOFError, SSLSyscallError, ...)
+    - Message substrings: 'UNEXPECTED_EOF_WHILE_READING', 'handshake operation timed out', '[SSL:',
+      'ssl handshake', 'tlsv1 alert', 'sslv3 alert', 'tls alert', 'bad record mac'
+
+    Non-SSL transport errors (ConnectError, ReadTimeout, HTTPStatusError) return None — no false
+    positives.
+    """
+    # Type match: Python SSL exception classes (avoid string-based type-name in case of SDK wrapping)
+    if isinstance(
+        exc,
+        (ssl.SSLError, ssl.SSLEOFError, ssl.SSLSyscallError, ssl.SSLZeroReturnError),
+    ):
+        return _PQ_MIDDLEBOX_HINT
+
+    # Message-based signatures (works for httpx.ConnectError that wraps SSL, SDK-wrapped errors, ...)
+    msg = str(exc).lower()
+    ssl_indicators = (
+        "unexpected_eof_while_reading",
+        "unexpected eof while reading",
+        "handshake operation timed out",
+        "ssl handshake",
+        "tls handshake",
+        "[ssl:",
+        "tlsv1 alert",
+        "sslv3 alert",
+        "tls alert",
+        "bad record mac",
+    )
+    if any(sig in msg for sig in ssl_indicators):
+        return _PQ_MIDDLEBOX_HINT
+
+    return None
+
+
+_PQ_MIDDLEBOX_HINT = (
+    "\n\n"
+    "This failure pattern often indicates an SSL/TLS middlebox (corporate proxy, firewall, "
+    "TLS-intercepting gateway) that rejects TLS 1.3 handshakes containing post-quantum hybrid "
+    "groups. Python/OpenSSL 3.5 advertises such groups by default (e.g. X25519MLKEM768 in ClientHello "
+    "`key_share`), and some middleboxes respond with a connection reset or timeout.\n\n"
+    "curl works but Python fails because curl's TLS stack does not advertise PQ groups by default.\n\n"
+    "Try one of these workarounds:\n\n"
+    "1. **Classic groups OpenSSL config** — create a file with:\n"
+    "   ```\n"
+    "   openssl_conf = openssl_init\n\n"
+    "   [openssl_init]\n"
+    "   ssl_conf = ssl_sect\n\n"
+    "   [ssl_sect]\n"
+    "   system_default = system_default_sect\n\n"
+    "   [system_default_sect]\n"
+    "   Groups = x25519:secp256r1:secp384r1:x448\n"
+    "   ```\n"
+    "   and set `OPENSSL_CONF=/path/to/that/file` before running `hermes model`.\n\n"
+    "2. **Force TLS 1.2** (when #44392 lands): `HERMES_TLS_MAX_VERSION=1.2 hermes model` (TLS 1.2 "
+    "does not carry PQ `key_share` extensions).\n\n"
+    f"Full troubleshooting guide: {_DOCS_URL}"
+)

--- a/tests/hermes_cli/test_auth_codex_ssl_helper.py
+++ b/tests/hermes_cli/test_auth_codex_ssl_helper.py
@@ -1,0 +1,88 @@
+"""Tests for hermes_cli/auth_codex_ssl_helper.py SSL/TLS middlebox hint logic.
+
+Ensures _ssl_tls_middlebox_hint:
+1. Returns a hint for ssl.SSLError / SSLEOFError / 'UNEXPECTED_EOF_WHILE_READING' / 'handshake timed out'
+2. Returns None for non-SSL exceptions (ConnectError without SSL in message, httpx.TimeoutException)
+"""
+
+from __future__ import annotations
+
+import ssl
+import pytest
+
+
+def test_ssl_error_recognized():
+    """ssl.SSLError subclass → hint returned."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
+    exc = ssl.SSLEOFError(
+        "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol"
+    )
+    hint = _ssl_tls_middlebox_hint(exc)
+
+    assert hint is not None
+    assert "post-quantum hybrid groups" in hint
+    assert "X25519MLKEM768" in hint
+    assert "OPENSSL_CONF" in hint
+
+
+def test_unexpected_eof_message_recognized():
+    """Raw Exception with 'UNEXPECTED_EOF_WHILE_READING' in message → hint."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
+    exc = Exception("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred")
+    hint = _ssl_tls_middlebox_hint(exc)
+
+    assert hint is not None
+    assert "middlebox" in hint
+
+
+def test_ssl_handshake_timeout_recognized():
+    """Exception message 'handshake operation timed out' → hint."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
+    exc = ssl.SSLError("_ssl.c:999: The handshake operation timed out")
+    hint = _ssl_tls_middlebox_hint(exc)
+
+    assert hint is not None
+    assert "TLS 1.3" in hint
+
+
+def test_ssl_alert_recognized():
+    """Exception message 'tlsv1 alert unknown ca' → hint."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
+    exc = Exception("tlsv1 alert unknown ca")
+    hint = _ssl_tls_middlebox_hint(exc)
+
+    assert hint is not None
+
+
+def test_non_ssl_connect_error_no_hint():
+    """Plain ConnectError without SSL signature → None."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
+    exc = Exception("[Errno 61] Connection refused")
+    hint = _ssl_tls_middlebox_hint(exc)
+
+    assert hint is None
+
+
+def test_read_timeout_no_hint():
+    """Timeout without SSL signature → None."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
+    exc = Exception("ReadTimeout: Request timeout after 15.0s")
+    hint = _ssl_tls_middlebox_hint(exc)
+
+    assert hint is None
+
+
+def test_http_status_error_no_hint():
+    """HTTP 429/500 status error → None."""
+    from hermes_cli.auth_codex_ssl_helper import _ssl_tls_middlebox_hint
+
+    exc = Exception("HTTP 429: Too Many Requests")
+    hint = _ssl_tls_middlebox_hint(exc)
+
+    assert hint is None

--- a/tests/hermes_cli/test_auth_codex_ssl_integration.py
+++ b/tests/hermes_cli/test_auth_codex_ssl_integration.py
@@ -1,0 +1,133 @@
+"""Integration tests: Codex login SSL failures _codex_login_post / _codex_poll_authorization_code."""
+
+from __future__ import annotations
+
+import ssl
+import pytest
+from unittest.mock import MagicMock
+
+
+def test_codex_login_post_ssl_failure_includes_hint(monkeypatch):
+    """_codex_login_post with SSL transport exception appends the PQ-middlebox hint."""
+    from hermes_cli.auth_codex import _codex_login_post
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            raise ssl.SSLEOFError("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex.httpx.Client", lambda *a, **k: _FakeClient()
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        _codex_login_post(
+            "https://auth.openai.com/api/accounts/deviceauth/usercode",
+            failure=("Failed to request device code", "device_code_request_failed"),
+            json={"client_id": "test"},
+        )
+
+    msg = str(exc_info.value)
+    assert "Failed to request device code" in msg
+    assert "[SSL: UNEXPECTED_EOF_WHILE_READING]" in msg
+    assert "post-quantum hybrid groups" in msg
+    assert "OPENSSL_CONF" in msg
+
+
+def test_codex_login_post_non_ssl_error_no_hint(monkeypatch):
+    """_codex_login_post with plain ConnectError: no hint appended."""
+    from hermes_cli.auth_codex import _codex_login_post
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            raise Exception("[Errno 61] Connection refused")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex.httpx.Client", lambda *a, **k: _FakeClient()
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        _codex_login_post(
+            "https://auth.openai.com/api/accounts/deviceauth/usercode",
+            failure=("Failed to request device code", "device_code_request_failed"),
+            json={"client_id": "test"},
+        )
+
+    msg = str(exc_info.value)
+    assert "Connection refused" in msg
+    assert "post-quantum" not in msg
+    assert "OPENSSL_CONF" not in msg
+
+
+def test_codex_poll_ssl_failure_includes_hint(monkeypatch):
+    """_codex_poll_authorization_code with SSL transport error → hint."""
+    from hermes_cli.auth_codex import _codex_poll_authorization_code
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            raise ssl.SSLError("_ssl.c:999: The handshake operation timed out")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex.httpx.Client", lambda *a, **k: _FakeClient()
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        _codex_poll_authorization_code(
+            "https://auth.openai.com",
+            device_auth_id="dummy",
+            user_code="CODE",
+            poll_interval=1,
+        )
+
+    msg = str(exc_info.value)
+    assert "Device auth poll transport failure" in msg
+    assert "handshake operation timed out" in msg
+    assert "middlebox" in msg
+
+
+def test_codex_poll_non_ssl_error_no_hint(monkeypatch):
+    """_codex_poll_authorization_code with plain ReadTimeout → no hint."""
+    from hermes_cli.auth_codex import _codex_poll_authorization_code
+
+    class _FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def post(self, *args, **kwargs):
+            raise Exception("ReadTimeout: exceeded 15.0s")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth_codex.httpx.Client", lambda *a, **k: _FakeClient()
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        _codex_poll_authorization_code(
+            "https://auth.openai.com",
+            device_auth_id="dummy",
+            user_code="CODE",
+            poll_interval=1,
+        )
+
+    msg = str(exc_info.value)
+    assert "ReadTimeout" in msg
+    assert "post-quantum" not in msg

--- a/website/docs/guides/codex-device-login-tls-failure.md
+++ b/website/docs/guides/codex-device-login-tls-failure.md
@@ -1,0 +1,171 @@
+---
+sidebar_position: 19
+title: "OpenAI Codex Device Login TLS Failure (SSL EOF / Handshake Timeout)"
+description: "Troubleshooting Python/OpenSSL 3.5 SSL/TLS failures when completing Codex device-code login: EOF, handshake timeout, middlebox rejection of PQ groups"
+---
+
+# OpenAI Codex Device Login TLS Failure
+
+## The symptom
+
+`hermes model` cannot complete the Codex device login flow; it fails during the authentication POST or token-exchange POST with one of:
+
+```text
+[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1016)
+```
+
+or:
+
+```text
+_ssl.c:999: The handshake operation timed out
+```
+
+`curl` or your browser reach the same OpenAI endpoints successfully from the same machine — no network outage — yet Python consistently fails. `hermes setup` and your *existing* credentials (token refresh) may work fine; only the *device code* path hits the wall.
+
+## Root cause
+
+**OpenSSL 3.5** (shipped with the Python interpreter uv bundles for Hermes v0.21+, or your system Python 3.11.16+) advertises **post-quantum hybrid key-exchange groups** by default — for example, `X25519MLKEM768` — in the TLS 1.3 ClientHello `key_share` and `supported_groups` extensions.
+
+A **TLS-intercepting middlebox** (corporate proxy, firewall, some CDNs, older cloud load balancers) that does not recognise the post-quantum group name can drop the connection, typically with:
+
+1. A TCP RST → `[SSL: UNEXPECTED_EOF_WHILE_READING]`
+2. A silent blackhole → `handshake operation timed out`
+
+`curl` succeeds because curl's TLS stack (OpenSSL 1.1.x or LibreSSL on macOS) does not advertise PQ groups by default, so the same host+port passes the middlebox when requested by curl but fails for Python.
+
+## Workarounds
+
+### 1. Classic-groups OpenSSL configuration (recommended)
+
+Create a file (e.g. `~/openssl-classic-groups.cnf`) with:
+
+```ini
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Groups = x25519:secp256r1:secp384r1:x448
+```
+
+This restricts the offered groups to classic elliptic curves, removing the PQ `X25519MLKEM768` extension that triggers the middlebox drop.
+
+Run:
+
+```bash
+OPENSSL_CONF=~/openssl-classic-groups.cnf hermes model
+```
+
+The device-code handshake should complete.
+
+### 2. Force TLS 1.2 (when #44392 lands)
+
+TLS 1.2 does not carry the `key_share` / `supported_groups` extensions that advertise PQ groups. Capping at TLS 1.2:
+
+```bash
+HERMES_TLS_MAX_VERSION=1.2 hermes model
+```
+
+will sidestep the PQ-rejecting middlebox.
+
+**Status**: Open PR [#44392](https://github.com/NousResearch/hermes-agent/pull/44392) introduces `HERMES_TLS_MAX_VERSION` for the *provider* (chat-completions) transport. That PR does not yet cover the device-login handshake path (`hermes_cli/auth_device_flow.py::_default_verify`), so this workaround will only reach the device-code flow once #44392 lands **and** a follow-up extends the cap to `_default_verify`. Track #44392 for progress.
+
+### 3. Corporate network: request PQ-aware firewall rule
+
+If you control the middlebox (enterprise firewall, load balancer), ask your IT team to allow the TLS 1.3 `X25519MLKEM768` group for OpenAI endpoints:
+
+- `auth.openai.com`
+- `api.openai.com`
+
+This is the long-term fix — post-quantum cryptography is the future standard, and blocking it breaks modern clients.
+
+## Why doesn't this break *all* Hermes OpenAI calls?
+
+Device-code login (`hermes model` → Codex device flow) hits `auth.openai.com/api/accounts/deviceauth/*` with a **new** TLS connection. If your existing token refresh or provider calls work, they likely:
+
+1. Use a cached TLS session or HTTP/2 connection from before OpenSSL 3.5.
+2. Go to a different endpoint (`api.openai.com`) that your middlebox allows through (different routing rule).
+3. Hit the device-code path less frequently (refresh tokens live for days; device login is rare).
+
+The PQ-group handshake failure shows up most visibly on **fresh** device-code logins because they always open a new connection to `auth.openai.com` from scratch.
+
+## Diagnostics
+
+### Confirm you are on OpenSSL 3.5
+
+```bash
+python3 -c "import ssl; print(ssl.OPENSSL_VERSION)"
+```
+
+Expected output on a system exhibiting the failure:
+
+```text
+OpenSSL 3.5.7 9 Jun 2026
+```
+
+or later 3.5.x release.
+
+### Test TLS 1.3 vs TLS 1.2 directly
+
+```bash
+# TLS 1.3 (will fail if your middlebox rejects PQ groups)
+python3 -c "
+import urllib.request, ssl
+ctx = ssl.create_default_context()
+ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+req = urllib.request.Request('https://auth.openai.com/codex/device', headers={'User-Agent': 'test'})
+try:
+    with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+        print('TLS 1.3: HTTP', r.status)
+except Exception as e:
+    print('TLS 1.3 failed:', e)
+"
+
+# TLS 1.2 (should succeed)
+python3 -c "
+import urllib.request, ssl
+ctx = ssl.create_default_context()
+ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+req = urllib.request.Request('https://auth.openai.com/codex/device', headers={'User-Agent': 'test'})
+with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+    print('TLS 1.2: HTTP', r.status)
+"
+```
+
+If **TLS 1.3 fails** with an SSL EOF and **TLS 1.2 succeeds**, you have a PQ-rejecting middlebox.
+
+### Verify the classic-groups config
+
+```bash
+OPENSSL_CONF=~/openssl-classic-groups.cnf python3 -c "
+import ssl
+ctx = ssl.create_default_context()
+# This doesn't directly print the groups, but a successful connection proves the config was applied.
+import urllib.request
+req = urllib.request.Request('https://auth.openai.com/codex/device', headers={'User-Agent': 'test'})
+with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+    print('Classic groups config: HTTP', r.status)
+"
+```
+
+## Related issues and PRs
+
+- [#106384](https://github.com/NousResearch/hermes-agent/issues/106384) — Original bug report
+- [#44392](https://github.com/NousResearch/hermes-agent/pull/44392) — `HERMES_TLS_MAX_VERSION` cap (provider path only, device-login follow-up planned)
+- This PR (#NNNN) — Preserve SSL error + hint in device-code failures
+
+## When will this be fixed upstream?
+
+**The "fix" is configuration, not code**: OpenSSL 3.5 advertising PQ groups is *correct* behavior per RFC 8446 and the IETF's post-quantum migration path. The failure lies with the middlebox rejecting valid TLS 1.3 extensions.
+
+Hermes will:
+
+1. Document the workaround (this guide — ✅ done).
+2. Preserve the SSL error + hint so the user sees "try `OPENSSL_CONF`" instead of a generic "login failed" (this PR — ✅ done).
+3. Extend `HERMES_TLS_MAX_VERSION` to the device-login path once #44392 merges (follow-up PR).
+
+If you control your network infrastructure, the long-term fix is to allow PQ groups at the firewall/proxy level.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/codex-device-login-tls-failure.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/codex-device-login-tls-failure.md
@@ -1,0 +1,171 @@
+---
+sidebar_position: 19
+title: "OpenAI Codex Device Login TLS Failure (SSL EOF / Handshake Timeout)"
+description: "Troubleshooting Python/OpenSSL 3.5 SSL/TLS failures when completing Codex device-code login: EOF, handshake timeout, middlebox rejection of PQ groups"
+---
+
+# OpenAI Codex Device Login TLS Failure
+
+## The symptom
+
+`hermes model` cannot complete the Codex device login flow; it fails during the authentication POST or token-exchange POST with one of:
+
+```text
+[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1016)
+```
+
+or:
+
+```text
+_ssl.c:999: The handshake operation timed out
+```
+
+`curl` or your browser reach the same OpenAI endpoints successfully from the same machine — no network outage — yet Python consistently fails. `hermes setup` and your *existing* credentials (token refresh) may work fine; only the *device code* path hits the wall.
+
+## Root cause
+
+**OpenSSL 3.5** (shipped with the Python interpreter uv bundles for Hermes v0.21+, or your system Python 3.11.16+) advertises **post-quantum hybrid key-exchange groups** by default — for example, `X25519MLKEM768` — in the TLS 1.3 ClientHello `key_share` and `supported_groups` extensions.
+
+A **TLS-intercepting middlebox** (corporate proxy, firewall, some CDNs, older cloud load balancers) that does not recognise the post-quantum group name can drop the connection, typically with:
+
+1. A TCP RST → `[SSL: UNEXPECTED_EOF_WHILE_READING]`
+2. A silent blackhole → `handshake operation timed out`
+
+`curl` succeeds because curl's TLS stack (OpenSSL 1.1.x or LibreSSL on macOS) does not advertise PQ groups by default, so the same host+port passes the middlebox when requested by curl but fails for Python.
+
+## Workarounds
+
+### 1. Classic-groups OpenSSL configuration (recommended)
+
+Create a file (e.g. `~/openssl-classic-groups.cnf`) with:
+
+```ini
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Groups = x25519:secp256r1:secp384r1:x448
+```
+
+This restricts the offered groups to classic elliptic curves, removing the PQ `X25519MLKEM768` extension that triggers the middlebox drop.
+
+Run:
+
+```bash
+OPENSSL_CONF=~/openssl-classic-groups.cnf hermes model
+```
+
+The device-code handshake should complete.
+
+### 2. Force TLS 1.2 (when #44392 lands)
+
+TLS 1.2 does not carry the `key_share` / `supported_groups` extensions that advertise PQ groups. Capping at TLS 1.2:
+
+```bash
+HERMES_TLS_MAX_VERSION=1.2 hermes model
+```
+
+will sidestep the PQ-rejecting middlebox.
+
+**Status**: Open PR [#44392](https://github.com/NousResearch/hermes-agent/pull/44392) introduces `HERMES_TLS_MAX_VERSION` for the *provider* (chat-completions) transport. That PR does not yet cover the device-login handshake path (`hermes_cli/auth_device_flow.py::_default_verify`), so this workaround will only reach the device-code flow once #44392 lands **and** a follow-up extends the cap to `_default_verify`. Track #44392 for progress.
+
+### 3. Corporate network: request PQ-aware firewall rule
+
+If you control the middlebox (enterprise firewall, load balancer), ask your IT team to allow the TLS 1.3 `X25519MLKEM768` group for OpenAI endpoints:
+
+- `auth.openai.com`
+- `api.openai.com`
+
+This is the long-term fix — post-quantum cryptography is the future standard, and blocking it breaks modern clients.
+
+## Why doesn't this break *all* Hermes OpenAI calls?
+
+Device-code login (`hermes model` → Codex device flow) hits `auth.openai.com/api/accounts/deviceauth/*` with a **new** TLS connection. If your existing token refresh or provider calls work, they likely:
+
+1. Use a cached TLS session or HTTP/2 connection from before OpenSSL 3.5.
+2. Go to a different endpoint (`api.openai.com`) that your middlebox allows through (different routing rule).
+3. Hit the device-code path less frequently (refresh tokens live for days; device login is rare).
+
+The PQ-group handshake failure shows up most visibly on **fresh** device-code logins because they always open a new connection to `auth.openai.com` from scratch.
+
+## Diagnostics
+
+### Confirm you are on OpenSSL 3.5
+
+```bash
+python3 -c "import ssl; print(ssl.OPENSSL_VERSION)"
+```
+
+Expected output on a system exhibiting the failure:
+
+```text
+OpenSSL 3.5.7 9 Jun 2026
+```
+
+or later 3.5.x release.
+
+### Test TLS 1.3 vs TLS 1.2 directly
+
+```bash
+# TLS 1.3 (will fail if your middlebox rejects PQ groups)
+python3 -c "
+import urllib.request, ssl
+ctx = ssl.create_default_context()
+ctx.maximum_version = ssl.TLSVersion.TLSv1_3
+req = urllib.request.Request('https://auth.openai.com/codex/device', headers={'User-Agent': 'test'})
+try:
+    with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+        print('TLS 1.3: HTTP', r.status)
+except Exception as e:
+    print('TLS 1.3 failed:', e)
+"
+
+# TLS 1.2 (should succeed)
+python3 -c "
+import urllib.request, ssl
+ctx = ssl.create_default_context()
+ctx.maximum_version = ssl.TLSVersion.TLSv1_2
+req = urllib.request.Request('https://auth.openai.com/codex/device', headers={'User-Agent': 'test'})
+with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+    print('TLS 1.2: HTTP', r.status)
+"
+```
+
+If **TLS 1.3 fails** with an SSL EOF and **TLS 1.2 succeeds**, you have a PQ-rejecting middlebox.
+
+### Verify the classic-groups config
+
+```bash
+OPENSSL_CONF=~/openssl-classic-groups.cnf python3 -c "
+import ssl
+ctx = ssl.create_default_context()
+# This doesn't directly print the groups, but a successful connection proves the config was applied.
+import urllib.request
+req = urllib.request.Request('https://auth.openai.com/codex/device', headers={'User-Agent': 'test'})
+with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+    print('Classic groups config: HTTP', r.status)
+"
+```
+
+## Related issues and PRs
+
+- [#106384](https://github.com/NousResearch/hermes-agent/issues/106384) — Original bug report
+- [#44392](https://github.com/NousResearch/hermes-agent/pull/44392) — `HERMES_TLS_MAX_VERSION` cap (provider path only, device-login follow-up planned)
+- This PR (#NNNN) — Preserve SSL error + hint in device-code failures
+
+## When will this be fixed upstream?
+
+**The "fix" is configuration, not code**: OpenSSL 3.5 advertising PQ groups is *correct* behavior per RFC 8446 and the IETF's post-quantum migration path. The failure lies with the middlebox rejecting valid TLS 1.3 extensions.
+
+Hermes will:
+
+1. Document the workaround (this guide — ✅ done).
+2. Preserve the SSL error + hint so the user sees "try `OPENSSL_CONF`" instead of a generic "login failed" (this PR — ✅ done).
+3. Extend `HERMES_TLS_MAX_VERSION` to the device-login path once #44392 merges (follow-up PR).
+
+If you control your network infrastructure, the long-term fix is to allow PQ groups at the firewall/proxy level.


### PR DESCRIPTION
## Summary

Codex device-code login (`hermes model` → OpenAI Codex) can fail with SSL/TLS errors (`[SSL: UNEXPECTED_EOF_WHILE_READING]` / `handshake operation timed out`) on Python/OpenSSL 3.5 when a middlebox rejects TLS 1.3 ClientHellos containing post-quantum hybrid groups (e.g. `X25519MLKEM768` in `key_share`). The resulting transport exception was either bare (`_codex_err("Failed to request device code: {exc}")`) or unhandled (mid-poll SSL error escaped raw), leaving the user with a dead-end "Login failed" message and no guidance.

This preserves the SSL error and appends a self-contained hint:

- PQ hybrid group root cause (`X25519MLKEM768` → oversized ClientHello → middlebox reset)
- Why curl works but Python fails (different TLS stack)
- Two workarounds: classic-groups `OPENSSL_CONF` (works today) and `HERMES_TLS_MAX_VERSION=1.2` (when #44392 lands + device-flow follow-up)
- Link to the new troubleshooting guide

## Root cause (verified on current `main`, d0df324862cb)

1. `hermes_cli/auth_codex.py::_codex_login_post` (line ~215) catches every transport exception from the 15s POST and re-raises `_codex_err(f"{failure[0]}: {exc}", ...)` — the raw SSL text survives only as an opaque suffix on "Failed to request device code:" with zero guidance.
2. `_codex_poll_authorization_code` (line ~729) has no transport-error handling at all — a mid-poll SSL EOF escapes as a bare `httpx.ConnectError`, which `_run_login` in `model_setup_flows_common.py` prints as a one-line `Login failed: [SSL: ...]`.

## Changes

- `hermes_cli/auth_codex_ssl_helper.py` — `_ssl_tls_middlebox_hint(exc)` detects SSL-flavored transport failures (ssl.SSLError subclasses, message patterns `UNEXPECTED_EOF_WHILE_READING`/`handshake operation timed out`/`[SSL:`/`tlsv1 alert`) and returns the PQ-middlebox hint, or None for unrelated errors (no false positives on plain `ConnectError`/`ReadTimeout`/HTTP errors).
- `hermes_cli/auth_codex.py`:
  - `_codex_login_post`: append hint when `_ssl_tls_middlebox_hint(exc)` is not None.
  - `_codex_poll_authorization_code`: wrap the `client.post(...)` in `try/except`, detect SSL errors, and raise `_codex_err(...{hint})`.
- `website/docs/guides/codex-device-login-tls-failure.md` — troubleshooting guide: symptom, root cause, two workarounds (classic-groups config + future TLS 1.2 cap), diagnostics (TLS 1.3 vs 1.2 probe), why this doesn't break all Hermes calls (cached connections, different endpoints).
- `website/i18n/zh-Hans/.../codex-device-login-tls-failure.md` — zh-Hans mirror.
- Tests:
  - `tests/hermes_cli/test_auth_codex_ssl_helper.py` — unit tests for `_ssl_tls_middlebox_hint`: ssl.SSLError/SSLEOFError/message patterns → hint; plain errors → None.
  - `tests/hermes_cli/test_auth_codex_ssl_integration.py` — integration tests for `_codex_login_post` and `_codex_poll_authorization_code`: SSL transport exceptions include hint, non-SSL exceptions don't.

## Testing

```bash
$ pytest tests/hermes_cli/test_auth_codex_ssl_helper.py tests/hermes_cli/test_auth_codex_ssl_integration.py -v
=============================== 11 passed in 2.9s ===============================

$ pytest tests/hermes_cli/test_auth_codex_provider.py -v
=============================== 11 passed in 0.7s ===============================
```

All `test_auth_codex_provider.py` baseline tests pass (no regressions).

## Scope

This PR deliberately does **not** implement a TLS version cap or OpenSSL config mutation — it only preserves the error + adds guidance. The two suggested workarounds:

1. **Classic-groups `OPENSSL_CONF`** — works today, requires the user to export `OPENSSL_CONF` before running `hermes model`.
2. **`HERMES_TLS_MAX_VERSION=1.2`** — requires #44392 to land **and** a follow-up to extend the cap from the provider path (`_get_tls_ssl_context`) to the device-flow path (`auth_device_flow._default_verify`). The PR body and docs guide note this explicitly.

## Rationale for the docs guide

Issue #106384 pt.2 suggests a `hermes doctor` diagnostic. That's a good follow-up, but:

- The diagnosis (TLS 1.3 success vs failure) requires a live network probe against `auth.openai.com`, which `hermes doctor` would need to do on every invocation. The failure is rare (affects only users behind PQ-rejecting middleboxes on Python/OpenSSL 3.5 during device-code login), so a per-run probe adds latency for 99% of users who never hit it.
- The hint is already inline in the error message (no separate `hermes doctor` run required to see it).

The docs guide provides the full diagnostic recipe for users who want to confirm the root cause themselves (the inline hint links to it).

## Related

- Fixes #106384
- Builds on the diagnosis by @gaoanze888 (comment https://github.com/NousResearch/hermes-agent/issues/106384#issuecomment-5599342734) — this PR takes the non-conflicting angle (error preservation + docs) and leaves the TLS-cap extension to #44392's follow-up.
