### PR TITLE
fix(tui_gateway): zombie-safe, Windows-safe compute-host PID supervision (salvage #68272 + codex port)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -577,6 +577,7 @@ def _pid_exists(pid: int) -> bool:
             # status (partial/stub psutil, access denied, transient race) falls through to the authoritative
             # ``pid_exists()`` below rather than raising.
             if psutil.Process(pid).status() == psutil.STATUS_ZOMBIE:
+                _reap_own_zombie(pid)
                 return False
         except getattr(psutil, "NoSuchProcess", ()):
             return False
@@ -588,6 +589,7 @@ def _pid_exists(pid: int) -> bool:
     if _IS_WINDOWS:
         return _pid_exists_win32_ctypes(pid)
     if _posix_is_zombie(pid):  # a zombie still answers os.kill(pid, 0)
+        _reap_own_zombie(pid)
         return False
     try:
         os.kill(pid, 0)  # windows-footgun: ok — POSIX-only branch (the whole point of _pid_exists)
@@ -596,6 +598,17 @@ def _pid_exists(pid: int) -> bool:
     except OSError:  # ProcessLookupError included
         return False
     return True
+
+
+def _reap_own_zombie(pid: int) -> None:
+    """Nonblocking ``waitpid`` so a zombie that is OUR child leaves the process table
+    (re-exec / a lost ``Popen`` handle can orphan the child bookkeeping without changing
+    parenthood — the kernel keeps the entry until the parent waits). Foreign children raise
+    ``ChildProcessError``; best-effort either way. Ported from openai/codex#43504."""
+    if _IS_WINDOWS:
+        return
+    with contextlib.suppress(ChildProcessError, OSError):
+        os.waitpid(pid, os.WNOHANG)
 
 
 def _posix_is_zombie(pid: int) -> bool:

--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -759,6 +759,7 @@ def main(argv: list[str]) -> int:
             REPO_ROOT / "plugins",
             REPO_ROOT / "scripts",
             REPO_ROOT / "acp_adapter",
+            REPO_ROOT / "tui_gateway",
         ]
         roots = [r for r in roots if r.exists()]
     elif args.diff:

--- a/tests/gateway/test_status_zombie_reap.py
+++ b/tests/gateway/test_status_zombie_reap.py
@@ -1,0 +1,65 @@
+"""``gateway.status._pid_exists`` must reap our own unreaped zombie children.
+
+An exited child whose ``Popen`` handle was lost (re-exec, supervisor restart) stays a
+zombie until the parent waits: it still occupies a process-table slot and — before the
+reap was added — kept ``ps``/``/proc`` state queries answering for a dead PID forever.
+Ported from openai/codex#43504.
+"""
+
+import os
+import subprocess
+import time
+
+import pytest
+
+from gateway import status
+
+pytestmark = pytest.mark.linux_only
+
+
+def _wait_for_zombie(pid: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    state = "?"
+    while time.monotonic() < deadline:
+        state = open(f"/proc/{pid}/stat").read().split()[2]
+        if state == "Z":
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"pid {pid} never became a zombie (state={state})")
+
+
+def test_pid_exists_reports_own_zombie_dead_and_reaps_it():
+    child = subprocess.Popen(["sleep", "60"])
+    try:
+        child.send_signal(9)
+        # Do NOT child.wait(): the point is an unreaped zombie.
+        _wait_for_zombie(child.pid)
+
+        assert status._pid_exists(child.pid) is False
+
+        # The probe reaped it: the process-table entry is gone (waitpid raises ECHILD).
+        deadline = time.monotonic() + 5.0
+        while os.path.exists(f"/proc/{child.pid}") and time.monotonic() < deadline:
+            time.sleep(0.02)
+        assert not os.path.exists(f"/proc/{child.pid}")
+        with pytest.raises(ChildProcessError):
+            os.waitpid(child.pid, os.WNOHANG)
+    finally:
+        # Neutralize Popen.__del__'s wait if the reap failed.
+        child.returncode = -9
+
+
+def test_pid_exists_foreign_zombie_still_reads_dead():
+    # A zombie that is NOT our child: waitpid fails (ECHILD) but the verdict stays dead.
+    child = subprocess.Popen(["sleep", "60"])
+    try:
+        child.send_signal(9)
+        _wait_for_zombie(child.pid)
+        # Simulate "foreign": _reap_own_zombie's waitpid on an already-reaped pid is a no-op.
+        child.wait()
+        # PID now fully gone; probe must report dead without raising.
+        assert status._pid_exists(child.pid) is False
+    finally:
+        if child.returncode is None:
+            child.kill()
+            child.wait()

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -118,12 +118,63 @@ def test_append_log_record_single_write_lines(tmp_path):
     assert all(line.endswith("x" * 2000) for line in lines)
 
 
+def test_supervisor_pid_probe_never_sends_signal_zero(monkeypatch):
+    from tui_gateway import host_supervisor
+
+    checked: list[int] = []
+    monkeypatch.setattr(
+        "gateway.status._pid_exists",
+        lambda pid: checked.append(int(pid)) or True,
+    )
+    monkeypatch.setattr(
+        host_supervisor.os,
+        "kill",
+        lambda *_args: pytest.fail("liveness probe sent a signal"),
+    )
+
+    assert host_supervisor._pid_alive(4242) is True
+    assert checked == [4242]
+
+
+def test_supervisor_pid_termination_uses_cross_platform_helper(tmp_path, monkeypatch):
+    from gateway import status as gateway_status
+    from tui_gateway import host_supervisor
+
+    calls: list[tuple[int, bool, object]] = []
+
+    def _terminate_pid(pid: int, *, force: bool = False, expected_start_time=None) -> None:
+        calls.append((pid, force, expected_start_time))
+
+    monkeypatch.setattr(gateway_status, "terminate_pid", _terminate_pid)
+    monkeypatch.setattr(gateway_status, "get_process_start_time", lambda _pid: 777)
+    monkeypatch.setattr(host_supervisor, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(
+        host_supervisor.os,
+        "kill",
+        lambda *_args: pytest.fail("supervisor bypassed cross-platform termination"),
+    )
+    supervisor = HostSupervisor(
+        registry_path=tmp_path / "dashboard-compute-host.json",
+        argv=[sys.executable, "-c", ""],
+        autostart=False,
+    )
+
+    supervisor._terminate_pid(4242, timeout=0)
+
+    # Forced kill carries the pre-captured start-time fingerprint (Windows requires it;
+    # a recycled PID is refused everywhere).
+    assert calls == [(4242, False, None), (4242, True, 777)]
+
+
 def test_supervisor_startup_reconcile_pid_reuse_guard(tmp_path, monkeypatch):
+    from tui_gateway import host_supervisor
+
     registry = tmp_path / "dashboard-compute-host.json"
     registry.write_text(json.dumps({"host_pid": os.getpid(), "boot_id": "stale"}), encoding="utf-8")
 
     killed: list[int] = []
     supervisor = HostSupervisor(registry_path=registry, argv=[sys.executable, "-c", ""], autostart=False)
+    monkeypatch.setattr(host_supervisor, "_pid_alive", lambda _pid: True)
     monkeypatch.setattr(supervisor, "_pid_matches_compute_host", lambda _pid: False)
     monkeypatch.setattr(supervisor, "_terminate_pid", lambda pid, **_kw: killed.append(pid))
 

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import queue
-import signal
 import subprocess
 import sys
 import threading
@@ -84,35 +83,31 @@ def _call_logged(cb: Callable[[dict], None], frame: dict, failure: str) -> None:
 
 
 def _pid_alive(pid: int) -> bool:
+    """Liveness via the canonical ``gateway.status._pid_exists`` (psutil-first, zombie-aware,
+    Windows-safe): ``os.kill(pid, 0)`` reports unreaped zombies as alive and maps sig 0 to
+    CTRL_C_EVENT on Windows console groups."""
     if pid <= 0:
         return False
     try:
-        os.kill(pid, 0)
-        return True
-    except Exception as exc:
-        return isinstance(exc, PermissionError)
+        from gateway.status import _pid_exists
 
-
-def _signal_pid(pid: int, sig: int, label: str) -> bool:
-    """Send ``sig``; False when the pid is gone or the signal failed (logged)."""
-    try:
-        os.kill(pid, sig)
-        return True
-    except ProcessLookupError:
-        return False
+        return bool(_pid_exists(pid))
     except Exception:
-        logger.debug("failed to %s compute host pid=%s", label, pid, exc_info=True)
+        logger.debug("failed to check liveness for pid=%s", pid, exc_info=True)
         return False
 
 
 def _pid_command(pid: int) -> str:
+    """Full command line via ``gateway.status._read_process_cmdline`` (psutil on Windows,
+    /proc + ps fallbacks on POSIX) — one cmdline policy for the whole repo."""
     if pid <= 0:
         return ""
-    with contextlib.suppress(Exception):  # Linux fast path
-        data = (Path("/proc") / str(pid) / "cmdline").read_bytes()
-        if data:
-            return data.replace(b"\x00", b" ").decode("utf-8", errors="replace")
-    return _check_output(["ps", "-p", str(pid), "-o", "command="])
+    try:
+        from gateway.status import _read_process_cmdline
+
+        return _read_process_cmdline(pid) or ""
+    except Exception:
+        return ""
 
 
 def is_compute_host_identity(pid: int) -> bool:
@@ -467,12 +462,24 @@ class HostSupervisor:
     _pid_matches_compute_host = staticmethod(is_compute_host_identity)
 
     def _terminate_pid(self, pid: int, *, timeout: float = _SHUTDOWN_TIMEOUT_SECS) -> None:
-        if not _signal_pid(pid, signal.SIGTERM, "SIGTERM"):
+        """Graceful-then-forced stop through ``gateway.status.terminate_pid`` (SIGTERM/SIGKILL on
+        POSIX, taskkill on Windows) instead of raw ``os.kill`` signals. The start-time fingerprint
+        is captured up front so the forced kill refuses a recycled PID (Windows requires it)."""
+        from gateway.status import get_process_start_time, terminate_pid
+
+        start_time = get_process_start_time(pid)
+        try:
+            terminate_pid(pid)
+        except Exception:
+            logger.debug("failed to terminate compute host pid=%s", pid, exc_info=True)
             return
         deadline = time.monotonic() + timeout
         while _pid_alive(pid):
             if time.monotonic() >= deadline:
-                _signal_pid(pid, signal.SIGKILL, "SIGKILL")
+                try:
+                    terminate_pid(pid, force=True, expected_start_time=start_time)
+                except Exception:
+                    logger.debug("failed to force-terminate compute host pid=%s", pid, exc_info=True)
                 return
             time.sleep(0.05)
 


### PR DESCRIPTION
Compute-host supervision no longer treats unreaped zombies as live processes, probes PIDs Windows-safely, and force-kills only with a PID-reuse guard.

## What changed

- **`tui_gateway/host_supervisor.py`** (salvage of #68272 by @brainx, cherry-picked with authorship intact): `_pid_alive` / `_pid_command` / `_terminate_pid` now delegate to the canonical `gateway.status` helpers instead of raw `os.kill(pid, 0)` + `/proc`/`ps` + `SIGTERM`/`SIGKILL`. On Windows, `os.kill(pid, 0)` maps sig 0 to `CTRL_C_EVENT` for the whole console group (bpo-14484); the canonical helpers are psutil-first and zombie-aware.
- **Hardening on top of the salvage:** `_terminate_pid` captures the process start-time fingerprint before the graceful kill and passes it to `terminate_pid(force=True, expected_start_time=...)` — `gateway.status` *requires* it on Windows and refuses a recycled PID everywhere (#89614). The bare salvage would have raised `OSError` on every Windows force-kill.
- **`gateway/status.py`** — port from **openai/codex#43504**: `_pid_exists` already reported zombies as dead; it now also fires a nonblocking `waitpid(pid, WNOHANG)` so a zombie that is *our own* child leaves the process table (a lost `Popen` handle otherwise leaves the entry pinned until process exit). Foreign zombies (`ECHILD`) are unaffected; Windows is a no-op.
- `tui_gateway/` added to the `check-windows-footguns.py` default roots (from #68272).

## Live repro

| | `_pid_alive(<real unreaped zombie>)` |
|---|---|
| origin/main | `True` — zombie counted alive; orphan cleanup waits on a corpse |
| this branch | `False` — and the probe reaps the table entry (`waitpid` → `ECHILD` afterwards) |

Reproduced live with a `kill -9`'d unreaped `sleep` child driven through the real modules on both trees.

## Validation

| Check | Result |
|---|---|
| `tests/gateway/test_status_zombie_reap.py` (new, `linux_only`, real zombie child) | red on base (zombie not reaped), green with fix — A/B verified |
| `tests/tui_gateway/` full directory | 124 files, 1096 passed |
| `tests/gateway/test_status.py` + phase1 supervisor tests | 87 passed |
| E2E (fresh interpreter, temp `HERMES_HOME`, real subprocesses, positive + negative) | OK |
| `check-windows-footguns.py --all`, `check_compat_pointers.py`, ruff | clean |

## Source & credit

- Salvages **#68272** (@brainx) — commit cherry-picked, authorship preserved; supersedes the narrower duplicates #84323, #90540, #94352, #97022, #97187 on the same call sites.
- Ports the zombie-reap behavior from **openai/codex#43504** ("Treat zombie processes as inactive in the Unix PID backend"), adapted from their `ps stat=` + `libc::waitpid` approach to our existing psutil/`/proc` zombie detection.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b707/rj-WZwuMvKE8pFqGl4--t_Z3sc1aCC.png)
