### PR TITLE
fix(tui-gateway): reject sessionless model switches

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9639,6 +9639,41 @@ def test_config_set_model_global_persists(monkeypatch):
     assert saved_values["model.base_url"] == "https://api.anthropic.com"
 
 
+def test_config_set_model_without_live_session_cannot_persist_implicitly(monkeypatch):
+    calls = []
+
+    def _fake_apply(sid, session, raw, **kwargs):
+        calls.append((sid, session, raw, kwargs))
+        return {"value": "new/model", "warning": "", "scope": "global"}
+
+    monkeypatch.setattr(server, "_apply_model_switch", _fake_apply)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "model", "value": "new/model --provider openai-codex"},
+        }
+    )
+
+    assert resp["error"]["code"] == 4001
+    assert "live session" in resp["error"]["message"]
+    assert "Settings" in resp["error"]["message"]
+    assert calls == []
+
+    explicit = server.handle_request(
+        {
+            "id": "2",
+            "method": "config.set",
+            "params": {"key": "model", "value": "new/model --provider openai-codex --global"},
+        }
+    )
+
+    assert explicit["error"]["code"] == 4001
+    assert "live session" in explicit["error"]["message"]
+    assert calls == []
+
+
 def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatch):
     seen = {"build": 0, "wait": 0, "requested": []}
     session = _session()
@@ -10314,6 +10349,27 @@ def test_config_set_model_once_requires_live_session(monkeypatch):
 
     assert resp["error"]["code"] == 5001
     assert "/model --once requires a live session" in resp["error"]["message"]
+
+
+def test_config_set_model_sessionless_once_global_keeps_canonical_conflict_error(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **_: (_ for _ in ()).throw(AssertionError("switch should not run")),
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic --once --global",
+            },
+        }
+    )
+
+    assert resp["error"]["code"] == 5001
+    assert resp["error"]["message"] == "/model --once cannot be combined with --global"
 
 
 def test_config_set_model_session_switch_clears_pending_once_restore(monkeypatch):

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -108,11 +108,11 @@ def _set_model(rid, params, key, value, session):
     """Live/deferred model switch; see _apply_model_switch and _apply_pending_model_switch."""
     if not value:
         return _err(rid, 4002, "model value required")
+    from hermes_cli.model_switch import parse_model_switch_args
     confirmed = bool(params.get("confirm_expensive_model", False))
+    parsed_flags = parse_model_switch_args(value)
     if session:
-        from hermes_cli.model_switch import parse_model_switch_args
         sid = params.get("session_id", "")
-        parsed_flags = parse_model_switch_args(value)
         if session.get("running"):
             return _stash_pending_model_switch(rid, key, value, session, confirmed, parsed_flags)
         explicit_provider = parsed_flags.explicit_provider
@@ -140,7 +140,21 @@ def _set_model(rid, params, key, value, session):
             with _session_profile_runtime_scope(session):
                 _persist_live_session_runtime(session)
     else:
-        result = _apply_model_switch("", {"agent": None}, value, confirm_expensive_model=confirmed)
+        # ``config.set model`` is a live-session surface. Older Desktop clients
+        # sent a fresh-draft pick before ``session.create`` (no session_id), and
+        # the legacy fallback silently persisted it as the profile default.
+        # Refuse stale draft requests even when an older client hardcoded
+        # ``--global``. Deliberate defaults use Settings -> Models (/api/model/set),
+        # while /model --global always belongs to a live session.
+        if parsed_flags.is_once and parsed_flags.is_global:
+            raise ValueError(parsed_flags.error_messages()[0])
+        if parsed_flags.is_once:
+            raise ValueError("/model --once requires a live session")
+        return _err(
+            rid,
+            4001,
+            "model switch requires a live session; use Settings -> Models to update the profile default",
+        )
     return _kv(rid, key, result["value"], warning=result["warning"],
                confirm_required=result.get("confirm_required", False),
                confirm_message=result.get("confirm_message", ""), scope=result.get("scope", "session"))


### PR DESCRIPTION
## What does this PR do?

Fails closed when `config.set model` arrives without a live TUI-gateway session. This prevents an older or stale Desktop client from silently overwriting `model.default` / `model.provider` before `session.create`, including clients that hardcoded `--global`.

This is backend compatibility hardening after #101287 fixed the current Desktop caller. Deliberate global writes are unchanged: Settings → Models still uses `/api/model/set`, and `/model ... --global` still works from a live session.

## Related Issue

Fixes #106397

Follow-up to #90235 / #101287.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Parse model flags before the live-session branch so sessionless validation can preserve canonical flag-conflict errors.
- Reject plain and legacy `--global` sessionless model switches with JSON-RPC error `4001` before `_apply_model_switch` can run.
- Preserve the existing `/model --once requires a live session` contract and the canonical `--once --global` conflict error.
- Add two invariant tests covering the persistence guard and conflict-error precedence.

## How to Test

1. Run:

   ```bash
   scripts/run_tests.sh tests/test_tui_gateway_server.py tests/gateway/test_model_switch_persistence.py tests/hermes_cli/test_model_switch_persist_default.py
   ```

   Result: **649 passed, 0 failed**.

2. Send `config.set` for `key: model` without `session_id`, once plain and once with `--global`; both must return `4001`, and `_apply_model_switch` must not be called.
3. Send sessionless `--once --global`; it must retain the canonical `/model --once cannot be combined with --global` error.
4. E2E against a temporary `HERMES_HOME`: both rejected requests left `config.yaml` byte-for-byte unchanged.

The new tests were observed failing before the corresponding production changes and passing afterward.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched open and closed issues/PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository's canonical `scripts/run_tests.sh` entrypoint and all affected tests pass
- [x] I've added tests for the bug fix
- [x] I've tested on Ubuntu Linux

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing command or config contract changed
- [x] `cli-config.yaml.example`: N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture/workflow change
- [x] Cross-platform impact considered — pure JSON-RPC/Python logic, no OS-specific behavior
- [x] Tool descriptions/schemas: N/A

## Review

An independent code-review pass found one error-precedence regression for sessionless `--once --global`; it was fixed with a RED→GREEN regression test. A second independent review passed with no security concerns, logic errors, or suggestions.
