### PR TITLE
fix(doctor): name the source of a silent approval bypass (#106504)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -25,6 +25,7 @@ from hermes_cli.doctor_connectivity import _has_healthy_oauth_fallback_for_apike
 from hermes_cli.doctor_tools import _safe_which
 
 from hermes_cli.doctor_config import (
+    _check_approval_bypass,
     _check_config_drift,
     _check_config_file,
     _check_env_file,
@@ -110,7 +111,7 @@ DOCTOR_CHECKS = (
     ('Security Advisories', _check_security_advisories), ('MCP Server Security', _check_mcp_security),
     ('Python Environment', _check_python_environment), ('SSL / CA Certificates', _check_certificates),
     ('Required Packages', _check_required_packages), ('Configuration Files', _check_env_file),
-    (None, _check_config_file), (None, _check_config_drift),
+    (None, _check_config_file), (None, _check_approval_bypass), (None, _check_config_drift),
     ('xAI Model Retirement (May 15, 2026)', _check_xai_retirement),
     ('Plugin import paths (removed Sep 14, 2026)', _check_plugin_compat), ('Auth Providers', _check_auth_providers),
     ('Directory Structure', _check_directory_structure), (None, _check_state_db),

--- a/hermes_cli/doctor_config.py
+++ b/hermes_cli/doctor_config.py
@@ -285,6 +285,41 @@ def _check_config_file(should_fix: bool, f: Finding) -> None:
         check_warn("config.yaml not found", "(using defaults)")
 
 
+def collect_approval_bypass_source(env_map: dict | None, approvals_mode) -> tuple[str, str] | None:
+    """``(mechanism, origin)`` naming an approval bypass that would be active on the next run without
+    an explicit ``--yolo`` flag, or ``None``. *env_map* is the on-disk ``.env`` (not ``os.environ``:
+    ``--yolo`` also writes ``HERMES_YOLO_MODE`` into the process env, so by the time doctor runs the
+    two are indistinguishable there — the file is the only place still naming a silent source).
+    *approvals_mode* is the raw (unmerged) ``approvals.mode`` from config.yaml."""
+    from utils import is_truthy_value
+    from tools.approval_context import _normalize_approval_mode
+    if isinstance(env_map, dict) and is_truthy_value(str(env_map.get("HERMES_YOLO_MODE", ""))):
+        return ("HERMES_YOLO_MODE", ".env")
+    if _normalize_approval_mode(approvals_mode) == "off":
+        return ("approvals.mode: off", "config.yaml")
+    return None
+
+
+@doctor_check()
+def _check_approval_bypass(should_fix: bool, f: Finding) -> None:
+    """Name the source when approval bypass is active from an env var or config key rather than an
+    explicit ``--yolo`` flag on this invocation — silent otherwise (#106504)."""
+    from hermes_cli.doctor import HERMES_HOME, _DHH
+    from hermes_cli.config import load_env, read_user_config_raw
+    env_map = {}
+    with warn_on_error(""):
+        env_map = load_env()
+    raw_config = read_user_config_raw(HERMES_HOME / "config.yaml")
+    approvals_mode = (raw_config.get("approvals") or {}).get("mode") if isinstance(raw_config, dict) else None
+    found = collect_approval_bypass_source(env_map, approvals_mode)
+    if found is None:
+        check_ok("Approval bypass not active (approvals enforced)")
+        return
+    mechanism, origin = found
+    check_warn(f"Approval bypass active via {mechanism}", f"(set in {_DHH}/{origin} — every command auto-allows)")
+    f.issues.append(f"Approval bypass is active via {mechanism} in {_DHH}/{origin}; remove or reset it to require approvals again")
+
+
 def _drift_config_version(f: Finding, should_fix: bool, config_path) -> None:
     from hermes_cli.config import check_config_version, migrate_config
     current_ver, latest_ver = check_config_version()

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1564,6 +1564,71 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "⚠" in out or "Deprecated" in out
 
 
+class TestApprovalBypassSource:
+    """#106504: doctor must name the source when approval bypass is active from an env var or
+    config key rather than an explicit --yolo flag."""
+
+    def test_no_bypass_returns_none(self):
+        assert doctor_config.collect_approval_bypass_source({"OPENAI_API_KEY": "sk-test"}, "smart") is None
+        assert doctor_config.collect_approval_bypass_source({}, None) is None
+
+    def test_yolo_env_var_names_dotenv_as_source(self):
+        found = doctor_config.collect_approval_bypass_source({"HERMES_YOLO_MODE": "1"}, "smart")
+        assert found == ("HERMES_YOLO_MODE", ".env")
+
+    def test_falsy_yolo_env_var_is_not_a_bypass(self):
+        assert doctor_config.collect_approval_bypass_source({"HERMES_YOLO_MODE": "0"}, "smart") is None
+        assert doctor_config.collect_approval_bypass_source({"HERMES_YOLO_MODE": "false"}, "smart") is None
+
+    def test_approvals_mode_off_names_config_yaml_as_source(self):
+        found = doctor_config.collect_approval_bypass_source({}, "off")
+        assert found == ("approvals.mode: off", "config.yaml")
+
+    def test_approvals_mode_off_as_yaml_bool_is_still_detected(self):
+        """YAML 1.1 parses a bare ``off:`` as False — read_user_config_raw() hands that bool
+        straight through, so the source must recognize it the same way the runtime does."""
+        found = doctor_config.collect_approval_bypass_source({}, False)
+        assert found == ("approvals.mode: off", "config.yaml")
+
+    def test_env_var_checked_before_config_mode(self):
+        """Both active at once: report the env var first (it is the more surprising, less visible one)."""
+        found = doctor_config.collect_approval_bypass_source({"HERMES_YOLO_MODE": "true"}, "off")
+        assert found[0] == "HERMES_YOLO_MODE"
+
+    def _run_check(self, monkeypatch, tmp_path, *, config_yaml: str = "", env_text: str = ""):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "config.yaml").write_text(config_yaml, encoding="utf-8")
+        (hermes_home / ".env").write_text(env_text, encoding="utf-8")
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", hermes_home)
+        monkeypatch.setattr(doctor_mod, "_DHH", "~/.hermes")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            finding = doctor_config._check_approval_bypass(False)
+        return buf.getvalue(), finding
+
+    def test_check_warns_and_names_dotenv_file(self, monkeypatch, tmp_path):
+        out, finding = self._run_check(monkeypatch, tmp_path, env_text="HERMES_YOLO_MODE=1\n")
+        assert "Approval bypass active via HERMES_YOLO_MODE" in out
+        assert "~/.hermes/.env" in out
+        assert any("HERMES_YOLO_MODE" in issue for issue in finding.issues)
+
+    def test_check_warns_and_names_config_yaml(self, monkeypatch, tmp_path):
+        out, finding = self._run_check(
+            monkeypatch, tmp_path, config_yaml="approvals:\n  mode: off\n",
+        )
+        assert "Approval bypass active via approvals.mode: off" in out
+        assert "~/.hermes/config.yaml" in out
+        assert finding.issues
+
+    def test_check_ok_when_no_bypass(self, monkeypatch, tmp_path):
+        out, finding = self._run_check(monkeypatch, tmp_path, env_text="OPENAI_API_KEY=sk-test\n")
+        assert "Approval bypass not active" in out
+        assert finding.issues == []
+
+
 class TestMacOSTCCGrants:
     """macOS TCC grant persistence check (issue #86385)."""
 


### PR DESCRIPTION
Fixes #106504.

## Problem

When `HERMES_YOLO_MODE=1` is set in a profile's `.env` (or inherited
from the root `.env`), or `approvals.mode: off` is set in
`config.yaml`, every command auto-allows and nothing tells the
operator *where* the bypass came from. `--yolo` on the command line is
an explicit, visible choice; a stale env var or config key is silent —
someone can be running fully unattended for a long time without
realizing why approval prompts stopped appearing (reported as a side
finding in #106441).

## Fix

Added a `hermes doctor` check (`_check_approval_bypass` in
`hermes_cli/doctor_config.py`) that reads the on-disk `.env` and
`config.yaml` directly — not `os.environ` — and names the exact file
responsible:

```
⚠ Approval bypass active via HERMES_YOLO_MODE (set in ~/.hermes/.env — every command auto-allows)
```
or
```
⚠ Approval bypass active via approvals.mode: off (set in ~/.hermes/config.yaml — every command auto-allows)
```

The check deliberately reads the files instead of the process
environment: an explicit `--yolo` flag also writes
`HERMES_YOLO_MODE` into `os.environ` before any approval code
imports (see the chokepoint comments in `hermes_cli/main.py`), so by
the time a diagnostic runs, a flag-set value and an inherited one are
indistinguishable in-process. The on-disk `.env` is the only place
that still tells the two apart, and it's exactly the "profile `.env`"
source the issue asks to name.

`approvals.mode: off` is normalized the same way the runtime approval
gate does (`tools.approval_context._normalize_approval_mode`), since
YAML 1.1 parses a bare `mode: off` as the boolean `False` rather than
the string `"off"` — this repo already has that exact gotcha handled
for the runtime check, so the doctor check reuses it instead of
re-guessing.

Scoped to the "one resolution-site log line naming the origin" part of
the issue; the profile-template `approvals:` block change is left for
a follow-up since it touches profile-creation code with its own
behavioral surface.

## Test plan

Added `TestApprovalBypassSource` to `tests/hermes_cli/test_doctor.py`:
unit tests for the pure `collect_approval_bypass_source()` helper
(including the YAML `off`→`False` gotcha) plus integration tests that
run `_check_approval_bypass` against real temp `.env`/`config.yaml`
files.

Confirmed the new tests fail without the fix:

```
$ git stash push -- hermes_cli/doctor.py hermes_cli/doctor_config.py
$ python -m pytest tests/hermes_cli/test_doctor.py -k ApprovalBypass -q
9 failed, 71 deselected in 0.75s
AttributeError: module 'hermes_cli.doctor_config' has no attribute 'collect_approval_bypass_source'
$ git stash pop
$ python -m pytest tests/hermes_cli/test_doctor.py -k ApprovalBypass -q
9 passed, 71 deselected in 0.49s
```

Full doctor suite still green:

```
$ python -m pytest tests/hermes_cli/test_doctor.py -q
80 passed in 17.09s
$ python -m pytest tests/hermes_cli/test_doctor_dedicated_provider_skip.py tests/hermes_cli/test_doctor_command_install.py tests/hermes_cli/test_doctor_journal_modes.py tests/tools/test_yolo_mode.py tests/tools/test_approval.py -q
177 passed in 13.37s
$ ruff check hermes_cli/doctor.py hermes_cli/doctor_config.py tests/hermes_cli/test_doctor.py
All checks passed!
```

## AI assistance disclosure

Written with Claude Code (Anthropic). I reviewed the diff, ran the
test suite locally, and verified the tests fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
