### PR TITLE
feat(plugins): bind slash commands to session context

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -753,10 +753,27 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
     # Plugin hook: on_session_start — fired once for a brand-new session, not on continuation.
     try:
+        from agent.agent_runtime_helpers import invoke_tool
+        from agent.runtime_cwd import resolve_agent_cwd
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+        from hermes_cli.plugin_invocation import PluginInvocation
+        _session_cwd = resolve_agent_cwd()
+
+        def _dispatch_plugin_tool(name, args):
+            return invoke_tool(agent, name, args, agent.session_id or "")
+
+        _plugin_invocation = PluginInvocation(
+            session_id=str(agent.session_id or ""), surface=str(getattr(agent, "platform", "") or "agent"),
+            platform=str(getattr(agent, "platform", "") or ""), cwd=_session_cwd, workspace=_session_cwd,
+            tool_names=frozenset(getattr(agent, "valid_tool_names", ()) or ()), authorized=True,
+            _dispatch=_dispatch_plugin_tool,
+        )
         _invoke_hook(
             "on_session_start", session_id=agent.session_id, model=agent.model,
             platform=getattr(agent, "platform", None) or "",
+            cwd=str(_session_cwd), workspace=str(_session_cwd),
+            tool_names=sorted(getattr(agent, "valid_tool_names", ()) or ()),
+            invocation=_plugin_invocation,
         )
     except Exception as exc:
         logger.warning("on_session_start hook failed: %s", exc)

--- a/cli.py
+++ b/cli.py
@@ -3297,13 +3297,34 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         return True
 
     def _run_plugin_slash_command(self, base_cmd: str, user_args: str) -> None:
-        from hermes_cli.plugins import get_plugin_command_handler, resolve_plugin_command_result
+        from hermes_cli.plugin_invocation import PluginInvocation
+        from hermes_cli.plugins import (
+            call_plugin_command_handler, get_plugin_command_handler, resolve_plugin_command_result,
+        )
 
         plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
         if not plugin_handler:
             return
         try:
-            result = resolve_plugin_command_result(plugin_handler(user_args))
+            agent = getattr(self, "agent", None)
+            tool_names = frozenset(getattr(agent, "valid_tool_names", ()) or ())
+
+            def _dispatch(name, args):
+                if agent is None:
+                    raise RuntimeError("No active session agent is available")
+                from agent.agent_runtime_helpers import invoke_tool
+                return invoke_tool(agent, name, args, self.session_id)
+
+            result = resolve_plugin_command_result(call_plugin_command_handler(
+                plugin_handler, user_args,
+                invocation=PluginInvocation(
+                    session_id=str(getattr(self, "session_id", "") or ""),
+                    session_key=str(getattr(self, "session_id", "") or ""),
+                    surface="cli", platform="cli",
+                    cwd=Path.cwd(), workspace=Path.cwd(), tool_names=tool_names,
+                    authorized=agent is not None, _dispatch=_dispatch if agent is not None else None,
+                ),
+            ))
             if result:
                 _cprint(str(result))
         except Exception as e:

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -945,6 +945,77 @@ class GatewayInboundMixin:
         except Exception as e:
             return f"Quick command error: {e}"
 
+    def _plugin_command_invocation(self, source: Optional[SessionSource]) -> Any:
+        """Immutable PluginInvocation bound to the gateway session of *source*.
+
+        Tool dispatch is only possible when the session has a usable agent (running or
+        cached) — never resolved from process-global state. A session with no agent
+        yields an empty, fail-closed context; legacy handlers (which ignore the
+        context) still run.
+        """
+        from pathlib import Path
+
+        from agent.runtime_cwd import scope_terminal_cwd
+        from hermes_cli.plugin_invocation import PluginInvocation
+
+        quick_key = ""
+        if source is not None:
+            try:
+                quick_key = str(self._session_key_for_source(source) or "")
+            except Exception:
+                quick_key = ""
+        agent = None
+        if quick_key:
+            try:
+                agent = self._resident_agent_for(quick_key)
+            except Exception:
+                agent = None
+
+        def _dispatch(name, args):
+            if agent is None:
+                raise RuntimeError("No session agent is available to run tools")
+            from agent.agent_runtime_helpers import invoke_tool
+            from tools.approval_context import reset_current_session_key, set_current_session_key
+            token = None
+            if quick_key:
+                try:  # approvals route to this chat only inside agent turns; bind explicitly (#review pattern)
+                    token = set_current_session_key(quick_key)
+                except Exception:
+                    token = None
+            try:
+                # Task id mirrors the identity the agent loop uses for terminal/browser scoping.
+                task_id = getattr(agent, "session_id", "") or quick_key or ""
+                return invoke_tool(agent, name, args, task_id)
+            finally:
+                if token is not None:
+                    with suppress(Exception):
+                        reset_current_session_key(token)
+
+        cwd_raw = ""
+        try:
+            cwd_raw = (scope_terminal_cwd() or "").strip()
+        except Exception:
+            cwd_raw = ""
+        platform = ""
+        if source is not None:
+            try:
+                _pf = getattr(source, "platform", None)
+                platform = _pf.value if hasattr(_pf, "value") else (str(_pf) if _pf else "")
+            except Exception:
+                platform = ""
+        return PluginInvocation(
+            session_id=str(getattr(agent, "session_id", "") or ""),
+            session_key=quick_key,
+            surface="gateway",
+            platform=platform,
+            cwd=Path(cwd_raw) if cwd_raw else None,
+            workspace=None,
+            tool_names=(frozenset(getattr(agent, "valid_tool_names", ()) or ())
+                        if agent is not None else frozenset()),
+            authorized=agent is not None,
+            _dispatch=_dispatch if agent is not None else None,
+        )
+
     async def _hm_dispatch_quick_and_plugin_commands(
         self, event: "MessageEvent", source: SessionSource, command: Optional[str]
     ) -> Tuple[bool, Optional[str], Optional[str]]:
@@ -981,10 +1052,19 @@ class GatewayInboundMixin:
         # underscored autocomplete form matches plugin commands registered with hyphens.
         if command:
             try:
-                from hermes_cli.plugins import get_plugin_command_handler
+                from hermes_cli.plugins import call_plugin_command_handler, get_plugin_command_handler
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
-                    result = plugin_handler(event.get_command_args().strip())
+                    # Plugin commands are never in the registry, so the early gate never fires for
+                    # them; apply the same admin/user policy to the raw typed name here (mirrors the
+                    # quick-command gate above; #44727). The policy stays disabled until an operator
+                    # lists an admin for the scope, so existing installs see no behavior change.
+                    _denied = self._check_slash_access(source, command)
+                    if _denied is not None:
+                        return True, _denied, command
+                    invocation = self._plugin_command_invocation(source)
+                    result = call_plugin_command_handler(
+                        plugin_handler, event.get_command_args().strip(), invocation=invocation)
                     if asyncio.iscoroutine(result):
                         result = await result
                     return True, str(result) if result else None, command

--- a/hermes_cli/plugin_invocation.py
+++ b/hermes_cli/plugin_invocation.py
@@ -1,0 +1,71 @@
+"""Public, immutable per-dispatch context for native plugin slash commands.
+
+The object is constructed by a host surface (CLI, messaging gateway, TUI/Desktop
+backend) at dispatch time and never resolves a session from process-global state.
+Plugins receive provenance and may request a tool through the host-provided
+dispatcher; no live agent, gateway, or adapter object leaks through this API.
+
+``dispatch_tool`` is deliberately the only execution capability. Surfaces bind it
+to that session's canonical agent tool path (request/execution middleware, plugin
+pre/post tool hooks, edit/approval guards) — never a bare registry dispatch — and
+an absent context fails closed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, FrozenSet
+
+#: Host-supplied executor: ``fn(name, args) -> tool result`` (JSON string or dict).
+ToolDispatcher = Callable[[str, dict[str, Any]], str | dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class PluginInvocation:
+    """Immutable provenance and authority for one plugin slash-command call.
+
+    Fields are populated by the invoking surface:
+
+    - ``session_id`` / ``session_key``: the host session identity (empty when the
+      surface has no active session).
+    - ``surface``: ``"cli"``, ``"gateway"``, ``"tui"``, ``"desktop"``, ...
+    - ``platform``: the delivery platform (``"cli"``, ``"telegram"``, ...).
+    - ``cwd`` / ``workspace``: the session's resolved working directory and
+      workspace root, when the surface knows them (else ``None``).
+    - ``tool_names``: the effective tool set of the session's agent; a dispatch
+      to anything else is refused.
+    - ``authorized``: whether this context may execute tools at all.
+
+    ``dispatch_tool`` runs only when *authorized*, the tool is in ``tool_names``,
+    and the surface supplied a session-bound dispatcher; any missing piece raises
+    rather than silently degrading.
+    """
+
+    session_id: str = ""
+    session_key: str = ""
+    surface: str = ""
+    platform: str = ""
+    cwd: Path | None = None
+    workspace: Path | None = None
+    tool_names: FrozenSet[str] = frozenset()
+    authorized: bool = False
+    _dispatch: ToolDispatcher | None = field(default=None, repr=False, compare=False)
+
+    def dispatch_tool(self, name: str, args: dict[str, Any]) -> str | dict[str, Any]:
+        """Run one tool through the active session's normal tool path.
+
+        Raises ``PermissionError`` when this invocation is not authorized or the
+        tool is outside the session's effective tool set, ``RuntimeError`` when the
+        surface provided no session-bound dispatcher, and ``TypeError`` for
+        non-dict arguments. A dispatcher may raise whatever the underlying tool
+        path raises.
+        """
+        if not self.authorized:
+            raise PermissionError("Plugin command tool dispatch is not authorized in this session")
+        if self._dispatch is None:
+            raise RuntimeError("No session-bound tool dispatcher is available")
+        if name not in self.tool_names:
+            raise PermissionError(f"Tool {name!r} is not available in this session")
+        if not isinstance(args, dict):
+            raise TypeError("Tool arguments must be a dictionary")
+        return self._dispatch(name, args)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -655,7 +655,13 @@ class PluginContext:
     ) -> Optional[PluginRegistration]:
         """Register an in-session slash command (``/name``); handler ``fn(raw_args: str) -> str | None``
         (sync or async). ``args_hint`` (e.g. ``"<file>"``) lets adapters like Discord surface an argument
-        field; without it the command registers parameterless there but still accepts trailing text."""
+        field; without it the command registers parameterless there but still accepts trailing text.
+
+        Handlers may opt in to the per-dispatch invocation context by declaring a keyword-only
+        ``invocation`` parameter (or ``**kwargs``): the surface then passes an immutable
+        ``hermes_cli.plugin_invocation.PluginInvocation`` (session provenance + ``dispatch_tool``).
+        Legacy one-argument handlers keep their exact call contract — signature inspection decides,
+        so existing plugins are never called with unexpected arguments."""
         clean = name.lower().strip().lstrip("/").replace(" ", "-")
         if not clean:
             logger.warning("Plugin '%s' tried to register a command with an empty name.", self.manifest.name)
@@ -1975,6 +1981,24 @@ def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None
+
+
+def call_plugin_command_handler(handler: Callable, raw_args: str, *, invocation=None) -> Any:
+    """Call a plugin command without breaking legacy ``handler(raw_args)`` plugins.
+
+    A handler explicitly accepting an ``invocation`` keyword (or ``**kwargs``)
+    receives the immutable, surface-bound context.  Signature inspection keeps
+    older plugins on their exact one-argument call contract.
+    """
+    try:
+        parameters = inspect.signature(handler).parameters.values()
+        accepts_invocation = any(
+            parameter.name == "invocation" or parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters
+        )
+    except (TypeError, ValueError):
+        accepts_invocation = False
+    return handler(raw_args, invocation=invocation) if accepts_invocation else handler(raw_args)
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/tests/gateway/test_plugin_command_slash_access.py
+++ b/tests/gateway/test_plugin_command_slash_access.py
@@ -1,0 +1,208 @@
+"""Gateway plugin slash commands: slash-access gating + PluginInvocation context.
+
+Drives the real ``GatewayRunner._hm_dispatch_quick_and_plugin_commands`` sink
+(object.__new__ construction, same pattern as test_slash_access_dispatch.py) so
+the actual gate and the surface-side context builder are exercised.
+
+Coverage targets:
+  - Backward compat: no ``allow_admin_from`` for the scope → no gate, handler runs.
+  - Admin runs any plugin command.
+  - Non-admin denied unless the command is in ``user_allowed_commands``.
+  - Plugin commands receive an immutable gateway-bound PluginInvocation (surface,
+    platform, session identity); fresh sessions (no agent) fail closed.
+  - A session with a usable cached agent authorizes dispatch against the agent's
+    effective tool set, and dispatch outside that set is refused.
+  - Legacy one-argument handlers are still called with exactly one argument.
+"""
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.event import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source(
+    *,
+    platform: Platform = Platform.DISCORD,
+    user_id: str = "user1",
+    chat_type: str = "dm",
+    chat_id: str = "c1",
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name=f"name-{user_id}",
+        chat_type=chat_type,
+    )
+
+
+def _make_event(text: str, source: SessionSource) -> MessageEvent:
+    return MessageEvent(text=text, source=source, message_id="m1")
+
+
+def _make_runner(*, platform_extra: dict | None = None,
+                 platform: Platform = Platform.DISCORD):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra=platform_extra or {},
+            )
+        }
+    )
+    runner.adapters = {platform: SimpleNamespace(send=None)}
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_sources = {}
+    return runner
+
+
+@pytest.fixture
+def plugin_handler_patch(monkeypatch):
+    """Install a fake ``get_plugin_command_handler`` resolving name ``plug``."""
+
+    def install(fake):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_command_handler",
+            lambda name: fake if name == "plug" else None,
+        )
+
+    return install
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_denied_for_non_admin_when_gating_enabled(plugin_handler_patch):
+    runner = _make_runner(platform_extra={"allow_admin_from": ["admin1"]})
+    calls = []
+    plugin_handler_patch(lambda args: calls.append(args) or "should not run")
+    source = _make_source(user_id="user1")
+    handled, result, command = await runner._hm_dispatch_quick_and_plugin_commands(
+        _make_event("/plug go", source), source, "plug")
+    assert handled is True
+    assert command == "plug"
+    assert "admin-only" in (result or "")
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_allowed_for_admin(plugin_handler_patch):
+    runner = _make_runner(platform_extra={"allow_admin_from": ["admin1"]})
+    plugin_handler_patch(lambda args: f"ran:{args}")
+    source = _make_source(user_id="admin1")
+    handled, result, _command = await runner._hm_dispatch_quick_and_plugin_commands(
+        _make_event("/plug go", source), source, "plug")
+    assert handled is True
+    assert result == "ran:go"
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_allowed_for_non_admin_in_user_allowed_commands(plugin_handler_patch):
+    runner = _make_runner(platform_extra={
+        "allow_admin_from": ["admin1"], "user_allowed_commands": ["plug"]})
+    plugin_handler_patch(lambda args: f"ran:{args}")
+    source = _make_source(user_id="user1")
+    handled, result, _command = await runner._hm_dispatch_quick_and_plugin_commands(
+        _make_event("/plug go", source), source, "plug")
+    assert handled is True
+    assert result == "ran:go"
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_ungated_when_no_admin_listed(plugin_handler_patch):
+    # No allow_admin_from for the scope → policy disabled → exact pre-gate behavior.
+    runner = _make_runner(platform_extra={})
+    plugin_handler_patch(lambda args: f"ran:{args}")
+    source = _make_source(user_id="user1")
+    handled, result, _command = await runner._hm_dispatch_quick_and_plugin_commands(
+        _make_event("/plug go", source), source, "plug")
+    assert handled is True
+    assert result == "ran:go"
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_receives_gateway_invocation(plugin_handler_patch):
+    runner = _make_runner(platform_extra={"allow_admin_from": ["admin1"]})
+    source = _make_source(user_id="admin1", chat_type="dm", chat_id="c1")
+    received = {}
+
+    def context_aware(args, *, invocation=None):
+        received["args"] = args
+        received["invocation"] = invocation
+        return "context-ok"
+
+    plugin_handler_patch(context_aware)
+    handled, result, _command = await runner._hm_dispatch_quick_and_plugin_commands(
+        _make_event("/plug alpha", source), source, "plug")
+    assert handled is True
+    assert result == "context-ok"
+    assert received["args"] == "alpha"
+    invocation = received["invocation"]
+    assert invocation is not None
+    assert invocation.surface == "gateway"
+    assert invocation.platform == "discord"
+    assert invocation.session_key == runner._session_key_for_source(source)
+    assert invocation.authorized is False  # fresh session: no agent yet → fail closed
+    assert invocation.tool_names == frozenset()
+    with pytest.raises(PermissionError, match="not authorized"):
+        invocation.dispatch_tool("read_file", {"path": "x"})
+
+
+@pytest.mark.asyncio
+async def test_legacy_plugin_handler_keeps_exact_one_argument_contract(plugin_handler_patch):
+    runner = _make_runner(platform_extra={"allow_admin_from": ["admin1"]})
+    source = _make_source(user_id="admin1")
+    received = []
+
+    def legacy(args):
+        received.append(args)
+        return "legacy-ok"
+
+    plugin_handler_patch(legacy)
+    handled, result, _command = await runner._hm_dispatch_quick_and_plugin_commands(
+        _make_event("/plug beta", source), source, "plug")
+    assert handled is True
+    assert result == "legacy-ok"
+    assert received == ["beta"]
+
+
+class _FakeAgent:
+    session_id = "sess-9"
+    platform = "discord"
+    valid_tool_names = ["read_file", "terminal"]
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_invocation_authorized_with_cached_agent(plugin_handler_patch):
+    runner = _make_runner(platform_extra={"allow_admin_from": ["admin1"]})
+    source = _make_source(user_id="admin1")
+    quick_key = runner._session_key_for_source(source)
+    runner._agent_cache[quick_key] = (_FakeAgent(), "signature")
+    received = {}
+
+    def context_aware(args, *, invocation=None):
+        received["invocation"] = invocation
+        return "auth-ok"
+
+    plugin_handler_patch(context_aware)
+    handled, result, _command = await runner._hm_dispatch_quick_and_plugin_commands(
+        _make_event("/plug gamma", source), source, "plug")
+    assert handled is True
+    assert result == "auth-ok"
+    invocation = received["invocation"]
+    assert invocation.authorized is True
+    assert invocation.session_id == "sess-9"
+    assert invocation.tool_names == frozenset({"read_file", "terminal"})
+    # Dispatch outside the session's effective tool set refuses even when authorized.
+    with pytest.raises(PermissionError, match="not available"):
+        invocation.dispatch_tool("web_search", {"query": "x"})

--- a/tests/hermes_cli/test_plugin_invocation.py
+++ b/tests/hermes_cli/test_plugin_invocation.py
@@ -1,0 +1,107 @@
+"""Unit tests for the public PluginInvocation API (hermes_cli/plugin_invocation.py).
+
+Contracts under test:
+  - dispatch_tool fails closed: no authority, no session dispatcher, or a tool
+    outside the session's effective tool set are all refused before any execution.
+  - arguments must be a dict.
+  - the invocation is immutable and carries surface provenance untouched.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.plugin_invocation import PluginInvocation
+
+
+class TestPluginInvocationDispatchFailClosed:
+    def test_refuses_when_not_authorized(self):
+        invocation = PluginInvocation(
+            tool_names=frozenset({"read_file"}), authorized=False,
+            _dispatch=lambda name, args: "unreachable",
+        )
+        with pytest.raises(PermissionError, match="not authorized"):
+            invocation.dispatch_tool("read_file", {"path": "x"})
+
+    def test_refuses_without_session_dispatcher(self):
+        invocation = PluginInvocation(
+            tool_names=frozenset({"read_file"}), authorized=True, _dispatch=None,
+        )
+        with pytest.raises(RuntimeError, match="[Nn]o session-bound tool dispatcher"):
+            invocation.dispatch_tool("read_file", {"path": "x"})
+
+    def test_refuses_tool_outside_session_tool_set(self):
+        invocation = PluginInvocation(
+            tool_names=frozenset({"read_file"}), authorized=True,
+            _dispatch=lambda name, args: "unreachable",
+        )
+        with pytest.raises(PermissionError, match="not available"):
+            invocation.dispatch_tool("terminal", {"command": "whoami"})
+
+    def test_refuses_non_dict_arguments(self):
+        invocation = PluginInvocation(
+            tool_names=frozenset({"read_file"}), authorized=True,
+            _dispatch=lambda name, args: "unreachable",
+        )
+        with pytest.raises(TypeError, match="dictionary"):
+            invocation.dispatch_tool("read_file", ["not", "a", "dict"])
+
+    def test_empty_context_fails_closed_everywhere(self):
+        # A surface with no live session builds the default context: dispatch_tool
+        # must refuse through the authorization check before anything else.
+        invocation = PluginInvocation()
+        with pytest.raises(PermissionError, match="not authorized"):
+            invocation.dispatch_tool("read_file", {"path": "x"})
+
+
+class TestPluginInvocationDispatchHappyPath:
+    def test_dispatches_through_session_bound_executor(self):
+        seen = {}
+
+        def executor(name, args):
+            seen["name"] = name
+            seen["args"] = dict(args)
+            return '{"ok": true}'
+
+        invocation = PluginInvocation(
+            session_id="session-1", session_key="session-1", surface="cli", platform="cli",
+            cwd=Path("/tmp"), workspace=Path("/tmp"),
+            tool_names=frozenset({"read_file", "terminal"}), authorized=True,
+            _dispatch=executor,
+        )
+        result = invocation.dispatch_tool("read_file", {"path": "notes.md"})
+        assert result == '{"ok": true}'
+        assert seen == {"name": "read_file", "args": {"path": "notes.md"}}
+
+
+class TestPluginInvocationImmutable:
+    def test_fields_are_read_only(self):
+        invocation = PluginInvocation(session_id="session-1", surface="gateway")
+        with pytest.raises((AttributeError, TypeError)):
+            invocation.session_id = "session-2"
+        with pytest.raises((AttributeError, TypeError)):
+            invocation.surface = "cli"
+        with pytest.raises((AttributeError, TypeError)):
+            invocation.tool_names = frozenset({"terminal"})
+        assert invocation.session_id == "session-1"
+        assert invocation.surface == "gateway"
+
+    def test_provenance_survives(self):
+        cwd = Path("/home/user/project")
+        invocation = PluginInvocation(
+            session_id="session-7", session_key="agent:main:telegram:dm:c1",
+            surface="gateway", platform="telegram", cwd=cwd, workspace=cwd,
+            tool_names=frozenset({"read_file"}), authorized=True,
+            _dispatch=lambda name, args: "x",
+        )
+        assert invocation.session_id == "session-7"
+        assert invocation.session_key == "agent:main:telegram:dm:c1"
+        assert invocation.surface == "gateway"
+        assert invocation.platform == "telegram"
+        assert invocation.cwd == cwd
+        assert invocation.workspace == cwd
+        assert invocation.tool_names == frozenset({"read_file"})
+        assert invocation.authorized is True
+        # Private wiring never leaks through the public projection.
+        assert "_dispatch" not in repr(invocation)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -25,7 +25,9 @@ from hermes_cli.plugins import (
     has_middleware,
     resolve_plugin_command_result,
     _portable_skill_namespace,
+    call_plugin_command_handler,
 )
+from hermes_cli.plugin_invocation import PluginInvocation
 from hermes_cli.relay_plugin_cutover import RELAY_PLUGINS_CONFIG_ENV
 from hermes_cli.middleware import (
     VALID_MIDDLEWARE,
@@ -2023,6 +2025,29 @@ class TestPreLlmCallTargetRouting:
 
 class TestPluginCommands:
     """Tests for plugin slash command registration via register_command()."""
+
+    def test_command_handler_keeps_legacy_one_argument_contract(self):
+        seen = []
+
+        def legacy(args):
+            seen.append(args)
+            return "ok"
+
+        invocation = PluginInvocation(session_id="session-1", surface="cli")
+        assert call_plugin_command_handler(legacy, "message", invocation=invocation) == "ok"
+        assert seen == ["message"]
+
+    def test_command_handler_passes_immutable_opt_in_invocation(self):
+        invocation = PluginInvocation(session_id="session-1", surface="gateway", authorized=True)
+
+        def context_aware(args, *, invocation=None):
+            return args, invocation
+
+        result, received = call_plugin_command_handler(context_aware, "message", invocation=invocation)
+        assert result == "message"
+        assert received is invocation
+        with pytest.raises((AttributeError, TypeError)):
+            received.session_id = "different"
 
 
 

--- a/tests/tui_gateway/test_plugin_invocation.py
+++ b/tests/tui_gateway/test_plugin_invocation.py
@@ -1,0 +1,66 @@
+"""TUI/Desktop plugin command context: methods_tools._plugin_command_invocation.
+
+The TUI server and the Desktop app share the tui_gateway backend; both route
+plugin slash commands through the same helper, so it is tested directly here.
+
+Coverage targets:
+  - Session-less dispatch yields an empty fail-closed context.
+  - A fresh session record (no agent yet) still carries provenance (surface,
+    platform, cwd) but refuses tool dispatch.
+  - A session with a live agent authorizes dispatch against the agent's effective
+    tool set and reports the session identity.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tui_gateway.methods_tools import _plugin_command_invocation
+
+
+class _FakeAgent:
+    session_id = "sess-t1"
+    platform = "tui"
+    valid_tool_names = ["read_file", "terminal"]
+
+
+def test_sessionless_dispatch_context_fails_closed():
+    invocation = _plugin_command_invocation(None)
+    assert invocation is not None
+    assert invocation.authorized is False
+    assert invocation.session_id == ""
+    assert invocation.session_key == ""
+    assert invocation.tool_names == frozenset()
+    with pytest.raises(PermissionError, match="not authorized"):
+        invocation.dispatch_tool("read_file", {"path": "x"})
+
+
+def test_fresh_session_carries_provenance_but_no_authority():
+    invocation = _plugin_command_invocation({
+        "session_key": "key-t1", "source": "desktop", "cwd": "C:/work/project",
+        "agent": None,
+    })
+    assert invocation.surface == "desktop"
+    assert invocation.platform == "desktop"
+    assert invocation.session_key == "key-t1"
+    assert invocation.cwd == Path("C:/work/project")
+    assert invocation.authorized is False
+    with pytest.raises(PermissionError, match="not authorized"):
+        invocation.dispatch_tool("read_file", {"path": "x"})
+
+
+def test_live_agent_session_authorizes_against_effective_tool_set():
+    invocation = _plugin_command_invocation({
+        "session_key": "key-t2", "source": "tui", "cwd": "C:/work/project",
+        "agent": _FakeAgent(),
+    })
+    assert invocation.surface == "tui"
+    assert invocation.session_id == "sess-t1"
+    assert invocation.authorized is True
+    assert invocation.tool_names == frozenset({"read_file", "terminal"})
+    # Refused before any tool execution: outside the session's effective set.
+    with pytest.raises(PermissionError, match="not available"):
+        invocation.dispatch_tool("web_search", {"query": "x"})
+    with pytest.raises(TypeError, match="dictionary"):
+        invocation.dispatch_tool("read_file", ["path"])

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -481,8 +481,69 @@ def _plugin_command_handler(name: str):
         return None
 
 
-def _run_plugin_command(handler, arg: str) -> str:
-    return str(_tools_mod("hermes_cli.plugins").resolve_plugin_command_result(handler(arg)) or "")
+def _plugin_command_invocation(session: dict | None):
+    """Immutable PluginInvocation for a TUI/Desktop session record, else None.
+
+    Tool dispatch needs the session's live agent and binds it through the canonical
+    agent tool path (middleware/hooks/approval guards). A record without an agent
+    (fresh or resumed session, or no session at all) yields a fail-closed context;
+    legacy handlers that ignore the context still run.
+    """
+    try:
+        from pathlib import Path
+
+        from hermes_cli.plugin_invocation import PluginInvocation
+    except Exception:
+        return None
+    agent = session.get("agent") if isinstance(session, dict) else None
+    session_key = str(session.get("session_key") or "") if isinstance(session, dict) else ""
+    source = str(session.get("source") or "").strip() if isinstance(session, dict) else ""
+    if not source and agent is not None:
+        try:
+            source = str(getattr(agent, "platform", "") or "").strip()
+        except Exception:
+            source = ""
+    cwd_raw = str(session.get("cwd") or "").strip() if isinstance(session, dict) else ""
+
+    def _dispatch(name, args):
+        if agent is None:
+            raise RuntimeError("No session agent is available to run tools")
+        from agent.agent_runtime_helpers import invoke_tool
+        from tools.approval_context import reset_current_session_key, set_current_session_key
+        token = None
+        if session_key:
+            try:  # approvals route to this session only inside agent turns; bind explicitly
+                token = set_current_session_key(session_key)
+            except Exception:
+                token = None
+        try:
+            task_id = getattr(agent, "session_id", "") or session_key or ""
+            return invoke_tool(agent, name, args, task_id)
+        finally:
+            if token is not None:
+                try:
+                    reset_current_session_key(token)
+                except Exception:
+                    pass
+
+    return PluginInvocation(
+        session_id=str(getattr(agent, "session_id", "") or ""),
+        session_key=session_key,
+        surface=source or "tui",
+        platform=source or (str(getattr(agent, "platform", "") or "") if agent is not None else ""),
+        cwd=Path(cwd_raw) if cwd_raw else None,
+        workspace=None,
+        tool_names=(frozenset(getattr(agent, "valid_tool_names", ()) or ())
+                    if agent is not None else frozenset()),
+        authorized=agent is not None,
+        _dispatch=_dispatch if agent is not None else None,
+    )
+
+
+def _run_plugin_command(handler, arg: str, session: dict | None = None) -> str:
+    return str(_tools_mod("hermes_cli.plugins").resolve_plugin_command_result(
+        _tools_mod("hermes_cli.plugins").call_plugin_command_handler(
+            handler, arg, invocation=_plugin_command_invocation(session))) or "")
 
 
 def _is_profile_skill_command(session: dict, base: str) -> bool:
@@ -504,7 +565,7 @@ def _is_profile_skill_command(session: dict, base: str) -> bool:
 def _dispatch_plugin(rid, params, session, name, arg):
     if handler := _plugin_command_handler(name):
         with contextlib.suppress(Exception):
-            return _ok(rid, {"type": "plugin", "output": _run_plugin_command(handler, arg)})
+            return _ok(rid, {"type": "plugin", "output": _run_plugin_command(handler, arg, session)})
     return None
 
 
@@ -835,7 +896,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4018, f"skill command: use command.dispatch for /{base}")
     if plugin_handler := _plugin_command_handler(base) if base else None:
         try:
-            return _ok(rid, {"output": _run_plugin_command(plugin_handler, arg) or "(no output)"})
+            return _ok(rid, {"output": _run_plugin_command(plugin_handler, arg, session) or "(no output)"})
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})
     worker = session.get("slash_worker")


### PR DESCRIPTION
## Scope

Adds a generic, backward-compatible plugin command invocation context. It contains immutable session provenance and only a session-bound tool dispatcher that uses the normal agent tool path. Existing `handler(raw_args)` commands remain unchanged; opt-in handlers accept `handler(raw_args, *, invocation=None)`.

The change also binds CLI, Gateway, and TUI/Desktop command dispatch, applies the Gateway slash-access gate to plugin commands, and supplies additive session-start lifecycle context for plugins that need a pre-turn baseline.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_invocation.py tests/gateway/test_plugin_command_slash_access.py tests/gateway/test_unknown_command.py tests/gateway/test_slash_access_dispatch.py tests/gateway/test_discord_slash_commands.py tests/tui_gateway/test_plugin_invocation.py tests/tui_gateway/test_compress_lock_skip.py`
- 126 passed, 0 failed

No `/commit` or Git-specific behavior is added to core.
