### PR TITLE
--in DIR wins over an inherited TERMINAL_CWD on every launch path (#106220, salvage #106243)

### DIFF
--- a/contributors/emails/Totoro-qaq@users.noreply.github.com
+++ b/contributors/emails/Totoro-qaq@users.noreply.github.com
@@ -1,0 +1,1 @@
+Totoro-qaq

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1443,6 +1443,15 @@ def _apply_in_dir(args) -> None:
     except OSError as e:
         print(f"Error: cannot enter --in directory {in_dir}: {e}")
         sys.exit(1)
+    # Every cwd consumer (resolve_agent_cwd -> Codex app-server thread cwd, the
+    # terminal tool, context-file discovery) prefers TERMINAL_CWD over the process
+    # cwd, so a value inherited from a parent surface, the shell or .env outlives
+    # this chdir and re-homes the session in the old directory (#106220). Refresh
+    # it. An unset variable stays unset: the backends then derive from the new
+    # process cwd (local exports it at cli import, docker mounts it, ssh and
+    # container backends keep their own remote/sandbox default).
+    if os.environ.get("TERMINAL_CWD", "").strip():
+        os.environ["TERMINAL_CWD"] = _target_dir
     args.no_restore_cwd = True
 
 

--- a/tests/hermes_cli/test_resume_latest_and_in_dir.py
+++ b/tests/hermes_cli/test_resume_latest_and_in_dir.py
@@ -229,3 +229,51 @@ def test_in_dir_expands_user_home(main_mod, launched, monkeypatch, tmp_path):
         assert os.getcwd() == str((home / "proj").resolve())
     finally:
         os.chdir(start)
+
+
+# ---------------------------------------------------------------------------
+# --in must win over an inherited TERMINAL_CWD (#106220)
+# ---------------------------------------------------------------------------
+
+
+def test_in_dir_replaces_inherited_terminal_cwd(main_mod, monkeypatch, tmp_path):
+    """A parent Hermes surface, the shell or .env can export TERMINAL_CWD before
+    the CLI starts. Every cwd consumer prefers that variable over the process
+    cwd, so a bare chdir left the Codex app-server thread, the terminal tool and
+    context-file discovery in the inherited directory."""
+    import os
+    from pathlib import Path
+
+    from agent.runtime_cwd import resolve_agent_cwd
+
+    inherited = tmp_path / "inherited"
+    target = tmp_path / "target"
+    inherited.mkdir()
+    target.mkdir()
+    monkeypatch.chdir(inherited)
+    monkeypatch.setenv("TERMINAL_CWD", str(inherited))
+
+    args = _args(in_dir=str(target))
+    main_mod._apply_in_dir(args)
+
+    assert Path.cwd().resolve() == target.resolve()
+    assert Path(os.environ["TERMINAL_CWD"]).resolve() == target.resolve()
+    assert resolve_agent_cwd().resolve() == target.resolve()
+    assert args.no_restore_cwd is True
+
+
+def test_in_dir_leaves_unset_terminal_cwd_unset(main_mod, monkeypatch, tmp_path):
+    """Without an inherited value the backends already derive from the process
+    cwd (local exports os.getcwd() at cli import, docker mounts it, the TUI
+    child inherits the chdir). Pre-seeding a host path here would leak it into
+    ssh/container backends that must keep their own default."""
+    import os
+
+    target = tmp_path / "target"
+    target.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    main_mod._apply_in_dir(_args(in_dir=str(target)))
+
+    assert "TERMINAL_CWD" not in os.environ


### PR DESCRIPTION
`hermes --in DIR` now actually runs the session in DIR even when a parent Hermes surface, the shell or `.env` had already exported `TERMINAL_CWD` — previously every cwd consumer (prompt "Current working directory" line, context-file discovery, the Codex app-server thread cwd) kept the inherited directory.

- `hermes_cli/main.py::_apply_in_dir`: after the `chdir`, refresh `TERMINAL_CWD` to the absolute `--in` target **when it is already set**. An unset variable stays unset, so no host path is pre-seeded into ssh/container backends and the local backend keeps deriving from the process cwd exactly as before.
- 2 invariant tests in `tests/hermes_cli/test_resume_latest_and_in_dir.py` (inherited value replaced and observed through `resolve_agent_cwd()`; unset stays unset). Sabotage run: reverting the `main.py` hunk turns `test_in_dir_replaces_inherited_terminal_cwd` red.
- `contributors/emails/` mapping for the contributor (my commit).

**Root cause:** `--in` only called `os.chdir`, while `agent/runtime_cwd.py::resolve_agent_cwd` (and every consumer behind it) prefers `TERMINAL_CWD` over `os.getcwd()`; `cli.py`'s import-time force-export rescues only the classic CLI on the local backend, and only when `_HERMES_GATEWAY` is not set — the TUI child env, docker/ssh backends and the app-server thread never saw the `--in` directory.

## Live repro (real imports, temp `HERMES_HOME`, fresh interpreter; `TERMINAL_CWD=A`, cwd=A, `--in B`)

`/tmp/probe_in_dir_106220.py <worktree> <label>` — `_apply_in_dir(Namespace(in_dir=B))` then `resolve_agent_cwd()`:

```
=== BEFORE (origin/main 511633be90e) ===
[before] os.getcwd()          = B
[before] TERMINAL_CWD          = A
[before] resolve_agent_cwd()   = A  (Codex app-server thread cwd, prompt cwd line)
[before] BUG FIRES: --in B, agent runs in A (inherited)
[before] unset control: TERMINAL_CWD in env = False; resolve_agent_cwd() = B

=== AFTER ===
[after] os.getcwd()          = B
[after] TERMINAL_CWD          = B
[after] resolve_agent_cwd()   = B  (Codex app-server thread cwd, prompt cwd line)
[after] NEGATIVE: --in B, agent runs in B
[after] unset control: TERMINAL_CWD in env = False; resolve_agent_cwd() = B
```

Per-surface probe (`terminal.backend: docker` in the temp config, then `import cli` and the TUI child-env assembly `build_subprocess_env` + `apply_terminal_config_to_env`):

| surface | before | after |
|---|---|---|
| classic CLI, local backend (`import cli` force-export) | B (already rescued) | B |
| docker backend after `import cli` → `resolve_agent_cwd()` | **A** | B |
| TUI child env `TERMINAL_CWD` | **A** | B |

Note: the local-backend rescue in `cli.py` is skipped when `_HERMES_GATEWAY=1` is inherited (e.g. a Hermes launched from inside a gateway-spawned terminal), so even the classic CLI hit this without the fix.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_resume_latest_and_in_dir.py` → 14 passed, 0 failed.
- `ruff check` clean on touched files; `check-windows-footguns.py --all` clean; `check_compat_pointers.py` clean; `git diff --check` clean; attribution audit green.

## Not covered (assessed)

The issue also asks that a *resumed* session's recorded cwd vs an explicit `--in` be reconciled, and for an explicit conflict error. `--in` already sets `no_restore_cwd`, so the resumed cwd is not restored over `--in`; no conflict error is added — silent precedence for the explicit flag is the existing contract. Persisted-session `session_cwd` overrides (`agent.session_cwd`) are a separate resolver layer and untouched.

Salvage of #106243 by @Totoro-qaq (cherry-picked, authorship preserved). Issue reported by @cyberryan76.

Closes #106220

## Infographic
![in-dir-terminal-cwd](https://v3b.fal.media/files/b/0aa9ba55/VhximDeJMzRBL0QpvYO3g_cbMES4ny.png)
