### PR TITLE
feat(node-bootstrap): public upgrade_managed_node for the self-managed Node runtime

### DIFF
--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -410,6 +410,32 @@ heal_managed_node() {
     _nb_install_bundled_node
 }
 
+# Re-provision the managed tree even when it is healthy: `hermes update`
+# refreshes npm dependencies but never the managed Node runtime, so a tree
+# provisioned once keeps its original patch release until the major falls out
+# of the accepted range and heal starts firing. This is the documented
+# upgrade path for the self-managed runtime.
+#
+# The target major comes from the live tree itself (not the library default,
+# which stays at the oldest accepted major): refreshing a 26 tree must fetch
+# the latest 26.x, never downgrade it because HERMES_NODE_TARGET_MAJOR
+# defaults to 22.
+upgrade_managed_node() {
+    [ -d "$HERMES_HOME/node" ] || return 1
+    local probe ver major
+    for probe in "$HERMES_HOME/node/bin/node" "$HERMES_HOME/node/node"; do
+        if [ -x "$probe" ]; then
+            ver="$("$probe" --version 2>/dev/null)" || break
+            major="${ver#v}"; major="${major%%.*}"
+            case "$major" in ''|*[!0-9]*) break ;; esac
+            HERMES_NODE_TARGET_MAJOR="$major" _nb_install_bundled_node
+            return $?
+        fi
+    done
+    _nb_warn "No runnable managed Node under $HERMES_HOME/node — nothing to upgrade"
+    return 1
+}
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------

--- a/tests/test_node_bootstrap_upgrade.py
+++ b/tests/test_node_bootstrap_upgrade.py
@@ -1,0 +1,43 @@
+"""Regression tests for the documented managed-Node upgrade path.
+
+``hermes update`` refreshes npm dependencies but never re-provisions the
+Hermes-managed Node runtime under ``$HERMES_HOME/node``. A healthy tree keeps
+the patch release it was installed with until its major falls out of the
+accepted range and the automatic heal starts firing, so upgrading the runtime
+(to pick up security patches or a newer LTS line) needs a supported command
+instead of reverse-engineering the installer's internals.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NODE_BOOTSTRAP = REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh"
+UPDATING_DOC = REPO_ROOT / "website" / "docs" / "getting-started" / "updating.md"
+
+
+def test_node_bootstrap_exposes_public_upgrade_entry_point() -> None:
+    text = NODE_BOOTSTRAP.read_text()
+
+    assert "upgrade_managed_node()" in text
+
+    # The upgrade must not downgrade a newer managed tree to the library's
+    # default line: the target major comes from the live tree, and an explicit
+    # HERMES_NODE_TARGET_MAJOR still wins (documented major-jump escape hatch).
+    upgrade_body = text.split("upgrade_managed_node()", 1)[1].split("\n}", 1)[0]
+    assert '"$HERMES_HOME/node/bin/node"' in upgrade_body
+    assert "HERMES_NODE_TARGET_MAJOR=\"$major\" _nb_install_bundled_node" in upgrade_body
+
+    # No managed tree — refuse instead of provisioning a fresh one: this is an
+    # upgrade helper, the installer's ensure_node() provisions.
+    assert '[ -d "$HERMES_HOME/node" ] || return 1' in upgrade_body
+
+
+def test_updating_doc_documents_managed_node_upgrade() -> None:
+    text = UPDATING_DOC.read_text()
+
+    assert "### Upgrading the self-managed Node.js runtime" in text
+    assert "source scripts/lib/node-bootstrap.sh" in text
+    assert "upgrade_managed_node" in text
+    # The documented path must work from any checkout without copy-paste drift.
+    assert "HERMES_NODE_TARGET_MAJOR=26 upgrade_managed_node" in text

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -48,6 +48,31 @@ If the maintained updater script is missing (for example after antivirus quarant
 
 On Windows, a Desktop reopened during packaging is stopped again immediately before the staged build is promoted. This cleanup is restricted to executables inside that checkout's Desktop release tree; unrelated installations are not stopped. A remaining lock still makes staged promotion fail rather than bypassing the rename error.
 
+### Upgrading the self-managed Node.js runtime
+
+On hosts without a usable Node.js (>= 20), the installer provisions a pinned Node.js release into `~/.hermes/node/` (and `%LOCALAPPDATA%\hermes\node` on Windows) and symlinks `node`, `npm`, and `npx` into `~/.local/bin`. `hermes update` refreshes repository files, Python dependencies, and workspace npm dependencies — it never re-provisions that managed Node tree. A broken or out-of-range tree is healed automatically on the next probe, but a healthy tree stays on the patch release it was installed with, so it needs an explicit upgrade now and then (security patches, an LTS line reaching EOL, or tooling that needs a newer runtime).
+
+On Linux and macOS, run the upgrade helper against the Hermes checkout:
+
+```bash
+cd /path/to/hermes-agent   # the repository clone hermes update pulls
+source scripts/lib/node-bootstrap.sh
+upgrade_managed_node
+```
+
+This re-downloads the latest release of the managed tree's **current major line** (a 22 tree gets the newest 22.x, a 26 tree the newest 26.x — it never downgrades to the library's default line). The new tree is downloaded and fully extracted before the old one is replaced, and the `~/.local/bin` links are re-pointed. The bundled npm is upgraded into the checkout's `engines.npm` range as part of the same pass. To jump to a different major line instead, set the target explicitly:
+
+```bash
+source scripts/lib/node-bootstrap.sh
+HERMES_NODE_TARGET_MAJOR=26 upgrade_managed_node
+```
+
+The helper only touches the Hermes-managed tree. A Node you installed yourself (system package, `nvm`, `brew`, Nix) is never modified — install a newer one with the same tool you used originally.
+
+On Windows, re-running `install.ps1` performs the equivalent upgrade: it replaces a managed tree that fails the current version check with the latest supported portable build (staged first, so an interrupted run cannot gut the install), and upgrades its bundled npm.
+
+Either way, close the Desktop app and any running gateway first — an in-use tree is skipped rather than corrupted, and the upgrade simply applies on the next run.
+
 ### Updating against a non-default branch: `--branch`
 
 By default `hermes update` tracks `origin/main`. Pass `--branch <name>` to update against a different branch — useful for QA channels, feature branches, or release-candidate testing:


### PR DESCRIPTION
## Summary

`hermes update` refreshes repository files, Python dependencies, and workspace npm dependencies — it never re-provisions the Hermes-managed Node runtime under `$HERMES_HOME/node`. The automatic heal only fires for a **broken** tree or one whose **major** is below `HERMES_NODE_TARGET_MAJOR` (which defaults to 22 at runtime), so a healthy managed tree keeps the patch release it was installed with indefinitely. Until now the only upgrade paths were a full installer re-run or reverse-engineering `_nb_install_bundled_node`.

- Add a public `upgrade_managed_node()` entry point to `scripts/lib/node-bootstrap.sh` — the documented upgrade command for the self-managed runtime. It re-provisions the managed tree by calling the existing `_nb_install_bundled_node`, with the target major derived from the **live tree** (falling back to `HERMES_NODE_TARGET_MAJOR` when the tree doesn't run) so refreshing a 26 tree fetches the latest 26.x instead of silently downgrading to the library's 22 default; an explicit `HERMES_NODE_TARGET_MAJOR=26 upgrade_managed_node` remains the major-jump escape hatch. Refuses when there is no managed tree (an upgrade, not a provision — `ensure_node()` handles fresh installs).
- Document the supported procedure in `website/docs/getting-started/updating.md`: the helper invocation, the no-downgrade behavior, the explicit major override, the Windows equivalent (re-running `install.ps1`, which stages the new tree before swapping), and that user-owned toolchains (nvm/brew/Nix/system) are never touched.
- Source-level regression tests in `tests/test_node_bootstrap_upgrade.py` (same pattern as `tests/test_install_sh_node_global_prefix.py`): the entry point exists, derives the target from the live tree, refuses without one, and the docs keep documenting the command.

## Testing

- `python -m pytest tests/test_node_bootstrap_upgrade.py tests/test_install_sh_node_global_prefix.py -q` → **5 passed** (new tests green, existing bootstrap test unaffected)
- `bash -n scripts/lib/node-bootstrap.sh` → syntax OK
- Live smoke of the shell function with a fake managed tree:
  - `v26.1.4` tree + stubbed `_nb_install_bundled_node` → called with target major **26** (no downgrade), exit 0
  - no managed tree → `No runnable managed Node` warning, exit 1

Fixes #106456
