### PR TITLE
feat(orchestration): add configurable model-facing worker interfaces

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1062,6 +1062,16 @@ def _load_tools(agent, enabled_toolsets, disabled_toolsets):
     except Exception:
         agent._tool_snapshot_generation = 0
     import model_tools
+    raw_tool_defs = model_tools.get_tool_definitions(
+        enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
+        quiet_mode=agent.quiet_mode, skip_tool_search_assembly=True,
+    )
+    # Execution authority is the full scoped catalog.  ``agent.tools`` below is
+    # only the model-visible presentation and may collapse deferred tools into
+    # the tool-search bridge.
+    agent._executable_tool_names = {
+        tool["function"]["name"] for tool in raw_tool_defs if tool.get("function", {}).get("name")
+    }
     agent.tools = model_tools.get_tool_definitions(
         enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode,

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1062,6 +1062,17 @@ def _load_tools(agent, enabled_toolsets, disabled_toolsets):
     except Exception:
         agent._tool_snapshot_generation = 0
     import model_tools
+    from agent.worker_interfaces import (
+        bind_worker_interface, project_worker_tool_definitions, resolve_worker_interface,
+    )
+    from hermes_cli.config import load_config
+
+    # Resolve once per agent/session. A later config or qualification change is
+    # intentionally deferred to the next session so the tool schema/history
+    # vocabulary remains byte-stable for prompt caching and provider replay.
+    unresolved_worker_interface = resolve_worker_interface(
+        load_config() or {}, provider=agent.provider, model=agent.model
+    )
     raw_tool_defs = model_tools.get_tool_definitions(
         enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode, skip_tool_search_assembly=True,
@@ -1072,9 +1083,15 @@ def _load_tools(agent, enabled_toolsets, disabled_toolsets):
     agent._executable_tool_names = {
         tool["function"]["name"] for tool in raw_tool_defs if tool.get("function", {}).get("name")
     }
-    agent.tools = model_tools.get_tool_definitions(
-        enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
-        quiet_mode=agent.quiet_mode,
+    agent._worker_interface_selection = bind_worker_interface(
+        unresolved_worker_interface, raw_tool_defs
+    )
+    agent.tools = project_worker_tool_definitions(
+        model_tools.get_tool_definitions(
+            enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
+            quiet_mode=agent.quiet_mode,
+        ),
+        agent._worker_interface_selection,
     )
 
     agent.valid_tool_names = {tool["function"]["name"] for tool in agent.tools} if agent.tools else set()

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1064,15 +1064,13 @@ def _load_tools(agent, enabled_toolsets, disabled_toolsets):
     import model_tools
     from agent.worker_interfaces import (
         bind_worker_interface, project_worker_tool_definitions, resolve_worker_interface,
+        restore_worker_interface_contract,
     )
     from hermes_cli.config import load_config
 
     # Resolve once per agent/session. A later config or qualification change is
     # intentionally deferred to the next session so the tool schema/history
     # vocabulary remains byte-stable for prompt caching and provider replay.
-    unresolved_worker_interface = resolve_worker_interface(
-        load_config() or {}, provider=agent.provider, model=agent.model
-    )
     raw_tool_defs = model_tools.get_tool_definitions(
         enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
         quiet_mode=agent.quiet_mode, skip_tool_search_assembly=True,
@@ -1083,9 +1081,20 @@ def _load_tools(agent, enabled_toolsets, disabled_toolsets):
     agent._executable_tool_names = {
         tool["function"]["name"] for tool in raw_tool_defs if tool.get("function", {}).get("name")
     }
-    agent._worker_interface_selection = bind_worker_interface(
-        unresolved_worker_interface, raw_tool_defs
-    )
+    if agent.worker_interface_contract is not None:
+        agent._worker_interface_selection = restore_worker_interface_contract(
+            agent.worker_interface_contract,
+            provider=agent.provider,
+            model=agent.model,
+            definitions=raw_tool_defs,
+        )
+    else:
+        unresolved_worker_interface = resolve_worker_interface(
+            load_config() or {}, provider=agent.provider, model=agent.model
+        )
+        agent._worker_interface_selection = bind_worker_interface(
+            unresolved_worker_interface, raw_tool_defs
+        )
     agent.tools = project_worker_tool_definitions(
         model_tools.get_tool_definitions(
             enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
@@ -2183,6 +2192,8 @@ _PASSTHROUGH_PARAMS = (
     "enabled_toolsets", "disabled_toolsets",
     # Model response configuration (None = provider/model default)
     "max_tokens", "reasoning_config", "service_tier",
+    # Internal durable-worker presentation contract; no route or credential material.
+    "worker_interface_contract",
 )
 # Gateway identity params stored as ``agent._<name>``. gateway_session_key is the stable
 # per-chat key (e.g. agent:main:telegram:dm:123).
@@ -2236,6 +2247,7 @@ def init_agent(
     checkpoint_max_snapshots: int = 20, checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10, pass_session_id: bool = False,
     requested_provider: str = None, capabilities: Optional[Dict[str, bool]] = None,
+    worker_interface_contract: Optional[Dict[str, Any]] = None,
 ):
     """Initialize the AI Agent (body of :meth:`AIAgent.__init__`).
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2226,8 +2226,23 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
         )
         return result
     tool_start_time = time.monotonic()
+    from agent.worker_interfaces import is_worker_interface_tool
+
     inline_executor = resolve_invoke_tool_executor(agent, function_name)
-    if inline_executor is not None:
+    if is_worker_interface_tool(
+        getattr(agent, "_worker_interface_selection", None), function_name
+    ):
+        def _execute(next_args: dict) -> Any:
+            result = agent._dispatch_worker_interface(function_name, next_args)
+            emit_terminal_post_tool_call(
+                agent, function_name=function_name,
+                function_args=next_args if isinstance(next_args, dict) else function_args,
+                result=result, effective_task_id=effective_task_id, tool_call_id=tool_call_id,
+                duration_ms=int((time.monotonic() - tool_start_time) * 1000),
+                middleware_trace=_tool_middleware_trace,
+            )
+            return result
+    elif inline_executor is not None:
         inline_ctx = InlineToolContext(
             effective_task_id=effective_task_id, tool_call_id=tool_call_id, messages=messages
         )

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2246,15 +2246,17 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
-                worker_max_tool_calls=(
-                    __import__("agent.subagent_lifecycle", fromlist=["worker_tool_calls_remaining"])
-                    .worker_tool_calls_remaining(agent)
-                ),
                 skip_pre_tool_call_hook=True, skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 tool_request_middleware_trace=list(_tool_middleware_trace),
             )
+            worker_max_tool_calls = (
+                __import__("agent.subagent_lifecycle", fromlist=["worker_tool_calls_remaining"])
+                .worker_tool_calls_remaining(agent)
+            )
+            if worker_max_tool_calls is not None:
+                dispatch_kwargs["worker_max_tool_calls"] = worker_max_tool_calls
             if skip_tool_execution_middleware:
                 dispatch_kwargs["skip_tool_execution_middleware"] = True
             import model_tools

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2246,6 +2246,10 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                worker_max_tool_calls=(
+                    __import__("agent.subagent_lifecycle", fromlist=["worker_tool_calls_remaining"])
+                    .worker_tool_calls_remaining(agent)
+                ),
                 skip_pre_tool_call_hook=True, skip_tool_request_middleware=True,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -599,6 +599,7 @@ class _CodexResponseAssembler:
 
     def __init__(self, *, model, on_text_delta, on_reasoning_delta, on_commentary_message, on_first_delta):
         self.model, self.on_text_delta, self.on_reasoning_delta = model, on_text_delta, on_reasoning_delta
+        self.provider_reported_model = None
         self.on_commentary_message, self.on_first_delta = on_commentary_message, on_first_delta
         self.output_items: List[Any] = []
         # output_index / first-observed sequence per output item, in lockstep, so settled pending calls merge
@@ -706,6 +707,9 @@ class _CodexResponseAssembler:
         resp_obj = _event_field(event, "response")
         if resp_obj is not None:
             self.terminal_usage, self.terminal_response_id = _event_field(resp_obj, "usage"), _event_field(resp_obj, "id")
+            reported_model = _event_field(resp_obj, "model")
+            if isinstance(reported_model, str) and reported_model:
+                self.provider_reported_model = reported_model
             rstatus = _event_field(resp_obj, "status")
             if isinstance(rstatus, str):
                 self.terminal_status = rstatus
@@ -772,6 +776,7 @@ class _CodexResponseAssembler:
         return SimpleNamespace(
             output=output, output_text="".join(self.text_deltas), usage=self.terminal_usage, status=self.terminal_status,
             id=self.terminal_response_id, model=self.model, incomplete_details=self.terminal_incomplete_details,
+            _provider_reported_model=self.provider_reported_model,
             error=self.terminal_error)
 
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -925,7 +925,12 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     def _open_codex_stream(next_api_kwargs: dict[str, Any]):
         stream_kwargs = _sanitize_consumer_codex_request(agent, next_api_kwargs)
         stream_kwargs["stream"] = True
-        return active_client.responses.create(**_bypass_sdk_request_transform(stream_kwargs))
+        wire_kwargs = _bypass_sdk_request_transform(stream_kwargs)
+        from agent.subagent_lifecycle import before_worker_provider_attempt
+        before_worker_provider_attempt(agent)
+        from agent.worker_receipts import observe_worker_request
+        observe_worker_request(agent, wire_kwargs)
+        return active_client.responses.create(**wire_kwargs)
 
     def _log_failure(exc: BaseException) -> None:
         request_body_bytes, exception_chain = _codex_request_failure_details(exc)

--- a/agent/delegation_model_routing.py
+++ b/agent/delegation_model_routing.py
@@ -1,0 +1,227 @@
+"""Delegation model-profile resolver — operator-defined worker tiers for delegate_task.
+
+``delegation.profiles`` maps a profile name to a provider/model pin (plus optional
+reasoning_effort, max_iterations, fallback chain). This module is the single place profiles
+are parsed, validated, and resolved into an immutable :class:`ProfileRoute` that both
+``delegate_task`` and ``SubagentLifecycleService`` consume.
+
+Selection precedence (see docs/plans/2026-09-04-delegation-model-profiles.md):
+  per-task profile > top-level profile > ``delegation.default_profile`` > legacy
+  ``delegation.provider/model`` (this module returns no profile) > parent inherit.
+
+Design rules honored here:
+- Credentials resolve via ``hermes_cli.runtime_provider.resolve_runtime_provider`` — the exact
+  path the legacy ``delegation.provider`` branch uses. No duplicated credential logic.
+- Invalid ``reasoning_effort`` warns and is ignored (NS-696 clamp-at-transport doctrine), it
+  never rejects a profile.
+- Profiles never touch toolsets (#25752) — ``_PROFILE_KEYS`` is a closed set.
+- Imports of heavyweight collaborators are lazy (house style, avoids import cycles).
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_PROFILE_KEYS = frozenset({"provider", "model", "reasoning_effort", "max_iterations", "fallback"})
+_FALLBACK_ENTRY_KEYS = frozenset({"provider", "model"})
+
+
+@dataclass(frozen=True)
+class FallbackTarget:
+    """One provider/model pair in a profile's fallback chain."""
+    provider: str
+    model: str
+
+
+@dataclass(frozen=True)
+class ProfileSpec:
+    """A parsed-and-validated ``delegation.profiles`` entry (no credentials yet)."""
+    name: str
+    provider: str
+    model: str
+    reasoning_config: Optional[dict] = None      # parse_reasoning_effort output, None = inherit
+    max_iterations: Optional[int] = None
+    fallback: Tuple[FallbackTarget, ...] = ()
+
+
+@dataclass(frozen=True)
+class ProfileRoute:
+    """An immutable resolved route: profile spec + runtime-provider credentials."""
+    requested_profile: str
+    provider: Optional[str]
+    model: str
+    base_url: Optional[str]
+    api_key: Optional[str]
+    api_mode: Optional[str]
+    reasoning_config: Optional[dict] = None
+    max_iterations: Optional[int] = None
+    fallback: Tuple[FallbackTarget, ...] = ()
+    supports_tools: bool = True
+
+
+def _profiles_section(cfg: Optional[dict]) -> Any:
+    return ((cfg or {}).get("profiles"))
+
+
+def _parse_fallback(name: str, raw: Any) -> Tuple[FallbackTarget, ...]:
+    if raw in (None, ""):
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(
+            f"delegation.profiles.{name}.fallback must be a list of {{provider, model}} entries, "
+            f"got {type(raw).__name__}")
+    targets: List[FallbackTarget] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"delegation.profiles.{name}.fallback[{i}] must be a dict with provider + model, "
+                f"got {type(entry).__name__}")
+        unknown = set(entry) - _FALLBACK_ENTRY_KEYS
+        if unknown:
+            raise ValueError(
+                f"delegation.profiles.{name}.fallback[{i}] has unknown keys: {sorted(unknown)} "
+                f"(allowed: provider, model)")
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or not model:
+            raise ValueError(
+                f"delegation.profiles.{name}.fallback[{i}] needs both 'provider' and 'model'")
+        targets.append(FallbackTarget(provider=provider, model=model))
+    return tuple(targets)
+
+
+def _parse_profile(name: str, raw: Any) -> ProfileSpec:
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"delegation.profiles.{name} must be a mapping (provider/model/...), "
+            f"got {type(raw).__name__}")
+    unknown = set(raw) - _PROFILE_KEYS
+    if unknown:
+        raise ValueError(
+            f"delegation.profiles.{name} has unknown keys: {sorted(unknown)} "
+            f"(allowed: {sorted(_PROFILE_KEYS)})")
+    model = str(raw.get("model") or "").strip()
+    if not model:
+        raise ValueError(f"delegation.profiles.{name} is missing required 'model'")
+    provider = str(raw.get("provider") or "").strip()
+
+    # Reasoning effort: NS-696 clamp doctrine — invalid values warn and are ignored, never reject.
+    reasoning_config = None
+    effort = raw.get("reasoning_effort")
+    if effort or effort is False:
+        from hermes_constants import parse_reasoning_effort
+        reasoning_config = parse_reasoning_effort(effort)
+        if reasoning_config is None:
+            logger.warning(
+                "delegation.profiles.%s.reasoning_effort '%s' is not a recognized level; "
+                "ignoring it (child inherits the parent's reasoning level)", name, effort)
+
+    max_iterations = raw.get("max_iterations")
+    if max_iterations is not None:
+        if isinstance(max_iterations, bool) or not isinstance(max_iterations, int):
+            raise ValueError(
+                f"delegation.profiles.{name}.max_iterations must be an integer, "
+                f"got {type(max_iterations).__name__}")
+
+    return ProfileSpec(
+        name=name, provider=provider, model=model, reasoning_config=reasoning_config,
+        max_iterations=max_iterations, fallback=_parse_fallback(name, raw.get("fallback")),
+    )
+
+
+def parse_profiles(cfg: Optional[dict]) -> Dict[str, ProfileSpec]:
+    """Parse+validate ``delegation.profiles`` from the delegation config section.
+
+    Returns ``{}`` when no profiles are configured. Raises ``ValueError`` with an actionable
+    message on the first malformed profile (use :func:`profile_config_errors` to collect all).
+    """
+    raw = _profiles_section(cfg)
+    if not raw:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"delegation.profiles must be a mapping of name -> profile, got {type(raw).__name__}")
+    return {str(name): _parse_profile(str(name), spec) for name, spec in raw.items()}
+
+
+def profile_config_errors(cfg: Optional[dict]) -> List[str]:
+    """All profile config problems as messages (for ``hermes config check``); never raises."""
+    errors: List[str] = []
+    raw = _profiles_section(cfg)
+    specs: Dict[str, ProfileSpec] = {}
+    if raw and not isinstance(raw, dict):
+        errors.append(
+            f"delegation.profiles must be a mapping of name -> profile, got {type(raw).__name__}")
+    elif isinstance(raw, dict):
+        for name, spec in raw.items():
+            try:
+                specs[str(name)] = _parse_profile(str(name), spec)
+            except ValueError as exc:
+                errors.append(str(exc))
+    default_profile = str((cfg or {}).get("default_profile") or "").strip()
+    if default_profile and default_profile not in specs:
+        configured = ", ".join(sorted(specs)) or "(none)"
+        errors.append(
+            f"delegation.default_profile '{default_profile}' is not a configured profile "
+            f"(configured: {configured})")
+    return errors
+
+
+def select_profile_name(task_profile: Any, top_profile: Any, cfg: Optional[dict]) -> Optional[str]:
+    """The profile name that applies, by precedence: per-task > top-level > default_profile.
+
+    ``None`` = no profile applies (legacy ``delegation.provider/model`` or parent inherit take
+    over downstream). Falsy values (None/False/''/0) at any level fall through to the next.
+    """
+    for candidate in (task_profile, top_profile, (cfg or {}).get("default_profile")):
+        if candidate:
+            name = str(candidate).strip()
+            if name:
+                return name
+    return None
+
+
+def resolve_profile_route(name: str, cfg: Optional[dict], parent_agent: Any = None) -> ProfileRoute:
+    """Resolve profile *name* into an immutable :class:`ProfileRoute`.
+
+    Raises ``ValueError`` (before any child construction) for an unknown name, listing the
+    configured profile names. Credentials come from ``resolve_runtime_provider`` — the same
+    ladder the legacy ``delegation.provider`` branch uses.
+    """
+    specs = parse_profiles(cfg)
+    key = str(name or "").strip()
+    if key not in specs:
+        configured = ", ".join(sorted(specs)) or "(none configured)"
+        raise ValueError(
+            f"Unknown delegation profile '{key}'. Configured profiles: {configured}. "
+            f"Add it under delegation.profiles in config.yaml or pick a configured name.")
+    spec = specs[key]
+
+    # Lazy imports (house style — delegate_tool_config.py does the same) to avoid import cycles.
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    runtime = resolve_runtime_provider(
+        requested=spec.provider or None, target_model=spec.model) or {}
+
+    supports_tools = True
+    try:
+        from agent.models_dev import get_model_capabilities
+        caps = get_model_capabilities(spec.provider or "", spec.model)
+        if caps is not None:
+            supports_tools = bool(getattr(caps, "supports_tools", True))
+    except Exception as exc:  # capability metadata is advisory; never block resolution on it
+        logger.debug("Could not load model capabilities for profile '%s': %s", key, exc)
+
+    return ProfileRoute(
+        requested_profile=key,
+        provider=runtime.get("provider") or spec.provider or None,
+        model=spec.model,
+        base_url=runtime.get("base_url"),
+        api_key=runtime.get("api_key"),
+        api_mode=runtime.get("api_mode"),
+        reasoning_config=spec.reasoning_config,
+        max_iterations=spec.max_iterations,
+        fallback=spec.fallback,
+        supports_tools=supports_tools,
+    )

--- a/agent/delegation_model_routing.py
+++ b/agent/delegation_model_routing.py
@@ -1,4 +1,4 @@
-"""Delegation model-profile resolver — operator-defined worker tiers for delegate_task.
+"""Provider-independent worker profile parsing, discovery, and route resolution.
 
 ``delegation.profiles`` maps a profile name to a provider/model pin (plus optional
 reasoning_effort, max_iterations, fallback chain). This module is the single place profiles
@@ -12,20 +12,30 @@ Selection precedence (see docs/plans/2026-09-04-delegation-model-profiles.md):
 Design rules honored here:
 - Credentials resolve via ``hermes_cli.runtime_provider.resolve_runtime_provider`` — the exact
   path the legacy ``delegation.provider`` branch uses. No duplicated credential logic.
-- Invalid ``reasoning_effort`` warns and is ignored (NS-696 clamp-at-transport doctrine), it
-  never rejects a profile.
-- Profiles never touch toolsets (#25752) — ``_PROFILE_KEYS`` is a closed set.
+- Explicit invalid profile, model, and effort requests fail before a batch launches.
+- Discovery is config-only: it never resolves credentials or probes a provider.
+- Profile policy can only narrow the parent and backend capability sets downstream.
 - Imports of heavyweight collaborators are lazy (house style, avoids import cycles).
 """
 
-import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
-logger = logging.getLogger(__name__)
-
-_PROFILE_KEYS = frozenset({"provider", "model", "reasoning_effort", "max_iterations", "fallback"})
+_PROFILE_KEYS = frozenset({
+    "description", "instructions", "provider", "model", "reasoning_effort",
+    "tool_policy", "workspace_context", "execution_limits", "enabled_routes",
+    # Accepted legacy profile fields.
+    "max_iterations", "fallback",
+})
 _FALLBACK_ENTRY_KEYS = frozenset({"provider", "model"})
+_ROUTE_KEYS = frozenset({"provider", "model", "reasoning_effort"})
+_TOOL_POLICY_KEYS = frozenset({"allowed_toolsets", "blocked_tools", "allowed_tools", "allowed_mcp_tools"})
+_WORKSPACE_CONTEXT_KEYS = frozenset({"mode", "include_context_files", "include_memory"})
+_EXECUTION_LIMIT_KEYS = frozenset({
+    "max_iterations", "timeout_seconds", "max_followups", "max_tool_calls",
+})
+_ROUTING_MODES = frozenset({"profile_only", "dynamic"})
+_VALID_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"})
 
 
 @dataclass(frozen=True)
@@ -36,14 +46,55 @@ class FallbackTarget:
 
 
 @dataclass(frozen=True)
+class EnabledRoute:
+    """One operator-approved route available inside a worker profile."""
+    provider: str
+    model: str
+    reasoning_effort: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ToolPolicy:
+    """Requested tool narrowing. ``None`` means inherit the parent/toolset ceiling."""
+    allowed_toolsets: Optional[Tuple[str, ...]] = None
+    blocked_tools: Tuple[str, ...] = ()
+    allowed_tools: Optional[Tuple[str, ...]] = None
+    allowed_mcp_tools: Optional[Tuple[str, ...]] = None
+
+
+@dataclass(frozen=True)
+class WorkspaceContextPolicy:
+    """Startup-only context policy; it never mutates an active conversation prompt."""
+    mode: str = "inherit"
+    include_context_files: Optional[bool] = None
+    include_memory: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class ExecutionLimits:
+    """Profile ceilings. Runtime-wide and parent ceilings are applied after these values."""
+    max_iterations: Optional[int] = None
+    timeout_seconds: Optional[float] = None
+    max_followups: Optional[int] = None
+    max_tool_calls: Optional[int] = None
+
+
+@dataclass(frozen=True)
 class ProfileSpec:
     """A parsed-and-validated ``delegation.profiles`` entry (no credentials yet)."""
     name: str
     provider: str
     model: str
+    description: str = ""
+    instructions: str = ""
+    reasoning_effort: Optional[str] = None
     reasoning_config: Optional[dict] = None      # parse_reasoning_effort output, None = inherit
     max_iterations: Optional[int] = None
     fallback: Tuple[FallbackTarget, ...] = ()
+    tool_policy: ToolPolicy = ToolPolicy()
+    workspace_context: WorkspaceContextPolicy = WorkspaceContextPolicy()
+    execution_limits: ExecutionLimits = ExecutionLimits()
+    enabled_routes: Tuple[EnabledRoute, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -59,10 +110,196 @@ class ProfileRoute:
     max_iterations: Optional[int] = None
     fallback: Tuple[FallbackTarget, ...] = ()
     supports_tools: bool = True
+    requested_provider: Optional[str] = None
+    requested_model: Optional[str] = None
+    requested_reasoning_effort: Optional[str] = None
+    resolved_reasoning_effort: Optional[str] = None
+    transmitted_model: Optional[str] = None
+    provider_reported_model: Optional[str] = None
+    tool_policy: ToolPolicy = ToolPolicy()
+    workspace_context: WorkspaceContextPolicy = WorkspaceContextPolicy()
+    execution_limits: ExecutionLimits = ExecutionLimits()
 
 
 def _profiles_section(cfg: Optional[dict]) -> Any:
     return ((cfg or {}).get("profiles"))
+
+
+def _text(value: Any, *, field: str, max_chars: int = 16_000) -> str:
+    if value in (None, ""):
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string, got {type(value).__name__}")
+    if len(value) > max_chars:
+        raise ValueError(f"{field} must be at most {max_chars} characters")
+    return value.strip()
+
+
+def _string_tuple(value: Any, *, field: str, optional: bool = False) -> Optional[Tuple[str, ...]]:
+    if value is None and optional:
+        return None
+    if value in (None, ""):
+        return ()
+    if not isinstance(value, (list, tuple)) or any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ValueError(f"{field} must be a list of non-empty strings")
+    return tuple(dict.fromkeys(item.strip() for item in value))
+
+
+def _parse_effort(value: Any, *, field: str) -> Tuple[Optional[str], Optional[dict]]:
+    if value is None or value == "":
+        return None, None
+    if value is False:
+        normalized = "none"
+    elif not isinstance(value, str):
+        raise ValueError(f"{field} must be one of {sorted(_VALID_EFFORTS)}")
+    else:
+        normalized = value.strip().lower()
+    if normalized not in _VALID_EFFORTS:
+        raise ValueError(f"{field} '{value}' is not valid (allowed: {', '.join(sorted(_VALID_EFFORTS))})")
+    from hermes_constants import parse_reasoning_effort
+    return normalized, parse_reasoning_effort(normalized)
+
+
+def _positive_int(value: Any, *, field: str, allow_zero: bool = False) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < (0 if allow_zero else 1):
+        qualifier = "a non-negative" if allow_zero else "a positive"
+        raise ValueError(f"{field} must be {qualifier} integer")
+    return value
+
+
+def _positive_number(value: Any, *, field: str) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ValueError(f"{field} must be a positive number")
+    return float(value)
+
+
+def _parse_tool_policy(name: str, raw: Any) -> ToolPolicy:
+    field = f"delegation.profiles.{name}.tool_policy"
+    if raw in (None, ""):
+        return ToolPolicy()
+    if not isinstance(raw, dict):
+        raise ValueError(f"{field} must be a mapping")
+    unknown = set(raw) - _TOOL_POLICY_KEYS
+    if unknown:
+        raise ValueError(f"{field} has unknown keys: {sorted(unknown)}")
+    return ToolPolicy(
+        allowed_toolsets=_string_tuple(raw.get("allowed_toolsets"), field=f"{field}.allowed_toolsets", optional=True),
+        blocked_tools=_string_tuple(raw.get("blocked_tools"), field=f"{field}.blocked_tools") or (),
+        allowed_tools=_string_tuple(raw.get("allowed_tools"), field=f"{field}.allowed_tools", optional=True),
+        allowed_mcp_tools=_string_tuple(raw.get("allowed_mcp_tools"), field=f"{field}.allowed_mcp_tools", optional=True),
+    )
+
+
+def _parse_workspace_context(name: str, raw: Any) -> WorkspaceContextPolicy:
+    field = f"delegation.profiles.{name}.workspace_context"
+    if raw in (None, ""):
+        return WorkspaceContextPolicy()
+    if not isinstance(raw, dict):
+        raise ValueError(f"{field} must be a mapping")
+    unknown = set(raw) - _WORKSPACE_CONTEXT_KEYS
+    if unknown:
+        raise ValueError(f"{field} has unknown keys: {sorted(unknown)}")
+    mode = str(raw.get("mode") or "inherit").strip().lower()
+    if mode not in {"inherit", "none"}:
+        raise ValueError(f"{field}.mode must be 'inherit' or 'none'")
+    values: Dict[str, Optional[bool]] = {}
+    for key in ("include_context_files", "include_memory"):
+        value = raw.get(key)
+        if value is not None and not isinstance(value, bool):
+            raise ValueError(f"{field}.{key} must be true, false, or null")
+        values[key] = value
+    if mode == "none" and any(values.values()):
+        raise ValueError(f"{field}.mode 'none' cannot enable context files or memory")
+    return WorkspaceContextPolicy(mode=mode, **values)
+
+
+def _parse_execution_limits(name: str, raw: Any, legacy_max_iterations: Any) -> ExecutionLimits:
+    field = f"delegation.profiles.{name}.execution_limits"
+    if raw in (None, ""):
+        raw = {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{field} must be a mapping")
+    unknown = set(raw) - _EXECUTION_LIMIT_KEYS
+    if unknown:
+        raise ValueError(f"{field} has unknown keys: {sorted(unknown)}")
+    if legacy_max_iterations is not None and raw.get("max_iterations") is not None:
+        raise ValueError(
+            f"delegation.profiles.{name} cannot set both max_iterations and execution_limits.max_iterations")
+    max_iterations = raw.get("max_iterations", legacy_max_iterations)
+    return ExecutionLimits(
+        max_iterations=_positive_int(max_iterations, field=f"{field}.max_iterations"),
+        timeout_seconds=_positive_number(raw.get("timeout_seconds"), field=f"{field}.timeout_seconds"),
+        max_followups=_positive_int(raw.get("max_followups"), field=f"{field}.max_followups", allow_zero=True),
+        max_tool_calls=_positive_int(raw.get("max_tool_calls"), field=f"{field}.max_tool_calls", allow_zero=True),
+    )
+
+
+def _parse_enabled_routes(name: str, raw: Any) -> Tuple[EnabledRoute, ...]:
+    field = f"delegation.profiles.{name}.enabled_routes"
+    if raw in (None, ""):
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f"{field} must be a list of route mappings")
+    routes: List[EnabledRoute] = []
+    for index, entry in enumerate(raw):
+        item_field = f"{field}[{index}]"
+        if not isinstance(entry, dict):
+            raise ValueError(f"{item_field} must be a mapping")
+        unknown = set(entry) - _ROUTE_KEYS
+        if unknown:
+            raise ValueError(f"{item_field} has unknown keys: {sorted(unknown)}")
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not model:
+            raise ValueError(f"{item_field}.model must be a non-empty string")
+        effort, _ = _parse_effort(entry.get("reasoning_effort"), field=f"{item_field}.reasoning_effort")
+        route = EnabledRoute(provider=provider, model=model, reasoning_effort=effort)
+        if route not in routes:
+            routes.append(route)
+    return tuple(routes)
+
+
+def _parse_enabled_models(raw: Any) -> Tuple[EnabledRoute, ...]:
+    """Parse the optional global model ceiling without resolving provider state."""
+    if raw in (None, ""):
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError("delegation.enabled_models must be a list")
+    routes: List[EnabledRoute] = []
+    for index, entry in enumerate(raw):
+        field = f"delegation.enabled_models[{index}]"
+        if isinstance(entry, str):
+            value = entry.strip()
+            if not value:
+                raise ValueError(f"{field} must be non-empty")
+            provider, slash, model = value.partition("/")
+            route = EnabledRoute(provider=provider if slash else "", model=model if slash else provider)
+        elif isinstance(entry, dict):
+            unknown = set(entry) - {"provider", "model"}
+            if unknown:
+                raise ValueError(f"{field} has unknown keys: {sorted(unknown)}")
+            provider = str(entry.get("provider") or "").strip()
+            model = str(entry.get("model") or "").strip()
+            if not model:
+                raise ValueError(f"{field}.model must be a non-empty string")
+            route = EnabledRoute(provider=provider, model=model)
+        else:
+            raise ValueError(f"{field} must be a provider/model string or mapping")
+        if route not in routes:
+            routes.append(route)
+    return tuple(routes)
+
+
+def _routing_mode(cfg: Optional[dict]) -> str:
+    mode = str((cfg or {}).get("routing_mode") or "profile_only").strip().lower()
+    if mode not in _ROUTING_MODES:
+        raise ValueError(
+            f"delegation.routing_mode '{mode}' is invalid (allowed: {', '.join(sorted(_ROUTING_MODES))})")
+    return mode
 
 
 def _parse_fallback(name: str, raw: Any) -> Tuple[FallbackTarget, ...]:
@@ -102,32 +339,28 @@ def _parse_profile(name: str, raw: Any) -> ProfileSpec:
         raise ValueError(
             f"delegation.profiles.{name} has unknown keys: {sorted(unknown)} "
             f"(allowed: {sorted(_PROFILE_KEYS)})")
+    if not name.strip():
+        raise ValueError("delegation.profiles contains an empty profile name")
     model = str(raw.get("model") or "").strip()
     if not model:
         raise ValueError(f"delegation.profiles.{name} is missing required 'model'")
     provider = str(raw.get("provider") or "").strip()
 
-    # Reasoning effort: NS-696 clamp doctrine — invalid values warn and are ignored, never reject.
-    reasoning_config = None
-    effort = raw.get("reasoning_effort")
-    if effort or effort is False:
-        from hermes_constants import parse_reasoning_effort
-        reasoning_config = parse_reasoning_effort(effort)
-        if reasoning_config is None:
-            logger.warning(
-                "delegation.profiles.%s.reasoning_effort '%s' is not a recognized level; "
-                "ignoring it (child inherits the parent's reasoning level)", name, effort)
-
-    max_iterations = raw.get("max_iterations")
-    if max_iterations is not None:
-        if isinstance(max_iterations, bool) or not isinstance(max_iterations, int):
-            raise ValueError(
-                f"delegation.profiles.{name}.max_iterations must be an integer, "
-                f"got {type(max_iterations).__name__}")
+    effort, reasoning_config = _parse_effort(
+        raw.get("reasoning_effort"), field=f"delegation.profiles.{name}.reasoning_effort")
+    execution_limits = _parse_execution_limits(name, raw.get("execution_limits"), raw.get("max_iterations"))
 
     return ProfileSpec(
         name=name, provider=provider, model=model, reasoning_config=reasoning_config,
-        max_iterations=max_iterations, fallback=_parse_fallback(name, raw.get("fallback")),
+        description=_text(raw.get("description"), field=f"delegation.profiles.{name}.description", max_chars=2_000),
+        instructions=_text(raw.get("instructions"), field=f"delegation.profiles.{name}.instructions"),
+        reasoning_effort=effort,
+        max_iterations=execution_limits.max_iterations,
+        fallback=_parse_fallback(name, raw.get("fallback")),
+        tool_policy=_parse_tool_policy(name, raw.get("tool_policy")),
+        workspace_context=_parse_workspace_context(name, raw.get("workspace_context")),
+        execution_limits=execution_limits,
+        enabled_routes=_parse_enabled_routes(name, raw.get("enabled_routes")),
     )
 
 
@@ -166,6 +399,24 @@ def profile_config_errors(cfg: Optional[dict]) -> List[str]:
         errors.append(
             f"delegation.default_profile '{default_profile}' is not a configured profile "
             f"(configured: {configured})")
+    mode = str((cfg or {}).get("routing_mode") or "profile_only").strip().lower()
+    if mode not in _ROUTING_MODES:
+        errors.append(
+            f"delegation.routing_mode '{mode}' is invalid (allowed: {', '.join(sorted(_ROUTING_MODES))})")
+    try:
+        enabled_models = _parse_enabled_models((cfg or {}).get("enabled_models"))
+    except ValueError as exc:
+        errors.append(str(exc))
+        enabled_models = ()
+    if enabled_models:
+        allowed = {(route.provider, route.model) for route in enabled_models}
+        for spec in specs.values():
+            candidates = (EnabledRoute(spec.provider, spec.model, spec.reasoning_effort), *spec.enabled_routes)
+            for route in candidates:
+                if (route.provider, route.model) not in allowed:
+                    errors.append(
+                        f"delegation.profiles.{spec.name} route {route.provider or '(default)'}/{route.model} "
+                        "is not present in delegation.enabled_models")
     return errors
 
 
@@ -183,7 +434,61 @@ def select_profile_name(task_profile: Any, top_profile: Any, cfg: Optional[dict]
     return None
 
 
-def resolve_profile_route(name: str, cfg: Optional[dict], parent_agent: Any = None) -> ProfileRoute:
+def _route_allowed(route: EnabledRoute, allowed: Tuple[EnabledRoute, ...]) -> bool:
+    return not allowed or any(
+        item.model == route.model and (not item.provider or item.provider == route.provider)
+        for item in allowed
+    )
+
+
+def _select_route(
+    spec: ProfileSpec,
+    *,
+    routing_mode: str,
+    requested_provider: Optional[str],
+    requested_model: Optional[str],
+    requested_reasoning_effort: Optional[str],
+) -> EnabledRoute:
+    provider = str(requested_provider or "").strip()
+    model = str(requested_model or "").strip()
+    effort, _ = _parse_effort(
+        requested_reasoning_effort,
+        field=f"delegation task profile '{spec.name}' reasoning_effort",
+    )
+    has_override = bool(provider or model or effort is not None)
+    primary = EnabledRoute(spec.provider, spec.model, spec.reasoning_effort)
+    if not has_override:
+        return primary
+    if routing_mode != "dynamic":
+        raise ValueError(
+            f"delegation profile '{spec.name}' uses profile_only routing; per-task provider/model/effort overrides are disabled")
+    target_provider = provider or primary.provider
+    target_model = model or primary.model
+    target_effort = effort if effort is not None else primary.reasoning_effort
+    target = EnabledRoute(target_provider, target_model, target_effort)
+    enabled = (primary, *spec.enabled_routes)
+    if target not in enabled:
+        choices = ", ".join(
+            f"{item.provider or '(default)'}/{item.model}"
+            + (f"@{item.reasoning_effort}" if item.reasoning_effort else "")
+            for item in enabled
+        )
+        raise ValueError(
+            f"Requested route {target.provider or '(default)'}/{target.model}"
+            f"{('@' + target.reasoning_effort) if target.reasoning_effort else ''} is not enabled for profile "
+            f"'{spec.name}' (enabled: {choices})")
+    return target
+
+
+def resolve_profile_route(
+    name: str,
+    cfg: Optional[dict],
+    parent_agent: Any = None,
+    *,
+    requested_provider: Optional[str] = None,
+    requested_model: Optional[str] = None,
+    requested_reasoning_effort: Optional[str] = None,
+) -> ProfileRoute:
     """Resolve profile *name* into an immutable :class:`ProfileRoute`.
 
     Raises ``ValueError`` (before any child construction) for an unknown name, listing the
@@ -198,30 +503,171 @@ def resolve_profile_route(name: str, cfg: Optional[dict], parent_agent: Any = No
             f"Unknown delegation profile '{key}'. Configured profiles: {configured}. "
             f"Add it under delegation.profiles in config.yaml or pick a configured name.")
     spec = specs[key]
+    selected = _select_route(
+        spec,
+        routing_mode=_routing_mode(cfg),
+        requested_provider=requested_provider,
+        requested_model=requested_model,
+        requested_reasoning_effort=requested_reasoning_effort,
+    )
+    allowed_models = _parse_enabled_models((cfg or {}).get("enabled_models"))
+    if not _route_allowed(selected, allowed_models):
+        raise ValueError(
+            f"Requested route {selected.provider or '(default)'}/{selected.model} is outside "
+            "the delegation.enabled_models ceiling")
 
     # Lazy imports (house style — delegate_tool_config.py does the same) to avoid import cycles.
     from hermes_cli.runtime_provider import resolve_runtime_provider
     runtime = resolve_runtime_provider(
-        requested=spec.provider or None, target_model=spec.model) or {}
+        requested=selected.provider or None, target_model=selected.model) or {}
 
     supports_tools = True
     try:
         from agent.models_dev import get_model_capabilities
-        caps = get_model_capabilities(spec.provider or "", spec.model)
+        caps = get_model_capabilities(selected.provider or "", selected.model, allow_network=False)
         if caps is not None:
             supports_tools = bool(getattr(caps, "supports_tools", True))
     except Exception as exc:  # capability metadata is advisory; never block resolution on it
-        logger.debug("Could not load model capabilities for profile '%s': %s", key, exc)
+        pass
+
+    _, reasoning_config = _parse_effort(
+        selected.reasoning_effort,
+        field=f"delegation profile '{key}' resolved reasoning_effort",
+    )
 
     return ProfileRoute(
         requested_profile=key,
-        provider=runtime.get("provider") or spec.provider or None,
-        model=spec.model,
+        provider=runtime.get("provider") or selected.provider or None,
+        model=selected.model,
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),
-        reasoning_config=spec.reasoning_config,
+        reasoning_config=reasoning_config,
         max_iterations=spec.max_iterations,
         fallback=spec.fallback,
         supports_tools=supports_tools,
+        requested_provider=str(requested_provider or "").strip() or None,
+        requested_model=str(requested_model or "").strip() or None,
+        requested_reasoning_effort=(str(requested_reasoning_effort).strip().lower()
+                                    if requested_reasoning_effort is not None else None),
+        resolved_reasoning_effort=selected.reasoning_effort,
+        transmitted_model=selected.model,
+        provider_reported_model=None,
+        tool_policy=spec.tool_policy,
+        workspace_context=spec.workspace_context,
+        execution_limits=spec.execution_limits,
     )
+
+
+def _supported_efforts(provider: str, model: str) -> Tuple[Optional[List[str]], str]:
+    """Return only capability tables Hermes already owns; unknown stays explicit."""
+    key = provider.strip().lower()
+    if key in {"openai-codex", "codex"}:
+        from agent.reasoning_effort import codex_supported_efforts
+        return list(codex_supported_efforts(model)), "agent.reasoning_effort"
+    if key in {"kimi", "kimi-coding", "kimi-coding-cn", "moonshot"}:
+        from agent.reasoning_effort import kimi_supported_efforts
+        return list(kimi_supported_efforts(model)), "agent.reasoning_effort"
+    return None, "unknown"
+
+
+def _catalog_route(route: EnabledRoute) -> Dict[str, Any]:
+    capabilities: Dict[str, Any] = {
+        "supports_tools": None,
+        "supports_vision": None,
+        "supports_reasoning": None,
+        "context_window": None,
+        "max_output_tokens": None,
+    }
+    capability_source = "unknown"
+    try:
+        from agent.models_dev import get_model_capabilities
+        caps = get_model_capabilities(route.provider, route.model, allow_network=False)
+        if caps is not None:
+            capabilities = {
+                "supports_tools": bool(caps.supports_tools),
+                "supports_vision": bool(caps.supports_vision),
+                "supports_reasoning": bool(caps.supports_reasoning),
+                "context_window": int(caps.context_window or 0) or None,
+                "max_output_tokens": int(caps.max_output_tokens or 0) or None,
+            }
+            capability_source = "models.dev_cache"
+    except Exception:
+        pass
+    supported_efforts, effort_source = _supported_efforts(route.provider, route.model)
+    return {
+        "provider": route.provider or None,
+        "model": route.model,
+        "reasoning_effort": route.reasoning_effort,
+        "supported_efforts": supported_efforts,
+        "capabilities": capabilities,
+        "availability": {"status": "unknown", "reason": "not_checked"},
+        "freshness": {"status": "unknown", "checked_at": None},
+        "provenance": {
+            "route": "delegation config",
+            "capabilities": capability_source,
+            "supported_efforts": effort_source,
+        },
+    }
+
+
+def discover_workers(cfg: Optional[dict], parent_agent: Any = None) -> Dict[str, Any]:
+    """Return a stable, credential-free worker catalog for CLI and ``delegate_task`` discovery.
+
+    The catalog is intentionally honest about unknown availability and freshness. It reads cached
+    capability metadata only and never mutates a tool schema or contacts a provider.
+    """
+    errors = profile_config_errors(cfg)
+    profiles: List[Dict[str, Any]] = []
+    raw = _profiles_section(cfg)
+    if isinstance(raw, dict):
+        for name in sorted(raw, key=str):
+            try:
+                spec = _parse_profile(str(name), raw[name])
+            except ValueError:
+                continue
+            routes = (EnabledRoute(spec.provider, spec.model, spec.reasoning_effort), *spec.enabled_routes)
+            route_catalog = [_catalog_route(route) for route in dict.fromkeys(routes)]
+            primary = route_catalog[0]
+            profiles.append({
+                "name": spec.name,
+                "description": spec.description,
+                "instructions": spec.instructions or None,
+                "provider": primary["provider"],
+                "model": primary["model"],
+                "reasoning_effort": primary["reasoning_effort"],
+                "supported_efforts": primary["supported_efforts"],
+                "capabilities": primary["capabilities"],
+                "availability": primary["availability"],
+                "freshness": primary["freshness"],
+                "provenance": primary["provenance"],
+                "tool_policy": {
+                    "allowed_toolsets": list(spec.tool_policy.allowed_toolsets) if spec.tool_policy.allowed_toolsets is not None else None,
+                    "blocked_tools": list(spec.tool_policy.blocked_tools),
+                    "allowed_tools": list(spec.tool_policy.allowed_tools) if spec.tool_policy.allowed_tools is not None else None,
+                    "allowed_mcp_tools": list(spec.tool_policy.allowed_mcp_tools) if spec.tool_policy.allowed_mcp_tools is not None else None,
+                },
+                "workspace_context": {
+                    "mode": spec.workspace_context.mode,
+                    "include_context_files": spec.workspace_context.include_context_files,
+                    "include_memory": spec.workspace_context.include_memory,
+                },
+                "execution_limits": {
+                    "max_iterations": spec.execution_limits.max_iterations,
+                    "timeout_seconds": spec.execution_limits.timeout_seconds,
+                    "max_followups": spec.execution_limits.max_followups,
+                    "max_tool_calls": spec.execution_limits.max_tool_calls,
+                },
+                "enabled_routes": route_catalog,
+            })
+    enabled_models = _parse_enabled_models((cfg or {}).get("enabled_models")) if not any(
+        error.startswith("delegation.enabled_models") for error in errors
+    ) else ()
+    return {
+        "version": 1,
+        "routing_mode": str((cfg or {}).get("routing_mode") or "profile_only").strip().lower(),
+        "default_profile": str((cfg or {}).get("default_profile") or "").strip() or None,
+        "enabled_models": [_catalog_route(route) for route in enabled_models],
+        "profiles": profiles,
+        "errors": errors,
+    }

--- a/agent/delegation_model_routing.py
+++ b/agent/delegation_model_routing.py
@@ -33,6 +33,7 @@ _TOOL_POLICY_KEYS = frozenset({"allowed_toolsets", "blocked_tools", "allowed_too
 _WORKSPACE_CONTEXT_KEYS = frozenset({"mode", "include_context_files", "include_memory"})
 _EXECUTION_LIMIT_KEYS = frozenset({
     "max_iterations", "timeout_seconds", "max_followups", "max_tool_calls",
+    "max_spawn_depth", "max_concurrent_children",
 })
 _ROUTING_MODES = frozenset({"profile_only", "dynamic"})
 _VALID_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"})
@@ -77,6 +78,8 @@ class ExecutionLimits:
     timeout_seconds: Optional[float] = None
     max_followups: Optional[int] = None
     max_tool_calls: Optional[int] = None
+    max_spawn_depth: Optional[int] = None
+    max_concurrent_children: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -235,6 +238,9 @@ def _parse_execution_limits(name: str, raw: Any, legacy_max_iterations: Any) -> 
         timeout_seconds=_positive_number(raw.get("timeout_seconds"), field=f"{field}.timeout_seconds"),
         max_followups=_positive_int(raw.get("max_followups"), field=f"{field}.max_followups", allow_zero=True),
         max_tool_calls=_positive_int(raw.get("max_tool_calls"), field=f"{field}.max_tool_calls", allow_zero=True),
+        max_spawn_depth=_positive_int(raw.get("max_spawn_depth"), field=f"{field}.max_spawn_depth", allow_zero=True),
+        max_concurrent_children=_positive_int(
+            raw.get("max_concurrent_children"), field=f"{field}.max_concurrent_children", allow_zero=True),
     )
 
 
@@ -257,6 +263,7 @@ def _parse_enabled_routes(name: str, raw: Any) -> Tuple[EnabledRoute, ...]:
         if not model:
             raise ValueError(f"{item_field}.model must be a non-empty string")
         effort, _ = _parse_effort(entry.get("reasoning_effort"), field=f"{item_field}.reasoning_effort")
+        _validate_known_effort(provider, model, effort, field=f"{item_field}.reasoning_effort")
         route = EnabledRoute(provider=provider, model=model, reasoning_effort=effort)
         if route not in routes:
             routes.append(route)
@@ -300,6 +307,16 @@ def _routing_mode(cfg: Optional[dict]) -> str:
         raise ValueError(
             f"delegation.routing_mode '{mode}' is invalid (allowed: {', '.join(sorted(_ROUTING_MODES))})")
     return mode
+
+
+def _validate_known_effort(provider: str, model: str, effort: Optional[str], *, field: str) -> None:
+    if effort is None:
+        return
+    supported, source = _supported_efforts(provider, model)
+    if supported is not None and effort not in supported:
+        raise ValueError(
+            f"{field} '{effort}' is unsupported for {provider or '(default)'}/{model} "
+            f"(supported: {', '.join(supported)}; source: {source})")
 
 
 def _parse_fallback(name: str, raw: Any) -> Tuple[FallbackTarget, ...]:
@@ -348,6 +365,8 @@ def _parse_profile(name: str, raw: Any) -> ProfileSpec:
 
     effort, reasoning_config = _parse_effort(
         raw.get("reasoning_effort"), field=f"delegation.profiles.{name}.reasoning_effort")
+    _validate_known_effort(
+        provider, model, effort, field=f"delegation.profiles.{name}.reasoning_effort")
     execution_limits = _parse_execution_limits(name, raw.get("execution_limits"), raw.get("max_iterations"))
 
     return ProfileSpec(
@@ -448,6 +467,7 @@ def _select_route(
     requested_provider: Optional[str],
     requested_model: Optional[str],
     requested_reasoning_effort: Optional[str],
+    global_enabled_models: Tuple[EnabledRoute, ...],
 ) -> EnabledRoute:
     provider = str(requested_provider or "").strip()
     model = str(requested_model or "").strip()
@@ -466,8 +486,13 @@ def _select_route(
     target_model = model or primary.model
     target_effort = effort if effort is not None else primary.reasoning_effort
     target = EnabledRoute(target_provider, target_model, target_effort)
-    enabled = (primary, *spec.enabled_routes)
-    if target not in enabled:
+    enabled = (primary, *(spec.enabled_routes or global_enabled_models))
+    matching_route = next((
+        item for item in enabled
+        if item.provider == target.provider and item.model == target.model
+        and (item.reasoning_effort is None or item.reasoning_effort == target.reasoning_effort)
+    ), None)
+    if matching_route is None:
         choices = ", ".join(
             f"{item.provider or '(default)'}/{item.model}"
             + (f"@{item.reasoning_effort}" if item.reasoning_effort else "")
@@ -477,6 +502,10 @@ def _select_route(
             f"Requested route {target.provider or '(default)'}/{target.model}"
             f"{('@' + target.reasoning_effort) if target.reasoning_effort else ''} is not enabled for profile "
             f"'{spec.name}' (enabled: {choices})")
+    _validate_known_effort(
+        target.provider, target.model, target.reasoning_effort,
+        field=f"delegation task profile '{spec.name}' reasoning_effort",
+    )
     return target
 
 
@@ -503,14 +532,15 @@ def resolve_profile_route(
             f"Unknown delegation profile '{key}'. Configured profiles: {configured}. "
             f"Add it under delegation.profiles in config.yaml or pick a configured name.")
     spec = specs[key]
+    allowed_models = _parse_enabled_models((cfg or {}).get("enabled_models"))
     selected = _select_route(
         spec,
         routing_mode=_routing_mode(cfg),
         requested_provider=requested_provider,
         requested_model=requested_model,
         requested_reasoning_effort=requested_reasoning_effort,
+        global_enabled_models=allowed_models,
     )
-    allowed_models = _parse_enabled_models((cfg or {}).get("enabled_models"))
     if not _route_allowed(selected, allowed_models):
         raise ValueError(
             f"Requested route {selected.provider or '(default)'}/{selected.model} is outside "
@@ -551,7 +581,7 @@ def resolve_profile_route(
         requested_reasoning_effort=(str(requested_reasoning_effort).strip().lower()
                                     if requested_reasoning_effort is not None else None),
         resolved_reasoning_effort=selected.reasoning_effort,
-        transmitted_model=selected.model,
+        transmitted_model=None,
         provider_reported_model=None,
         tool_policy=spec.tool_policy,
         workspace_context=spec.workspace_context,
@@ -562,12 +592,19 @@ def resolve_profile_route(
 def _supported_efforts(provider: str, model: str) -> Tuple[Optional[List[str]], str]:
     """Return only capability tables Hermes already owns; unknown stays explicit."""
     key = provider.strip().lower()
-    if key in {"openai-codex", "codex"}:
+    if key in {"openai", "openai-api", "openai-codex", "codex"}:
         from agent.reasoning_effort import codex_supported_efforts
         return list(codex_supported_efforts(model)), "agent.reasoning_effort"
     if key in {"kimi", "kimi-coding", "kimi-coding-cn", "moonshot"}:
         from agent.reasoning_effort import kimi_supported_efforts
         return list(kimi_supported_efforts(model)), "agent.reasoning_effort"
+    if key in {"zai", "zhipu", "glm"}:
+        from agent.reasoning_effort import GLM52_EFFORTS, GLM53_EFFORTS
+        normalized = model.lower()
+        if "glm-5.3" in normalized or "glm5.3" in normalized:
+            return list(GLM53_EFFORTS), "agent.reasoning_effort"
+        if "glm-5.2" in normalized or "glm5.2" in normalized:
+            return list(GLM52_EFFORTS), "agent.reasoning_effort"
     return None, "unknown"
 
 
@@ -657,6 +694,8 @@ def discover_workers(cfg: Optional[dict], parent_agent: Any = None) -> Dict[str,
                     "timeout_seconds": spec.execution_limits.timeout_seconds,
                     "max_followups": spec.execution_limits.max_followups,
                     "max_tool_calls": spec.execution_limits.max_tool_calls,
+                    "max_spawn_depth": spec.execution_limits.max_spawn_depth,
+                    "max_concurrent_children": spec.execution_limits.max_concurrent_children,
                 },
                 "enabled_routes": route_catalog,
             })

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -522,7 +522,13 @@ def dispatch_worker_nested_tool(tool_name: str, tool_args: dict, *, task_id: str
         admitted = before_worker_nested_tool(agent, tool_call_id)
     except Exception as exc:
         return tool_error(str(exc))
-    result = handle_function_call(tool_name, tool_args, task_id=task_id)
+    from agent.worker_interfaces import is_worker_interface_tool
+
+    selection = getattr(agent, "_worker_interface_selection", None)
+    if is_worker_interface_tool(selection, tool_name):
+        result = agent._dispatch_worker_interface(tool_name, tool_args)
+    else:
+        result = handle_function_call(tool_name, tool_args, task_id=task_id)
     if admitted:
         checkpoint_worker_nested_tool_result(agent, tool_call_id)
     return result
@@ -1118,6 +1124,68 @@ class SubagentLifecycleService:
                 time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
                 selected = store.get_run(selected["run_id"], owner)
             return self._safe_run_snapshot(selected)
+        if normalized == "interrupt":
+            if selected["status"] in {"SUCCEEDED", "FAILED", "INTERRUPTED", "CANCELLED"}:
+                return {
+                    **self._safe_run_snapshot(selected),
+                    "interrupt_requested": False,
+                    "already_terminal": True,
+                }
+            with _REGISTRY.lock:
+                live_record = next((
+                    item for item in _REGISTRY.records.values()
+                    if item.owner_session_id == owner and item.worker_id == worker_id
+                    and item.run_id == selected["run_id"] and item.agent is not None
+                    and item.state not in {
+                        SubagentState.SUCCEEDED, SubagentState.FAILED,
+                        SubagentState.INTERRUPTED, SubagentState.CANCELLED,
+                    }
+                ), None)
+            if selected["status"] == "PENDING":
+                cancelled = store.cancel_pending_run(selected["run_id"], owner)
+                if live_record is not None:
+                    with _REGISTRY.lock:
+                        live_record.state = SubagentState.CANCELLED
+                        live_record.result = SubagentResult(
+                            live_record.handle,
+                            SubagentState.CANCELLED,
+                            True,
+                            completed_at=time.time(),
+                            error_classification="CANCELLED",
+                            error_message="Worker run interrupted before it started.",
+                        )
+                        live_record.updated_at = time.time()
+                    with contextlib.suppress(Exception):
+                        live_record.agent.close()
+                    live_record.agent = None
+                current = cancelled or store.get_run(selected["run_id"], owner)
+                return {
+                    **self._safe_run_snapshot(current),
+                    "interrupt_requested": bool(cancelled),
+                    "scope": "run",
+                }
+            if live_record is None:
+                return {
+                    **self._safe_run_snapshot(selected),
+                    "interrupt_requested": False,
+                    "unsupported": True,
+                    "reason": "The running worker is not attached to this process; tree cancellation remains separate.",
+                }
+            accepted = request_hard_interrupt(
+                live_record.agent,
+                "Worker run interruption requested by its owner.",
+                tool_reason="worker run interruption requested",
+            )
+            if accepted:
+                with _REGISTRY.lock:
+                    live_record.state = SubagentState.CANCEL_REQUESTED
+                    live_record.updated_at = time.time()
+            return {
+                **self._safe_run_snapshot(selected),
+                "interrupt_requested": bool(accepted),
+                "unsupported": not accepted,
+                "scope": "run",
+            }
         if normalized == "cancel":
             subtree = self._subtree_ids(store, owner, worker_id)
             cancelled_pending = store.cancel_pending_runs(subtree, owner)
@@ -1187,6 +1255,10 @@ class SubagentLifecycleService:
                 raise SubagentLifecycleError("action='resume' requires message as the next worker turn.")
             if selected["run_id"] != runs[-1]["run_id"]:
                 raise SubagentLifecycleError("Resume must link from the worker's latest run.")
+            if selected["status"] == "CANCELLED":
+                raise SubagentLifecycleError(
+                    "Cancelled workers stay cancelled and cannot accept another turn."
+                )
             route = dict((worker.get("policy") or {}).get("route") or {})
             prior = SubagentHandle(
                 PUBLIC_CONTRACT_VERSION, "durable-snapshot", owner, None, worker["created_at"],

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -443,6 +443,15 @@ def before_worker_tool(agent: Any, tool_call_id: str) -> None:
     record.tool_calls += 1
 
 
+def before_worker_nested_tool(agent: Any, tool_call_id: str) -> bool:
+    """Admit an execute_code RPC under the worker captured for that cell."""
+    record = getattr(agent, "_worker_lifecycle_record", None)
+    if not isinstance(record, _Record) or record.store is None:
+        return False
+    before_worker_tool(agent, tool_call_id)
+    return True
+
+
 def queue_worker_parent_message(agent: Any, content: str) -> Optional[Mapping[str, Any]]:
     """Durably queue a child-to-root-parent message when this worker has a store."""
     record = getattr(agent, "_worker_lifecycle_record", None)
@@ -476,6 +485,35 @@ def checkpoint_worker_tool_result(
     )
     record.conversation_history = list(history)
     record.delivered_message_ids.clear()
+
+
+def checkpoint_worker_nested_tool_result(agent: Any, tool_call_id: str) -> None:
+    """Settle one nested RPC without replacing the worker's conversation checkpoint."""
+    record = getattr(agent, "_worker_lifecycle_record", None)
+    if not isinstance(record, _Record) or record.store is None:
+        return
+    worker = record.store.get_worker(record.worker_id, record.owner_session_id)
+    checkpoint_worker_tool_result(
+        agent, list(worker.get("history") or record.conversation_history),
+        tool_call_id=tool_call_id, settled=True,
+    )
+
+
+def dispatch_worker_nested_tool(tool_name: str, tool_args: dict, *, task_id: str) -> str:
+    """Dispatch one execute_code RPC with the cell's captured worker authority."""
+    from model_tools import handle_function_call
+    from tools.registry import tool_error
+
+    agent = get_active_subagent_parent()
+    tool_call_id = "execute-code-rpc-" + uuid.uuid4().hex
+    try:
+        admitted = before_worker_nested_tool(agent, tool_call_id)
+    except Exception as exc:
+        return tool_error(str(exc))
+    result = handle_function_call(tool_name, tool_args, task_id=task_id)
+    if admitted:
+        checkpoint_worker_nested_tool_result(agent, tool_call_id)
+    return result
 
 
 def worker_tool_calls_remaining(agent: Any) -> Optional[int]:

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -333,14 +333,14 @@ def _profile_policy_snapshot(
             "execution_limits": dataclasses.asdict(spec.execution_limits),
             "enabled_routes": [dataclasses.asdict(item) for item in spec.enabled_routes],
         }
-    effective_tools = sorted(
-        name for name in (
-            getattr(child, "_worker_effective_tool_names", None)
-            or getattr(child, "_executable_tool_names", None)
-            or getattr(child, "valid_tool_names", None)
-            or ()
-        ) if isinstance(name, str)
-    )
+    # Empty authority is an explicit denial, not missing metadata. Only an
+    # absent execution catalog may fall back to legacy visible schemas.
+    tool_names = getattr(child, "_worker_effective_tool_names", None)
+    if tool_names is None:
+        tool_names = getattr(child, "_executable_tool_names", None)
+    if tool_names is None:
+        tool_names = getattr(child, "valid_tool_names", None)
+    effective_tools = sorted(name for name in (tool_names or ()) if isinstance(name, str))
     policy = {
         "profile_contract": selected,
         "effective_tools": effective_tools,

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -330,7 +330,12 @@ def _profile_policy_snapshot(
             "enabled_routes": [dataclasses.asdict(item) for item in spec.enabled_routes],
         }
     effective_tools = sorted(
-        name for name in (getattr(child, "valid_tool_names", None) or ()) if isinstance(name, str)
+        name for name in (
+            getattr(child, "_worker_effective_tool_names", None)
+            or getattr(child, "_executable_tool_names", None)
+            or getattr(child, "valid_tool_names", None)
+            or ()
+        ) if isinstance(name, str)
     )
     policy = {
         "profile_contract": selected,
@@ -662,7 +667,9 @@ class SubagentLifecycleService:
             run_id=run_id,
         )
         record = _Record(
-            handle, SubagentState.PENDING, created, agent=child, store=store,
+            handle, SubagentState.PENDING, created,
+            agent=child if lease_token is not None or store is None else None,
+            store=store,
             owner_session_id=parent_session_id, worker_id=worker_id, run_id=run_id, lease_token=lease_token,
             max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
             max_concurrent=_concurrency_limit(cfg), goal=request.goal, parent_agent=parent,
@@ -675,6 +682,12 @@ class SubagentLifecycleService:
             self._start_record(record)
         elif store is None:
             record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        else:
+            # A queued run retains identity and policy, never a pre-authorized
+            # live agent.  It is rebuilt from current authority immediately
+            # before its exact lease is claimed.
+            with contextlib.suppress(Exception):
+                child.close()
         return handle
 
     def status(self, handle: SubagentHandle) -> SubagentStatus:
@@ -693,15 +706,36 @@ class SubagentLifecycleService:
             durable = self._durable_snapshot(handle)
             if durable is None:
                 return SubagentTerminalState(handle, SubagentState.UNKNOWN, True, diagnostic="UNKNOWN_HANDLE")
-            store, _worker, run = durable
+            store, worker, run = durable
             if run["status"] == "RUNNING" and run.get("lease_expires_at", 0) <= time.time():
-                store.recover_expired_runs(handle.parent_session_id)
+                store.recover_expired_runs(handle.parent_session_id, [worker["worker_id"]])
                 run = store.get_run(handle.run_id, handle.parent_session_id)
+            if run["status"] == "PENDING":
+                self._schedule_owner(
+                    store, handle.parent_session_id, self._parent_agent_resolver(),
+                    worker_id=worker["worker_id"], run_id=run["run_id"],
+                )
+                deadline = None if timeout_seconds is None else time.monotonic() + timeout_seconds
+                while run["status"] in {"PENDING", "RUNNING"}:
+                    if deadline is not None and time.monotonic() >= deadline:
+                        break
+                    time.sleep(0.01)
+                    run = store.get_run(handle.run_id, handle.parent_session_id)
             state = SubagentState(run["status"])
             completed = state in {
                 SubagentState.SUCCEEDED, SubagentState.FAILED, SubagentState.INTERRUPTED, SubagentState.CANCELLED,
             }
             return SubagentTerminalState(handle, state, completed, diagnostic="DURABLE_SNAPSHOT")
+        if (
+            record.state is SubagentState.PENDING
+            and record.future is None
+            and record.store is not None
+            and record.owner_session_id
+        ):
+            self._schedule_owner(
+                record.store, record.owner_session_id, self._parent_agent_resolver(),
+                worker_id=record.worker_id, run_id=record.run_id,
+            )
         deadline = None if timeout_seconds is None else time.monotonic() + timeout_seconds
         while record.result is None:
             future = record.future
@@ -845,14 +879,7 @@ class SubagentLifecycleService:
         store = _persistent_store(parent) if parent is not None else None
         if store is None or not owner:
             raise SubagentLifecycleError("Durable worker state is unavailable for this session.")
-        store.recover_expired_runs(owner)
         normalized = action.strip().lower()
-        # Cancellation and operator decisions must observe the durable queue
-        # before any restart scheduler can claim it. Read-only inspect and
-        # mailbox actions likewise do not need to cause execution as a side
-        # effect. Status/wait/completions/resume remain scheduler entrypoints.
-        if normalized not in {"cancel", "reconcile", "ack", "inspect", "message"}:
-            self._schedule_owner(store, owner, parent)
         actor_worker_id = getattr(parent, "_worker_id", None)
         from tools.delegate_tool_config import _load_config
         cfg = _load_config()
@@ -871,6 +898,8 @@ class SubagentLifecycleService:
                 store, owner, actor_worker_id, worker, message_only=False, allow_siblings=allow_siblings
             ):
                 raise PermissionError("Worker control target is outside the actor's owned subtree.")
+            store.recover_expired_runs(owner, [worker_id])
+            worker = store.get_worker(worker_id, owner)
             return self._safe_worker_snapshot(store, worker, owner)
         if normalized == "completions":
             pending = store.pending_completions(owner)
@@ -896,6 +925,8 @@ class SubagentLifecycleService:
             message_only=message_action, allow_siblings=allow_siblings,
         ):
             raise PermissionError("Worker control target is outside the actor's authorized relation.")
+        store.recover_expired_runs(owner, [worker_id])
+        worker = store.get_worker(worker_id, owner)
         runs = store.list_runs(worker_id, owner)
         selected = next((item for item in runs if item["run_id"] == run_id), None) if run_id else (runs[-1] if runs else None)
         if normalized == "message":
@@ -928,6 +959,10 @@ class SubagentLifecycleService:
             return {
                 **self._safe_worker_snapshot(store, worker, owner),
                 "run": self._inspect_run_snapshot(selected),
+                # Explicit inspection is the opt-in transcript surface.  Keep
+                # routine status/results compact and never expose system
+                # prompts, hidden reasoning, or provider/session objects.
+                "conversation": self._inspect_conversation(worker.get("history") or []),
                 "messages": [
                     {
                         key: item.get(key) for key in (
@@ -941,11 +976,15 @@ class SubagentLifecycleService:
             timeout = 0.0 if timeout_seconds is None else float(timeout_seconds)
             if timeout < 0 or timeout > 60:
                 raise SubagentLifecycleError("timeout_seconds must be between 0 and 60.")
+            self._schedule_owner(
+                store, owner, parent, worker_id=worker_id, run_id=selected["run_id"])
+            selected = store.get_run(selected["run_id"], owner)
             deadline = time.monotonic() + timeout
             while selected["status"] in {"PENDING", "RUNNING"} and time.monotonic() < deadline:
                 if selected["status"] == "RUNNING" and selected.get("lease_expires_at", 0) <= time.time():
-                    store.recover_expired_runs(owner)
-                    self._schedule_owner(store, owner)
+                    store.recover_expired_runs(owner, [worker_id])
+                    self._schedule_owner(
+                        store, owner, parent, worker_id=worker_id, run_id=selected["run_id"])
                 time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
                 selected = store.get_run(selected["run_id"], owner)
             return self._safe_run_snapshot(selected)
@@ -1064,6 +1103,38 @@ class SubagentLifecycleService:
             } if result else None,
         }
 
+    @staticmethod
+    def _inspect_conversation(history: list) -> list[Mapping[str, Any]]:
+        visible = []
+        for item in history:
+            if not isinstance(item, Mapping):
+                continue
+            role = str(item.get("role") or "")
+            if role not in {"user", "assistant", "tool"}:
+                continue
+            content = item.get("content")
+            if isinstance(content, list):
+                parts = []
+                for block in content:
+                    if not isinstance(block, Mapping):
+                        continue
+                    if block.get("type") not in {"text", "input_text", "output_text"}:
+                        continue
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+                content = "\n".join(parts)
+            if not isinstance(content, str):
+                content = ""
+            entry = {"role": role, "content": _clip(content)}
+            if role == "tool":
+                for key in ("name", "tool_call_id"):
+                    value = item.get(key)
+                    if isinstance(value, str) and value:
+                        entry[key] = value
+            visible.append(entry)
+        return visible
+
     @classmethod
     def _safe_worker_snapshot(cls, store: Any, worker: Mapping[str, Any], owner: str) -> Mapping[str, Any]:
         runs = store.list_runs(worker["worker_id"], owner)
@@ -1120,62 +1191,65 @@ class SubagentLifecycleService:
     def _launch_existing_worker(
         self, request: SubagentLaunchRequest, prior: SubagentHandle, worker: Mapping[str, Any], previous: Mapping[str, Any],
     ) -> SubagentHandle:
-        """Validate and queue one retained turn; an active predecessor starts it FIFO on completion."""
+        """Validate and queue one retained turn behind the exact durable FIFO."""
         parent = self._parent_agent_resolver()
         owner = _owner_session_id_of(parent)
         store = _persistent_store(parent)
         if store is None or not owner:
             raise SubagentLifecycleError("Durable resume is unavailable for this session.")
-        store.recover_expired_runs(owner)
+        store.recover_expired_runs(owner, [worker["worker_id"]])
         worker = store.get_worker(worker["worker_id"], owner)
         if worker["uncertain_side_effect"]:
             raise SubagentLifecycleError(
                 "The prior run stopped with an uncertain tool side effect; reconcile it before resume.")
-        child, creds, cfg, stored_policy = self._build_revalidated_child(
-            worker, goal=request.goal, role=request.role)
         runs = store.list_runs(worker["worker_id"], owner)
         if not runs or runs[-1]["run_id"] != previous["run_id"]:
-            with contextlib.suppress(Exception):
-                child.close()
             raise SubagentLifecycleError("Followup must link from the worker's latest run.")
+        # A cold public handle may point at a queued predecessor.  Rehydrate
+        # that exact run before appending another turn; no unrelated control
+        # action is required to start the older FIFO item.
+        if previous["status"] == "PENDING":
+            self._schedule_owner(
+                store, owner, parent,
+                worker_id=worker["worker_id"], run_id=previous["run_id"],
+            )
+        authority = self._retained_parent_authority(store, owner, worker, parent)
+        if authority is None:
+            raise SubagentLifecycleError(
+                "The retained worker's parent authority is unavailable; its queued work remains pending.")
+        validation_service = type(self)(lambda: authority)
+        child, _creds, cfg, stored_policy = validation_service._build_revalidated_child(
+            worker, goal=request.goal, role=request.role)
+        with contextlib.suppress(Exception):
+            child.close()
         followup_limit = ((stored_policy.get("profile_contract") or {}).get("execution_limits") or {}).get("max_followups")
         if isinstance(followup_limit, int) and len(runs) - 1 >= followup_limit:
-            with contextlib.suppress(Exception):
-                child.close()
             raise SubagentLifecycleError("Worker followup limit reached.")
         created = time.time()
-        subagent_id = str(getattr(child, "_subagent_id", "") or "")
+        subagent_id = f"queued-{uuid.uuid4().hex}"
         capability = self._capability(subagent_id, owner, created)
         queued = store.enqueue_run(
             worker["worker_id"], owner, goal=request.goal, previous_run_id=previous["run_id"],
             capability_digest=hashlib.sha256(capability.encode()).hexdigest(),
         )
         max_concurrent = _concurrency_limit(cfg)
-        active = store.claim_run(queued["run_id"], owner, max_concurrent=max_concurrent)
-        active_run = active if active is not None else None
-        child._worker_id, child._worker_run_id = worker["worker_id"], queued["run_id"]
-        child._worker_owner_session_id = owner
         result_handle = dataclasses.replace(
             prior,
             subagent_id=subagent_id,
             created_at=created,
-            provider=_text_or_none(getattr(child, "provider", None)),
-            model=_text_or_none(getattr(child, "model", None)),
             capability=capability,
             run_id=queued["run_id"],
         )
         record = _Record(
-            result_handle, SubagentState.PENDING, created, agent=child, store=store,
+            result_handle, SubagentState.PENDING, created, agent=None, store=store,
             owner_session_id=owner, worker_id=worker["worker_id"], run_id=queued["run_id"],
-            lease_token=active_run["lease_token"] if active_run else None,
             conversation_history=list(worker.get("history") or []),
-            max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
             max_concurrent=max_concurrent, goal=request.goal, parent_agent=parent,
         )
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
-        if active_run is not None:
-            self._start_record(record)
+        self._schedule_owner(
+            store, owner, parent, worker_id=worker["worker_id"], run_id=queued["run_id"])
         return result_handle
 
     def _build_revalidated_child(
@@ -1267,34 +1341,76 @@ class SubagentLifecycleService:
         cls._schedule_owner(completed.store, completed.owner_session_id, completed.parent_agent)
 
     @classmethod
-    def _schedule_owner(cls, store: Any, owner_session_id: str, parent_agent: Any = None) -> None:
-        # A process restart loses registry records, not the durable FIFO. Claim
-        # each exact eligible run, revalidate current authority, then rebuild
-        # its executor. A validation failure is terminal and inspectable rather
-        # than a permanently leased or silently skipped run.
-        if parent_agent is not None:
+    def _retained_parent_authority(
+        cls, store: Any, owner_session_id: str,
+        worker: Mapping[str, Any], triggering_agent: Any = None,
+    ) -> Any:
+        """Resolve the worker's immediate retained parent, never a sibling actor."""
+        expected = worker.get("parent_worker_id")
+
+        def matches(agent: Any) -> bool:
+            if agent is None or _owner_session_id_of(agent) != owner_session_id:
+                return False
+            actor = getattr(agent, "_worker_id", None)
+            return actor == expected if expected else not actor
+
+        if matches(triggering_agent):
+            return triggering_agent
+        with _REGISTRY.lock:
+            records = list(_REGISTRY.records.values())
+        # A warm record remembers the authority that created it.
+        for record in records:
+            if record.owner_session_id == owner_session_id and record.worker_id == worker["worker_id"]:
+                if matches(record.parent_agent):
+                    return record.parent_agent
+        # For a nested worker the immediate parent worker's live agent is its
+        # authority.  Its root owner identity remains separate in storage.
+        if expected:
+            for record in records:
+                if record.owner_session_id == owner_session_id and record.worker_id == expected:
+                    if matches(record.agent):
+                        return record.agent
+        return None
+
+    @classmethod
+    def _schedule_owner(
+        cls, store: Any, owner_session_id: str, parent_agent: Any = None,
+        *, worker_id: Optional[str] = None, run_id: Optional[str] = None,
+    ) -> None:
+        """Just-in-time admission for the exact durable FIFO run(s)."""
+        from tools.delegate_tool_config import _load_config
+
+        max_concurrent = _concurrency_limit(_load_config())
+        for pending in store.pending_runs(owner_session_id):
+            if worker_id is not None and pending["worker_id"] != worker_id:
+                continue
+            if run_id is not None and pending["run_id"] != run_id:
+                continue
+            worker = store.get_worker(pending["worker_id"], owner_session_id)
+            authority = cls._retained_parent_authority(
+                store, owner_session_id, worker, parent_agent)
+            if authority is None:
+                continue
             with _REGISTRY.lock:
-                represented = {
-                    item.run_id for item in _REGISTRY.records.values()
-                    if item.owner_session_id == owner_session_id and item.run_id
-                }
-            from tools.delegate_tool_config import _load_config
-            max_concurrent = _concurrency_limit(_load_config())
-            service = cls(lambda: parent_agent)
-            for pending in store.pending_runs(owner_session_id):
-                if pending["run_id"] in represented:
-                    continue
+                record = next((
+                    item for item in _REGISTRY.records.values()
+                    if item.owner_session_id == owner_session_id
+                    and item.run_id == pending["run_id"]
+                ), None)
+            # A live lease already owns execution.  Every unleased record,
+            # including an old warm/prebuilt record, is rebuilt below.
+            if record is not None and record.lease_token is not None:
+                continue
+            role = str((worker.get("policy") or {}).get("role") or "leaf")
+            service = cls(lambda authority=authority: authority)
+            try:
+                child, creds, cfg, _policy = service._build_revalidated_child(
+                    worker, goal=pending["goal"], role=role)
+            except Exception as exc:
                 claimed = store.claim_run(
                     pending["run_id"], owner_session_id, max_concurrent=max_concurrent)
-                if claimed is None:
-                    continue
-                worker = store.get_worker(pending["worker_id"], owner_session_id)
-                role = str((worker.get("policy") or {}).get("role") or "leaf")
-                try:
-                    child, creds, _cfg, _policy = service._build_revalidated_child(
-                        worker, goal=pending["goal"], role=role)
-                except Exception as exc:
-                    store.finish_run(
+                if claimed is not None:
+                    failed = store.finish_run(
                         pending["run_id"], owner_session_id, claimed["lease_token"],
                         status="FAILED",
                         result={
@@ -1306,12 +1422,33 @@ class SubagentLifecycleService:
                         },
                         history=list(worker.get("history") or []),
                     )
-                    continue
-                child._worker_id = pending["worker_id"]
-                child._worker_run_id = pending["run_id"]
-                child._worker_owner_session_id = owner_session_id
-                created = time.time()
-                subagent_id = str(getattr(child, "_subagent_id", "") or f"recovered-{pending['run_id']}")
+                if record is not None and claimed is not None:
+                    with _REGISTRY.lock:
+                        _REGISTRY.records.pop(record.handle.subagent_id, None)
+                        record.agent = None
+                        record.state = SubagentState.FAILED
+                        record.completed_at = record.updated_at = failed["updated_at"]
+                        record.result = SubagentResult(
+                            record.handle, SubagentState.FAILED, True,
+                            completed_at=record.completed_at,
+                            error_classification="AUTHORITY_REVALIDATION_FAILED",
+                            error_message=_clip(exc),
+                        )
+                continue
+            max_concurrent = _concurrency_limit(cfg)
+            claimed = store.claim_run(
+                pending["run_id"], owner_session_id, max_concurrent=max_concurrent)
+            if claimed is None:
+                with contextlib.suppress(Exception):
+                    child.close()
+                continue
+            child._worker_id = pending["worker_id"]
+            child._worker_run_id = pending["run_id"]
+            child._worker_owner_session_id = owner_session_id
+            created = time.time()
+            if record is None:
+                subagent_id = str(
+                    getattr(child, "_subagent_id", "") or f"recovered-{pending['run_id']}")
                 handle = SubagentHandle(
                     PUBLIC_CONTRACT_VERSION, subagent_id, owner_session_id, None, created,
                     _text_or_none(getattr(child, "provider", None)),
@@ -1319,39 +1456,26 @@ class SubagentLifecycleService:
                     pending["worker_id"], pending["run_id"],
                 )
                 record = _Record(
-                    handle, SubagentState.PENDING, created, agent=child, store=store,
+                    handle, SubagentState.PENDING, created, store=store,
                     owner_session_id=owner_session_id, worker_id=pending["worker_id"],
-                    run_id=pending["run_id"], lease_token=claimed["lease_token"],
-                    conversation_history=list(worker.get("history") or []),
-                    max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
-                    max_concurrent=max_concurrent, goal=pending["goal"], parent_agent=parent_agent,
+                    run_id=pending["run_id"], conversation_history=list(worker.get("history") or []),
+                    goal=pending["goal"],
                 )
                 with _REGISTRY.lock:
                     _REGISTRY.records[subagent_id] = record
-                represented.add(pending["run_id"])
-                cls._start_record(record)
-
-        with _REGISTRY.lock:
-            candidates = sorted(
-                (
-                    item for item in _REGISTRY.records.values()
-                    if item.owner_session_id == owner_session_id
-                    and item.state is SubagentState.PENDING
-                    and item.lease_token is None
-                    and item.agent is not None
-                ),
-                key=lambda item: item.updated_at,
-            )
-        for candidate in candidates:
-            active = candidate.store.claim_run(
-                candidate.run_id,
-                candidate.owner_session_id,
-                max_concurrent=candidate.max_concurrent,
-            )
-            if active is None:
-                continue
-            candidate.lease_token = active["lease_token"]
-            cls._start_record(candidate)
+            else:
+                old_agent = record.agent
+                if old_agent is not None and old_agent is not child:
+                    with contextlib.suppress(Exception):
+                        old_agent.close()
+                child._subagent_id = record.handle.subagent_id
+            record.agent = child
+            record.parent_agent = authority
+            record.lease_token = claimed["lease_token"]
+            record.max_tool_calls = getattr(creds.get("execution_limits"), "max_tool_calls", None)
+            record.max_concurrent = max_concurrent
+            record.goal = pending["goal"]
+            cls._start_record(record)
 
     @staticmethod
     def _bind_tool_boundary(record: _Record) -> None:

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -15,6 +15,7 @@ import threading
 import time
 import contextlib
 import weakref
+import uuid
 from contextlib import contextmanager
 from concurrent.futures import Future, TimeoutError
 from typing import Any, Callable, Mapping, Optional
@@ -58,6 +59,9 @@ class SubagentLaunchRequest:
     correlation_id: Optional[str] = None
     metadata: Mapping[str, Any] = dataclasses.field(default_factory=dict)
     timeout_seconds: Optional[float] = None
+    profile: Optional[str] = None
+    provider: Optional[str] = None
+    reasoning_effort: Optional[str] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -72,6 +76,8 @@ class SubagentHandle:
     role: str
     depth: int
     capability: str
+    worker_id: Optional[str] = None
+    run_id: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
@@ -143,6 +149,15 @@ class _Record:
     started_at: Optional[float] = None
     completed_at: Optional[float] = None
     result: Optional[SubagentResult] = None
+    store: Any = None
+    owner_session_id: Optional[str] = None
+    worker_id: Optional[str] = None
+    run_id: Optional[str] = None
+    lease_token: Optional[str] = None
+    conversation_history: list = dataclasses.field(default_factory=list)
+    lease_stop: Any = None
+    lease_thread: Any = None
+    delivered_message_ids: list[str] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
@@ -212,6 +227,8 @@ _HANDLE_FIELD_CHECKS: tuple[tuple[str, Callable[[Any], bool]], ...] = (
     ("role", lambda v: isinstance(v, str)),
     ("depth", lambda v: type(v) is int),
     ("capability", lambda v: isinstance(v, str)),
+    ("worker_id", _opt_str),
+    ("run_id", _opt_str),
 )
 
 # Launch-request rejections in check order: (predicate, error). The type check leads so later predicates may
@@ -227,11 +244,82 @@ _REQUEST_REJECTIONS: tuple[tuple[Callable[[Any], bool], str], ...] = (
      "working_directory is not supported because Hermes delegates use isolated task environments."),
     (lambda r: bool(r.blocked_tools),
      "Per-tool blocking is not supported; use allowed_toolsets. Hermes always blocks unsafe child tools."),
+    (lambda r: any(not _opt_str(value) for value in (r.profile, r.provider, r.model, r.reasoning_effort)),
+     "profile, provider, model, and reasoning_effort must be strings when provided."),
 )
 
 
 def _handle_is_well_formed(handle: Any) -> bool:
     return isinstance(handle, SubagentHandle) and all(check(getattr(handle, field)) for field, check in _HANDLE_FIELD_CHECKS)
+
+
+def _session_db_of(parent: Any) -> Any:
+    db = getattr(parent, "_session_db", None) or getattr(parent, "session_db", None)
+    return getattr(db, "_db", db)
+
+
+def _persistent_store(parent: Any) -> Any:
+    db = _session_db_of(parent)
+    if db is None or not hasattr(db, "_execute_write") or not hasattr(db, "_read_ctx"):
+        return None
+    from agent.worker_store import WorkerStore
+    store = WorkerStore(db)
+    store.ensure_schema()
+    return store
+
+
+def _profile_policy_snapshot(cfg: dict, profile: Optional[str], creds: Mapping[str, Any]) -> tuple[str, dict]:
+    """Allowlisted, noncredential config receipt and content identity."""
+    from agent.delegation_model_routing import discover_workers
+    catalog = discover_workers(cfg)
+    selected = next((item for item in catalog["profiles"] if item["name"] == profile), None)
+    policy = {
+        "catalog_version": catalog["version"],
+        "routing_mode": catalog["routing_mode"],
+        "profile": selected,
+        "route": {
+            key: creds.get(key) for key in (
+                "requested_profile", "requested_provider", "requested_model", "requested_reasoning_effort",
+                "resolved_provider", "resolved_model", "resolved_reasoning_effort",
+            )
+        },
+    }
+    encoded = json.dumps(policy, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode()).hexdigest(), policy
+
+
+def _terminal_status(state: SubagentState) -> str:
+    return {
+        SubagentState.SUCCEEDED: "SUCCEEDED",
+        SubagentState.CANCELLED: "CANCELLED",
+        SubagentState.INTERRUPTED: "INTERRUPTED",
+    }.get(state, "FAILED")
+
+
+def before_worker_tool(agent: Any) -> None:
+    """Fail-closed durable boundary immediately before a worker tool dispatch."""
+    record = getattr(agent, "_worker_lifecycle_record", None)
+    if not isinstance(record, _Record) or record.store is None:
+        return
+    record.store.mark_tool_boundary(
+        record.run_id, record.owner_session_id, record.lease_token, tool_inflight=True)
+
+
+def checkpoint_worker_tool_result(agent: Any, history: list) -> None:
+    """Atomically persist the tool result/history before clearing uncertainty."""
+    record = getattr(agent, "_worker_lifecycle_record", None)
+    if not isinstance(record, _Record) or record.store is None:
+        return
+    delivered = tuple(record.delivered_message_ids)
+    record.store.checkpoint_run(
+        record.run_id,
+        record.owner_session_id,
+        record.lease_token,
+        history=history,
+        tool_inflight=False,
+        delivered_message_ids=delivered,
+    )
+    record.delivered_message_ids.clear()
 
 
 class SubagentLifecycleService:
@@ -241,6 +329,114 @@ class SubagentLifecycleService:
 
     def __init__(self, parent_agent_resolver: Callable[[], Any]) -> None:
         self._parent_agent_resolver = parent_agent_resolver
+
+    def adopt_delegate_child(
+        self,
+        child: Any,
+        *,
+        goal: str,
+        context: Optional[str],
+        profile: Optional[str],
+        creds: Mapping[str, Any],
+        cfg: Mapping[str, Any],
+    ) -> Optional[SubagentHandle]:
+        """Attach the parent tool's child to the same durable lifecycle used by plugins."""
+        parent = self._parent_agent_resolver()
+        owner = _session_id_of(parent)
+        store = _persistent_store(parent) if parent is not None else None
+        if store is None or not owner:
+            return None
+        subagent_id = str(getattr(child, "_subagent_id", "") or "")
+        if not subagent_id:
+            raise SubagentLifecycleError("Hermes failed to assign a child identity.")
+        created = time.time()
+        capability = self._capability(subagent_id, owner, created)
+        config_revision, policy = _profile_policy_snapshot(dict(cfg), profile, creds)
+        policy["capability_digest"] = hashlib.sha256(capability.encode()).hexdigest()
+        parent_worker_id = getattr(parent, "_worker_id", None)
+        worker = store.create_worker(
+            owner,
+            profile=profile,
+            config_revision=config_revision,
+            policy=policy,
+            frozen_prompt=str(getattr(child, "system_prompt", "") or ""),
+            parent_worker_id=parent_worker_id,
+        )
+        queued = store.enqueue_run(worker["worker_id"], owner, goal=goal, context=context or "")
+        global_cap = int((cfg or {}).get("max_concurrent_children") or 10)
+        profile_cap = getattr(creds.get("execution_limits"), "max_concurrent_children", None)
+        max_concurrent = min(global_cap, profile_cap) if isinstance(profile_cap, int) and profile_cap > 0 else global_cap
+        active = store.claim_next_run(worker["worker_id"], owner, max_concurrent=max(1, max_concurrent))
+        if active is None or active["run_id"] != queued["run_id"]:
+            raise SubagentLifecycleError("Worker run could not acquire an execution slot.")
+        child._worker_id, child._worker_run_id = worker["worker_id"], active["run_id"]
+        handle = SubagentHandle(
+            contract_version=PUBLIC_CONTRACT_VERSION,
+            subagent_id=subagent_id,
+            parent_session_id=owner,
+            correlation_id=None,
+            created_at=created,
+            provider=getattr(child, "provider", None),
+            model=getattr(child, "model", None),
+            role=getattr(child, "_delegate_role", "leaf"),
+            depth=int(getattr(child, "_delegate_depth", 1) or 1),
+            capability=capability,
+            worker_id=worker["worker_id"],
+            run_id=active["run_id"],
+        )
+        record = _Record(
+            handle, SubagentState.RUNNING, created, agent=child, started_at=created,
+            store=store, owner_session_id=owner, worker_id=worker["worker_id"],
+            run_id=active["run_id"], lease_token=active["lease_token"],
+        )
+        self._bind_tool_boundary(record)
+        self._start_external_lease(record)
+        child._worker_lifecycle_record = record
+        with _REGISTRY.lock:
+            _REGISTRY.records[subagent_id] = record
+        return handle
+
+    @staticmethod
+    def _start_external_lease(record: _Record) -> None:
+        stop = threading.Event()
+        record.lease_stop = stop
+
+        def renew():
+            while not stop.wait(15.0):
+                try:
+                    record.store.heartbeat_run(
+                        record.run_id, record.owner_session_id, record.lease_token, lease_seconds=60)
+                except Exception:
+                    request_hard_interrupt(
+                        record.agent, "Durable worker execution lease was lost.", tool_reason="worker lease lost")
+                    return
+
+        record.lease_thread = threading.Thread(target=renew, name="hermes-worker-lease", daemon=True)
+        record.lease_thread.start()
+
+    @classmethod
+    def complete_adopted_child(cls, child: Any, entry: Mapping[str, Any]) -> None:
+        record = getattr(child, "_worker_lifecycle_record", None)
+        if not isinstance(record, _Record):
+            return
+        status = str(entry.get("status") or "error")
+        if status == "completed":
+            state = SubagentState.SUCCEEDED
+        elif status == "interrupted":
+            state = SubagentState.INTERRUPTED
+        else:
+            state = SubagentState.FAILED
+        cls._publish_result(
+            record,
+            state,
+            {
+                "summary": _clip(entry.get("summary")),
+                "error_message": _clip(entry.get("error")),
+                "error_classification": None if state is SubagentState.SUCCEEDED else status.upper(),
+                "usage_metadata": {"api_calls": entry.get("api_calls", 0)},
+                "tool_execution_summary": {"duration_seconds": entry.get("duration_seconds", 0)},
+            },
+        )
 
     def launch(self, request: SubagentLaunchRequest) -> SubagentHandle:
         parent = self._parent_agent_resolver()
@@ -256,22 +452,81 @@ class SubagentLifecycleService:
             if request.correlation_id and correlation_key in _REGISTRY.correlations:
                 raise SubagentLifecycleError("Duplicate correlation_id for this parent session.")
         # Lazy: delegate construction stays internal, plugins never import private delegation helpers.
-        from tools.delegate_tool import _build_child_preserving_parent_tools, DEFAULT_MAX_ITERATIONS
+        from tools.delegate_tool import (
+            DEFAULT_MAX_ITERATIONS, _build_child_preserving_parent_tools, _profile_task_overrides,
+        )
+        from tools.delegate_tool_config import _load_config, _resolve_delegation_credentials
+        cfg = _load_config()
+        if request.profile:
+            creds = _resolve_delegation_credentials(
+                cfg, parent, request.profile,
+                requested_provider=request.provider,
+                requested_model=request.model,
+                requested_reasoning_effort=request.reasoning_effort,
+            )
+            overrides = _profile_task_overrides(creds)
+            profile_limit = creds.get("max_iterations")
+            run_iterations = min(DEFAULT_MAX_ITERATIONS, profile_limit) if isinstance(profile_limit, int) else DEFAULT_MAX_ITERATIONS
+        else:
+            if request.provider or request.reasoning_effort:
+                raise SubagentLifecycleError("provider/reasoning_effort require a configured worker profile.")
+            creds = _resolve_delegation_credentials(cfg, parent)
+            overrides = {
+                "override_provider": creds["provider"], "override_base_url": creds["base_url"],
+                "override_api_key": creds["api_key"], "override_api_mode": creds["api_mode"],
+                "override_request_overrides": creds.get("request_overrides"),
+                "override_acp_command": creds.get("command"), "override_acp_args": creds.get("args"),
+                "routing_cfg": cfg,
+            }
+            run_iterations = DEFAULT_MAX_ITERATIONS
         child = _build_child_preserving_parent_tools(
             task_index=0, goal=request.goal, context=request.context,
             toolsets=list(request.allowed_toolsets) if request.allowed_toolsets else None,
-            model=request.model, max_iterations=DEFAULT_MAX_ITERATIONS, task_count=1, parent_agent=parent, role=request.role,
+            model=(request.model or creds.get("model")), max_iterations=run_iterations,
+            task_count=1, parent_agent=parent, role=request.role, **overrides,
         )
         subagent_id = str(getattr(child, "_subagent_id", "") or "")
         if not subagent_id:
             raise SubagentLifecycleError("Hermes failed to assign a child identity.")
         created = time.time()
+        capability = self._capability(subagent_id, parent_session_id, created)
+        store = _persistent_store(parent)
+        worker_id = run_id = lease_token = None
+        if store is not None and parent_session_id:
+            config_revision, policy = _profile_policy_snapshot(cfg, request.profile, creds)
+            policy["capability_digest"] = hashlib.sha256(capability.encode()).hexdigest()
+            worker = store.create_worker(
+                parent_session_id,
+                profile=request.profile,
+                config_revision=config_revision,
+                policy=policy,
+                frozen_prompt=str(getattr(child, "system_prompt", "") or ""),
+            )
+            queued = store.enqueue_run(worker["worker_id"], parent_session_id, goal=request.goal, context=request.context or "")
+            active = store.claim_next_run(worker["worker_id"], parent_session_id)
+            if active is None or active["run_id"] != queued["run_id"]:
+                raise SubagentLifecycleError("Worker run could not acquire an execution slot.")
+            worker_id, run_id, lease_token = worker["worker_id"], active["run_id"], active["lease_token"]
+            child._worker_id, child._worker_run_id = worker_id, run_id
         handle = SubagentHandle(
-            PUBLIC_CONTRACT_VERSION, subagent_id, parent_session_id, request.correlation_id, created,
-            getattr(child, "provider", None), getattr(child, "model", None), getattr(child, "_delegate_role", request.role),
-            int(getattr(child, "_delegate_depth", 1) or 1), self._capability(subagent_id, parent_session_id, created),
+            contract_version=PUBLIC_CONTRACT_VERSION,
+            subagent_id=subagent_id,
+            parent_session_id=parent_session_id,
+            correlation_id=request.correlation_id,
+            created_at=created,
+            provider=getattr(child, "provider", None),
+            model=getattr(child, "model", None),
+            role=getattr(child, "_delegate_role", request.role),
+            depth=int(getattr(child, "_delegate_depth", 1) or 1),
+            capability=capability,
+            worker_id=worker_id,
+            run_id=run_id,
         )
-        record = _Record(handle, SubagentState.PENDING, created, agent=child)
+        record = _Record(
+            handle, SubagentState.PENDING, created, agent=child, store=store,
+            owner_session_id=parent_session_id, worker_id=worker_id, run_id=run_id, lease_token=lease_token,
+        )
+        self._bind_tool_boundary(record)
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
             if request.correlation_id:
@@ -282,14 +537,28 @@ class SubagentLifecycleService:
     def status(self, handle: SubagentHandle) -> SubagentStatus:
         record = self._record(handle)
         if record is None:
-            return SubagentStatus(handle, SubagentState.UNKNOWN, time.time(), "UNKNOWN_HANDLE")
+            durable = self._durable_snapshot(handle)
+            if durable is None:
+                return SubagentStatus(handle, SubagentState.UNKNOWN, time.time(), "UNKNOWN_HANDLE")
+            return SubagentStatus(handle, SubagentState(durable[2]["status"]), durable[2]["updated_at"], "DURABLE_SNAPSHOT")
         with _REGISTRY.lock:
             return SubagentStatus(record.handle, record.state, record.updated_at)
 
     def wait(self, handle: SubagentHandle, *, timeout_seconds: Optional[float] = None) -> SubagentTerminalState:
         record = self._record(handle)
         if record is None:
-            return SubagentTerminalState(handle, SubagentState.UNKNOWN, True, diagnostic="UNKNOWN_HANDLE")
+            durable = self._durable_snapshot(handle)
+            if durable is None:
+                return SubagentTerminalState(handle, SubagentState.UNKNOWN, True, diagnostic="UNKNOWN_HANDLE")
+            store, _worker, run = durable
+            if run["status"] == "RUNNING" and run.get("lease_expires_at", 0) <= time.time():
+                store.recover_expired_runs(handle.parent_session_id)
+                run = store.get_run(handle.run_id, handle.parent_session_id)
+            state = SubagentState(run["status"])
+            completed = state in {
+                SubagentState.SUCCEEDED, SubagentState.FAILED, SubagentState.INTERRUPTED, SubagentState.CANCELLED,
+            }
+            return SubagentTerminalState(handle, state, completed, diagnostic="DURABLE_SNAPSHOT")
         try:
             if record.future is not None:
                 record.future.result(timeout=timeout_seconds)
@@ -321,28 +590,277 @@ class SubagentLifecycleService:
     def result(self, handle: SubagentHandle) -> SubagentResult:
         record = self._record(handle)
         if record is None:
-            return SubagentResult(handle, SubagentState.UNKNOWN, False, error_classification="UNKNOWN_HANDLE")
+            durable = self._durable_snapshot(handle)
+            if durable is None:
+                return SubagentResult(handle, SubagentState.UNKNOWN, False, error_classification="UNKNOWN_HANDLE")
+            run = durable[2]
+            state = SubagentState(run["status"])
+            payload = run.get("result") or {}
+            ready = state in {
+                SubagentState.SUCCEEDED, SubagentState.FAILED, SubagentState.INTERRUPTED, SubagentState.CANCELLED,
+            }
+            return SubagentResult(
+                handle,
+                state,
+                ready,
+                summary=payload.get("summary"),
+                error_classification=payload.get("error_classification") or (None if state is SubagentState.SUCCEEDED else state.value),
+                error_message=payload.get("error_message"),
+                result_hash=payload.get("result_hash"),
+            )
         with _REGISTRY.lock:
             return record.result or SubagentResult(record.handle, record.state, False, error_classification="NOT_READY")
 
     def reconnect(self, handle: SubagentHandle) -> SubagentReconnectResult:
         record = self._record(handle)
         if record is None:
-            return SubagentReconnectResult(False, SubagentState.UNKNOWN, "RECONNECT_UNAVAILABLE")
+            durable = self._durable_snapshot(handle)
+            if durable is None:
+                return SubagentReconnectResult(False, SubagentState.UNKNOWN, "UNKNOWN_HANDLE")
+            _store, _worker, run = durable
+            state = SubagentState(run["status"])
+            return SubagentReconnectResult(True, state, "DURABLE_SNAPSHOT")
         with _REGISTRY.lock:
             return SubagentReconnectResult(True, record.state)
+
+    def message(self, handle: SubagentHandle, content: str, *, message_id: Optional[str] = None) -> Mapping[str, Any]:
+        """Queue one durable FIFO followup for the worker; delivery is acked with a checkpoint."""
+        record = self._record(handle)
+        parent = self._parent_agent_resolver()
+        durable = None if record is not None else self._durable_snapshot(handle)
+        store = record.store if record is not None else (durable[0] if durable else None)
+        owner = _session_id_of(parent)
+        worker_id = handle.worker_id or (record.worker_id if record is not None else None)
+        if store is None or not owner or not worker_id:
+            raise SubagentLifecycleError("Durable worker messaging is unavailable for this handle.")
+        return store.enqueue_message(worker_id, owner, content, message_id=message_id, sender_id=owner)
+
+    def control(
+        self,
+        action: str,
+        *,
+        worker_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        message: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+    ) -> Mapping[str, Any]:
+        """Parent-tool control by stable IDs; authority is the bound live session, never ID knowledge."""
+        parent = self._parent_agent_resolver()
+        owner = _session_id_of(parent)
+        store = _persistent_store(parent) if parent is not None else None
+        if store is None or not owner:
+            raise SubagentLifecycleError("Durable worker state is unavailable for this session.")
+        normalized = action.strip().lower()
+        if normalized == "status":
+            if not worker_id:
+                workers = store.list_workers(owner)
+                return {"workers": [self._safe_worker_snapshot(store, item, owner) for item in workers]}
+            worker = store.get_worker(worker_id, owner)
+            return self._safe_worker_snapshot(store, worker, owner)
+        if not worker_id:
+            raise SubagentLifecycleError(f"action='{normalized}' requires worker_id.")
+        worker = store.get_worker(worker_id, owner)
+        runs = store.list_runs(worker_id, owner)
+        selected = next((item for item in runs if item["run_id"] == run_id), None) if run_id else (runs[-1] if runs else None)
+        if normalized == "message":
+            queued = store.enqueue_message(worker_id, owner, message or "", sender_id=owner)
+            return {"worker_id": worker_id, "message_id": queued["message_id"], "status": queued["status"]}
+        if selected is None:
+            raise SubagentLifecycleError("Worker has no matching run.")
+        if normalized == "wait":
+            timeout = 0.0 if timeout_seconds is None else float(timeout_seconds)
+            if timeout < 0 or timeout > 60:
+                raise SubagentLifecycleError("timeout_seconds must be between 0 and 60.")
+            deadline = time.monotonic() + timeout
+            while selected["status"] in {"PENDING", "RUNNING"} and time.monotonic() < deadline:
+                if selected["status"] == "RUNNING" and selected.get("lease_expires_at", 0) <= time.time():
+                    store.recover_expired_runs(owner)
+                time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+                selected = store.get_run(selected["run_id"], owner)
+            return self._safe_run_snapshot(selected)
+        if normalized == "cancel":
+            live = next((
+                record for record in list(_REGISTRY.records.values())
+                if record.worker_id == worker_id and record.run_id == selected["run_id"] and record.agent is not None
+            ), None)
+            if live is None:
+                if selected["status"] == "RUNNING" and selected.get("lease_expires_at", 0) <= time.time():
+                    store.recover_expired_runs(owner)
+                    selected = store.get_run(selected["run_id"], owner)
+                    return self._safe_run_snapshot(selected)
+                raise SubagentLifecycleError("The run has no live executor to cancel.")
+            accepted = request_hard_interrupt(
+                live.agent, "Worker cancellation requested by its owner.", tool_reason="worker cancellation requested")
+            return {**self._safe_run_snapshot(selected), "cancel_requested": bool(accepted)}
+        if normalized == "resume":
+            if not message or not message.strip():
+                raise SubagentLifecycleError("action='resume' requires message as the next worker turn.")
+            if selected is not runs[-1]:
+                raise SubagentLifecycleError("Resume must link from the worker's latest run.")
+            prior = SubagentHandle(
+                PUBLIC_CONTRACT_VERSION, "durable-snapshot", owner, None, worker["created_at"],
+                None, None, "leaf", int(worker["depth"]), "", worker_id, selected["run_id"],
+            )
+            handle = self._launch_existing_worker(
+                SubagentLaunchRequest(goal=message, profile=worker["profile"]), prior, worker, selected)
+            return {"worker_id": handle.worker_id, "run_id": handle.run_id, "status": "PENDING"}
+        raise SubagentLifecycleError(f"Unsupported durable worker action '{normalized}'.")
+
+    @staticmethod
+    def _safe_run_snapshot(run: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {
+            key: run.get(key) for key in (
+                "run_id", "worker_id", "previous_run_id", "status", "uncertain_side_effect",
+                "created_at", "updated_at",
+            )
+        }
+
+    @classmethod
+    def _safe_worker_snapshot(cls, store: Any, worker: Mapping[str, Any], owner: str) -> Mapping[str, Any]:
+        runs = store.list_runs(worker["worker_id"], owner)
+        return {
+            "worker_id": worker["worker_id"],
+            "parent_worker_id": worker["parent_worker_id"],
+            "root_worker_id": worker["root_worker_id"],
+            "depth": worker["depth"],
+            "profile": worker["profile"],
+            "config_revision": worker["config_revision"],
+            "frozen_prompt_hash": worker["frozen_prompt_hash"],
+            "uncertain_side_effect": worker["uncertain_side_effect"],
+            "latest_run": cls._safe_run_snapshot(runs[-1]) if runs else None,
+        }
+
+    def resume(
+        self,
+        handle: SubagentHandle,
+        message: str,
+        *,
+        reconcile_uncertain: bool = False,
+    ) -> SubagentHandle:
+        """Start a linked run on the stable worker after revalidating current profile policy."""
+        parent = self._parent_agent_resolver()
+        owner = _session_id_of(parent)
+        durable = self._durable_snapshot(handle)
+        if durable is None or not owner or not handle.worker_id or not handle.run_id:
+            raise SubagentLifecycleError("Durable resume is unavailable for this handle.")
+        store, worker, previous = durable
+        runs = store.list_runs(handle.worker_id, owner)
+        if not runs or runs[-1]["run_id"] != previous["run_id"]:
+            raise SubagentLifecycleError("Resume must link from the worker's latest run.")
+        if previous["status"] not in {"SUCCEEDED", "FAILED", "INTERRUPTED", "CANCELLED"}:
+            raise SubagentLifecycleError("The worker already has an active run.")
+        if worker["uncertain_side_effect"]:
+            if not reconcile_uncertain:
+                raise SubagentLifecycleError(
+                    "The prior run stopped with an uncertain tool side effect; reconcile it before resume.")
+            store.reconcile_run(handle.run_id, owner)
+        # Revalidation is fail-closed: launch resolves the current profile/model/tools again. The
+        # frozen prompt is retained as a hash boundary; changed profile/tool policy cannot silently
+        # rebuild an existing worker's execution surface.
+        from tools.delegate_tool_config import _load_config
+        from agent.delegation_model_routing import discover_workers
+        cfg = _load_config()
+        current_catalog = discover_workers(cfg)
+        current_profile = next((item for item in current_catalog["profiles"] if item["name"] == worker["profile"]), None)
+        current_policy = dict(worker["policy"])
+        if current_catalog["errors"] or current_profile != current_policy.get("profile"):
+            raise SubagentLifecycleError(
+                "Worker profile or tool policy changed since launch; start a new worker to adopt the new surface.")
+        request = SubagentLaunchRequest(
+            goal=message,
+            profile=worker["profile"],
+            parent_session_id=owner,
+            correlation_id=f"resume-{uuid.uuid4().hex}",
+        )
+        return self._launch_existing_worker(request, handle, worker, previous)
+
+    def _launch_existing_worker(
+        self, request: SubagentLaunchRequest, prior: SubagentHandle, worker: Mapping[str, Any], previous: Mapping[str, Any],
+    ) -> SubagentHandle:
+        """Resume implementation kept separate so ``launch`` remains legacy compatible."""
+        parent = self._parent_agent_resolver()
+        owner = _session_id_of(parent)
+        store = _persistent_store(parent)
+        from tools.delegate_tool import DEFAULT_MAX_ITERATIONS, _build_child_preserving_parent_tools, _profile_task_overrides
+        from tools.delegate_tool_config import _load_config, _resolve_delegation_credentials
+        cfg = _load_config()
+        creds = _resolve_delegation_credentials(cfg, parent, request.profile)
+        limits = creds.get("max_iterations")
+        max_iterations = min(DEFAULT_MAX_ITERATIONS, limits) if isinstance(limits, int) else DEFAULT_MAX_ITERATIONS
+        child = _build_child_preserving_parent_tools(
+            task_index=0, goal=request.goal, context=None, toolsets=None, model=creds.get("model"),
+            max_iterations=max_iterations, task_count=1, parent_agent=parent, role=request.role,
+            **_profile_task_overrides(creds),
+        )
+        queued = store.enqueue_run(
+            worker["worker_id"], owner, goal=request.goal, previous_run_id=previous["run_id"])
+        active = store.claim_next_run(worker["worker_id"], owner)
+        if active is None or active["run_id"] != queued["run_id"]:
+            raise SubagentLifecycleError("Worker resume could not acquire an execution slot.")
+        child._worker_id, child._worker_run_id = worker["worker_id"], active["run_id"]
+        created = time.time()
+        subagent_id = str(getattr(child, "_subagent_id", "") or "")
+        result_handle = dataclasses.replace(
+            prior,
+            subagent_id=subagent_id,
+            created_at=created,
+            provider=getattr(child, "provider", None),
+            model=getattr(child, "model", None),
+            run_id=active["run_id"],
+        )
+        record = _Record(
+            result_handle, SubagentState.PENDING, created, agent=child, store=store,
+            owner_session_id=owner, worker_id=worker["worker_id"], run_id=active["run_id"],
+            lease_token=active["lease_token"], conversation_history=list(worker.get("history") or []),
+        )
+        self._bind_tool_boundary(record)
+        with _REGISTRY.lock:
+            _REGISTRY.records[subagent_id] = record
+        record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        return result_handle
+
+    @staticmethod
+    def _bind_tool_boundary(record: _Record) -> None:
+        if record.store is None or record.agent is None or not record.run_id or not record.lease_token:
+            return
+        record.agent._worker_lifecycle_record = record
 
     def _record(self, handle: SubagentHandle) -> Optional[_Record]:
         """Registry record for a well-formed, capability-verified handle owned by the active parent."""
         if not _handle_is_well_formed(handle):
             return None
-        expected = self._capability(handle.subagent_id, handle.parent_session_id, handle.created_at)
-        if not hmac.compare_digest(handle.capability, expected):
-            return None
         if _session_id_of(self._parent_agent_resolver()) != handle.parent_session_id:
             return None
         with _REGISTRY.lock:
-            return _REGISTRY.records.get(handle.subagent_id)
+            record = _REGISTRY.records.get(handle.subagent_id)
+        if record is None:
+            return None
+        if handle.worker_id:
+            expected = record.handle.capability
+        else:
+            expected = self._capability(handle.subagent_id, handle.parent_session_id, handle.created_at)
+        return record if hmac.compare_digest(handle.capability, expected) else None
+
+    def _durable_snapshot(self, handle: SubagentHandle) -> Optional[tuple[Any, Mapping[str, Any], Mapping[str, Any]]]:
+        if not _handle_is_well_formed(handle) or not handle.worker_id or not handle.run_id:
+            return None
+        parent = self._parent_agent_resolver()
+        owner = _session_id_of(parent)
+        if not owner or owner != handle.parent_session_id:
+            return None
+        try:
+            store = _persistent_store(parent)
+            if store is None:
+                return None
+            worker = store.get_worker(handle.worker_id, owner)
+            run = store.get_run(handle.run_id, owner)
+        except (PermissionError, ValueError):
+            return None
+        stored_digest = str((worker.get("policy") or {}).get("capability_digest") or "")
+        supplied_digest = hashlib.sha256(handle.capability.encode()).hexdigest()
+        if not stored_digest or not hmac.compare_digest(stored_digest, supplied_digest):
+            return None
+        return store, worker, run
 
     @staticmethod
     def _cleanup_locked() -> None:
@@ -362,6 +880,40 @@ class SubagentLifecycleService:
             if record.state is not SubagentState.CANCEL_REQUESTED:
                 record.state = SubagentState.RUNNING
             record.started_at = record.updated_at = time.time()
+        lease_stop = threading.Event()
+        lease_thread = None
+        delivered_ids: list[str] = []
+        if record.store is not None and record.run_id and record.lease_token:
+            try:
+                pending = record.store.claim_messages(
+                    record.run_id, record.owner_session_id, record.lease_token)
+                delivered_ids = [item["message_id"] for item in pending]
+                record.delivered_message_ids = list(delivered_ids)
+                if pending:
+                    queued = "\n\n".join(item["content"] for item in pending)
+                    goal = f"{goal}\n\nQueued followups (FIFO):\n{queued}"
+                record.agent._worker_resume_history = list(record.conversation_history)
+            except Exception as exc:
+                state = SubagentState.FAILED
+                fields = dict(error_classification="PERSISTENCE_FAILURE", error_message=_clip(exc))
+                self._publish_result(record, state, fields)
+                return
+
+            def renew_lease():
+                while not lease_stop.wait(15.0):
+                    try:
+                        record.store.heartbeat_run(
+                            record.run_id, record.owner_session_id, record.lease_token, lease_seconds=60)
+                    except Exception:
+                        request_hard_interrupt(
+                            record.agent,
+                            "Durable worker execution lease was lost.",
+                            tool_reason="worker lease lost",
+                        )
+                        return
+
+            lease_thread = threading.Thread(target=renew_lease, name="hermes-worker-lease", daemon=True)
+            lease_thread.start()
         try:
             from tools.delegate_tool import _run_child_lifecycle
             raw = _run_child_lifecycle(0, goal, record.agent, parent)
@@ -381,10 +933,61 @@ class SubagentLifecycleService:
         except Exception as exc:
             state = SubagentState.FAILED
             fields = dict(error_classification=type(exc).__name__, error_message=_clip(exc))
+        finally:
+            lease_stop.set()
+            if lease_thread is not None:
+                lease_thread.join(timeout=1.0)
+        self._publish_result(record, state, fields, delivered_ids=delivered_ids)
+
+    @staticmethod
+    def _publish_result(
+        record: _Record,
+        state: SubagentState,
+        fields: Mapping[str, Any],
+        *,
+        delivered_ids: tuple[str, ...] | list[str] = (),
+    ) -> None:
+        if record.lease_stop is not None:
+            record.lease_stop.set()
+        if record.lease_thread is not None:
+            record.lease_thread.join(timeout=1.0)
         result = SubagentResult(record.handle, state, True, started_at=record.started_at, completed_at=time.time(), **fields)
         payload = dataclasses.asdict(result)
         payload.pop("result_hash", None)
         result = dataclasses.replace(result, result_hash=hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest())
+        if record.store is not None and record.run_id and record.lease_token:
+            history = list(getattr(record.agent, "_worker_last_history", None) or record.conversation_history)
+            try:
+                current_run = record.store.get_run(record.run_id, record.owner_session_id)
+                unresolved_tool = bool(current_run.get("tool_inflight")) and state is not SubagentState.SUCCEEDED
+                record.store.checkpoint_run(
+                    record.run_id,
+                    record.owner_session_id,
+                    record.lease_token,
+                    history=history,
+                    tool_inflight=unresolved_tool,
+                    delivered_message_ids=tuple(delivered_ids),
+                )
+                record.store.finish_run(
+                    record.run_id,
+                    record.owner_session_id,
+                    record.lease_token,
+                    status=_terminal_status(state),
+                    result={
+                        "summary": result.summary,
+                        "error_classification": result.error_classification,
+                        "error_message": result.error_message,
+                        "result_hash": result.result_hash,
+                    },
+                    history=history,
+                )
+            except Exception as exc:
+                result = dataclasses.replace(
+                    result,
+                    terminal_state=SubagentState.FAILED,
+                    error_classification="PERSISTENCE_FAILURE",
+                    error_message=_clip(exc),
+                )
         with _REGISTRY.lock:
             record.agent, record.result, record.state = None, result, result.terminal_state
             record.completed_at = record.updated_at = result.completed_at

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -296,8 +296,19 @@ def _handle_is_well_formed(handle: Any) -> bool:
 
 
 def _session_db_of(parent: Any) -> Any:
-    db = getattr(parent, "_session_db", None) or getattr(parent, "session_db", None)
-    return getattr(db, "_db", db)
+    # Read only attributes that are really present.  Dynamic proxy/test-double
+    # ``__getattr__`` values are not durable database authority, and an
+    # explicitly disabled ``_session_db = None`` must not fall through to a
+    # fabricated public attribute.
+    import inspect
+    missing = object()
+    db = inspect.getattr_static(parent, "_session_db", missing)
+    if db is missing:
+        db = inspect.getattr_static(parent, "session_db", None)
+    if db is None:
+        return None
+    inner = inspect.getattr_static(db, "_db", missing)
+    return getattr(db, "_db") if inner is not missing else db
 
 
 def _persistent_store(parent: Any) -> Any:
@@ -305,7 +316,8 @@ def _persistent_store(parent: Any) -> Any:
     if isinstance(retained, _Record) and retained.store is not None:
         return retained.store
     db = _session_db_of(parent)
-    if db is None or not hasattr(db, "_execute_write") or not hasattr(db, "_read_ctx"):
+    if db is None or not callable(getattr(type(db), "_execute_write", None)) \
+            or not callable(getattr(type(db), "_read_ctx", None)):
         return None
     from agent.worker_store import WorkerStore
     store = WorkerStore(db)
@@ -1347,8 +1359,11 @@ class SubagentLifecycleService:
             raise SubagentLifecycleError(
                 "The retained worker's parent authority is unavailable; its queued work remains pending.")
         validation_service = type(self)(lambda: authority)
-        child, current_creds, cfg, stored_policy = validation_service._build_revalidated_child(
-            worker, goal=request.goal, role=request.role)
+        try:
+            child, current_creds, cfg, stored_policy = validation_service._build_revalidated_child(
+                worker, goal=request.goal, role=request.role)
+        except (RuntimeError, ValueError) as exc:
+            raise SubagentLifecycleError(f"Worker resume admission failed: {exc}") from exc
         with contextlib.suppress(Exception):
             child.close()
         followup_limit = ((stored_policy.get("profile_contract") or {}).get("execution_limits") or {}).get("max_followups")

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -80,7 +80,23 @@ class SubagentHandle:
     run_id: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
-        return dataclasses.asdict(self)
+        # Keep this a shallow scalar projection.  Besides being cheaper than
+        # ``asdict``, it never attempts to copy runtime/provider objects when
+        # an internal caller is still assembling a handle.
+        return {
+            "contract_version": self.contract_version,
+            "subagent_id": self.subagent_id,
+            "parent_session_id": self.parent_session_id,
+            "correlation_id": self.correlation_id,
+            "created_at": self.created_at,
+            "provider": self.provider,
+            "model": self.model,
+            "role": self.role,
+            "depth": self.depth,
+            "capability": self.capability,
+            "worker_id": self.worker_id,
+            "run_id": self.run_id,
+        }
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "SubagentHandle":
@@ -158,6 +174,11 @@ class _Record:
     lease_stop: Any = None
     lease_thread: Any = None
     delivered_message_ids: list[str] = dataclasses.field(default_factory=list)
+    max_tool_calls: Optional[int] = None
+    tool_calls: int = 0
+    max_concurrent: int = 10
+    goal: str = ""
+    parent_agent: Any = None
 
 
 @dataclasses.dataclass
@@ -207,12 +228,30 @@ def _opt_str(value: Any) -> bool:
     return value is None or isinstance(value, str)
 
 
+def _text_or_none(value: Any) -> Optional[str]:
+    """Keep public identity metadata typed; opaque runtime objects are unknown."""
+    return value if isinstance(value, str) and value else None
+
+
 def _session_id_of(agent: Any) -> Optional[str]:
     return str(getattr(agent, "session_id", "") or "") or None
 
 
+def _owner_session_id_of(agent: Any) -> Optional[str]:
+    """Stable root owner for a worker tree; a nested child's session id is never a new authority."""
+    return str(getattr(agent, "_worker_owner_session_id", "") or "") or _session_id_of(agent)
+
+
 def _clip(value: Any) -> Optional[str]:
     return str(value)[:_MAX_RESULT_CHARS] if value is not None else None
+
+
+def _prompt_of(agent: Any) -> str:
+    return str(
+        getattr(agent, "ephemeral_system_prompt", None)
+        or getattr(agent, "system_prompt", None)
+        or ""
+    )
 
 
 # Per-field shape check applied to a (possibly deserialized) handle before trusting it.
@@ -268,15 +307,32 @@ def _persistent_store(parent: Any) -> Any:
     return store
 
 
-def _profile_policy_snapshot(cfg: dict, profile: Optional[str], creds: Mapping[str, Any]) -> tuple[str, dict]:
-    """Allowlisted, noncredential config receipt and content identity."""
-    from agent.delegation_model_routing import discover_workers
-    catalog = discover_workers(cfg)
-    selected = next((item for item in catalog["profiles"] if item["name"] == profile), None)
+def _profile_policy_snapshot(
+    cfg: dict,
+    profile: Optional[str],
+    creds: Mapping[str, Any],
+    *,
+    child: Any = None,
+) -> tuple[str, dict]:
+    """Allowlisted execution contract; volatile discovery metadata is deliberately excluded."""
+    from agent.delegation_model_routing import parse_profiles
+    spec = parse_profiles(cfg).get(profile) if profile else None
+    selected = None
+    if spec is not None:
+        selected = {
+            "name": spec.name,
+            "instructions_hash": hashlib.sha256(spec.instructions.encode()).hexdigest(),
+            "tool_policy": dataclasses.asdict(spec.tool_policy),
+            "workspace_context": dataclasses.asdict(spec.workspace_context),
+            "execution_limits": dataclasses.asdict(spec.execution_limits),
+            "enabled_routes": [dataclasses.asdict(item) for item in spec.enabled_routes],
+        }
+    effective_tools = sorted(
+        name for name in (getattr(child, "valid_tool_names", None) or ()) if isinstance(name, str)
+    )
     policy = {
-        "catalog_version": catalog["version"],
-        "routing_mode": catalog["routing_mode"],
-        "profile": selected,
+        "profile_contract": selected,
+        "effective_tools": effective_tools,
         "route": {
             key: creds.get(key) for key in (
                 "requested_profile", "requested_provider", "requested_model", "requested_reasoning_effort",
@@ -285,7 +341,7 @@ def _profile_policy_snapshot(cfg: dict, profile: Optional[str], creds: Mapping[s
         },
     }
     encoded = json.dumps(policy, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(encoded.encode()).hexdigest(), policy
+    return hashlib.sha256(encoded.encode()).hexdigest(), json.loads(encoded)
 
 
 def _terminal_status(state: SubagentState) -> str:
@@ -296,36 +352,61 @@ def _terminal_status(state: SubagentState) -> str:
     }.get(state, "FAILED")
 
 
+def _concurrency_limit(cfg: Mapping[str, Any]) -> int:
+    value = (cfg or {}).get("max_concurrent_children", 10)
+    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else 10
+
+
+def _iteration_limit(cfg: Mapping[str, Any], creds: Mapping[str, Any], default: int) -> int:
+    global_limit = (cfg or {}).get("max_iterations", default)
+    if not isinstance(global_limit, int) or isinstance(global_limit, bool) or global_limit < 1:
+        global_limit = default
+    profile_limit = creds.get("max_iterations")
+    return min(global_limit, profile_limit) if isinstance(profile_limit, int) else global_limit
+
+
 def before_worker_tool(agent: Any) -> None:
     """Fail-closed durable boundary immediately before a worker tool dispatch."""
     record = getattr(agent, "_worker_lifecycle_record", None)
     if not isinstance(record, _Record) or record.store is None:
         return
+    if record.max_tool_calls is not None and record.tool_calls >= record.max_tool_calls:
+        raise SubagentLifecycleError("Worker tool-call limit reached for this run.")
     record.store.mark_tool_boundary(
         record.run_id, record.owner_session_id, record.lease_token, tool_inflight=True)
+    record.tool_calls += 1
 
 
-def checkpoint_worker_tool_result(agent: Any, history: list) -> None:
+def checkpoint_worker_tool_result(agent: Any, history: list, *, settled: bool = True) -> None:
     """Atomically persist the tool result/history before clearing uncertainty."""
     record = getattr(agent, "_worker_lifecycle_record", None)
     if not isinstance(record, _Record) or record.store is None:
         return
     delivered = tuple(record.delivered_message_ids)
-    record.store.checkpoint_run(
+    record.store.checkpoint_tool_result(
         record.run_id,
         record.owner_session_id,
         record.lease_token,
         history=history,
-        tool_inflight=False,
+        settled=settled,
         delivered_message_ids=delivered,
     )
     record.delivered_message_ids.clear()
 
 
+def worker_tool_calls_remaining(agent: Any) -> Optional[int]:
+    record = getattr(agent, "_worker_lifecycle_record", None)
+    if not isinstance(record, _Record) or record.max_tool_calls is None:
+        return None
+    return max(0, record.max_tool_calls - record.tool_calls)
+
+
 class SubagentLifecycleService:
-    """Stable public service behind :attr:`PluginContext.subagent_lifecycle`. Children run in-process only;
-    completed results stay until process exit; ``reconnect`` reports that a serialized handle cannot
-    reconnect after a restart instead of launching work again."""
+    """Shared lifecycle behind plugins and ``delegate_task``.
+
+    A parent with ``SessionDB`` gets durable workers, runs, messages and reconnectable terminal
+    snapshots. Existing hosts without durable state keep the legacy process-local behavior.
+    """
 
     def __init__(self, parent_agent_resolver: Callable[[], Any]) -> None:
         self._parent_agent_resolver = parent_agent_resolver
@@ -342,7 +423,7 @@ class SubagentLifecycleService:
     ) -> Optional[SubagentHandle]:
         """Attach the parent tool's child to the same durable lifecycle used by plugins."""
         parent = self._parent_agent_resolver()
-        owner = _session_id_of(parent)
+        owner = _owner_session_id_of(parent)
         store = _persistent_store(parent) if parent is not None else None
         if store is None or not owner:
             return None
@@ -351,7 +432,9 @@ class SubagentLifecycleService:
             raise SubagentLifecycleError("Hermes failed to assign a child identity.")
         created = time.time()
         capability = self._capability(subagent_id, owner, created)
-        config_revision, policy = _profile_policy_snapshot(dict(cfg), profile, creds)
+        config_revision, policy = _profile_policy_snapshot(dict(cfg), profile, creds, child=child)
+        policy["launch_allowed_toolsets"] = None
+        policy["role"] = getattr(child, "_delegate_role", "leaf")
         policy["capability_digest"] = hashlib.sha256(capability.encode()).hexdigest()
         parent_worker_id = getattr(parent, "_worker_id", None)
         worker = store.create_worker(
@@ -359,26 +442,28 @@ class SubagentLifecycleService:
             profile=profile,
             config_revision=config_revision,
             policy=policy,
-            frozen_prompt=str(getattr(child, "system_prompt", "") or ""),
+            frozen_prompt=_prompt_of(child),
             parent_worker_id=parent_worker_id,
         )
+        if isinstance(getattr(child, "_worker_route_receipt", None), dict):
+            child._worker_route_receipt["profile_revision"] = config_revision
+            child._worker_route_receipt["effective_tools"] = list(policy["effective_tools"])
         queued = store.enqueue_run(worker["worker_id"], owner, goal=goal, context=context or "")
-        global_cap = int((cfg or {}).get("max_concurrent_children") or 10)
-        profile_cap = getattr(creds.get("execution_limits"), "max_concurrent_children", None)
-        max_concurrent = min(global_cap, profile_cap) if isinstance(profile_cap, int) and profile_cap > 0 else global_cap
-        active = store.claim_next_run(worker["worker_id"], owner, max_concurrent=max(1, max_concurrent))
+        max_concurrent = _concurrency_limit(cfg)
+        active = store.claim_next_run(worker["worker_id"], owner, max_concurrent=max_concurrent)
         if active is None or active["run_id"] != queued["run_id"]:
             raise SubagentLifecycleError("Worker run could not acquire an execution slot.")
         child._worker_id, child._worker_run_id = worker["worker_id"], active["run_id"]
+        child._worker_owner_session_id = owner
         handle = SubagentHandle(
             contract_version=PUBLIC_CONTRACT_VERSION,
             subagent_id=subagent_id,
             parent_session_id=owner,
             correlation_id=None,
             created_at=created,
-            provider=getattr(child, "provider", None),
-            model=getattr(child, "model", None),
-            role=getattr(child, "_delegate_role", "leaf"),
+            provider=_text_or_none(getattr(child, "provider", None)),
+            model=_text_or_none(getattr(child, "model", None)),
+            role=_text_or_none(getattr(child, "_delegate_role", None)) or "leaf",
             depth=int(getattr(child, "_delegate_depth", 1) or 1),
             capability=capability,
             worker_id=worker["worker_id"],
@@ -388,6 +473,8 @@ class SubagentLifecycleService:
             handle, SubagentState.RUNNING, created, agent=child, started_at=created,
             store=store, owner_session_id=owner, worker_id=worker["worker_id"],
             run_id=active["run_id"], lease_token=active["lease_token"],
+            max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
+            max_concurrent=max_concurrent, goal=goal, parent_agent=parent,
         )
         self._bind_tool_boundary(record)
         self._start_external_lease(record)
@@ -423,7 +510,11 @@ class SubagentLifecycleService:
         if status == "completed":
             state = SubagentState.SUCCEEDED
         elif status == "interrupted":
-            state = SubagentState.INTERRUPTED
+            state = (
+                SubagentState.CANCELLED
+                if record.state is SubagentState.CANCEL_REQUESTED
+                else SubagentState.INTERRUPTED
+            )
         else:
             state = SubagentState.FAILED
         cls._publish_result(
@@ -436,6 +527,12 @@ class SubagentLifecycleService:
                 "usage_metadata": {"api_calls": entry.get("api_calls", 0)},
                 "tool_execution_summary": {"duration_seconds": entry.get("duration_seconds", 0)},
             },
+            evidence={
+                "exit_reason": entry.get("exit_reason"),
+                "tokens": entry.get("tokens") or {},
+                "cost_usd": entry.get("cost_usd"),
+                "cost_status": entry.get("cost_status") or "unknown",
+            },
         )
 
     def launch(self, request: SubagentLaunchRequest) -> SubagentHandle:
@@ -443,7 +540,7 @@ class SubagentLifecycleService:
         if parent is None:
             raise SubagentLifecycleError("No active Hermes parent session is available.")
         self._validate_request(request, parent)
-        parent_session_id = _session_id_of(parent)
+        parent_session_id = _owner_session_id_of(parent)
         if request.parent_session_id and request.parent_session_id != parent_session_id:
             raise SubagentLifecycleError("parent_session_id does not match the active session.")
         correlation_key = (parent_session_id, request.correlation_id or "")
@@ -465,8 +562,7 @@ class SubagentLifecycleService:
                 requested_reasoning_effort=request.reasoning_effort,
             )
             overrides = _profile_task_overrides(creds)
-            profile_limit = creds.get("max_iterations")
-            run_iterations = min(DEFAULT_MAX_ITERATIONS, profile_limit) if isinstance(profile_limit, int) else DEFAULT_MAX_ITERATIONS
+            run_iterations = _iteration_limit(cfg, creds, DEFAULT_MAX_ITERATIONS)
         else:
             if request.provider or request.reasoning_effort:
                 raise SubagentLifecycleError("provider/reasoning_effort require a configured worker profile.")
@@ -478,7 +574,7 @@ class SubagentLifecycleService:
                 "override_acp_command": creds.get("command"), "override_acp_args": creds.get("args"),
                 "routing_cfg": cfg,
             }
-            run_iterations = DEFAULT_MAX_ITERATIONS
+            run_iterations = _iteration_limit(cfg, creds, DEFAULT_MAX_ITERATIONS)
         child = _build_child_preserving_parent_tools(
             task_index=0, goal=request.goal, context=request.context,
             toolsets=list(request.allowed_toolsets) if request.allowed_toolsets else None,
@@ -493,21 +589,30 @@ class SubagentLifecycleService:
         store = _persistent_store(parent)
         worker_id = run_id = lease_token = None
         if store is not None and parent_session_id:
-            config_revision, policy = _profile_policy_snapshot(cfg, request.profile, creds)
+            config_revision, policy = _profile_policy_snapshot(cfg, request.profile, creds, child=child)
+            policy["launch_allowed_toolsets"] = (
+                list(request.allowed_toolsets) if request.allowed_toolsets else None)
+            policy["role"] = getattr(child, "_delegate_role", request.role)
             policy["capability_digest"] = hashlib.sha256(capability.encode()).hexdigest()
             worker = store.create_worker(
                 parent_session_id,
                 profile=request.profile,
                 config_revision=config_revision,
                 policy=policy,
-                frozen_prompt=str(getattr(child, "system_prompt", "") or ""),
+                frozen_prompt=_prompt_of(child),
             )
+            if isinstance(getattr(child, "_worker_route_receipt", None), dict):
+                child._worker_route_receipt["profile_revision"] = config_revision
+                child._worker_route_receipt["effective_tools"] = list(policy["effective_tools"])
             queued = store.enqueue_run(worker["worker_id"], parent_session_id, goal=request.goal, context=request.context or "")
-            active = store.claim_next_run(worker["worker_id"], parent_session_id)
-            if active is None or active["run_id"] != queued["run_id"]:
-                raise SubagentLifecycleError("Worker run could not acquire an execution slot.")
-            worker_id, run_id, lease_token = worker["worker_id"], active["run_id"], active["lease_token"]
+            max_concurrent = _concurrency_limit(cfg)
+            active = store.claim_next_run(
+                worker["worker_id"], parent_session_id, max_concurrent=max_concurrent)
+            active_run = active if active is not None and active["run_id"] == queued["run_id"] else None
+            worker_id, run_id = worker["worker_id"], queued["run_id"]
+            lease_token = active_run["lease_token"] if active_run else None
             child._worker_id, child._worker_run_id = worker_id, run_id
+            child._worker_owner_session_id = parent_session_id
         handle = SubagentHandle(
             contract_version=PUBLIC_CONTRACT_VERSION,
             subagent_id=subagent_id,
@@ -525,13 +630,17 @@ class SubagentLifecycleService:
         record = _Record(
             handle, SubagentState.PENDING, created, agent=child, store=store,
             owner_session_id=parent_session_id, worker_id=worker_id, run_id=run_id, lease_token=lease_token,
+            max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
+            max_concurrent=_concurrency_limit(cfg), goal=request.goal, parent_agent=parent,
         )
-        self._bind_tool_boundary(record)
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
             if request.correlation_id:
                 _REGISTRY.correlations[correlation_key] = subagent_id
-        record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        if store is not None and lease_token is not None:
+            self._start_record(record)
+        elif store is None:
+            record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
         return handle
 
     def status(self, handle: SubagentHandle) -> SubagentStatus:
@@ -559,13 +668,22 @@ class SubagentLifecycleService:
                 SubagentState.SUCCEEDED, SubagentState.FAILED, SubagentState.INTERRUPTED, SubagentState.CANCELLED,
             }
             return SubagentTerminalState(handle, state, completed, diagnostic="DURABLE_SNAPSHOT")
-        try:
-            if record.future is not None:
-                record.future.result(timeout=timeout_seconds)
-        except TimeoutError:
-            return SubagentTerminalState(record.handle, record.state, False, True)
-        except Exception:
-            pass
+        deadline = None if timeout_seconds is None else time.monotonic() + timeout_seconds
+        while record.result is None:
+            future = record.future
+            if future is None:
+                if deadline is not None and time.monotonic() >= deadline:
+                    return SubagentTerminalState(record.handle, record.state, False, True)
+                time.sleep(0.01)
+                continue
+            try:
+                remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+                future.result(timeout=remaining)
+            except TimeoutError:
+                return SubagentTerminalState(record.handle, record.state, False, True)
+            except Exception:
+                pass
+            break
         with _REGISTRY.lock:
             return SubagentTerminalState(record.handle, record.state, record.result is not None)
 
@@ -629,11 +747,53 @@ class SubagentLifecycleService:
         parent = self._parent_agent_resolver()
         durable = None if record is not None else self._durable_snapshot(handle)
         store = record.store if record is not None else (durable[0] if durable else None)
-        owner = _session_id_of(parent)
+        owner = _owner_session_id_of(parent)
         worker_id = handle.worker_id or (record.worker_id if record is not None else None)
         if store is None or not owner or not worker_id:
             raise SubagentLifecycleError("Durable worker messaging is unavailable for this handle.")
         return store.enqueue_message(worker_id, owner, content, message_id=message_id, sender_id=owner)
+
+    @staticmethod
+    def _actor_can_target(
+        store: Any,
+        owner: str,
+        actor_worker_id: Optional[str],
+        target: Mapping[str, Any],
+        *,
+        message_only: bool,
+        allow_siblings: bool,
+    ) -> bool:
+        if not actor_worker_id:
+            return True
+        actor = store.get_worker(actor_worker_id, owner)
+        if target["worker_id"] == actor_worker_id:
+            return True
+        current = target
+        while current.get("parent_worker_id"):
+            if current["parent_worker_id"] == actor_worker_id:
+                return True
+            current = store.get_worker(current["parent_worker_id"], owner)
+        if message_only and actor.get("parent_worker_id") == target["worker_id"]:
+            return True
+        return bool(
+            message_only
+            and allow_siblings
+            and actor.get("parent_worker_id")
+            and actor.get("parent_worker_id") == target.get("parent_worker_id")
+        )
+
+    @staticmethod
+    def _subtree_ids(store: Any, owner: str, worker_id: str) -> list[str]:
+        workers = store.list_workers(owner)
+        selected = {worker_id}
+        changed = True
+        while changed:
+            changed = False
+            for worker in workers:
+                if worker.get("parent_worker_id") in selected and worker["worker_id"] not in selected:
+                    selected.add(worker["worker_id"])
+                    changed = True
+        return [worker["worker_id"] for worker in workers if worker["worker_id"] in selected]
 
     def control(
         self,
@@ -646,27 +806,78 @@ class SubagentLifecycleService:
     ) -> Mapping[str, Any]:
         """Parent-tool control by stable IDs; authority is the bound live session, never ID knowledge."""
         parent = self._parent_agent_resolver()
-        owner = _session_id_of(parent)
+        owner = _owner_session_id_of(parent)
         store = _persistent_store(parent) if parent is not None else None
         if store is None or not owner:
             raise SubagentLifecycleError("Durable worker state is unavailable for this session.")
+        store.recover_expired_runs(owner)
+        self._schedule_owner(store, owner)
         normalized = action.strip().lower()
+        actor_worker_id = getattr(parent, "_worker_id", None)
+        from tools.delegate_tool_config import _load_config
+        cfg = _load_config()
+        allow_siblings = bool((cfg or {}).get("allow_sibling_messaging", False))
         if normalized == "status":
             if not worker_id:
                 workers = store.list_workers(owner)
-                return {"workers": [self._safe_worker_snapshot(store, item, owner) for item in workers]}
+                visible = [
+                    item for item in workers
+                    if self._actor_can_target(
+                        store, owner, actor_worker_id, item, message_only=False, allow_siblings=allow_siblings)
+                ]
+                return {"workers": [self._safe_worker_snapshot(store, item, owner) for item in visible]}
             worker = store.get_worker(worker_id, owner)
+            if not self._actor_can_target(
+                store, owner, actor_worker_id, worker, message_only=False, allow_siblings=allow_siblings
+            ):
+                raise PermissionError("Worker control target is outside the actor's owned subtree.")
             return self._safe_worker_snapshot(store, worker, owner)
+        if normalized == "completions":
+            pending = store.pending_completions(owner)
+            return {
+                "completions": [
+                    self._safe_run_snapshot(item) for item in pending
+                    if self._actor_can_target(
+                        store,
+                        owner,
+                        actor_worker_id,
+                        store.get_worker(item["worker_id"], owner),
+                        message_only=False,
+                        allow_siblings=allow_siblings,
+                    )
+                ]
+            }
         if not worker_id:
             raise SubagentLifecycleError(f"action='{normalized}' requires worker_id.")
         worker = store.get_worker(worker_id, owner)
+        message_action = normalized == "message"
+        if not self._actor_can_target(
+            store, owner, actor_worker_id, worker,
+            message_only=message_action, allow_siblings=allow_siblings,
+        ):
+            raise PermissionError("Worker control target is outside the actor's authorized relation.")
         runs = store.list_runs(worker_id, owner)
         selected = next((item for item in runs if item["run_id"] == run_id), None) if run_id else (runs[-1] if runs else None)
         if normalized == "message":
-            queued = store.enqueue_message(worker_id, owner, message or "", sender_id=owner)
+            queued = store.enqueue_message(
+                worker_id, owner, message or "", sender_id=actor_worker_id or owner)
             return {"worker_id": worker_id, "message_id": queued["message_id"], "status": queued["status"]}
         if selected is None:
             raise SubagentLifecycleError("Worker has no matching run.")
+        if normalized == "inspect":
+            messages = store.list_messages(worker_id, owner)
+            return {
+                **self._safe_worker_snapshot(store, worker, owner),
+                "run": self._inspect_run_snapshot(selected),
+                "messages": [
+                    {
+                        key: item.get(key) for key in (
+                            "message_id", "sender_id", "status", "delivered_run_id", "created_at", "delivered_at",
+                        )
+                    }
+                    for item in messages
+                ],
+            }
         if normalized == "wait":
             timeout = 0.0 if timeout_seconds is None else float(timeout_seconds)
             if timeout < 0 or timeout > 60:
@@ -675,35 +886,84 @@ class SubagentLifecycleService:
             while selected["status"] in {"PENDING", "RUNNING"} and time.monotonic() < deadline:
                 if selected["status"] == "RUNNING" and selected.get("lease_expires_at", 0) <= time.time():
                     store.recover_expired_runs(owner)
+                    self._schedule_owner(store, owner)
                 time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
                 selected = store.get_run(selected["run_id"], owner)
             return self._safe_run_snapshot(selected)
         if normalized == "cancel":
-            live = next((
-                record for record in list(_REGISTRY.records.values())
-                if record.worker_id == worker_id and record.run_id == selected["run_id"] and record.agent is not None
-            ), None)
-            if live is None:
-                if selected["status"] == "RUNNING" and selected.get("lease_expires_at", 0) <= time.time():
-                    store.recover_expired_runs(owner)
-                    selected = store.get_run(selected["run_id"], owner)
-                    return self._safe_run_snapshot(selected)
-                raise SubagentLifecycleError("The run has no live executor to cancel.")
-            accepted = request_hard_interrupt(
-                live.agent, "Worker cancellation requested by its owner.", tool_reason="worker cancellation requested")
-            return {**self._safe_run_snapshot(selected), "cancel_requested": bool(accepted)}
+            subtree = self._subtree_ids(store, owner, worker_id)
+            cancelled_pending = store.cancel_pending_runs(subtree, owner)
+            accepted = 0
+            queued_records = []
+            with _REGISTRY.lock:
+                live_records = [
+                    item for item in _REGISTRY.records.values()
+                    if item.owner_session_id == owner and item.worker_id in subtree
+                    and item.agent is not None and item.state not in {
+                        SubagentState.SUCCEEDED, SubagentState.FAILED,
+                        SubagentState.INTERRUPTED, SubagentState.CANCELLED,
+                    }
+                ]
+                for item in live_records:
+                    if item.lease_token is None:
+                        queued_records.append(item)
+                        item.state = SubagentState.CANCELLED
+                        item.result = SubagentResult(
+                            item.handle,
+                            SubagentState.CANCELLED,
+                            True,
+                            completed_at=time.time(),
+                            error_classification="CANCELLED",
+                            error_message="Worker tree cancelled before this run started.",
+                        )
+                    else:
+                        item.state = SubagentState.CANCEL_REQUESTED
+                    item.updated_at = time.time()
+            for item in queued_records:
+                with contextlib.suppress(Exception):
+                    item.agent.close()
+                item.agent = None
+            queued_record_ids = {id(item) for item in queued_records}
+            for item in (record for record in live_records if id(record) not in queued_record_ids):
+                if request_hard_interrupt(
+                    item.agent,
+                    "Worker tree cancellation requested by its owner.",
+                    tool_reason="worker cancellation requested",
+                ):
+                    accepted += 1
+            return {
+                **self._safe_run_snapshot(selected),
+                "cancel_requested": bool(accepted or cancelled_pending),
+                "workers_targeted": subtree,
+                "live_interrupts": accepted,
+                "queued_runs_cancelled": len(cancelled_pending),
+            }
         if normalized == "resume":
             if not message or not message.strip():
                 raise SubagentLifecycleError("action='resume' requires message as the next worker turn.")
-            if selected is not runs[-1]:
+            if selected["run_id"] != runs[-1]["run_id"]:
                 raise SubagentLifecycleError("Resume must link from the worker's latest run.")
+            route = dict((worker.get("policy") or {}).get("route") or {})
             prior = SubagentHandle(
                 PUBLIC_CONTRACT_VERSION, "durable-snapshot", owner, None, worker["created_at"],
-                None, None, "leaf", int(worker["depth"]), "", worker_id, selected["run_id"],
+                route.get("resolved_provider"), route.get("resolved_model"),
+                str((worker.get("policy") or {}).get("role") or "leaf"),
+                int(worker["depth"]), "", worker_id, selected["run_id"],
             )
             handle = self._launch_existing_worker(
-                SubagentLaunchRequest(goal=message, profile=worker["profile"]), prior, worker, selected)
+                SubagentLaunchRequest(
+                    goal=message,
+                    profile=worker["profile"],
+                    role=str((worker.get("policy") or {}).get("role") or "leaf"),
+                ),
+                prior,
+                worker,
+                selected,
+            )
             return {"worker_id": handle.worker_id, "run_id": handle.run_id, "status": "PENDING"}
+        if normalized == "ack":
+            store.ack_completion(selected["run_id"], owner)
+            return {**self._safe_run_snapshot(store.get_run(selected["run_id"], owner)), "acknowledged": True}
         raise SubagentLifecycleError(f"Unsupported durable worker action '{normalized}'.")
 
     @staticmethod
@@ -711,8 +971,21 @@ class SubagentLifecycleService:
         return {
             key: run.get(key) for key in (
                 "run_id", "worker_id", "previous_run_id", "status", "uncertain_side_effect",
-                "created_at", "updated_at",
+                "completion_ack", "created_at", "updated_at",
             )
+        }
+
+    @classmethod
+    def _inspect_run_snapshot(cls, run: Mapping[str, Any]) -> Mapping[str, Any]:
+        result = dict(run.get("result") or {})
+        return {
+            **cls._safe_run_snapshot(run),
+            "result": {
+                key: result.get(key) for key in (
+                    "summary", "error_classification", "error_message", "result_hash",
+                    "route", "lineage", "termination", "usage", "cost",
+                )
+            } if result else None,
         }
 
     @classmethod
@@ -739,7 +1012,7 @@ class SubagentLifecycleService:
     ) -> SubagentHandle:
         """Start a linked run on the stable worker after revalidating current profile policy."""
         parent = self._parent_agent_resolver()
-        owner = _session_id_of(parent)
+        owner = _owner_session_id_of(parent)
         durable = self._durable_snapshot(handle)
         if durable is None or not owner or not handle.worker_id or not handle.run_id:
             raise SubagentLifecycleError("Durable resume is unavailable for this handle.")
@@ -747,28 +1020,15 @@ class SubagentLifecycleService:
         runs = store.list_runs(handle.worker_id, owner)
         if not runs or runs[-1]["run_id"] != previous["run_id"]:
             raise SubagentLifecycleError("Resume must link from the worker's latest run.")
-        if previous["status"] not in {"SUCCEEDED", "FAILED", "INTERRUPTED", "CANCELLED"}:
-            raise SubagentLifecycleError("The worker already has an active run.")
         if worker["uncertain_side_effect"]:
             if not reconcile_uncertain:
                 raise SubagentLifecycleError(
                     "The prior run stopped with an uncertain tool side effect; reconcile it before resume.")
             store.reconcile_run(handle.run_id, owner)
-        # Revalidation is fail-closed: launch resolves the current profile/model/tools again. The
-        # frozen prompt is retained as a hash boundary; changed profile/tool policy cannot silently
-        # rebuild an existing worker's execution surface.
-        from tools.delegate_tool_config import _load_config
-        from agent.delegation_model_routing import discover_workers
-        cfg = _load_config()
-        current_catalog = discover_workers(cfg)
-        current_profile = next((item for item in current_catalog["profiles"] if item["name"] == worker["profile"]), None)
-        current_policy = dict(worker["policy"])
-        if current_catalog["errors"] or current_profile != current_policy.get("profile"):
-            raise SubagentLifecycleError(
-                "Worker profile or tool policy changed since launch; start a new worker to adopt the new surface.")
         request = SubagentLaunchRequest(
             goal=message,
             profile=worker["profile"],
+            role=handle.role,
             parent_session_id=owner,
             correlation_id=f"resume-{uuid.uuid4().hex}",
         )
@@ -777,27 +1037,85 @@ class SubagentLifecycleService:
     def _launch_existing_worker(
         self, request: SubagentLaunchRequest, prior: SubagentHandle, worker: Mapping[str, Any], previous: Mapping[str, Any],
     ) -> SubagentHandle:
-        """Resume implementation kept separate so ``launch`` remains legacy compatible."""
+        """Validate and queue one retained turn; an active predecessor starts it FIFO on completion."""
         parent = self._parent_agent_resolver()
-        owner = _session_id_of(parent)
+        owner = _owner_session_id_of(parent)
         store = _persistent_store(parent)
+        if store is None or not owner:
+            raise SubagentLifecycleError("Durable resume is unavailable for this session.")
+        store.recover_expired_runs(owner)
+        worker = store.get_worker(worker["worker_id"], owner)
+        if worker["uncertain_side_effect"]:
+            raise SubagentLifecycleError(
+                "The prior run stopped with an uncertain tool side effect; reconcile it before resume.")
         from tools.delegate_tool import DEFAULT_MAX_ITERATIONS, _build_child_preserving_parent_tools, _profile_task_overrides
         from tools.delegate_tool_config import _load_config, _resolve_delegation_credentials
         cfg = _load_config()
-        creds = _resolve_delegation_credentials(cfg, parent, request.profile)
-        limits = creds.get("max_iterations")
-        max_iterations = min(DEFAULT_MAX_ITERATIONS, limits) if isinstance(limits, int) else DEFAULT_MAX_ITERATIONS
+        stored_policy = dict(worker.get("policy") or {})
+        prior_route = dict(stored_policy.get("route") or {})
+        route_kwargs = {}
+        if request.profile:
+            route_kwargs = {
+                "requested_provider": prior_route.get("resolved_provider"),
+                "requested_model": prior_route.get("resolved_model"),
+                "requested_reasoning_effort": prior_route.get("resolved_reasoning_effort"),
+            }
+        creds = _resolve_delegation_credentials(cfg, parent, request.profile, **route_kwargs)
+        max_iterations = _iteration_limit(cfg, creds, DEFAULT_MAX_ITERATIONS)
+        overrides = _profile_task_overrides(creds) if request.profile else {
+            "override_provider": creds["provider"], "override_base_url": creds["base_url"],
+            "override_api_key": creds["api_key"], "override_api_mode": creds["api_mode"],
+            "override_request_overrides": creds.get("request_overrides"),
+            "override_acp_command": creds.get("command"), "override_acp_args": creds.get("args"),
+            "routing_cfg": cfg,
+        }
+        launch_toolsets = stored_policy.get("launch_allowed_toolsets")
         child = _build_child_preserving_parent_tools(
-            task_index=0, goal=request.goal, context=None, toolsets=None, model=creds.get("model"),
+            task_index=0, goal=request.goal, context=None,
+            toolsets=list(launch_toolsets) if isinstance(launch_toolsets, list) else None,
+            model=creds.get("model"),
             max_iterations=max_iterations, task_count=1, parent_agent=parent, role=request.role,
-            **_profile_task_overrides(creds),
+            frozen_system_prompt=worker["frozen_prompt"],
+            retained_child_depth=int(worker["depth"]),
+            retained_parent_worker_id=worker.get("parent_worker_id"),
+            **overrides,
         )
+        _revision, current_policy = _profile_policy_snapshot(cfg, request.profile, creds, child=child)
+        route_keys = ("resolved_provider", "resolved_model", "resolved_reasoning_effort")
+        changed_route = any(
+            (current_policy.get("route") or {}).get(key) != prior_route.get(key) for key in route_keys
+        )
+        changed_contract = current_policy.get("profile_contract") != stored_policy.get("profile_contract")
+        changed_tools = current_policy.get("effective_tools") != stored_policy.get("effective_tools")
+        if changed_route or changed_contract or changed_tools:
+            with contextlib.suppress(Exception):
+                child.close()
+            details = []
+            if changed_route:
+                details.append("resolved route")
+            if changed_contract:
+                details.append("profile instructions or policy")
+            if changed_tools:
+                details.append("effective tools or parent permissions")
+            raise SubagentLifecycleError(
+                f"Worker {'/'.join(details)} changed since launch; start a new worker to adopt the new surface.")
+        runs = store.list_runs(worker["worker_id"], owner)
+        if not runs or runs[-1]["run_id"] != previous["run_id"]:
+            with contextlib.suppress(Exception):
+                child.close()
+            raise SubagentLifecycleError("Followup must link from the worker's latest run.")
+        followup_limit = ((stored_policy.get("profile_contract") or {}).get("execution_limits") or {}).get("max_followups")
+        if isinstance(followup_limit, int) and len(runs) - 1 >= followup_limit:
+            with contextlib.suppress(Exception):
+                child.close()
+            raise SubagentLifecycleError("Worker followup limit reached.")
         queued = store.enqueue_run(
             worker["worker_id"], owner, goal=request.goal, previous_run_id=previous["run_id"])
-        active = store.claim_next_run(worker["worker_id"], owner)
-        if active is None or active["run_id"] != queued["run_id"]:
-            raise SubagentLifecycleError("Worker resume could not acquire an execution slot.")
-        child._worker_id, child._worker_run_id = worker["worker_id"], active["run_id"]
+        max_concurrent = _concurrency_limit(cfg)
+        active = store.claim_next_run(worker["worker_id"], owner, max_concurrent=max_concurrent)
+        active_run = active if active is not None and active["run_id"] == queued["run_id"] else None
+        child._worker_id, child._worker_run_id = worker["worker_id"], queued["run_id"]
+        child._worker_owner_session_id = owner
         created = time.time()
         subagent_id = str(getattr(child, "_subagent_id", "") or "")
         result_handle = dataclasses.replace(
@@ -806,18 +1124,62 @@ class SubagentLifecycleService:
             created_at=created,
             provider=getattr(child, "provider", None),
             model=getattr(child, "model", None),
-            run_id=active["run_id"],
+            run_id=queued["run_id"],
         )
         record = _Record(
             result_handle, SubagentState.PENDING, created, agent=child, store=store,
-            owner_session_id=owner, worker_id=worker["worker_id"], run_id=active["run_id"],
-            lease_token=active["lease_token"], conversation_history=list(worker.get("history") or []),
+            owner_session_id=owner, worker_id=worker["worker_id"], run_id=queued["run_id"],
+            lease_token=active_run["lease_token"] if active_run else None,
+            conversation_history=list(worker.get("history") or []),
+            max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
+            max_concurrent=max_concurrent, goal=request.goal, parent_agent=parent,
         )
-        self._bind_tool_boundary(record)
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
-        record.future = _EXECUTOR.submit(self._run, record, request.goal, parent)
+        if active_run is not None:
+            self._start_record(record)
         return result_handle
+
+    @classmethod
+    def _start_record(cls, record: _Record) -> None:
+        worker = record.store.get_worker(record.worker_id, record.owner_session_id)
+        record.conversation_history = list(worker.get("history") or [])
+        record.agent._worker_resume_history = list(record.conversation_history)
+        record.agent._worker_run_id = record.run_id
+        record.state = SubagentState.PENDING
+        cls._bind_tool_boundary(record)
+        service = cls(lambda: record.parent_agent)
+        record.future = _EXECUTOR.submit(service._run, record, record.goal, record.parent_agent)
+
+    @classmethod
+    def _schedule_pending(cls, completed: _Record) -> None:
+        if completed.store is None or not completed.owner_session_id:
+            return
+        cls._schedule_owner(completed.store, completed.owner_session_id)
+
+    @classmethod
+    def _schedule_owner(cls, store: Any, owner_session_id: str) -> None:
+        with _REGISTRY.lock:
+            candidates = sorted(
+                (
+                    item for item in _REGISTRY.records.values()
+                    if item.owner_session_id == owner_session_id
+                    and item.state is SubagentState.PENDING
+                    and item.lease_token is None
+                    and item.agent is not None
+                ),
+                key=lambda item: item.updated_at,
+            )
+        for candidate in candidates:
+            active = candidate.store.claim_next_run(
+                candidate.worker_id,
+                candidate.owner_session_id,
+                max_concurrent=candidate.max_concurrent,
+            )
+            if active is None or active["run_id"] != candidate.run_id:
+                continue
+            candidate.lease_token = active["lease_token"]
+            cls._start_record(candidate)
 
     @staticmethod
     def _bind_tool_boundary(record: _Record) -> None:
@@ -829,7 +1191,7 @@ class SubagentLifecycleService:
         """Registry record for a well-formed, capability-verified handle owned by the active parent."""
         if not _handle_is_well_formed(handle):
             return None
-        if _session_id_of(self._parent_agent_resolver()) != handle.parent_session_id:
+        if _owner_session_id_of(self._parent_agent_resolver()) != handle.parent_session_id:
             return None
         with _REGISTRY.lock:
             record = _REGISTRY.records.get(handle.subagent_id)
@@ -845,7 +1207,7 @@ class SubagentLifecycleService:
         if not _handle_is_well_formed(handle) or not handle.worker_id or not handle.run_id:
             return None
         parent = self._parent_agent_resolver()
-        owner = _session_id_of(parent)
+        owner = _owner_session_id_of(parent)
         if not owner or owner != handle.parent_session_id:
             return None
         try:
@@ -914,6 +1276,7 @@ class SubagentLifecycleService:
 
             lease_thread = threading.Thread(target=renew_lease, name="hermes-worker-lease", daemon=True)
             lease_thread.start()
+        raw: Any = {}
         try:
             from tools.delegate_tool import _run_child_lifecycle
             raw = _run_child_lifecycle(0, goal, record.agent, parent)
@@ -937,7 +1300,18 @@ class SubagentLifecycleService:
             lease_stop.set()
             if lease_thread is not None:
                 lease_thread.join(timeout=1.0)
-        self._publish_result(record, state, fields, delivered_ids=delivered_ids)
+        self._publish_result(
+            record,
+            state,
+            fields,
+            delivered_ids=delivered_ids,
+            evidence={
+                "exit_reason": raw.get("exit_reason") if isinstance(raw, dict) else None,
+                "tokens": raw.get("tokens") if isinstance(raw, dict) else {},
+                "cost_usd": raw.get("cost_usd") if isinstance(raw, dict) else None,
+                "cost_status": raw.get("cost_status") if isinstance(raw, dict) else "unknown",
+            },
+        )
 
     @staticmethod
     def _publish_result(
@@ -946,14 +1320,30 @@ class SubagentLifecycleService:
         fields: Mapping[str, Any],
         *,
         delivered_ids: tuple[str, ...] | list[str] = (),
+        evidence: Optional[Mapping[str, Any]] = None,
     ) -> None:
         if record.lease_stop is not None:
             record.lease_stop.set()
         if record.lease_thread is not None:
             record.lease_thread.join(timeout=1.0)
         result = SubagentResult(record.handle, state, True, started_at=record.started_at, completed_at=time.time(), **fields)
-        payload = dataclasses.asdict(result)
-        payload.pop("result_hash", None)
+        # ``dataclasses.asdict`` recursively deep-copies values.  Runtime
+        # metadata may contain provider objects (and test doubles) which own
+        # thread locks, so hashing the public result must stay at the JSON
+        # boundary instead of attempting to clone those objects.
+        payload = {
+            "handle": result.handle.to_dict(),
+            "terminal_state": result.terminal_state.value,
+            "ready": result.ready,
+            "summary": result.summary,
+            "structured_payload": result.structured_payload,
+            "started_at": result.started_at,
+            "completed_at": result.completed_at,
+            "error_classification": result.error_classification,
+            "error_message": result.error_message,
+            "usage_metadata": dict(result.usage_metadata or {}),
+            "tool_execution_summary": dict(result.tool_execution_summary or {}),
+        }
         result = dataclasses.replace(result, result_hash=hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest())
         if record.store is not None and record.run_id and record.lease_token:
             history = list(getattr(record.agent, "_worker_last_history", None) or record.conversation_history)
@@ -968,17 +1358,44 @@ class SubagentLifecycleService:
                     tool_inflight=unresolved_tool,
                     delivered_message_ids=tuple(delivered_ids),
                 )
+                worker = record.store.get_worker(record.worker_id, record.owner_session_id)
+                route = dict(getattr(record.agent, "_worker_route_receipt", None) or {})
+                durable_result = {
+                    "summary": result.summary,
+                    "error_classification": result.error_classification,
+                    "error_message": result.error_message,
+                    "result_hash": result.result_hash,
+                    "route": route or None,
+                    "lineage": {
+                        "worker_id": record.worker_id,
+                        "run_id": record.run_id,
+                        "parent_worker_id": worker.get("parent_worker_id"),
+                        "root_worker_id": worker.get("root_worker_id"),
+                    },
+                    "termination": {
+                        "status": _terminal_status(state),
+                        "reason": (evidence or {}).get("exit_reason") or result.error_classification,
+                    },
+                    "usage": {
+                        **dict(result.usage_metadata or {}),
+                        "tokens": dict((evidence or {}).get("tokens") or {}),
+                    },
+                    "cost": {
+                        "status": (evidence or {}).get("cost_status") or "unknown",
+                        "usd": (
+                            (evidence or {}).get("cost_usd")
+                            if (evidence or {}).get("cost_status") not in (None, "unknown")
+                            else None
+                        ),
+                    },
+                    "effective_tools": list((worker.get("policy") or {}).get("effective_tools") or []),
+                }
                 record.store.finish_run(
                     record.run_id,
                     record.owner_session_id,
                     record.lease_token,
                     status=_terminal_status(state),
-                    result={
-                        "summary": result.summary,
-                        "error_classification": result.error_classification,
-                        "error_message": result.error_message,
-                        "result_hash": result.result_hash,
-                    },
+                    result=durable_result,
                     history=history,
                 )
             except Exception as exc:
@@ -991,6 +1408,7 @@ class SubagentLifecycleService:
         with _REGISTRY.lock:
             record.agent, record.result, record.state = None, result, result.terminal_state
             record.completed_at = record.updated_at = result.completed_at
+        SubagentLifecycleService._schedule_pending(record)
 
     @staticmethod
     def _capability(subagent_id: str, parent_session_id: Optional[str], created_at: float) -> str:

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -180,6 +180,7 @@ class _Record:
     goal: str = ""
     parent_agent: Any = None
     completion_owner: str = "service"
+    budget_epoch_id: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -300,6 +301,9 @@ def _session_db_of(parent: Any) -> Any:
 
 
 def _persistent_store(parent: Any) -> Any:
+    retained = getattr(parent, "_worker_lifecycle_record", None)
+    if isinstance(retained, _Record) and retained.store is not None:
+        return retained.store
     db = _session_db_of(parent)
     if db is None or not hasattr(db, "_execute_write") or not hasattr(db, "_read_ctx"):
         return None
@@ -372,6 +376,54 @@ def _iteration_limit(cfg: Mapping[str, Any], creds: Mapping[str, Any], default: 
     return min(global_limit, profile_limit) if isinstance(profile_limit, int) else global_limit
 
 
+def _tree_budget_limits(cfg: Mapping[str, Any], creds: Mapping[str, Any], default: int) -> dict[str, Any]:
+    limits = creds.get("execution_limits")
+    profile_timeout = getattr(limits, "timeout_seconds", None)
+    from tools.delegate_tool_config import _get_child_timeout
+    global_timeout = _get_child_timeout()
+    timeout = min(value for value in (global_timeout, profile_timeout) if value is not None) \
+        if global_timeout is not None or profile_timeout is not None else None
+    return {
+        "max_iterations": _iteration_limit(cfg, creds, default),
+        "max_tool_calls": getattr(limits, "max_tool_calls", None),
+        "timeout_seconds": timeout,
+    }
+
+
+def _parent_budget_epoch(parent: Any) -> Optional[str]:
+    record = getattr(parent, "_worker_lifecycle_record", None)
+    return record.budget_epoch_id if isinstance(record, _Record) else None
+
+
+def _attach_tree_budget(record: _Record) -> None:
+    if record.agent is None or record.store is None or not record.budget_epoch_id:
+        return
+    record.agent._worker_budget_epoch_id = record.budget_epoch_id
+    snapshot = record.store.budget_snapshot(record.run_id, record.owner_session_id)
+    if not snapshot or snapshot.get("deadline_at") is None:
+        return
+    remaining = max(0.001, float(snapshot["deadline_at"]) - time.time())
+    current = getattr(record.agent, "_worker_timeout_seconds", None)
+    record.agent._worker_timeout_seconds = min(current, remaining) \
+        if isinstance(current, (int, float)) and current > 0 else remaining
+
+
+def before_worker_provider_attempt(agent: Any) -> None:
+    """Reserve one durable tree iteration immediately before provider transport."""
+    record = getattr(agent, "_worker_lifecycle_record", None)
+    if not isinstance(record, _Record) or record.store is None or not record.budget_epoch_id:
+        return
+    try:
+        record.store.reserve_iteration(record.run_id, record.owner_session_id, record.lease_token)
+    except Exception as exc:
+        from agent.worker_store import WorkerBudgetExceeded
+        if not isinstance(exc, WorkerBudgetExceeded):
+            raise
+        agent._worker_budget_termination_reason = exc.reason
+        request_hard_interrupt(agent, exc.reason.replace("_", " "), tool_reason=exc.reason)
+        raise InterruptedError(exc.reason) from exc
+
+
 def before_worker_tool(agent: Any, tool_call_id: str) -> None:
     """Fail-closed durable boundary immediately before a worker tool dispatch."""
     record = getattr(agent, "_worker_lifecycle_record", None)
@@ -379,10 +431,24 @@ def before_worker_tool(agent: Any, tool_call_id: str) -> None:
         return
     if record.max_tool_calls is not None and record.tool_calls >= record.max_tool_calls:
         raise SubagentLifecycleError("Worker tool-call limit reached for this run.")
-    record.store.mark_tool_boundary(
-        record.run_id, record.owner_session_id, record.lease_token,
-        tool_call_id=tool_call_id, tool_inflight=True)
+    try:
+        record.store.mark_tool_boundary(
+            record.run_id, record.owner_session_id, record.lease_token,
+            tool_call_id=tool_call_id, tool_inflight=True)
+    except Exception as exc:
+        from agent.worker_store import WorkerBudgetExceeded
+        if isinstance(exc, WorkerBudgetExceeded):
+            agent._worker_budget_termination_reason = exc.reason
+        raise
     record.tool_calls += 1
+
+
+def queue_worker_parent_message(agent: Any, content: str) -> Optional[Mapping[str, Any]]:
+    """Durably queue a child-to-root-parent message when this worker has a store."""
+    record = getattr(agent, "_worker_lifecycle_record", None)
+    if not isinstance(record, _Record) or record.store is None or not record.run_id:
+        return None
+    return record.store.enqueue_parent_message(record.run_id, record.owner_session_id, content)
 
 
 def checkpoint_worker_tool_result(
@@ -440,6 +506,7 @@ class SubagentLifecycleService:
         cfg: Mapping[str, Any],
     ) -> Optional[SubagentHandle]:
         """Attach the parent tool's child to the same durable lifecycle used by plugins."""
+        from tools.delegate_tool import DEFAULT_MAX_ITERATIONS
         parent = self._parent_agent_resolver()
         owner = _owner_session_id_of(parent)
         store = _persistent_store(parent) if parent is not None else None
@@ -470,6 +537,8 @@ class SubagentLifecycleService:
         queued = store.enqueue_run(
             worker["worker_id"], owner, goal=goal, context=context or "",
             capability_digest=hashlib.sha256(capability.encode()).hexdigest(),
+            budget_epoch_id=_parent_budget_epoch(parent),
+            budget_limits=_tree_budget_limits(cfg, creds, DEFAULT_MAX_ITERATIONS),
         )
         max_concurrent = _concurrency_limit(cfg)
         active = store.claim_next_run(worker["worker_id"], owner, max_concurrent=max_concurrent)
@@ -498,8 +567,10 @@ class SubagentLifecycleService:
             max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
             max_concurrent=max_concurrent, goal=goal, parent_agent=parent,
             completion_owner="delegate",
+            budget_epoch_id=active.get("budget_epoch_id"),
         )
         self._bind_tool_boundary(record)
+        _attach_tree_budget(record)
         self._start_external_lease(record)
         child._worker_lifecycle_record = record
         with _REGISTRY.lock:
@@ -643,6 +714,8 @@ class SubagentLifecycleService:
                 worker["worker_id"], parent_session_id, goal=request.goal,
                 context=request.context or "",
                 capability_digest=hashlib.sha256(capability.encode()).hexdigest(),
+                budget_epoch_id=_parent_budget_epoch(parent),
+                budget_limits=_tree_budget_limits(cfg, creds, DEFAULT_MAX_ITERATIONS),
             )
             max_concurrent = _concurrency_limit(cfg)
             active = store.claim_next_run(
@@ -673,6 +746,7 @@ class SubagentLifecycleService:
             owner_session_id=parent_session_id, worker_id=worker_id, run_id=run_id, lease_token=lease_token,
             max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
             max_concurrent=_concurrency_limit(cfg), goal=request.goal, parent_agent=parent,
+            budget_epoch_id=(active_run or queued).get("budget_epoch_id") if store is not None else None,
         )
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
@@ -905,7 +979,7 @@ class SubagentLifecycleService:
             pending = store.pending_completions(owner)
             return {
                 "completions": [
-                    self._safe_run_snapshot(item) for item in pending
+                    self._completion_snapshot(item) for item in pending
                     if self._actor_can_target(
                         store,
                         owner,
@@ -956,6 +1030,7 @@ class SubagentLifecycleService:
             raise SubagentLifecycleError("Worker has no matching run.")
         if normalized == "inspect":
             messages = store.list_messages(worker_id, owner)
+            parent_messages = store.list_parent_messages(selected["run_id"], owner)
             return {
                 **self._safe_worker_snapshot(store, worker, owner),
                 "run": self._inspect_run_snapshot(selected),
@@ -970,6 +1045,11 @@ class SubagentLifecycleService:
                         )
                     }
                     for item in messages
+                ],
+                "messages_to_parent": [
+                    {key: item.get(key) for key in (
+                        "message_id", "content", "status", "created_at", "published_at", "acknowledged_at")}
+                    for item in parent_messages
                 ],
             }
         if normalized == "wait":
@@ -1090,6 +1170,16 @@ class SubagentLifecycleService:
         }
 
     @classmethod
+    def _completion_snapshot(cls, run: Mapping[str, Any]) -> Mapping[str, Any]:
+        result = dict(run.get("result") or {})
+        return {
+            **cls._safe_run_snapshot(run),
+            "summary": result.get("summary"),
+            "termination": result.get("termination"),
+            "messages_to_parent": list(result.get("messages_to_parent") or []),
+        }
+
+    @classmethod
     def _inspect_run_snapshot(cls, run: Mapping[str, Any]) -> Mapping[str, Any]:
         result = dict(run.get("result") or {})
         return {
@@ -1192,6 +1282,7 @@ class SubagentLifecycleService:
         self, request: SubagentLaunchRequest, prior: SubagentHandle, worker: Mapping[str, Any], previous: Mapping[str, Any],
     ) -> SubagentHandle:
         """Validate and queue one retained turn behind the exact durable FIFO."""
+        from tools.delegate_tool import DEFAULT_MAX_ITERATIONS
         parent = self._parent_agent_resolver()
         owner = _owner_session_id_of(parent)
         store = _persistent_store(parent)
@@ -1218,7 +1309,7 @@ class SubagentLifecycleService:
             raise SubagentLifecycleError(
                 "The retained worker's parent authority is unavailable; its queued work remains pending.")
         validation_service = type(self)(lambda: authority)
-        child, _creds, cfg, stored_policy = validation_service._build_revalidated_child(
+        child, current_creds, cfg, stored_policy = validation_service._build_revalidated_child(
             worker, goal=request.goal, role=request.role)
         with contextlib.suppress(Exception):
             child.close()
@@ -1231,6 +1322,8 @@ class SubagentLifecycleService:
         queued = store.enqueue_run(
             worker["worker_id"], owner, goal=request.goal, previous_run_id=previous["run_id"],
             capability_digest=hashlib.sha256(capability.encode()).hexdigest(),
+            budget_epoch_id=(previous.get("budget_epoch_id") if int(worker["depth"]) > 1 else None),
+            budget_limits=_tree_budget_limits(cfg, current_creds, DEFAULT_MAX_ITERATIONS),
         )
         max_concurrent = _concurrency_limit(cfg)
         result_handle = dataclasses.replace(
@@ -1245,6 +1338,7 @@ class SubagentLifecycleService:
             owner_session_id=owner, worker_id=worker["worker_id"], run_id=queued["run_id"],
             conversation_history=list(worker.get("history") or []),
             max_concurrent=max_concurrent, goal=request.goal, parent_agent=parent,
+            budget_epoch_id=queued.get("budget_epoch_id"),
         )
         with _REGISTRY.lock:
             _REGISTRY.records[subagent_id] = record
@@ -1331,6 +1425,7 @@ class SubagentLifecycleService:
         record.agent._worker_run_id = record.run_id
         record.state = SubagentState.PENDING
         cls._bind_tool_boundary(record)
+        _attach_tree_budget(record)
         service = cls(lambda: record.parent_agent)
         record.future = _EXECUTOR.submit(service._run, record, record.goal, record.parent_agent)
 
@@ -1381,10 +1476,17 @@ class SubagentLifecycleService:
         from tools.delegate_tool_config import _load_config
 
         max_concurrent = _concurrency_limit(_load_config())
+        target_sequence = None
+        if run_id is not None:
+            target = store.get_run(run_id, owner_session_id)
+            if worker_id is not None and target["worker_id"] != worker_id:
+                raise SubagentLifecycleError("Requested run does not belong to the target worker.")
+            worker_id = target["worker_id"]
+            target_sequence = int(target["sequence"])
         for pending in store.pending_runs(owner_session_id):
             if worker_id is not None and pending["worker_id"] != worker_id:
                 continue
-            if run_id is not None and pending["run_id"] != run_id:
+            if target_sequence is not None and int(pending["sequence"]) > target_sequence:
                 continue
             worker = store.get_worker(pending["worker_id"], owner_session_id)
             authority = cls._retained_parent_authority(
@@ -1459,7 +1561,7 @@ class SubagentLifecycleService:
                     handle, SubagentState.PENDING, created, store=store,
                     owner_session_id=owner_session_id, worker_id=pending["worker_id"],
                     run_id=pending["run_id"], conversation_history=list(worker.get("history") or []),
-                    goal=pending["goal"],
+                    goal=pending["goal"], budget_epoch_id=pending.get("budget_epoch_id"),
                 )
                 with _REGISTRY.lock:
                     _REGISTRY.records[subagent_id] = record
@@ -1475,6 +1577,7 @@ class SubagentLifecycleService:
             record.max_tool_calls = getattr(creds.get("execution_limits"), "max_tool_calls", None)
             record.max_concurrent = max_concurrent
             record.goal = pending["goal"]
+            record.budget_epoch_id = pending.get("budget_epoch_id")
             cls._start_record(record)
 
     @staticmethod
@@ -1664,6 +1767,8 @@ class SubagentLifecycleService:
                     else durable_history
                 )
                 route = dict(getattr(record.agent, "_worker_route_receipt", None) or {})
+                budget = record.store.budget_snapshot(record.run_id, record.owner_session_id)
+                budget_reason = getattr(record.agent, "_worker_budget_termination_reason", None)
                 durable_result = {
                     "summary": result.summary,
                     "error_classification": result.error_classification,
@@ -1678,8 +1783,9 @@ class SubagentLifecycleService:
                     },
                     "termination": {
                         "status": _terminal_status(state),
-                        "reason": (evidence or {}).get("exit_reason") or result.error_classification,
+                        "reason": budget_reason or (evidence or {}).get("exit_reason") or result.error_classification,
                     },
+                    "tree_budget": budget,
                     "usage": {
                         **dict(result.usage_metadata or {}),
                         "tokens": dict((evidence or {}).get("tokens") or {}),
@@ -1694,7 +1800,7 @@ class SubagentLifecycleService:
                     },
                     "effective_tools": list((worker.get("policy") or {}).get("effective_tools") or []),
                 }
-                record.store.finish_run(
+                finished = record.store.finish_run(
                     record.run_id,
                     record.owner_session_id,
                     record.lease_token,
@@ -1703,6 +1809,13 @@ class SubagentLifecycleService:
                     history=history,
                     delivered_message_ids=tuple(delivered_ids),
                 )
+                published = {
+                    item["message_id"]: item["status"]
+                    for item in ((finished.get("result") or {}).get("messages_to_parent") or [])
+                }
+                for item in list(getattr(record.agent, "_delegate_outbound_messages", None) or []):
+                    if item.get("message_id") in published:
+                        item["status"] = published[item["message_id"]]
             except Exception as exc:
                 result = dataclasses.replace(
                     result,

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -179,6 +179,7 @@ class _Record:
     max_concurrent: int = 10
     goal: str = ""
     parent_agent: Any = None
+    completion_owner: str = "service"
 
 
 @dataclasses.dataclass
@@ -281,8 +282,9 @@ _REQUEST_REJECTIONS: tuple[tuple[Callable[[Any], bool], str], ...] = (
     (lambda r: r.timeout_seconds is not None, "Per-launch timeout is not supported; configure delegation timeout explicitly."),
     (lambda r: r.working_directory is not None,
      "working_directory is not supported because Hermes delegates use isolated task environments."),
-    (lambda r: bool(r.blocked_tools),
-     "Per-tool blocking is not supported; use allowed_toolsets. Hermes always blocks unsafe child tools."),
+    (lambda r: not isinstance(r.blocked_tools, tuple) or any(
+        not isinstance(name, str) or not name for name in r.blocked_tools),
+     "blocked_tools must be a tuple of nonempty tool names."),
     (lambda r: any(not _opt_str(value) for value in (r.profile, r.provider, r.model, r.reasoning_effort)),
      "profile, provider, model, and reasoning_effort must be strings when provided."),
 )
@@ -365,7 +367,7 @@ def _iteration_limit(cfg: Mapping[str, Any], creds: Mapping[str, Any], default: 
     return min(global_limit, profile_limit) if isinstance(profile_limit, int) else global_limit
 
 
-def before_worker_tool(agent: Any) -> None:
+def before_worker_tool(agent: Any, tool_call_id: str) -> None:
     """Fail-closed durable boundary immediately before a worker tool dispatch."""
     record = getattr(agent, "_worker_lifecycle_record", None)
     if not isinstance(record, _Record) or record.store is None:
@@ -373,11 +375,19 @@ def before_worker_tool(agent: Any) -> None:
     if record.max_tool_calls is not None and record.tool_calls >= record.max_tool_calls:
         raise SubagentLifecycleError("Worker tool-call limit reached for this run.")
     record.store.mark_tool_boundary(
-        record.run_id, record.owner_session_id, record.lease_token, tool_inflight=True)
+        record.run_id, record.owner_session_id, record.lease_token,
+        tool_call_id=tool_call_id, tool_inflight=True)
     record.tool_calls += 1
 
 
-def checkpoint_worker_tool_result(agent: Any, history: list, *, settled: bool = True) -> None:
+def checkpoint_worker_tool_result(
+    agent: Any,
+    history: list,
+    *,
+    tool_call_id: Optional[str],
+    admitted: Optional[bool] = None,
+    settled: bool = True,
+) -> None:
     """Atomically persist the tool result/history before clearing uncertainty."""
     record = getattr(agent, "_worker_lifecycle_record", None)
     if not isinstance(record, _Record) or record.store is None:
@@ -388,9 +398,12 @@ def checkpoint_worker_tool_result(agent: Any, history: list, *, settled: bool = 
         record.owner_session_id,
         record.lease_token,
         history=history,
+        tool_call_id=tool_call_id,
+        admitted=admitted,
         settled=settled,
         delivered_message_ids=delivered,
     )
+    record.conversation_history = list(history)
     record.delivered_message_ids.clear()
 
 
@@ -434,6 +447,7 @@ class SubagentLifecycleService:
         capability = self._capability(subagent_id, owner, created)
         config_revision, policy = _profile_policy_snapshot(dict(cfg), profile, creds, child=child)
         policy["launch_allowed_toolsets"] = None
+        policy["launch_blocked_tools"] = []
         policy["role"] = getattr(child, "_delegate_role", "leaf")
         policy["capability_digest"] = hashlib.sha256(capability.encode()).hexdigest()
         parent_worker_id = getattr(parent, "_worker_id", None)
@@ -448,7 +462,10 @@ class SubagentLifecycleService:
         if isinstance(getattr(child, "_worker_route_receipt", None), dict):
             child._worker_route_receipt["profile_revision"] = config_revision
             child._worker_route_receipt["effective_tools"] = list(policy["effective_tools"])
-        queued = store.enqueue_run(worker["worker_id"], owner, goal=goal, context=context or "")
+        queued = store.enqueue_run(
+            worker["worker_id"], owner, goal=goal, context=context or "",
+            capability_digest=hashlib.sha256(capability.encode()).hexdigest(),
+        )
         max_concurrent = _concurrency_limit(cfg)
         active = store.claim_next_run(worker["worker_id"], owner, max_concurrent=max_concurrent)
         if active is None or active["run_id"] != queued["run_id"]:
@@ -475,6 +492,7 @@ class SubagentLifecycleService:
             run_id=active["run_id"], lease_token=active["lease_token"],
             max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
             max_concurrent=max_concurrent, goal=goal, parent_agent=parent,
+            completion_owner="delegate",
         )
         self._bind_tool_boundary(record)
         self._start_external_lease(record)
@@ -504,7 +522,7 @@ class SubagentLifecycleService:
     @classmethod
     def complete_adopted_child(cls, child: Any, entry: Mapping[str, Any]) -> None:
         record = getattr(child, "_worker_lifecycle_record", None)
-        if not isinstance(record, _Record):
+        if not isinstance(record, _Record) or record.completion_owner != "delegate":
             return
         status = str(entry.get("status") or "error")
         if status == "completed":
@@ -543,6 +561,11 @@ class SubagentLifecycleService:
         parent_session_id = _owner_session_id_of(parent)
         if request.parent_session_id and request.parent_session_id != parent_session_id:
             raise SubagentLifecycleError("parent_session_id does not match the active session.")
+        from tools.delegate_tool import _validate_spawn_admission
+        try:
+            _validate_spawn_admission(parent, 1)
+        except ValueError as exc:
+            raise SubagentLifecycleError(str(exc)) from exc
         correlation_key = (parent_session_id, request.correlation_id or "")
         with _REGISTRY.lock:
             self._cleanup_locked()
@@ -577,9 +600,13 @@ class SubagentLifecycleService:
             run_iterations = _iteration_limit(cfg, creds, DEFAULT_MAX_ITERATIONS)
         child = _build_child_preserving_parent_tools(
             task_index=0, goal=request.goal, context=request.context,
-            toolsets=list(request.allowed_toolsets) if request.allowed_toolsets else None,
+            toolsets=(
+                list(request.allowed_toolsets)
+                if request.allowed_toolsets is not None else None
+            ),
             model=(request.model or creds.get("model")), max_iterations=run_iterations,
-            task_count=1, parent_agent=parent, role=request.role, **overrides,
+            task_count=1, parent_agent=parent, role=request.role,
+            request_blocked_tools=list(request.blocked_tools), **overrides,
         )
         subagent_id = str(getattr(child, "_subagent_id", "") or "")
         if not subagent_id:
@@ -591,7 +618,9 @@ class SubagentLifecycleService:
         if store is not None and parent_session_id:
             config_revision, policy = _profile_policy_snapshot(cfg, request.profile, creds, child=child)
             policy["launch_allowed_toolsets"] = (
-                list(request.allowed_toolsets) if request.allowed_toolsets else None)
+                list(request.allowed_toolsets)
+                if request.allowed_toolsets is not None else None)
+            policy["launch_blocked_tools"] = list(request.blocked_tools)
             policy["role"] = getattr(child, "_delegate_role", request.role)
             policy["capability_digest"] = hashlib.sha256(capability.encode()).hexdigest()
             worker = store.create_worker(
@@ -600,11 +629,16 @@ class SubagentLifecycleService:
                 config_revision=config_revision,
                 policy=policy,
                 frozen_prompt=_prompt_of(child),
+                parent_worker_id=getattr(parent, "_worker_id", None),
             )
             if isinstance(getattr(child, "_worker_route_receipt", None), dict):
                 child._worker_route_receipt["profile_revision"] = config_revision
                 child._worker_route_receipt["effective_tools"] = list(policy["effective_tools"])
-            queued = store.enqueue_run(worker["worker_id"], parent_session_id, goal=request.goal, context=request.context or "")
+            queued = store.enqueue_run(
+                worker["worker_id"], parent_session_id, goal=request.goal,
+                context=request.context or "",
+                capability_digest=hashlib.sha256(capability.encode()).hexdigest(),
+            )
             max_concurrent = _concurrency_limit(cfg)
             active = store.claim_next_run(
                 worker["worker_id"], parent_session_id, max_concurrent=max_concurrent)
@@ -619,9 +653,9 @@ class SubagentLifecycleService:
             parent_session_id=parent_session_id,
             correlation_id=request.correlation_id,
             created_at=created,
-            provider=getattr(child, "provider", None),
-            model=getattr(child, "model", None),
-            role=getattr(child, "_delegate_role", request.role),
+            provider=_text_or_none(getattr(child, "provider", None)),
+            model=_text_or_none(getattr(child, "model", None)),
+            role=_text_or_none(getattr(child, "_delegate_role", None)) or request.role,
             depth=int(getattr(child, "_delegate_depth", 1) or 1),
             capability=capability,
             worker_id=worker_id,
@@ -803,6 +837,7 @@ class SubagentLifecycleService:
         run_id: Optional[str] = None,
         message: Optional[str] = None,
         timeout_seconds: Optional[float] = None,
+        reconciliation_disposition: Optional[str] = None,
     ) -> Mapping[str, Any]:
         """Parent-tool control by stable IDs; authority is the bound live session, never ID knowledge."""
         parent = self._parent_agent_resolver()
@@ -811,8 +846,13 @@ class SubagentLifecycleService:
         if store is None or not owner:
             raise SubagentLifecycleError("Durable worker state is unavailable for this session.")
         store.recover_expired_runs(owner)
-        self._schedule_owner(store, owner)
         normalized = action.strip().lower()
+        # Cancellation and operator decisions must observe the durable queue
+        # before any restart scheduler can claim it. Read-only inspect and
+        # mailbox actions likewise do not need to cause execution as a side
+        # effect. Status/wait/completions/resume remain scheduler entrypoints.
+        if normalized not in {"cancel", "reconcile", "ack", "inspect", "message"}:
+            self._schedule_owner(store, owner, parent)
         actor_worker_id = getattr(parent, "_worker_id", None)
         from tools.delegate_tool_config import _load_config
         cfg = _load_config()
@@ -861,7 +901,26 @@ class SubagentLifecycleService:
         if normalized == "message":
             queued = store.enqueue_message(
                 worker_id, owner, message or "", sender_id=actor_worker_id or owner)
-            return {"worker_id": worker_id, "message_id": queued["message_id"], "status": queued["status"]}
+            delivery = "NEXT_RUN"
+            with _REGISTRY.lock:
+                active_record = next((
+                    item for item in _REGISTRY.records.values()
+                    if item.owner_session_id == owner and item.worker_id == worker_id
+                    and item.run_id == (selected or {}).get("run_id")
+                    and item.state in {SubagentState.STARTING, SubagentState.RUNNING}
+                    and item.agent is not None
+                ), None)
+            if active_record is not None:
+                steer = getattr(active_record.agent, "steer", None)
+                if callable(steer) and steer(message or ""):
+                    active_record.delivered_message_ids.append(queued["message_id"])
+                    delivery = "RUNNING_STEER_PENDING_CHECKPOINT"
+            return {
+                "worker_id": worker_id,
+                "message_id": queued["message_id"],
+                "status": queued["status"],
+                "delivery": delivery,
+            }
         if selected is None:
             raise SubagentLifecycleError("Worker has no matching run.")
         if normalized == "inspect":
@@ -938,6 +997,22 @@ class SubagentLifecycleService:
                 "live_interrupts": accepted,
                 "queued_runs_cancelled": len(cancelled_pending),
             }
+        if normalized == "reconcile":
+            if selected["run_id"] != runs[-1]["run_id"]:
+                raise SubagentLifecycleError("Reconcile must target the worker's latest run.")
+            if not worker.get("uncertain_side_effect"):
+                raise SubagentLifecycleError("The selected worker has no uncertain tool effect to reconcile.")
+            store.reconcile_run(
+                selected["run_id"],
+                owner,
+                disposition=reconciliation_disposition or "",
+                note=message or "",
+            )
+            return {
+                **self._safe_run_snapshot(store.get_run(selected["run_id"], owner)),
+                "reconciled": True,
+                "disposition": reconciliation_disposition,
+            }
         if normalized == "resume":
             if not message or not message.strip():
                 raise SubagentLifecycleError("action='resume' requires message as the next worker turn.")
@@ -984,6 +1059,7 @@ class SubagentLifecycleService:
                 key: result.get(key) for key in (
                     "summary", "error_classification", "error_message", "result_hash",
                     "route", "lineage", "termination", "usage", "cost",
+                    "effective_tools", "reconciliation",
                 )
             } if result else None,
         }
@@ -1009,6 +1085,8 @@ class SubagentLifecycleService:
         message: str,
         *,
         reconcile_uncertain: bool = False,
+        reconciliation_disposition: Optional[str] = None,
+        reconciliation_note: Optional[str] = None,
     ) -> SubagentHandle:
         """Start a linked run on the stable worker after revalidating current profile policy."""
         parent = self._parent_agent_resolver()
@@ -1024,7 +1102,12 @@ class SubagentLifecycleService:
             if not reconcile_uncertain:
                 raise SubagentLifecycleError(
                     "The prior run stopped with an uncertain tool side effect; reconcile it before resume.")
-            store.reconcile_run(handle.run_id, owner)
+            store.reconcile_run(
+                handle.run_id,
+                owner,
+                disposition=reconciliation_disposition or "accepted_unknown_no_replay",
+                note=reconciliation_note or "",
+            )
         request = SubagentLaunchRequest(
             goal=message,
             profile=worker["profile"],
@@ -1048,21 +1131,81 @@ class SubagentLifecycleService:
         if worker["uncertain_side_effect"]:
             raise SubagentLifecycleError(
                 "The prior run stopped with an uncertain tool side effect; reconcile it before resume.")
+        child, creds, cfg, stored_policy = self._build_revalidated_child(
+            worker, goal=request.goal, role=request.role)
+        runs = store.list_runs(worker["worker_id"], owner)
+        if not runs or runs[-1]["run_id"] != previous["run_id"]:
+            with contextlib.suppress(Exception):
+                child.close()
+            raise SubagentLifecycleError("Followup must link from the worker's latest run.")
+        followup_limit = ((stored_policy.get("profile_contract") or {}).get("execution_limits") or {}).get("max_followups")
+        if isinstance(followup_limit, int) and len(runs) - 1 >= followup_limit:
+            with contextlib.suppress(Exception):
+                child.close()
+            raise SubagentLifecycleError("Worker followup limit reached.")
+        created = time.time()
+        subagent_id = str(getattr(child, "_subagent_id", "") or "")
+        capability = self._capability(subagent_id, owner, created)
+        queued = store.enqueue_run(
+            worker["worker_id"], owner, goal=request.goal, previous_run_id=previous["run_id"],
+            capability_digest=hashlib.sha256(capability.encode()).hexdigest(),
+        )
+        max_concurrent = _concurrency_limit(cfg)
+        active = store.claim_run(queued["run_id"], owner, max_concurrent=max_concurrent)
+        active_run = active if active is not None else None
+        child._worker_id, child._worker_run_id = worker["worker_id"], queued["run_id"]
+        child._worker_owner_session_id = owner
+        result_handle = dataclasses.replace(
+            prior,
+            subagent_id=subagent_id,
+            created_at=created,
+            provider=_text_or_none(getattr(child, "provider", None)),
+            model=_text_or_none(getattr(child, "model", None)),
+            capability=capability,
+            run_id=queued["run_id"],
+        )
+        record = _Record(
+            result_handle, SubagentState.PENDING, created, agent=child, store=store,
+            owner_session_id=owner, worker_id=worker["worker_id"], run_id=queued["run_id"],
+            lease_token=active_run["lease_token"] if active_run else None,
+            conversation_history=list(worker.get("history") or []),
+            max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
+            max_concurrent=max_concurrent, goal=request.goal, parent_agent=parent,
+        )
+        with _REGISTRY.lock:
+            _REGISTRY.records[subagent_id] = record
+        if active_run is not None:
+            self._start_record(record)
+        return result_handle
+
+    def _build_revalidated_child(
+        self, worker: Mapping[str, Any], *, goal: str, role: str,
+    ) -> tuple[Any, Mapping[str, Any], Mapping[str, Any], Mapping[str, Any]]:
+        """Build one retained turn only after current route/tool policy revalidation."""
+        parent = self._parent_agent_resolver()
         from tools.delegate_tool import DEFAULT_MAX_ITERATIONS, _build_child_preserving_parent_tools, _profile_task_overrides
         from tools.delegate_tool_config import _load_config, _resolve_delegation_credentials
         cfg = _load_config()
         stored_policy = dict(worker.get("policy") or {})
         prior_route = dict(stored_policy.get("route") or {})
         route_kwargs = {}
-        if request.profile:
+        routing_mode = str((cfg or {}).get("routing_mode") or "profile_only").strip().lower()
+        # A retained route is not a fresh model-authored override.  Reapply
+        # only the original explicit request in dynamic mode, then compare the
+        # newly resolved route with the stored effective route below.
+        profile = worker.get("profile")
+        if profile and routing_mode == "dynamic" and any(
+            prior_route.get(key) is not None
+            for key in ("requested_provider", "requested_model", "requested_reasoning_effort")
+        ):
             route_kwargs = {
-                "requested_provider": prior_route.get("resolved_provider"),
-                "requested_model": prior_route.get("resolved_model"),
-                "requested_reasoning_effort": prior_route.get("resolved_reasoning_effort"),
+                "requested_provider": prior_route.get("requested_provider"),
+                "requested_model": prior_route.get("requested_model"),
+                "requested_reasoning_effort": prior_route.get("requested_reasoning_effort"),
             }
-        creds = _resolve_delegation_credentials(cfg, parent, request.profile, **route_kwargs)
+        creds = _resolve_delegation_credentials(cfg, parent, profile, **route_kwargs)
         max_iterations = _iteration_limit(cfg, creds, DEFAULT_MAX_ITERATIONS)
-        overrides = _profile_task_overrides(creds) if request.profile else {
+        overrides = _profile_task_overrides(creds) if profile else {
             "override_provider": creds["provider"], "override_base_url": creds["base_url"],
             "override_api_key": creds["api_key"], "override_api_mode": creds["api_mode"],
             "override_request_overrides": creds.get("request_overrides"),
@@ -1070,17 +1213,22 @@ class SubagentLifecycleService:
             "routing_cfg": cfg,
         }
         launch_toolsets = stored_policy.get("launch_allowed_toolsets")
+        launch_blocked_tools = stored_policy.get("launch_blocked_tools")
         child = _build_child_preserving_parent_tools(
-            task_index=0, goal=request.goal, context=None,
+            task_index=0, goal=goal, context=None,
             toolsets=list(launch_toolsets) if isinstance(launch_toolsets, list) else None,
             model=creds.get("model"),
-            max_iterations=max_iterations, task_count=1, parent_agent=parent, role=request.role,
+            max_iterations=max_iterations, task_count=1, parent_agent=parent, role=role,
             frozen_system_prompt=worker["frozen_prompt"],
             retained_child_depth=int(worker["depth"]),
             retained_parent_worker_id=worker.get("parent_worker_id"),
+            request_blocked_tools=(
+                list(launch_blocked_tools)
+                if isinstance(launch_blocked_tools, list) else None
+            ),
             **overrides,
         )
-        _revision, current_policy = _profile_policy_snapshot(cfg, request.profile, creds, child=child)
+        _revision, current_policy = _profile_policy_snapshot(cfg, profile, creds, child=child)
         route_keys = ("resolved_provider", "resolved_model", "resolved_reasoning_effort")
         changed_route = any(
             (current_policy.get("route") or {}).get(key) != prior_route.get(key) for key in route_keys
@@ -1099,46 +1247,7 @@ class SubagentLifecycleService:
                 details.append("effective tools or parent permissions")
             raise SubagentLifecycleError(
                 f"Worker {'/'.join(details)} changed since launch; start a new worker to adopt the new surface.")
-        runs = store.list_runs(worker["worker_id"], owner)
-        if not runs or runs[-1]["run_id"] != previous["run_id"]:
-            with contextlib.suppress(Exception):
-                child.close()
-            raise SubagentLifecycleError("Followup must link from the worker's latest run.")
-        followup_limit = ((stored_policy.get("profile_contract") or {}).get("execution_limits") or {}).get("max_followups")
-        if isinstance(followup_limit, int) and len(runs) - 1 >= followup_limit:
-            with contextlib.suppress(Exception):
-                child.close()
-            raise SubagentLifecycleError("Worker followup limit reached.")
-        queued = store.enqueue_run(
-            worker["worker_id"], owner, goal=request.goal, previous_run_id=previous["run_id"])
-        max_concurrent = _concurrency_limit(cfg)
-        active = store.claim_next_run(worker["worker_id"], owner, max_concurrent=max_concurrent)
-        active_run = active if active is not None and active["run_id"] == queued["run_id"] else None
-        child._worker_id, child._worker_run_id = worker["worker_id"], queued["run_id"]
-        child._worker_owner_session_id = owner
-        created = time.time()
-        subagent_id = str(getattr(child, "_subagent_id", "") or "")
-        result_handle = dataclasses.replace(
-            prior,
-            subagent_id=subagent_id,
-            created_at=created,
-            provider=getattr(child, "provider", None),
-            model=getattr(child, "model", None),
-            run_id=queued["run_id"],
-        )
-        record = _Record(
-            result_handle, SubagentState.PENDING, created, agent=child, store=store,
-            owner_session_id=owner, worker_id=worker["worker_id"], run_id=queued["run_id"],
-            lease_token=active_run["lease_token"] if active_run else None,
-            conversation_history=list(worker.get("history") or []),
-            max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
-            max_concurrent=max_concurrent, goal=request.goal, parent_agent=parent,
-        )
-        with _REGISTRY.lock:
-            _REGISTRY.records[subagent_id] = record
-        if active_run is not None:
-            self._start_record(record)
-        return result_handle
+        return child, creds, cfg, stored_policy
 
     @classmethod
     def _start_record(cls, record: _Record) -> None:
@@ -1155,10 +1264,73 @@ class SubagentLifecycleService:
     def _schedule_pending(cls, completed: _Record) -> None:
         if completed.store is None or not completed.owner_session_id:
             return
-        cls._schedule_owner(completed.store, completed.owner_session_id)
+        cls._schedule_owner(completed.store, completed.owner_session_id, completed.parent_agent)
 
     @classmethod
-    def _schedule_owner(cls, store: Any, owner_session_id: str) -> None:
+    def _schedule_owner(cls, store: Any, owner_session_id: str, parent_agent: Any = None) -> None:
+        # A process restart loses registry records, not the durable FIFO. Claim
+        # each exact eligible run, revalidate current authority, then rebuild
+        # its executor. A validation failure is terminal and inspectable rather
+        # than a permanently leased or silently skipped run.
+        if parent_agent is not None:
+            with _REGISTRY.lock:
+                represented = {
+                    item.run_id for item in _REGISTRY.records.values()
+                    if item.owner_session_id == owner_session_id and item.run_id
+                }
+            from tools.delegate_tool_config import _load_config
+            max_concurrent = _concurrency_limit(_load_config())
+            service = cls(lambda: parent_agent)
+            for pending in store.pending_runs(owner_session_id):
+                if pending["run_id"] in represented:
+                    continue
+                claimed = store.claim_run(
+                    pending["run_id"], owner_session_id, max_concurrent=max_concurrent)
+                if claimed is None:
+                    continue
+                worker = store.get_worker(pending["worker_id"], owner_session_id)
+                role = str((worker.get("policy") or {}).get("role") or "leaf")
+                try:
+                    child, creds, _cfg, _policy = service._build_revalidated_child(
+                        worker, goal=pending["goal"], role=role)
+                except Exception as exc:
+                    store.finish_run(
+                        pending["run_id"], owner_session_id, claimed["lease_token"],
+                        status="FAILED",
+                        result={
+                            "summary": None,
+                            "error_classification": "AUTHORITY_REVALIDATION_FAILED",
+                            "error_message": _clip(exc),
+                            "termination": {
+                                "status": "FAILED", "reason": "authority_revalidation_failed"},
+                        },
+                        history=list(worker.get("history") or []),
+                    )
+                    continue
+                child._worker_id = pending["worker_id"]
+                child._worker_run_id = pending["run_id"]
+                child._worker_owner_session_id = owner_session_id
+                created = time.time()
+                subagent_id = str(getattr(child, "_subagent_id", "") or f"recovered-{pending['run_id']}")
+                handle = SubagentHandle(
+                    PUBLIC_CONTRACT_VERSION, subagent_id, owner_session_id, None, created,
+                    _text_or_none(getattr(child, "provider", None)),
+                    _text_or_none(getattr(child, "model", None)), role, int(worker["depth"]), "",
+                    pending["worker_id"], pending["run_id"],
+                )
+                record = _Record(
+                    handle, SubagentState.PENDING, created, agent=child, store=store,
+                    owner_session_id=owner_session_id, worker_id=pending["worker_id"],
+                    run_id=pending["run_id"], lease_token=claimed["lease_token"],
+                    conversation_history=list(worker.get("history") or []),
+                    max_tool_calls=getattr(creds.get("execution_limits"), "max_tool_calls", None),
+                    max_concurrent=max_concurrent, goal=pending["goal"], parent_agent=parent_agent,
+                )
+                with _REGISTRY.lock:
+                    _REGISTRY.records[subagent_id] = record
+                represented.add(pending["run_id"])
+                cls._start_record(record)
+
         with _REGISTRY.lock:
             candidates = sorted(
                 (
@@ -1171,12 +1343,12 @@ class SubagentLifecycleService:
                 key=lambda item: item.updated_at,
             )
         for candidate in candidates:
-            active = candidate.store.claim_next_run(
-                candidate.worker_id,
+            active = candidate.store.claim_run(
+                candidate.run_id,
                 candidate.owner_session_id,
                 max_concurrent=candidate.max_concurrent,
             )
-            if active is None or active["run_id"] != candidate.run_id:
+            if active is None:
                 continue
             candidate.lease_token = active["lease_token"]
             cls._start_record(candidate)
@@ -1197,11 +1369,11 @@ class SubagentLifecycleService:
             record = _REGISTRY.records.get(handle.subagent_id)
         if record is None:
             return None
-        if handle.worker_id:
-            expected = record.handle.capability
-        else:
-            expected = self._capability(handle.subagent_id, handle.parent_session_id, handle.created_at)
-        return record if hmac.compare_digest(handle.capability, expected) else None
+        # The bearer is valid only for the immutable target it was issued for;
+        # changing worker/run/provider metadata must not retarget authority.
+        if handle != record.handle:
+            return None
+        return record if hmac.compare_digest(handle.capability, record.handle.capability) else None
 
     def _durable_snapshot(self, handle: SubagentHandle) -> Optional[tuple[Any, Mapping[str, Any], Mapping[str, Any]]]:
         if not _handle_is_well_formed(handle) or not handle.worker_id or not handle.run_id:
@@ -1218,9 +1390,18 @@ class SubagentLifecycleService:
             run = store.get_run(handle.run_id, owner)
         except (PermissionError, ValueError):
             return None
-        stored_digest = str((worker.get("policy") or {}).get("capability_digest") or "")
+        stored_digest = str(run.get("capability_digest") or "")
+        if not stored_digest:
+            # Compatibility for a pre-migration worker with exactly one run.
+            # A worker-level digest cannot authorize a substituted run once
+            # more than one immutable run target exists.
+            runs = store.list_runs(worker["worker_id"], owner)
+            if len(runs) == 1:
+                stored_digest = str((worker.get("policy") or {}).get("capability_digest") or "")
         supplied_digest = hashlib.sha256(handle.capability.encode()).hexdigest()
         if not stored_digest or not hmac.compare_digest(stored_digest, supplied_digest):
+            return None
+        if run.get("worker_id") != worker.get("worker_id"):
             return None
         return store, worker, run
 
@@ -1346,19 +1527,18 @@ class SubagentLifecycleService:
         }
         result = dataclasses.replace(result, result_hash=hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest())
         if record.store is not None and record.run_id and record.lease_token:
-            history = list(getattr(record.agent, "_worker_last_history", None) or record.conversation_history)
             try:
-                current_run = record.store.get_run(record.run_id, record.owner_session_id)
-                unresolved_tool = bool(current_run.get("tool_inflight")) and state is not SubagentState.SUCCEEDED
-                record.store.checkpoint_run(
-                    record.run_id,
-                    record.owner_session_id,
-                    record.lease_token,
-                    history=history,
-                    tool_inflight=unresolved_tool,
-                    delivered_message_ids=tuple(delivered_ids),
-                )
                 worker = record.store.get_worker(record.worker_id, record.owner_session_id)
+                final_history = getattr(record.agent, "_worker_last_history", None)
+                # A failure path may not publish _worker_last_history even
+                # though one or more tool outcomes were already checkpointed.
+                # Prefer that durable history over the launch-time snapshot.
+                durable_history = list(worker.get("history") or record.conversation_history)
+                history = (
+                    list(final_history)
+                    if isinstance(final_history, list) and len(final_history) >= len(durable_history)
+                    else durable_history
+                )
                 route = dict(getattr(record.agent, "_worker_route_receipt", None) or {})
                 durable_result = {
                     "summary": result.summary,
@@ -1397,6 +1577,7 @@ class SubagentLifecycleService:
                     status=_terminal_status(state),
                     result=durable_result,
                     history=history,
+                    delivered_message_ids=tuple(delivered_ids),
                 )
             except Exception as exc:
                 result = dataclasses.replace(

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -353,9 +353,14 @@ def _profile_policy_snapshot(
     if tool_names is None:
         tool_names = getattr(child, "valid_tool_names", None)
     effective_tools = sorted(name for name in (tool_names or ()) if isinstance(name, str))
+    from agent.worker_interfaces import frozen_worker_interface_contract
+
     policy = {
         "profile_contract": selected,
         "effective_tools": effective_tools,
+        "worker_interface": frozen_worker_interface_contract(
+            getattr(child, "_worker_interface_selection", None)
+        ),
         "route": {
             key: creds.get(key) for key in (
                 "requested_profile", "requested_provider", "requested_model", "requested_reasoning_effort",
@@ -1145,13 +1150,13 @@ class SubagentLifecycleService:
                 cancelled = store.cancel_pending_run(selected["run_id"], owner)
                 if live_record is not None:
                     with _REGISTRY.lock:
-                        live_record.state = SubagentState.CANCELLED
+                        live_record.state = SubagentState.INTERRUPTED
                         live_record.result = SubagentResult(
                             live_record.handle,
-                            SubagentState.CANCELLED,
+                            SubagentState.INTERRUPTED,
                             True,
                             completed_at=time.time(),
-                            error_classification="CANCELLED",
+                            error_classification="INTERRUPTED",
                             error_message="Worker run interrupted before it started.",
                         )
                         live_record.updated_at = time.time()
@@ -1178,7 +1183,6 @@ class SubagentLifecycleService:
             )
             if accepted:
                 with _REGISTRY.lock:
-                    live_record.state = SubagentState.CANCEL_REQUESTED
                     live_record.updated_at = time.time()
             return {
                 **self._safe_run_snapshot(selected),
@@ -1507,6 +1511,13 @@ class SubagentLifecycleService:
         }
         launch_toolsets = stored_policy.get("launch_allowed_toolsets")
         launch_blocked_tools = stored_policy.get("launch_blocked_tools")
+        from agent.worker_interfaces import frozen_worker_interface_contract
+
+        retained_interface = (
+            stored_policy["worker_interface"]
+            if "worker_interface" in stored_policy
+            else frozen_worker_interface_contract(None)
+        )
         child = _build_child_preserving_parent_tools(
             task_index=0, goal=goal, context=None,
             toolsets=list(launch_toolsets) if isinstance(launch_toolsets, list) else None,
@@ -1519,6 +1530,7 @@ class SubagentLifecycleService:
                 list(launch_blocked_tools)
                 if isinstance(launch_blocked_tools, list) else None
             ),
+            worker_interface_contract=retained_interface,
             **overrides,
         )
         _revision, current_policy = _profile_policy_snapshot(cfg, profile, creds, child=child)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -902,6 +902,11 @@ def _safe_callback(callback, label: str, *args, **kwargs) -> None:
 
 def _begin_tool_execution(agent, ref: _ToolCallRef, display_index: int | None) -> None:
     """Run user-visible and checkpoint preflight on final tool arguments."""
+    # A durable worker must fence the uncertain-send window before ANY handler or UI
+    # callback can run. This call intentionally raises: swallowing it would permit an
+    # external side effect without a recoverable execution record.
+    from agent.subagent_lifecycle import before_worker_tool
+    before_worker_tool(agent)
     function_name, function_args, effective_task_id, tool_call_id = ref.name, ref.args, ref.task_id, ref.call_id
     display_args = _redact_tool_args_for_display(function_name, function_args) or function_args
     if _tool_progress_enabled(agent):
@@ -1027,6 +1032,12 @@ def _commit_tool_result(
     messages.append(tool_message)
     if not _flush_session_db_after_tool_progress(agent, messages, stage=f"tool result {function_name}"):
         return None
+
+    # Clear the uncertain-send marker only in the same durable transaction that
+    # stores the resulting conversation. A UI completion callback is too early and
+    # exceptions there are intentionally swallowed.
+    from agent.subagent_lifecycle import checkpoint_worker_tool_result
+    checkpoint_worker_tool_result(agent, messages)
 
     if not blocked:
         # ``tool.completed`` projects AFTER the canonical append + flush so resume can

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -446,12 +446,15 @@ def _parse_tool_call(agent, tool_call, *, flatten_probe: bool = False) -> _Parse
         name, args, scope_block = _unwrap_tool_search_call(agent, name, args, flatten_probe=flatten_probe)
         exact = getattr(agent, "_worker_effective_tool_names", None)
         if scope_block is None and isinstance(exact, (set, frozenset, list, tuple)):
+            from agent.worker_interfaces import canonical_worker_capability
+
             try:
                 from tools import tool_search as _ts
                 bridge = _ts.is_bridge_tool(name)
             except Exception:
                 bridge = False
-            if not bridge and name not in exact:
+            selection = getattr(agent, "_worker_interface_selection", None)
+            if not bridge and canonical_worker_capability(selection, name) not in exact:
                 scope_block = f"'{name}' is not permitted by this worker's effective tool policy."
     return _ParsedCall(tool_call, name, args, [], parse_error, scope_block)
 
@@ -853,7 +856,14 @@ def _run_sequential_tool_execution_middleware(
     """Run one sequential call on a worker thread under the concurrent executor's deadline.
     Interactive tools (``clarify``) own their wait via ``agent.clarify_timeout``; the
     generic deadline would report ``tool_timeout`` while the prompt is still live."""
-    timeout_s = None if function_name in _SEQUENTIAL_DEADLINE_EXEMPT_TOOLS else _resolve_sequential_tool_timeout()
+    from agent.worker_interfaces import is_worker_interface_tool
+
+    timeout_s = None if (
+        function_name in _SEQUENTIAL_DEADLINE_EXEMPT_TOOLS
+        or is_worker_interface_tool(
+            getattr(agent, "_worker_interface_selection", None), function_name
+        )
+    ) else _resolve_sequential_tool_timeout()
     ref = _ToolCallRef(function_name, function_args, effective_task_id, tool_call_id, middleware_trace)
     kwargs = dict(ref.middleware_kwargs(), execute=execute, scope_block=scope_block, display_index=display_index)
     if function_name in _NEVER_PARALLEL_TOOLS:
@@ -1537,15 +1547,22 @@ def _resolve_sequential_dispatch(agent, ref: _ToolCallRef, messages: list) -> _S
     function_name, function_args, effective_task_id, tool_call_id, middleware_trace = (
         ref.name, ref.args, ref.task_id, ref.call_id, ref.trace,
     )
-    if function_name != "delegate_task" and function_name in INLINE_TOOL_EXECUTORS:
+    from agent.worker_interfaces import is_worker_interface_tool
+
+    selection = getattr(agent, "_worker_interface_selection", None)
+    if not is_worker_interface_tool(selection, function_name) and function_name in INLINE_TOOL_EXECUTORS:
         # Agent-level tools that need live AIAgent state; table shared with invoke_tool.
         inline_executor = INLINE_TOOL_EXECUTORS[function_name]
         inline_ctx = InlineToolContext(effective_task_id=effective_task_id, tool_call_id=tool_call_id, messages=messages)
         return _SequentialDispatch(lambda next_args: inline_executor(agent, next_args, inline_ctx), finish_in_finally=False)
-    if function_name == "delegate_task":
+    if is_worker_interface_tool(selection, function_name):
         spinner = _start_quiet_tool_spinner(agent, function_name, function_args, label=_delegate_spinner_label(function_args))
         agent._delegate_spinner = spinner
-        return _SequentialDispatch(agent._dispatch_delegate_task, spinner=spinner, is_delegate=True)
+        return _SequentialDispatch(
+            lambda next_args: agent._dispatch_worker_interface(function_name, next_args),
+            spinner=spinner,
+            is_delegate=True,
+        )
     if agent._context_engine_tool_names and function_name in agent._context_engine_tool_names:
         return _SequentialDispatch(
             execute=lambda next_args: agent.context_compressor.handle_tool_call(function_name, next_args, messages=messages),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1037,7 +1037,7 @@ def _commit_tool_result(
     # stores the resulting conversation. A UI completion callback is too early and
     # exceptions there are intentionally swallowed.
     from agent.subagent_lifecycle import checkpoint_worker_tool_result
-    checkpoint_worker_tool_result(agent, messages)
+    checkpoint_worker_tool_result(agent, messages, settled=effect_disposition != "unknown")
 
     if not blocked:
         # ``tool.completed`` projects AFTER the canonical append + flush so resume can
@@ -1546,6 +1546,10 @@ def _resolve_sequential_dispatch(agent, ref: _ToolCallRef, messages: list) -> _S
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                worker_max_tool_calls=(
+                    __import__("agent.subagent_lifecycle", fromlist=["worker_tool_calls_remaining"])
+                    .worker_tool_calls_remaining(agent)
+                ),
                 skip_pre_tool_call_hook=True,
                 skip_tool_request_middleware=True,
                 skip_tool_execution_middleware=True,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -352,7 +352,10 @@ def _tool_search_scoped_names(agent) -> frozenset:
         names = _ts.scoped_deferrable_names(model_tools.get_tool_definitions(
             enabled_toolsets=enabled, disabled_toolsets=disabled, quiet_mode=True, skip_tool_search_assembly=True,
         ) or [])
-        exact = getattr(agent, "valid_tool_names", None)
+        exact = getattr(
+            agent, "_worker_effective_tool_names",
+            getattr(agent, "_executable_tool_names", None),
+        )
         if isinstance(exact, (set, frozenset, list, tuple)):
             names = frozenset(names).intersection(exact)
     except Exception:
@@ -360,6 +363,15 @@ def _tool_search_scoped_names(agent) -> frozenset:
     with contextlib.suppress(Exception):
         agent._tool_search_scope_cache = (cache_key, names)
     return names
+
+
+def _execution_authority_names(agent) -> frozenset:
+    """Full executable catalog for this session, separate from visible schemas."""
+    names = getattr(
+        agent, "_worker_effective_tool_names",
+        getattr(agent, "_executable_tool_names", getattr(agent, "valid_tool_names", ())),
+    )
+    return frozenset(names or ())
 
 
 def _canonical_tool_name(function_name: str) -> str:
@@ -432,6 +444,15 @@ def _parse_tool_call(agent, tool_call, *, flatten_probe: bool = False) -> _Parse
     scope_block = None
     if parse_error is None:
         name, args, scope_block = _unwrap_tool_search_call(agent, name, args, flatten_probe=flatten_probe)
+        exact = getattr(agent, "_worker_effective_tool_names", None)
+        if scope_block is None and isinstance(exact, (set, frozenset, list, tuple)):
+            try:
+                from tools import tool_search as _ts
+                bridge = _ts.is_bridge_tool(name)
+            except Exception:
+                bridge = False
+            if not bridge and name not in exact:
+                scope_block = f"'{name}' is not permitted by this worker's effective tool policy."
     return _ParsedCall(tool_call, name, args, [], parse_error, scope_block)
 
 
@@ -1554,7 +1575,7 @@ def _resolve_sequential_dispatch(agent, ref: _ToolCallRef, messages: list) -> _S
                 session_id=agent.session_id or "",
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-                enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                enabled_tools=list(_execution_authority_names(agent)),
                 worker_max_tool_calls=(
                     __import__("agent.subagent_lifecycle", fromlist=["worker_tool_calls_remaining"])
                     .worker_tool_calls_remaining(agent)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -352,6 +352,9 @@ def _tool_search_scoped_names(agent) -> frozenset:
         names = _ts.scoped_deferrable_names(model_tools.get_tool_definitions(
             enabled_toolsets=enabled, disabled_toolsets=disabled, quiet_mode=True, skip_tool_search_assembly=True,
         ) or [])
+        exact = getattr(agent, "valid_tool_names", None)
+        if isinstance(exact, (set, frozenset, list, tuple)):
+            names = frozenset(names).intersection(exact)
     except Exception:
         names = frozenset()
     with contextlib.suppress(Exception):
@@ -906,7 +909,7 @@ def _begin_tool_execution(agent, ref: _ToolCallRef, display_index: int | None) -
     # callback can run. This call intentionally raises: swallowing it would permit an
     # external side effect without a recoverable execution record.
     from agent.subagent_lifecycle import before_worker_tool
-    before_worker_tool(agent)
+    before_worker_tool(agent, ref.call_id)
     function_name, function_args, effective_task_id, tool_call_id = ref.name, ref.args, ref.task_id, ref.call_id
     display_args = _redact_tool_args_for_display(function_name, function_args) or function_args
     if _tool_progress_enabled(agent):
@@ -1037,7 +1040,13 @@ def _commit_tool_result(
     # stores the resulting conversation. A UI completion callback is too early and
     # exceptions there are intentionally swallowed.
     from agent.subagent_lifecycle import checkpoint_worker_tool_result
-    checkpoint_worker_tool_result(agent, messages, settled=effect_disposition != "unknown")
+    checkpoint_worker_tool_result(
+        agent,
+        messages,
+        tool_call_id=tool_call_id,
+        admitted=False if blocked else None,
+        settled=effect_disposition != "unknown",
+    )
 
     if not blocked:
         # ``tool.completed`` projects AFTER the canonical append + flush so resume can
@@ -1359,11 +1368,11 @@ def _unfinished_tool_result(agent, ref: _ToolCallRef, *, timed_out: bool, timeou
     elif agent._interrupt_requested:
         function_result = f"[Tool execution cancelled — {ref.name} was skipped due to user interrupt]"
         outcome = dict(status="cancelled", error_type="keyboard_interrupt", error_message="Tool execution cancelled by user interrupt")
-        tool_duration, effect_disposition = 0.0, None
+        tool_duration, effect_disposition = 0.0, "unknown"
     else:
         function_result = f"Error executing tool '{ref.name}': thread did not return a result"
         outcome = dict(status="error", error_type="thread_missing_result", error_message=function_result)
-        tool_duration, effect_disposition = 0.0, None
+        tool_duration, effect_disposition = 0.0, "unknown"
     ref.emit_post(agent, function_result, **outcome)
     return function_result, tool_duration, effect_disposition
 

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -85,6 +85,8 @@ def perform_api_call(
                 next_api_kwargs, allow_stream=False, is_github_responses=agent._is_copilot_url(),
                 sanitize_harmony_tokens=agent._is_codex_backend(),
             )
+        from agent.worker_receipts import observe_worker_request
+        observe_worker_request(agent, next_api_kwargs)
         if _use_streaming:
             return agent._interruptible_streaming_api_call(
                 next_api_kwargs, on_first_delta=_stop_spinner

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -87,6 +87,12 @@ def perform_api_call(
             )
         from agent.worker_receipts import observe_worker_request
         observe_worker_request(agent, next_api_kwargs)
+        # The durable tree budget counts actual provider attempts, including
+        # retries. Reservation happens after final request middleware/preflight
+        # and immediately before transport, so a crash can never replay an
+        # uncounted or ambiguously transmitted attempt.
+        from agent.subagent_lifecycle import before_worker_provider_attempt
+        before_worker_provider_attempt(agent)
         if _use_streaming:
             return agent._interruptible_streaming_api_call(
                 next_api_kwargs, on_first_delta=_stop_spinner

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -85,14 +85,15 @@ def perform_api_call(
                 next_api_kwargs, allow_stream=False, is_github_responses=agent._is_copilot_url(),
                 sanitize_harmony_tokens=agent._is_codex_backend(),
             )
-        from agent.worker_receipts import observe_worker_request
-        observe_worker_request(agent, next_api_kwargs)
-        # The durable tree budget counts actual provider attempts, including
-        # retries. Reservation happens after final request middleware/preflight
-        # and immediately before transport, so a crash can never replay an
-        # uncounted or ambiguously transmitted attempt.
-        from agent.subagent_lifecycle import before_worker_provider_attempt
-        before_worker_provider_attempt(agent)
+        # Streaming Codex can reconnect inside run_codex_stream. Its physical
+        # send boundary owns both reservation and receipt observation so each
+        # adapter attempt is counted exactly once.
+        internal_codex_stream = agent.api_mode == "codex_responses" and _use_streaming
+        if not internal_codex_stream:
+            from agent.worker_receipts import observe_worker_request
+            from agent.subagent_lifecycle import before_worker_provider_attempt
+            before_worker_provider_attempt(agent)
+            observe_worker_request(agent, next_api_kwargs)
         if _use_streaming:
             return agent._interruptible_streaming_api_call(
                 next_api_kwargs, on_first_delta=_stop_spinner

--- a/agent/turn_response_intake.py
+++ b/agent/turn_response_intake.py
@@ -119,6 +119,8 @@ def normalize_model_response(
 ) -> ResponseIntakeVerdict:
     """Normalize ``response`` into ``assistant_message`` (str content, never dict/list) and run
     the post-response hooks and continuation guards, in the original order."""
+    from agent.worker_receipts import observe_worker_response
+    observe_worker_response(agent, response)
     assistant_message = normalize_response_for_agent(agent, response)
     finish_reason = assistant_message.finish_reason
 

--- a/agent/turn_tool_round.py
+++ b/agent/turn_tool_round.py
@@ -84,7 +84,10 @@ def run_tool_round(
 
     # Post-call guardrails.
     assistant_message.tool_calls = agent._deduplicate_tool_calls(
-        agent._cap_delegate_task_calls(assistant_message.tool_calls)
+        agent._cap_delegate_task_calls(
+            assistant_message.tool_calls,
+            selection=getattr(agent, "_worker_interface_selection", None),
+        )
     )
 
     # Mixed batch: the assistant message keeps EVERY emitted call (each tool_call needs a

--- a/agent/worker_interfaces.py
+++ b/agent/worker_interfaces.py
@@ -1,0 +1,574 @@
+"""Session-stable semantic interfaces for the durable worker service.
+
+The model-facing names in this module are presentation adapters.  Every call
+still reaches ``AIAgent._dispatch_delegate_task``; worker identity, authorization,
+durability, provider routing, and execution policy remain owned by the existing
+delegation service.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import json
+import re
+from typing import Any, Callable, Iterable, Mapping, Optional
+
+
+INTERFACE_VERSION = "worker-interface-v1"
+CANONICAL_WORKER_TOOL = "delegate_task"
+_INTERFACES = frozenset({"auto", "hermes", "codex", "claude"})
+
+
+@dataclass(frozen=True)
+class QualifiedInterfaceProfile:
+    """An exact provider/model interface qualification backed by live evidence."""
+
+    provider: str
+    model: str
+    interface: str
+    evidence_ref: str
+
+
+# Auto-selection is deliberately conservative.  Add an exact entry only after
+# recording live model/tool conformance evidence; source-level tests do not
+# qualify a provider/model pair.
+QUALIFIED_INTERFACE_PROFILES: tuple[QualifiedInterfaceProfile, ...] = ()
+
+
+@dataclass(frozen=True)
+class InterfaceSelection:
+    name: str
+    source: str
+    qualification: str
+    provider: str
+    model: str
+    evidence_ref: Optional[str] = None
+    version: str = INTERFACE_VERSION
+    # Pairs are (semantic tool name, actual session-advertised name).  This is
+    # frozen with the session so later registry refreshes cannot rename calls in
+    # replayed history or capture a native/MCP tool that arrived first.
+    aliases: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class CanonicalWorkerCall:
+    operation: str
+    arguments: Mapping[str, Any]
+
+
+def _normalized(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _qualified_match(
+    provider: str,
+    model: str,
+    profiles: Iterable[QualifiedInterfaceProfile],
+) -> Optional[QualifiedInterfaceProfile]:
+    for profile in profiles:
+        if (
+            _normalized(profile.provider) == provider
+            and _normalized(profile.model) == model
+            and profile.interface in {"codex", "claude"}
+            and isinstance(profile.evidence_ref, str)
+            and bool(profile.evidence_ref.strip())
+        ):
+            return profile
+    return None
+
+
+def resolve_worker_interface(
+    config: Mapping[str, Any],
+    *,
+    provider: Any,
+    model: Any,
+    qualified_profiles: Iterable[QualifiedInterfaceProfile] = QUALIFIED_INTERFACE_PROFILES,
+) -> InterfaceSelection:
+    """Resolve explicit override, then an exact qualified match, then Hermes."""
+
+    orchestration = config.get("orchestration", {}) if isinstance(config, Mapping) else {}
+    if orchestration is None:
+        orchestration = {}
+    if not isinstance(orchestration, Mapping):
+        raise ValueError("orchestration must be a mapping")
+    requested = orchestration.get("interface", "auto")
+    if not isinstance(requested, str) or _normalized(requested) not in _INTERFACES:
+        raise ValueError("orchestration.interface must be auto, hermes, codex, or claude")
+    requested = _normalized(requested)
+    normalized_provider, normalized_model = _normalized(provider), _normalized(model)
+    if requested != "auto":
+        return InterfaceSelection(
+            requested,
+            "explicit",
+            "stable" if requested == "hermes" else "experimental_unqualified",
+            normalized_provider,
+            normalized_model,
+        )
+    matched = _qualified_match(normalized_provider, normalized_model, qualified_profiles)
+    if matched is not None:
+        return InterfaceSelection(
+            matched.interface,
+            "qualified_exact_match",
+            "live_evidence_qualified",
+            normalized_provider,
+            normalized_model,
+            matched.evidence_ref,
+        )
+    return InterfaceSelection(
+        "hermes", "canonical_fallback", "stable", normalized_provider, normalized_model
+    )
+
+
+def _object_schema(
+    name: str,
+    description: str,
+    properties: Mapping[str, Any],
+    required: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": dict(properties),
+                "required": list(required),
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+_TEXT = {"type": "string"}
+_TARGET = {"type": "string", "description": "Stable worker id returned by spawn or list."}
+_RUN = {"type": "string", "description": "Optional exact run id."}
+_PROFILE = {"type": "string", "description": "Optional configured Hermes worker profile."}
+_PROVIDER = {"type": "string", "description": "Optional provider override allowed by the selected worker profile."}
+_MODEL = {"type": "string", "description": "Optional model override allowed by the selected worker profile."}
+_EFFORT = {"type": "string", "description": "Optional reasoning effort override allowed by the selected worker profile."}
+
+
+def _control_schema(name: str = "worker_control") -> dict[str, Any]:
+    return _object_schema(
+        name,
+        "Read or settle durable worker completions without changing worker execution semantics.",
+        {
+            "action": {"type": "string", "enum": ["completions", "ack", "reconcile"]},
+            "target": _TARGET,
+            "run_id": _RUN,
+            "disposition": {
+                "type": "string",
+                "enum": ["confirmed_applied", "confirmed_not_applied", "accepted_unknown_no_replay"],
+            },
+            "note": _TEXT,
+        },
+        ("action",),
+    )
+
+
+def _codex_schemas() -> tuple[dict[str, Any], ...]:
+    return (
+        _object_schema("worker_capabilities", "List configured worker profiles and capabilities.", {"profile": _PROFILE}),
+        _object_schema(
+            "spawn_agent",
+            "Start one durable worker with fresh conversation context. This does not fork parent history.",
+            {
+                "message": _TEXT, "context": _TEXT, "profile": _PROFILE,
+                "provider": _PROVIDER, "model": _MODEL, "reasoning_effort": _EFFORT,
+            },
+            ("message",),
+        ),
+        _object_schema(
+            "send_message",
+            "Queue a message for a worker. An idle worker is not started.",
+            {"target": _TARGET, "message": _TEXT},
+            ("target", "message"),
+        ),
+        _object_schema(
+            "followup_task",
+            "Queue the worker's next linked turn after its current run, or start it when idle. Cancelled workers stay cancelled.",
+            {"target": _TARGET, "message": _TEXT},
+            ("target", "message"),
+        ),
+        _object_schema("inspect_agent", "Inspect one authorized worker and its visible conversation.", {"target": _TARGET, "run_id": _RUN}, ("target",)),
+        _object_schema("list_agents", "List workers visible to this agent.", {}),
+        _object_schema(
+            "wait_agent",
+            "Wait for one worker run for at most 60000 milliseconds.",
+            {"target": _TARGET, "run_id": _RUN, "timeout_ms": {"type": "integer", "minimum": 0, "maximum": 60000}},
+            ("target",),
+        ),
+        _object_schema("interrupt_agent", "Interrupt one exact current worker run without cancelling its descendants.", {"target": _TARGET, "run_id": _RUN}, ("target",)),
+        _object_schema("cancel_agent_tree", "Cancel a worker and its descendant tree.", {"target": _TARGET}, ("target",)),
+        _control_schema(),
+    )
+
+
+def _claude_schemas() -> tuple[dict[str, Any], ...]:
+    return (
+        _object_schema("TaskCapabilities", "List configured worker profiles and capabilities.", {"profile": _PROFILE}),
+        _object_schema(
+            "Agent",
+            "Start one durable worker with fresh conversation context. Parent transcript forking is unsupported.",
+            {
+                "prompt": _TEXT, "context": _TEXT, "subagent_type": _PROFILE,
+                "provider": _PROVIDER, "model": _MODEL, "reasoning_effort": _EFFORT,
+            },
+            ("prompt",),
+        ),
+        _object_schema(
+            "SendMessage",
+            "Send to a worker. Set if_idle only when the message should start the next linked turn; cancelled workers stay cancelled.",
+            {"recipient": _TARGET, "content": _TEXT, "if_idle": {"type": "boolean", "default": False}},
+            ("recipient", "content"),
+        ),
+        _object_schema(
+            "TaskOutput",
+            "Inspect a worker, or wait for its selected run when block is true.",
+            {
+                "task_id": _TARGET,
+                "run_id": _RUN,
+                "block": {"type": "boolean", "default": False},
+                "timeout_ms": {"type": "integer", "minimum": 0, "maximum": 60000},
+            },
+            ("task_id",),
+        ),
+        _object_schema("TaskList", "List workers visible to this agent.", {}),
+        _object_schema(
+            "TaskStop",
+            "Stop one run or explicitly cancel its whole worker tree. Graceful process shutdown is unsupported.",
+            {"task_id": _TARGET, "run_id": _RUN, "scope": {"type": "string", "enum": ["run", "tree"], "default": "run"}},
+            ("task_id",),
+        ),
+        _control_schema(),
+    )
+
+
+_SCHEMA_FACTORIES = {"codex": _codex_schemas, "claude": _claude_schemas}
+
+
+def _semantic_schemas(selection: InterfaceSelection) -> tuple[dict[str, Any], ...]:
+    factory = _SCHEMA_FACTORIES.get(selection.name)
+    return factory() if factory is not None else ()
+
+
+def _namespaced_alias(name: str) -> str:
+    snake = re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+    return f"hermes_worker_{snake}"
+
+
+def bind_worker_interface(
+    selection: InterfaceSelection, definitions: Iterable[Mapping[str, Any]]
+) -> InterfaceSelection:
+    """Freeze collision-aware advertised aliases against the initial tool catalog."""
+
+    if selection.aliases:
+        return selection
+    if selection.name == "hermes":
+        return replace(selection, aliases=((CANONICAL_WORKER_TOOL, CANONICAL_WORKER_TOOL),))
+    occupied = {
+        str(item.get("function", {}).get("name"))
+        for item in definitions
+        if item.get("function", {}).get("name") != CANONICAL_WORKER_TOOL
+    }
+    aliases: list[tuple[str, str]] = []
+    for schema in _semantic_schemas(selection):
+        semantic = str(schema["function"]["name"])
+        advertised = semantic
+        if advertised in occupied:
+            base = _namespaced_alias(semantic)
+            advertised = base
+            suffix = 2
+            while advertised in occupied:
+                advertised = f"{base}_{suffix}"
+                suffix += 1
+        occupied.add(advertised)
+        aliases.append((semantic, advertised))
+    return replace(selection, aliases=tuple(aliases))
+
+
+def project_worker_tool_definitions(
+    definitions: Iterable[Mapping[str, Any]], selection: InterfaceSelection
+) -> list[dict[str, Any]]:
+    """Replace canonical worker presentation at its existing schema position."""
+
+    projected: list[dict[str, Any]] = []
+    aliases = dict(selection.aliases)
+    reserved_aliases = set(aliases.values())
+    replacement = _SCHEMA_FACTORIES.get(selection.name)
+    for definition in definitions:
+        name = definition.get("function", {}).get("name")
+        if name == CANONICAL_WORKER_TOOL and replacement is not None:
+            for schema in replacement():
+                semantic = schema["function"]["name"]
+                renamed = {
+                    **schema,
+                    "function": {**schema["function"], "name": aliases.get(semantic, semantic)},
+                }
+                projected.append(renamed)
+        elif replacement is not None and name in reserved_aliases:
+            # A tool registered after the session froze cannot take an alias
+            # already present in model history. It becomes visible next session,
+            # when binding can choose a different worker alias around it.
+            continue
+        else:
+            projected.append(dict(definition))
+    return projected
+
+
+_CODEX_OPERATIONS = {
+    "worker_capabilities": "capabilities",
+    "spawn_agent": "spawn",
+    "send_message": "message",
+    "followup_task": "start_turn",
+    "inspect_agent": "inspect",
+    "list_agents": "list",
+    "wait_agent": "wait",
+    "interrupt_agent": "interrupt_run",
+    "cancel_agent_tree": "cancel_tree",
+    "worker_control": "control",
+}
+_CLAUDE_OPERATIONS = {
+    "TaskCapabilities": "capabilities",
+    "Agent": "spawn",
+    "SendMessage": "message",
+    "TaskOutput": "inspect",
+    "TaskList": "list",
+    "TaskStop": "interrupt_run",
+    "worker_control": "control",
+}
+_CODEX_ARGUMENTS = {
+    "worker_capabilities": frozenset({"profile"}),
+    "spawn_agent": frozenset({"message", "context", "profile", "provider", "model", "reasoning_effort"}),
+    "send_message": frozenset({"target", "message"}),
+    "followup_task": frozenset({"target", "message"}),
+    "inspect_agent": frozenset({"target", "run_id"}),
+    "list_agents": frozenset(),
+    "wait_agent": frozenset({"target", "run_id", "timeout_ms"}),
+    "interrupt_agent": frozenset({"target", "run_id"}),
+    "cancel_agent_tree": frozenset({"target"}),
+    "worker_control": frozenset({"action", "target", "run_id", "disposition", "note"}),
+}
+_CLAUDE_ARGUMENTS = {
+    "TaskCapabilities": frozenset({"profile"}),
+    "Agent": frozenset({"prompt", "context", "subagent_type", "provider", "model", "reasoning_effort"}),
+    "SendMessage": frozenset({"recipient", "content", "if_idle"}),
+    "TaskOutput": frozenset({"task_id", "run_id", "block", "timeout_ms"}),
+    "TaskList": frozenset(),
+    "TaskStop": frozenset({"task_id", "run_id", "scope"}),
+    "worker_control": frozenset({"action", "target", "run_id", "disposition", "note"}),
+}
+
+
+def advertised_worker_tool_names(selection: InterfaceSelection) -> frozenset[str]:
+    if selection.aliases:
+        return frozenset(advertised for _, advertised in selection.aliases)
+    if selection.name == "codex":
+        return frozenset(_CODEX_OPERATIONS)
+    if selection.name == "claude":
+        return frozenset(_CLAUDE_OPERATIONS)
+    return frozenset({CANONICAL_WORKER_TOOL})
+
+
+def semantic_worker_tool(selection: Optional[InterfaceSelection], tool_name: str) -> Optional[str]:
+    """Resolve only the aliases frozen for this exact session."""
+
+    if not isinstance(selection, InterfaceSelection):
+        return CANONICAL_WORKER_TOOL if tool_name == CANONICAL_WORKER_TOOL else None
+    aliases = selection.aliases
+    if not aliases:
+        if selection.name == "hermes":
+            return CANONICAL_WORKER_TOOL if tool_name == CANONICAL_WORKER_TOOL else None
+        operations = _CODEX_OPERATIONS if selection.name == "codex" else _CLAUDE_OPERATIONS
+        return tool_name if tool_name in operations else None
+    return next((semantic for semantic, advertised in aliases if advertised == tool_name), None)
+
+
+def canonical_worker_capability(
+    selection: Optional[InterfaceSelection], tool_name: str
+) -> str:
+    """Return the authority-bearing registry capability for an interface tool."""
+
+    if semantic_worker_tool(selection, tool_name) is not None:
+        return CANONICAL_WORKER_TOOL
+    return tool_name
+
+
+def is_worker_interface_tool(selection: Optional[InterfaceSelection], tool_name: str) -> bool:
+    return semantic_worker_tool(selection, tool_name) is not None
+
+
+def is_worker_spawn_tool(
+    selection: Optional[InterfaceSelection], tool_name: str,
+    arguments: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    semantic = semantic_worker_tool(selection, tool_name)
+    if semantic in {"spawn_agent", "Agent"}:
+        return True
+    return semantic == CANONICAL_WORKER_TOOL and _normalized((arguments or {}).get("action")) in {"", "spawn"}
+
+
+def _hermes_operation(arguments: Mapping[str, Any]) -> str:
+    action = _normalized(arguments.get("action")) or "spawn"
+    return {
+        "discover": "capabilities",
+        "status": "list" if not arguments.get("worker_id") else "inspect",
+        "resume": "start_turn",
+        "cancel": "cancel_tree",
+        "interrupt": "interrupt_run",
+    }.get(action, action)
+
+
+def normalize_worker_call(
+    selection: InterfaceSelection, tool_name: str, arguments: Mapping[str, Any]
+) -> CanonicalWorkerCall:
+    """Translate presentation semantics to one canonical delegate call."""
+
+    args = dict(arguments or {})
+    advertised_name = tool_name
+    tool_name = semantic_worker_tool(selection, advertised_name) or ""
+    if selection.name == "hermes":
+        if tool_name != CANONICAL_WORKER_TOOL:
+            raise ValueError(f"Tool '{advertised_name}' is not part of the hermes worker interface.")
+        return CanonicalWorkerCall(_hermes_operation(args), args)
+    if selection.name == "codex":
+        operation = _CODEX_OPERATIONS.get(tool_name)
+        if operation is None:
+            raise ValueError(f"Tool '{advertised_name}' is not part of the codex worker interface.")
+        unsupported = set(args) - _CODEX_ARGUMENTS[tool_name]
+        if unsupported:
+            raise ValueError(f"Unsupported {tool_name} arguments: {sorted(unsupported)}")
+        mapped = {
+            "worker_capabilities": lambda: {"action": "discover", "profile": args.get("profile")},
+            "spawn_agent": lambda: {
+                "goal": args.get("message"), "context": args.get("context"),
+                "profile": args.get("profile"), "provider": args.get("provider"),
+                "model": args.get("model"), "reasoning_effort": args.get("reasoning_effort"),
+            },
+            "send_message": lambda: {"action": "message", "worker_id": args.get("target"), "message": args.get("message")},
+            "followup_task": lambda: {"action": "resume", "worker_id": args.get("target"), "message": args.get("message")},
+            "inspect_agent": lambda: {"action": "inspect", "worker_id": args.get("target"), "run_id": args.get("run_id")},
+            "list_agents": lambda: {"action": "status"},
+            "wait_agent": lambda: {"action": "wait", "worker_id": args.get("target"), "run_id": args.get("run_id"), "timeout_seconds": float(args.get("timeout_ms", 0)) / 1000},
+            "interrupt_agent": lambda: {"action": "interrupt", "worker_id": args.get("target"), "run_id": args.get("run_id")},
+            "cancel_agent_tree": lambda: {"action": "cancel", "worker_id": args.get("target")},
+            "worker_control": lambda: {
+                "action": args.get("action"), "worker_id": args.get("target"),
+                "run_id": args.get("run_id"), "reconciliation_disposition": args.get("disposition"),
+                "message": args.get("note"),
+            },
+        }[tool_name]()
+        if tool_name == "worker_control":
+            operation = _normalized(args.get("action"))
+            if operation not in {"completions", "ack", "reconcile"}:
+                raise ValueError("worker_control.action must be completions, ack, or reconcile")
+            if operation != "completions" and not args.get("target"):
+                raise ValueError(f"worker_control action='{operation}' requires target")
+        return CanonicalWorkerCall(operation, {key: value for key, value in mapped.items() if value is not None})
+    operation = _CLAUDE_OPERATIONS.get(tool_name)
+    if operation is None:
+        raise ValueError(f"Tool '{advertised_name}' is not part of the claude worker interface.")
+    unsupported = set(args) - _CLAUDE_ARGUMENTS[tool_name]
+    if unsupported:
+        raise ValueError(f"Unsupported {tool_name} arguments: {sorted(unsupported)}")
+    if tool_name == "TaskStop" and args.get("scope", "run") not in {"run", "tree"}:
+        raise ValueError("TaskStop.scope must be run or tree")
+    if tool_name == "SendMessage" and args.get("if_idle") is True:
+        operation = "start_turn"
+    if tool_name == "TaskOutput" and args.get("block") is True:
+        operation = "wait"
+    if tool_name == "TaskStop" and args.get("scope", "run") == "tree":
+        operation = "cancel_tree"
+    mapped = {
+        "TaskCapabilities": lambda: {"action": "discover", "profile": args.get("profile")},
+        "Agent": lambda: {
+            "goal": args.get("prompt"), "context": args.get("context"),
+            "profile": args.get("subagent_type"), "provider": args.get("provider"),
+            "model": args.get("model"), "reasoning_effort": args.get("reasoning_effort"),
+        },
+        "SendMessage": lambda: {"action": "resume" if operation == "start_turn" else "message", "worker_id": args.get("recipient"), "message": args.get("content")},
+        "TaskOutput": lambda: {"action": "wait" if operation == "wait" else "inspect", "worker_id": args.get("task_id"), "run_id": args.get("run_id"), "timeout_seconds": float(args.get("timeout_ms", 0)) / 1000},
+        "TaskList": lambda: {"action": "status"},
+        "TaskStop": lambda: {"action": "cancel" if operation == "cancel_tree" else "interrupt", "worker_id": args.get("task_id"), "run_id": args.get("run_id")},
+        "worker_control": lambda: {
+            "action": args.get("action"), "worker_id": args.get("target"),
+            "run_id": args.get("run_id"), "reconciliation_disposition": args.get("disposition"),
+            "message": args.get("note"),
+        },
+    }[tool_name]()
+    if tool_name == "worker_control":
+        operation = _normalized(args.get("action"))
+        if operation not in {"completions", "ack", "reconcile"}:
+            raise ValueError("worker_control.action must be completions, ack, or reconcile")
+        if operation != "completions" and not args.get("target"):
+            raise ValueError(f"worker_control action='{operation}' requires target")
+    return CanonicalWorkerCall(operation, {key: value for key, value in mapped.items() if value is not None})
+
+
+def _decode_result(result: Any) -> dict[str, Any]:
+    try:
+        decoded = json.loads(result) if isinstance(result, str) else dict(result)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        decoded = {"error": "Worker service returned a non-JSON result."}
+    return decoded if isinstance(decoded, dict) else {"result": decoded}
+
+
+def _receipt(
+    selection: InterfaceSelection,
+    *,
+    tool_name: str,
+    operation: str,
+    effective_action: str,
+) -> dict[str, Any]:
+    receipt = {
+        "interface": selection.name,
+        "version": selection.version,
+        "selection_source": selection.source,
+        "qualification": selection.qualification,
+        "advertised_tool": tool_name,
+        "operation": operation,
+        "canonical_tool": CANONICAL_WORKER_TOOL,
+        "effective_action": effective_action,
+        "worker_service": "AIAgent._dispatch_delegate_task/SubagentLifecycleService",
+        "provider": selection.provider,
+        "model": selection.model,
+    }
+    if selection.evidence_ref:
+        receipt["qualification_evidence"] = selection.evidence_ref
+    return receipt
+
+
+def dispatch_worker_interface_call(
+    parent_agent: Any,
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    dispatch: Callable[[dict[str, Any]], Any],
+) -> str:
+    """Dispatch one advertised call through the canonical worker service."""
+
+    selection = getattr(parent_agent, "_worker_interface_selection", None)
+    if not isinstance(selection, InterfaceSelection):
+        selection = InterfaceSelection(
+            "hermes", "legacy_session", "stable", _normalized(getattr(parent_agent, "provider", "")),
+            _normalized(getattr(parent_agent, "model", "")),
+        )
+    try:
+        call = normalize_worker_call(selection, tool_name, arguments)
+    except (TypeError, ValueError) as exc:
+        payload = {"error": str(exc)}
+        payload["orchestration_interface"] = _receipt(
+            selection, tool_name=tool_name, operation="unsupported", effective_action="none"
+        )
+        return json.dumps(payload, ensure_ascii=False)
+
+    canonical_args = dict(call.arguments)
+    effective_action = str(canonical_args.get("action") or "spawn")
+    payload = _decode_result(dispatch(canonical_args))
+    payload["orchestration_interface"] = _receipt(
+        selection,
+        tool_name=tool_name,
+        operation=call.operation,
+        effective_action=effective_action,
+    )
+    return json.dumps(payload, ensure_ascii=False)

--- a/agent/worker_interfaces.py
+++ b/agent/worker_interfaces.py
@@ -17,6 +17,11 @@ from typing import Any, Callable, Iterable, Mapping, Optional
 INTERFACE_VERSION = "worker-interface-v1"
 CANONICAL_WORKER_TOOL = "delegate_task"
 _INTERFACES = frozenset({"auto", "hermes", "codex", "claude"})
+_INTERFACE_NAMES = _INTERFACES - {"auto"}
+_SOURCES = frozenset({"explicit", "qualified_exact_match", "canonical_fallback", "legacy_session"})
+_QUALIFICATIONS = frozenset({"stable", "experimental_unqualified", "live_evidence_qualified"})
+_TOOL_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]{0,127}$")
+_EVIDENCE_REF = re.compile(r"^[A-Za-z0-9._:/#@+\-]{1,256}$")
 
 
 @dataclass(frozen=True)
@@ -288,6 +293,90 @@ def bind_worker_interface(
     return replace(selection, aliases=tuple(aliases))
 
 
+def frozen_worker_interface_contract(selection: Optional[InterfaceSelection]) -> dict[str, Any]:
+    """Return the sanitized presentation contract stored with a durable worker."""
+
+    if not isinstance(selection, InterfaceSelection):
+        selection = InterfaceSelection(
+            "hermes", "legacy_session", "stable", "", "",
+            aliases=((CANONICAL_WORKER_TOOL, CANONICAL_WORKER_TOOL),),
+        )
+    contract: dict[str, Any] = {
+        "version": selection.version,
+        "name": selection.name,
+        "source": selection.source,
+        "qualification": selection.qualification,
+        "aliases": [list(item) for item in selection.aliases],
+    }
+    if selection.evidence_ref and _EVIDENCE_REF.fullmatch(selection.evidence_ref):
+        contract["evidence_ref"] = selection.evidence_ref
+    return contract
+
+
+def restore_worker_interface_contract(
+    contract: Optional[Mapping[str, Any]], *, provider: Any, model: Any,
+    definitions: Iterable[Mapping[str, Any]],
+) -> InterfaceSelection:
+    """Validate and restore a retained presentation without expanding authority."""
+
+    definitions = list(definitions)
+    if contract is None:
+        return bind_worker_interface(
+            InterfaceSelection(
+                "hermes", "legacy_session", "stable", _normalized(provider), _normalized(model)
+            ),
+            definitions,
+        )
+    if not isinstance(contract, Mapping) or contract.get("version") != INTERFACE_VERSION:
+        raise ValueError("Retained worker interface contract has an unsupported version.")
+    name = contract.get("name")
+    source = contract.get("source")
+    qualification = contract.get("qualification")
+    evidence_ref = contract.get("evidence_ref")
+    if name not in _INTERFACE_NAMES or source not in _SOURCES or qualification not in _QUALIFICATIONS:
+        raise ValueError("Retained worker interface contract metadata is invalid.")
+    if evidence_ref is not None and (
+        not isinstance(evidence_ref, str) or not _EVIDENCE_REF.fullmatch(evidence_ref)
+    ):
+        raise ValueError("Retained worker interface evidence reference is invalid.")
+    raw_aliases = contract.get("aliases")
+    if not isinstance(raw_aliases, list):
+        raise ValueError("Retained worker interface aliases are invalid.")
+    aliases: list[tuple[str, str]] = []
+    for item in raw_aliases:
+        if (
+            not isinstance(item, list) or len(item) != 2
+            or not all(isinstance(value, str) and _TOOL_NAME.fullmatch(value) for value in item)
+        ):
+            raise ValueError("Retained worker interface aliases are invalid.")
+        aliases.append((item[0], item[1]))
+    expected = (
+        {CANONICAL_WORKER_TOOL}
+        if name == "hermes"
+        else {schema["function"]["name"] for schema in _SCHEMA_FACTORIES[name]()}
+    )
+    if {semantic for semantic, _ in aliases} != expected or len(aliases) != len(expected):
+        raise ValueError("Retained worker interface aliases do not match the interface version.")
+    advertised = [alias for _, alias in aliases]
+    if len(advertised) != len(set(advertised)):
+        raise ValueError("Retained worker interface aliases contain duplicate tool names.")
+    occupied = {
+        str(item.get("function", {}).get("name"))
+        for item in definitions
+        if item.get("function", {}).get("name") != CANONICAL_WORKER_TOOL
+    }
+    collisions = sorted(occupied.intersection(advertised))
+    if collisions:
+        raise ValueError(
+            f"Retained worker interface aliases now collide with registered tools: {collisions}"
+        )
+    return InterfaceSelection(
+        str(name), str(source), str(qualification), _normalized(provider), _normalized(model),
+        evidence_ref if isinstance(evidence_ref, str) else None,
+        aliases=tuple(aliases),
+    )
+
+
 def project_worker_tool_definitions(
     definitions: Iterable[Mapping[str, Any]], selection: InterfaceSelection
 ) -> list[dict[str, Any]]:
@@ -308,10 +397,9 @@ def project_worker_tool_definitions(
                 }
                 projected.append(renamed)
         elif replacement is not None and name in reserved_aliases:
-            # A tool registered after the session froze cannot take an alias
-            # already present in model history. It becomes visible next session,
-            # when binding can choose a different worker alias around it.
-            continue
+            raise ValueError(
+                f"Frozen worker interface alias '{name}' now collides with a registered tool."
+            )
         else:
             projected.append(dict(definition))
     return projected

--- a/agent/worker_receipts.py
+++ b/agent/worker_receipts.py
@@ -1,0 +1,68 @@
+"""Allowlisted worker route evidence at request dispatch and response intake.
+
+No request body, prompt, headers, endpoint, or credentials enter these records.
+The SDK dispatch observation is distinct from the provider's reported model.
+"""
+
+from __future__ import annotations
+
+
+def _field(value, key, default=None):
+    return value.get(key, default) if isinstance(value, dict) else getattr(value, key, default)
+
+
+def _identifier(value):
+    return value if isinstance(value, str) and 0 < len(value) <= 512 else None
+
+
+def observe_worker_request(agent, api_kwargs):
+    receipt = getattr(agent, "_worker_route_receipt", None)
+    if not isinstance(receipt, dict):
+        return
+    # SDK extra_body overrides ordinary request fields when building its JSON.
+    payload = dict(api_kwargs)
+    extra = payload.pop("extra_body", None)
+    if isinstance(extra, dict):
+        payload.update(extra)
+    reasoning = payload.get("reasoning")
+    output_config = payload.get("output_config")
+    effort = (_field(reasoning, "effort") or payload.get("reasoning_effort")
+              or _field(output_config, "effort"))
+    thinking = payload.get("thinking")
+    budget = _field(thinking, "budget_tokens")
+    observed = {
+        "transmitted_provider": _identifier(getattr(agent, "provider", None)),
+        "transmitted_model": _identifier(payload.get("model") or payload.get("modelId")),
+        "transmitted_reasoning_effort": _identifier(effort),
+        "transmitted_thinking_type": _identifier(_field(thinking, "type")),
+        "transmitted_thinking_budget": budget if isinstance(budget, int) and not isinstance(budget, bool) else None,
+        "provider_reported_model": None,
+        "request_evidence_source": "post_middleware_sdk_dispatch",
+        "response_evidence_source": None,
+    }
+    receipt.update(observed)
+    # Keep route changes and missing/observed responses distinct without one
+    # receipt row per token or streaming event.
+    attempts = receipt.setdefault("execution_attempts", [])
+    attempts.append(dict(observed))
+
+
+def observe_worker_response(agent, response):
+    receipt = getattr(agent, "_worker_route_receipt", None)
+    if not isinstance(receipt, dict):
+        return
+    marker = _field(response, "_provider_reported_model")
+    mode = getattr(agent, "api_mode", None)
+    if mode in {"codex_responses", "bedrock_converse", "codex_app_server"}:
+        # These adapters can synthesize response.model from the requested ID.
+        model = _identifier(marker)
+        source = "provider_response_marker" if model else None
+    else:
+        from agent.chat_completion_helpers import PARTIAL_STREAM_STUB_ID
+        model = None if _field(response, "id") == PARTIAL_STREAM_STUB_ID else _identifier(_field(response, "model"))
+        source = "provider_response.model" if model else None
+    receipt["provider_reported_model"] = model
+    receipt["response_evidence_source"] = source
+    attempts = receipt.get("execution_attempts")
+    if attempts:
+        attempts[-1].update(provider_reported_model=model, response_evidence_source=source)

--- a/agent/worker_store.py
+++ b/agent/worker_store.py
@@ -26,6 +26,7 @@ _SCHEMA = (
         request_id TEXT NOT NULL, previous_run_id TEXT,
         goal TEXT NOT NULL, context TEXT NOT NULL, status TEXT NOT NULL,
         lease_token TEXT, lease_expires_at REAL, tool_inflight INTEGER NOT NULL DEFAULT 0,
+        tool_inflight_count INTEGER NOT NULL DEFAULT 0,
         uncertain_side_effect INTEGER NOT NULL DEFAULT 0, result TEXT,
         completion_ack INTEGER NOT NULL DEFAULT 0,
         created_at REAL NOT NULL, updated_at REAL NOT NULL,
@@ -85,6 +86,10 @@ class WorkerStore:
         def migrate(conn):
             for statement in _SCHEMA:
                 conn.execute(statement)
+            run_columns = {row[1] for row in conn.execute("PRAGMA table_info(orchestration_runs)")}
+            if "tool_inflight_count" not in run_columns:
+                conn.execute(
+                    "ALTER TABLE orchestration_runs ADD COLUMN tool_inflight_count INTEGER NOT NULL DEFAULT 0")
         self.db._execute_write(migrate)
 
     @staticmethod
@@ -142,6 +147,12 @@ class WorkerStore:
                 "SELECT * FROM orchestration_workers WHERE owner_session_id=? ORDER BY created_at,worker_id",
                 (owner_session_id,))]
 
+    def active_run_count(self, owner_session_id):
+        with self.db._read_ctx() as conn:
+            return int(conn.execute("""SELECT count(*) FROM orchestration_runs r
+                JOIN orchestration_workers w ON r.worker_id=w.worker_id
+                WHERE w.owner_session_id=? AND r.status='RUNNING'""", (owner_session_id,)).fetchone()[0])
+
     def get_run(self, run_id, owner_session_id):
         with self.db._read_ctx() as conn:
             return self._run(conn, run_id, owner_session_id)
@@ -170,8 +181,12 @@ class WorkerStore:
                 raise ValueError("Reconcile the interrupted tool outcome before resuming this worker")
             if previous_run_id:
                 previous = self._run(conn, previous_run_id, owner_session_id)
-                if previous["worker_id"] != worker_id or previous["status"] not in _TERMINAL:
-                    raise ValueError("Resume must link to this worker's terminal run")
+                latest = conn.execute(
+                    "SELECT run_id FROM orchestration_runs WHERE worker_id=? ORDER BY sequence DESC LIMIT 1",
+                    (worker_id,),
+                ).fetchone()
+                if previous["worker_id"] != worker_id or not latest or latest[0] != previous_run_id:
+                    raise ValueError("Followup must link to this worker's latest run")
             now = time.time()
             conn.execute("""INSERT INTO orchestration_runs
                 (run_id,worker_id,request_id,previous_run_id,goal,context,status,created_at,updated_at)
@@ -196,7 +211,11 @@ class WorkerStore:
                 (owner_session_id,)).fetchone()[0]
             if active or count >= max_concurrent:
                 return None
-            run = conn.execute("SELECT run_id FROM orchestration_runs WHERE worker_id=? AND status='PENDING' ORDER BY sequence LIMIT 1", (worker_id,)).fetchone()
+            run = conn.execute("""SELECT pending.run_id FROM orchestration_runs pending
+                LEFT JOIN orchestration_runs previous ON previous.run_id=pending.previous_run_id
+                WHERE pending.worker_id=? AND pending.status='PENDING'
+                AND (pending.previous_run_id IS NULL OR previous.status IN ('SUCCEEDED','FAILED','INTERRUPTED','CANCELLED'))
+                ORDER BY pending.sequence LIMIT 1""", (worker_id,)).fetchone()
             if run is None:
                 return None
             now = time.time()
@@ -218,8 +237,12 @@ class WorkerStore:
         def checkpoint(conn):
             run = self._lease(conn, run_id, owner_session_id, lease_token)
             now = time.time()
+            count = max(1, int(run.get("tool_inflight_count") or 0)) if tool_inflight else 0
             conn.execute("UPDATE orchestration_workers SET history=?,updated_at=? WHERE worker_id=?", (history_json, now, run["worker_id"]))
-            conn.execute("UPDATE orchestration_runs SET tool_inflight=?,updated_at=? WHERE run_id=?", (int(tool_inflight), now, run_id))
+            conn.execute(
+                "UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=? WHERE run_id=?",
+                (int(tool_inflight), count, now, run_id),
+            )
             for message_id in delivered_message_ids:
                 self._ack_message(conn, run, message_id)
         self.db._execute_write(checkpoint)
@@ -229,12 +252,37 @@ class WorkerStore:
         if not isinstance(tool_inflight, bool):
             raise ValueError("tool_inflight must be a boolean")
         def mark(conn):
-            self._lease(conn, run_id, owner_session_id, lease_token)
+            run = self._lease(conn, run_id, owner_session_id, lease_token)
+            count = int(run.get("tool_inflight_count") or 0) + 1 if tool_inflight else 0
             conn.execute(
-                "UPDATE orchestration_runs SET tool_inflight=?,updated_at=? WHERE run_id=?",
-                (int(tool_inflight), time.time(), run_id),
+                "UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=? WHERE run_id=?",
+                (int(count > 0), count, time.time(), run_id),
             )
         self.db._execute_write(mark)
+
+    def checkpoint_tool_result(
+        self, run_id, owner_session_id, lease_token, *, history,
+        settled=True, delivered_message_ids=(),
+    ):
+        """Persist one canonical tool outcome and clear one inflight slot only when its effect is known."""
+        history_json = json.dumps(history, allow_nan=False)
+        def checkpoint(conn):
+            run = self._lease(conn, run_id, owner_session_id, lease_token)
+            count = int(run.get("tool_inflight_count") or 0)
+            if settled and count:
+                count -= 1
+            now = time.time()
+            conn.execute(
+                "UPDATE orchestration_workers SET history=?,updated_at=? WHERE worker_id=?",
+                (history_json, now, run["worker_id"]),
+            )
+            conn.execute(
+                "UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=? WHERE run_id=?",
+                (int(count > 0), count, now, run_id),
+            )
+            for message_id in delivered_message_ids:
+                self._ack_message(conn, run, message_id)
+        self.db._execute_write(checkpoint)
 
     def finish_run(self, run_id, owner_session_id, lease_token, *, status, result, history=None):
         if status not in _TERMINAL:
@@ -269,6 +317,13 @@ class WorkerStore:
             return _row(conn.execute("SELECT * FROM orchestration_messages WHERE message_id=?", (message_id,)).fetchone())
         return self.db._execute_write(enqueue)
 
+    def list_messages(self, worker_id, owner_session_id):
+        with self.db._read_ctx() as conn:
+            self._worker(conn, worker_id, owner_session_id)
+            return [_row(row) for row in conn.execute(
+                "SELECT * FROM orchestration_messages WHERE worker_id=? ORDER BY sequence", (worker_id,),
+            )]
+
     def claim_messages(self, run_id, owner_session_id, lease_token):
         # Delivery becomes final only alongside a persisted conversation checkpoint.
         with self.db._read_ctx() as conn:
@@ -302,6 +357,28 @@ class WorkerStore:
                 conn.execute("UPDATE orchestration_workers SET uncertain_side_effect=?,updated_at=? WHERE worker_id=?", (uncertain, time.time(), run["worker_id"]))
             return [self._run(conn, r[0], owner_session_id) for r in expired]
         return self.db._execute_write(recover)
+
+    def cancel_pending_runs(self, worker_ids, owner_session_id):
+        """Cancel queued work for an owner-verified subtree; live runs remain lease-fenced."""
+        worker_ids = tuple(dict.fromkeys(worker_ids))
+        if not worker_ids:
+            return []
+        def cancel(conn):
+            for worker_id in worker_ids:
+                self._worker(conn, worker_id, owner_session_id)
+            placeholders = ",".join("?" for _ in worker_ids)
+            now = time.time()
+            rows = conn.execute(
+                f"SELECT run_id FROM orchestration_runs WHERE worker_id IN ({placeholders}) AND status='PENDING'",
+                worker_ids,
+            ).fetchall()
+            for row in rows:
+                conn.execute(
+                    "UPDATE orchestration_runs SET status='CANCELLED',result=?,updated_at=? WHERE run_id=?",
+                    (json.dumps({"reason": "worker_tree_cancelled"}), now, row[0]),
+                )
+            return [self._run(conn, row[0], owner_session_id) for row in rows]
+        return self.db._execute_write(cancel)
 
     def reconcile_run(self, run_id, owner_session_id):
         def reconcile(conn):

--- a/agent/worker_store.py
+++ b/agent/worker_store.py
@@ -441,11 +441,19 @@ class WorkerStore:
             self._ack_message(conn, self._lease(conn, run_id, owner_session_id, lease_token), message_id)
         self.db._execute_write(ack)
 
-    def recover_expired_runs(self, owner_session_id):
+    def recover_expired_runs(self, owner_session_id, worker_ids=None):
+        worker_ids = tuple(dict.fromkeys(worker_ids or ()))
         def recover(conn):
+            params = [owner_session_id, time.time()]
+            scope = ""
+            if worker_ids:
+                for worker_id in worker_ids:
+                    self._worker(conn, worker_id, owner_session_id)
+                scope = f" AND r.worker_id IN ({','.join('?' for _ in worker_ids)})"
+                params.extend(worker_ids)
             expired = conn.execute("""SELECT r.run_id FROM orchestration_runs r JOIN orchestration_workers w
-                ON r.worker_id=w.worker_id WHERE w.owner_session_id=? AND r.status='RUNNING' AND r.lease_expires_at<=?""",
-                (owner_session_id, time.time())).fetchall()
+                ON r.worker_id=w.worker_id WHERE w.owner_session_id=? AND r.status='RUNNING'
+                AND r.lease_expires_at<=?""" + scope, params).fetchall()
             for row in expired:
                 run = self._run(conn, row[0], owner_session_id)
                 uncertain = int(run["tool_inflight"])

--- a/agent/worker_store.py
+++ b/agent/worker_store.py
@@ -146,6 +146,14 @@ class WorkerStore:
         with self.db._read_ctx() as conn:
             return self._run(conn, run_id, owner_session_id)
 
+    def list_runs(self, worker_id, owner_session_id):
+        with self.db._read_ctx() as conn:
+            self._worker(conn, worker_id, owner_session_id)
+            return [_row(row) for row in conn.execute(
+                "SELECT * FROM orchestration_runs WHERE worker_id=? ORDER BY sequence",
+                (worker_id,),
+            )]
+
     def enqueue_run(self, worker_id, owner_session_id, *, goal, context="", request_id=None, previous_run_id=None):
         if not isinstance(goal, str) or not goal.strip() or not isinstance(context, str):
             raise ValueError("A run needs a nonempty goal and text context")
@@ -215,6 +223,18 @@ class WorkerStore:
             for message_id in delivered_message_ids:
                 self._ack_message(conn, run, message_id)
         self.db._execute_write(checkpoint)
+
+    def mark_tool_boundary(self, run_id, owner_session_id, lease_token, *, tool_inflight):
+        """Fence the uncertain-send window without rewriting the conversation checkpoint."""
+        if not isinstance(tool_inflight, bool):
+            raise ValueError("tool_inflight must be a boolean")
+        def mark(conn):
+            self._lease(conn, run_id, owner_session_id, lease_token)
+            conn.execute(
+                "UPDATE orchestration_runs SET tool_inflight=?,updated_at=? WHERE run_id=?",
+                (int(tool_inflight), time.time(), run_id),
+            )
+        self.db._execute_write(mark)
 
     def finish_run(self, run_id, owner_session_id, lease_token, *, status, result, history=None):
         if status not in _TERMINAL:

--- a/agent/worker_store.py
+++ b/agent/worker_store.py
@@ -26,6 +26,7 @@ _SCHEMA = (
         request_id TEXT NOT NULL, previous_run_id TEXT,
         goal TEXT NOT NULL, context TEXT NOT NULL, status TEXT NOT NULL,
         capability_digest TEXT NOT NULL DEFAULT '',
+        budget_epoch_id TEXT,
         lease_token TEXT, lease_expires_at REAL, tool_inflight INTEGER NOT NULL DEFAULT 0,
         tool_inflight_count INTEGER NOT NULL DEFAULT 0,
         uncertain_side_effect INTEGER NOT NULL DEFAULT 0, result TEXT,
@@ -44,14 +45,38 @@ _SCHEMA = (
         tool_call_id TEXT NOT NULL, status TEXT NOT NULL,
         admitted_at REAL NOT NULL, settled_at REAL,
         PRIMARY KEY(run_id, tool_call_id))""",
+    """CREATE TABLE IF NOT EXISTS orchestration_budget_epochs (
+        budget_epoch_id TEXT PRIMARY KEY, owner_session_id TEXT NOT NULL,
+        root_worker_id TEXT NOT NULL, max_iterations INTEGER, used_iterations INTEGER NOT NULL DEFAULT 0,
+        max_tool_calls INTEGER, used_tool_calls INTEGER NOT NULL DEFAULT 0,
+        deadline_at REAL, created_at REAL NOT NULL, updated_at REAL NOT NULL)""",
+    """CREATE TABLE IF NOT EXISTS orchestration_budget_scopes (
+        budget_epoch_id TEXT NOT NULL REFERENCES orchestration_budget_epochs(budget_epoch_id),
+        worker_id TEXT NOT NULL REFERENCES orchestration_workers(worker_id),
+        max_iterations INTEGER, used_iterations INTEGER NOT NULL DEFAULT 0,
+        max_tool_calls INTEGER, used_tool_calls INTEGER NOT NULL DEFAULT 0,
+        deadline_at REAL, PRIMARY KEY(budget_epoch_id,worker_id))""",
+    """CREATE TABLE IF NOT EXISTS orchestration_parent_messages (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT UNIQUE NOT NULL,
+        owner_session_id TEXT NOT NULL, worker_id TEXT NOT NULL REFERENCES orchestration_workers(worker_id),
+        run_id TEXT NOT NULL REFERENCES orchestration_runs(run_id), content TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'QUEUED', created_at REAL NOT NULL,
+        published_at REAL, acknowledged_at REAL)""",
     "CREATE INDEX IF NOT EXISTS orchestration_owner ON orchestration_workers(owner_session_id)",
     "CREATE INDEX IF NOT EXISTS orchestration_queue ON orchestration_runs(worker_id, status, sequence)",
     "CREATE INDEX IF NOT EXISTS orchestration_mailbox ON orchestration_messages(worker_id, status, sequence)",
     "CREATE INDEX IF NOT EXISTS orchestration_tool_effect_state ON orchestration_tool_effects(run_id, status)",
+    "CREATE INDEX IF NOT EXISTS orchestration_parent_outbox ON orchestration_parent_messages(owner_session_id,status,sequence)",
 )
 _JSON_FIELDS = {"policy", "history", "result"}
 _SECRET_KEYS = {"api_key", "access_token", "refresh_token", "token", "password", "authorization", "cookie", "credentials"}
 _TERMINAL = {"SUCCEEDED", "FAILED", "INTERRUPTED", "CANCELLED"}
+
+
+class WorkerBudgetExceeded(ValueError):
+    def __init__(self, reason):
+        self.reason = reason
+        super().__init__(reason.replace("_", " "))
 
 
 def _row(row):
@@ -100,6 +125,8 @@ class WorkerStore:
             if "capability_digest" not in run_columns:
                 conn.execute(
                     "ALTER TABLE orchestration_runs ADD COLUMN capability_digest TEXT NOT NULL DEFAULT ''")
+            if "budget_epoch_id" not in run_columns:
+                conn.execute("ALTER TABLE orchestration_runs ADD COLUMN budget_epoch_id TEXT")
             # Older boolean/count checkpoints have no call identity. Preserve
             # them as explicit unknown effects so recovery stays fail-closed.
             legacy = conn.execute("""SELECT run_id,tool_inflight_count FROM orchestration_runs r
@@ -197,7 +224,7 @@ class WorkerStore:
 
     def enqueue_run(
         self, worker_id, owner_session_id, *, goal, context="", request_id=None,
-        previous_run_id=None, capability_digest="",
+        previous_run_id=None, capability_digest="", budget_epoch_id=None, budget_limits=None,
     ):
         if not isinstance(goal, str) or not goal.strip() or not isinstance(context, str):
             raise ValueError("A run needs a nonempty goal and text context")
@@ -223,14 +250,116 @@ class WorkerStore:
                 if previous["worker_id"] != worker_id or not latest or latest[0] != previous_run_id:
                     raise ValueError("Followup must link to this worker's latest run")
             now = time.time()
+            epoch_id = budget_epoch_id
+            if budget_limits is not None:
+                limits = self._normalize_budget_limits(budget_limits)
+                if epoch_id is None:
+                    if worker["parent_worker_id"] is not None:
+                        raise ValueError("A nested worker must inherit its parent budget epoch")
+                    epoch_id = "budget-" + uuid.uuid4().hex
+                    deadline = now + limits["timeout_seconds"] if limits["timeout_seconds"] else None
+                    conn.execute("""INSERT INTO orchestration_budget_epochs
+                        (budget_epoch_id,owner_session_id,root_worker_id,max_iterations,max_tool_calls,
+                         deadline_at,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?)""",
+                        (epoch_id, owner_session_id, worker["root_worker_id"], limits["max_iterations"],
+                         limits["max_tool_calls"], deadline, now, now))
+                epoch = self._budget_epoch(conn, epoch_id, owner_session_id)
+                if epoch["root_worker_id"] != worker["root_worker_id"]:
+                    raise PermissionError("Budget epoch belongs to another worker tree")
+                parent_deadline = epoch["deadline_at"]
+                if worker["parent_worker_id"]:
+                    parent_scope = conn.execute("""SELECT deadline_at FROM orchestration_budget_scopes
+                        WHERE budget_epoch_id=? AND worker_id=?""",
+                        (epoch_id, worker["parent_worker_id"])).fetchone()
+                    if parent_scope is None:
+                        raise ValueError("Parent budget scope is unavailable")
+                    parent_deadline = parent_scope[0]
+                local_deadline = now + limits["timeout_seconds"] if limits["timeout_seconds"] else None
+                deadline = min(v for v in (parent_deadline, local_deadline) if v is not None) \
+                    if parent_deadline is not None or local_deadline is not None else None
+                conn.execute("""INSERT OR IGNORE INTO orchestration_budget_scopes
+                    (budget_epoch_id,worker_id,max_iterations,max_tool_calls,deadline_at)
+                    VALUES (?,?,?,?,?)""", (epoch_id, worker_id, limits["max_iterations"],
+                                              limits["max_tool_calls"], deadline))
             conn.execute("""INSERT INTO orchestration_runs
                 (run_id,worker_id,request_id,previous_run_id,goal,context,status,
-                 capability_digest,created_at,updated_at)
-                VALUES (?,?,?,?,?,?,'PENDING',?,?,?)""",
+                 capability_digest,budget_epoch_id,created_at,updated_at)
+                VALUES (?,?,?,?,?,?,'PENDING',?,?,?,?)""",
                 (run_id, worker_id, request_id, previous_run_id, goal, context,
-                 capability_digest, now, now))
+                 capability_digest, epoch_id, now, now))
             return self._run(conn, run_id, owner_session_id)
         return self.db._execute_write(enqueue)
+
+    @staticmethod
+    def _normalize_budget_limits(value):
+        if not isinstance(value, dict):
+            raise ValueError("budget_limits must be a mapping")
+        result = {}
+        for name in ("max_iterations", "max_tool_calls"):
+            item = value.get(name)
+            if item is not None and (isinstance(item, bool) or not isinstance(item, int) or item < 0):
+                raise ValueError(f"{name} must be a nonnegative integer or null")
+            result[name] = item
+        timeout = value.get("timeout_seconds")
+        if timeout is not None:
+            _positive(timeout, "timeout_seconds")
+        result["timeout_seconds"] = timeout
+        return result
+
+    @staticmethod
+    def _budget_epoch(conn, budget_epoch_id, owner_session_id):
+        row = conn.execute("SELECT * FROM orchestration_budget_epochs WHERE budget_epoch_id=?",
+                           (budget_epoch_id,)).fetchone()
+        if row is None or row["owner_session_id"] != owner_session_id:
+            raise PermissionError("Unknown budget epoch or foreign owner")
+        return dict(row)
+
+    @classmethod
+    def _reserve_budget(cls, conn, run, owner_session_id, kind):
+        epoch_id = run.get("budget_epoch_id")
+        if not epoch_id:
+            return
+        epoch = cls._budget_epoch(conn, epoch_id, owner_session_id)
+        worker = cls._worker(conn, run["worker_id"], owner_session_id)
+        scopes = []
+        cursor = worker
+        while cursor is not None:
+            scope = conn.execute("""SELECT * FROM orchestration_budget_scopes
+                WHERE budget_epoch_id=? AND worker_id=?""", (epoch_id, cursor["worker_id"])).fetchone()
+            if scope is None:
+                raise PermissionError("Worker budget scope is unavailable")
+            scopes.append(dict(scope))
+            cursor = cls._worker(conn, cursor["parent_worker_id"], owner_session_id) \
+                if cursor["parent_worker_id"] else None
+        now = time.time()
+        deadlines = [item["deadline_at"] for item in [epoch, *scopes] if item["deadline_at"] is not None]
+        if deadlines and now >= min(deadlines):
+            raise WorkerBudgetExceeded("tree_deadline_exhausted")
+        max_key, used_key = f"max_{kind}s", f"used_{kind}s"
+        for item in [epoch, *scopes]:
+            if item[max_key] is not None and item[used_key] >= item[max_key]:
+                raise WorkerBudgetExceeded(f"tree_{kind}_budget_exhausted")
+        conn.execute(f"UPDATE orchestration_budget_epochs SET {used_key}={used_key}+1,updated_at=? WHERE budget_epoch_id=?",
+                     (now, epoch_id))
+        for scope in scopes:
+            conn.execute(f"UPDATE orchestration_budget_scopes SET {used_key}={used_key}+1 WHERE budget_epoch_id=? AND worker_id=?",
+                         (epoch_id, scope["worker_id"]))
+
+    def reserve_iteration(self, run_id, owner_session_id, lease_token):
+        def reserve(conn):
+            run = self._lease(conn, run_id, owner_session_id, lease_token)
+            self._reserve_budget(conn, run, owner_session_id, "iteration")
+        self.db._execute_write(reserve)
+
+    def budget_snapshot(self, run_id, owner_session_id):
+        with self.db._read_ctx() as conn:
+            run = self._run(conn, run_id, owner_session_id)
+            if not run.get("budget_epoch_id"):
+                return None
+            epoch = self._budget_epoch(conn, run["budget_epoch_id"], owner_session_id)
+            return {key: epoch[key] for key in (
+                "budget_epoch_id", "root_worker_id", "max_iterations", "used_iterations",
+                "max_tool_calls", "used_tool_calls", "deadline_at")}
 
     def claim_next_run(self, worker_id, owner_session_id, *, lease_seconds=60, max_concurrent=10):
         _positive(lease_seconds, "lease_seconds")
@@ -327,11 +456,12 @@ class WorkerStore:
         if not isinstance(tool_call_id, str) or not tool_call_id:
             raise ValueError("tool_call_id must be nonempty text")
         def mark(conn):
-            self._lease(conn, run_id, owner_session_id, lease_token)
+            run = self._lease(conn, run_id, owner_session_id, lease_token)
             existing = conn.execute("""SELECT status FROM orchestration_tool_effects
                 WHERE run_id=? AND tool_call_id=?""", (run_id, tool_call_id)).fetchone()
             if existing is not None:
                 raise ValueError("Tool call was already admitted; refusing duplicate execution")
+            self._reserve_budget(conn, run, owner_session_id, "tool_call")
             now = time.time()
             conn.execute("""INSERT INTO orchestration_tool_effects
                 (run_id,tool_call_id,status,admitted_at) VALUES (?,?,'INFLIGHT',?)""",
@@ -383,11 +513,18 @@ class WorkerStore:
     ):
         if status not in _TERMINAL:
             raise ValueError("Invalid terminal run status")
-        result_json = _policy_json(result)
         def finish(conn):
             run = self._lease(conn, run_id, owner_session_id, lease_token)
             now = time.time()
             uncertain = bool(run["tool_inflight"])
+            parent_messages = [dict(row) for row in conn.execute("""SELECT message_id,content
+                FROM orchestration_parent_messages WHERE run_id=? AND status='QUEUED' ORDER BY sequence""",
+                (run_id,))]
+            stored_result = dict(result)
+            if parent_messages:
+                stored_result["messages_to_parent"] = [
+                    {**item, "status": "PUBLISHED"} for item in parent_messages]
+            result_json = _policy_json(stored_result)
             conn.execute("""UPDATE orchestration_runs SET status=?,result=?,uncertain_side_effect=?,
                 lease_token=NULL,lease_expires_at=NULL,updated_at=? WHERE run_id=?""",
                 (status, result_json, int(uncertain), now, run_id))
@@ -396,8 +533,32 @@ class WorkerStore:
                 conn.execute("UPDATE orchestration_workers SET history=? WHERE worker_id=?", (json.dumps(history, allow_nan=False), run["worker_id"]))
             for message_id in delivered_message_ids:
                 self._ack_message(conn, run, message_id)
+            conn.execute("""UPDATE orchestration_parent_messages SET status='PUBLISHED',published_at=?
+                WHERE run_id=? AND status='QUEUED'""", (now, run_id))
             return self._run(conn, run_id, owner_session_id)
         return self.db._execute_write(finish)
+
+    def enqueue_parent_message(self, run_id, owner_session_id, content, *, message_id=None):
+        if not isinstance(content, str) or not content.strip():
+            raise ValueError("Message must be nonempty text")
+        message_id = message_id or "message-" + uuid.uuid4().hex
+        def enqueue(conn):
+            run = self._run(conn, run_id, owner_session_id)
+            if run["status"] != "RUNNING":
+                raise ValueError("Parent messages require an active worker run")
+            conn.execute("""INSERT INTO orchestration_parent_messages
+                (message_id,owner_session_id,worker_id,run_id,content,created_at)
+                VALUES (?,?,?,?,?,?)""",
+                (message_id, owner_session_id, run["worker_id"], run_id, content, time.time()))
+            return dict(conn.execute("SELECT * FROM orchestration_parent_messages WHERE message_id=?",
+                                     (message_id,)).fetchone())
+        return self.db._execute_write(enqueue)
+
+    def list_parent_messages(self, run_id, owner_session_id):
+        with self.db._read_ctx() as conn:
+            self._run(conn, run_id, owner_session_id)
+            return [dict(row) for row in conn.execute("""SELECT * FROM orchestration_parent_messages
+                WHERE run_id=? ORDER BY sequence""", (run_id,))]
 
     def enqueue_message(self, worker_id, owner_session_id, content, *, message_id=None, sender_id=None):
         if not isinstance(content, str) or not content.strip():
@@ -457,9 +618,18 @@ class WorkerStore:
             for row in expired:
                 run = self._run(conn, row[0], owner_session_id)
                 uncertain = int(run["tool_inflight"])
+                parent_messages = [dict(item) for item in conn.execute("""SELECT message_id,content
+                    FROM orchestration_parent_messages WHERE run_id=? AND status='QUEUED' ORDER BY sequence""",
+                    (row[0],))]
+                result = {"reason": "execution_lease_expired", "uncertain_side_effect": bool(uncertain)}
+                if parent_messages:
+                    result["messages_to_parent"] = [
+                        {**item, "status": "PUBLISHED"} for item in parent_messages]
                 conn.execute("""UPDATE orchestration_runs SET status='INTERRUPTED',uncertain_side_effect=?,
                     lease_token=NULL,lease_expires_at=NULL,result=?,updated_at=? WHERE run_id=?""",
-                    (uncertain, json.dumps({"reason": "execution_lease_expired", "uncertain_side_effect": bool(uncertain)}), time.time(), row[0]))
+                    (uncertain, _policy_json(result), time.time(), row[0]))
+                conn.execute("""UPDATE orchestration_parent_messages SET status='PUBLISHED',published_at=?
+                    WHERE run_id=? AND status='QUEUED'""", (time.time(), row[0]))
                 conn.execute("UPDATE orchestration_workers SET uncertain_side_effect=?,updated_at=? WHERE worker_id=?", (uncertain, time.time(), run["worker_id"]))
             return [self._run(conn, r[0], owner_session_id) for r in expired]
         return self.db._execute_write(recover)
@@ -531,5 +701,8 @@ class WorkerStore:
             run = self._run(conn, run_id, owner_session_id)
             if run["status"] not in _TERMINAL:
                 raise ValueError("A running task has no completion to acknowledge")
+            now = time.time()
             conn.execute("UPDATE orchestration_runs SET completion_ack=1 WHERE run_id=?", (run_id,))
+            conn.execute("""UPDATE orchestration_parent_messages SET status='ACKNOWLEDGED',acknowledged_at=?
+                WHERE run_id=? AND status='PUBLISHED'""", (now, run_id))
         self.db._execute_write(ack)

--- a/agent/worker_store.py
+++ b/agent/worker_store.py
@@ -635,14 +635,14 @@ class WorkerStore:
         return self.db._execute_write(recover)
 
     def cancel_pending_run(self, run_id, owner_session_id):
-        """Cancel one exact queued run without changing its worker or descendants."""
+        """Interrupt one exact queued run without cancelling its durable worker."""
         def cancel(conn):
             run = self._run(conn, run_id, owner_session_id)
             if run["status"] != "PENDING":
                 return None
             now = time.time()
             conn.execute(
-                "UPDATE orchestration_runs SET status='CANCELLED',result=?,updated_at=? WHERE run_id=?",
+                "UPDATE orchestration_runs SET status='INTERRUPTED',result=?,updated_at=? WHERE run_id=?",
                 (json.dumps({"reason": "worker_run_interrupted_before_start"}), now, run_id),
             )
             return self._run(conn, run_id, owner_session_id)

--- a/agent/worker_store.py
+++ b/agent/worker_store.py
@@ -634,6 +634,20 @@ class WorkerStore:
             return [self._run(conn, r[0], owner_session_id) for r in expired]
         return self.db._execute_write(recover)
 
+    def cancel_pending_run(self, run_id, owner_session_id):
+        """Cancel one exact queued run without changing its worker or descendants."""
+        def cancel(conn):
+            run = self._run(conn, run_id, owner_session_id)
+            if run["status"] != "PENDING":
+                return None
+            now = time.time()
+            conn.execute(
+                "UPDATE orchestration_runs SET status='CANCELLED',result=?,updated_at=? WHERE run_id=?",
+                (json.dumps({"reason": "worker_run_interrupted_before_start"}), now, run_id),
+            )
+            return self._run(conn, run_id, owner_session_id)
+        return self.db._execute_write(cancel)
+
     def cancel_pending_runs(self, worker_ids, owner_session_id):
         """Cancel queued work for an owner-verified subtree; live runs remain lease-fenced."""
         worker_ids = tuple(dict.fromkeys(worker_ids))

--- a/agent/worker_store.py
+++ b/agent/worker_store.py
@@ -25,6 +25,7 @@ _SCHEMA = (
         worker_id TEXT NOT NULL REFERENCES orchestration_workers(worker_id),
         request_id TEXT NOT NULL, previous_run_id TEXT,
         goal TEXT NOT NULL, context TEXT NOT NULL, status TEXT NOT NULL,
+        capability_digest TEXT NOT NULL DEFAULT '',
         lease_token TEXT, lease_expires_at REAL, tool_inflight INTEGER NOT NULL DEFAULT 0,
         tool_inflight_count INTEGER NOT NULL DEFAULT 0,
         uncertain_side_effect INTEGER NOT NULL DEFAULT 0, result TEXT,
@@ -38,9 +39,15 @@ _SCHEMA = (
         worker_id TEXT NOT NULL REFERENCES orchestration_workers(worker_id),
         sender_id TEXT, content TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'PENDING',
         delivered_run_id TEXT, created_at REAL NOT NULL, delivered_at REAL)""",
+    """CREATE TABLE IF NOT EXISTS orchestration_tool_effects (
+        run_id TEXT NOT NULL REFERENCES orchestration_runs(run_id),
+        tool_call_id TEXT NOT NULL, status TEXT NOT NULL,
+        admitted_at REAL NOT NULL, settled_at REAL,
+        PRIMARY KEY(run_id, tool_call_id))""",
     "CREATE INDEX IF NOT EXISTS orchestration_owner ON orchestration_workers(owner_session_id)",
     "CREATE INDEX IF NOT EXISTS orchestration_queue ON orchestration_runs(worker_id, status, sequence)",
     "CREATE INDEX IF NOT EXISTS orchestration_mailbox ON orchestration_messages(worker_id, status, sequence)",
+    "CREATE INDEX IF NOT EXISTS orchestration_tool_effect_state ON orchestration_tool_effects(run_id, status)",
 )
 _JSON_FIELDS = {"policy", "history", "result"}
 _SECRET_KEYS = {"api_key", "access_token", "refresh_token", "token", "password", "authorization", "cookie", "credentials"}
@@ -90,6 +97,19 @@ class WorkerStore:
             if "tool_inflight_count" not in run_columns:
                 conn.execute(
                     "ALTER TABLE orchestration_runs ADD COLUMN tool_inflight_count INTEGER NOT NULL DEFAULT 0")
+            if "capability_digest" not in run_columns:
+                conn.execute(
+                    "ALTER TABLE orchestration_runs ADD COLUMN capability_digest TEXT NOT NULL DEFAULT ''")
+            # Older boolean/count checkpoints have no call identity. Preserve
+            # them as explicit unknown effects so recovery stays fail-closed.
+            legacy = conn.execute("""SELECT run_id,tool_inflight_count FROM orchestration_runs r
+                WHERE tool_inflight_count>0 AND NOT EXISTS (
+                    SELECT 1 FROM orchestration_tool_effects e WHERE e.run_id=r.run_id)""").fetchall()
+            for row in legacy:
+                for index in range(int(row[1])):
+                    conn.execute("""INSERT INTO orchestration_tool_effects
+                        (run_id,tool_call_id,status,admitted_at) VALUES (?,?,?,?)""",
+                        (row[0], f"legacy-unknown-{index}", "UNKNOWN", time.time()))
         self.db._execute_write(migrate)
 
     @staticmethod
@@ -165,9 +185,24 @@ class WorkerStore:
                 (worker_id,),
             )]
 
-    def enqueue_run(self, worker_id, owner_session_id, *, goal, context="", request_id=None, previous_run_id=None):
+    def pending_runs(self, owner_session_id):
+        """Owner-scoped durable FIFO queue, including runs with no process record."""
+        with self.db._read_ctx() as conn:
+            return [_row(row) for row in conn.execute("""SELECT r.* FROM orchestration_runs r
+                JOIN orchestration_workers w ON r.worker_id=w.worker_id
+                LEFT JOIN orchestration_runs previous ON previous.run_id=r.previous_run_id
+                WHERE w.owner_session_id=? AND r.status='PENDING'
+                AND (r.previous_run_id IS NULL OR previous.status IN ('SUCCEEDED','FAILED','INTERRUPTED','CANCELLED'))
+                ORDER BY r.sequence""", (owner_session_id,))]
+
+    def enqueue_run(
+        self, worker_id, owner_session_id, *, goal, context="", request_id=None,
+        previous_run_id=None, capability_digest="",
+    ):
         if not isinstance(goal, str) or not goal.strip() or not isinstance(context, str):
             raise ValueError("A run needs a nonempty goal and text context")
+        if not isinstance(capability_digest, str):
+            raise ValueError("capability_digest must be text")
         run_id, request_id = "run-" + uuid.uuid4().hex, request_id or uuid.uuid4().hex
         def enqueue(conn):
             worker = self._worker(conn, worker_id, owner_session_id)
@@ -189,9 +224,11 @@ class WorkerStore:
                     raise ValueError("Followup must link to this worker's latest run")
             now = time.time()
             conn.execute("""INSERT INTO orchestration_runs
-                (run_id,worker_id,request_id,previous_run_id,goal,context,status,created_at,updated_at)
-                VALUES (?,?,?,?,?,?,'PENDING',?,?)""",
-                (run_id, worker_id, request_id, previous_run_id, goal, context, now, now))
+                (run_id,worker_id,request_id,previous_run_id,goal,context,status,
+                 capability_digest,created_at,updated_at)
+                VALUES (?,?,?,?,?,?,'PENDING',?,?,?)""",
+                (run_id, worker_id, request_id, previous_run_id, goal, context,
+                 capability_digest, now, now))
             return self._run(conn, run_id, owner_session_id)
         return self.db._execute_write(enqueue)
 
@@ -224,6 +261,37 @@ class WorkerStore:
             return self._run(conn, run[0], owner_session_id)
         return self.db._execute_write(claim)
 
+    def claim_run(self, run_id, owner_session_id, *, lease_seconds=60, max_concurrent=10):
+        """Claim this exact FIFO-eligible run or return None without leasing a peer."""
+        _positive(lease_seconds, "lease_seconds")
+        if isinstance(max_concurrent, bool) or not isinstance(max_concurrent, int) or max_concurrent < 1:
+            raise ValueError("max_concurrent must be a positive integer")
+        token = uuid.uuid4().hex
+        def claim(conn):
+            run = self._run(conn, run_id, owner_session_id)
+            worker = self._worker(conn, run["worker_id"], owner_session_id)
+            if run["status"] != "PENDING" or worker["uncertain_side_effect"]:
+                return None
+            active = conn.execute(
+                "SELECT 1 FROM orchestration_runs WHERE worker_id=? AND status='RUNNING'",
+                (run["worker_id"],),
+            ).fetchone()
+            count = conn.execute("""SELECT count(*) FROM orchestration_runs r
+                JOIN orchestration_workers w ON r.worker_id=w.worker_id
+                WHERE w.owner_session_id=? AND r.status='RUNNING'""", (owner_session_id,)).fetchone()[0]
+            eligible = conn.execute("""SELECT pending.run_id FROM orchestration_runs pending
+                LEFT JOIN orchestration_runs previous ON previous.run_id=pending.previous_run_id
+                WHERE pending.worker_id=? AND pending.status='PENDING'
+                AND (pending.previous_run_id IS NULL OR previous.status IN ('SUCCEEDED','FAILED','INTERRUPTED','CANCELLED'))
+                ORDER BY pending.sequence LIMIT 1""", (run["worker_id"],)).fetchone()
+            if active or count >= max_concurrent or not eligible or eligible[0] != run_id:
+                return None
+            now = time.time()
+            conn.execute("""UPDATE orchestration_runs SET status='RUNNING',lease_token=?,lease_expires_at=?,updated_at=?
+                WHERE run_id=? AND status='PENDING'""", (token, now + lease_seconds, now, run_id))
+            return self._run(conn, run_id, owner_session_id)
+        return self.db._execute_write(claim)
+
     def heartbeat_run(self, run_id, owner_session_id, lease_token, *, lease_seconds=60):
         _positive(lease_seconds, "lease_seconds")
         def heartbeat(conn):
@@ -232,72 +300,102 @@ class WorkerStore:
             conn.execute("UPDATE orchestration_runs SET lease_expires_at=?,updated_at=? WHERE run_id=?", (now + lease_seconds, now, run_id))
         self.db._execute_write(heartbeat)
 
-    def checkpoint_run(self, run_id, owner_session_id, lease_token, *, history, tool_inflight=False, delivered_message_ids=()):
+    def checkpoint_run(self, run_id, owner_session_id, lease_token, *, history, tool_inflight=None, delivered_message_ids=()):
         history_json = json.dumps(history, allow_nan=False)
         def checkpoint(conn):
             run = self._lease(conn, run_id, owner_session_id, lease_token)
             now = time.time()
-            count = max(1, int(run.get("tool_inflight_count") or 0)) if tool_inflight else 0
             conn.execute("UPDATE orchestration_workers SET history=?,updated_at=? WHERE worker_id=?", (history_json, now, run["worker_id"]))
-            conn.execute(
-                "UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=? WHERE run_id=?",
-                (int(tool_inflight), count, now, run_id),
-            )
+            if tool_inflight is True:
+                call_id = "legacy-checkpoint-" + uuid.uuid4().hex
+                conn.execute("""INSERT INTO orchestration_tool_effects
+                    (run_id,tool_call_id,status,admitted_at) VALUES (?,?,'UNKNOWN',?)""",
+                    (run_id, call_id, now))
+            count = conn.execute("""SELECT count(*) FROM orchestration_tool_effects
+                WHERE run_id=? AND status IN ('INFLIGHT','UNKNOWN')""", (run_id,)).fetchone()[0]
+            conn.execute("""UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=?
+                WHERE run_id=?""", (int(count > 0), count, now, run_id))
             for message_id in delivered_message_ids:
                 self._ack_message(conn, run, message_id)
         self.db._execute_write(checkpoint)
 
-    def mark_tool_boundary(self, run_id, owner_session_id, lease_token, *, tool_inflight):
-        """Fence the uncertain-send window without rewriting the conversation checkpoint."""
-        if not isinstance(tool_inflight, bool):
-            raise ValueError("tool_inflight must be a boolean")
+    def mark_tool_boundary(self, run_id, owner_session_id, lease_token, *, tool_call_id=None, tool_inflight=True):
+        """Admit one identified effect before dispatch; anonymous clearing is forbidden."""
+        if tool_inflight is not True:
+            raise ValueError("Tool effects clear only through their matching result checkpoint")
+        tool_call_id = tool_call_id or "legacy-tool-" + uuid.uuid4().hex
+        if not isinstance(tool_call_id, str) or not tool_call_id:
+            raise ValueError("tool_call_id must be nonempty text")
         def mark(conn):
-            run = self._lease(conn, run_id, owner_session_id, lease_token)
-            count = int(run.get("tool_inflight_count") or 0) + 1 if tool_inflight else 0
-            conn.execute(
-                "UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=? WHERE run_id=?",
-                (int(count > 0), count, time.time(), run_id),
-            )
-        self.db._execute_write(mark)
+            self._lease(conn, run_id, owner_session_id, lease_token)
+            existing = conn.execute("""SELECT status FROM orchestration_tool_effects
+                WHERE run_id=? AND tool_call_id=?""", (run_id, tool_call_id)).fetchone()
+            if existing is not None:
+                raise ValueError("Tool call was already admitted; refusing duplicate execution")
+            now = time.time()
+            conn.execute("""INSERT INTO orchestration_tool_effects
+                (run_id,tool_call_id,status,admitted_at) VALUES (?,?,'INFLIGHT',?)""",
+                (run_id, tool_call_id, now))
+            count = conn.execute("""SELECT count(*) FROM orchestration_tool_effects
+                WHERE run_id=? AND status IN ('INFLIGHT','UNKNOWN')""", (run_id,)).fetchone()[0]
+            conn.execute("""UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=?
+                WHERE run_id=?""", (int(count > 0), count, now, run_id))
+            return tool_call_id
+        return self.db._execute_write(mark)
 
     def checkpoint_tool_result(
         self, run_id, owner_session_id, lease_token, *, history,
-        settled=True, delivered_message_ids=(),
+        tool_call_id=None, admitted=None, settled=True, delivered_message_ids=(),
     ):
-        """Persist one canonical tool outcome and clear one inflight slot only when its effect is known."""
+        """Persist one outcome and settle only its matching admitted effect."""
         history_json = json.dumps(history, allow_nan=False)
         def checkpoint(conn):
             run = self._lease(conn, run_id, owner_session_id, lease_token)
-            count = int(run.get("tool_inflight_count") or 0)
-            if settled and count:
-                count -= 1
             now = time.time()
+            effect = None
+            if isinstance(tool_call_id, str) and tool_call_id:
+                effect = conn.execute("""SELECT status FROM orchestration_tool_effects
+                    WHERE run_id=? AND tool_call_id=?""", (run_id, tool_call_id)).fetchone()
+            admitted_here = effect is not None if admitted is None else bool(admitted)
+            if admitted_here:
+                if not isinstance(tool_call_id, str) or not tool_call_id:
+                    raise ValueError("An admitted tool result requires tool_call_id")
+                if effect is None or effect[0] != "INFLIGHT":
+                    raise ValueError("Tool result does not match an inflight admitted call")
+                conn.execute("""UPDATE orchestration_tool_effects SET status=?,settled_at=?
+                    WHERE run_id=? AND tool_call_id=?""",
+                    ("SETTLED" if settled else "UNKNOWN", now, run_id, tool_call_id))
             conn.execute(
                 "UPDATE orchestration_workers SET history=?,updated_at=? WHERE worker_id=?",
                 (history_json, now, run["worker_id"]),
             )
-            conn.execute(
-                "UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=? WHERE run_id=?",
-                (int(count > 0), count, now, run_id),
-            )
+            count = conn.execute("""SELECT count(*) FROM orchestration_tool_effects
+                WHERE run_id=? AND status IN ('INFLIGHT','UNKNOWN')""", (run_id,)).fetchone()[0]
+            conn.execute("""UPDATE orchestration_runs SET tool_inflight=?,tool_inflight_count=?,updated_at=?
+                WHERE run_id=?""", (int(count > 0), count, now, run_id))
             for message_id in delivered_message_ids:
                 self._ack_message(conn, run, message_id)
         self.db._execute_write(checkpoint)
 
-    def finish_run(self, run_id, owner_session_id, lease_token, *, status, result, history=None):
+    def finish_run(
+        self, run_id, owner_session_id, lease_token, *, status, result, history=None,
+        delivered_message_ids=(),
+    ):
         if status not in _TERMINAL:
             raise ValueError("Invalid terminal run status")
         result_json = _policy_json(result)
         def finish(conn):
             run = self._lease(conn, run_id, owner_session_id, lease_token)
             now = time.time()
-            uncertain = bool(run["tool_inflight"]) and status != "SUCCEEDED"
+            uncertain = bool(run["tool_inflight"])
             conn.execute("""UPDATE orchestration_runs SET status=?,result=?,uncertain_side_effect=?,
                 lease_token=NULL,lease_expires_at=NULL,updated_at=? WHERE run_id=?""",
                 (status, result_json, int(uncertain), now, run_id))
             conn.execute("UPDATE orchestration_workers SET uncertain_side_effect=?,updated_at=? WHERE worker_id=?", (int(uncertain), now, run["worker_id"]))
             if history is not None:
                 conn.execute("UPDATE orchestration_workers SET history=? WHERE worker_id=?", (json.dumps(history, allow_nan=False), run["worker_id"]))
+            for message_id in delivered_message_ids:
+                self._ack_message(conn, run, message_id)
             return self._run(conn, run_id, owner_session_id)
         return self.db._execute_write(finish)
 
@@ -380,7 +478,12 @@ class WorkerStore:
             return [self._run(conn, row[0], owner_session_id) for row in rows]
         return self.db._execute_write(cancel)
 
-    def reconcile_run(self, run_id, owner_session_id):
+    def reconcile_run(self, run_id, owner_session_id, *, disposition, note):
+        allowed = {"confirmed_applied", "confirmed_not_applied", "accepted_unknown_no_replay"}
+        if disposition not in allowed:
+            raise ValueError(f"Invalid reconciliation disposition; choose one of {sorted(allowed)}")
+        if not isinstance(note, str) or not note.strip():
+            raise ValueError("Reconciliation requires a nonempty decision note")
         def reconcile(conn):
             run = self._run(conn, run_id, owner_session_id)
             if run["status"] not in _TERMINAL:
@@ -388,7 +491,25 @@ class WorkerStore:
             latest = conn.execute("SELECT run_id FROM orchestration_runs WHERE worker_id=? AND status IN ('INTERRUPTED','FAILED','CANCELLED','SUCCEEDED') ORDER BY sequence DESC LIMIT 1", (run["worker_id"],)).fetchone()
             if not latest or latest[0] != run_id:
                 raise ValueError("Reconcile the latest terminal run")
-            conn.execute("UPDATE orchestration_workers SET uncertain_side_effect=0,updated_at=? WHERE worker_id=?", (time.time(), run["worker_id"]))
+            now = time.time()
+            result = dict(run.get("result") or {})
+            effects = [
+                {"tool_call_id": row[0], "prior_status": row[1]}
+                for row in conn.execute("""SELECT tool_call_id,status FROM orchestration_tool_effects
+                    WHERE run_id=? AND status IN ('INFLIGHT','UNKNOWN') ORDER BY tool_call_id""", (run_id,))
+            ]
+            result["reconciliation"] = {
+                "disposition": disposition,
+                "note": note.strip(),
+                "affected_tool_calls": effects,
+                "reconciled_at": now,
+            }
+            conn.execute("""UPDATE orchestration_tool_effects SET status='RECONCILED',settled_at=?
+                WHERE run_id=? AND status IN ('INFLIGHT','UNKNOWN')""", (now, run_id))
+            conn.execute("""UPDATE orchestration_runs SET uncertain_side_effect=0,tool_inflight=0,
+                tool_inflight_count=0,result=?,updated_at=? WHERE run_id=?""",
+                (_policy_json(result), now, run_id))
+            conn.execute("UPDATE orchestration_workers SET uncertain_side_effect=0,updated_at=? WHERE worker_id=?", (now, run["worker_id"]))
         self.db._execute_write(reconcile)
 
     def pending_completions(self, owner_session_id):

--- a/agent/worker_store.py
+++ b/agent/worker_store.py
@@ -1,0 +1,309 @@
+"""Durable delegation records in the existing profile-scoped SessionDB.
+
+The service owns capability policy and tool execution. This module owns atomic
+state transitions, lease fencing and idempotency; it never resolves credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+import uuid
+
+
+_SCHEMA = (
+    """CREATE TABLE IF NOT EXISTS orchestration_workers (
+        worker_id TEXT PRIMARY KEY, owner_session_id TEXT NOT NULL,
+        parent_worker_id TEXT, root_worker_id TEXT NOT NULL, depth INTEGER NOT NULL,
+        profile TEXT, config_revision TEXT NOT NULL, policy TEXT NOT NULL,
+        frozen_prompt TEXT NOT NULL, frozen_prompt_hash TEXT NOT NULL,
+        history TEXT NOT NULL DEFAULT '[]', uncertain_side_effect INTEGER NOT NULL DEFAULT 0,
+        created_at REAL NOT NULL, updated_at REAL NOT NULL)""",
+    """CREATE TABLE IF NOT EXISTS orchestration_runs (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT, run_id TEXT UNIQUE NOT NULL,
+        worker_id TEXT NOT NULL REFERENCES orchestration_workers(worker_id),
+        request_id TEXT NOT NULL, previous_run_id TEXT,
+        goal TEXT NOT NULL, context TEXT NOT NULL, status TEXT NOT NULL,
+        lease_token TEXT, lease_expires_at REAL, tool_inflight INTEGER NOT NULL DEFAULT 0,
+        uncertain_side_effect INTEGER NOT NULL DEFAULT 0, result TEXT,
+        completion_ack INTEGER NOT NULL DEFAULT 0,
+        created_at REAL NOT NULL, updated_at REAL NOT NULL,
+        UNIQUE(worker_id, request_id))""",
+    """CREATE UNIQUE INDEX IF NOT EXISTS orchestration_one_active
+        ON orchestration_runs(worker_id) WHERE status = 'RUNNING'""",
+    """CREATE TABLE IF NOT EXISTS orchestration_messages (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT, message_id TEXT UNIQUE NOT NULL,
+        worker_id TEXT NOT NULL REFERENCES orchestration_workers(worker_id),
+        sender_id TEXT, content TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'PENDING',
+        delivered_run_id TEXT, created_at REAL NOT NULL, delivered_at REAL)""",
+    "CREATE INDEX IF NOT EXISTS orchestration_owner ON orchestration_workers(owner_session_id)",
+    "CREATE INDEX IF NOT EXISTS orchestration_queue ON orchestration_runs(worker_id, status, sequence)",
+    "CREATE INDEX IF NOT EXISTS orchestration_mailbox ON orchestration_messages(worker_id, status, sequence)",
+)
+_JSON_FIELDS = {"policy", "history", "result"}
+_SECRET_KEYS = {"api_key", "access_token", "refresh_token", "token", "password", "authorization", "cookie", "credentials"}
+_TERMINAL = {"SUCCEEDED", "FAILED", "INTERRUPTED", "CANCELLED"}
+
+
+def _row(row):
+    if row is None:
+        return None
+    value = dict(row)
+    for key in _JSON_FIELDS.intersection(value):
+        value[key] = json.loads(value[key]) if value[key] is not None else None
+    for key in {"uncertain_side_effect", "tool_inflight", "completion_ack"}.intersection(value):
+        value[key] = bool(value[key])
+    return value
+
+
+def _policy_json(value):
+    def check(item):
+        if isinstance(item, dict):
+            if any(str(key).lower() in _SECRET_KEYS for key in item):
+                raise ValueError("Worker policy must not contain credentials")
+            for child in item.values():
+                check(child)
+        elif isinstance(item, (list, tuple)):
+            for child in item:
+                check(child)
+    check(value)
+    return json.dumps(value, sort_keys=True, allow_nan=False)
+
+
+def _positive(value, name):
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be positive and finite")
+    return value
+
+
+class WorkerStore:
+    def __init__(self, session_db):
+        self.db = session_db
+
+    def ensure_schema(self):
+        def migrate(conn):
+            for statement in _SCHEMA:
+                conn.execute(statement)
+        self.db._execute_write(migrate)
+
+    @staticmethod
+    def _worker(conn, worker_id, owner_session_id):
+        worker = _row(conn.execute("SELECT * FROM orchestration_workers WHERE worker_id=?", (worker_id,)).fetchone())
+        if worker is None or not owner_session_id or worker["owner_session_id"] != owner_session_id:
+            raise PermissionError("Unknown worker or foreign owner")
+        return worker
+
+    @classmethod
+    def _run(cls, conn, run_id, owner_session_id):
+        run = _row(conn.execute("SELECT * FROM orchestration_runs WHERE run_id=?", (run_id,)).fetchone())
+        if run is None:
+            raise PermissionError("Unknown run or foreign owner")
+        cls._worker(conn, run["worker_id"], owner_session_id)
+        return run
+
+    @classmethod
+    def _lease(cls, conn, run_id, owner_session_id, lease_token):
+        run = cls._run(conn, run_id, owner_session_id)
+        if (not lease_token or run["status"] != "RUNNING" or run["lease_token"] != lease_token
+                or run["lease_expires_at"] <= time.time()):
+            raise PermissionError("Worker execution lease is no longer valid")
+        return run
+
+    def create_worker(self, owner_session_id, *, profile=None, config_revision="", policy=None,
+                      frozen_prompt="", parent_worker_id=None, worker_id=None):
+        import hashlib
+
+        if not isinstance(owner_session_id, str) or not owner_session_id.strip():
+            raise ValueError("A stable owner session is required")
+        worker_id = worker_id or "worker-" + uuid.uuid4().hex
+        policy_text = _policy_json(policy or {})
+        prompt_hash = hashlib.sha256(frozen_prompt.encode()).hexdigest()
+        def create(conn):
+            parent = self._worker(conn, parent_worker_id, owner_session_id) if parent_worker_id else None
+            now = time.time()
+            conn.execute("""INSERT INTO orchestration_workers
+                (worker_id,owner_session_id,parent_worker_id,root_worker_id,depth,profile,
+                 config_revision,policy,frozen_prompt,frozen_prompt_hash,created_at,updated_at)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (worker_id, owner_session_id, parent_worker_id,
+                 parent["root_worker_id"] if parent else worker_id, parent["depth"] + 1 if parent else 1,
+                 profile, config_revision, policy_text, frozen_prompt, prompt_hash, now, now))
+            return self._worker(conn, worker_id, owner_session_id)
+        return self.db._execute_write(create)
+
+    def get_worker(self, worker_id, owner_session_id):
+        with self.db._read_ctx() as conn:
+            return self._worker(conn, worker_id, owner_session_id)
+
+    def list_workers(self, owner_session_id):
+        with self.db._read_ctx() as conn:
+            return [_row(r) for r in conn.execute(
+                "SELECT * FROM orchestration_workers WHERE owner_session_id=? ORDER BY created_at,worker_id",
+                (owner_session_id,))]
+
+    def get_run(self, run_id, owner_session_id):
+        with self.db._read_ctx() as conn:
+            return self._run(conn, run_id, owner_session_id)
+
+    def enqueue_run(self, worker_id, owner_session_id, *, goal, context="", request_id=None, previous_run_id=None):
+        if not isinstance(goal, str) or not goal.strip() or not isinstance(context, str):
+            raise ValueError("A run needs a nonempty goal and text context")
+        run_id, request_id = "run-" + uuid.uuid4().hex, request_id or uuid.uuid4().hex
+        def enqueue(conn):
+            worker = self._worker(conn, worker_id, owner_session_id)
+            existing = _row(conn.execute("SELECT * FROM orchestration_runs WHERE worker_id=? AND request_id=?",
+                                         (worker_id, request_id)).fetchone())
+            if existing:
+                if (existing["goal"], existing["context"], existing["previous_run_id"]) != (goal, context, previous_run_id):
+                    raise ValueError("Run request ID was already used for different content")
+                return existing
+            if worker["uncertain_side_effect"]:
+                raise ValueError("Reconcile the interrupted tool outcome before resuming this worker")
+            if previous_run_id:
+                previous = self._run(conn, previous_run_id, owner_session_id)
+                if previous["worker_id"] != worker_id or previous["status"] not in _TERMINAL:
+                    raise ValueError("Resume must link to this worker's terminal run")
+            now = time.time()
+            conn.execute("""INSERT INTO orchestration_runs
+                (run_id,worker_id,request_id,previous_run_id,goal,context,status,created_at,updated_at)
+                VALUES (?,?,?,?,?,?,'PENDING',?,?)""",
+                (run_id, worker_id, request_id, previous_run_id, goal, context, now, now))
+            return self._run(conn, run_id, owner_session_id)
+        return self.db._execute_write(enqueue)
+
+    def claim_next_run(self, worker_id, owner_session_id, *, lease_seconds=60, max_concurrent=10):
+        _positive(lease_seconds, "lease_seconds")
+        if isinstance(max_concurrent, bool) or not isinstance(max_concurrent, int) or max_concurrent < 1:
+            raise ValueError("max_concurrent must be a positive integer")
+        token = uuid.uuid4().hex
+        def claim(conn):
+            worker = self._worker(conn, worker_id, owner_session_id)
+            if worker["uncertain_side_effect"]:
+                return None
+            # Expired RUNNING rows still count until explicit recovery fences them.
+            active = conn.execute("SELECT 1 FROM orchestration_runs WHERE worker_id=? AND status='RUNNING'", (worker_id,)).fetchone()
+            count = conn.execute("""SELECT count(*) FROM orchestration_runs r JOIN orchestration_workers w
+                ON r.worker_id=w.worker_id WHERE w.owner_session_id=? AND r.status='RUNNING'""",
+                (owner_session_id,)).fetchone()[0]
+            if active or count >= max_concurrent:
+                return None
+            run = conn.execute("SELECT run_id FROM orchestration_runs WHERE worker_id=? AND status='PENDING' ORDER BY sequence LIMIT 1", (worker_id,)).fetchone()
+            if run is None:
+                return None
+            now = time.time()
+            conn.execute("UPDATE orchestration_runs SET status='RUNNING',lease_token=?,lease_expires_at=?,updated_at=? WHERE run_id=?",
+                         (token, now + lease_seconds, now, run[0]))
+            return self._run(conn, run[0], owner_session_id)
+        return self.db._execute_write(claim)
+
+    def heartbeat_run(self, run_id, owner_session_id, lease_token, *, lease_seconds=60):
+        _positive(lease_seconds, "lease_seconds")
+        def heartbeat(conn):
+            self._lease(conn, run_id, owner_session_id, lease_token)
+            now = time.time()
+            conn.execute("UPDATE orchestration_runs SET lease_expires_at=?,updated_at=? WHERE run_id=?", (now + lease_seconds, now, run_id))
+        self.db._execute_write(heartbeat)
+
+    def checkpoint_run(self, run_id, owner_session_id, lease_token, *, history, tool_inflight=False, delivered_message_ids=()):
+        history_json = json.dumps(history, allow_nan=False)
+        def checkpoint(conn):
+            run = self._lease(conn, run_id, owner_session_id, lease_token)
+            now = time.time()
+            conn.execute("UPDATE orchestration_workers SET history=?,updated_at=? WHERE worker_id=?", (history_json, now, run["worker_id"]))
+            conn.execute("UPDATE orchestration_runs SET tool_inflight=?,updated_at=? WHERE run_id=?", (int(tool_inflight), now, run_id))
+            for message_id in delivered_message_ids:
+                self._ack_message(conn, run, message_id)
+        self.db._execute_write(checkpoint)
+
+    def finish_run(self, run_id, owner_session_id, lease_token, *, status, result, history=None):
+        if status not in _TERMINAL:
+            raise ValueError("Invalid terminal run status")
+        result_json = _policy_json(result)
+        def finish(conn):
+            run = self._lease(conn, run_id, owner_session_id, lease_token)
+            now = time.time()
+            uncertain = bool(run["tool_inflight"]) and status != "SUCCEEDED"
+            conn.execute("""UPDATE orchestration_runs SET status=?,result=?,uncertain_side_effect=?,
+                lease_token=NULL,lease_expires_at=NULL,updated_at=? WHERE run_id=?""",
+                (status, result_json, int(uncertain), now, run_id))
+            conn.execute("UPDATE orchestration_workers SET uncertain_side_effect=?,updated_at=? WHERE worker_id=?", (int(uncertain), now, run["worker_id"]))
+            if history is not None:
+                conn.execute("UPDATE orchestration_workers SET history=? WHERE worker_id=?", (json.dumps(history, allow_nan=False), run["worker_id"]))
+            return self._run(conn, run_id, owner_session_id)
+        return self.db._execute_write(finish)
+
+    def enqueue_message(self, worker_id, owner_session_id, content, *, message_id=None, sender_id=None):
+        if not isinstance(content, str) or not content.strip():
+            raise ValueError("Message must be nonempty text")
+        message_id = message_id or "message-" + uuid.uuid4().hex
+        def enqueue(conn):
+            self._worker(conn, worker_id, owner_session_id)
+            existing = _row(conn.execute("SELECT * FROM orchestration_messages WHERE message_id=?", (message_id,)).fetchone())
+            if existing:
+                if (existing["worker_id"], existing["content"], existing["sender_id"]) != (worker_id, content, sender_id):
+                    raise ValueError("Message ID was already used for different content")
+                return existing
+            conn.execute("INSERT INTO orchestration_messages(message_id,worker_id,sender_id,content,created_at) VALUES (?,?,?,?,?)",
+                         (message_id, worker_id, sender_id, content, time.time()))
+            return _row(conn.execute("SELECT * FROM orchestration_messages WHERE message_id=?", (message_id,)).fetchone())
+        return self.db._execute_write(enqueue)
+
+    def claim_messages(self, run_id, owner_session_id, lease_token):
+        # Delivery becomes final only alongside a persisted conversation checkpoint.
+        with self.db._read_ctx() as conn:
+            run = self._lease(conn, run_id, owner_session_id, lease_token)
+            return [_row(r) for r in conn.execute("SELECT * FROM orchestration_messages WHERE worker_id=? AND status='PENDING' ORDER BY sequence", (run["worker_id"],))]
+
+    @staticmethod
+    def _ack_message(conn, run, message_id):
+        message = conn.execute("SELECT worker_id FROM orchestration_messages WHERE message_id=?", (message_id,)).fetchone()
+        if not message or message[0] != run["worker_id"]:
+            raise PermissionError("Unknown message or foreign worker")
+        conn.execute("""UPDATE orchestration_messages SET status='DELIVERED',delivered_run_id=?,delivered_at=?
+            WHERE message_id=? AND status='PENDING'""", (run["run_id"], time.time(), message_id))
+
+    def ack_message(self, run_id, owner_session_id, lease_token, message_id):
+        def ack(conn):
+            self._ack_message(conn, self._lease(conn, run_id, owner_session_id, lease_token), message_id)
+        self.db._execute_write(ack)
+
+    def recover_expired_runs(self, owner_session_id):
+        def recover(conn):
+            expired = conn.execute("""SELECT r.run_id FROM orchestration_runs r JOIN orchestration_workers w
+                ON r.worker_id=w.worker_id WHERE w.owner_session_id=? AND r.status='RUNNING' AND r.lease_expires_at<=?""",
+                (owner_session_id, time.time())).fetchall()
+            for row in expired:
+                run = self._run(conn, row[0], owner_session_id)
+                uncertain = int(run["tool_inflight"])
+                conn.execute("""UPDATE orchestration_runs SET status='INTERRUPTED',uncertain_side_effect=?,
+                    lease_token=NULL,lease_expires_at=NULL,result=?,updated_at=? WHERE run_id=?""",
+                    (uncertain, json.dumps({"reason": "execution_lease_expired", "uncertain_side_effect": bool(uncertain)}), time.time(), row[0]))
+                conn.execute("UPDATE orchestration_workers SET uncertain_side_effect=?,updated_at=? WHERE worker_id=?", (uncertain, time.time(), run["worker_id"]))
+            return [self._run(conn, r[0], owner_session_id) for r in expired]
+        return self.db._execute_write(recover)
+
+    def reconcile_run(self, run_id, owner_session_id):
+        def reconcile(conn):
+            run = self._run(conn, run_id, owner_session_id)
+            if run["status"] not in _TERMINAL:
+                raise ValueError("Only a terminal run can be reconciled")
+            latest = conn.execute("SELECT run_id FROM orchestration_runs WHERE worker_id=? AND status IN ('INTERRUPTED','FAILED','CANCELLED','SUCCEEDED') ORDER BY sequence DESC LIMIT 1", (run["worker_id"],)).fetchone()
+            if not latest or latest[0] != run_id:
+                raise ValueError("Reconcile the latest terminal run")
+            conn.execute("UPDATE orchestration_workers SET uncertain_side_effect=0,updated_at=? WHERE worker_id=?", (time.time(), run["worker_id"]))
+        self.db._execute_write(reconcile)
+
+    def pending_completions(self, owner_session_id):
+        with self.db._read_ctx() as conn:
+            return [_row(r) for r in conn.execute("""SELECT r.* FROM orchestration_runs r JOIN orchestration_workers w
+                ON r.worker_id=w.worker_id WHERE w.owner_session_id=? AND r.completion_ack=0
+                AND r.status IN ('SUCCEEDED','FAILED','INTERRUPTED','CANCELLED') ORDER BY r.sequence""", (owner_session_id,))]
+
+    def ack_completion(self, run_id, owner_session_id):
+        def ack(conn):
+            run = self._run(conn, run_id, owner_session_id)
+            if run["status"] not in _TERMINAL:
+                raise ValueError("A running task has no completion to acknowledge")
+            conn.execute("UPDATE orchestration_runs SET completion_ack=1 WHERE run_id=?", (run_id,))
+        self.db._execute_write(ack)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1275,6 +1275,13 @@ DEFAULT_CONFIG = {
         # deliverable). Async-delegation results are NEVER suppressed.
         "surface_child_process_notifications": False,
     },
+    # Model-facing worker vocabulary. "auto" uses only provider/model pairs
+    # qualified by recorded live evidence; otherwise it preserves Hermes's
+    # canonical delegate_task surface. Explicit codex/claude styles are
+    # experimental presentation adapters and never alter model routing.
+    "orchestration": {
+        "interface": "auto",  # auto | hermes | codex | claude
+    },
     # Ephemeral prefill messages file — JSON list of {role, content} dicts injected at the start of
     # every API call for few-shot priming. Never saved to sessions/logs/trajectories.
     "prefill_messages_file": "",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1209,6 +1209,12 @@ DEFAULT_CONFIG = {
     # cheaper/faster model. Uses the same runtime provider resolution as CLI/gateway startup, so
     # every configured provider is supported.
     "delegation": {
+        # Worker definitions are local to the active Hermes profile. Model-facing
+        # discovery reads these on demand without rewriting cached tool schemas.
+        "profiles": {},
+        "default_profile": None,
+        "routing_mode": "profile_only",
+        "enabled_models": [],  # explicit provider/model catalog for dynamic routing
         "model": "",  # e.g. "google/gemini-3-flash-preview" (empty = inherit parent)
         "provider": "",  # e.g. "openrouter" (empty = inherit parent provider + credentials)
         # Fallback chain for delegated children (same entry format as the top-level list).

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2608,7 +2608,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
         "webhook", "whatsapp", "whatsapp-cloud", "worktree", "chat", "secrets", "security",
         "browser",
-        "verify",
+        "verify", "workers",
         # Plugin commands missing from top-level --help is an accepted trade-off.
         "help",
     }
@@ -3166,6 +3166,8 @@ def _build_cli_parser():
     build_moa_parser(subparsers)
     build_fallback_parser(subparsers)
     build_worktree_parser(subparsers)
+    from hermes_cli.workers import build_workers_parser
+    build_workers_parser(subparsers)
     build_browser_parser(subparsers)
     build_secrets_parser(subparsers)
     # OUTBOUND egress firewall; ``hermes proxy`` (gateway group) is the INBOUND one.

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -192,6 +192,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "runtime": "agent",
     "session": "general",
     "nous": "agent",
+    "orchestration": "agent",
 }
 
 

--- a/hermes_cli/workers.py
+++ b/hermes_cli/workers.py
@@ -1,0 +1,96 @@
+"""Manage worker profiles without launching agents or resolving credentials."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+
+
+def build_workers_parser(subparsers) -> None:
+    parser = subparsers.add_parser("workers", help="Configure delegation worker profiles")
+    commands = parser.add_subparsers(dest="workers_command")
+    listing = commands.add_parser("list", aliases=["ls"], help="Discover configured workers")
+    listing.add_argument("--json", action="store_true", help="Print the discovery catalog as JSON")
+    inspect = commands.add_parser("inspect", help="Inspect one worker profile")
+    inspect.add_argument("name")
+    inspect.add_argument("--json", action="store_true")
+    commands.add_parser("validate", help="Validate worker configuration without launching models")
+    configure = commands.add_parser("set", help="Create or replace one profile from a YAML mapping")
+    configure.add_argument("name")
+    configure.add_argument("--file", required=True, type=Path)
+    default = commands.add_parser("default", help="Select a default worker profile")
+    default.add_argument("name", help="Configured profile name, or '-' to inherit legacy settings")
+    parser.set_defaults(func=cmd_workers)
+
+
+def _catalog(config: dict) -> dict:
+    from agent.delegation_model_routing import discover_workers
+
+    return discover_workers(config.get("delegation", {}))
+
+
+def _validate(config: dict) -> None:
+    from agent.delegation_model_routing import profile_config_errors
+
+    errors = profile_config_errors(config.get("delegation", {}))
+    if errors:
+        raise ValueError("\n".join(errors))
+
+
+def _write_profile(args: argparse.Namespace) -> None:
+    import yaml
+    from hermes_cli.config import _CONFIG_LOCK, is_managed, read_raw_config, save_config
+
+    if is_managed():
+        raise ValueError("Worker configuration is managed; change it through your administrator.")
+    with _CONFIG_LOCK:
+        config = copy.deepcopy(read_raw_config() or {})
+        delegation = config.setdefault("delegation", {})
+        if not isinstance(delegation, dict):
+            raise ValueError("delegation must be a mapping before configuring workers")
+        if args.workers_command == "set":
+            try:
+                profile = yaml.safe_load(args.file.read_text(encoding="utf-8"))
+            except yaml.YAMLError as exc:
+                raise ValueError("The profile file is not valid YAML") from exc
+            if not isinstance(profile, dict):
+                raise ValueError("The profile file must contain one YAML mapping")
+            profiles = delegation.setdefault("profiles", {})
+            if not isinstance(profiles, dict):
+                raise ValueError("delegation.profiles must be a mapping")
+            profiles[args.name] = profile
+        else:
+            delegation["default_profile"] = None if args.name == "-" else args.name
+        _validate(config)
+        save_config(config)
+    print("Worker configuration saved. Existing worker conversations retain their original instructions.")
+
+
+def cmd_workers(args: argparse.Namespace) -> None:
+    from hermes_cli.config import load_config
+
+    command = args.workers_command or "list"
+    try:
+        if command in {"set", "default"}:
+            _write_profile(args)
+            return
+        config = load_config()
+        _validate(config)
+        if command == "validate":
+            print("Worker configuration is valid. Provider availability has not been probed.")
+            return
+        catalog = _catalog(config)
+        if command == "inspect":
+            entries = catalog["profiles"]
+            selected = next((entry for entry in entries if entry["name"] == args.name), None)
+            if selected is None:
+                raise ValueError(f"Unknown worker profile: {args.name}")
+            catalog = selected
+        # JSON keeps unknown availability and capabilities explicit, and is also
+        # useful to scripts invoking Hermes without importing agent internals.
+        print(json.dumps(catalog, indent=2, ensure_ascii=False))
+    except (ValueError, OSError, RuntimeError) as exc:
+        print(f"Worker configuration error: {exc}")
+        raise SystemExit(1) from exc

--- a/model_tools.py
+++ b/model_tools.py
@@ -752,7 +752,8 @@ def _approval_observability(ids: _CallIds):
 
 
 def _execute_tool(function_name: str, function_args: Dict[str, Any], original_args: Dict[str, Any], ids: _CallIds,
-                  *, user_task: Optional[str], enabled_tools: Optional[List[str]], skip_tool_execution_middleware: bool) -> Any:
+                  *, user_task: Optional[str], enabled_tools: Optional[List[str]],
+                  worker_max_tool_calls: Optional[int], skip_tool_execution_middleware: bool) -> Any:
     """Run the registry handler (through tool-execution middleware unless skipped)
     with the approval observability context bound for the duration."""
     dispatch_kwargs: Dict[str, Any] = {"task_id": ids.task_id, "session_id": ids.session_id}
@@ -760,6 +761,7 @@ def _execute_tool(function_name: str, function_args: Dict[str, Any], original_ar
         # Prefer the caller's list so subagents can't overwrite the parent's
         # tool set via the process-global.
         dispatch_kwargs["enabled_tools"] = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
+        dispatch_kwargs["worker_max_tool_calls"] = worker_max_tool_calls
     else:
         dispatch_kwargs["user_task"] = user_task
 
@@ -802,6 +804,7 @@ def handle_function_call(
     function_name: str, function_args: Dict[str, Any], task_id: Optional[str] = None,
     tool_call_id: Optional[str] = None, session_id: Optional[str] = None, turn_id: Optional[str] = None,
     api_request_id: Optional[str] = None, user_task: Optional[str] = None, enabled_tools: Optional[List[str]] = None,
+    worker_max_tool_calls: Optional[int] = None,
     skip_pre_tool_call_hook: bool = False, skip_tool_request_middleware: bool = False,
     skip_tool_execution_middleware: bool = False, tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None, disabled_toolsets: Optional[List[str]] = None,
@@ -838,6 +841,7 @@ def handle_function_call(
             return _emit(result, duration_ms=_elapsed_ms(start))
         return handle_function_call(
             *underlying, **asdict(ids), user_task=user_task, enabled_tools=enabled_tools,
+            worker_max_tool_calls=worker_max_tool_calls,
             skip_pre_tool_call_hook=skip_pre_tool_call_hook, skip_tool_request_middleware=skip_tool_request_middleware,
             skip_tool_execution_middleware=skip_tool_execution_middleware, tool_request_middleware_trace=list(trace),
             enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets,
@@ -867,7 +871,8 @@ def handle_function_call(
         # duration_ms (monotonic) is exposed to post_tool_call / transform_tool_result.
         start = time.monotonic()
         result = _execute_tool(function_name, function_args, original_args, ids, user_task=user_task,
-                               enabled_tools=enabled_tools, skip_tool_execution_middleware=skip_tool_execution_middleware)
+                               enabled_tools=enabled_tools, worker_max_tool_calls=worker_max_tool_calls,
+                               skip_tool_execution_middleware=skip_tool_execution_middleware)
         duration_ms = _elapsed_ms(start)
         _emit(result, duration_ms=duration_ms)
         return _apply_transform_tool_result_hook(function_name, function_args, result, duration_ms, ids)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1293,8 +1293,14 @@ class AIAgent(
             goal=function_args.get("goal"), context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
             max_iterations=function_args.get("max_iterations"), role=function_args.get("role"),
-            background=not (getattr(self, "_delegate_depth", 0) > 0), action=function_args.get("action"),
-            subagent_id=function_args.get("subagent_id"), message=function_args.get("message"), parent_agent=self,
+            background=not (getattr(self, "_delegate_depth", 0) > 0),
+            output_schema=function_args.get("output_schema"), action=function_args.get("action"),
+            subagent_id=function_args.get("subagent_id"), message=function_args.get("message"),
+            worker_id=function_args.get("worker_id"), run_id=function_args.get("run_id"),
+            timeout_seconds=function_args.get("timeout_seconds"), profile=function_args.get("profile"),
+            model_profile=function_args.get("model_profile"), provider=function_args.get("provider"),
+            model=function_args.get("model"), reasoning_effort=function_args.get("reasoning_effort"),
+            parent_agent=self,
         )
 
     _invoke_tool = _forward("agent.agent_runtime_helpers", "invoke_tool")

--- a/run_agent.py
+++ b/run_agent.py
@@ -270,6 +270,7 @@ class AIAgent(
         checkpoint_max_total_size_mb: int = 500, checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False, requested_provider: str = None,
         capabilities: Dict[str, bool] | None = None,
+        worker_interface_contract: Dict[str, Any] | None = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent`` (same keyword parameters, minus ``tool_delay``)."""
         init_kwargs = {k: v for k, v in locals().items() if k not in ("self", "tool_delay")}

--- a/run_agent.py
+++ b/run_agent.py
@@ -1298,6 +1298,7 @@ class AIAgent(
             subagent_id=function_args.get("subagent_id"), message=function_args.get("message"),
             worker_id=function_args.get("worker_id"), run_id=function_args.get("run_id"),
             timeout_seconds=function_args.get("timeout_seconds"), profile=function_args.get("profile"),
+            reconciliation_disposition=function_args.get("reconciliation_disposition"),
             model_profile=function_args.get("model_profile"), provider=function_args.get("provider"),
             model=function_args.get("model"), reasoning_effort=function_args.get("reasoning_effort"),
             parent_agent=self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1142,17 +1142,21 @@ class AIAgent(
     _drop_thinking_only_and_merge_users = _forward_static("agent.agent_runtime_helpers", "drop_thinking_only_and_merge_users")
 
     @staticmethod
-    def _cap_delegate_task_calls(tool_calls: list) -> list:
+    def _cap_delegate_task_calls(tool_calls: list, *, selection=None) -> list:
         """Cap delegate_task calls in one turn at max_concurrent_children (non-delegate calls all kept);
         returns the original list when nothing was truncated."""
         from tools.delegate_tool import _get_max_concurrent_children
         max_children = _get_max_concurrent_children()
-        delegate_count = sum(1 for tc in tool_calls if tc.function.name == "delegate_task")
+        from agent.worker_interfaces import is_worker_spawn_tool
+
+        delegate_count = sum(
+            1 for tc in tool_calls if is_worker_spawn_tool(selection, tc.function.name)
+        )
         if delegate_count <= max_children:
             return tool_calls
         kept_delegates, truncated = 0, []
         for tc in tool_calls:
-            if tc.function.name == "delegate_task":
+            if is_worker_spawn_tool(selection, tc.function.name):
                 if kept_delegates >= max_children:
                     continue
                 kept_delegates += 1
@@ -1307,6 +1311,14 @@ class AIAgent(
             model_profile=function_args.get("model_profile"), provider=function_args.get("provider"),
             model=function_args.get("model"), reasoning_effort=function_args.get("reasoning_effort"),
             parent_agent=self,
+        )
+
+    def _dispatch_worker_interface(self, function_name: str, function_args: dict) -> str:
+        """Translate one session-advertised worker call without changing transcript names."""
+        from agent.worker_interfaces import dispatch_worker_interface_call
+
+        return dispatch_worker_interface_call(
+            self, function_name, function_args, self._dispatch_delegate_task
         )
 
     _invoke_tool = _forward("agent.agent_runtime_helpers", "invoke_tool")

--- a/scripts/evals/interface_qualification.py
+++ b/scripts/evals/interface_qualification.py
@@ -1,0 +1,755 @@
+#!/usr/bin/env python3
+"""Opt-in live qualification for Hermes durable-worker presentation interfaces.
+
+The controller resolves explicitly selected, existing provider references only
+after ``--execute`` and passes the resulting runtime material to one isolated
+child per scenario over stdin.  Children use fresh Hermes homes.  Output is an
+allowlisted receipt: provider bodies, prompts, transcripts, and credentials are
+never included.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+from dataclasses import asdict, dataclass
+import io
+import json
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import traceback
+from typing import Any, Callable, Iterable, Mapping
+
+
+SCENARIO_IDS = (
+    "two_provider_retained_workflow",
+    "invalid_profile_rejected",
+    "foreign_worker_denied",
+    "idle_guidance_then_followup",
+)
+UNKNOWN = "unknown"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_repo_root_text = str(REPO_ROOT)
+sys.path[:] = [_repo_root_text, *(item for item in sys.path if item != _repo_root_text)]
+FIXTURE_PATH = REPO_ROOT / "tests/fixtures/orchestration/interface-qualification-v1.json"
+SAFE_RUNTIME_KEYS = ("api_key", "base_url")
+SAFE_USAGE_KEYS = (
+    "input_tokens", "output_tokens", "total_tokens", "cache_read_tokens",
+    "cache_write_tokens", "reasoning_tokens",
+)
+TERMINAL_STATES = {"SUCCEEDED", "FAILED", "INTERRUPTED", "CANCELLED"}
+ACTIVE_STATES = {"PENDING", "STARTING", "RUNNING", "CANCEL_REQUESTED"}
+
+
+@dataclass(frozen=True)
+class RouteChoice:
+    profile: str
+    provider: str
+    model: str
+    reasoning_effort: str
+    expected_provider: str | None = None
+
+
+def load_fixture(path: Path = FIXTURE_PATH) -> dict[str, Any]:
+    fixture = json.loads(path.read_text(encoding="utf-8"))
+    found = tuple(item.get("id") for item in fixture.get("scenarios", ()))
+    if found != SCENARIO_IDS:
+        raise ValueError(f"Expected the four {SCENARIO_IDS!r} scenarios in order; found {found!r}")
+    required = fixture.get("required_receipt_fields")
+    if not isinstance(required, list) or not all(isinstance(item, str) for item in required):
+        raise ValueError("Fixture required_receipt_fields must be a list of names")
+    return fixture
+
+
+def _number(value: Any) -> int | float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _safe_usage(value: Mapping[str, Any] | None) -> dict[str, int | float]:
+    value = value if isinstance(value, Mapping) else {}
+    return {key: number for key in SAFE_USAGE_KEYS if (number := _number(value.get(key))) is not None}
+
+
+def _error_classification(error: Any) -> str | None:
+    if not error:
+        return None
+    text = str(error).lower()
+    if "profile" in text and any(word in text for word in ("unknown", "missing", "unavailable", "configured")):
+        return "EXPECTED_INVALID_PROFILE_DENIAL"
+    if any(phrase in text for phrase in (
+        "foreign owner", "owned subtree", "authorized relation", "unknown worker", "outside the actor",
+    )):
+        return "EXPECTED_FOREIGN_OWNER_DENIAL"
+    if any(phrase in text for phrase in ("unsupported", "malformed", "not part of the")):
+        return "INVALID_TOOL_CALL"
+    return "SERVICE_ERROR"
+
+
+def _scenario_checks(scenario_id: str, observation: Mapping[str, Any]) -> list[bool]:
+    events = list(observation.get("events") or ())
+    workers = list(observation.get("workers") or ())
+    accepted = [item for item in events if item.get("accepted")]
+    expected_denials = [item for item in events if str(item.get("classification") or "").startswith("EXPECTED_")]
+    invalid = [item for item in events if item.get("classification") == "INVALID_TOOL_CALL"]
+    if scenario_id == "two_provider_retained_workflow":
+        profiles = {profile for item in accepted for profile in item.get("profiles", ())}
+        providers = {item.get("provider") for item in workers if item.get("provider")}
+        message_live = any(item.get("effective_action") == "message" and item.get("target_was_running") for item in accepted)
+        linked = any(item.get("linked_followup") and item.get("followup_avoids_labels") for item in accepted)
+        all_acked = bool(workers) and all(item.get("all_terminal_acked") for item in workers)
+        return [
+            len(profiles) >= 2 and len(providers) >= 2,
+            message_live,
+            linked,
+            bool(observation.get("retained_answer_match")),
+            observation.get("wire_route_agreement") is True and observation.get("tool_receipts_match") is True,
+            len(workers) == 2 and sum(item.get("run_count", 0) for item in workers) == 3
+            and all_acked and observation.get("duplicate_owned_executions") == 0,
+        ]
+    if scenario_id == "invalid_profile_rejected":
+        submitted = bool(events)
+        visible_denial = any(item.get("classification") == "EXPECTED_INVALID_PROFILE_DENIAL" for item in expected_denials)
+        return [submitted, visible_denial and not invalid, observation.get("counts_before") == observation.get("counts_after")]
+    if scenario_id == "foreign_worker_denied":
+        denied = any(item.get("classification") == "EXPECTED_FOREIGN_OWNER_DENIAL" for item in expected_denials)
+        return [denied, observation.get("foreign_preimage_unchanged") is True, len(events) == 1 and not accepted]
+    if scenario_id == "idle_guidance_then_followup":
+        guidance = any(
+            item.get("effective_action") == "message" and item.get("run_count_delta") == 0
+            for item in accepted
+        )
+        linked = any(item.get("linked_followup") and item.get("run_count_delta") == 1 for item in accepted)
+        new_ack = any(item.get("effective_action") == "ack" and item.get("targets_latest_run") for item in accepted)
+        return [
+            guidance,
+            linked,
+            bool(observation.get("retained_answer_match")),
+            new_ack and observation.get("prior_run_replayed") is False,
+        ]
+    raise ValueError(f"Unknown scenario {scenario_id!r}")
+
+
+def build_receipt(
+    scenario: Mapping[str, Any], observation: Mapping[str, Any], common: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build only allowlisted evidence; unknown observation keys are discarded."""
+    scenario_id = str(scenario["id"])
+    checks = _scenario_checks(scenario_id, observation)
+    assertion_text = list(scenario.get("assertions") or ())
+    if len(checks) != len(assertion_text):
+        raise ValueError(f"Assertion evaluator drift for {scenario_id}")
+    events = list(observation.get("events") or ())
+    invalid_count = sum(item.get("classification") == "INVALID_TOOL_CALL" for item in events)
+    receipt = {
+        "candidate_sha": common.get("candidate_sha", UNKNOWN),
+        "scenario_id": scenario_id,
+        "parent_provider": observation.get("parent_provider", common.get("parent_provider", UNKNOWN)),
+        "parent_model": observation.get("parent_model", common.get("parent_model", UNKNOWN)),
+        "requested_interface": common.get("requested_interface", UNKNOWN),
+        "selected_interface": observation.get("selected_interface", UNKNOWN),
+        "interface_version": observation.get("interface_version", UNKNOWN),
+        "advertised_orchestration_tool_names": sorted(set(observation.get("advertised_tool_names") or ())),
+        "observed_orchestration_tool_names": sorted({str(item.get("tool_name")) for item in events if item.get("tool_name")}),
+        "task_completed": bool(observation.get("parent_completed")) and all(checks),
+        "invalid_tool_calls": {
+            "structured": invalid_count,
+            "malformed_or_unobserved": observation.get("malformed_tool_calls", UNKNOWN),
+        },
+        "corrective_turns": observation.get("corrective_turns", UNKNOWN),
+        "elapsed_seconds": round(float(observation.get("elapsed_seconds") or 0.0), 3),
+        "token_usage": _safe_usage(observation.get("token_usage")),
+        "known_or_unknown_cost": observation.get("cost", {"status": UNKNOWN}),
+        "wire_route_agreement": observation.get("wire_route_agreement", UNKNOWN),
+        "authorization_violations": int(observation.get("authorization_violations") or 0),
+        "duplicate_owned_executions": int(observation.get("duplicate_owned_executions") or 0),
+        "assertions": [
+            {"assertion": text, "passed": passed}
+            for text, passed in zip(assertion_text, checks)
+        ],
+        "limits": dict(common.get("limits") or {}),
+        "error_type": observation.get("error_type"),
+    }
+    missing = [name for name in common["required_receipt_fields"] if name not in receipt]
+    if missing:
+        raise ValueError(f"Receipt omitted required fields: {missing}")
+    return receipt
+
+
+def run_suite(
+    fixture: Mapping[str, Any],
+    execute_scenario: Callable[[Mapping[str, Any]], Mapping[str, Any]],
+    common: Mapping[str, Any],
+) -> dict[str, Any]:
+    receipts = [build_receipt(scenario, execute_scenario(scenario), common) for scenario in fixture["scenarios"]]
+    qualified = len(receipts) == len(SCENARIO_IDS) and all(item["task_completed"] for item in receipts)
+    return {
+        "suite": fixture["version"],
+        "claim_class": fixture["claim_class"],
+        "candidate_sha": common["candidate_sha"],
+        "qualification": "qualified" if qualified else "unqualified",
+        "qualified": qualified,
+        "receipts": receipts,
+        "proof_boundary": (
+            "Exact candidate and selected routes for these four scenarios only; no statistical superiority, "
+            "release, runtime, fleet, or customer-readiness claim."
+        ),
+    }
+
+
+def _counts(store: Any, owner: str) -> dict[str, int]:
+    workers = store.list_workers(owner)
+    return {
+        "workers": len(workers),
+        "runs": sum(len(store.list_runs(item["worker_id"], owner)) for item in workers),
+        "messages": sum(len(store.list_messages(item["worker_id"], owner)) for item in workers),
+    }
+
+
+def _stable_foreign_snapshot(store: Any, owner: str, worker_id: str) -> dict[str, Any]:
+    worker = store.get_worker(worker_id, owner)
+    return {
+        "worker": {key: worker.get(key) for key in (
+            "worker_id", "owner_session_id", "profile", "config_revision", "policy",
+            "history", "uncertain_side_effect",
+        )},
+        "runs": [
+            {key: run.get(key) for key in (
+                "run_id", "worker_id", "previous_run_id", "goal", "context", "status",
+                "result", "completion_ack", "uncertain_side_effect",
+            )}
+            for run in store.list_runs(worker_id, owner)
+        ],
+        "messages": store.list_messages(worker_id, owner),
+    }
+
+
+def _target_from_args(arguments: Mapping[str, Any]) -> str | None:
+    for key in ("worker_id", "target", "recipient", "task_id"):
+        value = arguments.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _profiles_from_args(arguments: Mapping[str, Any]) -> list[str]:
+    result = []
+    for item in arguments.get("tasks") or ():
+        if isinstance(item, Mapping) and isinstance(item.get("profile"), str):
+            result.append(item["profile"])
+    for key in ("profile", "subagent_type"):
+        if isinstance(arguments.get(key), str):
+            result.append(arguments[key])
+    return result
+
+
+def _all_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        return " ".join(_all_text(item) for item in value.values())
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        return " ".join(_all_text(item) for item in value)
+    return ""
+
+
+def _instrument_interface(parent: Any, store: Any, owner: str) -> tuple[list[dict[str, Any]], Callable[[], None]]:
+    original = getattr(parent, "_dispatch_worker_interface", None)
+    if not callable(original):
+        raise RuntimeError("AIAgent._dispatch_worker_interface is unavailable; integrate the interface adapter first")
+    events: list[dict[str, Any]] = []
+
+    def dispatch(tool_name: str, arguments: Mapping[str, Any]) -> str:
+        arguments = dict(arguments or {})
+        target = _target_from_args(arguments)
+        before_runs: list[Mapping[str, Any]] = []
+        if target:
+            with contextlib.suppress(Exception):
+                before_runs = store.list_runs(target, owner)
+        event: dict[str, Any] = {
+            "tool_name": tool_name,
+            "profiles": _profiles_from_args(arguments),
+            "target_was_running": bool(before_runs and before_runs[-1].get("status") in ACTIVE_STATES),
+            "followup_avoids_labels": not any(
+                label in _all_text(arguments).lower() for label in ("cobalt", "amber", "violet", "sapphire", "silver")
+            ),
+        }
+        try:
+            result = original(tool_name, arguments)
+            payload = json.loads(result) if isinstance(result, str) else dict(result)
+            interface = payload.get("orchestration_interface") or {}
+            event.update({
+                "operation": interface.get("operation"),
+                "effective_action": interface.get("effective_action"),
+                "accepted": not bool(payload.get("error")),
+                "classification": _error_classification(payload.get("error")),
+            })
+        except Exception as exc:
+            event.update({"accepted": False, "classification": _error_classification(exc), "effective_action": "none"})
+            events.append(event)
+            raise
+        after_runs = []
+        if target:
+            with contextlib.suppress(Exception):
+                after_runs = store.list_runs(target, owner)
+        event["run_count_delta"] = len(after_runs) - len(before_runs)
+        event["linked_followup"] = bool(
+            len(after_runs) == len(before_runs) + 1 and before_runs
+            and after_runs[-1].get("previous_run_id") == before_runs[-1].get("run_id")
+        )
+        event["targets_latest_run"] = bool(
+            after_runs and payload.get("run_id") == after_runs[-1].get("run_id")
+        )
+        events.append(event)
+        return result
+
+    parent._dispatch_worker_interface = dispatch
+    return events, lambda: setattr(parent, "_dispatch_worker_interface", original)
+
+
+def _worker_observations(store: Any, owner: str, routes: Iterable[RouteChoice]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    expected = {route.profile: route for route in routes}
+    workers = []
+    usage: dict[str, int | float] = {}
+    known_costs: list[float] = []
+    for worker in store.list_workers(owner):
+        runs = store.list_runs(worker["worker_id"], owner)
+        route = expected.get(worker.get("profile"))
+        wire_matches = []
+        tools_match = []
+        retained_summary = ""
+        for run in runs:
+            result = run.get("result") or {}
+            receipt = result.get("route") or {}
+            expected_provider = (route.expected_provider or route.provider) if route else None
+            resolved = (receipt.get("resolved_provider"), receipt.get("resolved_model"))
+            transmitted = (receipt.get("transmitted_provider"), receipt.get("transmitted_model"))
+            match = bool(
+                route and receipt.get("requested_profile") == route.profile
+                and resolved == (expected_provider, route.model)
+                and transmitted == (expected_provider, route.model)
+                and receipt.get("request_evidence_source")
+                and receipt.get("response_evidence_source")
+            )
+            wire_matches.append(match)
+            tools_match.append(result.get("effective_tools") == [])
+            retained_summary = str(result.get("summary") or "").lower()
+            for key, value in _safe_usage((result.get("usage") or {}).get("tokens")).items():
+                usage[key] = usage.get(key, 0) + value
+            cost = _number((result.get("cost") or {}).get("usd"))
+            if cost is not None:
+                known_costs.append(float(cost))
+        workers.append({
+            "profile": worker.get("profile"),
+            "provider": (route.expected_provider or route.provider) if route else None,
+            "run_count": len(runs),
+            "all_terminal_acked": bool(runs) and all(
+                run.get("status") in TERMINAL_STATES and bool(run.get("completion_ack")) for run in runs
+            ),
+            "wire_matches": bool(wire_matches) and all(wire_matches),
+            "tools_match": bool(tools_match) and all(tools_match),
+            "retained_cobalt_violet": "cobalt" in retained_summary and "violet" in retained_summary,
+            "retained_sapphire_silver": "sapphire" in retained_summary and "silver" in retained_summary,
+        })
+    return workers, {
+        "child_usage": usage,
+        "cost": {"status": "known", "usd": round(sum(known_costs), 8)} if known_costs else {"status": UNKNOWN},
+    }
+
+
+def _setup_foreign(store: Any) -> tuple[str, str, dict[str, Any]]:
+    owner = "qualification-foreign-owner"
+    worker = store.create_worker(owner, profile="synthetic-foreign")
+    queued = store.enqueue_run(worker["worker_id"], owner, goal="synthetic foreign retained state")
+    active = store.claim_run(queued["run_id"], owner)
+    store.finish_run(
+        active["run_id"], owner, active["lease_token"], status="SUCCEEDED",
+        result={"summary": "synthetic foreign result"},
+        history=[{"role": "user", "content": "synthetic"}, {"role": "assistant", "content": "complete"}],
+    )
+    return owner, worker["worker_id"], _stable_foreign_snapshot(store, owner, worker["worker_id"])
+
+
+def _setup_idle(parent: Any, store: Any, owner: str, route: RouteChoice, timeout: float) -> tuple[str, str]:
+    from agent.subagent_lifecycle import SubagentLaunchRequest, SubagentLifecycleService
+
+    service = SubagentLifecycleService(lambda: parent)
+    handle = service.launch(SubagentLaunchRequest(
+        goal="Remember the synthetic label sapphire and report that you retained it.",
+        profile=route.profile,
+        role="leaf",
+    ))
+    terminal = service.wait(handle, timeout_seconds=timeout)
+    if not terminal.completed or terminal.state.value != "SUCCEEDED":
+        raise RuntimeError("Idle-scenario setup worker did not complete")
+    store.ack_completion(handle.run_id, owner)
+    return str(handle.worker_id), str(handle.run_id)
+
+
+def _build_config(packet: Mapping[str, Any]) -> dict[str, Any]:
+    routes = [RouteChoice(**item) for item in packet["routes"]]
+    profiles = {
+        route.profile: {
+            "description": "Perform only the supplied synthetic qualification task.",
+            "instructions": "Keep the answer concise and retain prior synthetic labels within this worker conversation.",
+            "provider": route.provider,
+            "model": route.model,
+            "reasoning_effort": route.reasoning_effort,
+            "tool_policy": {"allowed_tools": [], "allowed_mcp_tools": []},
+            "workspace_context": {"mode": "inherit", "include_memory": False, "include_context_files": False},
+            "execution_limits": {
+                "max_iterations": packet["limits"]["max_child_iterations"],
+                "timeout_seconds": packet["limits"]["max_child_seconds"],
+                "max_spawn_depth": 0,
+            },
+        }
+        for route in routes
+    }
+    return {
+        "model": {"provider": packet["parent_provider"], "default": packet["parent_model"]},
+        "orchestration": {"interface": packet["requested_interface"]},
+        "delegation": {
+            "profiles": profiles,
+            "routing_mode": "profile_only",
+            "max_concurrent_children": packet["limits"]["max_children"],
+            "max_iterations": packet["limits"]["max_child_iterations"],
+        },
+        "memory": {"memory_enabled": False, "user_profile_enabled": False},
+    }
+
+
+def _execute_child(packet: Mapping[str, Any]) -> dict[str, Any]:
+    import yaml
+
+    Path(os.environ["HERMES_HOME"], "config.yaml").write_text(
+        yaml.safe_dump(_build_config(packet)), encoding="utf-8"
+    )
+    credentials = packet["credentials"]
+    from hermes_cli import runtime_provider
+    original_resolver = runtime_provider.resolve_runtime_provider
+
+    def resolve(*, requested: str | None = None, target_model: str | None = None, **_kwargs: Any) -> dict[str, Any]:
+        if requested not in credentials:
+            raise ValueError("Qualification child only enables explicitly selected providers")
+        material = credentials[requested]
+        return original_resolver(
+            requested=requested,
+            target_model=target_model,
+            explicit_api_key=material.get("api_key"),
+            explicit_base_url=material.get("base_url"),
+        )
+
+    runtime_provider.resolve_runtime_provider = resolve
+    from agent.worker_store import WorkerStore
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+    from agent.worker_interfaces import advertised_worker_tool_names
+
+    parent_runtime = resolve(requested=packet["parent_provider"], target_model=packet["parent_model"])
+    db = SessionDB()
+    owner = f"interface-qualification-{packet['scenario']['id']}"
+    db.ensure_session(owner, source="worker-orchestration-interface-qualification")
+    parent = AIAgent(
+        **{key: parent_runtime[key] for key in ("provider", "api_key", "base_url", "api_mode")},
+        model=packet["parent_model"],
+        session_id=owner,
+        session_db=db,
+        enabled_toolsets=["delegation"],
+        max_iterations=packet["limits"]["max_parent_iterations"],
+        max_tokens=packet["limits"]["max_parent_tokens"],
+        reasoning_config={"effort": packet["parent_reasoning_effort"]},
+        run_budget_seconds=packet["limits"]["max_seconds_per_scenario"],
+        skip_memory=True,
+        skip_context_files=True,
+        skip_background_review=True,
+        save_trajectories=False,
+        quiet_mode=True,
+    )
+    store = WorkerStore(db)
+    store.ensure_schema()
+    routes = [RouteChoice(**item) for item in packet["routes"]]
+    scenario = packet["scenario"]
+    prompt = scenario.get("prompt")
+    foreign = None
+    prior_idle_run = None
+    if scenario["id"] == "foreign_worker_denied":
+        foreign_owner, foreign_id, foreign_before = _setup_foreign(store)
+        foreign = (foreign_owner, foreign_id, foreign_before)
+        prompt = scenario["prompt_template"].format(foreign_worker_id=foreign_id)
+    elif scenario["id"] == "idle_guidance_then_followup":
+        worker_id, prior_idle_run = _setup_idle(
+            parent, store, owner, routes[0], packet["limits"]["max_child_seconds"]
+        )
+        prompt = scenario["prompt_template"].format(worker_id=worker_id)
+    counts_before = _counts(store, owner)
+    events, restore_interface = _instrument_interface(parent, store, owner)
+    gate = threading.Event()
+    original_http = AIAgent._interruptible_api_call
+    held: set[str] = set()
+    held_lock = threading.Lock()
+
+    def held_http(agent: Any, *args: Any, **kwargs: Any) -> Any:
+        worker_id = getattr(agent, "_worker_id", None)
+        if scenario["id"] == "two_provider_retained_workflow" and worker_id:
+            with held_lock:
+                should_hold = worker_id not in held
+                held.add(worker_id)
+            if should_hold and not gate.wait(min(60, packet["limits"]["max_child_seconds"])):
+                raise TimeoutError("Controlled worker scheduling barrier expired")
+        return original_http(agent, *args, **kwargs)
+
+    AIAgent._interruptible_api_call = held_http
+    started = time.monotonic()
+    run_result: Any = None
+    run_error: Exception | None = None
+    try:
+        run_result = parent.run_conversation(str(prompt))
+    except Exception as exc:
+        run_error = exc
+    finally:
+        gate.set()
+        AIAgent._interruptible_api_call = original_http
+        restore_interface()
+    elapsed = time.monotonic() - started
+    counts_after = _counts(store, owner)
+    workers, run_evidence = _worker_observations(store, owner, routes)
+    all_runs = [run for worker in store.list_workers(owner) for run in store.list_runs(worker["worker_id"], owner)]
+    run_ids = [run["run_id"] for run in all_runs]
+    parent_usage = _safe_usage({
+        key: getattr(parent, f"session_{key}", None)
+        for key in SAFE_USAGE_KEYS
+    })
+    combined_usage = dict(run_evidence["child_usage"])
+    for key, value in parent_usage.items():
+        combined_usage[key] = combined_usage.get(key, 0) + value
+    selection = parent._worker_interface_selection
+    advertised = sorted(advertised_worker_tool_names(selection) & set(parent.valid_tool_names))
+    foreign_unchanged = None
+    if foreign:
+        foreign_unchanged = foreign[2] == _stable_foreign_snapshot(store, foreign[0], foreign[1])
+    retained_answer_match = any(
+        item["retained_cobalt_violet"] or item["retained_sapphire_silver"] for item in workers
+    )
+    latest_idle = None
+    if prior_idle_run and workers:
+        idle_worker = next((item for item in store.list_workers(owner) if item.get("profile") == routes[0].profile), None)
+        if idle_worker:
+            idle_runs = store.list_runs(idle_worker["worker_id"], owner)
+            latest_idle = idle_runs[-1] if idle_runs else None
+    wire_values = [item["wire_matches"] for item in workers]
+    tools_values = [item["tools_match"] for item in workers]
+    observation = {
+        "parent_provider": parent.provider,
+        "parent_model": parent.model,
+        "selected_interface": selection.name,
+        "interface_version": selection.version,
+        "advertised_tool_names": advertised,
+        "events": events,
+        "workers": workers,
+        "parent_completed": run_error is None and not (isinstance(run_result, Mapping) and run_result.get("failed")),
+        "counts_before": counts_before,
+        "counts_after": counts_after,
+        "foreign_preimage_unchanged": foreign_unchanged,
+        "retained_answer_match": retained_answer_match,
+        "wire_route_agreement": all(wire_values) if wire_values else "not_applicable",
+        "tool_receipts_match": all(tools_values) if tools_values else "not_applicable",
+        "duplicate_owned_executions": len(run_ids) - len(set(run_ids)),
+        "authorization_violations": int(bool(foreign and not foreign_unchanged)),
+        "prior_run_replayed": (
+            latest_idle is not None and latest_idle.get("run_id") == prior_idle_run
+        ) if prior_idle_run else False,
+        "elapsed_seconds": elapsed,
+        "token_usage": combined_usage,
+        "cost": run_evidence["cost"],
+        "malformed_tool_calls": UNKNOWN,
+        "corrective_turns": UNKNOWN,
+        "error_type": type(run_error).__name__ if run_error else None,
+    }
+    parent.close()
+    db.close()
+    runtime_provider.resolve_runtime_provider = original_resolver
+    return observation
+
+
+def _source_identity(repo_root: Path) -> str:
+    candidate = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"], cwd=repo_root,
+        text=True, capture_output=True, check=True,
+    ).stdout.strip()
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=all"], cwd=repo_root,
+        text=True, capture_output=True, check=True,
+    ).stdout.strip()
+    if dirty:
+        raise RuntimeError("Live qualification requires a committed, clean candidate")
+    return candidate
+
+
+def _resolve_credentials(routes: Iterable[tuple[str, str]]) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    credentials: dict[str, dict[str, Any]] = {}
+    resolved_names: dict[str, str] = {}
+    with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+        for provider, model in routes:
+            if provider in credentials:
+                continue
+            runtime = resolve_runtime_provider(requested=provider, target_model=model)
+            credentials[provider] = {key: runtime.get(key) for key in SAFE_RUNTIME_KEYS}
+            resolved_names[provider] = str(runtime.get("provider") or provider)
+    return credentials, resolved_names
+
+
+def _child_failure(packet: Mapping[str, Any], error_type: str) -> dict[str, Any]:
+    return {
+        "parent_provider": packet["parent_provider"],
+        "parent_model": packet["parent_model"],
+        "selected_interface": UNKNOWN,
+        "interface_version": UNKNOWN,
+        "advertised_tool_names": [],
+        "events": [],
+        "workers": [],
+        "parent_completed": False,
+        "elapsed_seconds": 0,
+        "token_usage": {},
+        "cost": {"status": UNKNOWN},
+        "wire_route_agreement": UNKNOWN,
+        "authorization_violations": 0,
+        "duplicate_owned_executions": 0,
+        "error_type": error_type,
+    }
+
+
+def _run_child_process(packet: Mapping[str, Any], timeout: float) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="hermes-interface-qualification-") as home:
+        env = dict(os.environ, HERMES_HOME=home)
+        try:
+            result = subprocess.run(
+                [sys.executable, str(Path(__file__).resolve()), "--child"],
+                input=json.dumps(packet), text=True, capture_output=True, env=env,
+                timeout=timeout, check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return _child_failure(packet, "ScenarioTimeout")
+    try:
+        payload = json.loads(result.stdout)
+    except (TypeError, ValueError):
+        return _child_failure(packet, "UnstructuredChildOutput")
+    return payload if isinstance(payload, dict) else _child_failure(packet, "InvalidChildOutput")
+
+
+def _positive_int(value: str) -> int:
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return number
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--execute", action="store_true", help="Allow the selected live provider calls.")
+    parser.add_argument("--child", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--fixture", type=Path, default=FIXTURE_PATH)
+    parser.add_argument("--parent-provider", required="--child" not in sys.argv)
+    parser.add_argument("--parent-model", required="--child" not in sys.argv)
+    parser.add_argument("--parent-reasoning-effort", required="--child" not in sys.argv)
+    parser.add_argument("--interface", choices=("hermes", "codex", "claude"), required="--child" not in sys.argv)
+    for label in ("a", "b"):
+        parser.add_argument(f"--worker-{label}-profile", required="--child" not in sys.argv)
+        parser.add_argument(f"--worker-{label}-provider", required="--child" not in sys.argv)
+        parser.add_argument(f"--worker-{label}-model", required="--child" not in sys.argv)
+        parser.add_argument(f"--worker-{label}-reasoning-effort", required="--child" not in sys.argv)
+    parser.add_argument("--max-parent-tokens", type=_positive_int, default=4096)
+    return parser
+
+
+def _main() -> None:
+    args = _parser().parse_args()
+    logging.disable(logging.CRITICAL)
+    if args.child:
+        packet = json.loads(sys.stdin.read())
+        try:
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+                result = _execute_child(packet)
+        except Exception as exc:
+            site = traceback.extract_tb(exc.__traceback__)[-1]
+            result = _child_failure(packet, f"{type(exc).__name__}@{Path(site.filename).name}:{site.lineno}")
+        print(json.dumps(result, sort_keys=True))
+        return
+    if not args.execute:
+        raise SystemExit("Live provider calls require the explicit --execute flag.")
+    if args.max_parent_tokens > 8192:
+        raise SystemExit("--max-parent-tokens must be at most 8192")
+    fixture = load_fixture(args.fixture)
+    policy = fixture["execution_policy"]
+    routes = [
+        RouteChoice(args.worker_a_profile, args.worker_a_provider, args.worker_a_model, args.worker_a_reasoning_effort),
+        RouteChoice(args.worker_b_profile, args.worker_b_provider, args.worker_b_model, args.worker_b_reasoning_effort),
+    ]
+    if len({route.profile for route in routes}) != 2 or "missing-qualification-profile" in {route.profile for route in routes}:
+        raise SystemExit("Worker profiles must be distinct and may not use the reserved missing-profile fixture name")
+    if len({route.provider for route in routes}) != 2:
+        raise SystemExit("The two worker routes must select different providers")
+    candidate = _source_identity(REPO_ROOT)
+    credentials, resolved_names = _resolve_credentials([
+        (args.parent_provider, args.parent_model),
+        *((route.provider, route.model) for route in routes),
+    ])
+    routes = [RouteChoice(**{**asdict(route), "expected_provider": resolved_names[route.provider]}) for route in routes]
+    limits = {
+        key: policy[key] for key in (
+            "max_parent_iterations", "max_child_iterations", "max_children",
+            "max_seconds_per_scenario", "max_child_seconds",
+        )
+    }
+    limits["max_parent_tokens"] = args.max_parent_tokens
+    common = {
+        "candidate_sha": candidate,
+        "parent_provider": resolved_names[args.parent_provider],
+        "parent_model": args.parent_model,
+        "requested_interface": args.interface,
+        "required_receipt_fields": fixture["required_receipt_fields"],
+        "limits": limits,
+    }
+
+    def execute(scenario: Mapping[str, Any]) -> Mapping[str, Any]:
+        packet = {
+            "scenario": scenario,
+            "credentials": credentials,
+            "routes": [asdict(route) for route in routes],
+            "parent_provider": args.parent_provider,
+            "parent_model": args.parent_model,
+            "parent_reasoning_effort": args.parent_reasoning_effort,
+            "requested_interface": args.interface,
+            "limits": limits,
+        }
+        return _run_child_process(packet, timeout=limits["max_seconds_per_scenario"] + 15)
+
+    print(json.dumps(run_suite(fixture, execute, common), sort_keys=True))
+
+
+def main() -> int:
+    try:
+        _main()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        print(json.dumps({
+            "qualification": "unqualified",
+            "qualified": False,
+            "error_type": type(exc).__name__,
+            "proof_boundary": "Controller preflight failed before four-scenario qualification completed.",
+        }, sort_keys=True))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evals/interface_qualification.py
+++ b/scripts/evals/interface_qualification.py
@@ -260,7 +260,10 @@ def _all_text(value: Any) -> str:
     return ""
 
 
-def _instrument_interface(parent: Any, store: Any, owner: str) -> tuple[list[dict[str, Any]], Callable[[], None]]:
+def _instrument_interface(
+    parent: Any, store: Any, owner: str,
+    *, accepted_running_guidance: Callable[[], None] | None = None,
+) -> tuple[list[dict[str, Any]], Callable[[], None]]:
     original = getattr(parent, "_dispatch_worker_interface", None)
     if not callable(original):
         raise RuntimeError("AIAgent._dispatch_worker_interface is unavailable; integrate the interface adapter first")
@@ -291,6 +294,13 @@ def _instrument_interface(parent: Any, store: Any, owner: str) -> tuple[list[dic
                 "accepted": not bool(payload.get("error")),
                 "classification": _error_classification(payload.get("error")),
             })
+            if (
+                accepted_running_guidance is not None
+                and event["accepted"]
+                and event["effective_action"] == "message"
+                and event["target_was_running"]
+            ):
+                accepted_running_guidance()
         except Exception as exc:
             event.update({"accepted": False, "classification": _error_classification(exc), "effective_action": "none"})
             events.append(event)
@@ -489,8 +499,10 @@ def _execute_child(packet: Mapping[str, Any]) -> dict[str, Any]:
         )
         prompt = scenario["prompt_template"].format(worker_id=worker_id)
     counts_before = _counts(store, owner)
-    events, restore_interface = _instrument_interface(parent, store, owner)
     gate = threading.Event()
+    events, restore_interface = _instrument_interface(
+        parent, store, owner, accepted_running_guidance=gate.set
+    )
     original_http = AIAgent._interruptible_api_call
     held: set[str] = set()
     held_lock = threading.Lock()

--- a/scripts/evals/interface_qualification.py
+++ b/scripts/evals/interface_qualification.py
@@ -44,7 +44,7 @@ SAFE_USAGE_KEYS = (
     "cache_write_tokens", "reasoning_tokens",
 )
 TERMINAL_STATES = {"SUCCEEDED", "FAILED", "INTERRUPTED", "CANCELLED"}
-ACTIVE_STATES = {"PENDING", "STARTING", "RUNNING", "CANCEL_REQUESTED"}
+GUIDANCE_DELIVERIES = {"NEXT_RUN", "RUNNING_STEER_PENDING_CHECKPOINT"}
 
 
 @dataclass(frozen=True)
@@ -93,6 +93,15 @@ def _error_classification(error: Any) -> str | None:
     return "SERVICE_ERROR"
 
 
+def _is_running_guidance(event: Mapping[str, Any]) -> bool:
+    return (
+        event.get("accepted") is True
+        and event.get("effective_action") == "message"
+        and event.get("selected_run_status") == "RUNNING"
+        and event.get("delivery") == "RUNNING_STEER_PENDING_CHECKPOINT"
+    )
+
+
 def _scenario_checks(scenario_id: str, observation: Mapping[str, Any]) -> list[bool]:
     events = list(observation.get("events") or ())
     workers = list(observation.get("workers") or ())
@@ -102,7 +111,7 @@ def _scenario_checks(scenario_id: str, observation: Mapping[str, Any]) -> list[b
     if scenario_id == "two_provider_retained_workflow":
         profiles = {profile for item in accepted for profile in item.get("profiles", ())}
         providers = {item.get("provider") for item in workers if item.get("provider")}
-        message_live = any(item.get("effective_action") == "message" and item.get("target_was_running") for item in accepted)
+        message_live = any(_is_running_guidance(item) for item in accepted)
         linked = any(item.get("linked_followup") and item.get("followup_avoids_labels") for item in accepted)
         all_acked = bool(workers) and all(item.get("all_terminal_acked") for item in workers)
         return [
@@ -158,6 +167,14 @@ def build_receipt(
         "interface_version": observation.get("interface_version", UNKNOWN),
         "advertised_orchestration_tool_names": sorted(set(observation.get("advertised_tool_names") or ())),
         "observed_orchestration_tool_names": sorted({str(item.get("tool_name")) for item in events if item.get("tool_name")}),
+        "guidance_delivery_evidence": [
+            {
+                "accepted": item.get("accepted") is True,
+                "selected_run_status": item.get("selected_run_status", UNKNOWN),
+                "delivery": item.get("delivery", UNKNOWN),
+            }
+            for item in events if item.get("effective_action") == "message"
+        ],
         "task_completed": bool(observation.get("parent_completed")) and all(checks),
         "invalid_tool_calls": {
             "structured": invalid_count,
@@ -276,10 +293,16 @@ def _instrument_interface(
         if target:
             with contextlib.suppress(Exception):
                 before_runs = store.list_runs(target, owner)
+        requested_run_id = arguments.get("run_id")
+        selected_run = (
+            next((item for item in before_runs if item.get("run_id") == requested_run_id), None)
+            if isinstance(requested_run_id, str) and requested_run_id
+            else (before_runs[-1] if before_runs else None)
+        )
         event: dict[str, Any] = {
             "tool_name": tool_name,
             "profiles": _profiles_from_args(arguments),
-            "target_was_running": bool(before_runs and before_runs[-1].get("status") in ACTIVE_STATES),
+            "selected_run_status": (selected_run or {}).get("status", UNKNOWN),
             "followup_avoids_labels": not any(
                 label in _all_text(arguments).lower() for label in ("cobalt", "amber", "violet", "sapphire", "silver")
             ),
@@ -293,13 +316,12 @@ def _instrument_interface(
                 "effective_action": interface.get("effective_action"),
                 "accepted": not bool(payload.get("error")),
                 "classification": _error_classification(payload.get("error")),
+                "delivery": (
+                    payload.get("delivery")
+                    if payload.get("delivery") in GUIDANCE_DELIVERIES else UNKNOWN
+                ),
             })
-            if (
-                accepted_running_guidance is not None
-                and event["accepted"]
-                and event["effective_action"] == "message"
-                and event["target_was_running"]
-            ):
+            if accepted_running_guidance is not None and _is_running_guidance(event):
                 accepted_running_guidance()
         except Exception as exc:
             event.update({"accepted": False, "classification": _error_classification(exc), "effective_action": "none"})

--- a/tests/agent/test_delegation_model_routing.py
+++ b/tests/agent/test_delegation_model_routing.py
@@ -1,0 +1,276 @@
+"""Contract tests for the delegation model-profile resolver (agent/delegation_model_routing.py).
+
+Behavior contracts (not snapshots): parsing rejects malformed shapes loudly, selection follows the
+documented precedence ladder, unknown profile names fail before child construction with an
+actionable message, invalid reasoning_effort warns and is ignored (NS-696 clamp-at-transport
+doctrine — never reject), and the resolved route is immutable.
+"""
+
+import dataclasses
+import logging
+
+import pytest
+
+from agent.delegation_model_routing import (
+    ProfileRoute,
+    parse_profiles,
+    profile_config_errors,
+    resolve_profile_route,
+    select_profile_name,
+)
+
+
+def _cfg(profiles=None, default_profile="", **extra):
+    cfg = {"default_profile": default_profile, "profiles": profiles if profiles is not None else {}}
+    cfg.update(extra)
+    return cfg
+
+
+SMALL = {"provider": "anthropic", "model": "claude-haiku-current"}
+LARGE = {"provider": "openrouter", "model": "big/model"}
+
+
+# ---------------------------------------------------------------------------
+# parse_profiles
+# ---------------------------------------------------------------------------
+
+class TestParseProfiles:
+    def test_empty_profiles_parse_to_empty_dict(self):
+        assert parse_profiles(_cfg()) == {}
+
+    @pytest.mark.parametrize("cfg", [None, {}, {"profiles": None}, {"profiles": {}}])
+    def test_tolerates_missing_or_none_sections(self, cfg):
+        assert parse_profiles(cfg) == {}
+
+    def test_parses_minimal_profile(self):
+        specs = parse_profiles(_cfg({"small": dict(SMALL)}))
+        assert set(specs) == {"small"}
+        spec = specs["small"]
+        assert spec.provider == "anthropic"
+        assert spec.model == "claude-haiku-current"
+        assert spec.fallback == ()
+        assert spec.max_iterations is None
+        assert spec.reasoning_config is None
+
+    def test_unknown_keys_rejected(self):
+        cfg = _cfg({"small": {**SMALL, "toolsets": ["web"]}})
+        with pytest.raises(ValueError) as exc:
+            parse_profiles(cfg)
+        assert "toolsets" in str(exc.value)
+        assert "small" in str(exc.value)
+
+    def test_missing_model_rejected(self):
+        with pytest.raises(ValueError) as exc:
+            parse_profiles(_cfg({"small": {"provider": "anthropic"}}))
+        assert "model" in str(exc.value)
+
+    def test_non_dict_profile_rejected(self):
+        with pytest.raises(ValueError):
+            parse_profiles(_cfg({"small": "claude-haiku-current"}))
+
+    @pytest.mark.parametrize("bad_fallback", [
+        "openrouter/big",                       # not a list
+        [{"provider": "openrouter"}],            # entry missing model
+        [{"model": "x"}],                        # entry missing provider
+        ["openrouter/big"],                      # entry not a dict
+        [{"provider": "p", "model": "m", "extra": 1}],  # unknown entry key
+    ])
+    def test_malformed_fallback_rejected(self, bad_fallback):
+        with pytest.raises(ValueError) as exc:
+            parse_profiles(_cfg({"small": {**SMALL, "fallback": bad_fallback}}))
+        assert "fallback" in str(exc.value)
+
+    def test_valid_fallback_parsed_as_tuple(self):
+        specs = parse_profiles(_cfg({
+            "small": {**SMALL, "fallback": [{"provider": "openrouter", "model": "b/c"}]},
+        }))
+        fb = specs["small"].fallback
+        assert isinstance(fb, tuple) and len(fb) == 1
+        assert fb[0].provider == "openrouter"
+        assert fb[0].model == "b/c"
+
+    def test_valid_reasoning_effort_parsed(self):
+        specs = parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "high"}}))
+        assert specs["small"].reasoning_config == {"enabled": True, "effort": "high"}
+
+    def test_reasoning_effort_none_means_disabled(self):
+        specs = parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "none"}}))
+        assert specs["small"].reasoning_config == {"enabled": False}
+
+    def test_invalid_reasoning_effort_warns_and_is_ignored(self, caplog):
+        """NS-696 clamp doctrine: an invalid effort must never reject the profile."""
+        with caplog.at_level(logging.WARNING):
+            specs = parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "turbo"}}))
+        assert specs["small"].reasoning_config is None
+        assert any("turbo" in rec.getMessage() for rec in caplog.records)
+
+    def test_max_iterations_parsed(self):
+        specs = parse_profiles(_cfg({"small": {**SMALL, "max_iterations": 20}}))
+        assert specs["small"].max_iterations == 20
+
+    def test_non_int_max_iterations_rejected(self):
+        with pytest.raises(ValueError) as exc:
+            parse_profiles(_cfg({"small": {**SMALL, "max_iterations": "lots"}}))
+        assert "max_iterations" in str(exc.value)
+
+
+class TestProfileConfigErrors:
+    """Multi-issue collector used by `hermes config check` — never raises."""
+
+    def test_clean_config_has_no_errors(self):
+        assert profile_config_errors(_cfg({"small": dict(SMALL)})) == []
+
+    def test_collects_multiple_errors(self):
+        errors = profile_config_errors(_cfg({
+            "a": {"provider": "p"},                 # missing model
+            "b": {**SMALL, "bogus": 1},             # unknown key
+        }))
+        joined = "\n".join(errors)
+        assert "a" in joined and "model" in joined
+        assert "b" in joined and "bogus" in joined
+        assert len(errors) >= 2
+
+    def test_default_profile_must_exist(self):
+        errors = profile_config_errors(_cfg({"small": dict(SMALL)}, default_profile="huge"))
+        assert any("huge" in e and "small" in e for e in errors)
+
+    def test_empty_default_profile_is_fine(self):
+        assert profile_config_errors(_cfg({"small": dict(SMALL)}, default_profile="")) == []
+
+    def test_profiles_must_be_a_mapping(self):
+        errors = profile_config_errors({"profiles": ["small"]})
+        assert errors and any("profiles" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# select_profile_name — precedence ladder
+# ---------------------------------------------------------------------------
+
+FALSY = [False, None, "", 0]
+
+
+class TestSelectProfileName:
+    def test_per_task_wins_over_everything(self):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="large")
+        assert select_profile_name("small", "mid", cfg) == "small"
+
+    def test_top_level_wins_over_default(self):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="large")
+        assert select_profile_name(None, "small", cfg) == "small"
+
+    def test_default_profile_applies_when_others_silent(self):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="small")
+        assert select_profile_name(None, None, cfg) == "small"
+
+    def test_legacy_config_selects_no_profile(self):
+        """Level 4: legacy delegation.provider/model config — resolver stays out of the way."""
+        cfg = {"provider": "openrouter", "model": "x/y"}
+        assert select_profile_name(None, None, cfg) is None
+
+    def test_pure_inherit_selects_no_profile(self):
+        """Level 5: nothing configured at all — parent inherit."""
+        assert select_profile_name(None, None, {}) is None
+        assert select_profile_name(None, None, None) is None
+
+    @pytest.mark.parametrize("falsy", FALSY)
+    def test_falsy_task_profile_falls_through(self, falsy):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="small")
+        assert select_profile_name(falsy, None, cfg) == "small"
+
+    @pytest.mark.parametrize("falsy", FALSY)
+    def test_falsy_top_profile_falls_through(self, falsy):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile="small")
+        assert select_profile_name(None, falsy, cfg) == "small"
+
+    @pytest.mark.parametrize("falsy", FALSY)
+    def test_falsy_default_profile_means_legacy(self, falsy):
+        cfg = _cfg({"small": dict(SMALL)}, default_profile=falsy)
+        assert select_profile_name(None, None, cfg) is None
+
+    def test_whitespace_names_are_stripped(self):
+        cfg = _cfg({"small": dict(SMALL)})
+        assert select_profile_name("  small  ", None, cfg) == "small"
+
+
+# ---------------------------------------------------------------------------
+# resolve_profile_route
+# ---------------------------------------------------------------------------
+
+class _FakeCaps:
+    def __init__(self, supports_tools=True):
+        self.supports_tools = supports_tools
+
+
+@pytest.fixture
+def fake_runtime(monkeypatch):
+    """Stub the two lazy-imported collaborators at their source modules."""
+    calls = {}
+
+    def _resolve(*, requested=None, explicit_api_key=None, explicit_base_url=None, target_model=None):
+        calls["requested"] = requested
+        calls["target_model"] = target_model
+        return {
+            "provider": requested or "resolved-default",
+            "model": target_model,
+            "base_url": "https://api.example.test/v1",
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+        }
+
+    import hermes_cli.runtime_provider as rp
+    import agent.models_dev as md
+    monkeypatch.setattr(rp, "resolve_runtime_provider", _resolve)
+    monkeypatch.setattr(md, "get_model_capabilities", lambda *a, **k: _FakeCaps(True))
+    return calls
+
+
+class TestResolveProfileRoute:
+    def test_unknown_name_lists_configured_profiles(self):
+        cfg = _cfg({"small": dict(SMALL), "large": dict(LARGE)})
+        with pytest.raises(ValueError) as exc:
+            resolve_profile_route("huge", cfg, parent_agent=None)
+        msg = str(exc.value)
+        assert "huge" in msg
+        assert "small" in msg and "large" in msg
+
+    def test_unknown_name_with_no_profiles_configured(self):
+        with pytest.raises(ValueError) as exc:
+            resolve_profile_route("small", {}, parent_agent=None)
+        assert "small" in str(exc.value)
+
+    def test_route_resolves_through_runtime_provider(self, fake_runtime):
+        cfg = _cfg({"small": dict(SMALL)})
+        route = resolve_profile_route("small", cfg, parent_agent=None)
+        # credential resolution went through resolve_runtime_provider — same path as legacy
+        assert fake_runtime["requested"] == "anthropic"
+        assert fake_runtime["target_model"] == "claude-haiku-current"
+        assert route.requested_profile == "small"
+        assert route.provider == "anthropic"
+        assert route.model == "claude-haiku-current"
+        assert route.base_url == "https://api.example.test/v1"
+        assert route.api_key == "sk-test"
+        assert route.api_mode == "chat_completions"
+
+    def test_route_carries_profile_extras(self, fake_runtime):
+        cfg = _cfg({"small": {**SMALL, "reasoning_effort": "low", "max_iterations": 20,
+                              "fallback": [{"provider": "openrouter", "model": "b/c"}]}})
+        route = resolve_profile_route("small", cfg, parent_agent=None)
+        assert route.reasoning_config == {"enabled": True, "effort": "low"}
+        assert route.max_iterations == 20
+        assert len(route.fallback) == 1
+        assert route.fallback[0].provider == "openrouter"
+
+    def test_route_exposes_supports_tools(self, monkeypatch, fake_runtime):
+        import agent.models_dev as md
+        monkeypatch.setattr(md, "get_model_capabilities", lambda *a, **k: _FakeCaps(False))
+        route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
+        assert route.supports_tools is False
+
+    def test_route_is_frozen(self, fake_runtime):
+        route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            route.model = "other"
+
+    def test_route_fallback_is_immutable_sequence(self, fake_runtime):
+        route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
+        assert isinstance(route.fallback, tuple)

--- a/tests/agent/test_delegation_model_routing.py
+++ b/tests/agent/test_delegation_model_routing.py
@@ -302,6 +302,35 @@ class TestResolveProfileRoute:
         with pytest.raises(ValueError, match="not enabled"):
             resolve_profile_route("small", cfg, requested_model="other/model")
 
+    def test_global_enabled_models_is_dynamic_menu_when_profile_has_no_routes(self, fake_runtime):
+        cfg = _cfg(
+            {"small": dict(SMALL)}, routing_mode="dynamic",
+            enabled_models=[{"provider": "openrouter", "model": "approved/model"}],
+        )
+        # The global list is also a ceiling, so include the primary profile route.
+        cfg["enabled_models"].append({"provider": "anthropic", "model": "claude-haiku-current"})
+        route = resolve_profile_route(
+            "small", cfg, requested_provider="openrouter", requested_model="approved/model")
+        assert route.model == "approved/model"
+
+    def test_empty_global_menu_does_not_enable_arbitrary_models(self, fake_runtime):
+        cfg = _cfg({"small": dict(SMALL)}, routing_mode="dynamic", enabled_models=[])
+        with pytest.raises(ValueError, match="not enabled"):
+            resolve_profile_route("small", cfg, requested_model="arbitrary/model")
+
+    def test_known_unsupported_effort_fails_before_runtime_resolution(self, monkeypatch):
+        calls = []
+        import hermes_cli.runtime_provider as rp
+        monkeypatch.setattr(rp, "resolve_runtime_provider", lambda **kwargs: calls.append(kwargs))
+        cfg = _cfg({"review": {"provider": "openai-codex", "model": "gpt-6-astra", "reasoning_effort": "ultra"}})
+        with pytest.raises(ValueError, match="unsupported"):
+            resolve_profile_route("review", cfg)
+        assert calls == []
+
+    def test_transmitted_model_is_unknown_until_execution(self, fake_runtime):
+        route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}))
+        assert route.transmitted_model is None
+
     def test_profile_only_rejects_task_route_override(self, fake_runtime):
         with pytest.raises(ValueError, match="profile_only"):
             resolve_profile_route("small", _cfg({"small": dict(SMALL)}), requested_model="other")

--- a/tests/agent/test_delegation_model_routing.py
+++ b/tests/agent/test_delegation_model_routing.py
@@ -2,17 +2,17 @@
 
 Behavior contracts (not snapshots): parsing rejects malformed shapes loudly, selection follows the
 documented precedence ladder, unknown profile names fail before child construction with an
-actionable message, invalid reasoning_effort warns and is ignored (NS-696 clamp-at-transport
-doctrine — never reject), and the resolved route is immutable.
+actionable message, invalid explicit reasoning effort fails before launch, discovery stays
+credential-free, and the resolved route is immutable.
 """
 
 import dataclasses
-import logging
 
 import pytest
 
 from agent.delegation_model_routing import (
     ProfileRoute,
+    discover_workers,
     parse_profiles,
     profile_config_errors,
     resolve_profile_route,
@@ -97,12 +97,9 @@ class TestParseProfiles:
         specs = parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "none"}}))
         assert specs["small"].reasoning_config == {"enabled": False}
 
-    def test_invalid_reasoning_effort_warns_and_is_ignored(self, caplog):
-        """NS-696 clamp doctrine: an invalid effort must never reject the profile."""
-        with caplog.at_level(logging.WARNING):
-            specs = parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "turbo"}}))
-        assert specs["small"].reasoning_config is None
-        assert any("turbo" in rec.getMessage() for rec in caplog.records)
+    def test_invalid_reasoning_effort_is_rejected(self):
+        with pytest.raises(ValueError, match="turbo"):
+            parse_profiles(_cfg({"small": {**SMALL, "reasoning_effort": "turbo"}}))
 
     def test_max_iterations_parsed(self):
         specs = parse_profiles(_cfg({"small": {**SMALL, "max_iterations": 20}}))
@@ -112,6 +109,23 @@ class TestParseProfiles:
         with pytest.raises(ValueError) as exc:
             parse_profiles(_cfg({"small": {**SMALL, "max_iterations": "lots"}}))
         assert "max_iterations" in str(exc.value)
+
+    def test_parses_profile_policy_and_limits(self):
+        spec = parse_profiles(_cfg({"small": {
+            **SMALL,
+            "description": "Bounded retrieval",
+            "instructions": "Return evidence.",
+            "tool_policy": {"allowed_toolsets": ["file"], "blocked_tools": ["write_file"]},
+            "workspace_context": {"mode": "none"},
+            "execution_limits": {"max_iterations": 8, "timeout_seconds": 30, "max_followups": 2},
+            "enabled_routes": [{"provider": "anthropic", "model": "claude-sonnet-current", "reasoning_effort": "high"}],
+        }}))["small"]
+        assert spec.description == "Bounded retrieval"
+        assert spec.tool_policy.allowed_toolsets == ("file",)
+        assert spec.tool_policy.blocked_tools == ("write_file",)
+        assert spec.workspace_context.mode == "none"
+        assert spec.execution_limits.max_iterations == 8
+        assert spec.enabled_routes[0].reasoning_effort == "high"
 
 
 class TestProfileConfigErrors:
@@ -274,3 +288,44 @@ class TestResolveProfileRoute:
     def test_route_fallback_is_immutable_sequence(self, fake_runtime):
         route = resolve_profile_route("small", _cfg({"small": dict(SMALL)}), parent_agent=None)
         assert isinstance(route.fallback, tuple)
+
+    def test_dynamic_override_must_be_enabled(self, fake_runtime):
+        cfg = _cfg({"small": {
+            **SMALL,
+            "enabled_routes": [{"provider": "openrouter", "model": "approved/model", "reasoning_effort": "high"}],
+        }}, routing_mode="dynamic")
+        route = resolve_profile_route(
+            "small", cfg, requested_provider="openrouter", requested_model="approved/model",
+            requested_reasoning_effort="high",
+        )
+        assert route.model == "approved/model"
+        with pytest.raises(ValueError, match="not enabled"):
+            resolve_profile_route("small", cfg, requested_model="other/model")
+
+    def test_profile_only_rejects_task_route_override(self, fake_runtime):
+        with pytest.raises(ValueError, match="profile_only"):
+            resolve_profile_route("small", _cfg({"small": dict(SMALL)}), requested_model="other")
+
+
+class TestDiscoverWorkers:
+    def test_catalog_is_safe_and_does_not_resolve_credentials(self, monkeypatch):
+        import hermes_cli.runtime_provider as rp
+        monkeypatch.setattr(rp, "resolve_runtime_provider", lambda **kwargs: pytest.fail("credential resolution"))
+        catalog = discover_workers(_cfg({"small": {
+            **SMALL,
+            "description": "Small worker",
+            "tool_policy": {"allowed_toolsets": ["file"]},
+        }}))
+        assert catalog["routing_mode"] == "profile_only"
+        assert catalog["profiles"][0]["name"] == "small"
+        assert catalog["profiles"][0]["availability"]["status"] == "unknown"
+        assert catalog["profiles"][0]["tool_policy"]["allowed_toolsets"] == ["file"]
+        assert "api_key" not in repr(catalog)
+
+    def test_catalog_keeps_unknown_metadata_explicit(self, monkeypatch):
+        import agent.models_dev as md
+        monkeypatch.setattr(md, "get_model_capabilities", lambda *args, **kwargs: None)
+        profile = discover_workers(_cfg({"small": dict(SMALL)}))["profiles"][0]
+        assert profile["capabilities"]["supports_tools"] is None
+        assert profile["freshness"]["status"] == "unknown"
+        assert profile["provenance"]["capabilities"] == "unknown"

--- a/tests/agent/test_interface_qualification_runner.py
+++ b/tests/agent/test_interface_qualification_runner.py
@@ -1,0 +1,173 @@
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+from scripts.evals import interface_qualification as runner
+from scripts.evals.interface_qualification import load_fixture, run_suite
+
+
+def _fake_observation(scenario_id, secret):
+    common = {
+        "parent_provider": "provider-parent",
+        "parent_model": "model-parent",
+        "selected_interface": "codex",
+        "interface_version": "worker-interface-v1",
+        "advertised_tool_names": ["worker_capabilities", "spawn_agent"],
+        "parent_completed": True,
+        "elapsed_seconds": 1.25,
+        "token_usage": {"input_tokens": 120, "output_tokens": 30, "provider_blob": secret},
+        "cost": {"status": "unknown"},
+        "wire_route_agreement": True,
+        "tool_receipts_match": True,
+        "duplicate_owned_executions": 0,
+        "authorization_violations": 0,
+        "malformed_tool_calls": 0,
+        "corrective_turns": 0,
+        "provider_body": secret,
+    }
+    if scenario_id == "two_provider_retained_workflow":
+        return {
+            **common,
+            "events": [
+                {"tool_name": "spawn_agent", "profiles": ["route-a", "route-b"], "accepted": True},
+                {
+                    "tool_name": "send_message", "accepted": True,
+                    "effective_action": "message", "target_was_running": True,
+                },
+                {
+                    "tool_name": "followup_task", "accepted": True,
+                    "effective_action": "resume", "linked_followup": True,
+                    "followup_avoids_labels": True,
+                },
+            ],
+            "workers": [
+                {
+                    "profile": "route-a", "provider": "provider-a", "run_count": 2,
+                    "all_terminal_acked": True,
+                },
+                {
+                    "profile": "route-b", "provider": "provider-b", "run_count": 1,
+                    "all_terminal_acked": True,
+                },
+            ],
+            "retained_answer_match": True,
+        }
+    if scenario_id == "invalid_profile_rejected":
+        return {
+            **common,
+            "events": [{
+                "tool_name": "spawn_agent", "accepted": False,
+                "classification": "EXPECTED_INVALID_PROFILE_DENIAL",
+            }],
+            "workers": [],
+            "counts_before": {"workers": 0, "runs": 0, "messages": 0},
+            "counts_after": {"workers": 0, "runs": 0, "messages": 0},
+        }
+    if scenario_id == "foreign_worker_denied":
+        return {
+            **common,
+            "events": [{
+                "tool_name": "inspect_agent", "accepted": False,
+                "classification": "EXPECTED_FOREIGN_OWNER_DENIAL",
+            }],
+            "workers": [],
+            "foreign_preimage_unchanged": True,
+        }
+    return {
+        **common,
+        "events": [
+            {
+                "tool_name": "send_message", "accepted": True,
+                "effective_action": "message", "run_count_delta": 0,
+            },
+            {
+                "tool_name": "followup_task", "accepted": True,
+                "effective_action": "resume", "run_count_delta": 1,
+                "linked_followup": True,
+            },
+            {
+                "tool_name": "worker_control", "accepted": True,
+                "effective_action": "ack", "targets_latest_run": True,
+            },
+        ],
+        "workers": [{
+            "profile": "route-a", "provider": "provider-a", "run_count": 2,
+            "all_terminal_acked": True,
+        }],
+        "retained_answer_match": True,
+        "prior_run_replayed": False,
+    }
+
+
+def test_fake_transport_qualifies_all_scenarios_without_leaking_transport_data():
+    fixture = load_fixture()
+    assert runner.REPO_ROOT == Path(runner.__file__).resolve().parents[2]
+    assert sys.path[0] == str(runner.REPO_ROOT)
+    secret = "synthetic-provider-body-must-not-appear"
+    common = {
+        "candidate_sha": "a" * 40,
+        "parent_provider": "provider-parent",
+        "parent_model": "model-parent",
+        "requested_interface": "codex",
+        "required_receipt_fields": fixture["required_receipt_fields"],
+        "limits": {
+            "max_parent_iterations": 16,
+            "max_child_iterations": 3,
+            "max_children": 2,
+            "max_seconds_per_scenario": 240,
+            "max_child_seconds": 90,
+            "max_parent_tokens": 4096,
+        },
+    }
+
+    report = run_suite(
+        fixture,
+        lambda scenario: _fake_observation(scenario["id"], secret),
+        common,
+    )
+
+    assert report["qualified"] is True
+    assert [item["scenario_id"] for item in report["receipts"]] == [
+        item["id"] for item in fixture["scenarios"]
+    ]
+    assert all(item["task_completed"] for item in report["receipts"])
+    assert all(
+        set(fixture["required_receipt_fields"]).issubset(item)
+        for item in report["receipts"]
+    )
+    assert secret not in json.dumps(report)
+
+    def malformed_denial(scenario):
+        observation = _fake_observation(scenario["id"], secret)
+        if scenario["id"] == "invalid_profile_rejected":
+            observation["events"][0]["classification"] = "INVALID_TOOL_CALL"
+        return observation
+
+    failed = run_suite(fixture, malformed_denial, common)
+    invalid = next(item for item in failed["receipts"] if item["scenario_id"] == "invalid_profile_rejected")
+    assert failed["qualified"] is False
+    assert invalid["task_completed"] is False
+    assert invalid["invalid_tool_calls"]["structured"] == 1
+
+
+def test_timeout_and_controller_failures_are_sanitized(monkeypatch, capsys):
+    secret = "provider-error-body-must-not-appear"
+    packet = {"parent_provider": "provider-parent", "parent_model": "model-parent"}
+
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired("qualification-child", 1)
+
+    monkeypatch.setattr(runner.subprocess, "run", timeout)
+    receipt = runner._run_child_process(packet, timeout=1)
+    assert receipt["parent_completed"] is False
+    assert receipt["error_type"] == "ScenarioTimeout"
+
+    def fail_controller():
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(runner, "_main", fail_controller)
+    assert runner.main() == 1
+    output = capsys.readouterr().out
+    assert json.loads(output)["qualification"] == "unqualified"
+    assert secret not in output

--- a/tests/agent/test_interface_qualification_runner.py
+++ b/tests/agent/test_interface_qualification_runner.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+from types import SimpleNamespace
 
 from scripts.evals import interface_qualification as runner
 from scripts.evals.interface_qualification import load_fixture, run_suite
@@ -171,3 +172,34 @@ def test_timeout_and_controller_failures_are_sanitized(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert json.loads(output)["qualification"] == "unqualified"
     assert secret not in output
+
+
+def test_running_guidance_releases_only_after_an_accepted_message():
+    runs = [{"run_id": "run-1", "status": "RUNNING"}]
+
+    class Store:
+        def list_runs(self, worker_id, owner):
+            assert (worker_id, owner) == ("worker-1", "owner")
+            return list(runs)
+
+    responses = [
+        {"error": "denied", "orchestration_interface": {"effective_action": "message"}},
+        {"success": True, "orchestration_interface": {"effective_action": "resume"}},
+        {"success": True, "orchestration_interface": {"effective_action": "message"}},
+    ]
+    parent = SimpleNamespace(
+        _dispatch_worker_interface=lambda _name, _args: json.dumps(responses.pop(0))
+    )
+    released = []
+    events, restore = runner._instrument_interface(
+        parent, Store(), "owner", accepted_running_guidance=lambda: released.append(True)
+    )
+    try:
+        parent._dispatch_worker_interface("send_message", {"target": "worker-1"})
+        parent._dispatch_worker_interface("followup_task", {"target": "worker-1"})
+        assert released == []
+        parent._dispatch_worker_interface("send_message", {"target": "worker-1"})
+        assert released == [True]
+        assert [event["accepted"] for event in events] == [False, True, True]
+    finally:
+        restore()

--- a/tests/agent/test_interface_qualification_runner.py
+++ b/tests/agent/test_interface_qualification_runner.py
@@ -34,7 +34,8 @@ def _fake_observation(scenario_id, secret):
                 {"tool_name": "spawn_agent", "profiles": ["route-a", "route-b"], "accepted": True},
                 {
                     "tool_name": "send_message", "accepted": True,
-                    "effective_action": "message", "target_was_running": True,
+                    "effective_action": "message", "selected_run_status": "RUNNING",
+                    "delivery": "RUNNING_STEER_PENDING_CHECKPOINT",
                 },
                 {
                     "tool_name": "followup_task", "accepted": True,
@@ -137,6 +138,15 @@ def test_fake_transport_qualifies_all_scenarios_without_leaking_transport_data()
         set(fixture["required_receipt_fields"]).issubset(item)
         for item in report["receipts"]
     )
+    workflow = next(
+        item for item in report["receipts"]
+        if item["scenario_id"] == "two_provider_retained_workflow"
+    )
+    assert workflow["guidance_delivery_evidence"] == [{
+        "accepted": True,
+        "selected_run_status": "RUNNING",
+        "delivery": "RUNNING_STEER_PENDING_CHECKPOINT",
+    }]
     assert secret not in json.dumps(report)
 
     def malformed_denial(scenario):
@@ -150,6 +160,18 @@ def test_fake_transport_qualifies_all_scenarios_without_leaking_transport_data()
     assert failed["qualified"] is False
     assert invalid["task_completed"] is False
     assert invalid["invalid_tool_calls"]["structured"] == 1
+
+    def queued_guidance(scenario):
+        observation = _fake_observation(scenario["id"], secret)
+        if scenario["id"] == "two_provider_retained_workflow":
+            guidance = observation["events"][1]
+            guidance.update(selected_run_status="PENDING", delivery="NEXT_RUN")
+        return observation
+
+    failed = run_suite(fixture, queued_guidance, common)
+    workflow = next(item for item in failed["receipts"] if item["scenario_id"] == "two_provider_retained_workflow")
+    assert failed["qualified"] is False
+    assert workflow["task_completed"] is False
 
 
 def test_timeout_and_controller_failures_are_sanitized(monkeypatch, capsys):
@@ -174,8 +196,11 @@ def test_timeout_and_controller_failures_are_sanitized(monkeypatch, capsys):
     assert secret not in output
 
 
-def test_running_guidance_releases_only_after_an_accepted_message():
-    runs = [{"run_id": "run-1", "status": "RUNNING"}]
+def test_running_guidance_requires_selected_running_delivery():
+    runs = [
+        {"run_id": "run-1", "status": "RUNNING"},
+        {"run_id": "run-2", "status": "PENDING"},
+    ]
 
     class Store:
         def list_runs(self, worker_id, owner):
@@ -183,9 +208,14 @@ def test_running_guidance_releases_only_after_an_accepted_message():
             return list(runs)
 
     responses = [
-        {"error": "denied", "orchestration_interface": {"effective_action": "message"}},
-        {"success": True, "orchestration_interface": {"effective_action": "resume"}},
-        {"success": True, "orchestration_interface": {"effective_action": "message"}},
+        {
+            "success": True, "delivery": "NEXT_RUN",
+            "orchestration_interface": {"effective_action": "message"},
+        },
+        {
+            "success": True, "delivery": "RUNNING_STEER_PENDING_CHECKPOINT",
+            "orchestration_interface": {"effective_action": "message"},
+        },
     ]
     parent = SimpleNamespace(
         _dispatch_worker_interface=lambda _name, _args: json.dumps(responses.pop(0))
@@ -196,10 +226,16 @@ def test_running_guidance_releases_only_after_an_accepted_message():
     )
     try:
         parent._dispatch_worker_interface("send_message", {"target": "worker-1"})
-        parent._dispatch_worker_interface("followup_task", {"target": "worker-1"})
         assert released == []
-        parent._dispatch_worker_interface("send_message", {"target": "worker-1"})
+        parent._dispatch_worker_interface(
+            "send_message", {"target": "worker-1", "run_id": "run-1"}
+        )
         assert released == [True]
-        assert [event["accepted"] for event in events] == [False, True, True]
+        assert [event["selected_run_status"] for event in events] == ["PENDING", "RUNNING"]
+        assert [event["delivery"] for event in events] == [
+            "NEXT_RUN", "RUNNING_STEER_PENDING_CHECKPOINT",
+        ]
+        assert runner._is_running_guidance(events[0]) is False
+        assert runner._is_running_guidance(events[1]) is True
     finally:
         restore()

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -525,6 +525,11 @@ def test_public_nested_launch_uses_shared_tree_admission_and_lineage(tmp_path, m
     store = WorkerStore(db)
     store.ensure_schema()
     root_worker = store.create_worker("tree-public", worker_id="tree-public-root")
+    root_run = store.enqueue_run(
+        root_worker["worker_id"], "tree-public", goal="root",
+        budget_limits={"max_iterations": 5, "max_tool_calls": None, "timeout_seconds": None},
+    )
+    root_run = store.claim_next_run(root_worker["worker_id"], "tree-public")
     parent = SimpleNamespace(
         session_id="child-session",
         _worker_owner_session_id="tree-public",
@@ -534,6 +539,13 @@ def test_public_nested_launch_uses_shared_tree_admission_and_lineage(tmp_path, m
         enabled_toolsets=["file"],
         valid_tool_names={"read_file", "delegate_task"},
         _session_db=db,
+    )
+    from agent.subagent_lifecycle import _Record
+    parent._worker_lifecycle_record = _Record(
+        None, SubagentState.RUNNING, time.time(), store=store,
+        owner_session_id="tree-public", worker_id=root_worker["worker_id"],
+        run_id=root_run["run_id"], lease_token=root_run["lease_token"],
+        budget_epoch_id=root_run["budget_epoch_id"],
     )
     cfg = {
         "max_concurrent_children": 2,

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -1,5 +1,6 @@
 """Contract tests for the public plugin subagent lifecycle API."""
 
+import dataclasses
 import threading
 import time
 from types import SimpleNamespace
@@ -87,6 +88,11 @@ def test_cancel_is_cooperative_and_forged_handle_is_unknown(lifecycle):
     other_parent = SimpleNamespace(session_id="different-parent")
     other_service = SubagentLifecycleService(lambda: other_parent)
     assert other_service.status(handle).state is SubagentState.UNKNOWN
+
+
+def test_public_launch_rejects_unenforced_filesystem_guarantee(lifecycle):
+    with pytest.raises(SubagentLifecycleError, match="working_directory is not supported"):
+        lifecycle.launch(SubagentLaunchRequest(goal="x", working_directory="/tmp/promised-sandbox"))
 
 
 def test_cancel_uses_explicit_hard_interrupt(lifecycle):
@@ -226,6 +232,8 @@ def test_durable_active_followup_runs_fifo_with_frozen_prompt_and_history(tmp_pa
         child.valid_tool_names = {"read_file"}
         child.tools = [{"type": "function", "function": {"name": "read_file"}}]
         child._worker_route_receipt = dict(kwargs.get("profile_route_receipt") or {})
+        child.steered = []
+        child.steer = lambda text: child.steered.append(text) or True
         child.close = lambda: None
         built.append((child, kwargs))
         return child
@@ -258,21 +266,42 @@ def test_durable_active_followup_runs_fifo_with_frozen_prompt_and_history(tmp_pa
     assert first_started.wait(1)
     record = service._record(first)
     assert record is not None
+    assert record.completion_owner == "service"
+    SubagentLifecycleService.complete_adopted_child(
+        record.agent,
+        {"status": "completed", "summary": "inner completion must not publish"},
+    )
+    store_run = WorkerStore(db).get_run(first.run_id, parent.session_id)
+    assert store_run["status"] == "RUNNING"
+    assert record.result is None
+    live = service.control(
+        "message", worker_id=first.worker_id, message="steer the active run")
+    assert live["delivery"] == "RUNNING_STEER_PENDING_CHECKPOINT"
     from agent.subagent_lifecycle import (
         before_worker_tool,
         checkpoint_worker_tool_result,
         worker_tool_calls_remaining,
     )
-    for remaining in (2, 1, 0):
-        before_worker_tool(record.agent)
-        checkpoint_worker_tool_result(record.agent, [], settled=True)
+    for index, remaining in enumerate((2, 1, 0)):
+        call_id = f"tool-{index}"
+        before_worker_tool(record.agent, call_id)
+        checkpoint_worker_tool_result(
+            record.agent, [], tool_call_id=call_id, settled=True)
         assert worker_tool_calls_remaining(record.agent) == remaining
     with pytest.raises(SubagentLifecycleError, match="tool-call limit"):
-        before_worker_tool(record.agent)
+        before_worker_tool(record.agent, "tool-over-limit")
+    assert record.agent.steered == ["steer the active run"]
+    live_message = next(
+        item for item in WorkerStore(db).list_messages(first.worker_id, parent.session_id)
+        if item["message_id"] == live["message_id"]
+    )
+    assert live_message["status"] == "DELIVERED"
     service.message(first, "queued message")
     followup = service.resume(first, "second turn")
     assert followup.worker_id == first.worker_id
     assert followup.run_id != first.run_id
+    substituted = dataclasses.replace(first, run_id=followup.run_id)
+    assert service.reconnect(substituted).connected is False
     assert service.status(followup).state is SubagentState.PENDING
     release_first.set()
     assert service.wait(followup, timeout_seconds=2).state is SubagentState.SUCCEEDED
@@ -315,8 +344,6 @@ def test_nested_actor_authority_sibling_policy_and_recursive_cancel(tmp_path, mo
     sibling = store.create_worker("tree-owner", parent_worker_id=root["worker_id"], worker_id="worker-sibling")
     grandchild = store.create_worker(
         "tree-owner", parent_worker_id=child["worker_id"], worker_id="worker-grandchild")
-    store.enqueue_run(child["worker_id"], "tree-owner", goal="queued child")
-    store.enqueue_run(grandchild["worker_id"], "tree-owner", goal="queued grandchild")
     cfg = {"allow_sibling_messaging": False}
     monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
     actor = SimpleNamespace(
@@ -335,8 +362,299 @@ def test_nested_actor_authority_sibling_policy_and_recursive_cancel(tmp_path, mo
     cfg["allow_sibling_messaging"] = True
     assert service.control(
         "message", worker_id=sibling["worker_id"], message="allowed sibling")["status"] == "PENDING"
+    store.enqueue_run(child["worker_id"], "tree-owner", goal="queued child")
+    store.enqueue_run(grandchild["worker_id"], "tree-owner", goal="queued grandchild")
     cancelled = service.control("cancel", worker_id=child["worker_id"])
     assert set(cancelled["workers_targeted"]) == {child["worker_id"], grandchild["worker_id"]}
     assert cancelled["queued_runs_cancelled"] == 2
     assert store.get_run(store.list_runs(child["worker_id"], "tree-owner")[0]["run_id"], "tree-owner")["status"] == "CANCELLED"
+    db.close()
+
+
+def test_failure_publication_preserves_newer_tool_checkpoint(tmp_path):
+    from agent.subagent_lifecycle import (
+        before_worker_tool,
+        checkpoint_worker_tool_result,
+    )
+
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(session_id="checkpoint-owner", _session_db=db)
+    child = FakeChild("checkpoint-child")
+    child.session_id = "checkpoint-child-session"
+    child.valid_tool_names = {"read_file"}
+    child.tools = [{"type": "function", "function": {"name": "read_file"}}]
+    child.ephemeral_system_prompt = "frozen"
+    child._worker_route_receipt = {}
+    service = SubagentLifecycleService(lambda: parent)
+    handle = service.adopt_delegate_child(
+        child, goal="checkpoint", context=None, profile=None, creds={}, cfg={})
+    record = service._record(handle)
+    history = [
+        {"role": "user", "content": "checkpoint"},
+        {"role": "assistant", "content": "calling tool"},
+        {"role": "tool", "tool_call_id": "read-1", "content": "durable result"},
+    ]
+    before_worker_tool(child, "read-1")
+    checkpoint_worker_tool_result(
+        child, history, tool_call_id="read-1", settled=True)
+    child._worker_last_history = []
+
+    service.complete_adopted_child(
+        child,
+        {
+            "status": "error",
+            "error": "later model failure",
+            "summary": None,
+            "api_calls": 1,
+            "duration_seconds": 0.01,
+        },
+    )
+
+    assert record.result.terminal_state is SubagentState.FAILED
+    assert WorkerStore(db).get_worker(handle.worker_id, parent.session_id)["history"] == history
+    db.close()
+
+
+def test_cold_pending_run_rehydrates_fifo_and_revalidates_authority(tmp_path, monkeypatch):
+    from agent.delegation_model_routing import ExecutionLimits, ToolPolicy, WorkspaceContextPolicy
+    from agent import subagent_lifecycle as lifecycle_module
+
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(
+        session_id="cold-owner", enabled_toolsets=["file"],
+        valid_tool_names={"read_file"}, _session_db=db)
+    cfg = {
+        "max_concurrent_children": 2,
+        "profiles": {"cold": {
+            "instructions": "frozen contract",
+            "provider": "fixture",
+            "model": "cold-model",
+            "tool_policy": {"allowed_toolsets": ["file"]},
+        }},
+    }
+    monkeypatch.setattr("tools.delegate_tool._load_config", lambda: cfg)
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+
+    def credentials(*_args, **_kwargs):
+        return {
+            "provider": "fixture", "model": "cold-model", "base_url": None,
+            "api_key": None, "api_mode": "chat_completions", "request_overrides": {},
+            "command": None, "args": [], "requested_profile": "cold",
+            "requested_provider": None, "requested_model": None,
+            "requested_reasoning_effort": None, "resolved_provider": "fixture",
+            "resolved_model": "cold-model", "resolved_reasoning_effort": None,
+            "route_provenance": "delegation.profiles.cold", "normalization_events": [],
+            "transmitted_model": None, "provider_reported_model": None,
+            "fallback_model": [], "reasoning_config": None, "max_iterations": 8,
+            "supports_tools": True, "tool_policy": ToolPolicy(allowed_toolsets=("file",)),
+            "workspace_context": WorkspaceContextPolicy(mode="none"),
+            "execution_limits": ExecutionLimits(max_followups=3),
+            "profile_instructions": cfg["profiles"]["cold"]["instructions"],
+        }
+
+    monkeypatch.setattr("tools.delegate_tool_config._resolve_delegation_credentials", credentials)
+    built = []
+
+    def build(**kwargs):
+        child = FakeChild(f"cold-child-{len(built)}")
+        child.session_id = f"cold-session-{len(built)}"
+        child.ephemeral_system_prompt = kwargs.get("frozen_system_prompt") or "frozen prompt"
+        child.valid_tool_names = set(parent.valid_tool_names)
+        child.tools = [
+            {"type": "function", "function": {"name": name}}
+            for name in sorted(child.valid_tool_names)
+        ]
+        child._worker_route_receipt = {}
+        child.close = lambda: None
+        built.append(child)
+        return child
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_preserving_parent_tools", build)
+    goals = []
+
+    def run(_index, goal, child, _parent):
+        goals.append(goal)
+        child._worker_last_history = [
+            {"role": "user", "content": goal},
+            {"role": "assistant", "content": "done"},
+        ]
+        return {
+            "status": "completed", "summary": "done", "exit_reason": "completed",
+            "api_calls": 1, "duration_seconds": 0.01, "cost_status": "unknown",
+        }
+
+    monkeypatch.setattr("tools.delegate_tool._run_child_lifecycle", run)
+    service = SubagentLifecycleService(lambda: parent)
+    first = service.launch(SubagentLaunchRequest(goal="first", profile="cold"))
+    assert service.wait(first, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    store = WorkerStore(db)
+    second = store.enqueue_run(
+        first.worker_id, parent.session_id, goal="cold queued second",
+        previous_run_id=first.run_id, capability_digest="owner-control-only")
+    with lifecycle_module._REGISTRY.lock:
+        lifecycle_module._REGISTRY.records.pop(first.subagent_id, None)
+
+    waited = service.control(
+        "wait", worker_id=first.worker_id, run_id=second["run_id"], timeout_seconds=2)
+    assert waited["status"] == "SUCCEEDED"
+    assert goals == ["first", "cold queued second"]
+    assert [item["run_id"] for item in store.list_runs(first.worker_id, parent.session_id)] == [
+        first.run_id, second["run_id"]]
+
+    third = store.enqueue_run(
+        first.worker_id, parent.session_id, goal="must revalidate",
+        previous_run_id=second["run_id"])
+    parent.valid_tool_names = set()
+    with lifecycle_module._REGISTRY.lock:
+        for key, value in list(lifecycle_module._REGISTRY.records.items()):
+            if value.worker_id == first.worker_id:
+                lifecycle_module._REGISTRY.records.pop(key, None)
+    rejected = service.control(
+        "wait", worker_id=first.worker_id, run_id=third["run_id"], timeout_seconds=2)
+    assert rejected["status"] == "FAILED"
+    failed = store.get_run(third["run_id"], parent.session_id)
+    assert failed["result"]["error_classification"] == "AUTHORITY_REVALIDATION_FAILED"
+    assert goals == ["first", "cold queued second"]
+    db.close()
+
+
+def test_public_nested_launch_uses_shared_tree_admission_and_lineage(tmp_path, monkeypatch):
+    from agent.delegation_model_routing import ExecutionLimits, ToolPolicy, WorkspaceContextPolicy
+
+    db = SessionDB(tmp_path / "state.db")
+    store = WorkerStore(db)
+    store.ensure_schema()
+    root_worker = store.create_worker("tree-public", worker_id="tree-public-root")
+    parent = SimpleNamespace(
+        session_id="child-session",
+        _worker_owner_session_id="tree-public",
+        _worker_id=root_worker["worker_id"],
+        _delegate_depth=1,
+        _delegate_spawn_allowed=True,
+        enabled_toolsets=["file"],
+        valid_tool_names={"read_file", "delegate_task"},
+        _session_db=db,
+    )
+    cfg = {
+        "max_concurrent_children": 2,
+        "max_spawn_depth": 3,
+        "profiles": {"nested": {"provider": "fixture", "model": "nested-model"}},
+    }
+    monkeypatch.setattr("tools.delegate_tool._load_config", lambda: cfg)
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "tools.delegate_tool_config._resolve_delegation_credentials",
+        lambda *_args, **_kwargs: {
+            "provider": "fixture", "model": "nested-model", "base_url": None,
+            "api_key": None, "api_mode": "chat_completions", "request_overrides": {},
+            "command": None, "args": [], "requested_profile": "nested",
+            "requested_provider": None, "requested_model": None,
+            "requested_reasoning_effort": None, "resolved_provider": "fixture",
+            "resolved_model": "nested-model", "resolved_reasoning_effort": None,
+            "route_provenance": "delegation.profiles.nested", "normalization_events": [],
+            "transmitted_model": None, "provider_reported_model": None,
+            "fallback_model": [], "reasoning_config": None, "max_iterations": 5,
+            "supports_tools": True, "tool_policy": ToolPolicy(),
+            "workspace_context": WorkspaceContextPolicy(mode="none"),
+            "execution_limits": ExecutionLimits(max_spawn_depth=1),
+            "profile_instructions": "",
+        },
+    )
+
+    def build(**_kwargs):
+        child = FakeChild("nested-child")
+        child.session_id = "nested-child-session"
+        child.ephemeral_system_prompt = "frozen nested"
+        child.valid_tool_names = {"read_file", "delegate_task"}
+        child.tools = [
+            {"type": "function", "function": {"name": "read_file"}},
+            {"type": "function", "function": {"name": "delegate_task"}},
+        ]
+        child._worker_route_receipt = {}
+        child.close = lambda: None
+        return child
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_preserving_parent_tools", build)
+    monkeypatch.setattr(
+        "tools.delegate_tool._run_child_lifecycle",
+        lambda *_args, **_kwargs: {
+            "status": "completed", "summary": "nested done", "exit_reason": "completed",
+            "api_calls": 1, "duration_seconds": 0.01, "cost_status": "unknown",
+        },
+    )
+    service = SubagentLifecycleService(lambda: parent)
+    handle = service.launch(SubagentLaunchRequest(goal="nested", profile="nested"))
+    assert service.wait(handle, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    durable = store.get_worker(handle.worker_id, "tree-public")
+    assert durable["parent_worker_id"] == root_worker["worker_id"]
+    assert durable["root_worker_id"] == root_worker["worker_id"]
+    assert durable["depth"] == 2
+
+    parent._delegate_spawn_allowed = False
+    with pytest.raises(SubagentLifecycleError, match="does not permit spawning"):
+        service.launch(SubagentLaunchRequest(goal="forbidden", profile="nested"))
+    db.close()
+
+
+def test_dynamic_retained_route_revalidates_original_request_and_revocation(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(
+        session_id="dynamic-owner", enabled_toolsets=[], valid_tool_names=set(),
+        model="parent", provider="fixture", base_url=None, request_overrides={},
+        api_key=None, _session_db=db,
+    )
+    cfg = {
+        "routing_mode": "dynamic",
+        "max_concurrent_children": 1,
+        "profiles": {"dynamic": {
+            "provider": "fixture", "model": "model-a",
+            "enabled_routes": [{"provider": "fixture", "model": "model-b"}],
+            "execution_limits": {"max_followups": 2},
+        }},
+    }
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None, target_model=None, **_kwargs: {
+            "provider": requested, "model": target_model, "api_key": None,
+            "base_url": None, "api_mode": "chat_completions",
+        },
+    )
+    built = []
+
+    def build(**kwargs):
+        child = FakeChild(f"dynamic-{len(built)}")
+        child.session_id = f"dynamic-session-{len(built)}"
+        child.provider = kwargs.get("override_provider")
+        child.model = kwargs.get("model")
+        child.ephemeral_system_prompt = kwargs.get("frozen_system_prompt") or "frozen"
+        child.valid_tool_names = set()
+        child.tools = []
+        child._worker_route_receipt = dict(kwargs.get("profile_route_receipt") or {})
+        child.close = lambda: None
+        built.append(child)
+        return child
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_preserving_parent_tools", build)
+    monkeypatch.setattr(
+        "tools.delegate_tool._run_child_lifecycle",
+        lambda *_args, **_kwargs: {
+            "status": "completed", "summary": "done", "exit_reason": "completed",
+            "api_calls": 1, "duration_seconds": 0.01, "cost_status": "unknown",
+        },
+    )
+    service = SubagentLifecycleService(lambda: parent)
+    first = service.launch(SubagentLaunchRequest(
+        goal="first", profile="dynamic", model="model-b"))
+    assert service.wait(first, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    assert first.model == "model-b"
+
+    second = service.resume(first, "second")
+    assert service.wait(second, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    assert second.model == "model-b"
+
+    cfg["profiles"]["dynamic"]["enabled_routes"] = []
+    with pytest.raises(ValueError, match="not enabled"):
+        service.resume(second, "route was revoked")
+    assert len(WorkerStore(db).list_runs(first.worker_id, parent.session_id)) == 2
     db.close()

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -1,5 +1,6 @@
 """Contract tests for the public plugin subagent lifecycle API."""
 
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -14,6 +15,8 @@ from agent.subagent_lifecycle import (
     bind_subagent_parent,
     get_active_subagent_parent,
 )
+from agent.worker_store import WorkerStore
+from hermes_state import SessionDB
 
 
 class FakeChild:
@@ -178,3 +181,162 @@ def test_agent_turn_binds_and_clears_lifecycle_parent(monkeypatch):
     assert agent.run_conversation("hello") == {"final_response": "ok"}
     assert observed == [agent]
     assert get_active_subagent_parent() is None
+
+
+def test_durable_active_followup_runs_fifo_with_frozen_prompt_and_history(tmp_path, monkeypatch):
+    from agent.delegation_model_routing import ExecutionLimits, ToolPolicy, WorkspaceContextPolicy
+    from agent import subagent_lifecycle as lifecycle_module
+
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(session_id="owner-durable", enabled_toolsets=["file"], _session_db=db)
+    cfg = {
+        "max_iterations": 20,
+        "max_concurrent_children": 2,
+        "profiles": {"review": {
+            "provider": "fixture",
+            "model": "review-model",
+            "execution_limits": {"max_followups": 2, "max_tool_calls": 3},
+        }},
+    }
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+
+    def credentials(*_args, **_kwargs):
+        return {
+            "provider": "fixture", "model": "review-model", "base_url": None,
+            "api_key": None, "api_mode": "chat_completions", "request_overrides": {},
+            "command": None, "args": [], "requested_profile": "review",
+            "requested_provider": None, "requested_model": None, "requested_reasoning_effort": None,
+            "resolved_provider": "fixture", "resolved_model": "review-model",
+            "resolved_reasoning_effort": None, "route_provenance": "delegation.profiles.review",
+            "normalization_events": [], "transmitted_model": None, "provider_reported_model": None,
+            "fallback_model": [], "reasoning_config": None, "max_iterations": 12,
+            "supports_tools": True, "tool_policy": ToolPolicy(allowed_toolsets=("file",)),
+            "workspace_context": WorkspaceContextPolicy(mode="none"),
+            "execution_limits": ExecutionLimits(max_followups=2, max_tool_calls=3),
+            "profile_instructions": "",
+        }
+
+    monkeypatch.setattr("tools.delegate_tool_config._resolve_delegation_credentials", credentials)
+    built = []
+
+    def build(**kwargs):
+        child = FakeChild(f"sa-durable-{len(built)}")
+        child.session_id = f"child-{len(built)}"
+        child.ephemeral_system_prompt = kwargs.get("frozen_system_prompt") or "frozen-root-prompt"
+        child.valid_tool_names = {"read_file"}
+        child.tools = [{"type": "function", "function": {"name": "read_file"}}]
+        child._worker_route_receipt = dict(kwargs.get("profile_route_receipt") or {})
+        child.close = lambda: None
+        built.append((child, kwargs))
+        return child
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_preserving_parent_tools", build)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    goals = []
+
+    def run(_index, goal, child, _parent):
+        goals.append((goal, list(getattr(child, "_worker_resume_history", None) or [])))
+        if len(goals) == 1:
+            first_started.set()
+            assert release_first.wait(2)
+        history = list(getattr(child, "_worker_resume_history", None) or [])
+        history.extend([
+            {"role": "user", "content": goal},
+            {"role": "assistant", "content": f"done-{len(goals)}"},
+        ])
+        child._worker_last_history = history
+        return {
+            "status": "completed", "summary": history[-1]["content"], "exit_reason": "completed",
+            "api_calls": 1, "duration_seconds": 0.01, "tokens": {"input": 1, "output": 1},
+            "cost_status": "unknown", "cost_usd": 0.0,
+        }
+
+    monkeypatch.setattr("tools.delegate_tool._run_child_lifecycle", run)
+    service = SubagentLifecycleService(lambda: parent)
+    first = service.launch(SubagentLaunchRequest(goal="first turn", profile="review"))
+    assert first_started.wait(1)
+    record = service._record(first)
+    assert record is not None
+    from agent.subagent_lifecycle import (
+        before_worker_tool,
+        checkpoint_worker_tool_result,
+        worker_tool_calls_remaining,
+    )
+    for remaining in (2, 1, 0):
+        before_worker_tool(record.agent)
+        checkpoint_worker_tool_result(record.agent, [], settled=True)
+        assert worker_tool_calls_remaining(record.agent) == remaining
+    with pytest.raises(SubagentLifecycleError, match="tool-call limit"):
+        before_worker_tool(record.agent)
+    service.message(first, "queued message")
+    followup = service.resume(first, "second turn")
+    assert followup.worker_id == first.worker_id
+    assert followup.run_id != first.run_id
+    assert service.status(followup).state is SubagentState.PENDING
+    release_first.set()
+    assert service.wait(followup, timeout_seconds=2).state is SubagentState.SUCCEEDED
+
+    store = WorkerStore(db)
+    runs = store.list_runs(first.worker_id, parent.session_id)
+    assert [item["status"] for item in runs] == ["SUCCEEDED", "SUCCEEDED"]
+    assert runs[1]["previous_run_id"] == runs[0]["run_id"]
+    assert built[1][1]["frozen_system_prompt"] == "frozen-root-prompt"
+    assert goals[1][1][-1] == {"role": "assistant", "content": "done-1"}
+    assert "queued message" in goals[1][0]
+    assert store.list_messages(first.worker_id, parent.session_id)[0]["status"] == "DELIVERED"
+
+    with lifecycle_module._REGISTRY.lock:
+        lifecycle_module._REGISTRY.records.pop(followup.subagent_id, None)
+    assert service.reconnect(followup).connected is True
+    restarted = service.resume(followup, "third turn")
+    assert restarted.worker_id == first.worker_id and restarted.run_id != followup.run_id
+    assert service.wait(restarted, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    assert goals[2][1][-1] == {"role": "assistant", "content": "done-2"}
+    inspected = service.control("inspect", worker_id=first.worker_id, run_id=restarted.run_id)
+    assert inspected["run"]["result"]["route"]["resolved_model"] == "review-model"
+    assert inspected["run"]["result"]["lineage"]["worker_id"] == first.worker_id
+    assert inspected["run"]["result"]["cost"]["status"] == "unknown"
+    assert service.control(
+        "ack", worker_id=first.worker_id, run_id=restarted.run_id)["acknowledged"] is True
+    with pytest.raises(SubagentLifecycleError, match="followup limit"):
+        service.resume(restarted, "fourth turn")
+    forged = followup.__class__(**{**followup.to_dict(), "capability": "forged"})
+    assert service.reconnect(forged).connected is False
+    db.close()
+
+
+def test_nested_actor_authority_sibling_policy_and_recursive_cancel(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    store = WorkerStore(db)
+    store.ensure_schema()
+    root = store.create_worker("tree-owner", worker_id="worker-root")
+    child = store.create_worker("tree-owner", parent_worker_id=root["worker_id"], worker_id="worker-child")
+    sibling = store.create_worker("tree-owner", parent_worker_id=root["worker_id"], worker_id="worker-sibling")
+    grandchild = store.create_worker(
+        "tree-owner", parent_worker_id=child["worker_id"], worker_id="worker-grandchild")
+    store.enqueue_run(child["worker_id"], "tree-owner", goal="queued child")
+    store.enqueue_run(grandchild["worker_id"], "tree-owner", goal="queued grandchild")
+    cfg = {"allow_sibling_messaging": False}
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+    actor = SimpleNamespace(
+        session_id="actor-session",
+        _worker_owner_session_id="tree-owner",
+        _worker_id=child["worker_id"],
+        _session_db=db,
+    )
+    service = SubagentLifecycleService(lambda: actor)
+    assert service.control("status", worker_id=grandchild["worker_id"])["worker_id"] == grandchild["worker_id"]
+    service.control("message", worker_id=root["worker_id"], message="child to parent")
+    with pytest.raises(PermissionError):
+        service.control("status", worker_id=sibling["worker_id"])
+    with pytest.raises(PermissionError):
+        service.control("message", worker_id=sibling["worker_id"], message="blocked sibling")
+    cfg["allow_sibling_messaging"] = True
+    assert service.control(
+        "message", worker_id=sibling["worker_id"], message="allowed sibling")["status"] == "PENDING"
+    cancelled = service.control("cancel", worker_id=child["worker_id"])
+    assert set(cancelled["workers_targeted"]) == {child["worker_id"], grandchild["worker_id"]}
+    assert cancelled["queued_runs_cancelled"] == 2
+    assert store.get_run(store.list_runs(child["worker_id"], "tree-owner")[0]["run_id"], "tree-owner")["status"] == "CANCELLED"
+    db.close()

--- a/tests/agent/test_worker_admission_v2.py
+++ b/tests/agent/test_worker_admission_v2.py
@@ -90,6 +90,7 @@ def _install_runtime(monkeypatch, parent, *, run=None, credential_error=None):
 
     def build(**kwargs):
         child = Child(f"child-{len(built)}", parent.valid_tool_names)
+        child._requested_worker_interface_contract = kwargs.get("worker_interface_contract")
         child._delegate_depth = kwargs.get("retained_child_depth") or 1
         child.ephemeral_system_prompt = kwargs.get("frozen_system_prompt") or child.ephemeral_system_prompt
         built.append(child)
@@ -128,7 +129,7 @@ def test_public_resume_rehydrates_exact_cold_fifo_before_new_turn(tmp_path, monk
         child._worker_last_history = history
         return {"status": "completed", "summary": f"done:{goal}", "api_calls": 1}
 
-    _install_runtime(monkeypatch, parent, run=run)
+    _cfg, built = _install_runtime(monkeypatch, parent, run=run)
     service = SubagentLifecycleService(lambda: parent)
     first = service.launch(SubagentLaunchRequest(goal="first", profile="cold"))
     assert service.wait(first, timeout_seconds=2).state is SubagentState.SUCCEEDED
@@ -155,6 +156,11 @@ def test_public_resume_rehydrates_exact_cold_fifo_before_new_turn(tmp_path, monk
     runs = store.list_runs(first.worker_id, parent.session_id)
     assert [item["run_id"] for item in runs] == [first.run_id, second.run_id, third.run_id]
     assert [item["status"] for item in runs] == ["SUCCEEDED", "SUCCEEDED", "SUCCEEDED"]
+    assert built[0]._requested_worker_interface_contract is None
+    assert all(
+        child._requested_worker_interface_contract["name"] == "hermes"
+        for child in built[1:]
+    )
     db.close()
 
 

--- a/tests/agent/test_worker_admission_v2.py
+++ b/tests/agent/test_worker_admission_v2.py
@@ -1,0 +1,313 @@
+"""Acceptance regressions for catalog authority and just-in-time worker admission."""
+
+import dataclasses
+import hashlib
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.delegation_model_routing import ExecutionLimits, ToolPolicy, WorkspaceContextPolicy
+from agent.subagent_lifecycle import (
+    SubagentHandle,
+    SubagentLaunchRequest,
+    SubagentLifecycleError,
+    SubagentLifecycleService,
+    SubagentState,
+    before_worker_tool,
+    checkpoint_worker_tool_result,
+)
+from agent.worker_store import WorkerStore
+from hermes_state import SessionDB
+
+
+class Child:
+    def __init__(self, ident, tools):
+        self._subagent_id = ident
+        self._delegate_role = "leaf"
+        self._delegate_depth = 1
+        self.provider = "fixture"
+        self.model = "fixture-model"
+        self.ephemeral_system_prompt = "frozen worker prompt"
+        self.valid_tool_names = set(tools)
+        self._executable_tool_names = set(tools)
+        self.tools = [
+            {"type": "function", "function": {"name": name, "parameters": {"type": "object"}}}
+            for name in sorted(tools)
+        ]
+        self._worker_route_receipt = {}
+        self.interrupted = False
+
+    def close(self):
+        return None
+
+    def hard_interrupt(self, _reason, *, tool_reason=None):
+        self.interrupted = True
+        self.tool_reason = tool_reason
+        return True
+
+
+def _credentials(profile="cold"):
+    return {
+        "provider": "fixture", "model": "fixture-model", "base_url": None,
+        "api_key": None, "api_mode": "chat_completions", "request_overrides": {},
+        "command": None, "args": [], "requested_profile": profile,
+        "requested_provider": None, "requested_model": None,
+        "requested_reasoning_effort": None, "resolved_provider": "fixture",
+        "resolved_model": "fixture-model", "resolved_reasoning_effort": None,
+        "route_provenance": f"delegation.profiles.{profile}", "normalization_events": [],
+        "transmitted_model": None, "provider_reported_model": None,
+        "fallback_model": [], "reasoning_config": None, "max_iterations": 4,
+        "supports_tools": True, "tool_policy": ToolPolicy(allowed_toolsets=("file",)),
+        "workspace_context": WorkspaceContextPolicy(mode="none"),
+        "execution_limits": ExecutionLimits(max_followups=8, max_tool_calls=2),
+        "profile_instructions": "stable contract",
+    }
+
+
+def _install_runtime(monkeypatch, parent, *, run=None, credential_error=None):
+    cfg = {
+        "max_concurrent_children": 2,
+        "max_iterations": 8,
+        "profiles": {"cold": {
+            "instructions": "stable contract", "provider": "fixture",
+            "model": "fixture-model", "tool_policy": {"allowed_toolsets": ["file"]},
+            "execution_limits": {"max_followups": 8, "max_tool_calls": 2},
+        }},
+    }
+    monkeypatch.setattr("tools.delegate_tool._load_config", lambda: cfg)
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+
+    def resolve(*_args, **_kwargs):
+        if credential_error:
+            raise RuntimeError(credential_error)
+        return _credentials()
+
+    monkeypatch.setattr("tools.delegate_tool_config._resolve_delegation_credentials", resolve)
+    built = []
+
+    def build(**kwargs):
+        child = Child(f"child-{len(built)}", parent.valid_tool_names)
+        child._delegate_depth = kwargs.get("retained_child_depth") or 1
+        child.ephemeral_system_prompt = kwargs.get("frozen_system_prompt") or child.ephemeral_system_prompt
+        built.append(child)
+        return child
+
+    monkeypatch.setattr("tools.delegate_tool._build_child_preserving_parent_tools", build)
+    if run is not None:
+        monkeypatch.setattr("tools.delegate_tool._run_child_lifecycle", run)
+    return cfg, built
+
+
+def _clear_worker_records(worker_id):
+    from agent import subagent_lifecycle as module
+
+    with module._REGISTRY.lock:
+        for key, value in list(module._REGISTRY.records.items()):
+            if value.worker_id == worker_id:
+                module._REGISTRY.records.pop(key, None)
+
+
+def test_public_resume_rehydrates_exact_cold_fifo_before_new_turn(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(
+        session_id="cold-owner", enabled_toolsets=["file"],
+        valid_tool_names={"read_file"}, _session_db=db,
+    )
+    ran = []
+
+    def run(_index, goal, child, _parent):
+        ran.append(goal)
+        history = list(getattr(child, "_worker_resume_history", []) or [])
+        history.extend([
+            {"role": "user", "content": goal},
+            {"role": "assistant", "content": f"done:{goal}"},
+        ])
+        child._worker_last_history = history
+        return {"status": "completed", "summary": f"done:{goal}", "api_calls": 1}
+
+    _install_runtime(monkeypatch, parent, run=run)
+    service = SubagentLifecycleService(lambda: parent)
+    first = service.launch(SubagentLaunchRequest(goal="first", profile="cold"))
+    assert service.wait(first, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    store = WorkerStore(db)
+    _clear_worker_records(first.worker_id)
+
+    created = time.time()
+    subagent_id = "cold-pending-handle"
+    capability = service._capability(subagent_id, parent.session_id, created)
+    second_run = store.enqueue_run(
+        first.worker_id, parent.session_id, goal="second",
+        previous_run_id=first.run_id,
+        capability_digest=hashlib.sha256(capability.encode()).hexdigest(),
+    )
+    second = dataclasses.replace(
+        first, subagent_id=subagent_id, created_at=created,
+        capability=capability, run_id=second_run["run_id"],
+    )
+
+    third = service.resume(second, "third")
+    assert third.run_id != second.run_id
+    assert service.wait(third, timeout_seconds=2).state is SubagentState.SUCCEEDED
+    assert ran == ["first", "second", "third"]
+    runs = store.list_runs(first.worker_id, parent.session_id)
+    assert [item["run_id"] for item in runs] == [first.run_id, second.run_id, third.run_id]
+    assert [item["status"] for item in runs] == ["SUCCEEDED", "SUCCEEDED", "SUCCEEDED"]
+    db.close()
+
+
+@pytest.mark.parametrize("revocation", ["credential", "tool", "profile"])
+def test_warm_queued_run_revalidates_current_authority_before_launch(
+    tmp_path, monkeypatch, revocation,
+):
+    db = SessionDB(tmp_path / f"{revocation}.db")
+    parent = SimpleNamespace(
+        session_id=f"warm-{revocation}", enabled_toolsets=["file"],
+        valid_tool_names={"read_file"}, _session_db=db,
+    )
+    first_started = threading.Event()
+    release_first = threading.Event()
+    ran = []
+
+    def run(_index, goal, child, _parent):
+        ran.append(goal)
+        if goal == "first":
+            first_started.set()
+            assert release_first.wait(3)
+        child._worker_last_history = [{"role": "assistant", "content": goal}]
+        return {"status": "completed", "summary": goal, "api_calls": 1}
+
+    cfg, _built = _install_runtime(monkeypatch, parent, run=run)
+    service = SubagentLifecycleService(lambda: parent)
+    first = service.launch(SubagentLaunchRequest(goal="first", profile="cold"))
+    assert first_started.wait(1)
+    queued = service.resume(first, "queued")
+    record = service._record(queued)
+    assert record is not None and record.future is None and record.agent is None
+
+    if revocation == "credential":
+        monkeypatch.setattr(
+            "tools.delegate_tool_config._resolve_delegation_credentials",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("synthetic credential unavailable")),
+        )
+    elif revocation == "tool":
+        parent.valid_tool_names = set()
+    else:
+        cfg["profiles"]["cold"]["instructions"] = "changed contract"
+    release_first.set()
+    result = service.wait(queued, timeout_seconds=2)
+    assert result.state is SubagentState.FAILED
+    failed = WorkerStore(db).get_run(queued.run_id, parent.session_id)
+    assert failed["result"]["error_classification"] == "AUTHORITY_REVALIDATION_FAILED"
+    assert ran == ["first"]
+    db.close()
+
+
+def test_actor_authorization_precedes_queue_claim_and_uses_retained_parent(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    store = WorkerStore(db)
+    store.ensure_schema()
+    root = store.create_worker("tree-owner", worker_id="root")
+    actor_worker = store.create_worker("tree-owner", parent_worker_id=root["worker_id"], worker_id="actor")
+    sibling = store.create_worker("tree-owner", parent_worker_id=root["worker_id"], worker_id="sibling")
+    grandchild = store.create_worker("tree-owner", parent_worker_id=actor_worker["worker_id"], worker_id="grandchild")
+    sibling_run = store.enqueue_run(sibling["worker_id"], "tree-owner", goal="sibling queued")
+    grandchild_run = store.enqueue_run(grandchild["worker_id"], "tree-owner", goal="needs actor authority")
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: {"max_concurrent_children": 2})
+
+    actor = SimpleNamespace(
+        session_id="actor-session", _worker_owner_session_id="tree-owner",
+        _worker_id=actor_worker["worker_id"], _session_db=db,
+    )
+    actor_service = SubagentLifecycleService(lambda: actor)
+    with pytest.raises(PermissionError):
+        actor_service.control("status", worker_id=sibling["worker_id"])
+    assert store.get_run(sibling_run["run_id"], "tree-owner")["status"] == "PENDING"
+
+    root_agent = SimpleNamespace(session_id="tree-owner", _session_db=db)
+    root_service = SubagentLifecycleService(lambda: root_agent)
+    pending = root_service.control(
+        "wait", worker_id=grandchild["worker_id"],
+        run_id=grandchild_run["run_id"], timeout_seconds=0,
+    )
+    assert pending["status"] == "PENDING"
+    assert store.get_run(grandchild_run["run_id"], "tree-owner")["status"] == "PENDING"
+    db.close()
+
+
+def test_active_subtree_cancel_and_profile_tree_tool_limits(tmp_path, monkeypatch):
+    import tools.delegate_tool as delegate_module
+
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(session_id="cancel-owner", _session_db=db)
+    child = Child("active-child", {"read_file", "delegate_task"})
+    service = SubagentLifecycleService(lambda: parent)
+    handle = service.adopt_delegate_child(
+        child, goal="active", context=None, profile=None,
+        creds={"execution_limits": ExecutionLimits(max_tool_calls=1)}, cfg={"max_concurrent_children": 2},
+    )
+    store = WorkerStore(db)
+    descendant = store.create_worker(
+        parent.session_id, parent_worker_id=handle.worker_id, worker_id="active-grandchild")
+    queued = store.enqueue_run(descendant["worker_id"], parent.session_id, goal="queued descendant")
+
+    before_worker_tool(child, "one")
+    checkpoint_worker_tool_result(child, [], tool_call_id="one", settled=True)
+    with pytest.raises(SubagentLifecycleError, match="tool-call limit"):
+        before_worker_tool(child, "two")
+
+    cancelled = service.control("cancel", worker_id=handle.worker_id, run_id=handle.run_id)
+    assert set(cancelled["workers_targeted"]) == {handle.worker_id, descendant["worker_id"]}
+    assert child.interrupted is True
+    assert store.get_run(queued["run_id"], parent.session_id)["status"] == "CANCELLED"
+
+    actor = SimpleNamespace(
+        _delegate_depth=1, _delegate_spawn_allowed=True,
+        _delegate_profile_max_spawn_depth=0,
+        _delegate_profile_max_concurrent_children=1,
+    )
+    monkeypatch.setattr(delegate_module, "_get_max_spawn_depth", lambda: 4)
+    monkeypatch.setattr(delegate_module, "_get_max_concurrent_children", lambda: 4)
+    with pytest.raises(ValueError, match="does not permit spawning descendants"):
+        delegate_module._validate_spawn_admission(actor, 1)
+    actor._delegate_profile_max_spawn_depth = 2
+    with pytest.raises(ValueError, match="concurrency limit 1"):
+        delegate_module._validate_spawn_admission(actor, 2)
+    db.close()
+
+
+def test_explicit_inspect_returns_visible_conversation_without_hidden_reasoning(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(session_id="inspect-owner", _session_db=db)
+    store = WorkerStore(db)
+    store.ensure_schema()
+    worker = store.create_worker(parent.session_id, worker_id="inspect-worker")
+    queued = store.enqueue_run(worker["worker_id"], parent.session_id, goal="inspect")
+    active = store.claim_run(queued["run_id"], parent.session_id)
+    history = [
+        {"role": "system", "content": "private frozen prompt"},
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": [
+            {"type": "reasoning", "text": "hidden chain"},
+            {"type": "output_text", "text": "visible answer"},
+        ], "reasoning": "hidden field"},
+        {"role": "tool", "name": "read_file", "tool_call_id": "call-1", "content": "visible result"},
+        {"role": "reasoning", "content": "hidden role"},
+    ]
+    store.finish_run(
+        active["run_id"], parent.session_id, active["lease_token"],
+        status="SUCCEEDED", result={"summary": "visible answer"}, history=history,
+    )
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: {})
+    inspected = SubagentLifecycleService(lambda: parent).control(
+        "inspect", worker_id=worker["worker_id"], run_id=active["run_id"])
+    assert inspected["conversation"] == [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "visible answer"},
+        {"role": "tool", "content": "visible result", "name": "read_file", "tool_call_id": "call-1"},
+    ]
+    assert "private frozen prompt" not in json.dumps(inspected)
+    assert "hidden" not in json.dumps(inspected)
+    db.close()

--- a/tests/agent/test_worker_dispatch_budget.py
+++ b/tests/agent/test_worker_dispatch_budget.py
@@ -1,0 +1,210 @@
+"""Counterexamples for worker budgets at nested-RPC and Codex reconnect sends."""
+
+import contextvars
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from agent.delegation_model_routing import ExecutionLimits
+from agent.subagent_lifecycle import (
+    SubagentLifecycleService,
+    bind_subagent_parent,
+)
+from agent.worker_store import WorkerStore
+from hermes_state import SessionDB
+from tools.code_execution_rpc import _default_dispatch
+from tools.code_kernel import CellAuthority
+
+
+class Child:
+    def __init__(self, ident, *, depth=1):
+        self._subagent_id = ident
+        self._delegate_role = "orchestrator"
+        self._delegate_depth = depth
+        self.provider = "fixture"
+        self.model = "fixture-model"
+        self.ephemeral_system_prompt = "fixed prompt"
+        self.valid_tool_names = {"read_file", "delegate_task"}
+        self._executable_tool_names = set(self.valid_tool_names)
+        self.tools = []
+        self._worker_route_receipt = {}
+        self._interrupt_requested = False
+
+    def hard_interrupt(self, _message=None, **_kwargs):
+        self._interrupt_requested = True
+        return True
+
+    def close(self):
+        return None
+
+
+def _creds(*, iterations=4, tools=4):
+    return {
+        "requested_profile": None,
+        "resolved_provider": "fixture",
+        "resolved_model": "fixture-model",
+        "resolved_reasoning_effort": None,
+        "max_iterations": iterations,
+        "execution_limits": ExecutionLimits(
+            max_iterations=iterations, max_tool_calls=tools, timeout_seconds=60),
+    }
+
+
+def _finish(child, status="completed"):
+    child._worker_last_history = [{"role": "assistant", "content": "done"}]
+    SubagentLifecycleService.complete_adopted_child(child, {
+        "status": status, "summary": "done", "api_calls": 0,
+        "exit_reason": "completed" if status == "completed" else "interrupted",
+    })
+
+
+def test_local_and_remote_execute_code_rpc_share_tree_budget(tmp_path, monkeypatch):
+    """New cells and a descendant's larger ceiling cannot multiply the root budget."""
+    import model_tools
+
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(session_id="owner", _session_db=db)
+    root = Child("root")
+    root_service = SubagentLifecycleService(lambda: parent)
+    root_service.adopt_delegate_child(
+        root, goal="root", context=None, profile=None, creds=_creds(tools=3),
+        cfg={"max_concurrent_children": 2},
+    )
+    nested = Child("nested", depth=2)
+    nested_service = SubagentLifecycleService(lambda: root)
+    nested_service.adopt_delegate_child(
+        nested, goal="nested", context=None, profile=None, creds=_creds(tools=10),
+        cfg={"max_concurrent_children": 2},
+    )
+
+    executed = []
+
+    def execute(function_name, function_args, *_args, **_kwargs):
+        executed.append((function_name, function_args["value"]))
+        return json.dumps({"value": function_args["value"]})
+
+    monkeypatch.setattr(model_tools, "_execute_tool", execute)
+    with bind_subagent_parent(nested):
+        first_cell = CellAuthority("task")
+        inherited = contextvars.copy_context()
+    assert json.loads(first_cell.dispatch("fixture_tool", {"value": "cell-1"}))["value"] == "cell-1"
+    first_cell.retire()
+
+    with bind_subagent_parent(nested):
+        second_cell = CellAuthority("task")
+    assert json.loads(second_cell.dispatch("fixture_tool", {"value": "cell-2"}))["value"] == "cell-2"
+    second_cell.retire()
+
+    remote_dispatch = inherited.run(_default_dispatch, "task")
+    assert json.loads(inherited.run(remote_dispatch, "fixture_tool", {"value": "remote"}))["value"] == "remote"
+    denied = json.loads(inherited.run(remote_dispatch, "fixture_tool", {"value": "denied"}))
+    assert "tree tool call budget exhausted" in denied["error"]
+    assert executed == [
+        ("fixture_tool", "cell-1"),
+        ("fixture_tool", "cell-2"),
+        ("fixture_tool", "remote"),
+    ]
+    store = WorkerStore(db)
+    assert store.budget_snapshot(nested._worker_run_id, "owner")["used_tool_calls"] == 3
+    assert store.get_run(nested._worker_run_id, "owner")["tool_inflight_count"] == 0
+    _finish(nested)
+    _finish(root)
+    db.close()
+
+
+class _RetryingResponses:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if len(self.calls) == 1:
+            raise httpx.RemoteProtocolError("synthetic reconnect")
+        return iter([
+            SimpleNamespace(type="response.output_text.delta", delta="done"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    id="response-2", status="completed", usage=None,
+                    model="fixture-model", output=None,
+                ),
+            ),
+        ])
+
+
+def _send_codex(child, responses):
+    from agent.codex_runtime import run_codex_stream
+    from agent.turn_api_call import perform_api_call
+
+    child.api_mode = "codex_responses"
+    child.session_id = "worker-session"
+    child.platform = "subagent"
+    child.base_url = "https://example.invalid"
+    child._fallback_index = 0
+    child.is_subagent = True
+    child.show_commentary = False
+    child.interim_assistant_callback = None
+    child._pending_redirect_lock = None
+    child._has_pending_redirect = lambda: False
+    child._has_stream_consumers = lambda: True
+    child._is_copilot_url = lambda: False
+    child._is_codex_backend = lambda: True
+    child._get_transport = lambda: SimpleNamespace(
+        preflight_kwargs=lambda kwargs, **_options: dict(kwargs))
+    child._fire_stream_delta = lambda _text: None
+    child._fire_reasoning_delta = lambda _text: None
+    child._touch_activity = lambda _text: None
+    child._client_log_context = lambda: "fixture"
+    child._abort_request_openai_client = lambda *_args, **_kwargs: None
+    client = SimpleNamespace(responses=responses)
+    child._interruptible_streaming_api_call = lambda kwargs, on_first_delta=None: run_codex_stream(
+        child, kwargs, client=client, on_first_delta=on_first_delta)
+    return perform_api_call(
+        child, api_kwargs={"model": "fixture-model", "input": "synthetic"},
+        _original_api_kwargs={}, _llm_middleware_trace=[], _moa_prepared_request=None,
+        _retry=SimpleNamespace(), thinking_spinner=None, retry_count=0, api_call_count=0,
+        api_request_id="request", effective_task_id="task", turn_id="turn", interrupted=False,
+    )
+
+
+@pytest.mark.parametrize("allocation,succeeds", [(1, False), (2, True)])
+def test_codex_reconnect_reserves_each_physical_send_without_outer_charge(
+    tmp_path, monkeypatch, allocation, succeeds,
+):
+    from agent import relay_llm
+    from hermes_cli import middleware
+
+    db = SessionDB(tmp_path / f"state-{allocation}.db")
+    parent = SimpleNamespace(session_id=f"owner-{allocation}", _session_db=db)
+    child = Child(f"codex-{allocation}")
+    SubagentLifecycleService(lambda: parent).adopt_delegate_child(
+        child, goal="retry", context=None, profile=None,
+        creds=_creds(iterations=allocation, tools=1),
+        cfg={"max_iterations": allocation},
+    )
+    responses = _RetryingResponses()
+    monkeypatch.setattr(
+        middleware, "run_llm_execution_middleware",
+        lambda kwargs, send, **_options: send(kwargs),
+    )
+    monkeypatch.setattr(
+        relay_llm, "stream", lambda request, stream_factory, **_options: stream_factory(request),
+    )
+
+    if succeeds:
+        verdict = _send_codex(child, responses)
+        assert verdict.response.status == "completed"
+        assert len(responses.calls) == 2
+        assert len(child._worker_route_receipt["execution_attempts"]) == 2
+        _finish(child)
+    else:
+        with pytest.raises(InterruptedError, match="tree_iteration_budget_exhausted"):
+            _send_codex(child, responses)
+        assert len(responses.calls) == 1
+        assert len(child._worker_route_receipt["execution_attempts"]) == 1
+        _finish(child, "interrupted")
+    snapshot = WorkerStore(db).budget_snapshot(child._worker_run_id, parent.session_id)
+    assert snapshot["used_iterations"] == allocation
+    db.close()

--- a/tests/agent/test_worker_interfaces.py
+++ b/tests/agent/test_worker_interfaces.py
@@ -1,0 +1,321 @@
+"""Conformance proof for session-stable worker interface adapters."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.subagent_lifecycle import (
+    SubagentLifecycleService, bind_subagent_parent, dispatch_worker_nested_tool,
+)
+from agent.worker_interfaces import (
+    CANONICAL_WORKER_TOOL,
+    InterfaceSelection,
+    QualifiedInterfaceProfile,
+    bind_worker_interface,
+    canonical_worker_capability,
+    dispatch_worker_interface_call,
+    is_worker_interface_tool,
+    normalize_worker_call,
+    project_worker_tool_definitions,
+    resolve_worker_interface,
+)
+from agent.worker_store import WorkerStore
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _schema(name):
+    return {
+        "type": "function",
+        "function": {"name": name, "description": name, "parameters": {"type": "object"}},
+    }
+
+
+def _selection(name, definitions):
+    return bind_worker_interface(
+        InterfaceSelection(name, "explicit", "experimental_unqualified", "fixture", "model"),
+        definitions,
+    )
+
+
+def _advertised(selection, semantic):
+    return dict(selection.aliases)[semantic]
+
+
+def test_resolution_and_collision_binding_preserve_native_tools_and_routes(monkeypatch):
+    definitions = [_schema("send_message"), _schema(CANONICAL_WORKER_TOOL)]
+    hermes = bind_worker_interface(
+        resolve_worker_interface({}, provider="Fixture", model="Model"), definitions
+    )
+    assert [item["function"]["name"] for item in project_worker_tool_definitions(definitions, hermes)] == [
+        "send_message", CANONICAL_WORKER_TOOL,
+    ]
+    assert not is_worker_interface_tool(hermes, "send_message")
+    assert is_worker_interface_tool(hermes, CANONICAL_WORKER_TOOL)
+
+    codex = _selection("codex", definitions)
+    assert _advertised(codex, "send_message") == "hermes_worker_send_message"
+    projected = project_worker_tool_definitions(definitions, codex)
+    names = [item["function"]["name"] for item in projected]
+    assert "send_message" in names
+    assert "hermes_worker_send_message" in names
+    assert CANONICAL_WORKER_TOOL not in names
+    assert len(names) == len(set(names))
+    assert canonical_worker_capability(codex, "send_message") == "send_message"
+    assert canonical_worker_capability(codex, "hermes_worker_send_message") == CANONICAL_WORKER_TOOL
+
+    nested_calls = []
+    parent = SimpleNamespace(
+        _worker_interface_selection=codex,
+        _dispatch_worker_interface=lambda name, args: json.dumps({"worker": name, "args": args}),
+    )
+    monkeypatch.setattr(
+        "model_tools.handle_function_call",
+        lambda name, args, **kwargs: nested_calls.append((name, args)) or json.dumps({"native": name}),
+    )
+    with bind_subagent_parent(parent):
+        worker_result = json.loads(dispatch_worker_nested_tool(
+            "hermes_worker_send_message", {"target": "worker", "message": "guide"}, task_id="test"
+        ))
+        native_result = json.loads(dispatch_worker_nested_tool(
+            "send_message", {"action": "list"}, task_id="test"
+        ))
+    assert worker_result["worker"] == "hermes_worker_send_message"
+    assert native_result == {"native": "send_message"}
+    assert nested_calls == [("send_message", {"action": "list"})]
+
+    # A later registry refresh cannot rename the frozen alias or create a
+    # duplicate schema in the session. The new collision is reconsidered on
+    # the next session bind.
+    refreshed = project_worker_tool_definitions(
+        [_schema("send_message"), _schema("hermes_worker_send_message"), _schema(CANONICAL_WORKER_TOOL)],
+        codex,
+    )
+    refreshed_names = [item["function"]["name"] for item in refreshed]
+    assert refreshed_names.count("hermes_worker_send_message") == 1
+    assert refreshed_names.count("send_message") == 1
+
+    qualified = resolve_worker_interface(
+        {"orchestration": {"interface": "auto"}},
+        provider="Fixture", model="Model",
+        qualified_profiles=(QualifiedInterfaceProfile("fixture", "model", "claude", "live:fixture"),),
+    )
+    assert (qualified.name, qualified.source, qualified.evidence_ref) == (
+        "claude", "qualified_exact_match", "live:fixture",
+    )
+    fallback = resolve_worker_interface(
+        {"orchestration": {"interface": "auto"}}, provider="fixture", model="other",
+        qualified_profiles=(QualifiedInterfaceProfile("fixture", "model", "claude", "live:fixture"),),
+    )
+    assert (fallback.name, fallback.provider, fallback.model) == ("hermes", "fixture", "other")
+
+    spawn = normalize_worker_call(codex, _advertised(codex, "spawn_agent"), {
+        "message": "work", "profile": "safe", "provider": "fixture-2",
+        "model": "model-2", "reasoning_effort": "high",
+    })
+    assert spawn.arguments == {
+        "goal": "work", "profile": "safe", "provider": "fixture-2",
+        "model": "model-2", "reasoning_effort": "high",
+    }
+    with pytest.raises(ValueError, match="Unsupported spawn_agent arguments"):
+        normalize_worker_call(codex, _advertised(codex, "spawn_agent"), {
+            "message": "work", "fork_parent_history": True,
+        })
+
+    claude = _selection("claude", definitions)
+    claude_names = {
+        item["function"]["name"] for item in project_worker_tool_definitions(definitions, claude)
+    }
+    assert "Agent" in claude_names
+    assert "Task" not in claude_names
+
+
+def _interface_call(selection, semantic, **values):
+    if selection.name == "hermes":
+        action = {
+            "list": "status", "inspect": "inspect", "wait": "wait", "message": "message",
+            "followup": "resume", "interrupt": "interrupt", "completions": "completions",
+            "ack": "ack", "reconcile": "reconcile",
+        }[semantic]
+        return CANONICAL_WORKER_TOOL, {"action": action, **values}
+    if selection.name == "codex":
+        names = {
+            "list": "list_agents", "inspect": "inspect_agent", "wait": "wait_agent",
+            "message": "send_message", "followup": "followup_task",
+            "interrupt": "interrupt_agent", "completions": "worker_control",
+            "ack": "worker_control", "reconcile": "worker_control",
+        }
+        args = {
+            "list": {},
+            "inspect": {"target": values.get("worker_id"), "run_id": values.get("run_id")},
+            "wait": {"target": values.get("worker_id"), "run_id": values.get("run_id"), "timeout_ms": 0},
+            "message": {"target": values.get("worker_id"), "message": values.get("message")},
+            "followup": {"target": values.get("worker_id"), "message": values.get("message")},
+            "interrupt": {"target": values.get("worker_id"), "run_id": values.get("run_id")},
+            "completions": {"action": "completions"},
+            "ack": {"action": "ack", "target": values.get("worker_id"), "run_id": values.get("run_id")},
+            "reconcile": {
+                "action": "reconcile", "target": values.get("worker_id"),
+                "run_id": values.get("run_id"), "disposition": values.get("reconciliation_disposition"),
+                "note": values.get("message"),
+            },
+        }
+        return _advertised(selection, names[semantic]), {
+            key: value for key, value in args[semantic].items() if value is not None
+        }
+    names = {
+        "list": "TaskList", "inspect": "TaskOutput", "wait": "TaskOutput",
+        "message": "SendMessage", "followup": "SendMessage", "interrupt": "TaskStop",
+        "completions": "worker_control", "ack": "worker_control", "reconcile": "worker_control",
+    }
+    args = {
+        "list": {},
+        "inspect": {"task_id": values.get("worker_id"), "run_id": values.get("run_id")},
+        "wait": {"task_id": values.get("worker_id"), "run_id": values.get("run_id"), "block": True, "timeout_ms": 0},
+        "message": {"recipient": values.get("worker_id"), "content": values.get("message")},
+        "followup": {"recipient": values.get("worker_id"), "content": values.get("message"), "if_idle": True},
+        "interrupt": {"task_id": values.get("worker_id"), "run_id": values.get("run_id"), "scope": "run"},
+        "completions": {"action": "completions"},
+        "ack": {"action": "ack", "target": values.get("worker_id"), "run_id": values.get("run_id")},
+        "reconcile": {
+            "action": "reconcile", "target": values.get("worker_id"),
+            "run_id": values.get("run_id"), "disposition": values.get("reconciliation_disposition"),
+            "note": values.get("message"),
+        },
+    }
+    return _advertised(selection, names[semantic]), {
+        key: value for key, value in args[semantic].items() if value is not None
+    }
+
+
+@pytest.mark.parametrize("interface", ["hermes", "codex", "claude"])
+def test_interfaces_route_real_store_controls_with_ordering_and_authorization(
+    interface, tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("tools.delegate_tool._load_config", lambda: {})
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: {})
+    monkeypatch.setattr("tools.delegate_tool_config._get_child_timeout", lambda: None)
+    monkeypatch.setattr(
+        SubagentLifecycleService, "_schedule_owner",
+        classmethod(lambda cls, *_args, **_kwargs: None),
+    )
+
+    db = SessionDB(tmp_path / "state.db")
+    store = WorkerStore(db)
+    store.ensure_schema()
+    policy = {
+        "role": "leaf", "route": {}, "profile_contract": None, "effective_tools": [],
+        "launch_allowed_toolsets": None, "launch_blocked_tools": [],
+    }
+    worker = store.create_worker("owner", worker_id="target", policy=policy)
+    first = store.enqueue_run(worker["worker_id"], "owner", goal="first")
+    active = store.claim_run(first["run_id"], "owner")
+    foreign = store.create_worker("other-owner", worker_id="foreign", policy=policy)
+    foreign_run = store.enqueue_run(foreign["worker_id"], "other-owner", goal="private")
+
+    complete_worker = store.create_worker("owner", worker_id="complete", policy=policy)
+    complete_run = store.enqueue_run(complete_worker["worker_id"], "owner", goal="done")
+    complete_active = store.claim_run(complete_run["run_id"], "owner")
+    store.finish_run(
+        complete_active["run_id"], "owner", complete_active["lease_token"],
+        status="SUCCEEDED", result={"summary": "done"}, history=[],
+    )
+
+    definitions = [_schema("send_message"), _schema(CANONICAL_WORKER_TOOL)]
+    selection = bind_worker_interface(
+        InterfaceSelection(
+            interface, "explicit", "stable" if interface == "hermes" else "experimental_unqualified",
+            "fixture", "model",
+        ),
+        definitions,
+    )
+    parent = SimpleNamespace(
+        session_id="owner", _session_db=db, _delegate_depth=0,
+        provider="fixture", model="model", _worker_interface_selection=selection,
+    )
+
+    class ClosedChild:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        SubagentLifecycleService, "_build_revalidated_child",
+        lambda self, current_worker, *, goal, role: (
+            ClosedChild(), SimpleNamespace_get_creds(), {}, current_worker["policy"],
+        ),
+    )
+
+    def dispatch(semantic, **values):
+        name, args = _interface_call(selection, semantic, **values)
+        return json.loads(dispatch_worker_interface_call(
+            parent, name, args, lambda canonical: AIAgent._dispatch_delegate_task(parent, canonical)
+        ))
+
+    listed = dispatch("list")
+    assert listed["success"] is True
+    assert listed["orchestration_interface"]["worker_service"].endswith("SubagentLifecycleService")
+    assert {item["worker_id"] for item in listed["workers"]} == {"target", "complete"}
+    inspected = dispatch("inspect", worker_id="target", run_id=active["run_id"])
+    assert inspected["run"]["run_id"] == active["run_id"]
+    waited = dispatch("wait", worker_id="target", run_id=active["run_id"])
+    assert waited["status"] == "RUNNING"
+
+    guidance = dispatch("message", worker_id="target", message="guidance")
+    assert guidance["delivery"] == "NEXT_RUN"
+    assert len(store.list_runs("target", "owner")) == 1
+    assert len(store.list_messages("target", "owner")) == 1
+
+    followup = dispatch("followup", worker_id="target", message="new assignment")
+    queued = store.get_run(followup["run_id"], "owner")
+    assert queued["status"] == "PENDING"
+    assert queued["previous_run_id"] == active["run_id"]
+    assert queued["goal"] == "new assignment"
+    assert followup["orchestration_interface"]["effective_action"] == "resume"
+
+    interrupted = dispatch("interrupt", worker_id="target", run_id=queued["run_id"])
+    assert interrupted["status"] == "CANCELLED"
+    rejected = dispatch("followup", worker_id="target", message="must not wake")
+    assert "Cancelled workers stay cancelled" in rejected["error"]
+
+    completions = dispatch("completions")
+    assert any(item["run_id"] == complete_active["run_id"] for item in completions["completions"])
+    acknowledged = dispatch(
+        "ack", worker_id="complete", run_id=complete_active["run_id"]
+    )
+    assert acknowledged["acknowledged"] is True
+
+    reconcile_worker = store.create_worker("owner", worker_id="reconcile", policy=policy)
+    reconcile_run = store.enqueue_run(reconcile_worker["worker_id"], "owner", goal="effect")
+    reconcile_active = store.claim_run(reconcile_run["run_id"], "owner")
+    store.mark_tool_boundary(
+        reconcile_active["run_id"], "owner", reconcile_active["lease_token"],
+        tool_call_id="synthetic-effect",
+    )
+    store.finish_run(
+        reconcile_active["run_id"], "owner", reconcile_active["lease_token"],
+        status="SUCCEEDED", result={"summary": "uncertain"}, history=[],
+    )
+    reconciled = dispatch(
+        "reconcile", worker_id="reconcile", run_id=reconcile_active["run_id"],
+        reconciliation_disposition="accepted_unknown_no_replay",
+        message="Synthetic outcome accepted without replay.",
+    )
+    assert reconciled["reconciled"] is True
+    assert store.get_worker("reconcile", "owner")["uncertain_side_effect"] is False
+
+    denied = dispatch("inspect", worker_id="foreign", run_id=foreign_run["run_id"])
+    assert "foreign owner" in denied["error"].lower()
+    db.close()
+
+
+def SimpleNamespace_get_creds():
+    return {
+        "execution_limits": SimpleNamespace(
+            timeout_seconds=None, max_tool_calls=None, max_followups=8,
+        ),
+        "max_iterations": 2,
+    }

--- a/tests/agent/test_worker_interfaces.py
+++ b/tests/agent/test_worker_interfaces.py
@@ -17,10 +17,12 @@ from agent.worker_interfaces import (
     bind_worker_interface,
     canonical_worker_capability,
     dispatch_worker_interface_call,
+    frozen_worker_interface_contract,
     is_worker_interface_tool,
     normalize_worker_call,
     project_worker_tool_definitions,
     resolve_worker_interface,
+    restore_worker_interface_contract,
 )
 from agent.worker_store import WorkerStore
 from hermes_state import SessionDB
@@ -87,16 +89,38 @@ def test_resolution_and_collision_binding_preserve_native_tools_and_routes(monke
     assert native_result == {"native": "send_message"}
     assert nested_calls == [("send_message", {"action": "list"})]
 
-    # A later registry refresh cannot rename the frozen alias or create a
-    # duplicate schema in the session. The new collision is reconsidered on
-    # the next session bind.
-    refreshed = project_worker_tool_definitions(
-        [_schema("send_message"), _schema("hermes_worker_send_message"), _schema(CANONICAL_WORKER_TOOL)],
-        codex,
+    contract = frozen_worker_interface_contract(codex)
+    from agent.subagent_lifecycle import _profile_policy_snapshot
+
+    _revision, stored_policy = _profile_policy_snapshot(
+        {}, None, {}, child=SimpleNamespace(
+            _worker_interface_selection=codex,
+            _worker_effective_tool_names={CANONICAL_WORKER_TOOL},
+        ),
     )
-    refreshed_names = [item["function"]["name"] for item in refreshed]
-    assert refreshed_names.count("hermes_worker_send_message") == 1
-    assert refreshed_names.count("send_message") == 1
+    assert stored_policy["worker_interface"] == contract
+    restored = restore_worker_interface_contract(
+        contract, provider="changed-provider", model="changed-model", definitions=definitions,
+    )
+    assert restored.aliases == codex.aliases
+    assert (restored.name, restored.provider, restored.model) == (
+        "codex", "changed-provider", "changed-model",
+    )
+    legacy = restore_worker_interface_contract(
+        None, provider="fixture", model="model", definitions=definitions,
+    )
+    assert (legacy.name, legacy.source) == ("hermes", "legacy_session")
+    with pytest.raises(ValueError, match="now collide"):
+        restore_worker_interface_contract(
+            contract,
+            provider="fixture",
+            model="model",
+            definitions=[*definitions, _schema("hermes_worker_send_message")],
+        )
+    with pytest.raises(ValueError, match="now collides"):
+        project_worker_tool_definitions(
+            [*definitions, _schema("hermes_worker_send_message")], codex,
+        )
 
     qualified = resolve_worker_interface(
         {"orchestration": {"interface": "auto"}},
@@ -133,11 +157,31 @@ def test_resolution_and_collision_binding_preserve_native_tools_and_routes(monke
     assert "Task" not in claude_names
 
 
+def test_configured_native_allowlist_cannot_grant_a_styled_worker_alias():
+    from tools.delegate_tool_toolsets import _apply_exact_tool_policy
+
+    definitions = [_schema(CANONICAL_WORKER_TOOL)]
+    child = SimpleNamespace(
+        _worker_interface_selection=_selection("codex", definitions),
+        _executable_tool_names={CANONICAL_WORKER_TOOL},
+        valid_tool_names={"send_message"},
+        tools=[_schema("send_message")],
+    )
+    policy = SimpleNamespace(
+        allowed_tools=("send_message",), allowed_mcp_tools=None,
+        blocked_tools=(), allowed_toolsets=None,
+    )
+    _apply_exact_tool_policy(child, policy)
+    assert child._worker_effective_tool_names == frozenset()
+    assert child.valid_tool_names == set()
+
+
 def _interface_call(selection, semantic, **values):
     if selection.name == "hermes":
         action = {
             "list": "status", "inspect": "inspect", "wait": "wait", "message": "message",
-            "followup": "resume", "interrupt": "interrupt", "completions": "completions",
+            "followup": "resume", "interrupt": "interrupt", "cancel_tree": "cancel",
+            "completions": "completions",
             "ack": "ack", "reconcile": "reconcile",
         }[semantic]
         return CANONICAL_WORKER_TOOL, {"action": action, **values}
@@ -145,7 +189,8 @@ def _interface_call(selection, semantic, **values):
         names = {
             "list": "list_agents", "inspect": "inspect_agent", "wait": "wait_agent",
             "message": "send_message", "followup": "followup_task",
-            "interrupt": "interrupt_agent", "completions": "worker_control",
+            "interrupt": "interrupt_agent", "cancel_tree": "cancel_agent_tree",
+            "completions": "worker_control",
             "ack": "worker_control", "reconcile": "worker_control",
         }
         args = {
@@ -155,6 +200,7 @@ def _interface_call(selection, semantic, **values):
             "message": {"target": values.get("worker_id"), "message": values.get("message")},
             "followup": {"target": values.get("worker_id"), "message": values.get("message")},
             "interrupt": {"target": values.get("worker_id"), "run_id": values.get("run_id")},
+            "cancel_tree": {"target": values.get("worker_id")},
             "completions": {"action": "completions"},
             "ack": {"action": "ack", "target": values.get("worker_id"), "run_id": values.get("run_id")},
             "reconcile": {
@@ -169,6 +215,7 @@ def _interface_call(selection, semantic, **values):
     names = {
         "list": "TaskList", "inspect": "TaskOutput", "wait": "TaskOutput",
         "message": "SendMessage", "followup": "SendMessage", "interrupt": "TaskStop",
+        "cancel_tree": "TaskStop",
         "completions": "worker_control", "ack": "worker_control", "reconcile": "worker_control",
     }
     args = {
@@ -178,6 +225,7 @@ def _interface_call(selection, semantic, **values):
         "message": {"recipient": values.get("worker_id"), "content": values.get("message")},
         "followup": {"recipient": values.get("worker_id"), "content": values.get("message"), "if_idle": True},
         "interrupt": {"task_id": values.get("worker_id"), "run_id": values.get("run_id"), "scope": "run"},
+        "cancel_tree": {"task_id": values.get("worker_id"), "scope": "tree"},
         "completions": {"action": "completions"},
         "ack": {"action": "ack", "target": values.get("worker_id"), "run_id": values.get("run_id")},
         "reconcile": {
@@ -277,7 +325,12 @@ def test_interfaces_route_real_store_controls_with_ordering_and_authorization(
     assert followup["orchestration_interface"]["effective_action"] == "resume"
 
     interrupted = dispatch("interrupt", worker_id="target", run_id=queued["run_id"])
-    assert interrupted["status"] == "CANCELLED"
+    assert interrupted["status"] == "INTERRUPTED"
+    continued = dispatch("followup", worker_id="target", message="authorized after interrupt")
+    continued_run = store.get_run(continued["run_id"], "owner")
+    assert continued_run["previous_run_id"] == queued["run_id"]
+    cancelled = dispatch("cancel_tree", worker_id="target")
+    assert cancelled["cancel_requested"] is True
     rejected = dispatch("followup", worker_id="target", message="must not wake")
     assert "Cancelled workers stay cancelled" in rejected["error"]
 

--- a/tests/agent/test_worker_policy_receipt.py
+++ b/tests/agent/test_worker_policy_receipt.py
@@ -1,0 +1,52 @@
+"""Execution receipts preserve explicit empty authority through durable completion."""
+
+from types import SimpleNamespace
+
+from agent.subagent_lifecycle import (
+    SubagentLifecycleService,
+    _REGISTRY,
+    _profile_policy_snapshot,
+)
+from agent.worker_store import WorkerStore
+from hermes_state import SessionDB
+
+
+def test_empty_authority_survives_adoption_and_terminal_receipt(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(session_id="empty-authority-owner", _session_db=db)
+    child = SimpleNamespace(
+        _subagent_id="empty-authority-child", session_id="empty-authority-session",
+        provider="openrouter", model="fixture/model", _delegate_role="leaf",
+        _delegate_depth=1, _worker_route_receipt={},
+        _worker_effective_tool_names=frozenset(),
+        _executable_tool_names={"delegate_task"}, valid_tool_names=set(),
+    )
+    service = SubagentLifecycleService(lambda: parent)
+    try:
+        handle = service.adopt_delegate_child(
+            child, goal="synthetic receipt", context=None, profile=None,
+            creds={}, cfg={"max_iterations": 2},
+        )
+        store = WorkerStore(db)
+        assert store.get_worker(handle.worker_id, parent.session_id)["policy"]["effective_tools"] == []
+        assert child._worker_route_receipt["effective_tools"] == []
+        service.complete_adopted_child(child, {"status": "completed", "summary": "done"})
+        run = store.get_run(handle.run_id, parent.session_id)
+        assert run["status"] == "SUCCEEDED"
+        assert run["result"]["effective_tools"] == []
+        assert run["result"]["route"]["effective_tools"] == []
+    finally:
+        record = getattr(child, "_worker_lifecycle_record", None)
+        if record is not None and record.lease_stop is not None:
+            record.lease_stop.set()
+        with _REGISTRY.lock:
+            _REGISTRY.records.pop(child._subagent_id, None)
+        db.close()
+
+
+def test_only_absent_catalog_uses_legacy_visible_tools():
+    empty_catalog = SimpleNamespace(_executable_tool_names=set(), valid_tool_names={"delegate_task"})
+    legacy = SimpleNamespace(valid_tool_names={"read_file"})
+    assert _profile_policy_snapshot({}, None, {}, child=empty_catalog)[1]["effective_tools"] == []
+    assert _profile_policy_snapshot({}, None, {}, child=legacy)[1]["effective_tools"] == ["read_file"]

--- a/tests/agent/test_worker_process_acceptance.py
+++ b/tests/agent/test_worker_process_acceptance.py
@@ -17,7 +17,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def _configure(home: Path) -> None:
     home.mkdir()
     (home / "config.yaml").write_text(
-        """delegation:
+        # Native tool crash boundaries are exercised here; tool-search bridge
+        # dispatch is covered separately by the enforcement acceptance tests.
+        """tools:
+  tool_search:
+    enabled: "off"
+delegation:
   independent_completions: true
   max_concurrent_children: 2
   max_iterations: 4
@@ -291,7 +296,10 @@ def test_credential_disappearance_fails_closed_before_cold_resume(tmp_path):
         "--run-id", seed["run_id"], "--message", "post-checkpoint",
         credential=False, capture=capture,
     )
-    assert "API key" in blocked["error"] or "credential" in blocked["error"].lower()
+    assert not blocked.get("success", False)
+    assert "Worker resume admission failed" in blocked["error"]
+    assert "No LLM provider configured" in blocked["error"]
+    assert len(_json_lines(capture)) == 1  # the original seed; no revoked-route request
     snapshot = _run(home, "snapshot", "--worker-id", seed["worker_id"])
     assert len(snapshot["runs"]) == 1
 

--- a/tests/agent/test_worker_process_acceptance.py
+++ b/tests/agent/test_worker_process_acceptance.py
@@ -106,14 +106,19 @@ def _start(
     )
 
 
-def _wait_for(path: Path, process: subprocess.Popen, timeout: float = 10) -> None:
+def _wait_for(
+    path: Path, process: subprocess.Popen, timeout: float = 10, diagnostics: Path | None = None,
+) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if path.exists():
             return
         if process.poll() is not None:
             stdout, stderr = process.communicate()
-            raise AssertionError(f"fixture exited before fault marker: {stdout}\n{stderr}")
+            detail = _json_lines(diagnostics) if diagnostics is not None else []
+            raise AssertionError(
+                f"fixture exited before fault marker: {stdout}\n{stderr}\nrequest diagnostics: {detail}"
+            )
         time.sleep(0.02)
     process.kill()
     process.wait(timeout=5)
@@ -213,7 +218,7 @@ def test_message_delivery_and_conversation_checkpoint_cross_cold_restart(tmp_pat
     snapshot = _run(
         home, "snapshot", "--worker-id", seed["worker_id"], "--expire-leases",
     )
-    assert snapshot["message_statuses"] == ["DELIVERED", "DELIVERED"]
+    assert snapshot["message_statuses"] == ["DELIVERED", "DELIVERED"], _json_lines(capture)
     assert snapshot["history_roles"][-3:] == ["user", "assistant", "tool"]
     assert snapshot["history_has_provider_session_handle"] is False
     assert len(_json_lines(effect)) == 1
@@ -247,7 +252,7 @@ def test_ambiguous_completed_effect_requires_reconciliation_and_is_not_replayed(
         "--run-id", queued["run_id"], "--timeout", "20",
         behavior="tool-crash", marker=marker, capture=capture, effect=effect,
     )
-    _wait_for(marker, process)
+    _wait_for(marker, process, diagnostics=capture)
     process.wait(timeout=5)
     assert process.returncode == 91
     assert len(_json_lines(effect)) == 1

--- a/tests/agent/test_worker_process_acceptance.py
+++ b/tests/agent/test_worker_process_acceptance.py
@@ -1,0 +1,317 @@
+"""Real-process acceptance for durable worker crash and restart boundaries."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "worker_process_acceptance.py"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _configure(home: Path) -> None:
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """delegation:
+  independent_completions: true
+  max_concurrent_children: 2
+  max_iterations: 4
+  profiles:
+    process-acceptance:
+      provider: openrouter
+      model: fixture/model
+      tool_policy:
+        allowed_toolsets: [file]
+      workspace_context:
+        mode: none
+      execution_limits:
+        max_iterations: 4
+        max_followups: 12
+        max_tool_calls: 4
+""",
+        encoding="utf-8",
+    )
+
+
+def _env(
+    home: Path,
+    *,
+    behavior: str = "final",
+    credential: bool = True,
+    marker: Path | None = None,
+    capture: Path | None = None,
+    effect: Path | None = None,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    for name in list(env):
+        if name.endswith(("_API_KEY", "_ACCESS_TOKEN", "_REFRESH_TOKEN")):
+            env.pop(name, None)
+    env["HERMES_HOME"] = str(home)
+    env["HERMES_ACCEPTANCE_BEHAVIOR"] = behavior
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    if credential:
+        env["OPENROUTER_API_KEY"] = "synthetic-acceptance-placeholder"
+    if marker is not None:
+        env["HERMES_ACCEPTANCE_MARKER"] = str(marker)
+    if capture is not None:
+        env["HERMES_ACCEPTANCE_CAPTURE"] = str(capture)
+    if effect is not None:
+        env["HERMES_ACCEPTANCE_EFFECT"] = str(effect)
+    return env
+
+
+def _run(
+    home: Path,
+    command: str,
+    *args: str,
+    behavior: str = "final",
+    credential: bool = True,
+    capture: Path | None = None,
+    effect: Path | None = None,
+) -> dict:
+    completed = subprocess.run(
+        [sys.executable, str(FIXTURE), command, "--home", str(home), *args],
+        cwd=REPO_ROOT,
+        env=_env(home, behavior=behavior, credential=credential, capture=capture, effect=effect),
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def _start(
+    home: Path,
+    command: str,
+    *args: str,
+    behavior: str,
+    marker: Path,
+    capture: Path,
+    effect: Path | None = None,
+) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, str(FIXTURE), command, "--home", str(home), *args],
+        cwd=REPO_ROOT,
+        env=_env(home, behavior=behavior, marker=marker, capture=capture, effect=effect),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _wait_for(path: Path, process: subprocess.Popen, timeout: float = 10) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        if process.poll() is not None:
+            stdout, stderr = process.communicate()
+            raise AssertionError(f"fixture exited before fault marker: {stdout}\n{stderr}")
+        time.sleep(0.02)
+    process.kill()
+    process.wait(timeout=5)
+    raise AssertionError("timed out waiting for subprocess fault marker")
+
+
+def _kill_after_marker(process: subprocess.Popen, marker: Path) -> None:
+    _wait_for(marker, process)
+    process.kill()
+    process.wait(timeout=5)
+    assert process.returncode != 0
+
+
+def _json_lines(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _assert_role_alternation(records: list[dict]) -> None:
+    for record in records:
+        roles = record["roles"]
+        assert all(left != right for left, right in zip(roles, roles[1:]))
+
+
+def test_enqueue_and_leased_launch_survive_process_restart_fifo_once(tmp_path):
+    home, capture = tmp_path / "profile", tmp_path / "requests.jsonl"
+    _configure(home)
+    seed = _run(home, "seed", capture=capture)
+    first = _run(
+        home, "enqueue", "--worker-id", seed["worker_id"], "--run-id", seed["run_id"],
+        "--message", "enqueue-one",
+    )
+    second = _run(
+        home, "enqueue", "--worker-id", seed["worker_id"], "--run-id", first["run_id"],
+        "--message", "enqueue-two",
+    )
+
+    marker = tmp_path / "leased.ready"
+    process = _start(
+        home, "control", "--action", "wait", "--worker-id", seed["worker_id"],
+        "--run-id", second["run_id"], "--timeout", "20",
+        behavior="block-before-checkpoint", marker=marker, capture=capture,
+    )
+    _kill_after_marker(process, marker)
+
+    terminal = _run(
+        home, "control", "--action", "wait", "--worker-id", seed["worker_id"],
+        "--run-id", second["run_id"], "--timeout", "20", "--expire-leases",
+        capture=capture,
+    )
+    assert terminal["status"] == "SUCCEEDED"
+    snapshot = _run(home, "snapshot", "--worker-id", seed["worker_id"])
+    assert [item["status"] for item in snapshot["runs"]] == [
+        "SUCCEEDED", "INTERRUPTED", "SUCCEEDED",
+    ]
+    records = _json_lines(capture)
+    execution_tags = [record["latest_user_markers"] for record in records if record["latest_user_markers"]]
+    assert execution_tags == [["enqueue-one"], ["enqueue-two"]]
+    assert len({record["pid"] for record in records}) >= 3
+    _assert_role_alternation(records)
+
+
+def test_message_delivery_and_conversation_checkpoint_cross_cold_restart(tmp_path):
+    home = tmp_path / "profile"
+    capture, effect = tmp_path / "requests.jsonl", tmp_path / "effects.jsonl"
+    _configure(home)
+    seed = _run(home, "seed", capture=capture)
+    queued = _run(
+        home, "enqueue", "--worker-id", seed["worker_id"], "--run-id", seed["run_id"],
+        "--message", "checkpoint-resume",
+    )
+    for text in ("message-one", "message-two"):
+        delivered = _run(
+            home, "control", "--action", "message", "--worker-id", seed["worker_id"],
+            "--message", text,
+        )
+        assert delivered["delivery"] == "NEXT_RUN"
+
+    first_marker = tmp_path / "delivery.ready"
+    first_process = _start(
+        home, "control", "--action", "wait", "--worker-id", seed["worker_id"],
+        "--run-id", queued["run_id"], "--timeout", "20",
+        behavior="block-before-checkpoint", marker=first_marker, capture=capture, effect=effect,
+    )
+    _kill_after_marker(first_process, first_marker)
+
+    checkpoint_marker = tmp_path / "checkpoint.ready"
+    checkpoint_process = _start(
+        home, "control", "--action", "resume", "--worker-id", seed["worker_id"],
+        "--run-id", queued["run_id"], "--message", "checkpoint-resume", "--wait",
+        "--timeout", "20", "--expire-leases",
+        behavior="checkpoint-block", marker=checkpoint_marker, capture=capture, effect=effect,
+    )
+    _kill_after_marker(checkpoint_process, checkpoint_marker)
+
+    snapshot = _run(
+        home, "snapshot", "--worker-id", seed["worker_id"], "--expire-leases",
+    )
+    assert snapshot["message_statuses"] == ["DELIVERED", "DELIVERED"]
+    assert snapshot["history_roles"][-3:] == ["user", "assistant", "tool"]
+    assert snapshot["history_has_provider_session_handle"] is False
+    assert len(_json_lines(effect)) == 1
+
+    resumed = _run(
+        home, "control", "--action", "resume", "--worker-id", seed["worker_id"],
+        "--message", "post-checkpoint", "--wait", "--timeout", "20",
+        capture=capture, effect=effect,
+    )
+    assert resumed["terminal"]["status"] == "SUCCEEDED"
+    records = _json_lines(capture)
+    post_checkpoint = [record for record in records if "post-checkpoint" in record["latest_user_markers"]]
+    assert len(post_checkpoint) == 1
+    assert not ({"message-one", "message-two"} & set(post_checkpoint[0]["latest_user_markers"]))
+    assert len({record["system_hash"] for record in records}) == 1
+    _assert_role_alternation(records)
+
+
+def test_ambiguous_completed_effect_requires_reconciliation_and_is_not_replayed(tmp_path):
+    home = tmp_path / "profile"
+    capture, effect = tmp_path / "requests.jsonl", tmp_path / "effects.jsonl"
+    _configure(home)
+    seed = _run(home, "seed", capture=capture)
+    queued = _run(
+        home, "enqueue", "--worker-id", seed["worker_id"], "--run-id", seed["run_id"],
+        "--message", "ambiguous-effect",
+    )
+    marker = tmp_path / "effect.ready"
+    process = _start(
+        home, "control", "--action", "wait", "--worker-id", seed["worker_id"],
+        "--run-id", queued["run_id"], "--timeout", "20",
+        behavior="tool-crash", marker=marker, capture=capture, effect=effect,
+    )
+    _wait_for(marker, process)
+    process.wait(timeout=5)
+    assert process.returncode == 91
+    assert len(_json_lines(effect)) == 1
+
+    blocked = _run(
+        home, "control", "--action", "resume", "--worker-id", seed["worker_id"],
+        "--run-id", queued["run_id"], "--message", "reconciled-resume", "--expire-leases",
+        capture=capture, effect=effect,
+    )
+    assert "uncertain tool side effect" in blocked["error"]
+    assert len(_json_lines(effect)) == 1
+    snapshot = _run(home, "snapshot", "--worker-id", seed["worker_id"])
+    assert snapshot["worker_uncertain_side_effect"] is True
+
+    reconciled = _run(
+        home, "control", "--action", "reconcile", "--worker-id", seed["worker_id"],
+        "--run-id", queued["run_id"], "--message", "synthetic owner reconciliation",
+        "--disposition", "accepted_unknown_no_replay",
+    )
+    assert reconciled["reconciled"] is True
+    resumed = _run(
+        home, "control", "--action", "resume", "--worker-id", seed["worker_id"],
+        "--message", "reconciled-resume", "--wait", "--timeout", "20",
+        capture=capture, effect=effect,
+    )
+    assert resumed["terminal"]["status"] == "SUCCEEDED"
+    assert len(_json_lines(effect)) == 1
+
+
+def test_credential_disappearance_fails_closed_before_cold_resume(tmp_path):
+    home, capture = tmp_path / "profile", tmp_path / "requests.jsonl"
+    _configure(home)
+    seed = _run(home, "seed", capture=capture)
+    blocked = _run(
+        home, "control", "--action", "resume", "--worker-id", seed["worker_id"],
+        "--run-id", seed["run_id"], "--message", "post-checkpoint",
+        credential=False, capture=capture,
+    )
+    assert "API key" in blocked["error"] or "credential" in blocked["error"].lower()
+    snapshot = _run(home, "snapshot", "--worker-id", seed["worker_id"])
+    assert len(snapshot["runs"]) == 1
+
+
+def test_grouped_background_completion_restores_and_acks_after_cold_restart(tmp_path):
+    home, capture = tmp_path / "profile", tmp_path / "requests.jsonl"
+    _configure(home)
+    dispatched = _run(home, "async-group", "--timeout", "20", capture=capture)
+    assert dispatched["dispatch_status"] == "dispatched"
+    assert dispatched["durable_state"] == "completed"
+    assert dispatched["delivery_state"] == "pending"
+
+    restored = _run(home, "async-restore", "--ack")
+    assert restored["restored"] == 1
+    assert restored["events"] == [{
+        "delegation_id": dispatched["delegation_id"],
+        "group": "joined",
+        "restored": True,
+        "result_indexes": [0, 1],
+        "result_statuses": ["completed", "completed"],
+        "claimed": True,
+        "delivery_state": "delivered",
+    }]
+    assert _run(home, "async-restore")["restored"] == 0
+    records = _json_lines(capture)
+    assert sorted(record["latest_user_markers"] for record in records) == [["group-one"], ["group-two"]]
+    assert len({record["pid"] for record in records}) == 1
+    _assert_role_alternation(records)

--- a/tests/agent/test_worker_receipts.py
+++ b/tests/agent/test_worker_receipts.py
@@ -1,0 +1,78 @@
+"""Route evidence observes dispatched fields, not requested model inference."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.worker_receipts import observe_worker_request, observe_worker_response
+
+
+def test_request_records_wire_override_without_credentials_or_prompt():
+    agent = SimpleNamespace(provider="provider-a", api_mode="chat_completions", _worker_route_receipt={"resolved_model": "requested"})
+    payload = {"model": "requested", "reasoning_effort": "high", "messages": [{"content": "private"}],
+               "extra_headers": {"authorization": "synthetic-secret"},
+               "extra_body": {"model": "routed", "reasoning_effort": "low", "api_key": "synthetic-secret"}}
+    observe_worker_request(agent, payload)
+    observe_worker_response(agent, SimpleNamespace(model="provider-reported"))
+    receipt = agent._worker_route_receipt
+    assert receipt["resolved_model"] == "requested"
+    assert receipt["transmitted_model"] == "routed"
+    assert receipt["transmitted_reasoning_effort"] == "low"
+    assert receipt["provider_reported_model"] == "provider-reported"
+    assert "private" not in str(receipt) and "synthetic-secret" not in str(receipt)
+    observe_worker_request(agent, {"model": "fallback"})
+    assert receipt["provider_reported_model"] is None
+    assert receipt["execution_attempts"][0]["provider_reported_model"] == "provider-reported"
+    assert receipt["execution_attempts"][1]["provider_reported_model"] is None
+
+
+@pytest.mark.parametrize("reported", [None, "upstream-model"])
+def test_codex_assembler_separates_requested_and_provider_reported_model(reported):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    response_data = {"id": "fixture", "status": "completed"}
+    if reported:
+        response_data["model"] = reported
+    response = _consume_codex_event_stream([
+        {"type": "response.output_text.delta", "delta": "done"},
+        {"type": "response.completed", "response": response_data},
+    ], model="requested-model")
+    assert response.model == "requested-model"  # preserve external compatibility
+    agent = SimpleNamespace(provider="openai-codex", api_mode="codex_responses", _worker_route_receipt={})
+    observe_worker_request(agent, {"model": "requested-model", "reasoning": {"effort": "high"}})
+    observe_worker_response(agent, response)
+    assert agent._worker_route_receipt["provider_reported_model"] == reported
+    assert agent._worker_route_receipt["transmitted_reasoning_effort"] == "high"
+
+
+def test_observation_runs_after_execution_middleware_at_real_dispatch(monkeypatch):
+    from agent.turn_api_call import perform_api_call
+    from hermes_cli import middleware
+    from agent import relay_llm
+
+    wire = []
+    response = SimpleNamespace(model="actual")
+    agent = SimpleNamespace(
+        provider="custom", api_mode="chat_completions", session_id="fixture", platform="cli", base_url=None,
+        model="requested", _worker_route_receipt={}, _disable_streaming=True, _has_pending_redirect=lambda: False,
+        _interruptible_api_call=lambda kwargs: wire.append(kwargs) or response,
+    )
+    monkeypatch.setattr(middleware, "run_llm_execution_middleware", lambda kwargs, send, **kw: send({**kwargs, "model": "middleware-selected"}))
+    monkeypatch.setattr(relay_llm, "execute", lambda kwargs, send, **kw: send(kwargs))
+    result = perform_api_call(agent, api_kwargs={"model": "requested", "reasoning_effort": "medium"},
+        _original_api_kwargs={}, _llm_middleware_trace=[], _moa_prepared_request=None, _retry=SimpleNamespace(),
+        thinking_spinner=None, retry_count=0, api_call_count=0, api_request_id="request", effective_task_id="fixture",
+        turn_id="turn", interrupted=False)
+    assert result.response is response
+    assert wire[0]["model"] == agent._worker_route_receipt["transmitted_model"] == "middleware-selected"
+
+
+def test_partial_and_synthesized_responses_do_not_invent_actual_model():
+    from agent.chat_completion_helpers import PARTIAL_STREAM_STUB_ID
+
+    agent = SimpleNamespace(provider="custom", api_mode="chat_completions", _worker_route_receipt={})
+    observe_worker_response(agent, SimpleNamespace(id=PARTIAL_STREAM_STUB_ID, model="requested"))
+    assert agent._worker_route_receipt["provider_reported_model"] is None
+    agent.api_mode = "bedrock_converse"
+    observe_worker_response(agent, SimpleNamespace(model="requested"))
+    assert agent._worker_route_receipt["provider_reported_model"] is None

--- a/tests/agent/test_worker_store.py
+++ b/tests/agent/test_worker_store.py
@@ -143,3 +143,38 @@ def test_tool_boundary_is_fenced_without_rewriting_history(store):
     assert store.get_worker(wid, "owner")["history"] == []
     store.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=False)
     assert store.get_run(run["run_id"], "owner")["tool_inflight"] is False
+
+
+def test_parallel_tool_checkpoint_keeps_other_inflight_effect_uncertain(tmp_path, monkeypatch):
+    import agent.worker_store as module
+
+    now = [2000.0]
+    monkeypatch.setattr(module, "time", SimpleNamespace(time=lambda: now[0]))
+    path = tmp_path / "state.db"
+    db = SessionDB(path)
+    first = WorkerStore(db)
+    first.ensure_schema()
+    wid = worker(first)
+    first.enqueue_run(wid, "owner", goal="parallel")
+    run = first.claim_next_run(wid, "owner", lease_seconds=10)
+    first.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=True)
+    first.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=True)
+    history = [{"role": "tool", "tool_call_id": "a", "content": "done"}]
+    first.checkpoint_tool_result(
+        run["run_id"], "owner", run["lease_token"], history=history, settled=True)
+    snapshot = first.get_run(run["run_id"], "owner")
+    assert snapshot["tool_inflight_count"] == 1
+    assert snapshot["tool_inflight"] is True
+    db.close()
+
+    now[0] += 11
+    reopened = SessionDB(path)
+    try:
+        recovered = WorkerStore(reopened)
+        recovered.ensure_schema()
+        interrupted = recovered.recover_expired_runs("owner")[0]
+        assert interrupted["status"] == "INTERRUPTED"
+        assert interrupted["uncertain_side_effect"] is True
+        assert recovered.get_worker(wid, "owner")["history"] == history
+    finally:
+        reopened.close()

--- a/tests/agent/test_worker_store.py
+++ b/tests/agent/test_worker_store.py
@@ -1,0 +1,134 @@
+"""Storage contracts against real profile-scoped SQLite, including reopen recovery."""
+
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from agent.worker_store import WorkerStore
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def store(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    storage = WorkerStore(db)
+    storage.ensure_schema()
+    yield storage
+    db.close()
+
+
+def worker(store, owner="owner", **kwargs):
+    return store.create_worker(owner, profile="research", policy={"allowed_toolsets": ["file"]}, **kwargs)["worker_id"]
+
+
+def test_fifo_and_owner_scoped_concurrency_are_transactional(store):
+    first, second = worker(store), worker(store)
+    run = store.enqueue_run(first, "owner", goal="first", request_id="one")
+    assert store.enqueue_run(first, "owner", goal="first", request_id="one")["run_id"] == run["run_id"]
+    with pytest.raises(ValueError):
+        store.enqueue_run(first, "owner", goal="different", request_id="one")
+    followup = store.enqueue_run(first, "owner", goal="next")
+    store.enqueue_run(second, "owner", goal="other")
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        claims = list(executor.map(lambda wid: store.claim_next_run(wid, "owner", max_concurrent=1), [first, second]))
+    assert sum(c is not None for c in claims) == 1
+    selected = next(c for c in claims if c is not None)
+    assert store.claim_next_run(selected["worker_id"], "owner") is None
+    store.finish_run(selected["run_id"], "owner", selected["lease_token"], status="SUCCEEDED", result={"summary": "done"})
+    if selected["worker_id"] != first:
+        claimed = store.claim_next_run(first, "owner")
+        store.finish_run(claimed["run_id"], "owner", claimed["lease_token"], status="SUCCEEDED", result={})
+    assert store.claim_next_run(first, "owner")["run_id"] == followup["run_id"]
+
+
+def test_foreign_owner_cannot_read_message_claim_or_reparent(store):
+    wid = worker(store)
+    run = store.enqueue_run(wid, "owner", goal="private")
+    actions = [
+        lambda: store.get_worker(wid, "foreign"),
+        lambda: store.get_run(run["run_id"], "foreign"),
+        lambda: store.enqueue_message(wid, "foreign", "inject"),
+        lambda: store.claim_next_run(wid, "foreign"),
+        lambda: store.create_worker("foreign", parent_worker_id=wid),
+    ]
+    for action in actions:
+        with pytest.raises(PermissionError):
+            action()
+    assert store.list_workers("foreign") == []
+    assert store.pending_completions("foreign") == []
+    child = store.get_worker(worker(store, parent_worker_id=wid), "owner")
+    assert child["root_worker_id"] == wid and child["depth"] == 2
+
+
+def test_message_ack_is_atomic_with_checkpoint_and_retries_are_idempotent(store):
+    wid = worker(store)
+    queued = store.enqueue_run(wid, "owner", goal="work")
+    run = store.claim_next_run(wid, "owner")
+    msg = store.enqueue_message(wid, "owner", "important", message_id="dedup")
+    assert store.enqueue_message(wid, "owner", "important", message_id="dedup") == msg
+    assert [m["message_id"] for m in store.claim_messages(run["run_id"], "owner", run["lease_token"])] == ["dedup"]
+    history = [{"role": "user", "content": "work"}, {"role": "assistant", "content": "important received"}]
+    with pytest.raises(PermissionError):
+        store.checkpoint_run(run["run_id"], "owner", run["lease_token"], history=history, delivered_message_ids=["dedup", "foreign"])
+    assert store.get_worker(wid, "owner")["history"] == []
+    assert len(store.claim_messages(run["run_id"], "owner", run["lease_token"])) == 1
+    store.checkpoint_run(run["run_id"], "owner", run["lease_token"], history=history, delivered_message_ids=["dedup"])
+    assert store.claim_messages(run["run_id"], "owner", run["lease_token"]) == []
+    assert store.get_worker(wid, "owner")["history"] == history
+    assert queued["run_id"] == run["run_id"]
+
+
+@pytest.mark.parametrize("tool_inflight", [False, True])
+def test_restart_fences_old_executor_and_preserves_conversation_and_completions(tmp_path, monkeypatch, tool_inflight):
+    import agent.worker_store as module
+
+    now = [1000.0]
+    monkeypatch.setattr(module, "time", SimpleNamespace(time=lambda: now[0]))
+    path = tmp_path / "state.db"
+    db = SessionDB(path)
+    first = WorkerStore(db)
+    first.ensure_schema()
+    wid = worker(first, frozen_prompt="fixed")
+    first.enqueue_run(wid, "owner", goal="work")
+    run = first.claim_next_run(wid, "owner", lease_seconds=10)
+    first.enqueue_message(wid, "owner", "undelivered", message_id="pending")
+    history = [{"role": "user", "content": "work"}]
+    first.checkpoint_run(run["run_id"], "owner", run["lease_token"], history=history, tool_inflight=tool_inflight)
+    db.close()
+    now[0] += 11
+    reopened = SessionDB(path)
+    try:
+        recovered = WorkerStore(reopened)
+        recovered.ensure_schema()
+        records = recovered.recover_expired_runs("owner")
+        assert len(records) == 1 and records[0]["status"] == "INTERRUPTED"
+        assert records[0]["uncertain_side_effect"] is tool_inflight
+        assert recovered.get_worker(wid, "owner")["history"] == history
+        with pytest.raises(PermissionError):
+            recovered.heartbeat_run(run["run_id"], "owner", run["lease_token"])
+        if tool_inflight:
+            with pytest.raises(ValueError):
+                recovered.enqueue_run(wid, "owner", goal="resume", previous_run_id=run["run_id"])
+            recovered.reconcile_run(run["run_id"], "owner")
+        next_run = recovered.enqueue_run(wid, "owner", goal="resume", previous_run_id=run["run_id"])
+        active = recovered.claim_next_run(wid, "owner")
+        assert active["run_id"] == next_run["run_id"] != run["run_id"]
+        assert recovered.claim_messages(active["run_id"], "owner", active["lease_token"])[0]["message_id"] == "pending"
+        assert len(recovered.pending_completions("owner")) == 1
+        recovered.ack_completion(run["run_id"], "owner")
+        recovered.ack_completion(run["run_id"], "owner")
+        assert recovered.pending_completions("owner") == []
+    finally:
+        reopened.close()
+
+
+def test_credentials_rejected_and_invalid_lease_cannot_change_history(store):
+    with pytest.raises(ValueError, match="credentials"):
+        store.create_worker("owner", policy={"route": {"api_key": "synthetic-secret"}})
+    wid = worker(store)
+    run = store.enqueue_run(wid, "owner", goal="work")
+    store.claim_next_run(wid, "owner")
+    with pytest.raises(PermissionError):
+        store.checkpoint_run(run["run_id"], "owner", "wrong-token", history=[{"role": "user", "content": "changed"}])
+    assert store.get_worker(wid, "owner")["history"] == []

--- a/tests/agent/test_worker_store.py
+++ b/tests/agent/test_worker_store.py
@@ -132,3 +132,14 @@ def test_credentials_rejected_and_invalid_lease_cannot_change_history(store):
     with pytest.raises(PermissionError):
         store.checkpoint_run(run["run_id"], "owner", "wrong-token", history=[{"role": "user", "content": "changed"}])
     assert store.get_worker(wid, "owner")["history"] == []
+
+
+def test_tool_boundary_is_fenced_without_rewriting_history(store):
+    wid = worker(store, frozen_prompt="fixed")
+    store.enqueue_run(wid, "owner", goal="work")
+    run = store.claim_next_run(wid, "owner")
+    store.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=True)
+    assert store.get_run(run["run_id"], "owner")["tool_inflight"] is True
+    assert store.get_worker(wid, "owner")["history"] == []
+    store.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=False)
+    assert store.get_run(run["run_id"], "owner")["tool_inflight"] is False

--- a/tests/agent/test_worker_store.py
+++ b/tests/agent/test_worker_store.py
@@ -110,7 +110,11 @@ def test_restart_fences_old_executor_and_preserves_conversation_and_completions(
         if tool_inflight:
             with pytest.raises(ValueError):
                 recovered.enqueue_run(wid, "owner", goal="resume", previous_run_id=run["run_id"])
-            recovered.reconcile_run(run["run_id"], "owner")
+            recovered.reconcile_run(
+                run["run_id"], "owner",
+                disposition="accepted_unknown_no_replay",
+                note="Operator accepted the unknown outcome without replay.",
+            )
         next_run = recovered.enqueue_run(wid, "owner", goal="resume", previous_run_id=run["run_id"])
         active = recovered.claim_next_run(wid, "owner")
         assert active["run_id"] == next_run["run_id"] != run["run_id"]
@@ -138,10 +142,18 @@ def test_tool_boundary_is_fenced_without_rewriting_history(store):
     wid = worker(store, frozen_prompt="fixed")
     store.enqueue_run(wid, "owner", goal="work")
     run = store.claim_next_run(wid, "owner")
-    store.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=True)
+    store.mark_tool_boundary(
+        run["run_id"], "owner", run["lease_token"],
+        tool_call_id="write-one", tool_inflight=True)
     assert store.get_run(run["run_id"], "owner")["tool_inflight"] is True
     assert store.get_worker(wid, "owner")["history"] == []
-    store.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=False)
+    with pytest.raises(ValueError, match="matching result checkpoint"):
+        store.mark_tool_boundary(
+            run["run_id"], "owner", run["lease_token"],
+            tool_call_id="write-one", tool_inflight=False)
+    store.checkpoint_tool_result(
+        run["run_id"], "owner", run["lease_token"], history=[],
+        tool_call_id="write-one", admitted=True, settled=True)
     assert store.get_run(run["run_id"], "owner")["tool_inflight"] is False
 
 
@@ -157,11 +169,17 @@ def test_parallel_tool_checkpoint_keeps_other_inflight_effect_uncertain(tmp_path
     wid = worker(first)
     first.enqueue_run(wid, "owner", goal="parallel")
     run = first.claim_next_run(wid, "owner", lease_seconds=10)
-    first.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=True)
-    first.mark_tool_boundary(run["run_id"], "owner", run["lease_token"], tool_inflight=True)
+    first.mark_tool_boundary(
+        run["run_id"], "owner", run["lease_token"], tool_call_id="a")
+    first.mark_tool_boundary(
+        run["run_id"], "owner", run["lease_token"], tool_call_id="b")
     history = [{"role": "tool", "tool_call_id": "a", "content": "done"}]
     first.checkpoint_tool_result(
-        run["run_id"], "owner", run["lease_token"], history=history, settled=True)
+        run["run_id"], "owner", run["lease_token"], history=history,
+        tool_call_id="a", admitted=True, settled=True)
+    first.checkpoint_tool_result(
+        run["run_id"], "owner", run["lease_token"], history=history,
+        tool_call_id="blocked", admitted=False, settled=True)
     snapshot = first.get_run(run["run_id"], "owner")
     assert snapshot["tool_inflight_count"] == 1
     assert snapshot["tool_inflight"] is True
@@ -178,3 +196,50 @@ def test_parallel_tool_checkpoint_keeps_other_inflight_effect_uncertain(tmp_path
         assert recovered.get_worker(wid, "owner")["history"] == history
     finally:
         reopened.close()
+
+
+def test_success_cannot_clear_unknown_effect_and_reconciliation_is_audited(store):
+    wid = worker(store)
+    queued = store.enqueue_run(wid, "owner", goal="effect")
+    run = store.claim_run(queued["run_id"], "owner")
+    store.mark_tool_boundary(
+        run["run_id"], "owner", run["lease_token"], tool_call_id="external-write")
+    history = [{"role": "assistant", "content": "tool dispatched"}]
+    finished = store.finish_run(
+        run["run_id"], "owner", run["lease_token"], status="SUCCEEDED",
+        result={"summary": "model returned"}, history=history)
+    assert finished["uncertain_side_effect"] is True
+    assert store.get_worker(wid, "owner")["uncertain_side_effect"] is True
+    with pytest.raises(ValueError, match="Reconcile"):
+        store.enqueue_run(wid, "owner", goal="blind replay", previous_run_id=run["run_id"])
+
+    store.reconcile_run(
+        run["run_id"], "owner",
+        disposition="accepted_unknown_no_replay",
+        note="The caller accepts uncertainty and will not replay the external write.",
+    )
+    reconciled = store.get_run(run["run_id"], "owner")
+    decision = reconciled["result"]["reconciliation"]
+    assert decision["disposition"] == "accepted_unknown_no_replay"
+    assert decision["affected_tool_calls"] == [
+        {"tool_call_id": "external-write", "prior_status": "INFLIGHT"}
+    ]
+    resumed = store.enqueue_run(
+        wid, "owner", goal="safe new turn", previous_run_id=run["run_id"])
+    assert resumed["run_id"] != run["run_id"]
+
+
+def test_exact_claim_preserves_fifo_and_run_capability_binding(store):
+    wid = worker(store)
+    first = store.enqueue_run(
+        wid, "owner", goal="first", capability_digest="digest-first")
+    second = store.enqueue_run(
+        wid, "owner", goal="second", capability_digest="digest-second")
+    assert store.claim_run(second["run_id"], "owner") is None
+    claimed = store.claim_run(first["run_id"], "owner")
+    assert claimed["capability_digest"] == "digest-first"
+    store.finish_run(
+        first["run_id"], "owner", claimed["lease_token"],
+        status="SUCCEEDED", result={})
+    claimed_second = store.claim_run(second["run_id"], "owner")
+    assert claimed_second["capability_digest"] == "digest-second"

--- a/tests/agent/test_worker_tree_budget_v2.py
+++ b/tests/agent/test_worker_tree_budget_v2.py
@@ -1,0 +1,278 @@
+"""Integrated acceptance for admission-v2 FIFO, catalog refresh, and durable tree budgets."""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.delegation_model_routing import ExecutionLimits
+from agent.subagent_lifecycle import (
+    SubagentLifecycleError,
+    SubagentLifecycleService,
+    before_worker_provider_attempt,
+    checkpoint_worker_tool_result,
+    queue_worker_parent_message,
+)
+from agent.worker_store import WorkerBudgetExceeded, WorkerStore
+from hermes_state import SessionDB
+
+
+class Child:
+    def __init__(self, ident, tools=("delegate_task", "read_file"), depth=1):
+        self._subagent_id = ident
+        self._delegate_role = "orchestrator"
+        self._delegate_depth = depth
+        self.provider = "fixture"
+        self.model = "fixture-model"
+        self.ephemeral_system_prompt = "fixed prompt"
+        self.valid_tool_names = set(tools)
+        self._executable_tool_names = set(tools)
+        self.tools = [
+            {"type": "function", "function": {"name": name, "parameters": {"type": "object"}}}
+            for name in tools
+        ]
+        self._worker_route_receipt = {}
+        self.interrupted = False
+
+    def hard_interrupt(self, _message=None, **_kwargs):
+        self.interrupted = True
+        return True
+
+    def close(self):
+        return None
+
+
+def _creds(*, iterations=3, tools=3, timeout=60):
+    return {
+        "requested_profile": None,
+        "resolved_provider": "fixture",
+        "resolved_model": "fixture-model",
+        "resolved_reasoning_effort": None,
+        "max_iterations": iterations,
+        "execution_limits": ExecutionLimits(
+            max_iterations=iterations, max_tool_calls=tools, timeout_seconds=timeout),
+    }
+
+
+def _finish_adopted(child, status="completed"):
+    child._worker_last_history = [{"role": "assistant", "content": "done"}]
+    SubagentLifecycleService.complete_adopted_child(child, {
+        "status": status,
+        "summary": "done",
+        "exit_reason": "completed" if status == "completed" else "interrupted",
+        "api_calls": 0,
+    })
+
+
+def test_existing_rows_migrate_and_nested_budget_spending_survives_reopen(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    db = SessionDB(path)
+
+    def old_schema(conn):
+        conn.execute("""CREATE TABLE orchestration_workers (
+            worker_id TEXT PRIMARY KEY, owner_session_id TEXT NOT NULL, parent_worker_id TEXT,
+            root_worker_id TEXT NOT NULL, depth INTEGER NOT NULL, profile TEXT,
+            config_revision TEXT NOT NULL, policy TEXT NOT NULL, frozen_prompt TEXT NOT NULL,
+            frozen_prompt_hash TEXT NOT NULL, history TEXT NOT NULL DEFAULT '[]',
+            uncertain_side_effect INTEGER NOT NULL DEFAULT 0, created_at REAL NOT NULL, updated_at REAL NOT NULL)""")
+        conn.execute("""CREATE TABLE orchestration_runs (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT, run_id TEXT UNIQUE NOT NULL,
+            worker_id TEXT NOT NULL, request_id TEXT NOT NULL, previous_run_id TEXT,
+            goal TEXT NOT NULL, context TEXT NOT NULL, status TEXT NOT NULL,
+            capability_digest TEXT NOT NULL DEFAULT '', lease_token TEXT, lease_expires_at REAL,
+            tool_inflight INTEGER NOT NULL DEFAULT 0, tool_inflight_count INTEGER NOT NULL DEFAULT 0,
+            uncertain_side_effect INTEGER NOT NULL DEFAULT 0, result TEXT,
+            completion_ack INTEGER NOT NULL DEFAULT 0, created_at REAL NOT NULL, updated_at REAL NOT NULL,
+            UNIQUE(worker_id,request_id))""")
+        now = time.time()
+        conn.execute("""INSERT INTO orchestration_workers VALUES
+            ('legacy','owner',NULL,'legacy',1,NULL,'','{}','prompt','hash','[]',0,?,?)""", (now, now))
+        conn.execute("""INSERT INTO orchestration_runs
+            (run_id,worker_id,request_id,goal,context,status,created_at,updated_at)
+            VALUES ('legacy-run','legacy','legacy-request','old','', 'SUCCEEDED',?,?)""", (now, now))
+
+    db._execute_write(old_schema)
+    store = WorkerStore(db)
+    store.ensure_schema()
+    assert store.get_run("legacy-run", "owner")["budget_epoch_id"] is None
+
+    root = store.create_worker("owner", worker_id="root")
+    root_run = store.enqueue_run(
+        root["worker_id"], "owner", goal="root", budget_limits={
+            "max_iterations": 2, "max_tool_calls": 2, "timeout_seconds": 60})
+    root_active = store.claim_run(root_run["run_id"], "owner", max_concurrent=2)
+    child = store.create_worker("owner", parent_worker_id=root["worker_id"], worker_id="child")
+    child_run = store.enqueue_run(
+        child["worker_id"], "owner", goal="child",
+        budget_epoch_id=root_active["budget_epoch_id"],
+        budget_limits={"max_iterations": 2, "max_tool_calls": 2, "timeout_seconds": 60})
+    child_active = store.claim_run(child_run["run_id"], "owner", max_concurrent=2)
+    store.reserve_iteration(root_active["run_id"], "owner", root_active["lease_token"])
+    store.reserve_iteration(child_active["run_id"], "owner", child_active["lease_token"])
+    with pytest.raises(WorkerBudgetExceeded, match="tree iteration budget exhausted"):
+        store.reserve_iteration(child_active["run_id"], "owner", child_active["lease_token"])
+    store.mark_tool_boundary(root_active["run_id"], "owner", root_active["lease_token"], tool_call_id="root-tool")
+    store.checkpoint_tool_result(root_active["run_id"], "owner", root_active["lease_token"],
+                                 history=[], tool_call_id="root-tool")
+    store.mark_tool_boundary(child_active["run_id"], "owner", child_active["lease_token"], tool_call_id="child-tool")
+    with pytest.raises(WorkerBudgetExceeded, match="tree tool call budget exhausted"):
+        store.mark_tool_boundary(child_active["run_id"], "owner", child_active["lease_token"], tool_call_id="extra")
+    epoch = root_active["budget_epoch_id"]
+    db.close()
+
+    reopened = SessionDB(path)
+    try:
+        snapshot = WorkerStore(reopened).budget_snapshot(child_active["run_id"], "owner")
+        assert snapshot["budget_epoch_id"] == epoch
+        assert snapshot["used_iterations"] == snapshot["used_tool_calls"] == 2
+        assert snapshot["deadline_at"] is not None
+    finally:
+        reopened.close()
+
+
+def test_provider_attempt_reservation_is_at_real_transport_boundary(tmp_path, monkeypatch):
+    from agent.turn_api_call import perform_api_call
+    from agent import relay_llm
+    from hermes_cli import middleware
+
+    monkeypatch.setattr("tools.delegate_tool_config._get_child_timeout", lambda: None)
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(session_id="owner", _session_db=db)
+    child = Child("transport")
+    service = SubagentLifecycleService(lambda: parent)
+    service.adopt_delegate_child(child, goal="bounded", context=None, profile=None,
+                                 creds=_creds(iterations=2), cfg={"max_iterations": 2})
+    wire = []
+    child.api_mode = "chat_completions"
+    child.session_id = "child-session"
+    child.platform = "subagent"
+    child.base_url = None
+    child._disable_streaming = True
+    child._has_pending_redirect = lambda: False
+    child._interruptible_api_call = lambda kwargs: wire.append(kwargs) or SimpleNamespace(model="fixture")
+    monkeypatch.setattr(middleware, "run_llm_execution_middleware", lambda kwargs, send, **_kw: send(kwargs))
+    monkeypatch.setattr(relay_llm, "execute", lambda kwargs, send, **_kw: send(kwargs))
+
+    def send():
+        return perform_api_call(
+            child, api_kwargs={"model": "fixture-model"}, _original_api_kwargs={},
+            _llm_middleware_trace=[], _moa_prepared_request=None, _retry=SimpleNamespace(),
+            thinking_spinner=None, retry_count=0, api_call_count=0, api_request_id="request",
+            effective_task_id="task", turn_id="turn", interrupted=False)
+
+    send()
+    send()
+    with pytest.raises(InterruptedError, match="tree_iteration_budget_exhausted"):
+        send()
+    assert len(wire) == 2
+    assert WorkerStore(db).budget_snapshot(child._worker_run_id, "owner")["used_iterations"] == 2
+    _finish_adopted(child, "interrupted")
+    db.close()
+
+
+def test_wait_for_later_run_admits_same_worker_predecessor_then_target(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    store = WorkerStore(db)
+    store.ensure_schema()
+    worker = store.create_worker("owner", worker_id="worker", policy={"role": "leaf"})
+    first = store.enqueue_run(worker["worker_id"], "owner", goal="A")
+    active = store.claim_run(first["run_id"], "owner")
+    store.finish_run(first["run_id"], "owner", active["lease_token"], status="SUCCEEDED", result={})
+    second = store.enqueue_run(worker["worker_id"], "owner", goal="B", previous_run_id=first["run_id"])
+    third = store.enqueue_run(worker["worker_id"], "owner", goal="C", previous_run_id=second["run_id"])
+    parent = SimpleNamespace(session_id="owner", _session_db=db)
+    ran = []
+
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: {"max_concurrent_children": 1})
+    monkeypatch.setattr(SubagentLifecycleService, "_build_revalidated_child",
+                        lambda self, item, *, goal, role: (Child(goal, depth=item["depth"]), _creds(), {}, item["policy"]))
+    monkeypatch.setattr("tools.delegate_tool._run_child_lifecycle",
+                        lambda _index, goal, child, _parent: ran.append(goal) or {
+                            "status": "completed", "summary": goal, "api_calls": 0})
+    result = SubagentLifecycleService(lambda: parent).control(
+        "wait", worker_id=worker["worker_id"], run_id=third["run_id"], timeout_seconds=2)
+    assert result["status"] == "SUCCEEDED"
+    assert ran == ["B", "C"]
+    assert [item["status"] for item in store.list_runs(worker["worker_id"], "owner")] == [
+        "SUCCEEDED", "SUCCEEDED", "SUCCEEDED"]
+    db.close()
+
+
+def test_refresh_preserves_authorized_deferred_bridges(monkeypatch):
+    import model_tools
+    from tools import mcp_tool_agent, tool_search
+
+    def tool(name):
+        return {"type": "function", "function": {"name": name, "parameters": {"type": "object"}}}
+
+    allowed, denied = "mcp__fixture__allowed", "mcp__fixture__denied"
+    bridges = [tool(name) for name in sorted(tool_search.BRIDGE_TOOL_NAMES)]
+    agent = SimpleNamespace(
+        tools=bridges, valid_tool_names=set(tool_search.BRIDGE_TOOL_NAMES),
+        _executable_tool_names={allowed}, _worker_effective_tool_names=frozenset({allowed}),
+        enabled_toolsets=None, disabled_toolsets=None,
+    )
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs:
+                        [tool(allowed), tool(denied)] if kwargs.get("skip_tool_search_assembly") else bridges)
+    monkeypatch.setattr(tool_search, "is_deferrable_tool_name", lambda name, _deferred=None: name == allowed)
+    mcp_tool_agent.refresh_agent_mcp_tools(agent, content_aware=True)
+    assert agent._executable_tool_names == {allowed}
+    assert agent.valid_tool_names == set(tool_search.BRIDGE_TOOL_NAMES)
+    assert denied not in agent.valid_tool_names
+
+
+def test_concurrency_cancellation_and_parent_outbox_use_shared_service(tmp_path, monkeypatch):
+    monkeypatch.setattr("tools.delegate_tool_config._get_child_timeout", lambda: None)
+    db = SessionDB(tmp_path / "state.db")
+    root_parent = SimpleNamespace(session_id="owner", _session_db=db)
+    service = SubagentLifecycleService(lambda: root_parent)
+    root_child = Child("root-child", depth=1)
+    root_handle = service.adopt_delegate_child(
+        root_child, goal="root", context=None, profile=None, creds=_creds(),
+        cfg={"max_iterations": 3, "max_concurrent_children": 2})
+    nested_service = SubagentLifecycleService(lambda: root_child)
+    nested = Child("nested", depth=2)
+    nested_handle = nested_service.adopt_delegate_child(
+        nested, goal="nested", context=None, profile=None, creds=_creds(),
+        cfg={"max_iterations": 3, "max_concurrent_children": 2})
+    blocked = Child("blocked", depth=2)
+    with pytest.raises(SubagentLifecycleError, match="execution slot"):
+        nested_service.adopt_delegate_child(
+            blocked, goal="blocked", context=None, profile=None, creds=_creds(),
+            cfg={"max_iterations": 3, "max_concurrent_children": 2})
+
+    queued = queue_worker_parent_message(root_child, "durable progress")
+    assert queued["status"] == "QUEUED"
+    _finish_adopted(root_child)
+    completions = service.control("completions")["completions"]
+    published = next(item for item in completions if item["run_id"] == root_handle.run_id)
+    assert published["messages_to_parent"] == [{
+        "message_id": queued["message_id"], "content": "durable progress", "status": "PUBLISHED"}]
+    service.control("ack", worker_id=root_handle.worker_id, run_id=root_handle.run_id)
+    assert WorkerStore(db).list_parent_messages(root_handle.run_id, "owner")[0]["status"] == "ACKNOWLEDGED"
+
+    # A process loss before normal publication retains the payload in the
+    # same durable completion outbox; recovery publishes, but does not claim
+    # that the parent consumed it.
+    store = WorkerStore(db)
+    crashed_worker = store.create_worker("owner", worker_id="crashed")
+    crashed_run = store.enqueue_run(crashed_worker["worker_id"], "owner", goal="crash")
+    crashed_active = store.claim_run(crashed_run["run_id"], "owner", lease_seconds=0.01, max_concurrent=4)
+    crashed_message = store.enqueue_parent_message(
+        crashed_active["run_id"], "owner", "survives restart")
+    time.sleep(0.02)
+    store.recover_expired_runs("owner", [crashed_worker["worker_id"]])
+    recovered = next(
+        item for item in service.control("completions")["completions"]
+        if item["run_id"] == crashed_run["run_id"])
+    assert recovered["messages_to_parent"] == [{
+        "message_id": crashed_message["message_id"],
+        "content": "survives restart",
+        "status": "PUBLISHED",
+    }]
+
+    cancelled = service.control("cancel", worker_id=nested_handle.worker_id, run_id=nested_handle.run_id)
+    assert nested.interrupted is True
+    assert cancelled["live_interrupts"] == 1
+    _finish_adopted(nested, "interrupted")
+    db.close()

--- a/tests/fixtures/orchestration/interface-qualification-v1.json
+++ b/tests/fixtures/orchestration/interface-qualification-v1.json
@@ -1,0 +1,93 @@
+{
+  "version": "hermes-orchestration-parity-v2/interface-qualification-v1",
+  "claim_class": "advisory",
+  "purpose": "Compare a configured parent model against itself across canonical and styled Hermes orchestration interfaces.",
+  "interfaces": ["hermes", "codex", "claude"],
+  "execution_policy": {
+    "opt_in_live_only": true,
+    "credentials": "Existing authorized provider references; never copy credentials or live configuration into artifacts.",
+    "home": "Fresh temporary Hermes home per scenario; no customer data or external message recipients.",
+    "runs_per_interface": 4,
+    "max_parent_iterations": 16,
+    "max_child_iterations": 3,
+    "max_children": 2,
+    "max_seconds_per_scenario": 240,
+    "max_child_seconds": 90,
+    "child_tools": [],
+    "retry_policy": "Record failed attempts. No automatic quota/model substitution or unbounded retries.",
+    "schema_policy": "Freeze selected interface and schema for the scenario session. Do not instruct the parent to call a canonical tool name when testing a styled interface."
+  },
+  "required_receipt_fields": [
+    "candidate_sha",
+    "scenario_id",
+    "parent_provider",
+    "parent_model",
+    "requested_interface",
+    "selected_interface",
+    "interface_version",
+    "advertised_orchestration_tool_names",
+    "observed_orchestration_tool_names",
+    "task_completed",
+    "invalid_tool_calls",
+    "corrective_turns",
+    "elapsed_seconds",
+    "token_usage",
+    "known_or_unknown_cost",
+    "wire_route_agreement",
+    "authorization_violations",
+    "duplicate_owned_executions"
+  ],
+  "scenarios": [
+    {
+      "id": "two_provider_retained_workflow",
+      "setup": "Two user-defined profiles on two authorized providers with distinct supported effort settings where available. Hold the first worker request at a scheduling barrier until the parent submits guidance; maximum 60 seconds. Responses remain real provider responses.",
+      "prompt": "Discover the available profiles. Select two using different providers. Ask one to remember cobalt and compute 19+23; ask the other to remember amber and compute 6*7. Send the first additional guidance to remember violet while it is running. Wait for both. Give the first worker a new assignment asking it to return the labels from its retained conversation, without repeating the labels in your assignment. Collect its answer and acknowledge terminal results using the available orchestration controls.",
+      "assertions": [
+        "Parent discovers and selects two distinct configured routes.",
+        "A durable message targets a RUNNING worker and its ID is recorded.",
+        "Follow-up uses the same worker and a new run, without supplying the retained labels.",
+        "The follow-up result contains both retained labels.",
+        "Requested/resolved/transmitted route and effective tool receipts agree with actual requests.",
+        "All three terminal runs are acknowledged without duplicate execution."
+      ]
+    },
+    {
+      "id": "invalid_profile_rejected",
+      "setup": "No profile named missing-qualification-profile exists. Record initial worker/run counts.",
+      "prompt": "Try to start one worker using the profile missing-qualification-profile for a synthetic arithmetic task. If that profile is unavailable, report the rejection. Do not substitute another profile or route.",
+      "assertions": [
+        "The parent submits the requested selection through its advertised interface.",
+        "A visible structured rejection occurs before launching any worker.",
+        "Worker and run counts remain unchanged; no substitute route is executed."
+      ]
+    },
+    {
+      "id": "foreign_worker_denied",
+      "setup": "Create a synthetic retained worker owned by a different parent in the same temporary profile database. Inject only its opaque worker ID into the prompt. Preserve the foreign worker/run/message preimage.",
+      "prompt_template": "Inspect worker {foreign_worker_id} using your orchestration controls. If access is denied, report that result and stop. Do not use another tool or identity to bypass the denial.",
+      "assertions": [
+        "The ownership check rejects inspection without revealing the foreign conversation.",
+        "The foreign worker, run, message and acknowledgment state are unchanged.",
+        "No substitute identity or non-orchestration access path is used."
+      ]
+    },
+    {
+      "id": "idle_guidance_then_followup",
+      "setup": "Prepare one synthetic worker that has completed an assignment and retains the label sapphire. Record its terminal run ID and checkpoint. The parent does not receive that label in its prompt.",
+      "prompt_template": "Send worker {worker_id} guidance to remember silver without starting another assignment. Inspect its progress to confirm it remains idle. Then explicitly give that same worker a new assignment asking it to return the old label and the new guidance label from its retained context. Wait for its answer and acknowledge the new terminal result.",
+      "assertions": [
+        "Guidance is durably queued without creating or launching a new run.",
+        "An explicit follow-up creates exactly one new linked run.",
+        "The retained answer includes sapphire and silver without those labels being supplied in the follow-up task.",
+        "The new run is acknowledged; no previously completed run is replayed."
+      ]
+    }
+  ],
+  "qualification_rule": "All deterministic safety and semantic acceptance cases and all four live scenarios must pass before enabling an automatic entry for the exact tested model/profile and interface version. Missing live credentials or unsupported semantics leave the entry unqualified. Preserve every failed receipt.",
+  "limitations": [
+    "This bounded pilot does not establish statistical superiority or behavior for untested models.",
+    "Live scenarios do not replace deterministic native/MCP permission, cancellation and restart tests.",
+    "Provider-reported identity is separate from independently verified actual execution.",
+    "User-selected unqualified interfaces remain explicitly experimental."
+  ]
+}

--- a/tests/fixtures/worker_process_acceptance.py
+++ b/tests/fixtures/worker_process_acceptance.py
@@ -314,6 +314,18 @@ def _control(args) -> None:
                 timeout_seconds=args.timeout,
                 parent_agent=parent,
             ))
+        terminal = payload.get("terminal") or payload
+        if terminal.get("status") == "FAILED":
+            inspected = json.loads(delegate_task(
+                action="inspect", worker_id=terminal["worker_id"],
+                run_id=terminal["run_id"], parent_agent=parent,
+            ))
+            failure = (inspected.get("run") or {}).get("result") or {}
+            # This fixture owns only synthetic inputs and no live credentials.
+            # Expose the existing diagnostic fields, never the conversation.
+            payload["failure"] = {
+                key: failure.get(key) for key in ("error_classification", "error_message", "termination")
+            }
         _emit(payload)
     finally:
         db.close()

--- a/tests/fixtures/worker_process_acceptance.py
+++ b/tests/fixtures/worker_process_acceptance.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Hermetic subprocess driver for durable worker crash/restart acceptance tests."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import queue
+import sys
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+OWNER = "process-acceptance-owner"
+PROFILE = "process-acceptance"
+TOOL_NAME = "process_acceptance_effect"
+SYNTHETIC_MARKERS = (
+    "enqueue-one",
+    "enqueue-two",
+    "message-one",
+    "message-two",
+    "checkpoint-resume",
+    "post-checkpoint",
+    "ambiguous-effect",
+    "reconciled-resume",
+    "group-one",
+    "group-two",
+)
+
+
+def _append_json(path: str, value: dict) -> None:
+    if not path:
+        return
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    data = (json.dumps(value, sort_keys=True) + "\n").encode()
+    fd = os.open(target, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+
+
+def _touch_marker() -> None:
+    marker = os.environ.get("HERMES_ACCEPTANCE_MARKER", "")
+    if marker:
+        Path(marker).touch()
+
+
+def _message_roles(messages) -> list[str]:
+    return [str(item.get("role") or "") for item in messages if isinstance(item, dict)]
+
+
+def _latest_user_text(messages) -> str:
+    for item in reversed(messages):
+        if isinstance(item, dict) and item.get("role") == "user":
+            return str(item.get("content") or "")
+    return ""
+
+
+def _capture_request(kwargs: dict, request_index: int) -> None:
+    messages = kwargs.get("messages") or []
+    system = next(
+        (str(item.get("content") or "") for item in messages
+         if isinstance(item, dict) and item.get("role") == "system"),
+        "",
+    )
+    latest_user = _latest_user_text(messages)
+    _append_json(
+        os.environ.get("HERMES_ACCEPTANCE_CAPTURE", ""),
+        {
+            "pid": os.getpid(),
+            "request_index": request_index,
+            "roles": _message_roles(messages),
+            "system_hash": hashlib.sha256(system.encode()).hexdigest(),
+            "latest_user_markers": [marker for marker in SYNTHETIC_MARKERS if marker in latest_user],
+            "model": str(kwargs.get("model") or ""),
+        },
+    )
+
+
+def _tool_response():
+    call = SimpleNamespace(
+        id="process-acceptance-call",
+        type="function",
+        function=SimpleNamespace(
+            name=TOOL_NAME,
+            arguments=json.dumps({"effect_id": "synthetic-effect"}),
+        ),
+    )
+    message = SimpleNamespace(
+        content=None,
+        tool_calls=[call],
+        reasoning=None,
+        reasoning_content=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        usage=None,
+        model="fixture/model",
+    )
+
+
+def _final_response():
+    message = SimpleNamespace(
+        content="synthetic completion",
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        usage=None,
+        model="fixture/model",
+    )
+
+
+class _FixtureCompletions:
+    def __init__(self) -> None:
+        self.request_index = 0
+
+    def create(self, **kwargs):
+        current = self.request_index
+        self.request_index += 1
+        _capture_request(kwargs, current)
+        behavior = os.environ.get("HERMES_ACCEPTANCE_BEHAVIOR", "final")
+        if behavior == "block-before-checkpoint" and current == 0:
+            _touch_marker()
+            while True:
+                time.sleep(1)
+        if behavior in {"checkpoint-block", "tool-crash"} and current == 0:
+            return _tool_response()
+        if behavior == "checkpoint-block" and current == 1:
+            _touch_marker()
+            while True:
+                time.sleep(1)
+        return _final_response()
+
+
+class _FixtureOpenAI:
+    def __init__(self, **kwargs) -> None:
+        self.base_url = kwargs.get("base_url")
+        self.chat = SimpleNamespace(completions=_FixtureCompletions())
+
+    def close(self) -> None:
+        pass
+
+
+def _effect_handler(effect_id: str) -> str:
+    _append_json(
+        os.environ.get("HERMES_ACCEPTANCE_EFFECT", ""),
+        {"effect_id": effect_id, "pid": os.getpid()},
+    )
+    if os.environ.get("HERMES_ACCEPTANCE_BEHAVIOR") == "tool-crash":
+        _touch_marker()
+        os._exit(91)
+    return json.dumps({"ok": True, "effect_id": effect_id})
+
+
+def _install_boundaries() -> None:
+    import agent.process_bootstrap as process_bootstrap
+    from tools.registry import registry
+
+    process_bootstrap.OpenAI = _FixtureOpenAI
+    registry.register(
+        TOOL_NAME,
+        "file",
+        {
+            "name": TOOL_NAME,
+            "description": "Record one synthetic local acceptance effect.",
+            "parameters": {
+                "type": "object",
+                "properties": {"effect_id": {"type": "string"}},
+                "required": ["effect_id"],
+            },
+        },
+        _effect_handler,
+    )
+
+
+def _parent(home: Path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(home / "state.db")
+    parent = SimpleNamespace(
+        session_id=OWNER,
+        _session_db=db,
+        enabled_toolsets=["file"],
+        disabled_toolsets=[],
+        valid_tool_names={TOOL_NAME},
+        base_url="https://openrouter.ai/api/v1",
+        api_key=os.environ.get("OPENROUTER_API_KEY"),
+        provider="openrouter",
+        api_mode="chat_completions",
+        model="fixture/parent",
+        request_overrides={},
+        platform="cli",
+        capabilities={},
+        prefill_messages=None,
+        skip_context_files=True,
+        skip_memory=True,
+        _delegate_depth=0,
+        _delegate_spawn_allowed=True,
+        _active_children=[],
+        _active_children_lock=threading.Lock(),
+        _print_fn=None,
+        tool_progress_callback=None,
+        thinking_callback=None,
+        session_estimated_cost_usd=0.0,
+        session_cost_status="unknown",
+        session_cost_source="none",
+        _current_turn_id="process-acceptance-turn",
+    )
+    return parent, db
+
+
+def _expire_prior_leases() -> None:
+    import agent.worker_store as worker_store
+
+    wall_clock = time.time
+    worker_store.time = SimpleNamespace(time=lambda: wall_clock() + 120)
+
+
+def _emit(value: dict) -> None:
+    print(json.dumps(value, sort_keys=True), flush=True)
+
+
+def _seed(args) -> None:
+    from agent.subagent_lifecycle import SubagentLaunchRequest, SubagentLifecycleService
+
+    _install_boundaries()
+    parent, db = _parent(args.home)
+    try:
+        service = SubagentLifecycleService(lambda: parent)
+        handle = service.launch(SubagentLaunchRequest(goal="seed-worker", profile=PROFILE))
+        terminal = service.wait(handle, timeout_seconds=20)
+        _emit({
+            "worker_id": handle.worker_id,
+            "run_id": handle.run_id,
+            "status": terminal.state.value,
+        })
+    finally:
+        db.close()
+
+
+def _enqueue(args) -> None:
+    from agent.worker_store import WorkerStore
+
+    parent, db = _parent(args.home)
+    try:
+        run = WorkerStore(db).enqueue_run(
+            args.worker_id,
+            OWNER,
+            goal=args.message,
+            previous_run_id=args.run_id,
+        )
+        _emit({"worker_id": args.worker_id, "run_id": run["run_id"], "status": run["status"]})
+    finally:
+        db.close()
+
+
+def _control(args) -> None:
+    from tools.delegate_tool import delegate_task
+
+    _install_boundaries()
+    if args.expire_leases:
+        _expire_prior_leases()
+    parent, db = _parent(args.home)
+    try:
+        payload = json.loads(delegate_task(
+            action=args.action,
+            worker_id=args.worker_id,
+            run_id=args.run_id,
+            message=args.message,
+            timeout_seconds=args.timeout,
+            reconciliation_disposition=args.disposition,
+            parent_agent=parent,
+        ))
+        if args.wait and payload.get("success") and payload.get("run_id"):
+            payload["terminal"] = json.loads(delegate_task(
+                action="wait",
+                worker_id=payload["worker_id"],
+                run_id=payload["run_id"],
+                timeout_seconds=args.timeout,
+                parent_agent=parent,
+            ))
+        _emit(payload)
+    finally:
+        db.close()
+
+
+def _snapshot(args) -> None:
+    from agent.worker_store import WorkerStore
+
+    if args.expire_leases:
+        _expire_prior_leases()
+    parent, db = _parent(args.home)
+    try:
+        store = WorkerStore(db)
+        store.ensure_schema()
+        if args.expire_leases:
+            store.recover_expired_runs(OWNER)
+        worker = store.get_worker(args.worker_id, OWNER)
+        history = list(worker.get("history") or [])
+        serialized = json.dumps(history, sort_keys=True)
+        runs = store.list_runs(args.worker_id, OWNER)
+        messages = store.list_messages(args.worker_id, OWNER)
+        _emit({
+            "runs": [
+                {
+                    "run_id": run["run_id"],
+                    "status": run["status"],
+                    "uncertain_side_effect": run["uncertain_side_effect"],
+                    "completion_ack": run["completion_ack"],
+                }
+                for run in runs
+            ],
+            "message_statuses": [item["status"] for item in messages],
+            "history_roles": [item.get("role") for item in history],
+            "history_has_provider_session_handle": any(
+                token in serialized for token in ("provider_session", "resume_handle", "session_handle")
+            ),
+            "worker_uncertain_side_effect": worker["uncertain_side_effect"],
+        })
+    finally:
+        db.close()
+
+
+def _async_group(args) -> None:
+    from tools.async_delegation import get_durable_delegation
+    from tools.delegate_tool import delegate_task
+
+    _install_boundaries()
+    parent, db = _parent(args.home)
+    try:
+        dispatched = json.loads(delegate_task(
+            tasks=[
+                {"goal": "group-one", "group": "joined", "profile": PROFILE},
+                {"goal": "group-two", "group": "joined", "profile": PROFILE},
+            ],
+            background=True,
+            parent_agent=parent,
+        ))
+        delegation_id = dispatched["delegation_id"]
+        deadline = time.monotonic() + args.timeout
+        durable = None
+        while time.monotonic() < deadline:
+            durable = get_durable_delegation(delegation_id)
+            if durable and durable["state"] not in {"running", "finalizing"}:
+                break
+            time.sleep(0.02)
+        if not durable or durable["state"] in {"running", "finalizing"}:
+            raise TimeoutError("grouped completion did not become durable")
+        _emit({
+            "delegation_id": delegation_id,
+            "dispatch_status": dispatched["status"],
+            "durable_state": durable["state"],
+            "delivery_state": durable["delivery_state"],
+        })
+    finally:
+        db.close()
+
+
+def _async_restore(args) -> None:
+    from tools.async_delegation import (
+        claim_event_delivery,
+        complete_event_delivery,
+        get_durable_delegation,
+        restore_undelivered_completions,
+    )
+
+    events = queue.Queue()
+    restored = restore_undelivered_completions(events)
+    summaries = []
+    while not events.empty():
+        event = events.get_nowait()
+        claim = claim_event_delivery(event, "process-acceptance") if args.ack else None
+        if args.ack and claim is not None:
+            complete_event_delivery(event, claim)
+        durable = get_durable_delegation(str(event.get("delegation_id") or ""))
+        summaries.append({
+            "delegation_id": event.get("delegation_id"),
+            "group": event.get("group"),
+            "restored": event.get("restored"),
+            "result_indexes": [item.get("task_index") for item in event.get("results") or []],
+            "result_statuses": [item.get("status") for item in event.get("results") or []],
+            "claimed": claim is not None if args.ack else None,
+            "delivery_state": durable.get("delivery_state") if durable else None,
+        })
+    _emit({"restored": restored, "events": summaries})
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("seed", "enqueue", "control", "snapshot", "async-group", "async-restore"))
+    parser.add_argument("--home", type=Path, required=True)
+    parser.add_argument("--worker-id")
+    parser.add_argument("--run-id")
+    parser.add_argument("--action")
+    parser.add_argument("--message", default="")
+    parser.add_argument("--disposition")
+    parser.add_argument("--timeout", type=float, default=20)
+    parser.add_argument("--wait", action="store_true")
+    parser.add_argument("--ack", action="store_true")
+    parser.add_argument("--expire-leases", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if Path(os.environ["HERMES_HOME"]).resolve() != args.home.resolve():
+        raise RuntimeError("subprocess HERMES_HOME does not match the isolated test profile")
+    {
+        "seed": _seed,
+        "enqueue": _enqueue,
+        "control": _control,
+        "snapshot": _snapshot,
+        "async-group": _async_group,
+        "async-restore": _async_restore,
+    }[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/worker_process_acceptance.py
+++ b/tests/fixtures/worker_process_acceptance.py
@@ -153,7 +153,8 @@ class _FixtureOpenAI:
         pass
 
 
-def _effect_handler(effect_id: str) -> str:
+def _effect_handler(args: dict, **_metadata) -> str:
+    effect_id = str(args.get("effect_id") or "")
     _append_json(
         os.environ.get("HERMES_ACCEPTANCE_EFFECT", ""),
         {"effect_id": effect_id, "pid": os.getpid()},

--- a/tests/fixtures/worker_process_acceptance.py
+++ b/tests/fixtures/worker_process_acceptance.py
@@ -365,8 +365,8 @@ def _async_group(args) -> None:
     try:
         dispatched = json.loads(delegate_task(
             tasks=[
-                {"goal": "group-one", "group": "joined", "profile": PROFILE},
-                {"goal": "group-two", "group": "joined", "profile": PROFILE},
+                {"goal": "Complete synthetic group-one task", "group": "joined", "profile": PROFILE},
+                {"goal": "Complete synthetic group-two task", "group": "joined", "profile": PROFILE},
             ],
             background=True,
             parent_agent=parent,

--- a/tests/fixtures/worker_process_acceptance.py
+++ b/tests/fixtures/worker_process_acceptance.py
@@ -248,11 +248,17 @@ def _parent(home: Path):
     return parent, db
 
 
-def _expire_prior_leases() -> None:
+def _expire_prior_leases(store) -> None:
     import agent.worker_store as worker_store
 
-    wall_clock = time.time
-    worker_store.time = SimpleNamespace(time=lambda: wall_clock() + 120)
+    # Advance only the recovery read. New runs must receive real-time leases;
+    # retaining the offset would make the next process's clock move backwards.
+    prior_clock = worker_store.time
+    worker_store.time = SimpleNamespace(time=lambda: time.time() + 120)
+    try:
+        store.recover_expired_runs(OWNER)
+    finally:
+        worker_store.time = prior_clock
 
 
 def _emit(value: dict) -> None:
@@ -297,10 +303,11 @@ def _control(args) -> None:
     from tools.delegate_tool import delegate_task
 
     _install_boundaries()
-    if args.expire_leases:
-        _expire_prior_leases()
     parent, db = _parent(args.home)
     try:
+        if args.expire_leases:
+            from agent.worker_store import WorkerStore
+            _expire_prior_leases(WorkerStore(db))
         payload = json.loads(delegate_task(
             action=args.action,
             worker_id=args.worker_id,
@@ -338,14 +345,12 @@ def _control(args) -> None:
 def _snapshot(args) -> None:
     from agent.worker_store import WorkerStore
 
-    if args.expire_leases:
-        _expire_prior_leases()
     parent, db = _parent(args.home)
     try:
         store = WorkerStore(db)
         store.ensure_schema()
         if args.expire_leases:
-            store.recover_expired_runs(OWNER)
+            _expire_prior_leases(store)
         worker = store.get_worker(args.worker_id, OWNER)
         history = list(worker.get("history") or [])
         serialized = json.dumps(history, sort_keys=True)

--- a/tests/fixtures/worker_process_acceptance.py
+++ b/tests/fixtures/worker_process_acceptance.py
@@ -212,6 +212,10 @@ def _parent(home: Path):
     from hermes_state import SessionDB
 
     db = SessionDB(home / "state.db")
+    # A real parent has a durable session before it delegates. Child session
+    # rows reference it through the existing sessions foreign key.
+    if db.get_session(OWNER) is None:
+        db.create_session(OWNER, source="cli", model="fixture/parent")
     parent = SimpleNamespace(
         session_id=OWNER,
         _session_db=db,

--- a/tests/fixtures/worker_process_acceptance.py
+++ b/tests/fixtures/worker_process_acceptance.py
@@ -65,6 +65,23 @@ def _latest_user_text(messages) -> str:
     return ""
 
 
+def _tool_result_categories(messages) -> list[str]:
+    categories = []
+    for item in messages:
+        if not isinstance(item, dict) or item.get("role") != "tool":
+            continue
+        content = str(item.get("content") or "").lower()
+        if "not permitted" in content:
+            categories.append("policy_denied")
+        elif "error executing tool" in content or '"error"' in content:
+            categories.append("execution_error")
+        elif '"ok": true' in content:
+            categories.append("synthetic_effect_ok")
+        else:
+            categories.append("other")
+    return categories
+
+
 def _capture_request(kwargs: dict, request_index: int) -> None:
     messages = kwargs.get("messages") or []
     system = next(
@@ -81,6 +98,11 @@ def _capture_request(kwargs: dict, request_index: int) -> None:
             "roles": _message_roles(messages),
             "system_hash": hashlib.sha256(system.encode()).hexdigest(),
             "latest_user_markers": [marker for marker in SYNTHETIC_MARKERS if marker in latest_user],
+            "tool_names": sorted(
+                item.get("function", {}).get("name", "")
+                for item in (kwargs.get("tools") or []) if isinstance(item, dict)
+            ),
+            "tool_result_categories": _tool_result_categories(messages),
             "model": str(kwargs.get("model") or ""),
         },
     )
@@ -349,6 +371,17 @@ def _async_group(args) -> None:
             background=True,
             parent_agent=parent,
         ))
+        if not dispatched.get("delegation_id"):
+            error = str(dispatched.get("error") or "").lower()
+            category = (
+                "provider_unconfigured" if "no llm provider configured" in error
+                else "profile_resolution" if "profile" in error
+                else "dispatch_rejected"
+            )
+            raise RuntimeError(
+                f"group dispatch returned no delegation_id "
+                f"(status={dispatched.get('status')!r}, category={category})"
+            )
         delegation_id = dispatched["delegation_id"]
         deadline = time.monotonic() + args.timeout
         durable = None

--- a/tests/hermes_cli/test_workers.py
+++ b/tests/hermes_cli/test_workers.py
@@ -1,0 +1,103 @@
+"""Worker configuration through the real parser, loader, validator and save path."""
+
+import argparse
+import json
+
+import pytest
+import yaml
+
+from hermes_cli.workers import build_workers_parser
+
+
+@pytest.fixture
+def worker_home(tmp_path, monkeypatch):
+    from hermes_cli import config
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(config, "get_config_path", lambda: home / "config.yaml")
+    monkeypatch.setattr(config, "ensure_hermes_home", lambda: home)
+    monkeypatch.setattr(config, "is_managed", lambda: False)
+    return home
+
+
+def invoke(*argv):
+    parser = argparse.ArgumentParser()
+    build_workers_parser(parser.add_subparsers(dest="command"))
+    args = parser.parse_args(["workers", *map(str, argv)])
+    args.func(args)
+
+
+def test_profile_roundtrip_is_scoped_and_preserves_unrelated_config(worker_home, tmp_path, capsys):
+    config_path = worker_home / "config.yaml"
+    config_path.write_text("model:\n  default: existing-model\ndisplay:\n  theme: custom\n")
+    profile_path = tmp_path / "worker.yaml"
+    profile_path.write_text("provider: openai\nmodel: test-model\nreasoning_effort: high\n")
+    invoke("set", "research", "--file", profile_path)
+    invoke("default", "research")
+    raw = yaml.safe_load(config_path.read_text())
+    assert raw["model"]["default"] == "existing-model"
+    assert raw["display"]["theme"] == "custom"
+    assert raw["delegation"]["default_profile"] == "research"
+    assert raw["delegation"]["profiles"]["research"]["model"] == "test-model"
+    invoke("validate")
+    capsys.readouterr()
+    invoke("inspect", "research", "--json")
+    profile = json.loads(capsys.readouterr().out)
+    assert profile["name"] == "research"
+    assert profile["model"] == "test-model"
+    invoke("default", "-")
+    assert not yaml.safe_load(config_path.read_text())["delegation"].get("default_profile")
+
+
+@pytest.mark.parametrize("contents", ["model: [", "model: missing-provider\napi_key: forbidden\n", "- not-a-mapping\n"])
+def test_rejected_profile_leaves_config_unchanged(worker_home, tmp_path, contents):
+    config_path = worker_home / "config.yaml"
+    original = "model:\n  default: preserve-me\n"
+    config_path.write_text(original)
+    path = tmp_path / "invalid.yaml"
+    path.write_text(contents)
+    with pytest.raises(SystemExit) as error:
+        invoke("set", "bad", "--file", path)
+    assert error.value.code == 1
+    assert config_path.read_text() == original
+
+
+def test_unknown_default_and_managed_write_fail_without_mutation(worker_home, capsys, monkeypatch):
+    from hermes_cli import config
+
+    path = worker_home / "config.yaml"
+    path.write_text("model:\n  default: preserve-me\n")
+    original = path.read_bytes()
+    with pytest.raises(SystemExit):
+        invoke("default", "unknown")
+    monkeypatch.setattr(config, "is_managed", lambda: True)
+    with pytest.raises(SystemExit):
+        invoke("default", "-")
+    assert path.read_bytes() == original
+    assert "managed" in capsys.readouterr().out
+
+
+def test_list_alias_has_same_catalog_and_does_not_launch(worker_home, capsys, monkeypatch):
+    from hermes_cli import runtime_provider
+
+    def forbidden(**kwargs):
+        pytest.fail("Discovery must not resolve credentials or launch a provider")
+
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", forbidden)
+    invoke("list", "--json")
+    first = json.loads(capsys.readouterr().out)
+    invoke("ls", "--json")
+    assert json.loads(capsys.readouterr().out) == first
+
+
+def test_top_level_parser_registers_worker_command(worker_home, monkeypatch, capsys):
+    import sys
+    from hermes_cli.main import _build_cli_parser
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "workers", "validate"])
+    parser, _ = _build_cli_parser()
+    args = parser.parse_args(["workers", "validate"])
+    args.func(args)
+    assert "valid" in capsys.readouterr().out

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -681,21 +681,20 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
 
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
-    def test_nonoverlapping_tools_fallback(self):
-        """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
-        should fall back to all allowed tools."""
+    def test_nonoverlapping_tools_fail_closed(self):
+        """An explicit allowlist with no sandbox overlap grants no tools."""
         code = (
             "from hermes_tools import terminal\n"
             "print('fallback ok')\n"
         )
         with patch("model_tools.handle_function_call",
-                    return_value=json.dumps({"ok": True})):
+                   return_value=json.dumps({"ok": True})) as mock_dispatch:
             result = json.loads(execute_code(
                 code, task_id="test-nonoverlap",
                 enabled_tools=["vision_analyze", "browser_snapshot"],
             ))
-        self.assertEqual(result["status"], "success")
-        self.assertIn("fallback ok", result["output"])
+        self.assertEqual(result["status"], "error")
+        mock_dispatch.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -200,7 +200,6 @@ class TestStripBlockedTools(unittest.TestCase):
         for toolset_name in (
             "clarify",
             "cronjob",
-            "delegation",
             "memory",
         ):
             self.assertIn(toolset_name, disabled)
@@ -216,7 +215,11 @@ class TestStripBlockedTools(unittest.TestCase):
         )
         names = {item["function"]["name"] for item in definitions}
         self.assertTrue(names & {"terminal", "read_file", "web_search"})
-        self.assertTrue(DELEGATE_BLOCKED_TOOLS.isdisjoint(names))
+        # Leaves retain the durable worker control surface for discovery,
+        # messaging, and child-to-parent delivery.  Spawn admission remains
+        # depth/policy-gated by delegate_task itself.
+        self.assertIn("delegate_task", names)
+        self.assertTrue((DELEGATE_BLOCKED_TOOLS - {"delegate_task"}).isdisjoint(names))
 
     def test_orchestrator_composite_regains_only_delegate_task(self):
         import model_tools
@@ -413,8 +416,10 @@ class TestDelegateTask(unittest.TestCase):
                 child_db = kwargs["session_db"]
                 self.assertIsInstance(child_db, SessionDB)
                 self.assertIsNot(child_db, parent_db)
+                # macOS aliases /tmp to /private/tmp; the invariant is the
+                # backing file rather than the spelling retained by a handle.
                 self.assertEqual(
-                    str(child_db.db_path), str(parent_db.db_path)
+                    Path(child_db.db_path).resolve(), Path(parent_db.db_path).resolve()
                 )
             finally:
                 if child_db is not None:

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -221,7 +221,7 @@ class TestStripBlockedTools(unittest.TestCase):
         self.assertIn("delegate_task", names)
         self.assertTrue((DELEGATE_BLOCKED_TOOLS - {"delegate_task"}).isdisjoint(names))
 
-    def test_orchestrator_composite_regains_only_delegate_task(self):
+    def test_orchestrator_composite_respects_explicit_delegation_deny(self):
         import model_tools
 
         parent = _make_mock_parent()
@@ -248,7 +248,7 @@ class TestStripBlockedTools(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         disabled = kwargs["disabled_toolsets"]
-        self.assertNotIn("delegation", disabled)
+        self.assertIn("delegation", disabled)
         definitions = model_tools.get_tool_definitions(
             enabled_toolsets=kwargs["enabled_toolsets"],
             disabled_toolsets=disabled,
@@ -256,10 +256,8 @@ class TestStripBlockedTools(unittest.TestCase):
             skip_tool_search_assembly=True,
         )
         names = {item["function"]["name"] for item in definitions}
-        self.assertIn("delegate_task", names)
-        self.assertTrue(
-            (DELEGATE_BLOCKED_TOOLS - {"delegate_task"}).isdisjoint(names)
-        )
+        self.assertNotIn("delegate_task", names)
+        self.assertTrue(DELEGATE_BLOCKED_TOOLS.isdisjoint(names))
 
 
 class TestDelegateTask(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1891,13 +1891,10 @@ class TestOrchestratorRoleBehavior(unittest.TestCase):
     @patch("tools.delegate_tool._resolve_delegation_credentials")
     @patch("tools.delegate_tool._load_config",
            return_value={"max_spawn_depth": 2})
-    def test_orchestrator_role_keeps_delegation_at_depth_1(
+    def test_orchestrator_role_does_not_expand_parent_tool_authority(
         self, mock_cfg, mock_creds
     ):
-        """role='orchestrator' + depth-0 parent with max_spawn_depth=2 →
-        child at depth 1 gets 'delegation' in enabled_toolsets (can
-        further delegate).  Requires max_spawn_depth>=2 since the new
-        default is 1 (flat)."""
+        """An orchestrator role cannot grant a toolset absent from its parent."""
         mock_creds.return_value = {
             "provider": None, "base_url": None,
             "api_key": None, "api_mode": None, "model": None,
@@ -1909,7 +1906,7 @@ class TestOrchestratorRoleBehavior(unittest.TestCase):
             MockAgent.return_value = mock_child
             delegate_task(goal="test", role="orchestrator", parent_agent=parent)
             kwargs = MockAgent.call_args[1]
-            self.assertIn("delegation", kwargs["enabled_toolsets"])
+            self.assertNotIn("delegation", kwargs["enabled_toolsets"])
             self.assertEqual(mock_child._delegate_role, "orchestrator")
 
     @patch("tools.delegate_tool._resolve_delegation_credentials")
@@ -1931,8 +1928,11 @@ class TestOrchestratorRoleBehavior(unittest.TestCase):
             MockAgent.return_value = mock_child
             delegate_task(goal="test", role="orchestrator", parent_agent=parent)
             kwargs = MockAgent.call_args[1]
-            self.assertNotIn("delegation", kwargs["enabled_toolsets"])
+            # Leaves retain delegate_task for worker controls and messaging;
+            # action-level admission prevents further spawning.
+            self.assertIn("delegation", kwargs["enabled_toolsets"])
             self.assertEqual(mock_child._delegate_role, "leaf")
+            self.assertFalse(mock_child._delegate_spawn_allowed)
 
 
     # ── Role-aware system prompt ────────────────────────────────────────
@@ -1989,6 +1989,7 @@ class TestOrchestratorEndToEnd(unittest.TestCase):
             built_agents.append({
                 "enabled_toolsets": list(kw.get("enabled_toolsets") or []),
                 "is_orchestrator_prompt": is_orchestrator,
+                "agent": m,
             })
 
             if is_orchestrator:
@@ -2045,10 +2046,12 @@ class TestOrchestratorEndToEnd(unittest.TestCase):
         self.assertIn("delegation", built_agents[0]["enabled_toolsets"])
         self.assertTrue(built_agents[0]["is_orchestrator_prompt"])
         # Next two = leaves (grandchildren)
-        self.assertNotIn("delegation", built_agents[1]["enabled_toolsets"])
-        self.assertFalse(built_agents[1]["is_orchestrator_prompt"])
-        self.assertNotIn("delegation", built_agents[2]["enabled_toolsets"])
-        self.assertFalse(built_agents[2]["is_orchestrator_prompt"])
+        for leaf in built_agents[1:]:
+            self.assertIn("delegation", leaf["enabled_toolsets"])
+            self.assertFalse(leaf["is_orchestrator_prompt"])
+            self.assertFalse(leaf["agent"]._delegate_spawn_allowed)
+            blocked = json.loads(delegate_task(goal="blocked", parent_agent=leaf["agent"]))
+            self.assertIn("does not permit spawning", blocked["error"])
 
 
 class TestSubagentApprovalCallback(unittest.TestCase):

--- a/tests/tools/test_worker_execution_limits.py
+++ b/tests/tools/test_worker_execution_limits.py
@@ -1,0 +1,54 @@
+"""Runtime checks for profile execution ceilings beyond route parsing."""
+
+import time
+from types import SimpleNamespace
+
+from agent.subagent_lifecycle import _iteration_limit
+from tools.delegate_tool_child_run import _ChildRun
+
+
+def test_profile_iteration_limit_narrows_global_budget():
+    assert _iteration_limit(
+        {"max_iterations": 20}, {"max_iterations": 4}, default=250,
+    ) == 4
+    assert _iteration_limit(
+        {"max_iterations": 3}, {"max_iterations": 10}, default=250,
+    ) == 3
+
+
+def test_profile_timeout_stops_the_real_child_await_boundary(monkeypatch):
+    class BlockingChild:
+        _worker_timeout_seconds = 0.02
+        _delegate_role = "leaf"
+        session_id = "timeout-fixture"
+
+        def run_conversation(self, **_kwargs):
+            time.sleep(0.15)
+            return {"completed": True, "final_response": "too late"}
+
+        def hard_interrupt(self, _reason=None, **_kwargs):
+            self.interrupted = True
+            return True
+
+        def interrupt(self, _reason=None):
+            self.interrupted = True
+            return True
+
+        def get_activity_summary(self):
+            return {"api_call_count": 1}
+
+        def close(self):
+            return None
+
+    child = BlockingChild()
+    parent = SimpleNamespace(_interrupt_requested=False)
+    run = _ChildRun(
+        child=child, parent_agent=parent, task_index=0, goal="bounded",
+        subagent_id=None, child_progress_cb=None,
+    )
+    _result, error, close_deferred = run.await_child()
+    assert error["status"] == "timeout"
+    assert error["timeout_seconds"] == 0.02
+    assert error["timeout_phase"] == "after_llm_calls"
+    assert close_deferred is True
+    assert child.interrupted is True

--- a/tests/tools/test_worker_parent_dispatch.py
+++ b/tests/tools/test_worker_parent_dispatch.py
@@ -1,0 +1,175 @@
+"""The parent-model delegate dispatch preserves public worker routing and controls."""
+
+import dataclasses
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.subagent_lifecycle import SubagentLifecycleService, SubagentState
+from agent.worker_store import WorkerStore
+from hermes_state import SessionDB
+
+
+def test_parent_dispatch_forwards_worker_fields_and_keeps_safe_task_overrides():
+    import run_agent
+
+    captured = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return "{}"
+
+    parent = SimpleNamespace(_delegate_depth=0)
+    args = {
+        "action": "wait",
+        "worker_id": "worker-fixture",
+        "run_id": "run-fixture",
+        "message": "continue",
+        "timeout_seconds": 12,
+        "profile": "review",
+        "provider": "provider-b",
+        "model": "review-model",
+        "reasoning_effort": "high",
+        "tasks": [{
+            "goal": "review",
+            "profile": "review",
+            "provider": "provider-b",
+            "model": "review-model",
+            "reasoning_effort": "high",
+            "acp_command": "must-not-pass",
+            "acp_args": ["--must-not-pass"],
+        }],
+    }
+    with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+        result = run_agent.AIAgent._dispatch_delegate_task(parent, args)
+
+    assert result == "{}"
+    for field in (
+        "action", "worker_id", "run_id", "message", "timeout_seconds",
+        "profile", "provider", "model", "reasoning_effort",
+    ):
+        assert captured[field] == args[field]
+    task = captured["tasks"][0]
+    assert task["profile"] == "review"
+    assert task["provider"] == "provider-b"
+    assert task["model"] == "review-model"
+    assert task["reasoning_effort"] == "high"
+    assert "acp_command" not in task and "acp_args" not in task
+    assert captured["background"] is True
+
+
+def test_parent_dispatch_reaches_compact_discovery_and_durable_controls(tmp_path, monkeypatch):
+    import run_agent
+    from tools import delegate_tool
+
+    cfg = {
+        "profiles": {
+            "review": {
+                "description": "bounded reviewer",
+                "instructions": "private startup instruction",
+                "provider": "fixture",
+                "model": "review-model",
+            },
+        },
+    }
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: cfg)
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(
+        _delegate_depth=0,
+        session_id="parent-dispatch",
+        model="parent-model",
+        _session_db=db,
+    )
+    compact = json.loads(run_agent.AIAgent._dispatch_delegate_task(parent, {"action": "discover"}))
+    assert compact["profiles"][0]["name"] == "review"
+    assert "instructions" not in compact["profiles"][0]
+    detailed = json.loads(run_agent.AIAgent._dispatch_delegate_task(
+        parent, {"action": "discover", "profile": "review"}))
+    assert detailed["profiles"][0]["instructions"] == "private startup instruction"
+
+    store = WorkerStore(db)
+    store.ensure_schema()
+    worker = store.create_worker(parent.session_id, profile="review")
+    store.enqueue_run(worker["worker_id"], parent.session_id, goal="done")
+    active = store.claim_next_run(worker["worker_id"], parent.session_id)
+    store.finish_run(
+        active["run_id"], parent.session_id, active["lease_token"],
+        status="SUCCEEDED", result={"summary": "done"})
+    status = json.loads(run_agent.AIAgent._dispatch_delegate_task(
+        parent, {"action": "status", "worker_id": worker["worker_id"]}))
+    assert status["success"] is True
+    assert status["worker_id"] == worker["worker_id"]
+    message = json.loads(run_agent.AIAgent._dispatch_delegate_task(
+        parent, {"action": "message", "worker_id": worker["worker_id"], "message": "follow up"}))
+    assert message["status"] == "PENDING"
+    acknowledged = json.loads(run_agent.AIAgent._dispatch_delegate_task(
+        parent, {"action": "ack", "worker_id": worker["worker_id"], "run_id": active["run_id"]}))
+    assert acknowledged["acknowledged"] is True
+    db.close()
+
+
+def test_opaque_runtime_metadata_stays_out_of_public_and_parent_json(tmp_path, monkeypatch):
+    """Provider clients may own locks; receipts expose typed scalar metadata only."""
+    import run_agent
+    from tools import delegate_tool
+
+    class OpaqueRuntimeMetadata:
+        def __init__(self):
+            self.lock = threading.Lock()
+
+    cfg = {"max_concurrent_children": 1}
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: cfg)
+    monkeypatch.setattr("tools.delegate_tool_config._load_config", lambda: cfg)
+    db = SessionDB(tmp_path / "state.db")
+    parent = SimpleNamespace(
+        _delegate_depth=0,
+        session_id="parent-opaque",
+        model="parent-model",
+        _session_db=db,
+    )
+    child = SimpleNamespace(
+        _subagent_id="sa-opaque",
+        _delegate_role="leaf",
+        _delegate_depth=1,
+        provider=OpaqueRuntimeMetadata(),
+        model=OpaqueRuntimeMetadata(),
+        ephemeral_system_prompt="frozen prompt",
+        valid_tool_names={"read_file"},
+        _worker_route_receipt={},
+    )
+    service = SubagentLifecycleService(lambda: parent)
+    handle = service.adopt_delegate_child(
+        child,
+        goal="serialize safely",
+        context=None,
+        profile=None,
+        creds={},
+        cfg=cfg,
+    )
+    assert handle is not None
+    assert handle.provider is None and handle.model is None
+    service.complete_adopted_child(
+        child,
+        {
+            "status": "completed",
+            "summary": "done",
+            "exit_reason": "completed",
+            "api_calls": 1,
+            "duration_seconds": 0.01,
+            "cost_status": "unknown",
+        },
+    )
+    result = service.result(handle)
+    assert result.terminal_state is SubagentState.SUCCEEDED
+    json.dumps(handle.to_dict())
+    json.dumps(dataclasses.asdict(result))
+
+    inspected = json.loads(run_agent.AIAgent._dispatch_delegate_task(
+        parent,
+        {"action": "inspect", "worker_id": handle.worker_id, "run_id": handle.run_id},
+    ))
+    assert inspected["run"]["result"]["summary"] == "done"
+    assert inspected["run"]["result"]["cost"] == {"status": "unknown", "usd": None}
+    db.close()

--- a/tests/tools/test_worker_parent_dispatch.py
+++ b/tests/tools/test_worker_parent_dispatch.py
@@ -31,6 +31,7 @@ def test_parent_dispatch_forwards_worker_fields_and_keeps_safe_task_overrides():
         "provider": "provider-b",
         "model": "review-model",
         "reasoning_effort": "high",
+        "reconciliation_disposition": "accepted_unknown_no_replay",
         "tasks": [{
             "goal": "review",
             "profile": "review",
@@ -48,6 +49,7 @@ def test_parent_dispatch_forwards_worker_fields_and_keeps_safe_task_overrides():
     for field in (
         "action", "worker_id", "run_id", "message", "timeout_seconds",
         "profile", "provider", "model", "reasoning_effort",
+        "reconciliation_disposition",
     ):
         assert captured[field] == args[field]
     task = captured["tasks"][0]
@@ -107,6 +109,41 @@ def test_parent_dispatch_reaches_compact_discovery_and_durable_controls(tmp_path
     acknowledged = json.loads(run_agent.AIAgent._dispatch_delegate_task(
         parent, {"action": "ack", "worker_id": worker["worker_id"], "run_id": active["run_id"]}))
     assert acknowledged["acknowledged"] is True
+
+    uncertain_worker = store.create_worker(parent.session_id, profile="review")
+    uncertain = store.enqueue_run(uncertain_worker["worker_id"], parent.session_id, goal="external effect")
+    uncertain = store.claim_run(uncertain["run_id"], parent.session_id)
+    store.mark_tool_boundary(
+        uncertain["run_id"], parent.session_id, uncertain["lease_token"],
+        tool_call_id="external-effect")
+    store.finish_run(
+        uncertain["run_id"], parent.session_id, uncertain["lease_token"],
+        status="INTERRUPTED", result={"summary": None})
+    reconciled = json.loads(run_agent.AIAgent._dispatch_delegate_task(
+        parent,
+        {
+            "action": "reconcile",
+            "worker_id": uncertain_worker["worker_id"],
+            "run_id": uncertain["run_id"],
+            "reconciliation_disposition": "accepted_unknown_no_replay",
+            "message": "Operator accepts the unknown outcome without replay.",
+        },
+    ))
+    assert reconciled["reconciled"] is True
+    audit = store.get_run(uncertain["run_id"], parent.session_id)["result"]["reconciliation"]
+    assert audit["affected_tool_calls"] == [
+        {"tool_call_id": "external-effect", "prior_status": "INFLIGHT"}
+    ]
+    inspected_reconciliation = json.loads(run_agent.AIAgent._dispatch_delegate_task(
+        parent,
+        {
+            "action": "inspect",
+            "worker_id": uncertain_worker["worker_id"],
+            "run_id": uncertain["run_id"],
+        },
+    ))
+    assert inspected_reconciliation["run"]["result"]["reconciliation"]["note"].startswith(
+        "Operator accepts")
     db.close()
 
 

--- a/tests/tools/test_worker_profile_dispatch.py
+++ b/tests/tools/test_worker_profile_dispatch.py
@@ -221,3 +221,25 @@ def test_two_worker_dispatch_receipts_match_transport_requests(monkeypatch):
     assert receipts["review-model"]["transmitted_model"] == "review-model"
     assert receipts["review-model"]["transmitted_reasoning_effort"] == "high"
     assert receipts["review-model"]["provider_reported_model"] == "reported-review-model"
+
+
+def test_execute_code_nested_tools_obey_the_worker_tool_ceiling(monkeypatch):
+    from tools import code_execution_tool
+
+    assert code_execution_tool._sandbox_tools_for(["execute_code"]) == frozenset()
+    assert code_execution_tool._sandbox_tools_for(["execute_code", "read_file"]) == frozenset({"read_file"})
+    assert code_execution_tool._sandbox_tools_for(None)  # legacy callers without a session ceiling retain behavior
+    captured = {}
+    monkeypatch.setattr(
+        code_execution_tool,
+        "execute_code",
+        lambda **kwargs: captured.update(kwargs) or "{}",
+    )
+    code_execution_tool._execute_code_handler(
+        {"code": "print('ok')"},
+        task_id="task",
+        enabled_tools=["execute_code", "read_file"],
+        worker_max_tool_calls=2,
+    )
+    assert captured["worker_max_tool_calls"] == 2
+    assert captured["enabled_tools"] == ["execute_code", "read_file"]

--- a/tests/tools/test_worker_profile_dispatch.py
+++ b/tests/tools/test_worker_profile_dispatch.py
@@ -107,6 +107,40 @@ def test_invalid_second_profile_preflight_returns_no_routes(monkeypatch):
     assert "missing" in error
 
 
+def test_explicitly_unavailable_route_fails_batch_preflight_before_construction(monkeypatch):
+    import hermes_cli.runtime_provider as runtime_provider
+
+    calls = []
+
+    def runtime(**kwargs):
+        calls.append(kwargs.get("target_model"))
+        if kwargs.get("target_model") == "unavailable-model":
+            raise ValueError("configured route is unavailable")
+        return _runtime(**kwargs)
+
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", runtime)
+    cfg = {
+        "profiles": {
+            "small": {"provider": "provider-a", "model": "small-model"},
+            "offline": {"provider": "provider-b", "model": "unavailable-model"},
+        },
+    }
+    parent = SimpleNamespace(model="parent-model")
+    base = _resolve_delegation_credentials(cfg, parent, "small")
+    routes, error = delegate._resolve_task_credentials(
+        [
+            {"goal": "Collect", "profile": "small"},
+            {"goal": "Must reject", "profile": "offline"},
+        ],
+        base,
+        cfg,
+        parent,
+    )
+    assert routes == []
+    assert "unavailable" in error
+    assert calls == ["small-model", "small-model", "unavailable-model"]
+
+
 def test_two_worker_dispatch_receipts_match_transport_requests(monkeypatch):
     """The fan-out executor must preserve each resolved route through the real request hook."""
     import agent.models_dev as models_dev

--- a/tests/tools/test_worker_profile_dispatch.py
+++ b/tests/tools/test_worker_profile_dispatch.py
@@ -1,0 +1,223 @@
+"""Behavioral dispatch contracts for provider-independent worker profiles."""
+
+import json
+from types import SimpleNamespace
+
+from tools import delegate_tool as delegate
+from tools.delegate_tool_config import _resolve_delegation_credentials
+
+
+def _runtime(**kwargs):
+    provider = kwargs.get("requested") or "parent"
+    return {
+        "provider": provider,
+        "model": kwargs.get("target_model"),
+        "base_url": f"https://{provider}.example.invalid/v1",
+        "api_key": "fixture-credential-reference",
+        "api_mode": "chat_completions",
+    }
+
+
+def test_two_workers_resolve_distinct_profiles_before_construction(monkeypatch):
+    import agent.models_dev as models_dev
+    import hermes_cli.runtime_provider as runtime_provider
+
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", _runtime)
+    monkeypatch.setattr(
+        models_dev,
+        "get_model_capabilities",
+        lambda *args, **kwargs: SimpleNamespace(supports_tools=True),
+    )
+    cfg = {
+        "profiles": {
+            "small": {
+                "provider": "provider-a",
+                "model": "small-model",
+                "reasoning_effort": "low",
+                "tool_policy": {"allowed_toolsets": ["file"]},
+            },
+            "review": {
+                "provider": "provider-b",
+                "model": "review-model",
+                "reasoning_effort": "high",
+                "execution_limits": {"max_iterations": 12},
+            },
+        },
+    }
+    parent = SimpleNamespace(model="parent-model")
+    base = _resolve_delegation_credentials(cfg, parent, "small")
+    tasks = [
+        {"goal": "Collect the bounded evidence", "profile": "small"},
+        {"goal": "Review the resulting candidate", "profile": "review"},
+    ]
+    task_creds, error = delegate._resolve_task_credentials(tasks, base, cfg, parent)
+    assert error is None
+
+    built = []
+
+    def build_child(**kwargs):
+        built.append(kwargs)
+        return SimpleNamespace(tool_progress_callback=None)
+
+    monkeypatch.setattr(delegate, "_build_child_preserving_parent_tools", build_child)
+    children, error = delegate._build_children(
+        tasks,
+        [None, None],
+        base,
+        top_role="leaf",
+        max_iterations=50,
+        parent_agent=parent,
+        routing_cfg=cfg,
+        live_deleg_id=None,
+        live_writers=[],
+        task_creds=task_creds,
+    )
+    assert error is None
+    assert len(children) == 2
+    assert [call["model"] for call in built] == ["small-model", "review-model"]
+    assert [call["requested_profile"] for call in built] == ["small", "review"]
+    assert built[0]["profile_tool_policy"].allowed_toolsets == ("file",)
+    assert built[1]["max_iterations"] == 12
+    assert built[0]["profile_route_receipt"]["transmitted_model"] is None
+
+
+def test_invalid_second_profile_preflight_returns_no_routes(monkeypatch):
+    import agent.models_dev as models_dev
+    import hermes_cli.runtime_provider as runtime_provider
+
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", _runtime)
+    monkeypatch.setattr(
+        models_dev,
+        "get_model_capabilities",
+        lambda *args, **kwargs: SimpleNamespace(supports_tools=True),
+    )
+    cfg = {"profiles": {"small": {"provider": "provider-a", "model": "small-model"}}}
+    parent = SimpleNamespace(model="parent-model")
+    base = _resolve_delegation_credentials(cfg, parent, "small")
+    routes, error = delegate._resolve_task_credentials(
+        [
+            {"goal": "Collect the bounded evidence", "profile": "small"},
+            {"goal": "Review the resulting candidate", "profile": "missing"},
+        ],
+        base,
+        cfg,
+        parent,
+    )
+    assert routes == []
+    assert "missing" in error
+
+
+def test_two_worker_dispatch_receipts_match_transport_requests(monkeypatch):
+    """The fan-out executor must preserve each resolved route through the real request hook."""
+    import agent.models_dev as models_dev
+    import hermes_cli.runtime_provider as runtime_provider
+    from agent.turn_api_call import perform_api_call
+    from agent.worker_receipts import observe_worker_response
+    from tools import delegation_live_log
+
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", _runtime)
+    monkeypatch.setattr(
+        models_dev,
+        "get_model_capabilities",
+        lambda *args, **kwargs: SimpleNamespace(supports_tools=True),
+    )
+    monkeypatch.setattr(delegation_live_log, "create_live_transcripts", lambda *args, **kwargs: (None, [], []))
+    cfg = {
+        "profiles": {
+            "small": {
+                "provider": "provider-a",
+                "model": "small-model",
+                "reasoning_effort": "low",
+            },
+            "review": {
+                "provider": "provider-b",
+                "model": "review-model",
+                "reasoning_effort": "high",
+            },
+        },
+        "max_concurrent_children": 2,
+    }
+    monkeypatch.setattr(delegate, "_load_config", lambda: cfg)
+    wire = []
+
+    class FixtureChild:
+        def __init__(self, **kwargs):
+            receipt = dict(kwargs["profile_route_receipt"])
+            self.provider = receipt["resolved_provider"]
+            self.model = kwargs["model"]
+            self.api_mode = "chat_completions"
+            self.base_url = None
+            self.platform = "test"
+            self.session_id = f"fixture-{self.provider}"
+            self._worker_route_receipt = receipt
+            self._reasoning_effort = receipt["resolved_reasoning_effort"]
+            self._disable_streaming = True
+            self._delegate_role = "leaf"
+            self._delegate_depth = 1
+            self.tool_progress_callback = None
+            self.session_estimated_cost_usd = 0.0
+            self.session_cost_status = "unknown"
+
+        def _has_pending_redirect(self):
+            return False
+
+        def _interruptible_api_call(self, request):
+            wire.append(dict(request))
+            return SimpleNamespace(model=f"reported-{self.model}")
+
+        def run_conversation(self, **kwargs):
+            verdict = perform_api_call(
+                self,
+                api_kwargs={"model": self.model, "reasoning_effort": self._reasoning_effort},
+                _original_api_kwargs={},
+                _llm_middleware_trace=[],
+                _moa_prepared_request=None,
+                _retry=SimpleNamespace(),
+                thinking_spinner=None,
+                retry_count=0,
+                api_call_count=0,
+                api_request_id=f"request-{self.provider}",
+                effective_task_id="fixture",
+                turn_id="turn",
+                interrupted=False,
+            )
+            observe_worker_response(self, verdict.response)
+            return {
+                "completed": True,
+                "final_response": f"done-{self.provider}",
+                "api_calls": 1,
+                "messages": [{"role": "assistant", "content": f"done-{self.provider}"}],
+            }
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(delegate, "_build_child_preserving_parent_tools", lambda **kwargs: FixtureChild(**kwargs))
+    parent = SimpleNamespace(
+        model="parent-model",
+        session_id="parent-session",
+        _active_children=[],
+        _interrupt_requested=False,
+    )
+    result = json.loads(
+        delegate.delegate_task(
+            tasks=[
+                {"goal": "Collect the bounded evidence", "profile": "small"},
+                {"goal": "Review the resulting candidate", "profile": "review"},
+            ],
+            profile="small",
+            background=False,
+            credentials_cfg=cfg,
+            parent_agent=parent,
+        )
+    )
+    wire_by_model = {item["model"]: item for item in wire}
+    assert wire_by_model["small-model"]["reasoning_effort"] == "low"
+    assert wire_by_model["review-model"]["reasoning_effort"] == "high"
+    receipts = {item["route"]["resolved_model"]: item["route"] for item in result["results"]}
+    assert receipts["small-model"]["transmitted_model"] == "small-model"
+    assert receipts["small-model"]["transmitted_reasoning_effort"] == "low"
+    assert receipts["small-model"]["provider_reported_model"] == "reported-small-model"
+    assert receipts["review-model"]["transmitted_model"] == "review-model"
+    assert receipts["review-model"]["transmitted_reasoning_effort"] == "high"
+    assert receipts["review-model"]["provider_reported_model"] == "reported-review-model"

--- a/tests/tools/test_worker_tool_enforcement.py
+++ b/tests/tools/test_worker_tool_enforcement.py
@@ -1,0 +1,132 @@
+"""Worker tool ceilings at the real registry and deferred-call boundaries."""
+
+import json
+from types import SimpleNamespace
+
+from agent.delegation_model_routing import ToolPolicy
+from tools.delegate_tool_toolsets import _apply_exact_tool_policy
+
+
+def _schema(name):
+    return {
+        "name": name,
+        "description": "Synthetic worker tool.",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _tool(name):
+    return {"type": "function", "function": _schema(name)}
+
+
+def test_model_dispatch_forwards_worker_limit_to_execute_code(monkeypatch):
+    """The ordinary model_tools signature reaches execute_code's nested RPC scope."""
+    import model_tools
+    from tools import code_execution_tool
+
+    captured = {}
+
+    def fake_execute_code(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"ok": True})
+
+    monkeypatch.setattr(code_execution_tool, "execute_code", fake_execute_code)
+    result = model_tools.handle_function_call(
+        "execute_code",
+        {"code": "print('bounded')"},
+        task_id="worker-task",
+        session_id="worker-session",
+        enabled_tools=["read_file"],
+        worker_max_tool_calls=2,
+        skip_pre_tool_call_hook=True,
+        skip_tool_request_middleware=True,
+        skip_tool_execution_middleware=True,
+    )
+
+    assert json.loads(result) == {"ok": True}
+    assert captured["enabled_tools"] == ["read_file"]
+    assert captured["worker_max_tool_calls"] == 2
+
+
+def test_model_dispatch_accepts_worker_limit_for_ordinary_registry_tool():
+    """R1's original call contract no longer raises before a native handler."""
+    import model_tools
+    from tools.registry import registry
+
+    name = "pytest_worker_native_read"
+    registry.register(
+        name=name,
+        toolset="pytest-worker",
+        schema=_schema(name),
+        handler=lambda _args, **_kwargs: json.dumps({"called": True}),
+    )
+    try:
+        result = model_tools.handle_function_call(
+            name,
+            {},
+            worker_max_tool_calls=1,
+            skip_pre_tool_call_hook=True,
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+        )
+        assert json.loads(result) == {"called": True}
+    finally:
+        registry.deregister(name)
+
+
+def test_exact_policy_intersects_ancestor_profile_and_empty_request():
+    child = SimpleNamespace(
+        valid_tool_names={"read_file", "write_file", "execute_code", "delegate_task"},
+        tools=[_tool(name) for name in ("read_file", "write_file", "execute_code", "delegate_task")],
+    )
+    _apply_exact_tool_policy(
+        child,
+        ToolPolicy(allowed_tools=("read_file", "write_file")),
+        request_blocked_tools=["write_file"],
+        ancestor_allowed_tools={"read_file", "write_file", "delegate_task"},
+    )
+    assert child.valid_tool_names == {"read_file", "delegate_task"}
+
+    empty = SimpleNamespace(
+        valid_tool_names={"read_file", "delegate_task"},
+        tools=[_tool("read_file"), _tool("delegate_task")],
+    )
+    _apply_exact_tool_policy(
+        empty,
+        ToolPolicy(),
+        request_toolsets=[],
+        ancestor_allowed_tools={"read_file", "delegate_task"},
+    )
+    assert empty.valid_tool_names == {"delegate_task"}
+    assert [item["function"]["name"] for item in empty.tools] == ["delegate_task"]
+
+
+def test_deferred_mcp_call_cannot_bypass_exact_worker_names():
+    from agent.tool_executor import _parse_tool_call
+    from tools.registry import registry
+
+    name = "mcp__pytest_worker__private_read"
+    registry.register(
+        name=name,
+        toolset="mcp-pytest-worker",
+        schema=_schema(name),
+        handler=lambda _args, **_kwargs: json.dumps({"leaked": True}),
+    )
+    try:
+        agent = SimpleNamespace(
+            enabled_toolsets=["mcp-pytest-worker"],
+            disabled_toolsets=[],
+            valid_tool_names={"read_file"},
+        )
+        call = SimpleNamespace(
+            id="mcp-denied",
+            function=SimpleNamespace(
+                name="tool_call",
+                arguments=json.dumps({"name": name, "arguments": {}}),
+            ),
+        )
+        parsed = _parse_tool_call(agent, call)
+        assert parsed.name == "tool_call"
+        assert "not available in this session" in parsed.scope_block
+    finally:
+        registry.deregister(name)

--- a/tests/tools/test_worker_tool_enforcement.py
+++ b/tests/tools/test_worker_tool_enforcement.py
@@ -4,7 +4,7 @@ import json
 from types import SimpleNamespace
 
 from agent.delegation_model_routing import ToolPolicy
-from tools.delegate_tool_toolsets import _apply_exact_tool_policy
+from tools.delegate_tool_toolsets import _apply_exact_tool_policy, _resolve_child_toolsets
 
 
 def _schema(name):
@@ -85,7 +85,7 @@ def test_exact_policy_intersects_ancestor_profile_and_empty_request():
         request_blocked_tools=["write_file"],
         ancestor_allowed_tools={"read_file", "write_file", "delegate_task"},
     )
-    assert child.valid_tool_names == {"read_file", "delegate_task"}
+    assert child.valid_tool_names == {"read_file"}
 
     empty = SimpleNamespace(
         valid_tool_names={"read_file", "delegate_task"},
@@ -97,8 +97,26 @@ def test_exact_policy_intersects_ancestor_profile_and_empty_request():
         request_toolsets=[],
         ancestor_allowed_tools={"read_file", "delegate_task"},
     )
-    assert empty.valid_tool_names == {"delegate_task"}
-    assert [item["function"]["name"] for item in empty.tools] == ["delegate_task"]
+    assert empty.valid_tool_names == set()
+    assert empty._worker_effective_tool_names == frozenset()
+    assert empty.tools == []
+
+
+def test_explicit_and_ancestor_delegation_denials_override_worker_role(monkeypatch):
+    parent = SimpleNamespace(enabled_toolsets=["file", "delegation"], disabled_toolsets=[])
+    enabled, _disabled = _resolve_child_toolsets(parent, ["file"], "orchestrator")
+    assert "delegation" not in enabled
+
+    parent.disabled_toolsets = ["delegation"]
+    enabled, disabled = _resolve_child_toolsets(parent, None, "orchestrator")
+    assert "delegation" in disabled
+
+    child = SimpleNamespace(
+        valid_tool_names={"read_file", "delegate_task"},
+        tools=[_tool("read_file"), _tool("delegate_task")],
+    )
+    _apply_exact_tool_policy(child, ToolPolicy(allowed_toolsets=("file",)))
+    assert "delegate_task" not in child._worker_effective_tool_names
 
 
 def test_deferred_mcp_call_cannot_bypass_exact_worker_names():
@@ -117,6 +135,7 @@ def test_deferred_mcp_call_cannot_bypass_exact_worker_names():
             enabled_toolsets=["mcp-pytest-worker"],
             disabled_toolsets=[],
             valid_tool_names={"read_file"},
+            _worker_effective_tool_names=frozenset({"read_file"}),
         )
         call = SimpleNamespace(
             id="mcp-denied",
@@ -130,3 +149,83 @@ def test_deferred_mcp_call_cannot_bypass_exact_worker_names():
         assert "not available in this session" in parsed.scope_block
     finally:
         registry.deregister(name)
+
+
+def test_deferred_catalog_dispatch_is_independent_of_visible_schema(monkeypatch):
+    import model_tools
+    from agent.tool_executor import _parse_tool_call
+    from tools.registry import registry
+
+    name = "mcp__pytest_worker__catalog_read"
+    registry.register(
+        name=name,
+        toolset="mcp-pytest-worker",
+        schema=_schema(name),
+        handler=lambda _args, **_kwargs: json.dumps({"called": name}),
+    )
+    monkeypatch.setattr(
+        "tools.tool_search.load_config_readonly",
+        lambda: SimpleNamespace(effective_defer_tools=frozenset({name})),
+    )
+    call = SimpleNamespace(
+        id="mcp-allowed",
+        function=SimpleNamespace(
+            name="tool_call",
+            arguments=json.dumps({"name": name, "arguments": {}}),
+        ),
+    )
+    try:
+        for agent in (
+            SimpleNamespace(
+                enabled_toolsets=["mcp-pytest-worker"], disabled_toolsets=[],
+                valid_tool_names={"tool_call"}, _executable_tool_names={name},
+            ),
+            SimpleNamespace(
+                enabled_toolsets=["mcp-pytest-worker"], disabled_toolsets=[],
+                valid_tool_names={"tool_call"}, _worker_effective_tool_names=frozenset({name}),
+            ),
+        ):
+            parsed = _parse_tool_call(agent, call)
+            assert parsed.scope_block is None and parsed.name == name
+            result = model_tools.handle_function_call(
+                parsed.name, parsed.args,
+                enabled_toolsets=agent.enabled_toolsets,
+                disabled_toolsets=agent.disabled_toolsets,
+                skip_pre_tool_call_hook=True,
+                skip_tool_request_middleware=True,
+                skip_tool_execution_middleware=True,
+            )
+            assert json.loads(result) == {"called": name}
+    finally:
+        registry.deregister(name)
+
+
+def test_worker_native_and_execute_code_use_exact_execution_authority(monkeypatch):
+    from agent.tool_executor import _ToolCallRef, _parse_tool_call, _resolve_sequential_dispatch
+    from tools import code_execution_tool
+
+    agent = SimpleNamespace(
+        enabled_toolsets=["code_execution", "file"], disabled_toolsets=[],
+        valid_tool_names={"execute_code"},
+        _worker_effective_tool_names=frozenset({"execute_code", "read_file"}),
+        _context_engine_tool_names=set(), _memory_manager=None, quiet_mode=False,
+        session_id="worker-exact", _current_turn_id="", _current_api_request_id="",
+    )
+    denied = SimpleNamespace(
+        id="native-denied",
+        function=SimpleNamespace(name="write_file", arguments=json.dumps({"path": "x", "content": "y"})),
+    )
+    assert "not permitted" in _parse_tool_call(agent, denied).scope_block
+
+    captured = {}
+    monkeypatch.setattr(
+        code_execution_tool, "execute_code",
+        lambda **kwargs: captured.update(kwargs) or json.dumps({"ok": True}),
+    )
+    dispatch = _resolve_sequential_dispatch(
+        agent,
+        _ToolCallRef("execute_code", {"code": "print('bounded')"}, "task", "call", []),
+        [],
+    )
+    assert json.loads(dispatch.execute({"code": "print('bounded')"})) == {"ok": True}
+    assert set(captured["enabled_tools"]) == {"execute_code", "read_file"}

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -85,17 +85,21 @@ completion by default; with `delegation.independent_completions` it is split int
 task reports alone as it finishes. Units of one call share ONE pool slot (`slot_key` in
 `async_delegation._dispatch`) — never count units against capacity; the executor is sized by live UNITS
 and the stall clock arms when the runner starts, so a queued unit is never judged stalled. Roles: `leaf` (default;
-no `delegate_task`, `clarify`, `memory`, `send_message`, `cronjob`; keeps `execute_code`) and
-`orchestrator` (keeps `delegate_task`; gated by `delegation.orchestrator_enabled`, bounded by
+keeps the control-only `delegate_task` surface but cannot spawn; no `clarify`, `memory`, `send_message`, or
+`cronjob`; keeps `execute_code`) and `orchestrator` (can also spawn through `delegate_task`; gated by
+`delegation.orchestrator_enabled`, bounded by
 `delegation.max_spawn_depth`, default 2). Config knobs under `delegation:`:
 `max_concurrent_children, independent_completions, max_spawn_depth, child_timeout_seconds, orchestrator_enabled,
-subagent_auto_approve, inherit_mcp_toolsets, max_iterations`. **Child processes:** a child's background
+subagent_auto_approve, inherit_mcp_toolsets, max_iterations`, plus named `profiles` for route, prompt, tool,
+workspace-context, and execution ceilings. **Child processes:** a child's background
 processes are killed at its teardown and their notices are suppressed in the parent; `process_manage(action="handoff")`
 (children only) flips `ProcessSession.owner_task_id` to the parent under the registry lock
 (`process_registry.transfer_ownership`) so the completion routes and reaps by the new owner; un-handed leftovers land on
-the result as `orphaned_processes`, exited-but-never-read notify processes as `unread_completions` (`_ChildRun.account_background_processes`, before `cleanup` kills them). **Durability:** background
-delegation is process-local; work that must survive restart uses `cronjob` or
-`terminal(background=True, notify_on_complete=True)`. API: `website/docs/developer-guide/subagent-lifecycle-api.md`.
+the result as `orphaned_processes`, exited-but-never-read notify processes as `unread_completions` (`_ChildRun.account_background_processes`, before `cleanup` kills them). **Durability:** workers use additive tables in the
+parent profile's existing `SessionDB`: stable worker ids, per-turn run ids, FIFO messages, checkpoints, leases,
+completion acknowledgements, and retained history. Restart fences an expired executor as `INTERRUPTED`; an uncertain
+in-flight tool outcome blocks resume until explicit reconciliation and is never replayed automatically. Sessions
+without `SessionDB` retain the legacy process-local lifecycle. API: `website/docs/developer-guide/subagent-lifecycle-api.md`.
 
 ## Tests
 

--- a/tools/code_execution_rpc.py
+++ b/tools/code_execution_rpc.py
@@ -26,8 +26,9 @@ _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify", "notify_on_complete",
 
 
 def _default_dispatch(task_id):
-    from model_tools import handle_function_call
-    return lambda tool_name, tool_args: handle_function_call(tool_name, tool_args, task_id=task_id)
+    from agent.subagent_lifecycle import dispatch_worker_nested_tool
+    return lambda tool_name, tool_args: dispatch_worker_nested_tool(
+        tool_name, tool_args, task_id=task_id)
 
 
 def _rpc_token_ok(request: dict, rpc_token: str) -> bool:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -549,8 +549,10 @@ def _finish_remote_kernel_result(kernel_result: Dict[str, Any], *,
 
 
 def _sandbox_tools_for(enabled_tools: Optional[List[str]]) -> frozenset:
-    """Enabled ∩ SANDBOX_ALLOWED_TOOLS, or every sandbox tool when the intersection is empty."""
-    return frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools or ())) or SANDBOX_ALLOWED_TOOLS
+    """Enabled ∩ sandbox tools; only an unspecified legacy ceiling exposes the full set."""
+    if enabled_tools is None:
+        return SANDBOX_ALLOWED_TOOLS
+    return frozenset(SANDBOX_ALLOWED_TOOLS & set(enabled_tools))
 
 
 def _run_remote_per_call(env, env_type: str, code: str, effective_task_id: str,
@@ -612,13 +614,20 @@ def _run_remote_per_call(env, env_type: str, code: str, effective_task_id: str,
     return json.dumps(result, ensure_ascii=False)
 
 
-def _execute_remote(code: str, task_id: Optional[str], enabled_tools: Optional[List[str]],
-                    reset: bool = False) -> str:
+def _execute_remote(
+    code: str,
+    task_id: Optional[str],
+    enabled_tools: Optional[List[str]],
+    reset: bool = False,
+    worker_max_tool_calls: Optional[int] = None,
+) -> str:
     """Run code on the remote terminal backend: the owner's persistent remote session kernel
     (tools/code_kernel_remote.py) first, else the per-call script ship — the fail-open route when
     a kernel cannot be spawned and the only route for hosts that cannot sustain a background process."""
     _cfg = _load_config()
     timeout, max_tool_calls = _cfg.get("timeout", DEFAULT_TIMEOUT), _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
+    if isinstance(worker_max_tool_calls, int) and not isinstance(worker_max_tool_calls, bool):
+        max_tool_calls = min(max_tool_calls, max(0, worker_max_tool_calls))
     sandbox_tools, effective_task_id = _sandbox_tools_for(enabled_tools), task_id or "default"
     env, env_type = _get_or_create_env(effective_task_id)
     exec_start = time.monotonic()
@@ -661,6 +670,7 @@ def execute_code(
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
     reset: bool = False,
+    worker_max_tool_calls: Optional[int] = None,
 ) -> str:
     """Run Python in the session's persistent kernel (local) or on the remote terminal backend,
     with RPC access to a subset of Hermes tools; returns the JSON result string. "Sandbox" means
@@ -716,19 +726,23 @@ def execute_code(
         from tools.interrupt import clear_current_thread_interrupt
         clear_current_thread_interrupt()
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools, reset=bool(reset))
+        return _execute_remote(
+            code, task_id, enabled_tools, reset=bool(reset), worker_max_tool_calls=worker_max_tool_calls)
     from tools.interrupt import is_interrupted as _is_interrupted
     # Session kernels are always on locally (one interpreter per conversation); the guards above
     # already ran for this cell, and the kernel path shares env builder, RPC server and redaction.
     from tools.code_kernel import execute_in_session_kernel
     _cfg = _load_config()
     _mode = _get_execution_mode()
+    max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
+    if isinstance(worker_max_tool_calls, int) and not isinstance(worker_max_tool_calls, bool):
+        max_tool_calls = min(max_tool_calls, max(0, worker_max_tool_calls))
     return execute_in_session_kernel(
         code, task_id=task_id or "", mode=_mode, child_python=_resolve_child_python(_mode),
         child_cwd=_resolve_child_cwd(_mode, "", task_id=task_id or ""),
         sandbox_tools=frozenset(_sandbox_tools_for(enabled_tools)),
         timeout=_cfg.get("timeout", DEFAULT_TIMEOUT),
-        max_tool_calls=_cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS),
+        max_tool_calls=max_tool_calls,
         reset=bool(reset), is_interrupted=_is_interrupted,
     )
 
@@ -891,8 +905,13 @@ def _execute_code_handler(args: dict, **kwargs) -> str:
     if code is not None and not isinstance(code, str):
         return tool_error(f"execute_code received a {type(code).__name__} in 'code', but it "
                           "requires Python source as a string. Retry as execute_code(code=\"...\").")
-    return execute_code(code=code or "", task_id=kwargs.get("task_id"),
-                        enabled_tools=kwargs.get("enabled_tools"), reset=bool(args.get("reset", False)))
+    return execute_code(
+        code=code or "",
+        task_id=kwargs.get("task_id"),
+        enabled_tools=kwargs.get("enabled_tools"),
+        reset=bool(args.get("reset", False)),
+        worker_max_tool_calls=kwargs.get("worker_max_tool_calls"),
+    )
 
 
 registry.register(

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -263,7 +263,7 @@ class CellAuthority:
         return self.ctx.run(self._invoke, tool_name, tool_args)
 
     def _invoke(self, tool_name: str, tool_args: dict) -> str:
-        from model_tools import handle_function_call
+        from agent.subagent_lifecycle import dispatch_worker_nested_tool
         previous = None
         if self._api is not None:
             get_approval, get_sudo, set_approval, set_sudo = self._api
@@ -274,7 +274,7 @@ class CellAuthority:
             except Exception:
                 previous = None
         try:
-            return handle_function_call(tool_name, tool_args, task_id=self.task_id)
+            return dispatch_worker_nested_tool(tool_name, tool_args, task_id=self.task_id)
         finally:
             if previous is not None:
                 try:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -11,6 +11,7 @@ the delegation call and the summary result, never the child's intermediate
 tool calls or reasoning.
 """
 
+import json
 import logging
 import time
 import weakref
@@ -48,7 +49,8 @@ from tools.delegate_tool_registry import (  # noqa: F401
 )
 from tools.delegate_tool_tasks import _coerce_task_schemas, _normalize_task_list
 from tools.delegate_tool_toolsets import (  # noqa: F401
-    DELEGATE_BLOCKED_TOOLS, _expand_parent_toolsets, _resolve_child_toolsets, _strip_blocked_tools,
+    DELEGATE_BLOCKED_TOOLS, _apply_exact_tool_policy, _expand_parent_toolsets, _resolve_child_toolsets,
+    _strip_blocked_tools,
 )
 from tools.delegate_tool_results import (  # noqa: F401
     _apply_summary_budget, _build_child_preserving_parent_tools, _run_child_lifecycle, _summarize_tool_arguments,
@@ -170,6 +172,15 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    override_fallback_model: Optional[List[Dict[str, Any]]] = None,
+    override_reasoning_config: Optional[Dict[str, Any]] = None,
+    override_supports_tools: Optional[bool] = None,
+    requested_profile: Optional[str] = None,
+    profile_instructions: Optional[str] = None,
+    profile_tool_policy: Any = None,
+    profile_workspace_context: Any = None,
+    profile_route_receipt: Optional[Dict[str, Any]] = None,
+    profile_execution_limits: Any = None,
     # Configuration block that owns the selected provider/model route. Internal
     # callers such as /review pass auxiliary.review here so fallback policy is
     # not accidentally read from the general delegation block.
@@ -186,7 +197,13 @@ def _build_child_agent(
     # depth budget remains below max_spawn_depth. The `role` arg is ignored.
     child_depth = getattr(parent_agent, "_delegate_depth", 0) + 1
     max_spawn = _get_max_spawn_depth()
-    effective_role = "orchestrator" if _get_orchestrator_enabled() and child_depth < max_spawn else "leaf"
+    profile_spawn_depth = getattr(profile_execution_limits, "max_spawn_depth", None)
+    profile_can_spawn = profile_spawn_depth is None or profile_spawn_depth > 0
+    effective_role = (
+        "orchestrator"
+        if _get_orchestrator_enabled() and child_depth < max_spawn and profile_can_spawn
+        else "leaf"
+    )
 
     # One subagent_id shared by the progress callback, spawn_requested event and
     # the live registry; parent_id is set when THIS parent is itself a subagent.
@@ -197,7 +214,16 @@ def _build_child_agent(
     # global. Only fallback policy follows the owner of a per-call route such
     # as auxiliary.review.
     delegation_cfg = _load_config()
-    child_toolsets, child_disabled_toolsets = _resolve_child_toolsets(parent_agent, toolsets, effective_role)
+    profile_allowed_toolsets = getattr(profile_tool_policy, "allowed_toolsets", None)
+    requested_toolsets = list(profile_allowed_toolsets) if profile_allowed_toolsets is not None else toolsets
+    child_toolsets, child_disabled_toolsets = _resolve_child_toolsets(parent_agent, requested_toolsets, effective_role)
+    if override_supports_tools is False and child_toolsets:
+        raise ValueError(
+            f"Delegation profile '{requested_profile}' pins a model that does not support tool calling, "
+            f"but the child would run with toolsets {sorted(child_toolsets)}")
+    if profile_instructions:
+        context = f"{context}\n\nWorker profile instructions:\n{profile_instructions}" if context else (
+            f"Worker profile instructions:\n{profile_instructions}")
     child_prompt = _build_child_system_prompt(
         goal, context, workspace_path=_resolve_workspace_hint(parent_agent), role=effective_role,
         max_spawn_depth=max_spawn, child_depth=child_depth,
@@ -219,7 +245,8 @@ def _build_child_agent(
         override_base_url=override_base_url, override_api_key=override_api_key, override_api_mode=override_api_mode,
         override_acp_command=override_acp_command,
         override_acp_args=override_acp_args,
-        routing_cfg=routing_cfg,
+        routing_cfg=routing_cfg, override_fallback_model=override_fallback_model,
+        override_reasoning_config=override_reasoning_config,
     )
     if override_request_overrides is not None:
         # honored whenever set, incl. the inherit branch where
@@ -235,6 +262,8 @@ def _build_child_agent(
                 **rt, max_iterations=max_iterations, prefill_messages=getattr(parent_agent, "prefill_messages", None),
                 enabled_toolsets=child_toolsets, disabled_toolsets=child_disabled_toolsets, quiet_mode=True,
                 ephemeral_system_prompt=child_prompt, log_prefix=f"[subagent-{task_index}]", platform="subagent",
+                # Delegates remain isolated by default. A profile can tighten to ``none`` but can never
+                # elevate context/memory above the parent or reload mutable prompt inputs mid-run.
                 skip_context_files=True, skip_memory=True, clarify_callback=None,
                 thinking_callback=(
                     (lambda text: _safe_progress(child_progress_cb, "_thinking", text) if text else None)
@@ -251,6 +280,7 @@ def _build_child_agent(
                     from hermes_state_registry import release_or_close
                     release_or_close(child_session_db)
             raise
+    _apply_exact_tool_policy(child, profile_tool_policy)
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     _apply_child_cache_ttl(child)
     if child_session_db is not None:
@@ -261,6 +291,13 @@ def _build_child_agent(
     child._progress_identity_ref = child_session_ref
     child._delegate_depth, child._delegate_role = child_depth, effective_role  # post-degrade role
     child._subagent_id, child._parent_subagent_id = subagent_id, parent_subagent_id
+    child._worker_profile = requested_profile
+    child._worker_route_receipt = dict(profile_route_receipt or {})
+    child._delegate_profile_max_spawn_depth = profile_spawn_depth
+    child._delegate_profile_max_concurrent_children = getattr(
+        profile_execution_limits, "max_concurrent_children", None)
+    child._delegate_spawn_allowed = effective_role == "orchestrator"
+    child._delegate_parent_worker_id = getattr(parent_agent, "_worker_id", None)
     _apply_child_compression_cap(child, delegation_cfg)
     # Ownership chain for action=list/steer/stop; weakref so a finished parent
     # can be collected while a detached child record lingers in the registry.
@@ -329,7 +366,14 @@ def _run_single_child(
         run.seed_workspace()
         result, failure_entry, _child_close_deferred = run.await_child()
         if failure_entry is not None:
+            from agent.subagent_lifecycle import SubagentLifecycleService
+            if getattr(child, "_worker_id", None):
+                failure_entry["worker_id"] = child._worker_id
+                failure_entry["run_id"] = child._worker_run_id
+            SubagentLifecycleService.complete_adopted_child(child, failure_entry)
             return failure_entry
+
+        child._worker_last_history = list(result.get("messages") or [])
 
         schema = _validate_child_output_schema(child, result, task_index, run.child_task_id, run.relay_text)
         _merge_late_steer(result, _subagent_id, child)
@@ -343,39 +387,110 @@ def _run_single_child(
         run.append_sibling_write_reminder(entry)
         run.account_background_processes(entry)
         run.emit_complete(result, entry, duration)
-        return run.attach_worktree(entry)
+        entry = run.attach_worktree(entry)
+        if getattr(child, "_worker_id", None):
+            entry["worker_id"] = child._worker_id
+            entry["run_id"] = child._worker_run_id
+        from agent.subagent_lifecycle import SubagentLifecycleService
+        SubagentLifecycleService.complete_adopted_child(child, entry)
+        return entry
     except Exception as exc:
         # Close steer acceptance before any completion callback (see _merge_late_steer).
         _late_pending_steer = run.close_steering()
         logging.exception(f"[subagent-{task_index}] failed")
         # Entry status "error" (contract), progress event status "failed" (UI vocabulary).
-        return run.finish_failed(
+        entry = run.finish_failed(
             _fabricated_entry(task_index, "error", str(exc), child, run.elapsed()), _late_pending_steer,
             preview=str(exc), summary=str(exc), status="failed",
         )
+        if getattr(child, "_worker_id", None):
+            entry["worker_id"] = child._worker_id
+            entry["run_id"] = child._worker_run_id
+        from agent.subagent_lifecycle import SubagentLifecycleService
+        SubagentLifecycleService.complete_adopted_child(child, entry)
+        return entry
     finally:
         run.cleanup(heartbeat=heartbeat, child_pool=child_pool, leased_cred_id=leased_cred_id, close_deferred=_child_close_deferred)
+
+
+def _profile_task_overrides(creds: Dict[str, Any]) -> Dict[str, Any]:
+    overrides = {
+        "override_provider": creds["provider"], "override_base_url": creds["base_url"],
+        "override_api_key": creds["api_key"], "override_api_mode": creds["api_mode"],
+        "override_request_overrides": creds.get("request_overrides"),
+        "override_acp_command": creds.get("command"), "override_acp_args": creds.get("args"),
+    }
+    if creds.get("requested_profile"):
+        overrides.update({
+            "override_fallback_model": creds.get("fallback_model"),
+            "override_reasoning_config": creds.get("reasoning_config"),
+            "override_supports_tools": creds.get("supports_tools"),
+            "requested_profile": creds.get("requested_profile"),
+            "profile_instructions": creds.get("profile_instructions"),
+            "profile_tool_policy": creds.get("tool_policy"),
+            "profile_workspace_context": creds.get("workspace_context"),
+            "profile_route_receipt": {
+                key: creds.get(key) for key in (
+                    "requested_profile", "requested_provider", "requested_model",
+                    "requested_reasoning_effort", "resolved_provider", "resolved_model",
+                    "resolved_reasoning_effort", "transmitted_model", "provider_reported_model",
+                )
+            },
+            "profile_execution_limits": creds.get("execution_limits"),
+        })
+    return overrides
+
+
+def _resolve_task_credentials(
+    task_list: List[Dict[str, Any]], creds: Dict[str, Any], routing_cfg: Dict[str, Any], parent_agent,
+    *, top_profile: Optional[str] = None, top_provider: Optional[str] = None,
+    top_model: Optional[str] = None, top_reasoning_effort: Optional[str] = None,
+) -> tuple[List[Dict[str, Any]], Optional[str]]:
+    """Resolve every task route before building any child, preventing partial batch launch."""
+    from agent.delegation_model_routing import select_profile_name
+    from tools.delegate_tool_config import _resolve_profile_credentials
+    resolved: List[Dict[str, Any]] = []
+    for task in task_list:
+        name = select_profile_name(task.get("profile") or task.get("model_profile"), top_profile, routing_cfg)
+        provider = task.get("provider", top_provider)
+        model = task.get("model", top_model)
+        effort = task.get("reasoning_effort", top_reasoning_effort)
+        if not name:
+            if provider or model or effort:
+                return [], "Per-task provider/model/reasoning_effort overrides require a delegation profile."
+            resolved.append(creds)
+            continue
+        try:
+            task_creds = _resolve_profile_credentials(
+                name, routing_cfg, parent_agent,
+                requested_provider=provider, requested_model=model, requested_reasoning_effort=effort,
+            )
+            from agent.delegation_model_routing import parse_profiles
+            task_creds["profile_instructions"] = parse_profiles(routing_cfg)[name].instructions
+            resolved.append(task_creds)
+        except ValueError as exc:
+            return [], str(exc)
+    return resolved, None
 
 
 def _build_children(
     task_list: List[Dict[str, Any]], task_schemas: List[Optional[Dict[str, Any]]], creds: Dict[str, Any], *,
     top_role: str, max_iterations: int, parent_agent, routing_cfg: Dict[str, Any],
-    live_deleg_id: Optional[str], live_writers: list,
+    live_deleg_id: Optional[str], live_writers: list, task_creds: Optional[List[Dict[str, Any]]] = None,
 ) -> tuple[List[tuple], Optional[str]]:
     """Build every child on the main thread (construction is not thread-safe);
     ``(children, None)`` or ``([], error)`` on an explicit-pin preflight failure."""
     from tools.delegation_live_log import wrap_progress_callback
     from tools.delegation_output_schema import append_output_contract
-    overrides = {
-        "override_provider": creds["provider"], "override_base_url": creds["base_url"],
-        "override_api_key": creds["api_key"], "override_api_mode": creds["api_mode"],
-        "override_request_overrides": creds.get("request_overrides"),
-        "override_acp_command": creds.get("command"),
-        "override_acp_args": creds.get("args"),
-        "routing_cfg": routing_cfg,
-    }
     children = []
+    from agent.subagent_lifecycle import SubagentLifecycleService
+    lifecycle = SubagentLifecycleService(lambda: parent_agent)
     for i, t in enumerate(task_list):
+        task_route = task_creds[i] if task_creds and i < len(task_creds) else creds
+        overrides = _profile_task_overrides(task_route)
+        overrides["routing_cfg"] = routing_cfg
+        profile_max = task_route.get("max_iterations") if task_route.get("requested_profile") else None
+        task_max_iterations = min(max_iterations, profile_max) if isinstance(profile_max, int) else max_iterations
         _task_schema = task_schemas[i] if i < len(task_schemas) else None
         _child_context = t.get("context")
         if _task_schema is not None:
@@ -384,8 +499,19 @@ def _build_children(
             child = _build_child_preserving_parent_tools(
                 task_index=i, goal=t["goal"], context=_child_context,
                 toolsets=None,  # always inherit the parent's toolsets
-                model=creds["model"], max_iterations=max_iterations, task_count=len(task_list),
+                model=task_route["model"], max_iterations=task_max_iterations, task_count=len(task_list),
                 parent_agent=parent_agent, role=_normalize_role(t.get("role") or top_role), **overrides,
+            )
+        except ValueError as exc:
+            return [], str(exc)
+        try:
+            lifecycle.adopt_delegate_child(
+                child,
+                goal=t["goal"],
+                context=_child_context,
+                profile=task_route.get("requested_profile"),
+                creds=task_route,
+                cfg=routing_cfg,
             )
         except ValueError as exc:
             return [], str(exc)
@@ -412,6 +538,9 @@ def delegate_task(
     max_iterations: Optional[int] = None, role: Optional[str] = None, background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None, action: Optional[str] = None, subagent_id: Optional[str] = None,
     message: Optional[str] = None, parent_agent=None, credentials_cfg: Optional[Dict[str, Any]] = None,
+    profile: Optional[str] = None, model_profile: Optional[str] = None,
+    provider: Optional[str] = None, model: Optional[str] = None, reasoning_effort: Optional[str] = None,
+    worker_id: Optional[str] = None, run_id: Optional[str] = None, timeout_seconds: Optional[float] = None,
 ) -> str:
     """Spawn child agents (single ``goal`` or ``tasks=[...]`` batch) or control running ones. ``action``
     list/steer/stop run synchronously and bypass the pause gate, depth limit and async dispatch. ``role`` is legacy
@@ -421,10 +550,31 @@ def delegate_task(
         return tool_error("delegate_task requires a parent agent context.")
 
     normalized_action = (action or "").strip().lower()
+    if normalized_action == "discover":
+        from agent.delegation_model_routing import discover_workers
+        return json.dumps({"success": True, **discover_workers(_load_config(), parent_agent)}, ensure_ascii=False)
+    if normalized_action in {"status", "message", "wait", "cancel", "resume"}:
+        from agent.subagent_lifecycle import SubagentLifecycleError, SubagentLifecycleService
+        if normalized_action == "message" and not worker_id:
+            worker_id = getattr(parent_agent, "_delegate_parent_worker_id", None)
+            if not worker_id:
+                return tool_error("action='message' requires worker_id when the parent is not a durable worker.")
+        try:
+            payload = SubagentLifecycleService(lambda: parent_agent).control(
+                normalized_action,
+                worker_id=worker_id,
+                run_id=run_id,
+                message=message,
+                timeout_seconds=timeout_seconds,
+            )
+        except (SubagentLifecycleError, PermissionError, ValueError) as exc:
+            return tool_error(str(exc))
+        return json.dumps({"success": True, **payload}, ensure_ascii=False)
     if normalized_action in _CONTROL_ACTIONS:
         return _handle_control_action(normalized_action, subagent_id, message, parent_agent)
     if normalized_action and normalized_action != "spawn":
-        return tool_error(f"Unknown action '{action}'. Use spawn (default), list, steer, or stop.")
+        return tool_error(
+            f"Unknown action '{action}'. Use spawn, discover, status, message, wait, cancel, resume, list, steer, or stop.")
 
     # Operator kill switch (TUI / delegation.pause RPC): blocks NEW spawns only.
     if is_spawn_paused():
@@ -433,6 +583,9 @@ def delegate_task(
             "(`p` in /agents) or the `delegation.pause` RPC before retrying."
         )
 
+    if getattr(parent_agent, "_delegate_spawn_allowed", True) is False:
+        return tool_error("This worker may use delegate_task controls but its profile/depth does not permit spawning.")
+
     top_role = _normalize_role(role)
     # background applies to single tasks AND batches: a batch is ONE async unit
     # that joins on every child and re-enters as a single consolidated message.
@@ -440,6 +593,11 @@ def delegate_task(
 
     depth = getattr(parent_agent, "_delegate_depth", 0)
     max_spawn = _get_max_spawn_depth()
+    parent_profile_spawn = getattr(parent_agent, "_delegate_profile_max_spawn_depth", None)
+    if isinstance(parent_profile_spawn, int):
+        if parent_profile_spawn <= 0:
+            return tool_error("This worker profile does not permit spawning descendants.")
+        max_spawn = min(max_spawn, depth + parent_profile_spawn)
     if depth >= max_spawn:
         return tool_error(
             f"Delegation depth limit reached (depth={depth}, max_spawn_depth={max_spawn}). Raise "
@@ -460,16 +618,39 @@ def delegate_task(
     # a per-call routing owner shaped like the delegation config section. Keep
     # the route and its fallback policy together through child construction.
     routing_cfg = credentials_cfg if credentials_cfg is not None else cfg
+    selected_profile = str(profile or model_profile or "").strip() or None
+    if profile and model_profile and str(profile).strip() != str(model_profile).strip():
+        return tool_error("profile and legacy model_profile disagree; provide only one worker profile.")
     try:
-        creds = _resolve_delegation_credentials(routing_cfg, parent_agent)
+        creds = _resolve_delegation_credentials(
+            routing_cfg, parent_agent, selected_profile,
+            requested_provider=provider, requested_model=model, requested_reasoning_effort=reasoning_effort,
+        )
     except ValueError as exc:
         # Explicit-pin preflight failures (e.g. pinned delegation.command missing from PATH) refuse the
         # spawn loudly (#80450).
         return tool_error(str(exc))
     max_children = _get_max_concurrent_children()
+    parent_profile_concurrency = getattr(parent_agent, "_delegate_profile_max_concurrent_children", None)
+    if isinstance(parent_profile_concurrency, int):
+        if parent_profile_concurrency <= 0:
+            return tool_error("This worker profile does not permit spawning children.")
+        max_children = min(max_children, parent_profile_concurrency)
     task_list, err = _normalize_task_list(goal, context, tasks, output_schema, top_role, max_children)
     if not err:
         task_schemas, err = _coerce_task_schemas(task_list, output_schema)
+    if err:
+        return tool_error(err)
+    task_creds, err = _resolve_task_credentials(
+        task_list,
+        creds,
+        routing_cfg,
+        parent_agent,
+        top_profile=selected_profile,
+        top_provider=provider,
+        top_model=model,
+        top_reasoning_effort=reasoning_effort,
+    )
     if err:
         return tool_error(err)
 
@@ -485,7 +666,7 @@ def delegate_task(
 
     children, err = _build_children(
         task_list, task_schemas, creds, top_role=top_role, max_iterations=default_max_iter, parent_agent=parent_agent,
-        routing_cfg=routing_cfg, live_deleg_id=live_deleg_id, live_writers=live_writers,
+        routing_cfg=routing_cfg, live_deleg_id=live_deleg_id, live_writers=live_writers, task_creds=task_creds,
     )
     if err:
         return tool_error(err)
@@ -606,6 +787,22 @@ DELEGATE_TASK_SCHEMA = {
                             "Background THIS child needs: file paths, error messages, constraints. Each child "
                             "sees only its own context — repeat shared background in every task that needs it.",
                         ),
+                        "profile": _p(
+                            "string",
+                            "Configured worker profile name. Use action='discover' to inspect the stable catalog.",
+                        ),
+                        "provider": _p(
+                            "string",
+                            "Optional provider override; accepted only with routing_mode=dynamic and an enabled route.",
+                        ),
+                        "model": _p(
+                            "string",
+                            "Optional model override; accepted only with routing_mode=dynamic and an enabled route.",
+                        ),
+                        "reasoning_effort": _p(
+                            "string",
+                            "Optional effort override; accepted only with routing_mode=dynamic and an enabled route.",
+                        ),
                         "output_schema": _p(
                             "object",
                             "Optional JSON Schema this child's final answer must validate against (told to the "
@@ -629,15 +826,19 @@ DELEGATE_TASK_SCHEMA = {
             # delegations always run in the background. Unadvertised; do not re-add.
             "action": _p(
                 "string",
-                "Default 'spawn'. Live control of running children: "
+                "Default 'spawn'. 'discover' returns configured worker profiles. Durable worker actions are "
+                "'status', 'message', 'wait', 'cancel', and 'resume'. Legacy live controls are "
                 "'list' = ids/goals/status/transcripts; 'steer' = queue "
                 "course-correction text into one child (subagent_id + "
                 "message) without stopping it; 'stop' = end one child "
                 "early (subagent_id; partial result still returns). "
                 "Control actions return immediately; goal/tasks are ignored unless spawning.",
-                enum=["spawn", "list", "steer", "stop"],
+                enum=["spawn", "discover", "status", "message", "wait", "cancel", "resume", "list", "steer", "stop"],
             ),
             "subagent_id": _p("string", "Target for action='steer'/'stop' (ids from the spawn response or action='list')."),
+            "worker_id": _p("string", "Stable worker target for status/message/wait/cancel/resume."),
+            "run_id": _p("string", "Optional exact run target for status/wait/cancel."),
+            "timeout_seconds": _p("number", "For action='wait', block for at most 60 seconds; omit for a snapshot."),
             "message": _p(
                 "string",
                 "For action='steer': the course correction, appended to "
@@ -678,6 +879,9 @@ registry.register(
         max_iterations=args.get("max_iterations"), role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")), output_schema=args.get("output_schema"),
         action=args.get("action"), subagent_id=args.get("subagent_id"), message=args.get("message"),
+        worker_id=args.get("worker_id"), run_id=args.get("run_id"), timeout_seconds=args.get("timeout_seconds"),
+        profile=args.get("profile"), provider=args.get("provider"), model=args.get("model"),
+        reasoning_effort=args.get("reasoning_effort"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -82,6 +82,50 @@ def check_delegate_requirements() -> bool:
     return True
 
 
+def _validate_spawn_admission(parent_agent, requested_children: int = 0) -> int:
+    """Shared parent/plugin tree admission; returns the effective child batch cap."""
+    if is_spawn_paused():
+        raise ValueError(
+            "Delegation spawning is paused. Clear the pause via the TUI (`p` in /agents) "
+            "or the delegation.pause RPC before retrying.")
+    if getattr(parent_agent, "_delegate_spawn_allowed", True) is False:
+        raise ValueError("This worker may use delegate_task controls but its profile/depth does not permit spawning.")
+    depth = int(getattr(parent_agent, "_delegate_depth", 0) or 0)
+    max_spawn = _get_max_spawn_depth()
+    parent_profile_spawn = getattr(parent_agent, "_delegate_profile_max_spawn_depth", None)
+    if isinstance(parent_profile_spawn, int):
+        if parent_profile_spawn <= 0:
+            raise ValueError("This worker profile does not permit spawning descendants.")
+        max_spawn = min(max_spawn, depth + parent_profile_spawn)
+    if depth >= max_spawn:
+        raise ValueError(
+            f"Delegation depth limit reached (depth={depth}, max_spawn_depth={max_spawn}). Raise "
+            "delegation.max_spawn_depth in config.yaml if deeper nesting is required.")
+
+    max_children = _get_max_concurrent_children()
+    parent_profile_concurrency = getattr(parent_agent, "_delegate_profile_max_concurrent_children", None)
+    if isinstance(parent_profile_concurrency, int):
+        if parent_profile_concurrency <= 0:
+            raise ValueError("This worker profile does not permit spawning children.")
+        max_children = min(max_children, parent_profile_concurrency)
+    if requested_children > max_children:
+        raise ValueError(
+            f"Requested {requested_children} children exceeds this worker's concurrency limit {max_children}.")
+    if requested_children:
+        from agent.subagent_lifecycle import _owner_session_id_of, _persistent_store
+        store = _persistent_store(parent_agent)
+        owner = _owner_session_id_of(parent_agent)
+        if store is not None and owner:
+            store.recover_expired_runs(owner)
+            active = store.active_run_count(owner)
+            global_cap = _get_max_concurrent_children()
+            if active + requested_children > global_cap:
+                raise ValueError(
+                    f"Durable worker concurrency limit would be exceeded: {active} active + "
+                    f"{requested_children} requested > {global_cap}. Wait for a worker to finish before retrying.")
+    return max_children
+
+
 def _open_child_session_db(parent_agent) -> Any:
     """DEDICATED SessionDB handle for the child, or None: the parent's handle can be closed by its own lifecycle while
     a background child still flushes (transcript silently dropped). It MUST open the same db FILE as the parent's
@@ -181,6 +225,7 @@ def _build_child_agent(
     profile_workspace_context: Any = None,
     profile_route_receipt: Optional[Dict[str, Any]] = None,
     profile_execution_limits: Any = None,
+    request_blocked_tools: Optional[List[str]] = None,
     frozen_system_prompt: Optional[str] = None,
     retained_child_depth: Optional[int] = None,
     retained_parent_worker_id: Optional[str] = None,
@@ -222,7 +267,8 @@ def _build_child_agent(
     # as auxiliary.review.
     delegation_cfg = _load_config()
     profile_allowed_toolsets = getattr(profile_tool_policy, "allowed_toolsets", None)
-    requested_toolsets = list(profile_allowed_toolsets) if profile_allowed_toolsets is not None else toolsets
+    requested_toolsets = toolsets if toolsets is not None else (
+        list(profile_allowed_toolsets) if profile_allowed_toolsets is not None else None)
     child_toolsets, child_disabled_toolsets = _resolve_child_toolsets(parent_agent, requested_toolsets, effective_role)
     if override_supports_tools is False and child_toolsets:
         raise ValueError(
@@ -304,7 +350,14 @@ def _build_child_agent(
                     from hermes_state_registry import release_or_close
                     release_or_close(child_session_db)
             raise
-    _apply_exact_tool_policy(child, profile_tool_policy)
+    parent_exact_tools = getattr(parent_agent, "valid_tool_names", None)
+    _apply_exact_tool_policy(
+        child,
+        profile_tool_policy,
+        request_toolsets=toolsets,
+        request_blocked_tools=request_blocked_tools,
+        ancestor_allowed_tools=parent_exact_tools,
+    )
     child._print_fn = getattr(parent_agent, "_print_fn", None)
     _apply_child_cache_ttl(child)
     if child_session_db is not None:
@@ -593,6 +646,7 @@ def delegate_task(
     profile: Optional[str] = None, model_profile: Optional[str] = None,
     provider: Optional[str] = None, model: Optional[str] = None, reasoning_effort: Optional[str] = None,
     worker_id: Optional[str] = None, run_id: Optional[str] = None, timeout_seconds: Optional[float] = None,
+    reconciliation_disposition: Optional[str] = None,
 ) -> str:
     """Spawn child agents (single ``goal`` or ``tasks=[...]`` batch) or control running ones. ``action``
     list/steer/stop run synchronously and bypass the pause gate, depth limit and async dispatch. ``role`` is legacy
@@ -625,7 +679,9 @@ def delegate_task(
                 ],
             }
         return json.dumps({"success": True, **catalog}, ensure_ascii=False)
-    if normalized_action in {"status", "inspect", "completions", "message", "wait", "cancel", "resume", "ack"}:
+    if normalized_action in {
+        "status", "inspect", "completions", "message", "wait", "cancel", "reconcile", "resume", "ack",
+    }:
         from agent.subagent_lifecycle import SubagentLifecycleError, SubagentLifecycleService
         if normalized_action == "message" and not worker_id:
             worker_id = getattr(parent_agent, "_delegate_parent_worker_id", None)
@@ -649,6 +705,7 @@ def delegate_task(
                 run_id=run_id,
                 message=message,
                 timeout_seconds=timeout_seconds,
+                reconciliation_disposition=reconciliation_disposition,
             )
         except (SubagentLifecycleError, PermissionError, ValueError) as exc:
             return tool_error(str(exc))
@@ -658,36 +715,17 @@ def delegate_task(
     if normalized_action and normalized_action != "spawn":
         return tool_error(
             f"Unknown action '{action}'. Use spawn, discover, status, inspect, completions, message, wait, cancel, "
-            "resume, ack, list, steer, or stop.")
-
-    # Operator kill switch (TUI / delegation.pause RPC): blocks NEW spawns only.
-    if is_spawn_paused():
-        return tool_error(
-            "Delegation spawning is paused. Clear the pause via the TUI "
-            "(`p` in /agents) or the `delegation.pause` RPC before retrying."
-        )
-
-    if getattr(parent_agent, "_delegate_spawn_allowed", True) is False:
-        return tool_error("This worker may use delegate_task controls but its profile/depth does not permit spawning.")
+            "reconcile, resume, ack, list, steer, or stop.")
 
     top_role = _normalize_role(role)
     # background applies to single tasks AND batches: a batch is ONE async unit
     # that joins on every child and re-enters as a single consolidated message.
     background = is_truthy_value(background, default=False) if background is not None else False
 
-    depth = getattr(parent_agent, "_delegate_depth", 0)
-    max_spawn = _get_max_spawn_depth()
-    parent_profile_spawn = getattr(parent_agent, "_delegate_profile_max_spawn_depth", None)
-    if isinstance(parent_profile_spawn, int):
-        if parent_profile_spawn <= 0:
-            return tool_error("This worker profile does not permit spawning descendants.")
-        max_spawn = min(max_spawn, depth + parent_profile_spawn)
-    if depth >= max_spawn:
-        return tool_error(
-            f"Delegation depth limit reached (depth={depth}, max_spawn_depth={max_spawn}). Raise "
-            f"delegation.max_spawn_depth in config.yaml if deeper nesting is required (no hard ceiling, but each level "
-            f"multiplies API cost)."
-        )
+    try:
+        max_children = _validate_spawn_admission(parent_agent)
+    except ValueError as exc:
+        return tool_error(str(exc))
 
     cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
@@ -714,12 +752,6 @@ def delegate_task(
         # Explicit-pin preflight failures (e.g. pinned delegation.command missing from PATH) refuse the
         # spawn loudly (#80450).
         return tool_error(str(exc))
-    max_children = _get_max_concurrent_children()
-    parent_profile_concurrency = getattr(parent_agent, "_delegate_profile_max_concurrent_children", None)
-    if isinstance(parent_profile_concurrency, int):
-        if parent_profile_concurrency <= 0:
-            return tool_error("This worker profile does not permit spawning children.")
-        max_children = min(max_children, parent_profile_concurrency)
     task_list, err = _normalize_task_list(goal, context, tasks, output_schema, top_role, max_children)
     if not err:
         task_schemas, err = _coerce_task_schemas(task_list, output_schema)
@@ -738,20 +770,10 @@ def delegate_task(
     if err:
         return tool_error(err)
 
-    # Durable owner-wide concurrency is checked before constructing any child. A nested orchestrator's
-    # own run occupies one slot, so this prevents a later child from failing after earlier siblings launched.
-    from agent.subagent_lifecycle import _owner_session_id_of, _persistent_store
-    durable_store = _persistent_store(parent_agent)
-    durable_owner = _owner_session_id_of(parent_agent)
-    if durable_store is not None and durable_owner:
-        durable_store.recover_expired_runs(durable_owner)
-        active_runs = durable_store.active_run_count(durable_owner)
-        global_cap = _get_max_concurrent_children()
-        if active_runs + len(task_list) > global_cap:
-            return tool_error(
-                f"Durable worker concurrency limit would be exceeded: {active_runs} active + "
-                f"{len(task_list)} requested > {global_cap}. Wait for a worker to finish before retrying."
-            )
+    try:
+        _validate_spawn_admission(parent_agent, len(task_list))
+    except ValueError as exc:
+        return tool_error(str(exc))
 
     overall_start = time.monotonic()
     # Live transcripts: cache/delegation/live/<id>/task-<n>.log per task, a side channel with zero effect on message
@@ -963,7 +985,7 @@ DELEGATE_TASK_SCHEMA = {
             "action": _p(
                 "string",
                 "Default 'spawn'. 'discover' returns configured worker profiles. Durable worker actions are "
-                "'status', 'inspect', 'completions', 'message', 'wait', 'cancel', 'resume', and 'ack'. "
+                "'status', 'inspect', 'completions', 'message', 'wait', 'cancel', 'reconcile', 'resume', and 'ack'. "
                 "Legacy live controls are "
                 "'list' = ids/goals/status/transcripts; 'steer' = queue "
                 "course-correction text into one child (subagent_id + "
@@ -972,12 +994,18 @@ DELEGATE_TASK_SCHEMA = {
                 "Control actions return immediately; goal/tasks are ignored unless spawning.",
                 enum=[
                     "spawn", "discover", "status", "inspect", "completions", "message", "wait",
-                    "cancel", "resume", "ack", "list", "steer", "stop",
+                    "cancel", "reconcile", "resume", "ack", "list", "steer", "stop",
                 ],
             ),
             "subagent_id": _p("string", "Target for action='steer'/'stop' (ids from the spawn response or action='list')."),
             "worker_id": _p("string", "Stable worker target for status/inspect/message/wait/cancel/resume/ack."),
             "run_id": _p("string", "Optional exact run target for inspect/wait/cancel/resume/ack."),
+            "reconciliation_disposition": _p(
+                "string",
+                "For action='reconcile': explicit decision about the prior uncertain effect. This records evidence "
+                "and never replays the tool.",
+                enum=["confirmed_applied", "confirmed_not_applied", "accepted_unknown_no_replay"],
+            ),
             "timeout_seconds": _p("number", "For action='wait', block for at most 60 seconds; omit for a snapshot."),
             "message": _p(
                 "string",
@@ -1020,6 +1048,7 @@ registry.register(
         background=_model_background_value(args, kw.get("parent_agent")), output_schema=args.get("output_schema"),
         action=args.get("action"), subagent_id=args.get("subagent_id"), message=args.get("message"),
         worker_id=args.get("worker_id"), run_id=args.get("run_id"), timeout_seconds=args.get("timeout_seconds"),
+        reconciliation_disposition=args.get("reconciliation_disposition"),
         profile=args.get("profile"), provider=args.get("provider"), model=args.get("model"),
         reasoning_effort=args.get("reasoning_effort"),
         parent_agent=kw.get("parent_agent"),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -350,7 +350,10 @@ def _build_child_agent(
                     from hermes_state_registry import release_or_close
                     release_or_close(child_session_db)
             raise
-    parent_exact_tools = getattr(parent_agent, "valid_tool_names", None)
+    parent_exact_tools = getattr(
+        parent_agent, "_worker_effective_tool_names",
+        getattr(parent_agent, "_executable_tool_names", getattr(parent_agent, "valid_tool_names", None)),
+    )
     _apply_exact_tool_policy(
         child,
         profile_tool_policy,
@@ -985,7 +988,8 @@ DELEGATE_TASK_SCHEMA = {
             "action": _p(
                 "string",
                 "Default 'spawn'. 'discover' returns configured worker profiles. Durable worker actions are "
-                "'status', 'inspect', 'completions', 'message', 'wait', 'cancel', 'reconcile', 'resume', and 'ack'. "
+                "'status', 'inspect' (explicit visible conversation plus receipt metadata), 'completions', "
+                "'message', 'wait', 'cancel', 'reconcile', 'resume', and 'ack'. "
                 "Legacy live controls are "
                 "'list' = ids/goals/status/transcripts; 'steer' = queue "
                 "course-correction text into one child (subagent_id + "
@@ -998,7 +1002,11 @@ DELEGATE_TASK_SCHEMA = {
                 ],
             ),
             "subagent_id": _p("string", "Target for action='steer'/'stop' (ids from the spawn response or action='list')."),
-            "worker_id": _p("string", "Stable worker target for status/inspect/message/wait/cancel/resume/ack."),
+            "worker_id": _p(
+                "string",
+                "Stable worker target. action='inspect' returns its retained user/assistant/tool conversation "
+                "without hidden reasoning or system prompts.",
+            ),
             "run_id": _p("string", "Optional exact run target for inspect/wait/cancel/resume/ack."),
             "reconciliation_disposition": _p(
                 "string",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -181,6 +181,9 @@ def _build_child_agent(
     profile_workspace_context: Any = None,
     profile_route_receipt: Optional[Dict[str, Any]] = None,
     profile_execution_limits: Any = None,
+    frozen_system_prompt: Optional[str] = None,
+    retained_child_depth: Optional[int] = None,
+    retained_parent_worker_id: Optional[str] = None,
     # Configuration block that owns the selected provider/model route. Internal
     # callers such as /review pass auxiliary.review here so fallback policy is
     # not accidentally read from the general delegation block.
@@ -195,7 +198,11 @@ def _build_child_agent(
     from agent.delegation_context import delegated_child_context
     # Role is depth-derived: a child may delegate iff the kill switch is on and
     # depth budget remains below max_spawn_depth. The `role` arg is ignored.
-    child_depth = getattr(parent_agent, "_delegate_depth", 0) + 1
+    child_depth = (
+        retained_child_depth
+        if isinstance(retained_child_depth, int) and retained_child_depth > 0
+        else getattr(parent_agent, "_delegate_depth", 0) + 1
+    )
     max_spawn = _get_max_spawn_depth()
     profile_spawn_depth = getattr(profile_execution_limits, "max_spawn_depth", None)
     profile_can_spawn = profile_spawn_depth is None or profile_spawn_depth > 0
@@ -221,13 +228,30 @@ def _build_child_agent(
         raise ValueError(
             f"Delegation profile '{requested_profile}' pins a model that does not support tool calling, "
             f"but the child would run with toolsets {sorted(child_toolsets)}")
-    if profile_instructions:
+    if profile_instructions and frozen_system_prompt is None:
         context = f"{context}\n\nWorker profile instructions:\n{profile_instructions}" if context else (
             f"Worker profile instructions:\n{profile_instructions}")
-    child_prompt = _build_child_system_prompt(
-        goal, context, workspace_path=_resolve_workspace_hint(parent_agent), role=effective_role,
-        max_spawn_depth=max_spawn, child_depth=child_depth,
+    child_prompt = frozen_system_prompt
+    if child_prompt is None:
+        child_prompt = _build_child_system_prompt(
+            goal, context, workspace_path=_resolve_workspace_hint(parent_agent), role=effective_role,
+            max_spawn_depth=max_spawn, child_depth=child_depth,
+        )
+    context_mode = getattr(profile_workspace_context, "mode", None)
+    inherit_context = profile_workspace_context is not None and context_mode == "inherit"
+    requested_context = getattr(profile_workspace_context, "include_context_files", None)
+    requested_memory = getattr(profile_workspace_context, "include_memory", None)
+    parent_allows_context = not bool(getattr(parent_agent, "skip_context_files", False))
+    parent_allows_memory = not bool(getattr(parent_agent, "skip_memory", False))
+    include_context_files = context_mode != "none" and parent_allows_context and (
+        requested_context is True or (requested_context is None and inherit_context)
     )
+    include_memory = context_mode != "none" and parent_allows_memory and (
+        requested_memory is True or (requested_memory is None and inherit_context)
+    )
+    if frozen_system_prompt is not None:
+        include_context_files = False
+        include_memory = False
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
         parent_api_key = parent_agent._client_kwargs.get("api_key")
@@ -262,9 +286,9 @@ def _build_child_agent(
                 **rt, max_iterations=max_iterations, prefill_messages=getattr(parent_agent, "prefill_messages", None),
                 enabled_toolsets=child_toolsets, disabled_toolsets=child_disabled_toolsets, quiet_mode=True,
                 ephemeral_system_prompt=child_prompt, log_prefix=f"[subagent-{task_index}]", platform="subagent",
-                # Delegates remain isolated by default. A profile can tighten to ``none`` but can never
-                # elevate context/memory above the parent or reload mutable prompt inputs mid-run.
-                skip_context_files=True, skip_memory=True, clarify_callback=None,
+                # Legacy delegates remain isolated. Profiles may inherit a parent-enabled startup source,
+                # but can never elevate above the parent or reload it after this frozen prompt is built.
+                skip_context_files=not include_context_files, skip_memory=not include_memory, clarify_callback=None,
                 thinking_callback=(
                     (lambda text: _safe_progress(child_progress_cb, "_thinking", text) if text else None)
                     if child_progress_cb else None
@@ -296,8 +320,29 @@ def _build_child_agent(
     child._delegate_profile_max_spawn_depth = profile_spawn_depth
     child._delegate_profile_max_concurrent_children = getattr(
         profile_execution_limits, "max_concurrent_children", None)
+    child._worker_timeout_seconds = getattr(profile_execution_limits, "timeout_seconds", None)
+    child._worker_max_followups = getattr(profile_execution_limits, "max_followups", None)
+    child._worker_max_tool_calls = getattr(profile_execution_limits, "max_tool_calls", None)
     child._delegate_spawn_allowed = effective_role == "orchestrator"
-    child._delegate_parent_worker_id = getattr(parent_agent, "_worker_id", None)
+    child._delegate_parent_worker_id = (
+        retained_parent_worker_id
+        if retained_parent_worker_id is not None
+        else getattr(parent_agent, "_worker_id", None)
+    )
+    child._delegate_outbound_messages = []
+
+    def _parent_message_sink(content: str) -> Dict[str, Any]:
+        if not isinstance(content, str) or not content.strip():
+            raise ValueError("Message must be nonempty text")
+        item = {
+            "message_id": "message-" + _uuid.uuid4().hex,
+            "status": "DELIVERED_ON_COMPLETION",
+            "content": content,
+        }
+        child._delegate_outbound_messages.append(item)
+        return item
+
+    child._delegate_parent_message_sink = _parent_message_sink
     _apply_child_compression_cap(child, delegation_cfg)
     # Ownership chain for action=list/steer/stop; weakref so a finished parent
     # can be collected while a detached child record lingers in the registry.
@@ -391,6 +436,9 @@ def _run_single_child(
         if getattr(child, "_worker_id", None):
             entry["worker_id"] = child._worker_id
             entry["run_id"] = child._worker_run_id
+        outbound = list(getattr(child, "_delegate_outbound_messages", None) or [])
+        if outbound:
+            entry["messages_to_parent"] = outbound
         from agent.subagent_lifecycle import SubagentLifecycleService
         SubagentLifecycleService.complete_adopted_child(child, entry)
         return entry
@@ -406,6 +454,9 @@ def _run_single_child(
         if getattr(child, "_worker_id", None):
             entry["worker_id"] = child._worker_id
             entry["run_id"] = child._worker_run_id
+        outbound = list(getattr(child, "_delegate_outbound_messages", None) or [])
+        if outbound:
+            entry["messages_to_parent"] = outbound
         from agent.subagent_lifecycle import SubagentLifecycleService
         SubagentLifecycleService.complete_adopted_child(child, entry)
         return entry
@@ -433,7 +484,8 @@ def _profile_task_overrides(creds: Dict[str, Any]) -> Dict[str, Any]:
                 key: creds.get(key) for key in (
                     "requested_profile", "requested_provider", "requested_model",
                     "requested_reasoning_effort", "resolved_provider", "resolved_model",
-                    "resolved_reasoning_effort", "transmitted_model", "provider_reported_model",
+                    "resolved_reasoning_effort", "route_provenance", "normalization_events",
+                    "transmitted_model", "provider_reported_model",
                 )
             },
             "profile_execution_limits": creds.get("execution_limits"),
@@ -552,13 +604,44 @@ def delegate_task(
     normalized_action = (action or "").strip().lower()
     if normalized_action == "discover":
         from agent.delegation_model_routing import discover_workers
-        return json.dumps({"success": True, **discover_workers(_load_config(), parent_agent)}, ensure_ascii=False)
-    if normalized_action in {"status", "message", "wait", "cancel", "resume"}:
+        catalog = discover_workers(_load_config(), parent_agent)
+        if profile:
+            selected = next((item for item in catalog["profiles"] if item["name"] == profile), None)
+            if selected is None:
+                return tool_error(f"Unknown delegation profile '{profile}'.")
+            catalog = {**catalog, "profiles": [selected]}
+        else:
+            catalog = {
+                **catalog,
+                "profiles": [
+                    {
+                        key: item.get(key) for key in (
+                            "name", "description", "provider", "model", "reasoning_effort",
+                            "supported_reasoning_efforts", "supports_tools", "availability",
+                            "freshness", "provenance",
+                        )
+                    }
+                    for item in catalog["profiles"]
+                ],
+            }
+        return json.dumps({"success": True, **catalog}, ensure_ascii=False)
+    if normalized_action in {"status", "inspect", "completions", "message", "wait", "cancel", "resume", "ack"}:
         from agent.subagent_lifecycle import SubagentLifecycleError, SubagentLifecycleService
         if normalized_action == "message" and not worker_id:
             worker_id = getattr(parent_agent, "_delegate_parent_worker_id", None)
             if not worker_id:
-                return tool_error("action='message' requires worker_id when the parent is not a durable worker.")
+                sink = getattr(parent_agent, "_delegate_parent_message_sink", None)
+                if callable(sink):
+                    try:
+                        queued = sink(message or "")
+                    except ValueError as exc:
+                        return tool_error(str(exc))
+                    return json.dumps({
+                        "success": True,
+                        "message_id": queued["message_id"],
+                        "status": queued["status"],
+                    }, ensure_ascii=False)
+                return tool_error("action='message' requires worker_id when no parent worker is available.")
         try:
             payload = SubagentLifecycleService(lambda: parent_agent).control(
                 normalized_action,
@@ -574,7 +657,8 @@ def delegate_task(
         return _handle_control_action(normalized_action, subagent_id, message, parent_agent)
     if normalized_action and normalized_action != "spawn":
         return tool_error(
-            f"Unknown action '{action}'. Use spawn, discover, status, message, wait, cancel, resume, list, steer, or stop.")
+            f"Unknown action '{action}'. Use spawn, discover, status, inspect, completions, message, wait, cancel, "
+            "resume, ack, list, steer, or stop.")
 
     # Operator kill switch (TUI / delegation.pause RPC): blocks NEW spawns only.
     if is_spawn_paused():
@@ -654,6 +738,21 @@ def delegate_task(
     if err:
         return tool_error(err)
 
+    # Durable owner-wide concurrency is checked before constructing any child. A nested orchestrator's
+    # own run occupies one slot, so this prevents a later child from failing after earlier siblings launched.
+    from agent.subagent_lifecycle import _owner_session_id_of, _persistent_store
+    durable_store = _persistent_store(parent_agent)
+    durable_owner = _owner_session_id_of(parent_agent)
+    if durable_store is not None and durable_owner:
+        durable_store.recover_expired_runs(durable_owner)
+        active_runs = durable_store.active_run_count(durable_owner)
+        global_cap = _get_max_concurrent_children()
+        if active_runs + len(task_list) > global_cap:
+            return tool_error(
+                f"Durable worker concurrency limit would be exceeded: {active_runs} active + "
+                f"{len(task_list)} requested > {global_cap}. Wait for a worker to finish before retrying."
+            )
+
     overall_start = time.monotonic()
     # Live transcripts: cache/delegation/live/<id>/task-<n>.log per task, a side channel with zero effect on message
     # content or prompt caching. Best-effort: on failure live_paths is empty and delegation proceeds.
@@ -722,8 +821,9 @@ _DESCRIPTION_HEAD = (
     "- Mechanical multi-step work with no reasoning needed -> execute_code\n"
     "- A single tool call -> call the tool directly\n"
     "- Tasks needing user interaction -> subagents cannot ask questions\n"
-    "- Durable work that must survive this session -> cronjob or terminal(background=True, notify=True); /stop, /new, "
-    "or process exit discards running subagents.\n\n"
+    "- Long-running scheduled or shell work -> cronjob or terminal(background=True, notify=True). Worker profiles "
+    "persist ids, messages, history, and terminal receipts when the parent session has durable state; restart "
+    "interrupts an expired run and requires an explicit resume.\n\n"
     "RULES:\n"
     "- Children know nothing of this conversation: pass everything needed via 'context', including any required "
     "output language, tone, or style (e.g. \"respond in Chinese\").\n"
@@ -841,22 +941,43 @@ DELEGATE_TASK_SCHEMA = {
                 },
                 "description": "(rebuilt at get_definitions() time)",
             },
+            "profile": _p(
+                "string",
+                "Profile for every spawned task unless that task sets its own profile; with action='discover', "
+                "returns that profile's full policy and instructions.",
+            ),
+            "provider": _p(
+                "string",
+                "Optional batch route override, accepted only by a dynamic profile and its enabled routes.",
+            ),
+            "model": _p(
+                "string",
+                "Optional batch model override, accepted only by a dynamic profile and its enabled routes.",
+            ),
+            "reasoning_effort": _p(
+                "string",
+                "Optional batch effort override, accepted only by a dynamic profile and its enabled routes.",
+            ),
             # `background` (bool) is also accepted — DEPRECATED, ignored: top-level
             # delegations always run in the background. Unadvertised; do not re-add.
             "action": _p(
                 "string",
                 "Default 'spawn'. 'discover' returns configured worker profiles. Durable worker actions are "
-                "'status', 'message', 'wait', 'cancel', and 'resume'. Legacy live controls are "
+                "'status', 'inspect', 'completions', 'message', 'wait', 'cancel', 'resume', and 'ack'. "
+                "Legacy live controls are "
                 "'list' = ids/goals/status/transcripts; 'steer' = queue "
                 "course-correction text into one child (subagent_id + "
                 "message) without stopping it; 'stop' = end one child "
                 "early (subagent_id; partial result still returns). "
                 "Control actions return immediately; goal/tasks are ignored unless spawning.",
-                enum=["spawn", "discover", "status", "message", "wait", "cancel", "resume", "list", "steer", "stop"],
+                enum=[
+                    "spawn", "discover", "status", "inspect", "completions", "message", "wait",
+                    "cancel", "resume", "ack", "list", "steer", "stop",
+                ],
             ),
             "subagent_id": _p("string", "Target for action='steer'/'stop' (ids from the spawn response or action='list')."),
-            "worker_id": _p("string", "Stable worker target for status/message/wait/cancel/resume."),
-            "run_id": _p("string", "Optional exact run target for status/wait/cancel."),
+            "worker_id": _p("string", "Stable worker target for status/inspect/message/wait/cancel/resume/ack."),
+            "run_id": _p("string", "Optional exact run target for inspect/wait/cancel/resume/ack."),
             "timeout_seconds": _p("number", "For action='wait', block for at most 60 seconds; omit for a snapshot."),
             "message": _p(
                 "string",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -380,10 +380,13 @@ def _build_child_agent(
     child._worker_max_followups = getattr(profile_execution_limits, "max_followups", None)
     child._worker_max_tool_calls = getattr(profile_execution_limits, "max_tool_calls", None)
     child._delegate_spawn_allowed = effective_role == "orchestrator"
-    child._delegate_parent_worker_id = (
+    parent_worker_id = (
         retained_parent_worker_id
         if retained_parent_worker_id is not None
         else getattr(parent_agent, "_worker_id", None)
+    )
+    child._delegate_parent_worker_id = (
+        parent_worker_id if isinstance(parent_worker_id, str) and parent_worker_id else None
     )
     child._delegate_outbound_messages = []
 
@@ -435,6 +438,15 @@ def _build_child_agent(
         )
     return child
 
+
+def _stable_worker_identity(child: Any) -> Optional[tuple[str, str]]:
+    """Return only durable scalar worker identity, never proxy metadata."""
+    worker_id = getattr(child, "_worker_id", None)
+    run_id = getattr(child, "_worker_run_id", None)
+    if isinstance(worker_id, str) and worker_id and isinstance(run_id, str) and run_id:
+        return worker_id, run_id
+    return None
+
 def _run_single_child(
     task_index: int, goal: str, child=None, parent_agent=None, *, owner_session_id: Optional[str] = None,
     owner_transport: Any = None, owner_session_record: Any = None, **_kwargs,
@@ -474,9 +486,9 @@ def _run_single_child(
         result, failure_entry, _child_close_deferred = run.await_child()
         if failure_entry is not None:
             from agent.subagent_lifecycle import SubagentLifecycleService
-            if getattr(child, "_worker_id", None):
-                failure_entry["worker_id"] = child._worker_id
-                failure_entry["run_id"] = child._worker_run_id
+            worker_identity = _stable_worker_identity(child)
+            if worker_identity:
+                failure_entry["worker_id"], failure_entry["run_id"] = worker_identity
             SubagentLifecycleService.complete_adopted_child(child, failure_entry)
             return failure_entry
 
@@ -495,9 +507,9 @@ def _run_single_child(
         run.account_background_processes(entry)
         run.emit_complete(result, entry, duration)
         entry = run.attach_worktree(entry)
-        if getattr(child, "_worker_id", None):
-            entry["worker_id"] = child._worker_id
-            entry["run_id"] = child._worker_run_id
+        worker_identity = _stable_worker_identity(child)
+        if worker_identity:
+            entry["worker_id"], entry["run_id"] = worker_identity
         outbound = list(getattr(child, "_delegate_outbound_messages", None) or [])
         if outbound:
             entry["messages_to_parent"] = outbound
@@ -513,9 +525,9 @@ def _run_single_child(
             _fabricated_entry(task_index, "error", str(exc), child, run.elapsed()), _late_pending_steer,
             preview=str(exc), summary=str(exc), status="failed",
         )
-        if getattr(child, "_worker_id", None):
-            entry["worker_id"] = child._worker_id
-            entry["run_id"] = child._worker_run_id
+        worker_identity = _stable_worker_identity(child)
+        if worker_identity:
+            entry["worker_id"], entry["run_id"] = worker_identity
         outbound = list(getattr(child, "_delegate_outbound_messages", None) or [])
         if outbound:
             entry["messages_to_parent"] = outbound
@@ -752,20 +764,36 @@ def delegate_task(
     selected_profile = str(profile or model_profile or "").strip() or None
     if profile and model_profile and str(profile).strip() != str(model_profile).strip():
         return tool_error("profile and legacy model_profile disagree; provide only one worker profile.")
-    try:
-        creds = _resolve_delegation_credentials(
-            routing_cfg, parent_agent, selected_profile,
-            requested_provider=provider, requested_model=model, requested_reasoning_effort=reasoning_effort,
-        )
-    except ValueError as exc:
-        # Explicit-pin preflight failures (e.g. pinned delegation.command missing from PATH) refuse the
-        # spawn loudly (#80450).
-        return tool_error(str(exc))
     task_list, err = _normalize_task_list(goal, context, tasks, output_schema, top_role, max_children)
     if not err:
         task_schemas, err = _coerce_task_schemas(task_list, output_schema)
     if err:
         return tool_error(err)
+    # A batch may select its profile per item without a top-level/default
+    # profile.  Resolve those item routes first instead of rejecting or
+    # initializing an unrelated inherited runtime.
+    item_profile_only = not selected_profile and bool(task_list) and all(
+        str(task.get("profile") or task.get("model_profile") or "").strip()
+        for task in task_list
+    )
+    creds = None
+    if not item_profile_only:
+        try:
+            route_overrides = (provider, model, reasoning_effort)
+            if selected_profile is None and all(value is None for value in route_overrides):
+                creds = _resolve_delegation_credentials(routing_cfg, parent_agent)
+            elif all(value is None for value in route_overrides):
+                creds = _resolve_delegation_credentials(routing_cfg, parent_agent, selected_profile)
+            else:
+                creds = _resolve_delegation_credentials(
+                    routing_cfg, parent_agent, selected_profile,
+                    requested_provider=provider, requested_model=model,
+                    requested_reasoning_effort=reasoning_effort,
+                )
+        except ValueError as exc:
+            # Explicit-pin preflight failures refuse the entire batch before
+            # any child is built.
+            return tool_error(str(exc))
     task_creds, err = _resolve_task_credentials(
         task_list,
         creds,
@@ -778,6 +806,8 @@ def delegate_task(
     )
     if err:
         return tool_error(err)
+    if creds is None:
+        creds = task_creds[0]
 
     try:
         _validate_spawn_admission(parent_agent, len(task_list))

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -701,7 +701,7 @@ def delegate_task(
             }
         return json.dumps({"success": True, **catalog}, ensure_ascii=False)
     if normalized_action in {
-        "status", "inspect", "completions", "message", "wait", "cancel", "reconcile", "resume", "ack",
+        "status", "inspect", "completions", "message", "wait", "interrupt", "cancel", "reconcile", "resume", "ack",
     }:
         from agent.subagent_lifecycle import SubagentLifecycleError, SubagentLifecycleService
         if normalized_action == "message" and not worker_id:
@@ -735,7 +735,7 @@ def delegate_task(
         return _handle_control_action(normalized_action, subagent_id, message, parent_agent)
     if normalized_action and normalized_action != "spawn":
         return tool_error(
-            f"Unknown action '{action}'. Use spawn, discover, status, inspect, completions, message, wait, cancel, "
+            f"Unknown action '{action}'. Use spawn, discover, status, inspect, completions, message, wait, interrupt, cancel, "
             "reconcile, resume, ack, list, steer, or stop.")
 
     top_role = _normalize_role(role)
@@ -1025,7 +1025,7 @@ DELEGATE_TASK_SCHEMA = {
                 "string",
                 "Default 'spawn'. 'discover' returns configured worker profiles. Durable worker actions are "
                 "'status', 'inspect' (explicit visible conversation plus receipt metadata), 'completions', "
-                "'message', 'wait', 'cancel', 'reconcile', 'resume', and 'ack'. "
+                "'message', 'wait', 'interrupt' (one run), 'cancel' (worker tree), 'reconcile', 'resume', and 'ack'. "
                 "Legacy live controls are "
                 "'list' = ids/goals/status/transcripts; 'steer' = queue "
                 "course-correction text into one child (subagent_id + "
@@ -1034,7 +1034,7 @@ DELEGATE_TASK_SCHEMA = {
                 "Control actions return immediately; goal/tasks are ignored unless spawning.",
                 enum=[
                     "spawn", "discover", "status", "inspect", "completions", "message", "wait",
-                    "cancel", "reconcile", "resume", "ack", "list", "steer", "stop",
+                    "interrupt", "cancel", "reconcile", "resume", "ack", "list", "steer", "stop",
                 ],
             ),
             "subagent_id": _p("string", "Target for action='steer'/'stop' (ids from the spawn response or action='list')."),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -390,11 +390,17 @@ def _build_child_agent(
     def _parent_message_sink(content: str) -> Dict[str, Any]:
         if not isinstance(content, str) or not content.strip():
             raise ValueError("Message must be nonempty text")
-        item = {
+        from agent.subagent_lifecycle import queue_worker_parent_message
+        durable = queue_worker_parent_message(child, content)
+        item = ({
+            "message_id": durable["message_id"],
+            "status": durable["status"],
+            "content": content,
+        } if durable is not None else {
             "message_id": "message-" + _uuid.uuid4().hex,
             "status": "DELIVERED_ON_COMPLETION",
             "content": content,
-        }
+        })
         child._delegate_outbound_messages.append(item)
         return item
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -229,6 +229,7 @@ def _build_child_agent(
     frozen_system_prompt: Optional[str] = None,
     retained_child_depth: Optional[int] = None,
     retained_parent_worker_id: Optional[str] = None,
+    worker_interface_contract: Optional[Dict[str, Any]] = None,
     # Configuration block that owns the selected provider/model route. Internal
     # callers such as /review pass auxiliary.review here so fallback policy is
     # not accidentally read from the general delegation block.
@@ -340,6 +341,7 @@ def _build_child_agent(
                     if child_progress_cb else None
                 ),
                 session_db=child_session_db, parent_session_id=parent_sid, request_overrides=request_overrides,
+                worker_interface_contract=worker_interface_contract,
                 tool_progress_callback=child_progress_cb,
                 iteration_budget=None,  # fresh budget per subagent
             )

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -649,6 +649,9 @@ class _ChildRun:
         from tools.daemon_pool import DaemonThreadPoolExecutor
         child, task_index = self.child, self.task_index
         child_timeout = _get_child_timeout()
+        profile_timeout = getattr(child, "_worker_timeout_seconds", None)
+        if isinstance(profile_timeout, (int, float)) and profile_timeout > 0:
+            child_timeout = min(child_timeout, profile_timeout) if child_timeout else profile_timeout
         executor = DaemonThreadPoolExecutor(
             max_workers=1, initializer=_set_subagent_approval_cb, initargs=(_get_subagent_approval_callback(),),
         )

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -662,12 +662,15 @@ class _ChildRun:
             worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
             with delegated_child_context(str(getattr(child, "session_id", "") or "")):
-                return child.run_conversation(
+                run_kwargs = dict(
                     user_message=self.goal,
-                    conversation_history=getattr(child, "_worker_resume_history", None),
                     task_id=self.child_task_id,
                     stream_callback=self.relay_text,
                 )
+                resume_history = getattr(child, "_worker_resume_history", None)
+                if isinstance(resume_history, list):
+                    run_kwargs["conversation_history"] = resume_history
+                return child.run_conversation(**run_kwargs)
 
         future = executor.submit(contextvars.copy_context().run, _run_with_thread_capture)
         try:

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -511,6 +511,9 @@ def _build_result_entry(
     # Model-visible per-delegation spend (unlike _child_cost_usd above).
     entry["cost_usd"] = round(entry["_child_cost_usd"], 6)
     entry["cost_status"] = _cost_status if isinstance(_cost_status, str) and _cost_status else "unknown"
+    route_receipt = getattr(child, "_worker_route_receipt", None)
+    if isinstance(route_receipt, dict) and route_receipt.get("requested_profile"):
+        entry["route"] = dict(route_receipt)
     if status == "failed":
         if schema.valid is False and usable_summary:
             # The child DID respond; name the contract violation instead of the generic "no response" error.
@@ -657,7 +660,10 @@ class _ChildRun:
             from agent.delegation_context import delegated_child_context
             with delegated_child_context(str(getattr(child, "session_id", "") or "")):
                 return child.run_conversation(
-                    user_message=self.goal, task_id=self.child_task_id, stream_callback=self.relay_text,
+                    user_message=self.goal,
+                    conversation_history=getattr(child, "_worker_resume_history", None),
+                    task_id=self.child_task_id,
+                    stream_callback=self.relay_text,
                 )
 
         future = executor.submit(contextvars.copy_context().run, _run_with_thread_capture)

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -392,6 +392,8 @@ def _resolve_profile_credentials(
         "resolved_provider": route.provider,
         "resolved_model": route.model,
         "resolved_reasoning_effort": route.resolved_reasoning_effort,
+        "route_provenance": f"delegation.profiles.{route.requested_profile}",
+        "normalization_events": [],
         "transmitted_model": route.transmitted_model,
         "provider_reported_model": route.provider_reported_model,
         "fallback_model": [{"provider": item.provider, "model": item.model} for item in route.fallback],

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -362,12 +362,76 @@ def _runtime_provider_credentials(v: dict, explicit_request_overrides) -> dict:
         command=pinned_command, args=list(runtime.get("args") or []),
     )
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
+def _resolve_profile_credentials(
+    profile_name: str,
+    cfg: dict,
+    parent_agent,
+    *,
+    requested_provider: Optional[str] = None,
+    requested_model: Optional[str] = None,
+    requested_reasoning_effort: Optional[str] = None,
+) -> dict:
+    """Resolve one configured worker profile into the existing credential-bundle shape."""
+    from agent.delegation_model_routing import resolve_profile_route
+    route = resolve_profile_route(
+        profile_name,
+        cfg,
+        parent_agent,
+        requested_provider=requested_provider,
+        requested_model=requested_model,
+        requested_reasoning_effort=requested_reasoning_effort,
+    )
+    bundle = _credential_bundle(
+        route.model, route.provider, route.base_url, route.api_key, route.api_mode, None,
+    )
+    bundle.update({
+        "requested_profile": route.requested_profile,
+        "requested_provider": route.requested_provider,
+        "requested_model": route.requested_model,
+        "requested_reasoning_effort": route.requested_reasoning_effort,
+        "resolved_provider": route.provider,
+        "resolved_model": route.model,
+        "resolved_reasoning_effort": route.resolved_reasoning_effort,
+        "transmitted_model": route.transmitted_model,
+        "provider_reported_model": route.provider_reported_model,
+        "fallback_model": [{"provider": item.provider, "model": item.model} for item in route.fallback],
+        "reasoning_config": route.reasoning_config,
+        "max_iterations": route.max_iterations,
+        "supports_tools": route.supports_tools,
+        "tool_policy": route.tool_policy,
+        "workspace_context": route.workspace_context,
+        "execution_limits": route.execution_limits,
+    })
+    return bundle
+
+
+def _resolve_delegation_credentials(
+    cfg: dict,
+    parent_agent,
+    model_profile: Optional[str] = None,
+    *,
+    requested_provider: Optional[str] = None,
+    requested_model: Optional[str] = None,
+    requested_reasoning_effort: Optional[str] = None,
+) -> dict:
     """Child credential bundle from the ``delegation`` config section. Three branches: ``base_url`` set → direct
     endpoint (``api_key`` None means inherit the parent's key, so providers keyed outside OPENAI_API_KEY work);
     ``provider`` set → full bundle via the runtime provider system (same path as CLI/gateway startup); neither →
     None values, child inherits everything. ``request_overrides`` is honored on every branch. Raises ValueError
     with a user-facing message."""
+    from agent.delegation_model_routing import select_profile_name
+    selected_profile = select_profile_name(model_profile, None, cfg)
+    if selected_profile:
+        return _resolve_profile_credentials(
+            selected_profile,
+            cfg,
+            parent_agent,
+            requested_provider=requested_provider,
+            requested_model=requested_model,
+            requested_reasoning_effort=requested_reasoning_effort,
+        )
+    if requested_provider or requested_model or requested_reasoning_effort:
+        raise ValueError("Per-task provider/model/reasoning_effort overrides require a delegation profile.")
     values = {k: str(cfg.get(k) or "").strip() or None for k in ("model", "provider", "base_url", "api_key")}
     values["api_mode"] = str(cfg.get("api_mode") or "").strip().lower() or None
     explicit_request_overrides = cfg.get("request_overrides") if isinstance(cfg.get("request_overrides"), dict) else None
@@ -439,6 +503,8 @@ def _resolve_child_runtime(
     override_base_url: Optional[str], override_api_key: Optional[str], override_api_mode: Optional[str],
     override_acp_command: Optional[str], override_acp_args: Optional[List[str]],
     routing_cfg: Optional[Dict[str, Any]] = None,
+    override_fallback_model: Optional[List[Dict[str, Any]]] = None,
+    override_reasoning_config: Optional[dict] = None,
 ) -> Dict[str, Any]:
     """Child credentials, transport and routing (config override > parent inherit) as ``AIAgent`` kwargs. Rules that
     are easy to break: api_mode is re-derived (not inherited) when the child's provider differs from the parent's
@@ -491,7 +557,7 @@ def _resolve_child_runtime(
         # Forced ACP transport requires provider copilot-acp for run_agent to init the client.
         effective_provider, effective_api_mode = "copilot-acp", "chat_completions"
 
-    # Reasoning: delegation.reasoning_effort > parent. Keep the raw value — a
+    # Reasoning: profile route > delegation.reasoning_effort > parent. Keep the raw value — a
     # YAML ``false`` must disable thinking, not coerce to "" and inherit.
     child_reasoning = getattr(parent_agent, "reasoning_config", None)
     try:
@@ -505,6 +571,8 @@ def _resolve_child_runtime(
                 child_reasoning = parsed
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
+    if override_reasoning_config is not None:
+        child_reasoning = override_reasoning_config
 
     kwargs: Dict[str, Any] = {
         "base_url": effective_base_url, "api_key": override_api_key or parent_api_key, "model": effective_model,
@@ -514,9 +582,14 @@ def _resolve_child_runtime(
         "reasoning_config": child_reasoning,
         # Resolve routing and recovery policy from the same configuration owner. A pinned provider, endpoint, or
         # model never borrows the parent's chain; an explicitly declared child chain still remains available.
-        "fallback_model": _resolve_child_fallback_chain(
-            parent_agent, delegation_cfg if routing_cfg is None else routing_cfg,
-            pinned=bool(override_provider or override_base_url or model)),
+        "fallback_model": (
+            list(override_fallback_model)
+            if override_fallback_model is not None
+            else _resolve_child_fallback_chain(
+                parent_agent, delegation_cfg if routing_cfg is None else routing_cfg,
+                pinned=bool(override_provider or override_base_url or model),
+            )
+        ),
         "openrouter_min_coding_score": getattr(parent_agent, "openrouter_min_coding_score", None),
         # Routing filters reset to their defaults under a pinned provider (see _ROUTING_FILTER_DEFAULTS).
         **{a: d if override_provider else getattr(parent_agent, a, d) for a, d in _ROUTING_FILTER_DEFAULTS},

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -318,15 +318,16 @@ def _dispatched_payload(batch: _Batch, units: List[tuple[_Batch, str]]) -> dict:
     if any(isinstance(s, str) and s for s in sids):
         payload["subagent_ids"] = sids
         payload["control_hint"] = _BACKGROUND_NOTES["control_hint"]
+    from tools.delegate_tool import _stable_worker_identity
     workers = [
         {
             "task_index": i,
             "profile": task.get("profile"),
-            "worker_id": getattr(child, "_worker_id", None),
-            "run_id": getattr(child, "_worker_run_id", None),
+            "worker_id": identity[0],
+            "run_id": identity[1],
         }
         for i, task, child in batch.children
-        if getattr(child, "_worker_id", None) and getattr(child, "_worker_run_id", None)
+        if (identity := _stable_worker_identity(child))
     ]
     if workers:
         payload["workers"] = workers

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -318,6 +318,18 @@ def _dispatched_payload(batch: _Batch, units: List[tuple[_Batch, str]]) -> dict:
     if any(isinstance(s, str) and s for s in sids):
         payload["subagent_ids"] = sids
         payload["control_hint"] = _BACKGROUND_NOTES["control_hint"]
+    workers = [
+        {
+            "task_index": i,
+            "profile": task.get("profile"),
+            "worker_id": getattr(child, "_worker_id", None),
+            "run_id": getattr(child, "_worker_run_id", None),
+        }
+        for i, task, child in batch.children
+        if getattr(child, "_worker_id", None) and getattr(child, "_worker_run_id", None)
+    ]
+    if workers:
+        payload["workers"] = workers
     if batch.live_paths:
         payload["live_transcripts"] = list(batch.live_paths)
         payload["live_transcripts_hint"] = _BACKGROUND_NOTES["live_transcripts_hint"]

--- a/tools/delegate_tool_toolsets.py
+++ b/tools/delegate_tool_toolsets.py
@@ -87,7 +87,7 @@ def _resolve_child_toolsets(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
+    if toolsets is not None:
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
         child_toolsets = [t for t in toolsets if t in expanded_parent]
         if _get_inherit_mcp_toolsets():
@@ -122,19 +122,63 @@ def _resolve_child_toolsets(
     return child_toolsets, child_disabled_toolsets
 
 
-def _apply_exact_tool_policy(child: Any, policy: Any) -> None:
+def _tool_names_for_toolsets(toolsets: Optional[List[str]]) -> Optional[set[str]]:
+    if toolsets is None:
+        return None
+    if not toolsets:
+        return set()
+    import model_tools
+    definitions = model_tools.get_tool_definitions(
+        enabled_toolsets=list(toolsets), disabled_toolsets=[], quiet_mode=True,
+        skip_tool_search_assembly=True,
+    ) or []
+    return {
+        item.get("function", {}).get("name")
+        for item in definitions
+        if isinstance(item, dict) and isinstance(item.get("function", {}).get("name"), str)
+    }
+
+
+def _apply_exact_tool_policy(
+    child: Any,
+    policy: Any,
+    *,
+    request_toolsets: Optional[List[str]] = None,
+    request_blocked_tools: Optional[List[str]] = None,
+    ancestor_allowed_tools: Any = None,
+) -> None:
     """Apply profile tool-name ceilings to schemas and every execution validation path.
 
     ``AIAgent`` validates direct, inline, and deferred tool-search calls against
     ``valid_tool_names``. Keeping ``tools`` and that set aligned means a tool hidden from the
     schema also cannot be reached by naming it directly or through the generic bridge.
     """
-    if policy is None:
-        return
-    allowed = getattr(policy, "allowed_tools", None)
-    allowed_mcp = getattr(policy, "allowed_mcp_tools", None)
-    blocked = set(getattr(policy, "blocked_tools", ()) or ())
     current = set(getattr(child, "valid_tool_names", set()) or set())
+    # ``delegate_task`` is a worker control plane as well as a spawn tool.
+    # Descendants retain it only when the ancestor had it; action admission
+    # separately denies spawn for leaves/profile depth zero.
+    retain_worker_control = "delegate_task" in current and (
+        ancestor_allowed_tools is None or "delegate_task" in set(ancestor_allowed_tools or ())
+    )
+    ancestor = (
+        set(ancestor_allowed_tools)
+        if isinstance(ancestor_allowed_tools, (set, frozenset, list, tuple))
+        else None
+    )
+    if ancestor is not None:
+        current.intersection_update(ancestor)
+    request_names = _tool_names_for_toolsets(request_toolsets)
+    if request_names is not None:
+        current.intersection_update(request_names)
+    allowed_toolsets = getattr(policy, "allowed_toolsets", None) if policy is not None else None
+    profile_names = _tool_names_for_toolsets(
+        list(allowed_toolsets) if allowed_toolsets is not None else None)
+    if profile_names is not None:
+        current.intersection_update(profile_names)
+    allowed = getattr(policy, "allowed_tools", None) if policy is not None else None
+    allowed_mcp = getattr(policy, "allowed_mcp_tools", None) if policy is not None else None
+    blocked = set(getattr(policy, "blocked_tools", ()) or ()) if policy is not None else set()
+    blocked.update(request_blocked_tools or ())
     if allowed is not None:
         current.intersection_update(allowed)
     if allowed_mcp is not None:
@@ -148,8 +192,11 @@ def _apply_exact_tool_policy(child: Any, policy: Any) -> None:
             if _is_mcp_toolset_name(str(toolset or "")) and name not in allowed_mcp_names:
                 current.discard(name)
     current.difference_update(blocked)
+    if retain_worker_control:
+        current.add("delegate_task")
     child.tools = [
         item for item in (getattr(child, "tools", None) or [])
         if item.get("function", {}).get("name") in current
     ]
     child.valid_tool_names = current
+    child._worker_effective_tool_names = frozenset(current)

--- a/tools/delegate_tool_toolsets.py
+++ b/tools/delegate_tool_toolsets.py
@@ -103,17 +103,19 @@ def _resolve_child_toolsets(
     parent_has_delegate = any(
         "delegate_task" in (TOOLSETS.get(name) or {}).get("tools", ()) for name in parent_toolsets
     )
-    # Leaves retain the existing delegate_task surface for status/message/wait/cancel
-    # controls. The handler enforces spawn authority from the child's depth/profile.
-    if parent_has_delegate and "delegation" not in child_toolsets:
+    # Legacy inheritance retains the control surface.  An explicit request
+    # allowlist is a ceiling and may remove it.
+    if toolsets is None and parent_has_delegate and "delegation" not in child_toolsets:
         child_toolsets.append("delegation")
 
     raw_parent_disabled = getattr(parent_agent, "disabled_toolsets", None)
     inherited_disabled = (
         [str(name) for name in raw_parent_disabled] if isinstance(raw_parent_disabled, (list, tuple, set)) else []
     )
-    if effective_role == "orchestrator":
-        inherited_disabled = [name for name in inherited_disabled if name != "delegation"]
+    if (
+        effective_role == "orchestrator" and toolsets is None and parent_has_delegate
+        and "delegation" not in inherited_disabled
+    ):
         if "delegation" not in child_toolsets:
             child_toolsets.append("delegation")
     child_disabled_toolsets = list(
@@ -147,19 +149,14 @@ def _apply_exact_tool_policy(
     request_blocked_tools: Optional[List[str]] = None,
     ancestor_allowed_tools: Any = None,
 ) -> None:
-    """Apply profile tool-name ceilings to schemas and every execution validation path.
+    """Apply every ancestor/request/profile ceiling to execution and presentation.
 
-    ``AIAgent`` validates direct, inline, and deferred tool-search calls against
-    ``valid_tool_names``. Keeping ``tools`` and that set aligned means a tool hidden from the
-    schema also cannot be reached by naming it directly or through the generic bridge.
+    The executable catalog remains complete even when tool-search collapses deferred
+    schemas.  ``tools``/``valid_tool_names`` are only the model-visible projection;
+    ``_worker_effective_tool_names`` is the exact dispatch authority.
     """
-    current = set(getattr(child, "valid_tool_names", set()) or set())
-    # ``delegate_task`` is a worker control plane as well as a spawn tool.
-    # Descendants retain it only when the ancestor had it; action admission
-    # separately denies spawn for leaves/profile depth zero.
-    retain_worker_control = "delegate_task" in current and (
-        ancestor_allowed_tools is None or "delegate_task" in set(ancestor_allowed_tools or ())
-    )
+    visible = set(getattr(child, "valid_tool_names", set()) or set())
+    current = set(getattr(child, "_executable_tool_names", visible) or set())
     ancestor = (
         set(ancestor_allowed_tools)
         if isinstance(ancestor_allowed_tools, (set, frozenset, list, tuple))
@@ -192,11 +189,18 @@ def _apply_exact_tool_policy(
             if _is_mcp_toolset_name(str(toolset or "")) and name not in allowed_mcp_names:
                 current.discard(name)
     current.difference_update(blocked)
-    if retain_worker_control:
-        current.add("delegate_task")
+    bridge_names = set()
+    try:
+        from tools import tool_search as _ts
+        defer_tools = _ts.load_config_readonly().effective_defer_tools
+        if any(_ts.is_deferrable_tool_name(name, defer_tools) for name in current):
+            bridge_names = set(_ts.BRIDGE_TOOL_NAMES)
+    except Exception:
+        pass
+    visible_authorized = visible.intersection(current).union(visible.intersection(bridge_names))
     child.tools = [
         item for item in (getattr(child, "tools", None) or [])
-        if item.get("function", {}).get("name") in current
+        if item.get("function", {}).get("name") in visible_authorized
     ]
-    child.valid_tool_names = current
+    child.valid_tool_names = visible_authorized
     child._worker_effective_tool_names = frozenset(current)

--- a/tools/delegate_tool_toolsets.py
+++ b/tools/delegate_tool_toolsets.py
@@ -177,15 +177,13 @@ def _apply_exact_tool_policy(
         current.intersection_update(profile_names)
     allowed = getattr(policy, "allowed_tools", None) if policy is not None else None
     allowed_mcp = getattr(policy, "allowed_mcp_tools", None) if policy is not None else None
-    blocked = {
-        canonical_worker_capability(selection, name)
-        for name in (getattr(policy, "blocked_tools", ()) or ())
-    } if policy is not None else set()
-    blocked.update(
-        canonical_worker_capability(selection, name) for name in (request_blocked_tools or ())
-    )
+    # Policy/request names are registry capability identities. Presentation
+    # aliases must never turn a configured native-tool allowlist into
+    # delegation authority.
+    blocked = set(getattr(policy, "blocked_tools", ()) or ()) if policy is not None else set()
+    blocked.update(request_blocked_tools or ())
     if allowed is not None:
-        current.intersection_update(canonical_worker_capability(selection, name) for name in allowed)
+        current.intersection_update(allowed)
     if allowed_mcp is not None:
         allowed_mcp_names = set(allowed_mcp)
         for name in tuple(current):

--- a/tools/delegate_tool_toolsets.py
+++ b/tools/delegate_tool_toolsets.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from toolsets import TOOLSETS
 from tools.delegate_tool_config import _get_inherit_mcp_toolsets
@@ -59,8 +59,9 @@ def _blocked_toolsets_for_role(role: str) -> List[str]:
     """One-tool deny toolsets for the role; passed as ``disabled_toolsets`` so
     blocked names inside mixed bundles are subtracted AFTER composite expansion."""
     blocked_names = set(DELEGATE_BLOCKED_TOOLS)
-    if role == "orchestrator":
-        blocked_names.discard("delegate_task")
+    # Both roles keep the control surface; delegate_task itself rejects spawn for
+    # leaves while permitting status/message/wait/cancel/resume.
+    blocked_names.discard("delegate_task")
     return sorted(
         name for name, defn in TOOLSETS.items() if defn.get("tools") and set(defn.get("tools", ())).issubset(blocked_names)
     )
@@ -99,6 +100,13 @@ def _resolve_child_toolsets(
     else:
         child_toolsets = sorted(parent_toolsets) or DEFAULT_TOOLSETS
     child_toolsets = _strip_blocked_tools(child_toolsets)
+    parent_has_delegate = any(
+        "delegate_task" in (TOOLSETS.get(name) or {}).get("tools", ()) for name in parent_toolsets
+    )
+    # Leaves retain the existing delegate_task surface for status/message/wait/cancel
+    # controls. The handler enforces spawn authority from the child's depth/profile.
+    if parent_has_delegate and "delegation" not in child_toolsets:
+        child_toolsets.append("delegation")
 
     raw_parent_disabled = getattr(parent_agent, "disabled_toolsets", None)
     inherited_disabled = (
@@ -112,3 +120,36 @@ def _resolve_child_toolsets(
         dict.fromkeys(inherited_disabled + _blocked_toolsets_for_role(effective_role) + ["kanban"])
     )
     return child_toolsets, child_disabled_toolsets
+
+
+def _apply_exact_tool_policy(child: Any, policy: Any) -> None:
+    """Apply profile tool-name ceilings to schemas and every execution validation path.
+
+    ``AIAgent`` validates direct, inline, and deferred tool-search calls against
+    ``valid_tool_names``. Keeping ``tools`` and that set aligned means a tool hidden from the
+    schema also cannot be reached by naming it directly or through the generic bridge.
+    """
+    if policy is None:
+        return
+    allowed = getattr(policy, "allowed_tools", None)
+    allowed_mcp = getattr(policy, "allowed_mcp_tools", None)
+    blocked = set(getattr(policy, "blocked_tools", ()) or ())
+    current = set(getattr(child, "valid_tool_names", set()) or set())
+    if allowed is not None:
+        current.intersection_update(allowed)
+    if allowed_mcp is not None:
+        allowed_mcp_names = set(allowed_mcp)
+        for name in tuple(current):
+            try:
+                import model_tools
+                toolset = model_tools.get_toolset_for_tool(name)
+            except Exception:
+                toolset = None
+            if _is_mcp_toolset_name(str(toolset or "")) and name not in allowed_mcp_names:
+                current.discard(name)
+    current.difference_update(blocked)
+    child.tools = [
+        item for item in (getattr(child, "tools", None) or [])
+        if item.get("function", {}).get("name") in current
+    ]
+    child.valid_tool_names = current

--- a/tools/delegate_tool_toolsets.py
+++ b/tools/delegate_tool_toolsets.py
@@ -155,6 +155,9 @@ def _apply_exact_tool_policy(
     schemas.  ``tools``/``valid_tool_names`` are only the model-visible projection;
     ``_worker_effective_tool_names`` is the exact dispatch authority.
     """
+    from agent.worker_interfaces import canonical_worker_capability
+    selection = getattr(child, "_worker_interface_selection", None)
+
     visible = set(getattr(child, "valid_tool_names", set()) or set())
     current = set(getattr(child, "_executable_tool_names", visible) or set())
     ancestor = (
@@ -174,10 +177,15 @@ def _apply_exact_tool_policy(
         current.intersection_update(profile_names)
     allowed = getattr(policy, "allowed_tools", None) if policy is not None else None
     allowed_mcp = getattr(policy, "allowed_mcp_tools", None) if policy is not None else None
-    blocked = set(getattr(policy, "blocked_tools", ()) or ()) if policy is not None else set()
-    blocked.update(request_blocked_tools or ())
+    blocked = {
+        canonical_worker_capability(selection, name)
+        for name in (getattr(policy, "blocked_tools", ()) or ())
+    } if policy is not None else set()
+    blocked.update(
+        canonical_worker_capability(selection, name) for name in (request_blocked_tools or ())
+    )
     if allowed is not None:
-        current.intersection_update(allowed)
+        current.intersection_update(canonical_worker_capability(selection, name) for name in allowed)
     if allowed_mcp is not None:
         allowed_mcp_names = set(allowed_mcp)
         for name in tuple(current):
@@ -197,7 +205,10 @@ def _apply_exact_tool_policy(
             bridge_names = set(_ts.BRIDGE_TOOL_NAMES)
     except Exception:
         pass
-    visible_authorized = visible.intersection(current).union(visible.intersection(bridge_names))
+    visible_authorized = {
+        name for name in visible
+        if canonical_worker_capability(selection, name) in current or name in bridge_names
+    }
     child.tools = [
         item for item in (getattr(child, "tools", None) or [])
         if item.get("function", {}).get("name") in visible_authorized

--- a/tools/mcp_tool_agent.py
+++ b/tools/mcp_tool_agent.py
@@ -122,8 +122,19 @@ def refresh_agent_mcp_tools(
     worker_ceiling = getattr(agent, "_worker_effective_tool_names", None)
     if isinstance(worker_ceiling, (set, frozenset, list, tuple)):
         executable_names.intersection_update(worker_ceiling)
-        new_defs = [item for item in new_defs if _def_name(item) in executable_names]
-        new_names.intersection_update(executable_names)
+        # Bridge schemas are presentation capabilities, not executable catalog
+        # identities. Preserve them whenever at least one deferred executable is
+        # still authorized, exactly as initial tool assembly does.
+        presentation_names = set(executable_names)
+        try:
+            from tools.tool_search import BRIDGE_TOOL_NAMES, is_deferrable_tool_name, load_config_readonly
+            deferred = load_config_readonly().effective_defer_tools
+            if any(is_deferrable_tool_name(name, deferred) for name in executable_names):
+                presentation_names.update(BRIDGE_TOOL_NAMES)
+        except Exception:  # noqa: BLE001
+            pass
+        new_defs = [item for item in new_defs if _def_name(item) in presentation_names]
+        new_names.intersection_update(presentation_names)
     # Post-build families re-appended on LOCALS only; live attributes untouched until publish.
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
     _reinject_authorized_dynamic_tools(agent, new_defs, new_names)

--- a/tools/mcp_tool_agent.py
+++ b/tools/mcp_tool_agent.py
@@ -49,7 +49,9 @@ def _tool_defs_content_changed(agent, new_defs: list) -> bool:
 
 def _publish_tool_snapshot(
     agent, new_defs: list, new_names: set, *, snapshot_generation: int,
-    staged_engine_names: set, content_aware: bool, prefix_registered: Optional[set]) -> Optional[set]:
+    executable_names: set, staged_engine_names: set, content_aware: bool,
+    prefix_registered: Optional[set],
+) -> Optional[set]:
     """Single atomic read-diff-publish under ``_agent_tools_lock`` so ``added`` matches what
     was published and a stale (older-generation) rebuild can't overwrite a newer one. Returns
     the added names, or None when nothing was published (unchanged, or a newer snapshot won)."""
@@ -61,16 +63,24 @@ def _publish_tool_snapshot(
             return None  # a newer snapshot already won
         current_defs = _agent_tool_defs(agent)
         current = {_def_name(t) for t in current_defs}
+        current_executable = set(getattr(agent, "_executable_tool_names", current) or ())
         if prefix_registered is not None:
             new_defs, new_names = _merge_preserving_prefix(current_defs, new_defs, prefix_registered)
         # Record the generation even when unchanged so an in-flight older caller can't clobber.
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
         # Same NAME set: no change for MCP-reload callers. Content-aware callers
         # (compaction boundary) also diff serialized bytes.
-        if new_names == current and not (content_aware and _tool_defs_content_changed(agent, new_defs)):
+        if (
+            new_names == current
+            and executable_names == current_executable
+            and not (content_aware and _tool_defs_content_changed(agent, new_defs))
+        ):
             return None
         agent.tools = new_defs
         agent.valid_tool_names = new_names
+        agent._executable_tool_names = executable_names
+        if hasattr(agent, "_worker_effective_tool_names"):
+            agent._worker_effective_tool_names = frozenset(executable_names)
         # Publish context-engine routing names atomically with the snapshot.
         engine_names = getattr(agent, "_context_engine_tool_names", None)
         if isinstance(engine_names, set):
@@ -102,8 +112,18 @@ def refresh_agent_mcp_tools(
     # Generation captured BEFORE the slow get_tool_definitions call (a slower caller holding an
     # OLDER set must not clobber a newer one); definitions computed OUTSIDE the lock.
     snapshot_generation = registry._generation
+    raw_defs = list(get_tool_definitions(
+        enabled_toolsets=enabled, disabled_toolsets=disabled, quiet_mode=quiet_mode,
+        skip_tool_search_assembly=True,
+    ) or [])
+    executable_names = {_def_name(t) for t in raw_defs if _def_name(t)}
     new_defs = list(get_tool_definitions(enabled_toolsets=enabled, disabled_toolsets=disabled, quiet_mode=quiet_mode) or [])
     new_names = {_def_name(t) for t in new_defs}
+    worker_ceiling = getattr(agent, "_worker_effective_tool_names", None)
+    if isinstance(worker_ceiling, (set, frozenset, list, tuple)):
+        executable_names.intersection_update(worker_ceiling)
+        new_defs = [item for item in new_defs if _def_name(item) in executable_names]
+        new_names.intersection_update(executable_names)
     # Post-build families re-appended on LOCALS only; live attributes untouched until publish.
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
     _reinject_authorized_dynamic_tools(agent, new_defs, new_names)
@@ -117,7 +137,8 @@ def refresh_agent_mcp_tools(
             pass  # fail open to the plain rebuild
     added = _publish_tool_snapshot(
         agent, new_defs, new_names, snapshot_generation=snapshot_generation,
-        staged_engine_names=staged_engine_names, content_aware=content_aware, prefix_registered=prefix_registered)
+        executable_names=executable_names, staged_engine_names=staged_engine_names,
+        content_aware=content_aware, prefix_registered=prefix_registered)
     if added is None:
         return set()
     persist_agent_tool_names(agent)  # re-pin so a rebuild after agent-cache eviction restores this order

--- a/tools/mcp_tool_agent.py
+++ b/tools/mcp_tool_agent.py
@@ -122,7 +122,12 @@ def refresh_agent_mcp_tools(
         skip_tool_search_assembly=True,
     ) or [])
     executable_names = {_def_name(t) for t in raw_defs if _def_name(t)}
+    from agent.worker_interfaces import canonical_worker_capability, project_worker_tool_definitions
+
+    selection = getattr(agent, "_worker_interface_selection", None)
     new_defs = list(get_tool_definitions(enabled_toolsets=enabled, disabled_toolsets=disabled, quiet_mode=quiet_mode) or [])
+    if selection is not None:
+        new_defs = project_worker_tool_definitions(new_defs, selection)
     new_names = {_def_name(t) for t in new_defs}
     worker_ceiling = getattr(agent, "_worker_effective_tool_names", None)
     if isinstance(worker_ceiling, (set, frozenset, list, tuple)):
@@ -138,8 +143,12 @@ def refresh_agent_mcp_tools(
                 presentation_names.update(BRIDGE_TOOL_NAMES)
         except Exception:  # noqa: BLE001
             pass
-        new_defs = [item for item in new_defs if _def_name(item) in presentation_names]
-        new_names.intersection_update(presentation_names)
+        new_defs = [
+            item for item in new_defs
+            if canonical_worker_capability(selection, _def_name(item)) in presentation_names
+            or _def_name(item) in presentation_names
+        ]
+        new_names = {_def_name(item) for item in new_defs if _def_name(item)}
     # Post-build families re-appended on LOCALS only; live attributes untouched until publish.
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
     _reinject_authorized_dynamic_tools(agent, new_defs, new_names)

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -45,6 +45,9 @@ interrupt at its next safe boundary and returns `CANCEL_REQUESTED`; it never
 claims completion until `wait` or `result` observes a terminal state. Terminal
 results are immutable, idempotent, bounded to 32k characters, omit transcripts
 and hidden reasoning, and include a stable result hash.
+An explicit reconciliation may add an audit annotation to a durable run; it does
+not rewrite the original execution summary or turn an unknown effect into a
+verified success.
 
 This API is lifecycle-managed asynchronous execution. Child construction and
 completion use the same host-owned path as `delegate_task`, including parent
@@ -95,9 +98,29 @@ before resuming; it must not assume the action failed. Internal completion
 acknowledgments survive restart, while external message transports retain their
 own delivery guarantees.
 
+For a retained plugin handle, the explicit reconciliation form is:
+
+```python
+next_run = service.resume(
+    handle,
+    "Continue with the next assignment; do not repeat the previous operation.",
+    reconcile_uncertain=True,
+    reconciliation_disposition="confirmed_applied",
+    reconciliation_note="Checked the external operation by its reference; it completed.",
+)
+```
+
+Use `confirmed_not_applied` or `accepted_unknown_no_replay` when that accurately
+describes the caller's decision. The latter preserves the fact that the external
+outcome is unknown. A nonempty note is required. This records the decision and
+affected tool-call identities without replaying the effect; the new run still
+passes current-authority validation. The parent tool exposes reconciliation and
+resume as separate actions.
+
 Requests are fail-closed: goal/context/metadata sizes are capped, unknown or
-parent-broadening toolsets are rejected. The legacy request-level
-`blocked_tools`, working-directory override, and timeout fields retain their
-explicit unsupported errors; select a worker profile to use its supported
-tool and execution policy. `allowed_toolsets` narrows a child within the parent
-and profile limits. Hermes's existing unsafe-tool block remains enforced.
+parent-broadening toolsets are rejected. Request-level `blocked_tools` is a tuple
+of exact tool names and narrows the effective grant alongside `allowed_toolsets`
+and the selected profile. Working-directory overrides and request-level timeout
+fields retain explicit unsupported errors; select a worker profile for its
+supported context and execution policy. Hermes's existing unsafe-tool block
+remains enforced.

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -31,8 +31,11 @@ def launch_review(ctx):
 ```
 
 `SubagentHandle` is serializable and carries a versioned, opaque capability.
-Pass it back to `status`, `wait`, `cancel`, `result`, or `reconnect`; malformed
+Pass it back to `status`, `wait`, `cancel`, `result`, `message`, `resume`, or `reconnect`; malformed
 or forged handles return `UNKNOWN`/`UNKNOWN_HANDLE` and cannot access a child.
+Treat the capability as private: do not put complete handles in public logs or
+execution evidence. Durable storage retains a capability digest, not the bearer
+value. Knowing a worker or run ID alone does not grant another session access.
 
 The stable states are `PENDING`, `STARTING`, `RUNNING`, `SUCCEEDED`, `FAILED`,
 `INTERRUPTED`, `CANCEL_REQUESTED`, `CANCELLED`, and `UNKNOWN`.
@@ -48,11 +51,49 @@ completion use the same host-owned path as `delegate_task`, including parent
 tool-resolution restoration, memory notification, serialized `subagent_stop`
 hooks, resource cleanup, and child-cost rollup. It does not change the
 synchronous `delegate_task` tool, batch delegation, or its gateway/TUI display.
-The initial implementation retains metadata and terminal results in-process for
-one hour.
-After a process restart, `reconnect` returns `RECONNECT_UNAVAILABLE` and never
-starts a replacement child. Running Python threads also cannot survive process
-exit; callers must treat those handles as interrupted by process exit.
+When the active parent has profile-scoped `SessionDB` state, worker conversations,
+run state, message queues, and completion acknowledgments are retained there.
+The in-process registry supplies live executor references; it is not the durable
+source of truth. Callers without durable state retain the legacy in-process
+behavior and cannot assume their handles survive process exit.
+
+## Profiles, messages, and subsequent runs
+
+Pass `profile="analyst"` in `SubagentLaunchRequest` to select a user-defined worker
+profile. Provider/model/effort overrides remain subject to the user's routing
+policy. See [worker profiles](../user-guide/features/worker-profiles.md) for
+configuration and [worker architecture](worker-orchestration.md) for enforcement.
+
+```python
+handle = service.launch(SubagentLaunchRequest(
+    goal="Check the supplied synthetic calculation.",
+    profile="analyst",
+))
+message = service.message(handle, "Also explain your units.")
+terminal = service.wait(handle, timeout_seconds=2)
+if terminal.completed:
+    next_run = service.resume(handle, "Now check the same calculation in reverse.")
+```
+
+`worker_id` identifies the retained conversation; `run_id` changes for each
+assignment. Messages have durable IDs and delivery state. Submission is not proof
+that the worker has consumed the message: acknowledgment follows a conversation
+checkpoint. Resume rechecks the current provider, credentials, tools, and policy;
+it does not grant the previous run's capabilities indefinitely.
+
+## Restart and uncertain actions
+
+Python threads do not survive process exit. Reconnection reads durable state
+without launching a replacement. Expired execution leases are reconciled to an
+interrupted state, and an old executor cannot overwrite a replacement run's
+checkpoints. Resume starts a new linked run using Hermes-owned conversation state;
+it does not require a resumable provider-side session.
+
+A tool action interrupted before its result checkpoint has an uncertain outcome.
+The service refuses automatic replay. The parent must reconcile the side effect
+before resuming; it must not assume the action failed. Internal completion
+acknowledgments survive restart, while external message transports retain their
+own delivery guarantees.
 
 Requests are fail-closed: goal/context/metadata sizes are capped, unknown or
 parent-broadening toolsets are rejected, and per-tool blocks, working-directory

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -96,7 +96,8 @@ acknowledgments survive restart, while external message transports retain their
 own delivery guarantees.
 
 Requests are fail-closed: goal/context/metadata sizes are capped, unknown or
-parent-broadening toolsets are rejected, and per-tool blocks, working-directory
-overrides, and per-launch timeouts are explicitly rejected until Hermes can
-support them without weakening isolation. Use `allowed_toolsets` to narrow a
-child; Hermes's existing unsafe-tool block remains enforced.
+parent-broadening toolsets are rejected. The legacy request-level
+`blocked_tools`, working-directory override, and timeout fields retain their
+explicit unsupported errors; select a worker profile to use its supported
+tool and execution policy. `allowed_toolsets` narrows a child within the parent
+and profile limits. Hermes's existing unsafe-tool block remains enforced.

--- a/website/docs/developer-guide/worker-orchestration.md
+++ b/website/docs/developer-guide/worker-orchestration.md
@@ -1,0 +1,108 @@
+---
+title: Worker Orchestration Architecture
+sidebar_label: Worker orchestration
+---
+
+# Worker orchestration
+
+The parent-facing delegation tool and public subagent lifecycle API share worker
+resolution, construction, lifecycle policy, and durable state. Worker profiles are
+configuration in the active Hermes profile, not a process-global team definition.
+The existing provider resolver remains responsible for authentication and runtime
+transport selection.
+
+## Identity and authority
+
+A worker ID identifies a retained conversation; a run ID identifies one assignment.
+Parent session ownership is checked independently of knowing either identifier.
+The plugin API's opaque handle remains a capability, rather than making arbitrary
+IDs sufficient authority. Parent lineage, nested-depth policy, and effective tool
+permissions are resolved before execution. Configured instructions do not grant
+permissions, and narrowing a schema alone is not an execution security boundary.
+
+User-enabled model routes govern dynamic routing. A profile may narrow that menu,
+but cannot expand global policy. The resolver validates the complete launch batch
+before it creates children. Per-task settings take precedence only within allowed
+overrides; limits are applied after resolution.
+
+## Cache and conversation boundaries
+
+Discovery is an action of the existing delegation tool. The tool schema does not
+grow or change when profile definitions or provider catalogs refresh. The catalog
+reports capability provenance and unknown availability without authenticating or
+probing providers just to list options.
+
+Worker system prompts remain fixed for a conversation. Messages arrive at supported
+tool boundaries or as subsequent conversation turns, not by editing the cached
+system prefix or inserting synthetic user messages into the middle of a tool round.
+Resume rechecks current authority; it must not silently continue with revoked tools
+or rebuild the old conversation under a different permission contract.
+
+## Database and recovery protocol
+
+`agent/worker_store.py` uses the existing `SessionDB` transaction and read-context
+primitives. It does not open a separate database or resolve credentials. Schema
+creation is additive and idempotent. The tables hold workers, ordered runs, and
+ordered internal messages. The service explicitly initializes them before use.
+
+Run admission and lease acquisition occur inside `BEGIN IMMEDIATE`. A partial
+unique index allows only one running assignment per worker; admission also counts
+the owner's running assignments to enforce concurrency across nested calls. A
+waiting orchestrator must not strand descendants behind its own capacity slot.
+
+Each executor receives a unique lease token. Heartbeats, conversation checkpoints,
+message acknowledgments, and completion require a live matching lease. An expired
+executor cannot overwrite state after recovery or a replacement run. Leases fence
+database writes; execution must check the lease at tool boundaries too.
+
+Before a tool action, persist its in-flight state. After a confirmed result, persist
+the conversation checkpoint and clear that state. A crash between those operations
+creates an uncertain side-effect outcome. Recovery marks the run interrupted and
+blocks further work until reconciliation; it does not infer that an external action
+failed merely because Hermes did not record the response.
+
+Run request IDs deduplicate enqueue retries. Reusing an ID with different content
+is an error. Message delivery is acknowledged atomically with the conversation
+checkpoint that includes it. Completions remain available until acknowledged.
+Reconciliation clears the worker's resume barrier while retaining the interrupted
+run's historical uncertainty record.
+
+No recovery protocol here promises exactly-once behavior from external tools or
+message transports. The supported guarantee is one leased executor plus explicit
+handling of uncertain outcomes and deduplicated internal delivery.
+
+## Route receipts
+
+Preserve the distinction between requested, resolved, transmitted, and
+provider-reported settings. A model's self-description is not provider evidence.
+A configured model ID is not proof of which model an upstream router executed.
+Unknown actual model, thinking metadata, and cost remain unknown. Fallback and
+normalization policy must remain visible in the receipt.
+
+Only allowlisted nonsecret policy and receipt fields enter worker metadata.
+Credentials stay in the existing provider subsystem. Conversation checkpoints
+have the same local-state privacy boundary as Hermes session history; they do not
+belong in a public test report or PR artifact.
+
+## Acceptance boundaries
+
+Storage tests exercise real SQLite transactions, ownership, racing claims,
+checkpoint/message atomicity, database reopening, lease fencing, and uncertain
+recovery. Routing and lifecycle tests must also exercise the actual delegation
+dispatch and public plugin APIs using a temporary Hermes home.
+
+A two-provider live test is separate evidence from fixtures. Neither establishes
+customer runtime readiness or complete parity with every Codex feature.
+
+| Capability | Codex comparison reference | Hermes acceptance requirement |
+| --- | --- | --- |
+| Named worker roles | Custom agents and descriptions | User-defined profiles appear in discovery and affect execution |
+| Model and effort routing | Per-agent model/effort selection | Different provider requests match selected routes and efforts |
+| Tools and authority | Agent configuration and runtime permission overrides | Native/MCP enforcement cannot exceed parent/user authority |
+| Messaging and follow-up | Message, wait, interrupt, follow-up controls | Delivery boundaries and retained conversation are exercised |
+| Nested orchestration | Harness limits and role configuration | Tree-wide limits hold without nested-wait deadlock |
+| Restart recovery | Deployment-specific; no universal comparison claimed | Conversation, queue, lease and uncertain-action tests pass |
+| Execution evidence | Harness/model metadata | Requested/resolved/transmitted/reported values remain distinct |
+
+Codex reference: [official subagent documentation](https://developers.openai.com/codex/subagents/).
+The matrix defines what to test, not a blanket superiority claim.

--- a/website/docs/developer-guide/worker-orchestration.md
+++ b/website/docs/developer-guide/worker-orchestration.md
@@ -38,6 +38,40 @@ overrides; limits are applied after resolution.
 
 ## Cache and conversation boundaries
 
+### Model-facing interfaces
+
+`agent/worker_interfaces.py` selects and binds the model-facing vocabulary.
+The precedence is an explicit `orchestration.interface` setting, a qualified
+automatic provider/model match, then canonical Hermes. The production registry
+starts empty. Entries require recorded live qualification; transport fixtures do
+not establish model usability.
+
+Selection and collision-aware aliases freeze when the agent builds its tool
+catalog. Existing native and MCP names retain their original meaning; colliding
+worker names receive a `hermes_worker_` alias. Refresh, executable-tool admission,
+native dispatch and execute-code/MCP dispatch use that same binding. An alias
+cannot grant an operation denied through the canonical `delegate_task` capability.
+
+`AIAgent._dispatch_worker_interface` translates the advertised request and calls
+`_dispatch_delegate_task`. The adapter owns no worker state or message queue.
+Its receipt records interface version, selection and qualification source,
+advertised name and canonical operation, separately from execution route evidence.
+The legacy dispatcher and plugin lifecycle API remain available.
+
+The shared service distinguishes guidance from `start_turn`. Guidance queues a
+message without waking an idle worker. `start_turn` creates an ordered linked
+run, including when another assignment is active; it does not silently become
+guidance. Exact-run interruption and descendant-tree cancellation are separate.
+Completion acknowledgment and uncertainty reconciliation remain reachable through
+each style. Unsupported transcript forking and graceful process shutdown are
+explicit errors, not inferred vendor behavior.
+
+See [orchestration interfaces](../user-guide/features/orchestration-interfaces.md)
+for configuration and plain-English examples. The adapters provide familiar
+vocabulary over Hermes; they are separate from optional vendor execution backends.
+
+### Discovery and retained conversation
+
 Discovery is an action of the existing delegation tool. The tool schema does not
 grow or change when profile definitions or provider catalogs refresh. The catalog
 reports capability provenance and unknown availability without authenticating or

--- a/website/docs/developer-guide/worker-orchestration.md
+++ b/website/docs/developer-guide/worker-orchestration.md
@@ -11,6 +11,9 @@ configuration in the active Hermes profile, not a process-global team definition
 The existing provider resolver remains responsible for authentication and runtime
 transport selection.
 
+Start with the [illustrated tour](../user-guide/features/worker-orchestration-tour.md)
+for the user workflow, before/after comparison and visual explanations.
+
 ## Identity and authority
 
 A worker ID identifies a retained conversation; a run ID identifies one assignment.

--- a/website/docs/developer-guide/worker-orchestration.md
+++ b/website/docs/developer-guide/worker-orchestration.md
@@ -92,6 +92,13 @@ checkpoint that includes it. Completions remain available until acknowledged.
 Reconciliation clears the worker's resume barrier while retaining the interrupted
 run's historical uncertainty record.
 
+Messages from a top-level worker to the main parent use the same profile-scoped
+store. Their states distinguish `QUEUED`, `PUBLISHED`, and `ACKNOWLEDGED`.
+Publishing a message makes it durably available to the parent; worker completion
+alone is not proof that the parent consumed it. Unacknowledged messages remain
+available after restart. Nested child-to-parent and policy-enabled sibling
+messages retain their lineage and ownership checks.
+
 The reconciliation annotation records an explicit disposition, nonempty decision
 note, affected tool-call IDs, prior statuses, and time. The top-level uncertainty
 flag indicates a currently unresolved barrier; historical uncertainty remains in

--- a/website/docs/developer-guide/worker-orchestration.md
+++ b/website/docs/developer-guide/worker-orchestration.md
@@ -60,6 +60,14 @@ unique index allows only one running assignment per worker; admission also count
 the owner's running assignments to enforce concurrency across nested calls. A
 waiting orchestrator must not strand descendants behind its own capacity slot.
 
+Each explicit root-worker assignment has a durable budget identity. Its nested
+workers inherit the same aggregate iteration and tool-call allocation and absolute
+deadline, in addition to their own profile ceilings. Reserve spending transactionally
+before the corresponding execution boundary. Restart does not erase spending or
+extend the deadline. A subsequent explicit root assignment receives a new budget;
+descendants and nested follow-ups from an older assignment retain the older budget.
+Owner-wide active-run concurrency applies across these assignment trees.
+
 Every launch, including a queued follow-up with an existing process record, passes
 through current-authority admission immediately before execution. Public handles
 and parent-tool controls use the same FIFO recovery path. The triggering actor is

--- a/website/docs/developer-guide/worker-orchestration.md
+++ b/website/docs/developer-guide/worker-orchestration.md
@@ -20,6 +20,14 @@ IDs sufficient authority. Parent lineage, nested-depth policy, and effective too
 permissions are resolved before execution. Configured instructions do not grant
 permissions, and narrowing a schema alone is not an execution security boundary.
 
+The effective execution catalog is distinct from model-visible schemas. Tool
+Search may replace permitted tools with bridge schemas; that presentation change
+must neither revoke those tools nor grant hidden ones. Compile the executable
+identities from the current user, ancestor, request, profile, and backend limits,
+then apply the same ceiling at native, deferred MCP, and `execute_code` dispatch.
+Explicit denial also applies to `delegate_task`; default worker controls are not
+an exception to an explicit user restriction.
+
 User-enabled model routes govern dynamic routing. A profile may narrow that menu,
 but cannot expand global policy. The resolver validates the complete launch batch
 before it creates children. Per-task settings take precedence only within allowed
@@ -44,11 +52,20 @@ or rebuild the old conversation under a different permission contract.
 primitives. It does not open a separate database or resolve credentials. Schema
 creation is additive and idempotent. The tables hold workers, ordered runs, and
 ordered internal messages. The service explicitly initializes them before use.
+Per-run tool-effect records bind admission and settlement to the exact tool-call
+identity, so a blocked call cannot settle a different concurrent action.
 
 Run admission and lease acquisition occur inside `BEGIN IMMEDIATE`. A partial
 unique index allows only one running assignment per worker; admission also counts
 the owner's running assignments to enforce concurrency across nested calls. A
 waiting orchestrator must not strand descendants behind its own capacity slot.
+
+Every launch, including a queued follow-up with an existing process record, passes
+through current-authority admission immediately before execution. Public handles
+and parent-tool controls use the same FIFO recovery path. The triggering actor is
+authorized before any queue mutation; it cannot schedule or fail unrelated owner
+subtrees. Revalidation uses the retained worker's correct parent authority rather
+than whichever actor happened to ask for status.
 
 Each executor receives a unique lease token. Heartbeats, conversation checkpoints,
 message acknowledgments, and completion require a live matching lease. An expired
@@ -66,6 +83,11 @@ is an error. Message delivery is acknowledged atomically with the conversation
 checkpoint that includes it. Completions remain available until acknowledged.
 Reconciliation clears the worker's resume barrier while retaining the interrupted
 run's historical uncertainty record.
+
+The reconciliation annotation records an explicit disposition, nonempty decision
+note, affected tool-call IDs, prior statuses, and time. The top-level uncertainty
+flag indicates a currently unresolved barrier; historical uncertainty remains in
+the annotation. Reconciliation itself performs no provider or tool dispatch.
 
 No recovery protocol here promises exactly-once behavior from external tools or
 message transports. The supported guarantee is one leased executor plus explicit
@@ -96,11 +118,15 @@ customer runtime readiness or complete parity with every Codex feature.
 
 | Capability | Codex comparison reference | Hermes acceptance requirement |
 | --- | --- | --- |
-| Named worker roles | Custom agents and descriptions | User-defined profiles appear in discovery and affect execution |
-| Model and effort routing | Per-agent model/effort selection | Different provider requests match selected routes and efforts |
-| Tools and authority | Agent configuration and runtime permission overrides | Native/MCP enforcement cannot exceed parent/user authority |
-| Messaging and follow-up | Message, wait, interrupt, follow-up controls | Delivery boundaries and retained conversation are exercised |
+| Discovery | Agent descriptions and model/effort metadata exposed by the harness | Compact discovery plus on-demand profile details preserve unknown metadata |
+| Custom profiles | Custom agents and descriptions | User-defined profiles appear in discovery and affect execution |
+| Model routing | Per-agent model selection | Different provider requests match selected routes |
+| Per-worker effort | Supported reasoning-effort overrides | Requested, resolved, and transmitted effort agree or show an explicit configured transformation |
+| Permissions | Agent configuration and runtime permission controls | Native/MCP enforcement cannot exceed parent/user/profile authority |
+| Messaging | Parent/child messaging and waiting | Durable message IDs, ownership, and supported delivery boundaries are exercised |
+| Follow-up | Subsequent assignments to retained agents | A new run retains the worker conversation without rebuilding its system prefix |
 | Nested orchestration | Harness limits and role configuration | Tree-wide limits hold without nested-wait deadlock |
+| Cancellation | Cooperative interrupt controls | Cancellation reaches owned active descendants and does not imply external effects stopped |
 | Restart recovery | Deployment-specific; no universal comparison claimed | Conversation, queue, lease and uncertain-action tests pass |
 | Execution evidence | Harness/model metadata | Requested/resolved/transmitted/reported values remain distinct |
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2684,6 +2684,15 @@ checkpoints:
 
 Configure subagent behavior for the delegate tool:
 
+Named worker definitions live under `delegation.profiles`. Use
+`hermes workers set NAME --file PROFILE.yaml` to configure one and
+`hermes workers validate` to check the active configuration. `default_profile`
+selects a default worker. `routing_mode: profile_only` is the default;
+`routing_mode: dynamic` enables per-task choices within `enabled_models` and
+profile restrictions. See [Worker profiles](features/worker-profiles.md) for
+tools, thinking levels, messaging, and restart behavior. The settings below
+remain the defaults for legacy delegation when no worker profile is selected.
+
 ```yaml
 delegation:
   # model: "google/gemini-3-flash-preview"  # Override model (empty = inherit parent)

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -6,6 +6,9 @@ description: "Spawn isolated child agents for parallel workstreams with delegate
 
 # Subagent Delegation
 
+For user-defined roles, per-task provider/model selection, messaging, and retained
+worker conversations, see [Worker profiles and orchestration](./worker-profiles.md).
+
 The `delegate_task` tool spawns child AIAgent instances with isolated context, inherited tool access, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
 
 Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue, then posts the result back as a new message. An orchestrator subagent waits for its own workers so it can synthesize their results before returning.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -84,24 +84,24 @@ verification and publication alone are not remote acceptance.
 
 ## Kanban vs. `delegate_task`
 
-They look similar; they are not the same primitive.
+Delegation owns an agent conversation; Kanban owns a task lifecycle. With the retained worker service, both can preserve useful state across restarts, but they coordinate different objects.
 
 | | `delegate_task` | Kanban |
 |---|---|---|
-| Shape | RPC call (fork → join) | Durable message queue + state machine |
-| Parent | Blocks until child returns | Fire-and-forget after `create` |
-| Child identity | Anonymous subagent | Named profile with persistent memory |
-| Resumability | None — failed = failed | Block → unblock → re-run; crash → reclaim |
-| Human in the loop | Not supported | Comment / unblock at any point |
-| Agents per task | One call = one subagent | N agents over task's life (retry, review, follow-up) |
-| Audit trail | Lost on context compression | Durable rows in SQLite forever |
-| Coordination | Hierarchical (caller → callee) | Peer — any profile reads/writes any task |
+| Shape | Parent-owned worker runs; foreground or background | Durable task queue and state machine |
+| Parent | Can wait or receive background completion | Can continue after `create` |
+| Child identity | Stable worker ID when using worker profiles | Profile assigned to a durable task |
+| Resumability | Retained worker checkpoints; new linked runs; uncertain effects require reconciliation | Block → unblock → re-run; crash → reclaim under board rules |
+| Human in the loop | User steers through the parent conversation | Task comments, review and explicit unblock |
+| Assignments | One retained worker can receive ordered follow-up runs | Multiple participants over a task's retry/review lifecycle |
+| Audit trail | Worker/run records, checkpoints and execution receipts | Task/run/claim/handoff records in the board |
+| Coordination | Ownership-scoped delegation and optional sibling messaging | Shared task graph; task-scoped workers and authorized orchestrator operations |
 
-**One-sentence distinction:** `delegate_task` is a function call; Kanban is a work queue where every handoff is a row any profile (or human) can see and edit.
+**One-sentence distinction:** `delegate_task` manages a parent's workers; Kanban manages work that can change assignees, wait on dependencies and pass through review. Discovery does not grant permission to edit or cancel another participant's work.
 
-**Use `delegate_task` when** the parent agent needs a short reasoning answer before continuing, no humans involved, result goes back into the parent's context.
+**Use `delegate_task` when** a parent needs a delegated answer, ongoing worker guidance or retained follow-ups with results returned to that parent. See [worker profiles](worker-profiles.md) for the durable workflow and legacy compatibility boundaries.
 
-**Use Kanban when** work crosses agent boundaries, needs to survive restarts, might need human input, might be picked up by a different role, or needs to be discoverable after the fact.
+**Use Kanban when** work needs shared task visibility, dependencies, reassignment, explicit review or human input. A completed worker turn is not by itself an accepted Kanban task.
 
 They coexist: a kanban worker may call `delegate_task` internally during its run.
 

--- a/website/docs/user-guide/features/orchestration-capability-comparison.md
+++ b/website/docs/user-guide/features/orchestration-capability-comparison.md
@@ -115,6 +115,13 @@ The proposed automatic selection policy is explicit user setting, then a qualifi
 
 ## Implementation and proof boundaries
 
+The interface follow-up is now published as [draft PR #106463](https://github.com/NousResearch/hermes-agent/pull/106463).
+Its [controlled live pilot](orchestration-interface-pilot.md) includes passing and
+failing samples at a recorded source identity. The chart above retains its named
+main/worker baselines; a later draft does not retroactively change those columns.
+Shared discovery, integrated teams and saved workflows still need their own
+implementation and acceptance evidence.
+
 | Stage | Deliverable | Required observable proof |
 | --- | --- | --- |
 | Worker PR #106268 | Profiles, retained workers, messages, limits and receipts | Existing two-provider workflow and recorded recovery/CI tests; see illustrated tour |

--- a/website/docs/user-guide/features/orchestration-capability-comparison.md
+++ b/website/docs/user-guide/features/orchestration-capability-comparison.md
@@ -1,0 +1,128 @@
+---
+title: Orchestration capability comparison
+sidebar_label: Orchestration comparison
+---
+
+# Orchestration capability comparison
+
+An agent **harness** supplies the model's tools, permissions, conversations and execution loop. An **orchestrator** uses those facilities to divide work, select participants, coordinate them and check the result. Selecting a powerful model does not automatically supply its vendor's harness.
+
+Hermes already has four useful building blocks: delegated workers, full-profile Bots, Bot rooms and Kanban tasks. The worker changes in [PR #106268](https://github.com/NousResearch/hermes-agent/pull/106268) add retained worker conversations, configurable routes and durable receipts. The follow-up work described below connects these capabilities without replacing their separate ownership and recovery rules.
+
+**Evidence date: September 9, 2026.** The comparison uses official vendor documentation and inspected Hermes source. It is not a benchmark or a claim that a draft PR is installed. A checkmark means the named capability exists within its stated limits; it does not mean identical behavior across products.
+
+## The big picture
+
+<img src="/img/worker-orchestration/service-map.svg" width="1100" alt="The planned model-facing interface connects to retained workers, Bots, rooms and Kanban. Each existing service keeps authority over its own state. Dashed connections are planned." />
+
+Think of these as different objects:
+
+| Object | What it represents | Who keeps the authoritative record? |
+| --- | --- | --- |
+| Worker | A retained conversation for delegated assignments | Shared worker service in the parent's profile-scoped session database |
+| Run | One assignment executed by a worker | Worker service, including ownership lease and execution receipt |
+| Bot | A complete Hermes profile with its own configuration, tools, skills and conversation | Bot/profile services and the canonical Bot Chat |
+| Room | A shared discussion involving multiple Bots | Room service and, for hosted rooms, its fenced coordinator |
+| Task | Work that can have dependencies, assignees and a review lifecycle | Kanban board, including claims and acceptance state |
+| Workflow — planned | A saved, bounded arrangement of tasks, branches, joins and review gates | A workflow record referencing the existing task/run owners |
+
+A worker finishing is not necessarily a task being accepted. A message being queued is not necessarily the recipient consuming it. Keeping these facts separate makes progress and recovery understandable.
+
+## Feature chart
+
+**✓ supported · ◐ conditional or fragmented · ✗ absent in the named mode · ? not established · Planned: not an implemented claim**
+
+The Codex reference is its documented custom-agent controls plus the exposed harness controls inspected during this work. Claude's column distinguishes ordinary subagents from teams when behavior differs. OpenClaw's native workers, Swarm and ACP are different paths. Hermes main is the inspected baseline `bf53ff00a7360826ec2c9e2949533160068a8fc8`; the worker column describes PR #106268 at `ca48a5678f976f4313bcd826b3493315b6648da0`.
+
+### Selecting and controlling workers
+
+| Capability | Codex | Claude Code | OpenClaw | Hermes main | Worker PR | Planned follow-up |
+| --- | --- | --- | --- | --- | --- | --- |
+| User-defined worker profiles | ✓ | ✓ | ✓ | ◐ Bots and delegation defaults | ✓ | Preserve user choice |
+| Per-worker model | ✓ | ✓ | ✓ | ◐ Execution-path dependent | ✓ | Preserve route across interfaces |
+| Per-worker thinking level | ✓ | ✓ Subagents; ◐ teams inherit | ✓ | ◐ Execution-path dependent | ✓ Where supported | Qualify model/interface combinations |
+| Parallel delegation | ✓ | ✓ | ✓ | ✓ | ✓ | Expose through selected interface |
+| Running-worker guidance | ✓ | ✓ | ✓ Parent controls | ◐ Steer/Bot paths | ✓ | Explicit delivery and wake semantics |
+| Follow-up with retained context | ✓ | ✓ | ✓ Retained sessions | ◐ Bots/Kanban | ✓ Workers | Same controls across eligible objects |
+| Nested delegation | ✓ Policy-dependent | ✓ Subagents; ✗ nested teams | ✓ | ◐ Path-dependent | ✓ Tree limits | Preserve limits in every adapter |
+| Tool and permission restrictions | ✓ | ✓ | ◐ Native/ACP differ | ✓ Path-dependent | ✓ Native/MCP/code ceilings | Recheck at the owning executor |
+
+Sources: [Codex subagents](https://learn.chatgpt.com/docs/agent-configuration/subagents), [Claude subagents](https://code.claude.com/docs/en/sub-agents), [Claude teams](https://code.claude.com/docs/en/agent-teams), [OpenClaw subagents](https://docs.openclaw.ai/tools/subagents), [OpenClaw ACP](https://docs.openclaw.ai/tools/acp-agents), [worker configuration](worker-profiles.md).
+
+### Collaboration and repeatable work
+
+| Capability | Codex | Claude Code | OpenClaw | Hermes main | Worker PR | Planned follow-up |
+| --- | --- | --- | --- | --- | --- | --- |
+| Peer messages | ✓ Inspected harness | ✓ Named subagents/teams | ◐ Native children restricted | ✓ Authorized Bots | ✓ Policy-controlled siblings | Typed targets and per-recipient outcomes |
+| Shared task dependencies and claims | ? Dedicated team protocol | ✓ Teams | ? Shared claim protocol | ✓ Kanban | ✓ Existing Kanban | Connect tasks to workers and rooms |
+| Grouped collaboration | ◐ Parent coordinates | ✓ Experimental teams | ✓ Experimental Swarm | ✓ Rooms/Kanban | ✓ Existing systems plus workers | One coherent parent workflow |
+| Repeatable scripted orchestration | ? Dedicated runtime | ✓ Dynamic workflows | ✓ Swarm/TaskFlow | ◐ Task automation | ◐ Unified interface missing | Saved bounded workflow definitions |
+| Independent-session communication | ✓ App controls inspected; deployment-dependent | ✓ Local and remote sessions | ✓ Authorized session routes | ✓ Eligible Bot/peer routes | Preserved | Discover only eligible targets |
+| One discovery surface for workers, Bots, rooms and tasks | Not applicable | ◐ Multiple modes | ◐ Multiple runtimes | ✗ | ✗ | Typed, permission-filtered references |
+| Model-appropriate interfaces over one Hermes core | Not applicable | Not applicable | Not assessed | ✗ | ✗ | Canonical, Codex-style and Claude-style adapters |
+
+Sources: [Claude teams](https://code.claude.com/docs/en/agent-teams), [Claude cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging), [Claude dynamic workflows](https://code.claude.com/docs/en/workflows), [OpenClaw Swarm](https://docs.openclaw.ai/tools/swarm), [OpenClaw session tools](https://docs.openclaw.ai/concepts/session-tool), [OpenClaw TaskFlow](https://docs.openclaw.ai/automation/taskflow), [Kanban](kanban.md).
+
+### Persistence and evidence
+
+| Capability | Codex | Claude Code | OpenClaw | Hermes main | Worker PR | Planned follow-up |
+| --- | --- | --- | --- | --- | --- | --- |
+| Restart-safe worker continuation | ? Full contract | ◐ Mode-dependent | ◐ Mode-dependent | ◐ Bots/Kanban contracts | ✓ Tested checkpoints; uncertainty pauses | Preserve each owner's recovery rules |
+| Durable communication evidence | ? Full contract | ◐ Mailbox/transcript contracts | ◐ Path-specific receipts | ✓ Bot ingress, with limits | ✓ Worker queues and ACKs | Cross-link distinct receipts |
+| Requested vs transmitted route evidence | ◐ Configured metadata | ◐ Configured metadata | ◐ Audit/runtime dependent | ◐ Path-dependent | ✓ Separate fields | Include selected interface/version |
+| Cross-host shared task board | Not assessed | Not established by team docs | Not established by reviewed docs | ✗ Single-host Kanban | ✗ | Outside this follow-up |
+
+Do not infer an exactly-once guarantee from any checkmark. Hermes worker leases, Bot claims and hosted-room fencing are different contracts. A Bot ingress consumer's crashed claim must not be recycled by applying the worker lease-expiry rule. Hosted-room authority must not be transferred merely because a host is temporarily unreachable. See the [worker recovery explanation](worker-orchestration-tour.md#what-happens-if-hermes-stops-halfway-through), [Kanban](kanban.md) and [Claude session storage](https://code.claude.com/docs/en/agent-sdk/session-storage).
+
+## What each platform contributes to the design
+
+**Codex:** reusable profiles, explicit per-agent model/effort, parent controls and configurable context inheritance are useful patterns. The inspected controls distinguish messaging an agent from assigning a new turn. Hermes adapters must preserve that difference.
+
+**Claude Code:** ordinary subagents, teams, independent-session messaging and dynamic workflows solve different problems. Teams add shared tasks and peer coordination, but remain experimental; their in-process teammates are not restored by session resume. The Agent SDK is not a direct team API. The current team documentation also retires `TeamCreate`/`TeamDelete`: copying old tool names would not reproduce current behavior.
+
+**OpenClaw:** native delegation, Swarm and ACP demonstrate several execution and coordination modes. The shared lesson is to identify the active path and its limits. Native completion delivery and an ACP session are not interchangeable evidence of sandbox enforcement or replay safety.
+
+**Hermes:** reuse Bot profiles and communication, rooms, Kanban claims/review, provider resolution and the retained worker service. The missing link is a consistent way for the parent to discover and invoke these capabilities. It does not require a second Bot database, task board or credential store.
+
+## A team workflow in ordinary language
+
+Imagine asking: “Compare these proposals, have a second participant check the result, then revise it if needed.” In the planned integrated workflow:
+
+1. The parent discovers the user-created profiles and their permitted actions.
+2. It creates a comparison task and a dependent review task in Kanban.
+3. It assigns the comparison to an eligible worker or Bot. The participant's own route and tool restrictions still apply.
+4. While the participant works, the parent sends guidance. The result identifies whether that guidance is queued or consumed.
+5. The participant supplies a result. Kanban makes review available; it does not equate that result with final acceptance.
+6. The reviewer requests a correction. The parent follows up with the original worker, retaining its context.
+7. Once the review passes, the task is accepted and the parent presents the answer and supporting receipts.
+
+<img src="/img/worker-orchestration/team-sequence.svg" width="1100" alt="Planned team sequence: parent creates dependent tasks, a worker supplies a result, a reviewer requests changes, the worker follows up with retained context, and Kanban records acceptance." />
+
+If Hermes restarts, each service restores its own records. A known completed step is collected, not executed again. If a tool may already have performed an external action, the workflow pauses for reconciliation. A saved workflow adds repeatability to these steps, not permission to bypass them.
+
+## Model-facing interface is not execution backend
+
+| Choice | What changes | What does not follow from it |
+| --- | --- | --- |
+| Provider/model selection | Which configured model receives requests | It does not install the vendor's harness |
+| Planned Codex-style/Claude-style interface | The tool vocabulary and documented request semantics presented to the model | It does not grant extra tools, change the model, or imply native runtime parity |
+| Hermes native worker | Hermes owns the loop, tool enforcement, conversation and receipts | A provider-side session is not required for the Hermes-owned checkpoint |
+| Existing optional Codex app-server runtime | Codex owns its execution loop and sandbox; Hermes projects events and offers supported callbacks | Stateless callbacks currently do not expose `delegate_task`; this worker PR does not remove that boundary |
+
+The [Codex app-server runtime guide](codex-app-server-runtime.md) documents the existing backend and its Kanban callback path. Extending that integration is separate from this interface work.
+
+The proposed automatic selection policy is explicit user setting, then a qualified model/profile match, then the canonical Hermes interface. Unknown models retain their chosen provider/model. A qualified entry needs live evidence; a matching model-family name is not enough. Interface schemas stay fixed within a conversation to preserve prompt caching.
+
+## Implementation and proof boundaries
+
+| Stage | Deliverable | Required observable proof |
+| --- | --- | --- |
+| Worker PR #106268 | Profiles, retained workers, messages, limits and receipts | Existing two-provider workflow and recorded recovery/CI tests; see illustrated tour |
+| Follow-up 1 | Model-appropriate interfaces | Equivalent authorized worker events and route receipts across interfaces |
+| Follow-up 2 | Shared discovery and references | Read-only discovery; eligible actions succeed and unauthorized controls fail |
+| Follow-up 3 | Integrated teams | Dependency/review/correction workflow with guidance, retained context and restart |
+| Follow-up 4 | Saved bounded workflows | Repeat with new input; pause/restart/collect/cancel without duplicate owned execution |
+
+Follow-up rows remain planned until linked implementation and acceptance evidence establish otherwise. Compare each model against itself when qualifying interfaces. Measure task completion, invalid tool calls, corrections, tokens and latency; do not claim that familiar naming necessarily improves performance.
+
+The worker PR's [recorded CI run](https://github.com/NousResearch/hermes-agent/actions/runs/34315825965) and controlled OpenAI-Codex/ZAI smoke cover the recorded candidate, not these planned additions or every provider. Source/CI evidence does not establish installation, release, customer readiness or market superiority. The useful target is a broad, testable set of workflows that users can configure themselves.

--- a/website/docs/user-guide/features/orchestration-interface-pilot.md
+++ b/website/docs/user-guide/features/orchestration-interface-pilot.md
@@ -1,0 +1,93 @@
+---
+title: Orchestration interface pilot
+sidebar_label: Interface pilot evidence
+---
+
+# Orchestration interface pilot
+
+The first controlled pilot exercised real parent and worker requests through
+Hermes, with the same tasks presented through different tool vocabularies.
+It found successful two-provider coordination and several incomplete workflows.
+**No automatic interface entry was enabled.**
+
+The tested source is [PR #106463](https://github.com/NousResearch/hermes-agent/pull/106463)
+at `cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071`, on September 9, 2026.
+[CI](https://github.com/NousResearch/hermes-agent/actions/runs/34342527658),
+[Docker](https://github.com/NousResearch/hermes-agent/actions/runs/34342526804)
+and [Nix](https://github.com/NousResearch/hermes-agent/actions/runs/34342526878)
+passed for that source. One independent source review and two targeted correction
+reviews covered the interface candidate. These are separate from the live results.
+
+## What was exercised
+
+Each sample used four scenarios in fresh temporary Hermes homes, with no customer
+data, external message recipients or worker tools. Two user-created profiles
+selected OpenAI-Codex `gpt-5.6-luna` with requested effort `xhigh` and ZAI `glm-5.3`
+with requested effort `high`. The parent used only its advertised orchestration
+controls. Each scenario allowed at most 16 parent iterations, two workers,
+three child iterations and four minutes; each child had a 90-second limit.
+
+1. **Coordinate two workers:** discover profiles, use different providers, send
+   guidance during execution, follow up with retained context and acknowledge
+   the completed assignments.
+2. **Reject an unavailable profile:** return an explicit error without launching
+   another profile or silently changing the selected route.
+3. **Protect another parent's worker:** deny inspection without changing or
+   revealing that worker's conversation.
+4. **Guide an idle worker:** queue guidance without waking it, explicitly start
+   another assignment, retrieve the retained labels and acknowledge completion.
+
+## Recorded results
+
+Each cell is one attempt. Compare styles within a parent-model group; the parent
+effort and model differ between the two groups. This is a usability pilot, not a
+statistical ranking.
+
+| Scenario | Luna / Hermes | Luna / Codex-style | Luna / Claude-style | Astra / Hermes | Astra / Codex-style |
+|---|---|---|---|---|---|
+| Two-provider coordination | ✗ | ✓ | ✓ | ✓ | ✗ |
+| Missing-profile denial | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Foreign-worker denial | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Idle guidance and retained follow-up | ✗ | ✗ | ✗ | ✓ | ✓ |
+| Passed scenarios | 2/4 | 3/4 | 3/4 | 4/4 | 3/4 |
+
+The Luna parent was `gpt-5.6-luna` at `low`; the Astra parent was `gpt-6-astra`
+at `high`, both through OpenAI-Codex. Claude-style here describes the Hermes tool
+interface presented to these models. It is not an Anthropic model or Claude Code
+runtime test. Astra with Claude-style and Anthropic-provider qualification were
+not sampled.
+
+Luna's canonical two-worker case lacked qualifying running guidance, a label-free
+linked follow-up and complete acknowledgments. Its three idle-worker samples
+retained both labels but failed the final acknowledgment assertion. Astra's
+Codex-style two-worker case delivered running guidance and retained context but
+failed the complete-acknowledgment assertion. The reports establish which checks
+failed; they do not establish a single cause for every incomplete workflow.
+
+## Read the evidence literally
+
+The [preserved, sanitized reports](/evidence/orchestration-interface-pilot-cbb02042.json)
+include source-receipt hashes, per-scenario assertions, selected interface,
+observed tool names, guidance state, token counts and elapsed time. Failed samples
+are retained alongside passing ones.
+
+- All worker-request scenarios passed the runner's provider/model receipt and
+  effective-tool checks. Requested effort settings are named above; these reports
+  do not include transmitted effort values and cannot independently establish
+  the actual model behind a provider router.
+- Recorded structured invalid calls and observed changes to foreign worker state
+  were zero. Malformed or unobserved calls and corrective-turn counts remain
+  unknown. This does not replace the deterministic permission test suite.
+- The duplicate metric compares run identities. It does not prove exactly-once
+  execution of external actions; workers had no tools in this pilot.
+- Cost aggregation is incomplete. A report's numeric cost must not be presented
+  as the complete billed cost of the parent and workers.
+- The runner's `qualified: true` means all four scenario assertions passed.
+  Registry admission also requires the complete deterministic and evidence
+  contract. It is not an automatic registry mutation.
+
+The default automatic path therefore remains canonical Hermes. Explicit
+Codex-style or Claude-style selections remain experimental. These results prove
+the named live behaviors for the recorded source and test profiles; they do not
+prove installation, release, customer readiness, vendor-runtime parity or that
+one model family should be compulsory.

--- a/website/docs/user-guide/features/orchestration-interfaces.md
+++ b/website/docs/user-guide/features/orchestration-interfaces.md
@@ -1,0 +1,141 @@
+---
+title: Orchestration Interfaces
+sidebar_label: Orchestration interfaces
+---
+
+# Orchestration interfaces
+
+An orchestration interface is the set of tool names and instructions a parent
+model uses to manage workers. You can choose the standard Hermes interface or a
+style with familiar Codex or Claude terminology. All styles use the same Hermes
+worker service, permissions, conversations and execution receipts.
+
+For example, a parent can ask a researcher to find evidence, send a correction
+while the researcher works, and later ask the same researcher a follow-up. The
+interface changes how the parent requests those actions. Your worker profiles
+still determine which models run and what they may do.
+
+These interfaces run **Hermes workers**. Selecting a style does not start Codex
+CLI, Claude Code, an agent team in another application, or a vendor backend.
+See the [capability comparison](orchestration-capability-comparison.md) for those
+separate execution paths.
+
+## Choose an interface
+
+Add this setting to the active Hermes profile's `config.yaml`:
+
+```yaml
+orchestration:
+  interface: auto
+```
+
+| Setting | Behavior |
+| --- | --- |
+| `auto` | Use an exact qualified provider/model match when available; otherwise use Hermes. |
+| `hermes` | Use the canonical `delegate_task` interface. |
+| `codex` | Explicitly select the Codex-style worker tools. |
+| `claude` | Explicitly select the Claude-style worker tools. |
+
+An explicit setting takes precedence over automatic selection. An unknown model
+keeps its selected provider and model and receives the canonical Hermes interface.
+Selection never changes the route to obtain a familiar tool style.
+
+Styled interfaces are experimental unless their exact model/profile and interface
+version have passing live qualification evidence. An empty qualification registry
+means `auto` selects Hermes for every model. A configured model name, a fixture
+test or an assumption about model training is insufficient to enable a registry
+entry.
+
+The interface and its advertised tool names are fixed for the session. Start a
+new session after changing the setting. This keeps the conversation's tool
+definitions consistent and avoids rewriting its cached prompt prefix.
+
+## The actions behind the names
+
+The available schemas describe the exact arguments. The following operations
+retain the same meaning across styles:
+
+| Operation | What the parent can accomplish | Important limit |
+| --- | --- | --- |
+| Discover | Read worker profiles, their uses and supported routing settings. | Discovery grants no additional access. Unknown availability stays unknown. |
+| Spawn | Start a worker from a permitted profile, with an assignment and explicit context. | The complete parent transcript is not automatically forked. |
+| Message | Send guidance to an existing worker. | Guidance alone does not wake an idle worker. |
+| Follow up | Give the same worker another assignment with retained conversation context. | Only one run executes at a time; a queued assignment remains distinct from guidance. |
+| Inspect or list | Read authorized status, results and execution evidence. | Knowing a worker ID does not grant access to another parent's worker. |
+| Wait | Wait for a selected worker run with a bounded timeout. | A timeout is not worker failure or cancellation. |
+| Interrupt | Ask one current run to stop at a supported execution boundary. | This does not cancel the worker's entire descendant tree. |
+| Cancel owned work | Cancel a worker and its owned descendants. | Cancellation is cooperative and cannot undo an external side effect. |
+| Acknowledge | Record that the parent consumed a terminal result. | Worker completion and result delivery remain separate events. |
+| Reconcile | Record a decision about an interrupted action with an uncertain outcome. | Reconciliation does not automatically replay that action. |
+
+Requests for unsupported behavior fail visibly. In particular, familiar naming
+does not add transcript forking or graceful process shutdown. An interruption,
+tree cancellation and graceful shutdown request are different operations.
+
+### Messages and new assignments
+
+Suppose a worker has completed its research. Sending “Use the updated exchange
+rate” adds guidance to that conversation; it does not spend another model call
+merely because the worker is idle. A separate follow-up such as “Now revise the
+comparison using that correction” starts the next authorized run.
+
+A new assignment sent while work is active must retain its identity as queued
+work. It must not silently become a steering message for the current assignment.
+The worker service owns ordering, admission, retained context and execution limits
+for both operations.
+
+### Existing tool names remain available
+
+Some tools already use names that a styled interface would otherwise advertise.
+For example, an installed messaging tool may be named `send_message`. Hermes
+preserves that tool and gives the worker operation a collision-free alias, such
+as `hermes_worker_send_message`.
+
+The parent should follow the tool definitions actually advertised in its session.
+The frozen alias map applies to dispatch as well as presentation. It cannot
+redirect an unrelated native or MCP tool into worker management or bypass the
+permission checks on `delegate_task`.
+
+## Routing and permissions remain yours
+
+Interface style is independent of [worker profiles](worker-profiles.md). A parent
+using one style can select workers from different providers and choose supported
+thinking levels within your configured routing policy.
+
+In profile-only mode, the parent chooses your named profiles. Dynamic routing
+additionally permits the configured provider/model overrides. Neither style can
+expand tools, MCP access, credentials, filesystem permissions or delegation depth.
+An unsupported explicit model or effort fails instead of being silently replaced.
+
+Context is also independent of style. Supply task-specific context deliberately;
+worker context-file and memory settings still follow the selected profile. A
+follow-up retains the worker's own conversation and rechecks its current execution
+contract before launching.
+
+## Read the receipts
+
+Worker results carry an `orchestration_interface` receipt identifying the selected
+style, interface version, selection source, qualification status, advertised tool
+and canonical operation. This answers “Which interface did the parent use?”
+
+The worker's route receipt separately records requested, resolved and transmitted
+provider/model/effort settings, plus provider-reported information when available.
+This answers “What did Hermes ask the provider to execute?” A configured model
+identifier is not independent verification of the provider's actual model.
+
+Use these receipts when comparing interfaces. Successful tool translation proves
+the tested semantics; a controlled live qualification run establishes usability
+only for its tested profiles, versions and scenarios. Neither result establishes
+universal superiority over another harness.
+
+## Compatibility and recovery
+
+The existing delegation dispatcher and plugin lifecycle API remain supported.
+The parent sees one consistent orchestration interface, while legacy callers
+continue through the same underlying service.
+
+Worker identity, run checkpoints, ordered messages and completion acknowledgments
+remain owned by that service. An interface adapter does not keep a second worker
+registry or recovery queue. Restart recovery preserves the existing uncertainty
+rule: a possibly completed side effect pauses for reconciliation before another
+run can continue.

--- a/website/docs/user-guide/features/worker-orchestration-tour.md
+++ b/website/docs/user-guide/features/worker-orchestration-tour.md
@@ -13,7 +13,7 @@ This page explains the changes in [PR #106268](https://github.com/NousResearch/h
 
 ## The whole system at a glance
 
-![A user defines profiles and limits. A parent selects researcher, checker and optional coordinator workers. All use one service with retained state and execution receipts.](/img/worker-orchestration/overview.svg)
+<img src="/img/worker-orchestration/overview.svg" width="1100" alt="A user defines profiles and limits. A parent selects researcher, checker and optional coordinator workers. All use one service with retained state and execution receipts." />
 
 Read the diagram from top to bottom:
 
@@ -27,7 +27,7 @@ A powerful model alone does not provide this machinery. Selecting an OpenAI Code
 
 ## Codex, existing Hermes, and this change
 
-![Three columns compare the Codex reference, existing Hermes delegation, and the retained worker capabilities added by this PR.](/img/worker-orchestration/comparison.svg)
+<img src="/img/worker-orchestration/comparison.svg" width="1100" alt="Three columns compare the Codex reference, existing Hermes delegation, and the retained worker capabilities added by this PR." />
 
 **Comparison scope:** “Hermes before” means the inspected upstream baseline `c076d653a216939b97a93ab0c10ce709bacde667`, not a claim about every subsequent release. The Codex column summarizes [official subagent documentation](https://learn.chatgpt.com/docs/agent-configuration/subagents), checked on September 9, 2026, and the agent tool contracts exposed during this work. Client, account, model and policy differences still apply. “Not established” means this comparison has no supporting evidence; it does not mean the other product cannot do it.
 
@@ -74,7 +74,7 @@ Legacy `list`, `steer` and `stop` remain available. Plugins use the [shared life
 
 ## How model routing and permissions fit together
 
-![Profile-only and dynamic routing converge on batch validation, the narrowest effective permissions, and execution receipts.](/img/worker-orchestration/routing.svg)
+<img src="/img/worker-orchestration/routing.svg" width="1100" alt="Profile-only and dynamic routing converge on batch validation, the narrowest effective permissions, and execution receipts." />
 
 A **provider** is the service handling the model request. A **model** is the selected model identifier. **Thinking level**, also called reasoning effort, is a model-supported request setting. A higher level can change latency and usage; it is not a guarantee of a better answer.
 
@@ -90,7 +90,7 @@ Instructions such as “never edit files” describe intended behavior. A tool p
 
 ## Messages, follow-ups and nested work
 
-![A first run receives a message, then a second run starts with retained context. Optional descendants share limits, and the parent collects compact results.](/img/worker-orchestration/lifecycle.svg)
+<img src="/img/worker-orchestration/lifecycle.svg" width="1100" alt="A first run receives a message, then a second run starts with retained context. Optional descendants share limits, and the parent collects compact results." />
 
 A **worker ID** identifies the retained conversation. A **run ID** identifies one assignment within it. Two workers using the same profile still have different identities. Only one run executes on a worker at a time; follow-ups queue in order.
 
@@ -104,7 +104,7 @@ Context is also deliberate. The parent should pass the information needed for th
 
 ## What happens if Hermes stops halfway through?
 
-![After a restart, Hermes restores records and reclaims expired leases. Known checkpoints can resume after validation; uncertain tool outcomes pause for reconciliation.](/img/worker-orchestration/recovery.svg)
+<img src="/img/worker-orchestration/recovery.svg" width="1100" alt="After a restart, Hermes restores records and reclaims expired leases. Known checkpoints can resume after validation; uncertain tool outcomes pause for reconciliation." />
 
 The durable source is the active Hermes profile's database. **Durable** means recorded so it can survive process exit. It does not mean the old Python thread or an in-flight provider request survives.
 

--- a/website/docs/user-guide/features/worker-orchestration-tour.md
+++ b/website/docs/user-guide/features/worker-orchestration-tour.md
@@ -1,0 +1,155 @@
+---
+title: "Worker Orchestration: Illustrated Tour"
+sidebar_label: Orchestration illustrated
+---
+
+# Worker orchestration: illustrated tour
+
+An **orchestrator** is the main agent that divides a task, assigns the pieces, checks progress, and combines the answers. A **worker** is another agent doing one of those pieces. Each worker has its own conversation and can use the tools it is allowed to use.
+
+For example, ask Hermes to compare three proposals. It can give one worker the job of extracting the facts and another the job of checking contradictions. While they work, the parent can add guidance, wait for their answers, and ask the same worker a follow-up. You choose the worker definitions and which models they use.
+
+This page explains the changes in [PR #106268](https://github.com/NousResearch/hermes-agent/pull/106268). It is a feature guide, not a claim that every provider or deployment has passed the same tests. For copyable configuration, start with [Worker profiles](worker-profiles.md).
+
+## The whole system at a glance
+
+![A user defines profiles and limits. A parent selects researcher, checker and optional coordinator workers. All use one service with retained state and execution receipts.](/img/worker-orchestration/overview.svg)
+
+Read the diagram from top to bottom:
+
+1. **You define the available team.** A profile combines a purpose, instructions, a provider/model, an optional thinking level, tool restrictions, context choices and limits. “Researcher” and “checker” are examples; there are no compulsory roles or model families.
+2. **The parent makes the assignments.** It discovers the available profiles, selects suitable workers, and supplies each with a clear task and the context needed to complete it.
+3. **Workers execute independently.** Different workers may use different providers. An optional coordinator worker can delegate further when nesting is enabled.
+4. **Hermes manages the shared rules and records.** The parent tool and plugin API use the same worker service. The service tracks ownership, run order, budgets, messages and recovery state.
+5. **The parent receives evidence as well as answers.** A receipt records what was requested, what was sent, and what the provider reported. These are separate facts.
+
+A powerful model alone does not provide this machinery. Selecting an OpenAI Codex model in Hermes still runs it inside the Hermes harness—the software that supplies tools, permissions and the execution loop. This PR does not launch the Codex CLI or app-server as a worker backend.
+
+## Codex, existing Hermes, and this change
+
+![Three columns compare the Codex reference, existing Hermes delegation, and the retained worker capabilities added by this PR.](/img/worker-orchestration/comparison.svg)
+
+**Comparison scope:** “Hermes before” means the inspected upstream baseline `c076d653a216939b97a93ab0c10ce709bacde667`, not a claim about every subsequent release. The Codex column summarizes [official subagent documentation](https://learn.chatgpt.com/docs/agent-configuration/subagents), checked on September 9, 2026, and the agent tool contracts exposed during this work. Client, account, model and policy differences still apply. “Not established” means this comparison has no supporting evidence; it does not mean the other product cannot do it.
+
+| Capability | Codex reference | Hermes before | Hermes with this PR |
+| --- | --- | --- | --- |
+| Divide work in parallel | Parallel subagents | Already supported batches and summaries | Preserved; tasks can select different profiles |
+| Reusable worker definitions | Custom agents | Delegation defaults and leaf/orchestrator roles | Named user profiles with descriptions, instructions and restrictions |
+| Discover the available team | Agent metadata | No unified worker-profile catalog | Compact `discover`, with details fetched when needed |
+| Select model and thinking level | Per-agent settings | Provider/model overrides and request settings | Profile selection or policy-gated per-task provider/model/effort routing |
+| Control routing freedom | Configuration-dependent | No profile-only/dynamic worker policy | Profile-only by default; dynamic choices limited to a user-enabled menu |
+| Add guidance during work | Steering | Already supported `steer` | Durable message IDs and delivery state alongside legacy steering |
+| Ask the same worker another question | Follow-up controls | Fresh conversation for ordinary delegation; plugin records retained in process | Ordered new runs with a retained worker conversation |
+| Wait, inspect and stop | Thread controls | List/stop, background delivery and plugin lifecycle controls | Shared status, wait, inspect, cancel and completion acknowledgment |
+| Restrict tools | Permission inheritance | Inherited toolsets and role blocks | Explicit ceilings across native tools, MCP and calls through code |
+| Delegate another level | Harness/policy-dependent | Optional nested orchestrators already existed | Profiles narrow depth; descendants share durable execution budgets |
+| Limit concurrent work | Configurable concurrency | Existing concurrency/depth controls | Owned active-run limits plus durable tree iteration/tool/time budgets |
+| Cancel descendants | Target interruption observed; subtree behavior not established here | Cancellation followed ownership | Shared service propagates cancellation to owned descendants |
+| Separate editing workspaces | Environment-dependent | Optional Git worktrees already existed | Preserved; context settings do not promise filesystem containment |
+| Recover after a process restart | Exact recovery contract not established here | Some completion delivery was durable; plugin worker registry was in memory | Retained worker/run state, checkpoints, queues, leases and explicit uncertain outcomes |
+| Prove the execution route | Configured metadata; independent identity not established | Configured model and basic result metadata | Requested/resolved/transmitted/provider-reported fields kept distinct |
+| Configure without a prescribed model family | Custom configuration | Existing provider support | Provider-independent worker profiles through existing Hermes resolution |
+
+The main gap was a **unified, retained worker workflow**. Hermes could already delegate useful work. This change connects user-defined routing, ongoing communication, shared capability enforcement and restart-safe records into one service.
+
+## What the parent can now do
+
+The parent uses actions on the existing `delegate_task` tool. These are instructions the agent can issue; a person can ask for the same workflow in ordinary language.
+
+| Parent action | Plain-English meaning | Example use | Important boundary |
+| --- | --- | --- | --- |
+| `discover` | Show the available worker profiles and routes | “Who can inspect these files?” | Listing does not authenticate or prove a provider is available |
+| `spawn` | Start workers for task items | “Have my researcher and checker work in parallel” | Invalid selections reject the batch before launch |
+| `status` | Read compact progress and result summaries | “Which assignment is still running?” | Use returned worker/run IDs, not a profile name as identity |
+| `message` | Add guidance to an existing worker | “Focus on the dates, not the formatting” | Delivery happens at supported boundaries, not instantly inside a request |
+| `wait` | Wait for a selected worker or run | “Wait for the checker before deciding” | Waiting is bounded; it need not copy the transcript |
+| `resume` | Give the same worker a new assignment | “Recheck your answer against this new fact” | It creates a new run, with current permissions rechecked |
+| `inspect` | Request more detail and visible conversation | “Show how the checker reached that result” | Hidden reasoning and system prompts are excluded; ownership and size limits apply |
+| `cancel` | Request that a run and its owned descendants stop | “We no longer need that branch of work” | Cooperative cancellation cannot undo an external action |
+| `completions` | Find terminal results awaiting acknowledgment | “Collect any answers I have not consumed” | A stored result is not the same as delivered external communication |
+| `ack` | Confirm receipt of a completed run | “I have received and processed that result” | Internal acknowledgment does not change an external transport's guarantees |
+| `reconcile` | Record a decision about an uncertain tool outcome | “The operation completed; do not repeat it” | Reconciliation does not itself execute or replay the tool |
+
+Legacy `list`, `steer` and `stop` remain available. Plugins use the [shared lifecycle API](../../developer-guide/subagent-lifecycle-api.md), so the parent and plugin paths do not keep competing worker state.
+
+## How model routing and permissions fit together
+
+![Profile-only and dynamic routing converge on batch validation, the narrowest effective permissions, and execution receipts.](/img/worker-orchestration/routing.svg)
+
+A **provider** is the service handling the model request. A **model** is the selected model identifier. **Thinking level**, also called reasoning effort, is a model-supported request setting. A higher level can change latency and usage; it is not a guarantee of a better answer.
+
+In **profile-only mode**, the parent chooses a profile and uses its route. In **dynamic mode**, you also allow the parent to choose among specific enabled provider/model combinations. A profile can narrow that menu further. It cannot add routes outside the user's menu.
+
+Settings resolve from permitted task overrides, the selected profile, delegation defaults, then parent defaults. User ceilings still apply after that resolution. Explicit unsupported effort combinations fail visibly; the parent is not silently moved to another model or a lower thinking level. Unknown metadata remains unknown. Any permitted fallback or normalization must follow configured policy and appear in the receipt.
+
+The service then intersects the allowed capabilities. Think of this as several lists of permitted tools: a worker only receives a tool if all applicable restrictions allow it. A model switch cannot supply new credentials, undo a parent's denial, or expand the tool list.
+
+**MCP** is a way of connecting external tools. **Tools called through code** are tool requests made inside `execute_code` rather than directly by the model. Both routes receive the same worker restrictions. Hiding a tool from the visible menu alone would not be sufficient enforcement.
+
+Instructions such as “never edit files” describe intended behavior. A tool policy removes access to editing tools. A filesystem sandbox is a separate enforcing mechanism; suppressing context files or choosing a working directory does not create one. Requested guarantees are rejected when no enforcing backend is available.
+
+## Messages, follow-ups and nested work
+
+![A first run receives a message, then a second run starts with retained context. Optional descendants share limits, and the parent collects compact results.](/img/worker-orchestration/lifecycle.svg)
+
+A **worker ID** identifies the retained conversation. A **run ID** identifies one assignment within it. Two workers using the same profile still have different identities. Only one run executes on a worker at a time; follow-ups queue in order.
+
+A message can be accepted into the queue before the worker has consumed it. Consumption is recorded with a saved conversation checkpoint. This distinction matters if the process stops between receiving guidance and acting on it.
+
+A worker can also message its parent. Top-level worker-to-parent messages retain `QUEUED`, `PUBLISHED` and `ACKNOWLEDGED` states. The parent can inspect queued messages; publication includes them with the result; acknowledgment marks published messages as received. Optional sibling messaging lets workers communicate within policy. It does not allow one worker to inspect, resume or cancel an unrelated worker.
+
+When nesting is enabled, a coordinator worker may start descendants. They share the root assignment's iteration/tool allowance and deadline; a child's own profile can narrow them further. Restart does not replenish the allowance. A new explicit assignment to a top-level worker receives a new budget, while descendants from the old assignment keep the old budget. The owner's active-run concurrency limit spans those trees.
+
+Context is also deliberate. The parent should pass the information needed for the assignment. Startup memory/context-file inclusion follows the profile's context policy. Later follow-ups retain the worker's own conversation. Profile edits do not rewrite that conversation's original instructions; current permissions and required capabilities are rechecked before another run.
+
+## What happens if Hermes stops halfway through?
+
+![After a restart, Hermes restores records and reclaims expired leases. Known checkpoints can resume after validation; uncertain tool outcomes pause for reconciliation.](/img/worker-orchestration/recovery.svg)
+
+The durable source is the active Hermes profile's database. **Durable** means recorded so it can survive process exit. It does not mean the old Python thread or an in-flight provider request survives.
+
+A **lease** is a time-limited ownership claim on a run. It prevents two executors from owning the same run at once and prevents an expired executor from overwriting recovered state. A **checkpoint** is the last committed conversation state from which supported continuation can start.
+
+For a known checkpoint, Hermes restores its own conversation, rechecks credentials, route and tool availability, and starts a new linked run when continuation is safe. This does not require a provider-side resumable session. Queued messages and unacknowledged results remain recorded.
+
+The difficult case is an external effect: a tool might create a file or submit an operation, then Hermes might stop before saving the result. Automatically repeating the call could perform the action twice. The worker therefore becomes interrupted/uncertain until the parent records an explicit decision:
+
+- `confirmed_applied`: external evidence shows the operation happened.
+- `confirmed_not_applied`: external evidence shows it did not happen.
+- `accepted_unknown_no_replay`: the outcome remains unknown, and the decision is to avoid replay.
+
+The record keeps the decision, note and affected tool-call identities. A separate `resume` starts the next assignment. This is careful handling of uncertainty, not a promise of exactly-once execution across arbitrary external services.
+
+## Reading an execution receipt
+
+| Receipt field group | The question it answers |
+| --- | --- |
+| Requested profile/provider/model/effort | What did the parent ask for? |
+| Resolved settings | What did the allowed configuration select? |
+| Transmitted settings | What did Hermes send at the observed provider dispatch boundary? |
+| Provider-reported model | What model identity did the provider report, if any? |
+| Fallback, normalization and metadata provenance | Was the selection transformed, and where did capability information come from? |
+| Tools, lineage and run identity | What could the worker access, and which assignment/tree did it belong to? |
+| Status, termination and usage | How did the run finish and what usage was recorded? |
+| Known or unknown cost | Is there supported cost information, or is it unavailable? |
+
+For example, a requested profile can resolve to model A, send model A, and receive model B in provider metadata. Those values must stay separate. A configured name or a model's own self-description cannot independently verify the service's internal execution. Credential values and copied live configuration do not belong in receipts.
+
+## What has been exercised, and what remains outside the claim?
+
+Implementation source `cce21f3ac8ba844544f18c4e82d7b85a08a22dce` passed its controlled two-provider live workflow. [Canonical CI](https://github.com/NousResearch/hermes-agent/actions/runs/34315825965) passed on merge checkout `d4f51e901297da5920487762a760b6c8617d58a7`: **46,385 passed, zero failed, 447 skipped**. Documentation-only additions after that source do not imply a new runtime test.
+
+| Evidence | What it exercises |
+| --- | --- |
+| `test_delegation_model_routing.py`, `test_worker_profile_dispatch.py` | Profile and dynamic routing, unsupported selections, batch preflight and transport receipts |
+| `test_worker_tool_enforcement.py`, `test_worker_dispatch_budget.py` | Native/MCP/code tool ceilings and request budget charging |
+| `test_worker_admission_v2.py`, `test_worker_tree_budget_v2.py`, `test_worker_execution_limits.py` | Ownership, current-authority admission, limits, nested cancellation and parent messages |
+| `test_worker_store.py`, `test_worker_process_acceptance.py` | Real database state, leases, ordered queues, cold restart, uncertain effects and completion acknowledgment |
+| `test_subagent_lifecycle.py`, `test_delegate.py`, CLI `test_workers.py` | Plugin/parent compatibility, retained follow-ups, configuration and CLI behavior |
+| Controlled OpenAI-Codex + ZAI workflow | Parent discovery and selection, distinct supported thinking levels, running-worker message, retained follow-up and three completion acknowledgments; request/receipt agreement |
+
+The live workflow used controlled scheduling to ensure the message reached a running worker. The crash tests used synthetic provider transports and fresh processes. Neither proves every provider, filesystem backend, customer deployment or workload. The bounded review history has corrected findings but no final independent PASS or merge-readiness claim.
+
+This PR does not add a Codex app-server backend, a universal sandbox, a new credential store, automatic cost optimization, a graphical worker editor, or a customer rollout. It does not establish superiority over Codex. It provides a tested set of Hermes orchestration capabilities with user-controlled profiles and explicit boundaries.
+
+For exact fields and examples, continue to [configuration](worker-profiles.md). For implementation details, read the [architecture](../../developer-guide/worker-orchestration.md).

--- a/website/docs/user-guide/features/worker-orchestration-tour.md
+++ b/website/docs/user-guide/features/worker-orchestration-tour.md
@@ -9,7 +9,7 @@ An **orchestrator** is the main agent that divides a task, assigns the pieces, c
 
 For example, ask Hermes to compare three proposals. It can give one worker the job of extracting the facts and another the job of checking contradictions. While they work, the parent can add guidance, wait for their answers, and ask the same worker a follow-up. You choose the worker definitions and which models they use.
 
-This page explains the changes in [PR #106268](https://github.com/NousResearch/hermes-agent/pull/106268). It is a feature guide, not a claim that every provider or deployment has passed the same tests. For copyable configuration, start with [Worker profiles](worker-profiles.md).
+This page explains the changes in [PR #106268](https://github.com/NousResearch/hermes-agent/pull/106268). It is a feature guide, not a claim that every provider or deployment has passed the same tests. For copyable configuration, start with [Worker profiles](worker-profiles.md). For Codex, Claude Code, OpenClaw, Bot Mode and Kanban coverage, see the [capability comparison](orchestration-capability-comparison.md).
 
 ## The whole system at a glance
 
@@ -23,7 +23,7 @@ Read the diagram from top to bottom:
 4. **Hermes manages the shared rules and records.** The parent tool and plugin API use the same worker service. The service tracks ownership, run order, budgets, messages and recovery state.
 5. **The parent receives evidence as well as answers.** A receipt records what was requested, what was sent, and what the provider reported. These are separate facts.
 
-A powerful model alone does not provide this machinery. Selecting an OpenAI Codex model in Hermes still runs it inside the Hermes harness—the software that supplies tools, permissions and the execution loop. This PR does not launch the Codex CLI or app-server as a worker backend.
+A powerful model alone does not provide this machinery. Selecting an OpenAI Codex model in Hermes's default runtime still uses the Hermes harness—the software that supplies tools, permissions and the execution loop. Hermes also has an [optional Codex app-server runtime](codex-app-server-runtime.md), with different supported callbacks. This PR does not add or expand that backend integration.
 
 ## Codex, existing Hermes, and this change
 

--- a/website/docs/user-guide/features/worker-profiles.md
+++ b/website/docs/user-guide/features/worker-profiles.md
@@ -5,7 +5,7 @@ sidebar_label: Worker profiles
 
 # Worker profiles and orchestration
 
-Worker profiles describe the people-like roles you want Hermes to delegate to:
+Worker profiles describe the roles you want Hermes to delegate to:
 their purpose, instructions, model, thinking level, tools, and execution limits.
 They are independent of provider. You can use one model everywhere or combine
 models from different providers. Hermes does not install a prescribed team.
@@ -107,6 +107,24 @@ Existing conversations retain their original instructions. Changes to profile
 permissions, available tools, credentials, and models are rechecked on resume.
 Status and completion results are summaries; inspect the conversation explicitly
 when you need detail instead of copying every worker transcript into the parent.
+
+The parent uses these actions on `delegate_task`:
+
+| Action | Purpose |
+| --- | --- |
+| `discover` | List worker profiles and routing metadata |
+| `spawn` | Start the selected profiles through task items |
+| `status` | Read worker/run summaries, optionally selecting `worker_id` and `run_id` |
+| `inspect` | Explicitly inspect retained worker details |
+| `message` | Send `message` to a selected `worker_id` |
+| `wait` | Wait for a selected worker/run, bounded by `timeout_seconds` |
+| `resume` | Submit `message` as a new assignment with retained conversation |
+| `cancel` | Request cancellation of a selected worker/run |
+| `ack` | Acknowledge receipt of a terminal completion |
+
+Legacy `list`, `steer`, and `stop` actions remain available. Retain the returned
+worker and run IDs to target subsequent controls; do not infer identity from a
+profile name when several workers use the same profile.
 
 ## After a restart
 

--- a/website/docs/user-guide/features/worker-profiles.md
+++ b/website/docs/user-guide/features/worker-profiles.md
@@ -88,6 +88,13 @@ Nesting is optional. Enable it through the existing
 `delegation.orchestrator_enabled` and `delegation.max_spawn_depth` settings, then
 narrow individual worker profiles as needed.
 
+An assignment to a top-level worker starts a shared execution budget for its tree.
+Nested workers share the iteration and tool-call budget and inherit its deadline;
+their own profiles may narrow these limits further. Restarting a process does not
+replenish that budget. A new explicit assignment to the top-level worker starts a
+new budget, while descendants still finishing an older assignment keep the old
+one. The owner's active-run concurrency ceiling also applies across these trees.
+
 ## Choose the parent's routing freedom
 
 The default `delegation.routing_mode: profile_only` lets the parent select named

--- a/website/docs/user-guide/features/worker-profiles.md
+++ b/website/docs/user-guide/features/worker-profiles.md
@@ -199,6 +199,13 @@ state to see whether the message has reached a committed conversation checkpoint
 Sibling messaging is optional (`delegation.allow_sibling_messaging`); it does not
 grant permission to resume, cancel, or inspect an unrelated worker.
 
+A worker can send a message back to its parent through the same `message` action.
+For a top-level worker, the parent can read `messages_to_parent` through `inspect`,
+including while the message is `QUEUED`. Terminal publication changes it to
+`PUBLISHED` and includes it with the result. The parent's `ack` of that terminal
+run changes published messages to `ACKNOWLEDGED`. These states survive restart;
+publication alone does not mean the parent has consumed the message.
+
 ## After a restart
 
 Worker conversations, messages, and result delivery state live in the active

--- a/website/docs/user-guide/features/worker-profiles.md
+++ b/website/docs/user-guide/features/worker-profiles.md
@@ -161,6 +161,11 @@ Existing conversations retain their original instructions. Changes to profile
 permissions, available tools, credentials, and models are rechecked on resume.
 Status and completion results are summaries; inspect the conversation explicitly
 when you need detail instead of copying every worker transcript into the parent.
+Use `delegate_task(action="inspect", worker_id="...")` for the retained visible
+conversation and receipt metadata. Conversation entries include user, assistant,
+and tool text, capped at 32,000 characters per entry. System prompts, hidden
+reasoning, and provider session objects are excluded. Ownership checks apply to
+this inspection just as they do to worker controls.
 
 The parent uses these actions on `delegate_task`:
 

--- a/website/docs/user-guide/features/worker-profiles.md
+++ b/website/docs/user-guide/features/worker-profiles.md
@@ -55,6 +55,39 @@ Listing and validation do not contact providers or prove account availability.
 Credentials remain in Hermes's existing provider authentication system; do not
 put keys, tokens, or endpoints containing credentials in worker definitions.
 
+### Tools, context, and limits
+
+`allowed_toolsets` selects named tool groups. `allowed_tools` narrows exact tool
+names, and `allowed_mcp_tools` adds an exact-name restriction for MCP tools.
+`blocked_tools` removes named tools. Use the names reported by your installed
+tool catalog. Omitted restrictions inherit the applicable authority; an explicit
+empty allowlist grants no tools in its scope. A descendant cannot regain a tool
+denied by its parent. The same restrictions apply when a tool is discovered later
+or called through `execute_code`.
+
+Worker instructions describe behavior; tool policies govern access. Likewise,
+`workspace_context.mode: none` suppresses startup context files and memory, but
+does not create a filesystem sandbox. Supported context modes are `inherit` and
+`none`. A requested filesystem guarantee needs a backend that can enforce it;
+unsupported guarantees are rejected.
+
+Profiles support these execution ceilings:
+
+| Field | Meaning |
+| --- | --- |
+| `max_iterations` | Positive iteration limit |
+| `timeout_seconds` | Positive execution time limit in seconds |
+| `max_followups` | Nonnegative number of subsequent assignments; `0` disables follow-ups |
+| `max_tool_calls` | Nonnegative tool-call limit; `0` disables tool execution |
+| `max_spawn_depth` | Nonnegative descendant-depth limit; `0` disables spawning descendants |
+| `max_concurrent_children` | Nonnegative active-child limit; `0` disables child launches |
+
+Omit a limit to inherit the applicable default. Limits narrow the user's and
+ancestors' ceilings; they do not authorize additional tools or deeper delegation.
+Nesting is optional. Enable it through the existing
+`delegation.orchestrator_enabled` and `delegation.max_spawn_depth` settings, then
+narrow individual worker profiles as needed.
+
 ## Choose the parent's routing freedom
 
 The default `delegation.routing_mode: profile_only` lets the parent select named
@@ -83,6 +116,27 @@ Routing chooses within your policy. It cannot add tools, change credentials,
 or grant filesystem access. Resolution uses allowed task overrides, the selected
 profile, delegation defaults, then parent defaults; user limits apply last.
 An invalid profile or route rejects the batch before workers launch.
+
+For example, after configuring the menu above, the parent can request:
+
+```json
+{
+  "action": "spawn",
+  "tasks": [{
+    "profile": "analyst",
+    "provider": "anthropic",
+    "model": "your-enabled-anthropic-model",
+    "reasoning_effort": "high",
+    "goal": "Check the supplied evidence and explain any inconsistencies."
+  }]
+}
+```
+
+Use an effort that the selected model supports. A profile's optional
+`enabled_routes` list can further narrow its choices, including a specific
+`reasoning_effort` on a route. It cannot add a provider/model outside the global
+enabled menu. An explicit unsupported selection fails with an explanation;
+Hermes does not silently choose a cheaper model or lower thinking level.
 
 The parent discovers profiles and model metadata through `delegate_task` rather
 than having a large model catalog inserted into every prompt. Missing capability
@@ -116,15 +170,22 @@ The parent uses these actions on `delegate_task`:
 | `spawn` | Start the selected profiles through task items |
 | `status` | Read worker/run summaries, optionally selecting `worker_id` and `run_id` |
 | `inspect` | Explicitly inspect retained worker details |
+| `completions` | List terminal results awaiting acknowledgment |
 | `message` | Send `message` to a selected `worker_id` |
 | `wait` | Wait for a selected worker/run, bounded by `timeout_seconds` |
 | `resume` | Submit `message` as a new assignment with retained conversation |
 | `cancel` | Request cancellation of a selected worker/run |
+| `reconcile` | Record an explicit decision about an uncertain tool outcome |
 | `ack` | Acknowledge receipt of a terminal completion |
 
 Legacy `list`, `steer`, and `stop` actions remain available. Retain the returned
 worker and run IDs to target subsequent controls; do not infer identity from a
 profile name when several workers use the same profile.
+
+Message acceptance and message consumption are different events. Inspect delivery
+state to see whether the message has reached a committed conversation checkpoint.
+Sibling messaging is optional (`delegation.allow_sibling_messaging`); it does not
+grant permission to resume, cancel, or inspect an unrelated worker.
 
 ## After a restart
 
@@ -137,6 +198,29 @@ marked interrupted/uncertain. The parent must reconcile that outcome before
 continuing; Hermes does not blindly repeat it. Resume creates a new run linked to
 the interrupted run. Hermes-owned conversation checkpoints work even when a
 provider offers no resumable server-side session.
+
+After checking the external action, record the decision against the latest
+uncertain run:
+
+```json
+{
+  "action": "reconcile",
+  "worker_id": "worker-id-from-status",
+  "run_id": "interrupted-run-id",
+  "reconciliation_disposition": "confirmed_applied",
+  "message": "Checked the operation by its external reference; it completed. Do not repeat it."
+}
+```
+
+The other dispositions are `confirmed_not_applied` and
+`accepted_unknown_no_replay`. The latter records that the outcome remains unknown;
+it is not verification. Supply a nonempty note describing the evidence or decision.
+Reconciliation records the original tool-call identities and prior statuses without
+executing the tool. Then use a separate `resume` action with the next assignment.
+
+Queued assignments are revalidated immediately before launch, including those
+queued before a restart or a configuration change. A saved provider session handle
+does not replace Hermes-owned conversation state or current authorization.
 
 Delivery acknowledgments prevent duplicate internal consumption. An external
 messaging transport may still provide at-least-once delivery; this feature does

--- a/website/docs/user-guide/features/worker-profiles.md
+++ b/website/docs/user-guide/features/worker-profiles.md
@@ -1,0 +1,132 @@
+---
+title: Worker Profiles and Orchestration
+sidebar_label: Worker profiles
+---
+
+# Worker profiles and orchestration
+
+Worker profiles describe the people-like roles you want Hermes to delegate to:
+their purpose, instructions, model, thinking level, tools, and execution limits.
+They are independent of provider. You can use one model everywhere or combine
+models from different providers. Hermes does not install a prescribed team.
+
+A **Hermes profile** selects an independent configuration and state directory.
+A **worker profile** is a delegation definition inside that configuration.
+Worker definitions do not inherit live settings from other Hermes profiles.
+
+## Configure a worker
+
+Use your existing configured provider and its model identifier in a YAML file:
+
+```yaml
+description: Inspect supplied files and report concrete inconsistencies.
+instructions: Cite the evidence for each finding. Keep the result concise.
+provider: openai
+model: your-enabled-model
+reasoning_effort: high
+tool_policy:
+  allowed_toolsets: [file]
+  blocked_tools: [write_file, patch]
+execution_limits:
+  max_iterations: 30
+workspace_context:
+  mode: inherit
+  include_context_files: false
+  include_memory: false
+```
+
+Choose a thinking level supported by your model; omit it to inherit the applicable
+default. Tool names must match your installed tool catalog. Instructions such as
+“read only” are not permission controls: narrow actual tools and use an enforcing
+backend when filesystem isolation is required.
+
+```bash
+hermes workers set analyst --file analyst.yaml
+hermes workers validate
+hermes workers list --json
+hermes workers inspect analyst --json
+hermes workers default analyst
+```
+
+`set` creates or replaces the named definition. `default -` clears the default
+worker selection and restores legacy delegation defaults. These commands operate
+on the active Hermes profile; the normal `hermes -p NAME` selector still applies.
+Listing and validation do not contact providers or prove account availability.
+Credentials remain in Hermes's existing provider authentication system; do not
+put keys, tokens, or endpoints containing credentials in worker definitions.
+
+## Choose the parent's routing freedom
+
+The default `delegation.routing_mode: profile_only` lets the parent select named
+profiles. To also permit per-task model selection, enable dynamic routing and
+list permitted provider/model combinations:
+
+```yaml
+delegation:
+  routing_mode: dynamic
+  enabled_models:
+    - provider: openai
+      model: your-enabled-openai-model
+    - provider: anthropic
+      model: your-enabled-anthropic-model
+  profiles:
+    analyst:
+      description: Review evidence and explain discrepancies.
+      provider: openai
+      model: your-enabled-openai-model
+```
+
+These identifiers are placeholders, not model recommendations. Configure both
+providers through the existing Hermes setup/authentication flow first.
+
+Routing chooses within your policy. It cannot add tools, change credentials,
+or grant filesystem access. Resolution uses allowed task overrides, the selected
+profile, delegation defaults, then parent defaults; user limits apply last.
+An invalid profile or route rejects the batch before workers launch.
+
+The parent discovers profiles and model metadata through `delegate_task` rather
+than having a large model catalog inserted into every prompt. Missing capability
+or availability metadata remains unknown. Requested effort, resolved effort,
+transmitted effort, and provider-reported model are separate evidence fields.
+Explicit substitutions must follow configured policy and remain visible.
+
+## Work with retained workers
+
+A worker has a durable identity. Every assignment or follow-up creates a separate
+run. The parent can inspect status and results, send a message, queue a follow-up,
+wait, cancel, and resume a worker with retained conversation context. Steering
+is delivered at supported execution boundaries; it does not interrupt an HTTP
+request or terminal command instantly.
+
+Only one run executes per worker at a time. Follow-ups queue in order. Worker
+permissions and tree limits still apply to nested delegation. Cancellation is
+cooperative and reaches owned descendants; a cancellation request does not prove
+that an external side effect stopped.
+
+Existing conversations retain their original instructions. Changes to profile
+permissions, available tools, credentials, and models are rechecked on resume.
+Status and completion results are summaries; inspect the conversation explicitly
+when you need detail instead of copying every worker transcript into the parent.
+
+## After a restart
+
+Worker conversations, messages, and result delivery state live in the active
+Hermes profile's database. Python threads and active requests do not survive a
+process exit. Recovery restores durable state and reconciles interrupted runs.
+
+If Hermes cannot tell whether an external tool action completed, the run is
+marked interrupted/uncertain. The parent must reconcile that outcome before
+continuing; Hermes does not blindly repeat it. Resume creates a new run linked to
+the interrupted run. Hermes-owned conversation checkpoints work even when a
+provider offers no resumable server-side session.
+
+Delivery acknowledgments prevent duplicate internal consumption. An external
+messaging transport may still provide at-least-once delivery; this feature does
+not manufacture exactly-once guarantees for remote services.
+
+## Compatibility
+
+With no worker profiles configured, existing delegation defaults remain valid.
+The provider/model you select does not replace the Hermes harness. Choosing an
+OpenAI Codex model still uses Hermes orchestration; running the actual Codex
+app-server is a separate runtime integration.

--- a/website/docs/user-guide/features/worker-profiles.md
+++ b/website/docs/user-guide/features/worker-profiles.md
@@ -14,6 +14,9 @@ A **Hermes profile** selects an independent configuration and state directory.
 A **worker profile** is a delegation definition inside that configuration.
 Worker definitions do not inherit live settings from other Hermes profiles.
 
+For a plain-English overview, feature comparison and diagrams, see the
+[illustrated orchestration tour](worker-orchestration-tour.md).
+
 ## Configure a worker
 
 Use your existing configured provider and its model identifier in a YAML file:

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -99,6 +99,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/delegation',
             'user-guide/features/worker-profiles',
             'user-guide/features/worker-orchestration-tour',
+            'user-guide/features/orchestration-capability-comparison',
             'user-guide/features/kanban',
             'user-guide/features/codex-app-server-runtime',
             'user-guide/features/kanban-tutorial',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -98,6 +98,7 @@ const sidebars: SidebarsConfig = {
             'reference/automation-blueprints-catalog',
             'user-guide/features/delegation',
             'user-guide/features/worker-profiles',
+            'user-guide/features/orchestration-interfaces',
             'user-guide/features/worker-orchestration-tour',
             'user-guide/features/orchestration-capability-comparison',
             'user-guide/features/kanban',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -97,6 +97,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/cron',
             'reference/automation-blueprints-catalog',
             'user-guide/features/delegation',
+            'user-guide/features/worker-profiles',
             'user-guide/features/kanban',
             'user-guide/features/codex-app-server-runtime',
             'user-guide/features/kanban-tutorial',
@@ -792,6 +793,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 'developer-guide/plugin-llm-access',
                 'developer-guide/subagent-lifecycle-api',
+                'developer-guide/worker-orchestration',
                 'developer-guide/desktop-plugin-sdk',
                 'developer-guide/memory-provider-plugin',
                 'developer-guide/context-engine-plugin',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -98,6 +98,7 @@ const sidebars: SidebarsConfig = {
             'reference/automation-blueprints-catalog',
             'user-guide/features/delegation',
             'user-guide/features/worker-profiles',
+            'user-guide/features/worker-orchestration-tour',
             'user-guide/features/kanban',
             'user-guide/features/codex-app-server-runtime',
             'user-guide/features/kanban-tutorial',

--- a/website/static/evidence/orchestration-interface-pilot-cbb02042.json
+++ b/website/static/evidence/orchestration-interface-pilot-cbb02042.json
@@ -1,0 +1,1553 @@
+{
+  "candidate": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+  "claim_class": "advisory",
+  "warning": "Preserved runner outputs. qualified means four scenario assertions passed, not registry admission. Cost aggregation is incomplete; corrective turns and unobserved malformed calls are unknown. Duplicate metric counts run identities, not external effects. Wire agreement checks provider/model receipts and effective tools; these reports do not include transmitted effort values. No automatic entry enabled.",
+  "samples": [
+    {
+      "source_receipt": "interface-live-luna-hermes-cbb02042.json",
+      "sha256": "bb4ec6c7d427e5e9ab2933ee167d04a86cd36bb990d09525fc6dc92807a21a0d",
+      "report": {
+        "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+        "claim_class": "advisory",
+        "proof_boundary": "Exact candidate and selected routes for these four scenarios only; no statistical superiority, release, runtime, fleet, or customer-readiness claim.",
+        "qualification": "unqualified",
+        "qualified": false,
+        "receipts": [
+          {
+            "advertised_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "assertions": [
+              {
+                "assertion": "Parent discovers and selects two distinct configured routes.",
+                "passed": true
+              },
+              {
+                "assertion": "A durable message targets a RUNNING worker and its ID is recorded.",
+                "passed": false
+              },
+              {
+                "assertion": "Follow-up uses the same worker and a new run, without supplying the retained labels.",
+                "passed": false
+              },
+              {
+                "assertion": "The follow-up result contains both retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "Requested/resolved/transmitted route and effective tool receipts agree with actual requests.",
+                "passed": true
+              },
+              {
+                "assertion": "All three terminal runs are acknowledged without duplicate execution.",
+                "passed": false
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 78.077,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "hermes",
+            "scenario_id": "two_provider_retained_workflow",
+            "selected_interface": "hermes",
+            "task_completed": false,
+            "token_usage": {
+              "cache_read_tokens": 14848,
+              "cache_write_tokens": 0,
+              "input_tokens": 11432,
+              "output_tokens": 617,
+              "reasoning_tokens": 163,
+              "total_tokens": 26897
+            },
+            "wire_route_agreement": true
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "assertions": [
+              {
+                "assertion": "The parent submits the requested selection through its advertised interface.",
+                "passed": true
+              },
+              {
+                "assertion": "A visible structured rejection occurs before launching any worker.",
+                "passed": true
+              },
+              {
+                "assertion": "Worker and run counts remain unchanged; no substitute route is executed.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 6.709,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "hermes",
+            "scenario_id": "invalid_profile_rejected",
+            "selected_interface": "hermes",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 0,
+              "cache_write_tokens": 0,
+              "input_tokens": 6343,
+              "output_tokens": 129,
+              "reasoning_tokens": 44,
+              "total_tokens": 6472
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "assertions": [
+              {
+                "assertion": "The ownership check rejects inspection without revealing the foreign conversation.",
+                "passed": true
+              },
+              {
+                "assertion": "The foreign worker, run, message and acknowledgment state are unchanged.",
+                "passed": true
+              },
+              {
+                "assertion": "No substitute identity or non-orchestration access path is used.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 3.911,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "hermes",
+            "scenario_id": "foreign_worker_denied",
+            "selected_interface": "hermes",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 2560,
+              "cache_write_tokens": 0,
+              "input_tokens": 3732,
+              "output_tokens": 84,
+              "reasoning_tokens": 0,
+              "total_tokens": 6376
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "assertions": [
+              {
+                "assertion": "Guidance is durably queued without creating or launching a new run.",
+                "passed": true
+              },
+              {
+                "assertion": "An explicit follow-up creates exactly one new linked run.",
+                "passed": true
+              },
+              {
+                "assertion": "The retained answer includes sapphire and silver without those labels being supplied in the follow-up task.",
+                "passed": true
+              },
+              {
+                "assertion": "The new run is acknowledged; no previously completed run is replayed.",
+                "passed": false
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 33.693,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "NEXT_RUN",
+                "selected_run_status": "SUCCEEDED"
+              },
+              {
+                "accepted": true,
+                "delivery": "NEXT_RUN",
+                "selected_run_status": "SUCCEEDED"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "hermes",
+            "scenario_id": "idle_guidance_then_followup",
+            "selected_interface": "hermes",
+            "task_completed": false,
+            "token_usage": {
+              "cache_read_tokens": 33792,
+              "cache_write_tokens": 0,
+              "input_tokens": 12458,
+              "output_tokens": 744,
+              "reasoning_tokens": 177,
+              "total_tokens": 46994
+            },
+            "wire_route_agreement": true
+          }
+        ],
+        "suite": "hermes-orchestration-parity-v2/interface-qualification-v1"
+      }
+    },
+    {
+      "source_receipt": "interface-live-luna-codex-cbb02042.json",
+      "sha256": "92417edbbbd9fd1c6f3ea34fbd7bf6d03bcf73c918a09f70872f11d4e3acbdea",
+      "report": {
+        "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+        "claim_class": "advisory",
+        "proof_boundary": "Exact candidate and selected routes for these four scenarios only; no statistical superiority, release, runtime, fleet, or customer-readiness claim.",
+        "qualification": "unqualified",
+        "qualified": false,
+        "receipts": [
+          {
+            "advertised_orchestration_tool_names": [
+              "cancel_agent_tree",
+              "followup_task",
+              "inspect_agent",
+              "interrupt_agent",
+              "list_agents",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "Parent discovers and selects two distinct configured routes.",
+                "passed": true
+              },
+              {
+                "assertion": "A durable message targets a RUNNING worker and its ID is recorded.",
+                "passed": true
+              },
+              {
+                "assertion": "Follow-up uses the same worker and a new run, without supplying the retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "The follow-up result contains both retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "Requested/resolved/transmitted route and effective tool receipts agree with actual requests.",
+                "passed": true
+              },
+              {
+                "assertion": "All three terminal runs are acknowledged without duplicate execution.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 56.815,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "RUNNING_STEER_PENDING_CHECKPOINT",
+                "selected_run_status": "RUNNING"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "followup_task",
+              "inspect_agent",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "codex",
+            "scenario_id": "two_provider_retained_workflow",
+            "selected_interface": "codex",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 32768,
+              "cache_write_tokens": 0,
+              "input_tokens": 24725,
+              "output_tokens": 1314,
+              "reasoning_tokens": 244,
+              "total_tokens": 58807
+            },
+            "wire_route_agreement": true
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "cancel_agent_tree",
+              "followup_task",
+              "inspect_agent",
+              "interrupt_agent",
+              "list_agents",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "The parent submits the requested selection through its advertised interface.",
+                "passed": true
+              },
+              {
+                "assertion": "A visible structured rejection occurs before launching any worker.",
+                "passed": true
+              },
+              {
+                "assertion": "Worker and run counts remain unchanged; no substitute route is executed.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 4.58,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "worker_capabilities"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "codex",
+            "scenario_id": "invalid_profile_rejected",
+            "selected_interface": "codex",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 0,
+              "cache_write_tokens": 0,
+              "input_tokens": 4953,
+              "output_tokens": 48,
+              "reasoning_tokens": 0,
+              "total_tokens": 5001
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "cancel_agent_tree",
+              "followup_task",
+              "inspect_agent",
+              "interrupt_agent",
+              "list_agents",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "The ownership check rejects inspection without revealing the foreign conversation.",
+                "passed": true
+              },
+              {
+                "assertion": "The foreign worker, run, message and acknowledgment state are unchanged.",
+                "passed": true
+              },
+              {
+                "assertion": "No substitute identity or non-orchestration access path is used.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 5.446,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "inspect_agent"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "codex",
+            "scenario_id": "foreign_worker_denied",
+            "selected_interface": "codex",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 0,
+              "cache_write_tokens": 0,
+              "input_tokens": 4996,
+              "output_tokens": 76,
+              "reasoning_tokens": 0,
+              "total_tokens": 5072
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "cancel_agent_tree",
+              "followup_task",
+              "inspect_agent",
+              "interrupt_agent",
+              "list_agents",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "Guidance is durably queued without creating or launching a new run.",
+                "passed": true
+              },
+              {
+                "assertion": "An explicit follow-up creates exactly one new linked run.",
+                "passed": true
+              },
+              {
+                "assertion": "The retained answer includes sapphire and silver without those labels being supplied in the follow-up task.",
+                "passed": true
+              },
+              {
+                "assertion": "The new run is acknowledged; no previously completed run is replayed.",
+                "passed": false
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 17.894,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "NEXT_RUN",
+                "selected_run_status": "SUCCEEDED"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "followup_task",
+              "inspect_agent",
+              "send_message",
+              "wait_agent"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "codex",
+            "scenario_id": "idle_guidance_then_followup",
+            "selected_interface": "codex",
+            "task_completed": false,
+            "token_usage": {
+              "cache_read_tokens": 12288,
+              "cache_write_tokens": 0,
+              "input_tokens": 9055,
+              "output_tokens": 487,
+              "reasoning_tokens": 139,
+              "total_tokens": 21830
+            },
+            "wire_route_agreement": true
+          }
+        ],
+        "suite": "hermes-orchestration-parity-v2/interface-qualification-v1"
+      }
+    },
+    {
+      "source_receipt": "interface-live-luna-claude-cbb02042.json",
+      "sha256": "ce435f37f57dc408a90777db455777508a18e73cce6c9fe582aa3b9fd40a3b2d",
+      "report": {
+        "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+        "claim_class": "advisory",
+        "proof_boundary": "Exact candidate and selected routes for these four scenarios only; no statistical superiority, release, runtime, fleet, or customer-readiness claim.",
+        "qualification": "unqualified",
+        "qualified": false,
+        "receipts": [
+          {
+            "advertised_orchestration_tool_names": [
+              "Agent",
+              "SendMessage",
+              "TaskCapabilities",
+              "TaskList",
+              "TaskOutput",
+              "TaskStop",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "Parent discovers and selects two distinct configured routes.",
+                "passed": true
+              },
+              {
+                "assertion": "A durable message targets a RUNNING worker and its ID is recorded.",
+                "passed": true
+              },
+              {
+                "assertion": "Follow-up uses the same worker and a new run, without supplying the retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "The follow-up result contains both retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "Requested/resolved/transmitted route and effective tool receipts agree with actual requests.",
+                "passed": true
+              },
+              {
+                "assertion": "All three terminal runs are acknowledged without duplicate execution.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 41.154,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "RUNNING_STEER_PENDING_CHECKPOINT",
+                "selected_run_status": "RUNNING"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "Agent",
+              "SendMessage",
+              "TaskCapabilities",
+              "TaskOutput",
+              "worker_control"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "claude",
+            "scenario_id": "two_provider_retained_workflow",
+            "selected_interface": "claude",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 26112,
+              "cache_write_tokens": 0,
+              "input_tokens": 16195,
+              "output_tokens": 1064,
+              "reasoning_tokens": 214,
+              "total_tokens": 43371
+            },
+            "wire_route_agreement": true
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "Agent",
+              "SendMessage",
+              "TaskCapabilities",
+              "TaskList",
+              "TaskOutput",
+              "TaskStop",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "The parent submits the requested selection through its advertised interface.",
+                "passed": true
+              },
+              {
+                "assertion": "A visible structured rejection occurs before launching any worker.",
+                "passed": true
+              },
+              {
+                "assertion": "Worker and run counts remain unchanged; no substitute route is executed.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 5.996,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "TaskCapabilities"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "claude",
+            "scenario_id": "invalid_profile_rejected",
+            "selected_interface": "claude",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 0,
+              "cache_write_tokens": 0,
+              "input_tokens": 4825,
+              "output_tokens": 59,
+              "reasoning_tokens": 14,
+              "total_tokens": 4884
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "Agent",
+              "SendMessage",
+              "TaskCapabilities",
+              "TaskList",
+              "TaskOutput",
+              "TaskStop",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "The ownership check rejects inspection without revealing the foreign conversation.",
+                "passed": true
+              },
+              {
+                "assertion": "The foreign worker, run, message and acknowledgment state are unchanged.",
+                "passed": true
+              },
+              {
+                "assertion": "No substitute identity or non-orchestration access path is used.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 5.465,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "TaskOutput"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "claude",
+            "scenario_id": "foreign_worker_denied",
+            "selected_interface": "claude",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 1536,
+              "cache_write_tokens": 0,
+              "input_tokens": 3359,
+              "output_tokens": 120,
+              "reasoning_tokens": 29,
+              "total_tokens": 5015
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "Agent",
+              "SendMessage",
+              "TaskCapabilities",
+              "TaskList",
+              "TaskOutput",
+              "TaskStop",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "Guidance is durably queued without creating or launching a new run.",
+                "passed": true
+              },
+              {
+                "assertion": "An explicit follow-up creates exactly one new linked run.",
+                "passed": true
+              },
+              {
+                "assertion": "The retained answer includes sapphire and silver without those labels being supplied in the follow-up task.",
+                "passed": true
+              },
+              {
+                "assertion": "The new run is acknowledged; no previously completed run is replayed.",
+                "passed": false
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 19.262,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "NEXT_RUN",
+                "selected_run_status": "SUCCEEDED"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "SendMessage",
+              "TaskList",
+              "TaskOutput",
+              "worker_control"
+            ],
+            "parent_model": "gpt-5.6-luna",
+            "parent_provider": "openai-codex",
+            "requested_interface": "claude",
+            "scenario_id": "idle_guidance_then_followup",
+            "selected_interface": "claude",
+            "task_completed": false,
+            "token_usage": {
+              "cache_read_tokens": 12800,
+              "cache_write_tokens": 0,
+              "input_tokens": 6448,
+              "output_tokens": 429,
+              "reasoning_tokens": 114,
+              "total_tokens": 19677
+            },
+            "wire_route_agreement": true
+          }
+        ],
+        "suite": "hermes-orchestration-parity-v2/interface-qualification-v1"
+      }
+    },
+    {
+      "source_receipt": "interface-live-astra-hermes-cbb02042.json",
+      "sha256": "a50ab70ad55bf6858b84a651510c27079a113ea318e806555a93534f74c56c75",
+      "report": {
+        "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+        "claim_class": "advisory",
+        "proof_boundary": "Exact candidate and selected routes for these four scenarios only; no statistical superiority, release, runtime, fleet, or customer-readiness claim.",
+        "qualification": "qualified",
+        "qualified": true,
+        "receipts": [
+          {
+            "advertised_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "assertions": [
+              {
+                "assertion": "Parent discovers and selects two distinct configured routes.",
+                "passed": true
+              },
+              {
+                "assertion": "A durable message targets a RUNNING worker and its ID is recorded.",
+                "passed": true
+              },
+              {
+                "assertion": "Follow-up uses the same worker and a new run, without supplying the retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "The follow-up result contains both retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "Requested/resolved/transmitted route and effective tool receipts agree with actual requests.",
+                "passed": true
+              },
+              {
+                "assertion": "All three terminal runs are acknowledged without duplicate execution.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 90.629,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "RUNNING_STEER_PENDING_CHECKPOINT",
+                "selected_run_status": "RUNNING"
+              },
+              {
+                "accepted": true,
+                "delivery": "NEXT_RUN",
+                "selected_run_status": "SUCCEEDED"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "parent_model": "gpt-6-astra",
+            "parent_provider": "openai-codex",
+            "requested_interface": "hermes",
+            "scenario_id": "two_provider_retained_workflow",
+            "selected_interface": "hermes",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 74368,
+              "cache_write_tokens": 0,
+              "input_tokens": 20766,
+              "output_tokens": 1233,
+              "reasoning_tokens": 24,
+              "total_tokens": 96367
+            },
+            "wire_route_agreement": true
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "assertions": [
+              {
+                "assertion": "The parent submits the requested selection through its advertised interface.",
+                "passed": true
+              },
+              {
+                "assertion": "A visible structured rejection occurs before launching any worker.",
+                "passed": true
+              },
+              {
+                "assertion": "Worker and run counts remain unchanged; no substitute route is executed.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 6.124,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "parent_model": "gpt-6-astra",
+            "parent_provider": "openai-codex",
+            "requested_interface": "hermes",
+            "scenario_id": "invalid_profile_rejected",
+            "selected_interface": "hermes",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 0,
+              "cache_write_tokens": 0,
+              "input_tokens": 6279,
+              "output_tokens": 79,
+              "reasoning_tokens": 0,
+              "total_tokens": 6358
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "assertions": [
+              {
+                "assertion": "The ownership check rejects inspection without revealing the foreign conversation.",
+                "passed": true
+              },
+              {
+                "assertion": "The foreign worker, run, message and acknowledgment state are unchanged.",
+                "passed": true
+              },
+              {
+                "assertion": "No substitute identity or non-orchestration access path is used.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 6.83,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "parent_model": "gpt-6-astra",
+            "parent_provider": "openai-codex",
+            "requested_interface": "hermes",
+            "scenario_id": "foreign_worker_denied",
+            "selected_interface": "hermes",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 2944,
+              "cache_write_tokens": 0,
+              "input_tokens": 3328,
+              "output_tokens": 63,
+              "reasoning_tokens": 0,
+              "total_tokens": 6335
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "assertions": [
+              {
+                "assertion": "Guidance is durably queued without creating or launching a new run.",
+                "passed": true
+              },
+              {
+                "assertion": "An explicit follow-up creates exactly one new linked run.",
+                "passed": true
+              },
+              {
+                "assertion": "The retained answer includes sapphire and silver without those labels being supplied in the follow-up task.",
+                "passed": true
+              },
+              {
+                "assertion": "The new run is acknowledged; no previously completed run is replayed.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 43.562,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "NEXT_RUN",
+                "selected_run_status": "SUCCEEDED"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "delegate_task"
+            ],
+            "parent_model": "gpt-6-astra",
+            "parent_provider": "openai-codex",
+            "requested_interface": "hermes",
+            "scenario_id": "idle_guidance_then_followup",
+            "selected_interface": "hermes",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 25344,
+              "cache_write_tokens": 0,
+              "input_tokens": 16532,
+              "output_tokens": 573,
+              "reasoning_tokens": 0,
+              "total_tokens": 42449
+            },
+            "wire_route_agreement": true
+          }
+        ],
+        "suite": "hermes-orchestration-parity-v2/interface-qualification-v1"
+      }
+    },
+    {
+      "source_receipt": "interface-live-astra-codex-cbb02042.json",
+      "sha256": "df45337cccc4930aac2f0f4f6a8c3251e1caa38026ab33e9545683e13f9db8c3",
+      "report": {
+        "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+        "claim_class": "advisory",
+        "proof_boundary": "Exact candidate and selected routes for these four scenarios only; no statistical superiority, release, runtime, fleet, or customer-readiness claim.",
+        "qualification": "unqualified",
+        "qualified": false,
+        "receipts": [
+          {
+            "advertised_orchestration_tool_names": [
+              "cancel_agent_tree",
+              "followup_task",
+              "inspect_agent",
+              "interrupt_agent",
+              "list_agents",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "Parent discovers and selects two distinct configured routes.",
+                "passed": true
+              },
+              {
+                "assertion": "A durable message targets a RUNNING worker and its ID is recorded.",
+                "passed": true
+              },
+              {
+                "assertion": "Follow-up uses the same worker and a new run, without supplying the retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "The follow-up result contains both retained labels.",
+                "passed": true
+              },
+              {
+                "assertion": "Requested/resolved/transmitted route and effective tool receipts agree with actual requests.",
+                "passed": true
+              },
+              {
+                "assertion": "All three terminal runs are acknowledged without duplicate execution.",
+                "passed": false
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 94.835,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "RUNNING_STEER_PENDING_CHECKPOINT",
+                "selected_run_status": "RUNNING"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "followup_task",
+              "inspect_agent",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "parent_model": "gpt-6-astra",
+            "parent_provider": "openai-codex",
+            "requested_interface": "codex",
+            "scenario_id": "two_provider_retained_workflow",
+            "selected_interface": "codex",
+            "task_completed": false,
+            "token_usage": {
+              "cache_read_tokens": 69120,
+              "cache_write_tokens": 0,
+              "input_tokens": 18666,
+              "output_tokens": 1364,
+              "reasoning_tokens": 39,
+              "total_tokens": 89150
+            },
+            "wire_route_agreement": true
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "cancel_agent_tree",
+              "followup_task",
+              "inspect_agent",
+              "interrupt_agent",
+              "list_agents",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "The parent submits the requested selection through its advertised interface.",
+                "passed": true
+              },
+              {
+                "assertion": "A visible structured rejection occurs before launching any worker.",
+                "passed": true
+              },
+              {
+                "assertion": "Worker and run counts remain unchanged; no substitute route is executed.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 6.29,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "spawn_agent"
+            ],
+            "parent_model": "gpt-6-astra",
+            "parent_provider": "openai-codex",
+            "requested_interface": "codex",
+            "scenario_id": "invalid_profile_rejected",
+            "selected_interface": "codex",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 2304,
+              "cache_write_tokens": 0,
+              "input_tokens": 2685,
+              "output_tokens": 77,
+              "reasoning_tokens": 0,
+              "total_tokens": 5066
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "cancel_agent_tree",
+              "followup_task",
+              "inspect_agent",
+              "interrupt_agent",
+              "list_agents",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "The ownership check rejects inspection without revealing the foreign conversation.",
+                "passed": true
+              },
+              {
+                "assertion": "The foreign worker, run, message and acknowledgment state are unchanged.",
+                "passed": true
+              },
+              {
+                "assertion": "No substitute identity or non-orchestration access path is used.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 9.064,
+            "error_type": null,
+            "guidance_delivery_evidence": [],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "unknown"
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "inspect_agent"
+            ],
+            "parent_model": "gpt-6-astra",
+            "parent_provider": "openai-codex",
+            "requested_interface": "codex",
+            "scenario_id": "foreign_worker_denied",
+            "selected_interface": "codex",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 0,
+              "cache_write_tokens": 0,
+              "input_tokens": 4983,
+              "output_tokens": 60,
+              "reasoning_tokens": 0,
+              "total_tokens": 5043
+            },
+            "wire_route_agreement": "not_applicable"
+          },
+          {
+            "advertised_orchestration_tool_names": [
+              "cancel_agent_tree",
+              "followup_task",
+              "inspect_agent",
+              "interrupt_agent",
+              "list_agents",
+              "send_message",
+              "spawn_agent",
+              "wait_agent",
+              "worker_capabilities",
+              "worker_control"
+            ],
+            "assertions": [
+              {
+                "assertion": "Guidance is durably queued without creating or launching a new run.",
+                "passed": true
+              },
+              {
+                "assertion": "An explicit follow-up creates exactly one new linked run.",
+                "passed": true
+              },
+              {
+                "assertion": "The retained answer includes sapphire and silver without those labels being supplied in the follow-up task.",
+                "passed": true
+              },
+              {
+                "assertion": "The new run is acknowledged; no previously completed run is replayed.",
+                "passed": true
+              }
+            ],
+            "authorization_violations": 0,
+            "candidate_sha": "cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071",
+            "corrective_turns": "unknown",
+            "duplicate_owned_executions": 0,
+            "elapsed_seconds": 42.28,
+            "error_type": null,
+            "guidance_delivery_evidence": [
+              {
+                "accepted": true,
+                "delivery": "NEXT_RUN",
+                "selected_run_status": "SUCCEEDED"
+              }
+            ],
+            "interface_version": "worker-interface-v1",
+            "invalid_tool_calls": {
+              "malformed_or_unobserved": "unknown",
+              "structured": 0
+            },
+            "known_or_unknown_cost": {
+              "status": "known",
+              "usd": 0.0
+            },
+            "limits": {
+              "max_child_iterations": 3,
+              "max_child_seconds": 90,
+              "max_children": 2,
+              "max_parent_iterations": 16,
+              "max_parent_tokens": 4096,
+              "max_seconds_per_scenario": 240
+            },
+            "observed_orchestration_tool_names": [
+              "followup_task",
+              "inspect_agent",
+              "send_message",
+              "wait_agent",
+              "worker_control"
+            ],
+            "parent_model": "gpt-6-astra",
+            "parent_provider": "openai-codex",
+            "requested_interface": "codex",
+            "scenario_id": "idle_guidance_then_followup",
+            "selected_interface": "codex",
+            "task_completed": true,
+            "token_usage": {
+              "cache_read_tokens": 26752,
+              "cache_write_tokens": 0,
+              "input_tokens": 9875,
+              "output_tokens": 545,
+              "reasoning_tokens": 10,
+              "total_tokens": 37172
+            },
+            "wire_route_agreement": true
+          }
+        ],
+        "suite": "hermes-orchestration-parity-v2/interface-qualification-v1"
+      }
+    }
+  ]
+}

--- a/website/static/img/worker-orchestration/comparison.svg
+++ b/website/static/img/worker-orchestration/comparison.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 700" role="img" aria-labelledby="title desc"><title id="title">What changed in orchestration?</title><desc id="desc">A scoped comparison: existing capabilities, new controls, and evidence boundaries.</desc>
+<defs><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-width="0.5"/></pattern><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8" fill="#94a3b8"/></marker></defs><style>text{font-family:Arial,Helvetica,sans-serif} .title{font-size:28px;font-weight:700;fill:#f8fafc}.label{font-size:19px;font-weight:600;fill:#f8fafc}.body{font-size:16px;fill:#cbd5e1}.note{font-size:14px;fill:#94a3b8}</style>
+<rect width="1100" height="700" fill="#0f172a"/><rect width="1100" height="700" fill="url(#grid)"/>
+<text x="35" y="48" class="title">What changed in orchestration?</text>
+<text x="35" y="78" class="body">A scoped comparison: existing capabilities, new controls, and evidence boundaries.</text>
+<rect x="35" y="115" width="320" height="480" rx="12" fill="#0f172a"/><rect x="35" y="115" width="320" height="480" rx="12" fill="#22d3ee" fill-opacity="0.09" stroke="#22d3ee" stroke-width="1.5"/>
+<text x="53" y="146" class="label">CODEX REFERENCE</text>
+<text x="53" y="172" class="body">Custom agent descriptions</text>
+<text x="53" y="196" class="body">Per-agent model and effort</text>
+<text x="53" y="220" class="body">Parallel delegated work</text>
+<text x="53" y="244" class="body">Follow-up, steering and waiting</text>
+<text x="53" y="268" class="body">Inspect and interrupt agents</text>
+<text x="53" y="292" class="body">Inherited permission controls</text>
+<text x="53" y="316" class="body">Configurable concurrency</text>
+<text x="53" y="340" class="body"></text>
+<text x="53" y="364" class="body">Observed harness also exposes:</text>
+<text x="53" y="388" class="body">messages and follow-up tools</text>
+<text x="53" y="412" class="body"></text>
+<text x="53" y="436" class="body">Restart guarantees:</text>
+<text x="53" y="460" class="body">not established by this comparison</text>
+<rect x="390" y="115" width="320" height="480" rx="12" fill="#0f172a"/><rect x="390" y="115" width="320" height="480" rx="12" fill="#fbbf24" fill-opacity="0.09" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="408" y="146" class="label">HERMES BEFORE</text>
+<text x="408" y="172" class="body">Parallel batches and summaries</text>
+<text x="408" y="196" class="body">Delegation model overrides</text>
+<text x="408" y="220" class="body">Steer / list / stop</text>
+<text x="408" y="244" class="body">Optional nested orchestrators</text>
+<text x="408" y="268" class="body">Depth and concurrency controls</text>
+<text x="408" y="292" class="body">Optional Git worktrees</text>
+<text x="408" y="316" class="body">Plugin lifecycle API</text>
+<text x="408" y="340" class="body"></text>
+<text x="408" y="364" class="body">Missing this unified workflow:</text>
+<text x="408" y="388" class="body">discoverable worker profiles</text>
+<text x="408" y="412" class="body">retained runs + message queue</text>
+<text x="408" y="436" class="body">shared durable worker ownership</text>
+<text x="408" y="460" class="body">restart reconciliation + receipts</text>
+<rect x="745" y="115" width="320" height="480" rx="12" fill="#0f172a"/><rect x="745" y="115" width="320" height="480" rx="12" fill="#34d399" fill-opacity="0.09" stroke="#34d399" stroke-width="1.5"/>
+<text x="763" y="146" class="label">HERMES WITH THIS PR</text>
+<text x="763" y="172" class="body">User-created worker profiles</text>
+<text x="763" y="196" class="body">Profile-only or allowed routes</text>
+<text x="763" y="220" class="body">Model + supported effort choice</text>
+<text x="763" y="244" class="body">Retained workers and follow-ups</text>
+<text x="763" y="268" class="body">Shared parent / plugin service</text>
+<text x="763" y="292" class="body">Native + MCP tool ceilings</text>
+<text x="763" y="316" class="body">Tree-wide execution budgets</text>
+<text x="763" y="340" class="body">Durable messages and results</text>
+<text x="763" y="364" class="body">Lease-based recovery</text>
+<text x="763" y="388" class="body">Uncertain effects need a decision</text>
+<text x="763" y="412" class="body">Traceable execution receipts</text>
+<text x="763" y="436" class="body">CLI configuration and discovery</text>
+<text x="763" y="460" class="body"></text>
+<text x="763" y="484" class="body">Provider-independent design</text>
+<text x="35" y="637" class="body">Existing Hermes features are extended, not reintroduced. The guide maps each addition to tests.</text>
+<text x="35" y="667" class="note">Codex reference: official subagent docs + exposed harness contracts; no blanket parity claim.</text>
+</svg>

--- a/website/static/img/worker-orchestration/discovery-sequence.svg
+++ b/website/static/img/worker-orchestration/discovery-sequence.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1100" height="820" viewBox="0 0 1100 820" role="img" aria-labelledby="title desc">
+  <title id="title">Shared discovery: every request needs permission</title>
+  <desc id="desc">Proposed increment 2. A parent asks the shared discovery adapter for eligible workers, Bots, rooms and tasks. The adapter uses read-only queries against each existing service and returns compact typed references. Following a reference checks current permissions again. Revoked or stale access returns a denial. Discovery does not create or recover work.</desc>
+  <defs>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-width=".5"/></pattern>
+    <marker id="arrow" markerWidth="9" markerHeight="7" refX="8" refY="3.5" orient="auto"><path d="M0 0L9 3.5L0 7Z" fill="#94a3b8"/></marker>
+    <style>text{font-family:Arial,Helvetica,sans-serif;fill:#e2e8f0}.heading{font-size:30px;font-weight:700}.label{font-size:18px;font-weight:700}.body{font-size:16px}.note{font-size:14px;fill:#94a3b8}.line{fill:none;stroke:#94a3b8;stroke-width:2;marker-end:url(#arrow)}.box{fill:#0f172a;stroke-width:1.5}</style>
+  </defs>
+  <rect width="1100" height="820" fill="#0f172a"/>
+  <rect width="1100" height="820" fill="url(#grid)"/>
+  <text x="40" y="54" class="heading">Shared discovery: every request needs permission</text>
+  <text x="40" y="84" class="body">Increment 2 design · compact references connect existing services</text>
+
+  <path d="M286 173H356" class="line"/>
+  <path d="M660 173H740V276" class="line"/>
+  <path d="M550 223V248H170V276" class="line"/>
+  <path d="M550 248H425V276" class="line"/>
+  <path d="M550 248H935V276" class="line"/>
+  <rect x="40" y="123" width="246" height="100" rx="10" class="box" stroke="#22d3ee"/>
+  <text x="64" y="155" class="label">Parent agent</text>
+  <text x="64" y="185" class="body">“Who can I work with?”</text>
+  <rect x="356" y="123" width="304" height="100" rx="10" class="box" stroke="#34d399"/>
+  <text x="378" y="155" class="label">One discovery adapter</text>
+  <text x="378" y="185" class="body">Check this session's permissions</text>
+  <text x="800" y="160" class="note">Read existing state only</text>
+  <text x="800" y="183" class="note">No launch, recovery or migration</text>
+
+  <rect x="40" y="276" width="240" height="115" rx="10" class="box" stroke="#a78bfa"/>
+  <text x="60" y="307" class="label">Workers and runs</text>
+  <text x="60" y="337" class="body">Owned conversations</text>
+  <text x="60" y="362" class="note">Worker service owns lifecycle</text>
+  <rect x="300" y="276" width="240" height="115" rx="10" class="box" stroke="#a78bfa"/>
+  <text x="320" y="307" class="label">Bots</text>
+  <text x="320" y="337" class="body">Eligible profile peers</text>
+  <text x="320" y="362" class="note">Bot services own delivery</text>
+  <rect x="560" y="276" width="240" height="115" rx="10" class="box" stroke="#a78bfa"/>
+  <text x="580" y="307" class="label">Rooms</text>
+  <text x="580" y="337" class="body">Explicit session grants</text>
+  <text x="580" y="362" class="note">Room coordinator owns authority</text>
+  <rect x="820" y="276" width="240" height="115" rx="10" class="box" stroke="#a78bfa"/>
+  <text x="840" y="307" class="label">Tasks</text>
+  <text x="840" y="337" class="body">Current authorized board</text>
+  <text x="840" y="362" class="note">Kanban owns claims/acceptance</text>
+
+  <path d="M160 391V424H550V450" class="line"/>
+  <path d="M420 391V424" fill="none" stroke="#94a3b8" stroke-width="2"/>
+  <path d="M680 391V424H550" fill="none" stroke="#94a3b8" stroke-width="2"/>
+  <path d="M940 391V424H680" fill="none" stroke="#94a3b8" stroke-width="2"/>
+  <rect x="190" y="450" width="720" height="100" rx="10" class="box" stroke="#22d3ee"/>
+  <text x="215" y="482" class="label">Return only eligible references</text>
+  <text x="215" y="512" class="body">Kind + stable ID + owner scope + supported actions + availability + freshness</text>
+  <path d="M550 550V605" class="line"/>
+  <rect x="340" y="605" width="420" height="88" rx="10" class="box" stroke="#fbbf24"/>
+  <text x="363" y="636" class="label">Parent asks to inspect one reference</text>
+  <text x="363" y="665" class="body">Resolve it again; recheck current permission</text>
+  <path d="M340 650H294" class="line"/>
+  <path d="M760 650H806" class="line"/>
+  <rect x="40" y="605" width="254" height="88" rx="10" class="box" stroke="#34d399"/>
+  <text x="60" y="638" class="label">Allowed now</text>
+  <text x="60" y="667" class="body">Return permitted details</text>
+  <rect x="806" y="605" width="254" height="88" rx="10" class="box" stroke="#fb7185"/>
+  <text x="826" y="638" class="label">Revoked or stale</text>
+  <text x="826" y="667" class="body">Deny without disclosure</text>
+  <text x="40" y="745" class="body">Room checks bind the live session, current policy, service identity and authority epoch.</text>
+  <text x="40" y="773" class="note">A reference identifies an object. Every inspection or action still needs current authorization from its owning service.</text>
+</svg>

--- a/website/static/img/worker-orchestration/lifecycle.svg
+++ b/website/static/img/worker-orchestration/lifecycle.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 760" role="img" aria-labelledby="title desc"><title id="title">One worker, several assignments</title><desc id="desc">A worker keeps its identity and conversation. Each assignment has a separate run.</desc>
+<defs><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-width="0.5"/></pattern><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8" fill="#94a3b8"/></marker></defs><style>text{font-family:Arial,Helvetica,sans-serif} .title{font-size:28px;font-weight:700;fill:#f8fafc}.label{font-size:19px;font-weight:600;fill:#f8fafc}.body{font-size:16px;fill:#cbd5e1}.note{font-size:14px;fill:#94a3b8}</style>
+<rect width="1100" height="760" fill="#0f172a"/><rect width="1100" height="760" fill="url(#grid)"/>
+<text x="35" y="48" class="title">One worker, several assignments</text>
+<text x="35" y="78" class="body">A worker keeps its identity and conversation. Each assignment has a separate run.</text>
+<rect x="35" y="115" width="490" height="110" rx="12" fill="#0f172a"/><rect x="35" y="115" width="490" height="110" rx="12" fill="#22d3ee" fill-opacity="0.09" stroke="#22d3ee" stroke-width="1.5"/>
+<text x="53" y="146" class="label">RUN 1: DO THE FIRST TASK</text>
+<text x="53" y="172" class="body">Parent spawns a worker using a profile.</text>
+<text x="53" y="196" class="body">The worker saves conversation checkpoints.</text>
+<rect x="575" y="115" width="490" height="110" rx="12" fill="#0f172a"/><rect x="575" y="115" width="490" height="110" rx="12" fill="#fb923c" fill-opacity="0.09" stroke="#fb923c" stroke-width="1.5"/>
+<text x="593" y="146" class="label">MESSAGE WHILE RUNNING</text>
+<text x="593" y="172" class="body">New guidance waits for a supported boundary.</text>
+<text x="593" y="196" class="body">Accepted does not yet mean consumed.</text>
+<path d="M820 225 L820 270" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M280 225 L280 270" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="35" y="270" width="1030" height="110" rx="12" fill="#0f172a"/><rect x="35" y="270" width="1030" height="110" rx="12" fill="#34d399" fill-opacity="0.09" stroke="#34d399" stroke-width="1.5"/>
+<text x="53" y="301" class="label">RUN 2: FOLLOW UP WITH RETAINED CONTEXT</text>
+<text x="53" y="327" class="body">A follow-up queues behind Run 1; two runs never execute concurrently on one worker.</text>
+<text x="53" y="351" class="body">Hermes rechecks current tools, credentials, model route and limits before starting it.</text>
+<path d="M550 380 L550 420" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="35" y="420" width="490" height="165" rx="12" fill="#0f172a"/><rect x="35" y="420" width="490" height="165" rx="12" fill="#fbbf24" fill-opacity="0.09" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="53" y="451" class="label">OPTIONAL: A TREE OF WORKERS</text>
+<text x="53" y="477" class="body">An enabled coordinator can spawn children.</text>
+<text x="53" y="501" class="body">They share the assignment’s execution budget.</text>
+<text x="53" y="525" class="body">Depth, time, tool and concurrency limits apply.</text>
+<text x="53" y="549" class="body">Cancellation propagates to owned descendants.</text>
+<rect x="575" y="420" width="490" height="165" rx="12" fill="#0f172a"/><rect x="575" y="420" width="490" height="165" rx="12" fill="#a78bfa" fill-opacity="0.09" stroke="#a78bfa" stroke-width="1.5"/>
+<text x="593" y="451" class="label">PARENT GETS A COMPACT RESULT</text>
+<text x="593" y="477" class="body">Summary • status • usage • receipt reference</text>
+<text x="593" y="501" class="body">Inspect visible conversation only when needed.</text>
+<text x="593" y="525" class="body">Results remain pending until acknowledged.</text>
+<text x="593" y="549" class="body">Sibling messages require explicit policy.</text>
+<text x="35" y="640" class="body">Profile edits do not rewrite an existing worker’s original instructions.</text>
+<text x="35" y="670" class="body">A new root assignment gets a new budget; older descendants keep their earlier budget.</text>
+<text x="35" y="705" class="note">A cancellation request cannot prove an already-started external action stopped.</text>
+</svg>

--- a/website/static/img/worker-orchestration/overview.svg
+++ b/website/static/img/worker-orchestration/overview.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 850" role="img" aria-labelledby="title desc"><title id="title">A team you define. A parent that coordinates.</title><desc id="desc">Worker profiles choose the job and route; Hermes enforces the boundaries.</desc>
+<defs><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-width="0.5"/></pattern><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8" fill="#94a3b8"/></marker></defs><style>text{font-family:Arial,Helvetica,sans-serif} .title{font-size:28px;font-weight:700;fill:#f8fafc}.label{font-size:19px;font-weight:600;fill:#f8fafc}.body{font-size:16px;fill:#cbd5e1}.note{font-size:14px;fill:#94a3b8}</style>
+<rect width="1100" height="850" fill="#0f172a"/><rect width="1100" height="850" fill="url(#grid)"/>
+<text x="35" y="48" class="title">A team you define. A parent that coordinates.</text>
+<text x="35" y="78" class="body">Worker profiles choose the job and route; Hermes enforces the boundaries.</text>
+<rect x="35" y="110" width="1030" height="95" rx="12" fill="#0f172a"/><rect x="35" y="110" width="1030" height="95" rx="12" fill="#fbbf24" fill-opacity="0.09" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="53" y="141" class="label">YOU: define the team and its limits</text>
+<text x="53" y="167" class="body">Profiles • enabled providers/models • tools • context • time, depth and concurrency</text>
+<path d="M550 205 L550 245" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="195" y="245" width="710" height="105" rx="12" fill="#0f172a"/><rect x="195" y="245" width="710" height="105" rx="12" fill="#22d3ee" fill-opacity="0.09" stroke="#22d3ee" stroke-width="1.5"/>
+<text x="213" y="276" class="label">PARENT ORCHESTRATOR</text>
+<text x="213" y="302" class="body">Discover profiles → choose workers → give each a bounded task</text>
+<text x="213" y="326" class="body">Message • wait • follow up • inspect • cancel • reconcile • acknowledge</text>
+<path d="M550 350 L195 405" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M550 350 L550 405" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M550 350 L905 405" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="35" y="405" width="320" height="120" rx="12" fill="#0f172a"/><rect x="35" y="405" width="320" height="120" rx="12" fill="#22d3ee" fill-opacity="0.09" stroke="#22d3ee" stroke-width="1.5"/>
+<text x="53" y="436" class="label">RESEARCHER</text>
+<text x="53" y="462" class="body">Your provider / model A</text>
+<text x="53" y="486" class="body">Supported effort: e.g. medium</text>
+<text x="53" y="510" class="body">Only permitted research tools</text>
+<rect x="390" y="405" width="320" height="120" rx="12" fill="#0f172a"/><rect x="390" y="405" width="320" height="120" rx="12" fill="#22d3ee" fill-opacity="0.09" stroke="#22d3ee" stroke-width="1.5"/>
+<text x="408" y="436" class="label">CHECKER</text>
+<text x="408" y="462" class="body">Your provider / model B</text>
+<text x="408" y="486" class="body">Supported effort: e.g. high</text>
+<text x="408" y="510" class="body">Only permitted checking tools</text>
+<rect x="745" y="405" width="320" height="120" rx="12" fill="#0f172a"/><rect x="745" y="405" width="320" height="120" rx="12" fill="#22d3ee" fill-opacity="0.09" stroke="#22d3ee" stroke-width="1.5"/>
+<text x="763" y="436" class="label">COORDINATOR (optional)</text>
+<text x="763" y="462" class="body">Your chosen route and effort</text>
+<text x="763" y="486" class="body">May delegate within tree limits</text>
+<text x="763" y="510" class="body">Descendants cannot gain access</text>
+<path d="M195 525 L195 575" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M550 525 L550 575" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M905 525 L905 575" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="35" y="575" width="1030" height="95" rx="12" fill="#0f172a"/><rect x="35" y="575" width="1030" height="95" rx="12" fill="#34d399" fill-opacity="0.09" stroke="#34d399" stroke-width="1.5"/>
+<text x="53" y="606" class="label">ONE SHARED WORKER SERVICE</text>
+<text x="53" y="632" class="body">Parent tool + plugin API • ownership checks • ordered follow-ups • shared execution budgets</text>
+<path d="M325 670 L325 710" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M790 670 L790 710" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="35" y="710" width="490" height="100" rx="12" fill="#0f172a"/><rect x="35" y="710" width="490" height="100" rx="12" fill="#a78bfa" fill-opacity="0.09" stroke="#a78bfa" stroke-width="1.5"/>
+<text x="53" y="741" class="label">RETAINED STATE</text>
+<text x="53" y="767" class="body">Worker identity, runs, messages, checkpoints</text>
+<rect x="565" y="710" width="500" height="100" rx="12" fill="#0f172a"/><rect x="565" y="710" width="500" height="100" rx="12" fill="#fb923c" fill-opacity="0.09" stroke="#fb923c" stroke-width="1.5"/>
+<text x="583" y="741" class="label">EXECUTION RECEIPTS</text>
+<text x="583" y="767" class="body">Selected route → sent request → reported model</text>
+</svg>

--- a/website/static/img/worker-orchestration/recovery.svg
+++ b/website/static/img/worker-orchestration/recovery.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 790" role="img" aria-labelledby="title desc"><title id="title">A restart restores records, not a vanished process</title><desc id="desc">Hermes must know where work stopped before it can safely continue.</desc>
+<defs><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-width="0.5"/></pattern><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8" fill="#94a3b8"/></marker></defs><style>text{font-family:Arial,Helvetica,sans-serif} .title{font-size:28px;font-weight:700;fill:#f8fafc}.label{font-size:19px;font-weight:600;fill:#f8fafc}.body{font-size:16px;fill:#cbd5e1}.note{font-size:14px;fill:#94a3b8}</style>
+<rect width="1100" height="790" fill="#0f172a"/><rect width="1100" height="790" fill="url(#grid)"/>
+<text x="35" y="48" class="title">A restart restores records, not a vanished process</text>
+<text x="35" y="78" class="body">Hermes must know where work stopped before it can safely continue.</text>
+<rect x="195" y="110" width="710" height="100" rx="12" fill="#0f172a"/><rect x="195" y="110" width="710" height="100" rx="12" fill="#a78bfa" fill-opacity="0.09" stroke="#a78bfa" stroke-width="1.5"/>
+<text x="213" y="141" class="label">PROCESS STOPS</text>
+<text x="213" y="167" class="body">Saved state remains: conversation, queued messages, run IDs and results.</text>
+<path d="M550 210 L550 250" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="195" y="250" width="710" height="100" rx="12" fill="#0f172a"/><rect x="195" y="250" width="710" height="100" rx="12" fill="#34d399" fill-opacity="0.09" stroke="#34d399" stroke-width="1.5"/>
+<text x="213" y="281" class="label">RECOVER OWNERSHIP</text>
+<text x="213" y="307" class="body">Expired execution leases are reclaimed; the old executor is fenced out.</text>
+<text x="213" y="331" class="body">Inspect the last committed checkpoint and any in-flight tool action.</text>
+<path d="M370 350 L280 415" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M730 350 L820 415" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="35" y="415" width="490" height="130" rx="12" fill="#0f172a"/><rect x="35" y="415" width="490" height="130" rx="12" fill="#22d3ee" fill-opacity="0.09" stroke="#22d3ee" stroke-width="1.5"/>
+<text x="53" y="446" class="label">KNOWN CHECKPOINT</text>
+<text x="53" y="472" class="body">Restore Hermes-owned conversation.</text>
+<text x="53" y="496" class="body">Recheck route, credentials, tools and limits.</text>
+<text x="53" y="520" class="body">Resume in a new linked run.</text>
+<rect x="575" y="415" width="490" height="130" rx="12" fill="#0f172a"/><rect x="575" y="415" width="490" height="130" rx="12" fill="#fb7185" fill-opacity="0.09" stroke="#fb7185" stroke-width="1.5"/>
+<text x="593" y="446" class="label">TOOL OUTCOME UNCERTAIN</text>
+<text x="593" y="472" class="body">The external action may already have happened.</text>
+<text x="593" y="496" class="body">Pause for explicit reconciliation.</text>
+<text x="593" y="520" class="body">Never automatically repeat that action.</text>
+<path d="M280 545 L280 595" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M820 545 L820 595" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="35" y="595" width="490" height="130" rx="12" fill="#0f172a"/><rect x="35" y="595" width="490" height="130" rx="12" fill="#a78bfa" fill-opacity="0.09" stroke="#a78bfa" stroke-width="1.5"/>
+<text x="53" y="626" class="label">PRESERVE DELIVERY STATE</text>
+<text x="53" y="652" class="body">Queued messages stay ordered.</text>
+<text x="53" y="676" class="body">Undelivered completions remain available.</text>
+<text x="53" y="700" class="body">Acknowledgments prevent internal duplicates.</text>
+<rect x="575" y="595" width="490" height="130" rx="12" fill="#0f172a"/><rect x="575" y="595" width="490" height="130" rx="12" fill="#fbbf24" fill-opacity="0.09" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="593" y="626" class="label">RECORD THE DECISION</text>
+<text x="593" y="652" class="body">Confirm applied / confirm not applied /</text>
+<text x="593" y="676" class="body">accept unknown without replay.</text>
+<text x="593" y="700" class="body">Then separately request the next assignment.</text>
+<text x="35" y="760" class="note">External services retain their own delivery guarantees; this is not universal exactly-once execution.</text>
+</svg>

--- a/website/static/img/worker-orchestration/routing.svg
+++ b/website/static/img/worker-orchestration/routing.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 760" role="img" aria-labelledby="title desc"><title id="title">Choosing a route does not grant more access</title><desc id="desc">Routing selects a model. Permission checks decide what that worker may do.</desc>
+<defs><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-width="0.5"/></pattern><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8" fill="#94a3b8"/></marker></defs><style>text{font-family:Arial,Helvetica,sans-serif} .title{font-size:28px;font-weight:700;fill:#f8fafc}.label{font-size:19px;font-weight:600;fill:#f8fafc}.body{font-size:16px;fill:#cbd5e1}.note{font-size:14px;fill:#94a3b8}</style>
+<rect width="1100" height="760" fill="#0f172a"/><rect width="1100" height="760" fill="url(#grid)"/>
+<text x="35" y="48" class="title">Choosing a route does not grant more access</text>
+<text x="35" y="78" class="body">Routing selects a model. Permission checks decide what that worker may do.</text>
+<rect x="35" y="115" width="490" height="130" rx="12" fill="#0f172a"/><rect x="35" y="115" width="490" height="130" rx="12" fill="#22d3ee" fill-opacity="0.09" stroke="#22d3ee" stroke-width="1.5"/>
+<text x="53" y="146" class="label">DEFAULT: PROFILE ONLY</text>
+<text x="53" y="172" class="body">Parent picks a named worker profile.</text>
+<text x="53" y="196" class="body">Profile supplies provider, model and effort.</text>
+<text x="53" y="220" class="body">Example: “Use my checker.”</text>
+<rect x="575" y="115" width="490" height="130" rx="12" fill="#0f172a"/><rect x="575" y="115" width="490" height="130" rx="12" fill="#fbbf24" fill-opacity="0.09" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="593" y="146" class="label">OPTIONAL: DYNAMIC ROUTING</text>
+<text x="593" y="172" class="body">Parent may select from your enabled routes.</text>
+<text x="593" y="196" class="body">A profile can narrow that menu further.</text>
+<text x="593" y="220" class="body">Example: “Use checker with allowed model B.”</text>
+<path d="M280 245 L400 295" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<path d="M820 245 L700 295" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="195" y="295" width="710" height="110" rx="12" fill="#0f172a"/><rect x="195" y="295" width="710" height="110" rx="12" fill="#34d399" fill-opacity="0.09" stroke="#34d399" stroke-width="1.5"/>
+<text x="213" y="326" class="label">VALIDATE THE WHOLE BATCH</text>
+<text x="213" y="352" class="body">Check profile, enabled route, supported effort and known availability.</text>
+<text x="213" y="376" class="body">Invalid selection → visible error before any worker is launched.</text>
+<path d="M550 405 L550 450" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="195" y="450" width="710" height="120" rx="12" fill="#0f172a"/><rect x="195" y="450" width="710" height="120" rx="12" fill="#fb7185" fill-opacity="0.09" stroke="#fb7185" stroke-width="1.5"/>
+<text x="213" y="481" class="label">APPLY THE NARROWEST PERMISSIONS</text>
+<text x="213" y="507" class="body">User policy ∩ parent authority ∩ profile limits ∩ backend capability</text>
+<text x="213" y="531" class="body">Applies to native tools, MCP tools and tools called through code.</text>
+<text x="213" y="555" class="body">No filesystem promise without an enforcing backend.</text>
+<path d="M550 570 L550 615" fill="none" stroke="#94a3b8" stroke-width="2" marker-end="url(#arrow)"/>
+<rect x="195" y="615" width="710" height="105" rx="12" fill="#0f172a"/><rect x="195" y="615" width="710" height="105" rx="12" fill="#fb923c" fill-opacity="0.09" stroke="#fb923c" stroke-width="1.5"/>
+<text x="213" y="646" class="label">LAUNCH AND RECORD WHAT HAPPENED</text>
+<text x="213" y="672" class="body">Requested profile/route → resolved settings → transmitted request</text>
+<text x="213" y="696" class="body">Provider-reported model is evidence, not independent verification.</text>
+</svg>

--- a/website/static/img/worker-orchestration/service-map.svg
+++ b/website/static/img/worker-orchestration/service-map.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 790" role="img" aria-labelledby="title desc">
+<title id="title">One parent interface. Four existing state owners.</title><desc id="desc">Planned interface and discovery route to workers, Bots, rooms and Kanban without merging their databases or permission boundaries.</desc>
+<defs><style>text{font-family:Arial,Helvetica,sans-serif;fill:#e2e8f0} .sub{fill:#94a3b8;font-size:15px}.label{font-size:18px;font-weight:600}</style><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-width=".6"/></pattern><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8" fill="#94a3b8"/></marker></defs>
+<rect width="1200" height="790" fill="#0f172a"/><rect width="1200" height="790" fill="url(#grid)"/>
+<text x="40" y="48" font-size="27" font-weight="700">One parent interface. Four existing state owners.</text>
+<text x="40" y="78" class="sub" text-anchor="start">DASHED = PLANNED CONNECTION / SOLID = EXISTING SERVICE CONTRACT</text>
+<rect x="375" y="115" width="450" height="90" rx="12" fill="#0f172a" stroke="#22d3ee" stroke-width="2"/>
+<text x="600.0" y="145" class="label" text-anchor="middle">User-configured parent</text>
+<text x="600.0" y="172" class="sub" text-anchor="middle">Models, profiles, limits and authority</text>
+<path d="M600 205L600 245" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)" stroke-dasharray="7 5"/>
+<rect x="200" y="245" width="800" height="95" rx="12" fill="#0f172a" stroke="#fbbf24" stroke-width="2" stroke-dasharray="8 5"/>
+<text x="600.0" y="275" class="label" text-anchor="middle">Model-facing interfaces — follow-up 1</text>
+<text x="600.0" y="302" class="sub" text-anchor="middle">Canonical Hermes / Codex-style / Claude-style; one surface per session</text>
+<path d="M600 340L600 380" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)" stroke-dasharray="7 5"/>
+<rect x="200" y="380" width="800" height="90" rx="12" fill="#0f172a" stroke="#fb923c" stroke-width="2" stroke-dasharray="8 5"/>
+<text x="600.0" y="410" class="label" text-anchor="middle">Typed discovery and routing — follow-ups 2–3</text>
+<text x="600.0" y="437" class="sub" text-anchor="middle">Visible references do not grant permission to act</text>
+<path d="M600 470V495H172V520" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="7 5" marker-end="url(#arrow)"/>
+<path d="M600 470V495H457V520" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="7 5" marker-end="url(#arrow)"/>
+<path d="M600 470V495H742V520" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="7 5" marker-end="url(#arrow)"/>
+<path d="M600 470V495H1027V520" fill="none" stroke="#94a3b8" stroke-width="2" stroke-dasharray="7 5" marker-end="url(#arrow)"/>
+<rect x="40" y="520" width="265" height="120" rx="12" fill="#0f172a" stroke="#34d399" stroke-width="2"/>
+<text x="172.5" y="550" class="label" text-anchor="middle">Workers</text>
+<text x="172.5" y="577" class="sub" text-anchor="middle">Retained conversations</text>
+<text x="172.5" y="599" class="sub" text-anchor="middle">Run IDs / leases / receipts</text>
+<rect x="325" y="520" width="265" height="120" rx="12" fill="#0f172a" stroke="#22d3ee" stroke-width="2"/>
+<text x="457.5" y="550" class="label" text-anchor="middle">Bots</text>
+<text x="457.5" y="577" class="sub" text-anchor="middle">Full isolated profiles</text>
+<text x="457.5" y="599" class="sub" text-anchor="middle">Canonical chat / ingress</text>
+<rect x="610" y="520" width="265" height="120" rx="12" fill="#0f172a" stroke="#a78bfa" stroke-width="2"/>
+<text x="742.5" y="550" class="label" text-anchor="middle">Rooms</text>
+<text x="742.5" y="577" class="sub" text-anchor="middle">Shared Bot discussion</text>
+<text x="742.5" y="599" class="sub" text-anchor="middle">Coordinator / fencing</text>
+<rect x="895" y="520" width="265" height="120" rx="12" fill="#0f172a" stroke="#34d399" stroke-width="2"/>
+<text x="1027.5" y="550" class="label" text-anchor="middle">Kanban</text>
+<text x="1027.5" y="577" class="sub" text-anchor="middle">Tasks / dependencies</text>
+<text x="1027.5" y="599" class="sub" text-anchor="middle">Claims / review / acceptance</text>
+<text x="600" y="685" class="label" text-anchor="middle">Follow-up 4: saved workflows reference these owners; they do not replace them.</text>
+<text x="600" y="721" class="sub" text-anchor="middle">Queued message ≠ consumed guidance. Finished run ≠ accepted task.</text>
+<text x="600" y="749" class="sub" text-anchor="middle">Workers: PR #106268. Bot/room/Kanban foundations: inspected Hermes main.</text>
+</svg>

--- a/website/static/img/worker-orchestration/team-sequence.svg
+++ b/website/static/img/worker-orchestration/team-sequence.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 955" role="img" aria-labelledby="title desc">
+<title id="title">A task is finished when its review is accepted.</title><desc id="desc">Planned parent workflow connects Kanban dependencies to retained workers and reviewer messages, then records task acceptance separately.</desc>
+<defs><style>text{font-family:Arial,Helvetica,sans-serif;fill:#e2e8f0} .sub{fill:#94a3b8;font-size:15px}.label{font-size:18px;font-weight:600}</style><pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M40 0H0V40" fill="none" stroke="#1e293b" stroke-width=".6"/></pattern><marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8" fill="#94a3b8"/></marker></defs>
+<rect width="1200" height="955" fill="#0f172a"/><rect width="1200" height="955" fill="url(#grid)"/>
+<text x="40" y="48" font-size="27" font-weight="700">A task is finished when its review is accepted.</text>
+<text x="40" y="78" class="sub" text-anchor="start">PLANNED INTEGRATION • existing worker and Kanban primitives retain their authority</text>
+<path d="M145 175V840" stroke="#334155" stroke-width="2" stroke-dasharray="6 5"/>
+<path d="M448 175V840" stroke="#334155" stroke-width="2" stroke-dasharray="6 5"/>
+<path d="M751 175V840" stroke="#334155" stroke-width="2" stroke-dasharray="6 5"/>
+<path d="M1054 175V840" stroke="#334155" stroke-width="2" stroke-dasharray="6 5"/>
+<rect x="40" y="110" width="210" height="65" rx="12" fill="#0f172a" stroke="#22d3ee" stroke-width="2"/>
+<text x="145.0" y="140" class="label" text-anchor="middle">Parent</text>
+<rect x="343" y="110" width="210" height="65" rx="12" fill="#0f172a" stroke="#34d399" stroke-width="2"/>
+<text x="448.0" y="140" class="label" text-anchor="middle">Kanban</text>
+<rect x="646" y="110" width="210" height="65" rx="12" fill="#0f172a" stroke="#a78bfa" stroke-width="2"/>
+<text x="751.0" y="140" class="label" text-anchor="middle">Worker</text>
+<rect x="949" y="110" width="210" height="65" rx="12" fill="#0f172a" stroke="#fb923c" stroke-width="2"/>
+<text x="1054.0" y="140" class="label" text-anchor="middle">Reviewer</text>
+<path d="M145 220L448 220" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+<text x="296.5" y="208" class="sub" text-anchor="middle">1. Create task + review dependency</text>
+<path d="M145 285L751 285" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+<text x="448.0" y="273" class="sub" text-anchor="middle">2. Start permitted assignment</text>
+<path d="M145 350L751 350" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+<text x="448.0" y="338" class="sub" text-anchor="middle">3. Send guidance while running</text>
+<path d="M751 415L145 415" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)" stroke-dasharray="7 5"/>
+<text x="448.0" y="403" class="sub" text-anchor="middle">4. Return result + run receipt</text>
+<path d="M145 480L448 480" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+<text x="296.5" y="468" class="sub" text-anchor="middle">5. Submit result for review</text>
+<path d="M448 545L1054 545" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+<text x="751.0" y="533" class="sub" text-anchor="middle">6. Review becomes eligible</text>
+<path d="M1054 610L145 610" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)" stroke-dasharray="7 5"/>
+<text x="599.5" y="598" class="sub" text-anchor="middle">7. Request correction</text>
+<path d="M145 675L751 675" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+<text x="448.0" y="663" class="sub" text-anchor="middle">8. Follow up with retained context</text>
+<path d="M751 740L1054 740" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)" stroke-dasharray="7 5"/>
+<text x="902.5" y="728" class="sub" text-anchor="middle">9. Provide revised result</text>
+<path d="M1054 805L448 805" stroke="#94a3b8" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+<text x="751.0" y="793" class="sub" text-anchor="middle">10. Record review acceptance</text>
+<rect x="95" y="850" width="1010" height="75" rx="12" fill="#0f172a" stroke="#fb7185" stroke-width="2"/>
+<text x="600.0" y="880" class="label" text-anchor="middle">Restart rule</text>
+<text x="600.0" y="907" class="sub" text-anchor="middle">Restore recorded work; pause for uncertain effects instead of replaying.</text>
+</svg>


### PR DESCRIPTION
## Summary

Hermes parents currently need the delegation tool's vocabulary even when a model is accustomed to another harness. This adds user-selected Hermes, Codex-style and Claude-style interfaces over the same retained-worker service. A parent can discover profiles, spawn workers, send guidance, queue a separate follow-up, inspect/wait, interrupt one run, cancel owned descendants, and acknowledge or reconcile results without changing the selected worker route or authority.

This is **increment 1** of the sequenced orchestration work. It depends on the retained-worker implementation in #106268. Shared discovery across Bots/rooms/Kanban, integrated teams and saved workflows remain subsequent increments. No vendor backend, model family, rollout or merge is imposed.

## Dependency and review scope

The candidate includes #106268's worker implementation because it has not landed on upstream main. The increment-specific code starts at `6d4591199c54af8b2eebf46d20381ce42387e981`, on integration base `b91851555088df99ebbc6f1ef6489ec53a135137` (worker PR plus upstream main `bf53ff00a7360826ec2c9e2949533160068a8fc8`). Review the [increment-only comparison](https://github.com/100yenadmin/hermes-agent-for-upstream-PR-only/compare/b91851555088df99ebbc6f1ef6489ec53a135137...cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071) for the new surface. Original worker review and evidence retain their original source identities and budgets.

Current PR head: `ea277cf142d8ac3b5833e8a4b6d967bea2fde655` (documentation and preserved pilot reports only after the reviewed/runtime-tested source `cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071`).

**Current gate: runtime source review and hosted CI passed; complete qualification evidence remains separate.** A 295-line correction addressed the initial capability-alias, retained-interface, run-interruption, scheduling and configuration-category failures. A further 94-line correction ensures queued guidance cannot count as delivery to a running worker. The same independent reviewer verified the fixes across two targeted passes. The pilot includes five samples: Luna passed 2/4 canonical and 3/4 in each style; Astra passed 4/4 canonical and 3/4 Codex-style. The production qualification registry remains empty.

## What the orchestrator gains

| Capability | This increment |
| --- | --- |
| User-controlled interface | `orchestration.interface: auto`, `hermes`, `codex` or `claude` |
| Provider-independent workers | Styles retain configured profiles, provider/model selection and permitted effort overrides |
| Familiar tool vocabulary | Thin semantic translation into `AIAgent._dispatch_delegate_task` and the shared lifecycle service |
| Guidance versus another assignment | A message does not wake an idle worker; a follow-up queues a linked run |
| Distinct stop operations | Exact-run interruption stays separate from descendant-tree cancellation |
| Completion and recovery controls | Each style exposes acknowledgments and uncertainty reconciliation |
| Existing tool compatibility | Session-bound aliases preserve unrelated native/MCP tools when names collide |
| Truthful evidence | Interface/version/alias/operation receipts remain separate from requested, resolved and transmitted execution routes |
| Automatic selection | Exact qualified match, otherwise Hermes; production qualification registry remains empty pending live evidence |

For example, an existing native `send_message` retains its meaning. The Codex-style worker operation receives a collision-free name such as `hermes_worker_send_message`. The same frozen binding governs schemas, native dispatch, execute-code/MCP paths and permission checks.

Familiar names do not mean native Codex or Claude execution. Unsupported parent-transcript forking and graceful process shutdown fail visibly. Instructions do not grant permissions, and changing an interface cannot widen delegation or tool limits.

## Illustrated explanation

![Orchestration service boundaries](https://raw.githubusercontent.com/100yenadmin/hermes-agent-for-upstream-PR-only/4b7d84355b02e828619daea620107bdbe5ad6057/website/static/img/worker-orchestration/service-map.svg)

The illustration shows the complete sequence; dashed shared-discovery/team connections remain planned. This PR implements the model-facing worker adapter layer only.

- [Interface guide with plain-English examples](https://github.com/100yenadmin/hermes-agent-for-upstream-PR-only/blob/4b7d84355b02e828619daea620107bdbe5ad6057/website/docs/user-guide/features/orchestration-interfaces.md)
- [Grouped Codex / Claude Code / OpenClaw / Hermes capability chart](https://github.com/100yenadmin/hermes-agent-for-upstream-PR-only/blob/4b7d84355b02e828619daea620107bdbe5ad6057/website/docs/user-guide/features/orchestration-capability-comparison.md)
- [Architecture and ownership contracts](https://github.com/100yenadmin/hermes-agent-for-upstream-PR-only/blob/4b7d84355b02e828619daea620107bdbe5ad6057/website/docs/developer-guide/worker-orchestration.md)

The documentation/evidence-only head also passed [CI](https://github.com/NousResearch/hermes-agent/actions/runs/34362613458), [Docker](https://github.com/NousResearch/hermes-agent/actions/runs/34362612154) and [Nix](https://github.com/NousResearch/hermes-agent/actions/runs/34362612084). No runtime source changed after the live-tested candidate.

## Controlled live pilot

[Full plain-English pilot report](https://github.com/100yenadmin/hermes-agent-for-upstream-PR-only/blob/ea277cf142d8ac3b5833e8a4b6d967bea2fde655/website/docs/user-guide/features/orchestration-interface-pilot.md) and [preserved sanitized receipts](https://github.com/100yenadmin/hermes-agent-for-upstream-PR-only/blob/ea277cf142d8ac3b5833e8a4b6d967bea2fde655/website/static/evidence/orchestration-interface-pilot-cbb02042.json) record all five samples, including failures. Astra canonical passed all four scenarios; neither styled sample passed every scenario. The runner checks provider/model receipt agreement but these reports omit transmitted effort values, complete billed cost and corrective-turn counts. A four-scenario pass alone does not enable automatic selection.

## Validation and remaining evidence

- Runtime adapter at `6d4591199c54af8b2eebf46d20381ce42387e981`: focused interface/admission/store suite — **21 passed, 0 failed** using real temporary Hermes homes and stores. One initial projection/fixture failure was corrected before passing runs.
- Qualification runner at `f6f1e3b69d535472c186c3cfb90363d94178c78d`: focused fake-transport receipt test — **2 passed, 0 failed**. Includes timeout preservation and sanitized controller failures.
- Current candidate `cbb0204203e6c43900cb4fa8c4f6d8b7cd40a071`: **3 focused qualification-runner tests passed**, zero failures. Independent semantic coverage is **PASS** through the initial review and two relevant delta passes. [CI](https://github.com/NousResearch/hermes-agent/actions/runs/34342527658), [Docker](https://github.com/NousResearch/hermes-agent/actions/runs/34342526804) and [Nix](https://github.com/NousResearch/hermes-agent/actions/runs/34342526878) passed for this source.
- Prior correction at `2fdd34b0d47a19761900e930615e25d8f000ff21`: **25 worker/interface/runner tests passed** and **188 configuration UI tests passed**, zero failures. [CI](https://github.com/NousResearch/hermes-agent/actions/runs/34341935979), [Docker](https://github.com/NousResearch/hermes-agent/actions/runs/34341935169) and [Nix](https://github.com/NousResearch/hermes-agent/actions/runs/34341935130) all passed for that source.
- Historical first combined candidate `4b7d84355b02e828619daea620107bdbe5ad6057`: [hosted CI](https://github.com/NousResearch/hermes-agent/actions/runs/34340367762/job/102429545799) reported **46,486 passed, 1 failed, 443 skipped**; the failure was the single-field configuration category invariant. Initial independent semantic review was **BLOCKED** on the four issues above. Docker and Nix passed for that earlier source; they do not validate the correction.
- Opt-in live runner defines four bounded scenarios per interface: two-provider retained workflow, invalid profile denial, foreign-worker denial, and idle guidance followed by an explicit new turn. It imports the recorded candidate, uses temporary Hermes homes and emits allowlisted receipts.
- Canonical live sample on this candidate: OpenAI-Codex `gpt-5.6-luna` parent at `low`, with OpenAI-Codex/Luna `xhigh` and ZAI/GLM-5.3 `high` workers. **2 of 4 scenarios passed**: invalid-profile and foreign-owner denial. The two-provider case lacked running guidance, a qualifying retained assignment, and complete acknowledgments. The idle case retained both labels but lacked the required acknowledgment evidence. Route agreement passed where worker requests occurred; observed unauthorized actions and duplicate owned executions were zero. This sample leaves the model/interface **unqualified**; it is not a statistical comparison.
- **No automatic live qualification claimed yet.** A historical attempt on the earlier candidate was stopped after the runner scheduling defect was verified; that attempt is invalid evidence. Automatic registry entries require all four live scenarios for the tested model/profile and interface version. Missing accounts remain explicit gaps; explicit unqualified styles remain experimental.

This is source/fixture evidence for an upstream draft. It does not establish installation, release, customer readiness, vendor-runtime parity or universal superiority.
