### PR TITLE
OpenCode Go screenshots no longer kill the session on HTTP 422 (#104731, #89057, salvage #104734 #47026)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -169,7 +169,8 @@ _IMAGE_CORRUPT_PATTERNS = (
 _MULTIMODAL_TOOL_CONTENT_PATTERNS = (
     "text is not set", "tool message content must be a string", "tool content must be a string",
     "tool message must be a string", "expected string, got list", "expected string, got array",
-    "tool_call.content must be string",
+    "tool_call.content must be string", "tool.content.str", "tool.content",
+    "input should be a valid string",
 )
 
 # Local-inference memory/resource-ceiling rejections (oMLX/MLX memory guard,
@@ -763,6 +764,7 @@ def _classify_400(c: _Ctx) -> Verdict:
 _STATUS_HANDLERS: Dict[int, Callable[[_Ctx], Verdict]] = {
     400: _classify_400, 401: lambda c: _V_AUTH_ROTATE, 402: lambda c: _classify_402(c.msg, dict),
     403: _status_403, 404: _status_404, 408: lambda c: _V_TIMEOUT, 413: lambda c: _V_PAYLOAD_TOO_LARGE,
+    422: lambda c: _first_match(c.msg, _IMAGE_TOOL_RULES) or _V_FORMAT_ERROR,
     429: _status_429, 500: _status_5xx, 502: _status_5xx,
     503: lambda c: _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_OVERLOADED,
     529: lambda c: _first_match(c.msg, _OVERFLOW_AS_5XX_RULES) or _V_OVERLOADED,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -169,8 +169,8 @@ _IMAGE_CORRUPT_PATTERNS = (
 _MULTIMODAL_TOOL_CONTENT_PATTERNS = (
     "text is not set", "tool message content must be a string", "tool content must be a string",
     "tool message must be a string", "expected string, got list", "expected string, got array",
-    "tool_call.content must be string", "tool.content.str", "tool.content",
-    "input should be a valid string",
+    # Console Go / pydantic-v2 relays behind opencode-go (422, param ``messages.N.tool.content.str``, #104731).
+    "tool_call.content must be string", "tool.content.str", "input should be a valid string",
 )
 
 # Local-inference memory/resource-ceiling rejections (oMLX/MLX memory guard,

--- a/contributors/emails/ycl_pj@163.com
+++ b/contributors/emails/ycl_pj@163.com
@@ -1,0 +1,2 @@
+yuanchenglu
+# PR #47026 salvage

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -115,6 +115,11 @@ opencode_go = OpenCodeGoProfile(
     name="opencode-go", aliases=("opencode_go", "go", "opencode-go-sub"), env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1", default_headers=dict(_ATTRIBUTION_HEADERS),
     default_aux_model="glm-5",
+    # opencode-go proxies to Xiaomi MiMo for mimo-* models; MiMo rejects
+    # list-type tool content with "text is not set" (400).  The direct
+    # xiaomi profile already sets supports_vision_tool_messages=False;
+    # propagate the same safety here for the relay path.
+    supports_vision_tool_messages=False,
 )
 
 register_provider(opencode_zen)

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -115,10 +115,11 @@ opencode_go = OpenCodeGoProfile(
     name="opencode-go", aliases=("opencode_go", "go", "opencode-go-sub"), env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1", default_headers=dict(_ATTRIBUTION_HEADERS),
     default_aux_model="glm-5",
-    # opencode-go proxies to Xiaomi MiMo for mimo-* models; MiMo rejects
-    # list-type tool content with "text is not set" (400).  The direct
-    # xiaomi profile already sets supports_vision_tool_messages=False;
-    # propagate the same safety here for the relay path.
+    # The Go relay's upstream validates tool content as a strict string: list-type tool
+    # content (native vision embeds) 422s with ``messages.N.tool.content.str Input should
+    # be a valid string`` (Console Go, #104731) or 400s ``text is not set`` (MiMo, #47026),
+    # and the rejected row stays in history so every later call dies too. Images in user
+    # messages are fine, so vision itself keeps working via the text-summary downgrade.
     supports_vision_tool_messages=False,
 )
 

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -253,3 +253,12 @@ class TestOpenCodeGoFullKwargsIntegration:
         )
         assert "extra_body" not in kwargs
         assert kwargs["reasoning_effort"] == "high"
+
+
+class TestOpenCodeGoVisionToolMessages:
+    """OpenCode Go provider profile declares supports_vision_tool_messages=False (#104731)."""
+
+    def test_supports_vision_true_and_tool_messages_false(self, opencode_go_profile):
+        assert opencode_go_profile.supports_vision is True
+        assert opencode_go_profile.supports_vision_tool_messages is False
+

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -254,11 +254,3 @@ class TestOpenCodeGoFullKwargsIntegration:
         assert "extra_body" not in kwargs
         assert kwargs["reasoning_effort"] == "high"
 
-
-class TestOpenCodeGoVisionToolMessages:
-    """OpenCode Go provider profile declares supports_vision_tool_messages=False (#104731)."""
-
-    def test_supports_vision_true_and_tool_messages_false(self, opencode_go_profile):
-        assert opencode_go_profile.supports_vision is True
-        assert opencode_go_profile.supports_vision_tool_messages is False
-

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -196,3 +196,42 @@ class TestRecoveryEndToEndClassification:
         )
         result = classify_api_error(err, provider="alibaba", model="qwen3.5-plus")
         assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+
+    def test_opencode_go_422_console_go_classifies(self):
+        """Regression test for #104731: Console Go relay HTTP 422 on list-type tool content."""
+        err = _FakeApiError(
+            status_code=422,
+            message=(
+                "Error code: 422 - {'error': {'param': 'messages.67.tool.content.str', "
+                "'type': 'invalid_request_error', 'message': 'Error from provider (Console Go): "
+                "Upstream request failed: [invalid_request_error] Input should be a valid string'}}"
+            ),
+        )
+        result = classify_api_error(err, provider="opencode-go", model="deepseek-v4-flash-vision-exp")
+        assert result.reason == FailoverReason.multimodal_tool_content_unsupported
+        assert result.retryable is True
+
+
+class TestOpenCodeGoProactiveToolResultDowngrade:
+    def _multimodal_result(self, png_b64: str = "iVBORw0KGgoAAAA"):
+        return {
+            "_multimodal": True,
+            "content": [
+                {"type": "text", "text": "detected 2 objects"},
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{png_b64}"}},
+            ],
+            "text_summary": "detected 2 objects",
+            "meta": {"png_bytes": 1024},
+        }
+
+    def test_returns_text_summary_for_opencode_go_proactively(self, monkeypatch):
+        """OpenCode Go rejects list-type tool content, so _tool_result_content_for_active_model
+        should proactively downgrade to a text summary (#104731)."""
+        agent = _make_agent(provider="opencode-go", model="deepseek-v4-flash-vision-exp")
+        agent._no_list_tool_content_models = set()
+        monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+        out = agent._tool_result_content_for_active_model("vision_analyze", self._multimodal_result())
+        assert isinstance(out, str)
+        assert "data:image" not in out
+        assert "image_url" not in out
+


### PR DESCRIPTION
Screenshots no longer permanently kill an OpenCode Go session: the relay's `HTTP 422 Input should be a valid string` on list-type tool content is now prevented up front and recovered from if it still arrives.

Salvages #104734 (@ericmaddox) and #47026 (@yuanchenglu) onto current main, with credit; supersedes #73027, #104736, #48121, #81955 (see below).

## Symptom

Desktop / CLI session on `opencode-go` (glm-5.3-flash, mimo, deepseek-vision…) runs `computer_use` or `vision_analyze`. The native-vision fast path puts the screenshot as an `image_url` part inside the **tool** message. Console Go validates tool content as a strict string and answers:

```
HTTP 422 {'param': 'messages.87.tool.content.str', 'type': 'invalid_request_error',
 'message': 'Error from provider (Console Go): Upstream request failed: [invalid_request_error] Input should be a valid string'}
```

422 had no `_STATUS_HANDLERS` entry → generic `format_error`, non-retryable → turn aborts. The rejected tool row is already persisted, so **every later message in that session** hits the same 422 (diagnostics bundle `943db196`: 21 identical failures across 2 sessions, `messages.87` and `messages.1238`, until the user gave up). Reported in #104731, #89057 (same relay, 500 variant), #72905 (unclassified 422).

## Change

- `plugins/model-providers/opencode-zen/__init__.py` — `opencode_go` profile declares `supports_vision_tool_messages=False`. Same veto shape as the xiaomi profile: `_supports_media_in_tool_results` keeps the native fast path closed for the relay and `_tool_result_content_for_active_model` emits the text summary, so the bad row never enters history. Images in user messages are unaffected (that is how aux vision talks to the relay already).
- `agent/error_classifier.py` — `422: _first_match(c.msg, _IMAGE_TOOL_RULES) or _V_FORMAT_ERROR` in `_STATUS_HANDLERS`, and `_MULTIMODAL_TOOL_CONTENT_PATTERNS` gains `"tool.content.str"` and `"input should be a valid string"`. A session that already carries a poisoned row (existing users, other strict relays) now takes the existing one-shot strip-and-retry in `turn_recovery.recover_after_classification` instead of dying.
- Tests: 2 invariants (classifier verdict on the exact Console Go body; proactive downgrade for opencode-go). The profile-flag snapshot test and the bare `"tool.content"` pattern from #104734 were dropped in the trim commit.

Root cause in one sentence: the relay accepts images only in user messages, and we had neither a profile veto nor a 422 classification for its rejection.

## Validation

Probe `/tmp/oc_probe.py` (exact 422 body from the bundle → `classify_api_error` → `recover_after_classification`; plus the tool-result builder):

| | origin/main `bf53ff00a73` | this branch |
|---|---|---|
| classify | `format_error`, retryable=False | `multimodal_tool_content_unsupported`, retryable=True |
| recovery | retry_now=False, tool.content stays `list` | retry_now=True, tool.content downgraded to `str` |
| proactive tool result | `list` (image part sent) | `str` (text summary) |

`scripts/run_tests.sh tests/agent/test_error_classifier.py tests/run_agent/test_multimodal_tool_content_recovery.py tests/run_agent/test_vision_tool_messages.py tests/tools/test_vision_native_fast_path.py tests/plugins/model_providers/ tests/run_agent/test_413_compression.py` → 18 files, 454 passed, 0 failed.

Not done live against opencode.ai (no Go key on this machine); the wire shape is the one from the user's bundle.

## Cluster

- #104734 @ericmaddox — cherry-picked (classifier 422 + profile flag + tests), trimmed.
- #47026 @yuanchenglu — cherry-picked (profile flag, earliest). The earlier sweeper objection ("scope to mimo-*") no longer holds: Console Go rejects list tool content for glm and deepseek-vision routes too, so the flag is provider-wide by nature.
- #73027 @JonthanaHanh — same 422 mechanism, older classifier layout; superseded. Its extra `chatcompletionrequesttoolmessagecontent` (Morph) pattern is not included (no reproduction in hand).
- #104736 @liuhao1024, #48121 — identical flag flip; superseded.
- #81955 @Koliham — relocates images into a synthetic user message mid-loop; rejected direction (AGENTS.md: never inject a synthetic user message mid-loop).

Fixes #104731. Fixes #89057. Closes #72905 (the 422 half; DeepInfra wording `input should be a valid string` is covered).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa9b86e/90hK63sm4QyEVujvzmLeO_SJodqEqx.png)
