### PR TITLE
fix(gateway): include attached images in /btw side questions

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -781,7 +781,8 @@ class GatewaySlashCommandsMixin(
     async def _handle_btw_command(self, event: MessageEvent) -> str:
         """Handle /btw <question> — one-shot auxiliary LLM call on a transcript snapshot; live history
         is never touched (alternation + prompt cache intact, current turn keeps running). Unlike /bg,
-        which spawns a fresh contextless session."""
+        which spawns a fresh contextless session. Attached images are vision-enriched in the
+        background before either side-answer path runs."""
         question = event.get_command_args().strip()
         if not question:
             return t("gateway.btw.usage")
@@ -791,7 +792,12 @@ class GatewaySlashCommandsMixin(
             history = await self.async_session_store.load_transcript(session_entry.session_id)
         except TranscriptReadError:
             return HISTORY_UNREADABLE
-        if not history:
+        # Slash commands bypass normal inbound media enrichment. Snapshot only images;
+        # per-attachment MIME must win over a mixed message's PHOTO classification.
+        from gateway.run import _event_media_is_image
+        image_paths = [path for i, path in enumerate(event.media_urls or [])
+                       if _event_media_is_image(event, i)]
+        if not history and not image_paths:
             return t("gateway.btw.no_history")
         try:
             model, rt = self._resolve_session_agent_runtime(source=source)
@@ -815,8 +821,16 @@ class GatewaySlashCommandsMixin(
         async def _run_side_question() -> None:
             from agent.side_question import answer_side_question
             try:
+                side_question = question
+                if image_paths:
+                    # /btw cannot call tools, and may use a text-only digest fallback.
+                    # Reuse vision preprocessing without staging native images on the
+                    # live session or modifying its transcript/cache prefix.
+                    from agent.auxiliary_client import scoped_runtime_main
+                    with scoped_runtime_main(main_runtime):
+                        side_question = await self._enrich_message_with_vision(question, image_paths)
                 answer = await asyncio.to_thread(
-                    answer_side_question, question, history_snapshot,
+                    answer_side_question, side_question, history_snapshot,
                     parent_agent=parent_agent, main_runtime=main_runtime)
                 reply = t("gateway.btw.answer", preview=preview, answer=answer or "")
             except Exception as e:

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -297,3 +297,124 @@ class TestHandleBtwCommand:
         event = _make_event(text="/btw what?")
         result = await runner._handle_btw_command(event)
         assert "❌" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_history", [True, False])
+@pytest.mark.parametrize("with_parent", [True, False])
+async def test_btw_attached_images_reach_side_answer(tmp_path, with_history, with_parent):
+    """Real handler + enrichment + side-question engine; only provider boundaries are fake."""
+    import base64
+    import copy
+    import io
+    from types import SimpleNamespace
+    from PIL import Image
+    from agent.auxiliary_client import _runtime_main_value
+    from gateway.platforms.event import MessageType
+
+    runner = _make_runner()
+    history = ([{"role": "user", "content": "Main task"},
+                {"role": "assistant", "content": "Working"}] if with_history else [])
+    original = copy.deepcopy(history)
+    store = AsyncMock()
+    store.get_or_create_session.return_value = MagicMock(session_id="s1")
+    store.load_transcript.return_value = history
+    store._store = runner.session_store
+    runner._async_session_store = store
+    runner._resolve_session_agent_runtime = MagicMock(return_value=(
+        "session-model", {"api_key": "test-only", "provider": "session-provider"}))
+    parent = MagicMock() if with_parent else None
+    runner._cached_agent_for = MagicMock(return_value=parent)
+    runner._reply_metadata = MagicMock(return_value={"thread_id": "thread-1"})
+    adapter = AsyncMock()
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    runner._enrich_inbound_images = AsyncMock(side_effect=AssertionError("must not stage native images"))
+
+    paths = [str(tmp_path / "one.png"), str(tmp_path / "notes.pdf"), str(tmp_path / "two.png")]
+    Image.new("RGB", (4, 4), (255, 0, 0)).save(paths[0])
+    Image.new("RGB", (4, 4), (0, 0, 255)).save(paths[2])
+    event = _make_event(text="/btw what do the signs say?", platform=Platform.WHATSAPP)
+    event.message_type = MessageType.PHOTO
+    event.media_urls = paths[:]
+    event.media_types = ["image/png", "application/pdf", "image/png"]
+    seen = []
+
+    async def vision(**kwargs):
+        assert _runtime_main_value("model") == "session-model"
+        block = next(b for b in kwargs["messages"][0]["content"] if b["type"] == "image_url")
+        data = base64.b64decode(block["image_url"]["url"].split(",", 1)[1])
+        with Image.open(io.BytesIO(data)) as image:
+            seen.append(image.convert("RGB").getpixel((0, 0)))
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(
+            content=f"Sign: {len(seen)}"))], usage=None)
+
+    def answer(**kwargs):
+        content = kwargs.get("user_message", kwargs.get("user_input"))
+        assert isinstance(content, str)
+        assert "Sign: 1" in content and "Sign: 2" in content
+        assert "what do the signs say?" in content
+        assert paths[1] not in content
+        return {"final_response": "Two signs."} if with_parent else "Two signs."
+
+    fork = MagicMock()
+    fork.run_conversation.side_effect = answer
+    with patch("tools.vision_tools.async_call_llm", side_effect=vision), \
+         patch("agent.background_review.build_cache_parity_fork", return_value=(fork, {}, False)), \
+         patch("agent.oneshot.run_oneshot", side_effect=answer):
+        ack = await runner._handle_btw_command(event)
+        assert "what do the signs say?" in ack
+        assert seen == []  # enrichment stays off the ack path
+        event.media_urls.clear()  # the background task owns a snapshot
+        for task in list(runner._background_tasks):
+            await task
+
+    assert seen == [(255, 0, 0), (0, 0, 255)]
+    assert history == original
+    assert event.text == "/btw what do the signs say?"
+    runner._enrich_inbound_images.assert_not_called()
+    adapter.send.assert_awaited_once()
+    assert "Two signs." in adapter.send.call_args.args[1]
+    assert adapter.send.call_args.kwargs["metadata"] == {"thread_id": "thread-1"}
+    if with_parent:
+        assert fork.run_conversation.call_args.kwargs["conversation_history"] == original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("media_type, mime, expected", [
+    ("photo", [], True),
+    ("document", ["image/jpeg"], True),
+    ("photo", ["application/pdf"], False),
+    ("text", [], False),
+])
+async def test_btw_image_classification_and_failure_notice(media_type, mime, expected):
+    from gateway.platforms.event import MessageType
+
+    runner = _make_runner()
+    store = AsyncMock()
+    store.get_or_create_session.return_value = MagicMock(session_id="s1")
+    history = [{"role": "user", "content": "Main"}, {"role": "assistant", "content": "OK"}]
+    store.load_transcript.return_value = history
+    store._store = runner.session_store
+    runner._async_session_store = store
+    runner._resolve_session_agent_runtime = MagicMock(return_value=("model", {"api_key": "test-only"}))
+    runner._cached_agent_for = MagicMock(return_value=None)
+    runner._reply_metadata = MagicMock(return_value=None)
+    adapter = AsyncMock()
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    event = _make_event(text="/btw inspect this")
+    event.message_type = MessageType(media_type)
+    event.media_urls = ["/test/attachment"]
+    event.media_types = mime
+
+    with patch("tools.vision_tools.vision_analyze_tool", new_callable=AsyncMock,
+               side_effect=RuntimeError("vision unavailable")) as vision, \
+         patch("agent.side_question.answer_side_question", return_value="Image unavailable") as answer:
+        await runner._handle_btw_command(event)
+        for task in list(runner._background_tasks):
+            await task
+    assert vision.await_count == int(expected)
+    question = answer.call_args.args[0]
+    if expected:
+        assert "something went wrong" in question
+    else:
+        assert question == "inspect this"


### PR DESCRIPTION
## Summary
Fix gateway `/btw <question>` dropping attached images. Its command handler bypasses normal inbound image enrichment and forwards only command text to a tool-disabled side answer.

Reuse existing auxiliary vision enrichment inside the background task, under the originating session's runtime. Forward descriptions to both cache-parity fork and text-only fallback. Snapshot/filter attachment paths before scheduling; do not stage native images or mutate main history. Permit a new-session side question when an image supplies context. Text-only behavior is unchanged.

## Scope
Only `gateway/slash_commands.py` and `tests/gateway/test_background_command.py`. No new configuration, dependencies, tools, or changes to `/bg`/CLI. Auxiliary vision must be available; existing failure notices are preserved rather than inventing image contents.

Related historical report: #25614. That report described the older `/btw` background alias; this targets today's separate side-question handler. Not claiming to close all historical background/attachment issues.

## Verification
Reproduction: send `/btw what do these signs say?` as the caption of two images. Before the fix, only the question reaches the side answer.

Red: initial regressions produced 6 failures, 2 passes on unchanged source.
Green: canonical per-file runner, 34 passed, 0 failed:
```
scripts/run_tests.sh -j 1 tests/gateway/test_background_command.py tests/agent/test_side_question.py tests/gateway/test_vision_preprocess.py tests/gateway/test_vision_memory_leak.py
```
Real temporary PNGs pass through the real vision preparation/base64 pipeline. Tests inspect decoded pixels at the mocked provider boundary and exercise both real side-answer paths. Coverage includes empty/populated history, mixed MIME attachments, photo fallback, scoped model routing, failure notices, immutable event/history and reply routing.

`ruff check` and `git diff --check` pass. Tested on macOS/Python 3.11. Full repository suite and live messaging/provider calls were not run. No gateway restart or production rollout claimed.

## Checklist
- [x] Bug fix; focused regression tests included
- [x] Existing PRs/issues and current source inspected
- [x] Only this fix in the branch; conventional commit
- [x] Cross-platform code, no new config or schema
- [ ] Full repository suite
