### PR TITLE
feat(skills): add mono-color — one/two-ink editorial print images (port of yanliudesign/mono-color-skill, 2.9k★ MIT)

### DIFF
--- a/optional-skills/creative/mono-color/LICENSE.txt
+++ b/optional-skills/creative/mono-color/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yan Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/optional-skills/creative/mono-color/SKILL.md
+++ b/optional-skills/creative/mono-color/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: mono-color
+description: "Generate one- or two-ink editorial print poster images."
+version: 1.0.0
+author: Yan Liu (adapted by Nous Research)
+license: MIT
+dependencies: []
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [design, poster, print, duotone, risograph, editorial, image-generation]
+    category: creative
+    related_skills: [baoyu-infographic, meme-generation, pixel-art]
+    upstream: https://github.com/yanliudesign/mono-color-skill
+---
+
+# Mono-Color Editorial Print Skill
+
+Turn any user theme, sentence, or reference photo into an original printed editorial artifact with one stable visual language: adaptive neutral substrate + one or two inks + mechanically reproduced image + typographic tension + concise human voice.
+
+This skill designs and generates the image; it does not imitate any one reference, copy a source composition, wording, logo, or artwork, and it never uses more than two printing inks.
+
+## When to Use
+
+The user asks for a monochrome editorial poster, duotone print, risograph/zine poster, halftone photo treatment, one-ink or two-ink cover, or names the mono-color style. Chinese trigger vocabulary includes 单色海报、双色印刷、单色调视觉、蓝色/绿色孔版印刷、网点照片、复古或当代编辑排版. Do not trigger merely because a request mentions a color.
+
+## Prerequisites
+
+- The Hermes `image_generate` tool (search/describe it via the deferred-tool catalog if not loaded). If image generation is unavailable, deliver prompt-only and say so.
+- The `design-system/` catalogs bundled with this skill (see Quick Reference).
+
+## Quick Reference
+
+Print modes:
+
+| Mode | When |
+|---|---|
+| Pure one-ink | User explicitly requests one ink, monochrome, or one named ink without a second color |
+| Chromatic ink + black | Quiet, observational, natural, architectural, long-form subjects; chromatic plate carries the image, carbon/charcoal carries text |
+| Complementary duotone | General default; dominant plate 70–85%, accent 15–30% with a specific role; fallback pair Cobalt + Terracotta `#2148B8` + `#C65F38` |
+| Overprint duotone | Two plates deliberately overlap; the darker mixed zone is not a third ink |
+
+Catalogs (source of truth — **when an exact value differs, the catalog wins over any prose**; read only the catalog relevant to the current decision):
+
+| File | Provides |
+|---|---|
+| `design-system/colors.json` | Substrate IDs + exact hex, one-ink palette, approved two-ink pairs |
+| `design-system/compositions.json` | Layout-family IDs and geometry |
+| `design-system/typography.json` | Type-hierarchy role IDs |
+| `design-system/rhythm.json` | Visual tension profiles, focal events, unresolved edges |
+| `design-system/imperfections.json` | Controlled print-imperfection effect IDs and ranges |
+| `design-system/carriers.json` | Carrier signals (poster, journal page, cover, etc.) |
+
+References:
+
+- `references/visual-language.md` — full color/space/image-treatment/typography/tone rules
+- `references/composition.md` — layout decision flow, layout families, composition grammar, rhythm
+- `references/quality-gate.md` — originality firewall, hard avoids, inspection checklist
+
+## Procedure
+
+1. **Read the input.** Extract five things:
+   - **Subject:** the one person, object, scene, or idea that must remain recognizable.
+   - **Intent:** poetic observation, announcement, field note, personal statement, cultural poster, or specimen page.
+   - **Words:** preserve exact supplied text verbatim in its original language — never translate or rewrite it. If no text is supplied, invent one English display phrase of 2–8 words and keep it stable across retries. Omit text only on explicit request.
+   - **Image role:** hero photograph, isolated specimen, cropped fragment, texture source, or none.
+   - **Representation:** faithful reproduction (default) or abstract symbol extraction (when the user asks for abstract, artistic, loose, experimental, less realistic, or less photographic treatment).
+
+   For a complex topic, pick one concrete visual metaphor; do not illustrate every point. If the user supplies an image, preserve its identity and factual content — crop/isolate/halftone it, never replace the subject or invent branded details.
+
+2. **Resolve the recipe manifest.** Fill every field; do not skip any and do not expose the manifest unless the user asks for process details. Look up IDs and exact values in `design-system/`.
+
+   ````yaml
+   subject: <one recognizable subject>
+   intent: <one intent from Input Reading>
+   exact_text: <user text, generated 2-8 word phrase, or none>
+   text_language: <language of supplied text, otherwise English>
+   representation: <faithful reproduction or abstract symbol extraction>
+   ratio: <explicit ratio or 3:4>
+   carrier: <one carrier ID from design-system/carriers.json or none>
+   substrate: <one substrate ID and exact hex from design-system/colors.json>
+   mode: <pure one-ink, chromatic + black, complementary duotone, or overprint duotone>
+   palette: <one palette ID from design-system/colors.json>
+   inks: <the palette's named ink or approved pair with exact hex values>
+   plate_roles: <one explicit role per ink plate>
+   layout: <one composition ID from design-system/compositions.json>
+   empty_paper: <explicit percentage>
+   visual_tension: <relaxed, balanced, or assertive from design-system/rhythm.json>
+   focal_event: <one strong visual event from design-system/rhythm.json>
+   release_zone: <one deliberately quiet region that gives the focal event room>
+   unresolved_edge: <one optional edge behavior from design-system/rhythm.json or none>
+   image_treatment: <one mechanical reproduction process>
+   type_hierarchy: <one role ID from design-system/typography.json>
+   disruption: <one deliberate disruption>
+   imperfection_seed: <stable hash derived from the resolved recipe>
+   imperfections: <0-2 restrained effect IDs for contemporary work, or 2-3 for tactile/vintage work>
+   ````
+
+   Defaults when the user hasn't chosen: ratio `3:4`; substrate Neutral White `#FAFAF7` (Cool Gray `#E9E9E5` for architecture/tech/restrained; Pale Beige `#F5F1E8` only for tactile/archival/nostalgic subjects — never assume beige merely because the work uses halftone or risograph language); mode complementary duotone with Cobalt + Terracotta; empty paper `35%`; tension `relaxed` for reflective/leisure/unspecified cultural subjects, `balanced` for editorial information, `assertive` only for forceful declarations; disruption = one off-center image crop, or one oversized word when there is no image. Explicit user choices override defaults unless they violate the two-ink limit or the originality firewall. Identical inputs must resolve to the identical manifest — never vary palette, layout, percentages, or process for novelty.
+
+   Resolve generic color words consistently: blue→Cobalt, green→Botanical Green, orange→Terracotta Orange, red→Signal Red, purple→Aubergine, black→Charcoal; green+black→Mint Green + Charcoal; blue+orange→Cobalt + Terracotta. Exact named inks always take precedence.
+
+3. **Choose the layout.** Walk the decision flow in `references/composition.md` top to bottom and take the first match (events→ruled information poster; botanical→archival plate; repeated object→object field; crossing layers→overprint collage; supplied photo→image field or editorial cover; isolated objects→specimen annotation; phrase-as-subject→type-led declaration; essay-like→editorial journal; otherwise editorial cover).
+
+4. **Compile the prompt** in five compact paragraphs, in order:
+   1. **Canvas and ink:** ratio, exact substrate hex and reason, exact one/two-ink palette hexes, print mode, plate roles, flat front-facing page (no mockup, frame, desk, or shadow).
+   2. **Original composition:** layout family, tension profile, one focal event, one release zone, margins (5–9%), empty-paper percentage (25–55%), grid, dominant object scale (45–80% of page) and edge crop, optional unresolved edge, one manual gesture.
+   3. **Subject:** what appears; for faithful reproduction, preservation/crop/halftone/paper exposure; for abstract extraction, the 2–4 identity anchors, dominant mass, structural contour, repeated rhythm, and where exposed paper cuts through.
+   4. **Typography and words:** hierarchy, type voices, exact short display text, and the explicit overlap/crossing/split/tight alignment between headline and dominant object.
+   5. **Material and avoids:** dots, fibers, bleed, misregistration, plus the hard negative constraints from `references/quality-gate.md`.
+
+   Describe only visible outcomes. Never mention reference artists, studios, sample posters, or "in the style of."
+
+5. **Generate and inspect.** Call `image_generate` with the compiled prompt. Inspect at full and thumbnail size against the checklist in `references/quality-gate.md`; regenerate once on failure (extra ink, missing plate roles, empty paper outside 25–55%, unrecognizable subject, no ≥5x type scale jump, garbled text, composition copying a reference, no identifiable focal event). If exact text still renders wrong after one retry, generate a text-light base image and state that typography should be overlaid in a layout tool — never pretend distorted text is correct.
+
+6. **Deliver.** Save outputs under `./mono-color-output/` in the user's working directory (create it if needed), or another location the user names. Present:
+   1. the generated image (path or rendered);
+   2. the final prompt in a fenced `text` block;
+   3. a short recipe note: Mode, Ink (exact hexes), Layout, Type (editorial + utility voice), Process, and one Originality sentence naming the structural departures from any supplied reference.
+
+   Stop at prompt-only only when the user explicitly asks or image generation is unavailable.
+
+## Pitfalls
+
+- **Never more than two printing inks.** The substrate is not an ink; overprint mixing and density variation are not extra inks. Gradients, rainbow accents, and full-color photography are always out.
+- **Catalog wins over prose.** When a hex, ID, range, or geometry in `design-system/` differs from any prose description, use the catalog value.
+- **Preserve supplied text verbatim** — original language, exact wording, no translation unless asked. Never distort microcopy or factual text with imperfection effects.
+- **Never copy a source composition, wording, logo, or artwork.** Change at least four structural features from any supplied reference (see the originality firewall). No fake signatures, mastheads, sponsors, URLs, or invented branding.
+- **Contemporary by default.** Do not add yellowed paper, sepia, distressed borders, or retro props merely because the work uses halftone or limited inks — only when the user asks for vintage/archival mood.
+- **One focal event, one release zone.** Never center everything, never distribute elements evenly like a template, never fill the quiet zone with decoration.
+
+## Verification
+
+- Manifest fully resolved, all IDs present in the `design-system/` catalogs.
+- Result uses one intentional white/gray/pale-beige substrate and ≤2 inks with clear plate roles.
+- 25–55% visibly empty paper; one dominant object at 45–80%; headline visibly crosses or locks to it.
+- Type hierarchy shows a 5–12x scale jump with ≤3 type voices.
+- Supplied subject and text preserved exactly; ≥4 structural features differ from every supplied reference.
+- An image was generated (unless prompt-only was requested) and saved under the output directory, and the recipe note was delivered.
+
+## Notice
+
+Upstream example artwork is not included: `examples/` in the source repo is all-rights-reserved (see upstream ASSET-LICENSE.md); only MIT-licensed text and design-system catalogs are vendored here. Code and text are MIT (see `LICENSE.txt`).

--- a/optional-skills/creative/mono-color/design-system/carriers.json
+++ b/optional-skills/creative/mono-color/design-system/carriers.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "carriers": [
+    {"id": "carrier_wall_poster", "name": "Wall poster", "ratios": ["3:4", "2:3"], "required_signals": ["poster edge or mounting context", "small date or venue tier"], "forbidden_signals": ["phone frame", "garment folds"]},
+    {"id": "carrier_zine", "name": "Bound zine", "ratios": ["3:4", "2:3"], "required_signals": ["binding or spine", "page edge or open spread"], "forbidden_signals": ["phone frame", "wall mounting"]},
+    {"id": "carrier_social_cover", "name": "Social cover", "ratios": ["3:4", "4:5"], "required_signals": ["screen-native crop", "one immediate headline tier"], "forbidden_signals": ["book binding", "garment folds"]},
+    {"id": "carrier_record_sleeve", "name": "Record or playlist sleeve", "ratios": ["1:1"], "required_signals": ["square sleeve geometry", "artist or track metadata"], "forbidden_signals": ["poster date hierarchy", "book binding"]},
+    {"id": "carrier_packaging", "name": "Packaging", "ratios": ["3:4", "1:1"], "required_signals": ["fold, seam, or label boundary", "product-scale information"], "forbidden_signals": ["floating poster sheet", "phone frame"]},
+    {"id": "carrier_merch", "name": "Garment merchandise", "ratios": ["3:4", "4:5"], "required_signals": ["fabric or garment silhouette", "print at wearable scale"], "forbidden_signals": ["floating poster sheet", "book binding"]},
+    {"id": "carrier_portfolio", "name": "Portfolio or exhibition", "ratios": ["3:4", "4:3"], "required_signals": ["book spread or exhibition wall", "caption or work label"], "forbidden_signals": ["phone chrome", "product nutrition panel"]}
+  ]
+}

--- a/optional-skills/creative/mono-color/design-system/colors.json
+++ b/optional-skills/creative/mono-color/design-system/colors.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "substrates": [
+    {"id": "substrate_neutral_white", "name": "Neutral White", "hex": "#FAFAF7", "role": "substrate", "counts_as_ink": false, "use_for": ["contemporary editorial", "culture", "events", "social", "image-led color"]},
+    {"id": "substrate_cool_gray", "name": "Cool Gray", "hex": "#E9E9E5", "role": "substrate", "counts_as_ink": false, "use_for": ["architecture", "technology", "charcoal-led systems", "restrained branding"]},
+    {"id": "substrate_pale_beige", "name": "Pale Beige", "hex": "#F5F1E8", "role": "substrate", "counts_as_ink": false, "use_for": ["tactile", "food", "travel", "intimate", "archive", "explicit nostalgia"]}
+  ],
+  "defaults": {
+    "substrate_id": "substrate_neutral_white",
+    "style_direction": "contemporary editorial",
+    "palette_id": "palette_cobalt_terracotta",
+    "mode": "controlled two-ink",
+    "dominant_percent": [70, 85],
+    "accent_percent": [15, 30],
+    "one_ink_when": ["explicit one-ink request", "explicit monochrome request", "one named ink without a second color"]
+  },
+  "inks": [
+    {"id": "ink_cobalt", "name": "Cobalt", "hex": "#2148B8", "moods": ["knowledge", "city", "music", "culture"]},
+    {"id": "ink_royal_blue", "name": "Royal Blue", "hex": "#2058D4", "moods": ["youth", "fashion", "movement"]},
+    {"id": "ink_botanical_green", "name": "Botanical Green", "hex": "#008A4B", "moods": ["botanical", "ecology", "archive"]},
+    {"id": "ink_mint_green", "name": "Mint Green", "hex": "#5EB783", "moods": ["observation", "nature", "quiet"]},
+    {"id": "ink_terracotta", "name": "Terracotta Orange", "hex": "#C65F38", "moods": ["travel", "summer", "food", "tactile"]},
+    {"id": "ink_signal_red", "name": "Signal Red", "hex": "#C83232", "moods": ["declaration", "music", "event", "civic"]},
+    {"id": "ink_aubergine", "name": "Aubergine", "hex": "#63365F", "moods": ["literature", "cinema", "night", "intimate"]},
+    {"id": "ink_charcoal", "name": "Charcoal", "hex": "#30343A", "moods": ["architecture", "photography", "research"]},
+    {"id": "ink_powder_blue", "name": "Powder Blue", "hex": "#9EB8D3", "moods": ["guide", "information"]},
+    {"id": "ink_oxblood", "name": "Oxblood", "hex": "#8F3434", "moods": ["bookstore", "archive", "natural wine"]},
+    {"id": "ink_electric_blue", "name": "Electric Blue", "hex": "#173AE3", "moods": ["culture", "contrast"]},
+    {"id": "ink_carbon", "name": "Carbon", "hex": "#242321", "moods": ["culture", "image-led"]},
+    {"id": "ink_mint_charcoal", "name": "Warm Charcoal", "hex": "#302D2E", "moods": ["journal", "essay"]},
+    {"id": "ink_ultramarine", "name": "Ultramarine", "hex": "#263E99", "moods": ["movement", "urban", "youth"]},
+    {"id": "ink_safety_orange", "name": "Safety Orange", "hex": "#E55D2B", "moods": ["movement", "object", "urban"]},
+    {"id": "ink_cyan", "name": "Cyan", "hex": "#159DDA", "moods": ["product", "playful", "exhibition"]},
+    {"id": "ink_brick_red", "name": "Brick Red", "hex": "#B64032", "moods": ["product", "playful", "exhibition"]},
+    {"id": "ink_tangerine", "name": "Tangerine", "hex": "#E46C2D", "moods": ["market", "festival", "notice"]},
+    {"id": "ink_slate_blue", "name": "Slate Blue", "hex": "#4773A5", "moods": ["market", "festival", "notice"]}
+  ],
+  "palettes": [
+    {"id": "palette_cobalt", "mode": "pure one-ink", "ink_ids": ["ink_cobalt"]},
+    {"id": "palette_terracotta", "mode": "pure one-ink", "ink_ids": ["ink_terracotta"]},
+    {"id": "palette_signal_red", "mode": "pure one-ink", "ink_ids": ["ink_signal_red"]},
+    {"id": "palette_aubergine", "mode": "pure one-ink", "ink_ids": ["ink_aubergine"]},
+    {"id": "palette_charcoal_signal_red", "mode": "chromatic + black", "ink_ids": ["ink_charcoal", "ink_signal_red"]},
+    {"id": "palette_cobalt_terracotta", "mode": "complementary duotone", "ink_ids": ["ink_cobalt", "ink_terracotta"]},
+    {"id": "palette_ultramarine_safety_orange", "mode": "overprint duotone", "ink_ids": ["ink_ultramarine", "ink_safety_orange"]},
+    {"id": "palette_botanical_oxblood", "mode": "complementary duotone", "ink_ids": ["ink_botanical_green", "ink_oxblood"]},
+    {"id": "palette_cyan_brick_red", "mode": "overprint duotone", "ink_ids": ["ink_cyan", "ink_brick_red"]},
+    {"id": "palette_mint_charcoal", "mode": "chromatic + black", "ink_ids": ["ink_mint_green", "ink_mint_charcoal"]}
+  ]
+}

--- a/optional-skills/creative/mono-color/design-system/compositions.json
+++ b/optional-skills/creative/mono-color/design-system/compositions.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "compositions": [
+    {"id": "composition_image_field", "layout": "image field", "dominant_subject_percent": [60, 80], "empty_paper_percent": [20, 40], "anchors": ["bottom", "side"], "title_relation": "crosses or is cut by the image", "manual_gesture_limit": 1},
+    {"id": "composition_specimen_annotation", "layout": "specimen annotation", "dominant_subject_percent": [45, 65], "empty_paper_percent": [35, 55], "anchors": ["center", "bottom"], "title_relation": "labels orbit one isolated specimen", "manual_gesture_limit": 1},
+    {"id": "composition_type_declaration", "layout": "type-led declaration", "dominant_subject_percent": [55, 80], "empty_paper_percent": [20, 45], "anchors": ["left", "top"], "title_relation": "type is the dominant object", "manual_gesture_limit": 1},
+    {"id": "composition_ruled_information", "layout": "ruled information poster", "dominant_subject_percent": [45, 65], "empty_paper_percent": [35, 55], "anchors": ["top", "left"], "title_relation": "headline and facts share one rule", "manual_gesture_limit": 1},
+    {"id": "composition_archival_plate", "layout": "archival plate", "dominant_subject_percent": [45, 60], "empty_paper_percent": [40, 55], "anchors": ["center", "bottom"], "title_relation": "small title indexes the plate", "manual_gesture_limit": 1},
+    {"id": "composition_editorial_cover", "layout": "editorial cover", "dominant_subject_percent": [55, 75], "empty_paper_percent": [25, 45], "anchors": ["bottom", "right"], "title_relation": "headline crosses the dominant crop", "manual_gesture_limit": 1},
+    {"id": "composition_object_field", "layout": "object field", "dominant_subject_percent": [50, 75], "empty_paper_percent": [25, 50], "anchors": ["center", "edge"], "title_relation": "title locks to repeated objects", "manual_gesture_limit": 1},
+    {"id": "composition_overprint_collage", "layout": "overprint collage", "dominant_subject_percent": [60, 80], "empty_paper_percent": [20, 40], "anchors": ["diagonal", "edge"], "title_relation": "title participates in one visible overprint collision", "manual_gesture_limit": 1},
+    {"id": "composition_editorial_journal", "layout": "editorial journal", "dominant_subject_percent": [45, 65], "empty_paper_percent": [35, 55], "anchors": ["top", "side"], "title_relation": "title sits inside the reading rhythm", "manual_gesture_limit": 1}
+  ]
+}

--- a/optional-skills/creative/mono-color/design-system/imperfections.json
+++ b/optional-skills/creative/mono-color/design-system/imperfections.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "selection": {
+    "contemporary_effect_count": [0, 2],
+    "material_effect_count": [2, 3],
+    "seed_strategy": "stable hash of subject, exact text, palette, and layout",
+    "preserve_across_retries": true
+  },
+  "effects": [
+    {
+      "id": "imperfection_ink_density",
+      "name": "Uneven ink density",
+      "range_percent": [6, 12],
+      "applies_to": ["image plate", "large display type", "solid shape"]
+    },
+    {
+      "id": "imperfection_dry_edge",
+      "name": "Dry-ink edge breakup",
+      "range_percent": [1, 4],
+      "applies_to": ["large display type", "image silhouette", "solid shape"]
+    },
+    {
+      "id": "imperfection_halftone_drift",
+      "name": "Halftone density drift",
+      "range_percent": [5, 10],
+      "applies_to": ["screened image", "halftone field"]
+    },
+    {
+      "id": "imperfection_registration_drift",
+      "name": "Registration drift",
+      "range_mm": [1, 3],
+      "applies_to": ["two-ink plate", "one-ink second impression"]
+    },
+    {
+      "id": "imperfection_broken_gesture",
+      "name": "Broken manual gesture",
+      "gap_percent": [4, 12],
+      "applies_to": ["loop", "underline", "arrow", "ruled gesture"]
+    }
+  ],
+  "guardrails": [
+    "Never alter supplied wording or factual information.",
+    "Never move the dominant object, headline anchor, or core grid.",
+    "Never reduce display-text readability below thumbnail scale.",
+    "Never create an additional ink color.",
+    "Apply registration drift only to image or display plates, never microcopy."
+  ]
+}

--- a/optional-skills/creative/mono-color/design-system/rhythm.json
+++ b/optional-skills/creative/mono-color/design-system/rhythm.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "default_profile": "tension_relaxed",
+  "focal_events": [
+    "oversized type",
+    "extreme subject crop",
+    "giant object or identifying detail",
+    "concentrated overprint collision",
+    "abnormal scale relationship"
+  ],
+  "release_devices": [
+    "open paper",
+    "pale halftone field",
+    "sparse support type",
+    "quiet alignment",
+    "low-detail image fade"
+  ],
+  "optional_unresolved_edges": [
+    "image fade before frame",
+    "inferable cropped word",
+    "broken alignment",
+    "open contour"
+  ],
+  "profiles": [
+    {
+      "id": "tension_relaxed",
+      "name": "Relaxed",
+      "empty_paper_percent": [25, 55],
+      "focal_event_count": 1,
+      "release_zone_count": 1,
+      "unresolved_edge": "optional",
+      "default_for": ["reflection", "travel", "summer", "leisure", "lifestyle", "unspecified cultural subject"],
+      "energy_distribution": "one audacious event, broad release, sparse support",
+      "subject_behavior": ["partial editorial crop", "ordinary in-between gesture", "identifying fragments", "indirect gaze or incomplete figure"]
+    },
+    {
+      "id": "tension_balanced",
+      "name": "Balanced",
+      "empty_paper_percent": [25, 50],
+      "focal_event_count": 1,
+      "release_zone_count": 1,
+      "unresolved_edge": "optional",
+      "default_for": ["event", "journal", "observation", "editorial information"],
+      "energy_distribution": "one clear event, structured support, readable release",
+      "subject_behavior": ["clear action", "controlled crop", "one dominant relationship"]
+    },
+    {
+      "id": "tension_assertive",
+      "name": "Assertive",
+      "empty_paper_percent": [20, 45],
+      "focal_event_count": 1,
+      "release_zone_count": 1,
+      "unresolved_edge": "optional",
+      "default_for": ["forceful declaration", "phrase-led subject", "high-contrast cultural event"],
+      "energy_distribution": "one dominant public gesture, compressed but subordinate support",
+      "subject_behavior": ["decisive crop", "public-facing gesture", "strong type-image collision"]
+    }
+  ],
+  "failure_signals": [
+    "safe headline-left complete-photo-right split",
+    "complete stock-photo person without a source image",
+    "equal emphasis across all elements",
+    "empty space filled with decorative microcopy",
+    "no focal event readable at thumbnail size"
+  ],
+  "guardrails": [
+    "Choose exactly one focal event and let every energetic secondary element extend it.",
+    "Keep one release zone visibly quieter than the focal event.",
+    "Do not confuse relaxed with uniformly small, pale, sparse, or low contrast.",
+    "Use an unresolved edge only when it strengthens the focal event or release zone.",
+    "Preserve the selected focal event and release zone across retries."
+  ]
+}

--- a/optional-skills/creative/mono-color/design-system/typography.json
+++ b/optional-skills/creative/mono-color/design-system/typography.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": 1,
+  "selection_rule": "Choose the role from content and verbal tone, not from a house-style default. Across a multi-image set, vary the display skeleton when the subjects differ; preserve one coherent hierarchy inside each image.",
+  "roles": [
+    {
+      "id": "type_literary",
+      "name": "Literary",
+      "display": "characterful old-style, transitional, or soft editorial serif; roman or italic",
+      "support": "small neutral grotesk or mono",
+      "scale_ratio": "6:1 to 12:1",
+      "behavior": ["sentence-like lowercase", "asymmetric natural line breaks", "tight leading", "may enter the image field"],
+      "use_for": ["reflection", "food", "tea", "books", "quiet lifestyle", "intimate observation"]
+    },
+    {
+      "id": "type_cultural_grotesk",
+      "name": "Cultural Grotesk",
+      "display": "wide geometric or neo-grotesk with assertive custom spacing",
+      "support": "compact grotesk or mono",
+      "scale_ratio": "8:1 to 16:1",
+      "behavior": ["letters may touch or optically interlock", "one word may span the page", "headline may overlay the image"],
+      "use_for": ["music", "youth culture", "fashion", "movement", "contemporary exhibitions"]
+    },
+    {
+      "id": "type_condensed_civic",
+      "name": "Condensed Civic",
+      "display": "heavy condensed or compressed grotesk",
+      "support": "plain grotesk or monospaced facts",
+      "scale_ratio": "8:1 to 14:1",
+      "behavior": ["stacked public headline", "date remains subordinate", "facts align to one strong edge"],
+      "use_for": ["event", "announcement", "public culture", "schedule"]
+    },
+    {
+      "id": "type_programmatic",
+      "name": "Programmatic",
+      "display": "medium grotesk or engineered modular sans",
+      "support": "tabular numerals, mono, or narrow information face",
+      "scale_ratio": "4:1 to 9:1",
+      "behavior": ["dates and numerals may become the anchor", "ruled clusters", "unequal information blocks", "bilingual-safe spacing"],
+      "use_for": ["festival program", "calendar", "research", "architecture", "multi-event information"]
+    },
+    {
+      "id": "type_rotated_display",
+      "name": "Rotated Display",
+      "display": "serif or grotesk selected for strong letter silhouettes",
+      "support": "small upright grotesk",
+      "scale_ratio": "10:1 to 20:1",
+      "behavior": ["one title rotates 90 degrees or runs vertically", "cropped words remain inferable", "orientation is the single disruption"],
+      "use_for": ["cover", "animal or object portrait", "fashion", "bold concept"]
+    },
+    {
+      "id": "type_handwritten_interjection",
+      "name": "Handwritten Interjection",
+      "display": "human handwritten phrase, quick script, or dry marker note used as a secondary voice",
+      "support": "clean sans or serif carries all factual information",
+      "scale_ratio": "2:1 to 6:1 relative to support type",
+      "behavior": ["one circled note or crossing phrase", "slight baseline irregularity", "never used for dates or essential facts"],
+      "use_for": ["invitation", "pool", "travel note", "social post", "personal aside"]
+    },
+    {
+      "id": "type_typographic_object",
+      "name": "Typographic Object",
+      "display": "oversized serif, grotesk, or abstracted letterforms chosen for the word shape",
+      "support": "minimal mono or plain grotesk",
+      "scale_ratio": "12:1 to 20:1",
+      "behavior": ["phrase is the dominant object", "one word may leave the page", "letters may split around or overprint the subject"],
+      "use_for": ["declaration", "poetry", "text-led cover", "single-word title"]
+    }
+  ],
+  "secondary_voice_rules": [
+    "Use one primary display skeleton per image; do not combine multiple novelty display faces.",
+    "A handwritten voice is optional and secondary, limited to one short phrase or annotation.",
+    "Choose at most one orientation event: rotated title, vertical stack, interlocked word, or handwritten interruption.",
+    "Within a multi-image series, consistency comes from ink, spacing, plate logic, and microtype discipline; display fonts may change with the content.",
+    "Never reproduce distinctive lettering, wording, or exact line breaks from a reference image."
+  ]
+}

--- a/optional-skills/creative/mono-color/references/composition.md
+++ b/optional-skills/creative/mono-color/references/composition.md
@@ -1,0 +1,64 @@
+# Composition: Decision Flow, Layout Families, Grammar, Rhythm
+
+When to load: while choosing the manifest's `layout`, `visual_tension`, `focal_event`, `release_zone`, and `unresolved_edge` fields, or writing the composition paragraph of the prompt. Geometry IDs live in `design-system/compositions.json` and `design-system/rhythm.json`; the catalog wins over this prose.
+
+## Space and Grid
+
+- Flat, front-facing paper canvas — no mockup, frame, desk, or cast shadow.
+- Default `3:4` vertical poster; respect a user-specified ratio.
+- Keep 25–55% of the canvas as visibly empty paper; generous outer margins of 5–9% of page width.
+- Align most elements to one invisible left edge or a simple 2–3 column editorial grid.
+- Create one deliberate disruption: a floating word, off-center image, oversized title, circular mark, or tiny annotation.
+- Never center every element; never distribute objects evenly like a template. Negative space is active pacing, not leftover room.
+
+## Composition Decision Flow
+
+Walk top to bottom; use the first matching rule unless the user explicitly requests a layout:
+
+1. Event, method, schedule, or factual announcement? → **ruled information poster**.
+2. Botanical, collected, or taxonomic subject? → **archival plate** (consider botanical green).
+3. One ordinary object explicitly requested as a repeated rhythm? → **object field**.
+4. Concept explicitly depends on two images/colors/type layers physically crossing? → **overprint collage** with overprint duotone.
+5. One supplied portrait or scene photograph?
+   - Faithful reproduction → **image field**.
+   - Abstract symbol extraction → **editorial cover** by default; **overprint collage** only when two extracted layers must physically cross.
+6. 1–3 supplied isolated objects intended for labels or comparison? → **specimen annotation**.
+7. The user's phrase itself is the main visual subject? → **type-led declaration**.
+8. Reflective, dated, or essay-like content with a primary photograph and readable text? → **editorial journal**.
+9. Otherwise → **editorial cover**.
+
+## Layout Families
+
+- **Image field:** large screened image crossing at least one page edge; headline overlaps or locks tightly to it; compact footer.
+- **Specimen annotation:** 1–3 isolated cutouts with numbered labels, one oversized phrase, asymmetric empty space.
+- **Type-led declaration:** headline controls the page; a smaller screened image interrupts or grounds it.
+- **Ruled information poster:** one dominant screened object/scene crossed by a headline; thin one-ink rules form one metadata band; the date stays subordinate.
+- **Archival plate:** title, one rectangular image plate, disciplined multi-column caption block.
+- **Editorial cover:** title near one edge, one dominant image zone, sparse issue-like microcopy, no fake masthead brand.
+- **Object field:** one recognizable object repeated at varied scale/crop/angle to form a printed rhythm; one open zone for title and facts.
+- **Overprint collage:** two ink plates carry separate object, image, geometric, or typographic layers and cross in selected zones — deliberate overlap, not everywhere.
+- **Editorial journal:** one primary screened photograph, a strong title or date, 2–3 disciplined text columns with real reading size and contrast.
+
+## Composition Grammar (Four Moves)
+
+Build every page from these, in the spirit of object-and-type construction rather than generic retro mood:
+
+1. **One object dominates.** One person, animal, ordinary object, or repeated specimen anchors the page at 45–80% of its area, cropped decisively at one or more edges when scale creates tension. No scattering of small atmospheric props. (A ruled information poster may reduce the image zone to 32–55% only when real supplied information needs the space. Dense overlap is allowed only in overprint collage and must still read as two printing plates.)
+2. **Type collides with the object.** One headline crosses, covers, splits around, or aligns tightly against the dominant image, staying readable. Never park every line in a detached safe zone above the image.
+3. **Paper cuts through the image.** Clipped highlights, irregular cutout gaps, halftone fade-outs, or plate knockouts make exposed paper a visible shape inside the composition, not only an outer margin.
+4. **One manual gesture interrupts the system.** One circled fact, hand-drawn line, registration mark, tiny symbol, rotated label, or ruled data strip — one gesture family only; multiple doodle styles turn the page into scrapbook decoration.
+
+Choose one dominant object and one dominant typographic event before adding secondary information. If either is missing, simplify rather than filling the page with mood-setting decoration.
+
+## Visual Tension and Uneven Energy
+
+Read `design-system/rhythm.json` whenever the user asks for relaxed, loose, effortless, casual, quiet, breezy, or understated work, or when the default intent maps to `relaxed`. Relaxation is a compositional decision, not a soft-focus mood — **uneven energy, not low energy**.
+
+For `relaxed` work choose exactly one strong focal event: oversized type, an extreme crop, one giant object or detail, a concentrated overprint collision, or one abnormal scale relationship. Let it feel decisive; then release the rest of the page with open paper, pale screening, sparse support type, or one quiet alignment. Do not make every element tasteful, small, or equally calm.
+
+- Keep 25–55% visibly empty paper, sized from the focal event rather than a fixed relaxed quota.
+- Display type may become large when it is the focal event; when the image or object is the focal event, type supports rather than competes.
+- One dominant collision or scale event; secondary elements may be energetic only when they extend that same event.
+- Avoid the safe split of headline on one side and a complete photograph on the other — the focal event must cross, crop, interrupt, or materially reorganize the page.
+- An unresolved edge (image fade, inferable cropped word, broken alignment, open contour) is optional; use one only when it strengthens the focal event, never as a decorative compliance mark.
+- At thumbnail size, the focal event must be immediately identifiable and the release zone visibly quieter.

--- a/optional-skills/creative/mono-color/references/quality-gate.md
+++ b/optional-skills/creative/mono-color/references/quality-gate.md
@@ -1,0 +1,63 @@
+# Quality Gate: Originality Firewall, Hard Avoids, Inspection
+
+When to load: before compiling the final prompt (avoids and firewall feed paragraph 5) and after each generation (inspection checklist and retry rules).
+
+## Originality Firewall
+
+A reference is evidence for a visual grammar, never a layout to trace. Before generation, change at least four of these from any supplied reference:
+
+- subject and crop; layout family; headline wording; headline location; image shape or count; grid structure; type pairing; metadata treatment; ratio; disruption device.
+
+Never reproduce a reference's exact object arrangement, line breaks, labels, dates, logos, border system, or distinctive slogan. Never include fake signatures or publication marks. If the user's source image contains protected or branded material, transform only the user's provided material and avoid presenting the result as an official artifact.
+
+## Hard Avoids
+
+Always exclude:
+
+- more than two printing inks, unassigned accent colors, gradients, rainbow accents, neon, or full-color photography;
+- clean vector-flat digital poster aesthetics;
+- beige lifestyle minimalism or a monochrome color wash;
+- glossy mockups, 3D depth, cinematic lighting, lens blur, hard shadows;
+- centered template symmetry, card grids, UI panels, stickers, decorative blobs;
+- scrapbook collage, uncontrolled overlap, grunge overload, torn-paper styling;
+- automatic vintage styling — yellowed paper, sepia aging, distressed borders, nostalgic props, retro type — merely because the image uses halftone or limited inks;
+- long paragraphs, marketing copy, CTA buttons, logos, URLs, QR codes;
+- exact imitation of a supplied poster or a recognizable artist signature.
+
+## Generation and Inspection
+
+1. Generate the image from the compiled prompt (Hermes `image_generate`).
+2. Inspect at full size and thumbnail size.
+3. Regenerate once when any of these fail:
+   - a one-ink composition shows a second ink, or a two-ink composition shows a third printing ink;
+   - a two-ink composition lacks clear plate roles, or the accent covers more than 30% without a subject-driven reason;
+   - the page reads as digitally color-graded rather than physically printed;
+   - empty paper falls outside 25–55%;
+   - the subject is unrecognizable;
+   - typography lacks a clear 5x or greater scale jump;
+   - long text is garbled or invented branding appears;
+   - the composition closely follows a supplied reference;
+   - a relaxed result has no immediately identifiable focal event or distributes equal emphasis across the whole page;
+   - a theme-only person becomes a complete stock-photo figure, or the page falls into a safe headline-left/photo-right split;
+   - the release zone is filled with decorative microcopy, gestures, or secondary focal points.
+4. If exact text renders incorrectly after one retry, generate a text-light base image and state that typography should be overlaid in a layout tool. Do not pretend distorted text is correct.
+
+## Final Quality Checklist
+
+- One intentionally selected white/gray/pale-beige substrate; no more than two printing inks.
+- Contemporary editorial by default; vintage/aged styling only when requested.
+- Two-ink work: each plate has a clear role; the accent remains controlled.
+- 25–55% of the page visibly empty.
+- Image reproduced through dots or mechanical print texture, not a color filter.
+- One object occupies 45–80% of the page (except a justified information-heavy layout).
+- Headline visibly crosses, covers, splits around, or locks tightly to the dominant object.
+- Exposed paper forms a visible shape inside the image (highlights, gaps, fade-outs, knockouts).
+- Exactly one manual gesture family; no mixed decorative doodle styles.
+- Type hierarchy: 5–12x scale jump, no more than three type voices.
+- Exactly one immediately identifiable focal event and one visibly quieter release zone.
+- Relaxed work concentrates energy in the focal event rather than reducing it everywhere.
+- With no source image, the figure feels observed in an ordinary in-between moment, not posed as an advertisement.
+- Page-filling type is the selected focal event while the remaining devices retreat.
+- Language is terse, specific, non-commercial; the user's supplied subject and text are preserved.
+- At least four structural features differ from every supplied reference.
+- An image was generated unless prompt-only was requested.

--- a/optional-skills/creative/mono-color/references/visual-language.md
+++ b/optional-skills/creative/mono-color/references/visual-language.md
@@ -1,0 +1,102 @@
+# Visual Language: Color, Image Treatment, Typography, Tone
+
+When to load: while resolving the manifest's substrate/palette/plate roles, writing image-treatment or typography prompt paragraphs, or inventing display text. Exact hex values and IDs live in `design-system/`; the catalog wins over this prose.
+
+## Color System
+
+Default to controlled two-ink. Give the dominant and accent plates separate content roles before composing; never use the second ink merely to decorate the page. Switch to pure one-ink only when the user explicitly requests one ink, monochrome, or one named ink without a second color. The paper substrate does not count as an ink.
+
+- **Substrate:** Neutral White `#FAFAF7` suits crisp cultural, social, event, and colorful image-led work; Cool Gray `#E9E9E5` suits architecture, technology, charcoal-led systems, restrained branding; Pale Beige `#F5F1E8` suits tactile, food, travel, intimate, archival, or explicitly nostalgic subjects.
+- **Contemporary default:** the substrate is clean and neutral, not yellowed. Halftone and plate logic describe reproduction, not an era. No fading, sepia, antique props, distressed borders, or aged-paper staining unless the user asks for retro/vintage/archival aging.
+- **Plate limit:** two assigned printing plates by default, never more than two; explicit one-ink requests use one plate.
+- **Ink density:** darker coverage may appear near-black and sparse halftones may appear pale — density changes, not extra inks.
+- **Paper exposure:** keep the paper visible. Never tint the whole page into a digital monochrome wash.
+
+### One-Ink Palette
+
+- **Cobalt / Ultramarine** `#2148B8` — default for technology, knowledge, cities, music, cultural subjects.
+- **Royal Blue** `#2058D4` — youth culture, fashion, movement, energetic editorial.
+- **Botanical Green** `#008A4B` — botanical, ecological, archival, explicitly green subjects.
+- **Mint Green** `#5EB783` — observation journals, soft natural subjects, quiet editorial photography.
+- **Terracotta Orange** `#C65F38` — classical art, food, travel, summer, tactile objects.
+- **Signal Red** `#C83232` — declarations, music, events, civic or public culture.
+- **Aubergine** `#63365F` — literature, cinema, night, intimate cultural subjects.
+- **Charcoal** `#30343A` — architecture, photography, research, restrained publications.
+
+### Two-Ink Recipes
+
+Use a known pair rather than improvising arbitrary colors:
+
+- **Powder Blue + Signal Red** `#9EB8D3` + `#C83232` — guides, announcements, information-heavy pages.
+- **Cobalt + Terracotta** `#2148B8` + `#C65F38` — travel, summer, food, lifestyle.
+- **Botanical Green + Oxblood** `#008A4B` + `#8F3434` — plants, natural wine, bookstores, archives.
+- **Charcoal + Signal Red** `#30343A` + `#C83232` — architecture, exhibitions, reports, conceptual work.
+- **Electric Blue + Carbon** `#173AE3` + `#242321` — high-contrast cultural events, image-led pages.
+- **Mint Green + Charcoal** `#5EB783` + `#302D2E` — journals, essays, observations, long-form reading.
+- **Ultramarine + Safety Orange** `#263E99` + `#E55D2B` — movement, objects, youth culture, active urban subjects.
+- **Cyan + Brick Red** `#159DDA` + `#B64032` — repeated products, exhibitions, playful information systems.
+- **Tangerine + Slate Blue** `#E46C2D` + `#4773A5` — markets, festivals, illustrated notices, large typographic compositions.
+
+Assign each plate a role before composing. These constraints keep the result mechanically printed rather than digitally color-graded.
+
+## Image Treatment
+
+Convert photographs and illustrations into the selected ink plate(s) plus substrate. Choose reproduction intensity from the subject instead of automatically aging every image:
+
+- crisp screening or clean plate separation for contemporary work; coarse halftone, risograph grain, cyanotype-like exposure, photocopy breakup, or newspaper screening only when materially useful or requested;
+- visible dots at close range, recognizable subject at thumbnail scale;
+- clipped highlights where paper shows through, dense shadows where ink pools;
+- optional mild ink bleed, uneven coverage, scan noise, paper fibers, or 1–2 mm registration drift between plates; fewer imperfections for contemporary/clean work;
+- medium contrast; no glossy photographic depth.
+
+When no source image is supplied, do not default to a polished photorealistic hero person or complete stock-photo figure. Prefer 2–4 identifying anchors (a hand on a handlebar, one bent leg, a wheel arc, loose fabric, hair direction). Build the subject from a partial editorial crop, simplified screened fragment, and one ordinary in-between gesture. Avoid advertising poses, victory gestures, athletic hero angles, catalog-style full bodies, and the safe headline-left/photo-right split unless asked.
+
+### Abstract Looseness
+
+When representation is `abstract symbol extraction`, transform the supplied image into a small visual vocabulary rather than filtering the whole photograph:
+
+1. Name 2–4 **identity anchors** that keep the subject recognizable; preserve their relationship, not their photographic detail.
+2. Convert the anchors into **one dominant mass**, **one structural contour**, and **one repeated rhythm** — flat plate shapes, broken hand-drawn lines, short strokes, dots, or paper cutouts; omit incidental scenery.
+3. Let paper replace at least 35% of the source scene. Crop one anchor at a page edge; let one type or line element cross it. Abstraction must create active space, not merely blur or posterize.
+4. Keep the abstract geometry deterministic; looseness comes only from slightly irregular contours, uneven repeated marks, and seeded controlled imperfections. Do not randomly move anchors between retries.
+5. At thumbnail scale, at least two identity anchors must still communicate the original subject without the caption.
+
+For complementary duotone abstraction: dominant ink carries structure and rhythm; accent ink is reserved for one identity anchor or one annotation — never distributed evenly.
+
+### Controlled Chance
+
+Keep composition, wording, palette, and hierarchy deterministic; introduce looseness only in the reproduction layer. Contemporary work: 0–2 restrained effects; tactile/vintage/archival work: 2–3 effects from `design-system/imperfections.json`, using a stable seed hashed from subject + exact text + palette + layout, preserved across retries.
+
+- Uneven ink density, dry-edge breakup, halftone drift, registration drift, or one broken manual gesture create the analog variation.
+- Apply variation to large type, image plates, solid shapes, or the single gesture family; never distort microcopy or factual text.
+- Keep all effect values inside catalog ranges; the same resolved input reproduces the same marks and offsets.
+- In one-ink work, registration drift may appear only as a pale second impression of the same ink — never another color.
+- Never use controlled chance to move the dominant object, change line breaks, alter the grid, or paper over an unresolved composition.
+
+## Typography
+
+Typography is a responsive cast, not a fixed house font. Read `design-system/typography.json` and choose one primary display skeleton from the subject, wording, and information structure — literary serif, wide cultural grotesk, compressed civic sans, engineered program type, rotated display, or word-as-object. Consistency across a set comes from ink, spacing, plate logic, and disciplined microtype, not from forcing every image into the same serif-plus-mono treatment.
+
+Role guide: Literary for intimate/quiet subjects; Cultural Grotesk for music and contemporary culture; Condensed Civic for public events; Programmatic when dates or structured facts lead; Rotated Display for bold covers; Handwritten Interjection only as a secondary human voice (never dates, locations, essential facts, or long copy); Typographic Object when the phrase itself is the image.
+
+Build each image with one primary display voice and one functional support voice; a third voice only as one short handwritten interjection. Choose at most one typographic behavior per image: natural lowercase sentence breaks (intimate); wide/interlocked capitals (music, movement, culture); compressed stacked lines (public events); tabular numerals with unequal ruled blocks (programs); one 90° rotation or vertical title (bold cover); one circled handwritten aside (invitation/personal note); oversized cropped letterforms (words as the dominant object). Do not repeat the same display category across every item of a multi-scene request unless the user asks for a unified campaign.
+
+Rules:
+
+- One dramatic scale jump: largest text 5–12x the microcopy size.
+- Lowercase for intimate statements, uppercase for public declarations.
+- Display copy 2–8 words; all other copy sparse.
+- Invented words default to natural English even when the request is in another language. Preserve user-supplied wording exactly; do not translate unless asked.
+- Exact readable wording only when supplied or concept-carrying; otherwise plausible microtype as texture — never invented organizations, URLs, sponsors, or event facts.
+- No gradient type, outline effects, drop shadows, inflated 3D letters, or generic luxury-fashion spacing.
+- Oversized type is valid only as the selected focal event; otherwise it stays subordinate to the image/object/crop/overprint event.
+- In relaxed work, one typographic move may be audacious while all supporting type becomes sparse and functional.
+- Never copy a reference's distinctive lettering, exact line breaks, or word arrangement — translate only the broader contrast, orientation, and voice relationship into an original solution.
+
+## Communication Tone
+
+Write like an independent cultural poster, field journal, or community print notice: terse, observant, romantic, free-spirited without sentimentality; human and specific rather than inspirational; quiet confidence, dry wit, or factual clarity; no sales language, CTA, hype, productivity slogans, or brand-manifesto voice.
+
+For summer, movement, travel, leisure, music, and night subjects, romantic freedom is the default register — expressed through a physical sensation, an open direction, an unhurried gesture, or a small relationship between subject and space. Favor fresh English fragments (an observation or invitation), never a generic motivational slogan. For factual, civic, scientific, or archival subjects, clarity overrides this romantic default.
+
+For romantic, intimate, nostalgic, or poetic prompts, express feeling through one observable relationship: two figures sharing one edge, an object carrying signs of use, a crop implying closeness, a small distance between forms. Do not default to string lights, wine glasses, fluttering fabric, stars, flowers, sunset silhouettes, or cinematic haze — those describe a romance category; a specific relationship creates romance while preserving graphic directness. Never reuse wording visible in reference images or repeat a stock phrase across unrelated outputs.

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -36,6 +36,7 @@ hermes skills uninstall <skill-name>
 | [**dynamic-workflow**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-dynamic-workflow) | Plan-in-code fan-outs, adversarial verification, waves. |
 | [**grok**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok) | Delegate coding to xAI Grok Build CLI (features, PRs). |
 | [**honcho**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho) | Configure and troubleshoot Honcho memory for Hermes. |
+| [**mono-color**](/docs/user-guide/skills/optional/creative/creative-mono-color) | Generate one- or two-ink editorial print poster images. |
 | [**openhands**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands) | Delegate coding to OpenHands CLI (model-agnostic, LiteLLM). |
 
 ## blockchain

--- a/website/docs/user-guide/skills/optional/creative/creative-mono-color.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-mono-color.md
@@ -1,0 +1,158 @@
+---
+title: "Mono Color — Generate one- or two-ink editorial print poster images"
+sidebar_label: "Mono Color"
+description: "Generate one- or two-ink editorial print poster images"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Mono Color
+
+Generate one- or two-ink editorial print poster images.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/creative/mono-color` |
+| Path | `optional-skills/creative/mono-color` |
+| Version | `1.0.0` |
+| Author | Yan Liu (adapted by Nous Research) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `design`, `poster`, `print`, `duotone`, `risograph`, `editorial`, `image-generation` |
+| Related skills | [`baoyu-infographic`](/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic), [`meme-generation`](/docs/user-guide/skills/optional/creative/creative-meme-generation), [`pixel-art`](/docs/user-guide/skills/optional/creative/creative-pixel-art) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Mono-Color Editorial Print Skill
+
+Turn any user theme, sentence, or reference photo into an original printed editorial artifact with one stable visual language: adaptive neutral substrate + one or two inks + mechanically reproduced image + typographic tension + concise human voice.
+
+This skill designs and generates the image; it does not imitate any one reference, copy a source composition, wording, logo, or artwork, and it never uses more than two printing inks.
+
+## When to Use
+
+The user asks for a monochrome editorial poster, duotone print, risograph/zine poster, halftone photo treatment, one-ink or two-ink cover, or names the mono-color style. Chinese trigger vocabulary includes 单色海报、双色印刷、单色调视觉、蓝色/绿色孔版印刷、网点照片、复古或当代编辑排版. Do not trigger merely because a request mentions a color.
+
+## Prerequisites
+
+- The Hermes `image_generate` tool (search/describe it via the deferred-tool catalog if not loaded). If image generation is unavailable, deliver prompt-only and say so.
+- The `design-system/` catalogs bundled with this skill (see Quick Reference).
+
+## Quick Reference
+
+Print modes:
+
+| Mode | When |
+|---|---|
+| Pure one-ink | User explicitly requests one ink, monochrome, or one named ink without a second color |
+| Chromatic ink + black | Quiet, observational, natural, architectural, long-form subjects; chromatic plate carries the image, carbon/charcoal carries text |
+| Complementary duotone | General default; dominant plate 70–85%, accent 15–30% with a specific role; fallback pair Cobalt + Terracotta `#2148B8` + `#C65F38` |
+| Overprint duotone | Two plates deliberately overlap; the darker mixed zone is not a third ink |
+
+Catalogs (source of truth — **when an exact value differs, the catalog wins over any prose**; read only the catalog relevant to the current decision):
+
+| File | Provides |
+|---|---|
+| `design-system/colors.json` | Substrate IDs + exact hex, one-ink palette, approved two-ink pairs |
+| `design-system/compositions.json` | Layout-family IDs and geometry |
+| `design-system/typography.json` | Type-hierarchy role IDs |
+| `design-system/rhythm.json` | Visual tension profiles, focal events, unresolved edges |
+| `design-system/imperfections.json` | Controlled print-imperfection effect IDs and ranges |
+| `design-system/carriers.json` | Carrier signals (poster, journal page, cover, etc.) |
+
+References:
+
+- `references/visual-language.md` — full color/space/image-treatment/typography/tone rules
+- `references/composition.md` — layout decision flow, layout families, composition grammar, rhythm
+- `references/quality-gate.md` — originality firewall, hard avoids, inspection checklist
+
+## Procedure
+
+1. **Read the input.** Extract five things:
+   - **Subject:** the one person, object, scene, or idea that must remain recognizable.
+   - **Intent:** poetic observation, announcement, field note, personal statement, cultural poster, or specimen page.
+   - **Words:** preserve exact supplied text verbatim in its original language — never translate or rewrite it. If no text is supplied, invent one English display phrase of 2–8 words and keep it stable across retries. Omit text only on explicit request.
+   - **Image role:** hero photograph, isolated specimen, cropped fragment, texture source, or none.
+   - **Representation:** faithful reproduction (default) or abstract symbol extraction (when the user asks for abstract, artistic, loose, experimental, less realistic, or less photographic treatment).
+
+   For a complex topic, pick one concrete visual metaphor; do not illustrate every point. If the user supplies an image, preserve its identity and factual content — crop/isolate/halftone it, never replace the subject or invent branded details.
+
+2. **Resolve the recipe manifest.** Fill every field; do not skip any and do not expose the manifest unless the user asks for process details. Look up IDs and exact values in `design-system/`.
+
+   ````yaml
+   subject: <one recognizable subject>
+   intent: <one intent from Input Reading>
+   exact_text: <user text, generated 2-8 word phrase, or none>
+   text_language: <language of supplied text, otherwise English>
+   representation: <faithful reproduction or abstract symbol extraction>
+   ratio: <explicit ratio or 3:4>
+   carrier: <one carrier ID from design-system/carriers.json or none>
+   substrate: <one substrate ID and exact hex from design-system/colors.json>
+   mode: <pure one-ink, chromatic + black, complementary duotone, or overprint duotone>
+   palette: <one palette ID from design-system/colors.json>
+   inks: <the palette's named ink or approved pair with exact hex values>
+   plate_roles: <one explicit role per ink plate>
+   layout: <one composition ID from design-system/compositions.json>
+   empty_paper: <explicit percentage>
+   visual_tension: <relaxed, balanced, or assertive from design-system/rhythm.json>
+   focal_event: <one strong visual event from design-system/rhythm.json>
+   release_zone: <one deliberately quiet region that gives the focal event room>
+   unresolved_edge: <one optional edge behavior from design-system/rhythm.json or none>
+   image_treatment: <one mechanical reproduction process>
+   type_hierarchy: <one role ID from design-system/typography.json>
+   disruption: <one deliberate disruption>
+   imperfection_seed: <stable hash derived from the resolved recipe>
+   imperfections: <0-2 restrained effect IDs for contemporary work, or 2-3 for tactile/vintage work>
+   ````
+
+   Defaults when the user hasn't chosen: ratio `3:4`; substrate Neutral White `#FAFAF7` (Cool Gray `#E9E9E5` for architecture/tech/restrained; Pale Beige `#F5F1E8` only for tactile/archival/nostalgic subjects — never assume beige merely because the work uses halftone or risograph language); mode complementary duotone with Cobalt + Terracotta; empty paper `35%`; tension `relaxed` for reflective/leisure/unspecified cultural subjects, `balanced` for editorial information, `assertive` only for forceful declarations; disruption = one off-center image crop, or one oversized word when there is no image. Explicit user choices override defaults unless they violate the two-ink limit or the originality firewall. Identical inputs must resolve to the identical manifest — never vary palette, layout, percentages, or process for novelty.
+
+   Resolve generic color words consistently: blue→Cobalt, green→Botanical Green, orange→Terracotta Orange, red→Signal Red, purple→Aubergine, black→Charcoal; green+black→Mint Green + Charcoal; blue+orange→Cobalt + Terracotta. Exact named inks always take precedence.
+
+3. **Choose the layout.** Walk the decision flow in `references/composition.md` top to bottom and take the first match (events→ruled information poster; botanical→archival plate; repeated object→object field; crossing layers→overprint collage; supplied photo→image field or editorial cover; isolated objects→specimen annotation; phrase-as-subject→type-led declaration; essay-like→editorial journal; otherwise editorial cover).
+
+4. **Compile the prompt** in five compact paragraphs, in order:
+   1. **Canvas and ink:** ratio, exact substrate hex and reason, exact one/two-ink palette hexes, print mode, plate roles, flat front-facing page (no mockup, frame, desk, or shadow).
+   2. **Original composition:** layout family, tension profile, one focal event, one release zone, margins (5–9%), empty-paper percentage (25–55%), grid, dominant object scale (45–80% of page) and edge crop, optional unresolved edge, one manual gesture.
+   3. **Subject:** what appears; for faithful reproduction, preservation/crop/halftone/paper exposure; for abstract extraction, the 2–4 identity anchors, dominant mass, structural contour, repeated rhythm, and where exposed paper cuts through.
+   4. **Typography and words:** hierarchy, type voices, exact short display text, and the explicit overlap/crossing/split/tight alignment between headline and dominant object.
+   5. **Material and avoids:** dots, fibers, bleed, misregistration, plus the hard negative constraints from `references/quality-gate.md`.
+
+   Describe only visible outcomes. Never mention reference artists, studios, sample posters, or "in the style of."
+
+5. **Generate and inspect.** Call `image_generate` with the compiled prompt. Inspect at full and thumbnail size against the checklist in `references/quality-gate.md`; regenerate once on failure (extra ink, missing plate roles, empty paper outside 25–55%, unrecognizable subject, no ≥5x type scale jump, garbled text, composition copying a reference, no identifiable focal event). If exact text still renders wrong after one retry, generate a text-light base image and state that typography should be overlaid in a layout tool — never pretend distorted text is correct.
+
+6. **Deliver.** Save outputs under `./mono-color-output/` in the user's working directory (create it if needed), or another location the user names. Present:
+   1. the generated image (path or rendered);
+   2. the final prompt in a fenced `text` block;
+   3. a short recipe note: Mode, Ink (exact hexes), Layout, Type (editorial + utility voice), Process, and one Originality sentence naming the structural departures from any supplied reference.
+
+   Stop at prompt-only only when the user explicitly asks or image generation is unavailable.
+
+## Pitfalls
+
+- **Never more than two printing inks.** The substrate is not an ink; overprint mixing and density variation are not extra inks. Gradients, rainbow accents, and full-color photography are always out.
+- **Catalog wins over prose.** When a hex, ID, range, or geometry in `design-system/` differs from any prose description, use the catalog value.
+- **Preserve supplied text verbatim** — original language, exact wording, no translation unless asked. Never distort microcopy or factual text with imperfection effects.
+- **Never copy a source composition, wording, logo, or artwork.** Change at least four structural features from any supplied reference (see the originality firewall). No fake signatures, mastheads, sponsors, URLs, or invented branding.
+- **Contemporary by default.** Do not add yellowed paper, sepia, distressed borders, or retro props merely because the work uses halftone or limited inks — only when the user asks for vintage/archival mood.
+- **One focal event, one release zone.** Never center everything, never distribute elements evenly like a template, never fill the quiet zone with decoration.
+
+## Verification
+
+- Manifest fully resolved, all IDs present in the `design-system/` catalogs.
+- Result uses one intentional white/gray/pale-beige substrate and ≤2 inks with clear plate roles.
+- 25–55% visibly empty paper; one dominant object at 45–80%; headline visibly crosses or locks to it.
+- Type hierarchy shows a 5–12x scale jump with ≤3 type voices.
+- Supplied subject and text preserved exactly; ≥4 structural features differ from every supplied reference.
+- An image was generated (unless prompt-only was requested) and saved under the output directory, and the recipe note was delivered.
+
+## Notice
+
+Upstream example artwork is not included: `examples/` in the source repo is all-rights-reserved (see upstream ASSET-LICENSE.md); only MIT-licensed text and design-system catalogs are vendored here. Code and text are MIT (see `LICENSE.txt`).

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -368,6 +368,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/creative/creative-impeccable',
                     'user-guide/skills/optional/creative/creative-kanban-video-orchestrator',
                     'user-guide/skills/optional/creative/creative-meme-generation',
+                    'user-guide/skills/optional/creative/creative-mono-color',
                     'user-guide/skills/optional/creative/creative-pixel-art',
                     'user-guide/skills/optional/creative/creative-pretext',
                     'user-guide/skills/optional/creative/creative-simple-english',


### PR DESCRIPTION
Ports **mono-color** (https://github.com/yanliudesign/mono-color-skill, MIT) as an optional creative skill: original one-ink / controlled two-ink editorial print images (risograph, duotone, halftone poster aesthetic) driven by machine-readable design-system catalogs.

## Why
- Trending: 2.9k★ in 3 weeks (created Aug 19), top-5 in the GH created-30d "skills" sweep two runs straight; professional designer author (Yan Liu) with versioned design-system JSON catalogs — unusually rigorous for a style skill.
- Distinct from our catalog: baoyu-infographic (info layouts), pixel-art, meme-generation — nothing covers editorial print/duotone poster design.

## Changes
- `optional-skills/creative/mono-color/` — SKILL.md (143-line hub), 3 `references/` (visual language, composition, quality gate), 6 `design-system/*.json` catalogs **vendored verbatim** (they're the source of truth; all parse), LICENSE.txt (MIT verbatim).
- Docs: generated page + one catalog row + one sidebar line (scoped).

## Key port decisions
| Decision | Detail |
|---|---|
| Asset license respected | Upstream `examples/` is **all-rights-reserved** (ASSET-LICENSE.md) and reference images are third-party copyrighted — none vendored; NOTICE added. MIT text + catalogs only |
| Hub restructure | Upstream 34 KB monolith → 143-line core (recipe manifest, mode/palette rules, prompt compiler) + 3 topic references with "When to load" lines |
| Rebind | Generation → `image_generate`; upstream hardcoded `~/Desktop/Claude skills/…` → neutral `./mono-color-output/` |
| Constraints 1:1 | Max two inks, exact-hex from catalogs, catalog-wins-over-prose, preserve user text verbatim, originality firewall |

## Validation
| Check | Result |
|---|---|
| All 6 design-system JSONs parse | ✅ |
| `scripts/run_tests.sh tests/skills/` | ✅ 1629 passed, 0 failed |
| `OptionalSkillSource().fetch("official/creative/mono-color")` | ✅ SkillBundle |
| windows-footguns / compat pointers / `git diff --check` | ✅ clean |
| Vendor-string audit incl. `Desktop/Claude` | ✅ attribution-only |

**License:** MIT (code/text); proprietary upstream artwork excluded. Credit: [@yanliudesign](https://github.com/yanliudesign).

## Infographic
![mono-color](https://v3b.fal.media/files/b/0aa9b799/WZj10gws3g8JLcB9da7FF_Nwj6zLCj.png)

DO NOT MERGE without Teknium's approval.
