### PR TITLE
Compaction keeps batch clarify answers for the summarizer (#106077, salvage #106089)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1457,7 +1457,25 @@ def _sum_clarify(name, args, content, content_len, line_count):
     # min_prune_chars guard and skips the >=200-char dedup.
     max_summary_chars = _PRUNE_MIN_CHARS - 1
     truncation_marker = "...[truncated]"
-    response = _json_dict(content).get("user_response")
+    parsed = _json_dict(content)
+    response = parsed.get("user_response")
+    # Batch clarify (``questions=[...]``) nests each answer inside ``responses[].user_response``
+    # rather than the top level; without this every batch answer was lost and the summarizer only
+    # saw "asked user a question" (#106077).
+    if response is None:
+        batch_responses = parsed.get("responses")
+        if isinstance(batch_responses, list) and batch_responses:
+            collected = []
+            for entry in batch_responses:
+                if not isinstance(entry, dict):
+                    continue
+                single = entry.get("user_response")
+                # multi_select emits a list of strings; flatten it so the summary keeps every choice.
+                if isinstance(single, str) and single:
+                    collected.append(single)
+                elif isinstance(single, list) and all(isinstance(s, str) and s for s in single):
+                    collected.extend(single)
+            response = collected if collected else None
     is_answer_shaped = (isinstance(response, str) and bool(response)) or (
         isinstance(response, list) and bool(response) and all(isinstance(s, str) and s for s in response)
     )

--- a/contributors/emails/gaoanze888@gmail.com
+++ b/contributors/emails/gaoanze888@gmail.com
@@ -1,0 +1,2 @@
+gaoanze888
+# PR #106089 salvage

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -266,18 +266,6 @@ class TestSummarizeToolResultClarify:
         assert "Choice A" in summary
         assert "Choice B" in summary
 
-    def test_batch_with_only_sentinel_falls_back_to_generic(self):
-        """A batch where every response is a timeout sentinel must not be quoted as a user answer."""
-        content = json.dumps({
-            "responses": [
-                {"question": "Q?", "user_response": "[user did not respond within 15m]"},
-            ]
-        })
-
-        summary = _summarize_tool_result("clarify", "{}", content)
-
-        assert summary == "[clarify] asked user a question"
-
 
 class TestShouldCompress:
     def test_below_threshold(self, compressor):

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -233,6 +233,51 @@ class TestSummarizeToolResultClarify:
 
             assert summary == "[clarify] asked user a question", sentinel
 
+    def test_preserves_batch_user_response_from_responses_list(self):
+        """Batch clarify (``questions=[...]``) nests answers inside ``responses[].user_response``;
+        the summarizer must surface them, not just 'asked user a question' (#106077)."""
+        content = json.dumps({
+            "responses": [
+                {
+                    "question": "May the fields be removed?",
+                    "choices_offered": None,
+                    "user_response": "Keep the fields until ratification.",
+                }
+            ]
+        })
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert summary == '[clarify] user responded: ["Keep the fields until ratification."]'
+
+    def test_preserves_batch_multi_select_and_skips_empties(self):
+        """A partially-answered batch (multi_select + a skipped question) still surfaces every real decision."""
+        content = json.dumps({
+            "responses": [
+                {"question": "Q1?", "user_response": "Answer one"},
+                {"question": "Q2?", "user_response": ["Choice A", "Choice B"]},
+                {"question": "Q3?", "user_response": ""},
+            ]
+        })
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert "Answer one" in summary
+        assert "Choice A" in summary
+        assert "Choice B" in summary
+
+    def test_batch_with_only_sentinel_falls_back_to_generic(self):
+        """A batch where every response is a timeout sentinel must not be quoted as a user answer."""
+        content = json.dumps({
+            "responses": [
+                {"question": "Q?", "user_response": "[user did not respond within 15m]"},
+            ]
+        })
+
+        summary = _summarize_tool_result("clarify", "{}", content)
+
+        assert summary == "[clarify] asked user a question"
+
 
 class TestShouldCompress:
     def test_below_threshold(self, compressor):


### PR DESCRIPTION
Batch `clarify` answers (the user's actual decision/permission text) now reach the compaction summarizer instead of being flattened to `[clarify] asked user a question` before it ever sees them.

- `agent/context_compressor.py::_sum_clarify` reads `responses[].user_response` when the top-level `user_response` is absent — the shape `tools/clarify_tool.py::_batch_result` emits for `questions=[...]`. Scalar answers are collected, `multi_select` lists are flattened, skipped (`""`) entries are dropped, and the existing sentinel check still rejects timeout/no-user prose.
- Single-question clarify results were already preserved; only the batch path was lost.
- Tests trimmed to two invariants (batch answer surfaces; multi_select + partial skip surfaces every real decision); both fail with the fix reverted.

**Live repro** (issue's offline script, real `ContextCompressor._prune_old_tool_results` → `_serialize_for_summary` → `_sample_summary_input`, batch producer shape):

| | summarizer input for the clarify tool result |
|---|---|
| before (origin/main `511633be90e`) | `[TOOL RESULT example-clarify]: [clarify] asked user a question` — answer text absent |
| after (this branch) | `[TOOL RESULT example-clarify]: [clarify] user responded: ["Keep the fields until ratification. This is a pendi…` — answer text present |

Root cause: the pre-summary tool-result demotion pass ran `_sum_clarify`, which only looked at the top-level `user_response` key, so every batch clarify result degraded to the generic stub.

Not changed (design, not bugs — flagged for maintainer): the clarify summary is capped at `_PRUNE_MIN_CHARS - 1` (199 chars) so it survives later prune passes, which still clips very long answers; lean-mode `_sample_summary_input` even-samples input over 160K chars and can elide mid-history corrections by construction. Raising either cap changes prune-floor / summarizer-budget behaviour and is out of scope here.

Credit: fix by @gaoanze888 (#106089, cherry-picked with authorship); issue and offline repro by @BroD369.

Closes #106077

## Infographic
![clarify-compress](https://v3b.fal.media/files/b/0aa9ba5e/LyDf0K5gRG0iWyDc65ZCj_4vVmEpjz.png)
