### PR TITLE
fix(kanban): archiving a running task terminates its worker (#76196, salvage #42858/#100613)

### DIFF
--- a/contributors/emails/asaxinw@gmail.com
+++ b/contributors/emails/asaxinw@gmail.com
@@ -1,0 +1,2 @@
+PINKIIILQWQ
+# PR #42858 salvage (#106437, archive terminates worker)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3487,20 +3487,29 @@ def specify_triage_task(
     return True
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
-    # Snapshot pid+claim before the DB update clears them, so we can
-    # terminate the worker process even after those columns are NULLed.
-    row = conn.execute(
-        "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?",
-        (task_id,),
-    ).fetchone()
-    prev_pid = row["worker_pid"] if row else None
-    prev_lock = row["claim_lock"] if row else None
-    # Terminate the worker process first (same order as reclaim_task).
-    # If the task wasn't running on this host, this is a safe no-op.
-    termination = _terminate_reclaimed_worker(prev_pid, prev_lock)
+def archive_task(conn: sqlite3.Connection, task_id: str, *, signal_fn=None) -> bool:
+    """Archive a task; a *running* task's host-local worker is terminated.
 
+    Clearing ``worker_pid`` in the DB alone left the OS process running past its
+    own archive — it kept executing (and pushing work) against a task nothing
+    tracked anymore (#76196). Snapshot pid+claim inside the archive txn so the
+    kill is contingent on THIS caller winning the archive transition (a losing
+    concurrent archiver must never signal the pid); the kill itself runs after
+    commit — ``_poll_worker_exit`` can wait ~5 s and must not hold the write
+    lock. Post-release kill is safe here because ``archived`` is terminal: no
+    dispatcher can spawn a duplicate worker off the released claim. The
+    termination outcome lands as its own ``archive_worker_termination`` event so
+    the ``archived`` event stays atomic with the status flip.
+    """
     with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not row:
+            return False
+        was_running = row["status"] == "running"
+        prev_pid, prev_lock = row["worker_pid"], row["claim_lock"]
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
             "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
@@ -3513,9 +3522,11 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id, outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        payload = {}
-        payload.update(termination)
-        _append_event(conn, task_id, "archived", payload, run_id=run_id)
+        _append_event(conn, task_id, "archived", None, run_id=run_id)
+    if was_running:
+        termination = _terminate_reclaimed_worker(prev_pid, prev_lock, signal_fn=signal_fn)
+        with write_txn(conn):
+            _append_event(conn, task_id, "archive_worker_termination", termination, run_id=run_id)
     # ``archived`` parents no longer block children; promote them now.
     recompute_ready(conn)
     # Reap the workspace on archive too (never-completed tasks kept it forever).

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3488,6 +3488,18 @@ def specify_triage_task(
 
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    # Snapshot pid+claim before the DB update clears them, so we can
+    # terminate the worker process even after those columns are NULLed.
+    row = conn.execute(
+        "SELECT worker_pid, claim_lock FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    prev_pid = row["worker_pid"] if row else None
+    prev_lock = row["claim_lock"] if row else None
+    # Terminate the worker process first (same order as reclaim_task).
+    # If the task wasn't running on this host, this is a safe no-op.
+    termination = _terminate_reclaimed_worker(prev_pid, prev_lock)
+
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -3501,7 +3513,9 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id, outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        payload = {}
+        payload.update(termination)
+        _append_event(conn, task_id, "archived", payload, run_id=run_id)
     # ``archived`` parents no longer block children; promote them now.
     recompute_ready(conn)
     # Reap the workspace on archive too (never-completed tasks kept it forever).

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1656,3 +1656,57 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_archive_running_task_terminates_worker(kanban_home, monkeypatch):
+    """``archive_task`` on a *running* task must actually signal its host-local
+    worker process, not just null ``worker_pid`` in the DB (#76196: a worker
+    kept running past its own archive and could still push/complete work
+    against a task nothing tracks anymore). The termination outcome is
+    auditable via the ``archive_worker_termination`` event."""
+    import json
+
+    with kbc.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        host = kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kbd._set_worker_pid(conn, t, 54321)
+
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+        signalled = []
+        assert kb.archive_task(
+            conn, t, signal_fn=lambda pid, sig: signalled.append((pid, sig)),
+        ) is True
+
+        assert signalled and signalled[0][0] == 54321
+
+        row = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'archive_worker_termination'",
+            (t,),
+        ).fetchone()
+        payload = json.loads(row["payload"])
+        assert payload["prev_pid"] == 54321
+        assert payload["host_local"] is True
+        assert payload["termination_attempted"] is True
+        assert payload["terminated"] is True
+        assert kb.get_task(conn, t).status == "archived"
+
+
+def test_archive_non_running_task_does_not_attempt_termination(kanban_home):
+    """A never-claimed (``triage``/``ready``/``done``) task has no live worker:
+    ``archive_task`` must not signal anything, and no termination event is
+    recorded — only for tasks that were actually ``running`` at archive time."""
+    with kbc.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        signalled = []
+        assert kb.archive_task(
+            conn, t, signal_fn=lambda pid, sig: signalled.append((pid, sig)),
+        ) is True
+        assert signalled == []
+        row = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND kind = 'archive_worker_termination'",
+            (t,),
+        ).fetchone()
+        assert row is None


### PR DESCRIPTION
Archiving a running kanban task now terminates its host-local worker process instead of leaving it running against a task nothing tracks anymore.

## Symptom
`archive_task` nulled `worker_pid`/`claim_lock` in the DB but never signalled the OS process — unlike `reclaim_task`, which already terminates via `_terminate_reclaimed_worker`. An archived-while-running worker kept executing (observed by contributors: 5+ minutes, culminating in a git push against the archived task), with no audit record. Reported in #76196.

## Salvage + credit
Cherry-picks #42858 (@PINKIIILQWQ) — earliest of a 2-PR duplicate cluster; #100613 (@moon2sun) fixes the same gap with the same helper and better tests, and its test shape is adopted in the hardening commit. Hardened per @teknium1's sweeper review on #42858:

- **Race-safe:** status/pid/claim snapshot moved INSIDE the archive txn — the kill fires only when this caller wins the archive transition; a losing concurrent archiver returns False and never signals the pid.
- **Running-only:** never-claimed/`ready`/`done` tasks skip termination entirely.
- **Kill post-commit:** `_poll_worker_exit` can block ~5 s and must not hold the SQLite write lock. Safe because `archived` is terminal — no dispatcher respawns off the released claim.
- **Audited:** termination outcome recorded as its own `archive_worker_termination` event; the `archived` event stays atomic with the status flip.
- 2 invariant tests (the sweeper's exact ask): running task → signalled + payload asserted; non-running → no signal, no event.

## Validation
| Check | Result |
|---|---|
| **Live repro (before, origin/main)** | real `sleep` worker, real pid: `worker_alive_after_archive=True` — process survived its own archive |
| **Live repro (after, this branch)** | `worker_alive_after_archive=False` in <0.3 s (clean SIGTERM), events: `[... 'archived', 'archive_worker_termination']` |
| `tests/hermes_cli/test_kanban*` (52 files) | 333 passed, 1 failed — `test_real_user_systemd_scope_preserves_worker_context` fails identically on unmodified main (host systemd dependency), pre-existing/unrelated |
| ruff / windows-footguns / compat pointers | clean |

Root cause in one sentence: the archive lifecycle action updated the DB row but never reached the live process.

Port trigger: weekly LobeHub PR scout (lobehub#19220 — same bug class: lifecycle actions must reach the running process, not just its row).

Closes #76196.

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9b781/-k0ZI8aA0hQ0UkdASqU3V_zvyTHP21.png)
