### PR TITLE
fix(cli): concurrent PTY reaps no longer raise KeyError into the terminal websocket (#106400, salvage #106415)

### DIFF
--- a/hermes_cli/pty_session.py
+++ b/hermes_cli/pty_session.py
@@ -191,7 +191,12 @@ class PtySessionRegistry:
             if not s.alive or (not s.attached and s.last_detached_at is not None and (now - s.last_detached_at) > self._ttl)
         ]
         for key in doomed:
-            await self._sessions.pop(key).close()
+            # Reaps overlap (attach_or_spawn and the background reaper) and close()
+            # awaits, so a concurrent reap can have popped this key already — skip
+            # it instead of raising KeyError into the websocket handler.
+            session = self._sessions.pop(key, None)
+            if session is not None:
+                await session.close()
 
     def _reap_one_idle_or_raise(self) -> None:
         idle = [s for s in self._sessions.values() if not s.attached and s.last_detached_at is not None]
@@ -203,4 +208,8 @@ class PtySessionRegistry:
 
     async def close_all(self) -> None:
         for key in list(self._sessions):
-            await self._sessions.pop(key).close()
+            # Same overlap window as reap_idle: an in-flight reap may have popped
+            # a snapshot key while we awaited an earlier close().
+            session = self._sessions.pop(key, None)
+            if session is not None:
+                await session.close()

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -277,3 +277,104 @@ async def test_reaper_loop_invokes_reap(monkeypatch):
     except asyncio.CancelledError:
         pass
     assert calls["n"] >= 2
+
+
+def _register_idle_session(reg, key):
+    from hermes_cli.pty_session import PtySession
+    bridge = FakeBridge([b""])
+    s = PtySession(key, bridge, buffer_cap=1024, read_timeout=0.01)
+    await_start = s.start()
+    return bridge, s, await_start
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reap_idle_is_idempotent():
+    """reap_idle is reached from attach_or_spawn and the run_reaper loop; both
+    may doom the same keys, so one reap can pop a key the other already took
+    while awaiting its close(). The second pop must skip, not raise."""
+    reg = make_registry(ttl=60.0)
+    bridges = []
+    sessions = []
+    for i in range(2):
+        bridge, s, start = _register_idle_session(reg, "k%d" % i)
+        await start
+        s.detach(None)                        # unattached, last_detached_at set
+        reg._sessions[s.key] = s
+        bridges.append(bridge)
+        sessions.append(s)
+
+    entered, release = asyncio.Event(), asyncio.Event()
+    original_close = sessions[0].close
+
+    async def gated_close():
+        entered.set()
+        await release.wait()
+        await original_close()
+
+    sessions[0].close = gated_close
+
+    far_future = time.monotonic() + 10_000    # both idle past ttl → doomed
+    first = asyncio.create_task(reg.reap_idle(now=far_future))
+    await entered.wait()                      # k0 popped; first reap parked in close()
+    await reg.reap_idle(now=far_future)       # second reap hits the taken k0
+
+    release.set()
+    await first
+    assert not reg._sessions
+    assert all(b.closed for b in bridges)
+
+
+@pytest.mark.asyncio
+async def test_close_all_survives_key_popped_by_concurrent_reap():
+    """close_all snapshots keys, then awaits each close(); a reap that runs
+    during that await can remove a later key from the snapshot."""
+    reg = make_registry(ttl=60.0)
+    bridges = []
+    sessions = []
+    for i in range(2):
+        bridge, s, start = _register_idle_session(reg, "k%d" % i)
+        await start
+        s.detach(None)
+        reg._sessions[s.key] = s
+        bridges.append(bridge)
+        sessions.append(s)
+
+    entered, release = asyncio.Event(), asyncio.Event()
+    original_close = sessions[0].close
+
+    async def gated_close():
+        entered.set()
+        await release.wait()
+        await original_close()
+
+    sessions[0].close = gated_close
+
+    closer = asyncio.create_task(reg.close_all())
+    await entered.wait()                      # close_all popped k0, parked in close()
+    await reg.reap_idle(now=time.monotonic() + 10_000)   # pops k1 meanwhile
+    release.set()
+    await closer                              # k1 of the snapshot is already gone
+
+    assert not reg._sessions
+    assert all(b.closed for b in bridges)
+
+
+@pytest.mark.asyncio
+async def test_reap_idle_closes_doomed_and_keeps_attached():
+    reg = make_registry(ttl=60.0)
+    live_bridge = FakeBridge([b""])
+    s_live, _ = await reg.attach_or_spawn("live", spawn=lambda: live_bridge)
+    await s_live.attach(FakeWS())             # attached → survives the reap
+
+    dead_bridge = FakeBridge([b""])
+    s_dead, _ = await reg.attach_or_spawn("dead", spawn=lambda: dead_bridge)
+    s_dead.alive = False                      # dead remnant → reaped
+
+    idle_bridge = FakeBridge([b""])
+    s_idle, _ = await reg.attach_or_spawn("idle", spawn=lambda: idle_bridge)
+    s_idle.detach(None)                       # idle past ttl → reaped
+
+    await reg.reap_idle(now=time.monotonic() + 10_000)
+    assert list(reg._sessions) == ["live"]
+    assert dead_bridge.closed and idle_bridge.closed and not live_bridge.closed
+    await reg.close_all()

--- a/tests/test_pty_session.py
+++ b/tests/test_pty_session.py
@@ -279,12 +279,29 @@ async def test_reaper_loop_invokes_reap(monkeypatch):
     assert calls["n"] >= 2
 
 
-def _register_idle_session(reg, key):
+async def _two_idle_sessions_first_close_gated(reg):
+    """Two detached (idle) sessions; k0's close() parks until ``release`` is set."""
     from hermes_cli.pty_session import PtySession
-    bridge = FakeBridge([b""])
-    s = PtySession(key, bridge, buffer_cap=1024, read_timeout=0.01)
-    await_start = s.start()
-    return bridge, s, await_start
+    bridges = []
+    for i in range(2):
+        bridge = FakeBridge([b""])
+        s = PtySession("k%d" % i, bridge, buffer_cap=1024, read_timeout=0.01)
+        await s.start()
+        s.detach(None)                        # unattached, last_detached_at set
+        reg._sessions[s.key] = s
+        bridges.append(bridge)
+
+    entered, release = asyncio.Event(), asyncio.Event()
+    k0 = reg._sessions["k0"]
+    original_close = k0.close
+
+    async def gated_close():
+        entered.set()
+        await release.wait()
+        await original_close()
+
+    k0.close = gated_close
+    return bridges, entered, release
 
 
 @pytest.mark.asyncio
@@ -293,33 +310,15 @@ async def test_concurrent_reap_idle_is_idempotent():
     may doom the same keys, so one reap can pop a key the other already took
     while awaiting its close(). The second pop must skip, not raise."""
     reg = make_registry(ttl=60.0)
-    bridges = []
-    sessions = []
-    for i in range(2):
-        bridge, s, start = _register_idle_session(reg, "k%d" % i)
-        await start
-        s.detach(None)                        # unattached, last_detached_at set
-        reg._sessions[s.key] = s
-        bridges.append(bridge)
-        sessions.append(s)
-
-    entered, release = asyncio.Event(), asyncio.Event()
-    original_close = sessions[0].close
-
-    async def gated_close():
-        entered.set()
-        await release.wait()
-        await original_close()
-
-    sessions[0].close = gated_close
+    bridges, entered, release = await _two_idle_sessions_first_close_gated(reg)
 
     far_future = time.monotonic() + 10_000    # both idle past ttl → doomed
     first = asyncio.create_task(reg.reap_idle(now=far_future))
     await entered.wait()                      # k0 popped; first reap parked in close()
-    await reg.reap_idle(now=far_future)       # second reap hits the taken k0
+    await reg.reap_idle(now=far_future)       # second reap takes k1
 
     release.set()
-    await first
+    await first                               # first reap reaches the taken k1
     assert not reg._sessions
     assert all(b.closed for b in bridges)
 
@@ -329,25 +328,7 @@ async def test_close_all_survives_key_popped_by_concurrent_reap():
     """close_all snapshots keys, then awaits each close(); a reap that runs
     during that await can remove a later key from the snapshot."""
     reg = make_registry(ttl=60.0)
-    bridges = []
-    sessions = []
-    for i in range(2):
-        bridge, s, start = _register_idle_session(reg, "k%d" % i)
-        await start
-        s.detach(None)
-        reg._sessions[s.key] = s
-        bridges.append(bridge)
-        sessions.append(s)
-
-    entered, release = asyncio.Event(), asyncio.Event()
-    original_close = sessions[0].close
-
-    async def gated_close():
-        entered.set()
-        await release.wait()
-        await original_close()
-
-    sessions[0].close = gated_close
+    bridges, entered, release = await _two_idle_sessions_first_close_gated(reg)
 
     closer = asyncio.create_task(reg.close_all())
     await entered.wait()                      # close_all popped k0, parked in close()
@@ -357,24 +338,3 @@ async def test_close_all_survives_key_popped_by_concurrent_reap():
 
     assert not reg._sessions
     assert all(b.closed for b in bridges)
-
-
-@pytest.mark.asyncio
-async def test_reap_idle_closes_doomed_and_keeps_attached():
-    reg = make_registry(ttl=60.0)
-    live_bridge = FakeBridge([b""])
-    s_live, _ = await reg.attach_or_spawn("live", spawn=lambda: live_bridge)
-    await s_live.attach(FakeWS())             # attached → survives the reap
-
-    dead_bridge = FakeBridge([b""])
-    s_dead, _ = await reg.attach_or_spawn("dead", spawn=lambda: dead_bridge)
-    s_dead.alive = False                      # dead remnant → reaped
-
-    idle_bridge = FakeBridge([b""])
-    s_idle, _ = await reg.attach_or_spawn("idle", spawn=lambda: idle_bridge)
-    s_idle.detach(None)                       # idle past ttl → reaped
-
-    await reg.reap_idle(now=time.monotonic() + 10_000)
-    assert list(reg._sessions) == ["live"]
-    assert dead_bridge.closed and idle_bridge.closed and not live_bridge.closed
-    await reg.close_all()


### PR DESCRIPTION
Overlapping `PtySessionRegistry.reap_idle()` calls (background reaper vs. `attach_or_spawn`) no longer raise `KeyError` into the dashboard terminal's websocket handler; `close_all()` tolerates the same overlap.

Fixes #106400

## Changes
- `hermes_cli/pty_session.py::PtySessionRegistry.reap_idle` — `pop(key)` → `pop(key, None)` and skip a key a concurrent reap already removed (cherry-picked from #106415, authorship preserved).
- `hermes_cli/pty_session.py::PtySessionRegistry.close_all` — same default-pop for the identical window (an in-flight reap removes a snapshot key while an earlier `close()` is awaited).
- `tests/test_pty_session.py` — two interleaving regressions (reap vs reap, close_all vs reap), both red on base.

**Root cause:** `reap_idle` builds a `doomed` key list and then awaits `close()` per key; a second reap running inside that await pops the same keys first, so the resumed reap's bare `dict.pop(key)` raises.

## Dropped from #106415 (shape gate)
- `test_reap_idle_closes_doomed_and_keeps_attached` — pins pre-existing selection behaviour the fix does not change and is not red on base; ≤ 2 invariant tests per fix. The two kept tests share one setup helper instead of duplicating it.
- No locks/flags added: the pop-with-default alone closes the race. Each session is popped by exactly one task (dict ops are atomic under the GIL, no await between the pop and the `None` check), so no double-close and no leaked session is possible.

## Validation
| Check | Before (origin/main) | After |
|---|---|---|
| Live repro, in-process asyncio: two overlapping `reap_idle` over 2 idle sessions whose `close()` awaits | `KeyError: 'k1'` from `reap_idle` | clean, both sessions closed |
| Live repro: `close_all` vs concurrent `reap_idle` | `KeyError: 'k1'` from `close_all` | clean |
| E2E, real `PtyBridge.spawn` children (`/bin/sh`), temp `HERMES_HOME`, `gather(reap_idle, attach_or_spawn, reap_idle)` | `[KeyError('e2e1'), KeyError('e2e2')]` | clean; reaped children exited; attached session survives overlapping reaps; `close_all` clean |
| `tests/test_pty_session.py` with fix reverted | 2 failed (`KeyError` at `reap_idle` / `close_all`), 12 passed | 14 passed |
| `tests/test_pty_keepalive_ws.py` + `tests/hermes_cli/test_pty_bridge.py` + `test_web_server_pty_idle_backoff.py` + `test_web_server_pty_reconnect.py` | — | 28 passed |

Related but distinct: #83171 (capacity-eviction close task in `_reap_one_idle_or_raise` is untracked and invisible to `close_all`) is a different defect on a different call path and is not covered here.

## Credits
- @liuhao1024 — fix and interleaving tests (#106415, cherry-picked)
- @3oltan-seo — report and the exact suggested fix (#106400)

## Infographic
![pty-reap](https://v3b.fal.media/files/b/0aa9ba2b/H1MVBipc5ec7imesTMSwD_7dIZeZSy.png)
