### PR TITLE
mem0 memory no longer drops long turns; sync cap configurable per embedder (#37421, #106235, salvage #37427)

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -30,6 +30,7 @@ Behavioral settings live in `$HERMES_HOME/mem0.json` (set them via `hermes memor
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `false` | Rerank search results for relevance (platform mode only) |
+| `sync_max_chars` | `450` | Per-message character cap applied before each turn is sent for fact extraction (cut at the last sentence boundary). Default fits 512-token embedders; raise it (e.g. `6000`) for 8k-token embedders such as `text-embedding-3-small`, `jina-embeddings-v3`, `bge-m3` |
 
 The plugin has three connection modes:
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -38,6 +38,8 @@ _DEFAULT_USER_ID = "hermes-user"
 # jina-embeddings-v3: 8192), and oversized turns make backend.add() raise — Ollama
 # answers HTTP 500, hosted APIs return INPUT_TOKEN_LIMIT_EXCEEDED — which _try only
 # logs, silently dropping the turn's memory extraction. Cap each message up front.
+# The default fits a 512-token embedder (measured: 450 OK, 600 -> HTTP 500 on
+# bge-small-zh-v1.5:f16); ``sync_max_chars`` in mem0.json raises it for larger windows.
 _SYNC_MSG_MAX_CHARS = 450
 
 
@@ -115,6 +117,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._config = self._backend = self._sync_thread = self._prefetch_thread = None
         self._mode, self._api_key, self._host, self._user_id, self._agent_id = "platform", "", "", _DEFAULT_USER_ID, "hermes"
         self._rerank_default, self._channel = False, "cli"  # channel = gateway name (cli/telegram/discord/...)
+        self._sync_max_chars = _SYNC_MSG_MAX_CHARS
         self._prefetch_query = self._prefetch_result = ""
         self._prefetch_done = self._atexit_registered = False
         self._consecutive_failures, self._breaker_open_until = 0, 0.0  # circuit breaker state
@@ -220,6 +223,7 @@ class Mem0MemoryProvider(MemoryProvider):
         _rr = cfg.get("rerank", False)
         self._rerank_default = _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         self._channel = kwargs.get("platform") or "cli"
+        self._sync_max_chars = int(cfg.get("sync_max_chars") or _SYNC_MSG_MAX_CHARS)
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
             atexit.register(self._shutdown_backend)
@@ -291,8 +295,8 @@ class Mem0MemoryProvider(MemoryProvider):
         def _sync():
             if self._backend is not None:
                 messages = [
-                    {"role": "user", "content": _truncate_for_sync(user_content)},
-                    {"role": "assistant", "content": _truncate_for_sync(assistant_content)},
+                    {"role": "user", "content": _truncate_for_sync(user_content, self._sync_max_chars)},
+                    {"role": "assistant", "content": _truncate_for_sync(assistant_content, self._sync_max_chars)},
                 ]
                 self._try(lambda: self._add(messages, infer=True), logger.warning, "Mem0 sync failed: %s")
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -33,6 +33,30 @@ _CLIENT_ERROR_TYPES = ("MemoryNotFoundError", "ValidationError")
 # so legacy mem0.json files written by the wizard don't override gateway-native ids.
 _DEFAULT_USER_ID = "hermes-user"
 
+# sync_turn sends the whole turn to the backend for fact extraction. OSS embedding
+# models often have small context windows (bge-small-zh-v1.5: 512 tokens ≈ 500 chars;
+# jina-embeddings-v3: 8192), and oversized turns make backend.add() raise — Ollama
+# answers HTTP 500, hosted APIs return INPUT_TOKEN_LIMIT_EXCEEDED — which _try only
+# logs, silently dropping the turn's memory extraction. Cap each message up front.
+_SYNC_MSG_MAX_CHARS = 450
+
+
+def _truncate_for_sync(text: str, max_len: int = _SYNC_MSG_MAX_CHARS) -> str:
+    """Cap a synced message at its last sentence boundary within ``max_len``.
+
+    Short messages pass through unchanged; long ones keep the last complete
+    sentence inside the window so fact extraction still sees coherent statements,
+    with a hard cut as fallback when no boundary exists (or one only appears in
+    the first third of the window, which usually means unsegmented input).
+    """
+    if len(text) <= max_len:
+        return text
+    for sep in ("。", "！", "？", ".\n", ".", "!", "?"):
+        cut = text[:max_len].rfind(sep)
+        if cut > max_len // 3:
+            return text[:cut + 1]
+    return text[:max_len]
+
 
 def _is_client_error(exc: Exception) -> bool:
     """True for user-caused errors (bad ID, not found) that should NOT trip circuit breaker."""
@@ -266,7 +290,10 @@ class Mem0MemoryProvider(MemoryProvider):
 
         def _sync():
             if self._backend is not None:
-                messages = [{"role": "user", "content": user_content}, {"role": "assistant", "content": assistant_content}]
+                messages = [
+                    {"role": "user", "content": _truncate_for_sync(user_content)},
+                    {"role": "assistant", "content": _truncate_for_sync(assistant_content)},
+                ]
                 self._try(lambda: self._add(messages, infer=True), logger.warning, "Mem0 sync failed: %s")
 
         with self._sync_lock:

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -180,6 +180,17 @@ class TestSyncTurnTruncation:
         assert len(sent[1]["content"]) <= mem0_plugin._SYNC_MSG_MAX_CHARS and sent[1]["content"].endswith(".")
         assert provider._consecutive_failures == 0
 
+    def test_sync_max_chars_config_raises_cap(self, monkeypatch, tmp_path):
+        """8k-token embedders should not be stuck at the 512-token default (#106235)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "test-key")
+        (tmp_path / "mem0.json").write_text('{"sync_max_chars": 3000}')
+        backend = FakeBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider.sync_turn("hi", "Long answer. " * 200, session_id="s1")  # 2600 chars
+        provider._sync_thread.join(timeout=2)
+        assert backend.captured[0][1][1]["content"] == "Long answer. " * 200
+
 
 class TestMem0Prefetch:
     """prefetch() must recall on the CURRENT question, synchronously.

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -146,6 +146,41 @@ class TestMem0V3Internal:
         assert call[2]["infer"] is True
 
 
+class TestSyncTurnTruncation:
+    """sync_turn must cap messages before ingestion so small-context embedding
+    backends (OSS Ollama bge-small-zh-v1.5: 512 tokens; jina-embeddings-v3 token
+    limits) don't fail the whole extraction — a failure _try only logs."""
+
+    def _make_provider(self, monkeypatch, backend):
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        provider._backend = backend
+        return provider
+
+    def test_small_context_backend_never_sees_oversized_input(self, monkeypatch):
+        """Regression for #106235/#37421: an OSS embedding backend with a small
+        context window raises on oversized input; truncation up front keeps the
+        extraction from being silently dropped (no breaker failures)."""
+
+        class SmallContextBackend(FakeBackend):
+            def add(self, messages, **kwargs):
+                if any(len(m["content"]) > mem0_plugin._SYNC_MSG_MAX_CHARS for m in messages):
+                    raise RuntimeError("HTTP 500: embedding input exceeds model context")
+                return super().add(messages, **kwargs)
+
+        backend = SmallContextBackend()
+        provider = self._make_provider(monkeypatch, backend)
+        provider.sync_turn("Short question?", "".join(f"Fact {i}. " for i in range(200)), session_id="s1")
+        provider._sync_thread.join(timeout=2)
+        assert len(backend.captured) == 1
+        sent = backend.captured[0][1]
+        assert sent[0]["content"] == "Short question?"  # under the cap: untouched
+        assert len(sent[1]["content"]) <= mem0_plugin._SYNC_MSG_MAX_CHARS and sent[1]["content"].endswith(".")
+        assert provider._consecutive_failures == 0
+
+
 class TestMem0Prefetch:
     """prefetch() must recall on the CURRENT question, synchronously.
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -414,6 +414,7 @@ The plugin authenticates with `X-API-Key` and uses the server's `/search` / `/me
 | `user_id` | `hermes-user` | User identifier |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `false` | Rerank search results for relevance (platform mode only) |
+| `sync_max_chars` | `450` | Per-message character cap applied before each turn is sent for fact extraction, cut at the last sentence boundary. The default fits 512-token embedders (Ollama `bge-small-zh-v1.5`, `all-minilm`); raise it (e.g. `6000`) for 8k-token embedders such as `text-embedding-3-small`, `jina-embeddings-v3` or `bge-m3` |
 
 **OSS supported providers:**
 


### PR DESCRIPTION
Long conversation turns no longer vanish from mem0 memory: `sync_turn()` now caps each message at a sentence boundary before ingestion, and the cap is configurable per embedder via `sync_max_chars` in `mem0.json`.

## Changes
- `plugins/memory/mem0/__init__.py`: `_truncate_for_sync()` — cap at the last sentence boundary within the window (CJK + Latin separators, hard cut fallback); `sync_turn()` applies it to both messages before `backend.add()`.
- `sync_max_chars` read from `mem0.json` in `initialize()` (default `450`, fits 512-token embedders such as Ollama `bge-small-zh-v1.5`); raise it for 8k-token embedders (`text-embedding-3-small`, `jina-embeddings-v3`, `bge-m3`).
- Docs: key added to `plugins/memory/mem0/README.md` and `website/docs/user-guide/features/memory-providers.md`.
- Tests: 2 invariants in `tests/plugins/memory/test_mem0_v3.py` — oversized turn still reaches a small-context backend (short text untouched, no breaker failure); `sync_max_chars` raises the cap (proven red without the config plumbing).

## Validation (live repro)
Real `Mem0MemoryProvider` import under a temp `HERMES_HOME` with `mem0.json` in OSS mode; fake backend whose `add()` raises `HTTP 500` on any message > 450 chars (szicely's measured `bge-small-zh-v1.5:f16` limit: 450 OK, 600 → 500). Turn: 130-char CJK user message + 1172-char assistant message.

| | `origin/main` (511633be90e) | this branch |
|---|---|---|
| log | `WARNING plugins.memory.mem0: Mem0 sync failed: Ollama error: 500 Internal Server Error (input 1172 chars)` | — |
| `backend.add` calls stored | `0` → **`RESULT: FAIL - turn silently dropped`** | `1` — `stored user: 130 chars` (untouched), `stored assistant: 443 chars, ends '...Here is a detailed outline.'` → **`RESULT: PASS - turn reached the backend`** |
| `sync_max_chars: 3000` in mem0.json | n/a | cap resolves to `3000`, full 1172-char message forwarded (the 512-token fake then rejects it — correct: the operator asked for a larger window) |

`scripts/run_tests.sh tests/plugins/memory/test_mem0_v3.py` → 25 passed, 0 failed.

## Root cause
`sync_turn()` forwarded the whole turn with no length guard, so any embedder rejection (Ollama HTTP 500, hosted `INPUT_TOKEN_LIMIT_EXCEEDED`) was swallowed by `_try()` as a warning and the turn's fact extraction was lost.

## vs #37427
Salvage of #37427 by @liuhao1024 — first commit (source-side truncation) cherry-picked verbatim; the test suite trimmed from 5 tests to 1 invariant. The second commit (Ollama `/api/show` probe + known-model table + cached resolver, +243 LOC) is replaced by a one-line config read: the operator already knows the embedder they configured, and a network probe plus a curated model list is the wrong cost for one integer. Dynamic-cap requirement, sentence-boundary design and the 450/600 measurements by @szicely (#106235). Co-authored-by trailers on both commits.

Refs #37421, Refs #106235

## Infographic
![mem0-sync-truncate](https://v3b.fal.media/files/b/0aa9ba7e/2af70A0PIWxHKnCPIA5NF_QxKDIRoW.png)
