### PR TITLE
feat(delegation): subagents can fork the parent conversation (salvage #91252, deepagents-confirmed)

### DIFF
--- a/tests/tools/test_delegation_fork.py
+++ b/tests/tools/test_delegation_fork.py
@@ -1,0 +1,166 @@
+"""Tests for delegate_task fork-context snapshots (kimi-code#3007 port).
+
+Covers tools/delegation_fork.py (snapshot building, tail trimming, capping,
+inheritance framing) and the delegate_tool wiring (fork flag resolution,
+snapshot attachment, degrade-to-blank behavior).
+"""
+
+import copy
+import unittest
+from unittest.mock import MagicMock
+
+from tools.delegation_fork import (
+    DEFAULT_FORK_MAX_MESSAGES,
+    INHERITANCE_NOTICE,
+    _fork_cap,
+    _trim_incomplete_tail,
+    build_fork_snapshot,
+    frame_forked_goal,
+)
+
+
+def _mk_parent(history):
+    parent = MagicMock()
+    parent.session_id = "sess-parent"
+    db = MagicMock()
+    db.get_messages_as_conversation.return_value = history
+    parent._session_db = db
+    return parent
+
+
+class TestTrimIncompleteTail(unittest.TestCase):
+    def test_trailing_tool_results_and_dangling_call_removed(self):
+        msgs = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": "do it"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "content": "partial", "tool_call_id": "t1"},
+        ]
+        trimmed = _trim_incomplete_tail(msgs)
+        # Ends at the last completed assistant reply: the trailing user
+        # prompt is dropped too, because the child's kickoff goal arrives
+        # as a user message and user;user would violate alternation.
+        self.assertEqual(len(trimmed), 2)
+        self.assertEqual(trimmed[-1]["content"], "a")
+
+    def test_clean_tail_untouched(self):
+        msgs = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "done"},
+        ]
+        self.assertEqual(_trim_incomplete_tail(msgs), msgs)
+
+    def test_completed_tool_round_trip_kept(self):
+        msgs = [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "content": "res", "tool_call_id": "t1"},
+            {"role": "assistant", "content": "final answer"},
+        ]
+        self.assertEqual(_trim_incomplete_tail(msgs), msgs)
+
+
+class TestBuildForkSnapshot(unittest.TestCase):
+    def test_snapshot_strips_system_and_bookkeeping(self):
+        parent = _mk_parent([
+            {"role": "system", "content": "SYSTEM PROMPT"},
+            {"role": "user", "content": "hello", "_row_id": 5,
+             "display_kind": "x", "observed": True},
+            {"role": "assistant", "content": "hi", "message_id": "m1"},
+        ])
+        snap = build_fork_snapshot(parent)
+        self.assertEqual([m["role"] for m in snap], ["user", "assistant"])
+        for m in snap:
+            for k in ("_row_id", "display_kind", "observed", "message_id"):
+                self.assertNotIn(k, m)
+
+    def test_snapshot_trims_in_flight_delegate_call(self):
+        parent = _mk_parent([
+            {"role": "user", "content": "investigate"},
+            {"role": "assistant", "content": "findings"},
+            {"role": "user", "content": "now delegate"},
+            {"role": "assistant", "content": "",
+             "tool_calls": [{"id": "dt", "function": {"name": "delegate_task"}}]},
+        ])
+        snap = build_fork_snapshot(parent)
+        # In-flight delegate call, and the user prompt that triggered it,
+        # are trimmed to the last completed assistant reply.
+        self.assertEqual(snap[-1]["content"], "findings")
+
+    def test_no_session_db_returns_none(self):
+        parent = MagicMock()
+        parent.session_id = "s"
+        parent._session_db = None
+        self.assertIsNone(build_fork_snapshot(parent))
+
+    def test_empty_history_returns_none(self):
+        self.assertIsNone(build_fork_snapshot(_mk_parent([])))
+
+    def test_db_error_returns_none(self):
+        parent = _mk_parent([])
+        parent._session_db.get_messages_as_conversation.side_effect = RuntimeError("boom")
+        self.assertIsNone(build_fork_snapshot(parent))
+
+    def test_cap_keeps_most_recent_and_repairs_leading_tool(self):
+        history = [{"role": "user", "content": "start"}]
+        for i in range(300):
+            history.append({"role": "assistant", "content": "",
+                            "tool_calls": [{"id": f"t{i}"}]})
+            history.append({"role": "tool", "content": f"r{i}",
+                            "tool_call_id": f"t{i}"})
+        history.append({"role": "assistant", "content": "done"})
+        parent = _mk_parent(history)
+        snap = build_fork_snapshot(parent, cfg={"fork_max_messages": 50})
+        self.assertLessEqual(len(snap), 50)
+        # Must not open on a tool result without its call.
+        self.assertNotEqual(snap[0]["role"], "tool")
+        self.assertEqual(snap[-1]["content"], "done")
+
+    def test_snapshot_deep_copies(self):
+        inner = {"role": "user", "content": "x", "meta": {"a": 1}}
+        parent = _mk_parent([inner, {"role": "assistant", "content": "y"}])
+        snap = build_fork_snapshot(parent)
+        snap[0]["meta"]["a"] = 999
+        self.assertEqual(inner["meta"]["a"], 1)
+
+    def test_fork_cap_resolution(self):
+        self.assertEqual(_fork_cap(None), DEFAULT_FORK_MAX_MESSAGES)
+        self.assertEqual(_fork_cap({"fork_max_messages": 80}), 80)
+        self.assertEqual(_fork_cap({"fork_max_messages": "junk"}),
+                         DEFAULT_FORK_MAX_MESSAGES)
+        # floor
+        self.assertEqual(_fork_cap({"fork_max_messages": 1}), 10)
+
+
+class TestFrameForkedGoal(unittest.TestCase):
+    def test_notice_prefixes_goal(self):
+        framed = frame_forked_goal("summarize the findings")
+        self.assertTrue(framed.startswith(INHERITANCE_NOTICE))
+        self.assertIn("summarize the findings", framed)
+
+
+class TestDelegateToolWiring(unittest.TestCase):
+    """The fork kwarg flows registry → delegate_task → child attachment."""
+
+    def test_registry_handler_passes_fork(self):
+        import inspect
+        from tools.delegate_tool import delegate_task
+        sig = inspect.signature(delegate_task)
+        self.assertIn("fork", sig.parameters)
+
+    def test_schema_declares_fork(self):
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("fork", props)
+        self.assertEqual(props["fork"]["type"], "boolean")
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("fork", task_props)
+
+    def test_fork_not_model_hidden(self):
+        from tools.delegate_tool import _MODEL_HIDDEN_TASK_FIELDS
+        self.assertNotIn("fork", _MODEL_HIDDEN_TASK_FIELDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -411,7 +411,8 @@ def delegate_task(
     goal: Optional[str] = None, context: Optional[str] = None, tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None, role: Optional[str] = None, background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None, action: Optional[str] = None, subagent_id: Optional[str] = None,
-    message: Optional[str] = None, parent_agent=None, credentials_cfg: Optional[Dict[str, Any]] = None,
+    message: Optional[str] = None, fork: Optional[bool] = None, parent_agent=None,
+    credentials_cfg: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Spawn child agents (single ``goal`` or ``tasks=[...]`` batch) or control running ones. ``action``
     list/steer/stop run synchronously and bypass the pause gate, depth limit and async dispatch. ``role`` is legacy
@@ -489,6 +490,30 @@ def delegate_task(
     )
     if err:
         return tool_error(err)
+    # ── Fork snapshots (kimi-code#3007 port; same mechanism as deepagents fork mode) ──
+    # Top-level fork applies to the single-goal form and acts as the batch default;
+    # per-task {"fork": true/false} overrides it. The parent transcript snapshot is
+    # built ONCE and shared read-only by every forked child (each child's
+    # run_conversation copies it into its own message list). No session DB or an
+    # empty transcript degrades to a blank-context spawn. Prompt-caching-safe: the
+    # parent's context is never mutated.
+    fork_flags = [
+        is_truthy_value(t.get("fork"), default=False)
+        if t.get("fork") is not None
+        else (is_truthy_value(fork, default=False) if fork is not None else False)
+        for t in (task_list or [])
+    ]
+    if any(fork_flags):
+        from tools.delegation_fork import build_fork_snapshot
+
+        fork_snapshot = build_fork_snapshot(parent_agent, cfg=cfg)
+        if fork_snapshot is not None:
+            for i, _t, child in children:
+                if i < len(fork_flags) and fork_flags[i]:
+                    # Read by _run_with_thread_capture in delegate_tool_child_run;
+                    # absent on non-forked tasks.
+                    with _quiet("Could not attach fork snapshot to child %d", i):
+                        child._fork_history = fork_snapshot
     batch = _Batch(
         task_list, children, parent_agent, creds, context, top_role, max_children,
         live_deleg_id, live_writers, live_paths, *origin, overall_start,
@@ -639,11 +664,26 @@ DELEGATE_TASK_SCHEMA = {
                             "together in ONE message; ungrouped tasks return individually as each finishes. This does not "
                             "order execution; if B needs A's output, dispatch B after A returns.",
                         ),
+                        "fork": _p(
+                            "boolean",
+                            "Per-task fork override. See top-level 'fork' for semantics.",
+                        ),
                     },
                     "required": ["goal"],
                 },
                 "description": "(rebuilt at get_definitions() time)",
             },
+            "fork": _p(
+                "boolean",
+                "Default false: subagents start with a BLANK context and know nothing of this "
+                "conversation. Set true to fork instead: the child starts from a one-time snapshot of "
+                "this conversation's history (framed as inherited reference material), so work that "
+                "builds on what was already established here needs no re-briefing. Fork workers that "
+                "CONTINUE your current investigation (avoids re-reading files); keep false for "
+                "independent tasks and for verifiers/reviewers whose judgment must not inherit your "
+                "framing. A fork re-sends the parent transcript on the child's first request and costs "
+                "accordingly. Per-task 'fork' in the tasks array overrides this default.",
+            ),
             # `background` (bool) is also accepted — DEPRECATED, ignored: top-level
             # delegations always run in the background. Unadvertised; do not re-add.
             "action": _p(
@@ -697,7 +737,7 @@ registry.register(
         max_iterations=args.get("max_iterations"), role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")), output_schema=args.get("output_schema"),
         action=args.get("action"), subagent_id=args.get("subagent_id"), message=args.get("message"),
-        parent_agent=kw.get("parent_agent"),
+        fork=args.get("fork"), parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,
     emoji="🔀",

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -656,8 +656,23 @@ class _ChildRun:
             worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
             with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+                _fork_history = getattr(child, "_fork_history", None)
+                _run_kwargs: Dict[str, Any] = {}
+                _run_goal = self.goal
+                if isinstance(_fork_history, list) and _fork_history:
+                    # Forked spawn (kimi-code#3007 port; deepagents fork mode is the
+                    # same mechanism): seed the parent's sanitized transcript through
+                    # the same conversation_history parameter the gateway uses for
+                    # session restore, and frame the kickoff goal with the inheritance
+                    # notice so the child reads the snapshot as reference material,
+                    # not its own past actions.
+                    from tools.delegation_fork import frame_forked_goal
+
+                    _run_kwargs["conversation_history"] = _fork_history
+                    _run_goal = frame_forked_goal(self.goal)
                 return child.run_conversation(
-                    user_message=self.goal, task_id=self.child_task_id, stream_callback=self.relay_text,
+                    user_message=_run_goal, task_id=self.child_task_id, stream_callback=self.relay_text,
+                    **_run_kwargs,
                 )
 
         future = executor.submit(contextvars.copy_context().run, _run_with_thread_capture)

--- a/tools/delegation_fork.py
+++ b/tools/delegation_fork.py
@@ -1,0 +1,175 @@
+"""Fork-context snapshots for delegate_task subagents.
+
+Port of MoonshotAI/kimi-code#3007 ("add a fork parameter to the Agent
+tool", MIT) adapted to Hermes' delegation architecture.
+
+With ``fork: true`` on ``delegate_task`` (or on an individual batch task),
+the child starts from a one-time snapshot of the calling agent's
+conversation history instead of a blank context. The snapshot is:
+
+* read from the PARENT's session in the session DB (``hermes_state``),
+  which incremental turn persistence keeps current up to the tool calls
+  of the in-flight turn — the same durable transcript the gateway uses
+  for session restore;
+* sanitized so the child never replays live scaffolding: the parent's
+  trailing assistant message carrying the in-flight ``delegate_task``
+  tool_call can never close inside the child, so the tail is trimmed to
+  the last coherent boundary and alternation is repaired with the same
+  ``repair_message_sequence`` used for gateway session replay;
+* framed with an inheritance notice so the child treats the seeded
+  messages as reference material from its parent, not as its own past
+  actions (mirrors kimi-code's inheritance-notice framing).
+
+The snapshot is seeded through ``run_conversation(conversation_history=...)``
+— the exact parameter the gateway uses to restore sessions — so no new
+message-injection path exists and role-alternation invariants hold.
+
+Cost note: a forked child's first request re-sends the parent transcript,
+so fork is opt-in per call and bounded by ``delegation.fork_max_messages``
+(default 200 most-recent messages).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Default cap on how many trailing parent messages a fork snapshot carries.
+DEFAULT_FORK_MAX_MESSAGES = 200
+
+# Message keys that are parent-session bookkeeping, not model context.
+_STRIP_KEYS = {"_row_id", "display_kind", "display_metadata", "observed", "message_id"}
+
+INHERITANCE_NOTICE = (
+    "You were forked from your parent agent's conversation. The messages "
+    "above are an inherited snapshot of the parent's session — treat them "
+    "as reference material describing what has already been established, "
+    "NOT as actions you performed yourself. Tool results in the snapshot "
+    "were produced by the parent. Your task follows."
+)
+
+
+def _fork_cap(cfg: Optional[Dict[str, Any]]) -> int:
+    """Resolve delegation.fork_max_messages with a safe floor."""
+    try:
+        raw = (cfg or {}).get("fork_max_messages", DEFAULT_FORK_MAX_MESSAGES)
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_FORK_MAX_MESSAGES
+    return max(10, value)
+
+
+def _trim_incomplete_tail(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop the parent's in-flight scaffolding from the snapshot tail.
+
+    The fork happens mid-turn: the parent's transcript ends with the
+    assistant message whose ``tool_calls`` include the very
+    ``delegate_task`` call being executed (and possibly tool results for
+    sibling calls in the same batch). Those calls can never be closed
+    inside the child, and an assistant tool_calls message without a
+    complete set of tool responses is a wire-invalid tail. Trim
+    backwards past any trailing tool results and the dangling
+    assistant-with-tool_calls message to the last coherent boundary.
+    """
+    msgs = list(messages)
+    while msgs:
+        tail = msgs[-1]
+        role = tail.get("role")
+        if role == "assistant" and not tail.get("tool_calls"):
+            # Coherent boundary: a completed assistant reply. The child's
+            # kickoff goal is appended as a user message by
+            # run_conversation, so the snapshot must end here — a trailing
+            # user message (the parent-turn prompt that triggered this
+            # delegation) or a dangling tool_calls/tool tail would break
+            # role alternation or tool-call adjacency in the child.
+            break
+        if role == "assistant" and tail.get("tool_calls"):
+            # Dangling call (the in-flight delegate_task itself, or a call
+            # whose responses were trimmed below it). Drop and continue —
+            # this can expose another incomplete boundary above.
+            msgs.pop()
+            continue
+        # tool results without their call kept, user prompts, anything else.
+        msgs.pop()
+    return msgs
+
+
+def build_fork_snapshot(
+    parent_agent: Any,
+    *,
+    cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[List[Dict[str, Any]]]:
+    """Build a sanitized copy of the parent's conversation for a forked child.
+
+    Returns ``None`` (fork degrades to a normal blank-context spawn, with a
+    log line) when the parent has no session DB, no session id, or an empty
+    transcript — never raises into the delegation path.
+    """
+    session_db = getattr(parent_agent, "_session_db", None)
+    session_id = getattr(parent_agent, "session_id", None)
+    if session_db is None or not session_id:
+        logger.info(
+            "fork requested but parent has no session DB/session id; "
+            "spawning with blank context"
+        )
+        return None
+
+    try:
+        history = session_db.get_messages_as_conversation(
+            str(session_id),
+            include_ancestors=True,
+            repair_alternation=True,
+        )
+    except Exception as exc:
+        logger.warning(
+            "fork snapshot read failed for session %s: %s; spawning with "
+            "blank context",
+            session_id,
+            exc,
+        )
+        return None
+
+    if not history:
+        logger.info(
+            "fork requested but parent session %s has no persisted messages; "
+            "spawning with blank context",
+            session_id,
+        )
+        return None
+
+    snapshot: List[Dict[str, Any]] = []
+    for msg in history:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "system":
+            # The child builds its own system prompt; the parent's must not
+            # be replayed as history.
+            continue
+        clean = {k: v for k, v in msg.items() if k not in _STRIP_KEYS}
+        snapshot.append(copy.deepcopy(clean))
+
+    snapshot = _trim_incomplete_tail(snapshot)
+    if not snapshot:
+        return None
+
+    cap = _fork_cap(cfg)
+    if len(snapshot) > cap:
+        snapshot = snapshot[-cap:]
+        # Never open on a dangling tool/assistant-tool_calls boundary after
+        # the cut: drop leading tool results without a preceding call.
+        while snapshot and snapshot[0].get("role") == "tool":
+            snapshot.pop(0)
+        snapshot = _trim_incomplete_tail(snapshot)
+        if not snapshot:
+            return None
+
+    return snapshot
+
+
+def frame_forked_goal(goal: str) -> str:
+    """Prefix the child's kickoff goal with the inheritance notice."""
+    return f"{INHERITANCE_NOTICE}\n\nYOUR TASK:\n{goal}"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2704,6 +2704,7 @@ delegation:
   worktree_isolation: false                 # Give each child its own git worktree branched from HEAD (local backend + git repos only; inspired by Muse Code). See Subagent Delegation → Worktree Isolation.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
+  fork_max_messages: 200                    # Cap on parent-transcript messages seeded into a forked child (delegate_task fork: true). Floor 10. See Subagent Delegation → Forked Subagents.
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -77,8 +77,8 @@ Keep schemas forgiving: require only the fields you will actually read. Tasks wi
 
 ## How Subagent Context Works
 
-:::warning Critical: Subagents Know Nothing
-Subagents start with a **completely fresh conversation**. They have zero knowledge of the parent's conversation history, prior tool calls, or anything discussed before delegation. The subagent's only context comes from the `goal` and `context` fields the parent agent populates when it calls `delegate_task`.
+:::warning Critical: Subagents Know Nothing (unless you fork)
+Subagents start with a **completely fresh conversation**. They have zero knowledge of the parent's conversation history, prior tool calls, or anything discussed before delegation. The subagent's only context comes from the `goal` and `context` fields the parent agent populates when it calls `delegate_task` — unless the call sets `fork: true` (see below).
 :::
 
 One exception: when the parent has a resolved workspace directory, every subagent's system prompt embeds that workspace's **project context files** (`.hermes.md` > AGENTS.md chain > CLAUDE.md > `.cursorrules` — the same discovery, priority, and size caps as the main agent's system prompt; SOUL.md is excluded). Subagents working in a repo operate under the repo's own conventions without having to rediscover them.
@@ -101,6 +101,31 @@ delegate_task(
 ```
 
 The subagent receives a focused system prompt built from your goal and context, instructing it to complete the task and provide a structured summary of what it did, what it found, any files modified, and any issues encountered.
+
+## Forked Subagents (`fork: true`)
+
+For work that *builds on the current conversation* — continuing an investigation, acting on findings already established — re-briefing everything into `context` is lossy and token-expensive. Set `fork: true` and the child instead starts from a one-time snapshot of the parent's conversation history:
+
+```python
+delegate_task(
+    goal="Write the full report on option B using everything we established above",
+    fork=True,
+)
+```
+
+How it works:
+
+- The snapshot is read from the parent's persisted session transcript and trimmed to the last *completed* assistant reply — the in-flight `delegate_task` tool call (which can never close inside the child), dangling tool results, and the triggering user prompt are removed so message-role alternation stays valid.
+- The parent's system prompt is never replayed; the child builds its own focused system prompt as usual.
+- The child's kickoff message is prefixed with an inheritance notice framing the seeded messages as *reference material produced by the parent*, not the child's own actions.
+- In a batch, top-level `fork` is the default and each task may override it with its own `fork` field — so one fan-out can mix forked continuations with blank-context workers.
+- The snapshot is capped to the most recent messages (`delegation.fork_max_messages` in `config.yaml`, default 200).
+
+**When to fork (decision rule):** fork **workers** that continue an investigation the parent already did — they skip re-reading files and re-establishing findings. Keep **verifiers and reviewers** isolated — independent judgment must not inherit the parent's framing. (The same rule LangChain's deepagents ships for its fork/isolated subagent modes; both it and kimi-code converged on this mechanism independently.)
+
+**Cost note:** a forked child's first request re-sends the parent transcript. Keep `fork` off (the default) for independent tasks; use it when re-briefing would lose important nuance.
+
+If the parent has no persisted session (rare: in-memory only runs), fork degrades gracefully to a normal blank-context spawn and logs the reason.
 
 ## Practical Examples
 


### PR DESCRIPTION
Subagents can now inherit the parent's conversation: `delegate_task(..., fork=true)` (or per-task `{"fork": true}`) seeds the child with a one-time sanitized snapshot of the parent's persisted transcript instead of a blank context.

Salvage of #91252 (port of MoonshotAI/kimi-code#3007), re-applied at the post-decomposition seams. LangChain's deepagents shipped the identical mechanism on Sep 8 (deepagents#6024/#6030/#6085 — `fork` vs `isolated` subagent context modes), independently confirming the pattern; this was flagged as a salvage candidate on #91252 at the time.

## Changes
- `tools/delegation_fork.py` (new): snapshot builder — reads the parent's durable session transcript (`get_messages_as_conversation`, ancestors + alternation repair), strips the system prompt and bookkeeping keys, trims the in-flight `delegate_task` scaffolding and triggering user prompt back to the last completed assistant reply, caps at `delegation.fork_max_messages` (default 200, floor 10), deep-copies. Plus the inheritance-notice goal framing.
- `tools/delegate_tool.py`: `fork` kwarg + top-level/per-task schema fields; snapshot built ONCE per batch after `_build_children`, attached only to forked children. Registry handler passes `fork` through.
- `tools/delegate_tool_child_run.py`: `_run_with_thread_capture` seeds `conversation_history=` (the exact gateway session-restore parameter — no new injection path) and frames the kickoff goal.
- Docs: delegation feature page (`Forked Subagents` section incl. the deepagents fork/isolate decision rule: fork workers continuing an investigation, isolate verifiers) + `fork_max_messages` config row.
- Tests: `tests/tools/test_delegation_fork.py` (15) — tail trimming, cap + leading-tool repair, deep-copy isolation, degrade-to-blank, schema/signature wiring.

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_deleg*` (23 files) | 291 passed, 0 failed |
| E2E vs real `state.db` (temp HERMES_HOME, purged `sys.modules`) | snapshot ends at last completed assistant reply; system stripped; no-DB degrades to `None` |
| ruff / windows-footguns / compat-pointers / `git diff --check` | clean |

**Live repro:** before — `delegate_task` schema has no `fork` field and children always spawn blank (verified on origin/main); after — E2E above seeds a real persisted transcript through `run_conversation(conversation_history=...)`.

Root cause of the original gap: children could only be briefed via `goal`/`context`, so continuations of an in-flight investigation paid a lossy re-brief.

Prompt-caching-safe: the parent's context is never mutated; the snapshot re-sends the parent transcript on the child's first request (cost note in the tool description and docs).

Supersedes #91252 (stale pre-decomposition base, CONFLICTING); original commit credited in this branch's message.

_Infographic omitted: image generation unavailable in this scheduled run._

🤖 Opened by the weekly deepagents PR scout (cron). **Awaiting review — not to be merged without Teknium's approval.**
