### PR TITLE
fix(agent): Codex patch-budget image 400 now shrinks and retries the image (#106337, salvage #106345)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -150,9 +150,14 @@ _PAYLOAD_TOO_LARGE_PATTERNS = (
 # Per-image size/dimension 400s (Anthropic 5 MB / 8000 px; MiniMax "media
 # exceeds size limit" #76039) — a specific 400 before the request hits 413. A
 # non-image media hit is harmless: the shrink pass finds no image parts.
+# "patches after processing": OpenAI Codex Responses rejects an image whose
+# tile-patch budget (ceil(w/32)×ceil(h/32)) exceeds its 30000-patch ceiling
+# with wording that names no image-size vocabulary — without this pattern it
+# fell to format_error (non-retryable), bypassing the shrink recovery (#106337).
 _IMAGE_TOO_LARGE_PATTERNS = (
     "image exceeds", "image too large", "image_too_large", "image size exceeds", "image dimensions exceed",
     "dimensions exceed max allowed size", "max allowed size: 8000", "media exceeds", "media too large",
+    "patches after processing",
 )
 
 # Undecodable image bytes → strip-and-retry, never shrink. xAI wordings

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -10,6 +10,7 @@ mutate ``agent`` / ``messages`` / ``api_messages`` in place. Logger name stays
 from __future__ import annotations
 
 import logging
+import math
 import re
 import time
 from dataclasses import dataclass
@@ -60,6 +61,17 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
             except Exception:
                 pass
     text = " ".join(parts).lower()
+    # OpenAI Codex Responses reports a tile-patch budget (ceil(w/32)×ceil(h/32))
+    # instead of a pixel ceiling. A square image is the worst case for the budget,
+    # so a per-side cap of isqrt(limit)*32 px keeps isqrt(limit)² ≤ limit — for the
+    # 30000-patch ceiling that is 5536 px. Without this the caller falls back to
+    # 8000 px and a 6000 px image that already exceeds the budget is skipped (#106337).
+    if "patches after processing" in text:
+        match = re.search(r"exceeding the limit of\s*(\d{2,7})", text)
+        if not match:
+            return None
+        max_dimension = math.isqrt(int(match.group(1))) * 32
+        return max_dimension if 512 <= max_dimension <= 8000 else None
     if "image" not in text or "dimension" not in text or "max allowed size" not in text:
         return None
     match = re.search(r"max allowed size(?:\s+for [^:]+)?:\s*(\d{3,5})\s*pixels?", text)

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -107,6 +107,64 @@ class TestImageTooLargeClassification:
         assert result.reason != FailoverReason.image_too_large
 
 
+class TestImagePatchBudgetMaxDimension:
+    """_image_error_max_dimension must derive a tile-aware per-side cap from a
+    Codex patch-budget rejection instead of falling back to the 8000 px default
+    — a 6000 px image exceeds the 30000-patch ceiling yet sails under 8000 px,
+    so the default cap would leave it unshrunk and burn the single retry (#106337).
+    """
+
+    def test_codex_patch_budget_maps_to_tile_aware_cap(self):
+        err = _FakeApiError(
+            status_code=400,
+            message=(
+                "The image you provided requires 33174 patches after processing, "
+                "exceeding the limit of 30000. Please resize the image and try again."
+            ),
+        )
+        # isqrt(30000) = 173 tiles per side → 173*32 = 5536 px; 173² = 29929 ≤ 30000.
+        assert _image_error_max_dimension(err) == 5536
+
+    def test_codex_patch_budget_non_square_worst_case_still_under_budget(self):
+        import math
+        cap = _image_error_max_dimension(_FakeApiError(
+            status_code=400,
+            message="requires 33174 patches after processing, exceeding the limit of 30000",
+        ))
+        tiles = math.ceil(cap / 32)
+        assert tiles * tiles <= 30000
+
+    def test_patch_wording_without_limit_returns_none(self):
+        err = _FakeApiError(
+            status_code=400,
+            message="image patches after processing are too numerous",
+        )
+        assert _image_error_max_dimension(err) is None
+
+    def test_non_patch_limit_of_wording_not_misread(self):
+        """"exceeding the limit of N" without the patch vocabulary must stay None."""
+        err = _FakeApiError(
+            status_code=400,
+            message="request exceeds the limit of 100 images per minute",
+        )
+        assert _image_error_max_dimension(err) is None
+
+    def test_patch_budget_below_floor_returns_none(self):
+        """A pathologically tiny budget maps under the 512 px floor → None (8000 fallback)."""
+        err = _FakeApiError(
+            status_code=400,
+            message="requires 90 patches after processing, exceeding the limit of 81",
+        )
+        assert _image_error_max_dimension(err) is None
+
+    def test_anthropic_pixel_ceiling_path_unchanged(self):
+        err = _FakeApiError(
+            status_code=400,
+            message="image dimensions exceed max allowed size: 8000 pixels per side",
+        )
+        assert _image_error_max_dimension(err) == 8000
+
+
 
 # ─── Shrink helper ───────────────────────────────────────────────────────────
 

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -78,6 +78,25 @@ class TestImageTooLargeClassification:
         assert result.reason == FailoverReason.image_too_large
         assert result.retryable is True
 
+    def test_codex_400_patch_budget_message(self):
+        """OpenAI Codex Responses rejects a high-resolution image on its
+        30000-tile-patch ceiling with wording that contains none of the
+        image-size vocabulary ("requires N patches after processing,
+        exceeding the limit").  It used to fall through to format_error /
+        non-retryable, so the shrink recovery was bypassed and the session
+        kept failing (or failover re-sent the same invalid image) (#106337).
+        """
+        err = _FakeApiError(
+            status_code=400,
+            message=(
+                "The image you provided requires 33174 patches after processing, "
+                "exceeding the limit of 30000. Please resize the image and try again."
+            ),
+        )
+        result = classify_api_error(err, provider="openai-codex", model="gpt-5.6-sol")
+        assert result.reason == FailoverReason.image_too_large
+        assert result.retryable is True
+
     def test_unrelated_400_still_not_image_too_large(self):
         """The new "media" patterns must not widen into ordinary 400s."""
         err = _FakeApiError(

--- a/tests/run_agent/test_image_shrink_recovery.py
+++ b/tests/run_agent/test_image_shrink_recovery.py
@@ -107,14 +107,18 @@ class TestImageTooLargeClassification:
         assert result.reason != FailoverReason.image_too_large
 
 
-class TestImagePatchBudgetMaxDimension:
-    """_image_error_max_dimension must derive a tile-aware per-side cap from a
-    Codex patch-budget rejection instead of falling back to the 8000 px default
-    — a 6000 px image exceeds the 30000-patch ceiling yet sails under 8000 px,
-    so the default cap would leave it unshrunk and burn the single retry (#106337).
-    """
+class TestImagePatchBudgetShrink:
+    def test_codex_patch_budget_shrinks_responses_image_under_budget(self):
+        """The Codex 400 names a tile-patch budget, not a pixel ceiling: a 5444x6200 PNG
+        (33174 patches) sails under the 8000 px default cap and would be left unshrunk,
+        burning the single retry (#106337). The cap derived from the rejection must make the
+        real shrink pass rewrite the Responses ``input_image`` part to within the budget."""
+        import io
 
-    def test_codex_patch_budget_maps_to_tile_aware_cap(self):
+        from PIL import Image
+
+        from agent.conversation_compression import try_shrink_image_parts_in_messages
+
         err = _FakeApiError(
             status_code=400,
             message=(
@@ -122,48 +126,23 @@ class TestImagePatchBudgetMaxDimension:
                 "exceeding the limit of 30000. Please resize the image and try again."
             ),
         )
-        # isqrt(30000) = 173 tiles per side → 173*32 = 5536 px; 173² = 29929 ≤ 30000.
-        assert _image_error_max_dimension(err) == 5536
+        cap = _image_error_max_dimension(err)
+        assert cap is not None and cap < 8000
 
-    def test_codex_patch_budget_non_square_worst_case_still_under_budget(self):
-        import math
-        cap = _image_error_max_dimension(_FakeApiError(
-            status_code=400,
-            message="requires 33174 patches after processing, exceeding the limit of 30000",
-        ))
-        tiles = math.ceil(cap / 32)
-        assert tiles * tiles <= 30000
+        buf = io.BytesIO()
+        Image.new("RGB", (5444, 6200), (200, 30, 30)).save(buf, format="PNG")
+        url = "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+        msgs = [{"role": "user", "content": [{"type": "input_image", "image_url": url}]}]
 
-    def test_patch_wording_without_limit_returns_none(self):
-        err = _FakeApiError(
-            status_code=400,
-            message="image patches after processing are too numerous",
-        )
-        assert _image_error_max_dimension(err) is None
+        assert try_shrink_image_parts_in_messages(msgs, max_dimension=cap) is True
+        shrunk = msgs[0]["content"][0]["image_url"]
+        w, h = Image.open(io.BytesIO(base64.b64decode(shrunk.split(",", 1)[1]))).size
+        assert -(-w // 32) * -(-h // 32) <= 30000
 
-    def test_non_patch_limit_of_wording_not_misread(self):
-        """"exceeding the limit of N" without the patch vocabulary must stay None."""
-        err = _FakeApiError(
-            status_code=400,
-            message="request exceeds the limit of 100 images per minute",
-        )
-        assert _image_error_max_dimension(err) is None
-
-    def test_patch_budget_below_floor_returns_none(self):
-        """A pathologically tiny budget maps under the 512 px floor → None (8000 fallback)."""
-        err = _FakeApiError(
-            status_code=400,
-            message="requires 90 patches after processing, exceeding the limit of 81",
-        )
-        assert _image_error_max_dimension(err) is None
-
-    def test_anthropic_pixel_ceiling_path_unchanged(self):
-        err = _FakeApiError(
-            status_code=400,
-            message="image dimensions exceed max allowed size: 8000 pixels per side",
-        )
-        assert _image_error_max_dimension(err) == 8000
-
+        # "limit of N" without the patch vocabulary is not a dimension ceiling.
+        assert _image_error_max_dimension(_FakeApiError(
+            status_code=400, message="request exceeds the limit of 100 images per minute",
+        )) is None
 
 
 # ─── Shrink helper ───────────────────────────────────────────────────────────


### PR DESCRIPTION
OpenAI Codex Responses' "requires N patches after processing, exceeding the limit of 30000" 400 now triggers the existing image-shrink recovery, so an oversized image is resized to fit the patch budget and the request retried instead of surfacing a terminal 400 (or failing over with the same invalid image).

- `agent/error_classifier.py::_IMAGE_TOO_LARGE_PATTERNS`: add `"patches after processing"` so the Codex wording classifies as `image_too_large` / retryable.
- `agent/turn_recovery.py::_image_error_max_dimension`: parse the reported patch limit and derive a per-side cap of `isqrt(limit) * 32` (5536 px for 30000). Without this the shrink pass ran with the 8000 px default and skipped every image between ~5542 and 8000 px — over the patch budget yet under the pixel cap — burning the single retry.
- Tests trimmed to two invariants: the classifier signal, and the real shrink pass rewriting a real 5444×6200 Responses `input_image` part to ≤ 30000 patches using the derived cap (both red on base, green with the fix).
- Shrink helper already handles the Responses `{"type": "input_image", "image_url": "data:..."}` shape, so no wire-format widening was needed.

## Validation

| Check | Before (origin/main) | After |
|---|---|---|
| Classifier-level repro from the issue | `reason=format_error retryable=False` | `reason=image_too_large retryable=True` |
| Derived shrink cap | 8000 (default) | 5536 |
| `try_shrink_image_parts_in_messages` on 5444×6200 PNG (33174 patches) | `changed=False`, still 33174 patches | `changed=True`, 2722×3100 = 8342 patches |
| Real `recover_after_classification` seam with an `AIAgent(provider="openai-codex")` and a Responses `input_image` part | — | `recovered=True`, part rewritten under budget; unrelated "limit of 100 images per minute" 400 does not enter the shrink path |
| `scripts/run_tests.sh tests/agent/test_error_classifier.py tests/run_agent/{repro_48013_image_shrink_brick,test_69078_image_corrupt_recovery,test_image_generate_parallel,test_image_rejection_fallback,test_image_shrink_recovery}.py` | — | 191 passed, 0 failed |

Root cause: the Codex patch-budget message contains none of the image-size vocabulary the classifier matches, and `_image_error_max_dimension` only understood pixel ceilings, so the shrink recovery was never entered and, once entered, would not have shrunk a sub-8000 px image.

Salvages #106345 from @liuhao1024 (both commits cherry-picked with authorship). #106346 by @KoNit-K was closed by its author in favour of #106345 (same two-part fix).
Closes #106337

## Infographic
![codex-patch-limit-image-too-large](https://v3b.fal.media/files/b/0aa9ba4b/2WKYX57OA9olYgptFgMEo_jKpyWW7o.png)
