### PR TITLE
Novita 429 'server overload' no longer rotates the credential or falls back early (#106205, salvage #106213)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -125,6 +125,7 @@ _RATE_LIMIT_PATTERNS = (
 _OVERLOADED_PATTERNS = (
     "overloaded", "temporarily overloaded", "service is temporarily overloaded",
     "service may be temporarily overloaded", "server is overloaded", "server overloaded",
+    "server overload", "server_overload",
     "service overloaded", "service is overloaded", "upstream overloaded", "currently overloaded",
     "at capacity", "over capacity",
 )

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -511,6 +511,24 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_rotate_credential is False
 
+    def test_429_novita_server_overload_is_overloaded_not_rate_limit(self):
+        """Novita returns HTTP 429 with message 'server overload, please try
+        again later' and error type 'server_overload' for a genuinely busy
+        server (not a credential quota). Neither phrase was in the overload
+        tuple, so it fell through to rate_limit and would rotate the credential
+        / fall back early instead of retrying the same key. (#106205)"""
+        e = MockAPIError(
+            "server overload, please try again later",
+            status_code=429,
+            body={"error": {"message": "server overload, please try again later",
+                            "type": "server_overload"}},
+        )
+        result = classify_api_error(e, provider="custom:novita")
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_fallback is False
+        assert result.should_rotate_credential is False
+
     def test_429_normal_rate_limit_still_rotates(self):
         """Guard: a genuine 429 rate limit (no overload language) must still
         classify as rate_limit and rotate the credential. (#14038)"""

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -511,7 +511,7 @@ class TestClassifyApiError:
         assert result.retryable is True
         assert result.should_rotate_credential is False
 
-    def test_429_novita_server_overload_is_overloaded_not_rate_limit(self):
+    def test_429_server_overload_is_overloaded_not_rate_limit(self):
         """Novita returns HTTP 429 with message 'server overload, please try
         again later' and error type 'server_overload' for a genuinely busy
         server (not a credential quota). Neither phrase was in the overload


### PR DESCRIPTION
A provider returning HTTP 429 with a `server overload` / `server_overload` body (Novita's wording) now backs off and retries on the same credential instead of rotating the key and falling back early.

## Changes
- `agent/error_classifier.py::_OVERLOADED_PATTERNS` gains `"server overload"` and `"server_overload"` (+1 line). Both the `_status_429` path and the message-tail rules read this tuple, so the 429 verdict becomes `FailoverReason.overloaded` (retryable, `should_fallback=False`, `should_rotate_credential=False`) — the same verdict Z.AI's 429-overload already gets since #53578.
- `tests/agent/test_error_classifier.py`: one invariant test for the Novita body (proven red on `origin/main` by sabotage-run: reverting the classifier hunk fails `test_429_server_overload_is_overloaded_not_rate_limit`, restoring it passes). The existing `test_429_normal_rate_limit_still_rotates` guard covers the negative case; no second test added.

## Validation
Live repro (`/tmp/novita_probe.py`: fresh interpreter, temp `HERMES_HOME`, `agent*`/`tools*`/`hermes*` purged from `sys.modules`, real `openai.APIStatusError` over an `httpx.Response(429)` with Novita's JSON body, `provider="custom:novita"`):

```
BEFORE @ 511633be90e (origin/main)
[before] novita 429 server_overload -> reason=rate_limit retryable=True should_fallback=True should_rotate_credential=True :: BUG FIRES
[before] guard plain 429 rate limit -> reason=rate_limit should_rotate_credential=True
AFTER @ 6eb27b50250
[after] novita 429 server_overload -> reason=overloaded retryable=True should_fallback=False should_rotate_credential=False :: NEGATIVE
[after] guard plain 429 rate limit -> reason=rate_limit should_rotate_credential=True
```

| Error | Before | After |
|---|---|---|
| HTTP 429 `server overload, please try again later` / type `server_overload` | `rate_limit` · rotate + fallback | `overloaded` · backoff+retry, no rotation |
| HTTP 429 `Rate limit exceeded` | `rate_limit` · rotate | `rate_limit` · rotate (unchanged) |
| HTTP 429 `temporarily overloaded` (Z.AI, #14038) | `overloaded` | `overloaded` (unchanged) |

`scripts/run_tests.sh tests/agent/test_error_classifier.py` → 141 passed, 0 failed. `ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check`, `audit_pr_attribution.py` all clean.

## Root cause
`_OVERLOADED_PATTERNS` (introduced in #53578 to route 429 overload bodies to `overloaded`) listed `server overloaded` but not Novita's `server overload` / `server_overload`, so the 429 fell through to the generic `_V_RATE_LIMIT` verdict.

## Salvage notes
Salvage of #106213 by @KeyArgo — both commits cherry-picked verbatim onto current `main` (fix + test rename), authorship preserved. No trimming needed: +19 LOC, one test. Reporter: @LouisMoretti (#106205), whose issue body supplied the repro script.

Related open PRs in the 429-overload family, not folded in (different mechanisms/surfaces): #77771 (Z.AI code 1305 in `auxiliary_client`), #95002 (Retry-After on upstream-capacity 429).

Closes #106205

## Infographic
![novita-429-server-overload](https://v3b.fal.media/files/b/0aa9ba2b/txXnkvLqS26imbAnwL6gh_B2xqso43.png)
