### PR TITLE
fix(state): compression cooldown rollback no longer crashes the turn when the session row vanished (#106271, salvage #106276)

### DIFF
--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -315,18 +315,12 @@ class SessionCompressionMixin:
                 "compression_failure_error = ? WHERE id = ?", (deadline, error, session_id))
             return cursor.rowcount == 1
         if not self._execute_write(_do):
-            # The session row was retired/expired (e.g. by the maintenance sweep) between
-            # the snapshot and this compensating write (#106271): a routine race must not
-            # crash the turn dispatcher when the rolled-back state no longer exists.
             logger.warning("compression cooldown rollback session missing: %s", session_id)
             return
         actual = self.get_compression_failure_cooldown_row(session_id)
         expected = _cooldown_row(True, deadline, error)
         if actual != expected:
             if not actual.get("session_exists", False):
-                # The session row vanished between the compensating UPDATE and this
-                # read-back: the same #106271 lifecycle race as the pre-update window
-                # above, and equally nothing left to restore or verify.
                 logger.warning("compression cooldown rollback session missing after restore: %s", session_id)
                 return
             raise RuntimeError(

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -300,9 +300,9 @@ class SessionCompressionMixin:
     def restore_compression_failure_cooldown_row(self, session_id: str, snapshot: Dict[str, Any]) -> None:
         """Restore and verify an exact cooldown-row snapshot. Unlike record/clear this
         rollback API propagates write and verification failures: cancellation must not be
-        reported mutation-free when compensation failed. The one tolerated exception is a
-        session row that vanished mid-attempt: its cooldown died with it, so there is
-        nothing left to restore (#106271)."""
+        reported mutation-free when compensation failed. The tolerated exception is a
+        session row that vanished mid-attempt — before or after the compensating write —
+        since its cooldown died with it and there is nothing left to restore (#106271)."""
         if not snapshot.get("session_exists", False):
             if self.get_compression_failure_cooldown_row(session_id).get("session_exists", False):
                 raise RuntimeError("cannot restore absent compression cooldown row: session now exists")
@@ -323,6 +323,12 @@ class SessionCompressionMixin:
         actual = self.get_compression_failure_cooldown_row(session_id)
         expected = _cooldown_row(True, deadline, error)
         if actual != expected:
+            if not actual.get("session_exists", False):
+                # The session row vanished between the compensating UPDATE and this
+                # read-back: the same #106271 lifecycle race as the pre-update window
+                # above, and equally nothing left to restore or verify.
+                logger.warning("compression cooldown rollback session missing after restore: %s", session_id)
+                return
             raise RuntimeError(
                 f"compression cooldown rollback verification failed: expected={expected!r}, actual={actual!r}")
 

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -300,7 +300,9 @@ class SessionCompressionMixin:
     def restore_compression_failure_cooldown_row(self, session_id: str, snapshot: Dict[str, Any]) -> None:
         """Restore and verify an exact cooldown-row snapshot. Unlike record/clear this
         rollback API propagates write and verification failures: cancellation must not be
-        reported mutation-free when compensation failed."""
+        reported mutation-free when compensation failed. The one tolerated exception is a
+        session row that vanished mid-attempt: its cooldown died with it, so there is
+        nothing left to restore (#106271)."""
         if not snapshot.get("session_exists", False):
             if self.get_compression_failure_cooldown_row(session_id).get("session_exists", False):
                 raise RuntimeError("cannot restore absent compression cooldown row: session now exists")
@@ -311,9 +313,13 @@ class SessionCompressionMixin:
             cursor = conn.execute(
                 "UPDATE sessions SET compression_failure_cooldown_until = ?, "
                 "compression_failure_error = ? WHERE id = ?", (deadline, error, session_id))
-            if cursor.rowcount != 1:
-                raise RuntimeError(f"compression cooldown rollback session missing: {session_id}")
-        self._execute_write(_do)
+            return cursor.rowcount == 1
+        if not self._execute_write(_do):
+            # The session row was retired/expired (e.g. by the maintenance sweep) between
+            # the snapshot and this compensating write (#106271): a routine race must not
+            # crash the turn dispatcher when the rolled-back state no longer exists.
+            logger.warning("compression cooldown rollback session missing: %s", session_id)
+            return
         actual = self.get_compression_failure_cooldown_row(session_id)
         expected = _cooldown_row(True, deadline, error)
         if actual != expected:

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -2253,6 +2253,49 @@ def test_force_cancel_restores_exact_expired_or_expiring_cooldown_row(
     assert db.get_compression_lock_holder(session_id) is None
 
 
+def test_exact_cooldown_restore_tolerates_a_concurrently_deleted_session(
+    tmp_path: Path,
+) -> None:
+    """A deleted session has no cooldown state left to compensate (#106271)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "COOLDOWN_ROLLBACK_DELETED_SESSION"
+    db.create_session(session_id, source="cli")
+    snapshot = db.get_compression_failure_cooldown_row(session_id)
+    assert snapshot["session_exists"] is True
+
+    assert db.delete_session(session_id) is True
+    db.restore_compression_failure_cooldown_row(session_id, snapshot)
+
+    assert db.get_compression_failure_cooldown_row(session_id) == {
+        "session_exists": False,
+        "cooldown_until": None,
+        "error": None,
+    }
+
+
+def test_exact_cooldown_restore_tolerates_deletion_before_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deletion after the compensating write is still an intentional no-op (#106271)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "COOLDOWN_ROLLBACK_DELETE_DURING_VERIFY"
+    db.create_session(session_id, source="cli")
+    snapshot = db.get_compression_failure_cooldown_row(session_id)
+    real_execute_write = db._execute_write
+
+    def _restore_then_delete(callback):
+        monkeypatch.setattr(db, "_execute_write", real_execute_write)
+        result = real_execute_write(callback)
+        assert db.delete_session(session_id) is True
+        return result
+
+    monkeypatch.setattr(db, "_execute_write", _restore_then_delete)
+    db.restore_compression_failure_cooldown_row(session_id, snapshot)
+
+    assert db.get_compression_failure_cooldown_row(session_id)["session_exists"] is False
+
+
 def test_cooldown_rollback_failure_surfaces_and_releases_lease(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
A compression summary attempt whose session row was retired mid-attempt no longer crashes the turn dispatcher with `RuntimeError: compression cooldown rollback session missing`; the failure-cooldown rollback logs a warning and no-ops because there is no cooldown left to restore.

## Changes
- `hermes_state_compression.py::restore_compression_failure_cooldown_row` — the compensating `UPDATE ... WHERE id = ?` returning `rowcount == 0` (session gone before the write) is a warn-and-return, not a raise; the read-back verification likewise tolerates `session_exists: False` (session gone between the write and the read-back). A mismatch on a **surviving** row still raises, and `_execute_write` exceptions still propagate, so the "cancellation must not be reported mutation-free when compensation failed" contract (#102138's clobber concern) is unchanged.
- `tests/agent/test_compression_concurrent_fork.py` — two invariant tests against the real SQLite `SessionDB`: deletion before the compensating write, and deletion between the write and the read-back. Both red on `origin/main`, green with the fix.
- Salvage follow-up (mine): dropped two inline comment paragraphs that restated the docstring's WHY; dropped the contributor's separate 4-test file in favour of the two tests above (≤2 invariant tests).

## Validation
| Check | Before (origin/main) | After (this branch) |
|---|---|---|
| Live repro, temp `HERMES_HOME`, real `SessionDB`: snapshot cooldown row → `delete_session` → `restore_compression_failure_cooldown_row` | `RuntimeError: compression cooldown rollback session missing: 20260903_235715_07bd64` | returns; `WARNING compression cooldown rollback session missing: …`; row stays absent |
| Same, session deleted between UPDATE and read-back | `RuntimeError: compression cooldown rollback verification failed: … actual={'session_exists': False, …}` | returns; `WARNING … session missing after restore` |
| Control: surviving row with mismatched columns | raises `verification failed` | still raises `verification failed` |
| `scripts/run_tests.sh tests/hermes_state/ tests/agent/test_compression_concurrent_fork.py` | — | 37 files, 359 passed, 0 failed, 3 skipped |
| Sabotage: the two new tests with `hermes_state_compression.py` reverted to main | 2 failed | 2 passed |

Root cause: the rollback's `_do` closure treated every `rowcount != 1` as a write failure, but a primary-key `UPDATE` matching zero rows only means the session was retired (e.g. by the maintenance sweep) during the attempt — a routine lifecycle race, not a failed compensation.

Salvages #106276 from @liuhao1024 (fix, both deletion windows)
Salvages #106277 from @1052326311 (regression tests; its identical fix hunk was redundant)
Closes #106271

## Infographic
![cooldown-rollback-missing-row](https://v3b.fal.media/files/b/0aa9ba69/nTqxwsagD4CahzMGpEZ4r_jLYAwKKZ.png)
