### PR TITLE
fix(computer-use): fail closed for strict CuaDriver actions

### DIFF
--- a/tests/tools/test_computer_use_cua_0_24_schema_contracts.py
+++ b/tests/tools/test_computer_use_cua_0_24_schema_contracts.py
@@ -1,0 +1,93 @@
+"""Strict CuaDriver input-schema adapter contracts."""
+
+from __future__ import annotations
+
+
+class _StrictSchemaSession:
+    def __init__(self, schemas: dict[str, set[str]]) -> None:
+        self._schemas = schemas
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def supports_input_property(self, tool: str, property_name: str) -> bool:
+        return property_name in self._schemas.get(tool, set())
+
+    def _has_tool(self, name: str) -> bool:
+        return name in self._schemas
+
+    def call_tool(self, name: str, args: dict[str, object], timeout: float = 30.0) -> dict[str, object]:
+        self.calls.append((name, dict(args)))
+        unexpected = set(args) - self._schemas[name]
+        if unexpected:
+            raise AssertionError(f"{name} received schema-forbidden fields: {sorted(unexpected)}")
+        return {"isError": False, "data": {}, "structuredContent": {"effect": "confirmed"}}
+
+
+def _backend(session: _StrictSchemaSession):
+    from tools.computer_use.cua_backend import CuaDriverBackend
+
+    backend = CuaDriverBackend.__new__(CuaDriverBackend)
+    backend._session = session
+    backend._session_id = "schema-contract-run"
+    backend._snapshot_tokens = {}
+    backend._active_pid = 42
+    backend._active_window_id = 7
+    return backend
+
+
+_COMMON = {"pid", "window_id", "session"}
+
+
+def test_canonical_double_click_preserves_requested_semantics_when_schema_supports_count():
+    session = _StrictSchemaSession({"click": _COMMON | {"element_index", "count", "button", "modifier"}})
+
+    result = _backend(session).click(element=5, click_count=2, button="right", modifiers=["shift"])
+
+    assert result.ok is True
+    assert session.calls == [
+        ("click", {"pid": 42, "element_index": 5, "window_id": 7, "count": 2,
+                   "button": "right", "modifier": ["shift"], "session": "schema-contract-run"})
+    ]
+
+
+def test_legacy_double_click_keeps_unmodified_left_element_behavior():
+    session = _StrictSchemaSession({
+        "click": _COMMON | {"element_index"},
+        "double_click": _COMMON | {"element_index"},
+    })
+
+    result = _backend(session).click(element=6, click_count=2)
+
+    assert result.ok is True
+    assert session.calls == [
+        ("double_click", {"pid": 42, "element_index": 6, "window_id": 7, "session": "schema-contract-run"})
+    ]
+
+
+def test_legacy_double_click_refuses_semantics_it_cannot_preserve_before_transport():
+    session = _StrictSchemaSession({"double_click": _COMMON | {"element_index"}})
+
+    result = _backend(session).click(element=6, click_count=2, button="middle", modifiers=["shift"])
+
+    assert result.ok is False
+    assert result.code == "double_click_unsupported"
+    assert session.calls == []
+
+
+def test_legacy_coordinate_double_click_refuses_screen_relative_transport():
+    session = _StrictSchemaSession({"double_click": _COMMON | {"x", "y"}})
+
+    result = _backend(session).click(x=10, y=20, click_count=2)
+
+    assert result.ok is False
+    assert result.code == "double_click_coordinate_origin_unsupported"
+    assert session.calls == []
+
+
+def test_element_drag_refuses_before_transport_when_schema_lacks_element_addresses():
+    session = _StrictSchemaSession({"drag": _COMMON | {"from_x", "from_y", "to_x", "to_y"}})
+
+    result = _backend(session).drag(from_element=1, to_element=9)
+
+    assert result.ok is False
+    assert result.code == "element_drag_unsupported"
+    assert session.calls == []

--- a/tools/computer_use/cua_backend_input.py
+++ b/tools/computer_use/cua_backend_input.py
@@ -101,13 +101,35 @@ class _InputMixin:
         button_norm = (button or "left").lower()
         if button_norm not in {"left", "right", "middle"}:
             return _refuse("click", f"unknown button {button!r} — expected left, right, middle.")
-        tool, args["button"] = ("double_click" if click_count == 2 else "click"), button_norm
+        if click_count == 2 and self._session.supports_input_property("click", "count"):
+            tool, args["count"] = "click", 2
+            if self._session.supports_input_property("click", "button"):
+                args["button"] = button_norm
+            elif button_norm != "left":
+                return _refuse("click", "The connected cua-driver cannot preserve the requested double-click "
+                               f"button {button_norm!r}.", code="double_click_unsupported")
+            if modifiers:
+                if not self._session.supports_input_property("click", "modifier"):
+                    return _refuse("click", "The connected cua-driver cannot preserve modifiers on this double-click.",
+                                   code="double_click_unsupported")
+                args["modifier"] = modifiers
+        elif click_count == 2:
+            tool = "double_click"
+            if button_norm != "left" or modifiers:
+                return _refuse("click", "The connected cua-driver only supports an unmodified left double-click; "
+                               "use a driver with canonical click count support.", code="double_click_unsupported")
+            if element is None and x is not None and y is not None:
+                return _refuse("click", "The connected cua-driver's legacy double_click uses screen-relative "
+                               "coordinates, but computer_use coordinates are relative to the captured window.",
+                               code="double_click_coordinate_origin_unsupported")
+        else:
+            tool, args["button"] = "click", button_norm
+            if modifiers:
+                args["modifier"] = modifiers
         refusal = self._pointer_args(tool, args, (
             ("element_index click", {"element_index": element} if element is not None else None),
             ("coordinate click", {"x": x, "y": y} if x is not None and y is not None else None),
         ), "click requires element= or x/y.")
-        if modifiers:
-            args["modifier"] = modifiers
         return refusal if refusal is not None else self._run_input_action(tool, args, delivery_mode, bring_to_front)
 
     def drag(self, *, from_element: Optional[int] = None, to_element: Optional[int] = None,
@@ -115,10 +137,17 @@ class _InputMixin:
              button: str = "left", modifiers: Optional[List[str]] = None,
              delivery_mode: Optional[str] = None, bring_to_front: bool = False) -> ActionResult:
         refusal, args = self._target_args("drag")
+        element_drag = from_element is not None and to_element is not None
+        if refusal is None and element_drag and not (
+            self._session.supports_input_property("drag", "from_element")
+            and self._session.supports_input_property("drag", "to_element")
+        ):
+            return _refuse("drag", "The connected cua-driver does not support element-addressed drag; "
+                           "use verified from_coordinate/to_coordinate values.", code="element_drag_unsupported")
         if refusal is None:
             refusal = self._pointer_args("drag", args, (
                 ("element-based drag", {"from_element": from_element, "to_element": to_element}
-                 if from_element is not None and to_element is not None else None),
+                 if element_drag else None),
                 ("coordinate drag", {"from_x": int(from_xy[0]), "from_y": int(from_xy[1]),
                                      "to_x": int(to_xy[0]), "to_y": int(to_xy[1])}
                  if from_xy is not None and to_xy is not None else None),


### PR DESCRIPTION
## Summary
- Use canonical `click` with `count: 2` only when the raw action schema advertises `count`; preserve button/modifier fields only when that same canonical schema accepts them.
- Keep legacy `double_click` limited to an unmodified left element click, refusing unsupported semantics and screen-relative coordinate transport before dispatch.
- Refuse element-addressed drag before transport when the raw `drag` schema lacks both `from_element` and `to_element`.

## Deliberately out of scope
- Coordinate-scroll schema recovery is covered by #100801.
- Drag button/modifier forwarding is covered by #68097.

## Verification
- `scripts/run_tests.sh -j 2 --file-timeout 120` across six focused computer-use files: 154 passed.
- The five strict-schema contracts fail against current `main` and pass with this patch.
- `ruff check`, bytecode compilation, and `git diff --check` pass.

The fixtures verify raw-schema transport/refusal behavior only; no live physical gestures were performed.