### PR TITLE
fix(anthropic): Claude Code OAuth identity floor — Fable 5.x no longer rejected (port prime-agent#1993)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -213,14 +213,28 @@ _FAST_MODE_BETA = "fast-mode-2026-02-01"
 _OAUTH_ONLY_BETAS = ["claude-code-20250219", "oauth-2025-04-20"]
 
 # Claude Code identity — OAuth requests without it intermittently 500. Anthropic rejects OAuth
-# requests whose user-agent version is too far behind the actual release, so the installed
-# version is detected and this fallback kept current.
-_CLAUDE_CODE_VERSION_FALLBACK = "2.1.74"
+# requests whose user-agent version is too far behind the actual release (Fable 5.x models are
+# gated on Claude Code >= 2.1.251 and older identities get "Claude Code X does not support this
+# model"), so the installed version is detected, clamped to the floor below, and this fallback
+# kept current with the npm ``@anthropic-ai/claude-code`` latest dist-tag.
+_CLAUDE_CODE_VERSION_FALLBACK = "2.1.266"
+# Oldest identity Anthropic accepts for the newest model families; a stale installed CLI would
+# otherwise undercut the fallback and re-break OAuth on exactly the machines that have Claude
+# Code installed.
+_CLAUDE_CODE_VERSION_FLOOR = (2, 1, 251)
 _claude_code_version_cache: Optional[str] = None
 
 
+def _version_tuple(version: str) -> Optional[tuple]:
+    """``"2.1.74"`` -> ``(2, 1, 74)``; None when any component is non-numeric."""
+    with suppress(ValueError):
+        return tuple(int(part) for part in version.split("."))
+    return None
+
+
 def _detect_claude_code_version() -> str:
-    """Installed Claude Code version (``claude --version``), else the static fallback."""
+    """Installed Claude Code version (``claude --version``), clamped to the identity floor,
+    else the static fallback."""
     for cmd in ("claude", "claude-code"):
         with suppress(Exception):
             result = subprocess.run(
@@ -230,6 +244,9 @@ def _detect_claude_code_version() -> str:
             if result.returncode == 0 and result.stdout.strip():
                 version = result.stdout.strip().split()[0]  # "2.1.74 (Claude Code)" or "2.1.74"
                 if version and version[0].isdigit():
+                    parsed = _version_tuple(version)
+                    if parsed is not None and parsed < _CLAUDE_CODE_VERSION_FLOOR:
+                        return _CLAUDE_CODE_VERSION_FALLBACK
                     return version
     return _CLAUDE_CODE_VERSION_FALLBACK
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -166,7 +166,7 @@ class TestReadClaudeCodeCredentials:
 
     def test_ignores_primary_api_key_for_native_anthropic_resolution(self, tmp_path, monkeypatch):
         claude_json = tmp_path / ".claude.json"
-        claude_json.write_text(json.dumps({"primaryApiKey": "sk-ant-api03-primary"}))
+        claude_json.write_text(json.dumps({"primaryApiKey": "sk-ant-api03-primary"}), encoding="utf-8")
         monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
 
         creds = read_claude_code_credentials()
@@ -205,7 +205,7 @@ class TestResolveAnthropicToken:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
-        (tmp_path / ".claude.json").write_text(json.dumps({"primaryApiKey": "sk-ant-api03-primary"}))
+        (tmp_path / ".claude.json").write_text(json.dumps({"primaryApiKey": "sk-ant-api03-primary"}), encoding="utf-8")
         monkeypatch.setattr("agent.anthropic_credentials.Path.home", lambda: tmp_path)
 
         assert resolve_anthropic_token() is None
@@ -430,7 +430,7 @@ class TestRefreshOauthToken:
         # Verify credentials were written back
         cred_file = tmp_path / ".claude" / ".credentials.json"
         assert cred_file.exists()
-        written = json.loads(cred_file.read_text())
+        written = json.loads(cred_file.read_text(encoding="utf-8"))
         assert written["claudeAiOauth"]["accessToken"] == "new-token-abc"
         assert written["claudeAiOauth"]["refreshToken"] == "new-refresh-456"
 
@@ -455,7 +455,7 @@ class TestWriteClaudeCodeCredentials:
         _write_claude_code_credentials("tok", "ref", 12345)
         cred_file = tmp_path / ".claude" / ".credentials.json"
         assert cred_file.exists()
-        data = json.loads(cred_file.read_text())
+        data = json.loads(cred_file.read_text(encoding="utf-8"))
         assert data["claudeAiOauth"]["accessToken"] == "tok"
         assert data["claudeAiOauth"]["refreshToken"] == "ref"
         assert data["claudeAiOauth"]["expiresAt"] == 12345
@@ -465,9 +465,9 @@ class TestWriteClaudeCodeCredentials:
         cred_dir = tmp_path / ".claude"
         cred_dir.mkdir()
         cred_file = cred_dir / ".credentials.json"
-        cred_file.write_text(json.dumps({"otherField": "keep-me"}))
+        cred_file.write_text(json.dumps({"otherField": "keep-me"}), encoding="utf-8")
         _write_claude_code_credentials("new-tok", "new-ref", 99999)
-        data = json.loads(cred_file.read_text())
+        data = json.loads(cred_file.read_text(encoding="utf-8"))
         assert data["otherField"] == "keep-me"
         assert data["claudeAiOauth"]["accessToken"] == "new-tok"
 
@@ -1896,3 +1896,26 @@ class TestFinalPayloadHasNoBlankTextBlocks:
         )
         image_blocks = [b for b in tool_result_block["content"] if b.get("type") == "image"]
         assert len(image_blocks) == 1
+
+
+class TestClaudeCodeVersionFloor:
+    """OAuth identity version floor (port of PrimeIntellect-ai/prime-agent#1993): Anthropic
+    gates the newest model families on a minimum Claude Code version; a detected CLI older
+    than the floor must not undercut the fallback identity."""
+
+    def _detect_with_stdout(self, monkeypatch, stdout):
+        import agent.anthropic_adapter as aa
+        result = MagicMock(returncode=0, stdout=stdout)
+        monkeypatch.setattr(aa.subprocess, "run", lambda *a, **k: result)
+        return aa._detect_claude_code_version()
+
+    def test_stale_installed_version_clamps_to_fallback(self, monkeypatch):
+        import agent.anthropic_adapter as aa
+        assert self._detect_with_stdout(monkeypatch, "2.1.74 (Claude Code)") == aa._CLAUDE_CODE_VERSION_FALLBACK
+
+    def test_recent_installed_version_wins(self, monkeypatch):
+        assert self._detect_with_stdout(monkeypatch, "2.1.260 (Claude Code)") == "2.1.260"
+
+    def test_fallback_is_at_or_above_floor(self):
+        import agent.anthropic_adapter as aa
+        assert aa._version_tuple(aa._CLAUDE_CODE_VERSION_FALLBACK) >= aa._CLAUDE_CODE_VERSION_FLOOR


### PR DESCRIPTION
Anthropic OAuth (Claude subscription) requests no longer get rejected on Claude Fable 5.x models because Hermes presented a stale Claude Code identity.

## Symptom
Anthropic now gates the newest model families (Fable 5.x) on a Claude Code client identity >= 2.1.251 and rejects OAuth requests carrying older versions ("Claude Code X does not support this model"). Hermes' fallback identity was `2.1.74`, and a machine with a stale installed `claude` CLI would detect and send an equally old version — breaking OAuth exactly for subscription users on the newest models.

Upstream evidence: PrimeIntellect-ai/prime-agent hit the identical rejection and bumped their impersonated version in [prime-agent#1993](https://github.com/PrimeIntellect-ai/prime-agent/pull/1993) (their pinned 2.1.75 was rejected for Fable 5.x; fixed at >= 2.1.251), then again in [prime-agent#2069](https://github.com/PrimeIntellect-ai/prime-agent/pull/2069).

## Change
- `_CLAUDE_CODE_VERSION_FALLBACK`: `2.1.74` → `2.1.266` (current `@anthropic-ai/claude-code` npm latest at time of PR).
- New `_CLAUDE_CODE_VERSION_FLOOR = (2, 1, 251)`: a *detected* CLI version below the floor clamps to the fallback instead of undercutting it. Prime pins a constant; Hermes detects the installed CLI, so the port needs the floor to fix the whole class — otherwise machines with an old CLI stay broken after the fallback bump.
- Non-numeric detected versions fall through to the plain "starts with a digit" acceptance as before.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py` | 98 passed, 0 failed |
| Live E2E (this machine, no `claude` CLI installed) | resolved identity `2.1.266`, floor satisfied |
| Invariant test | fallback always >= floor; stale detection (`2.1.74`) clamps; recent detection (`2.1.260`) wins |
| `ruff`, windows-footguns, compat pointers | clean (also fixed 6 pre-existing bare `read_text/write_text` in the touched test file per checker policy) |

**Live repro:** before — `_get_claude_code_version()` on this machine returned `2.1.74` (the stale fallback), the exact identity class Anthropic rejects for Fable 5.x per the upstream A/B; after — returns `2.1.266`, above the 2.1.251 gate. (A full wire A/B against a Fable 5.x OAuth request was not run: no Anthropic OAuth credential is configured on this host; the gate threshold is taken from prime-agent's live A/B in #1993.)

Root cause in one sentence: the impersonated Claude Code version was pinned in Feb-2026 territory while Anthropic moved the minimum accepted identity forward.

Ported by the weekly prime-agent PR scout (cron). Credit: Sebastian Müller (@badlogic lineage repo, PrimeIntellect-ai/prime-agent#1993).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b6f1/DKycKD_FxU3PzNhN2lg-__QQ7EphgD.png)
