### PR TITLE
fix(kanban): resolve completion references across boards

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2496,11 +2496,65 @@ def _verify_created_cards(
 _TASK_ID_PROSE_RE = re.compile(r"\bt_[a-f0-9]{8,}\b")
 
 
+def _iter_cross_board_db_paths() -> Iterable[Path]:
+    """Yield configured active and archived board databases below Kanban roots."""
+    root = boards_root().resolve(strict=False)
+    archive_root = root / "_archived"
+
+    for meta in list_boards(include_archived=True):
+        slug = meta["slug"]
+        if slug == DEFAULT_BOARD:
+            path = kanban_home() / "kanban.db"
+        else:
+            path = board_dir(slug) / "kanban.db"
+            try:
+                path.resolve().relative_to(root)
+            except (OSError, ValueError):
+                continue
+        if path.is_file():
+            yield path
+
+    if not archive_root.is_dir():
+        return
+    for board_archive in archive_root.iterdir():
+        path = board_archive / "kanban.db"
+        if not board_archive.is_dir() or not path.is_file():
+            continue
+        try:
+            path.resolve().relative_to(archive_root.resolve())
+        except (OSError, ValueError):
+            continue
+        yield path
+
+
+def _read_task_ids_read_only(path: Path, task_ids: Iterable[str]) -> list[str]:
+    """Return task ids missing from a board without mutating its database."""
+    task_ids = list(task_ids)
+    if not task_ids:
+        return []
+    uri = f"{path.resolve().as_uri()}?mode=ro"
+    other_conn = sqlite3.connect(uri, uri=True)
+    try:
+        placeholders = ",".join("?" * len(task_ids))
+        rows = other_conn.execute(
+            f"SELECT id FROM tasks WHERE id IN ({placeholders})", task_ids,
+        ).fetchall()
+        present = {row[0] for row in rows}
+        return [task_id for task_id in task_ids if task_id not in present]
+    finally:
+        other_conn.close()
+
+
 def _scan_prose_for_phantom_ids(conn: sqlite3.Connection, text: str) -> list[str]:
     """``t_<hex>`` references in ``text`` that don't resolve to a task (deduped; advisory)."""
     if not text:
         return []
-    return _missing_task_ids(conn, dict.fromkeys(_TASK_ID_PROSE_RE.findall(text)))
+    missing = _missing_task_ids(conn, dict.fromkeys(_TASK_ID_PROSE_RE.findall(text)))
+    for path in _iter_cross_board_db_paths():
+        if not missing:
+            break
+        missing = _read_task_ids_read_only(path, missing)
+    return missing
 
 
 class HallucinatedCardsError(ValueError):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sqlite3
 import subprocess
 import threading
 import time
@@ -1269,6 +1270,64 @@ def test_complete_prose_scan_ignores_archived_cross_board_ids(kanban_home):
             )
         ]
         assert "suspected_hallucinated_references" not in kinds
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("placement", ["active", "archived"])
+def test_complete_prose_scan_ignores_cross_board_db_symlink_outside_kanban_root(
+    kanban_home, tmp_path, placement,
+):
+    """Cross-board lookup must not follow active or archived DB symlinks out of root."""
+    outside_db = tmp_path / "outside" / "kanban.db"
+    outside_db.parent.mkdir()
+    outside_conn = kbc.connect(outside_db)
+    try:
+        outside_task = kb.create_task(outside_conn, title="outside", assignee="x")
+    finally:
+        outside_conn.close()
+
+    root = kb.boards_root()
+    if placement == "active":
+        root.mkdir(parents=True, exist_ok=True)
+        link = root / "outside-board"
+    else:
+        link = root / "_archived" / "outside-board"
+        link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(outside_db.parent, target_is_directory=True)
+    assert link.is_dir()
+    assert (link / "kanban.db").is_file()
+
+    conn = kbc.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="x")
+
+        assert kb.complete_task(conn, parent, summary=f"depended on {outside_task}") is True
+        payloads = [
+            json.loads(row["payload"])
+            for row in conn.execute(
+                "SELECT payload FROM task_events WHERE task_id=? "
+                "AND kind='suspected_hallucinated_references' ORDER BY id",
+                (parent,),
+            )
+        ]
+        assert payloads == [{
+            "phantom_refs": [outside_task],
+            "source": "completion_summary",
+        }]
+    finally:
+        conn.close()
+
+
+def test_cross_board_corrupt_in_root_db_error_propagates(kanban_home):
+    """A corrupt discovered board is an error, not an absent cross-board source."""
+    kb.create_board("corrupt-board")
+    (kb.board_dir("corrupt-board") / "kanban.db").write_bytes(b"not a sqlite database")
+
+    conn = kbc.connect()
+    try:
+        with pytest.raises(sqlite3.DatabaseError, match="file is not a database"):
+            kb._scan_prose_for_phantom_ids(conn, "referenced t_abcd1234ffff")
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1198,6 +1198,79 @@ def test_complete_can_retry_after_phantom_rejection(kanban_home):
         conn.close()
 
 
+def test_complete_prose_scan_flags_nonexistent_ids(kanban_home):
+    """Unknown task ids remain advisory diagnostics after cross-board lookup."""
+    conn = kbc.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="x")
+        assert kb.complete_task(
+            conn, parent, summary="also saw t_abcd1234ffff failing in CI",
+        ) is True
+        events = list(conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id=? ORDER BY id",
+            (parent,),
+        ))
+        payloads = [
+            json.loads(row["payload"])
+            for row in events
+            if row["kind"] == "suspected_hallucinated_references"
+        ]
+        assert payloads == [{
+            "phantom_refs": ["t_abcd1234ffff"],
+            "source": "completion_summary",
+        }]
+    finally:
+        conn.close()
+
+
+def test_complete_prose_scan_ignores_cross_board_ids(kanban_home):
+    """Summaries may link valid handoffs stored on another active board."""
+    kb.create_board("other-board")
+    other_conn = kb.connect(board="other-board")
+    conn = kb.connect()
+    try:
+        other = kb.create_task(other_conn, title="other", assignee="x")
+        parent = kb.create_task(conn, title="parent", assignee="x")
+
+        assert kb.complete_task(conn, parent, summary=f"depended on {other}") is True
+        kinds = [
+            row["kind"]
+            for row in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id=? ORDER BY id",
+                (parent,),
+            )
+        ]
+        assert "suspected_hallucinated_references" not in kinds
+    finally:
+        other_conn.close()
+        conn.close()
+
+
+def test_complete_prose_scan_ignores_archived_cross_board_ids(kanban_home):
+    """Archived boards remain valid sources for historical handoff ids."""
+    kb.create_board("historic-board")
+    historic_conn = kb.connect(board="historic-board")
+    try:
+        historic = kb.create_task(historic_conn, title="historic", assignee="x")
+    finally:
+        historic_conn.close()
+    kb.remove_board("historic-board")
+
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="x")
+
+        assert kb.complete_task(conn, parent, summary=f"depended on {historic}") is True
+        kinds = [
+            row["kind"]
+            for row in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id=? ORDER BY id",
+                (parent,),
+            )
+        ]
+        assert "suspected_hallucinated_references" not in kinds
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Hermes Kanban stores each board in a separate SQLite database, but completion-summary validation currently checks referenced task IDs only against the current board. Valid references to tasks on another active or archived board are therefore incorrectly reported as `suspected_hallucinated_references`.

This change resolves otherwise-missing task IDs against the configured active and archived board databases before classifying them as phantom references.

Cross-board databases are opened read-only. Discovery remains bounded to the configured Kanban roots, paths resolving outside those roots are ignored, and errors from corrupt in-root databases are propagated instead of being silently treated as missing tasks. Genuinely unknown task IDs continue to produce the existing advisory diagnostic.

No schema change, database mutation, cross-board linking, or new public interface is introduced.

## Related Issue

No matching issue or PR was found after searching the repository.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Discover configured active and archived Kanban databases.
  - Resolve missing completion-summary task IDs across those databases.
  - Open cross-board databases in read-only mode.
  - Ignore active and archived board paths resolving outside the configured roots.
  - Preserve errors from corrupt in-root databases.

- `tests/hermes_cli/test_kanban_core_functionality.py`
  - Verify valid active cross-board references are accepted.
  - Verify valid archived-board references are accepted.
  - Verify genuinely unknown IDs still produce a diagnostic.
  - Verify active and archived symlink escapes are ignored.
  - Verify corrupt in-root databases propagate their SQLite error.

## How to Test

1. Run the focused regression coverage:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py -q
```

2. Verify that completion summaries referencing tasks from the same board, another active board, and an archived board do not produce suspected_hallucinated_references.

3. Verify that an unknown task ID still produces the diagnostic, escaping board-directory symlinks are ignored, and a corrupt in-root board database raises its SQLite error.

Additional checks:

```bash
python -m compileall -q hermes_cli/kanban_db.py
git diff --check
```

Observed results:

- 6 focused cross-board and safety tests passed.
- All 30 tests in tests/hermes_cli/test_kanban_core_functionality.py passed.
- compileall passed.
- git diff --check passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(kanban):, test(kanban):)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run pytest tests/ -q and all tests pass — the focused Kanban suite passed; full-suite verification is left to upstream CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux 6.12, x86_64, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; no user-facing interface or configuration changed
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A; no config keys changed
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — implementation uses pathlib and SQLite URI read-only mode; no platform-specific runtime code was added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

Not applicable. This is a backend diagnostic fix with automated regression coverage.