### PR TITLE
Gemini session titles no longer break into ```json artifacts (#91927, salvage #91933 + #92406)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -267,6 +267,13 @@ def generate_title(
             # A title is a handful of tokens; a larger ceiling let chatty models burn seconds.
             max_tokens=64, temperature=0.3, timeout=timeout, main_runtime=main_runtime,
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            # The module contract above promises thinking-disabled operation,
+            # but nothing enforced it: with the aux default reasoning_effort
+            # "" (provider default), Gemini enables internal thinking and
+            # bills thought tokens against max_tokens=64 — the JSON payload
+            # never lands, and the prose fallback stores the opening fence
+            # ("```json") as the session title (#91927).
+            reasoning_config={"enabled": False},
         )
         title = _clean_title(_extract_title_text(response.choices[0].message.content or ""))
         # Answer-shaped output guard: titling is a 3-7 word task, so a title with many words is a model that

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -139,7 +139,17 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
         return None
     effort = str(reasoning_config.get("effort", "medium") or "medium").strip().lower()
     if reasoning_config.get("enabled") is False or effort == "none":
-        return {"includeThoughts": False}
+        # ``includeThoughts: False`` only omits thought parts from the returned
+        # response; the model may still reason internally and bill thought
+        # tokens against maxOutputTokens, starving small budgets (title
+        # generation's 64 tokens). Set thinkingBudget to 0 to actually disable
+        # thinking on families that document it: Gemini 2.5 and 3+ (plus the
+        # ``gemini-flash-latest`` alias); future majors are added only when the
+        # API documents thinkingBudget for them. (#91927)
+        config: dict[str, Any] = {"includeThoughts": False}
+        if normalized_model == "gemini-flash-latest" or normalized_model.startswith(("gemini-2.5-", "gemini-3")):
+            config["thinkingBudget"] = 0
+        return config
     thinking_config: dict[str, Any] = {"includeThoughts": True}
     # Gemini 2.5 takes thinkingBudget; don't guess one from coarse effort levels.
     if normalized_model.startswith("gemini-2.5-"):

--- a/tests/agent/test_gemini_thinking_config.py
+++ b/tests/agent/test_gemini_thinking_config.py
@@ -1,0 +1,97 @@
+"""Tests for Gemini thinking config — reasoning disabled sets thinkingBudget: 0.
+
+Issue #91927: Gemini models bill thought tokens against maxOutputTokens even
+when ``includeThoughts: False`` is set. To truly disable thinking so thought
+tokens don't starve a small max_tokens budget (e.g. title generation's 64
+tokens), ``thinkingBudget: 0`` must be set on models that support it.
+"""
+
+from agent.transports.chat_completions import (
+    _build_gemini_thinking_config,
+    _snake_case_gemini_thinking_config,
+)
+
+
+class TestBuildGeminiThinkingConfigDisabled:
+    """When reasoning is disabled, thinkingBudget must be 0 on supported models."""
+
+    def test_disabled_sets_thinking_budget_zero_gemini_25(self):
+        """Gemini 2.5 supports thinkingBudget; disabling reasoning must set it to 0."""
+        config = _build_gemini_thinking_config("gemini-2.5-flash", {"enabled": False})
+        assert config is not None
+        assert config.get("includeThoughts") is False
+        assert config.get("thinkingBudget") == 0
+
+    def test_disabled_sets_thinking_budget_zero_gemini_3(self):
+        """Gemini 3.x supports thinkingBudget; disabling reasoning must set it to 0."""
+        config = _build_gemini_thinking_config("gemini-3.6-flash", {"enabled": False})
+        assert config is not None
+        assert config.get("includeThoughts") is False
+        assert config.get("thinkingBudget") == 0
+
+    def test_disabled_sets_thinking_budget_zero_gemini_3_pro(self):
+        config = _build_gemini_thinking_config("gemini-3.1-pro", {"enabled": False})
+        assert config is not None
+        assert config.get("includeThoughts") is False
+        assert config.get("thinkingBudget") == 0
+
+    def test_disabled_no_thinking_budget_on_older_gemini(self):
+        """Older Gemini models (pre-2.5) don't support thinkingBudget; only
+        includeThoughts: False should be set."""
+        config = _build_gemini_thinking_config("gemini-1.5-flash", {"enabled": False})
+        assert config is not None
+        assert config.get("includeThoughts") is False
+        assert "thinkingBudget" not in config
+
+    def test_disabled_no_thinking_budget_on_non_gemini(self):
+        """Non-Gemini models must not get a thinking config at all."""
+        config = _build_gemini_thinking_config("gpt-4o", {"enabled": False})
+        assert config is None
+
+    def test_disabled_no_thinking_budget_on_gemma(self):
+        """Gemma models use the gemini provider but reject thinking_config."""
+        config = _build_gemini_thinking_config("gemma-2b", {"enabled": False})
+        assert config is None
+
+    def test_effort_none_also_sets_thinking_budget_zero(self):
+        """effort='none' is equivalent to enabled=False and must also set
+        thinkingBudget: 0 on supported models."""
+        config = _build_gemini_thinking_config("gemini-2.5-flash", {"effort": "none"})
+        assert config is not None
+        assert config.get("includeThoughts") is False
+        assert config.get("thinkingBudget") == 0
+
+
+class TestSnakeCaseGeminiThinkingConfig:
+    """Verify thinkingBudget is translated to thinking_budget for OpenAI-compat."""
+
+    def test_thinking_budget_translated(self):
+        config = {"includeThoughts": False, "thinkingBudget": 0}
+        translated = _snake_case_gemini_thinking_config(config)
+        assert translated is not None
+        assert translated.get("include_thoughts") is False
+        assert translated.get("thinking_budget") == 0
+
+    def test_no_thinking_budget_when_absent(self):
+        config = {"includeThoughts": False}
+        translated = _snake_case_gemini_thinking_config(config)
+        assert translated is not None
+        assert translated.get("include_thoughts") is False
+        assert "thinking_budget" not in translated
+
+
+class TestBuildGeminiThinkingConfigEnabled:
+    """When reasoning is enabled, thinkingBudget must NOT be set to 0."""
+
+    def test_enabled_does_not_zero_budget(self):
+        """When reasoning is enabled, thinkingBudget should not be forced to 0."""
+        config = _build_gemini_thinking_config("gemini-2.5-flash", {"enabled": True})
+        assert config is not None
+        assert config.get("includeThoughts") is True
+        assert "thinkingBudget" not in config
+
+    def test_effort_medium_does_not_zero_budget(self):
+        config = _build_gemini_thinking_config("gemini-3.6-flash", {"effort": "medium"})
+        assert config is not None
+        assert config.get("includeThoughts") is True
+        assert "thinkingBudget" not in config

--- a/tests/agent/test_gemini_thinking_config.py
+++ b/tests/agent/test_gemini_thinking_config.py
@@ -1,10 +1,12 @@
-"""Tests for Gemini thinking config — reasoning disabled sets thinkingBudget: 0.
+"""Disabling reasoning must actually stop Gemini thinking (#91927).
 
-Issue #91927: Gemini models bill thought tokens against maxOutputTokens even
-when ``includeThoughts: False`` is set. To truly disable thinking so thought
-tokens don't starve a small max_tokens budget (e.g. title generation's 64
-tokens), ``thinkingBudget: 0`` must be set on models that support it.
+``includeThoughts: False`` only hides thought parts; the model still reasons
+internally and bills thought tokens against maxOutputTokens, starving small
+budgets (title generation's 64 tokens). ``thinkingBudget: 0`` is the real
+off switch on families that document it.
 """
+
+import pytest
 
 from agent.transports.chat_completions import (
     _build_gemini_thinking_config,
@@ -12,86 +14,40 @@ from agent.transports.chat_completions import (
 )
 
 
-class TestBuildGeminiThinkingConfigDisabled:
-    """When reasoning is disabled, thinkingBudget must be 0 on supported models."""
-
-    def test_disabled_sets_thinking_budget_zero_gemini_25(self):
-        """Gemini 2.5 supports thinkingBudget; disabling reasoning must set it to 0."""
-        config = _build_gemini_thinking_config("gemini-2.5-flash", {"enabled": False})
+@pytest.mark.parametrize(
+    "model,expect_budget_zero",
+    [
+        ("gemini-2.5-flash", True),
+        ("gemini-3.6-flash", True),
+        ("gemini-3.1-pro", True),
+        ("gemini-flash-latest", True),
+        ("gemini-1.5-flash", False),  # pre-2.5: thinkingBudget undocumented
+    ],
+)
+def test_disabled_reasoning_zeroes_thinking_budget_where_supported(model, expect_budget_zero):
+    for reasoning in ({"enabled": False}, {"effort": "none"}):
+        config = _build_gemini_thinking_config(model, reasoning)
         assert config is not None
         assert config.get("includeThoughts") is False
-        assert config.get("thinkingBudget") == 0
-
-    def test_disabled_sets_thinking_budget_zero_gemini_3(self):
-        """Gemini 3.x supports thinkingBudget; disabling reasoning must set it to 0."""
-        config = _build_gemini_thinking_config("gemini-3.6-flash", {"enabled": False})
-        assert config is not None
-        assert config.get("includeThoughts") is False
-        assert config.get("thinkingBudget") == 0
-
-    def test_disabled_sets_thinking_budget_zero_gemini_3_pro(self):
-        config = _build_gemini_thinking_config("gemini-3.1-pro", {"enabled": False})
-        assert config is not None
-        assert config.get("includeThoughts") is False
-        assert config.get("thinkingBudget") == 0
-
-    def test_disabled_no_thinking_budget_on_older_gemini(self):
-        """Older Gemini models (pre-2.5) don't support thinkingBudget; only
-        includeThoughts: False should be set."""
-        config = _build_gemini_thinking_config("gemini-1.5-flash", {"enabled": False})
-        assert config is not None
-        assert config.get("includeThoughts") is False
-        assert "thinkingBudget" not in config
-
-    def test_disabled_no_thinking_budget_on_non_gemini(self):
-        """Non-Gemini models must not get a thinking config at all."""
-        config = _build_gemini_thinking_config("gpt-4o", {"enabled": False})
-        assert config is None
-
-    def test_disabled_no_thinking_budget_on_gemma(self):
-        """Gemma models use the gemini provider but reject thinking_config."""
-        config = _build_gemini_thinking_config("gemma-2b", {"enabled": False})
-        assert config is None
-
-    def test_effort_none_also_sets_thinking_budget_zero(self):
-        """effort='none' is equivalent to enabled=False and must also set
-        thinkingBudget: 0 on supported models."""
-        config = _build_gemini_thinking_config("gemini-2.5-flash", {"effort": "none"})
-        assert config is not None
-        assert config.get("includeThoughts") is False
-        assert config.get("thinkingBudget") == 0
+        assert (config.get("thinkingBudget") == 0) is expect_budget_zero
+        if not expect_budget_zero:
+            assert "thinkingBudget" not in config
 
 
-class TestSnakeCaseGeminiThinkingConfig:
-    """Verify thinkingBudget is translated to thinking_budget for OpenAI-compat."""
-
-    def test_thinking_budget_translated(self):
-        config = {"includeThoughts": False, "thinkingBudget": 0}
-        translated = _snake_case_gemini_thinking_config(config)
-        assert translated is not None
-        assert translated.get("include_thoughts") is False
-        assert translated.get("thinking_budget") == 0
-
-    def test_no_thinking_budget_when_absent(self):
-        config = {"includeThoughts": False}
-        translated = _snake_case_gemini_thinking_config(config)
-        assert translated is not None
-        assert translated.get("include_thoughts") is False
-        assert "thinking_budget" not in translated
-
-
-class TestBuildGeminiThinkingConfigEnabled:
-    """When reasoning is enabled, thinkingBudget must NOT be set to 0."""
-
-    def test_enabled_does_not_zero_budget(self):
-        """When reasoning is enabled, thinkingBudget should not be forced to 0."""
-        config = _build_gemini_thinking_config("gemini-2.5-flash", {"enabled": True})
+def test_enabled_reasoning_never_zeroes_budget_and_non_gemini_gets_nothing():
+    # Enabled reasoning must not be silently strangled by a zero budget.
+    for reasoning in ({"enabled": True}, {"effort": "medium"}):
+        config = _build_gemini_thinking_config("gemini-2.5-flash", reasoning)
         assert config is not None
         assert config.get("includeThoughts") is True
         assert "thinkingBudget" not in config
+    # Non-Gemini models on the same provider 400 on the field entirely (#17426).
+    assert _build_gemini_thinking_config("gpt-4o", {"enabled": False}) is None
+    assert _build_gemini_thinking_config("gemma-2b", {"enabled": False}) is None
 
-    def test_effort_medium_does_not_zero_budget(self):
-        config = _build_gemini_thinking_config("gemini-3.6-flash", {"effort": "medium"})
-        assert config is not None
-        assert config.get("includeThoughts") is True
-        assert "thinkingBudget" not in config
+
+def test_snake_case_translation_carries_thinking_budget():
+    translated = _snake_case_gemini_thinking_config({"includeThoughts": False, "thinkingBudget": 0})
+    assert translated == {"include_thoughts": False, "thinking_budget": 0}
+    translated = _snake_case_gemini_thinking_config({"includeThoughts": False})
+    assert translated == {"include_thoughts": False}

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -46,6 +46,29 @@ class TestGenerateTitle:
         assert captured_kwargs["task"] == "title_generation"
         assert captured_kwargs["timeout"] is None
 
+    def test_generate_title_disables_reasoning(self):
+        """The titling pass must explicitly disable thinking (#91927).
+
+        With the aux default reasoning_effort "" (provider default), Gemini
+        bills internal thought tokens against max_tokens=64, the JSON payload
+        never lands, and the prose fallback stores the opening fence
+        ("```json") as the title. Enforce the module's documented
+        thinking-disabled contract at the call site.
+        """
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Reasoning Off"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question") == "Reasoning Off"
+
+        assert captured_kwargs.get("reasoning_config") == {"enabled": False}
+
 
 
     def test_strips_think_blocks(self):


### PR DESCRIPTION
Session titles for Gemini-backed auxiliary models no longer come out as ` ```json ` / `{` fence artifacts — the titling pass now actually disables thinking, and Gemini's translator now emits the real off switch.

Salvages and combines two contributor PRs (cherry-picked, authorship intact), each covering one layer of #91927:

- **#91933 (@liuhao1024)** — `generate_title()` now passes `reasoning_config={"enabled": False}`. The module docstring always promised thinking-disabled operation; nothing enforced it, so the aux default (provider default effort) let Gemini think freely.
- **#92406 (@rkfshakti)** — `_build_gemini_thinking_config()` now emits `thinkingBudget: 0` alongside `includeThoughts: False` on families that document it (Gemini 2.5, 3+, `gemini-flash-latest`). `includeThoughts: False` alone only *hides* thought parts — the model still reasons internally and bills thought tokens against `maxOutputTokens`.
- Ours: conflict resolution onto current main, test file folded to 3 invariant tests (parametrized), live verification.

## Root cause

Gemini bills internal thinking tokens against `max_tokens`; the title pass budgets 64 tokens, so thinking ate the whole budget before the first output token, the JSON never landed, and the prose fallback stored the opening fence as the session title.

## Live verification (Gemini 2.5 Flash, real API, 2026-09-09)

| | finishReason | thought tokens | output |
|---|---|---|---|
| Before (no thinkingConfig) | `MAX_TOKENS` | 57 / 64 budget | `` ```json `` |
| After (`includeThoughts:false, thinkingBudget:0`) | `STOP` | 0 | `{"title": "uv Virtual Environment Setup"}` |

E2E through the real provider-profile path (no mocks): the Gemini profile projects `{"thinking_config": {"includeThoughts": False, "thinkingBudget": 0}}` on the native route and `extra_body.google.thinking_config` (snake_case) on the OpenAI-compat route; enabled reasoning is untouched (`includeThoughts: True`, no forced budget).

## Tests

`tests/agent/test_title_generator.py` (contract: title pass sends `reasoning_config={"enabled": False}`) and `tests/agent/test_gemini_thinking_config.py` (3 parametrized invariants: disabled ⇒ budget 0 on documented families only; enabled never zeroed; non-Gemini gets no field). Both green via `scripts/run_tests.sh`.

Related open PRs this supersedes/overlaps: #91957 (same symptom via config defaults), #92406 (cherry-picked here), #91933 (cherry-picked here).

Prompted by the weekly Centaur scout run (paradigmxyz/centaur#1535 lands the same class of fix — explicit low/none reasoning effort on small-budget utility calls — which flagged our open contributor PRs for the identical bug).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b742/vWCDCUTeXqCLdNpvNr1kY_NFET1ncC.png)
