### PR TITLE
fix(cli): Codex device login keeps the SSL error and hints at the OpenSSL 3.5 PQ-group workaround (#106384, salvage #106394 #106389 #106409)

### DIFF
--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -212,7 +212,7 @@ def _refresh_payload_access_token(
     return payload, access
 
 
-_SSL_TROUBLE_MARKERS = ("[SSL:", "_ssl.c")
+_SSL_TROUBLE_MARKERS = ("[SSL:", "_ssl.c", "UNEXPECTED_EOF")
 
 
 def _ssl_interop_hint(exc: BaseException) -> str:
@@ -221,14 +221,23 @@ def _ssl_interop_hint(exc: BaseException) -> str:
     OpenSSL 3.5+ advertises post-quantum hybrid groups (e.g. X25519MLKEM768) by default, and some
     intercepting middleboxes reject the resulting larger TLS 1.3 ClientHello — while curl, using a
     different TLS stack, still works, so the failure masquerades as a Codex outage (#106384).
+    httpx wraps the ``ssl.SSLError`` in a ``ConnectError``/``ConnectTimeout`` whose text usually
+    repeats the OpenSSL message; the cause chain is checked too in case it doesn't.
     """
-    if not any(marker in str(exc) for marker in _SSL_TROUBLE_MARKERS):
+    import ssl
+
+    chain = (exc, exc.__cause__, exc.__context__)
+    if not any(
+        isinstance(err, ssl.SSLError) or any(marker in str(err) for marker in _SSL_TROUBLE_MARKERS)
+        for err in chain if err is not None
+    ):
         return ""
     return (
         " This looks like a TLS handshake failure rather than a Codex outage: some networks reject"
         " the larger TLS 1.3 ClientHello that OpenSSL 3.5+ sends by default (post-quantum hybrid"
-        " groups). As a workaround, point OPENSSL_CONF at a config restricting Groups to classic"
-        " curves (x25519:secp256r1:secp384r1:x448) — see #106384 for details."
+        " groups). Workaround: point OPENSSL_CONF at a config restricting Groups to classic curves"
+        " (x25519:secp256r1:secp384r1:x448), or test with TLS 1.2 — see the Codex note in"
+        " https://hermes-agent.nousresearch.com/docs/integrations/providers"
     )
 
 

--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -212,13 +212,33 @@ def _refresh_payload_access_token(
     return payload, access
 
 
+_SSL_TROUBLE_MARKERS = ("[SSL:", "_ssl.c")
+
+
+def _ssl_interop_hint(exc: BaseException) -> str:
+    """Actionable hint for device-login transport errors that look like TLS middlebox interference.
+
+    OpenSSL 3.5+ advertises post-quantum hybrid groups (e.g. X25519MLKEM768) by default, and some
+    intercepting middleboxes reject the resulting larger TLS 1.3 ClientHello — while curl, using a
+    different TLS stack, still works, so the failure masquerades as a Codex outage (#106384).
+    """
+    if not any(marker in str(exc) for marker in _SSL_TROUBLE_MARKERS):
+        return ""
+    return (
+        " This looks like a TLS handshake failure rather than a Codex outage: some networks reject"
+        " the larger TLS 1.3 ClientHello that OpenSSL 3.5+ sends by default (post-quantum hybrid"
+        " groups). As a workaround, point OPENSSL_CONF at a config restricting Groups to classic"
+        " curves (x25519:secp256r1:secp384r1:x448) — see #106384 for details."
+    )
+
+
 def _codex_login_post(url: str, *, failure: Tuple[str, str], **kwargs: Any) -> "httpx.Response":
     """One 15s POST for the device-login flow; transport errors become ``_codex_err(*failure)``."""
     try:
         with _codex_http_client(timeout=httpx.Timeout(15.0)) as client:
             return client.post(url, **kwargs)
     except Exception as exc:
-        raise _codex_err(f"{failure[0]}: {exc}", failure[1])
+        raise _codex_err(f"{failure[0]}: {exc}{_ssl_interop_hint(exc)}", failure[1]) from exc
 
 
 def _codex_http_client(**kwargs: Any) -> "httpx.Client":
@@ -729,10 +749,15 @@ def _codex_poll_authorization_code(
         with _codex_http_client(timeout=httpx.Timeout(15.0)) as client:
             while time.monotonic() - start < max_wait:
                 time.sleep(poll_interval)
-                poll_resp = client.post(
-                    f"{issuer}/api/accounts/deviceauth/token",
-                    json={"device_auth_id": device_auth_id, "user_code": user_code},
-                    headers={"Content-Type": "application/json"})
+                try:
+                    poll_resp = client.post(
+                        f"{issuer}/api/accounts/deviceauth/token",
+                        json={"device_auth_id": device_auth_id, "user_code": user_code},
+                        headers={"Content-Type": "application/json"})
+                except Exception as exc:
+                    raise _codex_err(
+                        f"Device auth polling request failed: {exc}{_ssl_interop_hint(exc)}",
+                        "device_code_poll_error") from exc
                 if poll_resp.status_code == 200:
                     code_resp = poll_resp.json()
                     break

--- a/tests/hermes_cli/test_codex_device_login_ssl_hint.py
+++ b/tests/hermes_cli/test_codex_device_login_ssl_hint.py
@@ -1,0 +1,85 @@
+"""Regression tests: Codex device-login transport errors keep the underlying SSL detail.
+
+On networks whose middlebox rejects the larger TLS 1.3 ClientHello that OpenSSL 3.5+ sends
+(post-quantum hybrid groups), every device-login HTTP call dies with ``SSLEOFError`` /
+handshake timeouts while curl still works (#106384). Previously:
+
+* ``_codex_login_post`` swallowed the exception chain (no ``from exc``) and gave no hint;
+* the polling loop let the raw ``httpx`` error escape with no ``AuthError`` shaping at all.
+
+Both paths must keep the original SSL text, chain the cause, and append the OPENSSL_CONF
+workaround hint so the failure stops masquerading as a Codex outage.
+"""
+
+import httpx
+import pytest
+
+from hermes_cli import auth_codex
+from hermes_cli.auth import AuthError
+
+
+_SSL_EOF_MESSAGE = (
+    "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1016)")
+
+
+class _RaisingClient:
+    """Context-manager httpx.Client stand-in whose ``post`` always raises *exc*."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def post(self, url, **kwargs):
+        raise self._exc
+
+
+def _patch_client(monkeypatch, exc: BaseException) -> None:
+    monkeypatch.setattr(auth_codex, "_codex_http_client", lambda **kwargs: _RaisingClient(exc))
+
+
+def test_login_post_ssl_error_keeps_detail_and_hint(monkeypatch):
+    _patch_client(monkeypatch, httpx.ConnectError(_SSL_EOF_MESSAGE))
+
+    with pytest.raises(AuthError) as excinfo:
+        auth_codex._codex_login_post(
+            "https://auth.openai.com/api/accounts/deviceauth/usercode",
+            failure=("Failed to request device code", "device_code_request_failed"))
+
+    err = excinfo.value
+    assert err.code == "device_code_request_failed"
+    assert _SSL_EOF_MESSAGE in str(err)
+    assert "OPENSSL_CONF" in str(err)
+    assert "#106384" in str(err)
+    # ``raise ... from exc`` keeps the underlying transport error inspectable.
+    assert isinstance(err.__cause__, httpx.ConnectError)
+
+
+def test_login_post_non_ssl_error_has_no_interop_hint(monkeypatch):
+    _patch_client(monkeypatch, httpx.ConnectError("Connection refused"))
+
+    with pytest.raises(AuthError) as excinfo:
+        auth_codex._codex_login_post(
+            "https://auth.openai.com/api/accounts/deviceauth/usercode",
+            failure=("Failed to request device code", "device_code_request_failed"))
+
+    assert "Connection refused" in str(excinfo.value)
+    assert "OPENSSL_CONF" not in str(excinfo.value)
+
+
+def test_poll_authorization_code_ssl_error_surfaced_as_auth_error(monkeypatch):
+    _patch_client(monkeypatch, httpx.ConnectError(_SSL_EOF_MESSAGE))
+
+    with pytest.raises(AuthError) as excinfo:
+        auth_codex._codex_poll_authorization_code(
+            "https://auth.openai.com", device_auth_id="da", user_code="uc", poll_interval=0)
+
+    err = excinfo.value
+    assert err.code == "device_code_poll_error"
+    assert _SSL_EOF_MESSAGE in str(err)
+    assert "OPENSSL_CONF" in str(err)
+    assert isinstance(err.__cause__, httpx.ConnectError)

--- a/tests/hermes_cli/test_codex_device_login_ssl_hint.py
+++ b/tests/hermes_cli/test_codex_device_login_ssl_hint.py
@@ -1,15 +1,13 @@
-"""Regression tests: Codex device-login transport errors keep the underlying SSL detail.
+"""Codex device-login transport errors keep the underlying SSL detail and add a hint (#106384).
 
-On networks whose middlebox rejects the larger TLS 1.3 ClientHello that OpenSSL 3.5+ sends
-(post-quantum hybrid groups), every device-login HTTP call dies with ``SSLEOFError`` /
-handshake timeouts while curl still works (#106384). Previously:
-
-* ``_codex_login_post`` swallowed the exception chain (no ``from exc``) and gave no hint;
-* the polling loop let the raw ``httpx`` error escape with no ``AuthError`` shaping at all.
-
-Both paths must keep the original SSL text, chain the cause, and append the OPENSSL_CONF
-workaround hint so the failure stops masquerading as a Codex outage.
+OpenSSL 3.5+ advertises post-quantum hybrid groups; some middleboxes drop the resulting larger
+TLS 1.3 ClientHello, so every device-login POST dies with ``SSLEOFError`` / handshake timeouts
+while curl still works. Both transport paths (``_codex_login_post`` and the poll loop, which
+previously let the raw ``httpx`` error escape unshaped) must surface a typed ``AuthError`` that
+keeps the original text and appends the OPENSSL_CONF / TLS 1.2 hint — and only for SSL errors.
 """
+
+import ssl
 
 import httpx
 import pytest
@@ -38,48 +36,41 @@ class _RaisingClient:
         raise self._exc
 
 
-def _patch_client(monkeypatch, exc: BaseException) -> None:
-    monkeypatch.setattr(auth_codex, "_codex_http_client", lambda **kwargs: _RaisingClient(exc))
+def _login_post():
+    return auth_codex._codex_login_post(
+        "https://auth.openai.com/api/accounts/deviceauth/usercode",
+        failure=("Failed to request device code", "device_code_request_failed"))
 
 
-def test_login_post_ssl_error_keeps_detail_and_hint(monkeypatch):
-    _patch_client(monkeypatch, httpx.ConnectError(_SSL_EOF_MESSAGE))
+def _poll():
+    return auth_codex._codex_poll_authorization_code(
+        "https://auth.openai.com", device_auth_id="da", user_code="uc", poll_interval=0)
+
+
+@pytest.mark.parametrize(
+    "call, code",
+    [(_login_post, "device_code_request_failed"), (_poll, "device_code_poll_error")],
+    ids=["login_post", "poll"])
+def test_ssl_transport_error_keeps_detail_and_adds_hint(monkeypatch, call, code):
+    exc = ssl.SSLEOFError(8, _SSL_EOF_MESSAGE)
+    monkeypatch.setattr(auth_codex, "_codex_http_client", lambda **kw: _RaisingClient(exc))
 
     with pytest.raises(AuthError) as excinfo:
-        auth_codex._codex_login_post(
-            "https://auth.openai.com/api/accounts/deviceauth/usercode",
-            failure=("Failed to request device code", "device_code_request_failed"))
+        call()
 
     err = excinfo.value
-    assert err.code == "device_code_request_failed"
-    assert _SSL_EOF_MESSAGE in str(err)
+    assert err.code == code
+    assert "UNEXPECTED_EOF_WHILE_READING" in str(err)
     assert "OPENSSL_CONF" in str(err)
-    assert "#106384" in str(err)
-    # ``raise ... from exc`` keeps the underlying transport error inspectable.
-    assert isinstance(err.__cause__, httpx.ConnectError)
+    assert err.__cause__ is exc
 
 
-def test_login_post_non_ssl_error_has_no_interop_hint(monkeypatch):
-    _patch_client(monkeypatch, httpx.ConnectError("Connection refused"))
+def test_plain_timeout_has_no_ssl_hint(monkeypatch):
+    exc = httpx.ConnectTimeout("timed out")
+    monkeypatch.setattr(auth_codex, "_codex_http_client", lambda **kw: _RaisingClient(exc))
 
     with pytest.raises(AuthError) as excinfo:
-        auth_codex._codex_login_post(
-            "https://auth.openai.com/api/accounts/deviceauth/usercode",
-            failure=("Failed to request device code", "device_code_request_failed"))
+        _login_post()
 
-    assert "Connection refused" in str(excinfo.value)
+    assert "timed out" in str(excinfo.value)
     assert "OPENSSL_CONF" not in str(excinfo.value)
-
-
-def test_poll_authorization_code_ssl_error_surfaced_as_auth_error(monkeypatch):
-    _patch_client(monkeypatch, httpx.ConnectError(_SSL_EOF_MESSAGE))
-
-    with pytest.raises(AuthError) as excinfo:
-        auth_codex._codex_poll_authorization_code(
-            "https://auth.openai.com", device_auth_id="da", user_code="uc", poll_interval=0)
-
-    err = excinfo.value
-    assert err.code == "device_code_poll_error"
-    assert _SSL_EOF_MESSAGE in str(err)
-    assert "OPENSSL_CONF" in str(err)
-    assert isinstance(err.__cause__, httpx.ConnectError)

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -94,7 +94,20 @@ The OpenAI Codex provider authenticates via device code (open a URL, enter a cod
 
 If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add openai-codex` (or `hermes model` → **ChatGPT or Codex Subscription**) to start a fresh device-code login; the quarantine clears on the next successful exchange.
 
-Device login can fail with `[SSL: UNEXPECTED_EOF_WHILE_READING]` or a TLS handshake timeout on Python/OpenSSL 3.5+ when a middlebox rejects post-quantum groups such as X25519MLKEM768 (curl may still work). Hermes does not change default TLS policy. Point `OPENSSL_CONF` at a config that restricts `Groups` to classic curves (`x25519:secp256r1:secp384r1:x448`), or diagnose with TLS 1.2.
+Device login can fail with `[SSL: UNEXPECTED_EOF_WHILE_READING]` or a TLS handshake timeout on Python/OpenSSL 3.5+ when a middlebox rejects post-quantum groups such as X25519MLKEM768 (curl may still work). Hermes does not change default TLS policy. Point `OPENSSL_CONF` at a config that restricts `Groups` to classic curves before running `hermes model`, or diagnose with TLS 1.2:
+
+```ini
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Groups = x25519:secp256r1:secp384r1:x448
+```
 :::
 
 :::warning

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -93,6 +93,8 @@ Don't have a subscription yet? Get one at [portal.nousresearch.com/manage-subscr
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
 
 If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add openai-codex` (or `hermes model` → **ChatGPT or Codex Subscription**) to start a fresh device-code login; the quarantine clears on the next successful exchange.
+
+Device login can fail with `[SSL: UNEXPECTED_EOF_WHILE_READING]` or a TLS handshake timeout on Python/OpenSSL 3.5+ when a middlebox rejects post-quantum groups such as X25519MLKEM768 (curl may still work). Hermes does not change default TLS policy. Point `OPENSSL_CONF` at a config that restricts `Groups` to classic curves (`x25519:secp256r1:secp384r1:x448`), or diagnose with TLS 1.2.
 :::
 
 :::warning

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/providers.md
@@ -70,6 +70,21 @@ hermes portal info        # 随时查看登录状态和路由信息
 OpenAI Codex 提供商通过设备码（device code）认证——打开一个 URL 并输入验证码。Hermes 将生成的凭据存储在 `~/.hermes/auth.json` 的自有认证存储中，并在存在 `~/.codex/auth.json` 时可导入现有的 Codex CLI 凭据。无需安装 Codex CLI。
 
 如果 token 刷新因终端错误（HTTP 4xx、`invalid_grant`、授权被撤销等）失败，Hermes 会将该刷新 token 标记为失效并停止重试，避免出现大量重复的认证失败。下一次请求会显示类型化的重新认证提示。运行 `hermes auth add openai-codex`（或 `hermes model` → **ChatGPT or Codex Subscription**）开始新的设备码登录；成功交换后隔离状态自动解除。
+
+在 Python/OpenSSL 3.5+ 上，如果网络中间设备拒绝 X25519MLKEM768 等后量子密钥交换组，设备码登录可能报 `[SSL: UNEXPECTED_EOF_WHILE_READING]` 或 TLS 握手超时（此时 curl 仍可能正常）。Hermes 不会修改默认 TLS 策略。请在运行 `hermes model` 前将 `OPENSSL_CONF` 指向一个把 `Groups` 限制为经典曲线的配置文件，或用 TLS 1.2 进行诊断：
+
+```ini
+openssl_conf = openssl_init
+
+[openssl_init]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+Groups = x25519:secp256r1:secp384r1:x448
+```
 :::
 
 :::warning


### PR DESCRIPTION
Codex device login (`hermes model` → ChatGPT/Codex subscription) now keeps the raw OpenSSL error text on both transport paths and appends a one-line OPENSSL_CONF / TLS 1.2 hint when the failure is SSL-shaped, instead of a bare `Login failed: [SSL: …]` dead end.

## Changes

- `hermes_cli/auth_codex.py::_codex_login_post` — re-raises `from exc` (cause preserved) and appends `_ssl_interop_hint(exc)` to the typed `AuthError`.
- `hermes_cli/auth_codex.py::_codex_poll_authorization_code` — the poll POST had **no** transport-error handling; a mid-poll SSL EOF escaped as a bare `httpx` exception. It is now wrapped into `AuthError(device_code_poll_error)` with the same detail + hint. `KeyboardInterrupt` handling unchanged.
- `_ssl_interop_hint` fires only for SSL-flavoured errors: `ssl.SSLError` instances (or one hop of `__cause__`/`__context__`), or messages carrying `[SSL:` / `_ssl.c` / `UNEXPECTED_EOF`. A plain connect/read timeout gets no hint.
- Docs: one paragraph in the existing Codex note of `website/docs/integrations/providers.md` (+ the existing zh-Hans copy) with the reporter's exact `openssl.cnf` classic-groups snippet. No new docs page.
- `tests/hermes_cli/test_codex_device_login_ssl_hint.py` — 2 invariants (contributor's 3 trimmed): SSL error on login-post and poll keeps the raw text, gets the hint, keeps `__cause__`; plain `httpx.ConnectTimeout` gets no hint.

## Validation

| | before (origin/main) | after |
|---|---|---|
| `_codex_login_post` + `SSLEOFError` | `AuthError: Failed to request device code: [SSL: UNEXPECTED_EOF_WHILE_READING] …` — no guidance | same text + `This looks like a TLS handshake failure rather than a Codex outage … point OPENSSL_CONF at … or test with TLS 1.2 — see the Codex note in …/integrations/providers` |
| `_codex_poll_authorization_code` + `SSLEOFError` | **bare `SSLEOFError`** escapes (printed as `Login failed: [SSL: …]`) | `AuthError[device_code_poll_error]: Device auth polling request failed: [SSL: …] + hint` |
| either path + `httpx.ConnectTimeout("timed out")` | no hint | no hint (poll path now typed `AuthError`) |

**Live repro:** in-process, fresh interpreter per side, real `hermes_cli.auth_codex` imported from a detached `origin/main` worktree vs this branch, `httpx.Client.post` (the seam inside the real `_codex_http_client`) raising `ssl.SSLEOFError('[SSL: UNEXPECTED_EOF_WHILE_READING] …')` — before: login-post hint=False, poll = bare `SSLEOFError`; after: both `AuthError` with raw text + hint; negative (plain timeout) hint=False on both sides.

Tests red on base: `git checkout origin/main -- hermes_cli/auth_codex.py` → `2 failed, 1 passed` (both SSL cases fail; the no-hint negative passes); on the branch → `3 passed` (2 test functions, one parametrized ×2). Adjacent Codex auth suites (`test_auth_codex_provider/quota_probe/self_heal`, `test_auth_commands`): 48 passed via `scripts/run_tests.sh`.

## Root cause

OpenSSL 3.5+ advertises post-quantum hybrid groups (X25519MLKEM768) in the TLS 1.3 ClientHello; middleboxes that reject the larger hello kill the handshake, and the device-login code either swallowed that into a generic failure or let the raw exception escape the poll loop untyped.

## Scope / follow-up

- Hint-only: Hermes does not rewrite TLS policy, `OPENSSL_CONF`, or groups.
- The TLS max-version cap (`HERMES_TLS_MAX_VERSION`) and extending it to `auth_device_flow._default_verify` is PR #44392's scope — the follow-up once it lands.
- Dropped from the competing PRs (shape gates): #106409's new `hermes_cli/auth_codex_ssl_helper.py` module (<50 LOC of logic → lives in `auth_codex.py`), its new docs page + zh-Hans mirror (paragraph in the existing page instead), its whole-file reformat of `auth_codex.py`, and 11 tests; #106389's 80-line exception-chain walker / `_codex_exc_text` (the marker+`isinstance` check covers the same inputs) and its 11 tests.

Fixes #106384

## Credits

- @liuhao1024 — PR #106394, base of this salvage (cherry-picked, authorship preserved): the smallest complete fix covering both transport paths.
- @KoNit-K — PR #106389, earliest fix; the providers.md docs paragraph is cherry-picked under their authorship.
- @kokhlo — PR #106409, same fix plus the fullest diagnosis write-up and the poll-path gap analysis.
- @gaoanze888 — root-cause diagnosis on the issue (PQ hybrid group / uncapped `_default_verify` context) and the pointer to #44392.
- @GustavMhaler — reporter; the TLS 1.2 vs classic-groups measurements and the `openssl.cnf` workaround shipped in the docs.

## Infographic
![codex-ssl-hint](https://v3b.fal.media/files/b/0aa9ba38/OFeOEtM3kG2eZwwE4pYp6_bkTX8wo8.png)
