### PR TITLE
feat(agent): allow strict auxiliary model routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6782,6 +6782,13 @@ def _ladder_nous_rungs(
     """Nous-only rungs: stale-model self-heal, paid-account refresh, 401 refresh.
     Returns ``(response, None)`` or ``(None, first_err)`` to fall through."""
     client, task, tag = route.client, route.task, route.tag
+    if not allow_fallback and client_is_nous and _is_model_not_found_error(first_err):
+        logger.warning(
+            "Auxiliary %s%s: selected model %r was not found; allow_fallback=False "
+            "prevents Nous catalog healing. Select an available model or set "
+            "allow_fallback=True to permit a replacement.",
+            task or "call", tag, kwargs.get("model"),
+        )
     # A long-lived process can pin a Portal model since dropped from the catalog (every call
     # 404s); force a fresh Portal fetch and retry once.
     if allow_fallback and _is_model_not_found_error(first_err) and client_is_nous:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3353,17 +3353,22 @@ def _prepare_same_provider_retry(
     max_tokens: Optional[int], tools: Optional[list], effective_timeout: float,
     effective_extra_body: dict, reasoning_config: Optional[dict], async_mode: bool,
     extra_headers: Optional[Dict[str, str]] = None,
+    allow_fallback: bool = True,
 ) -> Tuple[Any, Dict[str, Any]]:
     """Rebuild (client, request kwargs) for a same-provider retry after credential recovery."""
+    if not allow_fallback:
+        resolved_model = final_model
     if task == "vision":
         effective_provider, retry_client, retry_model = resolve_vision_provider_client(
             provider=resolved_provider, model=final_model, base_url=resolved_base_url,
             api_key=resolved_api_key, async_mode=async_mode,
+            **({"allow_fallback": False} if not allow_fallback else {}),
         )
     else:
         retry_client, retry_model = _get_cached_client(
             resolved_provider, resolved_model, async_mode=async_mode, base_url=resolved_base_url,
             api_key=resolved_api_key, api_mode=resolved_api_mode, main_runtime=main_runtime,
+            **({"allow_fallback": False} if not allow_fallback else {}),
         )
         effective_provider = _effective_provider_for_client(retry_client, resolved_provider)
     if retry_client is None:
@@ -4193,7 +4198,8 @@ def _try_discovery_chain() -> Tuple[Optional[OpenAI], Optional[str], str]:
 
 
 def _resolve_auto_route(
-    main_runtime: Optional[Dict[str, Any]] = None, task: Optional[str] = None
+    main_runtime: Optional[Dict[str, Any]] = None, task: Optional[str] = None,
+    allow_fallback: bool = True,
 ) -> Tuple[Optional[OpenAI], Optional[str], str]:
     """Full auto-detection chain, including the selected provider identity. Priority: (1) main provider +
     main model, regardless of provider type ("auto" means "my main model for side tasks too"; explicit
@@ -4208,6 +4214,8 @@ def _resolve_auto_route(
     routed = _try_main_provider_route(main_provider, main_model, base_url, api_key, api_mode)
     if routed is not None:
         return routed
+    if not allow_fallback:
+        return None, None, main_provider
     if task:
         fb_client, fb_model, fb_label = _try_configured_fallback_chain(
             task, main_provider or "auto", reason="main provider unavailable")
@@ -4404,6 +4412,7 @@ class _ResolveRequest(NamedTuple):
     main_runtime: Optional[Dict[str, Any]]
     is_vision: bool
     task: Optional[str]
+    allow_fallback: bool = True
 
 
 _ResolveResult = Tuple[Optional[Any], Optional[str]]
@@ -4452,13 +4461,15 @@ def _route_or_warn(req: _ResolveRequest, client: Any, default: Optional[str], un
 
 def _resolve_auto_branch(req: _ResolveRequest) -> _ResolveResult:
     """Auto: try all providers in priority order; tag the client with the effective provider (survives cache reuse)."""
-    client, resolved, effective_provider = _resolve_auto_route(main_runtime=req.main_runtime, task=req.task)
+    client, resolved, effective_provider = _resolve_auto_route(
+        main_runtime=req.main_runtime, task=req.task,
+        **({"allow_fallback": False} if not req.allow_fallback else {}))
     if client is None:
         return None, None
     model = req.model
     # An OpenRouter-format model override won't work on a non-OpenRouter provider (e.g. local
     # server); drop it for the provider's default.
-    if model and "/" in model and resolved and "/" not in resolved:
+    if req.allow_fallback and model and "/" in model and resolved and "/" not in resolved:
         logger.debug("Dropping OpenRouter-format model %r for non-OpenRouter "
                      "auxiliary provider (using %r instead)", model, resolved)
         model = None
@@ -4834,6 +4845,7 @@ def resolve_provider_client(
     explicit_base_url: str = None, explicit_api_key: str = None, api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None, is_vision: bool = False,
     task: Optional[str] = None,
+    allow_fallback: bool = True,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: return a configured client (auth, base URL, API format) for a provider + optional model.
     The client always exposes ``.chat.completions.create()``; Codex/Responses providers get an adapter.
@@ -4889,7 +4901,7 @@ def resolve_provider_client(
         model = _get_aux_model_for_provider(provider) or _read_main_model_for_aux() or model
     req = _ResolveRequest(
         provider, original_provider, model, async_mode, raw_codex,
-        explicit_base_url, explicit_api_key, api_mode, main_runtime, is_vision, task,
+        explicit_base_url, explicit_api_key, api_mode, main_runtime, is_vision, task, allow_fallback,
     )
     branch = _EXPLICIT_PROVIDER_BRANCHES.get(provider)
     if branch is not None:
@@ -5051,6 +5063,7 @@ def _vision_main_provider_client(
 def _vision_auto_route(
     runtime: Dict[str, Any], resolved_model: Optional[str], resolved_api_mode: Optional[str],
     async_mode: bool,
+    allow_fallback: bool = True,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Auto-detect order: 1. main provider + model, 2. OpenRouter, 3. Nous Portal, 4. DeepInfra, 5. stop."""
     main_provider = str(runtime.get("provider") or _read_main_provider())
@@ -5066,6 +5079,8 @@ def _vision_auto_route(
         client, default_model = _vision_main_provider_client(main_provider, main_model, runtime, resolved_model, resolved_api_mode)
         if client is not None:
             return _finalize_vision_client(main_provider, client, default_model, resolved_model, async_mode)
+    if not allow_fallback:
+        return None, None, None
     # Aggregators use their dedicated vision model, not the user's main model.
     for candidate in _VISION_AUTO_PROVIDER_ORDER:
         if candidate == main_provider:
@@ -5086,6 +5101,7 @@ def resolve_vision_provider_client(
     provider: Optional[str] = None, model: Optional[str] = None, *, base_url: Optional[str] = None,
     api_key: Optional[str] = None, async_mode: bool = False,
     main_runtime: Optional[Dict[str, Any]] = None,
+    allow_fallback: bool = True,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
 
@@ -5106,7 +5122,9 @@ def resolve_vision_provider_client(
         )
         return provider_for_base_override, client, (final_model if client is not None else None)
     if requested == "auto":
-        return _vision_auto_route(runtime, resolved_model, resolved_api_mode, async_mode)
+        return _vision_auto_route(
+            runtime, resolved_model, resolved_api_mode, async_mode,
+            **({"allow_fallback": False} if not allow_fallback else {}))
     if requested in _VISION_AUTO_PROVIDER_ORDER:
         sync_client, default_model = _resolve_strict_vision_backend(requested, resolved_model)
         return _finalize_vision_client(requested, sync_client, default_model, resolved_model, async_mode)
@@ -5226,6 +5244,7 @@ def _refresh_nous_auxiliary_client(
     api_key: Optional[str] = None, api_mode: Optional[str] = None,
     main_runtime: Optional[Dict[str, Any]] = None, is_vision: bool = False,
     lookup_model: Optional[str] = None, lookup_task: Optional[str] = None,
+    allow_fallback: bool = True,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Refresh Nous runtime creds, rebuild the client, and replace the cache entry.
 
@@ -5256,6 +5275,8 @@ def _refresh_nous_auxiliary_client(
         api_mode=api_mode, main_runtime=main_runtime, is_vision=is_vision, task=lookup_task,
         model=lookup_model,
     )
+    if not allow_fallback and _normalize_aux_provider(cache_provider) == "auto":
+        cache_key += ("strict",)
     _store_cached_client(cache_key, client, final_model, bound_loop=current_loop)
     return client, final_model
 
@@ -5391,6 +5412,7 @@ def _get_cached_client(
     provider: str, model: str = None, async_mode: bool = False, base_url: str = None,
     api_key: str = None, api_mode: str = None, main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False, task: Optional[str] = None,
+    allow_fallback: bool = True,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Get or create a cached client for the given provider.
 
@@ -5407,6 +5429,8 @@ def _get_cached_client(
         provider, async_mode=async_mode, base_url=base_url, api_key=api_key, api_mode=api_mode,
         main_runtime=main_runtime, is_vision=is_vision, task=task, model=model,
     )
+    if not allow_fallback and _normalize_aux_provider(provider) == "auto":
+        cache_key += ("strict",)
     with _client_cache_lock:
         if cache_key in _client_cache:
             cached_client, cached_default, cached_loop = _client_cache[cache_key]
@@ -5414,6 +5438,8 @@ def _get_cached_client(
                 cached_loop is not None and cached_loop is current_loop and not cached_loop.is_closed()
             )
             if loop_ok:
+                if not allow_fallback:
+                    return cached_client, model or cached_default
                 return cached_client, _compat_model(cached_client, model, cached_default)
             # Stale async entry — evict. Only a closed owner loop may be awaited here; a live
             # foreign loop stays force-neutered.
@@ -5430,6 +5456,7 @@ def _get_cached_client(
     client, default_model = resolve_provider_client(
         provider, model, async_mode, explicit_base_url=base_url, explicit_api_key=effective_api_key,
         api_mode=api_mode, main_runtime=runtime, is_vision=is_vision, task=task,
+        **({"allow_fallback": False} if not allow_fallback else {}),
     )
     if client is not None:
         with _client_cache_lock:
@@ -6505,6 +6532,7 @@ def _resolve_call_client(
     api_key: Optional[str], resolved_provider: str, resolved_model: Optional[str],
     resolved_base_url: Optional[str], resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str], main_runtime: Optional[Dict[str, Any]], async_mode: bool,
+    allow_fallback: bool = True,
 ) -> _ResolvedAuxRoute:
     """Resolve the client for one aux call: vision chain, or cached text client with the
     explicit-provider fallback_chain / auto-chain rescue; RuntimeError when nothing is configured."""
@@ -6513,9 +6541,9 @@ def _resolve_call_client(
         effective_provider, client, final_model = resolve_vision_provider_client(
             provider=resolved_provider if resolved_provider != "auto" else provider,
             model=resolved_model or model, base_url=resolved_base_url or base_url,
-            api_key=resolved_api_key or api_key, async_mode=async_mode, main_runtime=main_runtime,
+            api_key=resolved_api_key or api_key, async_mode=async_mode, main_runtime=main_runtime, allow_fallback=allow_fallback,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
+        if allow_fallback and client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning("Vision provider %s unavailable, falling back to auto vision backends",
                            resolved_provider)
             effective_provider, client, final_model = resolve_vision_provider_client(
@@ -6527,9 +6555,9 @@ def _resolve_call_client(
         client, final_model = _get_cached_client(
             resolved_provider, resolved_model, async_mode=async_mode, base_url=resolved_base_url,
             api_key=resolved_api_key, api_mode=resolved_api_mode, main_runtime=main_runtime,
-            task=task)
+            task=task, **({"allow_fallback": False} if not allow_fallback else {}))
         effective_provider = _effective_provider_for_client(client, resolved_provider)
-        if client is None:
+        if client is None and allow_fallback:
             # Explicit provider with no credentials: honor the task fallback_chain before
             # raising (fallback entries may use OAuth / credential-pool auth).
             _explicit = (resolved_provider or "").strip().lower()
@@ -6576,6 +6604,7 @@ def _prepare_aux_request(
     timeout: Optional[float], extra_body: Optional[dict], reasoning_config: Optional[dict],
     extra_headers: Optional[Dict[str, str]], api_mode: Optional[str],
     route_info: Optional[Dict[str, str]], async_mode: bool,
+    allow_fallback: bool = True,
 ) -> _PreparedAuxRequest:
     """Shared head of call_llm/async_call_llm: resolve route + client, publish it, build request kwargs.
     Sync-only: compression fast lane, per-request ``extra_headers``, and ``base_info`` falling
@@ -6587,7 +6616,7 @@ def _prepare_aux_request(
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
     client, final_model, resolved_provider, effective_provider = _resolve_call_client(
-        task, provider=provider, model=model, base_url=base_url, api_key=api_key,
+        task, allow_fallback=allow_fallback, provider=provider, model=model, base_url=base_url, api_key=api_key,
         resolved_provider=resolved_provider, resolved_model=resolved_model,
         resolved_base_url=resolved_base_url, resolved_api_key=resolved_api_key,
         resolved_api_mode=resolved_api_mode, main_runtime=main_runtime, async_mode=async_mode,
@@ -6726,7 +6755,9 @@ def _ladder_parameter_rungs(
     return None, first_err, kwargs
 
 
-def _refreshed_nous_step(route: _LadderRoute, kwargs: Dict[str, Any], message: str) -> Optional[_LadderStep]:
+def _refreshed_nous_step(
+    route: _LadderRoute, kwargs: Dict[str, Any], message: str, *, allow_fallback: bool = True,
+) -> Optional[_LadderStep]:
     """Rebuild the Nous client after a credential event; None when nothing refreshed."""
     refreshed_client, refreshed_model = _refresh_nous_auxiliary_client(
         cache_provider=route.resolved_provider or "nous", model=route.final_model,
@@ -6734,24 +6765,26 @@ def _refreshed_nous_step(route: _LadderRoute, kwargs: Dict[str, Any], message: s
         base_url=route.resolved_base_url, api_key=route.resolved_api_key,
         api_mode=route.resolved_api_mode, main_runtime=route.main_runtime,
         is_vision=(route.task == "vision"),
+        **({"allow_fallback": False} if not allow_fallback else {}),
     )
     if refreshed_client is None:
         return None
     logger.info(message, route.task or "call", route.tag)
-    if refreshed_model and refreshed_model != kwargs.get("model"):
+    if allow_fallback and refreshed_model and refreshed_model != kwargs.get("model"):
         kwargs["model"] = refreshed_model
     return _LadderStep("call", (refreshed_client, kwargs))
 
 
 def _ladder_nous_rungs(
     first_err: Exception, route: _LadderRoute, kwargs: Dict[str, Any], client_is_nous: bool,
+    allow_fallback: bool = True,
 ):
     """Nous-only rungs: stale-model self-heal, paid-account refresh, 401 refresh.
     Returns ``(response, None)`` or ``(None, first_err)`` to fall through."""
     client, task, tag = route.client, route.task, route.tag
     # A long-lived process can pin a Portal model since dropped from the catalog (every call
     # 404s); force a fresh Portal fetch and retry once.
-    if _is_model_not_found_error(first_err) and client_is_nous:
+    if allow_fallback and _is_model_not_found_error(first_err) and client_is_nous:
         healed_model = _refresh_nous_recommended_model(
             vision=(task == "vision"), stale_model=kwargs.get("model"))
         if healed_model and healed_model != kwargs.get("model"):
@@ -6766,7 +6799,8 @@ def _ladder_nous_rungs(
     if _is_payment_error(first_err) and client_is_nous and _nous_portal_account_has_fresh_paid_access():
         step = _refreshed_nous_step(
             route, kwargs,
-            "Auxiliary %s%s: refreshed Nous runtime credentials after paid account check, retrying")
+            "Auxiliary %s%s: refreshed Nous runtime credentials after paid account check, retrying",
+            allow_fallback=allow_fallback)
         if step is not None:
             resp, first_err = yield from _rung(
                 step, lambda exc: _credential_rung_accepts(exc) or _is_connection_error(exc))
@@ -6774,7 +6808,8 @@ def _ladder_nous_rungs(
                 return resp, None
     if _is_auth_error(first_err) and client_is_nous:
         step = _refreshed_nous_step(
-            route, kwargs, "Auxiliary %s%s: refreshed Nous runtime credentials after 401, retrying")
+            route, kwargs, "Auxiliary %s%s: refreshed Nous runtime credentials after 401, retrying",
+            allow_fallback=allow_fallback)
         if step is not None:
             return (yield step), None
     return None, first_err
@@ -6914,6 +6949,7 @@ def _aux_recovery_ladder(
     resolved_base_url: Optional[str], resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str], final_model: Optional[str], max_tokens: Optional[int],
     main_runtime: Optional[Dict[str, Any]], route_info: Optional[Dict[str, str]],
+    allow_fallback: bool = True,
 ):
     """Ordered recovery rungs after the primary request failed (generator): parameter
     strips → Nous heal/refresh → credential refresh/pool rotation → provider fallback.
@@ -6928,15 +6964,16 @@ def _aux_recovery_ladder(
         return resp
     client_is_nous = (resolved_provider == "nous"
                       or base_url_host_matches(base_info, "inference-api.nousresearch.com"))
-    resp, first_err = yield from _ladder_nous_rungs(first_err, route, kwargs, client_is_nous)
+    resp, first_err = yield from _ladder_nous_rungs(first_err, route, kwargs, client_is_nous, allow_fallback=allow_fallback)
     if first_err is None:
         return resp
     resp, first_err = yield from _ladder_credential_rungs(first_err, route, kwargs, client_is_nous)
     if first_err is None:
         return resp
-    resp = yield from _ladder_provider_fallback(first_err, route)
-    if resp is not None:
-        return resp
+    if allow_fallback:
+        resp = yield from _ladder_provider_fallback(first_err, route)
+        if resp is not None:
+            return resp
     # Connection/timeout errors poison the cached client (closed transport, half-read
     # stream); evict so the next aux call rebuilds a fresh one.
     # Drop it from the cache regardless of whether we found a fallback above so the next auxiliary call
@@ -7002,8 +7039,14 @@ def call_llm(
     extra_headers: Optional[Dict[str, str]] = None, api_mode: str = None, stream: bool = False,
     stream_options: dict = None, route_info: Optional[Dict[str, str]] = None,
     latency_info: Optional[Dict[str, int]] = None,
+    allow_fallback: bool = True,
 ) -> Any:
-    """Run an auxiliary LLM request, applying the configured task limit."""
+    """Run an auxiliary LLM request, applying the configured task limit.
+
+    allow_fallback=False keeps the selected provider/model: unavailable routes raise,
+    including auto routes whose main backend is unavailable. Same-route transient
+    retries, parameter repairs, and credential refresh remain enabled.
+    """
     queue_started_at = time.monotonic()
     semaphore = _acquire_sync_aux_semaphore(task)
     if semaphore is not None:
@@ -7025,7 +7068,7 @@ def call_llm(
                 _stamp_latency_once, latency_info, "time_to_first_progress_ms", request_started_at)),
         ):
             response = _call_llm_impl(
-                task=task, provider=provider, model=model, base_url=base_url, api_key=api_key,
+                task=task, allow_fallback=allow_fallback, provider=provider, model=model, base_url=base_url, api_key=api_key,
                 main_runtime=main_runtime, messages=messages, temperature=temperature,
                 max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
                 reasoning_config=reasoning_config, extra_headers=extra_headers, api_mode=api_mode,
@@ -7063,6 +7106,7 @@ def _plan_aux_call(
     timeout: Optional[float], extra_body: Optional[dict], reasoning_config: Optional[dict],
     extra_headers: Optional[Dict[str, str]], api_mode: Optional[str],
     route_info: Optional[Dict[str, str]],
+    allow_fallback: bool = True,
 ) -> Tuple[_PreparedAuxRequest, Dict[str, Any], Dict[str, Any]]:
     """Shared head of both call impls: prepare the request and bundle the kwargs the recovery
     drivers pass to ``_retry_same_provider_*`` / ``_call_fallback_candidate_*``. One immutable
@@ -7070,7 +7114,7 @@ def _plan_aux_call(
     can't mix key and client from different runtimes."""
     main_runtime = _normalize_main_runtime(main_runtime)
     req = _prepare_aux_request(
-        task, provider=provider, model=model, base_url=base_url, api_key=api_key,
+        task, allow_fallback=allow_fallback, provider=provider, model=model, base_url=base_url, api_key=api_key,
         main_runtime=main_runtime, messages=messages, temperature=temperature,
         max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
         reasoning_config=reasoning_config, extra_headers=extra_headers,
@@ -7086,6 +7130,9 @@ def _plan_aux_call(
         resolved_api_key=req.resolved_api_key, resolved_api_mode=req.resolved_api_mode,
         main_runtime=main_runtime, final_model=req.final_model, extra_headers=extra_headers,
     )
+    if not allow_fallback:
+        retry_kwargs["allow_fallback"] = False
+        retry_kwargs["resolved_base_url"] = req.base_info or req.resolved_base_url
     return req, retry_kwargs, candidate_kwargs
 
 
@@ -7110,6 +7157,8 @@ def _ladder_step_call(
         return "call", step.args, dict(provider=req.resolved_provider, api_mode=req.resolved_api_mode)
     if step.kind == "retry_same_provider":
         retry_provider, retry_model = step.args
+        if not retry_kwargs.get("allow_fallback", True):
+            retry_provider, retry_model = req.request_provider, req.final_model
         return "retry", (), dict(retry_kwargs, resolved_provider=retry_provider, resolved_model=retry_model)
     return "fallback", step.args, candidate_kwargs
 
@@ -7117,10 +7166,11 @@ def _ladder_step_call(
 def _start_recovery_ladder(
     first_err: Exception, req: _PreparedAuxRequest, retry_kwargs: Dict[str, Any], *,
     task: Optional[str], async_mode: bool, route_info: Optional[Dict[str, str]],
+    allow_fallback: bool = True,
 ):
     """Build the recovery-ladder generator for a failed primary request."""
     return _aux_recovery_ladder(
-        first_err, client=req.client, kwargs=req.kwargs, task=task, async_mode=async_mode,
+        first_err, allow_fallback=allow_fallback, client=req.client, kwargs=req.kwargs, task=task, async_mode=async_mode,
         base_info=req.base_info, resolved_provider=req.resolved_provider,
         resolved_model=req.resolved_model, resolved_base_url=req.resolved_base_url,
         resolved_api_key=req.resolved_api_key, resolved_api_mode=req.resolved_api_mode,
@@ -7135,6 +7185,7 @@ def _call_llm_impl(
     timeout: float = None, extra_body: dict = None, reasoning_config: Optional[dict] = None,
     extra_headers: Optional[Dict[str, str]] = None, api_mode: str = None, stream: bool = False,
     stream_options: dict = None, route_info: Optional[Dict[str, str]] = None,
+    allow_fallback: bool = True,
 ) -> Any:
     """Centralized synchronous LLM call: resolve provider/model, auth, kwargs, fallbacks.
     task: aux task whose provider:model comes from config (ignored if provider set); api_mode
@@ -7142,7 +7193,7 @@ def _call_llm_impl(
     client defaults. stream=True returns the raw SDK stream (caller consumes/falls back)
     instead of a validated response. RuntimeError if no provider is configured."""
     req, retry_kwargs, candidate_kwargs = _plan_aux_call(
-        task, async_mode=False, provider=provider, model=model, base_url=base_url,
+        task, allow_fallback=allow_fallback, async_mode=False, provider=provider, model=model, base_url=base_url,
         api_key=api_key, main_runtime=main_runtime, messages=messages,
         temperature=temperature, max_tokens=max_tokens, tools=tools, timeout=timeout,
         extra_body=extra_body, reasoning_config=reasoning_config,
@@ -7217,7 +7268,7 @@ def _call_llm_impl(
                 return _retry_same_provider_sync(**kw)
             return _call_fallback_candidate_sync(*args, **kw)
         result = _drive_ladder(
-            _start_recovery_ladder(first_err, req, retry_kwargs, task=task, async_mode=False, route_info=route_info),
+            _start_recovery_ladder(first_err, req, retry_kwargs, allow_fallback=allow_fallback, task=task, async_mode=False, route_info=route_info),
             _perform)
         if result is _RERAISE_ORIGINAL:
             raise
@@ -7300,14 +7351,18 @@ async def async_call_llm(
     temperature: Optional[float] = None, max_tokens: int = None, tools: list = None,
     timeout: float = None, extra_body: dict = None, reasoning_config: Optional[dict] = None,
     route_info: Optional[Dict[str, str]] = None,
+    allow_fallback: bool = True,
 ) -> Any:
-    """Run an asynchronous auxiliary LLM request under the configured limit."""
+    """Run an asynchronous auxiliary LLM request under the configured limit.
+
+    allow_fallback has the same retry-versus-fallback contract as call_llm().
+    """
     semaphore = _acquire_async_aux_semaphore(task)
     if semaphore is not None:
         await semaphore.acquire()
     try:
         return await _async_call_llm_impl(
-            task=task, provider=provider, model=model, base_url=base_url, api_key=api_key,
+            task=task, allow_fallback=allow_fallback, provider=provider, model=model, base_url=base_url, api_key=api_key,
             main_runtime=main_runtime, messages=messages, temperature=temperature,
             max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
             reasoning_config=reasoning_config, route_info=route_info,
@@ -7323,11 +7378,12 @@ async def _async_call_llm_impl(
     temperature: Optional[float] = None, max_tokens: int = None, tools: list = None,
     timeout: float = None, extra_body: dict = None, reasoning_config: Optional[dict] = None,
     route_info: Optional[Dict[str, str]] = None,
+    allow_fallback: bool = True,
 ) -> Any:
     """Centralized asynchronous LLM call; see call_llm() for full documentation.
     No per-request header / api_mode override on the async entry point."""
     req, retry_kwargs, candidate_kwargs = _plan_aux_call(
-        task, async_mode=True, provider=provider, model=model, base_url=base_url,
+        task, allow_fallback=allow_fallback, async_mode=True, provider=provider, model=model, base_url=base_url,
         api_key=api_key, main_runtime=main_runtime, messages=messages,
         temperature=temperature, max_tokens=max_tokens, tools=tools, timeout=timeout,
         extra_body=extra_body, reasoning_config=reasoning_config,
@@ -7373,7 +7429,7 @@ async def _async_call_llm_impl(
             fb_client, _ = _to_async_client(fb_client, fb_model or "", is_vision=(task == "vision"))
             return await _call_fallback_candidate_async(fb_client, fb_model, fb_label, **kw)
         result = await _drive_ladder_async(
-            _start_recovery_ladder(first_err, req, retry_kwargs, task=task, async_mode=True, route_info=route_info),
+            _start_recovery_ladder(first_err, req, retry_kwargs, allow_fallback=allow_fallback, task=task, async_mode=True, route_info=route_info),
             _perform)
         if result is _RERAISE_ORIGINAL:
             raise

--- a/tests/agent/test_auxiliary_strict_route.py
+++ b/tests/agent/test_auxiliary_strict_route.py
@@ -1,6 +1,8 @@
 """Public auxiliary route contracts; SDK requests never leave the process."""
 
+import io
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -18,6 +20,171 @@ def clean_auxiliary_state():
     yield
     aux.shutdown_cached_clients()
     aux.clear_runtime_main()
+
+
+@pytest.fixture
+def nous_wire(tmp_path, monkeypatch):
+    from hermes_cli import models
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(aux, "_read_nous_auth", lambda: None)
+    monkeypatch.setattr(models, "_nous_recommended_cache", {})
+    catalog_requests = []
+
+    def catalog(request, **_kwargs):
+        assert request.full_url.endswith(models.NOUS_RECOMMENDED_MODELS_PATH)
+        catalog_requests.append(request.full_url)
+        return io.BytesIO(json.dumps({
+            f"{tier}RecommendedCompactionModel": {"modelName": "recommended-model"}
+            for tier in ("free", "paid")
+        }).encode())
+
+    monkeypatch.setattr(models, "_urlopen_model_catalog_request", catalog)
+
+    def install(respond):
+        requests = []
+        clients = []
+
+        def transport_for_url(client, _url):
+            def handle(request):
+                requests.append(request)
+                clients.append(client)
+                return respond(request)
+            return httpx.MockTransport(handle)
+
+        monkeypatch.setattr(httpx.Client, "_transport_for_url", transport_for_url)
+        monkeypatch.setattr(httpx.AsyncClient, "_transport_for_url", transport_for_url)
+        return requests, clients, catalog_requests
+
+    return install
+
+
+def _completion(request):
+    return httpx.Response(200, json={
+        "id": "fixture-response", "object": "chat.completion", "created": 1,
+        "model": json.loads(request.content)["model"],
+        "choices": [{"index": 0, "finish_reason": "stop",
+                     "message": {"role": "assistant", "content": "fixture result"}}],
+    })
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("provider", ["nous", "auto"])
+async def test_strict_nous_refresh_changes_destination(nous_wire, monkeypatch, asynchronous, provider):
+    old_base = "https://inference-api.nousresearch.com/v1"
+    fresh_base = "https://refreshed-nous.invalid/inference/v2"
+    credentials = MagicMock(side_effect=[
+        ("stale-fixture-key", old_base), ("fresh-fixture-key", fresh_base),
+    ])
+    monkeypatch.setattr(aux, "_resolve_nous_runtime_api", credentials)
+
+    def respond(request):
+        if request.url.host == "inference-api.nousresearch.com":
+            return httpx.Response(401, json={"error": {"message": "stale credential"}})
+        assert request.url.host == "refreshed-nous.invalid"
+        return _completion(request)
+
+    requests, clients, _catalog = nous_wire(respond)
+    kwargs = dict(
+        task="researcher", provider=provider, model="selected-model", allow_fallback=False,
+        main_runtime={"provider": "nous", "model": "selected-model"},
+        messages=[{"role": "user", "content": "fixture prompt"}],
+    )
+    for _ in range(2):
+        response = await aux.async_call_llm(**kwargs) if asynchronous else aux.call_llm(**kwargs)
+        assert response.choices[0].message.content == "fixture result"
+        assert response.model == "selected-model"
+
+    assert [(str(r.url), r.headers["authorization"], json.loads(r.content)["model"])
+            for r in requests] == [
+        (old_base + "/chat/completions", "Bearer stale-fixture-key", "selected-model"),
+        (fresh_base + "/chat/completions", "Bearer fresh-fixture-key", "selected-model"),
+        (fresh_base + "/chat/completions", "Bearer fresh-fixture-key", "selected-model"),
+    ]
+    assert clients[0] is not clients[1]
+    assert clients[1] is clients[2]
+    assert [call.kwargs["force_refresh"] for call in credentials.call_args_list] == [False, True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("provider", ["nous", "auto"])
+@pytest.mark.parametrize("strict", [False, True], ids=["default", "strict"])
+async def test_public_model_not_found_diagnostic(
+    nous_wire, monkeypatch, caplog, asynchronous, provider, strict,
+):
+    base = "https://inference-api.nousresearch.com/v1"
+    credentials = MagicMock(return_value=("fixture-secret-key", base))
+    monkeypatch.setattr(aux, "_resolve_nous_runtime_api", credentials)
+    details = {"message": "model does not exist; endpoint=https://fixture.invalid/v1?token=private-query",
+               "code": "model_not_found", "param": "model", "detail": "original provider detail"}
+
+    def respond(request):
+        assert request.url.host == "inference-api.nousresearch.com"
+        if json.loads(request.content)["model"] == "selected-model":
+            return httpx.Response(404, json={"error": details}, headers={"x-request-id": "fixture-request"})
+        return _completion(request)
+
+    requests, _clients, catalog = nous_wire(respond)
+    # Observe the SDK-created exception without replacing its construction or propagation.
+    sdk = openai.AsyncOpenAI if asynchronous else openai.OpenAI
+    make_error = sdk._make_status_error
+    errors = []
+
+    def record_error(self, *args, **kwargs):
+        error = make_error(self, *args, **kwargs)
+        errors.append((error, str(error)))
+        return error
+
+    monkeypatch.setattr(sdk, "_make_status_error", record_error)
+    kwargs = dict(
+        task="researcher", provider=provider, model="selected-model",
+        main_runtime={"provider": "nous", "model": "selected-model"},
+        messages=[{"role": "user", "content": "fixture prompt"}],
+    )
+    if strict:
+        kwargs["allow_fallback"] = False
+    with caplog.at_level(logging.WARNING, logger=aux.__name__):
+        if strict:
+            with pytest.raises(openai.NotFoundError) as caught:
+                if asynchronous:
+                    await aux.async_call_llm(**kwargs)
+                else:
+                    aux.call_llm(**kwargs)
+            assert len(errors) == 1
+            assert caught.value is errors[0][0]
+            assert type(caught.value) is openai.NotFoundError
+            assert caught.value.status_code == 404
+            assert str(caught.value) == errors[0][1]
+            assert caught.value.body == details
+            assert caught.value.response.json() == {"error": details}
+            assert caught.value.request_id == "fixture-request"
+        else:
+            response = await aux.async_call_llm(**kwargs) if asynchronous else aux.call_llm(**kwargs)
+            assert response.model == "recommended-model"
+            assert response.choices[0].message.content == "fixture result"
+
+    assert [json.loads(r.content)["model"] for r in requests] == (
+        ["selected-model"] if strict else ["selected-model", "recommended-model"])
+    assert len(catalog) == (1 if strict else 2)  # Initial discovery; only default heals.
+    credentials.assert_called_once_with(force_refresh=False)
+    warnings = [r.getMessage() for r in caplog.records
+                if r.name == aux.__name__ and r.levelno == logging.WARNING]
+    strict_warnings = [message for message in warnings if "allow_fallback=False" in message]
+    if strict:
+        assert len(strict_warnings) == 1
+        hint = strict_warnings[0]
+        assert "selected-model" in hint
+        assert "catalog" in hint
+        assert "Select an available model" in hint
+        assert "allow_fallback=True" in hint
+        assert "fixture-secret-key" not in hint
+        assert "private-query" not in hint
+        assert "https://" not in hint
+    else:
+        assert not strict_warnings
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_auxiliary_strict_route.py
+++ b/tests/agent/test_auxiliary_strict_route.py
@@ -1,0 +1,168 @@
+"""Public auxiliary route contracts; SDK requests never leave the process."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import openai
+import pytest
+import yaml
+
+from agent import auxiliary_client as aux
+
+
+@pytest.fixture(autouse=True)
+def clean_auxiliary_state():
+    aux.shutdown_cached_clients()
+    aux.clear_runtime_main()
+    yield
+    aux.shutdown_cached_clients()
+    aux.clear_runtime_main()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("selection", ["explicit", "auto", "vision-auto", "vision-explicit"])
+@pytest.mark.parametrize("outcome", ["payment", "unavailable", "transient"])
+@pytest.mark.parametrize("policy", [None, True, False], ids=["default", "fallback", "strict"])
+async def test_public_route_contract(tmp_path, monkeypatch, asynchronous, selection, outcome, policy):
+    task = "vision" if selection.startswith("vision-") else "researcher"
+    primary = {
+        "provider": "custom", "model": "fixture-model",
+        "base_url": "https://researcher.invalid/v1", "api_key": "fixture-key",
+    }
+    if outcome == "unavailable":
+        primary = {"provider": "fixture-unavailable", "model": "fixture-model"}
+    alternative = {
+        "provider": "custom", "model": "helper-model",
+        "base_url": "https://helper.invalid/v1", "api_key": "fixture-key",
+    }
+    route = dict(primary if selection.endswith("explicit") else {"provider": "auto"})
+    route["fallback_chain"] = [alternative]
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"auxiliary": {task: route}}), encoding="utf-8"
+    )
+    requests = []
+
+    def respond(request):
+        body = json.loads(request.content)
+        requests.append((request.url.host, body["model"]))
+        if request.url.host == "researcher.invalid":
+            if outcome == "payment":
+                return httpx.Response(402, request=request, json={"error": {"message": "Payment Required"}})
+            if outcome == "transient" and len(requests) == 1:
+                raise httpx.RemoteProtocolError("peer closed connection", request=request)
+        return httpx.Response(200, request=request, json={
+            "id": "fixture-response", "object": "chat.completion", "created": 1,
+            "model": body["model"], "choices": [{"index": 0, "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "fixture result"}}],
+        })
+
+    def send(_self, request, **_kwargs):
+        return respond(request)
+
+    async def asend(_self, request, **_kwargs):
+        return respond(request)
+
+    monkeypatch.setattr(httpx.Client, "send", send)
+    monkeypatch.setattr(httpx.AsyncClient, "send", asend)
+    # Let Hermes, rather than the SDK, exercise the transient retry.
+    monkeypatch.setattr(openai._base_client.BaseClient, "_should_retry", lambda *a, **k: False)
+    monkeypatch.setattr(aux.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(aux, "_is_provider_unhealthy", lambda *a, **k: False)
+    # Vision discovery uses a fixed backend list; supply its first candidate locally.
+    if selection.startswith("vision-"):
+        def vision_backend(*_args, **_kwargs):
+            return aux.resolve_provider_client(
+                "custom", "helper-model", explicit_base_url=alternative["base_url"],
+                explicit_api_key="fixture-key")
+        monkeypatch.setattr(aux, "_resolve_strict_vision_backend", vision_backend)
+    kwargs = dict(task=task, messages=[{"role": "user", "content": "fixture prompt"}],
+                  main_runtime=primary)
+    if policy is not None:
+        kwargs["allow_fallback"] = policy
+
+    async def invoke():
+        return await aux.async_call_llm(**kwargs) if asynchronous else aux.call_llm(**kwargs)
+
+    if policy is False and outcome in {"payment", "unavailable"}:
+        with pytest.raises((openai.APIStatusError, RuntimeError)):
+            await invoke()
+        assert all(host == "researcher.invalid" and model == "fixture-model"
+                   for host, model in requests)
+        assert bool(requests) == (outcome == "payment")
+    else:
+        response = await invoke()
+        assert response.choices[0].message.content == "fixture result"
+        if outcome == "transient":
+            assert requests == [("researcher.invalid", "fixture-model")] * 2
+        else:
+            # Existing vision discovery retains the explicitly requested model
+            # while replacing an unavailable backend. Keep default behavior.
+            expected_model = (
+                "fixture-model"
+                if selection == "vision-explicit" and outcome == "unavailable"
+                else "helper-model"
+            )
+            assert requests[-1] == ("helper.invalid", expected_model)
+            # A cached auto fallback must not become a strict call's primary route.
+            if selection == "auto" and outcome == "unavailable":
+                kwargs["allow_fallback"] = False
+                count = len(requests)
+                with pytest.raises(RuntimeError):
+                    await invoke()
+                assert len(requests) == count
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("provider", ["nous", "auto"])
+@pytest.mark.parametrize("status", [401, 404, 429])
+async def test_strict_model_and_credential_recovery(monkeypatch, tmp_path, asynchronous, provider, status):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("{}", encoding="utf-8")
+    error = Exception({401: "stale credential", 404: "model does not exist", 429: "rate limit"}[status])
+    error.status_code = status
+    client = MagicMock()
+    client.base_url = "https://inference-api.nousresearch.com/v1"
+    client.api_key = "stale-fixture-key"
+    client.chat.completions.create = (AsyncMock if asynchronous else MagicMock)(side_effect=error)
+    if status == 429:
+        client.chat.completions.create.side_effect = [error, error, {"ok": True}]
+    fresh = MagicMock()
+    fresh.base_url = client.base_url
+    fresh.chat.completions.create = (AsyncMock if asynchronous else MagicMock)(return_value={"ok": True})
+    monkeypatch.setattr(aux, "_try_nous", lambda **k: (client, "fixture-model"))
+    monkeypatch.setattr(aux, "_to_async_client", lambda c, m, **k: (c, m))
+    monkeypatch.setattr(aux, "_validate_llm_response", lambda response, *a, **k: response)
+    monkeypatch.setattr(aux, "_is_provider_unhealthy", lambda *a, **k: False)
+    refresh = MagicMock(return_value=("fresh-fixture-key", str(client.base_url)))
+    monkeypatch.setattr(aux, "_resolve_nous_runtime_api", refresh)
+    monkeypatch.setattr(aux, "_create_openai_client", lambda **k: fresh)
+    heal = MagicMock(return_value="alternative-model")
+    monkeypatch.setattr(aux, "_refresh_nous_recommended_model", heal)
+    monkeypatch.setattr(aux, "_recoverable_pool_provider", lambda *a, **k: "nous" if status == 429 else None)
+    rotate = MagicMock(return_value=True)
+    monkeypatch.setattr(aux, "_recover_provider_pool", rotate)
+    kwargs = dict(provider=provider, model="fixture-model", allow_fallback=False,
+                  main_runtime={"provider": "nous", "model": "fixture-model"},
+                  messages=[{"role": "user", "content": "fixture prompt"}])
+    if status in {401, 429}:
+        result = await aux.async_call_llm(**kwargs) if asynchronous else aux.call_llm(**kwargs)
+        assert result == {"ok": True}
+        if status == 401:
+            assert fresh.chat.completions.create.call_args.kwargs["model"] == "fixture-model"
+            refresh.assert_called_once()
+            assert not any(entry[0] is client for entry in aux._client_cache.values())
+        else:
+            rotate.assert_called_once()
+            assert [call.kwargs["model"] for call in client.chat.completions.create.call_args_list] == ["fixture-model"] * 3
+    else:
+        with pytest.raises(Exception, match="model does not exist"):
+            if asynchronous:
+                await aux.async_call_llm(**kwargs)
+            else:
+                aux.call_llm(**kwargs)
+        refresh.assert_not_called()
+    heal.assert_not_called()

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -220,3 +220,18 @@ Fallback behavior is exercised across several suites:
 - [Agent Loop Internals](./agent-loop.md)
 - [ACP Internals](./acp-internals.md)
 - [Context Compression & Prompt Caching](./context-compression-and-caching.md)
+
+### Auxiliary retry and fallback control
+
+The public `agent.auxiliary_client.call_llm()` and `async_call_llm()` APIs accept
+`allow_fallback: bool = True`. Existing callers retain configured recovery. Pass
+`allow_fallback=False` when a helper must use the selected provider and model.
+An unavailable route raises instead of trying task/main fallback chains or backend
+discovery; `auto` resolves only against the main route. Vision auto-selection keeps
+its normal main-provider vision model selection, without trying other providers.
+
+A retry repeats the selected route: transient transport retries, rejected-parameter
+repairs, token refresh, and credential-pool rotation remain available. Fallback
+changes the provider or model; strict calls also disable missing-model substitution.
+An explicit model stays selected across retries. The option is per call, leaves
+configuration untouched, and does not change compression callers that omit it.


### PR DESCRIPTION
## Summary
Add optional `allow_fallback=False` to synchronous and asynchronous auxiliary model calls. Retain current default behavior, including default vision/model discovery. Strict calls cannot silently switch backend/model after primary resolution or inference failure, and cannot reuse a cached fallback as their primary route. Same-route retry remains possible.

This is a general caller-controlled API, not a particular memory plugin or provider policy.

## Verification
- 356 tests passed across auxiliary routing, strict-call, caching, and async coverage.
- Primary success/failure/unavailability, auto/configured/explicit routes, sync/async, and cache isolation covered.
- Default vision behavior checked against unchanged upstream before correcting fixture expectations.
- Independent read-only review: GO.


## Integration verification
The combined upstream-pinned local candidate completed the canonical full suite: 46,800 passed, 369 skipped, 28 failures and one Photon collection failure. Every failure was independently reproduced on clean upstream with identical dependencies and filesystem isolation; no new failure remains unexplained. The targeted integration suite passed 808 tests (5 skipped). These are local results, not a claim that GitHub CI has passed.
