### PR TITLE
fix(tui-gateway): end leftover voice mode on session create/resume (#106503)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -20303,6 +20303,80 @@ def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(monkeypatch, 
     server._tts_stream_stop()
 
 
+def test_session_create_ends_voice_mode_left_on_by_another_session(monkeypatch, tmp_path):
+    """/voice on is process-global runtime state (HERMES_VOICE); opening another session
+    (create) must end it, or every new-session turn re-arms the full-duplex listener and a
+    VAD-only trip (ambient noise, empty transcript) silently aborts its unrelated text turns
+    (#106503)."""
+    monkeypatch.setenv("HERMES_VOICE", "1")
+    monkeypatch.setenv("HERMES_VOICE_TTS", "1")
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.voice",
+        types.SimpleNamespace(stop_continuous=lambda **_kw: None, speak_text=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+
+    resp = server._methods["session.create"]("r-voice-create", {"cols": 80})
+
+    assert "result" in resp
+    assert os.environ.get("HERMES_VOICE") == "0"
+    assert os.environ.get("HERMES_VOICE_TTS") == "0"
+
+
+def test_session_resume_ends_voice_mode_left_on_by_another_session(monkeypatch, tmp_path):
+    """Switching to / resuming another session also ends leftover voice mode — the TUI
+    counterpart of Desktop's session-switch voice reset (#61448), for the same cross-session
+    silent-abort failure mode (#106503)."""
+    monkeypatch.setenv("HERMES_VOICE", "1")
+    monkeypatch.setenv("HERMES_VOICE_TTS", "1")
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.voice",
+        types.SimpleNamespace(stop_continuous=lambda **_kw: None, speak_text=lambda *a, **k: None),
+    )
+    target = "voice-switch-target"
+
+    class FakeDB:
+        def get_session(self, sid):
+            return {"id": sid}
+
+        def reopen_session(self, sid):
+            return None
+
+        def get_resume_conversations(self, sid):
+            return ([], [])
+
+        def get_ancestor_display_prefix(self, _sid):
+            return []
+
+        def get_messages_as_conversation(self, sid, **_kw):
+            return []
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda t: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(
+        server, "_make_agent", lambda *a, **k: types.SimpleNamespace(model="test")
+    )
+    monkeypatch.setattr(
+        server, "_session_info", lambda agent, *a: {"model": "test", "tools": {}, "skills": {}}
+    )
+    monkeypatch.setattr(
+        server, "_init_session", lambda sid, key, agent, history, cols=80, **_kw: None
+    )
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
+
+    resp = server._methods["session.resume"]("r-voice-resume", {"session_id": target})
+
+    assert "result" in resp
+    assert os.environ.get("HERMES_VOICE") == "0"
+    assert os.environ.get("HERMES_VOICE_TTS") == "0"
+
+
 def test_full_duplex_generation_phase_interrupts_running_turn(monkeypatch, tmp_path):
     """Speech DURING LLM generation (no TTS audio yet) must interrupt the
     in-flight agent turn via the same seam session.interrupt uses, and the

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -347,6 +347,7 @@ def _(rid, params: dict) -> dict:
     # Return immediately so Ink can paint; the AIAgent builds right after the flush.
     _schedule_agent_build(sid)
     _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
+    _stop_voice_for_session_switch()  # a new session must not inherit another session's barge-in listener
     cwd = _sessions[sid]["cwd"]
     override = session_model_override or {}
     return _ok(rid, {
@@ -803,6 +804,7 @@ def _(rid, params: dict) -> dict:
         if (resp := _resume_guard(ctx)) is not None:
             return resp
         ctx.profile_resume_cwd = _str_param(ctx.found, "cwd") or _profile_configured_cwd(ctx.profile_home)
+        _stop_voice_for_session_switch()  # switching to this session ends voice mode left on by another
         # Fast path: reuse a session live IN THIS PROFILE (never another profile's runtime).
         with _session_resume_lock:
             live = _find_live_session_by_key(ctx.target, ctx.profile_home)

--- a/tui_gateway/methods_voice.py
+++ b/tui_gateway/methods_voice.py
@@ -60,6 +60,20 @@ def _end_voice_chat(*, stop_loop: bool, stop_tts: bool) -> None:
             _tts_stream_stop(user_barge=False)
 
 
+def _stop_voice_for_session_switch() -> None:
+    """End voice mode on a real session switch (session.create / session.resume).
+
+    HERMES_VOICE is process-global runtime state, so without this the mode Session A enabled
+    survives into Session B: every B turn re-arms the full-duplex listener, and a VAD-only trip
+    (ambient noise, empty transcript) aborts B's unrelated text turn with nothing submitted
+    afterward (#106503). Desktop already resets voice on session switches (#61448); this is the
+    TUI-gateway counterpart. Like /voice off, no push event — clients refresh via voice status."""
+    if not (_voice_mode_enabled() or _voice_tts_enabled()):
+        return
+    logger.debug("voice: session switch ends voice mode left on by another session")
+    _end_voice_chat(stop_loop=True, stop_tts=True)
+
+
 def _tts_lease_async(lease: str, active: bool) -> None:
     """Acquire/release a TTS lease off the RPC thread (acquiring warms a local engine; must not
     block the toggle's reply). Best-effort."""


### PR DESCRIPTION
## What does this PR do?

`HERMES_VOICE` / `HERMES_VOICE_TTS` are process-global runtime flags, so `/voice on` in Session A survives creating, switching to, or resuming Session B inside the same TUI process. Every Session B text turn then re-arms the full-duplex barge-in listener, and a VAD-only trip (ambient noise or a short non-speech capture) interrupts B's running turn through the process-global `agent.interrupt()` seam **before** transcription runs. When STT returns an empty transcript nothing is submitted afterward, so the visible result is exactly the failure in #106503: the user's message is stored, no tools run, no reply comes back, and the logs show only a generic `interrupt_abort`. Restarting the TUI clears it only because the flags default to off in a new process.

This PR ends leftover voice mode at the server-observable session-switch seams — `session.create` and `session.resume` (after request validation, on the success path). This mirrors the Desktop session-switch voice reset already shipped in #61448 and is fix direction 1 from the issue ("explicitly stop voice mode on a real Session switch"). The full-duplex listener then unwinds itself through its existing `should_stop` check (`not _voice_mode_enabled()`); no listener internals change. Generation-phase interruption for the session that actually owns voice mode is untouched, so the intentional behavior locked by `test_full_duplex_generation_phase_interrupts_running_turn` is preserved.

Scope note: like `/voice off` (which returns status but pushes no event), the reset emits no push event — clients keep refreshing voice state via the existing status payload. Hosted-room internal `session.create`/`session.resume` forwards also pass through these seams; that reads as correct too, since another surface starting a session is a session switch in the same sense.

## Related Issue

Fixes #106503

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_voice.py` — added `_stop_voice_for_session_switch()`: no-op when voice/TTS are already off; otherwise `_end_voice_chat(stop_loop=True, stop_tts=True)` (tears down the continuous recorder loop and cuts live streaming TTS, both process-global).
- `tui_gateway/methods_session.py` — call `_stop_voice_for_session_switch()` in `session.create` (after agent-build scheduling, before the response) and in `session.resume` (after the locate/guard chain, before the live-reuse fast path). Bare-name call through the existing `bind_module` seam, same pattern as `session.interrupt` calling `_tts_stream_stop()`.
- `tests/test_tui_gateway_server.py` — two regressions: `test_session_create_ends_voice_mode_left_on_by_another_session` and `test_session_resume_ends_voice_mode_left_on_by_another_session`, both asserting `HERMES_VOICE`/`HERMES_VOICE_TTS` flip to `"0"` across the RPC.

## How to Test

1. `.venv/bin/python -m pytest tests/test_tui_gateway_server.py -k "voice_mode_left_on_by_another_session" -q` — should pass (2 passed).
2. `.venv/bin/python -m pytest tests/test_tui_gateway_server.py -q` — full file: 639 passed (all existing voice/full-duplex/session-create/resume behavior intact).
3. Manual equivalent of the issue's repro, no microphone needed: with `HERMES_VOICE=1` and `HERMES_VOICE_TTS=1` set, call `session.create` (or `session.resume` against a live/fake row) and observe both flags read back `"0"` afterward; with voice already off the helpers are a no-op and the RPC response is unchanged.

Observed result: locally, steps 1–2 pass — `2 passed` and `639 passed`, `ruff check` clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-architecture) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — bug fix, no skill added.

## Screenshots / Logs

Regression test output:

```text
$ .venv/bin/python -m pytest tests/test_tui_gateway_server.py -q
639 passed in 32.79s

$ .venv/bin/ruff check tui_gateway/methods_voice.py tui_gateway/methods_session.py tests/test_tui_gateway_server.py
All checks passed!
```
