### PR TITLE
fix(bedrock): correct the Llama 4 context windows to the measured values

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -945,9 +945,14 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     ), 200_000),
     # Amazon Nova
     **dict.fromkeys(("amazon.nova-pro", "amazon.nova-lite"), 300_000), "amazon.nova-micro": 128_000,
-    # Meta Llama / Mistral / DeepSeek
+    # Meta Llama / Mistral / DeepSeek. The two Llama 4 windows are the number Converse itself
+    # states when it rejects an oversized prompt, measured in us-east-1 and us-east-2. Scout is
+    # deliberately not the 10M of its model card: Bedrock serves less, and a table value above
+    # what the API enforces turns early compaction into hard ValidationExceptions.
+    "meta.llama4-maverick": 1_048_576,
+    "meta.llama4-scout": 3_500_000,
     **dict.fromkeys((
-        "meta.llama4-maverick", "meta.llama4-scout", "meta.llama3-3-70b-instruct", "mistral.mistral-large", "deepseek.v3",
+        "meta.llama3-3-70b-instruct", "mistral.mistral-large", "deepseek.v3",
     ), 128_000),
     # OpenAI on Bedrock (Mantle/Responses route): docs.aws.amazon.com/bedrock/latest/userguide/model-cards-openai.html
     **dict.fromkeys(BEDROCK_OPENAI_RESPONSES_MODEL_IDS, 272_000),

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1003,6 +1003,17 @@ class TestBedrockContextLength:
             mock_probe.assert_not_called()
 
 
+    def test_llama4_windows_are_the_measured_ones(self):
+        # Both rows sat at 128K -- an eighth of Maverick's window and a
+        # twenty-seventh of Scout's -- so a Llama 4 session compacted long
+        # before it had to whenever the live probe could not run.
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length(
+            "us.meta.llama4-maverick-17b-instruct-v1:0", probe=False) == 1_048_576
+        assert get_bedrock_context_length(
+            "us.meta.llama4-scout-17b-instruct-v1:0", probe=False) == 3_500_000
+
+
 class TestBedrockContextProbe:
     """Test the live context-window probe that reads the real window from
     Bedrock's 'prompt is too long' validation error."""


### PR DESCRIPTION
## What does this PR do?

`BEDROCK_CONTEXT_LENGTHS` (`agent/bedrock_adapter.py:934`) puts both Llama 4 models in the 128K group. Bedrock enforces **1,048,576** for Maverick and **3,500,000** for Scout, so the table is short by 8x and 27x.

**On the path most callers take, that table is not a fallback — it is the answer.** `model_metadata.py:1670` calls `get_bedrock_context_length(model)` with **no region**, and the getter only probes `if probe and region`. No region → no probe → the table is the sole source. Measured on this PR's base with `probe=False`:

| model id | before | after |
|---|---|---|
| `us.meta.llama4-maverick-17b-instruct-v1:0` | **128,000** | 1,048,576 |
| `us.meta.llama4-scout-17b-instruct-v1:0` | **128,000** | 3,500,000 |

So a Llama 4 session compacted almost immediately whenever the probe could not run, and the operator had no way to see why.

I re-measured both windows against Converse rather than reading them off a model card — two regions, plus accepted probes where Bedrock reports its own exact `usage.inputTokens`. Full log under *Screenshots / Logs*, including the two ways the measurement can lie to you.

## Related Issue

No issue — found reading the table.

This replaces my own #98726, which I am closing. That PR was written against the one-key-per-line version of this table; `main` has since compacted it into `dict.fromkeys` groups, so it needs rewriting rather than rebasing. This is the rewrite, and it deliberately carries **less** — see *What I left out*.

**It also deliberately does not touch `claude-opus-5`.** That row is genuinely missing from this table too, but #75824 (@ryrenz, oldest), #92273 (@bagg3rs) and #83071 (@nickkpoon) are all already open against it, and #75824 is written against the current compacted table and carries a drift guard whose dotted-to-hyphen normalisation is better than the one I had written. A fourth competing row would help nobody, so I dropped mine and left a verification note on #75824 instead. My own #98494 covered the same ground and is closed in favour of theirs, not of this.

**This PR and #75824 do not conflict, and I checked rather than assuming.** A real three-way merge of the two heads succeeds with no conflict, so either can land first. The two hunks in `bedrock_adapter.py` are 12 lines apart (`@@ -933` theirs, `@@ -945` mine) and touch different rows.

One warning if you try to stack them by hand: `git apply` of one on top of the other *does* fail, because both append a test at the same anchor in `tests/agent/test_bedrock_adapter.py` (right after `mock_probe.assert_not_called()`) and `git apply` matches context strictly. That is a patch-application artefact, not a merge conflict — `git merge-tree` on the same pair is clean.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/bedrock_adapter.py` — lift `meta.llama4-maverick` and `meta.llama4-scout` out of the 128K `dict.fromkeys` group and give each its measured value. Four comment lines recording *why* Scout is 3.5M and not the 10M on its model card, because that is the part of this change a future reader will otherwise "correct" back. `+9/-2`; the surrounding group and every other row are untouched.
- `tests/agent/test_bedrock_adapter.py` — one case in `TestBedrockContextLength`, `test_llama4_windows_are_the_measured_ones`, pinning both windows through `get_bedrock_context_length(..., probe=False)` with realistic inference-profile ids.

Total: 2 files, `+18/-2`, one commit. No function signature moves, no behaviour change outside these two dict entries.

## How to Test

```bash
# the new test against the old table
git checkout 7dc796463d                     # this PR's base
git checkout fix/bedrock-llama4-measured-context-windows -- tests/agent/test_bedrock_adapter.py
pytest tests/agent/test_bedrock_adapter.py -q -p no:randomly
#  -> 1 failed, 78 passed
#     AssertionError: assert 128000 == 1048576

git checkout fix/bedrock-llama4-measured-context-windows
pytest tests/agent/test_bedrock_adapter.py -q -p no:randomly
#  -> 79 passed
```

Every Bedrock suite in the tree, on this branch: `test_bedrock_adapter.py` 79 passed, `test_bedrock_integration.py` 35 passed, `test_bedrock_1m_context.py` 2 passed, `test_bedrock_empty_text_blocks.py` 3 passed, `test_bedrock_interrupt_post_worker.py` 2 passed, `test_bedrock_transport_replay.py` 2 passed.

Those first two are the only files in `tests/` that import either `BEDROCK_CONTEXT_LENGTHS` or `get_bedrock_context_length` (`grep -rln` over `tests/ agent/`). The consumers of the value also pass unchanged: `test_model_metadata.py` 121 passed, `test_model_metadata_local_ctx.py` 37 passed, `test_turn_context.py` 20 passed, `test_uncompressed_context_guardrail.py` 7 passed, and eleven more context suites.

`ruff check .` passes repo-wide. `ruff format --check` flags both touched files — but it flags them identically on the pristine base, and no workflow in `.github/workflows/` runs `ruff format`, so this adds no formatting debt and graduates none.

## Known limitation, stated up front

**The Scout row only takes effect on the no-region path.** With a region, `probe_bedrock_context_length` walks `_BEDROCK_PROBE_TIERS = (1_300_000, 2_200_000)` and does `return tier_tokens` on the *first acceptance*. Scout accepted 2,222,258 tokens in my measurement, so it will accept tier 1 as well — acceptance is monotone in length — and the probe therefore returns **1,300,000**, below both this PR's value and what the API actually enforces.

That is a pre-existing shortfall in the probe, not something this change introduces, and fixing it means editing the getter or the tiers rather than the table, so I have left it alone. The smallest honest fix is to treat an accepted tier as a floor rather than an answer — `max(probed, table_lookup)` — which is exactly what the probe's own docstring already calls it: *"An accepted tier is a safe lower bound"*. Say the word and I will send that separately. It may also interact with #104128, which is reworking probe caching in the same area, so it is probably better as its own PR either way.

Maverick is unaffected on both paths: tier 1 at 1,300,000 pads past 1,048,576, so the probe gets the parseable rejection and returns the right number.

## What I left out

#98726 also added four rows I am **not** carrying: `mistral.pixtral-large` 131,072, `deepseek.v3.2` 163,840, `minimax.minimax-m2` 196,608, `kimi-k2` 262,144. They were labelled "measured" there and I did not re-measure any of them today. I am not willing to re-assert numbers in a new PR that I have not re-verified in the same sitting. None of those keys exists on `main`, so omitting them regresses nothing; they can come back with their own log attached.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — one commit, `fix(bedrock): ...`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — and it changed this PR: the search is what turned up the three open `claude-opus-5` PRs, which is why that row is no longer here. No open PR touches the Llama 4 rows.
- [x] My PR contains **only** changes related to this fix (2 files, `+18/-2`, one commit)
- [ ] I've run `pytest tests/ -q` and all tests pass — partially; I'd rather you read the note than have me tick this
- [x] I've added tests for my changes
- [x] I've tested on my platform: Amazon Linux 2023 x86_64, CPython 3.11.14

**What I actually ran, and what I could not.** I ran the complete `tests/agent/` directory on both this branch and its base, so the number is attributable rather than decorative:

| | `tests/agent/` |
|---|---|
| base | 32 failed, 6612 passed, 31 skipped |
| this branch | 32 failed, **6613 passed**, 31 skipped |

`+1 passed` — the one test this PR adds — and the failing set is **byte-identical** between the two (`diff` of the sorted `FAILED` lines is empty). Those 32 are pre-existing on `main` in my environment and all sit in auxiliary-client / provider-resolution / skill-command territory; `test_auxiliary_client.py`, `test_auxiliary_main_first.py` and `test_auxiliary_named_custom_providers.py` account for 18 of them. Nothing that reads a context window. Happy to paste the list if it's useful.

I did **not** get a whole-`tests/` run: on my box it hits 36 collection errors from optional dependencies I don't have installed (`aiohttp` and the acp/gateway stack), and the rest exceeds my remote-execution time ceiling. Rather than tick the box on a number I can't attribute, I'm leaving it unticked and showing you the scoped run above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the four comment lines in the table are the documentation for the Scout value; no `docs/` change applies
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — N/A, two dict literals; no platform-conditional code
- [x] Tool descriptions/schemas — N/A, no tool behaviour change

## Screenshots / Logs

Measured 2026-09-09 against `bedrock-runtime` `Converse`, from my own AWS account, on `us.meta.llama4-*-17b-instruct-v1:0`.

Method: pad the prompt with `"data " * int(target / 0.9)` and read what the API says. Length validation runs **before** inference, so a **rejected** probe is free; an **accepted** probe bills the input tokens but returns `usage.inputTokens` — Bedrock's own exact count, and therefore a precise verified floor. Actual tokens land at ≈1.111 per target unit.

| model | region | target | outcome |
|---|---|---|---|
| Maverick | us-east-1 | 2,000,000 | rejected — `This model's maximum context length is 1048576 tokens. Please reduce the length of the prompt` |
| Maverick | us-east-1 | 1,000,000 | rejected — same number (pads to 1,111,111 > 1,048,576) |
| Maverick | us-east-1 | 750,000 | **accepted**, `usage.inputTokens = 833,369` |
| Maverick | us-east-1 | 500,000 | **accepted**, `usage.inputTokens = 555,591` |
| Maverick | us-east-2 | 2,000,000 | rejected — same number |
| Scout | us-east-1 | 2,000,000 | **accepted**, `usage.inputTokens = 2,222,258` |
| Scout | us-east-1 | 3,500,000 | rejected — `This model's maximum context length is 3500000 tokens. Please reduce the length of the prompt` |
| Scout | us-east-2 | 3,500,000 | rejected — same number |
| both | both | 5,000,000 | rejected, but **unparseable**: `Input is too long for requested model.` — no number |

Both numbers are identical in two regions, and every acceptance sits below the stated maximum for its model, which is the internal consistency check. Total billed input across the run: 3,611,218 tokens.

Two caveats about the method, because each of them cost me a wrong reading before it could cost you one:

- **At large overshoot the error stops being parseable.** A 5,000,000-token target — a 27.8 MB payload — returns `Input is too long for requested model.` in both regions for both models, with no maximum in it. `parse_context_limit_from_error` correctly returns `None` there. So a descending probe finds the number and an aggressive one does not; the existing comment on `_BEDROCK_PROBE_TIERS` is right about this, and it is also why I could not initially reproduce the error string my own earlier PR quoted.
- **Throttling looks like a length rejection if you only check that the call raised.** After Scout accepted 2.22M tokens, my next three "rejected" results were actually `Too many tokens, please wait before trying again`, which carries no window. I discarded those three and re-ran the 3,500,000 probe after a 180 s backoff; that backed-off run is the one in the table.

The before/after lookups were produced by importing the module at each revision and calling `get_bedrock_context_length(model_id, probe=False)` — no network, so they are the resolution the no-region path actually performs.
