### PR TITLE
fix(gateway): scoped PID queries validate against the probed home

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1457,7 +1457,8 @@ def get_running_pid(
     An explicit ``pid_path`` is a scoped query into that home's identity files: records are
     validated against the probed home (not the serve process's), and a live record is never
     cleanup-unlinked, so polling another profile must not delete its gateway.pid/gateway.lock
-    (#106406)."""
+    (#106406). The unscoped path keeps main's poison-file housekeeping: a live record owned by
+    another home inside this home's gateway.pid is unlinked on refusal (#89315)."""
     resolved_pid_path = pid_path or _get_pid_path()
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     if is_gateway_runtime_lock_active(resolved_lock_path):
@@ -1478,11 +1479,11 @@ def get_running_pid(
                 record, pid, expected_home=expected_home
             ):
                 return pid
-            # A live record we could not adopt may still be a real gateway: unlinking its
-            # identity files would break that home's double-run protection while the PID
-            # is alive, so leave cleanup to a poll after it dies.
+            # Scoped only: a live record we could not adopt may still be a real gateway;
+            # unlinking its identity files would break that home's double-run protection
+            # while the PID is alive. Unscoped keeps the #89315 poison-file cleanup.
             saw_live_pid = True
-        if not saw_live_pid:
+        if expected_home is None or not saw_live_pid:
             _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return get_runtime_status_running_pid() if pid_path is None else None
     # Lock inactive: the runtime-status fallback runs BEFORE cleanup here.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -450,6 +450,15 @@ def _pid_record_belongs_to_current_profile(record: Optional[dict[str, Any]]) -> 
     return not record_home or _same_hermes_home(record_home, _get_process_hermes_home())
 
 
+def _pid_record_matches_home(record: Optional[dict[str, Any]], expected_home: Path) -> bool:
+    """True when the record's ``hermes_home`` matches ``expected_home`` (legacy records: True).
+    Scoped queries validate against the probed home, not the serve process's."""
+    if not isinstance(record, dict):
+        return False
+    record_home = record.get("hermes_home")
+    return not record_home or _same_hermes_home(record_home, expected_home)
+
+
 def _build_runtime_status_record() -> dict[str, Any]:
     return {
         **_build_pid_record(), "gateway_state": "starting", "exit_reason": None,
@@ -1444,20 +1453,37 @@ def planned_stop_marker_targets_self() -> bool:
 def get_running_pid(
     pid_path: Optional[Path] = None, *, cleanup_stale: bool = True
 ) -> Optional[int]:
-    """PID of a running gateway (lock + PID file verified against the live process), or None."""
+    """PID of a running gateway (lock + PID file verified against the live process), or None.
+    An explicit ``pid_path`` is a scoped query into that home's identity files: records are
+    validated against the probed home (not the serve process's), and a live record is never
+    cleanup-unlinked, so polling another profile must not delete its gateway.pid/gateway.lock
+    (#106406)."""
     resolved_pid_path = pid_path or _get_pid_path()
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     if is_gateway_runtime_lock_active(resolved_lock_path):
         records = (
             _read_pid_record(resolved_pid_path), _read_gateway_lock_record(resolved_lock_path),
         )
+        expected_home = pid_path.parent if pid_path is not None else None
+        saw_live_pid = False
         for record in records:
             pid = _live_pid_from_record(record)
-            if pid is None or not _pid_record_belongs_to_current_profile(record):
+            if pid is None:
                 continue
-            if _record_matches_live_gateway_pid(record, pid):
+            home_ok = (
+                _pid_record_belongs_to_current_profile(record) if expected_home is None
+                else _pid_record_matches_home(record, expected_home)
+            )
+            if home_ok and _record_matches_live_gateway_pid(
+                record, pid, expected_home=expected_home
+            ):
                 return pid
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+            # A live record we could not adopt may still be a real gateway: unlinking its
+            # identity files would break that home's double-run protection while the PID
+            # is alive, so leave cleanup to a poll after it dies.
+            saw_live_pid = True
+        if not saw_live_pid:
+            _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return get_runtime_status_running_pid() if pid_path is None else None
     # Lock inactive: the runtime-status fallback runs BEFORE cleanup here.
     runtime_pid = get_runtime_status_running_pid() if pid_path is None else None

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -170,6 +170,70 @@ class TestGatewayPidState:
         (process_home / "gateway.pid").unlink(missing_ok=True)
 
 
+class TestScopedGatewayPidQuery:
+    """get_running_pid(pid_path) is a scoped query into another home's identity files (#106406):
+    records are validated against the probed home (not the serve process's) and a live record is
+    never cleanup-unlinked, so a scoped status poll must not delete a live foreign gateway's
+    gateway.pid/gateway.lock."""
+
+    def _write_scoped_profile(self, tmp_path):
+        profile_dir = tmp_path / "profiles" / "wiki"
+        profile_dir.mkdir(parents=True)
+        record = {
+            "pid": 4242,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "--profile", "wiki"],
+            "start_time": 123,
+            "hermes_home": str(profile_dir.resolve()),
+        }
+        pid_path = profile_dir / "gateway.pid"
+        pid_path.write_text(json.dumps(record))
+        (profile_dir / "gateway.lock").write_text(json.dumps(record))
+        return profile_dir, pid_path, record
+
+    def test_scoped_query_reports_live_foreign_profile_pid(self, tmp_path, monkeypatch):
+        # The serve process polls from the DEFAULT home; the live wiki record must still count.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default-home"))
+        profile_dir, pid_path, _ = self._write_scoped_profile(tmp_path)
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline",
+            lambda pid: "python -m hermes_cli.main gateway --profile wiki",
+        )
+        assert status.get_running_pid(pid_path) == 4242
+        assert pid_path.exists()
+        assert (profile_dir / "gateway.lock").exists()
+
+    def test_scoped_query_never_unlinks_live_foreign_identity(self, tmp_path, monkeypatch):
+        # Live PID whose record claims a THIRD home: not adoptable, but its identity files must
+        # survive the poll (double-run/takeover protection).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default-home"))
+        profile_dir, pid_path, record = self._write_scoped_profile(tmp_path)
+        # Both identity files migrate together in the real world; repoint both homes.
+        record["hermes_home"] = str((tmp_path / "elsewhere").resolve())
+        pid_path.write_text(json.dumps(record))
+        (profile_dir / "gateway.lock").write_text(json.dumps(record))
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+        assert status.get_running_pid(pid_path) is None
+        assert pid_path.exists()
+        assert (profile_dir / "gateway.lock").exists()
+
+    def test_scoped_query_still_cleans_dead_pid_record(self, tmp_path, monkeypatch):
+        # A dead PID's stale record is still cleanup-unlinked, scoped or not.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default-home"))
+        profile_dir, pid_path, _ = self._write_scoped_profile(tmp_path)
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: False)
+        assert status.get_running_pid(pid_path) is None
+        assert not pid_path.exists()
+        assert not (profile_dir / "gateway.lock").exists()
+
+
 class TestGatewayRuntimeStatus:
     def test_clear_profile_platforms_preserves_primary_entries(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

A scoped gateway status query (`?profile=<name>` on the dashboard, or any explicit `get_running_pid(pid_path)` caller) validated the PID/lock records against the **serve process's** HERMES_HOME instead of the probed home. Two consequences:

1. A live foreign profile's record was rejected ("not the current profile"), the loop found no PID, and `get_running_pid` fell through to `_cleanup_invalid_pid_path(..., cleanup_stale=True)`, **force-unlinking that profile's live `gateway.pid` + `gateway.lock`** on every poll — breaking its double-run/takeover protection. The dashboard also reported `running=false` for every scoped profile.
2. Fleet-style callers (`hermes_cli/gateway.py` profile scans with `cleanup_stale=False`) were spared the deletion but still got `None` for every live foreign gateway.

This makes `get_running_pid` scoping-aware, mirroring the sibling `get_runtime_status_running_pid(..., expected_home=...)` already used by the runtime-status rung of the same ladder:

- An explicit `pid_path` now validates records against the **probed home** (`pid_path.parent`, via the new `_pid_record_matches_home`) and passes `expected_home` into `_record_matches_live_gateway_pid` so the live-cmdline ownership check uses the right profile.
- A record whose PID is alive but cannot be adopted is **never cleanup-unlinked** — unlinking identity files of a possibly-real gateway while its PID is alive would break that home's double-run protection. Genuinely stale (dead-PID) records still clean up exactly as before.
- Unscoped (zero-arg) calls keep the `_pid_record_belongs_to_current_profile` path and are unaffected.

## Related Issue

Fixes #106406

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py`: added `_pid_record_matches_home` (record's `hermes_home` vs an explicit home, legacy records stay accepted) next to `_pid_record_belongs_to_current_profile`.
- `gateway/status.py`: `get_running_pid` derives `expected_home` from an explicit `pid_path`, uses it for record validation and the live-gateway match, and skips the cleanup-unlink when any live record was seen but not adopted.
- `tests/gateway/test_status.py`: new `TestScopedGatewayPidQuery` — live foreign profile reports its real PID (verified red on pre-fix code: returned `None` and deleted both identity files), live record with a third-home claim returns `None` **without** deleting `gateway.pid`/`gateway.lock`, and a dead-PID record is still cleanup-unlinked.

## How to Test

1. Unit: `PYTHONPATH=. python -m pytest tests/gateway/test_status.py -q` — Observed result: 77 passed, 2 skipped (includes the 3 new tests; the two live-foreign cases fail on pre-fix code with `None == 4242` and missing identity files).
2. Surrounding call sites: `pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_status.py tests/hermes_cli/test_gateway_multiplex_status.py tests/hermes_cli/test_gateway_proc_fallback.py tests/hermes_cli/test_subcommands_profile_gateway.py tests/hermes_cli/test_gateway_runtime_health.py -q` — Observed result: 62 passed, 5 skipped. Dashboard endpoints: `pytest tests/hermes_cli/test_dashboard_auth_status_endpoint.py tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_web_server.py -q` — Observed result: 219 passed, 1 skipped.
3. `ruff check gateway/status.py tests/gateway/test_status.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.contributing.com/Conventional Commits) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — two neighbors: #104113 (cross-profile probe deletion, no issue) keeps the probe returning `None` for foreign records and does not touch the scoped-misreport half; #106449 (filed 9 minutes before this PR, same issue #106406) landed while this fix was already in flight — it shares the `expected_home` approach but skips cleanup for **every** scoped read (dead-PID records included, so stale files linger); this PR keeps stale-record housekeeping on scoped reads, and 1c7343f9c0 restores main's unscoped poison-file cleanup on the #89315 contract so both PRs agree there. Happy to consolidate whichever direction maintainers prefer.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — record validation goes through `_same_hermes_home` (normcase-aware) and the live match reuses the existing `expected_home` machinery already exercised on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

