### PR TITLE
Cron schedule changed from one-shot to recurring keeps firing instead of retiring after one run (#106096, salvage #106106)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1897,6 +1897,38 @@ def _normalize_job_updates(job: Dict[str, Any], updates: Dict[str, Any]) -> None
             updates["repeat"] = {"times": normalize_repeat_value(_rp), "completed": completed}
 
 
+def _rederive_repeat_for_schedule_change(
+    job: Dict[str, Any], updates: Dict[str, Any]
+) -> None:
+    """Re-derive the ``repeat`` default when a schedule update flips the kind.
+
+    ``create_job`` derives it from the schedule kind (once -> 1, recurring -> forever); the update
+    path must honour the same contract, otherwise a one-shot turned recurring keeps its ``times=1``
+    budget and retires after one fire, while a recurring job turned one-shot never completes. An
+    explicit ``repeat`` in the same update wins; a same-kind schedule edit leaves ``repeat`` alone.
+    """
+    if "schedule" not in updates or "repeat" in updates:
+        return
+    new_schedule = updates["schedule"]
+    if isinstance(new_schedule, str):
+        new_schedule = parse_schedule(new_schedule)
+        updates["schedule"] = new_schedule
+    old_kind = (job.get("schedule") or {}).get("kind")
+    new_kind = new_schedule.get("kind")
+    if old_kind == new_kind:
+        return
+    repeat = dict(job.get("repeat") or {})
+    times = repeat.get("times")
+    if new_kind == "once" and times is None:
+        repeat["times"] = 1
+    elif new_kind != "once" and old_kind == "once" and times == 1:
+        repeat["times"] = None
+    else:
+        return
+    repeat.setdefault("completed", 0)
+    updates["repeat"] = repeat
+
+
 def _apply_schedule_update(updated: Dict[str, Any], updates: Dict[str, Any], job_id: str) -> None:
     """Parse a string schedule, refresh ``schedule_display`` and (unless paused) ``next_run_at``."""
     updated_schedule = updated["schedule"]
@@ -1936,6 +1968,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         raise ValueError(f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}")
 
     def apply(jobs, i, job):
+        _rederive_repeat_for_schedule_change(job, updates)
         _normalize_job_updates(job, updates)
         previous_inference_axes = _normalized_inference_axes(job)
         updated = _apply_skill_fields({**job, **updates})

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -438,6 +438,61 @@ class TestJobCRUD:
         with pytest.raises(ValueError, match="Invalid repeat"):
             update_job(job["id"], {"repeat": "banana"})
 
+    def test_oneshot_turned_recurring_becomes_forever(self, tmp_cron_dir):
+        """A one-shot budget must not survive a schedule change to a recurring kind.
+
+        create_job derives repeat from the schedule kind; update_job must honour
+        the same contract when the kind flips, otherwise a job "fixed" from a
+        one-shot to `every 15m` keeps times=1 and retires after its first fire.
+        """
+        from cron.jobs import update_job
+
+        job = create_job(prompt="poll", schedule="in 15m")
+        assert job["repeat"]["times"] == 1
+
+        updated = update_job(job["id"], {"schedule": "every 15m"})
+        assert updated["schedule"]["kind"] == "interval"
+        assert updated["repeat"]["times"] is None
+
+    def test_recurring_turned_oneshot_becomes_once(self, tmp_cron_dir):
+        """The reverse flip must gain the one-shot default instead of staying forever."""
+        from cron.jobs import update_job
+
+        job = create_job(prompt="poll", schedule="every 15m")
+        assert job["repeat"]["times"] is None
+
+        updated = update_job(job["id"], {"schedule": "in 15m"})
+        assert updated["schedule"]["kind"] == "once"
+        assert updated["repeat"]["times"] == 1
+
+    def test_explicit_repeat_in_same_update_wins(self, tmp_cron_dir):
+        """An explicit repeat beats the re-derived default on kind flips."""
+        from cron.jobs import update_job
+
+        job = create_job(prompt="poll", schedule="in 15m")
+
+        updated = update_job(job["id"], {"schedule": "every 15m", "repeat": 3})
+        assert updated["repeat"]["times"] == 3
+
+    def test_same_kind_schedule_edit_keeps_repeat(self, tmp_cron_dir):
+        """Re-pointing a recurring schedule at another cadence is not a kind flip."""
+        from cron.jobs import update_job
+
+        job = create_job(prompt="poll", schedule="every 15m", repeat=5)
+
+        updated = update_job(job["id"], {"schedule": "every 30m"})
+        assert updated["schedule"]["kind"] == "interval"
+        assert updated["repeat"]["times"] == 5
+
+    def test_explicit_finite_oneshot_keeps_budget_turned_recurring(self, tmp_cron_dir):
+        """An explicitly finite one-shot (repeat=2) carries its budget to the recurring side."""
+        from cron.jobs import update_job
+
+        job = create_job(prompt="poll", schedule="in 15m", repeat=2)
+
+        updated = update_job(job["id"], {"schedule": "every 15m"})
+        assert updated["repeat"]["times"] == 2
+
     def test_rejects_stale_past_one_shot_at_creation(self, tmp_cron_dir, monkeypatch):
         now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
         monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -444,6 +444,7 @@ class TestJobCRUD:
         create_job derives repeat from the schedule kind; update_job must honour
         the same contract when the kind flips, otherwise a job "fixed" from a
         one-shot to `every 15m` keeps times=1 and retires after its first fire.
+        An explicit repeat in the same update still wins over the re-derived default.
         """
         from cron.jobs import update_job
 
@@ -453,6 +454,9 @@ class TestJobCRUD:
         updated = update_job(job["id"], {"schedule": "every 15m"})
         assert updated["schedule"]["kind"] == "interval"
         assert updated["repeat"]["times"] is None
+
+        explicit = create_job(prompt="poll", schedule="in 15m")
+        assert update_job(explicit["id"], {"schedule": "every 15m", "repeat": 3})["repeat"]["times"] == 3
 
     def test_recurring_turned_oneshot_becomes_once(self, tmp_cron_dir):
         """The reverse flip must gain the one-shot default instead of staying forever."""
@@ -464,34 +468,6 @@ class TestJobCRUD:
         updated = update_job(job["id"], {"schedule": "in 15m"})
         assert updated["schedule"]["kind"] == "once"
         assert updated["repeat"]["times"] == 1
-
-    def test_explicit_repeat_in_same_update_wins(self, tmp_cron_dir):
-        """An explicit repeat beats the re-derived default on kind flips."""
-        from cron.jobs import update_job
-
-        job = create_job(prompt="poll", schedule="in 15m")
-
-        updated = update_job(job["id"], {"schedule": "every 15m", "repeat": 3})
-        assert updated["repeat"]["times"] == 3
-
-    def test_same_kind_schedule_edit_keeps_repeat(self, tmp_cron_dir):
-        """Re-pointing a recurring schedule at another cadence is not a kind flip."""
-        from cron.jobs import update_job
-
-        job = create_job(prompt="poll", schedule="every 15m", repeat=5)
-
-        updated = update_job(job["id"], {"schedule": "every 30m"})
-        assert updated["schedule"]["kind"] == "interval"
-        assert updated["repeat"]["times"] == 5
-
-    def test_explicit_finite_oneshot_keeps_budget_turned_recurring(self, tmp_cron_dir):
-        """An explicitly finite one-shot (repeat=2) carries its budget to the recurring side."""
-        from cron.jobs import update_job
-
-        job = create_job(prompt="poll", schedule="in 15m", repeat=2)
-
-        updated = update_job(job["id"], {"schedule": "every 15m"})
-        assert updated["repeat"]["times"] == 2
 
     def test_rejects_stale_past_one_shot_at_creation(self, tmp_cron_dir, monkeypatch):
         now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
Changing a cron job's schedule from one-shot to recurring (or back) now re-derives the `repeat` default the same way `create_job` does, so a job "fixed" from `in 15m` to `every 15m` keeps firing instead of retiring after its first run.

- `cron/jobs.py::_rederive_repeat_for_schedule_change` runs first in `update_job`'s `apply()`: when the update flips the schedule kind and the caller passed no `repeat`, the implicit `times=1` one-shot budget becomes `None` (forever) and a recurring job turned one-shot gains `times=1`. An explicit `repeat` in the same update wins; same-kind edits and explicitly finite budgets are untouched (the reverse direction is the inconsistency the issue calls out: `cronjob list` showed `forever` on a one-shot).
- Two invariant tests in `tests/cron/test_jobs.py::TestJobCRUD` (both directions; explicit repeat folded into the first), proven red on `origin/main` (2 failed / 113 passed) and green with the fix.
- Trimmed the contributor's five tests to those two in a separate commit; the tool surface (`cronjob(action="update", schedule=...)`) needs no change — it funnels into `update_job`.

## Live repro

Both runs: the issue's two-call snippet against a real `jobs.json` in a temp `HERMES_HOME`, then `mark_job_run` to simulate the first fire.

| | `origin/main` (511633be90e) | this branch |
|---|---|---|
| `create_job(schedule="in 15m")` | `once {'times': 1, 'completed': 0}` | same |
| `update_job(id, {"schedule": "every 15m"})` | `interval {'times': 1, 'completed': 0}` | `interval {'times': None, 'completed': 0}` |
| reverse: `every 15m` → `in 15m` | `once {'times': None, ...}` | `once {'times': 1, ...}` |
| after 1st fire of the "recurring" job | `state=completed enabled=False` (retired) | `state=scheduled enabled=True` |
| `cronjob(action="update", schedule="every 15m")` reply | `repeat: once` | `repeat: forever` |

Root cause: `create_job` derives `repeat` from the schedule kind (`once` → 1, recurring → forever) but `update_job` only re-parsed the schedule and refreshed `schedule_display`/`next_run_at`; `_normalize_job_updates` touched `repeat` only when the caller passed one, so `_advance_after_run` hit `finite and completed >= times` on the first fire.

Tests: `scripts/run_tests.sh tests/cron/` — 100 files, 1227 passed, 0 failed.

Credit: fix and tests by @kokhlo (#106106, cherry-picked with authorship). @biggieb327-lgtm's #106174 / #106172 carry a byte-identical `cron/jobs.py` hunk (the issue author's proposed diff) bundled with unrelated fixes — superseded by this PR for the cron part.

Closes #106096

## Infographic
![cron-repeat-rederive](https://v3b.fal.media/files/b/0aa9ba5b/9oCwRiFoGsbjoKdB790Xc_vYPddrh5.png)
