### PR TITLE
fix(tui_gateway): surface interrupted clarify as timeout, not empty cancel-all

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -257,6 +257,65 @@ def test_live_session_payload_replays_pending_clarify(server):
     assert "pending_clarify" not in other
 
 
+def test_clear_pending_releases_clarify_interrupt_as_timeout(server):
+    """session.interrupt on a blocked clarify must surface as a timeout ("user
+    walked away"), not as an empty cancel-all the agent re-prompts forever."""
+    from tools.clarify_tool import TIMEOUT_RESPONSE
+
+    ev = threading.Event()
+    with server._prompt_lock:
+        server._pending["rid-q"] = ("runtime-session", ev)
+        server._pending_prompt_payloads["rid-q"] = ("clarify.request", {"question": "?"})
+
+    try:
+        server._clear_pending("runtime-session")
+    finally:
+        with server._prompt_lock:
+            server._pending.pop("rid-q", None)
+            server._pending_prompt_payloads.pop("rid-q", None)
+
+    assert ev.is_set()
+    assert server._answers.pop("rid-q", None) == TIMEOUT_RESPONSE
+
+
+def test_clear_pending_keeps_empty_answer_for_non_clarify_prompts(server):
+    """Other blocking prompts (secret/sudo/approval) keep the historical
+    empty-answer release contract on interrupt."""
+    ev = threading.Event()
+    with server._prompt_lock:
+        server._pending["rid-s"] = ("runtime-session", ev)
+        server._pending_prompt_payloads["rid-s"] = ("secret.request", {"env_var": "X"})
+
+    try:
+        server._clear_pending("runtime-session")
+    finally:
+        with server._prompt_lock:
+            server._pending.pop("rid-s", None)
+            server._pending_prompt_payloads.pop("rid-s", None)
+
+    assert ev.is_set()
+    assert server._answers.pop("rid-s", None) == ""
+
+
+def test_clear_pending_scoped_to_owning_session(server):
+    """session.interrupt must not collaterally cancel prompts owned by other
+    sessions sharing the same tui_gateway process."""
+    ev_other = threading.Event()
+    with server._prompt_lock:
+        server._pending["rid-o"] = ("other-session", ev_other)
+        server._pending_prompt_payloads["rid-o"] = ("clarify.request", {"question": "?"})
+
+    try:
+        server._clear_pending("runtime-session")
+    finally:
+        with server._prompt_lock:
+            server._pending.pop("rid-o", None)
+            server._pending_prompt_payloads.pop("rid-o", None)
+
+    assert not ev_other.is_set()
+    assert "rid-o" not in server._answers
+
+
 def test_disable_flush_env_var_actually_wires_to_module_constant(monkeypatch):
     """End-to-end: setting `HERMES_TUI_GATEWAY_NO_FLUSH=1` and importing
     `tui_gateway.transport` fresh actually flips `_DISABLE_FLUSH` true.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1358,12 +1358,22 @@ def _tour_request(sid: str, payload: dict) -> str:
 
 
 def _clear_pending(sid: str | None = None) -> None:
-    """Release pending prompts with an empty answer: only *sid*'s (session.interrupt must not cancel other
-    sessions' prompts), or every one when *sid* is None (shutdown)."""
+    """Release pending prompts: only *sid*'s (session.interrupt must not cancel other
+    sessions' prompts), or every one when *sid* is None (shutdown).
+
+    A clarify released by interrupt/shutdown is NOT a voluntary cancel: surface it to
+    the tool as the timeout sentinel ("user walked away") instead of empty answers the
+    agent re-prompts forever (boucle bug 08/09 — voir
+    /srv/docs/incidents/2026-09-08-boucle-clarify-liste-choix.md). Other prompt types
+    keep the historical empty-answer contract.
+    """
+    from tools.clarify_tool import TIMEOUT_RESPONSE
+
     with _prompt_lock:
         for rid, (owner_sid, ev) in list(_pending.items()):
             if sid is None or owner_sid == sid:
-                _answers[rid] = ""
+                event = _pending_prompt_payloads.get(rid, (None,))[0]
+                _answers[rid] = TIMEOUT_RESPONSE if event == "clarify.request" else ""
                 ev.set()
 
 


### PR DESCRIPTION
## Summary

When a `clarify` prompt is blocked and the user interrupts the turn (Stop/Échap), or the orphan reaper fires after a client disconnect, `_clear_pending` (`tui_gateway/server.py`) releases the pending prompt with an **empty answer**. `tools/clarify_tool._run_batch` treats any falsy reply as a voluntary cancel-all, so the agent receives `{"responses": [{"user_response": ""}, ...]}` **without** `timed_out` — indistinguishable from the user deliberately skipping. The LLM then does the natural thing: **re-prompts the same questions**, which blocks again, which the user interrupts again → an infinite user-visible loop.

Observed 3+ times in the field (07-08/09/2026): sessions stuck 2-5 min on clarify cards the user could not answer, then interrupted, then the agent re-posting the same questions.

## Fix

`_clear_pending` now distinguishes prompt types: a `clarify.request` released by interrupt/shutdown gets the canonical `TIMEOUT_RESPONSE` sentinel instead of `""`. `_run_batch` already maps that sentinel to `timed_out: true`, so the agent learns the user walked away and stops re-prompting.

Unchanged behavior:
- Voluntary cancel (Skip / Annuler button → `clarify.respond` with empty answer) still resolves as a plain cancel-all (`""`), per the existing contract.
- Other blocking prompt types (`secret.request`, `sudo.request`, `approval.request`) keep the historical empty-answer release.
- Interrupt release stays scoped to the owning session (no collateral cancellation of other sessions' prompts on the shared tui_gateway).

## Tests

3 invariants in `tests/tui_gateway/test_protocol.py`:
1. interrupt on a `clarify.request` → `_answers[rid]` carries `TIMEOUT_RESPONSE` (agent will see `timed_out: true`);
2. interrupt on a non-clarify prompt (`secret.request`) → `""` unchanged;
3. `_clear_pending(sid)` never touches prompts owned by another session.

## Verification

Live E2E on a self-hosted setup (backend `hermes serve` v0.21.1 + desktop app): interrupting a blocked clarify now returns `timed_out: true` in the tool result (previously: empty responses, no flag, re-prompt loop). Also confirmed by a separate reporter on #98503.

## Related

- #98503 — desktop clarify card never renders (transport routing): different surface bug (client-side), same "user cannot answer → interrupt → re-prompt" pain. This fix removes the re-prompt half server-side.
- #98645, #100132, #96718, #96766 — clarify rendering regressions on desktop.
