### PR TITLE
feat(matrix): render LaTeX math as Element data-mx-maths markup so equations typeset instead of arriving as raw dollars (#106458, salvage #106452 #31594 #106494)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -581,6 +581,59 @@ def _scoped_recovery_key() -> str:
     return _startup_env_secret("MATRIX_RECOVERY_KEY")
 
 
+
+# --- LaTeX math ($...$, $$...$$) -> Element data-mx-maths markup ---
+# Element (feature_latex_maths) typesets <div|span data-mx-maths="TEX"> at display time.
+# Our sanitizer allowlists tags/attrs, so data-mx-maths cannot pass through HTML
+# sanitization directly. Instead, math is swapped for opaque sentinel tokens before
+# Markdown conversion (protecting TeX from escaping) and expanded back to math
+# markup after sanitization. Tokens are plain printable text with no special
+# HTML/Markdown meaning, so both the Markdown converter and the sanitizer
+# pass them through verbatim.
+_TEX_TOKEN_RE = re.compile(r"HERMESTEX(?:DISPLAY|INLINE)(\d+)HERMESTEXEND")
+_TEX_DISPLAY_TOKEN = "HERMESTEXDISPLAY%dHERMESTEXEND"
+_TEX_INLINE_TOKEN = "HERMESTEXINLINE%dHERMESTEXEND"
+
+
+def _latex_to_tokens(text: str) -> tuple[str, list[tuple[str, str]]]:
+    """Replace ``$$...$$``/``$...$`` with sentinel tokens.
+
+    Returns the tokenized text plus an ordered ``(tag, tex)`` store, where tag
+    is ``div`` for display math and ``span`` for inline math. Dollars that do
+    not form a pair (prices, literals) are left untouched.
+    """
+    if not text or "$" not in text:
+        return text, []
+    store: list[tuple[str, str]] = []
+
+    def _sub_display(match: re.Match[str]) -> str:
+        store.append(("div", match.group(1).strip()))
+        return _TEX_DISPLAY_TOKEN % (len(store) - 1)
+
+    def _sub_inline(match: re.Match[str]) -> str:
+        store.append(("span", match.group(1).strip()))
+        return _TEX_INLINE_TOKEN % (len(store) - 1)
+
+    text = re.sub(r"\$\$([^\n$]+?)\$\$", _sub_display, text)
+    text = re.sub(r"(?<![\\$\w])\$([^\n$]+?)\$(?!\w)", _sub_inline, text)
+    return text, store
+
+
+def _tokens_to_mx_maths(html: str, store: list[tuple[str, str]]) -> str:
+    """Expand sentinel tokens into ``data-mx-maths`` markup (TeX HTML-escaped)."""
+
+    def _expand(match: re.Match[str]) -> str:
+        idx = int(match.group(1))
+        if idx >= len(store):
+            # Not one of our tokens (user-typed text that collides with the
+            # sentinel format) — leave it verbatim.
+            return match.group(0)
+        tag, tex = store[idx]
+        escaped = _html_escape(tex, quote=True)
+        return f'<{tag} data-mx-maths="{escaped}">{escaped}</{tag}>'
+
+    return _TEX_TOKEN_RE.sub(_expand, html)
+
 def _sanitize_matrix_html(html: str) -> str:
     sanitizer = _MatrixHtmlSanitizer()
     try:
@@ -2752,6 +2805,8 @@ class MatrixAdapter(BasePlatformAdapter):
     def _markdown_to_html(self, text: str) -> str:
         """Markdown → org.matrix.custom.html via ``markdown`` when installed, else the regex fallback."""
         text = _pre_sanitize_matrix_markdown(text)
+        _tex_store = []
+        text, _tex_store = _latex_to_tokens(text)
         with suppress(ImportError):
             import markdown as _md
             md = _md.Markdown(extensions=["fenced_code", "tables", "nl2br", "sane_lists"])
@@ -2761,8 +2816,10 @@ class MatrixAdapter(BasePlatformAdapter):
             md.reset()
             if html.count("<p>") == 1:
                 html = html.replace("<p>", "").replace("</p>", "")
-            return _sanitize_matrix_html(html)
-        return _sanitize_matrix_html(self._markdown_to_html_fallback(text))
+            html = _tokens_to_mx_maths(_sanitize_matrix_html(html), _tex_store)
+            return html
+        _fb = _sanitize_matrix_html(self._markdown_to_html_fallback(text))
+        return _tokens_to_mx_maths(_fb, _tex_store)
 
     @staticmethod
     def _sanitize_link_url(url: str) -> str:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -581,7 +581,6 @@ def _scoped_recovery_key() -> str:
     return _startup_env_secret("MATRIX_RECOVERY_KEY")
 
 
-
 # --- LaTeX math ($...$, $$...$$) -> Element data-mx-maths markup ---
 # Element (feature_latex_maths) typesets <div|span data-mx-maths="TEX"> at display time.
 # Our sanitizer allowlists tags/attrs, so data-mx-maths cannot pass through HTML
@@ -2805,8 +2804,7 @@ class MatrixAdapter(BasePlatformAdapter):
     def _markdown_to_html(self, text: str) -> str:
         """Markdown → org.matrix.custom.html via ``markdown`` when installed, else the regex fallback."""
         text = _pre_sanitize_matrix_markdown(text)
-        _tex_store = []
-        text, _tex_store = _latex_to_tokens(text)
+        text, tex_store = _latex_to_tokens(text)
         with suppress(ImportError):
             import markdown as _md
             md = _md.Markdown(extensions=["fenced_code", "tables", "nl2br", "sane_lists"])
@@ -2816,10 +2814,8 @@ class MatrixAdapter(BasePlatformAdapter):
             md.reset()
             if html.count("<p>") == 1:
                 html = html.replace("<p>", "").replace("</p>", "")
-            html = _tokens_to_mx_maths(_sanitize_matrix_html(html), _tex_store)
-            return html
-        _fb = _sanitize_matrix_html(self._markdown_to_html_fallback(text))
-        return _tokens_to_mx_maths(_fb, _tex_store)
+            return _tokens_to_mx_maths(_sanitize_matrix_html(html), tex_store)
+        return _tokens_to_mx_maths(_sanitize_matrix_html(self._markdown_to_html_fallback(text)), tex_store)
 
     @staticmethod
     def _sanitize_link_url(url: str) -> str:

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2921,9 +2921,11 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         payload = {"msgtype": "m.text", "body": message}
         with suppress(ImportError):
             import markdown as _md
-            html = _md.markdown(message, extensions=["fenced_code", "tables"])
+            tokenized, tex_store = _latex_to_tokens(message)
+            html = _md.markdown(tokenized, extensions=["fenced_code", "tables"])
             payload["format"] = "org.matrix.custom.html"
-            payload["formatted_body"] = re.sub(r"<h[1-6]>(.*?)</h[1-6]>", r"<strong>\1</strong>", html)
+            payload["formatted_body"] = _tokens_to_mx_maths(
+                re.sub(r"<h[1-6]>(.*?)</h[1-6]>", r"<strong>\1</strong>", html), tex_store)
         # asyncio.wait_for, not aiohttp.ClientTimeout: cron invokes this via
         # run_coroutine_threadsafe ("Timeout context manager should be used inside a task").
         async with aiohttp.ClientSession() as session:

--- a/tests/gateway/test_matrix_latex_maths.py
+++ b/tests/gateway/test_matrix_latex_maths.py
@@ -1,0 +1,145 @@
+"""Tests for LaTeX math ($...$ / $$...$$) -> Element data-mx-maths markup."""
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+        },
+    )
+    return MatrixAdapter(config)
+
+
+# ---------------------------------------------------------------------------
+# _latex_to_tokens / _tokens_to_mx_maths unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLatexToTokens:
+    def setup_method(self):
+        from plugins.platforms.matrix.adapter import _latex_to_tokens
+
+        self.convert = _latex_to_tokens
+
+    def test_inline_math_becomes_span_token(self):
+        text, store = self.convert("Energy: $E = mc^2$ indeed.")
+        assert store == [("span", "E = mc^2")]
+        assert "E = mc^2" not in text
+        assert "$" not in text
+
+    def test_display_math_becomes_div_token(self):
+        text, store = self.convert("$$\\hat{H}\\Psi = E\\Psi$$")
+        assert store == [("div", "\\hat{H}\\Psi = E\\Psi")]
+
+    def test_mixed_math_all_captured(self):
+        # Display ($$...$$) is tokenized before inline ($...$), so store order
+        # follows regex pass order, not text order. Index-token correspondence
+        # is what matters.
+        text, store = self.convert("$a$ then $$b$$ then $c$")
+        assert sorted((tex, tag) for tag, tex in store) == [
+            ("a", "span"),
+            ("b", "div"),
+            ("c", "span"),
+        ]
+
+    def test_unpaired_dollars_untouched(self):
+        text, store = self.convert("Costs $5 or $10 today.")
+        assert store == []
+        assert text == "Costs $5 or $10 today."
+
+    def test_no_math_no_change(self):
+        text, store = self.convert("No math here.")
+        assert store == []
+        assert text == "No math here."
+
+    def test_backslash_dollar_not_math(self):
+        _, store = self.convert(r"Escaped \\$5 not math.")
+        assert store == []
+
+
+class TestTokensToMxMaths:
+    def setup_method(self):
+        from plugins.platforms.matrix.adapter import (
+            _latex_to_tokens,
+            _tokens_to_mx_maths,
+        )
+
+        self.tokenize = _latex_to_tokens
+        self.expand = _tokens_to_mx_maths
+
+    def test_inline_expansion(self):
+        tex = r"\psi(x)"
+        text, store = self.tokenize(f"Wave: ${tex}$")
+        html = self.expand(text, store)
+        assert html == f'Wave: <span data-mx-maths="{tex}">{tex}</span>'
+
+    def test_display_expansion(self):
+        text, store = self.tokenize("$$x^2$$")
+        html = self.expand(text, store)
+        assert 'data-mx-maths="x^2"' in html
+
+    def test_tex_is_html_escaped(self):
+        text, store = self.tokenize('$a<b & c>"d$')
+        html = self.expand(text, store)
+        assert "<b &" not in html
+        assert "data-mx-maths=" in html
+
+    def test_no_token_left_behind(self):
+        text, store = self.tokenize("$a$ $$b$$")
+        html = self.expand(text, store)
+        assert "HERMESTEX" not in html
+
+    def test_user_text_colliding_with_sentinel_is_safe(self):
+        # Adversarial literal that matches the sentinel format but has no
+        # matching store entry must pass through unchanged, not raise.
+        html = self.expand("HERMESTEXDISPLAY99HERMESTEXEND", [])
+        assert html == "HERMESTEXDISPLAY99HERMESTEXEND"
+
+    def test_mismatched_store_is_safe(self):
+        # Expansion with an empty store leaves unknown tokens alone
+        html = self.expand("HERMESTEXDISPLAY99HERMESTEXEND", [])
+        assert "data-mx-maths" not in html
+
+
+# ---------------------------------------------------------------------------
+# Integration through _markdown_to_html (the outbound pipeline)
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownToHtmlLatex:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_inline_math_reaches_formatted_html(self):
+        html = self.adapter._markdown_to_html("Wave: $\\psi(x) = e^{ikx}$ ok")
+        assert 'data-mx-maths="\\psi(x) = e^{ikx}"' in html
+        assert "HERMESTEX" not in html
+
+    def test_display_math_reaches_formatted_html(self):
+        html = self.adapter._markdown_to_html("$$\\hat{H}\\Psi = E\\Psi$$")
+        assert 'data-mx-maths="\\hat{H}\\Psi = E\\Psi"' in html
+
+    def test_markdown_formatting_still_applied(self):
+        html = self.adapter._markdown_to_html("**bold** with $x^2$")
+        assert "<strong>" in html
+        assert 'data-mx-maths="x^2"' in html
+
+    def test_dollar_amounts_not_converted(self):
+        html = self.adapter._markdown_to_html("Costs $5 or $10 today.")
+        assert "data-mx-maths" not in html
+
+    def test_math_inside_code_block_still_converted(self):
+        # Note: sentinel conversion happens before Markdown sees the text,
+        # so even code-span math becomes markup. Documented trade-off: the
+        # composer-style consumers (chat) rarely put $...$ in code spans.
+        html = self.adapter._markdown_to_html("Use `$x$` here.")
+        assert 'data-mx-maths="x"' in html

--- a/tests/gateway/test_matrix_latex_maths.py
+++ b/tests/gateway/test_matrix_latex_maths.py
@@ -1,145 +1,25 @@
-"""Tests for LaTeX math ($...$ / $$...$$) -> Element data-mx-maths markup."""
-
-import pytest
+"""Outbound ``$...$`` / ``$$...$$`` become Element ``data-mx-maths`` markup (#106458)."""
 
 from gateway.config import PlatformConfig
+from plugins.platforms.matrix.adapter import MatrixAdapter
 
 
-def _make_adapter():
-    from plugins.platforms.matrix.adapter import MatrixAdapter
-
-    config = PlatformConfig(
-        enabled=True,
-        token="syt_test_token",
-        extra={
-            "homeserver": "https://matrix.example.org",
-            "user_id": "@bot:example.org",
-        },
-    )
-    return MatrixAdapter(config)
+def _adapter() -> MatrixAdapter:
+    return MatrixAdapter(PlatformConfig(
+        enabled=True, token="syt_test_token",
+        extra={"homeserver": "https://matrix.example.org", "user_id": "@bot:example.org"}))
 
 
-# ---------------------------------------------------------------------------
-# _latex_to_tokens / _tokens_to_mx_maths unit tests
-# ---------------------------------------------------------------------------
+def test_inline_and_display_math_survive_sanitizer_with_escaped_tex():
+    content = _adapter()._build_text_message_content("Wave: $a<b$ and $$\\hat{H}\\Psi = E\\Psi$$")
+    html = content["formatted_body"]
+    assert '<span data-mx-maths="a&lt;b">a&lt;b</span>' in html
+    assert '<div data-mx-maths="\\hat{H}\\Psi = E\\Psi">\\hat{H}\\Psi = E\\Psi</div>' in html
+    assert "$" not in html
+    # Plain-text fallback keeps the raw TeX for clients without the Labs feature.
+    assert content["body"] == "Wave: $a<b$ and $$\\hat{H}\\Psi = E\\Psi$$"
 
 
-class TestLatexToTokens:
-    def setup_method(self):
-        from plugins.platforms.matrix.adapter import _latex_to_tokens
-
-        self.convert = _latex_to_tokens
-
-    def test_inline_math_becomes_span_token(self):
-        text, store = self.convert("Energy: $E = mc^2$ indeed.")
-        assert store == [("span", "E = mc^2")]
-        assert "E = mc^2" not in text
-        assert "$" not in text
-
-    def test_display_math_becomes_div_token(self):
-        text, store = self.convert("$$\\hat{H}\\Psi = E\\Psi$$")
-        assert store == [("div", "\\hat{H}\\Psi = E\\Psi")]
-
-    def test_mixed_math_all_captured(self):
-        # Display ($$...$$) is tokenized before inline ($...$), so store order
-        # follows regex pass order, not text order. Index-token correspondence
-        # is what matters.
-        text, store = self.convert("$a$ then $$b$$ then $c$")
-        assert sorted((tex, tag) for tag, tex in store) == [
-            ("a", "span"),
-            ("b", "div"),
-            ("c", "span"),
-        ]
-
-    def test_unpaired_dollars_untouched(self):
-        text, store = self.convert("Costs $5 or $10 today.")
-        assert store == []
-        assert text == "Costs $5 or $10 today."
-
-    def test_no_math_no_change(self):
-        text, store = self.convert("No math here.")
-        assert store == []
-        assert text == "No math here."
-
-    def test_backslash_dollar_not_math(self):
-        _, store = self.convert(r"Escaped \\$5 not math.")
-        assert store == []
-
-
-class TestTokensToMxMaths:
-    def setup_method(self):
-        from plugins.platforms.matrix.adapter import (
-            _latex_to_tokens,
-            _tokens_to_mx_maths,
-        )
-
-        self.tokenize = _latex_to_tokens
-        self.expand = _tokens_to_mx_maths
-
-    def test_inline_expansion(self):
-        tex = r"\psi(x)"
-        text, store = self.tokenize(f"Wave: ${tex}$")
-        html = self.expand(text, store)
-        assert html == f'Wave: <span data-mx-maths="{tex}">{tex}</span>'
-
-    def test_display_expansion(self):
-        text, store = self.tokenize("$$x^2$$")
-        html = self.expand(text, store)
-        assert 'data-mx-maths="x^2"' in html
-
-    def test_tex_is_html_escaped(self):
-        text, store = self.tokenize('$a<b & c>"d$')
-        html = self.expand(text, store)
-        assert "<b &" not in html
-        assert "data-mx-maths=" in html
-
-    def test_no_token_left_behind(self):
-        text, store = self.tokenize("$a$ $$b$$")
-        html = self.expand(text, store)
-        assert "HERMESTEX" not in html
-
-    def test_user_text_colliding_with_sentinel_is_safe(self):
-        # Adversarial literal that matches the sentinel format but has no
-        # matching store entry must pass through unchanged, not raise.
-        html = self.expand("HERMESTEXDISPLAY99HERMESTEXEND", [])
-        assert html == "HERMESTEXDISPLAY99HERMESTEXEND"
-
-    def test_mismatched_store_is_safe(self):
-        # Expansion with an empty store leaves unknown tokens alone
-        html = self.expand("HERMESTEXDISPLAY99HERMESTEXEND", [])
-        assert "data-mx-maths" not in html
-
-
-# ---------------------------------------------------------------------------
-# Integration through _markdown_to_html (the outbound pipeline)
-# ---------------------------------------------------------------------------
-
-
-class TestMarkdownToHtmlLatex:
-    def setup_method(self):
-        self.adapter = _make_adapter()
-
-    def test_inline_math_reaches_formatted_html(self):
-        html = self.adapter._markdown_to_html("Wave: $\\psi(x) = e^{ikx}$ ok")
-        assert 'data-mx-maths="\\psi(x) = e^{ikx}"' in html
-        assert "HERMESTEX" not in html
-
-    def test_display_math_reaches_formatted_html(self):
-        html = self.adapter._markdown_to_html("$$\\hat{H}\\Psi = E\\Psi$$")
-        assert 'data-mx-maths="\\hat{H}\\Psi = E\\Psi"' in html
-
-    def test_markdown_formatting_still_applied(self):
-        html = self.adapter._markdown_to_html("**bold** with $x^2$")
-        assert "<strong>" in html
-        assert 'data-mx-maths="x^2"' in html
-
-    def test_dollar_amounts_not_converted(self):
-        html = self.adapter._markdown_to_html("Costs $5 or $10 today.")
-        assert "data-mx-maths" not in html
-
-    def test_math_inside_code_block_still_converted(self):
-        # Note: sentinel conversion happens before Markdown sees the text,
-        # so even code-span math becomes markup. Documented trade-off: the
-        # composer-style consumers (chat) rarely put $...$ in code spans.
-        html = self.adapter._markdown_to_html("Use `$x$` here.")
-        assert 'data-mx-maths="x"' in html
+def test_unpaired_dollars_and_sentinel_collisions_pass_through_unchanged():
+    text = "Costs $5 or $10 today; HERMESTEXINLINE7HERMESTEXEND is not ours"
+    assert _adapter()._markdown_to_html(text) == text

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -24,6 +24,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 | **Interactive controls** | Dangerous-command approval and `/model` selection can use Matrix reactions. Approval reactions can be limited to the user who requested the action. |
 | **Thinking and tool activity** | Matrix uses threaded, editable thinking/tool-activity panes when gateway progress is enabled, so updates do not flood the main room timeline. |
 | **Shared rooms with multiple users** | By default, Hermes isolates session history per user inside the room. Two people talking in the same room do not share one transcript unless you explicitly disable that. |
+| **LaTeX math** | `$...$` (inline) and `$$...$$` (display) in replies are sent as Element `data-mx-maths` markup, so clients with **Settings → Labs → Render LaTeX maths in messages** typeset them with KaTeX. Unpaired dollars (`$5 or $10`) stay literal, and the plain-text `body` keeps the raw TeX for other clients. |
 
 :::tip
 The bot automatically joins rooms when invited. Just invite the bot's Matrix user to any room and it will join and start responding.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/matrix.md
@@ -21,6 +21,7 @@ Hermes 兼容任何 Matrix homeserver——Synapse、Conduit、Dendrite 或 matr
 | **线程** | Hermes 支持 Matrix 线程（MSC3440）。在线程中回复时，Hermes 会将线程上下文与主房间时间线隔离。机器人已参与的线程无需提及即可响应。 |
 | **自动线程** | 默认情况下，Hermes 会为其在房间中响应的每条消息自动创建线程，以保持对话隔离。设置 `MATRIX_AUTO_THREAD=false` 可禁用此功能。设置 `MATRIX_DM_AUTO_THREAD=true`（默认 false）可同时为私聊消息自动创建线程——这与 `MATRIX_DM_MENTION_THREADS` 不同，后者仅在私聊中 @提及 Bot 时才创建线程。 |
 | **多用户共享房间** | 默认情况下，Hermes 在房间内按用户隔离会话历史。同一房间中的两个人不会共享同一对话记录，除非你明确禁用该功能。 |
+| **LaTeX 数学公式** | 回复中的 `$...$`（行内）和 `$$...$$`（独立行）会以 Element 的 `data-mx-maths` 标记发送，启用了 **设置 → 实验室 → 渲染消息中的 LaTeX 数学公式** 的客户端会用 KaTeX 排版。未配对的美元符号（`$5 or $10`）保持原样，纯文本 `body` 仍保留原始 TeX 供其他客户端显示。 |
 
 :::tip
 机器人在被邀请时会自动加入房间。只需将机器人的 Matrix 用户邀请到任意房间，它就会加入并开始响应。


### PR DESCRIPTION
Outbound Matrix messages containing `$...$` / `$$...$$` now reach Element as `<span|div data-mx-maths="TEX">` markup, so clients with **Labs → Render LaTeX maths in messages** typeset them with KaTeX instead of showing raw dollars.

Fixes #106458

## Changes

- `plugins/platforms/matrix/adapter.py` (salvaged from #106452 by @romanovzky, the issue reporter): `_latex_to_tokens()` swaps `$$…$$` / `$…$` for opaque printable sentinels **before** Markdown conversion; `_tokens_to_mx_maths()` expands them to `data-mx-maths` markup **after** `_sanitize_matrix_html()`, HTML-escaping the TeX in both the attribute and the element body. The sanitizer allowlist is **not** widened — no `div`/`span`/`data-*` become generally admissible; the only markup that can appear post-sanitization is what the expander itself emits from its own store. Expansion is index-checked, so user text colliding with the sentinel format passes through verbatim (no `IndexError`).
- Widened to the sibling outbound path: `_standalone_send` (cron delivery without a gateway) builds `formatted_body` through its own `markdown` call and never went through `_markdown_to_html`; it now tokenizes/expands around that conversion too (own commit).
- Plain-text `body` is untouched and keeps the raw TeX for clients without the Labs feature.
- Docs: one row in the "How Hermes Behaves" table of `website/docs/user-guide/messaging/matrix.md` and the same row in the zh-Hans mirror.

### Trimmed from #106452 (salvage bar)

- 17 unit tests → 2 invariant tests in `tests/gateway/test_matrix_latex_maths.py` (inline + display reach `formatted_body` as escaped `data-mx-maths` while `body` keeps the TeX; unpaired dollars + sentinel-collision text pass through unchanged).
- Dead `_tex_store = []` pre-assignment and `_fb`/`html` temporaries in `_markdown_to_html` removed (tidy only).
- Known trade-off inherited from #106452 and kept: tokenization runs before Markdown, so `$…$` inside an inline code span is also converted (fenced code is fine — `$A $B` with no closing pair is never matched; `` `echo $HOME and $PATH` `` renders unchanged in the live probe below because `$HOME and $` is followed by `P`, a word char). #31594's larger protected-region machinery (fences, indented code, link destinations, `\$` escape, 4096 cap, per-call random token) was reviewed and not carried: it is the pre-sanitize-restore design plus a conditional allowlist widening, which the issue explicitly argues against, and at +152 LOC it is ~3× this fix.

## Validation

| Case | Before (origin/main) | After |
|---|---|---|
| Gateway send, Klein-Gordon `$$\mathcal{L} = …$$` | `formatted_body=None` (raw `$$…$$` in body only) | `formatted_body='<div data-mx-maths="\mathcal{L} = \frac12(\partial_\mu\phi)^2 - \frac12 m^2\phi^2">…</div>'`, `body` unchanged |
| Gateway send, `Costs $5 or $10` | `formatted_body=None` | `formatted_body=None` (unchanged, no markup) |
| Cron `_standalone_send` (real aiohttp PUT to a loopback server), Klein-Gordon | `<p>$$\mathcal{L} = …$$</p>` | `<p><div data-mx-maths="…">…</div></p>` |
| Cron `_standalone_send`, `Costs $5 or $10` | `<p>Costs $5 or $10</p>` | `<p>Costs $5 or $10</p>` |
| `$a<b$` | raw | `<span data-mx-maths="a&lt;b">a&lt;b</span>` (escaped) |
| `HERMESTEXINLINE99HERMESTEXEND` typed by a user | raw | raw (index-checked; no exception) |

- Tests: `scripts/run_tests.sh tests/gateway/test_matrix_latex_maths.py` → **2 passed**. Red on base: with `plugins/platforms/matrix/adapter.py` checked out from `origin/main`, `test_inline_and_display_math_survive_sanitizer_with_escaped_tex` **FAILS** (1 failed, 1 passed); restored → 2 passed.
- Regression: `test_matrix.py`, `test_matrix_message_length.py`, `test_matrix_mention.py` + new file → **134 passed, 0 failed**.
- E2E (fresh interpreter, worktree at `sys.path[0]`, temp `HERMES_HOME`, real `MatrixAdapter._build_text_message_content` and real `_standalone_send` over HTTP): table above, run against `origin/main` and this branch.
- `ruff check` clean, `check-windows-footguns.py --all` clean, `check_compat_pointers.py` clean, `audit_pr_attribution.py` ✅.

**Root cause:** Element inserts `data-mx-maths` at send time and only typesets that attribute at display time, while `_MatrixHtmlSanitizer` (correctly) drops `span`/`div` and every `data-*` attribute — so no outbound path could ever carry the markup.

## Credits

- @YuuuXie — earliest implementation (#31594, May 24), reworked on review to the plugin adapter; independently identified the `\x02`-sentinel mangling problem and the single-pass display/inline concern.
- @romanovzky — issue reporter (#106458) and author of the salvaged commit (#106452): post-sanitization expansion, index-checked, allowlist untouched. Commit re-authored from `miguel@users.noreply.github.com` to the `<id>+login` noreply form (misconfigured local git identity, not malice).
- @kyssta-exe — independent fix (#106494); its allowlist widening + pre-sanitize injection was not carried for the same reason as #31594.

## Infographic

![matrix-maths](https://v3b.fal.media/files/b/0aa9ba36/PXCqnuLCrizTYI5h2MSMp_Bt5wCF3N.png)
