### PR TITLE
fix(tools): empty old_string rejection now tells the model how to recover (cline#13970)

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -21,9 +21,13 @@ class TestExactMatch:
         assert new == content  # untouched
 
     def test_empty_old_string_rejected(self):
+        """The rejection must carry a recovery path — a bare "cannot be empty"
+        leaves models re-sending the identical call until the loop detector
+        kills the run (cline/cline#13970)."""
         new, count, _, err = fuzzy_find_and_replace("abc", "", "x")
         assert count == 0
         assert err is not None
+        assert "read the file" in err and "write_file" in err
 
     def test_identical_strings(self):
         new, count, _, err = fuzzy_find_and_replace("abc", "abc", "abc")

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -342,11 +342,21 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     ``(content, 0, None, error)``.
     """
     if not old_string:
-        return content, 0, None, "old_string cannot be empty"
+        # Actionable recovery text: a terse "cannot be empty" leaves the model
+        # re-sending the identical call until the loop detector kills the run
+        # (upstream report: cline/cline#13970 — Kimi K3 looped on old_text: null).
+        return content, 0, None, (
+            "old_string is empty — nothing to match. Set old_string to the exact "
+            "existing text the replacement should replace (read the file first if "
+            "unsure). To create a new file or fully rewrite one, use write_file "
+            "instead. Do not re-send this call unchanged.")
     if not old_string.strip():
         # Whitespace-only anchors match trivially and mass-replace or
         # ambiguity-error; never meaningful.
-        return content, 0, None, "old_string is only whitespace — provide non-blank text to match"
+        return content, 0, None, (
+            "old_string is only whitespace — provide non-blank text to match. Set it "
+            "to the exact existing text the replacement should replace (read the file "
+            "first if unsure). Do not re-send this call unchanged.")
     if old_string == new_string:
         return content, 0, None, IDENTICAL_STRINGS_ERROR
 


### PR DESCRIPTION
Patch calls with an empty or whitespace-only `old_string` now get an error that states the recovery instead of a dead end, so models stop re-sending the identical call.

Port of cline/cline#13970 (same failure class, observed there with Kimi K3): the model emitted `old_text: null` repeatedly because the error — "old_string cannot be empty" — names the problem but not the way out, so the next call was byte-identical until loop detection killed the run. Hermes's `fuzzy_find_and_replace` had the same terse rejection behind `patch`, V4A hunks, and `skill_manage` patch.

## Changes

- `tools/fuzzy_match.py::fuzzy_find_and_replace` — the empty rejection now says: set `old_string` to the exact existing text the replacement should replace, read the file first if unsure, use `write_file` for new files/full rewrites, and "Do not re-send this call unchanged." The whitespace-only rejection gets the same recovery text. Single choke point covers every caller (`patch_replace`, `patch_parser` V4A path, `skill_manager_tool`).
- One invariant test asserting the rejection carries the recovery path (`read the file` + `write_file`); no test pinned the old wording.

No behavior change for valid calls — same return shape, same match chain.

## Validation

| Check | Result |
|---|---|
| **Live repro** (real `ShellFileOperations` + `LocalEnvironment`) | before: `'old_string cannot be empty'` · after: full recovery message surfaces through `patch_replace` |
| `scripts/run_tests.sh` fuzzy_match + patch_parser + already_applied + file_operations | 170 passed |
| ruff, windows-footguns, `git diff --check` | clean |

Upstream reference: cline/cline#13970.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b71f/065gHrhAiB8MiDF0F6nr1_sOLUVF3y.png)
