### PR TITLE
feat(computer-use): sensitive-app blocklist — trading, crypto wallets, password vaults denied by default (Cowork-inspired)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2228,6 +2228,14 @@ DEFAULT_CONFIG = {
         # Path (~ ok) to the reviewed manifest for permission_mode bounded; passed as
         # --capability-manifest. See cua.ai/docs/reference/cua-driver/permission-modes
         "capability_manifest": "",
+        # App blocklist (Cowork-inspired): deterministic per-app denial at the tool boundary.
+        # block_sensitive_apps gates the built-in sensitive list (trading/brokerage, crypto wallets,
+        # password managers — tools/computer_use/app_blocklist.py); blocked_apps adds patterns,
+        # unblocked_apps exempts built-in ones (false-positive valve). Token-sequence matching:
+        # "kraken" blocks the Kraken exchange app, never GitKraken.
+        "block_sensitive_apps": True,
+        "blocked_apps": [],
+        "unblocked_apps": [],
         # macOS only: allow an UNSIGNED CuaDriver.app for the private-session daemon. False fails
         # closed unless signed with the official com.trycua.driver identity. Only for local driver
         # development from source.

--- a/tests/tools/test_computer_use_app_blocklist.py
+++ b/tests/tools/test_computer_use_app_blocklist.py
@@ -1,0 +1,56 @@
+"""Computer-use app blocklist (Cowork-inspired): deterministic denial at the tool boundary.
+
+Claude Cowork ships an app blocklist for computer use — "Prevent Claude from accessing certain
+apps by adding them to a blocklist. Any requests from Claude to use blocked applications will be
+automatically denied" — with trading/crypto apps blocked by default. These tests pin the Hermes
+port's contract: the built-in sensitive list denies BOTH the explicit ``app=`` path and the
+sticky-target path pre-approval, token matching never over-blocks lookalike names, and the
+config knobs (blocked_apps / unblocked_apps / block_sensitive_apps) all take effect.
+"""
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tools.computer_use import app_blocklist
+from tools.computer_use.tool import _dispatch, _reject_unsafe
+
+
+@pytest.fixture
+def cu_config(monkeypatch):
+    """Point the blocklist at a controlled computer_use config block."""
+    def set_cfg(**cfg):
+        monkeypatch.setattr(app_blocklist, "_cfg", lambda: cfg)
+        return cfg
+    return set_cfg
+
+
+def test_sensitive_default_blocks_both_paths_without_overblocking(cu_config):
+    cu_config()  # empty config: built-in sensitive list active by default
+    # Explicit app= target denied before approval, structured code, and capture is covered too.
+    for action, args in (("capture", {"app": "Ledger Live"}), ("type", {"text": "x", "app": "1Password"})):
+        out = json.loads(_reject_unsafe(action, args))
+        assert out["code"] == "app_blocked"
+    # Sticky-target path: input to a blocklisted current target is denied even without app=.
+    backend = SimpleNamespace(_last_app="Robinhood")
+    out = json.loads(_dispatch(backend, "type", {"text": "sell everything"}))
+    assert out["code"] == "app_blocked" and "Robinhood" in out["error"]
+    # Token matching never over-blocks lookalikes or unrelated apps; unknown target fails open.
+    for name in ("GitKraken", "kate", "Ledger of Accounts.xlsx - LibreOffice", ""):
+        assert app_blocklist.blocked_app_match(name) is None, name
+    assert _reject_unsafe("click", {"element": 1}) is None  # no app= → no explicit-path denial
+
+
+def test_config_knobs_extend_exempt_and_disable(cu_config):
+    # blocked_apps extends; matching is case/punctuation-insensitive token sequence.
+    cu_config(blocked_apps=["My Bank"])
+    assert app_blocklist.blocked_app_match("my-bank Desktop") == "My Bank"
+    assert app_blocklist.blocked_app_match("MyBankHelper") is None  # one token ≠ two-token pattern
+    # unblocked_apps exempts a built-in pattern (false-positive valve) but not the others.
+    cu_config(unblocked_apps=["kraken"])
+    assert app_blocklist.blocked_app_match("Kraken Pro") is None
+    assert app_blocklist.blocked_app_match("Coinbase") == "coinbase"
+    # block_sensitive_apps=False disables the built-in list; explicit blocked_apps still applies.
+    cu_config(block_sensitive_apps=False, blocked_apps=["coinbase"])
+    assert app_blocklist.blocked_app_match("Robinhood") is None
+    assert app_blocklist.blocked_app_match("Coinbase") == "coinbase"

--- a/tools/computer_use/app_blocklist.py
+++ b/tools/computer_use/app_blocklist.py
@@ -1,0 +1,83 @@
+"""Deterministic per-app blocklist for the computer_use tool (inspired by Claude Cowork's app blocklist,
+support.claude.com article 14128542: "Prevent Claude from accessing certain apps by adding them to a
+blocklist. Any requests ... will be automatically denied", with investment/trading/crypto apps blocked
+by default).
+
+Matching is token-sequence based, not substring: an app name and a pattern are both split on
+non-alphanumeric runs and a pattern matches only as a consecutive token subsequence. So the default
+pattern ``kraken`` blocks the Kraken trading app ("Kraken", "Kraken Pro") but never GitKraken (one
+token, ``gitkraken``), and ``ledger live`` blocks "Ledger Live" without touching a "Ledger" column in
+some spreadsheet app's window title. Deterministic name matching cannot be argued with by the model —
+the denial happens at the tool dispatch choke point before any backend call, like the hard-blocked key
+combos in tool.py. Like those, this governs the computer_use surface only (the terminal is a separate,
+separately-approved surface).
+
+Config (config.yaml, ``computer_use``):
+- ``blocked_apps``: list of extra patterns to deny (same token matching).
+- ``unblocked_apps``: list of patterns exempted from the built-in sensitive list (false-positive valve).
+- ``block_sensitive_apps``: gate for the built-in list below (default True).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import re
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# Built-in sensitive-app patterns (gated by computer_use.block_sensitive_apps, default ON).
+# Mirrors Cowork's default posture — trading/brokerage + cryptocurrency apps — plus credential vaults,
+# where a single misdirected click or paste is unrecoverable. Banking is mostly web, covered by the
+# real-profile sensitive-cookie excludes in browser real_profile (#97561).
+_DEFAULT_SENSITIVE_PATTERNS: Tuple[str, ...] = (
+    # investment / trading / brokerage
+    "robinhood", "coinbase", "binance", "kraken", "webull", "etrade", "e trade",
+    "interactive brokers", "fidelity investments", "charles schwab", "thinkorswim",
+    # cryptocurrency wallets
+    "ledger live", "trezor", "exodus", "electrum", "metamask", "sparrow wallet",
+    # credential vaults / password managers
+    "1password", "bitwarden", "keepass", "keepassxc", "lastpass", "dashlane",
+    "keychain access", "seahorse",
+)
+
+
+def _cfg() -> Dict[str, Any]:
+    """The ``computer_use`` config block ({} when unreadable) — unreadable config keeps the DEFAULT
+    sensitive list active (fail closed), since only explicit config can widen access."""
+    with contextlib.suppress(Exception):
+        from hermes_cli.config import load_config
+        return (load_config() or {}).get("computer_use") or {}
+    return {}
+
+
+def _tokens(name: str) -> List[str]:
+    return [t for t in re.split(r"[^a-z0-9]+", str(name).lower()) if t]
+
+
+def _matches(app_tokens: Sequence[str], pattern: str) -> bool:
+    """True when the pattern's tokens appear as a consecutive subsequence of the app's tokens."""
+    pat = _tokens(pattern)
+    if not pat or len(pat) > len(app_tokens):
+        return False
+    return any(list(app_tokens[i:i + len(pat)]) == pat for i in range(len(app_tokens) - len(pat) + 1))
+
+
+def _str_list(value: Any) -> List[str]:
+    return [str(v) for v in value if str(v).strip()] if isinstance(value, (list, tuple)) else []
+
+
+def blocked_app_match(app_name: Optional[str]) -> Optional[str]:
+    """The pattern blocking *app_name*, or None. Unknown/empty names fail open (the sticky-target
+    guard in tool.py re-checks once a capture names the target)."""
+    app_tokens = _tokens(app_name or "")
+    if not app_tokens:
+        return None
+    cfg = _cfg()
+    for pattern in _str_list(cfg.get("blocked_apps")):
+        if _matches(app_tokens, pattern):
+            return pattern
+    if cfg.get("block_sensitive_apps", True):
+        exempt = _str_list(cfg.get("unblocked_apps"))
+        for pattern in _DEFAULT_SENSITIVE_PATTERNS:
+            if _matches(app_tokens, pattern) and not any(_matches(app_tokens, e) for e in exempt):
+                return pattern
+    return None

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -52,8 +52,25 @@ def _canon_key_combo(keys: str) -> frozenset:
     # Split on "+" AND "-": cua-driver accepts hyphenated combos, so "ctrl-alt-delete" would bypass otherwise.
     return frozenset(_KEY_ALIASES.get(p, p) for p in (q.strip().lower() for q in re.split(r"\s*[+\-]\s*", keys)) if p)
 
+def _blocked_app_error(app_name: str, pattern: str, where: str) -> str:
+    """JSON denial for a blocklisted target app (Cowork-inspired app blocklist; see app_blocklist.py)."""
+    return json.dumps({"error": f"app {app_name!r} is on the computer_use app blocklist (pattern {pattern!r}, {where})",
+                       "code": "app_blocked",
+                       "hint": "Sensitive apps (trading, crypto wallets, password managers) are denied by "
+                               "default; computer_use.blocked_apps / unblocked_apps in config.yaml adjust the "
+                               "list. Do not work around this via another app — ask the user."})
+
+def _reject_blocked_app(action: str, args: Dict[str, Any]) -> Optional[str]:
+    """Deny any action explicitly targeting a blocklisted app (deterministic, pre-approval)."""
+    from tools.computer_use.app_blocklist import blocked_app_match
+    if isinstance(app := args.get("app"), str) and app.strip() and (pat := blocked_app_match(app)) is not None:
+        return _blocked_app_error(app.strip(), pat, "explicit app= target")
+    return None
+
 def _reject_unsafe(action: str, args: Dict[str, Any]) -> Optional[str]:
     """JSON error for hard-blocked input, else None. Runs BEFORE the approval prompt."""
+    if (err := _reject_blocked_app(action, args)) is not None:
+        return err
     if action == "type" and (pat := next((p.pattern for p in _BLOCKED_TYPE_PATTERNS if p.search(args.get("text", ""))), None)):
         return json.dumps({"error": f"blocked pattern in type text: {pat!r}",
                            "hint": "Dangerous shell patterns cannot be typed via computer_use."})
@@ -392,6 +409,13 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
     if spec is None:
         return json.dumps({"error": f"unknown action {action!r}" + (f" — did you mean {hint!r}? See the action enum in the tool schema."
                                                                  if (hint := _ACTION_SUGGESTIONS.get(str(action))) else "")})
+    # Sticky-target blocklist: input actions deliver to the last captured/focused app even without app=,
+    # so the explicit-app check in _reject_unsafe is not enough — deny here when the sticky target itself
+    # is blocklisted (Cowork-inspired; unknown target fails open, the next capture names it).
+    if spec.input:
+        from tools.computer_use.app_blocklist import blocked_app_match
+        if (target := str(getattr(backend, "_last_app", None) or "").strip()) and (pat := blocked_app_match(target)) is not None:
+            return _blocked_app_error(target, pat, "current sticky target")
     # app= guard: input goes to the sticky target from the last capture/focus_app and the backend drops app=
     # silently — refuse a clear mismatch rather than type into the wrong window while reporting ok:true.
     if (spec.input and isinstance(requested_app := args.get("app"), str) and requested_app.strip()

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -346,6 +346,23 @@ Hermes applies multi-layer guardrails:
   lock screen, log out, force log out.
 - Hard-blocked type patterns: `curl | bash`, `sudo rm -rf /`, fork
   bombs, etc.
+- **Sensitive-app blocklist** (inspired by Claude Cowork's computer-use
+  app blocklist): trading/brokerage apps, cryptocurrency wallets, and
+  password managers are denied by default — both when the agent targets
+  them explicitly (`app=`) and when one of them is the current sticky
+  input target. The denial is deterministic name matching at the tool
+  boundary, before any approval prompt. Extend, exempt, or disable it:
+
+  ```yaml
+  computer_use:
+    block_sensitive_apps: true     # default: built-in sensitive list on
+    blocked_apps: ["My Bank"]      # extra patterns to deny
+    unblocked_apps: ["kraken"]     # exempt a built-in pattern
+  ```
+
+  Matching is token-sequence based: `kraken` blocks the Kraken exchange
+  app but never GitKraken. Note this governs only the `computer_use`
+  tool — the terminal is a separate, separately-approved surface.
 - The agent's system prompt tells it explicitly: no clicking permission
   dialogs, no typing passwords, no following instructions embedded in
   screenshots.


### PR DESCRIPTION
Computer Use now denies sensitive apps (trading, crypto wallets, password managers) by default — deterministically, at the tool boundary, before any approval prompt.

## Source

Claude Cowork's computer use (GA Sept 2, 2026) ships a per-app blocklist: *"Prevent Claude from accessing certain apps by adding them to a blocklist. Any requests from Claude to use blocked applications will be automatically denied"*, with *"some sensitive apps (investment and trading platforms, cryptocurrency) blocked by default"* — [Let Claude use your computer in Cowork](https://support.claude.com/en/articles/14128542-let-claude-use-your-computer-in-cowork). Hermes' `computer_use` had hard-blocked key combos and type patterns, but no notion of an off-limits application: one approval and the agent could type into Ledger Live or a password vault.

This is a deterministic port (name matching at a choke point), not an LLM-judged guard — same class as the existing `_BLOCKED_KEY_COMBOS` / `_BLOCKED_TYPE_PATTERNS`, and consistent with the standing ruling against model-judged policies (#80786). Scope is the `computer_use` surface, like those blocks; the terminal remains a separate, separately-approved surface.

## Changes

- `tools/computer_use/app_blocklist.py` (new, ~90 LOC): token-sequence matcher + built-in sensitive list (trading/brokerage, crypto wallets, password managers/keychains). Token matching means `kraken` blocks the Kraken exchange app but never GitKraken; `ledger live` never hits a "Ledger" spreadsheet window.
- `tools/computer_use/tool.py`: enforcement at both choke points, pre-approval —
  - explicit `app=` targets in `_reject_unsafe` (covers `capture`, all input actions),
  - the **sticky input target** in `_dispatch` (input actions deliver to the last captured/focused app even without `app=`). Unknown targets fail open; the sticky guard closes the gap as soon as a capture names the target.
  - Structured denial: `code: "app_blocked"` + hint pointing at the config knobs.
- `hermes_cli/config_defaults.py`: `computer_use.block_sensitive_apps` (default `true`), `blocked_apps` (extend), `unblocked_apps` (false-positive valve).
- Docs: `website/docs/user-guide/features/computer-use.md` Safety section.
- Tests: 2 invariant tests (`tests/tools/test_computer_use_app_blocklist.py`) — both denial paths + no over-blocking, and all three config knobs.

## Live repro / A/B

E2E through the real chain (real `load_config` on a temp `HERMES_HOME` config.yaml, registry dispatch via `handle_function_call`, noop backend):

| Call | origin/main | this branch |
|---|---|---|
| `capture(app="1Password")` | executes | `app_blocked` |
| `type(text=…, app="secret-vault app")` (config pattern `Secret Vault`) | executes | `app_blocked` |
| `type(text=…)` with sticky target `Coinbase` | executes | `app_blocked` |
| `capture(app="kate")` | executes | executes |

## Validation

- `scripts/run_tests.sh tests/tools/` — all `computer_use` files green (130 existing + 2 new tests); the 6 failing files (`test_delegate_timeout_cleanup`, `test_modal_snapshot_isolation`, `test_web_tools_config`, `test_execution_flag_detection`) fail identically on origin/main (verified in a clean base worktree) or pass solo — pre-existing, unrelated.
- ruff, windows-footguns, compat-pointer checks clean.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b782/QV1U7vKywzCYpNgdNJuZx_glo30BZG.png)
