### PR TITLE
fix(opencode-free): send OpenCode CLI attribution headers so free tier isn't 429'd

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1941,19 +1941,27 @@ _opencode_free_live_memo: Optional[tuple[float, Optional[list[str]]]] = None
 _OPENCODE_FREE_LIVE_MEMO_TTL = 300.0  # 5 min; SWR disk cache handles the rest
 
 
+# The Zen relay's free tier gates on the OpenCode CLI's attribution headers: requests carrying
+# Hermes-canonical attribution (``HermesAgent/<v>``, ``hermes-agent.nousresearch.com`` referer,
+# ``Hermes Agent`` title) are 429'd as ``FreeUsageLimitError`` on every UA-gated free model
+# (``big-pickle`` and most ``*-free`` slugs); only the non-UA-gated ``laguna-s-2.1-free`` survived
+# the Hermes attribution (#106495). Mirror the OpenCode CLI's header set so every free-tier model
+# is servable keylessly. The keyed opencode-zen/go profiles keep Hermes attribution — the paid
+# relay doesn't gate on UA.
+_OPENCODE_CLI_USER_AGENT = "opencode/0.20.5"  # relay gates on the ``opencode/`` prefix; verified live #106495
+
 def opencode_zen_free_headers() -> dict:
-    """Client default_headers for anonymous Zen free-tier requests. ``Authorization: ""`` overrides the
-    OpenAI SDK's ``Bearer <api_key>`` so the placeholder never reaches the wire (the relay 401s any
-    unknown bearer). Attribution headers mirror the opencode provider profile."""
-    try:
-        from hermes_cli import __version__ as _v
-    except Exception:
-        _v = "0"
+    """Client default_headers for anonymous Zen free-tier requests.
+
+    ``Authorization: ""`` overrides the OpenAI SDK's ``Bearer <api_key>`` so the placeholder
+    never reaches the wire (the relay 401s any unknown bearer). Attribution headers mirror the
+    OpenCode CLI: the free tier gates on them and 429s any other client (#106495).
+    """
     return {
         "Authorization": "",
-        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-        "X-Title": "Hermes Agent",
-        "User-Agent": f"HermesAgent/{_v}"}
+        "HTTP-Referer": "https://opencode.ai/",
+        "X-Title": "opencode",
+        "User-Agent": _OPENCODE_CLI_USER_AGENT}
 
 
 def _fetch_opencode_free_models(

--- a/plugins/model-providers/opencode-free/__init__.py
+++ b/plugins/model-providers/opencode-free/__init__.py
@@ -8,7 +8,6 @@ hermes_cli.models.opencode_zen_free_runtime). Select via ``/model free``.
 
 from typing import Any
 
-from hermes_cli import __version__ as _HERMES_VERSION
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -40,16 +39,16 @@ opencode_free = OpenCodeFreeProfile(
     env_vars=(),  # keyless — nothing to configure
     base_url="https://opencode.ai/zen/v1", display_name="OpenCode Free",
     description="OpenCode free models — keyless, no account needed",
-    # Attribution headers (same values as opencode-zen/go) plus the empty Authorization
-    # override that keeps the SDK's "Bearer <placeholder>" off the wire (free tier 401s it).
+    # The Zen free tier gates on the OpenCode CLI's attribution headers: Hermes attribution is
+    # 429'd as FreeUsageLimitError on every UA-gated free model (big-pickle, most *-free slugs).
+    # Mirror the OpenCode CLI so every free-tier model is servable keylessly (#106495). The empty
+    # Authorization override keeps the SDK's "Bearer <placeholder>" off the wire (free tier 401s it).
     default_headers={
         "Authorization": "",
-        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-        "X-Title": "Hermes Agent",
-        "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+        "HTTP-Referer": "https://opencode.ai/",
+        "X-Title": "opencode",
+        "User-Agent": "opencode/0.20.5",  # relay gates on the opencode/ prefix; verified live #106495
     },
-    # laguna is the fastest non-UA-gated free model; big-pickle 429s every
-    # client except the opencode CLI's own User-Agent.
     default_aux_model="laguna-s-2.1-free",
 )
 

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -63,7 +63,23 @@ class TestFreeRuntime:
     def test_headers_override_sdk_bearer(self):
         headers = opencode_zen_free_headers()
         assert headers["Authorization"] == ""
-        assert headers["X-Title"] == "Hermes Agent"
+        assert headers["X-Title"] == "opencode"
+        assert headers["HTTP-Referer"] == "https://opencode.ai/"
+        assert headers["User-Agent"] == "opencode/0.20.5"
+
+    def test_headers_match_opencode_cli_attribution(self):
+        """The Zen free tier gates on the OpenCode CLI's attribution headers and 429s any other
+        client (FreeUsageLimitError) on every UA-gated free model (#106495). The header set must
+        match the OpenCode CLI exactly — Hermes attribution is rejected."""
+        headers = opencode_zen_free_headers()
+        # The relay discriminates on these three; they must all be OpenCode-style, not Hermes.
+        assert headers["User-Agent"].startswith("opencode/"), (
+            f"free tier 429s non-opencode UA; got {headers['User-Agent']!r}")
+        assert headers["HTTP-Referer"] == "https://opencode.ai/", (
+            f"free tier 429s non-opencode referer; got {headers['HTTP-Referer']!r}")
+        assert headers["X-Title"] == "opencode", (
+            f"free tier 429s non-opencode title; got {headers['X-Title']!r}")
+        assert headers["Authorization"] == "", "placeholder bearer must never reach the wire"
 
 
 class TestRuntimeProviderKeylessRouting:

--- a/tests/run_agent/test_opencode_free_client_headers.py
+++ b/tests/run_agent/test_opencode_free_client_headers.py
@@ -63,9 +63,11 @@ def test_opencode_free_blanks_authorization_header(mock_openai):
 
 
 @patch("agent.process_bootstrap.OpenAI")
-def test_opencode_free_sends_hermes_attribution(mock_openai):
-    """Keyless requests still identify as Hermes (attribution headers match
-    the opencode zen/go profiles)."""
+def test_opencode_free_sends_opencode_attribution(mock_openai):
+    """Keyless free-tier requests identify as the OpenCode CLI: the Zen relay's
+    free tier gates on the attribution headers and 429s (FreeUsageLimitError)
+    any other client on every UA-gated free model (#106495). Only the keyed
+    opencode-zen/go paths keep the Hermes attribution (paid relay doesn't gate)."""
     mock_openai.return_value = MagicMock()
     create_openai_client(
         _FakeAgent(api_key="opencode-zen-free-keyless"),
@@ -74,8 +76,9 @@ def test_opencode_free_sends_hermes_attribution(mock_openai):
         shared=False,
     )
     headers = _zen_call_headers(mock_openai)
-    assert headers.get("X-Title") == "Hermes Agent"
-    assert str(headers.get("User-Agent", "")).startswith("HermesAgent/")
+    assert headers.get("X-Title") == "opencode"
+    assert headers.get("HTTP-Referer") == "https://opencode.ai/"
+    assert str(headers.get("User-Agent", "")).startswith("opencode/")
 
 
 @patch("agent.process_bootstrap.OpenAI")


### PR DESCRIPTION
## Problem

OpenCode Zen free-tier models (`big-pickle`, most `*-free` slugs) fail with HTTP 429 `FreeUsageLimitError` because the relay's free tier gates on the **OpenCode CLI's attribution headers** — it 429s any client that doesn't identify as opencode (#106495).

The reporter verified (same model, same IP, requests seconds apart) that the relay returns:
- **429** with the bundled Hermes attribution: `User-Agent: HermesAgent/x.x`, `HTTP-Referer: https://hermes-agent.nousresearch.com`, `X-Title: Hermes Agent`
- **200** with the OpenCode CLI's attribution: `User-Agent: opencode/0.20.5`, `HTTP-Referer: https://opencode.ai/`, `X-Title: opencode`

Only `laguna-s-2.1-free` survived the Hermes attribution — the existing `opencode-free` profile comment notes *"big-pickle 429s every client except the opencode CLI's own User-Agent"* and pins laguna as the aux default as a **workaround**. This PR removes that workaround's necessity by sending the header set the free tier actually accepts.

## Root cause

Two code paths set Hermes-canonical attribution headers for the free tier:

1. **`opencode_zen_free_headers()`** (`hermes_cli/models.py`) — the runtime-healing path that pins free slugs to the Zen relay keylessly. Sent `HermesAgent/<v>`, `hermes-agent.nousresearch.com`, `Hermes Agent`.
2. **`OpenCodeFreeProfile.default_headers`** (`plugins/model-providers/opencode-free/__init__.py`) — the profile's static default headers (applied on model switch). Sent the same Hermes-canonical set.

Both 429 every UA-gated free model. The keyed `opencode-zen`/`opencode-go` paths are **unaffected** — the paid relay doesn't gate on UA, and their attribution is left as Hermes (verified by the existing `test_opencode_*_applies_attribution_via_profile_fallback` tests, which still pass unchanged).

## Fix

Mirror the OpenCode CLI's attribution headers in **both** free-tier sources:
- `User-Agent: opencode/0.20.5` (relay gates on the `opencode/` prefix)
- `HTTP-Referer: https://opencode.ai/`
- `X-Title: opencode`

The empty `Authorization: ""` override (which keeps the SDK's `Bearer <placeholder>` off the wire — the free tier 401s any unknown bearer) is preserved unchanged.

The `x-opencode-session` header (from `merge_opencode_session_headers()` in `agent/opencode_affinity.py`) is already correctly applied at request time and is orthogonal to the attribution headers — not touched.

## Tests

- **Updated** `test_headers_override_sdk_bearer` / `test_opencode_free_sends_opencode_attribution` (renamed from `..._sends_hermes_attribution`) to assert the OpenCode-style headers.
- **Added** `test_headers_match_opencode_cli_attribution` — a focused regression guard that every free-tier attribution header the relay gates on (`User-Agent`, `HTTP-Referer`, `X-Title`) is OpenCode-style, with an explanatory failure message.
- **Mutation-verified**: stashed the source fix → the 3 OpenCode-asserting tests FAIL → restored → 3 PASS. The keyed-path attribution tests (`test_opencode_go_*`, `test_opencode_zen_*`) pass unchanged, proving the paid paths are not affected.
- Full free-tier suite (17 tests) passes. `ruff check` clean on all 4 files.

Fixes #106495
