### PR TITLE
fix(cli): keep one-shot work in its launch directory

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -785,7 +785,15 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     def host_info_value(label: str) -> str:
         """New prompts delimit runtime hints; legacy prompts put them before context."""
         prefix = f"{label}:"
-        host_lines = (runtime.split("\n\n", 1)[0] if runtime_marker else prompt).splitlines()
+        if runtime_marker:
+            # The renderer-owned runtime block is authoritative, so its first
+            # paragraph can be parsed directly even when field ordering evolves.
+            # Embedder prose follows a blank line and cannot shadow these fields.
+            for line in runtime.split("\n\n", 1)[0].splitlines():
+                if line.startswith(prefix):
+                    return line[len(prefix):].strip()
+            return ""
+        host_lines = prompt.splitlines()
         for idx, line in enumerate(host_lines):
             if line.startswith("User home directory:"):
                 for candidate in host_lines[idx + 1: idx + 4]:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -950,11 +950,16 @@ def _local_host_hints() -> list[str]:
         else f"macOS ({platform.mac_ver()[0] or platform.release()})" if sys.platform == "darwin"
         else f"{platform.system()} ({platform.release()})"
     )
-    host_lines = [f"Host: {host}", f"User home directory: {os.path.expanduser('~')}"]
+    host_lines = [f"Host: {host}"]
     try:
         host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
     except OSError:
         pass
+    host_lines.append(f"User home directory: {os.path.expanduser('~')}")
+    host_lines.append(
+        "Workspace rule: resolve terminal and file-tool paths from the current working directory above. "
+        "Do not substitute the user home directory unless the user explicitly requests it."
+    )
     if not (sys.platform == "win32" and not is_wsl()):
         return ["\n".join(host_lines)]
     host_lines.append(

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -176,6 +176,18 @@ def run_oneshot(
     the CLI layer: latest/title/--continue resolution) whose transcript is loaded and continued
     by this turn. Returns the exit code; the caller owns process termination.
     """
+    # A local one-shot is workspace-scoped to the directory from which it was
+    # launched (after --in/resume handling in main.py). A stale TERMINAL_CWD
+    # loaded from legacy environment config otherwise overrides os.getcwd() in
+    # the system prompt and every terminal/file tool, so the agent can write a
+    # correct patch into the wrong checkout while claiming success.
+    terminal_env = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    if terminal_env in {"", "local"}:
+        try:
+            os.environ["TERMINAL_CWD"] = os.getcwd()
+        except OSError:
+            pass
+
     # Silence every stdlib logger: AIAgent, tools and provider adapters log to stderr through the
     # root logger. File handlers from setup_logging() keep working (level-independent).
     logging.disable(logging.CRITICAL)

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -197,6 +197,42 @@ def _pending_fleet_restart_needed() -> bool:
     return not _live_fleet_covers_receipt(_current_checkout_sha())
 
 
+def _superseded_marker_has_current_gateway_successor() -> bool:
+    """True when a later checkout has a live gateway fleet on that later code.
+
+    ``fleet_restart_pending`` can survive a manual restart because the gateway
+    command does not own update receipts.  Suppress the cheap startup warning
+    only for the narrow, observable supersession case: the marker names a
+    different checkout and every currently discovered gateway is stamped with
+    the current checkout SHA.  Missing, malformed, empty, or stale evidence
+    remains fail closed; the marker and receipt stay intact for ``hermes
+    update`` catch-up.
+    """
+    try:
+        marker_sha = ""
+        for line in _fleet_restart_pending_marker_path().read_text(encoding="utf-8").splitlines():
+            key, separator, value = line.partition("=")
+            if separator and key == "expected_sha":
+                marker_sha = value.strip()
+                break
+        current_sha = _current_checkout_sha() or ""
+        if not marker_sha or not current_sha or marker_sha == current_sha:
+            return False
+
+        from hermes_cli.update_receipt import collect_fleet_versions
+
+        fleet = collect_fleet_versions()
+        return bool(fleet) and all(
+            isinstance(row, dict)
+            and row.get("state") == "current"
+            and row.get("code_sha") == current_sha
+            for row in fleet
+        )
+    except Exception as exc:
+        logger.debug("Could not reconcile superseded fleet marker: %s", exc)
+        return False
+
+
 def _warn_pending_fleet_restart(*, startup: bool = False) -> None:
     """Print the specific interrupted-update fleet-restart warning."""
     stream = sys.stderr if startup else sys.stdout
@@ -209,7 +245,7 @@ def _warn_pending_fleet_restart(*, startup: bool = False) -> None:
 def _warn_pending_fleet_restart_on_startup() -> None:
     """Cheap CLI-startup hint. Never restarts; never raises."""
     with suppress(Exception):
-        if _pending_fleet_restart_needed():
+        if _pending_fleet_restart_needed() and not _superseded_marker_has_current_gateway_successor():
             _warn_pending_fleet_restart(startup=True)
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -801,6 +801,20 @@ class TestEnvironmentHints:
         _pb._BACKEND_PROBE_CACHE.clear()
         assert f"Current working directory: {tmp_path}" in _pb.build_environment_hints()
 
+    def test_build_environment_hints_marks_cwd_as_the_tool_workspace(self, monkeypatch, tmp_path):
+        """A model must not mistake the adjacent home-directory hint for its workspace."""
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.chdir(tmp_path)
+        hints = _pb.build_environment_hints()
+
+        assert hints.index(f"Current working directory: {tmp_path}") < hints.index("User home directory:")
+        assert "resolve terminal and file-tool paths from the current working directory above" in hints
+        assert "Do not substitute the user home directory" in hints
+
 
     def test_probe_remote_backend_imports_real_factory(self, monkeypatch):
         """Regression for #53667: the probe imported a nonexistent

--- a/tests/hermes_cli/test_oneshot_cwd.py
+++ b/tests/hermes_cli/test_oneshot_cwd.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from hermes_cli.oneshot import run_oneshot
+
+
+def test_local_oneshot_pins_tools_to_launch_directory(monkeypatch, tmp_path):
+    stale = tmp_path / "stale"
+    stale.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setenv("TERMINAL_CWD", str(stale))
+
+    observed = {}
+
+    def fake_run_agent(*_args, **_kwargs):
+        observed["cwd"] = Path(__import__("os").environ["TERMINAL_CWD"])
+        return "ok", {}
+
+    monkeypatch.setattr("hermes_cli.oneshot._run_agent", fake_run_agent)
+
+    assert run_oneshot("do the work") == 0
+    assert observed["cwd"] == workspace
+
+
+def test_remote_oneshot_preserves_backend_cwd(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CWD", "/workspace")
+
+    observed = {}
+
+    def fake_run_agent(*_args, **_kwargs):
+        observed["cwd"] = __import__("os").environ["TERMINAL_CWD"]
+        return "ok", {}
+
+    monkeypatch.setattr("hermes_cli.oneshot._run_agent", fake_run_agent)
+
+    assert run_oneshot("do the work") == 0
+    assert observed["cwd"] == "/workspace"

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -182,6 +182,43 @@ def test_pending_needed_when_marker_exists():
     assert update_cmd._pending_fleet_restart_needed() is False
 
 
+def test_startup_warning_suppressed_when_later_checkout_gateway_supersedes_marker(
+    monkeypatch, capsys,
+):
+    update_cmd._write_fleet_restart_pending_marker(expected_sha="old")
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: "new")
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda: [{"profile": "default", "state": "current", "code_sha": "new"}],
+    )
+
+    update_cmd._warn_pending_fleet_restart_on_startup()
+
+    assert capsys.readouterr().err == ""
+    assert update_cmd._fleet_restart_pending_marker_path().is_file()
+
+
+@pytest.mark.parametrize(
+    "marker_sha,fleet",
+    [
+        pytest.param("new", [{"state": "current", "code_sha": "new"}], id="current-marker"),
+        pytest.param("old", [], id="empty-fleet"),
+        pytest.param("old", [{"state": "stale", "code_sha": "old"}], id="stale-gateway"),
+        pytest.param("old", [{"state": "unknown", "code_sha": None}], id="unknown-gateway"),
+    ],
+)
+def test_startup_warning_kept_without_current_superseding_gateway(
+    monkeypatch, capsys, marker_sha, fleet,
+):
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=marker_sha)
+    monkeypatch.setattr(update_cmd_fleet, "_current_checkout_sha", lambda: "new")
+    monkeypatch.setattr("hermes_cli.update_receipt.collect_fleet_versions", lambda: fleet)
+
+    update_cmd._warn_pending_fleet_restart_on_startup()
+
+    assert "pulled new code but did not restart" in capsys.readouterr().err
+
+
 def test_pending_needed_when_unfinished_receipt_runtime_sha_skews(monkeypatch):
     disk_sha = "e" * 40
     old_sha = "7" * 40


### PR DESCRIPTION
A local one-shot could load a stale `TERMINAL_CWD` from legacy environment configuration even though its session metadata recorded the actual launch directory. The system prompt also placed the user-home hint before the working directory. In practice, a coding turn could write and test valid files in the wrong directory, then report success for an untouched workspace.

This change makes the launch directory authoritative for local one-shots after `--in`/resume handling, preserves backend-owned paths for remote one-shots, and states the workspace contract explicitly in the runtime prompt. It also stops an old fleet-restart marker from emitting a permanent startup warning after a later checkout has a nonempty gateway fleet entirely stamped with the later SHA; current, malformed, empty, unknown, and stale evidence still fails closed, and update receipts remain intact for catch-up.

Live validation: a pre-fix canary wrote outside its launch directory and falsely reported completion. The post-fix canary completed in 57.806 seconds without delegation, wrote both files only inside the launch directory, and its four tests passed in an independent process.

Validation:
- `scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py tests/hermes_cli/test_update_obligation_identity.py tests/hermes_cli/test_pending_supervisor_recovery.py tests/hermes_cli/test_oneshot_cwd.py tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -q` (187 passed, 8 skipped on macOS)
- Ruff on all changed Python and focused test files
- `python3 scripts/check_compat_pointers.py`
- `git diff --check`
