### PR TITLE
fix(desktop): UI language survives the update relaunch — startup locale read retries (#105465, #26665, salvage #76158 + #105470)

### DIFF
--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesConfigRecord } from '@/hermes'
@@ -246,5 +246,68 @@ describe('I18nProvider', () => {
 
     expect(screen.getByTestId('locale').textContent).toBe('en')
     expect(screen.getByTestId('label').textContent).toBe('Language')
+  })
+
+  it('retries a transient config failure and applies the persisted locale', async () => {
+    const getConfig = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('backend not ready yet'))
+      .mockResolvedValueOnce({ display: { language: 'zh-Hans' } })
+
+    const configClient: I18nConfigClient = {
+      getConfig,
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    // First attempt fails → settles on English (permanent-failure contract).
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+    expect(screen.getByTestId('locale').textContent).toBe('en')
+
+    // The bounded retry succeeds and applies the persisted language.
+    await waitFor(() => expect(screen.getByTestId('locale').textContent).toBe('zh'), { timeout: 5_000 })
+    expect(getConfig).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops retrying after the bounded retry budget is exhausted', async () => {
+    vi.useFakeTimers()
+    const getConfig = vi.fn().mockRejectedValue(new Error('backend unavailable'))
+
+    const configClient: I18nConfigClient = {
+      getConfig,
+      saveConfig: vi.fn()
+    }
+
+    render(
+      <I18nProvider configClient={configClient} initialLocale="zh">
+        <LanguageProbe />
+      </I18nProvider>
+    )
+
+    // Flush the initial attempt: it fails and settles on English.
+    await act(async () => {})
+    expect(screen.getByTestId('locale').textContent).toBe('en')
+    expect(getConfig).toHaveBeenCalledTimes(1)
+
+    // Budget is 10 retries at 3s each; run the whole budget to completion.
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(3_000)
+      })
+    }
+    expect(getConfig).toHaveBeenCalledTimes(11)
+
+    // No timer is left after the budget is spent — nothing fires later.
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+    })
+    expect(getConfig).toHaveBeenCalledTimes(11)
+
+    vi.useRealTimers()
   })
 })

--- a/apps/desktop/src/i18n/context.test.tsx
+++ b/apps/desktop/src/i18n/context.test.tsx
@@ -310,4 +310,41 @@ describe('I18nProvider', () => {
 
     vi.useRealTimers()
   })
+
+  it('a late startup read never overrides a language the user picked mid-retry', async () => {
+    vi.useFakeTimers()
+
+    const getConfig = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('backend not ready yet'))
+      .mockResolvedValue({ display: { language: 'en' } })
+
+    const configClient: I18nConfigClient = {
+      getConfig,
+      saveConfig: vi.fn().mockResolvedValue({ ok: true })
+    }
+
+    render(
+      <I18nProvider configClient={configClient}>
+        <LanguageProbe target="ja" />
+      </I18nProvider>
+    )
+
+    await act(async () => {})
+    expect(screen.getByTestId('locale').textContent).toBe('en')
+
+    // User picks Japanese while the startup retry is still pending.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'switch' }))
+    })
+    expect(screen.getByTestId('locale').textContent).toBe('ja')
+
+    // The retry resolves with the stale on-disk value; the explicit pick wins.
+    await act(async () => {
+      vi.advanceTimersByTime(3_000)
+    })
+    expect(screen.getByTestId('locale').textContent).toBe('ja')
+
+    vi.useRealTimers()
+  })
 })

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -114,6 +114,16 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
 
     let cancelled = false
     let retryTimer: ReturnType<typeof setTimeout> | null = null
+    let retryCount = 0
+
+    // The desktop races its own backend at startup: the renderer mounts before
+    // the backend is ready, so the first /api/config call can time out. We keep
+    // the established permanent-failure contract — a rejected config load
+    // settles on English so the UI stays usable — but bounded retries recover
+    // transient startup failures, applying the persisted display.language once
+    // the backend comes up.
+    const MAX_LOCALE_RETRIES = 10
+    const LOCALE_RETRY_DELAY_MS = 3_000
 
     const loadLocale = () => {
       setIsLoadingConfig(true)
@@ -132,16 +142,14 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
           }
 
           setConfigLoadError(toError(error))
+          setLocaleState(DEFAULT_LOCALE)
 
-          // The desktop races its own backend at startup: the renderer mounts
-          // before the backend is ready, and the first /api/config call times
-          // out (60s). Falling back to the default locale permanently made the
-          // UI stuck in English until a manual language switch. Retry with a
-          // short delay instead — the backend comes up, the next attempt
-          // succeeds, and the persisted display.language takes effect.
-          retryTimer = setTimeout(() => {
-            loadLocale()
-          }, 3_000)
+          if (retryCount < MAX_LOCALE_RETRIES) {
+            retryCount += 1
+            retryTimer = setTimeout(() => {
+              loadLocale()
+            }, LOCALE_RETRY_DELAY_MS)
+          }
         })
         .finally(() => {
           if (!cancelled) {

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -113,31 +113,51 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
     }
 
     let cancelled = false
+    let retryTimer: ReturnType<typeof setTimeout> | null = null
 
-    setIsLoadingConfig(true)
-    setConfigLoadError(null)
+    const loadLocale = () => {
+      setIsLoadingConfig(true)
+      setConfigLoadError(null)
 
-    configClient
-      .getConfig()
-      .then(config => {
-        if (!cancelled) {
-          setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
-        }
-      })
-      .catch(error => {
-        if (!cancelled) {
+      return configClient
+        .getConfig()
+        .then(config => {
+          if (!cancelled) {
+            setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
+          }
+        })
+        .catch(error => {
+          if (cancelled) {
+            return
+          }
+
           setConfigLoadError(toError(error))
-          setLocaleState(DEFAULT_LOCALE)
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingConfig(false)
-        }
-      })
+
+          // The desktop races its own backend at startup: the renderer mounts
+          // before the backend is ready, and the first /api/config call times
+          // out (60s). Falling back to the default locale permanently made the
+          // UI stuck in English until a manual language switch. Retry with a
+          // short delay instead — the backend comes up, the next attempt
+          // succeeds, and the persisted display.language takes effect.
+          retryTimer = setTimeout(() => {
+            loadLocale()
+          }, 3_000)
+        })
+        .finally(() => {
+          if (!cancelled) {
+            setIsLoadingConfig(false)
+          }
+        })
+    }
+
+    loadLocale()
 
     return () => {
       cancelled = true
+
+      if (retryTimer) {
+        clearTimeout(retryTimer)
+      }
     }
   }, [configClient, initialLocale])
 

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -99,6 +99,9 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
   const [configLoadError, setConfigLoadError] = useState<Error | null>(null)
   const [saveError, setSaveError] = useState<Error | null>(null)
   const localeRef = useRef(locale)
+  // Set once the user picks a language through setLocale: a startup read that
+  // resolves (or fails) after that must never overwrite an explicit choice.
+  const userLocaleRef = useRef(false)
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -132,12 +135,12 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
       return configClient
         .getConfig()
         .then(config => {
-          if (!cancelled) {
+          if (!cancelled && !userLocaleRef.current) {
             setLocaleState(normalizeLocale(getConfigDisplayLanguage(config)))
           }
         })
         .catch(error => {
-          if (cancelled) {
+          if (cancelled || userLocaleRef.current) {
             return
           }
 
@@ -173,6 +176,7 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
     async (next: Locale) => {
       const previousLocale = localeRef.current
 
+      userLocaleRef.current = true
       setSaveError(null)
       setLocaleState(next)
 

--- a/contributors/emails/mengyuyuan@users.noreply.github.com
+++ b/contributors/emails/mengyuyuan@users.noreply.github.com
@@ -1,0 +1,2 @@
+mengyuyuan
+# PR #76158 salvage


### PR DESCRIPTION
The Desktop UI comes back in the language you saved after a `hermes update` relaunch or slow cold start, instead of pinning to English for the whole session.

## Context

`I18nProvider` (`apps/desktop/src/i18n/context.tsx`) read `display.language` from the backend exactly once on mount. Right after an update relaunch the renderer mounts while the backend is still settling, so that single GET rejected; the `catch` set English and never tried again, even though `display.language: zh` was intact in config.yaml. Re-selecting the language in Settings "fixed" it until the next update. Reported in #105465 and (since May) #26665.

## Changes

Salvage of #76158 (@mengyuyuan, Aug 1, earliest fix; 2 commits cherry-picked verbatim) with the one guard from #105470 (@webtecnica, Sep 8) grafted on as a co-authored commit:

- Startup config read retries up to 10× at 3 s on failure; English remains the deterministic fallback while retries run and once they are spent, so the UI is always usable (#76158).
- A language the user picks mid-retry is recorded in a ref; a startup read that resolves or fails afterwards never overrides it (#105470's `userLocaleRef`, folded onto the #76158 base).
- Retry timer cleared on unmount; no setState after cancellation.
- Contributor email mapping for @mengyuyuan (`contributors/emails/`).

Renderer only; no backend or contract change.

## Live repro

Same-provider vitest with the real `I18nProvider`: first `getConfig` rejects (backend not ready), second resolves `zh-Hans`.
before: locale settles `en` and stays `en` (test `retries a transient config failure…` fails on base).
after: `en` → `zh` once the retry succeeds; the mid-retry user pick test (`ja` stays `ja` after a late `en` read) fails without the third commit and passes with it.

## Validation

- `npx vitest run --project ui src/i18n/context.test.tsx` — 14/14 (11 base + 2 from #76158 + 1 new).
- `tsc -p apps/desktop --noEmit` clean; eslint on the two files shows only the 5 warnings already present on base.

## Closes

Closes #105465. Closes #26665. Supersedes #76158 and #105470 (both credited above).

## Infographic

![Your language survives the update](https://v3b.fal.media/files/b/0aa9b8c6/DCbhpwobhnUyrsXq5Y807_fNvPUO9b.png)
