### PR TITLE
fix(delegation): floor implicit non-stream stale timeout at 150s for delegated children (P-0097)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -551,6 +551,20 @@ class AIAgent(
         reasoning_floor = get_reasoning_stale_timeout_floor(self.model)
         if reasoning_floor is not None:
             return reasoning_floor, False
+        # Delegated children sit behind Cloudflare-fronted aggregators whose Proxy Read
+        # Timeout (120s) exceeds the implicit 90s default: the local watchdog would kill
+        # the doomed call before the gateway's own 524 arrives, so retries re-enter the
+        # same window with 120s+ backoff (~12min to a guaranteed death). Floor the
+        # implicit timeout at 150s for children so a genuinely hung origin surfaces as
+        # the provider's 524 (actionable, retry_after-honored) instead of our 90s kill.
+        # (#60203 follow-up; see kanban t_5806fd2b RCA §4.2.)
+        try:
+            from agent.delegation_context import is_delegated_child_context
+
+            if is_delegated_child_context() or getattr(self, "platform", None) == "subagent":
+                return 150.0, True
+        except Exception:
+            pass
         return 90.0, True
 
     def _compute_non_stream_stale_timeout(self, api_payload: Any) -> float:

--- a/tests/agent/test_delegate_child_stale_watchdog_e2e.py
+++ b/tests/agent/test_delegate_child_stale_watchdog_e2e.py
@@ -1,0 +1,464 @@
+"""End-to-end repro/gate tests for P-0097 (kanban t_a227df9e).
+
+Incident: delegate_task children (platform="subagent") that ended up in
+NON-streaming mode (streaming disabled by a provider signal or model config)
+hit the inline ``direct_api_call`` path with the implicit 90s stale-call
+watchdog (run_agent._resolved_api_call_stale_timeout_base). Sitting behind a
+Cloudflare-fronted aggregator whose Proxy Read Timeout is 120s, the local
+watchdog killed every doomed call before the gateway's own 524 arrived, so
+retries re-entered the same >120s window with growing backoff: the child died
+silently after ~12 minutes of guaranteed-fatal retries. The fix (t_5806fd2b
+RCA §4.2) floors the implicit stale timeout at 150s for delegated children so
+the provider's actionable 524 wins the race.
+
+The resolver-level unit tests live in test_non_stream_stale_timeout.py. This
+file proves the behavior END-TO-END through the real conversation loop, the
+real inline dispatch, the real watchdog timers, and a real OpenAI-wire client
+talking to an in-process mock provider:
+
+1. test_child_nonstream_hang_retries_sequentially_and_ends_gracefully —
+   the incident shape (silent hang): the child must not wedge, must run its
+   retry attempts sequentially on the caller thread, and must terminate in a
+   graceful failed turn result.
+2. test_child_streaming_transient_524s_then_recovers — children stream by
+   default; transient 524s must be retried and a healthy SSE stream must
+   complete the turn with the recovered answer.
+3. test_child_nonstream_provider_524_arrives_before_local_kill — the RCA
+   race: with the provider error arriving well inside the (floored) local
+   watchdog window, the turn must surface the provider's 524, never a local
+   "Non-streaming API call timed out" kill.
+
+The mock provider is a real HTTP server; the agent's ``base_url`` stays
+cloud-shaped (non-local, so the local-endpoint stale-disable short-circuit
+cannot mask the watchdog) while a per-request OpenAI client is injected
+pointing at the mock — the same seam production uses
+(``agent._create_request_openai_client``).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from agent.delegation_context import delegated_child_context
+from hermes_state import SessionDB
+
+CLOUD_BASE_URL = "https://zai-relay.example.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# In-process mock OpenAI-wire provider
+# ---------------------------------------------------------------------------
+
+
+class _MockProvider:
+    """Thread-safe scripted OpenAI-wire provider.
+
+    ``script`` is a callable ``(request_count, body_dict) -> response`` where
+    response is one of:
+      ("hang",)                      — accept the request and never respond
+      ("status", code, payload_dict) — respond with an HTTP status + JSON body
+      ("sse", chunks)                — respond 200 with an SSE chat stream
+    """
+
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.requests = []  # list of parsed request bodies, in arrival order
+        self.script = lambda count, body: ("hang",)
+        self._server = None
+        self._thread = None
+        self.port = None
+
+    # -- lifecycle ---------------------------------------------------------
+    def start(self):
+        provider = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args):  # silence
+                pass
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length) if length else b""
+                try:
+                    body = json.loads(raw.decode("utf-8"))
+                except Exception:
+                    body = {"stream": False}
+                with provider.lock:
+                    provider.requests.append(body)
+                    count = len(provider.requests)
+                    outcome = provider.script(count, body)
+                if outcome[0] == "hang":
+                    # Hold the connection open; the watchdog abort shuts the
+                    # socket from the client side. Thread stays parked (daemon).
+                    threading.Event().wait(120)
+                    return
+                if outcome[0] == "status":
+                    _, code, payload = outcome
+                    payload_bytes = json.dumps(payload).encode("utf-8")
+                    self.send_response(code)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(payload_bytes)))
+                    self.end_headers()
+                    self.wfile.write(payload_bytes)
+                    return
+                if outcome[0] == "sse":
+                    _, chunks = outcome
+                    events = []
+                    for piece in chunks:
+                        events.append(
+                            "data: "
+                            + json.dumps(
+                                {
+                                    "id": "chatcmpl-test",
+                                    "object": "chat.completion.chunk",
+                                    "created": 1,
+                                    "model": "test-model",
+                                    "choices": [
+                                        {
+                                            "index": 0,
+                                            "delta": {"content": piece},
+                                            "finish_reason": None,
+                                        }
+                                    ],
+                                }
+                            )
+                            + "\n\n"
+                        )
+                    events.append(
+                        "data: "
+                        + json.dumps(
+                            {
+                                "id": "chatcmpl-test",
+                                "object": "chat.completion.chunk",
+                                "created": 1,
+                                "model": "test-model",
+                                "choices": [
+                                    {"index": 0, "delta": {}, "finish_reason": "stop"}
+                                ],
+                            }
+                        )
+                        + "\n\n"
+                    )
+                    events.append("data: [DONE]\n\n")
+                    payload_bytes = "".join(events).encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.send_header("Content-Length", str(len(payload_bytes)))
+                    self.end_headers()
+                    self.wfile.write(payload_bytes)
+                    return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        self.port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+
+    # -- helpers -----------------------------------------------------------
+    @property
+    def request_count(self) -> int:
+        with self.lock:
+            return len(self.requests)
+
+    def streamed_requests(self) -> int:
+        with self.lock:
+            return sum(1 for body in self.requests if body.get("stream"))
+
+
+@pytest.fixture
+def mock_provider():
+    provider = _MockProvider()
+    provider.start()
+    try:
+        yield provider
+    finally:
+        provider.stop()
+
+
+# ---------------------------------------------------------------------------
+# Environment + backoff isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_timeout_env(monkeypatch):
+    """Timeout knobs must come from production defaults, not the ambient env
+    of whichever machine runs the suite."""
+    for var in (
+        "HERMES_API_CALL_STALE_TIMEOUT",
+        "HERMES_STREAM_STALE_TIMEOUT",
+        "HERMES_API_TIMEOUT",
+        "HERMES_STREAM_STALE_GIVEUP",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _fast_retry_backoff(monkeypatch):
+    """Collapse inter-attempt backoff so tests exercise the watchdog timing,
+    not the sleep."""
+    from agent import retry_utils as _retry_utils
+
+    monkeypatch.setattr(_retry_utils, "jittered_backoff", lambda *a, **k: 0.0)
+    monkeypatch.setattr(_retry_utils, "adaptive_rate_limit_backoff", lambda *a, **k: 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Child agent factory (mirrors delegate_tool._build_child_agent)
+# ---------------------------------------------------------------------------
+
+
+def _make_child_agent(tmp_path, mock_provider: _MockProvider, *, retries: int = 3):
+    from openai import OpenAI
+    from run_agent import AIAgent
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "sess-repro-child"
+    db.create_session(session_id=sid, source="cli")
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url=CLOUD_BASE_URL,  # cloud-shaped: keeps the local-endpoint stale-disable out of the picture
+        provider="openai-compat",
+        model="test-model",
+        max_iterations=10,
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+        platform="subagent",
+        session_db=db,
+        session_id=sid,
+    )
+    # Production children get _api_max_retries from config (default 3); pin it
+    # so attempt accounting is exact regardless of host config.
+    agent._api_max_retries = retries
+
+    # Per-request client injection (the same seam production uses), pointed at
+    # the mock. max_retries=0 keeps SDK-internal retries out of the accounting.
+    def _fake_create_request_client(*, reason, api_kwargs=None):
+        return OpenAI(
+            api_key="test-key",
+            base_url=f"http://127.0.0.1:{mock_provider.port}/v1",
+            max_retries=0,
+        )
+
+    agent._create_request_openai_client = _fake_create_request_client
+    agent._close_request_openai_client = lambda *a, **k: None
+    return agent
+
+
+def _run_turn_with_deadline(agent, user_message, *, timeout_s: float = 90.0):
+    """Run one child turn on a worker thread with a hard join deadline so a
+    regression that wedges the child fails the test instead of hanging CI."""
+    holder = {}
+
+    def _target():
+        try:
+            with delegated_child_context("sess-repro-child"):
+                holder["result"] = agent.run_conversation(user_message)
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            holder["error"] = exc
+
+    thread = threading.Thread(target=_target, daemon=True, name="child-turn")
+    started = time.monotonic()
+    thread.start()
+    thread.join(timeout=timeout_s)
+    elapsed = time.monotonic() - started
+    if thread.is_alive():
+        import sys as _sys
+        import traceback as _tb
+
+        frames = _sys._current_frames()
+        for tid, frame in frames.items():
+            if tid == threading.main_thread().ident:
+                continue
+            stack = "".join(_tb.format_stack(frame)).strip()
+            print(f"=== WEDGED THREAD {tid} STACK ===\n{stack}\n=== END STACK ===", flush=True)
+    assert not thread.is_alive(), (
+        f"child turn wedged: run_conversation did not return within {timeout_s}s "
+        "(the P-0097 death-spiral regression)"
+    )
+    if "error" in holder:
+        raise holder["error"]
+    return holder["result"], elapsed
+
+
+# ---------------------------------------------------------------------------
+# 1. The incident shape: non-stream child vs a silently hanging provider
+# ---------------------------------------------------------------------------
+
+
+def test_child_nonstream_hang_retries_sequentially_and_ends_gracefully(
+    tmp_path, mock_provider, monkeypatch
+):
+    """A delegated child forced into non-streaming mode against a silently
+    hanging provider must run its inline watchdog, retry sequentially on the
+    caller thread (no nested-pool wedge), and end in a graceful failed turn —
+    not a 12-minute silent death spiral and not a hung tool call."""
+    monkeypatch.setattr("agent.chat_completion_helpers.env_int", lambda *a, **k: 0)
+
+    class _ScaledTimer(threading.Timer):
+        """Compress production watchdog windows (150s) to 0.5s so the retry
+        machinery is exercised end-to-end in seconds."""
+
+        def __init__(self, interval, function, args=None, kwargs=None):
+            super().__init__(min(float(interval), 0.5), function, args, kwargs)
+
+    monkeypatch.setattr(threading, "Timer", _ScaledTimer)
+
+    attempts = {"now": 0}
+    lock = threading.Lock()
+
+    def _script(count, body):
+        with lock:
+            attempts["now"] = count
+        assert body.get("stream") is not True, (
+            "the incident child is in non-streaming mode; a streaming request "
+            "here means the fixture lost the non-stream state"
+        )
+        return ("hang",)
+
+    mock_provider.script = _script
+
+    agent = _make_child_agent(tmp_path, mock_provider)
+    agent._disable_streaming = True  # the incident state (streaming disabled downstream)
+
+    # Windows reality check (#85252): the watchdog's shutdown(SHUT_RDWR) does NOT
+    # wake a recv() parked on a silent socket — production bounds the read with
+    # the per-call timeout knob (HERMES_API_TIMEOUT-derived). Compress it so the
+    # parked read unblocks promptly after the watchdog kill instead of waiting
+    # out the 1800s default; the stale watchdog remains the actual killer.
+    agent._resolved_api_call_timeout = lambda: 2.0
+
+    result, elapsed = _run_turn_with_deadline(agent, "Summarize the incident", timeout_s=60)
+
+    # Exactly one request per retry attempt, run sequentially to completion.
+    assert mock_provider.request_count == 3, (
+        f"expected exactly 3 sequential attempts, saw {mock_provider.request_count}"
+    )
+
+    # The turn terminates as a graceful failure with the watchdog's actionable
+    # timeout surfaced in the response text — the child is never silently lost.
+    assert isinstance(result, dict), f"run_conversation returned {type(result)}"
+    final_text = str(result.get("final_response") or "")
+    failed = result.get("failed")
+    assert failed or "timed out" in final_text.lower() or "timeout" in final_text.lower(), (
+        f"expected a graceful failed-turn result, got: { {k: result.get(k) for k in ('failed', 'completed', 'final_response')} }"
+    )
+    assert "timed out" in final_text.lower() or (result.get("failed") is True), final_text[:400]
+
+    # Three compressed watchdog windows must actually elapse: the calls were
+    # bounded by the stale watchdog, not failed instantly.
+    assert elapsed >= 1.2, f"3 watchdog windows should take >=1.2s, took {elapsed:.2f}s"
+    assert elapsed < 45, f"retry loop ran away ({elapsed:.1f}s)"
+
+
+# ---------------------------------------------------------------------------
+# 2. Children stream by default; transient 524s retry, healthy SSE completes
+# ---------------------------------------------------------------------------
+
+
+def test_child_streaming_transient_524s_then_recovers(tmp_path, mock_provider, monkeypatch):
+    """Default (streaming) children hit the streaming watchdog path, not the
+    non-stream one: two transient gateway 524s must be retried and the healthy
+    SSE stream must complete the turn with the recovered answer."""
+    monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "10")
+
+    def _script(count, body):
+        assert body.get("stream") is True, "children stream by default; expected stream=true"
+        if count <= 2:
+            return (
+                "status",
+                524,
+                {
+                    "error": {
+                        "message": "A timeout occurred: origin did not respond within the proxy read timeout",
+                        "code": 524,
+                    }
+                },
+            )
+        return ("sse", ["Gateway relay "])
+
+    mock_provider.script = _script
+
+    agent = _make_child_agent(tmp_path, mock_provider)
+
+    result, elapsed = _run_turn_with_deadline(agent, "Summarize the incident", timeout_s=60)
+
+    assert mock_provider.request_count == 3, mock_provider.request_count
+    assert mock_provider.streamed_requests() == 3
+    final_text = str(result.get("final_response") or "")
+    assert "Gateway relay" in final_text, (
+        f"streamed answer did not reach the final response: {final_text[:300]!r}"
+    )
+    assert not result.get("failed"), result.get("failed")
+    assert elapsed < 45
+
+
+# ---------------------------------------------------------------------------
+# 3. The RCA race: the provider's 524 must arrive before any local kill
+# ---------------------------------------------------------------------------
+
+
+def test_child_nonstream_provider_524_arrives_before_local_kill(tmp_path, mock_provider):
+    """With the fix, the child's implicit non-stream watchdog (150s) is longer
+    than the gateway's time-to-524, so the turn fails with the provider's
+    actionable 524 — never the local 'Non-streaming API call timed out' kill
+    that made the incident unrecoverable."""
+    delay_s = 12.0
+
+    def _script(count, body):
+        assert body.get("stream") is not True
+        time.sleep(delay_s)
+        return (
+            "status",
+            524,
+            {
+                "error": {
+                    "message": "A timeout occurred: origin did not respond within the proxy read timeout",
+                    "code": 524,
+                }
+            },
+        )
+
+    mock_provider.script = _script
+
+    agent = _make_child_agent(tmp_path, mock_provider, retries=2)
+    agent._disable_streaming = True
+
+    # The floored child budget must cover the REAL gateway window the RCA
+    # measured (Cloudflare proxy read timeout ~120s), with room to spare.
+    # Pre-fix the implicit budget was 90s < 120s — this assertion is the
+    # fix-discriminating tripwire; fail cheaply here if it is re-tightened.
+    effective_budget = agent._compute_non_stream_stale_timeout({})
+    assert effective_budget >= 120.0, (
+        f"child stale budget {effective_budget}s no longer covers the ~120s "
+        "gateway proxy window — the P-0097 race is re-armed"
+    )
+
+    result, elapsed = _run_turn_with_deadline(agent, "Summarize the incident", timeout_s=120)
+
+    assert mock_provider.request_count == 2
+    final_text = str(result.get("final_response") or "")
+    assert "524" in final_text or "origin did not respond" in final_text or "proxy read timeout" in final_text, (
+        f"expected the provider's 524 to be surfaced, got: {final_text[:400]!r}"
+    )
+    assert "non-streaming api call timed out" not in final_text.lower(), (
+        "the local stale watchdog fired before the provider's 524 — pre-fix behavior"
+    )
+    # Two full provider-error cycles happened before the terminal result.
+    assert elapsed >= 2 * delay_s - 1, f"expected >= {2 * delay_s}s, took {elapsed:.1f}s"

--- a/tests/agent/test_non_stream_stale_timeout.py
+++ b/tests/agent/test_non_stream_stale_timeout.py
@@ -120,3 +120,77 @@ def test_openai_codex_stale_floor_tiers():
 
     assert openai_codex_stale_timeout_floor(55_000) == 900.0
     assert openai_codex_stale_timeout_floor(120_000) == 1200.0
+
+
+# ── delegated-child 150s floor (t_5806fd2b) ───────────────────────────────
+
+
+def _make_subagent_agent(tmp_path: Path, **overrides):
+    """Child-shaped AIAgent: nous chat-completions, subagent platform stamp."""
+    from run_agent import AIAgent
+    kwargs = dict(
+        model="z-ai/glm-5.3-flash",
+        provider="nous",
+        api_key="sk-dummy",
+        base_url="https://inference-api.nousresearch.com/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="subagent",
+    )
+    kwargs.update(overrides)
+    return AIAgent(**kwargs)
+
+
+def test_delegated_child_implicit_floor_is_150s(monkeypatch, tmp_path):
+    """Delegated children get a 150s implicit non-stream stale floor: their gateway's
+    Cloudflare Proxy Read Timeout (120s) exceeds the 90s default, so the local watchdog
+    must never win the race against the provider's actionable 524 (t_5806fd2b)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    agent = _make_subagent_agent(tmp_path)
+    base, implicit = agent._resolved_api_call_stale_timeout_base()
+    assert base == 150.0
+    assert implicit is True
+
+
+def test_delegated_child_context_var_floor(monkeypatch, tmp_path):
+    """The delegation ContextVar alone (no platform stamp) also raises the floor."""
+    from agent.delegation_context import delegated_child_context
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    _write_config(tmp_path, "")
+
+    agent = _make_subagent_agent(tmp_path, platform="cli")
+    with delegated_child_context("sess-x"):
+        base, _ = agent._resolved_api_call_stale_timeout_base()
+    assert base == 150.0
+
+
+def test_delegated_child_explicit_config_still_wins(monkeypatch, tmp_path):
+    """Explicit user/provider stale_timeout_seconds still beats the child floor."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(tmp_path, """\
+providers:
+  nous:
+    stale_timeout_seconds: 300
+""")
+    monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+
+    import importlib
+    from hermes_cli import timeouts as to_mod
+    importlib.reload(to_mod)
+
+    try:
+        agent = _make_subagent_agent(tmp_path)
+        base, implicit = agent._resolved_api_call_stale_timeout_base()
+        assert base == 300.0
+        assert implicit is False
+    finally:
+        importlib.reload(to_mod)


### PR DESCRIPTION
# Problem

P-0097: delegate_task children dying at the final-answer stage with `HTTP 524` or Hermes' own `Non-streaming API call timed out after 90s` watchdog error (11 dead children across 9 runs, 2026-09-01→02).

## Root cause

Pre-Sep-4 code detoured delegated children (`should_use_direct_api_call`) onto the NON-streaming wire inside `interruptible_streaming_api_call()`. Final-answer turns carry the full transcript (230–360 KB requests, 14–41 messages) and ask GLM for the longest server-side generation of the session. Non-streaming, that generation must finish inside one Cloudflare Proxy Read Timeout (~120 s) on the Cloudflare-fronted nous gateway — or inside Hermes' **90 s implicit non-stream stale watchdog**, 90 s < 120 s, so the local kill won the race. Either way the call was doomed, and `compute_error_backoff()` honored the 524 body's `retry_after: 120`, so each retry re-entered the same >120 s doomed window with 120 s+ backoff: ~12 min of guaranteed-fatal cycling before the child died.

The streaming fix itself ("children … must still STREAM", inline dispatch) already shipped upstream (f1ccf436a2 → 869228cab4, Sep 4–7) and the failure cluster ended. **This PR is the watchdog-race hardening that closes the remaining hole:** with a >90 s silent origin, the local 90 s watchdog would still kill the doomed call before the gateway's actionable 524 arrives, and retries would re-enter the same window — the P-0097 death spiral, re-armed.

## Change

`run_agent.py` — `AIAgent._resolved_api_call_stale_timeout_base()`:

- When the agent is a delegated child (`is_delegated_child_context()` **or** `platform == "subagent"`) and the stale timeout is otherwise implicit, the base is floored at **150.0 s** instead of 90.0 s.
- 150 s > Cloudflare's ~120 s proxy window, so on a genuinely hung origin the **provider's 524 arrives first**: it is actionable, its `retry_after` is honored, and the turn surfaces a real gateway error instead of a silent local kill.
- Explicit user config always wins: per-model/provider `stale_timeout_seconds` and `HERMES_API_CALL_STALE_TIMEOUT` are checked before the floor, and the floor returns `uses_implicit_default=True`, preserving the run-budget cap and the local-endpoint auto-disable semantics.
- The reasoning-model floor and cron behavior are untouched (cron's watchdog is separately handled and has its own suite).

## Tests

- **Repro/gate — `tests/agent/test_delegate_child_stale_watchdog_e2e.py` (3 behavioral tests):** drives the real conversation loop, real inline dispatch, real watchdog timers, and a real OpenAI-wire HTTP mock (in-process server; cloud-shaped `base_url` so the local-endpoint stale-disable cannot mask the watchdog; per-request client injection — the same seam production uses).
  1. child non-stream silent hang → sequential retries, graceful failed turn, no wedge;
  2. child streaming with transient 524s → retried, healthy SSE completes the turn;
  3. **the discriminating tripwire:** provider 524 arriving at ~12 s must surface the provider error, never a local watchdog kill, and asserts `effective_budget >= 120.0` (the CF proxy window) so re-tightening the child floor fails the test cheaply. Verified: fails on pre-fix HEAD (90.0) at exactly that assertion, passes with this fix.
- **Resolver unit tests — `tests/agent/test_non_stream_stale_timeout.py` (+3):** 150 s child floor (platform stamp), ContextVar path, explicit `stale_timeout_seconds` precedence.
- No regression: non-stream stale / reasoning-floor / run-budget / cron-watchdog / nonstream-notice / stream-inline / subagent lifecycle+progress+stop / delegate-cascade suites all pass on the PR branch (see Verification).

## Verification

- Full targeted suite on the PR branch: **140 passed** (repro/gate 3 + resolver 8 [= 5 pre-existing + 3 new] + stream-inline/reasoning-floor/run-budget/cron-watchdog 89 + nonstream notice 10 + subagent lifecycle/progress/stop + sequential-deadline exempt 24 + delegate cascade 6).
- Pre-fix discrimination proven independently via throwaway `git worktree` at HEAD (869228cab4): T3 fails `test_...e2e.py:448: AssertionError` (budget 90.0 < 120.0), then passes with the fix.

Linked problem: P-0097 (kanban t_968ad1ba); RCA: kanban t_5806fd2b (`rca_delegation_524.md`); repro task: t_a227df9e.
