### PR TITLE
fix(discord): setup no longer accepts a numeric application ID as the bot token (port openclaw#140531)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6861,6 +6861,38 @@ def _clean_discord_user_ids(raw: str) -> list:
     return cleaned
 
 
+def _discord_token_shape_error(token: str) -> Optional[str]:
+    """Reject a Discord bot token that is really the numeric application ID.
+
+    Users routinely paste the application ID from the Developer Portal's General
+    Information page instead of the bot token (Bot page); the gateway then fails
+    at runtime with an opaque 401. A real bot token is dot-separated base64 and
+    never purely numeric, so this is a safe, narrow shape check (port of
+    openclaw/openclaw#140531).
+    """
+    if token and token.strip().isdigit():
+        return ("That looks like a numeric application ID, not a bot token. "
+                "Paste the bot token from the Discord Developer Portal (Bot page), "
+                "not the application ID (General Information page).")
+    return None
+
+
+def _prompt_discord_bot_token(prompt) -> str:
+    """Prompt for the bot token, re-prompting once when the answer is a numeric app ID."""
+    from hermes_cli.cli_output import print_error
+    token = ""
+    for _attempt in range(2):
+        token = prompt("Discord bot token", password=True)
+        if not token:
+            return ""
+        error = _discord_token_shape_error(token)
+        if error is None:
+            return token
+        print_error(error)
+    # Second consecutive numeric answer: trust the user, keep the value.
+    return token
+
+
 def interactive_setup() -> None:
     """Guide the user through Discord bot setup: token, allowlist, home channel (lazy CLI imports)."""
     from hermes_cli.config import get_env_value, remove_env_value, save_env_value
@@ -6900,7 +6932,7 @@ def interactive_setup() -> None:
         "Save Changes in the Developer Portal before starting the gateway.",
         "Docs: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord",
     )
-    token = prompt("Discord bot token", password=True)
+    token = _prompt_discord_bot_token(prompt)
     if not token:
         return
     save_env_value("DISCORD_BOT_TOKEN", token)

--- a/tests/gateway/test_discord_plugin_setup.py
+++ b/tests/gateway/test_discord_plugin_setup.py
@@ -78,3 +78,33 @@ class TestDiscordSetupPrivilegedIntentsGuidance:
         assert "discord.com/developers/applications" in joined
 
 
+
+
+class TestDiscordTokenShapeGuard:
+    """A numeric application ID pasted as the bot token is rejected with guidance
+    (port of openclaw/openclaw#140531)."""
+
+    def test_numeric_app_id_reprompts_then_accepts_real_token(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        saved, removed, errors = {}, [], []
+        real_token = "«redacted»." + "part2.part3"
+        _patch_setup_io(
+            monkeypatch,
+            ["1234567890123456789", real_token, "", ""],
+            saved,
+            removed,
+            existing={},
+        )
+        monkeypatch.setattr(cli_output_mod, "print_error", lambda *a, **_kw: errors.append(" ".join(map(str, a))))
+        interactive_setup()
+        assert saved.get("DISCORD_BOT_TOKEN") == real_token
+        assert any("application ID" in e for e in errors)
+
+    def test_non_numeric_token_saves_without_error(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        saved, removed, errors = {}, [], []
+        _patch_setup_io(monkeypatch, _PROMPTS_BLANK, saved, removed, existing={})
+        monkeypatch.setattr(cli_output_mod, "print_error", lambda *a, **_kw: errors.append(" ".join(map(str, a))))
+        interactive_setup()
+        assert saved.get("DISCORD_BOT_TOKEN") == _PROMPTS_BLANK[0]
+        assert errors == []


### PR DESCRIPTION
## What does this PR do?

`hermes setup` for Discord now rejects a **numeric application ID pasted as the bot token** with pointed guidance and one re-prompt, instead of saving it and failing later with an opaque 401 at gateway start.

Port of [openclaw/openclaw#140531](https://github.com/openclaw/openclaw/pull/140531).

- New `_discord_token_shape_error()` + `_prompt_discord_bot_token()` in `plugins/platforms/discord/adapter.py`: an all-digit answer prints *"That looks like a numeric application ID, not a bot token. Paste the bot token from the Discord Developer Portal (Bot page), not the application ID (General Information page)."* and re-prompts once.
- A second consecutive numeric answer is kept (user override — never a hard wall), matching the source PR's warn-don't-block spirit.
- Non-numeric tokens save exactly as before; empty answer still aborts setup. Real bot tokens are dot-separated base64 and never purely numeric, so false positives are structurally impossible.

## Root cause

The Discord Developer Portal shows the numeric application ID front-and-center on General Information; the bot token lives on the Bot page. Setup saved any string verbatim, so the mistake only surfaced at runtime.

## Adaptation notes

- The guard lives in the **plugin's `interactive_setup()`** — the active dispatch target — per the prior review verdict on #9983, which found that gateway setup prefers registered plugin setup functions and legacy `_setup_standard_platform` edits never run. This lands the Discord half of that review's "move validation into the active plugin setup functions" direction; Telegram is already covered on main (`_is_valid_telegram_bot_token`).
- 2 invariant tests in the existing `tests/gateway/test_discord_plugin_setup.py` (numeric → re-prompt → real token saved; non-numeric → no error path).

## Validation

| Check | Result |
|---|---|
| Fix reverted (stash) | new test FAILS (numeric ID saved verbatim) — proven red on base |
| Fix applied | 4 passed, 0 failed |
| E2E (repo venv, real import) | numeric/whitespace-numeric rejected; dot-separated, opaque, empty accepted/pass-through |
| ruff / windows-footguns / compat-pointers / `git diff --check` | clean |

**Live repro:** before — `interactive_setup()` on main saves `"1234567890123456789"` as `DISCORD_BOT_TOKEN` verbatim (proven by the red test run above); after — the same input is rejected with guidance and the corrected token is saved.

## Infographic

![discord-setup-guard](https://v3b.fal.media/files/b/0aa9b77c/mj_rIuq2tCiHV_6xG7RYf_5fwOuqd6.png)
