### PR TITLE
fix(image-gen): do not retry managed FAL billing 409s

### DIFF
--- a/tests/tools/test_fal_common.py
+++ b/tests/tools/test_fal_common.py
@@ -300,17 +300,16 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "https://q.example.com/status",
             "cancel_url": "https://q.example.com/cancel",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
         result = client.submit("my-app", {"prompt": "hello"})
 
-        client._maybe_retry_request.assert_called_once()
-        call_args = client._maybe_retry_request.call_args
-        assert call_args[0][0] is client._http_client
-        assert call_args[0][1] == "POST"
-        assert call_args[0][2] == "https://queue.example.com/my-app"
+        client._http_client.request.assert_called_once()
+        call_args = client._http_client.request.call_args
+        assert call_args[0][0] == "POST"
+        assert call_args[0][1] == "https://queue.example.com/my-app"
         assert call_args[1]["json"] == {"prompt": "hello"}
         assert call_args[1]["timeout"] == 120.0
         client._raise_for_status.assert_called_once_with(response)
@@ -326,13 +325,13 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
         client.submit("my-app", {}, path="sub/path")
 
-        url = client._maybe_retry_request.call_args[0][2]
+        url = client._http_client.request.call_args[0][1]
         assert url == "https://queue.example.com/my-app/sub/path"
 
     def test_submit_with_path_strips_leading_slash(self):
@@ -344,13 +343,13 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
         client.submit("my-app", {}, path="/leading/slash")
 
-        url = client._maybe_retry_request.call_args[0][2]
+        url = client._http_client.request.call_args[0][1]
         assert url == "https://queue.example.com/my-app/leading/slash"
 
     def test_submit_with_webhook_url(self):
@@ -362,13 +361,13 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
         client.submit("my-app", {}, webhook_url="https://hook.example.com/cb")
 
-        url = client._maybe_retry_request.call_args[0][2]
+        url = client._http_client.request.call_args[0][1]
         assert "fal_webhook=https%3A%2F%2Fhook.example.com%2Fcb" in url
 
     def test_submit_with_hint(self):
@@ -381,7 +380,7 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
@@ -401,7 +400,7 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
@@ -421,7 +420,7 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
@@ -438,7 +437,7 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
@@ -458,7 +457,7 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
@@ -474,13 +473,13 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
         client.submit("my-app", {}, headers={"X-Custom": "value"})
 
-        headers = client._maybe_retry_request.call_args[1]["headers"]
+        headers = client._http_client.request.call_args[1]["headers"]
         assert headers["X-Custom"] == "value"
 
     def test_submit_with_none_headers_defaults_to_empty_dict(self):
@@ -492,13 +491,13 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
         client.submit("my-app", {}, headers=None)
 
-        headers = client._maybe_retry_request.call_args[1]["headers"]
+        headers = client._http_client.request.call_args[1]["headers"]
         assert headers == {}
 
     def test_submit_uses_custom_default_timeout(self):
@@ -514,13 +513,13 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
         client.submit("app", {})
 
-        assert client._maybe_retry_request.call_args[1]["timeout"] == 300.0
+        assert client._http_client.request.call_args[1]["timeout"] == 300.0
 
     def test_submit_falls_back_to_120_when_no_default_timeout(self):
         """SyncClient without default_timeout attr → 120.0 fallback."""
@@ -537,13 +536,13 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
         client.submit("app", {})
 
-        assert client._maybe_retry_request.call_args[1]["timeout"] == 120.0
+        assert client._http_client.request.call_args[1]["timeout"] == 120.0
 
     def test_submit_passes_request_handle_kwargs(self):
         client, _, _ = self._make_client()
@@ -554,7 +553,7 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "https://q.example.com/status",
             "cancel_url": "https://q.example.com/cancel",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
@@ -580,7 +579,7 @@ class TestManagedFalSyncClientSubmit:
             "status_url": "",
             "cancel_url": "",
         }
-        client._maybe_retry_request = MagicMock(return_value=response)
+        client._http_client.request = MagicMock(return_value=response)
         client._raise_for_status = MagicMock()
         client._request_handle_class = MagicMock()
 
@@ -595,11 +594,190 @@ class TestManagedFalSyncClientSubmit:
             start_timeout=60,
         )
 
-        url = client._maybe_retry_request.call_args[0][2]
+        url = client._http_client.request.call_args[0][1]
         assert "app/sub?" in url
         assert "fal_webhook=" in url
         client._add_hint_header.assert_called_once()
         client._add_priority_header.assert_called_once()
         client._add_timeout_header.assert_called_once()
-        headers = client._maybe_retry_request.call_args[1]["headers"]
+        headers = client._http_client.request.call_args[1]["headers"]
         assert headers["X-Custom"] == "val"
+
+
+# ---------------------------------------------------------------------------
+# Managed queue submit must not retry deterministic 409s (billing / idempotency)
+# ---------------------------------------------------------------------------
+
+# Managed queue submit must not retry deterministic 409s (billing / idempotency).
+# The tests wire fal_client's retry helper so a regression that calls
+# _maybe_retry_request again would POST more than once with the same
+# x-idempotency-key and fail call_count == 1.
+_FAL_RETRY_CODES = (408, 409, 429)
+_FAL_MAX_ATTEMPTS = 10
+_BILLING_409_DETAIL = "BILLING_ERROR: unsupported_pricing_meter"
+_IDEMPOTENCY_409_DETAIL = (
+    "idempotency key is already bound to a different request "
+    "without a reusable request handle"
+)
+
+
+class _FakeFalResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+        self.headers = {}
+
+    def json(self):
+        return self._payload
+
+
+class _FakeFalHTTPError(Exception):
+    """Stand-in for fal_client.client.FalClientHTTPError / httpx.HTTPStatusError."""
+
+    def __init__(self, message, response):
+        super().__init__(message)
+        self.response = response
+        self.status_code = response.status_code
+
+
+def _fal_style_raise_for_status(response):
+    if getattr(response, "status_code", 200) < 400:
+        return
+    payload = {}
+    try:
+        payload = response.json()
+    except Exception:
+        payload = {}
+    detail = payload.get("detail", getattr(response, "text", "")) if isinstance(payload, dict) else getattr(response, "text", "")
+    raise _FakeFalHTTPError(str(detail), response)
+
+
+def _fal_style_maybe_retry_request(
+    client, method, url, json=None, timeout=None, headers=None, extra_retry_codes=None, **kwargs
+):
+    extra = extra_retry_codes or []
+    last_exc = None
+    for attempt in range(1, _FAL_MAX_ATTEMPTS + 1):
+        try:
+            response = client.request(
+                method, url, json=json, timeout=timeout, headers=headers, **kwargs
+            )
+            _fal_style_raise_for_status(response)
+            return response
+        except _FakeFalHTTPError as exc:
+            last_exc = exc
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status in _FAL_RETRY_CODES or status in extra:
+                if attempt < _FAL_MAX_ATTEMPTS:
+                    continue
+            raise
+    raise last_exc
+
+
+def _wire_production_retry_client(http_client):
+    """_ManagedFalSyncClient whose submit goes through the real retry helper path."""
+    fal_client, _ = _make_fal_client_mock(http_client=http_client)
+    fal_client.client._maybe_retry_request = _fal_style_maybe_retry_request
+    fal_client.client._raise_for_status = _fal_style_raise_for_status
+    fal_client.client.SyncRequestHandle = MagicMock()
+    client = _ManagedFalSyncClient(
+        fal_client, key="k", queue_run_origin="https://queue.example.com"
+    )
+    return client, fal_client.client.SyncRequestHandle
+
+
+class TestManagedFalSubmitNoRetryBilling409:
+    def test_billing_409_does_not_retry_same_idempotency_key(self):
+        http_client = MagicMock()
+        billing = _FakeFalResponse(
+            409,
+            {"error": "BILLING_ERROR", "detail": _BILLING_409_DETAIL},
+        )
+        idempotency_conflict = _FakeFalResponse(409, {"detail": _IDEMPOTENCY_409_DETAIL})
+
+        def fake_request(*_args, **_kwargs):
+            # First POST is the billing 409; subsequent POSTs (the production bug)
+            # replay the same idempotency key and get a bound-key conflict.
+            if http_client.request.call_count <= 1:
+                return billing
+            return idempotency_conflict
+
+        http_client.request.side_effect = fake_request
+
+        client, _ = _wire_production_retry_client(http_client)
+
+        with pytest.raises(_FakeFalHTTPError) as exc_info:
+            client.submit(
+                "openai/gpt-image-2.5/flare/text-to-image",
+                {"prompt": "a cat"},
+                headers={"x-idempotency-key": "fixed-key"},
+            )
+
+        assert http_client.request.call_count == 1
+        err = str(exc_info.value)
+        assert "unsupported_pricing_meter" in err
+        assert "BILLING_ERROR" in err
+        assert "already bound" not in err
+        headers = http_client.request.call_args.kwargs["headers"]
+        assert headers["x-idempotency-key"] == "fixed-key"
+
+    def test_idempotency_bound_409_without_reusable_handle_is_not_retried(self):
+        http_client = MagicMock()
+        http_client.request.return_value = _FakeFalResponse(
+            409, {"detail": _IDEMPOTENCY_409_DETAIL}
+        )
+        client, _ = _wire_production_retry_client(http_client)
+
+        with pytest.raises(_FakeFalHTTPError) as exc_info:
+            client.submit(
+                "fal-ai/flux-2-pro",
+                {"prompt": "x"},
+                headers={"x-idempotency-key": "fixed-key"},
+            )
+
+        assert http_client.request.call_count == 1
+        assert "already bound" in str(exc_info.value)
+        assert "reusable request handle" in str(exc_info.value)
+
+    def test_success_200_parses_handle_with_single_post(self):
+        http_client = MagicMock()
+        payload = {
+            "request_id": "req-ok",
+            "response_url": "https://q.example.com/resp",
+            "status_url": "https://q.example.com/status",
+            "cancel_url": "https://q.example.com/cancel",
+        }
+        http_client.request.return_value = _FakeFalResponse(200, payload)
+        client, handle_cls = _wire_production_retry_client(http_client)
+
+        result = client.submit("my-app", {"prompt": "hello"})
+
+        assert http_client.request.call_count == 1
+        request_call = http_client.request.call_args
+        assert request_call.args[0] == "POST"
+        assert request_call.args[1] == "https://queue.example.com/my-app"
+        assert request_call.kwargs["json"] == {"prompt": "hello"}
+        handle_cls.assert_called_once()
+        kwargs = handle_cls.call_args.kwargs
+        assert kwargs["request_id"] == "req-ok"
+        assert kwargs["response_url"] == payload["response_url"]
+        assert kwargs["status_url"] == payload["status_url"]
+        assert kwargs["cancel_url"] == payload["cancel_url"]
+        assert kwargs["client"] is http_client
+        assert result is handle_cls.return_value
+
+    def test_transport_error_is_not_treated_as_billing(self):
+        class TransportError(Exception):
+            pass
+
+        http_client = MagicMock()
+        http_client.request.side_effect = TransportError("connection reset")
+        client, _ = _wire_production_retry_client(http_client)
+
+        with pytest.raises(TransportError, match="connection reset") as exc_info:
+            client.submit("my-app", {"prompt": "hello"})
+
+        err = str(exc_info.value)
+        assert "BILLING_ERROR" not in err
+        assert "unsupported_pricing_meter" not in err

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -427,6 +427,7 @@ class TestManagedGatewayErrorTranslation:
         """403 from managed gateway → ValueError mentioning FAL_KEY + hermes tools."""
         from unittest.mock import MagicMock
 
+        monkeypatch.setattr(image_tool, "_load_fal_client", lambda: MagicMock())
         # Simulate: managed mode active, managed submit raises 4xx.
         managed_gateway = MagicMock()
         managed_gateway.gateway_origin = "https://fal-queue-gateway.example.com"
@@ -457,6 +458,7 @@ class TestManagedGatewayErrorTranslation:
         they should bubble up unchanged so callers can retry or diagnose."""
         from unittest.mock import MagicMock
 
+        monkeypatch.setattr(image_tool, "_load_fal_client", lambda: MagicMock())
         managed_gateway = MagicMock()
         monkeypatch.setattr(image_tool, "_resolve_managed_fal_gateway",
                             lambda: managed_gateway)
@@ -469,6 +471,34 @@ class TestManagedGatewayErrorTranslation:
 
         with pytest.raises(ConnectionError):
             image_tool._submit_fal_request("fal-ai/flux-2-pro", {"prompt": "x"})
+
+
+    def test_409_billing_error_preserves_pricing_meter_detail(self, image_tool, monkeypatch):
+        """Managed 409 BILLING_ERROR must surface unsupported_pricing_meter in ValueError."""
+        from unittest.mock import MagicMock
+
+        monkeypatch.setattr(image_tool, "_load_fal_client", lambda: MagicMock())
+        managed_gateway = MagicMock()
+        monkeypatch.setattr(image_tool, "_resolve_managed_fal_gateway",
+                            lambda: managed_gateway)
+
+        billing = _MockHttpxError(
+            409, "BILLING_ERROR: unsupported_pricing_meter for this model")
+        mock_managed_client = MagicMock()
+        mock_managed_client.submit.side_effect = billing
+        monkeypatch.setattr(image_tool, "_get_managed_fal_client",
+                            lambda gw: mock_managed_client)
+
+        with pytest.raises(ValueError) as exc_info:
+            image_tool._submit_fal_request("fal-ai/flux-2-pro", {"prompt": "x"})
+
+        msg = str(exc_info.value)
+        assert "409" in msg
+        assert "unsupported_pricing_meter" in msg
+        assert "FAL_KEY" in msg
+        assert exc_info.value.__cause__ is billing
+        # 401/403 still get the entitlement appendix; 409 must not drop billing detail.
+        assert "fal-ai/flux-2-pro" in msg
 
 
 class TestKreaModelNormalization:

--- a/tests/tools/test_managed_media_gateways.py
+++ b/tests/tools/test_managed_media_gateways.py
@@ -94,14 +94,20 @@ def _install_fake_fal_client(captured):
             }
 
     def _maybe_retry_request(client, method, url, json=None, timeout=None, headers=None):
-        captured["submit_via"] = "managed_client"
-        captured["http_client"] = client
-        captured["method"] = method
-        captured["submit_url"] = url
-        captured["arguments"] = json
-        captured["timeout"] = timeout
-        captured["headers"] = headers
-        return FakeResponse()
+        # Kept so _ManagedFalSyncClient init still finds the helper; submit
+        # must use a single httpx POST (FakeHttpClient.request) instead.
+        return FakeHttpClient().request(method, url, json=json, timeout=timeout, headers=headers)
+
+    class FakeHttpClient:
+        def request(self, method, url, json=None, timeout=None, headers=None, **kwargs):
+            captured["submit_via"] = "managed_client"
+            captured["http_client"] = self
+            captured["method"] = method
+            captured["submit_url"] = url
+            captured["arguments"] = json
+            captured["timeout"] = timeout
+            captured["headers"] = headers
+            return FakeResponse()
 
     class SyncRequestHandle:
         def __init__(self, request_id, response_url, status_url, cancel_url, client):
@@ -117,7 +123,7 @@ def _install_fake_fal_client(captured):
             captured["client_key"] = key
             captured["client_timeout"] = default_timeout
             self.default_timeout = default_timeout
-            self._client = object()
+            self._client = FakeHttpClient()
 
     fal_client_module = types.SimpleNamespace(
         submit=submit,
@@ -186,6 +192,7 @@ def test_managed_fal_submit_uses_gateway_origin_and_nous_token(monkeypatch):
         "tools.image_generation_tool",
         "image_generation_tool.py",
     )
+    image_generation_tool.fal_client = sys.modules["fal_client"]
     monkeypatch.setattr(image_generation_tool.uuid, "uuid4", lambda: "fal-submit-123")
     
     image_generation_tool._submit_fal_request(

--- a/tools/fal_common.py
+++ b/tools/fal_common.py
@@ -93,9 +93,14 @@ class _ManagedFalSyncClient:
             if self._add_timeout_header is None:
                 raise RuntimeError("fal_client.client.add_timeout_header is required for timeout requests")
             self._add_timeout_header(start_timeout, request_headers)
-        response = self._maybe_retry_request(
-            self._http_client, "POST", url, json=arguments,
-            timeout=getattr(self._sync_client, "default_timeout", 120.0), headers=request_headers)
+        # Single POST: fal_client retries 408/409/429, but a managed-queue 409
+        # (billing / idempotency-key already bound) is deterministic. Retrying
+        # with the same x-idempotency-key masks BILLING_ERROR as a bound-key
+        # conflict. Transient TransportError/Timeout still bubble to the caller.
+        response = self._http_client.request(
+            "POST", url, json=arguments,
+            timeout=getattr(self._sync_client, "default_timeout", 120.0),
+            headers=request_headers)
         self._raise_for_status(response)
         data = response.json()
         return self._request_handle_class(

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -135,12 +135,19 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
             if status in {401, 402, 403}:
                 gateway_message = "\n\n" + nous_tool_gateway_unavailable_message(
                     "managed FAL image generation", force_fresh=True)
+            detail = str(exc).strip()
+            # Keep 401/403 on the entitlement-appendix path. For other 4xx
+            # (notably 409 BILLING_ERROR / unsupported_pricing_meter), surface
+            # the upstream body so callers are not left with only HTTP status.
+            detail_suffix = ""
+            if status not in {401, 402, 403} and detail:
+                detail_suffix = f"\n\n{detail}"
             raise ValueError(
                 f"Nous Subscription gateway rejected model '{model}' (HTTP {status}). This model "
                 f"may not yet be enabled on the Nous Portal's FAL proxy. Either:\n"
                 f"  • Set FAL_KEY in your environment to use FAL.ai directly, or\n"
                 f"  • Pick a different model via `hermes tools` → Image Generation."
-                f"{gateway_message}") from exc
+                f"{gateway_message}{detail_suffix}") from exc
         raise
 
 


### PR DESCRIPTION
## What does this PR do?

Managed FAL queue submits go through `fal_client.client._maybe_retry_request`, which retries HTTP **409** (`RETRY_CODES = [408, 409, 429]`). When the Nous Subscription gateway rejects a model with `BILLING_ERROR` / `unsupported_pricing_meter`, that first 409 already binds the `x-idempotency-key`. Retries then surface `idempotency key is already bound ... without a reusable request handle`, masking the real billing failure (seen with GPT Image 2.5 Flare/Sunburst on the managed gateway).

This PR makes `_ManagedFalSyncClient.submit` issue a **single** POST (`httpx.request` + `_raise_for_status`) so deterministic managed-queue 409s are not retried, and appends the original upstream detail onto the existing 4xx → `ValueError` translation for non-401/402/403 statuses.

Portal pricing meters themselves are out of scope here — claim is client-side error fidelity only.

## Related Issue

Addresses #106469

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `tools/fal_common.py`: managed submit no longer uses `_maybe_retry_request` for the idempotent queue POST
- `tools/image_generation_tool.py`: preserve billing/conflict detail on translated 409 (and other non-entitlement 4xx)
- `tests/tools/test_fal_common.py`: RED→GREEN — billing 409 and idempotency-bound 409 POST exactly once; 200 handle + TransportError fail-open
- `tests/tools/test_image_generation.py`: ValueError retains `unsupported_pricing_meter`
- `tests/tools/test_managed_media_gateways.py`: align fake client with single-shot `httpx.request` path

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_fal_common.py -k 'TestManagedFalSubmitNoRetryBilling409'
scripts/run_tests.sh tests/tools/test_image_generation.py -k 'TestManagedGatewayErrorTranslation'
scripts/run_tests.sh tests/tools/test_managed_media_gateways.py
# Combined focused: 108 passed
```

On pre-fix main, the billing-409 test asserted `call_count == 1` but observed `10` (fal_client max attempts), and the image-gen translation dropped `unsupported_pricing_meter`.

## Proof / review

- Self-review P0: 0
- Independent review P0: 0 (triggered by diff >200 lines)
- Ownership: no open competing PR for #106469 at push time

## Risks

- Managed queue submit no longer retries 408/429/ingress 5xx at the fal_client helper layer (single POST; callers still see the error). Video managed FAL shares `_ManagedFalSyncClient` and inherits the no-409-retry behavior; its separate 4xx wrapper does not yet append billing detail.

## Checklist

- [x] Focused tests added and green locally
- [x] No catalog removal / model-name heuristic for gpt-image-2.5
- [x] Does not claim Portal meters are fixed

Made with [Cursor](https://cursor.com)