### PR TITLE
feat(delegate): context_mode=fork — subagents replay the parent conversation

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -73,6 +73,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("goal", task_props)
         self.assertIn("context", task_props)
         self.assertIn("output_schema", task_props)
+        self.assertIn("context_mode", task_props)
+        self.assertEqual(task_props["context_mode"]["enum"], ["isolated", "fork"])
         # toolsets is intentionally NOT exposed to the model — subagents always
         # inherit the parent's toolsets. Letting the model name toolsets was a
         # capability-selection surface the model should not control.
@@ -510,7 +512,7 @@ class TestToolNamePreservation(unittest.TestCase):
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
 
-            def capture_and_return(user_message, task_id=None, stream_callback=None):
+            def capture_and_return(user_message, task_id=None, stream_callback=None, conversation_history=None):
                 captured["saved"] = list(mock_child._delegate_saved_tool_names)
                 return {"final_response": "ok", "completed": True, "api_calls": 1}
 
@@ -2006,7 +2008,7 @@ class TestOrchestratorEndToEnd(unittest.TestCase):
                 m.thinking_callback = None
                 orch_mock["agent"] = m
 
-                def _orchestrator_run(user_message=None, task_id=None, stream_callback=None):
+                def _orchestrator_run(user_message=None, task_id=None, stream_callback=None, conversation_history=None):
                     # Re-entrant: orchestrator spawns two leaves
                     delegate_task(
                         tasks=[
@@ -2231,6 +2233,191 @@ class TestFallbackModelInheritance(unittest.TestCase):
                 with self.assertRaises(ValueError) as ctx:
                     _resolve_delegation_credentials(cfg, parent)
         self.assertIn("missing-acp-binary", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestForkContextMode(unittest.TestCase):
+    """context_mode='fork': child replays the parent's conversation history."""
+
+    def test_fork_passes_history_to_run_conversation(self):
+        import model_tools
+
+        parent = _make_mock_parent(depth=0)
+        parent._session_messages = [
+            {"role": "user", "content": "read foo.py"},
+            {"role": "assistant", "content": "it does X"},
+        ]
+
+        captured = {}
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+
+            def capture(user_message, task_id=None, stream_callback=None, conversation_history=None):
+                captured["history"] = conversation_history
+                return {"final_response": "ok", "completed": True, "api_calls": 1}
+
+            mock_child.run_conversation.side_effect = capture
+            MockAgent.return_value = mock_child
+            delegate_task(
+                tasks=[{"goal": "g", "context_mode": "fork"}],
+                parent_agent=parent,
+            )
+        self.assertEqual(captured["history"], parent._session_messages)
+
+    def test_isolated_default_passes_no_history(self):
+        parent = _make_mock_parent(depth=0)
+        parent._session_messages = [{"role": "user", "content": "x"}]
+
+        captured = {}
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+
+            def capture(user_message, task_id=None, stream_callback=None, conversation_history=None):
+                captured["history"] = conversation_history
+                return {"final_response": "ok", "completed": True, "api_calls": 1}
+
+            mock_child.run_conversation.side_effect = capture
+            MockAgent.return_value = mock_child
+            delegate_task(goal="g", parent_agent=parent)
+        self.assertIsNone(captured["history"])
+
+    def test_fork_with_empty_parent_falls_back_to_isolated(self):
+        parent = _make_mock_parent(depth=0)
+        parent._session_messages = []
+
+        captured = {}
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+
+            def capture(user_message, task_id=None, stream_callback=None, conversation_history=None):
+                captured["history"] = conversation_history
+                return {"final_response": "ok", "completed": True, "api_calls": 1}
+
+            mock_child.run_conversation.side_effect = capture
+            MockAgent.return_value = mock_child
+            delegate_task(
+                tasks=[{"goal": "g", "context_mode": "fork"}],
+                parent_agent=parent,
+            )
+        # Empty snapshot -> clone is [] -> falsy, no history replay; isolated path.
+        self.assertIsNone(captured["history"])
+
+    def test_fork_clone_is_structural_not_aliased(self):
+        """#100795 analog: mutating the replayed history must NOT touch the
+        parent's _session_messages (repair_message_sequence sanitizes in place)."""
+        parent = _make_mock_parent(depth=0)
+        parent._session_messages = [
+            {"role": "user", "content": "read foo.py"},
+            {"role": "assistant", "content": "it does X",
+             "tool_calls": [{"id": "t1", "function": {"name": "f", "arguments": "{}"}}]},
+        ]
+
+        def capture(user_message, task_id=None, stream_callback=None, conversation_history=None):
+            history = conversation_history or []
+            # Simulate the child-side in-place sanitizers (repair pass).
+            history[0]["content"] = "MUTATED"
+            if history[1].get("tool_calls"):
+                history[1]["tool_calls"][0]["id"] = "MUTATED"
+            return {"final_response": "ok", "completed": True, "api_calls": 1}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.side_effect = capture
+            MockAgent.return_value = mock_child
+            delegate_task(
+                tasks=[{"goal": "g", "context_mode": "fork"}],
+                parent_agent=parent,
+            )
+        self.assertEqual(parent._session_messages[0]["content"], "read foo.py")
+        self.assertEqual(parent._session_messages[1]["tool_calls"][0]["id"], "t1")
+
+    def test_fork_excises_unanswered_trailing_tool_call(self):
+        """Mid-turn fork: snapshot ends with assistant(tool_calls) — the in-flight
+        delegate_task itself. It must be excised, not replayed unanswered."""
+        parent = _make_mock_parent(depth=0)
+        parent._session_messages = [
+            {"role": "user", "content": "do the thing"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "call_99", "function": {"name": "delegate_task", "arguments": "{}"}}]},
+        ]
+
+        captured = {}
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+
+            def capture(user_message, task_id=None, stream_callback=None, conversation_history=None):
+                captured["history"] = conversation_history
+                return {"final_response": "ok", "completed": True, "api_calls": 1}
+
+            mock_child.run_conversation.side_effect = capture
+            MockAgent.return_value = mock_child
+            delegate_task(
+                tasks=[{"goal": "g", "context_mode": "fork"}],
+                parent_agent=parent,
+            )
+        replayed = captured["history"]
+        self.assertEqual(len(replayed), 1)  # assistant(tool_calls) excised
+        self.assertEqual(replayed[0]["role"], "user")
+
+    def test_fork_caps_snapshot_at_fork_max_messages(self):
+        """delegation.fork_max_messages caps the snapshot; cut opens on a
+        coherent boundary (leading tool results dropped)."""
+        parent = _make_mock_parent(depth=0)
+        n = 250
+        parent._session_messages = (
+            [{"role": "user", "content": "m"} for _ in range(250)]
+        )
+
+        captured = {}
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+
+            def capture(user_message, task_id=None, stream_callback=None, conversation_history=None):
+                captured["history"] = conversation_history
+                return {"final_response": "ok", "completed": True, "api_calls": 1}
+
+            mock_child.run_conversation.side_effect = capture
+            MockAgent.return_value = mock_child
+            with patch("tools.delegate_tool._load_config", return_value={"fork_max_messages": 50}):
+                delegate_task(
+                    tasks=[{"goal": "g", "context_mode": "fork"}],
+                    parent_agent=parent,
+                )
+        self.assertEqual(len(captured["history"]), 50)
+
+    def test_fork_goal_carries_inheritance_notice(self):
+        """Forked child's kickoff goal is framed as inherited reference."""
+        parent = _make_mock_parent(depth=0)
+        parent._session_messages = [{"role": "user", "content": "x"}]
+
+        captured = {}
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+
+            def capture(user_message, task_id=None, stream_callback=None, conversation_history=None):
+                captured["goal"] = user_message
+                return {"final_response": "ok", "completed": True, "api_calls": 1}
+
+            mock_child.run_conversation.side_effect = capture
+            MockAgent.return_value = mock_child
+            delegate_task(
+                tasks=[{"goal": "do the thing", "context_mode": "fork"}],
+                parent_agent=parent,
+            )
+        self.assertIn("inherited snapshot", captured["goal"])
+        self.assertIn("do the thing", captured["goal"])
+
+        # Isolated tasks keep the raw goal.
+        captured.clear()
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.side_effect = capture
+            MockAgent.return_value = mock_child
+            delegate_task(goal="do the thing", parent_agent=parent)
+        self.assertEqual(captured["goal"], "do the thing")
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2622,6 +2622,7 @@ def _run_single_child(
     owner_session_id: Optional[str] = None,
     owner_transport: Any = None,
     owner_session_record: Any = None,
+    fork_history: Optional[List[Dict[str, Any]]] = None,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -3006,9 +3007,28 @@ def _run_single_child(
 
             with delegated_child_context(str(getattr(child, "session_id", "") or "")):
                 return child.run_conversation(
-                    user_message=goal,
+                    user_message=(
+                        # Inheritance notice (kimi-port parity): frame the
+                        # replayed snapshot as reference material, not the
+                        # child's own past actions.
+                        "You were forked from your parent agent's conversation. "
+                        "The conversation above is an inherited snapshot of the "
+                        "parent's session — treat it as reference material "
+                        "describing what has already been established, NOT as "
+                        "actions you performed yourself. Tool results in it "
+                        "were produced by the parent.\n\nYOUR TASK:\n" + goal
+                    )
+                    if fork_history
+                    else goal,
                     task_id=child_task_id,
                     stream_callback=_relay_child_text,
+                    # Fork mode: replay the parent's conversation so the child
+                    # skips re-gathering context already established. NOT
+                    # prompt-cache reuse — the child has its own system prompt
+                    # and tool list, so the prefix is cold. run_conversation
+                    # initializes messages=list(conversation_history)
+                    # (turn_context.py).
+                    conversation_history=fork_history,
                 )
 
         _child_context = contextvars.copy_context()
@@ -4180,6 +4200,51 @@ def delegate_task(
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
         effective_role = _normalize_role(t.get("role") or top_role)
+        # Fork mode: capture the parent's live conversation ONCE (structural
+        # clone, same recipe as _spawn_background_review) so every forked
+        # child replays the identical snapshot. Isolated tasks pass
+        # fork_history=None and take no new code paths.
+        fork_history = None
+        if (t.get("context_mode") or "isolated") == "fork":
+            try:
+                from agent.turn_finalizer import _clone_background_review_messages
+
+                fork_history = _clone_background_review_messages(
+                    list(getattr(parent_agent, "_session_messages", None) or [])
+                )
+                # Cap the snapshot (kimi-port parity): delegation.fork_max_messages,
+                # default 200, floor 10. Cut to the most recent messages; never
+                # open on a dangling tool-result boundary after the cut.
+                try:
+                    cap = max(10, int(cfg.get("fork_max_messages", 200)))
+                except (TypeError, ValueError):
+                    cap = 200
+                if len(fork_history) > cap:
+                    fork_history = fork_history[-cap:]
+                    while fork_history and fork_history[0].get("role") == "tool":
+                        fork_history.pop(0)
+                # Excise an in-progress unanswered delegate_task call from the
+                # snapshot tail: replaying it as an unanswered tool_use would
+                # rely on repair_message_sequence's prune, which can merge the
+                # parent's last user text into the child's goal. LangChain's
+                # fork excises the trailing tool call the same way.
+                while fork_history:
+                    last = fork_history[-1]
+                    if isinstance(last, dict) and last.get("role") == "assistant" and last.get("tool_calls"):
+                        fork_history.pop()
+                    else:
+                        break
+            except Exception:
+                logger.warning(
+                    "Task %d context_mode=fork: snapshot failed; falling back to isolated",
+                    i,
+                    exc_info=True,
+                )
+                fork_history = None
+        # Stash on the task dict so both single and batch executors reach it.
+        # Empty snapshot → clone is [] → same as no history (isolated path).
+        if fork_history:
+            t["_fork_history"] = fork_history
         # T1-24: schema'd tasks get the contract appended to their context
         # so the child knows the expected output shape before it starts.
         _task_schema = task_schemas[i] if i < len(task_schemas) else None
@@ -4262,6 +4327,7 @@ def delegate_task(
                 owner_session_id=_origin_ui_session_id or None,
                 owner_transport=_origin_owner_transport,
                 owner_session_record=_origin_owner_session_record,
+                fork_history=_t.get("_fork_history"),
             )
             results.append(result)
         else:
@@ -4287,6 +4353,7 @@ def delegate_task(
                         owner_session_id=_origin_ui_session_id or None,
                         owner_transport=_origin_owner_transport,
                         owner_session_record=_origin_owner_session_record,
+                        fork_history=t.get("_fork_history"),
                     )
                     futures[future] = i
 
@@ -5142,8 +5209,9 @@ def _build_top_level_description() -> str:
         "terminal(background=True, notify=True); /stop, /new, or "
         "process exit discards running subagents.\n\n"
         "RULES:\n"
-        "- Children know nothing of this conversation: pass everything needed "
-        "via 'context', including any required output language, tone, or "
+        "- Children know nothing of this conversation unless you set "
+        "context_mode='fork' on a task: pass everything needed via "
+        "'context', including any required output language, tone, or "
         "style (e.g. \"respond in Chinese\").\n"
         "- Child summaries are SELF-REPORTS, not verified facts: a child "
         "claiming \"uploaded successfully\" or \"file written\" may be wrong. "
@@ -5269,6 +5337,27 @@ DELEGATE_TASK_SCHEMA = {
                                 "schema_valid, plus schema_errors on "
                                 "failure). Keep it forgiving — require only "
                                 "fields you will read."
+                            ),
+                        },
+                        "context_mode": {
+                            "type": "string",
+                            "enum": ["isolated", "fork"],
+                            "description": (
+                                "Default 'isolated': fresh context, only "
+                                "goal+context. 'fork': child replays a "
+                                "snapshot of your conversation so far (this "
+                                "task appended). Use when the child would "
+                                "otherwise re-read files or redo research "
+                                "already in this thread. NOT prompt-cache "
+                                "reuse — the child has a different system "
+                                "prompt, tool list, and cache scope, so its "
+                                "first request is a cold prefix at full "
+                                "input rates; the benefit is skipped "
+                                "re-gathering work only. The child also "
+                                "sees your in-progress reasoning, file "
+                                "contents read this session, and any "
+                                "secrets in tool results. Empty/failed "
+                                "snapshot falls back to isolated."
                             ),
                         },
                     },


### PR DESCRIPTION
## Summary

Adds a per-task `context_mode: "fork"` option to `delegate_task`: the child
starts from a structural clone of the parent's conversation instead of a
blank context, via the existing `run_conversation(conversation_history=...)`
seed path (the same parameter gateway session restore uses — no new
message-injection surface).

Inspired by MoonshotAI/kimi-code#3007 (MIT) and LangChain deepagents' fork
mode. **Related upstream work:** `kimi-port/delegate-fork-context` covers the
same category; this PR deliberately differs in three design points (see
below) and is submitted as an alternative for the maintainers to pick.

## Behavior

- Snapshot is built **once per call** (same structural-clone recipe as the
  background-review fork) and shared read-only by every forked child in the
  batch; each child re-copies at seed time.
- Capped at `delegation.fork_max_messages` (default 200, floor 10). After a
  cut, leading tool results without a preceding call are dropped — the child
  never opens mid-tool.
- An in-flight trailing `assistant(tool_calls)` (the very `delegate_task`
  call being executed) is excised, so the child never replays an unanswered
  call or a user/user merged prompt.
- Forked goals are framed with an inheritance notice: the seeded messages are
  reference material from the parent, not the child's own past actions.
- Empty or failed snapshot degrades safely to the normal isolated spawn
  (log line, no exception into the delegation path).

## Deliberate differences from kimi-port/delegate-fork-context

| Aspect | This PR | kimi-port branch |
|---|---|---|
| Parameter | `context_mode: enum[isolated, fork]` | `fork: bool` |
| Snapshot source | in-memory `_session_messages` (structural clone, same recipe as background review) | session DB roundtrip (`get_messages_as_conversation`) |
| Cache wording | honest: fork is **not** prompt-cache reuse — the child has its own system prompt and tool list, so the replayed prefix is cold at full input rates; the benefit is skipped re-gathering work only | — |
| Footprint | ~70 lines in `delegate_tool.py` | new `tools/delegation_fork.py` (175 lines) + docs |

The in-memory source avoids the session-DB read and `_STRIP_KEYS`
bookkeeping-key handling entirely; the clone recipe is already proven by the
background-review fork. If maintainers prefer the session-DB source (durable
across restarts, includes ancestor sessions), the snapshot builder is a
drop-in swap.

## Tests

88 tests in `tests/tools/test_delegate.py`, including 8 fork-specific:
schema invariant (`context_mode` enum), history pass-through, isolated
default (no history), empty-parent fallback, aliasing safety (mutating the
replay never touches the parent transcript — #100795 analog), tail excision,
`fork_max_messages` cap, inheritance notice on forked goals only.
Full local run: 143 passed across the delegate + background-review suites.

## Test plan

- [x] `pytest tests/tools/test_delegate.py` — 88 passed
- [x] Delegate + background-review related suites — 143 passed
- [ ] Maintainer review of the snapshot-source choice (in-memory vs session DB)
