### PR TITLE
feat: /archive archives the current session from chat; sessions unarchive restores it

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3173,6 +3173,7 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         "profile": ("_handle_profile_command", False), "toolsets": ("show_toolsets", False),
         "config": ("show_config", False), "redraw": ("_cmd_redraw", True), "clear": ("_cmd_clear", True),
         "history": ("show_history", False), "title": ("_cmd_title", True), "new": ("_cmd_new", True),
+        "archive": ("_cmd_archive_session", True),
         "model": ("_handle_model_switch", True), "codex-runtime": ("_handle_codex_runtime", True),
         "retry": ("_cmd_retry", True), "prompt": ("_handle_prompt_compose_command", True),
         "undo": ("_cmd_undo", True), "save": ("save_conversation", True), "skills": ("_cmd_skills", True),

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -776,6 +776,16 @@ class GatewayInboundMixin:
             self._handle_reset_command,
         )
 
+    async def _hm_cmd_archive(self, event, source, _quick_key):
+        if await asyncio.to_thread(self._is_telegram_topic_root_lobby, source):
+            return True, self._telegram_topic_root_new_message()
+        return await self._hm_confirm_destructive(
+            event, "archive",
+            "This archives the current session (hidden from listings; restorable with "
+            "`hermes sessions unarchive`) and starts a fresh one.",
+            self._handle_archive_command,
+        )
+
     async def _hm_cmd_start(self, event, source, _quick_key):
         logger.info("Ignoring /start platform ping for session %s", _quick_key)
         return True, ""
@@ -907,6 +917,7 @@ class GatewayInboundMixin:
     # handled by ``_hm_cmd_<name>`` → ``(handled, result)``; ``(False, None)`` falls through to the agent.
     _HM_CANONICAL_COMMANDS = frozenset({
         "new", "start", "egress", "learn", "plan", "init", "blueprint", "undo", "queue", "steer", "moa",
+        "archive",
     })
 
     async def _hm_dispatch_canonical_command(

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -783,6 +783,35 @@ class GatewaySessionCommandsMixin:
                 os.remove(temp_path)
                 os.rmdir(temp_dir)
 
+    async def _handle_archive_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+        """Handle /archive — archive the current session (soft-hide, restorable), then start fresh.
+
+        Inspired by Factory Droid v0.209's "archive sessions from chat": the archived flag and
+        bulk `hermes sessions archive` already exist, but the session you are IN could not be
+        archived without switching away first. Reuses the full /new reset pipeline so agent
+        eviction, hooks and delegation expiry behave identically.
+        """
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        old_entry = self.session_store._entries.get(session_key)
+        old_sid = str(getattr(old_entry, "session_id", "") or "")
+        if not self._session_db:
+            return self._session_db_unavailable_reply()
+        row = await self._session_db.get_session(old_sid) if old_sid else None
+        if not row or not row.get("message_count"):
+            return t("gateway.archive.nothing_to_archive")
+        title = row.get("title") or ""
+        reset_reply = await self._handle_reset_command(event)
+        archived = False
+        try:
+            archived = bool(await self._session_db.set_session_archived(old_sid, True))
+        except Exception:
+            logger.warning("Failed to archive session %s from /archive", old_sid, exc_info=True)
+        if not archived:
+            return t("gateway.archive.failed", session_id=old_sid)
+        label = t("gateway.archive.titled_label", title=title) if title else ""
+        return t("gateway.archive.done", session_id=old_sid, label=label) + f"\n{reset_reply}"
+
     async def _handle_title_command(self, event: MessageEvent) -> str:
         """Handle /title command — set or show the current session's title."""
         source = event.source

--- a/hermes_cli/cli_loops_mixin.py
+++ b/hermes_cli/cli_loops_mixin.py
@@ -163,6 +163,41 @@ class CLILoopsMixin:
             return True  # confirmation cancelled — command handled, keep REPL alive
         self.new_session(title=title)
 
+    def _cmd_archive_session(self, cmd_original: str):
+        """/archive — archive the current session (soft-hide, restorable) and start fresh.
+
+        Inspired by Factory Droid v0.209's "archive sessions from chat": archive state
+        already exists in state.db (`sessions.archived`, bulk `hermes sessions archive`),
+        but the session you are IN could not be archived without leaving it first.
+        """
+        from cli import _cprint
+        from hermes_state import format_session_db_unavailable
+        if not self._session_db:
+            _cprint(f"  {format_session_db_unavailable()}")
+            return True
+        old_id = self.session_id
+        sess = self._session_db.get_session(old_id) if old_id else None
+        if not sess or not sess.get("message_count"):
+            _cprint("  📦 Nothing to archive yet — this session has no saved messages.")
+            return True
+        if self._confirm_destructive_slash(
+            "archive",
+            "This archives the current session (hidden from listings; restore with\n"
+            "`hermes sessions unarchive <id>`) and starts a fresh one.",
+            cmd_original=cmd_original,
+        ) is None:
+            return True  # confirmation cancelled — command handled, keep REPL alive
+        title = self._session_db.get_session_title(old_id)
+        # Rotate FIRST: new_session flushes the in-flight turn to the old session and ends it,
+        # so the archived row carries the complete transcript.
+        self.new_session(silent=True)
+        if self._session_db.set_session_archived(old_id, True):
+            label = f" ('{title}')" if title else ""
+            _cprint(f"  📦 Archived session {old_id}{label} — starting fresh.")
+            _cprint(f"  Restore it later: hermes sessions unarchive {old_id}")
+        else:
+            _cprint("  Session could not be archived (not found in database).")
+
     def _cmd_retry(self, cmd_original: str):
         retry_msg = self.retry_last()
         if retry_msg and hasattr(self, '_pending_input'):

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -69,6 +69,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("undo", "Back up N user turns and re-prompt (default 1)", "Session",
                args_hint="[N]"),
     CommandDef("title", "Set a title for the current session", "Session", args_hint="[name]"),
+    CommandDef("archive", "Archive the current session (hidden from listings) and start fresh", "Session"),
     CommandDef("handoff", "Hand off this session to a messaging platform (Telegram, Discord, etc.)", "Session",
                args_hint="<platform>", cli_only=True, argument_mode="options"),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",

--- a/hermes_cli/commands_platforms.py
+++ b/hermes_cli/commands_platforms.py
@@ -368,7 +368,7 @@ _SLACK_RESERVED_COMMANDS = frozenset({
 # parity test reads this set. Aliases are never pinned ahead of canonicals.
 _SLACK_VIA_HERMES_ONLY = frozenset({
     "topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat",
-    "refine", "review", "pause", "whoami", "platform", "insights"})
+    "refine", "review", "pause", "whoami", "platform", "insights", "archive"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -713,6 +713,19 @@ def _cmd_pin(db, args, pinning):
     return 1 if failures else None
 
 
+def _cmd_unarchive(db, args):
+    """Restore archived session(s) to listings/resume (the /archive escape hatch)."""
+    failures = 0
+    for raw_id in args.session_ids:
+        resolved = db.resolve_session_id(raw_id)
+        if resolved and db.set_session_archived(resolved, False):
+            title = db.get_session_title(resolved)
+            print(f"Un-archived session '{resolved}'.{f'  ({title})' if title else ''}")
+        else:
+            failures += _not_found(raw_id)
+    return 1 if failures else None
+
+
 def _cmd_pinned(db, args):
     # limit=1 keeps the recency page minimal; include_pinned back-fills ALL pinned rows the page missed.
     rows = db.list_sessions_rich(limit=1, include_pinned=True, exclude_sources=_default_exclude(args))
@@ -942,6 +955,7 @@ _DB_HANDLERS = {
     "prune": partial(_cmd_prune_or_archive, action="prune"), "pin": partial(_cmd_pin, pinning=True),
     "archive": partial(_cmd_prune_or_archive, action="archive"), "unpin": partial(_cmd_pin, pinning=False),
     "retitle-skills": _cmd_retitle_skills, "browse": _cmd_browse, "optimize": _cmd_optimize,
+    "unarchive": _cmd_unarchive,
     "clean-markers": _cmd_clean_markers, "optimize-storage": _cmd_optimize_storage,
     "repair-routing": _cmd_repair_routing, "stats": _cmd_stats,
 }

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -226,6 +226,11 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
     sessions_unpin.add_argument(
         "session_ids", nargs="+", help="Session ID(s) or unique prefix(es) to unpin")
 
+    sessions_unarchive = sessions_subparsers.add_parser(
+        "unarchive", help="Un-archive (restore to listings) archived session(s)")
+    sessions_unarchive.add_argument(
+        "session_ids", nargs="+", help="Session ID(s) or unique prefix(es) to un-archive")
+
     sessions_pinned = sessions_subparsers.add_parser("pinned", help="List pinned sessions")
     add_json_flag(sessions_pinned, "Emit machine-readable JSON (for backup/restore scripting)")
 

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Vaardigheids-herlaai het misluk: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Nog niks om te argiveer nie — hierdie sessie het geen gestoorde boodskappe nie."
+    failed:                "⚠️ Kon nie sessie {session_id} argiveer nie — 'n nuwe sessie is steeds begin."
+    titled_label:          " (“{title}”)"
+    done:                  "📦 Sessie {session_id}{label} geargiveer — herstel dit met `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Sessie herstel! Begin van voor."
     header_new:            "✨ Nuwe sessie begin!"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -269,6 +269,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ فشلت إعادة تحميل المهارات: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 لا يوجد ما يمكن أرشفته بعد — لا تحتوي هذه الجلسة على رسائل محفوظة."
+    failed:                "⚠️ تعذّرت أرشفة الجلسة {session_id} — ومع ذلك بدأت جلسة جديدة."
+    titled_label:          " («{title}»)"
+    done:                  "📦 تمت أرشفة الجلسة {session_id}{label} — استعدها عبر `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ أُعيد ضبط الجلسة! بداية جديدة."
     header_new:            "✨ بدأت جلسة جديدة!"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Skill-Neuladen fehlgeschlagen: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Noch nichts zu archivieren — diese Sitzung hat keine gespeicherten Nachrichten."
+    failed:                "⚠️ Sitzung {session_id} konnte nicht archiviert werden — eine neue Sitzung wurde trotzdem gestartet."
+    titled_label:          " („{title}“)"
+    done:                  "📦 Sitzung {session_id}{label} archiviert — Wiederherstellung mit `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Sitzung zurückgesetzt! Neuanfang."
     header_new:            "✨ Neue Sitzung gestartet!"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -261,6 +261,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Skills reload failed: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Nothing to archive yet — this session has no saved messages."
+    failed:                "⚠️ Could not archive session {session_id} — a fresh session was still started."
+    titled_label:          " (“{title}”)"
+    done:                  "📦 Archived session {session_id}{label} — restore it with `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Session reset! Starting fresh."
     header_new:            "✨ New session started!"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Falló la recarga de skills: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Nada que archivar todavía — esta sesión no tiene mensajes guardados."
+    failed:                "⚠️ No se pudo archivar la sesión {session_id} — aun así se inició una sesión nueva."
+    titled_label:          " (“{title}”)"
+    done:                  "📦 Sesión {session_id}{label} archivada — restaúrala con `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ ¡Sesión reiniciada! Empezando de nuevo."
     header_new:            "✨ ¡Nueva sesión iniciada!"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Échec du rechargement des skills : {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Rien à archiver pour l’instant — cette session n’a aucun message enregistré."
+    failed:                "⚠️ Impossible d’archiver la session {session_id} — une nouvelle session a tout de même été démarrée."
+    titled_label:          " (« {title} »)"
+    done:                  "📦 Session {session_id}{label} archivée — restaurez-la avec `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Session réinitialisée ! Nouveau départ."
     header_new:            "✨ Nouvelle session démarrée !"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -250,6 +250,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Theip ar athlódáil scileanna: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Níl aon rud le cartlannú fós — níl aon teachtaireachtaí sábháilte sa seisiún seo."
+    failed:                "⚠️ Níorbh fhéidir seisiún {session_id} a chartlannú — cuireadh tús le seisiún nua mar sin féin."
+    titled_label:          " (“{title}”)"
+    done:                  "📦 Cartlannaíodh seisiún {session_id}{label} — athchóirigh é le `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Seisiún athshocraithe! Ag tosú as an nua."
     header_new:            "✨ Seisiún nua tosaithe!"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Készségek újratöltése sikertelen: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Még nincs mit archiválni — ebben a munkamenetben nincs mentett üzenet."
+    failed:                "⚠️ Nem sikerült archiválni a(z) {session_id} munkamenetet — az új munkamenet így is elindult."
+    titled_label:          " („{title}”)"
+    done:                  "📦 A(z) {session_id}{label} munkamenet archiválva — visszaállítás: `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Munkamenet visszaállítva! Kezdjük tiszta lappal."
     header_new:            "✨ Új munkamenet elindítva!"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Ricaricamento delle skill non riuscito: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Niente da archiviare per ora — questa sessione non ha messaggi salvati."
+    failed:                "⚠️ Impossibile archiviare la sessione {session_id} — è stata comunque avviata una nuova sessione."
+    titled_label:          " (“{title}”)"
+    done:                  "📦 Sessione {session_id}{label} archiviata — ripristinala con `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Sessione reimpostata! Si ricomincia da zero."
     header_new:            "✨ Nuova sessione avviata!"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ スキルの再読み込みに失敗しました: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 まだアーカイブするものがありません — このセッションには保存されたメッセージがありません。"
+    failed:                "⚠️ セッション {session_id} をアーカイブできませんでした — 新しいセッションは開始されました。"
+    titled_label:          "(「{title}」)"
+    done:                  "📦 セッション {session_id}{label} をアーカイブしました — `hermes sessions unarchive {session_id}` で復元できます。"
+
   reset:
     header_default:        "✨ セッションをリセットしました。新たに開始します。"
     header_new:            "✨ 新しいセッションを開始しました。"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ 스킬 재로드 실패: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 아직 보관할 내용이 없습니다 — 이 세션에는 저장된 메시지가 없습니다."
+    failed:                "⚠️ 세션 {session_id}을(를) 보관하지 못했습니다 — 새 세션은 시작되었습니다."
+    titled_label:          " (“{title}”)"
+    done:                  "📦 세션 {session_id}{label}을(를) 보관했습니다 — `hermes sessions unarchive {session_id}`로 복원하세요."
+
   reset:
     header_default:        "✨ 세션이 초기화되었습니다! 새로 시작합니다."
     header_new:            "✨ 새 세션이 시작되었습니다!"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Falha ao recarregar skills: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Nada para arquivar ainda — esta sessão não tem mensagens salvas."
+    failed:                "⚠️ Não foi possível arquivar a sessão {session_id} — uma nova sessão foi iniciada mesmo assim."
+    titled_label:          " (“{title}”)"
+    done:                  "📦 Sessão {session_id}{label} arquivada — restaure com `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Sessão reiniciada! A começar do zero."
     header_new:            "✨ Nova sessão iniciada!"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Ошибка перезагрузки навыков: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Пока нечего архивировать — в этой сессии нет сохранённых сообщений."
+    failed:                "⚠️ Не удалось архивировать сессию {session_id} — новая сессия всё равно запущена."
+    titled_label:          " («{title}»)"
+    done:                  "📦 Сессия {session_id}{label} архивирована — восстановить: `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Сеанс сброшен! Начинаем с чистого листа."
     header_new:            "✨ Новый сеанс запущен!"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Beceri yeniden yükleme başarısız: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Henüz arşivlenecek bir şey yok — bu oturumda kayıtlı mesaj yok."
+    failed:                "⚠️ {session_id} oturumu arşivlenemedi — yine de yeni bir oturum başlatıldı."
+    titled_label:          " (“{title}”)"
+    done:                  "📦 {session_id}{label} oturumu arşivlendi — `hermes sessions unarchive {session_id}` ile geri yükleyin."
+
   reset:
     header_default:        "✨ Oturum sıfırlandı! Yeniden başlıyoruz."
     header_new:            "✨ Yeni oturum başlatıldı!"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ Помилка перезавантаження навичок: {error}"
 
+  archive:
+    nothing_to_archive:    "📦 Поки нічого архівувати — у цій сесії немає збережених повідомлень."
+    failed:                "⚠️ Не вдалося архівувати сесію {session_id} — нову сесію все одно розпочато."
+    titled_label:          " («{title}»)"
+    done:                  "📦 Сесію {session_id}{label} архівовано — відновити: `hermes sessions unarchive {session_id}`."
+
   reset:
     header_default:        "✨ Сесію скинуто! Починаємо з чистого аркуша."
     header_new:            "✨ Нову сесію запущено!"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ 技能重新載入失敗：{error}"
 
+  archive:
+    nothing_to_archive:    "📦 目前沒有可封存的內容 — 此工作階段沒有已儲存的訊息。"
+    failed:                "⚠️ 無法封存工作階段 {session_id} — 仍已開始新的工作階段。"
+    titled_label:          "（「{title}」）"
+    done:                  "📦 已封存工作階段 {session_id}{label} — 使用 `hermes sessions unarchive {session_id}` 還原。"
+
   reset:
     header_default:        "✨ 工作階段已重設！重新開始。"
     header_new:            "✨ 新工作階段已啟動！"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -246,6 +246,12 @@ gateway:
     item_no_desc:          "    - {name}"
     failed:                "❌ 技能重新加载失败：{error}"
 
+  archive:
+    nothing_to_archive:    "📦 暂无可归档内容 — 此会话没有已保存的消息。"
+    failed:                "⚠️ 无法归档会话 {session_id} — 已照常开始新会话。"
+    titled_label:          "（“{title}”）"
+    done:                  "📦 已归档会话 {session_id}{label} — 使用 `hermes sessions unarchive {session_id}` 恢复。"
+
   reset:
     header_default:        "✨ 会话已重置！重新开始。"
     header_new:            "✨ 新会话已启动！"

--- a/tests/cli/test_slash_dispatch_table.py
+++ b/tests/cli/test_slash_dispatch_table.py
@@ -12,7 +12,7 @@ from cli import HermesCLI
 # Command names that had an explicit branch in the pre-dispatch-table chain.
 OLD_CHAIN_COMMANDS = [
     "exit", "quit", "help", "palette", "whoami", "profile", "tools", "toolsets",
-    "config", "redraw", "clear", "history", "title", "handoff", "new", "resume",
+    "config", "redraw", "clear", "history", "title", "archive", "handoff", "new", "resume",
     "sessions", "model", "codex-runtime", "personality", "pet", "hatch", "retry",
     "prompt", "undo", "branch", "worktree", "save", "cron", "suggestions",
     "blueprint", "curator", "kanban", "skills", "learn", "init", "memory",

--- a/tests/hermes_cli/test_archive_current_session.py
+++ b/tests/hermes_cli/test_archive_current_session.py
@@ -1,0 +1,108 @@
+"""/archive from chat + `hermes sessions unarchive` (inspired by Factory Droid v0.209).
+
+The archived flag and bulk `hermes sessions archive` predate this; these tests pin the
+two new access paths: un-archiving by ID/prefix from the CLI, and archiving the session
+you are currently IN (which must rotate to a fresh session BEFORE flagging the old row
+so the archived transcript is complete).
+"""
+
+import sys
+import types
+
+
+class _FakeDB:
+    def __init__(self, known=("20260909_101500_ab12cd",), message_count=3):
+        self.known = set(known)
+        self.message_count = message_count
+        self.archive_calls = []
+
+    def resolve_session_id(self, session_id):
+        for k in self.known:
+            if k.startswith(session_id):
+                return k
+        return None
+
+    def get_session(self, session_id):
+        if session_id in self.known:
+            return {"id": session_id, "message_count": self.message_count}
+        return None
+
+    def set_session_archived(self, session_id, archived):
+        self.archive_calls.append((session_id, archived))
+        return session_id in self.known
+
+    def get_session_title(self, session_id):
+        return "Droid Port" if session_id in self.known else None
+
+    def list_sessions_rich(self, **kwargs):
+        return []
+
+    def close(self):
+        pass
+
+
+def test_sessions_unarchive_accepts_unique_prefix(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    db = _FakeDB()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: db)
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "unarchive", "20260909_101500"])
+    try:
+        main_mod.main()
+        code = 0
+    except SystemExit as e:
+        code = e.code or 0
+    out = capsys.readouterr().out
+    assert code == 0
+    assert db.archive_calls == [("20260909_101500_ab12cd", False)]
+    assert "Un-archived session '20260909_101500_ab12cd'." in out
+
+
+def test_cli_archive_rotates_before_flagging_old_session():
+    """/archive must start the fresh session BEFORE archiving the old row (flush-then-archive),
+    and must archive the OLD id, not the new one."""
+    from hermes_cli.cli_loops_mixin import CLILoopsMixin
+
+    db = _FakeDB()
+    order = []
+
+    stub = types.SimpleNamespace(
+        _session_db=db,
+        session_id="20260909_101500_ab12cd",
+        _confirm_destructive_slash=lambda *a, **k: "once",
+    )
+
+    def _new_session(silent=False, title=None):
+        order.append("rotate")
+        stub.session_id = "20260909_110000_ffeedd"
+
+    stub.new_session = _new_session
+    _orig = db.set_session_archived
+
+    def _tracked(session_id, archived):
+        order.append("archive")
+        return _orig(session_id, archived)
+
+    db.set_session_archived = _tracked
+
+    CLILoopsMixin._cmd_archive_session(stub, "/archive")
+    assert order == ["rotate", "archive"]
+    assert db.archive_calls == [("20260909_101500_ab12cd", True)]
+
+
+def test_cli_archive_refuses_empty_session():
+    """A session with no saved messages is not archived (nothing to keep) and is not rotated."""
+    from hermes_cli.cli_loops_mixin import CLILoopsMixin
+
+    db = _FakeDB(message_count=0)
+    rotated = []
+    stub = types.SimpleNamespace(
+        _session_db=db,
+        session_id="20260909_101500_ab12cd",
+        _confirm_destructive_slash=lambda *a, **k: "once",
+        new_session=lambda **k: rotated.append(True),
+    )
+    CLILoopsMixin._cmd_archive_session(stub, "/archive")
+    assert db.archive_calls == []
+    assert rotated == []

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -44,6 +44,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/retry` | Retry the last message (resend to agent) |
 | `/undo` | Remove the last user/assistant exchange |
 | `/title` | Set a title for the current session (usage: /title My Session Name) |
+| `/archive` | Archive the current session (soft-hide, restorable with `hermes sessions unarchive <id>`) and start a fresh one. Inspired by Factory Droid's archive-from-chat. |
 | `/compress [here [N] \| focus topic]` | Manually compress conversation context (flush memories + summarize). `/compress here [N]` summarizes everything except the most recent N exchanges (default 2), kept verbatim — pick your own compression boundary. A focus topic narrows what a full summary preserves. |
 | `/rollback` | List or restore filesystem checkpoints (usage: /rollback [number]) |
 | `/diff [staged\|all\|session] [--stat] [path...]` | Show git changes in the working directory. Default: unstaged changes plus untracked files. `staged` shows what's staged for commit, `all` everything since HEAD, and `session` the cumulative diff of everything Hermes changed here (from the earliest retained checkpoint baseline — requires checkpoints to be enabled; complements `/rollback diff <N>`). `--stat` prints just the changed-file summary; path arguments restrict the diff. |
@@ -253,6 +254,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/compress [here [N] \| focus topic]` | Manually compress conversation context. `/compress here [N]` keeps the most recent N exchanges (default 2) verbatim and summarizes the rest. A focus topic narrows what a full summary preserves. |
 | `/topic [off\|help\|session-id]` | **Telegram DM only.** Manage user-managed multi-session topic mode. `/topic` enables it or shows status; `/topic off` disables it and clears bindings; `/topic help` shows usage; `/topic <session-id>` inside a topic restores a previous session. See [Multi-session DM mode](/user-guide/messaging/telegram#multi-session-dm-mode-topic). |
 | `/title [name]` | Set or show the session title. |
+| `/archive` | Archive the current session (hidden from listings, restorable with `hermes sessions unarchive <id>`) and start a fresh one. |
 | `/resume [name]` | Resume a previously named session. |
 | `/sessions [all] [search <query>]` | List previous sessions for this chat; the active session appears with a `(current)` marker. `/sessions search <query>` filters by title/id match (most recently active first); `/sessions all` lists across origins (admin only — non-admins get a notice and the chat-scoped list). |
 | `/usage` | Show token usage, estimated cost breakdown (input/output), context window state, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits pulled live from the provider's API. |

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -573,7 +573,12 @@ hermes sessions archive --title "dry run" --yes
 At least one filter is required — a bare `hermes sessions archive` refuses to
 archive your entire history. Archived sessions are hidden from
 `hermes sessions list` and `/resume` but remain in the database and can be
-unarchived from the Desktop/Dashboard session list.
+unarchived from the Desktop/Dashboard session list or with
+`hermes sessions unarchive <id>` (accepts unique ID prefixes).
+
+You can also archive the session you are currently in from any chat surface
+with `/archive` (CLI and gateway) — it archives the current transcript and
+starts a fresh session, printing the ID to unarchive later.
 
 ### Session Statistics
 


### PR DESCRIPTION
Archiving the session you are currently in now works from any chat surface (`/archive`), and archived sessions can be restored from the CLI (`hermes sessions unarchive`).

Inspired by **Factory Droid v0.209** — ["Archive sessions from chat with /archive or Ctrl+X, and restore sessions from the Archived tab"](https://docs.factory.ai/changelog/release-notes). Hermes already had the storage side (`sessions.archived` flag, bulk `hermes sessions archive`, Desktop-sidebar archive), but two gaps remained: the **current** session could not be archived without leaving it first, and restore was **GUI-only** — no CLI path existed at all.

## Changes

- **`/archive` (CLI):** destructive-confirm modal (same gate as `/new`, honors `now`/`--yes`), refuses empty sessions, rotates to a fresh session FIRST (so the in-flight turn is flushed and the archived row carries the complete transcript), then soft-hides the old session and prints the restore command.
- **`/archive` (gateway, all messaging platforms):** same confirm flow via `_hm_confirm_destructive`; the handler reuses the full `/new` reset pipeline (agent eviction, session hooks, delegation expiry), then flags the old row. Replies i18n'd across all 17 locales (`gateway.archive.*`).
- **`hermes sessions unarchive <id...>`:** restores by ID or unique prefix, mirroring `pin`/`unpin` (per-ID feedback, exit 1 on unknown IDs).
- **Slack:** native slashes sit at Slack's 50-command cap; `/archive` is routed through `/hermes archive` there per the documented demotion rule so `/usage` keeps its native slot.
- Docs: `reference/slash-commands.md` (both tables) + `user-guide/sessions.md`.

## Ours vs theirs

Droid archives in place and offers an "Archived" tab. Hermes archives are lineage-aware (`set_session_archived` walks the compression chain) and the restore path is scriptable (`sessions unarchive`, prefix matching) rather than GUI-only. Ctrl+X keybinding and a Desktop "Archived tab" filter were deliberately left out — Desktop restore already exists (sidebar action menu, see #98823), and a keybinding is separable UI polish.

**Live repro:** before — on `origin/main`, `resolve_command('archive')` and `HermesCLI._slash_handler('archive')` both return `None` (no such command on any surface), and `hermes sessions unarchive` is an argparse invalid-choice error. After — exercised live in a real CLI pty: `/archive` on an empty session prints the refusal; after seeding a message it shows the confirm modal, archives (`archived=1` verified directly in state.db), starts fresh, and `hermes sessions unarchive 20260909_023734` (prefix) restores it, exit 0; unknown ID exits 1.

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_archive_current_session.py` (3 invariants: unarchive-by-prefix, rotate-before-flag ordering, empty-session refusal) | pass |
| `tests/agent/test_i18n.py` (17-locale key + placeholder parity) | 36 pass |
| test_commands, test_sessions_pin, test_sessions_error_exit_codes, test_prune_spares_pinned, gateway destructive-confirm + busy-bypass suites | all pass |
| E2E (real SessionDB, temp `HERMES_HOME`): archive hides from `list_sessions_rich`, unarchive restores, unknown id exit 1 | pass |
| ruff / windows-footguns / compat-pointers / `git diff --check` | clean |

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b760/o9NflyFxfGsy62U7v5jKd_c1lR3CGE.png)

---
Opened by the weekly Factory Droid feature scout (cron). Not merge-approved — awaiting review.
