### PR TITLE
fix(anthropic): opt into thinking-prefix drop_block on Claude 5.1+ so prefix mutations stop 400ing turns

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -89,6 +89,20 @@ _NO_XHIGH_CLAUDE_SUBSTRINGS = ("claude-opus-4-6", "claude-opus-4.6", "claude-son
 # 400s the turn, a spurious one only leaves thinking on — so when in doubt, add the family.
 _MANDATORY_THINKING_CLAUDE_SUBSTRINGS = ("claude-fable",)
 _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-8", "opus-4.8", "opus-5")
+# Claude 5.1+ binds each thinking-block signature to the full conversation prefix (system, tools,
+# every earlier message). Hermes mutates that prefix between turns in sanctioned ways (compression,
+# orphan tool-call stripping, OAuth identity transforms), so a replayed signed block behind a
+# changed prefix answers HTTP 400 on enforcement-enabled accounts unless the request opts into
+# ``thinking.block_binding.prefix_mismatch_behavior="drop_block"`` under this beta. Enforcement is
+# on for API accounts created after 2026-08-31 and expands to everyone on later models.
+# Docs: https://platform.claude.com/docs/en/build-with-claude/preserved-thinking
+# (Ported from anomalyco/opencode#47884.)
+_THINKING_BINDING_BETA = "thinking-binding-controls-2026-08-01"
+# Accept gateway namespaces (``anthropic/claude-fable-5.1``) and ``@suffix``/``:suffix`` variants
+# without treating a snapshot date (``claude-opus-5-20260901``) as a minor version.
+_CLAUDE_VERSION_RE = re.compile(
+    r"(?:^|[./])claude-[a-z]+-(?P<major>\d+)(?:[.-](?P<minor>\d{1,2}))?(?:$|[-:@])", re.IGNORECASE
+)
 
 
 def _is_claude_model(model: str | None) -> bool:
@@ -197,6 +211,35 @@ def _supports_fast_mode(model: str) -> bool:
     bill at standard speed), Opus 4.7 hard-400s on the param. Dedicated ``...-fast`` ids select
     fast inference via the model field and must NOT also receive the speed parameter."""
     return "-fast" not in model and any(v in model for v in _FAST_MODE_SUPPORTED_SUBSTRINGS)
+
+
+def _supports_thinking_block_binding(model: str) -> bool:
+    """True for Claude 5.1+ (``claude-<family>-<major>[.<minor>]``), where Anthropic enforces
+    thinking-prefix binding. A version floor, not an allowlist: enforcement expands to every later
+    model, so an allowlist would silently route a new model into hard 400s. Snapshot dates
+    (``claude-opus-5-20260901``) are not minor versions; models without a parseable version
+    (Haiku is additionally excluded — it has no extended thinking) return False."""
+    if "haiku" in model.lower():
+        return False
+    match = _CLAUDE_VERSION_RE.search(model)
+    if not match:
+        return False
+    major, minor = int(match.group("major")), int(match.group("minor") or 0)
+    return major > 5 or (major == 5 and minor >= 1)
+
+
+def _apply_thinking_block_binding(kwargs: Dict[str, Any]) -> None:
+    """Default ``thinking.block_binding.prefix_mismatch_behavior="drop_block"`` on ``kwargs``.
+    Adaptive models think by DEFAULT, so a missing ``thinking`` param still replays signed blocks —
+    materialize the adaptive form first. An explicit disable keeps the omission (nothing to bind)."""
+    thinking = kwargs.get("thinking")
+    if isinstance(thinking, dict) and thinking.get("type") == "disabled":
+        return
+    if not isinstance(thinking, dict):
+        thinking_new: Dict[str, Any] = {"type": "adaptive", "display": "summarized"}
+        kwargs["thinking"] = thinking = thinking_new
+    if "block_binding" not in thinking:
+        thinking["block_binding"] = {"prefix_mismatch_behavior": "drop_block"}
 
 
 # Beta headers safe on ordinary/native Anthropic requests. GA on Claude 4.6+ (harmless no-op
@@ -575,12 +618,24 @@ def build_anthropic_kwargs(
         for key in ("temperature", "top_p", "top_k"):
             kwargs.pop(key, None)
     # Fast mode: native Anthropic only — third-party providers reject the unknown beta/param and
-    # Anthropic scopes it to the Claude API (not Bedrock/Vertex/Foundry). Per-request extra_headers
-    # OVERRIDE the client-level anthropic-beta header, so rebuild the full beta list.
+    # Anthropic scopes it to the Claude API (not Bedrock/Vertex/Foundry).
+    extra_betas: list[str] = []
     if fast_mode and not _is_third_party_anthropic_endpoint(base_url) and _supports_fast_mode(model):
         kwargs.setdefault("extra_body", {})["speed"] = "fast"
+        extra_betas.append(_FAST_MODE_BETA)
+    # Thinking-prefix binding (Claude 5.1+): only where signed thinking blocks actually replay —
+    # direct Anthropic and Nous Portal. Other third-party Anthropic-compatible endpoints have their
+    # signatures stripped in convert_messages_to_anthropic (same predicate) and would reject the
+    # unknown parameter/beta.
+    replays_signed_thinking = not _is_third_party_anthropic_endpoint(base_url) or _is_nous_portal_endpoint(base_url)
+    if replays_signed_thinking and _supports_thinking_block_binding(model):
+        _apply_thinking_block_binding(kwargs)
+        extra_betas.append(_THINKING_BINDING_BETA)
+    # Per-request extra_headers OVERRIDE the client-level anthropic-beta header, so rebuild the
+    # full beta list whenever any request-scoped beta is added.
+    if extra_betas:
         betas = _common_betas_for_base_url(base_url, drop_context_1m_beta=drop_context_1m_beta)
-        kwargs["extra_headers"] = _beta_header(betas + (_OAUTH_ONLY_BETAS if is_oauth else []) + [_FAST_MODE_BETA])
+        kwargs["extra_headers"] = _beta_header(betas + (_OAUTH_ONLY_BETAS if is_oauth else []) + extra_betas)
     return kwargs
 
 

--- a/tests/agent/test_anthropic_thinking_block_binding.py
+++ b/tests/agent/test_anthropic_thinking_block_binding.py
@@ -1,0 +1,80 @@
+"""Thinking-prefix block binding (Claude 5.1+) — port of anomalyco/opencode#47884.
+
+Claude 5.1+ binds each thinking-block signature to the full conversation prefix; a replay
+behind a changed prefix answers HTTP 400 unless the request opts into
+``thinking.block_binding.prefix_mismatch_behavior="drop_block"`` under the
+``thinking-binding-controls-2026-08-01`` beta. Hermes mutates the prefix in sanctioned ways
+(compression, orphan tool-call stripping), so the opt-in defaults on for enforcing models.
+"""
+
+import pytest
+
+from agent.anthropic_adapter import build_anthropic_kwargs
+
+
+_MSGS = [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        ("claude-fable-5-1", True),
+        ("claude-fable-5.1", True),
+        ("anthropic/claude-fable-5.1", True),
+        ("claude-fable-5-1@20260901", True),
+        ("claude-sonnet-6", True),
+        # A snapshot date is not a minor version.
+        ("claude-opus-5-20260901", False),
+        ("claude-opus-4-8", False),
+        ("claude-fable-5", False),
+        ("claude-haiku-5-1", False),  # no extended thinking
+        ("kimi-k2.5", False),
+    ],
+)
+def test_block_binding_defaults_by_model_version(model, expected):
+    """Enforcing models (5.1+) get drop_block + the binding beta; older/foreign models are
+    untouched (some deployments reject the unknown parameter — opencode#46848)."""
+    kwargs = build_anthropic_kwargs(
+        model=model, messages=list(_MSGS), tools=None, max_tokens=1024,
+        reasoning_config={"enabled": True, "effort": "medium"},
+    )
+    thinking = kwargs.get("thinking") or {}
+    binding = thinking.get("block_binding")
+    header = kwargs.get("extra_headers", {}).get("anthropic-beta", "")
+    if expected:
+        assert binding == {"prefix_mismatch_behavior": "drop_block"}
+        assert "thinking-binding-controls-2026-08-01" in header
+        # The rebuilt header must keep the always-on betas (it OVERRIDES the client header).
+        assert "interleaved-thinking-2025-05-14" in header
+    else:
+        assert binding is None
+        assert "thinking-binding-controls-2026-08-01" not in header
+
+
+def test_block_binding_respects_disable_and_third_party_endpoints():
+    """An explicit thinking disable keeps the omission (nothing replays), and third-party
+    Anthropic-compatible endpoints — where signatures are stripped anyway — never receive the
+    unknown parameter/beta. reasoning_config=None still binds: adaptive models think by default.
+    (claude-sonnet-6 accepts a true disable; mandatory-thinking families like claude-fable omit the
+    disable and keep thinking on, so they correctly keep the binding.)"""
+    disabled = build_anthropic_kwargs(
+        model="claude-sonnet-6", messages=list(_MSGS), tools=None, max_tokens=1024,
+        reasoning_config={"enabled": False},
+    )
+    assert "block_binding" not in (disabled.get("thinking") or {})
+
+    third_party = build_anthropic_kwargs(
+        model="claude-fable-5-1", messages=list(_MSGS), tools=None, max_tokens=1024,
+        reasoning_config={"enabled": True, "effort": "medium"},
+        base_url="https://api.minimax.io/anthropic",
+    )
+    assert "block_binding" not in (third_party.get("thinking") or {})
+    assert "thinking-binding-controls" not in third_party.get("extra_headers", {}).get("anthropic-beta", "")
+
+    no_reasoning = build_anthropic_kwargs(
+        model="claude-fable-5-1", messages=list(_MSGS), tools=None, max_tokens=1024,
+        reasoning_config=None,
+    )
+    assert (no_reasoning.get("thinking") or {}).get("block_binding") == {
+        "prefix_mismatch_behavior": "drop_block"
+    }


### PR DESCRIPTION
Claude 5.1+ conversations no longer 400 when a signed thinking block replays behind a changed prefix: requests now opt into Anthropic's `drop_block` prefix-mismatch behavior.

## What

Anthropic now binds each thinking-block signature to the full conversation prefix (system, tools, every earlier message) on Claude 5.1+ ([docs](https://platform.claude.com/docs/en/build-with-claude/preserved-thinking)). Hermes mutates that prefix in sanctioned ways — compression, orphan tool-call stripping, OAuth identity transforms — so on enforcement-enabled accounts (created after 2026-08-31, expanding to all accounts on later models) a replayed signed block behind a changed prefix answers HTTP 400 and kills the turn.

- `build_anthropic_kwargs` now defaults `thinking.block_binding.prefix_mismatch_behavior="drop_block"` and attaches the `thinking-binding-controls-2026-08-01` beta for Claude 5.1+.
- **Version floor, not allowlist** (`claude-<family>-<major>[.<minor>]`, 5.1+): enforcement expands to every later model, so an allowlist would silently route a new model into hard 400s. Snapshot dates (`claude-opus-5-20260901`) are not minor versions; gateway prefixes (`anthropic/...`) and `@`/`:` suffixes resolve.
- Scoped to routes that actually **replay** signed thinking: direct Anthropic and Nous Portal. Other third-party Anthropic-compatible endpoints have signatures stripped in `convert_messages_to_anthropic` (same predicate) and would reject the unknown parameter/beta.
- Explicit thinking disables keep the omission; `reasoning_config=None` still binds (adaptive models think by default, so signed blocks replay regardless).
- The fast-mode beta rebuild generalizes into a shared `extra_betas` list so request-scoped betas compose instead of the last one overwriting the header.

## Root cause

Hermes never sends the binding opt-in, so Anthropic's default `error` behavior turns every sanctioned prefix mutation into a dead turn on enforcing accounts.

## Validation

| Check | Result |
|---|---|
| New invariant tests (11 cases: version floor, snapshot dates, gateway prefixes, disable, third-party, no-reasoning-config) | red on base (6 failures), green with fix |
| `tests/agent/` Anthropic suites (109 tests, 3 files) | pass |
| **Live repro:** real request via Nous Portal → `anthropic/claude-fable-5.1` with `block_binding` + beta header | accepted end-to-end, `stop_reason=end_turn`, request id `gen-1788946579-epHKSEcdPcGeN1aVIj1K` |
| ruff / windows-footguns / compat-pointers | clean |

Live-repro caveat: no direct `api.anthropic.com` credential on this box and no enforcement-enabled account available, so the *before* 400 is per Anthropic's documented enforcement rather than reproduced locally; the *after* path (new request shape accepted) is verified live. Their upstream fix shipped the same shape after a week of iteration (their initial 4.x-wide default broke deployments; this port starts at their final 5.1+ floor with the Haiku exclusion).

Port of anomalyco/opencode#47884 (@rekram1-node), adapted from their vendored-SDK patch into `build_anthropic_kwargs` — Hermes builds Messages bodies directly, so no SDK patching is needed.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b746/Tl-L7AU53oaTmAcJxH7FJ_TVjqgErZ.png)
