### PR TITLE
fix(gateway): scoped profile status polls no longer delete a live foreign gateway's pid/lock (#106406, salvage #106454 #104113)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1457,7 +1457,8 @@ def get_running_pid(
     An explicit ``pid_path`` is a scoped query into that home's identity files: records are
     validated against the probed home (not the serve process's), and a live record is never
     cleanup-unlinked, so polling another profile must not delete its gateway.pid/gateway.lock
-    (#106406)."""
+    (#106406). The unscoped path keeps main's poison-file housekeeping: a live record owned by
+    another home inside this home's gateway.pid is unlinked on refusal (#89315)."""
     resolved_pid_path = pid_path or _get_pid_path()
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     if is_gateway_runtime_lock_active(resolved_lock_path):
@@ -1478,11 +1479,11 @@ def get_running_pid(
                 record, pid, expected_home=expected_home
             ):
                 return pid
-            # A live record we could not adopt may still be a real gateway: unlinking its
-            # identity files would break that home's double-run protection while the PID
-            # is alive, so leave cleanup to a poll after it dies.
+            # Scoped only: a live record we could not adopt may still be a real gateway;
+            # unlinking its identity files would break that home's double-run protection
+            # while the PID is alive. Unscoped keeps the #89315 poison-file cleanup.
             saw_live_pid = True
-        if not saw_live_pid:
+        if expected_home is None or not saw_live_pid:
             _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return get_runtime_status_running_pid() if pid_path is None else None
     # Lock inactive: the runtime-status fallback runs BEFORE cleanup here.

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -450,15 +450,6 @@ def _pid_record_belongs_to_current_profile(record: Optional[dict[str, Any]]) -> 
     return not record_home or _same_hermes_home(record_home, _get_process_hermes_home())
 
 
-def _pid_record_matches_home(record: Optional[dict[str, Any]], expected_home: Path) -> bool:
-    """True when the record's ``hermes_home`` matches ``expected_home`` (legacy records: True).
-    Scoped queries validate against the probed home, not the serve process's."""
-    if not isinstance(record, dict):
-        return False
-    record_home = record.get("hermes_home")
-    return not record_home or _same_hermes_home(record_home, expected_home)
-
-
 def _build_runtime_status_record() -> dict[str, Any]:
     return {
         **_build_pid_record(), "gateway_state": "starting", "exit_reason": None,
@@ -1473,7 +1464,7 @@ def get_running_pid(
                 continue
             home_ok = (
                 _pid_record_belongs_to_current_profile(record) if expected_home is None
-                else _pid_record_matches_home(record, expected_home)
+                else not recorded_gateway_home_conflicts(record, expected_home=expected_home)
             )
             if home_ok and _record_matches_live_gateway_pid(
                 record, pid, expected_home=expected_home

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -450,6 +450,15 @@ def _pid_record_belongs_to_current_profile(record: Optional[dict[str, Any]]) -> 
     return not record_home or _same_hermes_home(record_home, _get_process_hermes_home())
 
 
+def _pid_record_matches_home(record: Optional[dict[str, Any]], expected_home: Path) -> bool:
+    """True when the record's ``hermes_home`` matches ``expected_home`` (legacy records: True).
+    Scoped queries validate against the probed home, not the serve process's."""
+    if not isinstance(record, dict):
+        return False
+    record_home = record.get("hermes_home")
+    return not record_home or _same_hermes_home(record_home, expected_home)
+
+
 def _build_runtime_status_record() -> dict[str, Any]:
     return {
         **_build_pid_record(), "gateway_state": "starting", "exit_reason": None,
@@ -1444,20 +1453,37 @@ def planned_stop_marker_targets_self() -> bool:
 def get_running_pid(
     pid_path: Optional[Path] = None, *, cleanup_stale: bool = True
 ) -> Optional[int]:
-    """PID of a running gateway (lock + PID file verified against the live process), or None."""
+    """PID of a running gateway (lock + PID file verified against the live process), or None.
+    An explicit ``pid_path`` is a scoped query into that home's identity files: records are
+    validated against the probed home (not the serve process's), and a live record is never
+    cleanup-unlinked, so polling another profile must not delete its gateway.pid/gateway.lock
+    (#106406)."""
     resolved_pid_path = pid_path or _get_pid_path()
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     if is_gateway_runtime_lock_active(resolved_lock_path):
         records = (
             _read_pid_record(resolved_pid_path), _read_gateway_lock_record(resolved_lock_path),
         )
+        expected_home = pid_path.parent if pid_path is not None else None
+        saw_live_pid = False
         for record in records:
             pid = _live_pid_from_record(record)
-            if pid is None or not _pid_record_belongs_to_current_profile(record):
+            if pid is None:
                 continue
-            if _record_matches_live_gateway_pid(record, pid):
+            home_ok = (
+                _pid_record_belongs_to_current_profile(record) if expected_home is None
+                else _pid_record_matches_home(record, expected_home)
+            )
+            if home_ok and _record_matches_live_gateway_pid(
+                record, pid, expected_home=expected_home
+            ):
                 return pid
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+            # A live record we could not adopt may still be a real gateway: unlinking its
+            # identity files would break that home's double-run protection while the PID
+            # is alive, so leave cleanup to a poll after it dies.
+            saw_live_pid = True
+        if not saw_live_pid:
+            _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return get_runtime_status_running_pid() if pid_path is None else None
     # Lock inactive: the runtime-status fallback runs BEFORE cleanup here.
     runtime_pid = get_runtime_status_running_pid() if pid_path is None else None

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -170,6 +170,70 @@ class TestGatewayPidState:
         (process_home / "gateway.pid").unlink(missing_ok=True)
 
 
+class TestScopedGatewayPidQuery:
+    """get_running_pid(pid_path) is a scoped query into another home's identity files (#106406):
+    records are validated against the probed home (not the serve process's) and a live record is
+    never cleanup-unlinked, so a scoped status poll must not delete a live foreign gateway's
+    gateway.pid/gateway.lock."""
+
+    def _write_scoped_profile(self, tmp_path):
+        profile_dir = tmp_path / "profiles" / "wiki"
+        profile_dir.mkdir(parents=True)
+        record = {
+            "pid": 4242,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "--profile", "wiki"],
+            "start_time": 123,
+            "hermes_home": str(profile_dir.resolve()),
+        }
+        pid_path = profile_dir / "gateway.pid"
+        pid_path.write_text(json.dumps(record))
+        (profile_dir / "gateway.lock").write_text(json.dumps(record))
+        return profile_dir, pid_path, record
+
+    def test_scoped_query_reports_live_foreign_profile_pid(self, tmp_path, monkeypatch):
+        # The serve process polls from the DEFAULT home; the live wiki record must still count.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default-home"))
+        profile_dir, pid_path, _ = self._write_scoped_profile(tmp_path)
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline",
+            lambda pid: "python -m hermes_cli.main gateway --profile wiki",
+        )
+        assert status.get_running_pid(pid_path) == 4242
+        assert pid_path.exists()
+        assert (profile_dir / "gateway.lock").exists()
+
+    def test_scoped_query_never_unlinks_live_foreign_identity(self, tmp_path, monkeypatch):
+        # Live PID whose record claims a THIRD home: not adoptable, but its identity files must
+        # survive the poll (double-run/takeover protection).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default-home"))
+        profile_dir, pid_path, record = self._write_scoped_profile(tmp_path)
+        # Both identity files migrate together in the real world; repoint both homes.
+        record["hermes_home"] = str((tmp_path / "elsewhere").resolve())
+        pid_path.write_text(json.dumps(record))
+        (profile_dir / "gateway.lock").write_text(json.dumps(record))
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+        assert status.get_running_pid(pid_path) is None
+        assert pid_path.exists()
+        assert (profile_dir / "gateway.lock").exists()
+
+    def test_scoped_query_still_cleans_dead_pid_record(self, tmp_path, monkeypatch):
+        # A dead PID's stale record is still cleanup-unlinked, scoped or not.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default-home"))
+        profile_dir, pid_path, _ = self._write_scoped_profile(tmp_path)
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: False)
+        assert status.get_running_pid(pid_path) is None
+        assert not pid_path.exists()
+        assert not (profile_dir / "gateway.lock").exists()
+
+
 class TestGatewayRuntimeStatus:
     def test_clear_profile_platforms_preserves_primary_entries(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -206,23 +206,6 @@ class TestScopedGatewayPidQuery:
         assert pid_path.exists()
         assert (profile_dir / "gateway.lock").exists()
 
-    def test_scoped_query_never_unlinks_live_foreign_identity(self, tmp_path, monkeypatch):
-        # Live PID whose record claims a THIRD home: not adoptable, but its identity files must
-        # survive the poll (double-run/takeover protection).
-        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default-home"))
-        profile_dir, pid_path, record = self._write_scoped_profile(tmp_path)
-        # Both identity files migrate together in the real world; repoint both homes.
-        record["hermes_home"] = str((tmp_path / "elsewhere").resolve())
-        pid_path.write_text(json.dumps(record))
-        (profile_dir / "gateway.lock").write_text(json.dumps(record))
-        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock: True)
-        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
-        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
-        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
-        assert status.get_running_pid(pid_path) is None
-        assert pid_path.exists()
-        assert (profile_dir / "gateway.lock").exists()
-
     def test_scoped_query_still_cleans_dead_pid_record(self, tmp_path, monkeypatch):
         # A dead PID's stale record is still cleanup-unlinked, scoped or not.
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default-home"))


### PR DESCRIPTION
A dashboard `?profile=<name>` status poll (or any scoped `get_running_pid(pid_path)` call) now reports a live foreign profile's gateway PID and leaves its `gateway.pid` / `gateway.lock` untouched instead of force-deleting them and reporting `running=false`.

Fixes #106406

## Changes

- `gateway/status.py::get_running_pid` — an explicit `pid_path` is a scoped query: records are validated against the probed home (`pid_path.parent`) via the existing `recorded_gateway_home_conflicts(record, expected_home=...)`, and the live-cmdline ownership check receives that `expected_home` — mirroring the sibling `get_runtime_status_running_pid(..., expected_home=...)` rung of the same ladder.
- Scoped only: when a live PID was seen but could not be adopted, `_cleanup_invalid_pid_path` is skipped — unlinking a possibly-real gateway's identity files while its PID is alive would break that home's double-run/takeover protection. Dead-PID scoped records still clean up as before.
- Unscoped (zero-arg) calls are unchanged: `_pid_record_belongs_to_current_profile` plus the #89315 poison-file cleanup on refusal (`tests/gateway/test_cross_profile_kill_refusal.py` still green).
- Trimmed during salvage: the contributor's `_pid_record_matches_home` helper (a near-copy of `recorded_gateway_home_conflicts`) is replaced by the existing predicate; the third-home-claim test (same `saw_live_pid` branch) is dropped to keep the fix at two invariant tests.

## Validation

| Check | Before (origin/main) | After |
|---|---|---|
| Live repro — real temp `HERMES_HOME`, real held flock, real dummy process with `--profile wiki` argv, `get_running_pid(profile_dir/"gateway.pid")` | `pid=None`, `gateway.pid`/`gateway.lock` **unlinked** | `pid=<dummy pid>`, both files intact |
| Dead-PID scoped record | cleaned | still cleaned |
| `tests/gateway/test_status.py::TestScopedGatewayPidQuery` | `test_scoped_query_reports_live_foreign_profile_pid` FAILS (`assert None == 4242`) | 76 passed, 2 skipped |
| Neighbouring suites (`tests/hermes_cli/test_gateway*.py`, `test_status.py`, `test_profiles.py`, dashboard status endpoints, `test_cross_profile_kill_refusal.py`) | — | 153 passed, 5 skipped |

**Root cause:** `get_running_pid` validated every record with `_pid_record_belongs_to_current_profile`, which compares against the serve process's `HERMES_HOME` rather than the probed profile's, so a live foreign record was rejected and the function fell through to `_cleanup_invalid_pid_path(cleanup_stale=True)`.

## Related, not covered here

#102942 / #96582 (reader-side unlink race: a reader observes the lock as inactive, a new gateway acquires it, then the reader's cleanup unlinks the new owner's files; and the launchd `--external-supervisor` satellite-probe variant). The satellite-profile trigger described in #102942 step 2 is the `_pid_record_belongs_to_current_profile` mismatch on an **unscoped** probe of the root home, which is a different predicate path from this scoped fix and is deliberately kept (#89315 poison-file contract). The inactive-lock TOCTOU in #96582 is a different mechanism (lock check vs. unlink not atomic) and is not addressed by this PR.

## Credits

- @liuhao1024 — PR #106454, the salvaged fix (scope-aware validation against the probed home + live-record unlink protection; commits cherry-picked with authorship preserved).
- @aniruddhaadak80 — PR #104113, earliest fix for the unlink half (code-scan find, Sep 6). It suppresses the unlink but still returns `None` for a live foreign profile, so the scoped dashboard would keep reporting `running=false`; superseded by the scoped-validation mechanism here.
- @gaoanze888 — PR #106449, independent same-mechanism fix (self-closed as superseded by #106454).
- @3oltan-seo — issue #106406, precise diagnosis of the fallthrough.
- @King071016 — the Windows dashboard-polling manifestation reported on #96582.

## Infographic
![gateway-pid-scope](https://v3b.fal.media/files/b/0aa9ba39/vKa4Y3qQqPVCSxktoMg_1_8gJZ7y0x.png)
