### PR TITLE
fix(line): postback cache must not drop real answer or swallow later sends (#106446)

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -317,7 +317,15 @@ def build_postback_button_message(text: str, button_label: str, request_id: str)
 
 # Gateway busy-ack prefixes (interrupting / queued / steered / background review);
 # these bypass a PENDING postback cache so they land as visible bubbles.
-_SYSTEM_BYPASS_PREFIXES: Tuple[str, ...] = ("⚡ Interrupting", "⏳ Queued", "⏩ Steered", "💾")
+_SYSTEM_BYPASS_PREFIXES: Tuple[str, ...] = (
+    "⚡ Interrupting",
+    "⏳ Queued",
+    "⏩ Steered",
+    "💾",
+    # The periodic slow-LLM heartbeat must land as a visible bubble, not consume the
+    # postback cache slot (PENDING→READY) and shadow the real answer (#106446).
+    "⏳ Working",
+)
 
 
 def _is_system_bypass(content: str) -> bool:
@@ -578,6 +586,11 @@ class LineAdapter(BasePlatformAdapter):
         request_id = parsed.get("request_id", "") if parsed.get("action") == "show_response" else ""
         entry = self._cache.get(request_id) if request_id else None
         if not self._client or not reply_token or not entry:
+            # Entry evicted/missing: if the stale postback mapping still points at this
+            # request, clear it so subsequent sends don't keep routing through the dead
+            # cache path (#106446).
+            if request_id and self._pending_buttons.get(chat_id) == request_id:
+                self._pending_buttons.pop(chat_id, None)
             return
         state = entry.state
         if state is State.READY:
@@ -634,8 +647,16 @@ class LineAdapter(BasePlatformAdapter):
         # busy-acks, which must land as visible bubbles.
         pending_rid = self._pending_buttons.get(chat_id)
         if pending_rid and not _is_system_bypass(content):
-            self._cache.set_ready(pending_rid, content)
-            return SendResult(success=True, message_id=pending_rid)
+            entry = self._cache.get(pending_rid)
+            # Only cache while the request is still PENDING. A non-PENDING slot — a
+            # prior heartbeat already latched READY, the answer was already delivered
+            # (DELIVERED), or the entry was evicted — means set_ready is a silent no-op,
+            # so caching here would drop the real payload while reporting success (#106446).
+            # Deliver directly as a visible bubble and clear the stale postback mapping.
+            if entry is not None and entry.state is State.PENDING:
+                self._cache.set_ready(pending_rid, content)
+                return SendResult(success=True, message_id=pending_rid)
+            self._pending_buttons.pop(chat_id, None)
         # System busy-acks (interrupting / queued / steered) bypass the postback cache and route directly to
         # LINE so they reach the user as visible bubbles. Source: PR #18153.
         return await self._send_text_chunks(chat_id, content, force_push=False)

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -270,6 +270,105 @@ class TestSendRouting:
 
 
 # ---------------------------------------------------------------------------
+# 8b. Postback cache integrity: heartbeats must not shadow the real answer,
+#     and stale mappings must not swallow later sends (#106446).
+# ---------------------------------------------------------------------------
+
+class TestPostbackCacheIntegrity:
+
+    @pytest.fixture
+    def adapter(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+
+        cfg = PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+        })
+        ad = LineAdapter(cfg)
+        ad._client = MagicMock()
+        ad._client.reply = AsyncMock()
+        ad._client.push = AsyncMock()
+        return ad
+
+    def test_working_heartbeat_is_a_system_bypass(self):
+        # The periodic slow-LLM heartbeat must bypass the postback cache so it
+        # lands as a visible bubble instead of latching READY and shadowing
+        # the real answer (#106446).
+        assert _is_system_bypass("⏳ Working — 3 min — iteration 1/60, research_market")
+        assert _is_system_bypass("⏳ Working")
+
+    def test_heartbeat_does_not_shadow_the_real_answer(self, adapter):
+        # Repro A from #106446: the heartbeat cached as the READY payload caused
+        # the final answer's set_ready to no-op (READY) and be silently dropped.
+        rid = adapter._cache.register_pending("Uchat")
+        adapter._pending_buttons["Uchat"] = rid
+
+        heartbeat = asyncio.run(adapter.send("Uchat", "⏳ Working — 3 min — iteration 1/60"))
+        answer = asyncio.run(adapter.send("Uchat", "Final answer: task completed"))
+
+        # Both sends succeed; the heartbeat was delivered directly as a bubble...
+        assert heartbeat.success and answer.success
+        adapter._client.push.assert_called()
+        # ...so the postback slot stayed PENDING and the real answer cached for the tap.
+        cached = adapter._cache.get(rid)
+        assert cached.state is State.PENDING or cached.state is State.READY
+        assert cached.payload == "Final answer: task completed"
+
+    def test_stale_delivered_mapping_does_not_swallow_later_send(self, adapter):
+        # Repro B from #106446: after the postback answer was delivered, a stale
+        # _pending_buttons mapping routed later sends through the dead cache path
+        # (set_ready no-op on DELIVERED) and silently dropped the content.
+        rid = adapter._cache.register_pending("Uchat")
+        adapter._cache.set_ready(rid, "previous answer")
+        adapter._cache.mark_delivered(rid)  # user tapped; entry is DELIVERED
+        adapter._pending_buttons["Uchat"] = rid  # stale mapping not yet cleared
+
+        result = asyncio.run(adapter.send("Uchat", "a later message"))
+
+        # The later message is delivered directly (not swallowed)...
+        assert result.success
+        adapter._client.push.assert_called()
+        sent = adapter._client.push.call_args.args[1]
+        assert any(m.get("text") == "a later message" for m in sent)
+        # ...and the stale mapping is cleared so the next send routes normally.
+        assert "Uchat" not in adapter._pending_buttons
+
+    def test_pending_answer_caches_for_postback_tap(self, adapter):
+        # Regression guard: the happy path — first answer caches while PENDING.
+        rid = adapter._cache.register_pending("Uchat")
+        adapter._pending_buttons["Uchat"] = rid
+
+        result = asyncio.run(adapter.send("Uchat", "the real answer"))
+
+        assert result.success and result.message_id == rid
+        cached = adapter._cache.get(rid)
+        assert cached.state is State.READY
+        assert cached.payload == "the real answer"
+        # Nothing pushed — the answer is cached for the postback tap, not sent now.
+        adapter._client.push.assert_not_called()
+
+    def test_postback_for_evicted_entry_clears_stale_mapping(self, adapter):
+        # A postback whose cache entry was evicted must still clear the stale
+        # _pending_buttons mapping so subsequent sends route normally (#106446).
+        rid = adapter._cache.register_pending("Uchat")
+        adapter._pending_buttons["Uchat"] = rid
+        adapter._cache._entries.pop(rid)  # simulate eviction
+
+        event = {
+            "replyToken": "rt",
+            "source": {"type": "user", "userId": "Uchat"},
+            "postback": {"data": json.dumps({"action": "show_response", "request_id": rid})},
+        }
+        asyncio.run(adapter._handle_postback_event(event))
+
+        # Nothing to deliver (entry gone) so no reply, but the stale mapping is cleared.
+        adapter._client.reply.assert_not_called()
+        assert "Uchat" not in adapter._pending_buttons
+
+
+# ---------------------------------------------------------------------------
 # 9. Register() metadata + plugin entry points
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #106446 — the slow-LLM postback cache could cache a `⏳ Working` progress heartbeat as the answer, silently drop the actual final answer, and keep swallowing later messages through a stale mapping.

The reporter provided exact affected functions and two reproducible test cases; both are covered by regression tests below.

## Root cause

Three independent gaps in `plugins/platforms/line/adapter.py`:

1. **Heartbeat shadows the answer.** `_SYSTEM_BYPASS_PREFIXES` (`⚡ Interrupting`, `⏳ Queued`, `⏩ Steered`, `💾`) did not include the periodic `⏳ Working` heartbeat. So `send()` cached the heartbeat via `set_ready()` (PENDING → READY), and the real final answer's later `set_ready()` was a silent no-op on the already-READY slot — the user tapped the postback button and got the heartbeat, not the answer.

2. **`set_ready()` no-op silently drops the payload.** `send()` called `self._cache.set_ready(pending_rid, content)` and returned `success=True` **regardless of whether the transition actually happened**. `RequestCache.set_ready()` only transitions `PENDING → READY`; it is a no-op for `READY` / `DELIVERED` / `ERROR` / missing entries. So once a heartbeat, a delivered answer, or an eviction made the slot non-PENDING, every subsequent `send()` reported success while the content never reached the user.

3. **Stale mapping never cleared on missing entry.** `_handle_postback_event()` returned immediately when the referenced cache entry was missing (`if not entry: return`), leaving the dead `_pending_buttons[chat_id]` mapping in place — so later sends kept routing through the dead cache path instead of delivering directly.

## Fix

| Change | What |
|--------|------|
| `_SYSTEM_BYPASS_PREFIXES` | Add `⏳ Working` so the heartbeat bypasses the cache and lands as a visible bubble (mirrors the existing interrupting / queued / steered busy-acks). |
| `send()` | Guard to only cache while the entry is still `PENDING`; otherwise deliver directly as a visible bubble (`_send_text_chunks`) and clear the stale `pending_buttons` mapping. |
| `_handle_postback_event()` | When the entry is evicted/missing, clear the stale mapping if it still points at the requested `request_id`. |

The unscoped happy path (PENDING slot, first answer) is **100% unchanged**: `set_ready()` semantics are untouched (still a `PENDING → READY` no-op otherwise), and the existing `test_set_ready_on_delivered_is_noop` regression test stays green.

## Tests

Added `TestPostbackCacheIntegrity` (5 tests) to `tests/gateway/test_line_plugin.py`:

| Test | Catches bug? | Repro |
|------|-------------|-------|
| `test_working_heartbeat_is_a_system_bypass` | ✅ | — |
| `test_heartbeat_does_not_shadow_the_real_answer` | ✅ | A |
| `test_stale_delivered_mapping_does_not_swallow_later_send` | ✅ | B |
| `test_postback_for_evicted_entry_clears_stale_mapping` | ✅ | B |
| `test_pending_answer_caches_for_postback_tap` | (guard) | — |

**Mutation-verified:** with the adapter reverted to `main` (fix stashed), the 4 bug-catching tests **FAIL** and the 1 happy-path guard **passes both** — confirming the tests actually exercise the fix and the regression surface is preserved.

```
# buggy main (fix stashed):
FAILED test_working_heartbeat_is_a_system_bypass
FAILED test_heartbeat_does_not_shadow_the_real_answer
FAILED test_stale_delivered_mapping_does_not_swallow_later_send
FAILED test_postback_for_evicted_entry_clears_stale_mapping
1 passed   # happy-path guard

# fix restored:
36 passed  # 31 existing + 5 new
```

`ruff check` clean on both files.

## Prior art / non-overlap

- **#64466** (closed, Aug 2026) was the AI-reviewed-and-approved fix for the same root cause (`@tonydwb: Verdict: Approved`, 35+/4-) but was closed without merge and the branch was deleted. This PR revives that approach with an independently-designed fix derived from the reporter's analysis + repros.
- **#38629** ("bind postback cache entries to chat ids") addresses chat-id keying — complementary, different concern (and stale, won't rebase: references a `chat_id` field that doesn't exist on current `_CacheEntry`).
- **#102439** ("scope postback/copy fields per profile") addresses env-var profile scoping in `__init__` — different function, no overlap.

No open PR addresses the heartbeat-shadow / stale-mapping data-loss bug.

Fixes #106446
