### PR TITLE
Desktop sidebar tells auto-discovered repos apart from explicit projects (#106162, salvage #81359)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -94,25 +94,17 @@ describe('ProjectOverviewRow', () => {
     expect(container.querySelector('[data-sessions-project="p1"]')).toBeTruthy()
   })
 
-  it('renders the folder-library lead glyph for explicit projects', () => {
-    const explicit = { id: 'p1', label: 'Explicit', isAuto: false } as unknown as SidebarProjectTree
-
-    const { container } = render(<ProjectOverviewRow project={explicit} />)
-
-    expect(container.querySelector('.codicon-folder-library')).toBeTruthy()
-    expect(container.querySelector('.codicon-repo')).toBeNull()
-  })
-
-  it('defaults to the folder-library lead glyph when isAuto is absent (explicit nodes omit it)', () => {
+  it('explicit projects keep the folder-library glyph and a plain accessible name', () => {
     const explicit = { id: 'p1', label: 'Explicit' } as unknown as SidebarProjectTree
 
     const { container } = render(<ProjectOverviewRow project={explicit} />)
 
     expect(container.querySelector('.codicon-folder-library')).toBeTruthy()
     expect(container.querySelector('.codicon-repo')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Enter Explicit' })).toBeTruthy()
   })
 
-  it('renders the repo lead glyph and an "Auto-discovered" tooltip for auto projects', () => {
+  it('auto-discovered repos get the repo glyph, an "Auto-discovered" tooltip, and an accessible name that says so', () => {
     const auto = { id: '/Users/dev/my-repo', label: 'my-repo', isAuto: true } as unknown as SidebarProjectTree
 
     const { container } = render(<ProjectOverviewRow project={auto} />)
@@ -120,7 +112,7 @@ describe('ProjectOverviewRow', () => {
     expect(container.querySelector('.codicon-repo')).toBeTruthy()
     expect(container.querySelector('.codicon-folder-library')).toBeNull()
 
-    const link = screen.getByRole('button', { name: 'Enter my-repo' })
+    const link = screen.getByRole('button', { name: 'Enter my-repo (Auto-discovered)' })
     expect(tipTrigger(link)).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -17,7 +17,8 @@ vi.mock('@/i18n', () => ({
         projects: {
           enter: (label: string) => `Enter ${label}`,
           reorder: (label: string) => `Reorder ${label}`,
-          toggle: (label: string, open: boolean) => `${open ? 'Show' : 'Hide'} ${label} sessions`
+          toggle: (label: string, open: boolean) => `${open ? 'Show' : 'Hide'} ${label} sessions`,
+          autoDiscovered: 'Auto-discovered'
         }
       }
     }
@@ -91,5 +92,35 @@ describe('ProjectOverviewRow', () => {
     const { container } = render(<ProjectOverviewRow project={project} />)
 
     expect(container.querySelector('[data-sessions-project="p1"]')).toBeTruthy()
+  })
+
+  it('renders the folder-library lead glyph for explicit projects', () => {
+    const explicit = { id: 'p1', label: 'Explicit', isAuto: false } as unknown as SidebarProjectTree
+
+    const { container } = render(<ProjectOverviewRow project={explicit} />)
+
+    expect(container.querySelector('.codicon-folder-library')).toBeTruthy()
+    expect(container.querySelector('.codicon-repo')).toBeNull()
+  })
+
+  it('defaults to the folder-library lead glyph when isAuto is absent (explicit nodes omit it)', () => {
+    const explicit = { id: 'p1', label: 'Explicit' } as unknown as SidebarProjectTree
+
+    const { container } = render(<ProjectOverviewRow project={explicit} />)
+
+    expect(container.querySelector('.codicon-folder-library')).toBeTruthy()
+    expect(container.querySelector('.codicon-repo')).toBeNull()
+  })
+
+  it('renders the repo lead glyph and an "Auto-discovered" tooltip for auto projects', () => {
+    const auto = { id: '/Users/dev/my-repo', label: 'my-repo', isAuto: true } as unknown as SidebarProjectTree
+
+    const { container } = render(<ProjectOverviewRow project={auto} />)
+
+    expect(container.querySelector('.codicon-repo')).toBeTruthy()
+    expect(container.querySelector('.codicon-folder-library')).toBeNull()
+
+    const link = screen.getByRole('button', { name: 'Enter my-repo' })
+    expect(tipTrigger(link)).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react'
 
 import { type NewSessionSplitHandler, startNewSessionDrag } from '@/app/chat/new-session-drag'
 import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
@@ -27,7 +28,10 @@ import { WorkspaceAddButton } from './workspace-header'
 
 // A bare color dot (no icon) or an icon glyph — tinted by `color` when set, else
 // the lead's default tertiary. The glyph wrapper centers + caps size either way.
-export function projectIcon({ color, icon, isNoProject }: SidebarProjectTree) {
+// Auto-discovered repos (git lanes Desktop found by scanning disk, not rows in
+// projects.db) get the `repo` glyph so a glance tells explicit projects
+// (`folder-library`) apart from incidental disk/session findings.
+export function projectIcon({ color, icon, isAuto, isNoProject }: SidebarProjectTree) {
   if (color && !icon) {
     return (
       <SidebarRowLeadGlyph>
@@ -38,7 +42,10 @@ export function projectIcon({ color, icon, isNoProject }: SidebarProjectTree) {
 
   return (
     <SidebarRowLeadGlyph style={color ? { color } : undefined}>
-      <Codicon name={icon || (isNoProject ? 'home' : 'folder-library')} size={SIDEBAR_LEAD_ICON_SIZE} />
+      <Codicon
+        name={icon || (isNoProject ? 'home' : isAuto ? 'repo' : 'folder-library')}
+        size={SIDEBAR_LEAD_ICON_SIZE}
+      />
     </SidebarRowLeadGlyph>
   )
 }
@@ -115,6 +122,16 @@ export function ProjectOverviewRow({
     <SidebarRowLead>{projectIcon(project)}</SidebarRowLead>
   )
 
+  const labelLink = (
+    <SidebarRowLink
+      aria-label={s.projects.enter(project.label)}
+      labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
+      onClick={() => onEnter?.(project.id)}
+    >
+      {project.label}
+    </SidebarRowLink>
+  )
+
   const shell = (
     <SidebarGroupRow
       actions={
@@ -155,15 +172,7 @@ export function ProjectOverviewRow({
       }
       className={cn(dragging && 'cursor-grabbing bg-(--ui-sidebar-surface-background)')}
       data-glass-opaque={dragging ? '' : undefined}
-      label={
-        <SidebarRowLink
-          aria-label={s.projects.enter(project.label)}
-          labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
-          onClick={() => onEnter?.(project.id)}
-        >
-          {project.label}
-        </SidebarRowLink>
-      }
+      label={project.isAuto ? <Tip label={s.projects.autoDiscovered}>{labelLink}</Tip> : labelLink}
       lead={lead}
       // The label is grab surface too, not just the lead's grabber — same
       // listeners, minus the controls that keep their own gestures. A project

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -124,7 +124,13 @@ export function ProjectOverviewRow({
 
   const labelLink = (
     <SidebarRowLink
-      aria-label={s.projects.enter(project.label)}
+      // The glyph is aria-hidden and the tooltip only speaks on hover, so the
+      // link's own name carries the auto cue — screen readers get it too.
+      aria-label={
+        project.isAuto
+          ? `${s.projects.enter(project.label)} (${s.projects.autoDiscovered})`
+          : s.projects.enter(project.label)
+      }
       labelClassName={cn('hover:text-foreground hover:underline', isActive && 'text-foreground')}
       onClick={() => onEnter?.(project.id)}
     >

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1781,6 +1781,7 @@ export const ar = defineLocale({
     projects: {
       sectionLabel: 'المشاريع',
       home: 'الرئيسية',
+      autoDiscovered: 'مكتشف تلقائيًا',
       newButton: 'مشروع جديد',
       createTitle: 'مشروع جديد',
       createDesc: 'سمِّ مساحة العمل وأضف مجلدا أو أكثر.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2414,6 +2414,7 @@ export const en: Translations = {
     projects: {
       sectionLabel: 'Projects',
       home: 'Home',
+      autoDiscovered: 'Auto-discovered',
       newButton: 'New project',
       createTitle: 'New project',
       createDesc: 'Name a workspace and add one or more folders.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2088,6 +2088,7 @@ export const ja = defineLocale({
     projects: {
       sectionLabel: 'プロジェクト',
       home: 'ホーム',
+      autoDiscovered: '自動検出',
       newButton: '新規プロジェクト',
       createTitle: '新規プロジェクト',
       createDesc: 'ワークスペースに名前を付け、1つ以上のフォルダを追加します。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2059,6 +2059,7 @@ export interface Translations {
     projects: {
       sectionLabel: string
       home: string
+      autoDiscovered: string
       newButton: string
       createTitle: string
       createDesc: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2013,6 +2013,7 @@ export const zhHant = defineLocale({
     projects: {
       sectionLabel: '專案',
       home: '主頁',
+      autoDiscovered: '自動探索',
       newButton: '新增專案',
       createTitle: '新增專案',
       createDesc: '為工作區命名並新增一個或多個資料夾。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2580,6 +2580,7 @@ export const zh: Translations = {
     projects: {
       sectionLabel: '项目',
       home: '主页',
+      autoDiscovered: '自动发现',
       newButton: '新建项目',
       createTitle: '新建项目',
       createDesc: '为工作区命名并添加一个或多个文件夹。',


### PR DESCRIPTION
Auto-discovered repo lanes in the Desktop sidebar's Projects overview are now told apart from explicit projects — by glyph, by tooltip, and by accessible name — instead of rendering identically under the same PROJECTS header.

**Salvage of #81359 by @DavidMetcalfe** (cherry-picked, authorship preserved) plus one maintainer follow-up.

## What changed

- `apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx`
  - `projectIcon()` renders the `repo` codicon for `isAuto` nodes; explicit projects keep `folder-library`, Home keeps `home`, and a user-set `icon`/`color` still wins (the color-dot branch is untouched).
  - The row label of an auto lane is wrapped in a `Tip` reading **"Auto-discovered"**.
  - **Follow-up (mine):** the label link's `aria-label` appends the same string for auto lanes — `Open my-repo (Auto-discovered)` — because the codicon is `aria-hidden` and a Radix tooltip only speaks on hover, so the salvaged change alone left screen readers with no distinction.
- `apps/desktop/src/i18n/{types,en,zh,zh-hant,ja,ar}.ts`: new `sidebar.projects.autoDiscovered` key (`ru.ts` inherits via `defineLocale` fallback, like the neighbouring keys).
- `overview-row.test.tsx`: contributor's three tests trimmed to two invariants (explicit → `folder-library` + plain name; auto → `repo` + tooltip + `(Auto-discovered)` name).

Salvage notes: the PR predates `SidebarGroupRow` (the row's label became a `label=` prop, #6b1e12c7f48 and friends); the conflict was resolved to main's structure with the PR's original `Tip`-wrap semantics, nothing else. Already-on-main check: `isAuto` was never read in `overview-row.tsx` on `origin/main` (#86756 fixed the lane *dedupe* family, not the rendering).

## Validation

Live A/B of the real `ProjectOverviewRow` with the real Desktop stylesheet (Vite dev server from this worktree, isolated headless Chromium, fixture rows: Home, explicit `Physio-Agent`, themed `Gusidian`, auto `semanticscholar-MCP-Server`):

| Row | origin/main | this branch |
|---|---|---|
| explicit `p_5fdbf16a` | `codicon-folder-library`, `Open Physio-Agent`, no tip | unchanged |
| themed `p_aa11` (color, no icon) | color dot, `Open Gusidian (themed)` | unchanged |
| Home `__no_project__` | `codicon-home`, `Open Home` | unchanged |
| **auto** `/Users/dev/semanticscholar-MCP-Server` | `codicon-folder-library`, `Open semanticscholar-MCP-Server`, **no tip** | **`codicon-repo`**, **`Open semanticscholar-MCP-Server (Auto-discovered)`**, **tooltip trigger present** |

Before: ![before](https://files.catbox.moe/l8kblk.png)  After: ![after](https://files.catbox.moe/w2a268.png)

(Renderer-level A/B, not a native Electron window — the sidebar row component is mounted standalone with `@/styles.css`; the codicon font is confirmed painted, not tofu.)

- `npx vitest run --project ui src/app/chat/sidebar/projects/` → 5 files, 87 tests passed. Sabotage run: with `origin/main`'s `overview-row.tsx` swapped in, the auto-row test fails (red on base).
- `npx tsc --noEmit -p apps/desktop/tsconfig.json` clean (covers all six locales + tests); `eslint` clean on touched files; `git diff --check` clean.

## Coverage against the issues

- #80383 (glyph-only) — already closed by Teknium citing #86756; this PR delivers what that issue actually asked for. Covered.
- #106162 acceptance list:
  - [x] distinguish without opening the menu (glyph + tooltip)
  - [x] screen-reader output exposes the distinction (aria-label follow-up)
  - [x] existing project colors and custom icons keep working (they take precedence; test-covered on the explicit branch, live-verified on the themed row)
  - [x] tests cover rendered + accessible distinction for `isAuto` true vs false
  - [ ] **not covered:** an explicit **"Add to Projects" / convert** menu action (today adoption is implicit via Appearance, `store/projects.ts::setProjectAppearance`) — a new action + i18n in `project-menu.tsx`, a design call
  - [ ] **not covered:** consistency across context menu / command palette / project pickers (`project-menu.tsx` already branches on `isAuto` for its action set but does not name the type; no palette/picker surface was touched)
  - [ ] **not covered:** the sort-tier confusion under Grouping: Project / Ordering: Updated (`model.ts::sortProjectsForOverview` ranks explicit before auto) — behaviour change, belongs with #70444
  - [ ] a visible `Auto` badge was declared optional; not added (sidebar density)
- #73888 (information-architecture: broad-folder ownership, impact preview, Home naming, separate section) — not addressed; needs-decision.

Refs #106162
Refs #73888
Refs #80383

## Infographic
![auto-discovered-vs-explicit](https://v3b.fal.media/files/b/0aa9ba65/B2Wwx2bJptwCoLMg6YSYe_VLm7fhFD.png)
