### PR TITLE
debug share stops promising 6h auto-delete on the dpaste.com fallback and shrinks its retention to 1 day (#106164, salvage #106178)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1175,8 +1175,8 @@ class GatewaySlashCommandsMixin(
         """Handle /debug — upload ONLY the summary (system info + log tails), never full logs, to
         protect privacy; ``hermes debug share`` from the CLI does full uploads."""
         from hermes_cli.debug import (_GATEWAY_PRIVACY_NOTICE, _best_effort_sweep_expired_pastes,
-                                      _capture_dump, _schedule_auto_delete, collect_debug_report,
-                                      upload_to_pastebin)
+                                      _capture_dump, _is_dpaste_url, _schedule_auto_delete,
+                                      collect_debug_report, upload_to_pastebin)
 
         def _collect_and_upload():  # blocking I/O (dump capture, log reads, uploads) -> thread
             _best_effort_sweep_expired_pastes()
@@ -1185,11 +1185,15 @@ class GatewaySlashCommandsMixin(
                 urls = {"Report": upload_to_pastebin(report)}
             except Exception as exc:
                 return t("gateway.debug.upload_failed", error=exc)
-            _schedule_auto_delete(list(urls.values()))  # auto-deletion after 6 hours
+            _schedule_auto_delete(list(urls.values()))  # paste.rs only; dpaste.com has no delete
             label_width = max(len(k) for k in urls)
+            # The 6-hour line is only true for paste.rs; the privacy notice above already states
+            # the dpaste.com fallback retention, so drop the line rather than contradict it.
+            auto_delete = [] if any(map(_is_dpaste_url, urls.values())) else [
+                t("gateway.debug.auto_delete")]
             return "\n".join([_GATEWAY_PRIVACY_NOTICE, "", t("gateway.debug.header"), "",
                               *(f"`{label:<{label_width}}`  {url}" for label, url in urls.items()),
-                              "", t("gateway.debug.auto_delete"), t("gateway.debug.full_logs_hint"),
+                              "", *auto_delete, t("gateway.debug.full_logs_hint"),
                               t("gateway.debug.share_hint")])
 
         # _run_in_executor_with_context, not a bare hop: this collects the profile's logs/config off

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -116,6 +116,10 @@ upload, but the following personal data is NOT redacted and will be public:
 The resulting URL is public to anyone who has the link. Pastes auto-delete
 after 6 hours, but may be archived by third parties in the meantime.
 
+If paste.rs is unreachable, uploads fall back to dpaste.com: those pastes
+stay public for the --expire window (default: 1 day) and CANNOT be deleted
+with `hermes debug delete`.
+
 Use --local to view the report without uploading.
 """
 
@@ -124,7 +128,8 @@ _GATEWAY_PRIVACY_NOTICE = (
     "(may contain conversation fragments) to a public paste service. "
     "Full logs are NOT included from the gateway — use `hermes debug share` "
     "from the CLI for full log uploads.\n"
-    "Pastes auto-delete after 6 hours.")
+    "Pastes auto-delete after 6 hours (dpaste.com fallback pastes: kept for "
+    "1 day, cannot be deleted).")
 
 
 def _extract_paste_id(url: str) -> Optional[str]:
@@ -136,10 +141,19 @@ def _extract_paste_id(url: str) -> Optional[str]:
     return None
 
 
+def _is_dpaste_url(url: str) -> bool:
+    """Whether *url* is a dpaste.com paste (no unauthenticated delete exists for those)."""
+    return url.strip().startswith(("https://dpaste.com/", "http://dpaste.com/"))
+
+
 def delete_paste(url: str) -> bool:
     """Delete a paste.rs paste (the only service with unauthenticated DELETE). True on success."""
     paste_id = _extract_paste_id(url)
     if not paste_id:
+        if _is_dpaste_url(url):
+            raise ValueError(
+                "Cannot delete: dpaste.com pastes cannot be deleted (anonymous "
+                "uploads have no owner token); they expire on their own.  Got: " + url)
         raise ValueError(f"Cannot delete: only paste.rs URLs are supported.  Got: {url}")
     req = urllib.request.Request(f"{_PASTE_RS_URL}{paste_id}", method="DELETE",
                                  headers={"User-Agent": _USER_AGENT})
@@ -175,7 +189,7 @@ def _upload_paste_rs(content: str) -> str:
     return _post_paste("paste.rs", _PASTE_RS_URL, content.encode("utf-8"), "text/plain; charset=utf-8")
 
 
-def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
+def _upload_dpaste_com(content: str, expiry_days: int = 1) -> str:
     boundary = "----HermesDebugBoundary9f3c"
     fields = (("content", content), ("syntax", "text"), ("expiry_days", str(expiry_days)))
     body = ("".join(f'--{boundary}\r\nContent-Disposition: form-data; name="{n}"\r\n\r\n{v}\r\n'
@@ -184,8 +198,13 @@ def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
                        f"multipart/form-data; boundary={boundary}")
 
 
-def upload_to_pastebin(content: str, expiry_days: int = 7) -> str:
-    """Upload *content* to a paste service, trying paste.rs then dpaste.com."""
+def upload_to_pastebin(content: str, expiry_days: int = 1) -> str:
+    """Upload *content* to a paste service, trying paste.rs then dpaste.com.
+
+    ``expiry_days`` applies only to the dpaste.com fallback (paste.rs pastes are
+    swept after 6h); dpaste.com's minimum is 1 day and anonymous pastes cannot
+    be deleted afterwards, so callers must not promise a shorter retention.
+    """
     errors: list[str] = []
     for service, upload in (
         ("paste.rs", lambda: _upload_paste_rs(content)),
@@ -406,12 +425,13 @@ class DebugShareResult:
     urls: dict  # label -> paste URL (e.g. {"Report": "...", "agent.log": "..."})
     failures: list  # human-readable "label: error" strings for optional uploads
     redacted: bool  # whether force-mode redaction was applied before upload
-    auto_delete_seconds: int  # how long until the pastes auto-delete
+    auto_delete_seconds: int  # how long until the pastes auto-delete (paste.rs only;
+    # dpaste.com fallbacks outlive this and cannot be deleted)
     report: str = ""  # the summary report text (kept for local fallback)
 
 
 def build_debug_share(
-    *, log_lines: int = 200, expiry: int = 7, redact: bool = True) -> DebugShareResult:
+        *, log_lines: int = 200, expiry: int = 1, redact: bool = True) -> DebugShareResult:
     """Collect the debug report + full logs, upload each, return the URLs.
 
     Shared by ``hermes debug share`` and the dashboard ``POST /api/ops/debug-share``. Blocking
@@ -460,7 +480,7 @@ def _confirm_upload(args) -> bool:
 def run_debug_share(args):
     """Collect debug report + full logs, upload each, print URLs."""
     log_lines = getattr(args, "lines", 200)
-    expiry = getattr(args, "expire", 7)
+    expiry = getattr(args, "expire", 1)
     redact = not getattr(args, "no_redact", False)
 
     if getattr(args, "local", False):
@@ -492,9 +512,18 @@ def run_debug_share(args):
         print(f"  {label:<{label_width}}  {url}")
     if result.failures:
         print(f"\n  (failed to upload: {', '.join(result.failures)})")
-    print(f"\n⏱  Pastes will auto-delete in {result.auto_delete_seconds // 3600} hours.\n"
-          "To delete now:  hermes debug delete <url>\n"
-          "\nShare these links with the Hermes team for support.")
+    dpaste_urls = [u for u in result.urls.values() if _is_dpaste_url(u)]
+    if dpaste_urls:
+        print(f"\n⏱  paste.rs pastes will auto-delete in "
+              f"{result.auto_delete_seconds // 3600} hours.")
+        print(f"⚠️  {len(dpaste_urls)} of {len(result.urls)} upload(s) fell back to "
+              f"dpaste.com: those pastes stay public for {expiry} day(s) and CANNOT be "
+              "deleted with `hermes debug delete`.\n"
+              "\nShare these links with the Hermes team for support.")
+    else:
+        print(f"\n⏱  Pastes will auto-delete in {result.auto_delete_seconds // 3600} hours.\n"
+              "To delete now:  hermes debug delete <url>\n"
+              "\nShare these links with the Hermes team for support.")
 
 
 _NOUS_PRIVACY_NOTICE = """\
@@ -588,7 +617,7 @@ Commands:
 
 Options (share):
   --lines N    Number of log lines to include (default: 200)
-  --expire N   Paste expiry in days (default: 7)
+  --expire N   dpaste.com fallback retention in days (default: 1)
   --local      Print report locally instead of uploading
   --nous       Upload to Nous-internal storage (private, staff-only,
                auto-deletes in 14 days) instead of a public paste

--- a/hermes_cli/subcommands/debug.py
+++ b/hermes_cli/subcommands/debug.py
@@ -19,7 +19,7 @@ Examples:
     hermes debug share              Upload debug report (asks for confirmation)
     hermes debug share --yes        Skip confirmation (for scripts/CI)
     hermes debug share --lines 500  Include more log lines
-    hermes debug share --expire 30  Keep paste for 30 days
+    hermes debug share --expire 30  Keep dpaste.com fallback pastes for 30 days
     hermes debug share --local      Print report locally (no upload)
     hermes debug share --no-redact  Disable upload-time secret redaction
     hermes debug share --nous       Upload to Nous-internal storage (private)
@@ -32,7 +32,11 @@ Examples:
         "--lines", type=int, default=200,
         help="Number of log lines to include per log file (default: 200)")
     share_parser.add_argument(
-        "--expire", type=int, default=7, help="Paste expiry in days (default: 7)")
+        "--expire", type=int, default=1,
+        help="dpaste.com fallback retention in days (minimum 1; default: 1). "
+            "paste.rs pastes are always deleted after 6 hours, but if the "
+            "upload falls back to dpaste.com the pastes live for this many "
+            "days and cannot be deleted.")
     share_parser.add_argument(
         "--local", action="store_true", help="Print the report locally instead of uploading")
     share_parser.add_argument(

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -632,6 +632,14 @@ class TestDeletePaste:
         assert req.method == "DELETE"
         assert "paste.rs/abc123" in req.full_url
 
+    def test_dpaste_url_error_explains_no_delete(self):
+        """dpaste.com pastes have no owner token, so the user must be told the
+        paste cannot be deleted and will expire on its own (#106164)."""
+        from hermes_cli.debug import delete_paste
+
+        with pytest.raises(ValueError, match="cannot be deleted.*expire on their own"):
+            delete_paste("https://dpaste.com/ABC123")
+
 
 class TestScheduleAutoDelete:
     """``_schedule_auto_delete`` used to spawn a detached Python subprocess
@@ -814,6 +822,29 @@ class TestShareIncludesAutoDelete:
         assert "PUBLIC paste service" in out
         assert "NOT redacted" in out
 
+    def test_share_output_warns_on_dpaste_fallback(self, hermes_home, capsys):
+        """With dpaste.com URLs the output must not promise 6-hour auto-delete
+        or a working `hermes debug delete` (#106164)."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 1
+        args.local = False
+        args.nous = False
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://dpaste.com/TEST"), \
+             patch("hermes_cli.debug._schedule_auto_delete"):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "fell back to dpaste.com" in out
+        assert "CANNOT be deleted" in out
+        assert "To delete now" not in out
+        assert "paste.rs pastes will auto-delete in 6 hours" in out
+
 
 # ---------------------------------------------------------------------------
 # build_debug_share — structured core used by the dashboard endpoint
@@ -873,7 +904,6 @@ class TestBuildDebugShare:
         assert "Report" in result.urls
         assert len(result.failures) == 1
         assert "paste service hiccup" in result.failures[0]
-
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`hermes debug share` and the gateway `/debug` no longer tell the user their logs auto-delete in 6 hours when the upload actually landed on dpaste.com, and the dpaste fallback now keeps pastes for dpaste's minimum (1 day) instead of 7.

User-reported (#106164, fired in the wild during a paste.rs outage on 2026-09-09).

## Changes

- `hermes_cli/debug.py` — dpaste fallback default `expiry_days` 7 → 1 (dpaste's minimum; the API has no shorter window) in `_upload_dpaste_com`, `upload_to_pastebin`, `build_debug_share`, `run_debug_share`; the CLI + gateway privacy notices disclose the fallback retention *before* the user consents; the post-upload summary prints the real retention and "CANNOT be deleted with `hermes debug delete`" when any URL is dpaste, and only keeps the "auto-delete in 6 hours / To delete now" lines for paste.rs; `delete_paste()` explains why dpaste URLs cannot be deleted (anonymous pastes have no owner token) instead of "only paste.rs URLs are supported".
- `hermes_cli/subcommands/debug.py` — `--expire` default 7 → 1 and help text that says what the flag actually controls (dpaste fallback retention only).
- `gateway/slash_commands.py` (follow-up) — the gateway `/debug` twin drops the localized "Pastes will auto-delete in 6 hours." line when the URL it just printed is a dpaste paste; `_GATEWAY_PRIVACY_NOTICE` in the same reply already states the fallback retention.
- `tests/hermes_cli/test_debug.py` — 2 invariant tests (both red on `origin/main`, green here): dpaste delete error explains itself; share output with a dpaste URL warns and does not offer `To delete now`.

**Root cause:** the output/notice text and `_schedule_auto_delete` were written for paste.rs (unauthenticated DELETE, 6h sweep) and never branched on which service actually took the upload, while `_upload_dpaste_com` posted `expiry_days=7`.

## Validation

Live repro (`/tmp/lane_dpaste_repro.py <repo> <label>`): real imports, temp `HERMES_HOME`, real `run_debug()` / `run_debug_delete()` / `GatewayRunner._handle_debug_command`, argparse default read from the real parser. Only `urllib.request.urlopen` inside `hermes_cli.debug` is replaced: paste.rs raises `URLError`, dpaste.com returns a fake URL and the posted multipart fields are captured. No bytes left the machine.

**Before (origin/main 511633be90e):**
```
posted to dpaste.com: [{'content': '<608 chars>', 'syntax': 'text', 'expiry_days': '7'}]
share output tail:
    Debug report uploaded:
      Report  https://dpaste.com/SIMULATED
    ⏱  Pastes will auto-delete in 6 hours.
    To delete now:  hermes debug delete <url>
`hermes debug delete https://dpaste.com/SIMULATED`:
    ✗ Cannot delete: only paste.rs URLs are supported.  Got: https://dpaste.com/SIMULATED
gateway /debug reply tail:
    `Report`  https://dpaste.com/SIMULATED
    ⏱ Pastes will auto-delete in 6 hours.
VERDICT: BUG FIRES
```

**After (this branch):**
```
posted to dpaste.com: [{'content': '<608 chars>', 'syntax': 'text', 'expiry_days': '1'}]
share output tail:
    Debug report uploaded:
      Report  https://dpaste.com/SIMULATED
    ⏱  paste.rs pastes will auto-delete in 6 hours.
    ⚠️  1 of 1 upload(s) fell back to dpaste.com: those pastes stay public for 1 day(s) and CANNOT be deleted with `hermes debug delete`.
`hermes debug delete https://dpaste.com/SIMULATED`:
    ✗ Cannot delete: dpaste.com pastes cannot be deleted (anonymous uploads have no owner token); they expire on their own.  Got: https://dpaste.com/SIMULATED
gateway /debug reply tail:
    `Report`  https://dpaste.com/SIMULATED
    For full log uploads, use `hermes debug share` from the CLI.
VERDICT: NEGATIVE (fixed)
```

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_debug.py tests/gateway/test_debug_command.py tests/hermes_cli/test_dashboard_admin_endpoints.py` | 96 passed, 0 failed |
| Sabotage: the 2 new tests against a pristine `origin/main` checkout | 2 failed (both bite) |
| `ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check`, `audit_pr_attribution.py` | clean |

## Salvage notes

Salvage of #106178 by @liuhao1024 (cherry-picked; authorship preserved). Trimmed inside the pick: 7 tests → 2 invariants (dropped 5 tests that only pinned the new default value or re-asserted the unchanged paste.rs wording). Follow-up commit (mine): the gateway `/debug` twin, which the original PR did not cover.

Overlapping open PRs, deliberately not folded in:
- #94911 (@fangliquanflq) removes the dpaste fallback outright and reworks non-interactive consent across CLI/gateway/dashboard/desktop (+536/−309, 22 files). That is a design call (drop the fallback vs. keep it honest); this PR is the minimal honest fix that leaves the door open either way.
- #54821 (@ooiuuii) bounds the paste-service response read (#54819) — independent hardening of the same helpers, no overlap in intent.

Not covered here: the dashboard (`web/src/pages/SystemPage.tsx`) and Desktop strings still say "auto-deletes in 6h" unconditionally; `auto_delete_seconds` in the `/api/ops/debug-share` payload has no per-URL service flag. Left for a JS-side follow-up rather than widening this Python PR.

Refs #106164

## Infographic
![debug-share-dpaste-honest-fallback](https://v3b.fal.media/files/b/0aa9ba5a/2j813KWg56eM07DqwUEPF_T3YPUsxT.png)
