### PR TITLE
fix(telegram): present clarify batches with progress controls

### DIFF
--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -335,6 +335,19 @@ class GatewayInboundMixin:
         # they can retry; on timeout the agent unblocks with an empty response.
         if not _raw_clarify_reply or _raw_clarify_reply.startswith("/"):
             return None
+        if (_pending_clarify.awaiting_text and _pending_clarify.requires_text_reply_binding
+                and str(getattr(event, "reply_to_message_id", "") or "")
+                != (_pending_clarify.text_reply_to_message_id or "")):
+            # A batch can contain multiple open-text cards. Do not let ordinary
+            # active-session prose silently answer whichever one happens to be next.
+            # Release all batch cards before it falls through, so the follow-up cannot
+            # sit hidden behind an unlimited clarify timeout.
+            _clarify_mod.cancel_bound_batch_for_session(_quick_key)
+            logger.info(
+                "Gateway cancelled reply-bound clarify batch for unbound text follow-up "
+                "(session=%s, id=%s)", _quick_key, _pending_clarify.clarify_id,
+            )
+            return None
         _text_outcome = _clarify_mod.attempt_text_response_for_session(_quick_key, _raw_clarify_reply)
         if _text_outcome == _clarify_mod.TEXT_RESOLVED:
             logger.info(

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -8,6 +8,7 @@ so ``patch("gateway.run.X")`` keeps intercepting them at call time.
 from __future__ import annotations
 
 import logging
+import inspect
 from typing import TYPE_CHECKING
 import asyncio
 import concurrent.futures
@@ -335,19 +336,43 @@ class GatewayInboundMixin:
         # they can retry; on timeout the agent unblocks with an empty response.
         if not _raw_clarify_reply or _raw_clarify_reply.startswith("/"):
             return None
-        if (_pending_clarify.awaiting_text and _pending_clarify.requires_text_reply_binding
-                and str(getattr(event, "reply_to_message_id", "") or "")
-                != (_pending_clarify.text_reply_to_message_id or "")):
-            # A batch can contain multiple open-text cards. Do not let ordinary
-            # active-session prose silently answer whichever one happens to be next.
-            # Release all batch cards before it falls through, so the follow-up cannot
-            # sit hidden behind an unlimited clarify timeout.
-            _clarify_mod.cancel_bound_batch_for_session(_quick_key)
-            logger.info(
-                "Gateway cancelled reply-bound clarify batch for unbound text follow-up "
-                "(session=%s, id=%s)", _quick_key, _pending_clarify.clarify_id,
+        if _pending_clarify.awaiting_text and _pending_clarify.requires_text_reply_binding:
+            _reply_to = str(getattr(event, "reply_to_message_id", "") or "")
+            _expected_reply_to = _pending_clarify.text_reply_to_message_id
+            _event_source = getattr(event, "source", None)
+            _same_bound_context = (
+                (not _pending_clarify.text_reply_chat_id or str(getattr(_event_source, "chat_id", "")) == _pending_clarify.text_reply_chat_id)
+                and (not _pending_clarify.text_reply_user_id or str(getattr(_event_source, "user_id", "")) == _pending_clarify.text_reply_user_id)
+                and (not _pending_clarify.text_reply_thread_id or str(getattr(_event_source, "thread_id", "")) == _pending_clarify.text_reply_thread_id)
             )
-            return None
+            if not _expected_reply_to:
+                # Ambiguous delivery has no safe correlation id: it may neither
+                # consume prose nor cancel a still-visible batch.
+                return None
+            if _reply_to and (_reply_to != _expected_reply_to or not _same_bound_context):
+                # An explicit reply to another card (including a late batch-A
+                # reply) is not an unbound follow-up for this batch.
+                return None
+            if not _reply_to:
+                # A batch can contain multiple open-text cards. Do not let ordinary
+                # active-session prose silently answer whichever one happens to be next.
+                # Release all batch cards before it falls through, so the follow-up cannot
+                # sit hidden behind an unlimited clarify timeout.
+                _clarify_mod.cancel_bound_batch_for_session(_quick_key)
+                _clarify_adapter = getattr(self, "_adapter_for_source", lambda _source: None)(source)
+                _invalidate = getattr(_clarify_adapter, "invalidate_clarify_batch_for_session", None)
+                if callable(_invalidate):
+                    try:
+                        _invalidation = _invalidate(_quick_key)
+                        if inspect.isawaitable(_invalidation):
+                            await _invalidation
+                    except Exception:
+                        logger.debug("Failed to visibly invalidate cancelled clarify batch", exc_info=True)
+                logger.info(
+                    "Gateway cancelled reply-bound clarify batch for unbound text follow-up "
+                    "(session=%s, id=%s)", _quick_key, _pending_clarify.clarify_id,
+                )
+                return None
         _text_outcome = _clarify_mod.attempt_text_response_for_session(_quick_key, _raw_clarify_reply)
         if _text_outcome == _clarify_mod.TEXT_RESOLVED:
             logger.info(

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1249,9 +1249,9 @@ class TurnRunner:
             with suppress(Exception):
                 ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
             batch_metadata = dict(ctx._status_thread_metadata or {})
-            batch_metadata["_clarify_initiator_user_id"] = getattr(ctx.source, "user_id", None)
-            batch_metadata["_clarify_initiator_chat_id"] = getattr(ctx.source, "chat_id", None)
-            batch_metadata["_clarify_initiator_thread_id"] = getattr(ctx.source, "thread_id", None)
+            initiator = getattr(ctx, "source", None)
+            for attr in ("user_id", "chat_id", "thread_id"):
+                batch_metadata[f"_clarify_initiator_{attr}"] = getattr(initiator, attr, None)
             fut = self._schedule(
                 send_batch(chat_id=ctx._status_chat_id, questions=questions, clarify_ids=clarify_ids,
                            batch_id=batch_id, session_key=session_key, metadata=batch_metadata),

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1248,9 +1248,13 @@ class TurnRunner:
             self._close_native_stream_boundary("Clarify", "💬 等待你的选择...", reopen=True)
             with suppress(Exception):
                 ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
+            batch_metadata = dict(ctx._status_thread_metadata or {})
+            batch_metadata["_clarify_initiator_user_id"] = getattr(ctx.source, "user_id", None)
+            batch_metadata["_clarify_initiator_chat_id"] = getattr(ctx.source, "chat_id", None)
+            batch_metadata["_clarify_initiator_thread_id"] = getattr(ctx.source, "thread_id", None)
             fut = self._schedule(
                 send_batch(chat_id=ctx._status_chat_id, questions=questions, clarify_ids=clarify_ids,
-                           batch_id=batch_id, session_key=session_key, metadata=ctx._status_thread_metadata),
+                           batch_id=batch_id, session_key=session_key, metadata=batch_metadata),
                 "Clarify batch send failed to schedule",
             )
             try:

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1224,7 +1224,7 @@ class TurnRunner:
             logger.warning("%s boundary timed out or failed: %s", reason, err)
             return False
 
-    def _clarify_callback_sync(self, question: str, choices, multi_select: bool = False) -> str:
+    def _clarify_callback_sync(self, question: str, choices, multi_select: bool = False, questions=None) -> Any:
         """Present a clarify prompt and block on a response (clarify_tool's synchronous contract):
         schedule send_clarify on the gateway loop, block on the primitive's threading.Event with a
         timeout. Returns the response string, or a sentinel when none arrived."""
@@ -1235,6 +1235,42 @@ class TurnRunner:
         if not ctx._status_adapter:
             return ""
         session_key = ctx.session_key or ""
+        # A native batch-capable adapter receives all independent questions at once. This preserves
+        # partial answers and uses one shared timeout; adapters without the method retain the
+        # clarify_tool legacy per-question fallback.
+        send_batch = getattr(ctx._status_adapter, "send_clarify_batch", None)
+        if questions and callable(send_batch):
+            batch_id = uuid.uuid4().hex[:10]
+            clarify_ids = [uuid.uuid4().hex[:10] for _ in questions]
+            for clarify_id, spec in zip(clarify_ids, questions):
+                clarify_mod.register(clarify_id, session_key, spec["question"], spec.get("choices"),
+                                     multi_select=bool(spec.get("multi_select")))
+            self._close_native_stream_boundary("Clarify", "💬 等待你的选择...", reopen=True)
+            with suppress(Exception):
+                ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
+            fut = self._schedule(
+                send_batch(chat_id=ctx._status_chat_id, questions=questions, clarify_ids=clarify_ids,
+                           batch_id=batch_id, session_key=session_key, metadata=ctx._status_thread_metadata),
+                "Clarify batch send failed to schedule",
+            )
+            try:
+                send_result = fut.result(timeout=15) if fut is not None else None
+            except Exception:
+                send_result = None
+            if not getattr(send_result, "success", False):
+                for clarify_id in clarify_ids:
+                    clarify_mod.resolve_gateway_clarify(clarify_id, "")
+                with suppress(Exception):
+                    ctx._status_adapter.clear_clarify_batch(batch_id)
+                return {"answers": {entry["qid"]: "" for entry in questions}, "timed_out": True}
+            try:
+                answers_by_id, timed_out = clarify_mod.wait_for_batch_responses(
+                    clarify_ids, clarify_mod.get_clarify_timeout())
+            finally:
+                with suppress(Exception):
+                    ctx._status_adapter.clear_clarify_batch(batch_id)
+            return {"answers": {entry["qid"]: answers_by_id.get(clarify_id, "")
+                                for entry, clarify_id in zip(questions, clarify_ids)}, "timed_out": timed_out}
         clarify_id = uuid.uuid4().hex[:10]
         choices = list(choices) if choices else None
         clarify_mod.register(

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1254,23 +1254,41 @@ class TurnRunner:
                 "Clarify batch send failed to schedule",
             )
             try:
-                send_result = fut.result(timeout=15) if fut is not None else None
-            except Exception:
-                send_result = None
-            if not getattr(send_result, "success", False):
-                for clarify_id in clarify_ids:
-                    clarify_mod.resolve_gateway_clarify(clarify_id, "")
-                with suppress(Exception):
-                    ctx._status_adapter.clear_clarify_batch(batch_id)
-                return {"answers": {entry["qid"]: "" for entry in questions}, "timed_out": True}
-            try:
+                try:
+                    send_result = fut.result(timeout=15) if fut is not None else None
+                except TimeoutError:
+                    # A connector timeout is ambiguous: Telegram may already show every
+                    # card while its acknowledgement arrives late. Keep registrations
+                    # armed exactly like the single-question path so those cards remain
+                    # answerable.
+                    logger.warning("Clarify batch send timed out; retaining pending cards for late replies")
+                    send_result = True
+                except Exception:
+                    logger.warning("Clarify batch send failed", exc_info=True)
+                    send_result = None
+                if not getattr(send_result, "success", send_result is True):
+                    # Resolve and collect only this batch's cards. clear_session() could
+                    # cancel an unrelated pending card in the same session.
+                    for clarify_id in clarify_ids:
+                        clarify_mod.resolve_gateway_clarify(clarify_id, "")
+                    clarify_mod.wait_for_batch_responses(clarify_ids, timeout=0)
+                    return {"answers": {entry["qid"]: "" for entry in questions}, "timed_out": True}
                 answers_by_id, timed_out = clarify_mod.wait_for_batch_responses(
                     clarify_ids, clarify_mod.get_clarify_timeout())
+                return {"answers": {entry["qid"]: answers_by_id.get(clarify_id, "")
+                                    for entry, clarify_id in zip(questions, clarify_ids)}, "timed_out": timed_out}
             finally:
                 with suppress(Exception):
                     ctx._status_adapter.clear_clarify_batch(batch_id)
-            return {"answers": {entry["qid"]: answers_by_id.get(clarify_id, "")
-                                for entry, clarify_id in zip(questions, clarify_ids)}, "timed_out": timed_out}
+                # A batch always returns control to the active turn, including after an
+                # undeliverable card or shared timeout. Restore the continuation stream
+                # and typing indicator rather than leaving the chat visually stalled.
+                sc = self._stream_consumer()
+                if sc is not None:
+                    with suppress(Exception):
+                        sc.request_reopen_seed()
+                with suppress(Exception):
+                    ctx._status_adapter.resume_typing_for_chat(ctx._status_chat_id)
         clarify_id = uuid.uuid4().hex[:10]
         choices = list(choices) if choices else None
         clarify_mod.register(

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1244,7 +1244,7 @@ class TurnRunner:
             clarify_ids = [uuid.uuid4().hex[:10] for _ in questions]
             for clarify_id, spec in zip(clarify_ids, questions):
                 clarify_mod.register(clarify_id, session_key, spec["question"], spec.get("choices"),
-                                     multi_select=bool(spec.get("multi_select")))
+                                     multi_select=bool(spec.get("multi_select")), require_text_reply_binding=True)
             self._close_native_stream_boundary("Clarify", "💬 等待你的选择...", reopen=True)
             with suppress(Exception):
                 ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3875,7 +3875,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     text += "\n\n<i>Antworte mit Text oder nutze Überspringen.</i>"
                 rows.extend([[InlineKeyboardButton("⏭ Überspringen", callback_data=f"cl:{clarify_id}:skip")],
                              [InlineKeyboardButton("📊 Fortschritt", callback_data=f"clb:{batch_id}:status"), InlineKeyboardButton("✅ Abschließen", callback_data=f"clb:{batch_id}:continue")]])
-                return text, InlineKeyboardMarkup(rows), lambda msg: self._clarify_state.__setitem__(clarify_id, session_key)
+                def remember_batch_card(msg, clarify_id=clarify_id):
+                    self._clarify_state[clarify_id] = session_key
+                    # Bound text prevents an unrelated follow-up from being consumed by an
+                    # open-text card in the same displayed batch.
+                    try:
+                        from tools.clarify_gateway import bind_text_reply_to
+                        bind_text_reply_to(clarify_id, getattr(msg, "message_id", None))
+                    except Exception:
+                        logger.debug("Telegram clarify batch card binding failed", exc_info=True)
+                return text, InlineKeyboardMarkup(rows), remember_batch_card
             last_result = await self._send_prompt("send_clarify_batch", chat_id, metadata, build, parse_mode=ParseMode.HTML, thread_id=self._metadata_thread_id(metadata))
             if not last_result.success:
                 self._clarify_batch_state.pop(batch_id, None)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -517,6 +517,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._approval_state: Dict[int, str] = {}  # message_id → session_key
         self._slash_confirm_state: Dict[str, str] = {}  # confirm_id → session_key
         self._clarify_state: Dict[str, str] = {}  # clarify_id → session_key
+        self._clarify_batch_state: Dict[str, dict] = {}  # batch_id → session + clarify ids
         # "important" (default): only final responses, approvals and slash confirmations notify;
         # "all": every message notifies (display.platforms.telegram.notifications).
         self._notifications_mode: str = "important"
@@ -3852,6 +3853,39 @@ class TelegramAdapter(BasePlatformAdapter):
         return await self._send_prompt(
             "send_clarify", chat_id, metadata, build, parse_mode=ParseMode.HTML, thread_id=self._metadata_thread_id(metadata))
 
+    async def send_clarify_batch(
+        self, chat_id: str, questions: list, clarify_ids: list[str], batch_id: str, session_key: str,
+        metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        """Render all batch questions at once; batch controls collect input, never approve an action."""
+        if len(questions) != len(clarify_ids):
+            return SendResult(success=False, error="Clarify batch question/id mismatch")
+        total = len(questions)
+        self._clarify_batch_state[batch_id] = {"session_key": session_key, "clarify_ids": list(clarify_ids), "total": total}
+        last_result = SendResult(success=True)
+        for index, (spec, clarify_id) in enumerate(zip(questions, clarify_ids), start=1):
+            question, choices = str(spec.get("question") or ""), spec.get("choices") or None
+            def build(question=question, choices=choices, clarify_id=clarify_id, index=index):
+                text = f"❓ <b>{index}/{total}</b> {_html.escape(question)}"
+                rows = []
+                if choices:
+                    text += "\n\n" + "\n".join(f"{i + 1}. {_html.escape(str(c))}" for i, c in enumerate(choices))
+                    rows.extend([[InlineKeyboardButton(str(i + 1), callback_data=f"cl:{clarify_id}:{i}")] for i in range(len(choices))])
+                    rows.append([InlineKeyboardButton("✏️ Andere Antwort", callback_data=f"cl:{clarify_id}:other")])
+                else:
+                    text += "\n\n<i>Antworte mit Text oder nutze Überspringen.</i>"
+                rows.extend([[InlineKeyboardButton("⏭ Überspringen", callback_data=f"cl:{clarify_id}:skip")],
+                             [InlineKeyboardButton("📊 Fortschritt", callback_data=f"clb:{batch_id}:status"), InlineKeyboardButton("✅ Abschließen", callback_data=f"clb:{batch_id}:continue")]])
+                return text, InlineKeyboardMarkup(rows), lambda msg: self._clarify_state.__setitem__(clarify_id, session_key)
+            last_result = await self._send_prompt("send_clarify_batch", chat_id, metadata, build, parse_mode=ParseMode.HTML, thread_id=self._metadata_thread_id(metadata))
+            if not last_result.success:
+                self._clarify_batch_state.pop(batch_id, None)
+                return last_result
+        return last_result
+
+    def clear_clarify_batch(self, batch_id: str) -> None:
+        """Forget terminal batch UI state after the runner has collected its result."""
+        self._clarify_batch_state.pop(batch_id, None)
+
     @staticmethod
     def _provider_get_label():
         try:
@@ -4255,7 +4289,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
         for prefix, handler in (
             ("gt:", self._handle_gmail_triage_callback), ("ea:", self._handle_exec_approval_callback),
-            ("sc:", self._handle_slash_confirm_callback), ("cl:", self._handle_clarify_callback),
+            ("sc:", self._handle_slash_confirm_callback), ("clb:", self._handle_clarify_batch_callback),
+            ("cl:", self._handle_clarify_callback),
             ("update_prompt:", self._handle_update_prompt_callback)):
             if data.startswith(prefix):
                 await handler(query, data, cb)
@@ -4374,6 +4409,20 @@ class TelegramAdapter(BasePlatformAdapter):
         if not session_key:
             return
         user_display = getattr(query.from_user, "first_name", "User")
+        if choice_token == "skip":
+            self._clarify_state.pop(clarify_id, None)
+            try:
+                from tools.clarify_gateway import resolve_gateway_clarify
+                resolved = resolve_gateway_clarify(clarify_id, "")
+            except Exception as exc:
+                logger.error("[%s] clarify skip failed: %s", self.name, exc)
+                resolved = False
+            if resolved:
+                await query.answer(text="Übersprungen")
+                await self._edit_html_quiet(query, f"❓ {_html.escape(query.message.text or '')}\n\n<i>Übersprungen</i>")
+            else:
+                await self._notify_clarify_expired(query, user_display)
+            return
         if choice_token == "other":
             # Flip to text-capture: the gateway's text-intercept resolves the clarify with the next message.
             # Do NOT pop _clarify_state yet — still needed if the entry gets cleared by something else.
@@ -4425,6 +4474,39 @@ class TelegramAdapter(BasePlatformAdapter):
             # Entry evicted / gateway restarted between ask and tap.
             await self._notify_clarify_expired(query, user_display)
             logger.warning("Telegram clarify button: resolve_gateway_clarify returned False (id=%s)", clarify_id)
+
+    async def _handle_clarify_batch_callback(self, query, data: str, cb: Dict[str, Any]) -> None:
+        """``clb:<batch_id>:status|continue`` controls collection, never an approval."""
+        parts = data.split(":", 2)
+        if len(parts) != 3:
+            return
+        batch = self._clarify_batch_state.get(parts[1])
+        if not batch:
+            await query.answer(text="Diese Fragen sind nicht mehr aktiv.")
+            return
+        if not await self._callback_authorized(query, cb, "⛔ Du darfst diese Fragen nicht beantworten."):
+            return
+        try:
+            from tools import clarify_gateway as clarify_mod
+            with clarify_mod._lock:
+                entries = [clarify_mod._entries.get(cid) for cid in batch["clarify_ids"]]
+                answered = sum(bool(entry and entry.event.is_set()) for entry in entries)
+        except Exception:
+            answered = 0
+        if parts[2] == "status":
+            await query.answer(text=f"Fortschritt: {answered}/{batch['total']} beantwortet")
+            return
+        if parts[2] != "continue":
+            return
+        try:
+            for clarify_id in batch["clarify_ids"]:
+                clarify_mod.resolve_gateway_clarify(clarify_id, "")
+        except Exception as exc:
+            logger.error("[%s] clarify batch continue failed: %s", self.name, exc)
+            await query.answer(text="Abschließen fehlgeschlagen")
+            return
+        self._clarify_batch_state.pop(parts[1], None)
+        await query.answer(text=f"Abgeschlossen: {answered}/{batch['total']} beantwortet")
 
     async def _handle_update_prompt_callback(self, query, data: str, cb: Dict[str, Any]) -> None:
         """``update_prompt:<y|n>`` — forward the answer to the update process."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3860,7 +3860,12 @@ class TelegramAdapter(BasePlatformAdapter):
         if len(questions) != len(clarify_ids):
             return SendResult(success=False, error="Clarify batch question/id mismatch")
         total = len(questions)
-        self._clarify_batch_state[batch_id] = {"session_key": session_key, "clarify_ids": list(clarify_ids), "total": total}
+        self._clarify_batch_state[batch_id] = {
+            "session_key": session_key, "clarify_ids": list(clarify_ids), "total": total,
+            "chat_id": str(chat_id), "cards": {},
+            "initiator_user_id": (metadata or {}).get("_clarify_initiator_user_id"),
+            "initiator_thread_id": (metadata or {}).get("_clarify_initiator_thread_id"),
+        }
         last_result = SendResult(success=True)
         for index, (spec, clarify_id) in enumerate(zip(questions, clarify_ids), start=1):
             question, choices = str(spec.get("question") or ""), spec.get("choices") or None
@@ -3875,13 +3880,21 @@ class TelegramAdapter(BasePlatformAdapter):
                     text += "\n\n<i>Antworte mit Text oder nutze Überspringen.</i>"
                 rows.extend([[InlineKeyboardButton("⏭ Überspringen", callback_data=f"cl:{clarify_id}:skip")],
                              [InlineKeyboardButton("📊 Fortschritt", callback_data=f"clb:{batch_id}:status"), InlineKeyboardButton("✅ Abschließen", callback_data=f"clb:{batch_id}:continue")]])
-                def remember_batch_card(msg, clarify_id=clarify_id):
+                def remember_batch_card(msg, clarify_id=clarify_id, text=text):
                     self._clarify_state[clarify_id] = session_key
                     # Bound text prevents an unrelated follow-up from being consumed by an
                     # open-text card in the same displayed batch.
                     try:
                         from tools.clarify_gateway import bind_text_reply_to
-                        bind_text_reply_to(clarify_id, getattr(msg, "message_id", None))
+                        bound = bind_text_reply_to(
+                            clarify_id, getattr(msg, "message_id", None), chat_id=chat_id,
+                            user_id=(metadata or {}).get("_clarify_initiator_user_id"),
+                            thread_id=(metadata or {}).get("_clarify_initiator_thread_id"),
+                        )
+                        if bound:
+                            self._clarify_batch_state.get(batch_id, {}).get("cards", {})[clarify_id] = {
+                                "message_id": str(getattr(msg, "message_id", "")), "text": text,
+                            }
                     except Exception:
                         logger.debug("Telegram clarify batch card binding failed", exc_info=True)
                 return text, InlineKeyboardMarkup(rows), remember_batch_card
@@ -3894,6 +3907,31 @@ class TelegramAdapter(BasePlatformAdapter):
     def clear_clarify_batch(self, batch_id: str) -> None:
         """Forget terminal batch UI state after the runner has collected its result."""
         self._clarify_batch_state.pop(batch_id, None)
+
+    async def invalidate_clarify_batch_for_session(self, session_key: str) -> None:
+        """Disable visible cards after unbound prose releases a batch.
+
+        Terminal state is owned by clarify_gateway; Telegram edits are best
+        effort so stale cards do not imply that their buttons still work.
+        """
+        if not self._bot:
+            return
+        for batch_id, batch in list(self._clarify_batch_state.items()):
+            if batch.get("session_key") != session_key:
+                continue
+            for card in batch.get("cards", {}).values():
+                message_id = card.get("message_id")
+                if not message_id:
+                    continue
+                try:
+                    await self._bot.edit_message_text(
+                        chat_id=int(batch["chat_id"]), message_id=int(message_id),
+                        text=f"{card.get('text', '')}\n\n<i>Abgebrochen – neue Nachricht erkannt.</i>",
+                        parse_mode=ParseMode.HTML, reply_markup=None,
+                    )
+                except Exception:
+                    logger.debug("Telegram clarify card invalidation failed", exc_info=True)
+            self._clarify_batch_state.pop(batch_id, None)
 
     @staticmethod
     def _provider_get_label():
@@ -4417,6 +4455,15 @@ class TelegramAdapter(BasePlatformAdapter):
             "This prompt has already been resolved.", pop=False)
         if not session_key:
             return
+        try:
+            from tools.clarify_gateway import _entries as _clarify_entries
+            _bound_entry = _clarify_entries.get(clarify_id)
+            if (_bound_entry is not None and _bound_entry.text_reply_user_id
+                    and str(getattr(query.from_user, "id", "")) != _bound_entry.text_reply_user_id):
+                await query.answer(text="⛔ Du darfst diese Frage nicht beantworten.")
+                return
+        except Exception:
+            logger.debug("[%s] clarify callback binding check failed", self.name, exc_info=True)
         user_display = getattr(query.from_user, "first_name", "User")
         if choice_token == "skip":
             self._clarify_state.pop(clarify_id, None)
@@ -4494,6 +4541,10 @@ class TelegramAdapter(BasePlatformAdapter):
             await query.answer(text="Diese Fragen sind nicht mehr aktiv.")
             return
         if not await self._callback_authorized(query, cb, "⛔ Du darfst diese Fragen nicht beantworten."):
+            return
+        if (batch.get("initiator_user_id")
+                and str(getattr(query.from_user, "id", "")) != str(batch["initiator_user_id"])):
+            await query.answer(text="⛔ Du darfst diese Fragen nicht beantworten.")
             return
         try:
             from tools import clarify_gateway as clarify_mod

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -166,3 +166,55 @@ async def test_gateway_batch_text_reply_skips_button_resolved_card_and_answers_n
     assert second.response == "blue"
 
 
+@pytest.mark.asyncio
+async def test_unbound_batch_followup_is_not_silently_consumed_and_releases_wait():
+    """Only a reply to the screenshot card may fill it; a follow-up releases the batch."""
+    _clear_clarify_state()
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    screenshot = cm.register(
+        "screenshot", "telegram:batch", "Send screenshot?", None,
+        require_text_reply_binding=True,
+    )
+    assert cm.bind_text_reply_to("screenshot", "prompt-42") is True
+
+    runner = object.__new__(GatewayRunner)
+    runner._pending_event_audio_paths = lambda event: []
+    runner._adapter_for_source = lambda source: None
+
+    event = _event("und?")
+    event.reply_to_message_id = "some-other-message"
+    result = await runner._hm_clarify_reply(event, event.source, "telegram:batch")
+
+    assert result is None
+    assert screenshot.event.is_set()
+    assert screenshot.response == ""
+
+
+@pytest.mark.asyncio
+async def test_bound_reply_to_open_batch_card_is_consumed_as_its_answer():
+    """The explicit Telegram reply anchor still permits the intended screenshot answer."""
+    _clear_clarify_state()
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    screenshot = cm.register(
+        "screenshot", "telegram:batch", "Send screenshot?", None,
+        require_text_reply_binding=True,
+    )
+    assert cm.bind_text_reply_to("screenshot", "prompt-42") is True
+
+    runner = object.__new__(GatewayRunner)
+    runner._pending_event_audio_paths = lambda event: []
+    runner._adapter_for_source = lambda source: None
+
+    event = _event("here is the screenshot")
+    event.reply_to_message_id = "prompt-42"
+    result = await runner._hm_clarify_reply(event, event.source, "telegram:batch")
+
+    assert result == ""
+    assert screenshot.event.is_set()
+    assert screenshot.response == "here is the screenshot"
+
+

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -167,8 +167,8 @@ async def test_gateway_batch_text_reply_skips_button_resolved_card_and_answers_n
 
 
 @pytest.mark.asyncio
-async def test_unbound_batch_followup_is_not_silently_consumed_and_releases_wait():
-    """Only a reply to the screenshot card may fill it; a follow-up releases the batch."""
+async def test_late_reply_to_another_card_does_not_cancel_current_batch():
+    """A direct reply to batch A must not release batch B just because its id differs."""
     _clear_clarify_state()
     from gateway.run import GatewayRunner
     from tools import clarify_gateway as cm
@@ -188,8 +188,53 @@ async def test_unbound_batch_followup_is_not_silently_consumed_and_releases_wait
     result = await runner._hm_clarify_reply(event, event.source, "telegram:batch")
 
     assert result is None
-    assert screenshot.event.is_set()
-    assert screenshot.response == ""
+    assert not screenshot.event.is_set()
+    assert screenshot.response is None
+
+
+@pytest.mark.asyncio
+async def test_unbound_batch_followup_releases_wait_and_visibly_invalidates_cards():
+    """Bare prose releases the batch and calls the adapter's stale-card hook."""
+    _clear_clarify_state()
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    screenshot = cm.register("screenshot", "telegram:batch", "Send screenshot?", None,
+                             require_text_reply_binding=True)
+    assert cm.bind_text_reply_to("screenshot", "prompt-42") is True
+    adapter = MagicMock()
+    adapter.invalidate_clarify_batch_for_session = AsyncMock()
+    runner = object.__new__(GatewayRunner)
+    runner._pending_event_audio_paths = lambda event: []
+    runner._adapter_for_source = lambda source: adapter
+    event = _event("new unrelated follow-up")
+
+    assert await runner._hm_clarify_reply(event, event.source, "telegram:batch") is None
+    assert screenshot.event.is_set() and screenshot.response == ""
+    adapter.invalidate_clarify_batch_for_session.assert_awaited_once_with("telegram:batch")
+
+
+@pytest.mark.asyncio
+async def test_missing_delivery_id_and_cross_user_reply_cannot_change_batch_state():
+    """No id and a reply from another user both fail closed without cancellation."""
+    _clear_clarify_state()
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    card = cm.register("card", "telegram:batch", "Text?", None, require_text_reply_binding=True)
+    runner = object.__new__(GatewayRunner)
+    runner._pending_event_audio_paths = lambda event: []
+    runner._adapter_for_source = lambda source: None
+    missing_id = _event("answer")
+    assert await runner._hm_clarify_reply(missing_id, missing_id.source, "telegram:batch") is None
+    assert not card.event.is_set()
+
+    assert cm.bind_text_reply_to("card", "prompt-42", chat_id="12345", user_id="user1")
+    other_user = _event("answer")
+    other_user.source.user_id = "user2"
+    other_user.reply_to_message_id = "prompt-42"
+    assert await runner._hm_clarify_reply(other_user, other_user.source, "telegram:batch") is None
+    assert not card.event.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -139,3 +139,30 @@ async def test_active_session_bypass_uses_profile_namespaced_key_under_multiplex
     assert adapter._pending_messages == {}
 
 
+@pytest.mark.asyncio
+async def test_gateway_batch_text_reply_skips_button_resolved_card_and_answers_next_question():
+    """The real gateway intercept must target the next unresolved batch card."""
+    _clear_clarify_state()
+    from gateway.run import GatewayRunner
+    from tools import clarify_gateway as cm
+
+    cm.register("q1", "telegram:batch", "First?", ["one", "two"])
+    second = cm.register("q2", "telegram:batch", "Second?", ["red", "blue"])
+    assert cm.resolve_gateway_clarify("q1", "one") is True
+
+    runner = object.__new__(GatewayRunner)
+    runner._pending_event_audio_paths = lambda event: []
+    runner._adapter_for_source = lambda source: None
+
+    async def prepare_reply(event):
+        return "2"
+
+    runner._prepare_clarify_reply_text = prepare_reply
+    event = _event("2")
+    result = await runner._hm_clarify_reply(event, event.source, "telegram:batch")
+
+    assert result == ""
+    assert second.event.is_set()
+    assert second.response == "blue"
+
+

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -222,8 +222,8 @@ class TestTelegramClarifyBatch:
 
         adapter = _make_adapter()
         adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=100))
-        cm.register("cid-budget", "sk-batch", "Budget?", ["850", "500"])
-        cm.register("cid-shot", "sk-batch", "Screenshot?", None)
+        cm.register("cid-budget", "sk-batch", "Budget?", ["850", "500"], require_text_reply_binding=True)
+        cm.register("cid-shot", "sk-batch", "Screenshot?", None, require_text_reply_binding=True)
 
         result = await adapter.send_clarify_batch(
             chat_id="12345",
@@ -237,6 +237,9 @@ class TestTelegramClarifyBatch:
         )
         assert result.success is True
         assert adapter._bot.send_message.await_count == 2
+        with cm._lock:
+            assert cm._entries["cid-shot"].requires_text_reply_binding is True
+            assert cm._entries["cid-shot"].text_reply_to_message_id == "100"
 
         # The user has answered the choice; the screenshot remains open.
         assert cm.resolve_gateway_clarify("cid-budget", "850") is True

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -210,6 +210,58 @@ class TestTelegramClarifyCallback:
         assert adapter._clarify_state["cidC"] == "sk-auth"
 
 
+class TestTelegramClarifyBatch:
+    """A batch keeps partial answers while explicit controls drive its lifecycle."""
+
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_batch_progress_does_not_consume_open_answer_and_continue_skips_remaining(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=100))
+        cm.register("cid-budget", "sk-batch", "Budget?", ["850", "500"])
+        cm.register("cid-shot", "sk-batch", "Screenshot?", None)
+
+        result = await adapter.send_clarify_batch(
+            chat_id="12345",
+            questions=[
+                {"qid": "q0", "question": "Budget?", "choices": ["850", "500"]},
+                {"qid": "q1", "question": "Screenshot?", "choices": None},
+            ],
+            clarify_ids=["cid-budget", "cid-shot"],
+            batch_id="batch1",
+            session_key="sk-batch",
+        )
+        assert result.success is True
+        assert adapter._bot.send_message.await_count == 2
+
+        # The user has answered the choice; the screenshot remains open.
+        assert cm.resolve_gateway_clarify("cid-budget", "850") is True
+        query = AsyncMock()
+        query.data = "clb:batch1:status"
+        query.message = MagicMock(chat_id=12345)
+        query.from_user = MagicMock(id="777", first_name="Tester")
+        query.answer = AsyncMock()
+        update = MagicMock(callback_query=query)
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        with cm._lock:
+            assert cm._entries["cid-shot"].event.is_set() is False
+        assert "1/2" in query.answer.call_args.kwargs["text"]
+
+        query.data = "clb:batch1:continue"
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+        with cm._lock:
+            assert cm._entries["cid-shot"].response == ""
+            assert cm._entries["cid-shot"].event.is_set() is True
+
+
 # ===========================================================================
 # Base adapter fallback render — text numbered list
 # ===========================================================================

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -264,6 +264,54 @@ class TestTelegramClarifyBatch:
             assert cm._entries["cid-shot"].response == ""
             assert cm._entries["cid-shot"].event.is_set() is True
 
+    @pytest.mark.asyncio
+    async def test_batch_card_binds_chat_user_and_invalidation_edits_visible_cards(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=MagicMock(message_id=100))
+        adapter._bot.edit_message_text = AsyncMock()
+        cm.register("cid-shot", "sk-batch", "Screenshot?", None, require_text_reply_binding=True)
+
+        result = await adapter.send_clarify_batch(
+            chat_id="12345", questions=[{"qid": "q1", "question": "Screenshot?", "choices": None}],
+            clarify_ids=["cid-shot"], batch_id="batch1", session_key="sk-batch",
+            metadata={"_clarify_initiator_user_id": "user1", "_clarify_initiator_thread_id": "topic7"},
+        )
+        assert result.success is True
+        with cm._lock:
+            entry = cm._entries["cid-shot"]
+            assert (entry.text_reply_chat_id, entry.text_reply_user_id, entry.text_reply_thread_id) == (
+                "12345", "user1", "topic7")
+
+        await adapter.invalidate_clarify_batch_for_session("sk-batch")
+        adapter._bot.edit_message_text.assert_awaited_once()
+        kwargs = adapter._bot.edit_message_text.call_args.kwargs
+        assert kwargs["reply_markup"] is None
+        assert "Abgebrochen" in kwargs["text"]
+        assert "batch1" not in adapter._clarify_batch_state
+
+    @pytest.mark.asyncio
+    async def test_other_authorized_user_cannot_tap_bound_batch_card(self):
+        from tools import clarify_gateway as cm
+
+        adapter = _make_adapter()
+        cm.register("cid-shot", "sk-batch", "Screenshot?", None, require_text_reply_binding=True)
+        assert cm.bind_text_reply_to("cid-shot", "100", user_id="user1")
+        adapter._clarify_state["cid-shot"] = "sk-batch"
+        query = AsyncMock()
+        query.data = "cl:cid-shot:skip"
+        query.message = MagicMock(chat_id=12345)
+        query.from_user = MagicMock(id="user2", first_name="Other")
+        query.answer = AsyncMock()
+        update = MagicMock(callback_query=query)
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        assert not cm._entries["cid-shot"].event.is_set()
+        assert "nicht beantworten" in query.answer.call_args.kwargs["text"]
+
 
 # ===========================================================================
 # Base adapter fallback render — text numbered list

--- a/tests/gateway/test_turn_runner_clarify_batch.py
+++ b/tests/gateway/test_turn_runner_clarify_batch.py
@@ -1,5 +1,7 @@
 """Gateway native clarify-batch bridge regressions."""
 
+import concurrent.futures
+
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -23,6 +25,7 @@ def test_native_batch_callback_registers_once_sends_all_and_returns_partial_answ
     runner = object.__new__(TurnRunner)
     runner._ctx = ctx
     runner._close_native_stream_boundary = MagicMock()
+    runner._stream_consumer = MagicMock(return_value=None)
     future = MagicMock()
     future.result.return_value = SendResult(success=True)
     runner._schedule = MagicMock(return_value=future)
@@ -38,3 +41,52 @@ def test_native_batch_callback_registers_once_sends_all_and_returns_partial_answ
     assert [q["question"] for q in kwargs["questions"]] == ["Budget?", "Screenshot?"]
     assert len(kwargs["clarify_ids"]) == 2
     adapter.clear_clarify_batch.assert_called_once_with(kwargs["batch_id"])
+
+
+def test_native_batch_send_timeout_keeps_cards_armed_until_batch_wait_and_restores_continuation(monkeypatch):
+    """A late Telegram send acknowledgement must not invalidate rendered cards."""
+    from tools import clarify_gateway as cm
+
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+
+    adapter = MagicMock()
+    adapter.send_clarify_batch = MagicMock()
+    ctx = SimpleNamespace(
+        _status_adapter=adapter, _status_chat_id="42", _status_thread_metadata={}, session_key="telegram:42",
+    )
+    runner = object.__new__(TurnRunner)
+    runner._ctx = ctx
+    runner._close_native_stream_boundary = MagicMock()
+    stream = MagicMock()
+    runner._stream_consumer = MagicMock(return_value=stream)
+    future = MagicMock()
+    future.result.side_effect = concurrent.futures.TimeoutError()
+    runner._schedule = MagicMock(return_value=future)
+    observed = {}
+
+    real_wait = cm.wait_for_batch_responses
+
+    def wait_for_batch(ids, timeout):
+        observed["ids"] = ids
+        observed["timeout"] = timeout
+        assert all(not cm._entries[cid].event.is_set() for cid in ids)
+        for cid in ids:
+            cm.resolve_gateway_clarify(cid, "answer")
+        return real_wait(ids, timeout=0)
+
+    monkeypatch.setattr(cm, "wait_for_batch_responses", wait_for_batch)
+
+    result = runner._clarify_callback_sync("", None, questions=[
+        {"qid": "q0", "question": "First?", "choices": ["A", "B"]},
+        {"qid": "q1", "question": "Second?", "choices": ["C", "D"]},
+    ])
+
+    assert result == {"answers": {"q0": "answer", "q1": "answer"}, "timed_out": False}
+    assert observed["timeout"] == cm.get_clarify_timeout()
+    assert cm._entries == {}
+    assert cm._session_index == {}
+    adapter.clear_clarify_batch.assert_called_once()
+    adapter.resume_typing_for_chat.assert_called_once_with("42")
+    stream.request_reopen_seed.assert_called_once()

--- a/tests/gateway/test_turn_runner_clarify_batch.py
+++ b/tests/gateway/test_turn_runner_clarify_batch.py
@@ -1,0 +1,40 @@
+"""Gateway native clarify-batch bridge regressions."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from gateway.platforms.base import SendResult
+from gateway.run_turn_runner import TurnRunner
+
+
+def test_native_batch_callback_registers_once_sends_all_and_returns_partial_answers(monkeypatch):
+    from tools import clarify_gateway as cm
+
+    with cm._lock:
+        cm._entries.clear()
+        cm._session_index.clear()
+
+    adapter = MagicMock()
+    adapter.send_clarify_batch = MagicMock()
+    ctx = SimpleNamespace(
+        _status_adapter=adapter, _status_chat_id="42", _status_thread_metadata={"thread_id": "7"},
+        session_key="telegram:42:7",
+    )
+    runner = object.__new__(TurnRunner)
+    runner._ctx = ctx
+    runner._close_native_stream_boundary = MagicMock()
+    future = MagicMock()
+    future.result.return_value = SendResult(success=True)
+    runner._schedule = MagicMock(return_value=future)
+    monkeypatch.setattr(cm, "wait_for_batch_responses", lambda ids, timeout: ({ids[0]: "850", ids[1]: ""}, False))
+
+    result = runner._clarify_callback_sync("", None, questions=[
+        {"qid": "q0", "question": "Budget?", "choices": ["850", "500"]},
+        {"qid": "q1", "question": "Screenshot?", "choices": None},
+    ])
+
+    assert result == {"answers": {"q0": "850", "q1": ""}, "timed_out": False}
+    kwargs = adapter.send_clarify_batch.call_args.kwargs
+    assert [q["question"] for q in kwargs["questions"]] == ["Budget?", "Screenshot?"]
+    assert len(kwargs["clarify_ids"]) == 2
+    adapter.clear_clarify_batch.assert_called_once_with(kwargs["batch_id"])

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -52,6 +52,29 @@ class TestClarifyPrimitive:
         assert cm.resolve_gateway_clarify("id-race", "") is False
         assert entry.response == "A"
 
+    def test_concurrent_bound_batch_cancel_preserves_first_answer(self):
+        """The cancel path and a button tap have one terminal-state winner."""
+        from tools import clarify_gateway as cm
+
+        entry = cm.register("id-bound-race", "sk-bound-race", "Pick", ["A"],
+                            require_text_reply_binding=True)
+        barrier = threading.Barrier(2)
+
+        def answer():
+            barrier.wait()
+            cm.resolve_gateway_clarify("id-bound-race", "A")
+
+        thread = threading.Thread(target=answer)
+        thread.start()
+        barrier.wait()
+        cm.cancel_bound_batch_for_session("sk-bound-race")
+        thread.join(timeout=5)
+        assert entry.event.is_set()
+        # Either terminal transition may linearize first, but no later cancel
+        # may overwrite a selected answer.
+        if entry.response == "A":
+            assert cm.cancel_bound_batch_for_session("sk-bound-race") == 0
+
     def test_open_ended_auto_awaits_text(self):
         """Clarify with no choices is in text-capture mode immediately."""
         from tools import clarify_gateway as cm

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -87,6 +87,50 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
     return entry.response
 
 
+def wait_for_batch_responses(clarify_ids: List[str], timeout: float) -> tuple[Dict[str, str], bool]:
+    """Wait once for a set of clarifies and retain every response (including explicit skips).
+
+    The shared deadline makes a batch bounded as one user interaction rather than one timeout per
+    question. Entries remain indexed until the batch settles so adapters can report progress.
+    """
+    with _lock:
+        entries = [(cid, _entries.get(cid)) for cid in clarify_ids]
+    deadline = None if timeout is None or float(timeout) <= 0.0 else time.monotonic() + float(timeout)
+    try:
+        from tools.environments.base import touch_activity_if_due
+    except Exception:  # pragma: no cover - optional
+        touch_activity_if_due = None
+    activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
+    timed_out = False
+    while any(entry is not None and not entry.event.is_set() for _, entry in entries):
+        remaining = 1.0 if deadline is None else deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        next_pending = next(entry for _, entry in entries if entry is not None and not entry.event.is_set())
+        next_pending.event.wait(timeout=min(1.0, remaining))
+        if touch_activity_if_due is not None:
+            touch_activity_if_due(activity_state, "waiting for user clarify batch responses")
+    responses: Dict[str, str] = {}
+    with _lock:
+        for clarify_id, entry in entries:
+            if entry is None:
+                timed_out = True
+                continue
+            if entry.event.is_set():
+                responses[clarify_id] = entry.response or ""
+            else:
+                timed_out = True
+                responses[clarify_id] = ""
+            _entries.pop(clarify_id, None)
+            ids = _session_index.get(entry.session_key) or []
+            if clarify_id in ids:
+                ids.remove(clarify_id)
+            if not ids:
+                _session_index.pop(entry.session_key, None)
+    return responses, timed_out
+
+
 def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
     """Unblock the waiter on ``clarify_id``; False if already resolved/expired/unknown."""
     with _lock:

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -31,6 +31,11 @@ class _ClarifyEntry:
     # its card, otherwise an unrelated active-session follow-up could become its answer.
     requires_text_reply_binding: bool = False
     text_reply_to_message_id: Optional[str] = None
+    # A Telegram message id is only unique in its chat. These fields make a
+    # reply-bound card fail closed when a group session is shared.
+    text_reply_chat_id: Optional[str] = None
+    text_reply_user_id: Optional[str] = None
+    text_reply_thread_id: Optional[str] = None
 
 
 _lock = threading.RLock()
@@ -62,7 +67,8 @@ def register(clarify_id: str, session_key: str, question: str, choices: Optional
     return entry
 
 
-def bind_text_reply_to(clarify_id: str, message_id: object) -> bool:
+def bind_text_reply_to(clarify_id: str, message_id: object, *, chat_id: object = None,
+                       user_id: object = None, thread_id: object = None) -> bool:
     """Bind typed input for a batch card to its rendered platform message."""
     value = str(message_id).strip() if message_id is not None else ""
     with _lock:
@@ -70,6 +76,9 @@ def bind_text_reply_to(clarify_id: str, message_id: object) -> bool:
         if entry is None or not value:
             return False
         entry.text_reply_to_message_id = value
+        entry.text_reply_chat_id = str(chat_id) if chat_id is not None else None
+        entry.text_reply_user_id = str(user_id) if user_id is not None else None
+        entry.text_reply_thread_id = str(thread_id) if thread_id is not None else None
         return True
 
 

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -149,7 +149,11 @@ def get_pending_for_session(session_key: str, *, include_choice_prompts: bool = 
     with _lock:
         for cid in _session_index.get(session_key) or []:
             entry = _entries.get(cid)
-            if entry is not None and (include_choice_prompts or entry.awaiting_text):
+            # Resolved batch cards stay indexed until the shared waiter collects every
+            # answer. They are no longer candidates for a typed reply: choosing Q1 by
+            # button must let typed text target the next unresolved card, Q2.
+            if (entry is not None and not entry.event.is_set()
+                    and (include_choice_prompts or entry.awaiting_text)):
                 return entry
         return None
 
@@ -278,7 +282,10 @@ def mark_awaiting_text(clarify_id: str) -> bool:
 def has_pending(session_key: str) -> bool:
     """True when this session has at least one pending clarify entry."""
     with _lock:
-        return any(_entries.get(cid) is not None for cid in _session_index.get(session_key) or [])
+        return any(
+            (entry := _entries.get(cid)) is not None and not entry.event.is_set()
+            for cid in _session_index.get(session_key) or []
+        )
 
 
 def clear_session(session_key: str) -> int:

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -27,6 +27,10 @@ class _ClarifyEntry:
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
+    # Batch cards are displayed side-by-side. Free prose must explicitly reply to
+    # its card, otherwise an unrelated active-session follow-up could become its answer.
+    requires_text_reply_binding: bool = False
+    text_reply_to_message_id: Optional[str] = None
 
 
 _lock = threading.RLock()
@@ -44,15 +48,47 @@ TEXT_NO_PENDING = "no_pending"
 
 
 def register(clarify_id: str, session_key: str, question: str, choices: Optional[List[str]],
-             multi_select: bool = False) -> _ClarifyEntry:
+             multi_select: bool = False, require_text_reply_binding: bool = False) -> _ClarifyEntry:
     """Register a pending clarify request; caller then blocks on ``wait_for_response``.
     Open-ended (no choices) entries start in text mode: the next message IS the response."""
-    entry = _ClarifyEntry(clarify_id, session_key, question, list(choices) if choices else None,
-                          bool(multi_select) and bool(choices), awaiting_text=not bool(choices))
+    entry = _ClarifyEntry(
+        clarify_id, session_key, question, list(choices) if choices else None,
+        bool(multi_select) and bool(choices), awaiting_text=not bool(choices),
+        requires_text_reply_binding=bool(require_text_reply_binding),
+    )
     with _lock:
         _entries[clarify_id] = entry
         _session_index.setdefault(session_key, []).append(clarify_id)
     return entry
+
+
+def bind_text_reply_to(clarify_id: str, message_id: object) -> bool:
+    """Bind typed input for a batch card to its rendered platform message."""
+    value = str(message_id).strip() if message_id is not None else ""
+    with _lock:
+        entry = _entries.get(clarify_id)
+        if entry is None or not value:
+            return False
+        entry.text_reply_to_message_id = value
+        return True
+
+
+def cancel_bound_batch_for_session(session_key: str) -> int:
+    """Release every unresolved reply-bound batch card when the user sends a follow-up.
+
+    A batch owns one blocked agent turn.  An unbound message is ordinary conversation, not
+    an answer to a card, so keeping the remaining cards armed would hide that follow-up behind
+    a potentially unlimited clarify timeout.
+    """
+    cancelled = 0
+    with _lock:
+        for clarify_id in _session_index.get(session_key) or []:
+            entry = _entries.get(clarify_id)
+            if entry is not None and entry.requires_text_reply_binding and not entry.event.is_set():
+                entry.response = ""
+                entry.event.set()
+                cancelled += 1
+    return cancelled
 
 
 def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:


### PR DESCRIPTION
## Summary
- render native Telegram clarify batches together with per-question skip, progress, and explicit completion controls
- preserve partial answers through the shared batch deadline and return them to the clarify caller
- add regression coverage for progress, completion, and native batch bridging

## Tests
- `scripts/run_tests.sh tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_turn_runner_clarify_batch.py`