### PR TITLE
WhatsApp replies to disappearing/view-once messages keep their quoted text (#106066, salvage #106081)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -41,6 +41,7 @@ import {
   buildTextSendPayload,
   createBoundedMessageStore,
   extractBridgeEvent,
+  getMessageContent,
   inboundReadReceiptKeys,
   inferMediaType,
   mediaPayloadForFile,
@@ -223,28 +224,6 @@ function emitDebugEvent(payload) {
   try {
     console.log(JSON.stringify({ event: 'debug', ...payload }));
   } catch {}
-}
-
-function getMessageContent(msg) {
-  const content = msg?.message || {};
-  if (content.ephemeralMessage?.message) return content.ephemeralMessage.message;
-  if (content.viewOnceMessage?.message) return content.viewOnceMessage.message;
-  if (content.viewOnceMessageV2?.message) return content.viewOnceMessageV2.message;
-  if (content.documentWithCaptionMessage?.message) return content.documentWithCaptionMessage.message;
-  if (content.templateMessage?.hydratedTemplate) return content.templateMessage.hydratedTemplate;
-  if (content.buttonsMessage) return content.buttonsMessage;
-  if (content.listMessage) return content.listMessage;
-  return content;
-}
-
-function getContextInfo(messageContent) {
-  if (!messageContent || typeof messageContent !== 'object') return {};
-  for (const value of Object.values(messageContent)) {
-    if (value && typeof value === 'object' && value.contextInfo) {
-      return value.contextInfo;
-    }
-  }
-  return {};
 }
 
 mkdirSync(SESSION_DIR, { recursive: true });

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -411,4 +411,61 @@ import {
   console.log('  ✓ captioned failed download keeps caption and appends note');
 }
 
+// -- quoted message envelopes --------------------------------------------
+{
+  // WhatsApp wraps disappearing (ephemeral), view-once and re-shared
+  // document messages in envelope types. The quote extractor must see
+  // through them, or a reply to such a message keeps its quoted ID but
+  // loses the quoted text entirely (#106066).
+  for (const [fixture, quotedMessage] of [
+    ['plain conversation', { conversation: 'Example appointment at 11:40' }],
+    ['ephemeral-wrapped', {
+      ephemeralMessage: { message: { conversation: 'Example appointment at 11:40' } },
+    }],
+    ['view-once wrapped', {
+      viewOnceMessageV2: { message: { conversation: 'Example appointment at 11:40' } },
+    }],
+    ['document-with-caption envelope', {
+      documentWithCaptionMessage: {
+        message: { documentMessage: { caption: 'the signed contract', fileName: 'contract.pdf' } },
+      },
+    }],
+    ['extended text inside ephemeral', {
+      ephemeralMessage: {
+        message: { extendedTextMessage: { text: 'Example appointment at 11:40' } },
+      },
+    }],
+  ]) {
+    const event = await extractBridgeEvent({
+      msg: {
+        key: { id: `reply-${fixture}`, remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 123,
+        message: {
+          extendedTextMessage: {
+            text: 'confirmed',
+            contextInfo: {
+              stanzaId: 'original-id',
+              participant: '15559998888@s.whatsapp.net',
+              quotedMessage,
+            },
+          },
+        },
+      },
+      chatId: '15551234567@s.whatsapp.net',
+      senderId: '15550001111@s.whatsapp.net',
+      senderNumber: '15550001111',
+      botIds: ['15559998888@s.whatsapp.net'],
+      downloadMedia: async () => Buffer.from(''),
+    });
+    assert.equal(event.quotedMessageId, 'original-id', fixture);
+    assert.equal(event.hasQuotedMessage, true, fixture);
+    if (fixture === 'document-with-caption envelope') {
+      assert.equal(event.quotedText, 'the signed contract', fixture);
+    } else {
+      assert.equal(event.quotedText, 'Example appointment at 11:40', fixture);
+    }
+  }
+  console.log('  ✓ quoted message text survives ephemeral/view-once/document envelopes');
+}
+
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -468,4 +468,43 @@ import {
   console.log('  ✓ quoted message text survives ephemeral/view-once/document envelopes');
 }
 
+{
+  // Nested envelopes (ephemeral wrapping viewOnce wrapping the payload) and
+  // the second envelope position: quoted text must resolve there as well.
+  const quotedMessage = {
+    ephemeralMessage: {
+      message: {
+        viewOnceMessageV2: {
+          message: { extendedTextMessage: { text: 'Example appointment at 11:40' } },
+        },
+      },
+    },
+  };
+  const event = await extractBridgeEvent({
+    msg: {
+      key: { id: 'reply-nested', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+      messageTimestamp: 123,
+      message: {
+        ephemeralMessage: {
+          message: {
+            extendedTextMessage: {
+              text: 'confirmed',
+              contextInfo: { stanzaId: 'original-id', participant: '15559998888@s.whatsapp.net', quotedMessage },
+            },
+          },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+    botIds: ['15559998888@s.whatsapp.net'],
+    downloadMedia: async () => Buffer.from(''),
+  });
+  assert.equal(event.quotedMessageId, 'original-id');
+  assert.equal(event.hasQuotedMessage, true);
+  assert.equal(event.quotedText, 'Example appointment at 11:40');
+  console.log('  ✓ nested envelopes: quote text resolves through both layers');
+}
+
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -19,15 +19,26 @@ export function normalizeWhatsAppId(value) {
 }
 
 function unwrapMessageEnvelopes(content) {
-  if (content?.ephemeralMessage?.message) return content.ephemeralMessage.message;
-  if (content?.viewOnceMessage?.message) return content.viewOnceMessage.message;
-  if (content?.viewOnceMessageV2?.message) return content.viewOnceMessageV2.message;
-  if (content?.documentWithCaptionMessage?.message) return content.documentWithCaptionMessage.message;
-  return content;
+  let cur = content;
+  // Envelopes nest (ephemeral wrapping viewOnce wrapping the payload); peel
+  // until an inner message is reached so nested quotes resolve too.
+  for (let i = 0; i < 8 && cur; i++) {
+    const next =
+      cur.ephemeralMessage?.message ??
+      cur.viewOnceMessage?.message ??
+      cur.viewOnceMessageV2?.message ??
+      cur.documentWithCaptionMessage?.message;
+    if (next === undefined) break;
+    cur = next;
+  }
+  return cur;
 }
 
 export function getMessageContent(msg) {
   const content = unwrapMessageEnvelopes(msg?.message || {});
+  // A peeled envelope returns its inner message immediately: the payload
+  // shape (template/buttons/list/etc.) applies to unenveloped messages.
+  if (content !== (msg?.message || {})) return content;
   if (content.templateMessage?.hydratedTemplate) return content.templateMessage.hydratedTemplate;
   if (content.buttonsMessage) return content.buttonsMessage;
   if (content.listMessage) return content.listMessage;

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -18,12 +18,16 @@ export function normalizeWhatsAppId(value) {
   return String(value).replace(':', '@');
 }
 
+function unwrapMessageEnvelopes(content) {
+  if (content?.ephemeralMessage?.message) return content.ephemeralMessage.message;
+  if (content?.viewOnceMessage?.message) return content.viewOnceMessage.message;
+  if (content?.viewOnceMessageV2?.message) return content.viewOnceMessageV2.message;
+  if (content?.documentWithCaptionMessage?.message) return content.documentWithCaptionMessage.message;
+  return content;
+}
+
 export function getMessageContent(msg) {
-  const content = msg?.message || {};
-  if (content.ephemeralMessage?.message) return content.ephemeralMessage.message;
-  if (content.viewOnceMessage?.message) return content.viewOnceMessage.message;
-  if (content.viewOnceMessageV2?.message) return content.viewOnceMessageV2.message;
-  if (content.documentWithCaptionMessage?.message) return content.documentWithCaptionMessage.message;
+  const content = unwrapMessageEnvelopes(msg?.message || {});
   if (content.templateMessage?.hydratedTemplate) return content.templateMessage.hydratedTemplate;
   if (content.buttonsMessage) return content.buttonsMessage;
   if (content.listMessage) return content.listMessage;
@@ -190,16 +194,17 @@ export function buildLocationPayload({ latitude, longitude, name, address } = {}
 }
 
 function textFromQuotedMessage(quotedMessage) {
-  if (!quotedMessage) return '';
-  if (quotedMessage.conversation) return quotedMessage.conversation;
-  if (quotedMessage.extendedTextMessage?.text) return quotedMessage.extendedTextMessage.text;
-  if (quotedMessage.imageMessage?.caption) return quotedMessage.imageMessage.caption;
-  if (quotedMessage.videoMessage?.caption) return quotedMessage.videoMessage.caption;
-  if (quotedMessage.documentMessage?.caption) return quotedMessage.documentMessage.caption;
-  if (quotedMessage.documentMessage?.fileName) return `[Document: ${quotedMessage.documentMessage.fileName}]`;
-  if (quotedMessage.locationMessage) return formatLocationText(quotedMessage.locationMessage, false);
-  if (quotedMessage.contactMessage) return formatContactText(quotedMessage.contactMessage);
-  if (quotedMessage.pollCreationMessage) return formatPollText(quotedMessage.pollCreationMessage);
+  const content = unwrapMessageEnvelopes(quotedMessage);
+  if (!content) return '';
+  if (content.conversation) return content.conversation;
+  if (content.extendedTextMessage?.text) return content.extendedTextMessage.text;
+  if (content.imageMessage?.caption) return content.imageMessage.caption;
+  if (content.videoMessage?.caption) return content.videoMessage.caption;
+  if (content.documentMessage?.caption) return content.documentMessage.caption;
+  if (content.documentMessage?.fileName) return `[Document: ${content.documentMessage.fileName}]`;
+  if (content.locationMessage) return formatLocationText(content.locationMessage, false);
+  if (content.contactMessage) return formatContactText(content.contactMessage);
+  if (content.pollCreationMessage) return formatPollText(content.pollCreationMessage);
   return '';
 }
 

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -35,10 +35,11 @@ function unwrapMessageEnvelopes(content) {
 }
 
 export function getMessageContent(msg) {
-  const content = unwrapMessageEnvelopes(msg?.message || {});
+  const raw = msg?.message || {};
+  const content = unwrapMessageEnvelopes(raw);
   // A peeled envelope returns its inner message immediately: the payload
   // shape (template/buttons/list/etc.) applies to unenveloped messages.
-  if (content !== (msg?.message || {})) return content;
+  if (content !== raw) return content;
   if (content.templateMessage?.hydratedTemplate) return content.templateMessage.hydratedTemplate;
   if (content.buttonsMessage) return content.buttonsMessage;
   if (content.listMessage) return content.listMessage;


### PR DESCRIPTION
Replying to a disappearing (ephemeral) or view-once WhatsApp message no longer drops the quoted text from the inbound event — the bridge now sees through the same envelopes for `contextInfo.quotedMessage` that it already peels for the outer message.

- `textFromQuotedMessage()` unwraps `ephemeralMessage` / `viewOnceMessage` / `viewOnceMessageV2` / `documentWithCaptionMessage` before reading `conversation` / `extendedTextMessage.text` / media captions; envelopes can nest (Baileys' own normalizer peels them iteratively), so the peel is bounded-iterative and shared with `getMessageContent()` — one unwrapping list, not two.
- `getMessageContent()` keeps its previous contract: a peeled envelope returns its inner message immediately; the template/buttons/list payload branches only apply to unenveloped messages.
- `bridge.js` drops its private copy of `getMessageContent` (and an unused `getContextInfo`) and imports the helpers' version, so the poll-update path and the extractor can't drift on which envelopes they peel.
- Regression coverage in `bridge.native.test.mjs`: the issue's ephemeral fixture + view-once / document-caption / nested-envelope variants with the plain quote as control (fails on `origin/main`: `AssertionError: ephemeral-wrapped`).

**Live repro** (issue #106066 node script, `extractBridgeEvent` from the real module):

| | `plain` quote | `ephemeral-wrapped` quote |
|---|---|---|
| before (`origin/main` 511633be90e) | `quotedText: "Example appointment at 11:40"` | `quotedText: ""` |
| after (this branch) | `quotedText: "Example appointment at 11:40"` | `quotedText: "Example appointment at 11:40"` |

Root cause: `extractBridgeEvent()` handed `contextInfo.quotedMessage` straight to `textFromQuotedMessage()`, which read bare payload fields, while only the outer message went through `getMessageContent()`'s envelope unwrapping — so a wrapped quote kept `quotedMessageId` / `hasQuotedMessage` but lost its text.

Tests: `node scripts/whatsapp-bridge/bridge.native.test.mjs` (all passed), the other five `scripts/whatsapp-bridge/*.test.mjs` suites, `scripts/run_tests.sh tests/gateway/test_whatsapp_bridge_dir_resolution.py tests/gateway/test_whatsapp_stale_bridge.py` (5 passed).

Credit: fix and tests by @kokhlo (#106081, cherry-picked with authorship). The nested-envelope handling matches the direction of @PRATHAMESH75 (#106082) and @liuhao1024 (#106085), who independently reached the same root cause.

Closes #106066

## Infographic
![wa-quote](https://v3b.fal.media/files/b/0aa9ba79/bRDzD6ZvLEM8fd8jEkJDz_nhPj5X8C.png)
