### PR TITLE
fix(state): diagnose futile FTS deferral from a stable holder set

### DIFF
--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -80,9 +80,21 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
         lines.append(("info", "FTS tables: " + (", ".join(present) if present else "none"), ""))
     deferral = stats.get("fts_rebuild_deferral")
     if isinstance(deferral, dict):
-        lines.append(("warn", f"state.db FTS repair is blocked after {deferral.get('attempts') or '?'} deferral(s) "
-                      f"by PID(s) {deferral.get('holder_pids') or [] or 'unknown'}",
-                      "(stop the listed processes, then run 'hermes sessions optimize-storage' with the gateway stopped)"))
+        pids = deferral.get("holder_pids") or []
+        attempts = deferral.get("attempts") or "?"
+        futile = deferral.get("futile") is True or deferral.get("kind") == "permanent_holder"
+        if futile:
+            lines.append((
+                "warn",
+                f"state.db FTS repair is blocked by a permanent holder "
+                f"(another Hermes service, PID(s) {pids}) after {attempts} futile deferral(s)",
+                "(stop the other Hermes service; leave this gateway running — "
+                "retry_deferred_fts_recovery admits once this process is the sole holder)",
+            ))
+        else:
+            lines.append(("warn", f"state.db FTS repair is blocked after {attempts} deferral(s) "
+                          f"by PID(s) {pids or 'unknown'}",
+                          "(stop the listed processes, then run 'hermes sessions optimize-storage' with the gateway stopped)"))
     # Oversized DB: suggest auto_prune, plus the offline optimize-storage pass when the FTS rebuild is
     # pending OR the DB predates the current trigram layout (fts_storage_version < FTS_STORAGE_VERSION).
     if logical is not None and logical > STATE_DB_SIZE_WARN_BYTES:

--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -82,12 +82,14 @@ def _render_state_db_stats(stats: dict, holders=None) -> list:
     if isinstance(deferral, dict):
         pids = deferral.get("holder_pids") or []
         attempts = deferral.get("attempts") or "?"
-        futile = deferral.get("futile") is True or deferral.get("kind") == "permanent_holder"
+        futile = deferral.get("futile") is True or deferral.get("kind") in {
+            "stable_holder", "permanent_holder",
+        }
         if futile:
             lines.append((
                 "warn",
-                f"state.db FTS repair is blocked by a permanent holder "
-                f"(another Hermes service, PID(s) {pids}) after {attempts} futile deferral(s)",
+                f"state.db FTS repair is blocked by a stable holder set "
+                f"(PID(s) {pids}) after {attempts} futile deferral(s)",
                 "(stop the other Hermes service; leave this gateway running — "
                 "retry_deferred_fts_recovery admits once this process is the sole holder)",
             ))

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -37,6 +37,21 @@ _FTS_HOLDER_ESCALATE_SECONDS = 60.0
 _FTS_STALE_RETRY_SECONDS = 60.0
 _FTS_STALE_RETRY_MAX_SECONDS = 3600.0
 
+
+def _fts_holder_pid_set(value):
+    """Sorted unique positive PIDs, or None when the stored set is missing/unusable."""
+    if not isinstance(value, (list, tuple)):
+        return None
+    pids = set()
+    for item in value:
+        try:
+            pid = int(item)
+        except (TypeError, ValueError):
+            return None
+        if pid > 0:
+            pids.add(pid)
+    return sorted(pids)
+
 # schema_read_probe_statements() cache (parses SCHEMA_SQL in an in-memory DB; once per process).
 _READ_PROBE_STATEMENTS: Optional[tuple] = None
 
@@ -422,7 +437,8 @@ class SessionSchemaMixin:
         """Record a deferral diagnostic for the foreign processes holding the DB; True = defer
         (holders remain). After ``_FTS_HOLDER_ESCALATE_ATTEMPTS`` deferrals spanning
         ``_FTS_HOLDER_ESCALATE_SECONDS``, provably inactive orphan Desktop backends are
-        reaped and the holders re-checked."""
+        reaped and the holders re-checked. A stable PID set that survives that reap is
+        recorded as a futile/permanent-holder diagnostic; the orphan predicate is unchanged."""
         now = time.time()
         try:
             row = cursor.execute(
@@ -439,14 +455,9 @@ class SessionSchemaMixin:
             first_seen, attempts = now, 1
         if first_seen > now or first_seen < 0:
             first_seen = now
-        diagnostic = {
-            "first_seen": first_seen, "last_seen": now, "attempts": attempts,
-            "holder_pids": sorted({pid for pid, _path in foreign_holders if pid > 0}),
-        }
-        cursor.execute(
-            "INSERT INTO state_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-            (FTS_REBUILD_DEFERRAL_KEY, json.dumps(diagnostic, sort_keys=True)),
-        )
+        previous_pids = _fts_holder_pid_set(record.get("holder_pids"))
+        holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
+        futile = False
         if attempts >= _FTS_HOLDER_ESCALATE_ATTEMPTS and now - first_seen >= _FTS_HOLDER_ESCALATE_SECONDS:
             reaped = self._reap_inactive_orphan_desktop_holders(
                 foreign_holders, min_age_seconds=_FTS_HOLDER_ESCALATE_SECONDS,
@@ -457,20 +468,59 @@ class SessionSchemaMixin:
                     "state.db FTS rebuild deferrals; checking holders again.", reaped, attempts,
                 )
                 foreign_holders = self._foreign_state_db_holders()
+                holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
             if foreign_holders:
-                logger.error(
-                    "state.db FTS repair remains blocked after %d deferrals "
-                    "by holder(s) %s. Stop the listed processes, then run "
-                    "`hermes sessions optimize-storage` with the gateway stopped. "
-                    "`hermes doctor` reports this degraded state.", attempts, foreign_holders,
-                )
+                if previous_pids is not None and holder_pids and holder_pids == previous_pids:
+                    futile = True
+                    logger.error(
+                        "state.db FTS repair is futile after %d deferrals: the same "
+                        "holder PID set %s is a permanent holder (another Hermes "
+                        "service), not a transient peer. Stop the other Hermes "
+                        "service; leave this gateway running. "
+                        "retry_deferred_fts_recovery admits once this process is "
+                        "the sole holder. `hermes doctor` reports this degraded state.",
+                        attempts, holder_pids,
+                    )
+                else:
+                    logger.error(
+                        "state.db FTS repair remains blocked after %d deferrals "
+                        "by holder(s) %s. Stop the listed processes, then run "
+                        "`hermes sessions optimize-storage` with the gateway stopped. "
+                        "`hermes doctor` reports this degraded state.", attempts, foreign_holders,
+                    )
+            else:
+                self._fts_stale_retry_after = 0.0
+                self._fts_stale_retry_interval = 0.0
+                self._fts_permanent_holder_deferral = False
+        diagnostic = {
+            "first_seen": first_seen, "last_seen": now, "attempts": attempts,
+            "holder_pids": holder_pids,
+        }
+        if futile:
+            diagnostic["futile"] = True
+            diagnostic["kind"] = "permanent_holder"
+            self._fts_permanent_holder_deferral = True
+        else:
+            self._fts_permanent_holder_deferral = False
+        cursor.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (FTS_REBUILD_DEFERRAL_KEY, json.dumps(diagnostic, sort_keys=True)),
+        )
         if not foreign_holders:
             return False
-        logger.warning(
-            "Deferred stale state.db FTS rebuild while foreign processes "
-            "hold the database or WAL sidecars (%s); canonical writes and LIKE search remain available (deferral %d).",
-            foreign_holders, attempts,
-        )
+        if futile:
+            logger.warning(
+                "Deferred stale state.db FTS rebuild while a permanent foreign holder "
+                "blocks repair (%s); stop the other Hermes service and leave this "
+                "gateway running (deferral %d).",
+                foreign_holders, attempts,
+            )
+        else:
+            logger.warning(
+                "Deferred stale state.db FTS rebuild while foreign processes "
+                "hold the database or WAL sidecars (%s); canonical writes and LIKE search remain available (deferral %d).",
+                foreign_holders, attempts,
+            )
         return True
 
     def _recover_stale_fts(self, cursor: sqlite3.Cursor, *, legacy: bool, timeout_seconds=None) -> bool:
@@ -513,6 +563,11 @@ class SessionSchemaMixin:
         if self.read_only or self._conn is None:
             return False
         now = time.monotonic()
+        if getattr(self, "_fts_permanent_holder_deferral", False) and not self._foreign_state_db_holders():
+            # Permanent holder gone: do not wait out a doubled-to-cap backoff (#106393).
+            self._fts_stale_retry_after = 0.0
+            self._fts_stale_retry_interval = 0.0
+            self._fts_permanent_holder_deferral = False
         if now < getattr(self, "_fts_stale_retry_after", 0.0):
             return False
         interval = float(getattr(self, "_fts_stale_retry_interval", 0.0))

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -437,8 +437,10 @@ class SessionSchemaMixin:
         """Record a deferral diagnostic for the foreign processes holding the DB; True = defer
         (holders remain). After ``_FTS_HOLDER_ESCALATE_ATTEMPTS`` deferrals spanning
         ``_FTS_HOLDER_ESCALATE_SECONDS``, provably inactive orphan Desktop backends are
-        reaped and the holders re-checked. A stable PID set that survives that reap is
-        recorded as a futile/permanent-holder diagnostic; the orphan predicate is unchanged."""
+        reaped and the holders re-checked. A PID set that survives that reap is recorded
+        as a futile/stable-holder heuristic — evidence the set is stable, not proof the
+        holder is supervised. Classification does not admit rebuild, change the live
+        write path, or loosen the orphan predicate."""
         now = time.time()
         try:
             row = cursor.execute(
@@ -474,8 +476,8 @@ class SessionSchemaMixin:
                     futile = True
                     logger.error(
                         "state.db FTS repair is futile after %d deferrals: the same "
-                        "holder PID set %s is a permanent holder (another Hermes "
-                        "service), not a transient peer. Stop the other Hermes "
+                        "holder PID set %s survived orphan reap (stable holder set, "
+                        "not proof the process is supervised). Stop the other Hermes "
                         "service; leave this gateway running. "
                         "retry_deferred_fts_recovery admits once this process is "
                         "the sole holder. `hermes doctor` reports this degraded state.",
@@ -491,17 +493,17 @@ class SessionSchemaMixin:
             else:
                 self._fts_stale_retry_after = 0.0
                 self._fts_stale_retry_interval = 0.0
-                self._fts_permanent_holder_deferral = False
+                self._fts_stable_holder_deferral = False
         diagnostic = {
             "first_seen": first_seen, "last_seen": now, "attempts": attempts,
             "holder_pids": holder_pids,
         }
         if futile:
             diagnostic["futile"] = True
-            diagnostic["kind"] = "permanent_holder"
-            self._fts_permanent_holder_deferral = True
+            diagnostic["kind"] = "stable_holder"
+            self._fts_stable_holder_deferral = True
         else:
-            self._fts_permanent_holder_deferral = False
+            self._fts_stable_holder_deferral = False
         cursor.execute(
             "INSERT INTO state_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             (FTS_REBUILD_DEFERRAL_KEY, json.dumps(diagnostic, sort_keys=True)),
@@ -510,7 +512,7 @@ class SessionSchemaMixin:
             return False
         if futile:
             logger.warning(
-                "Deferred stale state.db FTS rebuild while a permanent foreign holder "
+                "Deferred stale state.db FTS rebuild while a stable foreign holder set "
                 "blocks repair (%s); stop the other Hermes service and leave this "
                 "gateway running (deferral %d).",
                 foreign_holders, attempts,
@@ -521,6 +523,8 @@ class SessionSchemaMixin:
                 "hold the database or WAL sidecars (%s); canonical writes and LIKE search remain available (deferral %d).",
                 foreign_holders, attempts,
             )
+        # Holders remain: keep deferring. futile/stable_holder is diagnostic only —
+        # it must not admit rebuild or change write-path safety (#106393).
         return True
 
     def _recover_stale_fts(self, cursor: sqlite3.Cursor, *, legacy: bool, timeout_seconds=None) -> bool:
@@ -563,11 +567,11 @@ class SessionSchemaMixin:
         if self.read_only or self._conn is None:
             return False
         now = time.monotonic()
-        if getattr(self, "_fts_permanent_holder_deferral", False) and not self._foreign_state_db_holders():
-            # Permanent holder gone: do not wait out a doubled-to-cap backoff (#106393).
+        if getattr(self, "_fts_stable_holder_deferral", False) and not self._foreign_state_db_holders():
+            # Stable holder set gone: do not wait out a doubled-to-cap backoff (#106393).
             self._fts_stale_retry_after = 0.0
             self._fts_stale_retry_interval = 0.0
-            self._fts_permanent_holder_deferral = False
+            self._fts_stable_holder_deferral = False
         if now < getattr(self, "_fts_stale_retry_after", 0.0):
             return False
         interval = float(getattr(self, "_fts_stale_retry_interval", 0.0))

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -16,6 +16,7 @@ rebuild later, outside the failed live write/search operation.
 import json
 import os
 import sqlite3
+import time
 
 import pytest
 
@@ -25,6 +26,24 @@ import hermes_state_schema
 from hermes_state import SessionDB
 from hermes_state_common import FTS_REBUILD_DEFERRAL_KEY, FTS_STALE_KEY, LEGACY_FTS_SQL, LEGACY_FTS_TRIGRAM_SQL, SCHEMA_SQL, _FTS_TRIGGERS
 from hermes_state_dbfile import _concrete_state_db_holder_pids, _is_inactive_orphan_desktop_holder
+
+
+def _deferral_is_futile(record):
+    if not isinstance(record, dict):
+        return False
+    if record.get("futile") is True:
+        return True
+    kind = str(record.get("kind") or record.get("status") or "").lower()
+    return "futile" in kind or "permanent_holder" in kind
+
+
+def _doctor_deferral_blob(stats):
+    from hermes_cli.doctor_state import _render_state_db_stats
+
+    return " ".join(
+        " ".join(str(part) for part in row)
+        for row in _render_state_db_stats(stats)
+    ).lower()
 
 
 @pytest.fixture
@@ -782,6 +801,243 @@ class TestRuntimeFtsRebuild:
             assert _meta_value(db_path, FTS_STALE_KEY) is None
             assert _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY) is None
             assert reopened.search_messages("before restart")
+        finally:
+            reopened.close()
+
+    def test_stable_permanent_holder_marks_futile_deferral(
+        self, db, tmp_path, monkeypatch, caplog
+    ):
+        """Same supervised holder across the escalate window is futile, not a transient peer."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db,
+            "rebuild_fts",
+            lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (
+                FTS_REBUILD_DEFERRAL_KEY,
+                json.dumps({
+                    "first_seen": 1.0,
+                    "last_seen": 30.0,
+                    "attempts": 2,
+                    "holder_pids": [4242],
+                }),
+            ),
+        )
+        raw.commit()
+        raw.close()
+
+        monkeypatch.setattr(
+            SessionDB,
+            "_foreign_state_db_holders",
+            lambda self: [(4242, str(db_path) + "-wal")],
+        )
+        monkeypatch.setattr(
+            SessionDB,
+            "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [],
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: 120.0)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            record = json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY))
+            assert _deferral_is_futile(record), record
+            assert record.get("holder_pids") == [4242]
+            assert reopened._fts_stale is True
+            from hermes_cli.doctor_state import _render_state_db_stats
+            from hermes_state_dbfile import collect_state_db_stats
+
+            blob = _doctor_deferral_blob(collect_state_db_stats(db_path))
+            assert "stop the other hermes service" in blob
+            assert "gateway" in blob
+            assert "canonical writes and like search remain available" not in caplog.text.lower()
+        finally:
+            reopened.close()
+
+    def test_changing_holder_pids_do_not_mark_futile(
+        self, db, tmp_path, monkeypatch
+    ):
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db,
+            "rebuild_fts",
+            lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (
+                FTS_REBUILD_DEFERRAL_KEY,
+                json.dumps({
+                    "first_seen": 1.0,
+                    "last_seen": 30.0,
+                    "attempts": 2,
+                    "holder_pids": [4242],
+                }),
+            ),
+        )
+        raw.commit()
+        raw.close()
+
+        monkeypatch.setattr(
+            SessionDB,
+            "_foreign_state_db_holders",
+            lambda self: [(9999, str(db_path) + "-wal")],
+        )
+        monkeypatch.setattr(
+            SessionDB,
+            "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [],
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: 120.0)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            record = json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY))
+            assert not _deferral_is_futile(record), record
+            assert record.get("holder_pids") == [9999]
+            assert reopened._fts_stale is True
+        finally:
+            reopened.close()
+
+    def test_orphan_reap_clearing_holders_does_not_mark_futile(
+        self, db, tmp_path, monkeypatch
+    ):
+        """CONTROL: escalate + successful orphan reap stays on the existing rebuild path."""
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db,
+            "rebuild_fts",
+            lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (
+                FTS_REBUILD_DEFERRAL_KEY,
+                json.dumps({
+                    "first_seen": 1.0,
+                    "last_seen": 30.0,
+                    "attempts": 2,
+                    "holder_pids": [4242],
+                }),
+            ),
+        )
+        raw.commit()
+        raw.close()
+
+        holder_scans = iter(([(4242, str(db_path) + "-wal")], []))
+        reaped = []
+        monkeypatch.setattr(
+            SessionDB,
+            "_foreign_state_db_holders",
+            lambda self: next(holder_scans),
+        )
+        monkeypatch.setattr(
+            SessionDB,
+            "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: reaped.extend(holders) or [4242],
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: 120.0)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reaped == [(4242, str(db_path) + "-wal")]
+            leftover = _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY)
+            if leftover is not None:
+                assert not _deferral_is_futile(json.loads(leftover)), leftover
+            assert reopened._fts_stale is False
+            assert _meta_value(db_path, FTS_STALE_KEY) is None
+        finally:
+            reopened.close()
+
+    def test_permanent_holder_clear_resets_stale_retry_backoff(
+        self, db, tmp_path, monkeypatch
+    ):
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db,
+            "rebuild_fts",
+            lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (
+                FTS_REBUILD_DEFERRAL_KEY,
+                json.dumps({
+                    "first_seen": 1.0,
+                    "last_seen": 30.0,
+                    "attempts": 2,
+                    "holder_pids": [4242],
+                }),
+            ),
+        )
+        raw.commit()
+        raw.close()
+
+        current_holders = [(4242, str(db_path) + "-wal")]
+        monkeypatch.setattr(
+            SessionDB,
+            "_foreign_state_db_holders",
+            lambda self: list(current_holders),
+        )
+        monkeypatch.setattr(
+            SessionDB,
+            "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [],
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: 120.0)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            record = json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY))
+            assert _deferral_is_futile(record), record
+            current_holders = []
+            reopened._fts_stale_retry_after = time.monotonic() + 3600.0
+            reopened._fts_stale_retry_interval = 3600.0
+            assert reopened.retry_deferred_fts_recovery() is True
+            assert reopened._fts_stale is False
         finally:
             reopened.close()
 

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -34,7 +34,7 @@ def _deferral_is_futile(record):
     if record.get("futile") is True:
         return True
     kind = str(record.get("kind") or record.get("status") or "").lower()
-    return "futile" in kind or "permanent_holder" in kind
+    return "futile" in kind or "stable_holder" in kind or "permanent_holder" in kind
 
 
 def _doctor_deferral_blob(stats):
@@ -804,10 +804,10 @@ class TestRuntimeFtsRebuild:
         finally:
             reopened.close()
 
-    def test_stable_permanent_holder_marks_futile_deferral(
+    def test_stable_holder_set_marks_futile_deferral(
         self, db, tmp_path, monkeypatch, caplog
     ):
-        """Same supervised holder across the escalate window is futile, not a transient peer."""
+        """Same holder PID set across the escalate window is a stable-set heuristic, not a transient peer."""
         if not db._fts_enabled:
             pytest.skip("FTS5 unavailable in this build")
         db_path = tmp_path / "state.db"
@@ -855,15 +855,19 @@ class TestRuntimeFtsRebuild:
         try:
             record = json.loads(_meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY))
             assert _deferral_is_futile(record), record
+            assert record.get("kind") == "stable_holder"
             assert record.get("holder_pids") == [4242]
             assert reopened._fts_stale is True
             from hermes_cli.doctor_state import _render_state_db_stats
             from hermes_state_dbfile import collect_state_db_stats
 
             blob = _doctor_deferral_blob(collect_state_db_stats(db_path))
+            assert "stable holder" in blob
             assert "stop the other hermes service" in blob
             assert "gateway" in blob
+            assert "permanent holder" not in blob
             assert "canonical writes and like search remain available" not in caplog.text.lower()
+            assert "permanent holder" not in caplog.text.lower()
         finally:
             reopened.close()
 
@@ -982,7 +986,7 @@ class TestRuntimeFtsRebuild:
         finally:
             reopened.close()
 
-    def test_permanent_holder_clear_resets_stale_retry_backoff(
+    def test_stable_holder_clear_resets_stale_retry_backoff(
         self, db, tmp_path, monkeypatch
     ):
         if not db._fts_enabled:

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -109,6 +109,32 @@ def test_collect_and_render_stale_fts_holder_deferral(populated_db):
     assert any("4242" in warning and "optimize-storage" in warning for warning in warnings)
 
 
+def test_render_permanent_holder_deferral_is_actionable():
+    from hermes_cli.doctor_state import _render_state_db_stats
+
+    lines = _render_state_db_stats(
+        _base_stats(
+            fts_rebuild_deferral={
+                "attempts": 12,
+                "holder_pids": [4242],
+                "first_seen": 1.0,
+                "futile": True,
+                "kind": "permanent_holder",
+            }
+        )
+    )
+    warnings = [
+        " ".join((text, detail)).lower()
+        for kind, text, detail in lines
+        if kind == "warn"
+    ]
+    blob = " ".join(warnings)
+    assert "4242" in blob
+    assert "stop the other hermes service" in blob
+    assert "gateway" in blob
+    assert "optimize-storage" not in blob or "leave this gateway" in blob
+
+
 def test_collect_stats_missing_file_never_raises(tmp_path):
     stats = collect_state_db_stats(tmp_path / "nope" / "state.db")
     assert isinstance(stats, dict)

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -109,7 +109,7 @@ def test_collect_and_render_stale_fts_holder_deferral(populated_db):
     assert any("4242" in warning and "optimize-storage" in warning for warning in warnings)
 
 
-def test_render_permanent_holder_deferral_is_actionable():
+def test_render_stable_holder_deferral_is_actionable():
     from hermes_cli.doctor_state import _render_state_db_stats
 
     lines = _render_state_db_stats(
@@ -119,7 +119,7 @@ def test_render_permanent_holder_deferral_is_actionable():
                 "holder_pids": [4242],
                 "first_seen": 1.0,
                 "futile": True,
-                "kind": "permanent_holder",
+                "kind": "stable_holder",
             }
         )
     )
@@ -130,6 +130,8 @@ def test_render_permanent_holder_deferral_is_actionable():
     ]
     blob = " ".join(warnings)
     assert "4242" in blob
+    assert "stable holder" in blob
+    assert "permanent holder" not in blob
     assert "stop the other hermes service" in blob
     assert "gateway" in blob
     assert "optimize-storage" not in blob or "leave this gateway" in blob


### PR DESCRIPTION
## What does this PR do?

When stale-FTS repair is blocked by a **stable holder set** that survives orphan Desktop reap (same PID set across the escalate window), deferral had no operator-visible exit. Escalate already logged to `errors.log`, yet the WARNING still claimed “canonical writes remain available,” and `hermes doctor` did not distinguish “waiting for a transient peer” from “this holder set is not clearing.”

This PR is the **diagnostic/backoff slice only**: mark a PID set that survives post-escalate reap as `futile` / `kind=stable_holder` in `state_meta` (heuristic: the set is stable, not proof the process is supervised), surface an actionable doctor message (stop the **other** Hermes service; leave this gateway running), stop the misleading write-availability claim on the futile path, and reset in-process stale-retry backoff when holders finally clear so recovery is not stuck behind the 3600s cap.

Does **not** loosen `_is_inactive_orphan_desktop_holder`, does **not** admit rebuild while holders remain (`_defer_stale_fts_for_holders` still returns `True` → `_recover_stale_fts` still returns `False`), and does **not** implement the write-safety/repair-serialization exit. Live transcript INSERTs can still fail through stale FTS triggers until that parent defect is fixed.

## Related Issue

Addresses #106393

Does **not** close #106393. The write-safety/repair-admission invariant (canonical writes remaining durable while a non-orphan holder blocks rebuild) stays open on that issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state_schema.py` — after escalate, if reap leaves the same holder PID set, persist `futile=true` / `kind=stable_holder`; adjust futile deferral logging; reset `_fts_stale_retry_*` when holders clear
- `hermes_cli/doctor_state.py` — distinct, actionable doctor text for stable-holder-set deferral
- `tests/state/test_fts_runtime_rebuild.py`, `tests/test_state_db_stats.py` — RED→GREEN coverage + CONTROL for changing PIDs / orphan reap

## How to Test

1. Focused suite (proved RED on pre-fix, GREEN after):
   `scripts/run_tests.sh tests/state/test_fts_runtime_rebuild.py tests/test_state_db_stats.py tests/state/test_fts_rebuild_admission.py -v --tb=short`
2. Result on this branch: **90 passed, 0 failed, 4 skipped**
3. CONTROL: changing holder PIDs and successful orphan reap still do **not** mark futile

## Proof Receipt

- BEFORE (pre-fix): 3 new tests failed (missing `futile` mark / old doctor copy / “canonical writes remain available”); 2 CONTROL passed
- AFTER: full focused suite green (90 passed)
- Follow-up (review): `kind=stable_holder`; `Fixes` → `Addresses`; admission/`return True` unchanged; focused suite still 90 passed
- Self-review P0 = 0; independent review P0 = 0 (APPROVE)
- Ownership: no open competing PR for `106393` at push time; pr-watcher stop-file clear

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused pytest via `scripts/run_tests.sh` and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin) focused suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — holder scan still Linux-/proc-shaped; diagnostic is fail-open elsewhere
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Residual risks

- Futile flag is in-process for the fast backoff-reset path; gateway restart with peer already gone still relies on open-time recovery.
- Transient PID-set flicker can clear `futile` for one cycle before re-marking after the next escalate match.
- This slice does not make canonical writes durable while the stable holder remains.