### PR TITLE
fix(web): stop desktop CJK IME commits from hitting mobile-replacement heuristics (#106487)

### DIFF
--- a/web/src/lib/pty-mobile-input.test.ts
+++ b/web/src/lib/pty-mobile-input.test.ts
@@ -7,10 +7,20 @@ import {
 } from "./pty-mobile-input";
 
 describe("shouldTreatInputAsMobileReplacement", () => {
-  it("recognizes explicit browser replacement input", () => {
+  it("recognizes explicit browser replacement input regardless of platform", () => {
     expect(shouldTreatInputAsMobileReplacement("insertReplacementText", "Kain", false)).toBe(true);
-    expect(shouldTreatInputAsMobileReplacement("insertFromComposition", "Kain", false)).toBe(true);
-    expect(shouldTreatInputAsMobileReplacement("insertCompositionText", "Kain", false)).toBe(true);
+    expect(shouldTreatInputAsMobileReplacement("insertReplacementText", "Kain", true)).toBe(true);
+  });
+
+  it("treats IME composition commits as replacement-like only on mobile-like keyboards", () => {
+    // Desktop IME (e.g. macOS/Windows CJK input) fires the same
+    // insertFromComposition/insertCompositionText inputTypes as a mobile
+    // keyboard. Only mobile keyboards get Gboard-style replacement
+    // handling — desktop commits must pass through unchanged (#106487).
+    expect(shouldTreatInputAsMobileReplacement("insertFromComposition", "Kain", true)).toBe(true);
+    expect(shouldTreatInputAsMobileReplacement("insertCompositionText", "Kain", true)).toBe(true);
+    expect(shouldTreatInputAsMobileReplacement("insertFromComposition", "你好", false)).toBe(false);
+    expect(shouldTreatInputAsMobileReplacement("insertCompositionText", "你好", false)).toBe(false);
   });
 
   it("treats multi-character mobile insertText as replacement-like", () => {

--- a/web/src/lib/pty-mobile-input.ts
+++ b/web/src/lib/pty-mobile-input.ts
@@ -77,12 +77,19 @@ export function shouldTreatInputAsMobileReplacement(
   data: string | null | undefined,
   isMobileLike: boolean,
 ): boolean {
+  if (inputType === "insertReplacementText") {
+    return true;
+  }
+  // insertFromComposition/insertCompositionText fire for *any* IME commit,
+  // desktop CJK included — they are not mobile-specific like
+  // insertReplacementText. Gating them on isMobileLike keeps the
+  // Gboard-style replacement heuristics off the desktop IME path, where the
+  // committed text should be forwarded unchanged (#106487).
   if (
-    inputType === "insertReplacementText" ||
     inputType === "insertFromComposition" ||
     inputType === "insertCompositionText"
   ) {
-    return true;
+    return isMobileLike;
   }
   return isMobileLike && inputType === "insertText" && (data?.length ?? 0) > 1;
 }

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -17,6 +17,8 @@ class FakeWebglAddon {
 }
 
 class FakeTerminal {
+  static instances: FakeTerminal[] = [];
+
   options: Record<string, unknown>;
   rows = 24;
   cols = 80;
@@ -24,9 +26,14 @@ class FakeTerminal {
     registerOscHandler: vi.fn(),
   };
   unicode = { activeVersion: "" };
+  // A real textarea so ChatPage's beforeinput/compositionend IME wiring
+  // (guarded by `if (term.textarea)`) actually runs under test.
+  textarea = document.createElement("textarea");
+  dataHandler: ((data: string) => void) | null = null;
 
   constructor(options: Record<string, unknown>) {
     this.options = options;
+    FakeTerminal.instances.push(this);
   }
 
   attachCustomKeyEventHandler() {
@@ -49,8 +56,13 @@ class FakeTerminal {
 
   loadAddon() {}
 
-  onData() {
-    return { dispose() {} };
+  onData(cb: (data: string) => void) {
+    this.dataHandler = cb;
+    return {
+      dispose: () => {
+        this.dataHandler = null;
+      },
+    };
   }
 
   onResize() {
@@ -146,7 +158,7 @@ class FakeWebSocket {
     this.readyState = 3;
   }
 
-  send() {}
+  send = vi.fn();
 }
 
 type CloseEventLike = {
@@ -191,6 +203,7 @@ async function render(ui: ReactNode) {
 
 beforeEach(() => {
   FakeWebSocket.instances = [];
+  FakeTerminal.instances = [];
   maybeReloadForLoopbackWsAuthFailure.mockClear();
   apiMocks.buildWsUrl.mockReset();
   apiMocks.buildWsUrl.mockResolvedValue("ws://localhost/api/pty?channel=chat-1");
@@ -320,6 +333,68 @@ describe("ChatPage", () => {
       "resize",
       "scroll",
     ]);
+  });
+});
+
+function dispatchBeforeInput(
+  target: EventTarget,
+  inputType: string,
+  data: string,
+) {
+  const event = new Event("beforeinput", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "inputType", { value: inputType });
+  Object.defineProperty(event, "data", { value: data });
+  target.dispatchEvent(event);
+}
+
+function dispatchCompositionEnd(target: EventTarget, data: string) {
+  const event = new Event("compositionend", { bubbles: true });
+  Object.defineProperty(event, "data", { value: data });
+  target.dispatchEvent(event);
+}
+
+describe("ChatPage desktop IME input (#106487)", () => {
+  it("forwards a desktop IME composition commit unchanged instead of running mobile-replacement heuristics", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    await vi.waitFor(() => expect(FakeTerminal.instances).toHaveLength(1));
+
+    const term = FakeTerminal.instances[0];
+    const ws = FakeWebSocket.instances[0];
+    expect(term.dataHandler).not.toBeNull();
+
+    act(() => {
+      ws.onopen?.();
+    });
+
+    // Seed the tracked composer line with the same CJK text the IME is
+    // about to (re-)commit. Some browser/IME combinations re-fire the final
+    // composition commit; this is the scenario where the Latin-oriented
+    // "duplicated last word" replacement heuristic can fire against CJK
+    // text once the mobile-replacement window is (wrongly) armed on
+    // desktop.
+    act(() => {
+      term.dataHandler!("你好");
+    });
+
+    act(() => {
+      dispatchBeforeInput(term.textarea, "insertCompositionText", "你好");
+      dispatchCompositionEnd(term.textarea, "你好");
+      term.dataHandler!("你好");
+    });
+
+    const sent = ws.send.mock.calls.map((call) => call[0] as string);
+    // Desktop IME text must reach the PTY unchanged — not prefixed with
+    // DELETE bytes from a mistaken mobile line-replacement.
+    expect(sent.some((data) => data.includes("\x7f"))).toBe(false);
+    expect(sent.at(-1)).toBe("你好");
   });
 });
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -871,7 +871,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         }
       };
       const markCompositionEnd = (ev: CompositionEvent) => {
-        mobileReplacementInputUntilRef.current = Date.now() + MOBILE_REPLACEMENT_WINDOW_MS;
+        // compositionend fires for every IME commit, desktop CJK included —
+        // only arm the mobile-replacement window when a mobile-like keyboard
+        // is actually in play, or desktop IME text gets routed through
+        // Gboard-style replacement heuristics it was never meant for
+        // (#106487).
+        if (isMobileLike) {
+          mobileReplacementInputUntilRef.current = Date.now() + MOBILE_REPLACEMENT_WINDOW_MS;
+        }
         compositionForwarder.onCompositionEnd(ev.data);
       };
 


### PR DESCRIPTION
Fixes #106487.

## Problem

In the dashboard Chat tab, composing Chinese (or any CJK) text with a desktop
IME is unreliable — committed text can arrive duplicated/garbled with a
drifting cursor, while pasting the same text works flawlessly.

Two independent call sites in the mobile-line-replacement pipeline
(`web/src/lib/pty-mobile-input.ts` + `web/src/pages/ChatPage.tsx`) treat
**any** IME composition commit as a candidate "mobile keyboard replacement"
(the Gboard-style predictive-text-swap heuristic), regardless of platform:

1. `shouldTreatInputAsMobileReplacement()` returned `true` for
   `insertFromComposition`/`insertCompositionText` unconditionally — these
   input types fire for any IME commit, desktop CJK included, not just
   mobile keyboards.
2. `ChatPage`'s `compositionend` handler (`markCompositionEnd`) armed the
   350ms mobile-replacement window unconditionally on every composition end,
   bypassing the `isMobileLike` check entirely.

Either one alone is enough to arm the window for a desktop CJK commit. Once
armed, `replacementLineForMobileInput()`'s Latin word-boundary heuristics
(`\S+`, `toLocaleLowerCase()` word matching) can misfire against CJK text —
e.g. when a browser/IME re-fires the same composed clause, the current line
exactly matches the incoming text and the code emits `DELETE` bytes followed
by a re-send of the same text, instead of forwarding the commit unchanged.
That matches the reported "duplicated/garbled, cursor drifts" symptom, and
explains why paste (which bypasses this whole pipeline) works reliably.

## Fix

Gate both arming sites on `isMobileLike`, so the mobile-replacement
heuristics only apply to actual mobile keyboards:

- `pty-mobile-input.ts`: `insertFromComposition`/`insertCompositionText`
  only count as replacement-like when `isMobileLike` is true.
  `insertReplacementText` (desktop/mobile spellcheck-swap) is untouched.
- `ChatPage.tsx`: `markCompositionEnd` only arms
  `mobileReplacementInputUntilRef` when `isMobileLike` is true; it still
  always forwards the commit to `compositionForwarder.onCompositionEnd`
  (the IME-commit fallback for browsers where xterm doesn't emit `onData`).

Desktop IME commits now flow through unchanged, the same path DOM paste
already uses successfully.

## Test plan

Added/updated tests that fail without the fix and pass with it:

- `pty-mobile-input.test.ts`: `shouldTreatInputAsMobileReplacement` now
  asserts composition input types are replacement-like only when
  `isMobileLike` is true (desktop CJK case explicitly checked with `"你好"`).
- `ChatPage.test.tsx`: new integration test that dispatches a real
  `beforeinput`/`compositionend` sequence for a CJK commit through a
  (jsdom) textarea, arms the seeded composer-line duplicate scenario, and
  asserts the WebSocket send is the raw `"你好"` with no `DELETE` (`\x7f`)
  bytes prepended.

Verified the fix is not a no-op: reverted only the two source files
(`git checkout HEAD~1 -- web/src/lib/pty-mobile-input.ts web/src/pages/ChatPage.tsx`)
and confirmed both new/updated tests fail against the pre-fix code:

```
❯ src/lib/pty-mobile-input.test.ts (11 tests | 1 failed)
    × treats IME composition commits as replacement-like only on mobile-like keyboards
      AssertionError: expected true to be false

❯ src/pages/ChatPage.test.tsx (7 tests | 1 failed)
    × forwards a desktop IME composition commit unchanged instead of running mobile-replacement heuristics
      AssertionError: expected true to be false
      (sent.some(data => data.includes("\x7f"))) was true
```

Restored the fix and re-ran the full suite:

```
Test Files  40 passed (40)
     Tests  297 passed (297)
```

Also ran `tsc -p . --noEmit` (clean) and `eslint .` (0 errors; only the
same pre-existing warnings present on `main`, unrelated to this change).

## AI assistance disclosure

This change was written with AI assistance (Claude Code), including the
root-cause analysis, the fix, and the tests, per the repo's automated
contribution norms. All test output above was captured from actual runs
against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
