### PR TITLE
feat(approval): cloud metadata-endpoint (IMDS) credential fetches now require approval

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -234,6 +234,40 @@ class TestSafeCommand:
             assert desc is None
 
 
+class TestCloudMetadataEndpoint:
+    IMDS_KEY = "cloud metadata endpoint access (instance credentials)"
+
+    def test_metadata_credential_fetches_flagged(self):
+        # AWS/Azure link-local IP, GCP hostname, AWS IPv6 form, Alibaba Cloud IP —
+        # each is an instance-credential fetch and must prompt for approval.
+        aws_ip = ".".join(["169", "254", "169", "254"])
+        ali_ip = ".".join(["100", "100", "100", "200"])
+        for cmd in (
+            f"curl http://{aws_ip}/latest/meta-data/iam/security-credentials/",
+            'curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+            f"wget http://{aws_ip}/latest/api/token",
+            f'curl -H "Metadata: true" "http://{aws_ip}/metadata/identity/oauth2/token?api-version=2018-02-01"',
+            "curl http://[fd00:ec2::254]/latest/meta-data/",
+            f"curl http://{ali_ip}/latest/meta-data/ram/security-credentials/",
+        ):
+            is_dangerous, key, _ = detect_dangerous_command(cmd)
+            assert is_dangerous is True, cmd
+            assert key == self.IMDS_KEY, cmd
+
+    def test_other_link_local_and_ordinary_urls_not_flagged(self):
+        # Other 169.254.x.x link-local addresses and ordinary URLs are unrelated
+        # to instance credentials and must not trip this rule.
+        for cmd in (
+            "curl http://169.254.1.1/status",
+            "ping 169.254.100.100",
+            "curl https://example.com/api/169.254.169.2540",  # longer dotted run, not the endpoint
+            "curl https://metadata.google.internal.example.com/",  # different host
+        ):
+            is_dangerous, key, _ = detect_dangerous_command(cmd)
+            assert not (is_dangerous and key == self.IMDS_KEY), cmd
+
+
+
 def _clear_session(key):
     """Replace for removed clear_session() — directly clear internal state."""
     approval_module._session_approved.pop(key, None)

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -286,6 +286,19 @@ DANGEROUS_PATTERNS = [
     (r'\b(bash|sh|zsh|ksh)\s+<\s*<?\s*\(\s*(curl|wget)\b', "execute remote script via process substitution"),
     # eval/source/. $(curl ...) — equivalent to piping remote content to a shell.
     (r'(?:\beval\b|\bsource\b|\.)\s*(?:\$\(\s*|`\s*)(?:curl|wget)\b', "execute remote content via command substitution"),
+    # Cloud instance-metadata (IMDS) credential endpoints — deterministic containment-escape
+    # detection. On a cloud VM these serve live IAM/service-account credentials to ANY local
+    # process with no auth, so a fetch is credential exfiltration unless the operator expects it.
+    # The host literals have no other use, so their appearance ANYWHERE in the command (any HTTP
+    # client, env assignment, or script argument) is the signal; lookarounds keep other 169.254.x.x
+    # link-local addresses and longer dotted strings out. This prompts for approval (legit uses
+    # exist on real cloud VMs) — it is NOT a hardline block. Covers the link-local IPv4 endpoint
+    # (AWS/Azure/GCP/OpenStack), its AWS IPv6 form fd00:ec2::254, the GCP hostname, and Alibaba
+    # Cloud's 100.100.100.200.
+    (r'(?<![\d.])(?:169\.254\.169\.254|100\.100\.100\.200)(?![\d.])'
+     r'|(?<![\w.-])metadata\.google\.internal(?![\w.-])'
+     r'|fd00:ec2::254',
+     "cloud metadata endpoint access (instance credentials)"),
     # Decode-and-execute: `echo <base64> | base64 -d | bash` carries no dangerous keywords in the
     # raw text yet runs arbitrary commands.
     (r'\b(base64|base32|base16)\s+(?:-[dD]|--decode)\b.*\|\s*\b(bash|sh|zsh|ksh|dash)\b', "pipe decoded content to shell (possible command obfuscation)"),


### PR DESCRIPTION
Terminal commands that fetch cloud instance-metadata (IMDS) credential endpoints now require approval instead of being auto-approved.

Inspired by the Containment Escape rule in [Claude Code 2.1.257](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md): their auto mode stops auto-approving cloud metadata-credential fetches (plus egress evasion and cross-tenant reach) unless the environment marks them expected. Hermes adapts the metadata-credential piece as a deterministic `DANGEROUS_PATTERNS` entry at the terminal approval layer — no LLM judging, fail-closed prompt — rather than their sandbox-specific auto-mode machinery.

## Changes

- `tools/approval_detection.py`: one new `DANGEROUS_PATTERNS` entry, `cloud metadata endpoint access (instance credentials)`, covering `169.254.169.254` (AWS/Azure/GCP/OpenStack), its AWS IPv6 form `fd00:ec2::254`, `metadata.google.internal` (GCP), and `100.100.100.200` (Alibaba Cloud). The host literals have no other use, so their appearance in a command is the signal regardless of HTTP client; lookarounds keep other `169.254.x.x` link-local addresses and longer host/dotted strings (`...169.2540`, `metadata.google.internal.example.com`) out.
- `tests/tools/test_approval.py`: 2 invariant tests (`TestCloudMetadataEndpoint::test_metadata_credential_fetches_flagged`, `::test_other_link_local_and_ordinary_urls_not_flagged`), proven red on unfixed base.

**Prompt, not a block:** this is a `DANGEROUS_PATTERNS` entry (approval prompt; denied in unattended approve-modes), not a hardline floor — legitimate uses exist on real cloud VMs (agents managing their own instance, debugging IAM roles), so the operator decides.

## Live probe (before = origin/main, after = this branch)

| Command | Before | After |
|---|---|---|
| `curl http://169.254.169.254/latest/meta-data/iam/security-credentials/` | auto-approved | prompts |
| `curl -H "Metadata-Flavor: Google" http://metadata.google.internal/.../token` | auto-approved | prompts |
| `wget http://169.254.169.254/latest/api/token` | auto-approved | prompts |
| Azure identity token URL on `169.254.169.254` | auto-approved | prompts |
| `curl http://[fd00:ec2::254]/latest/meta-data/` | auto-approved | prompts |
| `curl http://100.100.100.200/latest/meta-data/ram/...` (Alibaba) | auto-approved | prompts |
| `curl http://169.254.1.1/status` (other link-local) | safe | safe |
| `ping 169.254.100.100` | safe | safe |

**Live repro:** before — `detect_dangerous_command` returned `(False, None, None)` for all six IMDS commands on `origin/main`; after — all six return `(True, 'cloud metadata endpoint access (instance credentials)', ...)` while negatives stay safe.

Tests: `tests/tools/` run; the 4 failing files (`test_execution_flag_detection`, `test_modal_snapshot_isolation`, `test_web_tools_config`, flaky `test_delegate_timeout_cleanup`) fail identically on unmodified `origin/main` — pre-existing, unrelated.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b6eb/N1Bi2oP5v1MF8XAjborgY_K4d9YIit.png)
