### PR TITLE
fix(group-chat): retry a member turn that fails transiently instead of consuming the mention

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-round-members.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-round-members.ts
@@ -23,7 +23,19 @@ export interface GroupRoundMemberContext {
   startEpoch: number
   binding: { isLive(): boolean }
   isCurrent(): boolean
+  // Per-drive count of transient (thrown) turn failures per member key. A
+  // thrown turn (e.g. a ws_orphan_reap 4001 the turn-level retry couldn't
+  // recover) must NOT silently consume the user's delta and go stale: leave
+  // the watermark unadvanced so the next round re-drives the member, up to
+  // MAX_FAILED_TURN_RETRIES, after which the room settles against a
+  // genuinely-down member.
+  failedRetries?: Map<string, number>
 }
+
+/** How many extra times a member whose turn THREW is re-driven before the
+ *  round loop gives up and lets the room settle. Timeouts (reply===null
+ *  without a throw) keep their existing stranded-harvest path untouched. */
+export const MAX_FAILED_TURN_RETRIES = 1
 
 /** #93129: a held member's skip must consume its delta exactly once —
  *  advance the watermark past the current log so the same entries never
@@ -108,7 +120,7 @@ function prepareGroupRoundMember(context: GroupRoundMemberContext, member: Group
 export async function runGroupRoundMember(
   context: GroupRoundMemberContext,
   member: GroupMember
-): Promise<boolean | null> {
+): Promise<boolean | null | 'retry'> {
   const { thread, startEpoch, binding } = context
   const prepared = prepareGroupRoundMember(context, member)
 
@@ -126,6 +138,7 @@ export async function runGroupRoundMember(
     return r
   })
   let reply: null | string = null
+  let turnFailed = false
 
   try {
     reply = await runGroupChatMemberTurn(context.group, member, prompt, thread, deltaImages)
@@ -155,6 +168,7 @@ export async function runGroupRoundMember(
     })
     noteBotAttention(groupMemberKey(member), reason || error?.message || error)
     reply = null // a failed turn is a pass, never a room error
+    turnFailed = true
   }
 
   // #93127: the turn may have finished AFTER a newer user send bumped
@@ -195,6 +209,26 @@ export async function runGroupRoundMember(
     })
 
     return null
+  }
+
+  // A THROWN turn (transient reap) that still has retries left must NOT
+  // advance the watermark: leaving the user's delta unseen lets the NEXT
+  // round re-drive this member instead of silently consuming the mention.
+  // Only real throws are retried (timeouts keep the stranded-harvest path),
+  // and only up to MAX_FAILED_TURN_RETRIES so the room still settles against
+  // a genuinely-down member. Return true so spokeThisRound stays > 0 and the
+  // round loop runs another round (the room would otherwise settle after a
+  // silent round before the re-drive) — no entry is appended, so this only
+  // keeps the loop alive; the actual reply lands on the retry round.
+  if (turnFailed && context.failedRetries) {
+    const memberKey = groupMemberKey(member)
+    const priorRetries = context.failedRetries.get(memberKey) || 0
+
+    if (priorRetries < MAX_FAILED_TURN_RETRIES) {
+      context.failedRetries.set(memberKey, priorRetries + 1)
+
+      return 'retry'
+    }
   }
 
   // The member has now seen everything up to the pre-reply log length.

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.stale-mention.repro.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.stale-mention.repro.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as groupChat from './group-chat'
+import type * as groupRounds from './group-rounds'
+import { createGroupGateway, drain, runTimersInline, scriptedStorage } from './group-test-utils'
+import type { GatewayOptions, ScriptedGateway } from './group-test-utils'
+import type * as groupTurns from './group-turns'
+import type { GroupMember } from './types'
+
+// Reproduction for the "member never answers, message goes stale" report.
+//
+// Source path proven before writing this (group-rounds.ts):
+//   - a failed member turn is swallowed to `reply = null` (catch, ~L665),
+//   - the loop STILL advances that member's watermark to log.length (~L706),
+//   - the only re-drive for a silent-but-owed member,
+//     `unaddressedGroupMentions`, counts ONLY member->member handoffs
+//     (`entry.from.kind !== 'member'` is skipped, ~L361).
+//
+// So when the USER directly @-mentions a member and that member's turn fails
+// once on a transient reap, the user's message is consumed (watermark past it)
+// and never re-driven — the bot stays silent forever. This test pins the
+// CORRECT behavior (the member eventually answers), so it is RED on today's
+// code and GREEN once the re-drive covers a user-cited member.
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+
+  return pluginSdkMock(host)
+})
+
+interface Room {
+  chat: typeof groupChat
+  gateway: ScriptedGateway
+  rounds: typeof groupRounds
+  turns: typeof groupTurns
+}
+
+async function loadRoom(options: GatewayOptions = {}): Promise<Room> {
+  vi.resetModules()
+  const gateway = createGroupGateway(options)
+
+  for (const key of Object.keys(host)) {
+    delete host[key]
+  }
+
+  Object.assign(host, gateway.host)
+
+  const [chat, rounds, turns, shared] = await Promise.all([
+    import('./group-chat'),
+    import('./group-rounds'),
+    import('./group-turns'),
+    import('./shared')
+  ])
+
+  shared.setPluginCtx(scriptedStorage(gateway.storage))
+
+  return { chat, gateway, rounds, turns }
+}
+
+const MEMBERS: GroupMember[] = [
+  { name: 'research', title: '' },
+  { name: 'builder', title: '' }
+]
+
+const log = (room: Room, group: string) => room.chat.$groupChats.get()[group]?.log || []
+
+async function settle(room: Room, group: string) {
+  await drain(() => Boolean(room.chat.$groupChats.get()[group]?.running))
+}
+
+beforeEach(() => {
+  runTimersInline()
+})
+
+describe('user-mentioned member whose first turn fails transiently', () => {
+  it('still answers the user (the mention is not permanently consumed)', async () => {
+    // builder throws a non-4001 error on its FIRST submit (a transient reap
+    // that the turn-level 4001 retry does not cover), then would answer.
+    let builderAttempts = 0
+
+    const room = await loadRoom({
+      turn: ({ profile }) => {
+        if (profile === 'builder') {
+          builderAttempts += 1
+
+          if (builderAttempts === 1) {
+            throw new Error('transient reap: gateway socket dropped mid-turn')
+          }
+
+          return 'builder here — on it.'
+        }
+
+        return '(pass)'
+      }
+    })
+
+    // The user addresses builder directly.
+    room.rounds.sendToGroupChat('Council', MEMBERS, '@builder can you take a look?')
+    await settle(room, 'Council')
+
+    const memberLines = log(room, 'Council')
+      .filter(entry => entry.from.kind === 'member')
+      .map(entry => `${entry.from.name}: ${entry.text}`)
+
+    // CORRECT behavior: builder eventually posts its reply. On today's code the
+    // failed first turn is swallowed, the watermark is advanced past the user
+    // message, and the user-cited member is never re-driven — so builder stays
+    // silent and this assertion fails (the bug).
+    expect(memberLines.some(line => line.startsWith('builder:'))).toBe(true)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -434,7 +434,9 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
     thread,
     startEpoch,
     binding,
-    isCurrent
+    isCurrent,
+    // Per-drive transient-failure retry counters (see GroupRoundMemberContext).
+    failedRetries: new Map<string, number>()
   }
 
   let posted = 0
@@ -512,7 +514,12 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
           return
         }
 
-        if (result) {
+        // 'retry' = a transient failure that must be re-driven next round:
+        // keep the round alive (so the loop doesn't settle before the retry)
+        // without counting it as a posted message.
+        if (result === 'retry') {
+          spokeThisRound += 1
+        } else if (result) {
           posted += 1
           spokeThisRound += 1
         }


### PR DESCRIPTION
## Problem

In a Bot Mode group chat, a member turn that **throws** a transient error (e.g. a `ws_orphan_reap` / 4001 that the turn-level retry in `group-turns.ts` could not recover) is caught and downgraded to `reply = null` — *"a failed turn is a pass, never a room error"*. That part is intended.

The bug: the same code path still **advanced the member's watermark** past the user's message, and the round loop then settled (no member spoke that round → `spokeThisRound === 0` → room settles). Because `unaddressedGroupMentions` only re-drives **member → member** handoffs (it skips `entry.from.kind !== 'member'`), a user's direct `@mention` that hit one transient failure was **permanently consumed** — the bot went silent and the message went stale, with no retry and no error surfaced.

This is the real-world "members stop receiving messages in the group / message goes stale" symptom.

## Root cause (line-level)

`apps/desktop/src/plugins/hermes-bots/group-round-members.ts`, `runGroupRoundMember`:
- `catch` block sets `reply = null` (correct) but falls through to the unconditional watermark advance `r.watermarks[markKey] = r.log.length`, marking the user's delta as "seen" even though the turn never produced output.
- The round driver in `group-rounds.ts` counts only real replies toward `spokeThisRound`, so after a silent failed round the room settles before the member is ever re-driven.

## Fix

- Track a thrown turn (`turnFailed`) distinctly from a legitimate empty/pass reply.
- On a thrown turn with retries left (`MAX_FAILED_TURN_RETRIES = 1`), **do not advance the watermark** (leave the user's delta unseen) and return a `'retry'` signal that keeps the round alive (`spokeThisRound += 1`) **without** counting as a posted message toward `GROUP_CHAT_MAX_MESSAGES`. The member is re-driven the next round.
- Timeouts (`reply === null` without a throw) keep their existing stranded-harvest path untouched.
- After the retry budget is exhausted the room settles normally against a genuinely-down member — no infinite loop (retry count is per-drive, per-member).

Zero change to the happy path or to member→member handoffs.

## Test

Adds `group-rounds.stale-mention.repro.test.ts`: drives the real `runGroupChatRounds` with a `@`-mentioned member whose first turn throws a transient reap. **RED on base** (the user mention is permanently consumed, member never speaks), **GREEN with the fix** (the member is re-driven and answers).

## Verification

- repro test: RED on base → GREEN with fix
- full `apps/desktop/src/plugins/hermes-bots/` vitest suite: **585 passed**
- `npm run typecheck`: exit 0
