### PR TITLE
fix(cli): concurrent PTY reaps skip already-popped keys instead of raising

### DIFF
--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -191,7 +191,12 @@ class PtySessionRegistry:
             if not s.alive or (not s.attached and s.last_detached_at is not None and (now - s.last_detached_at) > self._ttl)
         ]
         for key in doomed:
-            await self._sessions.pop(key).close()
+            # Reaps overlap (attach_or_spawn and the background reaper) and close()
+            # awaits, so a concurrent reap can have popped this key already — skip
+            # it instead of raising KeyError into the websocket handler.
+            session = self._sessions.pop(key, None)
+            if session is not None:
+                await session.close()
 
     def _reap_one_idle_or_raise(self) -> None:
         idle = [s for s in self._sessions.values() if not s.attached and s.last_detached_at is not None]
@@ -203,4 +208,8 @@ class PtySessionRegistry:
 
     async def close_all(self) -> None:
         for key in list(self._sessions):
-            await self._sessions.pop(key).close()
+            # Same overlap window as reap_idle: an in-flight reap may have popped
+            # a snapshot key while we awaited an earlier close().
+            session = self._sessions.pop(key, None)
+            if session is not None:
+                await session.close()

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -277,3 +277,104 @@ async def test_reaper_loop_invokes_reap(monkeypatch):
     except asyncio.CancelledError:
         pass
     assert calls["n"] >= 2
+
+
+def _register_idle_session(reg, key):
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b""])
+    s = PtySession(key, bridge, buffer_cap=1024, read_timeout=0.01)
+    await_start = s.start()
+    return bridge, s, await_start
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reap_idle_is_idempotent():
+    """reap_idle is reached from attach_or_spawn and the run_reaper loop; both
+    may doom the same keys, so one reap can pop a key the other already took
+    while awaiting its close(). The second pop must skip, not raise."""
+    reg = make_registry(ttl=60.0)
+    bridges = []
+    sessions = []
+    for i in range(2):
+        bridge, s, start = _register_idle_session(reg, "k%d" % i)
+        await start
+        s.detach(None)                        # unattached, last_detached_at set
+        reg._sessions[s.key] = s
+        bridges.append(bridge)
+        sessions.append(s)
+
+    entered, release = asyncio.Event(), asyncio.Event()
+    original_close = sessions[0].close
+
+    async def gated_close():
+        entered.set()
+        await release.wait()
+        await original_close()
+
+    sessions[0].close = gated_close
+
+    far_future = time.monotonic() + 10_000    # both idle past ttl → doomed
+    first = asyncio.create_task(reg.reap_idle(now=far_future))
+    await entered.wait()                      # k0 popped; first reap parked in close()
+    await reg.reap_idle(now=far_future)       # second reap hits the taken k0
+
+    release.set()
+    await first
+    assert not reg._sessions
+    assert all(b.closed for b in bridges)
+
+
+@pytest.mark.asyncio
+async def test_close_all_survives_key_popped_by_concurrent_reap():
+    """close_all snapshots keys, then awaits each close(); a reap that runs
+    during that await can remove a later key from the snapshot."""
+    reg = make_registry(ttl=60.0)
+    bridges = []
+    sessions = []
+    for i in range(2):
+        bridge, s, start = _register_idle_session(reg, "k%d" % i)
+        await start
+        s.detach(None)
+        reg._sessions[s.key] = s
+        bridges.append(bridge)
+        sessions.append(s)
+
+    entered, release = asyncio.Event(), asyncio.Event()
+    original_close = sessions[0].close
+
+    async def gated_close():
+        entered.set()
+        await release.wait()
+        await original_close()
+
+    sessions[0].close = gated_close
+
+    closer = asyncio.create_task(reg.close_all())
+    await entered.wait()                      # close_all popped k0, parked in close()
+    await reg.reap_idle(now=time.monotonic() + 10_000)   # pops k1 meanwhile
+    release.set()
+    await closer                              # k1 of the snapshot is already gone
+
+    assert not reg._sessions
+    assert all(b.closed for b in bridges)
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_closes_doomed_and_keeps_attached():
+    reg = make_registry(ttl=60.0)
+    live_bridge = FakeBridge([b""])
+    s_live, _ = await reg.attach_or_spawn("live", spawn=lambda: live_bridge)
+    await s_live.attach(FakeWS())             # attached → survives the reap
+
+    dead_bridge = FakeBridge([b""])
+    s_dead, _ = await reg.attach_or_spawn("dead", spawn=lambda: dead_bridge)
+    s_dead.alive = False                      # dead remnant → reaped
+
+    idle_bridge = FakeBridge([b""])
+    s_idle, _ = await reg.attach_or_spawn("idle", spawn=lambda: idle_bridge)
+    s_idle.detach(None)                       # idle past ttl → reaped
+
+    await reg.reap_idle(now=time.monotonic() + 10_000)
+    assert list(reg._sessions) == ["live"]
+    assert dead_bridge.closed and idle_bridge.closed and not live_bridge.closed
+    await reg.close_all()


### PR DESCRIPTION
## What does this PR do?

`PtySessionRegistry.reap_idle()` is reached from two concurrent tasks: every `attach_or_spawn()` call and the background `run_reaper` loop (every 60 s). Each reap builds its own doomed list, then pops keys and awaits `close()`. Because `close()` awaits, a second reap running during that window reaches a key the first reap already popped — and `dict.pop(key)` without a default raised `KeyError`, which on the `attach_or_spawn` path propagates straight into the websocket handler and kills it (`web_routers/chat_ws.py:489`). `close_all()` has the same overlap window against an in-flight reap, since it snapshots keys and then awaits each `close()`.

This PR makes overlapping reaps idempotent: pop with a `None` default and skip keys a concurrent reap already removed. Which sessions get reaped — dead remnants and idle-past-ttl detached sessions — is unchanged; attached sessions were and remain untouched.

## Related Issue

Fixes #106400

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/pty_session.py` — `reap_idle()`: `pop(key)` → `pop(key, None)` + skip when `None`, so a concurrent reap that already took the key is a no-op instead of a `KeyError` into the websocket handler.
- `hermes_cli/pty_session.py` — `close_all()`: same default-pop for the identical overlap window (key popped by an in-flight reap while an earlier `close()` is awaited).
- `tests/test_pty_session.py` — three regression tests: two deterministic interleavings (gated `close()` parks one reap/`close_all` while a second reap takes the overlapping key — both reproduced the `KeyError` on the pre-fix code) and one behavioral guard that doomed sessions are closed while attached sessions survive.

## How to Test

1. `python -m pytest tests/test_pty_session.py -q` — Observed result: `15 passed` (12 pre-existing + 3 new). Before the fix, the two new interleaving tests fail with `KeyError` at `hermes_cli/pty_session.py:194` / `:206`; after the fix they pass.
2. `python -m pytest tests/hermes_cli/test_pty_bridge.py tests/hermes_cli/test_web_server_pty_idle_backoff.py tests/hermes_cli/test_web_server_pty_import.py tests/hermes_cli/test_web_server_pty_reconnect.py -q` — Observed result: `26 passed`.
3. `python -m pytest tests/hermes_cli/test_web_server.py tests/test_pty_keepalive_ws.py -q` — Observed result: `19 passed` (keep-alive/ws surface) / `187 passed, 1 skipped` (web server surface).
4. `ruff check hermes_cli/pty_session.py tests/test_pty_session.py` — Observed result: all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Pre-fix failure reproduced by the new regression tests (RED run before the production change):

```
tests/test_pty_session.py::test_concurrent_reap_idle_is_idempotent - KeyError
hermes_cli/pty_session.py:194: KeyError

tests/test_pty_session.py::test_close_all_survives_key_popped_by_concurrent_reap
hermes_cli/pty_session.py:206: KeyError: 'k1'
```

Post-fix: `15 passed`.