### PR TITLE
fix(process): size worker memory limits to host resources

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2296,9 +2296,70 @@ class TestSystemdCgroupIsolation:
         warning.assert_not_called()
         assert f"MemoryMax={123 * 1024 * 1024}" in argv
 
-    def test_worker_memory_limit_caps_oversized_local_guard_override(
-        self, monkeypatch
-    ):
+    def test_worker_memory_limit_scales_beyond_four_gib_on_large_host(self, monkeypatch):
+        import tools.process_registry as pr
+
+        monkeypatch.delenv("TERMINAL_LOCAL_MEMORY_MAX_MB", raising=False)
+        monkeypatch.setattr(
+            pr.Path,
+            "read_text",
+            lambda self, **_kwargs: (
+                "0::/worker.slice"
+                if str(self) == "/proc/self/cgroup"
+                else "max"
+            ),
+        )
+        monkeypatch.setattr(
+            pr.os,
+            "sysconf",
+            lambda name: {"SC_PHYS_PAGES": 4 * 1024 * 1024, "SC_PAGE_SIZE": 4096}[name],
+        )
+
+        assert pr._worker_memory_max_bytes() == 8 * 1024 * 1024 * 1024
+
+    def test_worker_memory_limit_honors_enclosing_cgroup(self, monkeypatch):
+        import tools.process_registry as pr
+
+        monkeypatch.delenv("TERMINAL_LOCAL_MEMORY_MAX_MB", raising=False)
+        monkeypatch.setattr(
+            pr.Path,
+            "read_text",
+            lambda self, **_kwargs: (
+                "0::/worker.slice"
+                if str(self) == "/proc/self/cgroup"
+                else str(6 * 1024 * 1024 * 1024)
+            ),
+        )
+        monkeypatch.setattr(
+            pr.os,
+            "sysconf",
+            lambda name: {"SC_PHYS_PAGES": 4 * 1024 * 1024, "SC_PAGE_SIZE": 4096}[name],
+        )
+
+        assert pr._worker_memory_max_bytes() == 6 * 1024 * 1024 * 1024
+
+    def test_worker_memory_limit_honors_explicit_lower_override(self, monkeypatch):
+        import tools.process_registry as pr
+
+        monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "1024")
+        monkeypatch.setattr(
+            pr.Path,
+            "read_text",
+            lambda self, **_kwargs: (
+                "0::/worker.slice"
+                if str(self) == "/proc/self/cgroup"
+                else str(6 * 1024 * 1024 * 1024)
+            ),
+        )
+        monkeypatch.setattr(
+            pr.os,
+            "sysconf",
+            lambda name: {"SC_PHYS_PAGES": 4 * 1024 * 1024, "SC_PAGE_SIZE": 4096}[name],
+        )
+
+        assert pr._worker_memory_max_bytes() == 1024 * 1024 * 1024
+
+    def test_worker_memory_limit_falls_back_when_no_resource_signals(self, monkeypatch):
         import tools.process_registry as pr
 
         monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "999999")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -84,14 +84,15 @@ _SYSTEMD_SCOPE_PROBED_AT = 0.0
 _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
 _MIN_WORKER_MEMORY_MAX_BYTES = 64 * 1024 * 1024
 _DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
-_WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
+
 
 
 def _worker_memory_max_bytes() -> int:
     """Finite per-worker cgroup limit that can never widen host risk.
     ``TERMINAL_LOCAL_MEMORY_MAX_MB`` is honored only when it *tightens* the safe
     bound (min of the gateway's cgroup-v2 ``memory.max`` and half of physical RAM,
-    capped at 4 GiB), so an oversized override cannot exceed the enclosing slice.
+    with no arbitrary host-size cap), so an oversized override cannot exceed the
+    enclosing slice.
 
     The proposed local-memory-guard environment override is honored when it tightens the safe bound, so this
     isolation composes with PR #57121 instead of inventing a second knob.
@@ -121,7 +122,7 @@ def _worker_memory_max_bytes() -> int:
                 candidates.append(int(raw_limit))
     with suppress(OSError, ValueError, TypeError):
         physical_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(os.sysconf("SC_PAGE_SIZE"))
-        candidates.append(min(_WORKER_MEMORY_MAX_CAP_BYTES, max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2)))
+        candidates.append(max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2))
     safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES
     return min(override_bound, safe_bound) if override_bound else safe_bound
 


### PR DESCRIPTION
## Problem
Worker scopes are capped at 4 GiB even when the host and enclosing cgroup permit substantially more memory. A larger configured memory value cannot lift this ceiling, resulting in avoidable cgroup OOM terminations on large hosts.

## Change
Remove the fixed 4 GiB clamp. Keep the existing finite bound from half physical RAM and the enclosing cgroup-v2 limit, the conservative fallback, and the environment override that can only tighten the bound. No OOM policy or service changes.

## Verification
- tests/tools/test_process_registry.py: 107 passed, 4 skipped
- Added coverage for large hosts, enclosing cgroup limits, tightening overrides and missing resource signals.
- git diff --check and compileall passed.

Local tests are not a claim of production rollout or upstream CI completion.