### PR TITLE
fix(gateway): scoped ?profile= status query must not delete foreign gateway.pid/lock (#106406)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1442,25 +1442,54 @@ def planned_stop_marker_targets_self() -> bool:
 
 
 def get_running_pid(
-    pid_path: Optional[Path] = None, *, cleanup_stale: bool = True
+    pid_path: Optional[Path] = None,
+    *,
+    cleanup_stale: bool = True,
+    expected_home: Optional[Path | str] = None,
 ) -> Optional[int]:
-    """PID of a running gateway (lock + PID file verified against the live process), or None."""
+    """PID of a running gateway (lock + PID file verified against the live process), or None.
+
+    A scoped ``pid_path`` (another profile's ``gateway.pid``) reads that profile's identity
+    files: the record is validated against the target home (``expected_home``, defaulting to
+    ``pid_path.parent``) instead of this process's home, so a live foreign profile's record is
+    accepted rather than rejected as cross-profile poison — and a stale/mismatched record is never
+    ``cleanup_stale``-unlinked: a read-only status query must not destroy a foreign gateway's
+    ``gateway.pid``/``gateway.lock`` (#106406). ``resolve_gateway_liveness`` owns the scoped
+    runtime-status fallback (rung 3), so the lock-inactive scoped path returns None without it.
+    """
     resolved_pid_path = pid_path or _get_pid_path()
+    scoped = pid_path is not None
+    if expected_home is None and scoped:
+        expected_home = resolved_pid_path.parent
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     if is_gateway_runtime_lock_active(resolved_lock_path):
         records = (
-            _read_pid_record(resolved_pid_path), _read_gateway_lock_record(resolved_lock_path),
+            _read_pid_record(resolved_pid_path),
+            _read_gateway_lock_record(resolved_lock_path),
         )
         for record in records:
             pid = _live_pid_from_record(record)
-            if pid is None or not _pid_record_belongs_to_current_profile(record):
+            if pid is None:
                 continue
-            if _record_matches_live_gateway_pid(record, pid):
-                return pid
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
-        return get_runtime_status_running_pid() if pid_path is None else None
+            # Scoped read: validate the record against the target home, not this process's home
+            # (a named profile's record legitimately names a different HERMES_HOME than the serve
+            # process). Unscoped: keep the cross-profile guard (another home's record must not
+            # lend the default gateway its identity).
+            if scoped:
+                if recorded_gateway_home_conflicts(record, expected_home=expected_home):
+                    continue
+            elif not _pid_record_belongs_to_current_profile(record):
+                continue
+            if not _record_matches_live_gateway_pid(record, pid, expected_home=expected_home):
+                continue
+            return pid
+        # Never force-unlink foreign identity files on a scoped read (#106406).
+        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale and not scoped)
+        return None if scoped else get_runtime_status_running_pid()
     # Lock inactive: the runtime-status fallback runs BEFORE cleanup here.
-    runtime_pid = get_runtime_status_running_pid() if pid_path is None else None
+    if scoped:
+        return None
+    runtime_pid = get_runtime_status_running_pid()
     if runtime_pid is None:
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
     return runtime_pid

--- a/tests/gateway/test_status_scoped_pid_query.py
+++ b/tests/gateway/test_status_scoped_pid_query.py
@@ -1,0 +1,193 @@
+"""Scoped gateway status query regression tests (#106406).
+
+A scoped ``?profile=X`` status query reads ``<X>/gateway.pid`` to report whether
+profile X's gateway is running. Before #106406, ``get_running_pid`` validated that
+record against THIS (serve) process's ``HERMES_HOME`` and, on the mismatch,
+``cleanup_stale``-unlinked the foreign profile's ``gateway.pid``/``gateway.lock`` —
+turning a read-only status query into data destruction plus a wrong "not running"
+report.
+
+These tests pin the scoped contract:
+
+* a foreign profile's LIVE record is accepted (validated against the target home,
+  not the serve home) and its PID returned;
+* a third-profile POISON record inside the queried profile's dir is rejected;
+* neither case, nor an inactive lock, ever ``cleanup_stale``-unlinks the foreign
+  identity files — a scoped read is read-only.
+
+The unscoped path's stale-file cleanup is preserved as a regression guard so the
+fix does not silently relax the default gateway's poison-file housekeeping.
+
+Only process-inspection DEPENDENCIES (lock liveness, /proc readers) are faked;
+``get_running_pid`` itself runs unmocked.
+"""
+
+import json
+
+import pytest
+
+from gateway import status
+
+
+def _record(pid: int, hermes_home, *, start_time: int = 123, argv=None) -> dict:
+    return {
+        "pid": pid,
+        "kind": "hermes-gateway",
+        "argv": argv or ["python", "-m", "hermes_cli.main", "gateway", "run"],
+        "start_time": start_time,
+        "hermes_home": str(hermes_home),
+    }
+
+
+def _write_identity_files(home, pid_record: dict, *, lock_record=None) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "gateway.pid").write_text(json.dumps(pid_record))
+    if lock_record is not None:
+        (home / "gateway.lock").write_text(json.dumps(lock_record))
+
+
+@pytest.fixture
+def serve_home(tmp_path, monkeypatch):
+    """HERMES_HOME of the serve process issuing the scoped query (≠ the queried profile)."""
+    home = tmp_path / "serve-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _stub_live_process(monkeypatch, live_pid: int, cmdline: str):
+    """Fake /proc readers so ``live_pid`` looks like a running gateway with ``cmdline``."""
+    monkeypatch.setattr(status, "_pid_exists", lambda pid: pid == live_pid)
+    monkeypatch.setattr(
+        status,
+        "_get_process_start_time",
+        lambda pid: 123 if pid == live_pid else None,
+    )
+    monkeypatch.setattr(
+        status,
+        "_read_process_cmdline",
+        lambda pid: cmdline if pid == live_pid else None,
+    )
+
+
+@pytest.mark.skipif(
+    "sys.platform == 'win32'",
+    reason="POSIX profile-path semantics; real flock path covered elsewhere",
+)
+class TestScopedStatusQueryPreservesForeignFiles:
+    def test_scoped_returns_foreign_pid_without_unlinking(
+        self, tmp_path, serve_home, monkeypatch
+    ):
+        """A scoped query reports the foreign profile's live gateway and leaves its files intact."""
+        work_home = tmp_path / "root-home" / "profiles" / "work"
+        work_home.mkdir(parents=True)
+        foreign_pid = 4242
+        record = _record(foreign_pid, work_home)
+        _write_identity_files(work_home, record, lock_record=record)
+
+        monkeypatch.setattr(
+            status, "is_gateway_runtime_lock_active", lambda _lock_path: True
+        )
+        monkeypatch.setattr(status, "_read_pid_record", lambda _p: record)
+        monkeypatch.setattr(status, "_read_gateway_lock_record", lambda _p: record)
+        _stub_live_process(
+            monkeypatch, foreign_pid, "hermes --profile work gateway run"
+        )
+
+        pid_path = work_home / "gateway.pid"
+        result = status.get_running_pid(pid_path)
+
+        assert result == foreign_pid, (
+            "scoped query should report the foreign profile's live gateway"
+        )
+        assert pid_path.exists(), (
+            "scoped read must NOT unlink the foreign profile's gateway.pid (#106406)"
+        )
+        assert (work_home / "gateway.lock").exists(), (
+            "scoped read must NOT unlink the foreign gateway.lock (#106406)"
+        )
+
+    def test_scoped_third_profile_poison_returns_none_without_unlinking(
+        self, tmp_path, serve_home, monkeypatch
+    ):
+        """A third-profile poison record is rejected but its host files are never deleted."""
+        work_home = tmp_path / "root-home" / "profiles" / "work"
+        work_home.mkdir(parents=True)
+        third_home = tmp_path / "root-home" / "profiles" / "other"
+        third_home.mkdir(parents=True)
+        foreign_pid = 4242
+        # Poison: the record sitting inside work_home names a THIRD profile's home.
+        record = _record(foreign_pid, third_home)
+        _write_identity_files(work_home, record, lock_record=record)
+
+        monkeypatch.setattr(
+            status, "is_gateway_runtime_lock_active", lambda _lock_path: True
+        )
+        monkeypatch.setattr(status, "_read_pid_record", lambda _p: record)
+        monkeypatch.setattr(status, "_read_gateway_lock_record", lambda _p: record)
+        _stub_live_process(
+            monkeypatch, foreign_pid, "hermes --profile other gateway run"
+        )
+
+        pid_path = work_home / "gateway.pid"
+        result = status.get_running_pid(pid_path)
+
+        assert result is None, (
+            "a third-profile poison record must not be lent as work's gateway"
+        )
+        assert pid_path.exists(), (
+            "scoped read must NOT unlink even a poisoned foreign pid file (#106406)"
+        )
+        assert (work_home / "gateway.lock").exists(), (
+            "scoped read must NOT unlink the poisoned foreign lock (#106406)"
+        )
+
+    def test_scoped_inactive_lock_returns_none_without_unlinking(
+        self, tmp_path, serve_home, monkeypatch
+    ):
+        """A scoped query with an inactive foreign lock reports None and deletes nothing."""
+        work_home = tmp_path / "root-home" / "profiles" / "work"
+        work_home.mkdir(parents=True)
+        record = _record(4242, work_home)
+        _write_identity_files(work_home, record, lock_record=None)
+
+        monkeypatch.setattr(
+            status, "is_gateway_runtime_lock_active", lambda _lock_path: False
+        )
+        # A scoped query must not fall back to the (serve-process) runtime status.
+        monkeypatch.setattr(
+            status,
+            "get_runtime_status_running_pid",
+            lambda *a, **k: pytest.fail("scoped query must not consult runtime status"),
+        )
+
+        pid_path = work_home / "gateway.pid"
+        result = status.get_running_pid(pid_path)
+
+        assert result is None
+        assert pid_path.exists(), (
+            "scoped read with an inactive lock must NOT unlink the foreign pid file (#106406)"
+        )
+
+
+class TestUnscopedCleanupRegressionGuard:
+    def test_unscoped_stale_pid_file_is_still_cleaned_up(self, serve_home, monkeypatch):
+        """Regression guard: the unscoped default path still cleans up a stale pid file."""
+        stale_pid = 99998
+        record = _record(stale_pid, serve_home)
+        _write_identity_files(serve_home, record, lock_record=None)
+
+        monkeypatch.setattr(
+            status, "is_gateway_runtime_lock_active", lambda _lock_path: False
+        )
+        monkeypatch.setattr(
+            status, "get_runtime_status_running_pid", lambda *a, **k: None
+        )
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: False)
+
+        result = status.get_running_pid()
+
+        assert result is None
+        assert not (serve_home / "gateway.pid").exists(), (
+            "unscoped stale pid file SHOULD be cleaned up (existing behavior preserved)"
+        )


### PR DESCRIPTION
## Summary

Fixes #106406.

A scoped gateway status query (`GET /gateway/status?profile=work`, or any caller that passes another profile's `gateway.pid` path) turned a **read-only status check into data destruction** + a wrong "not running" report.

### Root cause

`get_running_pid` validated a scoped `pid_path`'s record against **this (serve) process's** `HERMES_HOME` via `_pid_record_belongs_to_current_profile`, which has no `expected_home` override. A live foreign profile's record legitimately names a *different* home, so it was rejected as cross-profile poison. The validation loop then exhausted and `_cleanup_invalid_pid_path(cleanup_stale=True)` **force-unlinked the foreign profile's `gateway.pid` AND `gateway.lock`**.

Two catastrophic effects from a single read-only `?profile=` query:
1. **misreport** — the queried profile reports "not running" while it actually is;
2. **data destruction** — the live foreign gateway's `gateway.lock` is deleted, breaking its identity checks / restart coordination.

The sibling `get_runtime_status_running_pid(expected_home=...)` (line 972) already handles this correctly: it skips the unscoped guard when scoped and validates via `_record_matches_live_gateway_pid(..., expected_home=...)`. `get_running_pid` did not.

### Fix

Follow the sibling pattern — seam-safe, no caller signature changes:

- Add `expected_home: Optional[Path | str] = None` kwarg to `get_running_pid`. When scoped (`pid_path is not None`) and `expected_home is None`, derive `expected_home = pid_path.parent` (the queried profile's home).
- For scoped reads, validate via `recorded_gateway_home_conflicts(record, expected_home=...)` (accepts the foreign record) instead of the unscoped `_pid_record_belongs_to_current_profile` guard.
- Gate `cleanup_stale` to `cleanup_stale and not scoped` — a scoped read is **read-only** and must never `unlink` foreign identity files.
- `resolve_gateway_liveness` already owns the scoped runtime-status fallback (rung 3, `probe_kwargs = {"expected_home": profile_dir} if scoped`), so the lock-inactive scoped path returns `None` without consulting runtime status.

**Unscoped behavior is unchanged** (`scoped = pid_path is not None`): the cross-profile poison guard and stale-file cleanup are preserved exactly — verified by the regression-guard test and the existing `test_cross_profile_kill_refusal.py` suite (82 passing, 2 platform-skipped).

## Why not #66691

#66691 only touches the **unscoped** runtime-status fallback and is stale (53 days, 0 comments, won't rebase against current main). It does **not** touch `get_running_pid`'s scoped `pid_path` path, so it cannot fix #106406's data-destruction. This PR addresses the scoped path the sibling already models.

## Test plan

New `tests/gateway/test_status_scoped_pid_query.py` — 4 tests:

| Test | Scoped? | Asserts |
|------|---------|---------|
| `test_scoped_returns_foreign_pid_without_unlinking` | yes | returns the foreign profile's live PID; `gateway.pid` + `gateway.lock` survive |
| `test_scoped_third_profile_poison_returns_none_without_unlinking` | yes | third-profile poison record rejected (returns None); files survive |
| `test_scoped_inactive_lock_returns_none_without_unlinking` | yes | inactive lock → None, no runtime-status fallback, files survive |
| `test_unscoped_stale_pid_file_is_still_cleaned_up` | no | regression guard: unscoped stale pid file IS cleaned up |

**Mutation-verified:** with the fix reverted to `main`, all 3 scoped tests **fail** (bug deletes foreign files / wrong result) and the unscoped guard **passes** (existing behavior preserved). With the fix, all 4 pass. Only process-inspection *dependencies* (lock liveness, `/proc` readers) are faked — `get_running_pid` runs unmocked.

```
$ pytest tests/gateway/test_status_scoped_pid_query.py tests/gateway/test_status.py tests/hermes_cli/test_cross_profile_kill_refusal.py -q
86 passed, 2 skipped in 4.96s
$ ruff check gateway/status.py tests/gateway/test_status_scoped_pid_query.py
All checks passed!
```

## Search-first

Confirmed no open or closed PR references #106406 and no PR matches `get_running_pid expected_home` (searched at PR-open time). The issue timeline has 0 cross-referenced PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
