### PR TITLE
fix(classifier): LiteLLM terminal_quota_exhausted 429s classify as billing, not rate_limit (port omo#6677)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -92,6 +92,11 @@ _BILLING_PATTERNS = (
     "billing hard limit", "exceeded your current quota", "account is deactivated", "plan does not include",
     "out of extra usage", "out of funds", "run out of funds", "balance_depleted",
     "model_not_supported_on_free_tier", "not available on the free tier",
+    # LiteLLM proxies word a hard cap as "hard billing limit" (structured twin:
+    # ``terminal_quota_exhausted`` in _BILLING_ERROR_CODES). "terminal billing
+    # limit" free text is NOT matched: substring rules can't negate the
+    # "non-terminal billing limit" wording, and the structured code covers it.
+    "hard billing limit",
 )
 
 # Not proof of exhaustion: Anthropic returns the same "out of extra usage" body
@@ -107,7 +112,7 @@ _XAI_SPENDING_LIMIT_ERROR_CODE = "personal-team-blocked:spending-limit"
 _BILLING_ERROR_CODES = frozenset({
     "insufficient_quota", "billing_not_active", "payment_required", "insufficient_credits",
     "no_usable_credits", "balance_depleted", "model_not_supported_on_free_tier",
-    "member_spend_cap_exceeded", _XAI_SPENDING_LIMIT_ERROR_CODE,
+    "member_spend_cap_exceeded", "terminal_quota_exhausted", _XAI_SPENDING_LIMIT_ERROR_CODE,
 })
 
 # Transient rate limiting. Bedrock "Throttling error: Too many tokens" also
@@ -725,6 +730,11 @@ def _status_404(c: _Ctx) -> Verdict:
 
 
 def _status_429(c: _Ctx) -> Verdict:
+    # A structured billing code is decisive: LiteLLM stamps
+    # ``terminal_quota_exhausted`` (a hard cap, not throttling) on 429s, and
+    # this handler always returns, so _by_error_code never sees the code.
+    if c.code in _BILLING_ERROR_CODES:
+        return _V_BILLING
     # Z.AI/Zhipu reuse 429 for server-wide overload: back off on the same
     # key instead of burning the pool (#14038).
     if any(p in c.msg for p in _OVERLOADED_PATTERNS):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -539,6 +539,30 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.should_rotate_credential is True
 
+    def test_429_with_structured_terminal_quota_code_is_billing(self):
+        """LiteLLM stamps ``terminal_quota_exhausted`` on a hard-cap 429. The
+        429 handler always returns a verdict, so the structured billing code
+        must be honored inside it — otherwise the exhausted key is retried
+        (upstream this respawned duplicate subagents; ported from
+        code-yeongyu/oh-my-openagent#6677)."""
+        e = MockAPIError(
+            "request failed", status_code=429,
+            body={"error": {"code": "terminal_quota_exhausted", "message": "request failed"}},
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_429_hard_billing_limit_text_is_billing(self):
+        """The free-text twin: "hard billing limit" is exhaustion wording, not
+        throttling, even though it contains no reset signal to disambiguate."""
+        result = classify_api_error(
+            MockAPIError("hard billing limit reached for this key", status_code=429)
+        )
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
     # ── 5xx that are actually request-validation errors ──
     # Some OpenAI-compatible gateways (e.g. codex.nekos.me) return
     # request-validation failures with a 5xx status. These are


### PR DESCRIPTION
A hard-cap 429 carrying LiteLLM's structured `terminal_quota_exhausted` code now classifies as **billing** (non-retryable, fall back) instead of rate_limit — the exhausted key stops being retried against a wall that cannot clear until someone pays.

Port from code-yeongyu/oh-my-openagent#6677 (credit: @niStee), adapted to Hermes' `agent/error_classifier.py` staged pipeline.

## Root cause
`_status_429` always returns a verdict, so the later `_by_error_code` stage — which already maps `_BILLING_ERROR_CODES` → billing — never saw a structured code on a 429. Combined with `terminal_quota_exhausted` not being in the code set at all, the hard cap classified as `rate_limit` (retryable, 429 cooldown). Upstream, the same misclassification respawned duplicate subagent sessions on the exhausted key.

## Changes
- `_status_429` checks `c.code in _BILLING_ERROR_CODES` first — a structured billing code is decisive and outranks message heuristics.
- `terminal_quota_exhausted` added to `_BILLING_ERROR_CODES`, so the 402, status-less, and code-stage paths all agree.
- `"hard billing limit"` added to `_BILLING_PATTERNS` (the set had only the reversed `"billing hard limit"` order). `"terminal billing limit"` free text is deliberately **not** matched: substring rules cannot negate omo's observed `"non-terminal billing limit"` wording, and the structured code covers that shape.

## Ours vs theirs
omo classifies in a flat `classifyRuntimeFallbackError` with regexes (including a negative-lookahead-style non-terminal guard) and returns `abort`. Hermes already has the billing verdict + pool/fallback machinery, so the port is 8 LOC into the existing table/stage structure; the non-terminal false-positive class is handled by omitting the ambiguous text pattern rather than regex negation.

**Live repro:** on `origin/main`, `classify_api_error(429, code=terminal_quota_exhausted)` → `rate_limit retryable=True`; same probe on this branch → `billing retryable=False should_fallback=True`. Guards re-verified green: plain rate-limit 429 stays `rate_limit`, overload body still outranks (`overloaded`), periodic "resets in 5 minutes" quota stays `rate_limit`.

| Probe (HTTP 429) | Before | After |
|---|---|---|
| structured `terminal_quota_exhausted` | rate_limit, retryable | **billing, non-retryable** |
| "hard billing limit reached" | rate_limit, retryable | **billing, non-retryable** |
| "Rate limit exceeded, retry after 20s" | rate_limit | rate_limit (unchanged) |
| "service temporarily overloaded" | overloaded | overloaded (unchanged) |
| "usage limit… resets in 5 minutes" | rate_limit | rate_limit (unchanged) |

Tests: 2 invariant tests, red on base / green here; `tests/agent/test_error_classifier.py` 142✓, plus fallback-matrix / classification-hook / 402 / cooldown suites 37✓.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b752/zVUUI5axEGMT5neRk7OJn_mhHmf93t.png)
