### PR TITLE
feat(matrix): render LaTeX math via Element data-mx-maths markup

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -581,6 +581,59 @@ def _scoped_recovery_key() -> str:
     return _startup_env_secret("MATRIX_RECOVERY_KEY")
 
 
+
+# --- LaTeX math ($...$, $$...$$) -> Element data-mx-maths markup ---
+# Element (feature_latex_maths) typesets <div|span data-mx-maths="TEX"> at display time.
+# Our sanitizer allowlists tags/attrs, so data-mx-maths cannot pass through HTML
+# sanitization directly. Instead, math is swapped for opaque sentinel tokens before
+# Markdown conversion (protecting TeX from escaping) and expanded back to math
+# markup after sanitization. Tokens are plain printable text with no special
+# HTML/Markdown meaning, so both the Markdown converter and the sanitizer
+# pass them through verbatim.
+_TEX_TOKEN_RE = re.compile(r"HERMESTEX(?:DISPLAY|INLINE)(\d+)HERMESTEXEND")
+_TEX_DISPLAY_TOKEN = "HERMESTEXDISPLAY%dHERMESTEXEND"
+_TEX_INLINE_TOKEN = "HERMESTEXINLINE%dHERMESTEXEND"
+
+
+def _latex_to_tokens(text: str) -> tuple[str, list[tuple[str, str]]]:
+    """Replace ``$$...$$``/``$...$`` with sentinel tokens.
+
+    Returns the tokenized text plus an ordered ``(tag, tex)`` store, where tag
+    is ``div`` for display math and ``span`` for inline math. Dollars that do
+    not form a pair (prices, literals) are left untouched.
+    """
+    if not text or "$" not in text:
+        return text, []
+    store: list[tuple[str, str]] = []
+
+    def _sub_display(match: re.Match[str]) -> str:
+        store.append(("div", match.group(1).strip()))
+        return _TEX_DISPLAY_TOKEN % (len(store) - 1)
+
+    def _sub_inline(match: re.Match[str]) -> str:
+        store.append(("span", match.group(1).strip()))
+        return _TEX_INLINE_TOKEN % (len(store) - 1)
+
+    text = re.sub(r"\$\$([^\n$]+?)\$\$", _sub_display, text)
+    text = re.sub(r"(?<![\\$\w])\$([^\n$]+?)\$(?!\w)", _sub_inline, text)
+    return text, store
+
+
+def _tokens_to_mx_maths(html: str, store: list[tuple[str, str]]) -> str:
+    """Expand sentinel tokens into ``data-mx-maths`` markup (TeX HTML-escaped)."""
+
+    def _expand(match: re.Match[str]) -> str:
+        idx = int(match.group(1))
+        if idx >= len(store):
+            # Not one of our tokens (user-typed text that collides with the
+            # sentinel format) — leave it verbatim.
+            return match.group(0)
+        tag, tex = store[idx]
+        escaped = _html_escape(tex, quote=True)
+        return f'<{tag} data-mx-maths="{escaped}">{escaped}</{tag}>'
+
+    return _TEX_TOKEN_RE.sub(_expand, html)
+
 def _sanitize_matrix_html(html: str) -> str:
     sanitizer = _MatrixHtmlSanitizer()
     try:
@@ -2752,6 +2805,8 @@ class MatrixAdapter(BasePlatformAdapter):
     def _markdown_to_html(self, text: str) -> str:
         """Markdown → org.matrix.custom.html via ``markdown`` when installed, else the regex fallback."""
         text = _pre_sanitize_matrix_markdown(text)
+        _tex_store = []
+        text, _tex_store = _latex_to_tokens(text)
         with suppress(ImportError):
             import markdown as _md
             md = _md.Markdown(extensions=["fenced_code", "tables", "nl2br", "sane_lists"])
@@ -2761,8 +2816,10 @@ class MatrixAdapter(BasePlatformAdapter):
             md.reset()
             if html.count("<p>") == 1:
                 html = html.replace("<p>", "").replace("</p>", "")
-            return _sanitize_matrix_html(html)
-        return _sanitize_matrix_html(self._markdown_to_html_fallback(text))
+            html = _tokens_to_mx_maths(_sanitize_matrix_html(html), _tex_store)
+            return html
+        _fb = _sanitize_matrix_html(self._markdown_to_html_fallback(text))
+        return _tokens_to_mx_maths(_fb, _tex_store)
 
     @staticmethod
     def _sanitize_link_url(url: str) -> str:

--- a/tests/gateway/test_matrix_latex_maths.py
+++ b/tests/gateway/test_matrix_latex_maths.py
@@ -1,0 +1,145 @@
+"""Tests for LaTeX math ($...$ / $$...$$) -> Element data-mx-maths markup."""
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+        },
+    )
+    return MatrixAdapter(config)
+
+
+# ---------------------------------------------------------------------------
+# _latex_to_tokens / _tokens_to_mx_maths unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLatexToTokens:
+    def setup_method(self):
+        from plugins.platforms.matrix.adapter import _latex_to_tokens
+
+        self.convert = _latex_to_tokens
+
+    def test_inline_math_becomes_span_token(self):
+        text, store = self.convert("Energy: $E = mc^2$ indeed.")
+        assert store == [("span", "E = mc^2")]
+        assert "E = mc^2" not in text
+        assert "$" not in text
+
+    def test_display_math_becomes_div_token(self):
+        text, store = self.convert("$$\\hat{H}\\Psi = E\\Psi$$")
+        assert store == [("div", "\\hat{H}\\Psi = E\\Psi")]
+
+    def test_mixed_math_all_captured(self):
+        # Display ($$...$$) is tokenized before inline ($...$), so store order
+        # follows regex pass order, not text order. Index-token correspondence
+        # is what matters.
+        text, store = self.convert("$a$ then $$b$$ then $c$")
+        assert sorted((tex, tag) for tag, tex in store) == [
+            ("a", "span"),
+            ("b", "div"),
+            ("c", "span"),
+        ]
+
+    def test_unpaired_dollars_untouched(self):
+        text, store = self.convert("Costs $5 or $10 today.")
+        assert store == []
+        assert text == "Costs $5 or $10 today."
+
+    def test_no_math_no_change(self):
+        text, store = self.convert("No math here.")
+        assert store == []
+        assert text == "No math here."
+
+    def test_backslash_dollar_not_math(self):
+        _, store = self.convert(r"Escaped \\$5 not math.")
+        assert store == []
+
+
+class TestTokensToMxMaths:
+    def setup_method(self):
+        from plugins.platforms.matrix.adapter import (
+            _latex_to_tokens,
+            _tokens_to_mx_maths,
+        )
+
+        self.tokenize = _latex_to_tokens
+        self.expand = _tokens_to_mx_maths
+
+    def test_inline_expansion(self):
+        tex = r"\psi(x)"
+        text, store = self.tokenize(f"Wave: ${tex}$")
+        html = self.expand(text, store)
+        assert html == f'Wave: <span data-mx-maths="{tex}">{tex}</span>'
+
+    def test_display_expansion(self):
+        text, store = self.tokenize("$$x^2$$")
+        html = self.expand(text, store)
+        assert 'data-mx-maths="x^2"' in html
+
+    def test_tex_is_html_escaped(self):
+        text, store = self.tokenize('$a<b & c>"d$')
+        html = self.expand(text, store)
+        assert "<b &" not in html
+        assert "data-mx-maths=" in html
+
+    def test_no_token_left_behind(self):
+        text, store = self.tokenize("$a$ $$b$$")
+        html = self.expand(text, store)
+        assert "HERMESTEX" not in html
+
+    def test_user_text_colliding_with_sentinel_is_safe(self):
+        # Adversarial literal that matches the sentinel format but has no
+        # matching store entry must pass through unchanged, not raise.
+        html = self.expand("HERMESTEXDISPLAY99HERMESTEXEND", [])
+        assert html == "HERMESTEXDISPLAY99HERMESTEXEND"
+
+    def test_mismatched_store_is_safe(self):
+        # Expansion with an empty store leaves unknown tokens alone
+        html = self.expand("HERMESTEXDISPLAY99HERMESTEXEND", [])
+        assert "data-mx-maths" not in html
+
+
+# ---------------------------------------------------------------------------
+# Integration through _markdown_to_html (the outbound pipeline)
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownToHtmlLatex:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_inline_math_reaches_formatted_html(self):
+        html = self.adapter._markdown_to_html("Wave: $\\psi(x) = e^{ikx}$ ok")
+        assert 'data-mx-maths="\\psi(x) = e^{ikx}"' in html
+        assert "HERMESTEX" not in html
+
+    def test_display_math_reaches_formatted_html(self):
+        html = self.adapter._markdown_to_html("$$\\hat{H}\\Psi = E\\Psi$$")
+        assert 'data-mx-maths="\\hat{H}\\Psi = E\\Psi"' in html
+
+    def test_markdown_formatting_still_applied(self):
+        html = self.adapter._markdown_to_html("**bold** with $x^2$")
+        assert "<strong>" in html
+        assert 'data-mx-maths="x^2"' in html
+
+    def test_dollar_amounts_not_converted(self):
+        html = self.adapter._markdown_to_html("Costs $5 or $10 today.")
+        assert "data-mx-maths" not in html
+
+    def test_math_inside_code_block_still_converted(self):
+        # Note: sentinel conversion happens before Markdown sees the text,
+        # so even code-span math becomes markup. Documented trade-off: the
+        # composer-style consumers (chat) rarely put $...$ in code spans.
+        html = self.adapter._markdown_to_html("Use `$x$` here.")
+        assert 'data-mx-maths="x"' in html


### PR DESCRIPTION
Element clients with the `feature_latex_maths` lab enabled typeset `<div|span data-mx-maths="TEX">` elements at **display time** — they do not scan message text for `$...$`. The Matrix gateway's outbound HTML sanitizer (`_MatrixHtmlSanitizer`) correctly allowlists tags and attributes, which means `data-mx-maths` markup can never survive the trip — so any message Hermes sends containing `$...$` shows up in Element as raw dollars.

This PR fixes that without weakening the sanitizer.

## What does this PR do?

Converts `$...$` (inline) and `$$...$$` (display) in outgoing Matrix messages to Element-compatible `<span|div data-mx-maths="TEX">` markup, so users with Element's LaTeX lab enabled see rendered equations instead of raw dollar signs.

Why this approach: the sanitizer's allowlist intentionally excludes `div`/`span`/`data-*` attributes, and relaxing it would widen the outbound HTML surface. Instead, the change works **around** sanitization, not through it:

1. Before Markdown conversion, `$...$`/`$$...$$` are swapped for opaque printable sentinel tokens. The tokens contain no HTML- or Markdown-special characters, so the Markdown converter and the sanitizer both pass them through verbatim — and the TeX inside them is never escaped or mangled.
2. After sanitization, tokens are expanded back to `data-mx-maths` markup, with the TeX HTML-escaped in both the attribute and the body.

Safety properties:

- Unpaired dollars (prices like `$5 or $10`, literals) are left untouched
- Expansion is index-checked: adversarial text that collides with the sentinel format (e.g. a user literally typing the token string) passes through verbatim instead of raising `IndexError` in the gateway
- No new dependencies; `_html_escape` was already imported at module level

Known trade-off (documented in the tests): tokenization precedes Markdown conversion, so `$...$` inside inline code spans is also converted. Chat composer input rarely puts `$...$` in code spans; skipping fenced/spanned code would require a pre-pass, which I've left out for simplicity but am happy to add if reviewers prefer.

## Related Issue

No issue exists yet — happy to file one if preferred. (Discovered while debugging why equations from the gateway rendered as raw `$...$` in Element Desktop 1.12.25 despite the client's `feature_latex_maths` lab being correctly enabled: Element's math rendering is send-time-tagged, not display-time-parsed, and the gateway never sent the tags.)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/matrix/adapter.py`
  - Added `_latex_to_tokens()` / `_tokens_to_mx_maths()` helpers plus sentinel-format constants (module level, near `_sanitize_matrix_html`)
  - Hooked both into `_markdown_to_html()` (both the `markdown`-library path and the regex fallback path)
- `tests/gateway/test_matrix_latex_maths.py` (new)
  - 17 tests: tokenization (inline/display/mixed/unpaired/escaped dollars), expansion (round-trip, HTML escaping, sentinel-collision safety), and integration through `_markdown_to_html`

## How to Test

1. `pytest tests/gateway/test_matrix_latex_maths.py -o 'addopts=' -q` → 17 passed
2. End-to-end: connect the Matrix gateway, enable Element's **Settings → Labs → Render LaTeX maths in messages**, and send a message through the gateway containing `Wave: $\psi(x) = e^{ikx}$` and a `$$...$$` display equation — both typeset in Element instead of showing raw dollars
3. Negative case: a message containing `Costs $5 or $10 today.` renders unchanged, with no markup and no conversion

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(verified all Matrix-gateway tests + new LaTeX suite; full suite not run locally — see note below)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (Container: Debian 13, Python 3.14)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python change, no platform-specific code; new tests pass on any POSIX dev setup and use no platform features)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool changes)

## For New Skills

(Deleted — not applicable.)

## Screenshots / Logs

Test run:

```
$ pytest tests/gateway/test_matrix_latex_maths.py -o 'addopts=' -q
.................                                                        [100%]
17 passed in 0.58s
```

No-regression check (failure set of the existing Matrix suite is byte-identical before/after; the 12 pre-existing failures are e2ee/connect tests requiring a live `mautrix[encryption]` install):

```
$ git stash && pytest tests/gateway/test_matrix.py -o 'addopts=' -q | grep FAILED | sort > /tmp/pristine.txt && git stash pop
$ pytest tests/gateway/test_matrix.py -o 'addopts=' -q | grep FAILED | sort > /tmp/patched.txt
$ diff /tmp/pristine.txt /tmp/patched.txt && echo IDENTICAL
IDENTICAL
```

Rendered output in Element (gateway sends `Wave: $\psi(x) = e^{ikx}$ and $$\hat{H}\Psi = E\Psi$$`):

Formatted HTML in the outgoing event:

```html
Wave: <span data-mx-maths="\psi(x) = e^{ikx}">\psi(x) = e^{ikx}</span> and
<div data-mx-maths="\hat{H}\Psi = E\Psi">\hat{H}\Psi = E\Psi</div>
```


### Note on local test coverage

All `tests/gateway/test_matrix*.py` plus the new suite were run locally. The
**full** `pytest tests/ -q` suite requires every optional dependency group
(mautrix, API-server extras, etc.) and was not run end-to-end in the dev
container; CI will be the authoritative full-suite run.
