### PR TITLE
fix(guardrails): stall guard catches repeating multi-call cycles, not just consecutive streaks (port oh-my-pi#10521)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import deque
 from dataclasses import asdict, dataclass, field, fields
 from typing import Any, Mapping
 
@@ -35,6 +36,15 @@ STALL_GUARD_REPEATABLE_TOOLS = frozenset({"process_manage"})
 _STALL_GUARD_REPEATABLE_SUFFIXES = ("_get_result", "_poll")  # generated / MCP poller conventions
 # Nth consecutive identical (tool, args, result) call that fires the notice; 3 tolerates one double-check.
 STALL_GUARD_IDENTICAL_CALL_THRESHOLD = 3
+# Repeating multi-call cycles (A,B,A,B,... with identical args AND results) defeat the
+# consecutive streak above — every alternation resets it, so a model replaying the same
+# 2–4 call batch each iteration ran to the budget unflagged (port of can1357/oh-my-pi#10521,
+# which widened their loop guard from single-call turns to whole tool-call batches).
+# Longest cycle period detected; laps reuse the streak thresholds (notice at
+# STALL_GUARD_IDENTICAL_CALL_THRESHOLD laps, halt at no_progress_block_after laps).
+_STALL_GUARD_MAX_CYCLE_PERIOD = 4
+# History window: enough for block_after laps of the longest cycle plus slack.
+_STALL_GUARD_CYCLE_HISTORY = 64
 # From the 2nd byte-identical repeat the duplicate payload becomes a reference stub; smaller results
 # aren't worth it, errors never are. The args preview keeps WHAT was called if compression evicts the original.
 IDENTICAL_RESULT_STUB_MIN_CHARS = 512
@@ -249,6 +259,11 @@ _DECISION_MESSAGES: dict[str, str] = {
         "Stopped {tool_name}: the same call with identical arguments returned the same result "
         "{count} times in a row. Stop repeating it unchanged; use the result already provided or change strategy."
     ),
+    "identical_cycle_halt": (
+        "Stopped {tool_name}: the same repeating cycle of tool calls (period {period}) with identical "
+        "arguments and identical results has run {count} times. Repeating the batch unchanged is not "
+        "progress; use the results already provided or change strategy."
+    ),
     "loop_web_search_cap": (
         "Blocked web_search: this turn has already made {cap} web searches, the per-turn limit. "
         "This looks like a runaway search loop. Work with the results you already have and give the user your answer."
@@ -263,6 +278,13 @@ _IDENTICAL_CALL_NOTICE = (
     "[hermes note: this is the {ordinal} consecutive identical call to "
     "{tool_name} with identical arguments returning the same result. "
     "Do not repeat it — change arguments, use a different tool, or "
+    "proceed with what you have.]"
+)
+
+_IDENTICAL_CYCLE_NOTICE = (
+    "[hermes note: the last {count} rounds repeated the same cycle of {period} tool calls "
+    "(ending with {tool_name}) with identical arguments and identical results. "
+    "Do not repeat the batch — change arguments, use a different tool, or "
     "proceed with what you have.]"
 )
 
@@ -298,6 +320,10 @@ class ToolCallGuardrailController:
         self._identical_streak_result_hash: str = ""
         self._identical_streak_count: int = 0
         self._identical_streak_first_call_id: str = ""
+        # Batch-cycle loop breaker (port of can1357/oh-my-pi#10521): sequence of
+        # (signature, result_hash, repeatable) for every observed call this turn, so a repeating
+        # multi-call cycle (A,B,A,B,...) is caught even though it resets the consecutive streak above.
+        self._call_history: deque[tuple[ToolCallSignature, str, bool]] = deque(maxlen=_STALL_GUARD_CYCLE_HISTORY)
         # tool_call_id -> spillover path, so a stub referencing a persisted-output preview can't dangle.
         self._persisted_result_paths: dict[str, str] = {}
         self._turn_web_search_count = 0
@@ -434,10 +460,58 @@ class ToolCallGuardrailController:
             if self.config.hard_stop_enabled and count >= self.config.no_progress_block_after and self._halt_decision is None:
                 self._decide("halt", "identical_call_streak_halt", tool_name, count, signature)
 
+        # Batch-cycle detection (oh-my-pi#10521): a repeating multi-call cycle resets the
+        # consecutive streak on every alternation, so check the call history for a period-p lap.
+        if is_plain_str:
+            self._call_history.append((signature, result_hash, is_stall_guard_repeatable(tool_name)))
+        else:
+            self._call_history.clear()
+        if notice is None and is_plain_str:
+            cycle = self._detect_identical_cycle()
+            if cycle is not None:
+                period, laps = cycle
+                notice = _IDENTICAL_CYCLE_NOTICE.format(count=laps, period=period, tool_name=tool_name)
+                if self.config.hard_stop_enabled and laps >= self.config.no_progress_block_after and self._halt_decision is None:
+                    self._decide("halt", "identical_cycle_halt", tool_name, laps, signature, period=period)
+
         stub = None
         if is_plain_str and count >= 2 and not failed and len(result) >= IDENTICAL_RESULT_STUB_MIN_CHARS:
             stub = self._build_result_reference_stub(tool_name, args)
         return IdenticalCallObservation(notice=notice, stub=stub)
+
+    def _detect_identical_cycle(self) -> tuple[int, int] | None:
+        """Detect a repeating identical-call cycle ending at the latest observed call.
+
+        Returns ``(period, laps)`` for the smallest period 2..max whose trailing laps
+        (identical signature AND result per position) reach the notice threshold, else None.
+        Period 1 is the consecutive streak's job. A cycle made ONLY of poller-exempt tools
+        is exempt (an unchanged poll loop is legitimate waiting); one non-exempt call in
+        the cycle keeps the guard armed, matching the single-call exemption semantics.
+        """
+        history = self._call_history
+        for period in range(2, _STALL_GUARD_MAX_CYCLE_PERIOD + 1):
+            if len(history) < period * STALL_GUARD_IDENTICAL_CALL_THRESHOLD:
+                continue
+            laps = 1
+            # Count how many consecutive trailing laps equal the final lap.
+            while True:
+                base = len(history) - period * (laps + 1)
+                if base < 0:
+                    break
+                lap_equal = all(
+                    history[base + i][:2] == history[len(history) - period + i][:2]
+                    for i in range(period)
+                )
+                if not lap_equal:
+                    break
+                laps += 1
+            if laps >= STALL_GUARD_IDENTICAL_CALL_THRESHOLD:
+                tail = [history[len(history) - period + i] for i in range(period)]
+                if all(repeatable for _, _, repeatable in tail):
+                    continue
+                # A constant sub-cycle would already have fired at a smaller period.
+                return period, laps
+        return None
 
     def record_persisted_result(self, tool_call_id: str, file_path: str) -> None:
         """Remember the spillover path a persisted result was saved to."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -1253,9 +1253,9 @@ class AIAgent(
         if decision.should_halt:
             self._set_tool_guardrail_halt(decision)
         else:
-            # observe_call may have raised the identical-call streak halt (hard_stop_enabled, tool-agnostic).
+            # observe_call may have raised the identical-call streak or batch-cycle halt (hard_stop_enabled, tool-agnostic).
             streak_halt = self._tool_guardrails.halt_decision
-            if streak_halt is not None and streak_halt.code == "identical_call_streak_halt":
+            if streak_halt is not None and streak_halt.code in ("identical_call_streak_halt", "identical_cycle_halt"):
                 function_result = append_toolguard_guidance(function_result, streak_halt)
                 self._set_tool_guardrail_halt(streak_halt)
         if stall_notice:

--- a/tests/agent/test_stall_guards.py
+++ b/tests/agent/test_stall_guards.py
@@ -387,3 +387,50 @@ def test_ignores_conversational_future_offers():
     assert not trailing_continue_intent(
         "If you want, I will happily review the PR once CI is green. Just say so!"
     )
+
+
+# ── batch-cycle loop breaker (port of can1357/oh-my-pi#10521) ───────────────
+
+
+def test_repeating_two_call_cycle_fires_notice_and_halts_under_hard_stop():
+    """An A,B,A,B,... cycle of identical (args, result) pairs defeats the
+    consecutive streak (every alternation resets it) but must still be caught:
+    notice at the threshold-th lap, halt at no_progress_block_after laps."""
+    from agent.tool_guardrails import ToolCallGuardrailConfig
+
+    c = ToolCallGuardrailController(ToolCallGuardrailConfig(hard_stop_enabled=True))
+    pairs = (({"command": "make build"}, "error: X\n"),
+             ({"command": "tail -5 build.log"}, "still broken\n"))
+    first_notice_call = None
+    calls = 0
+    for _ in range(30):
+        for args, result in pairs:
+            calls += 1
+            notice = c.observe_call("terminal", args, result).notice
+            if notice is not None and first_notice_call is None:
+                first_notice_call = calls
+                assert "cycle" in notice
+        if c.halt_decision is not None:
+            break
+    # Notice on the last call of the threshold-th lap (period 2 × threshold 3).
+    assert first_notice_call == 2 * STALL_GUARD_IDENTICAL_CALL_THRESHOLD
+    assert c.halt_decision is not None
+    assert c.halt_decision.code == "identical_cycle_halt"
+
+
+def test_cycle_guard_stays_silent_for_progressing_and_poller_cycles():
+    """A cycle whose results change every lap is real work; a cycle made only
+    of poller-exempt tools is legitimate waiting. Neither may fire."""
+    from agent.tool_guardrails import ToolCallGuardrailConfig
+
+    progressing = ToolCallGuardrailController(ToolCallGuardrailConfig(hard_stop_enabled=True))
+    for i in range(20):
+        for args in ({"command": "make"}, {"command": "tail log"}):
+            assert progressing.observe_call("terminal", args, f"output {i}").notice is None
+    assert progressing.halt_decision is None
+
+    pollers = ToolCallGuardrailController(ToolCallGuardrailConfig(hard_stop_enabled=True))
+    for _ in range(20):
+        for args in ({"action": "poll", "session_id": "a"}, {"action": "poll", "session_id": "b"}):
+            assert pollers.observe_call("process_manage", args, "running").notice is None
+    assert pollers.halt_decision is None


### PR DESCRIPTION
A model replaying the same **multi-call batch** every iteration (`make build` → `tail build.log` → repeat, all with identical args and identical results) runs to the iteration budget without the stall guard ever firing — this PR makes that cycle notice at 3 laps and hard-stop at the existing `no_progress_block_after` threshold.

Port of [can1357/oh-my-pi#10521](https://github.com/can1357/oh-my-pi/pull/10521) (@JamieJ5926), which fixed the same blind spot in their loop guard by hashing the whole tool-call batch instead of single-call turns. Hermes' shape of the bug: `observe_call` tracks a **consecutive** identical-call streak, so any alternation (period ≥ 2) resets it on every call.

## Changes
- `agent/tool_guardrails.py`: bounded per-turn call history (`deque`, 64 entries) + `_detect_identical_cycle()` — smallest period 2–4 whose trailing laps are identical per position (signature AND result hash). Notice text `identical_cycle` + halt code `identical_cycle_halt`, reusing the period-1 streak's thresholds (`STALL_GUARD_IDENTICAL_CALL_THRESHOLD` notice, `no_progress_block_after` halt under `hard_stop_enabled`).
- `run_agent.py::_append_guardrail_observation`: propagation seam widened to carry the new decision code (was hardwired to `identical_call_streak_halt`).
- 2 invariant tests in `tests/agent/test_stall_guards.py` (positive proven red on base; negative green on base).

## Safety
- Cycles whose results change between laps never fire — a real edit→re-run cycle changes the result hash.
- Cycles made **only** of poller-exempt tools (`process_manage`, `*_poll`, `*_get_result`) are exempt: an unchanged poll loop is legitimate waiting, matching the single-call exemption semantics.
- Period 1 stays the consecutive streak's job — no behavior change for existing streak/stub paths.
- History is per-turn (cleared in `reset_for_turn`) and additive-only: no existing counter, threshold, or config key changes.

**Live repro:** before — 60 calls in an A,B 2-cycle on origin/main: zero notices, no halt decision. After — notice on call 6 (3rd lap), `identical_cycle_halt` recorded and guidance appended through the production `_append_guardrail_observation` seam (E2E run, not mocks); varied-args, changing-result, and poller-only cycles all stay silent.

## Validation
| Check | Result |
| --- | --- |
| New tests on base (sabotage) | positive RED, negative green |
| New tests on branch | green |
| `tests/agent/` full directory | green (3 unrelated load flakes pass in isolation) |
| ruff / windows-footguns / compat pointers / `git diff --check` | clean |

Relation to the open guardrail cluster: #103180 (near-identical Jaccard window), #101833 (cross-turn streak persistence), #85352 (cross-turn no-progress) all target *different* axes (fuzzy matching, turn persistence); none detects exact multi-call cycles within a turn. This is additive and does not collide with any of them.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b756/_oywOZuNn2VHuWnGlLxML_eEKJrWtN.png)
