### PR TITLE
fix(hermes_cli): OpenCode Go picker no longer offers the delisted ox-alpha-free (#106447, salvage #106290)

### DIFF
--- a/contributors/emails/htkt82ephone@gmail.com
+++ b/contributors/emails/htkt82ephone@gmail.com
@@ -1,0 +1,2 @@
+ten82e
+# PR #106290 salvage

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1932,6 +1932,9 @@ _OPENCODE_ZEN_FREE_BASE_URL = "https://opencode.ai/zen/v1"
 
 # ``-free``-suffixed slugs that are KEYED (Go-subscription) models, NOT anonymous-servable —
 # excluded from the keyless catalog despite the suffix (ox-alpha-free is Ox Alpha's Go twin).
+# The Go relay delisted ox-alpha-free (2026-09-09; GET /zen/go/v1/models omits it, POST → 401),
+# so it is gone from the opencode-go curated floor too — the exclusion stays so a stale live
+# list can never route it into the keyless catalog.
 _OPENCODE_FREE_KEYED_SUFFIX_MODELS = frozenset({"ox-alpha-free"})
 
 # In-process memo for _fetch_opencode_free_models(): (fetched_at, ids-or-None). Validation and

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -240,15 +240,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free",
         "muse-spark-1.3-contributor-free",
     ],
-    # Synced against opencode.ai/docs/go + live GET /zen/go/v1/models. "ox-alpha-free" is the
-    # Go-subscription twin of Zen's keyless Ox Alpha (NOT keyless — the Go relay requires a Go key).
+    # Synced against opencode.ai/docs/go + live GET /zen/go/v1/models. Known-delisted models are
+    # REMOVED (the live-first merge would otherwise keep offering a model that 401s): "ox-alpha-free"
+    # — the Go-subscription twin of Zen's keyless Ox Alpha — was delisted 2026-09-09.
     "opencode-go": [
         "kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "kimi-k2.5", "gpt-5.6-luna", "grok-4.5", "glm-5.3",
         "glm-5.3-flash", "glm-5.2", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro",
         "mimo-v2-omni", "minimax-m3", "minimax-m2.7", "minimax-m2.5", "deepseek-v4-pro",
         "deepseek-v4-flash", "qwen3.8-max", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus",
         "qwen3.5-plus", "hy3", "hy3-preview", "muse-spark-1.2-contributor", "muse-spark-1.3-contributor",
-        "ox-alpha-free",
     ],
     "kilocode": [
         "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4",

--- a/tests/hermes_cli/test_provider_live_curated_merge.py
+++ b/tests/hermes_cli/test_provider_live_curated_merge.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock, patch
 
 from hermes_cli.models import (
     _LIVE_FIRST_PICKER_PROVIDERS,
-    _PROVIDER_MODELS,
     provider_model_ids,
 )
 
@@ -106,9 +105,4 @@ class TestGenericProviderLiveCuratedMerge:
 
         assert "ox-alpha-free" not in result
         assert {"deepseek-v4-flash", "kimi-k3", "omen-alpha"} <= set(result)
-
-    def test_opencode_go_curated_floor_excludes_delisted_ox_alpha_free(self):
-        """The static floor must not carry a known-delisted Go model (offline fallback must
-        not offer a model that 401s — same policy as opencode-free/x-preview-f-free)."""
-        assert "ox-alpha-free" not in _PROVIDER_MODELS["opencode-go"]
 

--- a/tests/hermes_cli/test_provider_live_curated_merge.py
+++ b/tests/hermes_cli/test_provider_live_curated_merge.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from hermes_cli.models import (
     _LIVE_FIRST_PICKER_PROVIDERS,
+    _PROVIDER_MODELS,
     provider_model_ids,
 )
 
@@ -85,4 +86,29 @@ class TestGenericProviderLiveCuratedMerge:
         ):
             zen_result = set(provider_model_ids("opencode-zen"))
         assert {"a", "b", "c"} <= zen_result
+
+    def test_opencode_go_merge_does_not_resurrect_delisted_model(self):
+        """#95914 bug class, end-to-end through provider_model_ids with the REAL curated floor:
+        the Go relay (GET /zen/go/v1/models) delisted ox-alpha-free 2026-09-09. The live-first
+        merge must not resurrect it from the curated floor, or the picker keeps offering a model
+        that now 401s (REVERT-PROOF: a stale floor re-adds it and this fails)."""
+        assert "opencode-go" in _LIVE_FIRST_PICKER_PROVIDERS
+        live = ["deepseek-v4-flash", "kimi-k3", "omen-alpha"]  # current Go relay (no ox-alpha-free)
+
+        with (
+            patch("providers.get_provider_profile", return_value=self._make_profile(live)),
+            patch(
+                "hermes_cli.auth.resolve_api_key_provider_credentials",
+                return_value={"api_key": "k", "base_url": ""},
+            ),
+        ):
+            result = provider_model_ids("opencode-go")
+
+        assert "ox-alpha-free" not in result
+        assert {"deepseek-v4-flash", "kimi-k3", "omen-alpha"} <= set(result)
+
+    def test_opencode_go_curated_floor_excludes_delisted_ox_alpha_free(self):
+        """The static floor must not carry a known-delisted Go model (offline fallback must
+        not offer a model that 401s — same policy as opencode-free/x-preview-f-free)."""
+        assert "ox-alpha-free" not in _PROVIDER_MODELS["opencode-go"]
 


### PR DESCRIPTION
The OpenCode Go model picker no longer offers `ox-alpha-free`, a slug the Go relay has delisted and rejects with HTTP 401.

Fixes #106447

## Changes

- `hermes_cli/models_catalog_static.py::_PROVIDER_MODELS["opencode-go"]` — drop `ox-alpha-free`; the adjacent comment records the delisting (cherry-picked from #106290, authorship preserved).
- `hermes_cli/models.py::_OPENCODE_FREE_KEYED_SUFFIX_MODELS` — unchanged (still `{"ox-alpha-free"}`, still correct); the comment beside it notes the delisting so nobody "cleans it up" later.
- `tests/hermes_cli/test_provider_live_curated_merge.py` — one invariant test, `test_opencode_go_merge_does_not_resurrect_delisted_model`: `provider_model_ids("opencode-go")` with a live list that lacks the slug must not resurrect it from the real curated floor.
- Dropped from #106290: `test_opencode_go_curated_floor_excludes_delisted_ox_alpha_free` (a snapshot of the static table; the merge test already fails if the slug is re-added).
- `contributors/emails/` mapping for @ten82e.

## Root cause

`opencode-go` has no `_PROVIDER_CATALOG_FETCHERS` entry, so `_profile_live_catalog` merges the curated `_PROVIDER_MODELS` floor into the live `/zen/go/v1/models` result (live-first); curated entries the live API stops returning are retained by design, so a delisted slug has to leave the floor.

## Validation

| Check | Before | After |
|---|---|---|
| Live relay `GET https://opencode.ai/zen/go/v1/models` (curl, no key, 2026-09-09) | 200, 35 models, `ox-alpha-free` absent, `omen-alpha` present | same |
| Live relay `POST /zen/go/v1/chat/completions` `{"model":"ox-alpha-free"}` | 401 `ModelError: Model ox-alpha-free is not supported` | same (relay-side; confirms the slug is dead) |
| E2E: real `provider_model_ids("opencode-go", force_refresh=True)` against the live relay, worktree at `sys.path[0]`, purged `sys.modules`, temp `HERMES_HOME` | 36 models, `ox-alpha-free` **offered** | 35 models, `ox-alpha-free` **absent**; `kimi-k3` (curated) and `omen-alpha` (live) both still present |
| `test_opencode_go_merge_does_not_resurrect_delisted_model` with `origin/main` static table | FAILED (`'ox-alpha-free' not in [...]`) | passes |
| `scripts/run_tests.sh` on `test_provider_live_curated_merge.py`, `test_opencode_free_live_catalog.py`, `test_opencode_go_profile.py` | — | 16 passed, 0 failed |
| `check_model_list_dupes.py hermes_cli/models_catalog_static.py agent/usage_pricing.py` | — | no duplicates |
| ruff, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check` | — | clean |

**Live repro:** before — picker path returns 36 Go models including `ox-alpha-free` (selecting it → 401); after — 35 models, slug absent.

## Credits

- @ten82e — PR #106290 (the fix and the merge-path regression test; cherry-picked, authorship preserved)
- @cagerber — issue #106447 (live evidence, root-cause trace through `_profile_live_catalog`, and the note that `_OPENCODE_FREE_KEYED_SUFFIX_MODELS` must stay)

## Infographic
![ox-alpha-go](https://v3b.fal.media/files/b/0aa9ba2b/N_McOFHGepIOtXepYAZjX_Xuq3NhqI.png)
