### PR TITLE
fix(update): rebind the Windows gateway respawn to the install venv interpreter

### DIFF
--- a/contributors/emails/1834199672@qq.com
+++ b/contributors/emails/1834199672@qq.com
@@ -1,0 +1,2 @@
+licat2023
+# PR: Windows gateway respawn venv rebind

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -525,6 +525,54 @@ def _install_startup_entry(script_path: Path) -> Path:
     return entry
 
 
+def _install_venv_spec() -> tuple[Path, Path] | None:
+    """(console ``python.exe``, venv root) for the install venv, or None when it isn't installed."""
+    from hermes_cli.gateway import PROJECT_ROOT
+    from hermes_constants import project_venv_dir, venv_python_path
+
+    root = project_venv_dir(PROJECT_ROOT)
+    if root is None:
+        return None
+    console = venv_python_path(root, windows=True)
+    return (console, root) if console.exists() else None
+
+
+def _venv_root_for_interpreter(python_exe: Path) -> Path | None:
+    """Venv root when *python_exe* sits in a venv's ``Scripts`` dir (``pyvenv.cfg`` one level up)."""
+    root = python_exe.parent.parent
+    return root if (root / "pyvenv.cfg").exists() else None
+
+
+def _pyvenv_home(venv_root: Path) -> Path | None:
+    """``home =`` directory from a venv's ``pyvenv.cfg`` (the base install), or None."""
+    try:
+        for line in (venv_root / "pyvenv.cfg").read_text(encoding="utf-8", errors="replace").splitlines():
+            key, _, value = line.partition("=")
+            if key.strip().lower() == "home" and value.strip():
+                return Path(value.strip())
+    except OSError:
+        return None
+    return None
+
+
+def _is_install_venv_base_interpreter(python_exe: Path) -> bool:
+    """True when *python_exe* is the base interpreter the install venv was built from.
+
+    A uv venv's ``Scripts\\python.exe`` is a trampoline: it re-execs the base interpreter with
+    ``__PYVENV_LAUNCHER__`` set, so the running gateway — and the argv snapshot the updater replays
+    — is the base-interpreter *child*. That child has no ``pyvenv.cfg`` above it, so a verbatim
+    replay loses the venv (see ``_resolve_detached_python``)."""
+    spec = _install_venv_spec()
+    if spec is None:
+        return False
+    base_home = _pyvenv_home(spec[1])
+    if base_home is None:
+        return False
+    return os.path.normcase(os.path.normpath(str(python_exe))) == os.path.normcase(
+        os.path.normpath(str(base_home / python_exe.name))
+    )
+
+
 def _resolve_detached_python(python_exe: str) -> tuple[str, Path, list[str]]:
     """Return (hidden_console_python, venv_dir, extra_pythonpath) for detached runs. ``extra_pythonpath``
     is always empty now; the tuple shape is kept so every call site stays unchanged.
@@ -547,19 +595,34 @@ def _resolve_detached_python(python_exe: str) -> tuple[str, Path, list[str]]:
     ``pythonw.exe``. When the sibling console ``python.exe`` exists, swap to it so respawns and regenerated
     launchers get the hidden-console design instead of resurrecting the console-less daemon (the
     #54220/#56747 flash class, plus the ``sys.stderr is None`` startup-crash class from #71671).
+
+    Base-interpreter rebind: a captured argv can lead with the venv's *base* interpreter instead — the
+    uv trampoline's child, which is what the process table and ``_capture_gateway_argv`` see for a running
+    gateway. Replayed verbatim it has no ``pyvenv.cfg`` above it, so it loses the venv and dies on the
+    first third-party import (``ModuleNotFoundError: No module named 'yaml'``) — a completed update then
+    reported a failed gateway restart. Rebinding to the install venv's console ``python.exe`` is what a
+    clean gateway start does, and it covers both call paths (``_build_gateway_argv`` cold start and
+    ``windowless_gateway_restart_spec`` respawn).
     """
     p = Path(python_exe)
+    resolved = python_exe
     if p.name.lower() in ("pythonw.exe", "pythonw"):
         sibling = p.with_name("python.exe" if p.suffix else "python")
         try:
             if sibling.exists():
                 p = sibling
-                python_exe = str(sibling)
+                resolved = str(sibling)
         except OSError:
             # Can't stat the sibling — keep the original interpreter: a console-less gateway is
             # worse than a hidden-console one, but a failed respawn is worse still.
             pass
-    return (python_exe, p.parent.parent, [])
+    venv_root = _venv_root_for_interpreter(p)
+    if venv_root is None and _is_install_venv_base_interpreter(p):
+        rebound = _install_venv_spec()
+        if rebound is not None:
+            p, venv_root = rebound
+            resolved = str(p)
+    return (resolved, venv_root if venv_root is not None else p.parent.parent, [])
 
 
 def _prepend_pythonpath(env_overlay: dict[str, str], entries: list[str]) -> None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -426,6 +426,20 @@ def _log_only_write(text: str) -> None:
             log_file.flush()
 
 
+def _resume_windows_gateways_at_exit(token) -> None:
+    """atexit wrapper for the Windows gateway resume.
+
+    The resume stays retryable on purpose (a failed service start / launcher refresh leaves
+    ``resume_needed`` True), so this hook re-runs it after the main path already recorded the outcome.
+    An exception raised *here* has no caller: CPython prints "Exception ignored in atexit callback"
+    plus a traceback into update.log, which reads as a second, unrelated failure and buries the
+    outcome the main path already set. Log it and let the process exit on that outcome."""
+    try:
+        _m()._resume_windows_gateways_after_update(token)
+    except Exception as exc:
+        _log_only_write(f"Windows gateway resume at exit failed: {exc}\n")
+
+
 def _run_logged_subprocess(cmd, *, cwd=None, env=None):
     """Stream combined build output to update.log, retaining it for failure reporting."""
     import codecs
@@ -1268,7 +1282,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
     _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
     if _windows_gateway_resume:
         import atexit as _atexit
-        _atexit.register(_m()._resume_windows_gateways_after_update, _windows_gateway_resume)
+        _atexit.register(_resume_windows_gateways_at_exit, _windows_gateway_resume)
 
     # Any venv python still running (typically the Desktop `hermes serve` backend) keeps .pyd
     # locked and would corrupt the sync; refuse rather than race (the app respawns a killed

--- a/tests/hermes_cli/test_update_gateway_launcher_refresh.py
+++ b/tests/hermes_cli/test_update_gateway_launcher_refresh.py
@@ -82,6 +82,49 @@ def test_restart_spec_normalizes_legacy_pythonw_argv(tmp_path):
     assert env["VIRTUAL_ENV"] == str(tmp_path / "venv")
 
 
+@pytest.mark.windows_only
+def test_restart_spec_rebinds_uv_base_interpreter_to_install_venv(
+    tmp_path, monkeypatch
+):
+    """A uv venv's ``Scripts\\python.exe`` is a trampoline, so the *running* gateway — and the
+    argv snapshot ``_capture_gateway_argv`` hands to the post-update replay — is its
+    base-interpreter child. Replayed verbatim that interpreter has no ``pyvenv.cfg`` above it,
+    loses the venv, and dies on the first third-party import
+    (``ModuleNotFoundError: No module named 'yaml'`` in gateway-stdio.log), which the updater
+    then reports as a failed gateway restart. The respawn must come back on the install venv's
+    console python instead.
+
+    ``windows_only``: the rewrite only runs on Windows (off Windows the spec returns its argv
+    untouched), and the venv layout under test is the Windows ``Scripts/`` one.
+    """
+    project = tmp_path / "project"
+    base_home = tmp_path / "uv" / "python" / "cpython-3.11-windows-x86_64-none"
+    scripts = project / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    base_home.mkdir(parents=True)
+    console = scripts / "python.exe"
+    base = base_home / "python.exe"
+    console.write_text("", encoding="utf-8")
+    base.write_text("", encoding="utf-8")
+    (project / "venv" / "pyvenv.cfg").write_text(
+        f"home = {base_home}\nimplementation = CPython\n", encoding="utf-8"
+    )
+
+    import hermes_cli.gateway as gateway
+
+    monkeypatch.setattr(gateway, "PROJECT_ROOT", project)
+
+    argv = [str(base), "-m", "hermes_cli.main", "gateway", "run"]
+    with mock.patch.object(
+        gateway_windows, "_stable_gateway_working_dir", return_value=str(tmp_path)
+    ), mock.patch("hermes_cli.config.get_hermes_home", return_value=str(tmp_path)):
+        new_argv, cwd, env = gateway_windows.windowless_gateway_restart_spec(list(argv))
+
+    assert new_argv[0] == str(console)
+    assert new_argv[1:] == argv[1:]
+    assert env["VIRTUAL_ENV"] == str(project / "venv")
+
+
 # ---------------------------------------------------------------------------
 # _refresh_windows_gateway_launchers: hermes update regenerates launchers
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_windows_gateway_job_teardown_48820.py
+++ b/tests/hermes_cli/test_windows_gateway_job_teardown_48820.py
@@ -189,3 +189,29 @@ class TestResumeLivenessGate:
         with patch("builtins.print"):
             _resume_windows_gateways_after_update(_token({"work": 2222}))
         assert seen.get("all_profiles") is True
+
+
+def test_at_exit_resume_reports_failure_without_raising(monkeypatch):
+    """The registered atexit hook must never raise.
+
+    The resume stays retryable on purpose (a failed service start / launcher refresh leaves
+    ``resume_needed`` True), so this hook re-runs it after the main path already recorded the
+    outcome. An exception raised here has no caller: CPython prints "Exception ignored in atexit
+    callback" plus a traceback into update.log, which reads as a second, unrelated failure and
+    buries the outcome the main path set.
+    """
+    import hermes_cli.update_cmd as update_cmd
+
+    # ``_m()`` resolves hermes_cli.main at call time, and main is where the resume name is
+    # bound — patching update_cmd_windows would leave the real resume running.
+    monkeypatch.setattr(
+        hm,
+        "_resume_windows_gateways_after_update",
+        lambda _token: (_ for _ in ()).throw(RuntimeError("resume blew up")),
+    )
+    logged: list[str] = []
+    monkeypatch.setattr(update_cmd, "_log_only_write", logged.append)
+
+    update_cmd._resume_windows_gateways_at_exit({"resume_needed": True})
+
+    assert any("resume blew up" in entry for entry in logged)


### PR DESCRIPTION
## What does this PR do?

`hermes update` on Windows can complete every stage (git pull, deps, web UI, desktop build, skills, config) and still exit 1, because the post-update gateway relaunch respawns the gateway with an interpreter that cannot see the venv. The gateway dies at import time and the updater reports a failed update:

```
ModuleNotFoundError: No module named 'yaml'          # logs/gateway-stdio.log, respawned gateway
RuntimeError: Windows gateway relaunch after update was not verified alive   # updater, exit 1
```

**Root cause.** A uv venv's `venv\Scripts\python.exe` is a trampoline: it re-execs the base CPython with `__PYVENV_LAUNCHER__` set. So a running gateway appears in the process table — and in the argv snapshot `_capture_gateway_argv` takes for the post-update replay — as the **base-interpreter child** (`...\uv\python\cpython-3.11-...\python.exe`), with the venv launcher only as its parent. `_pause_windows_gateways_for_update()` classifies that worker as *unmapped* and `_relaunch_paused_gateways()` replays the argv verbatim through `windowless_gateway_restart_spec()` → `_resolve_detached_python()`, which only normalized `pythonw.exe → python.exe`. The base interpreter has no `pyvenv.cfg` above it, so the respawn loses the venv: `hermes_cli` still imports via the `PYTHONPATH` overlay, but `import yaml` (`hermes_cli/config.py:24`) fails and the process dies before logging.

**Fix.** `_resolve_detached_python()` now detects the install venv's own base interpreter (`home =` in `venv/pyvenv.cfg`) and rebinds it to the venv's console `python.exe`, also returning the correct venv root (previously the overlay's `VIRTUAL_ENV` was derived as the base interpreter's grandparent, e.g. `...\uv\python`). This covers both call paths — the cold-start `_build_gateway_argv()` and the respawn `windowless_gateway_restart_spec()` — and leaves an interpreter that already lives in some other venv untouched.

A second, independent defect is fixed in the same area: on a failed liveness verification the resume leaves `resume_needed` True by design (it stays retryable), so the registered `atexit` hook re-ran the whole resume. Because that second attempt also raised, the exception escaped finalization as `Exception ignored in atexit callback` plus a traceback that buried the outcome the main path had already recorded. The hook is now registered through `_resume_windows_gateways_at_exit()`, which logs and swallows — the retry semantics and the exit code the main path set are unchanged.

## Related Issue

Fixes #106489

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway_windows.py` — new `_install_venv_spec()`, `_venv_root_for_interpreter()`, `_pyvenv_home()`, `_is_install_venv_base_interpreter()`; `_resolve_detached_python()` rebinds the install venv's base interpreter to `venv\Scripts\python.exe` and returns the real venv root. Reuses `hermes_constants.project_venv_dir()` / `venv_python_path()` so `venv` and `.venv` layouts both resolve.
- `hermes_cli/update_cmd.py` — new `_resume_windows_gateways_at_exit()` atexit wrapper; `_atexit.register()` now uses it instead of the raw resume.
- `tests/hermes_cli/test_update_gateway_launcher_refresh.py` — new `test_restart_spec_rebinds_uv_base_interpreter_to_install_venv`.
- `tests/hermes_cli/test_windows_gateway_job_teardown_48820.py` — new `test_at_exit_resume_reports_failure_without_raising`.
- `contributors/emails/1834199672@qq.com` — contributor attribution mapping required by `contributor-check.yml` (housekeeping commit).

## How to Test

1. Reproduce on `main` (Windows, uv venv, a running gateway with no profile→PID mapping):
   `venv\Scripts\python.exe -m hermes_cli.main update --yes --gateway --force --branch main --keep-stash`
   → update stages all ✓, then `logs/gateway-stdio.log` gets `ModuleNotFoundError: No module named 'yaml'` and the updater exits 1.
2. Interpreter-level A/B (no update needed; real install paths):
   ```python
   captured = [str(base_python), "-m", "hermes_cli.main", "gateway", "run"]   # base = pyvenv.cfg home
   new_argv, cwd, overlay = windowless_gateway_restart_spec(list(captured))
   ```
   Before: `new_argv[0]` is the base interpreter, `VIRTUAL_ENV=...\uv\python`, `import yaml` → `ModuleNotFoundError`.
   After: `new_argv[0] = ...\hermes-agent\venv\Scripts\python.exe`, `VIRTUAL_ENV=...\hermes-agent\venv`, probe exits 0 with `prefix=...\venv yaml=6.0.3`.
3. Unit tests: `scripts/run_tests.sh tests/hermes_cli/test_update_gateway_launcher_refresh.py tests/hermes_cli/test_windows_gateway_job_teardown_48820.py` → 11 passed.
4. Regression: `scripts/run_tests.sh` over the 13 gateway-restart/update files that touch this subsystem → 166 passed (see Logs).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(update):`, `chore:`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (open + closed; closest is #53459, which normalized a captured `hermes.exe` wrapper — same class, different interpreter shape)
- [x] My PR contains **only** changes related to this fix (the extra commit is the `contributor-check.yml` email mapping that CI requires)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not claimed**: on a Windows host the suite carries many pre-existing environment failures (CI's full run is the Linux lane; the Windows lane runs only `windows_only`-marked tests). I ran the canonical `scripts/run_tests.sh` over the 13 files that touch this subsystem (166 passed) and over most of the suite in chunks (see Logs); **no failure landed in any file this PR touches**.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Windows_NT 10.0.26200), uv 0.12.0 venv, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior fix, docstrings updated in place
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-only paths; `windowless_gateway_restart_spec()` still early-returns off Windows and `_resolve_detached_python()` is only reached from the Windows launch paths, so POSIX is unaffected
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Respawned gateway before the fix (`logs/gateway-stdio.log`, appears twice — in-process resume + atexit):

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "...\hermes_cli\main.py", line 575, in <module>
    from hermes_cli.config import get_hermes_home
  File "...\hermes_cli\config.py", line 24, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

Real-path A/B receipt (worktree code, real install paths, no gateway started):

```
captured argv[0]    : C:\Users\<user>\AppData\Roaming\uv\python\cpython-3.11-windows-x86_64-none\python.exe
respawn  argv[0]    : C:\Users\<user>\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe
respawn  cwd        : C:\Users\<user>\AppData\Local\hermes
VIRTUAL_ENV         : C:\Users\<user>\AppData\Local\hermes\hermes-agent\venv
tail preserved      : True
FIXED  probe rc     : 0   OK prefix=...\venv yaml=6.0.3
BEFORE probe rc     : 1   ModuleNotFoundError: No module named 'yaml'
```

Test runs (canonical runner, `TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0`, per-file subprocess isolation):

```
tests/hermes_cli/test_update_gateway_launcher_refresh.py    3 passed
tests/hermes_cli/test_windows_gateway_job_teardown_48820.py 8 passed
13-file gateway-restart/update regression set             166 passed
ruff check .                                              All checks passed
```

Chunked full-suite sweep on this Windows host (the same canonical runner, `-j 16` per chunk; CI's full run is the Linux lane):

```
tests/agent + acp + acp_adapter + computer_use + conformance
  + integration + perf_guards + security + monitoring + relay
  + secret_sources                                    578 files: 6,801 passed /  54 failed / 57 skipped
tests/gateway + desktop + dashboard                   800 files: 7,827 passed /  89 failed / 60 skipped
tests/hermes_cli                                      857 files: 8,055 passed / 223 failed (chunk stopped at 93%)
```

Every failure in those chunks was checked against the FAILED list: **none is in a file this PR touches** (the gateway-restart/update files all pass). The Windows failures are pre-existing environment gaps — the repo's full suite is a Linux-lane gate, and the Windows lane only runs `-m windows_only`.

Both new tests are red on `main` (verified by stashing only the two source files and re-running): the rebind test fails with `argv[0] == base interpreter`, the atexit test with `AttributeError: _resume_windows_gateways_at_exit`.

One pre-existing failure surfaced while running the wider set and is **not** related to this change: `tests/tools/test_windows_native_support.py::TestWindowlessGatewayRestartSpec::test_noop_on_non_windows` assumes a non-Windows host but carries no `windows_only` marker, so it fails on any Windows host (reproduced on unpatched `main`).
