### PR TITLE
fix(cli): npm mirror config in $HERMES_HOME/npmrc survives hermes update so Windows desktop rebuilds stop failing (#106373, salvage #106382 #106381)

### DIFF
--- a/hermes_cli/main_tui_launch.py
+++ b/hermes_cli/main_tui_launch.py
@@ -420,37 +420,22 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
     sys.exit(1)
 
 
-def _persistent_npm_userconfig() -> Optional[dict[str, str]]:
-    """``NPM_CONFIG_USERCONFIG`` for ``$HERMES_HOME/npmrc`` when it exists.
-
-    The repo-root ``.npmrc`` is git-tracked, so the updater's autostash parks
-    any mirror/proxy line added there and every update reinstalls without it
-    (restricted networks then prune optional native deps like get-windows and
-    the rebuild fails). ``$HERMES_HOME`` lives outside the git tree, survives
-    autostash/reset, and the update hand-off already carries ``HERMES_HOME``
-    down to every npm child. An explicit ``NPM_CONFIG_USERCONFIG`` wins.
-    """
-    from hermes_constants import get_hermes_home
-
-    if os.environ.get("NPM_CONFIG_USERCONFIG", "").strip():
-        return None
-    try:
-        candidate = get_hermes_home() / "npmrc"
-    except Exception:
-        return None
-    if not candidate.is_file():
-        return None
-    return {"NPM_CONFIG_USERCONFIG": str(candidate)}
-
-
 def _npm_lifecycle_env(env: dict[str, str] | None = None) -> dict[str, str]:
     """Build a clean environment for the pinned UI toolchain lifecycle."""
     run_env = {**os.environ, **(env or {}), "CI": "1"}
     # esbuild treats this as an executable override. If a shell points it at a
     # different release, the pinned package's postinstall rejects that binary.
     run_env.pop("ESBUILD_BINARY_PATH", None)
-    for key, value in (_persistent_npm_userconfig() or {}).items():
-        run_env.setdefault(key, value)
+    # The repo-root ``.npmrc`` is git-tracked, so the updater's autostash parks
+    # any mirror/proxy line added there and every update reinstalls without it
+    # (restricted networks then prune optional native deps like get-windows and
+    # the rebuild fails). ``$HERMES_HOME`` lives outside the git tree and the
+    # update hand-off already carries ``HERMES_HOME`` down to every npm child.
+    # An explicit ``NPM_CONFIG_USERCONFIG`` wins (#106373).
+    from hermes_constants import get_hermes_home
+    npmrc = get_hermes_home() / "npmrc"
+    if npmrc.is_file():
+        run_env.setdefault("NPM_CONFIG_USERCONFIG", os.fspath(npmrc))
     return run_env
 
 

--- a/hermes_cli/main_tui_launch.py
+++ b/hermes_cli/main_tui_launch.py
@@ -420,12 +420,37 @@ def _ensure_tui_workspace(tui_dir: Path) -> None:
     sys.exit(1)
 
 
+def _persistent_npm_userconfig() -> Optional[dict[str, str]]:
+    """``NPM_CONFIG_USERCONFIG`` for ``$HERMES_HOME/npmrc`` when it exists.
+
+    The repo-root ``.npmrc`` is git-tracked, so the updater's autostash parks
+    any mirror/proxy line added there and every update reinstalls without it
+    (restricted networks then prune optional native deps like get-windows and
+    the rebuild fails). ``$HERMES_HOME`` lives outside the git tree, survives
+    autostash/reset, and the update hand-off already carries ``HERMES_HOME``
+    down to every npm child. An explicit ``NPM_CONFIG_USERCONFIG`` wins.
+    """
+    from hermes_constants import get_hermes_home
+
+    if os.environ.get("NPM_CONFIG_USERCONFIG", "").strip():
+        return None
+    try:
+        candidate = get_hermes_home() / "npmrc"
+    except Exception:
+        return None
+    if not candidate.is_file():
+        return None
+    return {"NPM_CONFIG_USERCONFIG": str(candidate)}
+
+
 def _npm_lifecycle_env(env: dict[str, str] | None = None) -> dict[str, str]:
     """Build a clean environment for the pinned UI toolchain lifecycle."""
     run_env = {**os.environ, **(env or {}), "CI": "1"}
     # esbuild treats this as an executable override. If a shell points it at a
     # different release, the pinned package's postinstall rejects that binary.
     run_env.pop("ESBUILD_BINARY_PATH", None)
+    for key, value in (_persistent_npm_userconfig() or {}).items():
+        run_env.setdefault(key, value)
     return run_env
 
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -778,3 +778,59 @@ def test_make_tui_argv_omits_workspace_and_scrubs_esbuild_override(
     assert "ESBUILD_BINARY_PATH" not in calls[0][1]["env"]
     assert calls[1][0][0][1:] == ["run", "build"]
     assert "ESBUILD_BINARY_PATH" not in calls[1][1]["env"]
+
+
+class TestPersistentNpmUserconfig:
+    """$HERMES_HOME/npmrc must reach every npm lifecycle child process."""
+
+    def test_hermes_home_npmrc_sets_userconfig(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "npmrc").write_text(
+            "node_get_windows_binary_host_mirror=https://ghproxy.net/https://github.com/sindresorhus/get-windows/releases/download/\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+        monkeypatch.delenv("ESBUILD_BINARY_PATH", raising=False)
+
+        env = main_tui_launch._npm_lifecycle_env()
+
+        assert env["NPM_CONFIG_USERCONFIG"] == str(home / "npmrc")
+
+    def test_missing_npmrc_leaves_env_untouched(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+
+        env = main_tui_launch._npm_lifecycle_env()
+
+        assert "NPM_CONFIG_USERCONFIG" not in env
+
+    def test_explicit_userconfig_wins(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "npmrc").write_text(
+            "registry=https://example.invalid\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("NPM_CONFIG_USERCONFIG", str(tmp_path / "custom-npmrc"))
+
+        env = main_tui_launch._npm_lifecycle_env()
+
+        assert env["NPM_CONFIG_USERCONFIG"] == str(tmp_path / "custom-npmrc")
+
+    def test_caller_env_does_not_override_userconfig(self, tmp_path, monkeypatch):
+        env_in = {"NPM_CONFIG_USERCONFIG": "/from-caller/npmrc"}
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "npmrc").write_text(
+            "registry=https://example.invalid\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
+
+        env = main_tui_launch._npm_lifecycle_env(env_in)
+
+        assert env["NPM_CONFIG_USERCONFIG"] == "/from-caller/npmrc"

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -781,56 +781,34 @@ def test_make_tui_argv_omits_workspace_and_scrubs_esbuild_override(
 
 
 class TestPersistentNpmUserconfig:
-    """$HERMES_HOME/npmrc must reach every npm lifecycle child process."""
+    """$HERMES_HOME/npmrc must reach every npm lifecycle child process (#106373)."""
 
     def test_hermes_home_npmrc_sets_userconfig(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
         (home / "npmrc").write_text(
-            "node_get_windows_binary_host_mirror=https://ghproxy.net/https://github.com/sindresorhus/get-windows/releases/download/\n",
+            "node_get_windows_binary_host_mirror=https://mirror.example/get-windows/\n",
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(home))
         monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
-        monkeypatch.delenv("ESBUILD_BINARY_PATH", raising=False)
 
         env = main_tui_launch._npm_lifecycle_env()
 
-        assert env["NPM_CONFIG_USERCONFIG"] == str(home / "npmrc")
+        assert env["NPM_CONFIG_USERCONFIG"] == os.fspath(home / "npmrc")
 
-    def test_missing_npmrc_leaves_env_untouched(self, tmp_path, monkeypatch):
+    def test_explicit_userconfig_wins_and_missing_file_sets_nothing(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(home))
         monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
 
-        env = main_tui_launch._npm_lifecycle_env()
+        assert "NPM_CONFIG_USERCONFIG" not in main_tui_launch._npm_lifecycle_env()
 
-        assert "NPM_CONFIG_USERCONFIG" not in env
-
-    def test_explicit_userconfig_wins(self, tmp_path, monkeypatch):
-        home = tmp_path / "home"
-        home.mkdir()
-        (home / "npmrc").write_text(
-            "registry=https://example.invalid\n", encoding="utf-8"
-        )
-        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "npmrc").write_text("registry=https://example.invalid\n", encoding="utf-8")
         monkeypatch.setenv("NPM_CONFIG_USERCONFIG", str(tmp_path / "custom-npmrc"))
+        assert main_tui_launch._npm_lifecycle_env()["NPM_CONFIG_USERCONFIG"] == str(tmp_path / "custom-npmrc")
 
-        env = main_tui_launch._npm_lifecycle_env()
-
-        assert env["NPM_CONFIG_USERCONFIG"] == str(tmp_path / "custom-npmrc")
-
-    def test_caller_env_does_not_override_userconfig(self, tmp_path, monkeypatch):
-        env_in = {"NPM_CONFIG_USERCONFIG": "/from-caller/npmrc"}
-        home = tmp_path / "home"
-        home.mkdir()
-        (home / "npmrc").write_text(
-            "registry=https://example.invalid\n", encoding="utf-8"
-        )
-        monkeypatch.setenv("HERMES_HOME", str(home))
-        monkeypatch.delenv("NPM_CONFIG_USERCONFIG", raising=False)
-
-        env = main_tui_launch._npm_lifecycle_env(env_in)
-
+        monkeypatch.delenv("NPM_CONFIG_USERCONFIG")
+        env = main_tui_launch._npm_lifecycle_env({"NPM_CONFIG_USERCONFIG": "/from-caller/npmrc"})
         assert env["NPM_CONFIG_USERCONFIG"] == "/from-caller/npmrc"

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -539,6 +539,8 @@ ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/ \
   bash -c 'cd "$HOME/.hermes/hermes-agent/apps/desktop" && CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack'
 ```
 
+**Other native downloads (e.g. the `get-windows` prebuilt on Windows) that need a mirror:** put the npm keys in `$HERMES_HOME/npmrc` (`%LOCALAPPDATA%\hermes\npmrc` on Windows, `~/.hermes/npmrc` elsewhere) — for example `node_get_windows_binary_host_mirror=https://<mirror>/sindresorhus/get-windows/releases/download/`. Every `npm ci`/`npm run` the updater spawns (desktop, web and TUI builds) points `NPM_CONFIG_USERCONFIG` at that file when it exists, so the config survives `hermes update`; the repo-root `.npmrc` is git-tracked and gets autostashed on every update, and `~/.npmrc` may be missed because the desktop hand-off inherits the GUI's environment. An `NPM_CONFIG_USERCONFIG` you set yourself is never overridden.
+
 To clear a corrupt cached zip by hand:
 
 ```bash


### PR DESCRIPTION
On restricted networks a Windows desktop `hermes update` no longer loses the user's npm mirror config on every run, so the `get-windows` prebuilt stops being pruned and the rebuild stops ending in **REBUILD FAILED**.

Fixes #106373 — salvage of #106382 (@kokhlo), credits #106381 (@KoNit-K).

## Changes

- `hermes_cli/main_tui_launch.py::_npm_lifecycle_env` exports `NPM_CONFIG_USERCONFIG=$HERMES_HOME/npmrc` when that file exists and the variable isn't already set (process env or caller env). Every updater npm spawn — `_run_npm_install_deterministic` (desktop/web/TUI installs), `_build_desktop_app`, the web build and the TUI build — already goes through this one function, so no second path needed widening (verified by grepping every `subprocess` npm call in `hermes_cli/` and `scripts/desktop-update/`).
- Path built with `pathlib` + `os.fspath` (Windows-safe); `scripts/check-windows-footguns.py --all` clean.
- Docs: one paragraph in `website/docs/user-guide/desktop.md` (troubleshooting section, next to `ELECTRON_MIRROR`) describing `$HERMES_HOME/npmrc`. No zh-Hans copy of that page exists.
- Tests trimmed from 4 to 2 invariants in `tests/hermes_cli/test_tui_npm_install.py::TestPersistentNpmUserconfig`.

**Dropped from #106382 in my follow-up commit:** the separate `_persistent_npm_userconfig()` helper, its `try/except` around `get_hermes_home()` (it cannot raise) and the dict-returning indirection — the fix is one `is_file()` check plus a `setdefault`, inlined.

**Not carried from #106381:** the `USERPROFILE`/`HOME` backfill (main already builds the child env from a full `os.environ` snapshot, so a Windows child that lacks `USERPROFILE` cannot be re-derived from the same parent env; `$HERMES_HOME/npmrc` is the durable answer) and the `npm_config_*_binary_host_mirror` forwarding loop (`run_env` starts as `{**os.environ, ...}` — those vars are already forwarded; the loop is dead code). `.npmrc` as a second file name was also dropped: one documented location.

## Root cause

The updater's npm children only ever saw npm config from the git-tracked repo-root `.npmrc` (autostashed on every update) or from `%USERPROFILE%\.npmrc` (missed when the desktop hand-off inherits the GUI's environment); nothing outside the git tree was ever consulted.

## Validation

| | before | after |
|---|---|---|
| `_npm_lifecycle_env()` with `$HERMES_HOME/npmrc` present → real `npm config get node_get_windows_binary_host_mirror` | `undefined` | `https://mirror.example/get-windows/` |
| no `npmrc` file | `NPM_CONFIG_USERCONFIG` unset | unset (unchanged) |
| explicit `NPM_CONFIG_USERCONFIG` preset (process or caller env) | — | preset value wins, npm reads that file |

**Live repro:** before `npm config get node_get_windows_binary_host_mirror` under the updater env → `undefined` / after → the mirror URL from `$HERMES_HOME/npmrc` (real `find_node_executable("npm")` subprocess, real `_npm_lifecycle_env`, temp `HERMES_HOME`, fresh interpreter with `hermes*`/`tools*` purged).

Tests: `scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py` → 32 passed. Red on base: `test_hermes_home_npmrc_sets_userconfig` fails with `origin/main`'s `main_tui_launch.py` checked out; passes with the fix.

Not verifiable here: the full Windows desktop hand-off → `npm ci` → `stage-native-deps.mjs` chain (needs a Windows desktop on a GitHub-blocked network). The env choke point and npm's consumption of it are proven above.

## Credits

- @Orion3754 — reporter; full diagnosis of both failure paths in #106373.
- @kokhlo — #106382, the salvaged fix (authorship preserved via cherry-pick).
- @KoNit-K — #106381, independent fix at the same choke point, opened first.

## Infographic
![npmrc-home](https://v3b.fal.media/files/b/0aa9ba3e/6CiDyC8CXTtQlz0kfwb7n_yNZ7CHCv.png)
