### PR TITLE
fix(sessions): a stale explicit-close stamp no longer makes a session permanently uncompressible

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2883,17 +2883,19 @@ def _salvage_or_refuse_grown_transcript(
     return compressed, None
 
 
-def _parent_deliberately_ended(session_db: Any, session_id: str, holder: Optional[str] = None) -> bool:
+def _parent_deliberately_ended(
+    session_db: Any, session_id: str, turn_lease_holder: Optional[str] = None,
+) -> bool:
     """True when publish_compression_child() would fail closed on the parent's end stamp, so the
-    durable pre-publish flush is skipped. The store owns the verdict (#106459): an explicit close with
-    no continuation is stale, not deliberate. Fails OPEN: an unreadable row must not turn a cheap
-    guard into a new way to lose compression."""
+    durable pre-publish flush is skipped. The store owns the verdict (#106459): an explicit close is
+    stale only when this turn was admitted after it. Fails OPEN: an unreadable row must not turn a
+    cheap guard into a new way to lose compression."""
     verdict = getattr(session_db, "compression_parent_deliberately_ended", None)
     if callable(verdict):
         try:
-            # *holder* is this attempt's compression-lease holder: the store orders an explicit close
-            # against the lease acquisition to tell a stale stamp from a close made mid-compression.
-            return bool(verdict(session_id, holder=holder))
+            # *turn_lease_holder* is this turn's session-turn lease: the store orders an explicit close
+            # against its admission to tell a stale stamp from a close made during the turn.
+            return bool(verdict(session_id, turn_lease_holder=turn_lease_holder))
         except Exception:
             return False
     # Stores without the verdict (test stand-ins): taxonomy-only fallback.
@@ -2956,7 +2958,8 @@ def _publish_rotated_compaction(
     # The flush is durable and NOT rolled back on abort: a deliberately-ended parent
     # fails publish forever, so check that before writing. Automatic end stamps are
     # healed by publish (don't abort); the lease is re-acquirable (don't check it).
-    if _parent_deliberately_ended(agent._session_db, old_session_id, holder=lease.holder):
+    turn_lease_holder = getattr(agent, "_active_session_turn_lease_holder", None)
+    if _parent_deliberately_ended(agent._session_db, old_session_id, turn_lease_holder=turn_lease_holder):
         raise RuntimeError(f"Compression parent already ended: {old_session_id}")
     # Foreign-tail ceiling: the flush below writes OUR rows (already in handoff);
     # rows above the start watermark up to this MAX(id) are foreign appends.
@@ -2986,7 +2989,7 @@ def _publish_rotated_compaction(
         compression_lock_holder=lease.holder, require_compression_lease=lease.holder is not None,
         require_lease_refresh=lease.holder is not None, lease_ttl_seconds=lease.ttl,
         watermark=(lease.watermark if _foreign_tail_ceiling is not None else None),
-        watermark_ceiling=_foreign_tail_ceiling,
+        watermark_ceiling=_foreign_tail_ceiling, turn_lease_holder=turn_lease_holder,
     )
     # `already_present` stamping is done by run_agent's _sync_persisted_markers;
     # this branch covers inserted/merged only; direct callers must use that wrapper.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2884,8 +2884,17 @@ def _salvage_or_refuse_grown_transcript(
 
 
 def _parent_deliberately_ended(session_db: Any, session_id: str) -> bool:
-    """True when the parent row was ended by a non-automatic reason. Fails OPEN: an
-    unreadable row must not turn a cheap guard into a new way to lose compression."""
+    """True when publish_compression_child() would fail closed on the parent's end stamp, so the
+    durable pre-publish flush is skipped. The store owns the verdict (#106459): an explicit close with
+    no continuation is stale, not deliberate. Fails OPEN: an unreadable row must not turn a cheap
+    guard into a new way to lose compression."""
+    verdict = getattr(session_db, "compression_parent_deliberately_ended", None)
+    if callable(verdict):
+        try:
+            return bool(verdict(session_id))
+        except Exception:
+            return False
+    # Stores without the verdict (test stand-ins): taxonomy-only fallback.
     reader = getattr(session_db, "get_session", None)
     if not callable(reader):
         return False

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2883,7 +2883,7 @@ def _salvage_or_refuse_grown_transcript(
     return compressed, None
 
 
-def _parent_deliberately_ended(session_db: Any, session_id: str) -> bool:
+def _parent_deliberately_ended(session_db: Any, session_id: str, holder: Optional[str] = None) -> bool:
     """True when publish_compression_child() would fail closed on the parent's end stamp, so the
     durable pre-publish flush is skipped. The store owns the verdict (#106459): an explicit close with
     no continuation is stale, not deliberate. Fails OPEN: an unreadable row must not turn a cheap
@@ -2891,7 +2891,9 @@ def _parent_deliberately_ended(session_db: Any, session_id: str) -> bool:
     verdict = getattr(session_db, "compression_parent_deliberately_ended", None)
     if callable(verdict):
         try:
-            return bool(verdict(session_id))
+            # *holder* is this attempt's compression-lease holder: the store orders an explicit close
+            # against the lease acquisition to tell a stale stamp from a close made mid-compression.
+            return bool(verdict(session_id, holder=holder))
         except Exception:
             return False
     # Stores without the verdict (test stand-ins): taxonomy-only fallback.
@@ -2954,7 +2956,7 @@ def _publish_rotated_compaction(
     # The flush is durable and NOT rolled back on abort: a deliberately-ended parent
     # fails publish forever, so check that before writing. Automatic end stamps are
     # healed by publish (don't abort); the lease is re-acquirable (don't check it).
-    if _parent_deliberately_ended(agent._session_db, old_session_id):
+    if _parent_deliberately_ended(agent._session_db, old_session_id, holder=lease.holder):
         raise RuntimeError(f"Compression parent already ended: {old_session_id}")
     # Foreign-tail ceiling: the flush below writes OUR rows (already in handoff);
     # rows above the start watermark up to this MAX(id) are foreign appends.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2883,19 +2883,15 @@ def _salvage_or_refuse_grown_transcript(
     return compressed, None
 
 
-def _parent_deliberately_ended(
-    session_db: Any, session_id: str, turn_lease_holder: Optional[str] = None,
-) -> bool:
+def _parent_deliberately_ended(session_db: Any, session_id: str) -> bool:
     """True when publish_compression_child() would fail closed on the parent's end stamp, so the
-    durable pre-publish flush is skipped. The store owns the verdict (#106459): an explicit close is
-    stale only when this turn was admitted after it. Fails OPEN: an unreadable row must not turn a
-    cheap guard into a new way to lose compression."""
+    durable pre-publish flush is skipped. The store owns the verdict (#106459): a stale explicit close
+    was already healed when this turn was admitted, so any explicit close seen here is preserved. Fails
+    OPEN: an unreadable row must not turn a cheap guard into a new way to lose compression."""
     verdict = getattr(session_db, "compression_parent_deliberately_ended", None)
     if callable(verdict):
         try:
-            # *turn_lease_holder* is this turn's session-turn lease: the store orders an explicit close
-            # against its admission to tell a stale stamp from a close made during the turn.
-            return bool(verdict(session_id, turn_lease_holder=turn_lease_holder))
+            return bool(verdict(session_id))
         except Exception:
             return False
     # Stores without the verdict (test stand-ins): taxonomy-only fallback.
@@ -2958,8 +2954,7 @@ def _publish_rotated_compaction(
     # The flush is durable and NOT rolled back on abort: a deliberately-ended parent
     # fails publish forever, so check that before writing. Automatic end stamps are
     # healed by publish (don't abort); the lease is re-acquirable (don't check it).
-    turn_lease_holder = getattr(agent, "_active_session_turn_lease_holder", None)
-    if _parent_deliberately_ended(agent._session_db, old_session_id, turn_lease_holder=turn_lease_holder):
+    if _parent_deliberately_ended(agent._session_db, old_session_id):
         raise RuntimeError(f"Compression parent already ended: {old_session_id}")
     # Foreign-tail ceiling: the flush below writes OUR rows (already in handoff);
     # rows above the start watermark up to this MAX(id) are foreign appends.
@@ -2989,7 +2984,7 @@ def _publish_rotated_compaction(
         compression_lock_holder=lease.holder, require_compression_lease=lease.holder is not None,
         require_lease_refresh=lease.holder is not None, lease_ttl_seconds=lease.ttl,
         watermark=(lease.watermark if _foreign_tail_ceiling is not None else None),
-        watermark_ceiling=_foreign_tail_ceiling, turn_lease_holder=turn_lease_holder,
+        watermark_ceiling=_foreign_tail_ceiling,
     )
     # `already_present` stamping is done by run_agent's _sync_persisted_markers;
     # this branch covers inserted/merged only; direct callers must use that wrapper.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2885,9 +2885,10 @@ def _salvage_or_refuse_grown_transcript(
 
 def _parent_deliberately_ended(session_db: Any, session_id: str) -> bool:
     """True when publish_compression_child() would fail closed on the parent's end stamp, so the
-    durable pre-publish flush is skipped. The store owns the verdict (#106459): a stale explicit close
-    was already healed when this turn was admitted, so any explicit close seen here is preserved. Fails
-    OPEN: an unreadable row must not turn a cheap guard into a new way to lose compression."""
+    durable pre-publish flush is skipped. The store owns the verdict (#106459): a stale explicit close is
+    healed by the host that still routes the session before the turn starts, so any explicit close seen
+    here is preserved. Fails OPEN: an unreadable row must not turn a cheap guard into a new way to lose
+    compression."""
     verdict = getattr(session_db, "compression_parent_deliberately_ended", None)
     if callable(verdict):
         try:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -120,6 +120,10 @@ _COMPRESSION_CHILD_SQL = ("EXISTS (SELECT 1 FROM sessions p        WHERE p.id = 
 # ended that way.  Must stay identical to the recovery fence in find_latest_gateway_session_for_peer.
 _RESET_END_REASONS = ("session_reset", "session_switch", "idle", "daily", "suspended", "resume_pending_expired")
 _RESET_END_REASONS_SQL = ", ".join(f"'{reason}'" for reason in _RESET_END_REASONS)
+# Deliberate conversation boundaries: the reset set plus CLI /new, which ends the predecessor as
+# 'new_session' (hermes_cli/cli_session_mixin.py) without a reset child row.  A compression rotation must
+# never heal one of these (#106459); tools/session_search_tool.py derives its fresh-reset set from it.
+_BOUNDARY_END_REASONS = frozenset(_RESET_END_REASONS) | {"new_session"}
 
 # Accidental end reasons recovery treats as resumable (docs/session-lifecycle.md); single source of truth for
 # recovery SQL and SessionDB.RECOVERABLE_END_REASONS.  superseded_by_resume = sentinel-parked runtime replaced

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -15,6 +15,10 @@ from hermes_state_common import (
     _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _ended_by_compression,
     _sql_session_last_active, is_automatic_end_reason)
 
+# The compression lock row including when it was acquired: the ordering signal that tells a stale
+# end stamp (written before this attempt took the lease) from a deliberate close written during it.
+_LOCK_ROW_WITH_ACQUIRED_SQL = "SELECT holder, acquired_at, expires_at FROM compression_locks WHERE session_id = ?"
+
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
 
@@ -70,18 +74,24 @@ def _claim_lease_row(conn, table: str, key_col: str, key: str, holder: str, now:
 class SessionCompressionMixin:
     """Compression lineage, cooldown/streak counters, locks and turn leases."""
 
-    def _compression_parent_obstacle(self, conn, parent_session_id: str, parent) -> Optional[str]:
+    def _compression_parent_obstacle(
+        self, conn, parent_session_id: str, parent, *, lease_acquired_at: Optional[float],
+    ) -> Optional[str]:
         """Why publishing a compression child of *parent* (a row with ``ended_at`` / ``end_reason``) must
         fail closed, or None when the parent is live or its stamp is stale and may be cleared.
 
         Single owner of the verdict for publish_compression_child() and the agent's pre-flush guard
-        (#106459). Only another path owning the lineage fails closed: a ``'compression'`` stamp names a
-        continuation, a reset reason is a deliberate conversation boundary, and an explicit close that
-        already has a continuation child was superseded. An automatic-cleanup stamp is stale by
-        construction (#88197), and so is an explicit close (``tui_close``, ``cli_close``,
-        ``webhook_complete``, ``new_session``, ...) with NO continuation child: the lease holder rotating
-        this parent is provably still the conversation's writer and nothing else claims it. Failing closed
-        there made every compression compute its result and discard it, forever."""
+        (#106459). Lineage owned elsewhere fails closed: a ``'compression'`` stamp names a continuation,
+        a reset reason is a deliberate conversation boundary, and an explicit close that already has a
+        continuation child was superseded. An automatic-cleanup stamp is stale by construction (#88197).
+        An explicit close (``tui_close``, ``cli_close``, ``webhook_complete``, ``new_session``, ...) is
+        decided by ORDER against this attempt's compression lease, *lease_acquired_at*: a stamp written
+        before the lease was taken is stale (the writer acquired the lease and has driven the row since;
+        failing closed there made every compression compute its result and discard it, forever), while a
+        close written after it is the user closing the session mid-compression (``session.close`` waits
+        five seconds for the turn thread, then stamps ``tui_close``) and must be preserved. A lease only
+        grants publication ownership; without its ordering (no lease, foreign holder) an explicit close
+        cannot be proven stale and fails closed."""
         if parent is None or parent["ended_at"] is None:
             return None
         reason = parent["end_reason"]
@@ -99,12 +109,26 @@ class SessionCompressionMixin:
         ).fetchone()
         if child is not None:
             return f"closed ({reason}) with a published continuation"
+        if lease_acquired_at is None:
+            return f"closed ({reason}) with no compression-lease ordering to prove the stamp stale"
+        if float(parent["ended_at"]) >= float(lease_acquired_at):
+            return f"closed ({reason}) after this compression attempt acquired its lease"
         return None
 
-    def compression_parent_deliberately_ended(self, session_id: str) -> bool:
+    def _lease_acquired_at_for(self, conn, session_id: str, holder: Optional[str]) -> Optional[float]:
+        """When *holder*'s live compression lease on *session_id* was acquired, or None."""
+        if not holder:
+            return None
+        row = conn.execute(_LOCK_ROW_WITH_ACQUIRED_SQL, (session_id,)).fetchone()
+        if row is None or row["holder"] != holder or row["acquired_at"] is None:
+            return None
+        return float(row["acquired_at"])
+
+    def compression_parent_deliberately_ended(self, session_id: str, *, holder: Optional[str] = None) -> bool:
         """Read-only twin of publish_compression_child()'s liveness verdict, for the agent's guard that
         runs BEFORE the durable pre-publish flush: True only when publish would fail closed on
-        *session_id*'s end stamp. A missing row is not an obstacle (publish reports that itself)."""
+        *session_id*'s end stamp. *holder* is this attempt's compression-lease holder, the ordering
+        signal for explicit closes. A missing row is not an obstacle (publish reports that itself)."""
         if not session_id:
             return False
         # The public reader on purpose: an unreadable row raises to the guard, which fails open
@@ -113,7 +137,9 @@ class SessionCompressionMixin:
         if not parent or parent.get("ended_at") is None:
             return False
         with self._read_ctx() as conn:
-            return self._compression_parent_obstacle(conn, session_id, parent) is not None
+            acquired_at = self._lease_acquired_at_for(conn, session_id, holder)
+            return self._compression_parent_obstacle(
+                conn, session_id, parent, lease_acquired_at=acquired_at) is not None
 
     def find_live_compression_child(self, parent_session_id: str) -> Optional[Dict[str, Any]]:
         """The unique live direct child of a compression-ended session, else None. A stale
@@ -249,7 +275,7 @@ class SessionCompressionMixin:
                 conn.execute(
                     "UPDATE compression_locks SET expires_at = ? WHERE session_id = ? AND holder = ?",
                     (time.time() + lease_ttl_seconds, parent_session_id, compression_lock_holder))
-            lock_row = conn.execute(_LOCK_ROW_SQL, (parent_session_id,)).fetchone()
+            lock_row = conn.execute(_LOCK_ROW_WITH_ACQUIRED_SQL, (parent_session_id,)).fetchone()
             if require_compression_lease and (
                 lock_row is None or not compression_lock_holder
                 or lock_row["holder"] != compression_lock_holder
@@ -271,14 +297,20 @@ class SessionCompressionMixin:
                 # (#106459) — is cleared here: this lease holder is still continuing the conversation,
                 # and left alone the stamp wedges rotation forever. The closure UPDATE below re-stamps
                 # end_reason='compression'. Lineage owned elsewhere fails closed (see the verdict).
-                obstacle = self._compression_parent_obstacle(conn, parent_session_id, parent)
+                lease_acquired_at = (
+                    float(lock_row["acquired_at"])
+                    if lock_row is not None and compression_lock_holder
+                    and lock_row["holder"] == compression_lock_holder and lock_row["acquired_at"] is not None
+                    else None)
+                obstacle = self._compression_parent_obstacle(
+                    conn, parent_session_id, parent, lease_acquired_at=lease_acquired_at)
                 if obstacle is not None:
                     raise RuntimeError(f"Compression parent already ended: {parent_session_id} ({obstacle})")
                 if not is_automatic_end_reason(parent["end_reason"]):
                     logger.warning(
-                        "Compression parent %s carries a stale %r end stamp with no continuation; clearing "
-                        "it so the rotation held by the compression lease can publish (#106459)",
-                        parent_session_id, parent["end_reason"])
+                        "Compression parent %s carries a stale %r end stamp written before this compression "
+                        "lease was acquired and with no continuation; clearing it so the rotation can publish "
+                        "(#106459)", parent_session_id, parent["end_reason"])
                 conn.execute(
                     "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                     (parent_session_id,))

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -15,11 +15,6 @@ from hermes_state_common import (
     _BOUNDARY_END_REASONS, _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS,
     _ended_by_compression, _sql_session_last_active, is_automatic_end_reason)
 
-# The conversation's turn lease including when it was admitted (agent/turn_facade_lease.py takes one per
-# turn; refresh only extends expires_at): the ordering signal that tells a stale end stamp (written before
-# this turn was admitted) from a deliberate close written during it.
-_TURN_LEASE_ROW_WITH_ACQUIRED_SQL = "SELECT holder, acquired_at FROM session_turn_leases WHERE conversation_id = ?"
-
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
 
@@ -75,74 +70,80 @@ def _claim_lease_row(conn, table: str, key_col: str, key: str, holder: str, now:
 class SessionCompressionMixin:
     """Compression lineage, cooldown/streak counters, locks and turn leases."""
 
-    def _compression_parent_obstacle(
-        self, conn, parent_session_id: str, parent, *, turn_admitted_at: Optional[float],
-    ) -> Optional[str]:
-        """Why publishing a compression child of *parent* (a row with ``ended_at`` / ``end_reason``) must
-        fail closed, or None when the parent is live or its stamp is stale and may be cleared.
-
-        Single owner of the verdict for publish_compression_child() and the agent's pre-flush guard
-        (#106459). Lineage owned elsewhere fails closed: a ``'compression'`` stamp names a continuation,
-        a boundary reason (reset reasons, CLI ``new_session``) is a deliberate end of the conversation,
-        and an explicit close that already has a continuation child was superseded. An automatic-cleanup
-        stamp is stale by construction (#88197).
-
-        An explicit close (``tui_close``, ``cli_close``, ``webhook_complete``, ...) is cleared only on
-        POSITIVE evidence that the session was driven after it: *turn_admitted_at*, when this writer's
-        turn lease on the conversation was admitted (``session_turn_leases.acquired_at``; the façade takes
-        one per turn before loading the transcript). A stamp older than that means a host admitted a new
-        turn on the row with the stamp in place, so the session is still routed and the stamp missed it
-        (the #106459 field shape, where every rotation computed its summary and discarded it, forever).
-        Every sanctioned resume clears the stamp first (``reopen_session``), and a host never admits a
-        turn on a session it is closing, so that order cannot describe a live close. A stamp at or after
-        admission is a close made during this turn (``session.close`` stamps ``tui_close`` after a
-        five-second grace even while the turn thread runs on) and is preserved. The compression lease is
-        no evidence: it is taken inside the turn, after any such close. Without an admitted turn of our
-        own (no lease, foreign holder) an explicit close cannot be proven stale and fails closed; a stamp
-        that lands mid-turn therefore costs that turn's rotation, and the next admitted turn proves it
-        stale."""
-        if parent is None or parent["ended_at"] is None:
+    def _end_stamp_class(self, conn, session_id: str, row) -> Optional[str]:
+        """Classify *row*'s end stamp (a mapping with ``ended_at`` / ``end_reason``): None when live,
+        ``'automatic'`` (cleanup stamp, stale by construction, #88197), ``'compression'`` (names a
+        continuation), ``'boundary'`` (reset reasons and CLI ``new_session``: a deliberate end of the
+        conversation), ``'superseded'`` (an explicit close whose continuation child was already published),
+        or ``'explicit'`` (``tui_close``, ``cli_close``, ``webhook_complete``, ...: a close with no
+        continuation). Single owner of the taxonomy for turn admission, publish_compression_child() and
+        the agent's pre-flush guard (#106459, never-patch-predicates)."""
+        if row is None or row["ended_at"] is None:
             return None
-        reason = parent["end_reason"]
+        reason = row["end_reason"]
         if is_automatic_end_reason(reason):
-            return None
+            return "automatic"
         if reason == "compression":
-            return "closed by compression"
+            return "compression"
         if reason in _BOUNDARY_END_REASONS:
-            return f"closed by a {reason} boundary"
+            return "boundary"
         child = conn.execute(
             "SELECT 1 FROM sessions WHERE parent_session_id = ?"
             + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="")
             + " LIMIT 1",
-            (parent_session_id, parent_session_id, parent_session_id),
+            (session_id, session_id, session_id),
         ).fetchone()
-        if child is not None:
+        return "superseded" if child is not None else "explicit"
+
+    def _compression_parent_obstacle(self, conn, parent_session_id: str, parent) -> Optional[str]:
+        """Why publishing a compression child of *parent* must fail closed, or None when the parent is live
+        or carries an automatic-cleanup stamp that publish may clear (#88197).
+
+        Every other stamp fails closed here, explicit closes included: a stale explicit close is healed at
+        TURN ADMISSION (``try_acquire_session_turn_lease``), never at publication. Healing at publication
+        cannot be made safe, because ``end_session()`` is first-stamp-wins: while a stale stamp occupies
+        the row, a close the user makes during the turn is a no-op write, so the store could not tell the
+        stale stamp from a deliberate close that failed to record. With the row cleared at admission, an
+        explicit stamp present at publication was written after this turn began (a deliberate close, or a
+        foreign writer's mis-stamp that costs this one rotation) or no turn was admitted at all, and
+        publish must not resurrect it."""
+        kind = self._end_stamp_class(conn, parent_session_id, parent)
+        if kind in (None, "automatic"):
+            return None
+        reason = parent["end_reason"]
+        if kind == "compression":
+            return "closed by compression"
+        if kind == "boundary":
+            return f"closed by a {reason} boundary"
+        if kind == "superseded":
             return f"closed ({reason}) with a published continuation"
-        if turn_admitted_at is None:
-            return f"closed ({reason}) with no admitted turn of ours to prove the stamp stale"
-        if float(parent["ended_at"]) >= float(turn_admitted_at):
-            return f"closed ({reason}) after this turn was admitted"
-        return None
+        return f"closed ({reason}); an explicit close is healed only at turn admission"
 
-    def _turn_admitted_at_for(self, conn, session_id: str, holder: Optional[str]) -> Optional[float]:
-        """When *holder*'s turn lease on *session_id*'s conversation was admitted, or None. Ownership is
-        by holder, as in the transcript-write guard: an expired row nobody reclaimed is still this turn."""
-        if not holder:
-            return None
-        conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
-        row = conn.execute(_TURN_LEASE_ROW_WITH_ACQUIRED_SQL, (conversation_id,)).fetchone()
-        if row is None or row["holder"] != holder or row["acquired_at"] is None:
-            return None
-        return float(row["acquired_at"])
+    def _heal_stale_explicit_close_on_admission(self, conn, session_id: str, holder: str) -> None:
+        """Inside the turn-lease claim transaction: a host is admitting a turn on *session_id*, so an
+        explicit-close stamp already on its row is stale and is cleared (#106459). Every sanctioned resume
+        clears stamps first (``reopen_session``) and a host never admits a turn on a session it is closing,
+        so a stamp that survives to admission can only have missed a still-routed session (the field shape:
+        the TUI kept accepting prompts on a ``tui_close``-stamped row while every rotation aborted).
+        Clearing here, atomically with the claim, is what keeps a close made DURING the turn observable:
+        ``end_session()`` is first-stamp-wins and could not record it over the stale stamp. Automatic stamps
+        are left for publish (#88197); ``'compression'``, boundary and superseded stamps are lineage owned
+        elsewhere and are left alone, and publish fails closed on them."""
+        row = conn.execute(_ENDED_ROW_SQL, (session_id,)).fetchone()
+        if self._end_stamp_class(conn, session_id, row) != "explicit":
+            return
+        conn.execute(
+            "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ? AND ended_at = ? AND end_reason = ?",
+            (session_id, row["ended_at"], row["end_reason"]))
+        logger.warning(
+            "Session %s carried a stale %r end stamp when %s admitted a turn on it; cleared so the "
+            "conversation can compress and a later close is recorded (#106459)",
+            session_id, row["end_reason"], holder)
 
-    def compression_parent_deliberately_ended(
-        self, session_id: str, *, turn_lease_holder: Optional[str] = None,
-    ) -> bool:
+    def compression_parent_deliberately_ended(self, session_id: str) -> bool:
         """Read-only twin of publish_compression_child()'s liveness verdict, for the agent's guard that
         runs BEFORE the durable pre-publish flush: True only when publish would fail closed on
-        *session_id*'s end stamp. *turn_lease_holder* is this turn's session-turn-lease holder, the
-        ordering signal for explicit closes. A missing row is not an obstacle (publish reports that
-        itself)."""
+        *session_id*'s end stamp. A missing row is not an obstacle (publish reports that itself)."""
         if not session_id:
             return False
         # The public reader on purpose: an unreadable row raises to the guard, which fails open
@@ -151,9 +152,7 @@ class SessionCompressionMixin:
         if not parent or parent.get("ended_at") is None:
             return False
         with self._read_ctx() as conn:
-            admitted_at = self._turn_admitted_at_for(conn, session_id, turn_lease_holder)
-            return self._compression_parent_obstacle(
-                conn, session_id, parent, turn_admitted_at=admitted_at) is not None
+            return self._compression_parent_obstacle(conn, session_id, parent) is not None
 
     def find_live_compression_child(self, parent_session_id: str) -> Optional[Dict[str, Any]]:
         """The unique live direct child of a compression-ended session, else None. A stale
@@ -269,8 +268,7 @@ class SessionCompressionMixin:
         system_prompt: str = None, cwd: str = None, profile_name: str = None,
         compression_lock_holder: str = None, require_compression_lease: bool = True,
         require_lease_refresh: bool = False, lease_ttl_seconds: float = 300.0,
-        watermark: Optional[int] = None, watermark_ceiling: Optional[int] = None,
-        turn_lease_holder: Optional[str] = None) -> None:
+        watermark: Optional[int] = None, watermark_ceiling: Optional[int] = None) -> None:
         """Atomically close a parent and publish its durable compression child: closure, child row, and
         handoff commit in one transaction, so readers see the live parent or a complete child, never an
         ended parent with a missing/empty child. *watermark* (parent's ``get_active_message_watermark`` at compression start): parent rows with ``id
@@ -280,8 +278,6 @@ class SessionCompressionMixin:
         watermark_ceiling]`` is foreign tail (``None`` = unbounded). *require_lease_refresh* +
         *compression_lock_holder* refreshes the lease on the same ``conn`` before the expiry check (no
         TOCTOU window), so a refresher that died on transient DB errors gets one last chance.
-        *turn_lease_holder* names this turn's session-turn lease; its admission time is the only evidence
-        that lets an explicit-close stamp on the parent be cleared (see ``_compression_parent_obstacle``).
 
         See #75316.
         ``None`` = unbounded (no internal flush happened). See #47202.
@@ -310,20 +306,13 @@ class SessionCompressionMixin:
             if parent is None:
                 raise RuntimeError(f"Compression parent not found: {parent_session_id}")
             if parent["ended_at"] is not None:
-                # A stale stamp — automatic cleanup (#88197) or an explicit close that a later admitted
-                # turn proves stale (#106459) — is cleared here: the conversation is still being driven,
-                # and left alone the stamp wedges rotation forever. The closure UPDATE below re-stamps
-                # end_reason='compression'. Lineage owned elsewhere fails closed (see the verdict).
-                obstacle = self._compression_parent_obstacle(
-                    conn, parent_session_id, parent,
-                    turn_admitted_at=self._turn_admitted_at_for(conn, parent_session_id, turn_lease_holder))
+                # An automatic-cleanup stamp (#88197) is cleared here: this lease holder is still
+                # continuing the conversation, and left alone the stamp wedges rotation forever. The
+                # closure UPDATE below re-stamps end_reason='compression'. Every other stamp fails closed
+                # (see the verdict); a stale explicit close is healed at turn admission, not here (#106459).
+                obstacle = self._compression_parent_obstacle(conn, parent_session_id, parent)
                 if obstacle is not None:
                     raise RuntimeError(f"Compression parent already ended: {parent_session_id} ({obstacle})")
-                if not is_automatic_end_reason(parent["end_reason"]):
-                    logger.warning(
-                        "Compression parent %s carries a stale %r end stamp: this turn was admitted after it "
-                        "and it has no continuation; clearing it so the rotation can publish (#106459)",
-                        parent_session_id, parent["end_reason"])
                 conn.execute(
                     "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                     (parent_session_id,))
@@ -576,10 +565,15 @@ class SessionCompressionMixin:
         expires_at = now + max(0.1, float(ttl_seconds))
         def _do(conn):
             conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
-            return _claim_lease_row(
+            acquired = _claim_lease_row(
                 conn, "session_turn_leases", "conversation_id", conversation_id, holder, now, expires_at,
                 lambda h, e: float(e) <= now or _compression_lock_holder_process_is_dead(h),
             )[0]
+            if acquired:
+                # Same transaction as the claim: no window in which a deliberate close could land on the
+                # still-stamped row and be lost to first-stamp-wins (#106459).
+                self._heal_stale_explicit_close_on_admission(conn, session_id, holder)
+            return acquired
         return bool(self._execute_write(_do, patience_s=patience_s))
 
     def acquire_session_turn_lease(

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -12,12 +12,13 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_state_common import (
-    _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _ended_by_compression,
-    _sql_session_last_active, is_automatic_end_reason)
+    _BOUNDARY_END_REASONS, _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS,
+    _ended_by_compression, _sql_session_last_active, is_automatic_end_reason)
 
-# The compression lock row including when it was acquired: the ordering signal that tells a stale
-# end stamp (written before this attempt took the lease) from a deliberate close written during it.
-_LOCK_ROW_WITH_ACQUIRED_SQL = "SELECT holder, acquired_at, expires_at FROM compression_locks WHERE session_id = ?"
+# The conversation's turn lease including when it was admitted (agent/turn_facade_lease.py takes one per
+# turn; refresh only extends expires_at): the ordering signal that tells a stale end stamp (written before
+# this turn was admitted) from a deliberate close written during it.
+_TURN_LEASE_ROW_WITH_ACQUIRED_SQL = "SELECT holder, acquired_at FROM session_turn_leases WHERE conversation_id = ?"
 
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
@@ -75,23 +76,31 @@ class SessionCompressionMixin:
     """Compression lineage, cooldown/streak counters, locks and turn leases."""
 
     def _compression_parent_obstacle(
-        self, conn, parent_session_id: str, parent, *, lease_acquired_at: Optional[float],
+        self, conn, parent_session_id: str, parent, *, turn_admitted_at: Optional[float],
     ) -> Optional[str]:
         """Why publishing a compression child of *parent* (a row with ``ended_at`` / ``end_reason``) must
         fail closed, or None when the parent is live or its stamp is stale and may be cleared.
 
         Single owner of the verdict for publish_compression_child() and the agent's pre-flush guard
         (#106459). Lineage owned elsewhere fails closed: a ``'compression'`` stamp names a continuation,
-        a reset reason is a deliberate conversation boundary, and an explicit close that already has a
-        continuation child was superseded. An automatic-cleanup stamp is stale by construction (#88197).
-        An explicit close (``tui_close``, ``cli_close``, ``webhook_complete``, ``new_session``, ...) is
-        decided by ORDER against this attempt's compression lease, *lease_acquired_at*: a stamp written
-        before the lease was taken is stale (the writer acquired the lease and has driven the row since;
-        failing closed there made every compression compute its result and discard it, forever), while a
-        close written after it is the user closing the session mid-compression (``session.close`` waits
-        five seconds for the turn thread, then stamps ``tui_close``) and must be preserved. A lease only
-        grants publication ownership; without its ordering (no lease, foreign holder) an explicit close
-        cannot be proven stale and fails closed."""
+        a boundary reason (reset reasons, CLI ``new_session``) is a deliberate end of the conversation,
+        and an explicit close that already has a continuation child was superseded. An automatic-cleanup
+        stamp is stale by construction (#88197).
+
+        An explicit close (``tui_close``, ``cli_close``, ``webhook_complete``, ...) is cleared only on
+        POSITIVE evidence that the session was driven after it: *turn_admitted_at*, when this writer's
+        turn lease on the conversation was admitted (``session_turn_leases.acquired_at``; the façade takes
+        one per turn before loading the transcript). A stamp older than that means a host admitted a new
+        turn on the row with the stamp in place, so the session is still routed and the stamp missed it
+        (the #106459 field shape, where every rotation computed its summary and discarded it, forever).
+        Every sanctioned resume clears the stamp first (``reopen_session``), and a host never admits a
+        turn on a session it is closing, so that order cannot describe a live close. A stamp at or after
+        admission is a close made during this turn (``session.close`` stamps ``tui_close`` after a
+        five-second grace even while the turn thread runs on) and is preserved. The compression lease is
+        no evidence: it is taken inside the turn, after any such close. Without an admitted turn of our
+        own (no lease, foreign holder) an explicit close cannot be proven stale and fails closed; a stamp
+        that lands mid-turn therefore costs that turn's rotation, and the next admitted turn proves it
+        stale."""
         if parent is None or parent["ended_at"] is None:
             return None
         reason = parent["end_reason"]
@@ -99,7 +108,7 @@ class SessionCompressionMixin:
             return None
         if reason == "compression":
             return "closed by compression"
-        if reason in _RESET_END_REASONS:
+        if reason in _BOUNDARY_END_REASONS:
             return f"closed by a {reason} boundary"
         child = conn.execute(
             "SELECT 1 FROM sessions WHERE parent_session_id = ?"
@@ -109,26 +118,31 @@ class SessionCompressionMixin:
         ).fetchone()
         if child is not None:
             return f"closed ({reason}) with a published continuation"
-        if lease_acquired_at is None:
-            return f"closed ({reason}) with no compression-lease ordering to prove the stamp stale"
-        if float(parent["ended_at"]) >= float(lease_acquired_at):
-            return f"closed ({reason}) after this compression attempt acquired its lease"
+        if turn_admitted_at is None:
+            return f"closed ({reason}) with no admitted turn of ours to prove the stamp stale"
+        if float(parent["ended_at"]) >= float(turn_admitted_at):
+            return f"closed ({reason}) after this turn was admitted"
         return None
 
-    def _lease_acquired_at_for(self, conn, session_id: str, holder: Optional[str]) -> Optional[float]:
-        """When *holder*'s live compression lease on *session_id* was acquired, or None."""
+    def _turn_admitted_at_for(self, conn, session_id: str, holder: Optional[str]) -> Optional[float]:
+        """When *holder*'s turn lease on *session_id*'s conversation was admitted, or None. Ownership is
+        by holder, as in the transcript-write guard: an expired row nobody reclaimed is still this turn."""
         if not holder:
             return None
-        row = conn.execute(_LOCK_ROW_WITH_ACQUIRED_SQL, (session_id,)).fetchone()
+        conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
+        row = conn.execute(_TURN_LEASE_ROW_WITH_ACQUIRED_SQL, (conversation_id,)).fetchone()
         if row is None or row["holder"] != holder or row["acquired_at"] is None:
             return None
         return float(row["acquired_at"])
 
-    def compression_parent_deliberately_ended(self, session_id: str, *, holder: Optional[str] = None) -> bool:
+    def compression_parent_deliberately_ended(
+        self, session_id: str, *, turn_lease_holder: Optional[str] = None,
+    ) -> bool:
         """Read-only twin of publish_compression_child()'s liveness verdict, for the agent's guard that
         runs BEFORE the durable pre-publish flush: True only when publish would fail closed on
-        *session_id*'s end stamp. *holder* is this attempt's compression-lease holder, the ordering
-        signal for explicit closes. A missing row is not an obstacle (publish reports that itself)."""
+        *session_id*'s end stamp. *turn_lease_holder* is this turn's session-turn-lease holder, the
+        ordering signal for explicit closes. A missing row is not an obstacle (publish reports that
+        itself)."""
         if not session_id:
             return False
         # The public reader on purpose: an unreadable row raises to the guard, which fails open
@@ -137,9 +151,9 @@ class SessionCompressionMixin:
         if not parent or parent.get("ended_at") is None:
             return False
         with self._read_ctx() as conn:
-            acquired_at = self._lease_acquired_at_for(conn, session_id, holder)
+            admitted_at = self._turn_admitted_at_for(conn, session_id, turn_lease_holder)
             return self._compression_parent_obstacle(
-                conn, session_id, parent, lease_acquired_at=acquired_at) is not None
+                conn, session_id, parent, turn_admitted_at=admitted_at) is not None
 
     def find_live_compression_child(self, parent_session_id: str) -> Optional[Dict[str, Any]]:
         """The unique live direct child of a compression-ended session, else None. A stale
@@ -255,7 +269,8 @@ class SessionCompressionMixin:
         system_prompt: str = None, cwd: str = None, profile_name: str = None,
         compression_lock_holder: str = None, require_compression_lease: bool = True,
         require_lease_refresh: bool = False, lease_ttl_seconds: float = 300.0,
-        watermark: Optional[int] = None, watermark_ceiling: Optional[int] = None) -> None:
+        watermark: Optional[int] = None, watermark_ceiling: Optional[int] = None,
+        turn_lease_holder: Optional[str] = None) -> None:
         """Atomically close a parent and publish its durable compression child: closure, child row, and
         handoff commit in one transaction, so readers see the live parent or a complete child, never an
         ended parent with a missing/empty child. *watermark* (parent's ``get_active_message_watermark`` at compression start): parent rows with ``id
@@ -265,6 +280,8 @@ class SessionCompressionMixin:
         watermark_ceiling]`` is foreign tail (``None`` = unbounded). *require_lease_refresh* +
         *compression_lock_holder* refreshes the lease on the same ``conn`` before the expiry check (no
         TOCTOU window), so a refresher that died on transient DB errors gets one last chance.
+        *turn_lease_holder* names this turn's session-turn lease; its admission time is the only evidence
+        that lets an explicit-close stamp on the parent be cleared (see ``_compression_parent_obstacle``).
 
         See #75316.
         ``None`` = unbounded (no internal flush happened). See #47202.
@@ -275,7 +292,7 @@ class SessionCompressionMixin:
                 conn.execute(
                     "UPDATE compression_locks SET expires_at = ? WHERE session_id = ? AND holder = ?",
                     (time.time() + lease_ttl_seconds, parent_session_id, compression_lock_holder))
-            lock_row = conn.execute(_LOCK_ROW_WITH_ACQUIRED_SQL, (parent_session_id,)).fetchone()
+            lock_row = conn.execute(_LOCK_ROW_SQL, (parent_session_id,)).fetchone()
             if require_compression_lease and (
                 lock_row is None or not compression_lock_holder
                 or lock_row["holder"] != compression_lock_holder
@@ -293,24 +310,20 @@ class SessionCompressionMixin:
             if parent is None:
                 raise RuntimeError(f"Compression parent not found: {parent_session_id}")
             if parent["ended_at"] is not None:
-                # A stale stamp — automatic cleanup (#88197) or an explicit close with no continuation
-                # (#106459) — is cleared here: this lease holder is still continuing the conversation,
+                # A stale stamp — automatic cleanup (#88197) or an explicit close that a later admitted
+                # turn proves stale (#106459) — is cleared here: the conversation is still being driven,
                 # and left alone the stamp wedges rotation forever. The closure UPDATE below re-stamps
                 # end_reason='compression'. Lineage owned elsewhere fails closed (see the verdict).
-                lease_acquired_at = (
-                    float(lock_row["acquired_at"])
-                    if lock_row is not None and compression_lock_holder
-                    and lock_row["holder"] == compression_lock_holder and lock_row["acquired_at"] is not None
-                    else None)
                 obstacle = self._compression_parent_obstacle(
-                    conn, parent_session_id, parent, lease_acquired_at=lease_acquired_at)
+                    conn, parent_session_id, parent,
+                    turn_admitted_at=self._turn_admitted_at_for(conn, parent_session_id, turn_lease_holder))
                 if obstacle is not None:
                     raise RuntimeError(f"Compression parent already ended: {parent_session_id} ({obstacle})")
                 if not is_automatic_end_reason(parent["end_reason"]):
                     logger.warning(
-                        "Compression parent %s carries a stale %r end stamp written before this compression "
-                        "lease was acquired and with no continuation; clearing it so the rotation can publish "
-                        "(#106459)", parent_session_id, parent["end_reason"])
+                        "Compression parent %s carries a stale %r end stamp: this turn was admitted after it "
+                        "and it has no continuation; clearing it so the rotation can publish (#106459)",
+                        parent_session_id, parent["end_reason"])
                 conn.execute(
                     "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                     (parent_session_id,))

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -12,8 +12,8 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_state_common import (
-    _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _ended_by_compression, _sql_session_last_active,
-    is_automatic_end_reason)
+    _COMPRESSION_LOCK_ROW_SQL as _LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _ended_by_compression,
+    _sql_session_last_active, is_automatic_end_reason)
 
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
@@ -69,6 +69,51 @@ def _claim_lease_row(conn, table: str, key_col: str, key: str, holder: str, now:
 
 class SessionCompressionMixin:
     """Compression lineage, cooldown/streak counters, locks and turn leases."""
+
+    def _compression_parent_obstacle(self, conn, parent_session_id: str, parent) -> Optional[str]:
+        """Why publishing a compression child of *parent* (a row with ``ended_at`` / ``end_reason``) must
+        fail closed, or None when the parent is live or its stamp is stale and may be cleared.
+
+        Single owner of the verdict for publish_compression_child() and the agent's pre-flush guard
+        (#106459). Only another path owning the lineage fails closed: a ``'compression'`` stamp names a
+        continuation, a reset reason is a deliberate conversation boundary, and an explicit close that
+        already has a continuation child was superseded. An automatic-cleanup stamp is stale by
+        construction (#88197), and so is an explicit close (``tui_close``, ``cli_close``,
+        ``webhook_complete``, ``new_session``, ...) with NO continuation child: the lease holder rotating
+        this parent is provably still the conversation's writer and nothing else claims it. Failing closed
+        there made every compression compute its result and discard it, forever."""
+        if parent is None or parent["ended_at"] is None:
+            return None
+        reason = parent["end_reason"]
+        if is_automatic_end_reason(reason):
+            return None
+        if reason == "compression":
+            return "closed by compression"
+        if reason in _RESET_END_REASONS:
+            return f"closed by a {reason} boundary"
+        child = conn.execute(
+            "SELECT 1 FROM sessions WHERE parent_session_id = ?"
+            + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="")
+            + " LIMIT 1",
+            (parent_session_id, parent_session_id, parent_session_id),
+        ).fetchone()
+        if child is not None:
+            return f"closed ({reason}) with a published continuation"
+        return None
+
+    def compression_parent_deliberately_ended(self, session_id: str) -> bool:
+        """Read-only twin of publish_compression_child()'s liveness verdict, for the agent's guard that
+        runs BEFORE the durable pre-publish flush: True only when publish would fail closed on
+        *session_id*'s end stamp. A missing row is not an obstacle (publish reports that itself)."""
+        if not session_id:
+            return False
+        # The public reader on purpose: an unreadable row raises to the guard, which fails open
+        # (tests/agent/test_compression_rotation_state.py pins that contract).
+        parent = self.get_session(session_id)
+        if not parent or parent.get("ended_at") is None:
+            return False
+        with self._read_ctx() as conn:
+            return self._compression_parent_obstacle(conn, session_id, parent) is not None
 
     def find_live_compression_child(self, parent_session_id: str) -> Optional[Dict[str, Any]]:
         """The unique live direct child of a compression-ended session, else None. A stale
@@ -222,12 +267,18 @@ class SessionCompressionMixin:
             if parent is None:
                 raise RuntimeError(f"Compression parent not found: {parent_session_id}")
             if parent["ended_at"] is not None:
-                # An AUTOMATIC end stamp (tui_shutdown, ws_disconnect, orphan reap, idle/LRU
-                # evict) is stale by construction — this lease holder is still continuing the
-                # conversation, and left alone it wedges rotation forever. Clear it; the closure
-                # UPDATE below re-stamps end_reason='compression'. Deliberate boundaries fail closed.
+                # A stale stamp — automatic cleanup (#88197) or an explicit close with no continuation
+                # (#106459) — is cleared here: this lease holder is still continuing the conversation,
+                # and left alone the stamp wedges rotation forever. The closure UPDATE below re-stamps
+                # end_reason='compression'. Lineage owned elsewhere fails closed (see the verdict).
+                obstacle = self._compression_parent_obstacle(conn, parent_session_id, parent)
+                if obstacle is not None:
+                    raise RuntimeError(f"Compression parent already ended: {parent_session_id} ({obstacle})")
                 if not is_automatic_end_reason(parent["end_reason"]):
-                    raise RuntimeError(f"Compression parent already ended: {parent_session_id}")
+                    logger.warning(
+                        "Compression parent %s carries a stale %r end stamp with no continuation; clearing "
+                        "it so the rotation held by the compression lease can publish (#106459)",
+                        parent_session_id, parent["end_reason"])
                 conn.execute(
                     "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                     (parent_session_id,))

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -76,8 +76,8 @@ class SessionCompressionMixin:
         continuation), ``'boundary'`` (reset reasons and CLI ``new_session``: a deliberate end of the
         conversation), ``'superseded'`` (an explicit close whose continuation child was already published),
         or ``'explicit'`` (``tui_close``, ``cli_close``, ``webhook_complete``, ...: a close with no
-        continuation). Single owner of the taxonomy for turn admission, publish_compression_child() and
-        the agent's pre-flush guard (#106459, never-patch-predicates)."""
+        continuation). Single owner of the taxonomy for ``reopen_if_explicitly_closed()``,
+        publish_compression_child() and the agent's pre-flush guard (#106459, never-patch-predicates)."""
         if row is None or row["ended_at"] is None:
             return None
         reason = row["end_reason"]
@@ -99,14 +99,14 @@ class SessionCompressionMixin:
         """Why publishing a compression child of *parent* must fail closed, or None when the parent is live
         or carries an automatic-cleanup stamp that publish may clear (#88197).
 
-        Every other stamp fails closed here, explicit closes included: a stale explicit close is healed at
-        TURN ADMISSION (``try_acquire_session_turn_lease``), never at publication. Healing at publication
-        cannot be made safe, because ``end_session()`` is first-stamp-wins: while a stale stamp occupies
-        the row, a close the user makes during the turn is a no-op write, so the store could not tell the
-        stale stamp from a deliberate close that failed to record. With the row cleared at admission, an
-        explicit stamp present at publication was written after this turn began (a deliberate close, or a
-        foreign writer's mis-stamp that costs this one rotation) or no turn was admitted at all, and
-        publish must not resurrect it."""
+        Every other stamp fails closed here, explicit closes included. A stale explicit close is healed only
+        by the host that still routes the session (``reopen_if_explicitly_closed()``, called by the TUI as it
+        starts a turn), never by the store: healing at publication cannot be made safe because
+        ``end_session()`` is first-stamp-wins -- while a stale stamp occupies the row, a close made during
+        the turn is a no-op write -- and healing at turn-lease admission cannot either, because a turn
+        worker can take its lease after the host has already closed the session. An explicit stamp present
+        here is therefore a deliberate close, a foreign writer's mis-stamp that costs this one rotation, or
+        a stamp no host has vouched against, and publish must not resurrect it."""
         kind = self._end_stamp_class(conn, parent_session_id, parent)
         if kind in (None, "automatic"):
             return None
@@ -117,28 +117,43 @@ class SessionCompressionMixin:
             return f"closed by a {reason} boundary"
         if kind == "superseded":
             return f"closed ({reason}) with a published continuation"
-        return f"closed ({reason}); an explicit close is healed only at turn admission"
+        return f"closed ({reason}); an explicit close is healed only by the host that still routes the session"
 
-    def _heal_stale_explicit_close_on_admission(self, conn, session_id: str, holder: str) -> None:
-        """Inside the turn-lease claim transaction: a host is admitting a turn on *session_id*, so an
-        explicit-close stamp already on its row is stale and is cleared (#106459). Every sanctioned resume
-        clears stamps first (``reopen_session``) and a host never admits a turn on a session it is closing,
-        so a stamp that survives to admission can only have missed a still-routed session (the field shape:
-        the TUI kept accepting prompts on a ``tui_close``-stamped row while every rotation aborted).
-        Clearing here, atomically with the claim, is what keeps a close made DURING the turn observable:
-        ``end_session()`` is first-stamp-wins and could not record it over the stale stamp. Automatic stamps
-        are left for publish (#88197); ``'compression'``, boundary and superseded stamps are lineage owned
-        elsewhere and are left alone, and publish fails closed on them."""
-        row = conn.execute(_ENDED_ROW_SQL, (session_id,)).fetchone()
-        if self._end_stamp_class(conn, session_id, row) != "explicit":
-            return
-        conn.execute(
-            "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ? AND ended_at = ? AND end_reason = ?",
-            (session_id, row["ended_at"], row["end_reason"]))
-        logger.warning(
-            "Session %s carried a stale %r end stamp when %s admitted a turn on it; cleared so the "
-            "conversation can compress and a later close is recorded (#106459)",
-            session_id, row["end_reason"], holder)
+    def reopen_if_explicitly_closed(
+        self, session_id: str, *, provenance: str, patience_s: Optional[float] = None,
+    ) -> Optional[str]:
+        """Clear an explicit-close stamp (``tui_close``, ``cli_close``, ``webhook_complete``, ...) from a
+        session a HOST has just proven is still routed to it, returning the reason cleared or None.
+        *provenance* names that proof and is logged; *patience_s* bounds the write for a caller holding a
+        hot lock. Narrow twin of ``reopen_session()``, which clears any stamp: automatic (left to publish,
+        #88197), ``'compression'``, boundary and superseded stamps are lineage owned elsewhere and are
+        never touched here. The UPDATE is conditional on the exact stamp that was read, so a close landing
+        between the read and the write survives.
+
+        The store cannot make this call itself (#106459). Acquiring the session turn lease is not proof of
+        routing: the TUI starts a turn worker before that worker reaches ``run_conversation()``, so a
+        ``session.close`` can pop the session, wait out its grace and stamp ``tui_close`` in between, and a
+        late lease would then clear a deliberate close that nothing re-applies. Only a host that holds the
+        registry claim can say "this conversation is still mine and I am accepting a turn for it" -- the
+        gateway's stale-route self-heal (#54878) is the same rule on the routing table. Call it under
+        whatever lock makes the host's claim atomic with its teardown."""
+        if not session_id:
+            return None
+        def _do(conn):
+            row = conn.execute(_ENDED_ROW_SQL, (session_id,)).fetchone()
+            if self._end_stamp_class(conn, session_id, row) != "explicit":
+                return None
+            conn.execute(
+                "UPDATE sessions SET ended_at = NULL, end_reason = NULL "
+                "WHERE id = ? AND ended_at = ? AND end_reason = ?",
+                (session_id, row["ended_at"], row["end_reason"]))
+            return str(row["end_reason"])
+        reason = self._execute_write(_do, patience_s=patience_s)
+        if reason is not None:
+            logger.warning(
+                "Session %s carried a stale %r end stamp while %s; cleared so the conversation can "
+                "compress and a later close is recorded (#106459)", session_id, reason, provenance)
+        return reason
 
     def compression_parent_deliberately_ended(self, session_id: str) -> bool:
         """Read-only twin of publish_compression_child()'s liveness verdict, for the agent's guard that
@@ -309,7 +324,7 @@ class SessionCompressionMixin:
                 # An automatic-cleanup stamp (#88197) is cleared here: this lease holder is still
                 # continuing the conversation, and left alone the stamp wedges rotation forever. The
                 # closure UPDATE below re-stamps end_reason='compression'. Every other stamp fails closed
-                # (see the verdict); a stale explicit close is healed at turn admission, not here (#106459).
+                # (see the verdict); a stale explicit close is healed by the routing host, not here (#106459).
                 obstacle = self._compression_parent_obstacle(conn, parent_session_id, parent)
                 if obstacle is not None:
                     raise RuntimeError(f"Compression parent already ended: {parent_session_id} ({obstacle})")
@@ -565,15 +580,10 @@ class SessionCompressionMixin:
         expires_at = now + max(0.1, float(ttl_seconds))
         def _do(conn):
             conversation_id = self._session_turn_lease_key_on_conn(conn, session_id)
-            acquired = _claim_lease_row(
+            return _claim_lease_row(
                 conn, "session_turn_leases", "conversation_id", conversation_id, holder, now, expires_at,
                 lambda h, e: float(e) <= now or _compression_lock_holder_process_is_dead(h),
             )[0]
-            if acquired:
-                # Same transaction as the claim: no window in which a deliberate close could land on the
-                # still-stamped row and be lost to first-stamp-wins (#106459).
-                self._heal_stale_explicit_close_on_admission(conn, session_id, holder)
-            return acquired
         return bool(self._execute_write(_do, patience_s=patience_s))
 
     def acquire_session_turn_lease(

--- a/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
+++ b/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
@@ -1,5 +1,6 @@
 """Regression tests for #106459 — an over-limit session must not become permanently
-uncompressible because its row carries a stale explicit-close stamp.
+uncompressible because its row carries a stale explicit-close stamp, and a close the user
+makes mid-compression must never be resurrected.
 
 ``publish_compression_child`` used to fail closed on ANY non-automatic ``end_reason``
 (``tui_close``, ``cli_close``, ``webhook_complete``, ``new_session``, gateway-recovery and
@@ -9,18 +10,23 @@ history and hit ``Context length exceeded … Cannot compress further`` again; m
 ``/compress`` reported "No changes". The agent's pre-flush guard re-implemented the same
 taxonomy and aborted even earlier.
 
-Contract under test (single verdict owner ``_compression_parent_obstacle``): a writer
-holding the compression lease is provably still the conversation's writer, so an explicit
-close with NO continuation child is stale and is cleared inside the publish transaction,
-exactly like an automatic stamp (#88197). Lineage owned elsewhere still fails closed: a
-``'compression'`` stamp, a reset boundary, or an explicit close whose continuation child was
-already published.
+Contract under test (single verdict owner ``_compression_parent_obstacle``): an explicit
+close is ordered against this attempt's compression lease. A stamp written BEFORE the lease
+was acquired is stale — the writer took the lease and has driven the row since — and is
+cleared inside the publish transaction like an automatic stamp (#88197). A close written
+AFTER the lease was acquired is the user closing the session while compression runs
+(``session.close`` waits five seconds for the turn thread, then stamps ``tui_close``) and
+is preserved: publish fails closed and no child is created. Without a lease of our own the
+stamp cannot be proven stale and also fails closed. Lineage owned elsewhere always fails
+closed: a ``'compression'`` stamp, a reset boundary, or an explicit close whose
+continuation child was already published.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -30,6 +36,7 @@ from hermes_state import SessionDB
 from hermes_state_common import _RESET_END_REASONS
 
 STALE_EXPLICIT_CLOSES = ["tui_close", "cli_close", "webhook_complete", "new_session"]
+HOLDER = "compression-writer"
 
 
 @pytest.fixture
@@ -41,32 +48,43 @@ def db(tmp_path: Path):
         handle.close()
 
 
-def _publish(db: SessionDB, parent: str, child: str) -> None:
+def _publish(db: SessionDB, parent: str, child: str, *, holder: str | None = None) -> None:
     db.publish_compression_child(
         parent_session_id=parent,
         child_session_id=child,
         source="tui",
         messages=[{"role": "user", "content": "[CONTEXT COMPACTION] summary"}],
-        require_compression_lease=False,
+        require_compression_lease=holder is not None,
+        compression_lock_holder=holder,
     )
 
 
-def _stamp(db: SessionDB, session_id: str, reason: str) -> None:
+def _stamp(db: SessionDB, session_id: str, reason: str, *, age: float = 0.0) -> None:
+    """End the row with *reason*; ``age`` backdates the stamp so its order against a lease
+    acquired afterwards is unambiguous."""
     db.end_session(session_id, reason)
+    if age:
+        db._write_sql("UPDATE sessions SET ended_at = ? WHERE id = ?", (time.time() - age, session_id))
     row = db.get_session(session_id)
     assert row["ended_at"] is not None and row["end_reason"] == reason
 
 
-class TestPublishClearsStaleExplicitClose:
+def _lease(db: SessionDB, session_id: str, holder: str = HOLDER) -> str:
+    assert db.try_acquire_compression_lock(session_id, holder, ttl_seconds=300.0)
+    return holder
+
+
+class TestStaleStampBeforeTheLeaseIsCleared:
     @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
-    def test_explicit_close_without_continuation_publishes(self, db: SessionDB, reason: str, caplog) -> None:
+    def test_explicit_close_before_the_lease_publishes(self, db: SessionDB, reason: str, caplog) -> None:
         parent = f"P_{reason}"
         db.create_session(parent, source="tui")
         db.append_message(parent, "user", content="hello")
-        _stamp(db, parent, reason)
+        _stamp(db, parent, reason, age=60.0)  # the #106459 shape: the mark predates this attempt
+        holder = _lease(db, parent)
 
         with caplog.at_level(logging.WARNING, logger="hermes_state"):
-            _publish(db, parent, f"C_{reason}")
+            _publish(db, parent, f"C_{reason}", holder=holder)
 
         parent_row = db.get_session(parent)
         assert parent_row["end_reason"] == "compression"  # the true boundary, not the stale stamp
@@ -80,23 +98,65 @@ class TestPublishClearsStaleExplicitClose:
         """The field shape: the stamp lands once, and every later rotation must still publish."""
         parent = "P_repeat"
         db.create_session(parent, source="tui")
-        _stamp(db, parent, "cli_close")
-        _publish(db, parent, "C_1")
-        _publish(db, "C_1", "C_2")
+        _stamp(db, parent, "cli_close", age=60.0)
+        _publish(db, parent, "C_1", holder=_lease(db, parent))
+        _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"))
         assert db.get_session("C_1")["end_reason"] == "compression"
         assert db.get_session("C_2")["parent_session_id"] == "C_1"
+
+
+class TestDeliberateCloseAfterTheLeaseIsPreserved:
+    def test_close_during_compression_fails_closed(self, db: SessionDB) -> None:
+        """The reviewer's probe: acquire the lease, then the user closes the session
+        (``session.close`` stamps ``tui_close`` after its five-second wait), then publish."""
+        parent = "P_closed_mid_compression"
+        db.create_session(parent, source="tui")
+        holder = _lease(db, parent)
+        time.sleep(0.01)
+        _stamp(db, parent, "tui_close")
+
+        with pytest.raises(RuntimeError, match="already ended.*after this compression attempt acquired its lease"):
+            _publish(db, parent, "C_never", holder=holder)
+
+        assert db.get_session("C_never") is None
+        row = db.get_session(parent)
+        assert row["end_reason"] == "tui_close" and row["ended_at"] is not None  # the user's close survives
+
+    def test_close_at_the_same_instant_fails_closed(self, db: SessionDB) -> None:
+        parent = "P_tie"
+        db.create_session(parent, source="tui")
+        holder = _lease(db, parent)
+        acquired_at = db._read_one("SELECT acquired_at FROM compression_locks WHERE session_id = ?", (parent,))[0]
+        db.end_session(parent, "tui_close")
+        db._write_sql("UPDATE sessions SET ended_at = ? WHERE id = ?", (acquired_at, parent))
+
+        with pytest.raises(RuntimeError, match="after this compression attempt acquired its lease"):
+            _publish(db, parent, "C_tie", holder=holder)
+        assert db.get_session(parent)["end_reason"] == "tui_close"
+
+    @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
+    def test_without_a_lease_an_explicit_close_cannot_be_proven_stale(self, db: SessionDB, reason: str) -> None:
+        parent = f"P_nolease_{reason}"
+        db.create_session(parent, source="tui")
+        _stamp(db, parent, reason, age=60.0)
+        with pytest.raises(RuntimeError, match="already ended.*no compression-lease ordering"):
+            _publish(db, parent, f"C_{reason}")  # require_compression_lease=False: no ordering signal
+        assert db.get_session(f"C_{reason}") is None
+        assert db.get_session(parent)["end_reason"] == reason
 
 
 class TestLineageOwnedElsewhereStillFailsClosed:
     def test_explicit_close_with_published_continuation_fails_closed(self, db: SessionDB) -> None:
         parent = "P_superseded"
         db.create_session(parent, source="tui")
-        _publish(db, parent, "C_first")  # a continuation now exists
+        _publish(db, parent, "C_first", holder=_lease(db, parent))  # a continuation now exists
+        db.release_compression_lock(parent, HOLDER)
         db.reopen_session(parent)
-        _stamp(db, parent, "tui_close")
+        _stamp(db, parent, "tui_close", age=60.0)
+        holder = _lease(db, parent, holder="second-writer")
 
         with pytest.raises(RuntimeError, match="already ended.*published continuation"):
-            _publish(db, parent, "C_second")
+            _publish(db, parent, "C_second", holder=holder)
         assert db.get_session("C_second") is None
         assert db.get_session(parent)["end_reason"] == "tui_close"  # untouched
 
@@ -105,37 +165,57 @@ class TestLineageOwnedElsewhereStillFailsClosed:
         assert reason in _RESET_END_REASONS
         parent = f"P_{reason}"
         db.create_session(parent, source="tui")
-        _stamp(db, parent, reason)
+        _stamp(db, parent, reason, age=60.0)
+        holder = _lease(db, parent)
         with pytest.raises(RuntimeError, match=f"already ended.*{reason} boundary"):
-            _publish(db, parent, f"C_{reason}")
+            _publish(db, parent, f"C_{reason}", holder=holder)
         assert db.get_session(f"C_{reason}") is None
 
     def test_compression_stamp_fails_closed(self, db: SessionDB) -> None:
         parent = "P_compression"
         db.create_session(parent, source="tui")
-        _stamp(db, parent, "compression")
+        _stamp(db, parent, "compression", age=60.0)
+        holder = _lease(db, parent)
         with pytest.raises(RuntimeError, match="already ended.*closed by compression"):
-            _publish(db, parent, "C_x")
+            _publish(db, parent, "C_x", holder=holder)
 
 
 class TestVerdictIsSharedWithTheAgentGuard:
     """The pre-flush guard must agree with publish, or a durable flush is skipped (or written for nothing)."""
 
     def test_read_only_verdict_matches_publish(self, db: SessionDB) -> None:
-        for sid, reason in [("live", None), ("auto", "ws_disconnect"), ("stale", "tui_close")]:
+        for sid, reason in [("live", None), ("auto", "ws_disconnect")]:
             db.create_session(sid, source="tui")
             if reason:
-                _stamp(db, sid, reason)
+                _stamp(db, sid, reason, age=60.0)
             assert db.compression_parent_deliberately_ended(sid) is False, (sid, reason)
+
+        db.create_session("stale", source="tui")
+        _stamp(db, "stale", "tui_close", age=60.0)
+        assert db.compression_parent_deliberately_ended("stale") is True  # no lease: unprovable
+        _lease(db, "stale")
+        assert db.compression_parent_deliberately_ended("stale", holder=HOLDER) is False
+        assert db.compression_parent_deliberately_ended("stale", holder="someone-else") is True
+
+        db.create_session("closed_mid", source="tui")
+        _lease(db, "closed_mid")
+        time.sleep(0.01)
+        _stamp(db, "closed_mid", "tui_close")
+        assert db.compression_parent_deliberately_ended("closed_mid", holder=HOLDER) is True
+
         for sid, reason in [("reset", "session_reset"), ("comp", "compression")]:
             db.create_session(sid, source="tui")
-            _stamp(db, sid, reason)
-            assert db.compression_parent_deliberately_ended(sid) is True, (sid, reason)
+            _stamp(db, sid, reason, age=60.0)
+            _lease(db, sid)
+            assert db.compression_parent_deliberately_ended(sid, holder=HOLDER) is True, (sid, reason)
+
         db.create_session("superseded", source="tui")
-        _publish(db, "superseded", "superseded_child")
+        _publish(db, "superseded", "superseded_child", holder=_lease(db, "superseded"))
+        db.release_compression_lock("superseded", HOLDER)
         db.reopen_session("superseded")
-        _stamp(db, "superseded", "cli_close")
-        assert db.compression_parent_deliberately_ended("superseded") is True
+        _stamp(db, "superseded", "cli_close", age=60.0)
+        _lease(db, "superseded")
+        assert db.compression_parent_deliberately_ended("superseded", holder=HOLDER) is True
         assert db.compression_parent_deliberately_ended("missing") is False
         assert db.compression_parent_deliberately_ended("") is False
 
@@ -143,18 +223,21 @@ class TestVerdictIsSharedWithTheAgentGuard:
         from agent.conversation_compression import _parent_deliberately_ended
 
         db.create_session("stale", source="tui")
-        _stamp(db, "stale", "tui_close")
-        assert _parent_deliberately_ended(db, "stale") is False
+        _stamp(db, "stale", "tui_close", age=60.0)
+        _lease(db, "stale")
+        assert _parent_deliberately_ended(db, "stale", holder=HOLDER) is False
+        assert _parent_deliberately_ended(db, "stale") is True  # no lease ordering to lean on
         db.create_session("reset", source="tui")
-        _stamp(db, "reset", "session_reset")
-        assert _parent_deliberately_ended(db, "reset") is True
+        _stamp(db, "reset", "session_reset", age=60.0)
+        _lease(db, "reset")
+        assert _parent_deliberately_ended(db, "reset", holder=HOLDER) is True
 
     def test_agent_guard_fails_open_and_keeps_the_taxonomy_fallback(self) -> None:
         from agent.conversation_compression import _parent_deliberately_ended
 
         broken = MagicMock()
         broken.compression_parent_deliberately_ended.side_effect = RuntimeError("db unavailable")
-        assert _parent_deliberately_ended(broken, "x") is False
+        assert _parent_deliberately_ended(broken, "x", holder=HOLDER) is False
 
         class TaxonomyOnlyStore:  # a stand-in without the verdict: old behaviour is retained
             def get_session(self, session_id):
@@ -197,12 +280,12 @@ class TestRotationEndToEnd:
         return agent
 
     def test_stale_explicit_close_does_not_wedge_rotation(self, db: SessionDB) -> None:
-        """#106459 end-to-end: the live session's row carries an explicit-close stamp, and
-        auto-compaction still rotates instead of computing and discarding forever."""
+        """#106459 end-to-end: the live session's row carries an explicit-close stamp that predates
+        the attempt, and auto-compaction still rotates instead of computing and discarding forever."""
         parent = "PARENT_106459_E2E"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
-        _stamp(db, parent, "tui_close")
+        _stamp(db, parent, "tui_close", age=60.0)
 
         msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
         agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
@@ -212,11 +295,31 @@ class TestRotationEndToEnd:
         child_row = db.get_session(agent.session_id)
         assert child_row is not None and child_row["parent_session_id"] == parent
 
+    def test_close_during_compression_still_aborts_rotation(self, db: SessionDB) -> None:
+        """The user closes the session while the summary is being produced: the close wins."""
+        parent = "PARENT_106459_CLOSE_MID"
+        db.create_session(parent, source="tui")
+        agent = self._build_agent(db, parent)
+        compressor = agent.context_compressor
+        summary = compressor.compress.return_value
+
+        def close_while_summarizing(*args, **kwargs):
+            time.sleep(0.01)
+            db.end_session(parent, "tui_close")  # session.close lands after the lease was acquired
+            return summary
+
+        compressor.compress.side_effect = close_while_summarizing
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+
+        assert agent.session_id == parent, "a close made mid-compression must not be resurrected"
+        assert db.get_session(parent)["end_reason"] == "tui_close"
+
     def test_reset_boundary_still_aborts_rotation(self, db: SessionDB) -> None:
         parent = "PARENT_106459_RESET"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
-        _stamp(db, parent, "session_reset")
+        _stamp(db, parent, "session_reset", age=60.0)
 
         msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
         agent._compress_context(list(msgs), "sys", approx_tokens=120_000)

--- a/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
+++ b/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
@@ -1,0 +1,225 @@
+"""Regression tests for #106459 — an over-limit session must not become permanently
+uncompressible because its row carries a stale explicit-close stamp.
+
+``publish_compression_child`` used to fail closed on ANY non-automatic ``end_reason``
+(``tui_close``, ``cli_close``, ``webhook_complete``, ``new_session``, gateway-recovery and
+cron reasons), and ``end_session()`` is first-stamp-wins, so nothing ever cleared it. Every
+turn then ran the compression, discarded its result at publication, kept the oversized
+history and hit ``Context length exceeded … Cannot compress further`` again; manual
+``/compress`` reported "No changes". The agent's pre-flush guard re-implemented the same
+taxonomy and aborted even earlier.
+
+Contract under test (single verdict owner ``_compression_parent_obstacle``): a writer
+holding the compression lease is provably still the conversation's writer, so an explicit
+close with NO continuation child is stale and is cleared inside the publish transaction,
+exactly like an automatic stamp (#88197). Lineage owned elsewhere still fails closed: a
+``'compression'`` stamp, a reset boundary, or an explicit close whose continuation child was
+already published.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_common import _RESET_END_REASONS
+
+STALE_EXPLICIT_CLOSES = ["tui_close", "cli_close", "webhook_complete", "new_session"]
+
+
+@pytest.fixture
+def db(tmp_path: Path):
+    handle = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield handle
+    finally:
+        handle.close()
+
+
+def _publish(db: SessionDB, parent: str, child: str) -> None:
+    db.publish_compression_child(
+        parent_session_id=parent,
+        child_session_id=child,
+        source="tui",
+        messages=[{"role": "user", "content": "[CONTEXT COMPACTION] summary"}],
+        require_compression_lease=False,
+    )
+
+
+def _stamp(db: SessionDB, session_id: str, reason: str) -> None:
+    db.end_session(session_id, reason)
+    row = db.get_session(session_id)
+    assert row["ended_at"] is not None and row["end_reason"] == reason
+
+
+class TestPublishClearsStaleExplicitClose:
+    @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
+    def test_explicit_close_without_continuation_publishes(self, db: SessionDB, reason: str, caplog) -> None:
+        parent = f"P_{reason}"
+        db.create_session(parent, source="tui")
+        db.append_message(parent, "user", content="hello")
+        _stamp(db, parent, reason)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            _publish(db, parent, f"C_{reason}")
+
+        parent_row = db.get_session(parent)
+        assert parent_row["end_reason"] == "compression"  # the true boundary, not the stale stamp
+        assert parent_row["ended_at"] is not None
+        child_row = db.get_session(f"C_{reason}")
+        assert child_row is not None and child_row["parent_session_id"] == parent
+        assert any(reason in rec.getMessage() and "stale" in rec.getMessage() for rec in caplog.records), (
+            "clearing an explicit-close stamp must be logged with the stale reason")
+
+    def test_repeated_rotation_is_not_wedged(self, db: SessionDB) -> None:
+        """The field shape: the stamp lands once, and every later rotation must still publish."""
+        parent = "P_repeat"
+        db.create_session(parent, source="tui")
+        _stamp(db, parent, "cli_close")
+        _publish(db, parent, "C_1")
+        _publish(db, "C_1", "C_2")
+        assert db.get_session("C_1")["end_reason"] == "compression"
+        assert db.get_session("C_2")["parent_session_id"] == "C_1"
+
+
+class TestLineageOwnedElsewhereStillFailsClosed:
+    def test_explicit_close_with_published_continuation_fails_closed(self, db: SessionDB) -> None:
+        parent = "P_superseded"
+        db.create_session(parent, source="tui")
+        _publish(db, parent, "C_first")  # a continuation now exists
+        db.reopen_session(parent)
+        _stamp(db, parent, "tui_close")
+
+        with pytest.raises(RuntimeError, match="already ended.*published continuation"):
+            _publish(db, parent, "C_second")
+        assert db.get_session("C_second") is None
+        assert db.get_session(parent)["end_reason"] == "tui_close"  # untouched
+
+    @pytest.mark.parametrize("reason", ["session_reset", "session_switch", "idle", "daily"])
+    def test_reset_boundary_fails_closed(self, db: SessionDB, reason: str) -> None:
+        assert reason in _RESET_END_REASONS
+        parent = f"P_{reason}"
+        db.create_session(parent, source="tui")
+        _stamp(db, parent, reason)
+        with pytest.raises(RuntimeError, match=f"already ended.*{reason} boundary"):
+            _publish(db, parent, f"C_{reason}")
+        assert db.get_session(f"C_{reason}") is None
+
+    def test_compression_stamp_fails_closed(self, db: SessionDB) -> None:
+        parent = "P_compression"
+        db.create_session(parent, source="tui")
+        _stamp(db, parent, "compression")
+        with pytest.raises(RuntimeError, match="already ended.*closed by compression"):
+            _publish(db, parent, "C_x")
+
+
+class TestVerdictIsSharedWithTheAgentGuard:
+    """The pre-flush guard must agree with publish, or a durable flush is skipped (or written for nothing)."""
+
+    def test_read_only_verdict_matches_publish(self, db: SessionDB) -> None:
+        for sid, reason in [("live", None), ("auto", "ws_disconnect"), ("stale", "tui_close")]:
+            db.create_session(sid, source="tui")
+            if reason:
+                _stamp(db, sid, reason)
+            assert db.compression_parent_deliberately_ended(sid) is False, (sid, reason)
+        for sid, reason in [("reset", "session_reset"), ("comp", "compression")]:
+            db.create_session(sid, source="tui")
+            _stamp(db, sid, reason)
+            assert db.compression_parent_deliberately_ended(sid) is True, (sid, reason)
+        db.create_session("superseded", source="tui")
+        _publish(db, "superseded", "superseded_child")
+        db.reopen_session("superseded")
+        _stamp(db, "superseded", "cli_close")
+        assert db.compression_parent_deliberately_ended("superseded") is True
+        assert db.compression_parent_deliberately_ended("missing") is False
+        assert db.compression_parent_deliberately_ended("") is False
+
+    def test_agent_guard_delegates_to_the_store(self, db: SessionDB) -> None:
+        from agent.conversation_compression import _parent_deliberately_ended
+
+        db.create_session("stale", source="tui")
+        _stamp(db, "stale", "tui_close")
+        assert _parent_deliberately_ended(db, "stale") is False
+        db.create_session("reset", source="tui")
+        _stamp(db, "reset", "session_reset")
+        assert _parent_deliberately_ended(db, "reset") is True
+
+    def test_agent_guard_fails_open_and_keeps_the_taxonomy_fallback(self) -> None:
+        from agent.conversation_compression import _parent_deliberately_ended
+
+        broken = MagicMock()
+        broken.compression_parent_deliberately_ended.side_effect = RuntimeError("db unavailable")
+        assert _parent_deliberately_ended(broken, "x") is False
+
+        class TaxonomyOnlyStore:  # a stand-in without the verdict: old behaviour is retained
+            def get_session(self, session_id):
+                return {"ended_at": 1.0, "end_reason": "tui_close"}
+
+        assert _parent_deliberately_ended(TaxonomyOnlyStore(), "x") is True
+
+
+class TestRotationEndToEnd:
+    def _build_agent(self, db: SessionDB, session_id: str):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                platform="tui",
+                quiet_mode=True,
+                session_db=db,
+                session_id=session_id,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        compressor = MagicMock()
+        compressor.compress.return_value = [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail"},
+        ]
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_compress_aborted = False
+        compressor._last_summary_auth_failure = False
+        compressor._last_aux_model_failure_model = None
+        compressor._last_aux_model_failure_error = None
+        agent.context_compressor = compressor
+        agent.compression_in_place = False  # rotation path
+        return agent
+
+    def test_stale_explicit_close_does_not_wedge_rotation(self, db: SessionDB) -> None:
+        """#106459 end-to-end: the live session's row carries an explicit-close stamp, and
+        auto-compaction still rotates instead of computing and discarding forever."""
+        parent = "PARENT_106459_E2E"
+        db.create_session(parent, source="tui")
+        agent = self._build_agent(db, parent)
+        _stamp(db, parent, "tui_close")
+
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+
+        assert agent.session_id != parent, "rotation aborted on the stale explicit-close stamp"
+        assert db.get_session(parent)["end_reason"] == "compression"
+        child_row = db.get_session(agent.session_id)
+        assert child_row is not None and child_row["parent_session_id"] == parent
+
+    def test_reset_boundary_still_aborts_rotation(self, db: SessionDB) -> None:
+        parent = "PARENT_106459_RESET"
+        db.create_session(parent, source="tui")
+        agent = self._build_agent(db, parent)
+        _stamp(db, parent, "session_reset")
+
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+
+        assert agent.session_id == parent
+        assert db.get_session(parent)["end_reason"] == "session_reset"

--- a/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
+++ b/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
@@ -10,20 +10,19 @@ compression, discarded its result at publication, kept the oversized history and
 "No changes". The agent's pre-flush guard re-implemented the same taxonomy and aborted even
 earlier.
 
-Contract under test (single verdict owner ``_compression_parent_obstacle``): an explicit
-close is cleared only on POSITIVE evidence that the session was driven after it — this
-writer's session turn lease (``session_turn_leases.acquired_at``, taken once per turn by the
-façade before the transcript is loaded) was admitted AFTER the stamp. Every sanctioned resume
-clears the stamp first (``reopen_session``) and a host never admits a turn on a session it is
-closing, so that order can only mean the stamp missed a still-routed session. A stamp at or
-after admission is a close made during this turn (``session.close`` stamps ``tui_close``
-after a five-second grace even while the turn thread runs on, and that thread later takes the
-compression lease) and is preserved: publish fails closed and no child is created. The
-compression lease is no evidence — it is taken inside the turn, after any such close. Without
-an admitted turn of our own the stamp cannot be proven stale and also fails closed. Lineage
-owned elsewhere always fails closed: a ``'compression'`` stamp, a boundary reason (the reset
-reasons and CLI ``new_session``), or an explicit close whose continuation child was already
-published.
+Contract under test. A stale explicit close is healed at TURN ADMISSION
+(``try_acquire_session_turn_lease``, taken once per turn by the façade before the transcript
+is loaded), inside the claim transaction: every sanctioned resume clears stamps first
+(``reopen_session``) and a host never admits a turn on a session it is closing, so a stamp
+that survives to admission can only have missed a still-routed session. Healing there, and
+never at publication, is what keeps a close made DURING the turn observable: ``end_session()``
+is first-stamp-wins, so while a stale stamp occupied the row a deliberate close was a no-op
+write and the store could not tell the two apart. Publication (single verdict owner
+``_compression_parent_obstacle``, shared with the agent's pre-flush guard) clears only
+automatic-cleanup stamps (#88197) and fails closed on everything else: an explicit close (a
+deliberate close during this turn, a foreign writer's mis-stamp that costs this one rotation,
+or no admitted turn at all), a ``'compression'`` stamp, a boundary reason (the reset reasons
+and CLI ``new_session``), and an explicit close whose continuation child was already published.
 """
 
 from __future__ import annotations
@@ -42,7 +41,11 @@ from hermes_state_common import _BOUNDARY_END_REASONS, _RESET_END_REASONS
 STALE_EXPLICIT_CLOSES = ["tui_close", "cli_close", "webhook_complete"]
 BOUNDARIES = sorted(_BOUNDARY_END_REASONS)
 HOLDER = "compression-writer"
-TURN = "pid=1:turn=t1:platform=tui"
+# Holders carry this process's pid: a dead pid makes a lease reclaimable, which is not what these probe.
+TURN = f"pid={os.getpid()}:turn=t1:platform=tui"
+TURN_2 = f"pid={os.getpid()}:turn=t2:platform=tui"
+OTHER_PROCESS = f"pid={os.getpid()}:turn=t9:platform=cli"
+NOT_HEALED = "healed only at turn admission"
 
 
 @pytest.fixture
@@ -54,8 +57,7 @@ def db(tmp_path: Path):
         handle.close()
 
 
-def _publish(db: SessionDB, parent: str, child: str, *, holder: str | None = None,
-             turn: str | None = None) -> None:
+def _publish(db: SessionDB, parent: str, child: str, *, holder: str | None = None) -> None:
     db.publish_compression_child(
         parent_session_id=parent,
         child_session_id=child,
@@ -63,13 +65,12 @@ def _publish(db: SessionDB, parent: str, child: str, *, holder: str | None = Non
         messages=[{"role": "user", "content": "[CONTEXT COMPACTION] summary"}],
         require_compression_lease=holder is not None,
         compression_lock_holder=holder,
-        turn_lease_holder=turn,
     )
 
 
 def _stamp(db: SessionDB, session_id: str, reason: str, *, age: float = 0.0) -> None:
-    """End the row with *reason*; ``age`` backdates the stamp so its order against a turn
-    admitted afterwards is unambiguous."""
+    """End the row with *reason*; ``age`` backdates the stamp so it is unambiguously older than
+    anything that follows."""
     db.end_session(session_id, reason)
     if age:
         db._write_sql("UPDATE sessions SET ended_at = ? WHERE id = ?", (time.time() - age, session_id))
@@ -78,189 +79,208 @@ def _stamp(db: SessionDB, session_id: str, reason: str, *, age: float = 0.0) -> 
 
 
 def _lease(db: SessionDB, session_id: str, holder: str = HOLDER) -> str:
-    """The compression lease: publication ownership, never evidence about the stamp."""
+    """The compression lease: publication ownership only."""
     assert db.try_acquire_compression_lock(session_id, holder, ttl_seconds=300.0)
     return holder
 
 
-def _turn(db: SessionDB, session_id: str, holder: str = TURN) -> str:
+def _admit(db: SessionDB, session_id: str, holder: str = TURN) -> str:
     """Admit a turn on the conversation, as ``admit_durable_turn_lease`` does before a turn runs."""
     assert db.try_acquire_session_turn_lease(session_id, holder, ttl_seconds=300.0)
     return holder
 
 
-def _turn_admitted_at(db: SessionDB, session_id: str) -> float:
-    key = db._session_turn_lease_key(session_id)
-    return db._read_one("SELECT acquired_at FROM session_turn_leases WHERE conversation_id = ?", (key,))[0]
+def _live(db: SessionDB, session_id: str) -> bool:
+    row = db.get_session(session_id)
+    return row["ended_at"] is None and row["end_reason"] is None
 
 
-class TestStaleStampBeforeTheTurnIsCleared:
+class TestAdmissionHealsAStaleExplicitClose:
     @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
-    def test_explicit_close_before_the_turn_publishes(self, db: SessionDB, reason: str, caplog) -> None:
+    def test_stale_explicit_close_is_cleared_when_a_turn_is_admitted(self, db: SessionDB, reason: str, caplog) -> None:
         parent = f"P_{reason}"
         db.create_session(parent, source="tui")
         db.append_message(parent, "user", content="hello")
         _stamp(db, parent, reason, age=60.0)  # the #106459 shape: the mark predates this turn
-        turn = _turn(db, parent)
-        holder = _lease(db, parent)
 
         with caplog.at_level(logging.WARNING, logger="hermes_state"):
-            _publish(db, parent, f"C_{reason}", holder=holder, turn=turn)
+            _admit(db, parent)
 
-        parent_row = db.get_session(parent)
-        assert parent_row["end_reason"] == "compression"  # the true boundary, not the stale stamp
-        assert parent_row["ended_at"] is not None
-        child_row = db.get_session(f"C_{reason}")
-        assert child_row is not None and child_row["parent_session_id"] == parent
+        assert _live(db, parent), "admission must clear the stale stamp"
         assert any(reason in rec.getMessage() and "stale" in rec.getMessage() for rec in caplog.records), (
             "clearing an explicit-close stamp must be logged with the stale reason")
+        _publish(db, parent, f"C_{reason}", holder=_lease(db, parent))
+        parent_row = db.get_session(parent)
+        assert parent_row["end_reason"] == "compression" and parent_row["ended_at"] is not None
+        child_row = db.get_session(f"C_{reason}")
+        assert child_row is not None and child_row["parent_session_id"] == parent
 
     def test_repeated_rotation_is_not_wedged(self, db: SessionDB) -> None:
         """The field shape: the stamp lands once, and every later turn must still rotate."""
         parent = "P_repeat"
         db.create_session(parent, source="tui")
         _stamp(db, parent, "cli_close", age=60.0)
-        turn = _turn(db, parent)
-        _publish(db, parent, "C_1", holder=_lease(db, parent), turn=turn)
-        db.release_session_turn_lease(parent, turn)
-        turn = _turn(db, "C_1", holder="pid=1:turn=t2:platform=tui")
-        _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"), turn=turn)
+        _admit(db, parent)
+        _publish(db, parent, "C_1", holder=_lease(db, parent))
+        db.release_session_turn_lease(parent, TURN)
+        _admit(db, "C_1", holder=TURN_2)
+        _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"))
         assert db.get_session("C_1")["end_reason"] == "compression"
         assert db.get_session("C_2")["parent_session_id"] == "C_1"
 
-    def test_stale_close_on_a_compression_child_is_ordered_by_the_conversation_lease(self, db: SessionDB) -> None:
-        """The turn lease is keyed by the lineage root; a stamp on a later segment is ordered against it."""
+    def test_stale_close_on_a_compression_child_is_healed_on_that_row(self, db: SessionDB) -> None:
+        """The turn lease is keyed by the lineage root; the stamp cleared is the admitted segment's."""
         root = "P_root"
         db.create_session(root, source="tui")
-        turn = _turn(db, root)
-        _publish(db, root, "C_1", holder=_lease(db, root), turn=turn)
-        db.release_session_turn_lease(root, turn)
+        _admit(db, root)
+        _publish(db, root, "C_1", holder=_lease(db, root))
+        db.release_session_turn_lease(root, TURN)
         _stamp(db, "C_1", "tui_close", age=60.0)
-        turn = _turn(db, "C_1", holder="pid=1:turn=t2:platform=tui")
         assert db._session_turn_lease_key("C_1") == root
 
-        _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"), turn=turn)
-        assert db.get_session("C_1")["end_reason"] == "compression"
+        _admit(db, "C_1", holder=TURN_2)
+        assert _live(db, "C_1")
+        assert db.get_session(root)["end_reason"] == "compression"  # the root's own stamp is lineage, untouched
+        _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"))
         assert db.get_session("C_2")["parent_session_id"] == "C_1"
 
-    def test_a_stamp_that_lands_mid_turn_costs_that_turn_only(self, db: SessionDB) -> None:
-        """No evidence yet during the turn the stamp landed in: that rotation fails closed. The next
-        admitted turn is the evidence, and it rotates."""
-        parent = "P_mid_turn"
+    @pytest.mark.parametrize("reason", ["ws_disconnect", "compression", *BOUNDARIES])
+    def test_admission_leaves_every_other_stamp_alone(self, db: SessionDB, reason: str) -> None:
+        sid = f"S_{reason}"
+        db.create_session(sid, source="tui")
+        _stamp(db, sid, reason, age=60.0)
+        _admit(db, sid)
+        row = db.get_session(sid)
+        assert row["end_reason"] == reason and row["ended_at"] is not None
+
+    def test_admission_leaves_a_superseded_explicit_close_alone(self, db: SessionDB) -> None:
+        parent = "P_superseded_admit"
         db.create_session(parent, source="tui")
-        turn = _turn(db, parent)
-        time.sleep(0.01)
-        _stamp(db, parent, "webhook_complete")  # a foreign stale writer, during our turn
-        with pytest.raises(RuntimeError, match="already ended.*after this turn was admitted"):
-            _publish(db, parent, "C_never", holder=_lease(db, parent), turn=turn)
-        assert db.get_session("C_never") is None
-        db.release_compression_lock(parent, HOLDER)
-        db.release_session_turn_lease(parent, turn)
+        _admit(db, parent)
+        _publish(db, parent, "C_first", holder=_lease(db, parent))  # a continuation now exists
+        db.release_session_turn_lease(parent, TURN)
+        db.reopen_session(parent)
+        _stamp(db, parent, "tui_close", age=60.0)
+        _admit(db, parent, holder=TURN_2)
+        assert db.get_session(parent)["end_reason"] == "tui_close"
 
-        time.sleep(0.01)
-        turn = _turn(db, parent, holder="pid=1:turn=t2:platform=tui")
-        _publish(db, parent, "C_next", holder=_lease(db, parent), turn=turn)
-        assert db.get_session(parent)["end_reason"] == "compression"
-        assert db.get_session("C_next")["parent_session_id"] == parent
-
-
-class TestDeliberateCloseDuringTheTurnIsPreserved:
-    def test_close_after_the_turn_was_admitted_fails_closed(self, db: SessionDB) -> None:
-        """The reviewer's probe: the turn is running, ``session.close`` stamps ``tui_close`` after its
-        grace period without interrupting the turn thread, and that thread then acquires the
-        compression lease and publishes."""
-        parent = "P_closed_during_turn"
+    def test_a_refused_admission_heals_nothing(self, db: SessionDB) -> None:
+        """Only an ADMITTED turn is evidence; a claim refused because another live holder owns the
+        turn must leave the row exactly as it found it."""
+        parent = "P_busy"
         db.create_session(parent, source="tui")
-        turn = _turn(db, parent)
-        time.sleep(0.01)
-        _stamp(db, parent, "tui_close")
-        holder = _lease(db, parent)  # the lease is younger than the close: no evidence either way
+        _admit(db, parent, holder=OTHER_PROCESS)  # another live holder owns the turn
+        _stamp(db, parent, "tui_close", age=60.0)
+        assert not db.try_acquire_session_turn_lease(parent, TURN, ttl_seconds=300.0)
+        assert db.get_session(parent)["end_reason"] == "tui_close"
 
-        with pytest.raises(RuntimeError, match="already ended.*after this turn was admitted"):
-            _publish(db, parent, "C_never", holder=holder, turn=turn)
 
-        assert db.get_session("C_never") is None
-        row = db.get_session(parent)
-        assert row["end_reason"] == "tui_close" and row["ended_at"] is not None  # the user's close survives
-
+class TestADeliberateCloseIsNeverHealedAtPublication:
     def test_close_during_compression_fails_closed(self, db: SessionDB) -> None:
-        """The earlier probe: lease first, then the close, then publish."""
+        """First probe: lease, then the user closes, then publish."""
         parent = "P_closed_mid_compression"
         db.create_session(parent, source="tui")
-        turn = _turn(db, parent)
+        _admit(db, parent)
         holder = _lease(db, parent)
-        time.sleep(0.01)
         _stamp(db, parent, "tui_close")
 
-        with pytest.raises(RuntimeError, match="already ended.*after this turn was admitted"):
-            _publish(db, parent, "C_never", holder=holder, turn=turn)
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
+            _publish(db, parent, "C_never", holder=holder)
+        assert db.get_session("C_never") is None
+        assert db.get_session(parent)["end_reason"] == "tui_close"  # the user's close survives
+
+    def test_close_after_the_turn_was_admitted_fails_closed(self, db: SessionDB) -> None:
+        """Second probe: the turn is running, ``session.close`` stamps after its grace without
+        interrupting the turn thread, and that thread then takes the compression lease."""
+        parent = "P_closed_during_turn"
+        db.create_session(parent, source="tui")
+        _admit(db, parent)
+        _stamp(db, parent, "tui_close")
+        holder = _lease(db, parent)
+
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
+            _publish(db, parent, "C_never", holder=holder)
         assert db.get_session("C_never") is None
         assert db.get_session(parent)["end_reason"] == "tui_close"
 
-    def test_close_at_the_same_instant_fails_closed(self, db: SessionDB) -> None:
-        parent = "P_tie"
+    def test_close_during_a_turn_that_began_on_a_stale_stamp_is_recorded_and_wins(self, db: SessionDB) -> None:
+        """Third probe: the turn is admitted on a row carrying the stale stamp this fix heals, then the
+        user closes during the turn. Admission cleared the stale stamp, so the close is recorded
+        (first-stamp-wins would have dropped it) and publication preserves it."""
+        parent = "P_stale_then_closed"
         db.create_session(parent, source="tui")
-        turn = _turn(db, parent)
-        db.end_session(parent, "tui_close")
-        db._write_sql("UPDATE sessions SET ended_at = ? WHERE id = ?", (_turn_admitted_at(db, parent), parent))
+        _stamp(db, parent, "tui_close", age=60.0)
+        before = time.time()
+        _admit(db, parent)
+        assert _live(db, parent)
+        db.end_session(parent, "tui_close")  # the user's close, now an actual write
+        holder = _lease(db, parent)
 
-        with pytest.raises(RuntimeError, match="after this turn was admitted"):
-            _publish(db, parent, "C_tie", holder=_lease(db, parent), turn=turn)
-        assert db.get_session(parent)["end_reason"] == "tui_close"
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
+            _publish(db, parent, "C_never", holder=holder)
+        assert db.get_session("C_never") is None
+        row = db.get_session(parent)
+        assert row["end_reason"] == "tui_close" and row["ended_at"] >= before, "the fresh close, not the stale one"
 
     @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
-    def test_without_an_admitted_turn_an_explicit_close_cannot_be_proven_stale(
-        self, db: SessionDB, reason: str,
-    ) -> None:
+    def test_without_an_admitted_turn_a_stale_close_is_not_healed(self, db: SessionDB, reason: str) -> None:
         parent = f"P_noturn_{reason}"
         db.create_session(parent, source="tui")
         _stamp(db, parent, reason, age=60.0)
-        holder = _lease(db, parent)  # a compression lease younger than the stamp proves nothing
-        with pytest.raises(RuntimeError, match="already ended.*no admitted turn of ours"):
+        holder = _lease(db, parent)  # a compression lease is publication ownership, not evidence
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
             _publish(db, parent, f"C_{reason}", holder=holder)
-        with pytest.raises(RuntimeError, match="already ended.*no admitted turn of ours"):
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
             _publish(db, parent, f"C_{reason}")  # lease-less publication: same contract
         assert db.get_session(f"C_{reason}") is None
         assert db.get_session(parent)["end_reason"] == reason
 
-    def test_a_foreign_turn_is_not_our_evidence(self, db: SessionDB) -> None:
-        parent = "P_foreign_turn"
+    def test_a_stamp_that_lands_mid_turn_costs_that_turn_only(self, db: SessionDB) -> None:
+        """A foreign writer's mis-stamp during the turn cannot be told from a deliberate close, so that
+        rotation fails closed; the next admitted turn heals it and rotates."""
+        parent = "P_mid_turn"
         db.create_session(parent, source="tui")
-        _stamp(db, parent, "tui_close", age=60.0)
-        _turn(db, parent, holder="pid=2:turn=t9:platform=cli")
-        with pytest.raises(RuntimeError, match="already ended.*no admitted turn of ours"):
-            _publish(db, parent, "C_never", holder=_lease(db, parent), turn=TURN)
+        _admit(db, parent)
+        _stamp(db, parent, "webhook_complete")
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
+            _publish(db, parent, "C_never", holder=_lease(db, parent))
         assert db.get_session("C_never") is None
-        assert db.get_session(parent)["end_reason"] == "tui_close"
+        db.release_compression_lock(parent, HOLDER)
+        db.release_session_turn_lease(parent, TURN)
+
+        _admit(db, parent, holder=TURN_2)
+        _publish(db, parent, "C_next", holder=_lease(db, parent))
+        assert db.get_session(parent)["end_reason"] == "compression"
+        assert db.get_session("C_next")["parent_session_id"] == parent
 
 
 class TestLineageOwnedElsewhereStillFailsClosed:
     def test_explicit_close_with_published_continuation_fails_closed(self, db: SessionDB) -> None:
         parent = "P_superseded"
         db.create_session(parent, source="tui")
-        turn = _turn(db, parent)
-        _publish(db, parent, "C_first", holder=_lease(db, parent), turn=turn)  # a continuation now exists
+        _admit(db, parent)
+        _publish(db, parent, "C_first", holder=_lease(db, parent))  # a continuation now exists
         db.release_compression_lock(parent, HOLDER)
-        db.release_session_turn_lease(parent, turn)
+        db.release_session_turn_lease(parent, TURN)
         db.reopen_session(parent)
         _stamp(db, parent, "tui_close", age=60.0)
-        turn = _turn(db, parent, holder="pid=1:turn=t2:platform=tui")
+        _admit(db, parent, holder=TURN_2)
         holder = _lease(db, parent, holder="second-writer")
 
         with pytest.raises(RuntimeError, match="already ended.*published continuation"):
-            _publish(db, parent, "C_second", holder=holder, turn=turn)
+            _publish(db, parent, "C_second", holder=holder)
         assert db.get_session("C_second") is None
         assert db.get_session(parent)["end_reason"] == "tui_close"  # untouched
 
     @pytest.mark.parametrize("reason", BOUNDARIES)
-    def test_boundary_fails_closed_even_when_older_than_the_turn(self, db: SessionDB, reason: str) -> None:
+    def test_boundary_fails_closed_even_after_admission(self, db: SessionDB, reason: str) -> None:
         assert reason in _RESET_END_REASONS or reason == "new_session"  # CLI /new is a boundary too
         parent = f"P_{reason}"
         db.create_session(parent, source="tui")
         _stamp(db, parent, reason, age=60.0)
-        turn = _turn(db, parent)
+        _admit(db, parent)
         with pytest.raises(RuntimeError, match=f"already ended.*{reason} boundary"):
-            _publish(db, parent, f"C_{reason}", holder=_lease(db, parent), turn=turn)
+            _publish(db, parent, f"C_{reason}", holder=_lease(db, parent))
         assert db.get_session(f"C_{reason}") is None
         assert db.get_session(parent)["end_reason"] == reason
 
@@ -268,9 +288,9 @@ class TestLineageOwnedElsewhereStillFailsClosed:
         parent = "P_compression"
         db.create_session(parent, source="tui")
         _stamp(db, parent, "compression", age=60.0)
-        turn = _turn(db, parent)
+        _admit(db, parent)
         with pytest.raises(RuntimeError, match="already ended.*closed by compression"):
-            _publish(db, parent, "C_x", holder=_lease(db, parent), turn=turn)
+            _publish(db, parent, "C_x", holder=_lease(db, parent))
 
 
 class TestVerdictIsSharedWithTheAgentGuard:
@@ -285,35 +305,30 @@ class TestVerdictIsSharedWithTheAgentGuard:
 
         db.create_session("stale", source="tui")
         _stamp(db, "stale", "tui_close", age=60.0)
-        assert db.compression_parent_deliberately_ended("stale") is True  # no turn: unprovable
-        _lease(db, "stale")
-        assert db.compression_parent_deliberately_ended("stale", turn_lease_holder=TURN) is True  # no such turn
-        _turn(db, "stale")
-        assert db.compression_parent_deliberately_ended("stale", turn_lease_holder=TURN) is False
-        assert db.compression_parent_deliberately_ended("stale", turn_lease_holder="someone-else") is True
+        assert db.compression_parent_deliberately_ended("stale") is True  # not healed until a turn is admitted
+        _admit(db, "stale")
+        assert db.compression_parent_deliberately_ended("stale") is False  # healed at admission
 
         db.create_session("closed_mid", source="tui")
-        _turn(db, "closed_mid")
-        time.sleep(0.01)
+        _admit(db, "closed_mid")
         _stamp(db, "closed_mid", "tui_close")
-        assert db.compression_parent_deliberately_ended("closed_mid", turn_lease_holder=TURN) is True
+        assert db.compression_parent_deliberately_ended("closed_mid") is True
 
         for sid, reason in [("reset", "session_reset"), ("new", "new_session"), ("comp", "compression")]:
             db.create_session(sid, source="tui")
             _stamp(db, sid, reason, age=60.0)
-            _turn(db, sid)
-            assert db.compression_parent_deliberately_ended(sid, turn_lease_holder=TURN) is True, (sid, reason)
+            _admit(db, sid)
+            assert db.compression_parent_deliberately_ended(sid) is True, (sid, reason)
 
         db.create_session("superseded", source="tui")
-        turn = _turn(db, "superseded")
-        _publish(db, "superseded", "superseded_child", holder=_lease(db, "superseded"), turn=turn)
+        _admit(db, "superseded")
+        _publish(db, "superseded", "superseded_child", holder=_lease(db, "superseded"))
         db.release_compression_lock("superseded", HOLDER)
-        db.release_session_turn_lease("superseded", turn)
+        db.release_session_turn_lease("superseded", TURN)
         db.reopen_session("superseded")
         _stamp(db, "superseded", "cli_close", age=60.0)
-        _turn(db, "superseded", holder="pid=1:turn=t2:platform=tui")
-        assert db.compression_parent_deliberately_ended(
-            "superseded", turn_lease_holder="pid=1:turn=t2:platform=tui") is True
+        _admit(db, "superseded", holder=TURN_2)
+        assert db.compression_parent_deliberately_ended("superseded") is True
         assert db.compression_parent_deliberately_ended("missing") is False
         assert db.compression_parent_deliberately_ended("") is False
 
@@ -322,20 +337,20 @@ class TestVerdictIsSharedWithTheAgentGuard:
 
         db.create_session("stale", source="tui")
         _stamp(db, "stale", "tui_close", age=60.0)
-        _turn(db, "stale")
-        assert _parent_deliberately_ended(db, "stale", turn_lease_holder=TURN) is False
-        assert _parent_deliberately_ended(db, "stale") is True  # no admitted turn to lean on
+        assert _parent_deliberately_ended(db, "stale") is True
+        _admit(db, "stale")
+        assert _parent_deliberately_ended(db, "stale") is False
         db.create_session("reset", source="tui")
         _stamp(db, "reset", "session_reset", age=60.0)
-        _turn(db, "reset")
-        assert _parent_deliberately_ended(db, "reset", turn_lease_holder=TURN) is True
+        _admit(db, "reset")
+        assert _parent_deliberately_ended(db, "reset") is True
 
     def test_agent_guard_fails_open_and_keeps_the_taxonomy_fallback(self) -> None:
         from agent.conversation_compression import _parent_deliberately_ended
 
         broken = MagicMock()
         broken.compression_parent_deliberately_ended.side_effect = RuntimeError("db unavailable")
-        assert _parent_deliberately_ended(broken, "x", turn_lease_holder=TURN) is False
+        assert _parent_deliberately_ended(broken, "x") is False
 
         class TaxonomyOnlyStore:  # a stand-in without the verdict: old behaviour is retained
             def get_session(self, session_id):
@@ -380,9 +395,14 @@ class TestRotationEndToEnd:
     @staticmethod
     def _admit_turn(db: SessionDB, agent, session_id: str) -> None:
         """What ``admit_durable_turn_lease`` does at the start of ``run_conversation``."""
-        _turn(db, session_id)
+        _admit(db, session_id)
         agent._active_session_turn_lease_holder = TURN
         agent._active_session_turn_lease_ttl_seconds = 300.0
+
+    @staticmethod
+    def _compress(agent) -> None:
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
 
     def test_stale_explicit_close_does_not_wedge_rotation(self, db: SessionDB) -> None:
         """#106459 end-to-end: the live session's row carries an explicit-close stamp that predates
@@ -393,33 +413,47 @@ class TestRotationEndToEnd:
         _stamp(db, parent, "tui_close", age=60.0)
         self._admit_turn(db, agent, parent)
 
-        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
-        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+        self._compress(agent)
 
         assert agent.session_id != parent, "rotation aborted on the stale explicit-close stamp"
         assert db.get_session(parent)["end_reason"] == "compression"
         child_row = db.get_session(agent.session_id)
         assert child_row is not None and child_row["parent_session_id"] == parent
 
+    def test_close_during_a_turn_that_began_on_a_stale_stamp_aborts_rotation(self, db: SessionDB) -> None:
+        """Third probe end-to-end: stale stamp, admit the turn, the user closes during it, compress."""
+        parent = "PARENT_106459_STALE_THEN_CLOSED"
+        db.create_session(parent, source="tui")
+        agent = self._build_agent(db, parent)
+        _stamp(db, parent, "tui_close", age=60.0)
+        self._admit_turn(db, agent, parent)
+        before = time.time()
+        db.end_session(parent, "tui_close")  # session.close during the turn
+
+        self._compress(agent)
+
+        assert agent.session_id == parent, "a close made during the turn must not be resurrected"
+        row = db.get_session(parent)
+        assert row["end_reason"] == "tui_close" and row["ended_at"] >= before
+        assert db._read_one("SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?", (parent,))[0] == 0
+
     def test_close_after_the_turn_was_admitted_aborts_rotation(self, db: SessionDB) -> None:
-        """The reviewer's probe end-to-end: close first, the still-running turn then compresses,
-        acquires the lease second, and publish creates no child."""
+        """Second probe end-to-end: close first, the still-running turn then compresses and takes the
+        lease second; publish creates no child."""
         parent = "PARENT_106459_CLOSE_FIRST"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
         self._admit_turn(db, agent, parent)
-        time.sleep(0.01)
-        db.end_session(parent, "tui_close")  # session.close, after its grace, with the turn thread alive
+        db.end_session(parent, "tui_close")
 
-        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
-        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+        self._compress(agent)
 
-        assert agent.session_id == parent, "a close made during the turn must not be resurrected"
+        assert agent.session_id == parent
         assert db.get_session(parent)["end_reason"] == "tui_close"
         assert db._read_one("SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?", (parent,))[0] == 0
 
     def test_close_during_compression_still_aborts_rotation(self, db: SessionDB) -> None:
-        """The user closes the session while the summary is being produced: the close wins."""
+        """First probe end-to-end: the user closes while the summary is being produced."""
         parent = "PARENT_106459_CLOSE_MID"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
@@ -428,27 +462,24 @@ class TestRotationEndToEnd:
         summary = compressor.compress.return_value
 
         def close_while_summarizing(*args, **kwargs):
-            time.sleep(0.01)
             db.end_session(parent, "tui_close")  # session.close lands after the lease was acquired
             return summary
 
         compressor.compress.side_effect = close_while_summarizing
-        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
-        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+        self._compress(agent)
 
         assert agent.session_id == parent, "a close made mid-compression must not be resurrected"
         assert db.get_session(parent)["end_reason"] == "tui_close"
 
     def test_without_an_admitted_turn_a_stale_close_is_not_healed(self, db: SessionDB) -> None:
-        """No turn lease (a caller outside the façade): nothing proves the stamp stale, so the
-        pre-#106459 contract stands and the close is preserved."""
+        """No turn lease (a caller outside the façade): nothing healed the stamp, so the pre-#106459
+        contract stands and the close is preserved."""
         parent = "PARENT_106459_NO_TURN"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
         _stamp(db, parent, "tui_close", age=60.0)
 
-        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
-        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+        self._compress(agent)
 
         assert agent.session_id == parent
         assert db.get_session(parent)["end_reason"] == "tui_close"
@@ -461,8 +492,7 @@ class TestRotationEndToEnd:
         _stamp(db, parent, reason, age=60.0)
         self._admit_turn(db, agent, parent)
 
-        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
-        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+        self._compress(agent)
 
         assert agent.session_id == parent
         assert db.get_session(parent)["end_reason"] == reason

--- a/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
+++ b/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
@@ -1,25 +1,29 @@
 """Regression tests for #106459 — an over-limit session must not become permanently
 uncompressible because its row carries a stale explicit-close stamp, and a close the user
-makes mid-compression must never be resurrected.
+makes during a turn must never be resurrected.
 
 ``publish_compression_child`` used to fail closed on ANY non-automatic ``end_reason``
-(``tui_close``, ``cli_close``, ``webhook_complete``, ``new_session``, gateway-recovery and
-cron reasons), and ``end_session()`` is first-stamp-wins, so nothing ever cleared it. Every
-turn then ran the compression, discarded its result at publication, kept the oversized
-history and hit ``Context length exceeded … Cannot compress further`` again; manual
-``/compress`` reported "No changes". The agent's pre-flush guard re-implemented the same
-taxonomy and aborted even earlier.
+(``tui_close``, ``cli_close``, ``webhook_complete``, gateway-recovery and cron reasons), and
+``end_session()`` is first-stamp-wins, so nothing ever cleared it. Every turn then ran the
+compression, discarded its result at publication, kept the oversized history and hit
+``Context length exceeded … Cannot compress further`` again; manual ``/compress`` reported
+"No changes". The agent's pre-flush guard re-implemented the same taxonomy and aborted even
+earlier.
 
 Contract under test (single verdict owner ``_compression_parent_obstacle``): an explicit
-close is ordered against this attempt's compression lease. A stamp written BEFORE the lease
-was acquired is stale — the writer took the lease and has driven the row since — and is
-cleared inside the publish transaction like an automatic stamp (#88197). A close written
-AFTER the lease was acquired is the user closing the session while compression runs
-(``session.close`` waits five seconds for the turn thread, then stamps ``tui_close``) and
-is preserved: publish fails closed and no child is created. Without a lease of our own the
-stamp cannot be proven stale and also fails closed. Lineage owned elsewhere always fails
-closed: a ``'compression'`` stamp, a reset boundary, or an explicit close whose
-continuation child was already published.
+close is cleared only on POSITIVE evidence that the session was driven after it — this
+writer's session turn lease (``session_turn_leases.acquired_at``, taken once per turn by the
+façade before the transcript is loaded) was admitted AFTER the stamp. Every sanctioned resume
+clears the stamp first (``reopen_session``) and a host never admits a turn on a session it is
+closing, so that order can only mean the stamp missed a still-routed session. A stamp at or
+after admission is a close made during this turn (``session.close`` stamps ``tui_close``
+after a five-second grace even while the turn thread runs on, and that thread later takes the
+compression lease) and is preserved: publish fails closed and no child is created. The
+compression lease is no evidence — it is taken inside the turn, after any such close. Without
+an admitted turn of our own the stamp cannot be proven stale and also fails closed. Lineage
+owned elsewhere always fails closed: a ``'compression'`` stamp, a boundary reason (the reset
+reasons and CLI ``new_session``), or an explicit close whose continuation child was already
+published.
 """
 
 from __future__ import annotations
@@ -33,10 +37,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hermes_state import SessionDB
-from hermes_state_common import _RESET_END_REASONS
+from hermes_state_common import _BOUNDARY_END_REASONS, _RESET_END_REASONS
 
-STALE_EXPLICIT_CLOSES = ["tui_close", "cli_close", "webhook_complete", "new_session"]
+STALE_EXPLICIT_CLOSES = ["tui_close", "cli_close", "webhook_complete"]
+BOUNDARIES = sorted(_BOUNDARY_END_REASONS)
 HOLDER = "compression-writer"
+TURN = "pid=1:turn=t1:platform=tui"
 
 
 @pytest.fixture
@@ -48,7 +54,8 @@ def db(tmp_path: Path):
         handle.close()
 
 
-def _publish(db: SessionDB, parent: str, child: str, *, holder: str | None = None) -> None:
+def _publish(db: SessionDB, parent: str, child: str, *, holder: str | None = None,
+             turn: str | None = None) -> None:
     db.publish_compression_child(
         parent_session_id=parent,
         child_session_id=child,
@@ -56,12 +63,13 @@ def _publish(db: SessionDB, parent: str, child: str, *, holder: str | None = Non
         messages=[{"role": "user", "content": "[CONTEXT COMPACTION] summary"}],
         require_compression_lease=holder is not None,
         compression_lock_holder=holder,
+        turn_lease_holder=turn,
     )
 
 
 def _stamp(db: SessionDB, session_id: str, reason: str, *, age: float = 0.0) -> None:
-    """End the row with *reason*; ``age`` backdates the stamp so its order against a lease
-    acquired afterwards is unambiguous."""
+    """End the row with *reason*; ``age`` backdates the stamp so its order against a turn
+    admitted afterwards is unambiguous."""
     db.end_session(session_id, reason)
     if age:
         db._write_sql("UPDATE sessions SET ended_at = ? WHERE id = ?", (time.time() - age, session_id))
@@ -70,21 +78,34 @@ def _stamp(db: SessionDB, session_id: str, reason: str, *, age: float = 0.0) -> 
 
 
 def _lease(db: SessionDB, session_id: str, holder: str = HOLDER) -> str:
+    """The compression lease: publication ownership, never evidence about the stamp."""
     assert db.try_acquire_compression_lock(session_id, holder, ttl_seconds=300.0)
     return holder
 
 
-class TestStaleStampBeforeTheLeaseIsCleared:
+def _turn(db: SessionDB, session_id: str, holder: str = TURN) -> str:
+    """Admit a turn on the conversation, as ``admit_durable_turn_lease`` does before a turn runs."""
+    assert db.try_acquire_session_turn_lease(session_id, holder, ttl_seconds=300.0)
+    return holder
+
+
+def _turn_admitted_at(db: SessionDB, session_id: str) -> float:
+    key = db._session_turn_lease_key(session_id)
+    return db._read_one("SELECT acquired_at FROM session_turn_leases WHERE conversation_id = ?", (key,))[0]
+
+
+class TestStaleStampBeforeTheTurnIsCleared:
     @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
-    def test_explicit_close_before_the_lease_publishes(self, db: SessionDB, reason: str, caplog) -> None:
+    def test_explicit_close_before_the_turn_publishes(self, db: SessionDB, reason: str, caplog) -> None:
         parent = f"P_{reason}"
         db.create_session(parent, source="tui")
         db.append_message(parent, "user", content="hello")
-        _stamp(db, parent, reason, age=60.0)  # the #106459 shape: the mark predates this attempt
+        _stamp(db, parent, reason, age=60.0)  # the #106459 shape: the mark predates this turn
+        turn = _turn(db, parent)
         holder = _lease(db, parent)
 
         with caplog.at_level(logging.WARNING, logger="hermes_state"):
-            _publish(db, parent, f"C_{reason}", holder=holder)
+            _publish(db, parent, f"C_{reason}", holder=holder, turn=turn)
 
         parent_row = db.get_session(parent)
         assert parent_row["end_reason"] == "compression"  # the true boundary, not the stale stamp
@@ -95,89 +116,161 @@ class TestStaleStampBeforeTheLeaseIsCleared:
             "clearing an explicit-close stamp must be logged with the stale reason")
 
     def test_repeated_rotation_is_not_wedged(self, db: SessionDB) -> None:
-        """The field shape: the stamp lands once, and every later rotation must still publish."""
+        """The field shape: the stamp lands once, and every later turn must still rotate."""
         parent = "P_repeat"
         db.create_session(parent, source="tui")
         _stamp(db, parent, "cli_close", age=60.0)
-        _publish(db, parent, "C_1", holder=_lease(db, parent))
-        _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"))
+        turn = _turn(db, parent)
+        _publish(db, parent, "C_1", holder=_lease(db, parent), turn=turn)
+        db.release_session_turn_lease(parent, turn)
+        turn = _turn(db, "C_1", holder="pid=1:turn=t2:platform=tui")
+        _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"), turn=turn)
         assert db.get_session("C_1")["end_reason"] == "compression"
         assert db.get_session("C_2")["parent_session_id"] == "C_1"
 
+    def test_stale_close_on_a_compression_child_is_ordered_by_the_conversation_lease(self, db: SessionDB) -> None:
+        """The turn lease is keyed by the lineage root; a stamp on a later segment is ordered against it."""
+        root = "P_root"
+        db.create_session(root, source="tui")
+        turn = _turn(db, root)
+        _publish(db, root, "C_1", holder=_lease(db, root), turn=turn)
+        db.release_session_turn_lease(root, turn)
+        _stamp(db, "C_1", "tui_close", age=60.0)
+        turn = _turn(db, "C_1", holder="pid=1:turn=t2:platform=tui")
+        assert db._session_turn_lease_key("C_1") == root
 
-class TestDeliberateCloseAfterTheLeaseIsPreserved:
-    def test_close_during_compression_fails_closed(self, db: SessionDB) -> None:
-        """The reviewer's probe: acquire the lease, then the user closes the session
-        (``session.close`` stamps ``tui_close`` after its five-second wait), then publish."""
-        parent = "P_closed_mid_compression"
+        _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"), turn=turn)
+        assert db.get_session("C_1")["end_reason"] == "compression"
+        assert db.get_session("C_2")["parent_session_id"] == "C_1"
+
+    def test_a_stamp_that_lands_mid_turn_costs_that_turn_only(self, db: SessionDB) -> None:
+        """No evidence yet during the turn the stamp landed in: that rotation fails closed. The next
+        admitted turn is the evidence, and it rotates."""
+        parent = "P_mid_turn"
         db.create_session(parent, source="tui")
-        holder = _lease(db, parent)
+        turn = _turn(db, parent)
+        time.sleep(0.01)
+        _stamp(db, parent, "webhook_complete")  # a foreign stale writer, during our turn
+        with pytest.raises(RuntimeError, match="already ended.*after this turn was admitted"):
+            _publish(db, parent, "C_never", holder=_lease(db, parent), turn=turn)
+        assert db.get_session("C_never") is None
+        db.release_compression_lock(parent, HOLDER)
+        db.release_session_turn_lease(parent, turn)
+
+        time.sleep(0.01)
+        turn = _turn(db, parent, holder="pid=1:turn=t2:platform=tui")
+        _publish(db, parent, "C_next", holder=_lease(db, parent), turn=turn)
+        assert db.get_session(parent)["end_reason"] == "compression"
+        assert db.get_session("C_next")["parent_session_id"] == parent
+
+
+class TestDeliberateCloseDuringTheTurnIsPreserved:
+    def test_close_after_the_turn_was_admitted_fails_closed(self, db: SessionDB) -> None:
+        """The reviewer's probe: the turn is running, ``session.close`` stamps ``tui_close`` after its
+        grace period without interrupting the turn thread, and that thread then acquires the
+        compression lease and publishes."""
+        parent = "P_closed_during_turn"
+        db.create_session(parent, source="tui")
+        turn = _turn(db, parent)
         time.sleep(0.01)
         _stamp(db, parent, "tui_close")
+        holder = _lease(db, parent)  # the lease is younger than the close: no evidence either way
 
-        with pytest.raises(RuntimeError, match="already ended.*after this compression attempt acquired its lease"):
-            _publish(db, parent, "C_never", holder=holder)
+        with pytest.raises(RuntimeError, match="already ended.*after this turn was admitted"):
+            _publish(db, parent, "C_never", holder=holder, turn=turn)
 
         assert db.get_session("C_never") is None
         row = db.get_session(parent)
         assert row["end_reason"] == "tui_close" and row["ended_at"] is not None  # the user's close survives
 
+    def test_close_during_compression_fails_closed(self, db: SessionDB) -> None:
+        """The earlier probe: lease first, then the close, then publish."""
+        parent = "P_closed_mid_compression"
+        db.create_session(parent, source="tui")
+        turn = _turn(db, parent)
+        holder = _lease(db, parent)
+        time.sleep(0.01)
+        _stamp(db, parent, "tui_close")
+
+        with pytest.raises(RuntimeError, match="already ended.*after this turn was admitted"):
+            _publish(db, parent, "C_never", holder=holder, turn=turn)
+        assert db.get_session("C_never") is None
+        assert db.get_session(parent)["end_reason"] == "tui_close"
+
     def test_close_at_the_same_instant_fails_closed(self, db: SessionDB) -> None:
         parent = "P_tie"
         db.create_session(parent, source="tui")
-        holder = _lease(db, parent)
-        acquired_at = db._read_one("SELECT acquired_at FROM compression_locks WHERE session_id = ?", (parent,))[0]
+        turn = _turn(db, parent)
         db.end_session(parent, "tui_close")
-        db._write_sql("UPDATE sessions SET ended_at = ? WHERE id = ?", (acquired_at, parent))
+        db._write_sql("UPDATE sessions SET ended_at = ? WHERE id = ?", (_turn_admitted_at(db, parent), parent))
 
-        with pytest.raises(RuntimeError, match="after this compression attempt acquired its lease"):
-            _publish(db, parent, "C_tie", holder=holder)
+        with pytest.raises(RuntimeError, match="after this turn was admitted"):
+            _publish(db, parent, "C_tie", holder=_lease(db, parent), turn=turn)
         assert db.get_session(parent)["end_reason"] == "tui_close"
 
     @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
-    def test_without_a_lease_an_explicit_close_cannot_be_proven_stale(self, db: SessionDB, reason: str) -> None:
-        parent = f"P_nolease_{reason}"
+    def test_without_an_admitted_turn_an_explicit_close_cannot_be_proven_stale(
+        self, db: SessionDB, reason: str,
+    ) -> None:
+        parent = f"P_noturn_{reason}"
         db.create_session(parent, source="tui")
         _stamp(db, parent, reason, age=60.0)
-        with pytest.raises(RuntimeError, match="already ended.*no compression-lease ordering"):
-            _publish(db, parent, f"C_{reason}")  # require_compression_lease=False: no ordering signal
+        holder = _lease(db, parent)  # a compression lease younger than the stamp proves nothing
+        with pytest.raises(RuntimeError, match="already ended.*no admitted turn of ours"):
+            _publish(db, parent, f"C_{reason}", holder=holder)
+        with pytest.raises(RuntimeError, match="already ended.*no admitted turn of ours"):
+            _publish(db, parent, f"C_{reason}")  # lease-less publication: same contract
         assert db.get_session(f"C_{reason}") is None
         assert db.get_session(parent)["end_reason"] == reason
+
+    def test_a_foreign_turn_is_not_our_evidence(self, db: SessionDB) -> None:
+        parent = "P_foreign_turn"
+        db.create_session(parent, source="tui")
+        _stamp(db, parent, "tui_close", age=60.0)
+        _turn(db, parent, holder="pid=2:turn=t9:platform=cli")
+        with pytest.raises(RuntimeError, match="already ended.*no admitted turn of ours"):
+            _publish(db, parent, "C_never", holder=_lease(db, parent), turn=TURN)
+        assert db.get_session("C_never") is None
+        assert db.get_session(parent)["end_reason"] == "tui_close"
 
 
 class TestLineageOwnedElsewhereStillFailsClosed:
     def test_explicit_close_with_published_continuation_fails_closed(self, db: SessionDB) -> None:
         parent = "P_superseded"
         db.create_session(parent, source="tui")
-        _publish(db, parent, "C_first", holder=_lease(db, parent))  # a continuation now exists
+        turn = _turn(db, parent)
+        _publish(db, parent, "C_first", holder=_lease(db, parent), turn=turn)  # a continuation now exists
         db.release_compression_lock(parent, HOLDER)
+        db.release_session_turn_lease(parent, turn)
         db.reopen_session(parent)
         _stamp(db, parent, "tui_close", age=60.0)
+        turn = _turn(db, parent, holder="pid=1:turn=t2:platform=tui")
         holder = _lease(db, parent, holder="second-writer")
 
         with pytest.raises(RuntimeError, match="already ended.*published continuation"):
-            _publish(db, parent, "C_second", holder=holder)
+            _publish(db, parent, "C_second", holder=holder, turn=turn)
         assert db.get_session("C_second") is None
         assert db.get_session(parent)["end_reason"] == "tui_close"  # untouched
 
-    @pytest.mark.parametrize("reason", ["session_reset", "session_switch", "idle", "daily"])
-    def test_reset_boundary_fails_closed(self, db: SessionDB, reason: str) -> None:
-        assert reason in _RESET_END_REASONS
+    @pytest.mark.parametrize("reason", BOUNDARIES)
+    def test_boundary_fails_closed_even_when_older_than_the_turn(self, db: SessionDB, reason: str) -> None:
+        assert reason in _RESET_END_REASONS or reason == "new_session"  # CLI /new is a boundary too
         parent = f"P_{reason}"
         db.create_session(parent, source="tui")
         _stamp(db, parent, reason, age=60.0)
-        holder = _lease(db, parent)
+        turn = _turn(db, parent)
         with pytest.raises(RuntimeError, match=f"already ended.*{reason} boundary"):
-            _publish(db, parent, f"C_{reason}", holder=holder)
+            _publish(db, parent, f"C_{reason}", holder=_lease(db, parent), turn=turn)
         assert db.get_session(f"C_{reason}") is None
+        assert db.get_session(parent)["end_reason"] == reason
 
     def test_compression_stamp_fails_closed(self, db: SessionDB) -> None:
         parent = "P_compression"
         db.create_session(parent, source="tui")
         _stamp(db, parent, "compression", age=60.0)
-        holder = _lease(db, parent)
+        turn = _turn(db, parent)
         with pytest.raises(RuntimeError, match="already ended.*closed by compression"):
-            _publish(db, parent, "C_x", holder=holder)
+            _publish(db, parent, "C_x", holder=_lease(db, parent), turn=turn)
 
 
 class TestVerdictIsSharedWithTheAgentGuard:
@@ -192,30 +285,35 @@ class TestVerdictIsSharedWithTheAgentGuard:
 
         db.create_session("stale", source="tui")
         _stamp(db, "stale", "tui_close", age=60.0)
-        assert db.compression_parent_deliberately_ended("stale") is True  # no lease: unprovable
+        assert db.compression_parent_deliberately_ended("stale") is True  # no turn: unprovable
         _lease(db, "stale")
-        assert db.compression_parent_deliberately_ended("stale", holder=HOLDER) is False
-        assert db.compression_parent_deliberately_ended("stale", holder="someone-else") is True
+        assert db.compression_parent_deliberately_ended("stale", turn_lease_holder=TURN) is True  # no such turn
+        _turn(db, "stale")
+        assert db.compression_parent_deliberately_ended("stale", turn_lease_holder=TURN) is False
+        assert db.compression_parent_deliberately_ended("stale", turn_lease_holder="someone-else") is True
 
         db.create_session("closed_mid", source="tui")
-        _lease(db, "closed_mid")
+        _turn(db, "closed_mid")
         time.sleep(0.01)
         _stamp(db, "closed_mid", "tui_close")
-        assert db.compression_parent_deliberately_ended("closed_mid", holder=HOLDER) is True
+        assert db.compression_parent_deliberately_ended("closed_mid", turn_lease_holder=TURN) is True
 
-        for sid, reason in [("reset", "session_reset"), ("comp", "compression")]:
+        for sid, reason in [("reset", "session_reset"), ("new", "new_session"), ("comp", "compression")]:
             db.create_session(sid, source="tui")
             _stamp(db, sid, reason, age=60.0)
-            _lease(db, sid)
-            assert db.compression_parent_deliberately_ended(sid, holder=HOLDER) is True, (sid, reason)
+            _turn(db, sid)
+            assert db.compression_parent_deliberately_ended(sid, turn_lease_holder=TURN) is True, (sid, reason)
 
         db.create_session("superseded", source="tui")
-        _publish(db, "superseded", "superseded_child", holder=_lease(db, "superseded"))
+        turn = _turn(db, "superseded")
+        _publish(db, "superseded", "superseded_child", holder=_lease(db, "superseded"), turn=turn)
         db.release_compression_lock("superseded", HOLDER)
+        db.release_session_turn_lease("superseded", turn)
         db.reopen_session("superseded")
         _stamp(db, "superseded", "cli_close", age=60.0)
-        _lease(db, "superseded")
-        assert db.compression_parent_deliberately_ended("superseded", holder=HOLDER) is True
+        _turn(db, "superseded", holder="pid=1:turn=t2:platform=tui")
+        assert db.compression_parent_deliberately_ended(
+            "superseded", turn_lease_holder="pid=1:turn=t2:platform=tui") is True
         assert db.compression_parent_deliberately_ended("missing") is False
         assert db.compression_parent_deliberately_ended("") is False
 
@@ -224,20 +322,20 @@ class TestVerdictIsSharedWithTheAgentGuard:
 
         db.create_session("stale", source="tui")
         _stamp(db, "stale", "tui_close", age=60.0)
-        _lease(db, "stale")
-        assert _parent_deliberately_ended(db, "stale", holder=HOLDER) is False
-        assert _parent_deliberately_ended(db, "stale") is True  # no lease ordering to lean on
+        _turn(db, "stale")
+        assert _parent_deliberately_ended(db, "stale", turn_lease_holder=TURN) is False
+        assert _parent_deliberately_ended(db, "stale") is True  # no admitted turn to lean on
         db.create_session("reset", source="tui")
         _stamp(db, "reset", "session_reset", age=60.0)
-        _lease(db, "reset")
-        assert _parent_deliberately_ended(db, "reset", holder=HOLDER) is True
+        _turn(db, "reset")
+        assert _parent_deliberately_ended(db, "reset", turn_lease_holder=TURN) is True
 
     def test_agent_guard_fails_open_and_keeps_the_taxonomy_fallback(self) -> None:
         from agent.conversation_compression import _parent_deliberately_ended
 
         broken = MagicMock()
         broken.compression_parent_deliberately_ended.side_effect = RuntimeError("db unavailable")
-        assert _parent_deliberately_ended(broken, "x", holder=HOLDER) is False
+        assert _parent_deliberately_ended(broken, "x", turn_lease_holder=TURN) is False
 
         class TaxonomyOnlyStore:  # a stand-in without the verdict: old behaviour is retained
             def get_session(self, session_id):
@@ -279,13 +377,21 @@ class TestRotationEndToEnd:
         agent.compression_in_place = False  # rotation path
         return agent
 
+    @staticmethod
+    def _admit_turn(db: SessionDB, agent, session_id: str) -> None:
+        """What ``admit_durable_turn_lease`` does at the start of ``run_conversation``."""
+        _turn(db, session_id)
+        agent._active_session_turn_lease_holder = TURN
+        agent._active_session_turn_lease_ttl_seconds = 300.0
+
     def test_stale_explicit_close_does_not_wedge_rotation(self, db: SessionDB) -> None:
         """#106459 end-to-end: the live session's row carries an explicit-close stamp that predates
-        the attempt, and auto-compaction still rotates instead of computing and discarding forever."""
+        the turn, and auto-compaction still rotates instead of computing and discarding forever."""
         parent = "PARENT_106459_E2E"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
         _stamp(db, parent, "tui_close", age=60.0)
+        self._admit_turn(db, agent, parent)
 
         msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
         agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
@@ -295,11 +401,29 @@ class TestRotationEndToEnd:
         child_row = db.get_session(agent.session_id)
         assert child_row is not None and child_row["parent_session_id"] == parent
 
+    def test_close_after_the_turn_was_admitted_aborts_rotation(self, db: SessionDB) -> None:
+        """The reviewer's probe end-to-end: close first, the still-running turn then compresses,
+        acquires the lease second, and publish creates no child."""
+        parent = "PARENT_106459_CLOSE_FIRST"
+        db.create_session(parent, source="tui")
+        agent = self._build_agent(db, parent)
+        self._admit_turn(db, agent, parent)
+        time.sleep(0.01)
+        db.end_session(parent, "tui_close")  # session.close, after its grace, with the turn thread alive
+
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+
+        assert agent.session_id == parent, "a close made during the turn must not be resurrected"
+        assert db.get_session(parent)["end_reason"] == "tui_close"
+        assert db._read_one("SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?", (parent,))[0] == 0
+
     def test_close_during_compression_still_aborts_rotation(self, db: SessionDB) -> None:
         """The user closes the session while the summary is being produced: the close wins."""
         parent = "PARENT_106459_CLOSE_MID"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
+        self._admit_turn(db, agent, parent)
         compressor = agent.context_compressor
         summary = compressor.compress.return_value
 
@@ -315,14 +439,30 @@ class TestRotationEndToEnd:
         assert agent.session_id == parent, "a close made mid-compression must not be resurrected"
         assert db.get_session(parent)["end_reason"] == "tui_close"
 
-    def test_reset_boundary_still_aborts_rotation(self, db: SessionDB) -> None:
-        parent = "PARENT_106459_RESET"
+    def test_without_an_admitted_turn_a_stale_close_is_not_healed(self, db: SessionDB) -> None:
+        """No turn lease (a caller outside the façade): nothing proves the stamp stale, so the
+        pre-#106459 contract stands and the close is preserved."""
+        parent = "PARENT_106459_NO_TURN"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
-        _stamp(db, parent, "session_reset", age=60.0)
+        _stamp(db, parent, "tui_close", age=60.0)
 
         msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
         agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
 
         assert agent.session_id == parent
-        assert db.get_session(parent)["end_reason"] == "session_reset"
+        assert db.get_session(parent)["end_reason"] == "tui_close"
+
+    @pytest.mark.parametrize("reason", ["session_reset", "new_session"])
+    def test_boundary_still_aborts_rotation(self, db: SessionDB, reason: str) -> None:
+        parent = f"PARENT_106459_{reason}"
+        db.create_session(parent, source="tui")
+        agent = self._build_agent(db, parent)
+        _stamp(db, parent, reason, age=60.0)
+        self._admit_turn(db, agent, parent)
+
+        msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+        agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
+
+        assert agent.session_id == parent
+        assert db.get_session(parent)["end_reason"] == reason

--- a/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
+++ b/tests/hermes_state/test_106459_stale_explicit_close_stamp.py
@@ -1,6 +1,6 @@
 """Regression tests for #106459 — an over-limit session must not become permanently
 uncompressible because its row carries a stale explicit-close stamp, and a close the user
-makes during a turn must never be resurrected.
+makes must never be resurrected.
 
 ``publish_compression_child`` used to fail closed on ANY non-automatic ``end_reason``
 (``tui_close``, ``cli_close``, ``webhook_complete``, gateway-recovery and cron reasons), and
@@ -10,19 +10,17 @@ compression, discarded its result at publication, kept the oversized history and
 "No changes". The agent's pre-flush guard re-implemented the same taxonomy and aborted even
 earlier.
 
-Contract under test. A stale explicit close is healed at TURN ADMISSION
-(``try_acquire_session_turn_lease``, taken once per turn by the façade before the transcript
-is loaded), inside the claim transaction: every sanctioned resume clears stamps first
-(``reopen_session``) and a host never admits a turn on a session it is closing, so a stamp
-that survives to admission can only have missed a still-routed session. Healing there, and
-never at publication, is what keeps a close made DURING the turn observable: ``end_session()``
-is first-stamp-wins, so while a stale stamp occupied the row a deliberate close was a no-op
-write and the store could not tell the two apart. Publication (single verdict owner
-``_compression_parent_obstacle``, shared with the agent's pre-flush guard) clears only
-automatic-cleanup stamps (#88197) and fails closed on everything else: an explicit close (a
-deliberate close during this turn, a foreign writer's mis-stamp that costs this one rotation,
-or no admitted turn at all), a ``'compression'`` stamp, a boundary reason (the reset reasons
-and CLI ``new_session``), and an explicit close whose continuation child was already published.
+Contract under test. The store never decides on its own that an explicit close is stale.
+Publication (single verdict owner ``_compression_parent_obstacle``, shared with the agent's
+pre-flush guard) clears only automatic-cleanup stamps (#88197) and fails closed on every other
+stamp. Turn-lease admission clears nothing: a TUI turn worker can take its lease after the host
+has already closed the session. A stale explicit close is cleared only through
+``reopen_if_explicitly_closed()``, called by the host that still routes the session -- the TUI,
+under ``_sessions_lock`` as it starts a turn for a session it still has registered (covered in
+``tests/tui_gateway/test_106459_routing_provenance_reopen.py``). That method clears only explicit
+closes with no published continuation and leaves automatic, ``'compression'``, boundary (reset
+reasons and CLI ``new_session``) and superseded stamps alone. Here the host's call is stood in
+for by ``_host_reopen``.
 """
 
 from __future__ import annotations
@@ -44,8 +42,8 @@ HOLDER = "compression-writer"
 # Holders carry this process's pid: a dead pid makes a lease reclaimable, which is not what these probe.
 TURN = f"pid={os.getpid()}:turn=t1:platform=tui"
 TURN_2 = f"pid={os.getpid()}:turn=t2:platform=tui"
-OTHER_PROCESS = f"pid={os.getpid()}:turn=t9:platform=cli"
-NOT_HEALED = "healed only at turn admission"
+NOT_HEALED = "healed only by the host that still routes the session"
+PROVENANCE = "the test host still routes the session"
 
 
 @pytest.fixture
@@ -85,9 +83,14 @@ def _lease(db: SessionDB, session_id: str, holder: str = HOLDER) -> str:
 
 
 def _admit(db: SessionDB, session_id: str, holder: str = TURN) -> str:
-    """Admit a turn on the conversation, as ``admit_durable_turn_lease`` does before a turn runs."""
+    """Admit a turn on the conversation, as ``admit_durable_turn_lease`` does inside the turn worker."""
     assert db.try_acquire_session_turn_lease(session_id, holder, ttl_seconds=300.0)
     return holder
+
+
+def _host_reopen(db: SessionDB, session_id: str) -> str | None:
+    """What the TUI does under ``_sessions_lock`` for a session it still has registered."""
+    return db.reopen_if_explicitly_closed(session_id, provenance=PROVENANCE)
 
 
 def _live(db: SessionDB, session_id: str) -> bool:
@@ -95,21 +98,83 @@ def _live(db: SessionDB, session_id: str) -> bool:
     return row["ended_at"] is None and row["end_reason"] is None
 
 
-class TestAdmissionHealsAStaleExplicitClose:
+class TestReopenIfExplicitlyClosed:
     @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
-    def test_stale_explicit_close_is_cleared_when_a_turn_is_admitted(self, db: SessionDB, reason: str, caplog) -> None:
+    def test_clears_each_explicit_close_and_logs_the_provenance(self, db: SessionDB, reason: str, caplog) -> None:
+        sid = f"S_{reason}"
+        db.create_session(sid, source="tui")
+        _stamp(db, sid, reason, age=60.0)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            assert _host_reopen(db, sid) == reason
+
+        assert _live(db, sid)
+        assert any(reason in r.getMessage() and PROVENANCE in r.getMessage() and "stale" in r.getMessage()
+                   for r in caplog.records), "clearing must be logged with the reason and the host's provenance"
+
+    @pytest.mark.parametrize("reason", ["ws_disconnect", "compression", *BOUNDARIES])
+    def test_leaves_every_other_stamp_alone(self, db: SessionDB, reason: str) -> None:
+        sid = f"S_{reason}"
+        db.create_session(sid, source="tui")
+        _stamp(db, sid, reason, age=60.0)
+        assert _host_reopen(db, sid) is None
+        row = db.get_session(sid)
+        assert row["end_reason"] == reason and row["ended_at"] is not None
+
+    def test_leaves_a_superseded_close_alone(self, db: SessionDB) -> None:
+        parent = "P_superseded_reopen"
+        db.create_session(parent, source="tui")
+        _publish(db, parent, "C_first", holder=_lease(db, parent))  # a continuation now exists
+        db.release_compression_lock(parent, HOLDER)
+        db.reopen_session(parent)
+        _stamp(db, parent, "tui_close", age=60.0)
+        assert _host_reopen(db, parent) is None
+        assert db.get_session(parent)["end_reason"] == "tui_close"
+
+    def test_live_missing_and_empty_ids_are_no_ops(self, db: SessionDB) -> None:
+        db.create_session("live", source="tui")
+        assert _host_reopen(db, "live") is None
+        assert _live(db, "live")
+        assert _host_reopen(db, "missing") is None
+        assert _host_reopen(db, "") is None
+
+
+class TestTurnAdmissionHealsNothing:
+    @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
+    def test_admitting_a_turn_leaves_an_explicit_close(self, db: SessionDB, reason: str) -> None:
+        """A lease is not routing provenance: the store must not treat its acquisition as proof."""
+        sid = f"S_admit_{reason}"
+        db.create_session(sid, source="tui")
+        _stamp(db, sid, reason, age=60.0)
+        _admit(db, sid)
+        assert db.get_session(sid)["end_reason"] == reason
+
+    def test_a_late_turn_lease_after_the_host_closed_leaves_the_close(self, db: SessionDB) -> None:
+        """Fourth review probe, store level: the TUI accepted a prompt and started a worker, the user closed
+        the session (pop, grace, ``tui_close``), and only then did the worker reach ``run_conversation()``
+        and take its turn lease. Nothing re-applies the close afterwards, so the lease must not clear it."""
+        sid = "S_late_worker"
+        db.create_session(sid, source="tui")
+        _stamp(db, sid, "tui_close")  # teardown finished before the worker took its lease
+        _admit(db, sid)
+        assert db.get_session(sid)["end_reason"] == "tui_close"
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
+            _publish(db, sid, "C_never", holder=_lease(db, sid))
+        assert db.get_session("C_never") is None
+        assert db.get_session(sid)["end_reason"] == "tui_close"
+
+
+class TestHostReopenUnwedgesRotation:
+    @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
+    def test_a_stale_close_cleared_by_the_host_lets_the_rotation_publish(self, db: SessionDB, reason: str) -> None:
         parent = f"P_{reason}"
         db.create_session(parent, source="tui")
         db.append_message(parent, "user", content="hello")
         _stamp(db, parent, reason, age=60.0)  # the #106459 shape: the mark predates this turn
-
-        with caplog.at_level(logging.WARNING, logger="hermes_state"):
-            _admit(db, parent)
-
-        assert _live(db, parent), "admission must clear the stale stamp"
-        assert any(reason in rec.getMessage() and "stale" in rec.getMessage() for rec in caplog.records), (
-            "clearing an explicit-close stamp must be logged with the stale reason")
+        assert _host_reopen(db, parent) == reason
+        _admit(db, parent)
         _publish(db, parent, f"C_{reason}", holder=_lease(db, parent))
+
         parent_row = db.get_session(parent)
         assert parent_row["end_reason"] == "compression" and parent_row["ended_at"] is not None
         child_row = db.get_session(f"C_{reason}")
@@ -120,64 +185,55 @@ class TestAdmissionHealsAStaleExplicitClose:
         parent = "P_repeat"
         db.create_session(parent, source="tui")
         _stamp(db, parent, "cli_close", age=60.0)
+        _host_reopen(db, parent)
         _admit(db, parent)
         _publish(db, parent, "C_1", holder=_lease(db, parent))
         db.release_session_turn_lease(parent, TURN)
+        _host_reopen(db, "C_1")  # nothing to clear on the live continuation
         _admit(db, "C_1", holder=TURN_2)
         _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"))
         assert db.get_session("C_1")["end_reason"] == "compression"
         assert db.get_session("C_2")["parent_session_id"] == "C_1"
 
-    def test_stale_close_on_a_compression_child_is_healed_on_that_row(self, db: SessionDB) -> None:
-        """The turn lease is keyed by the lineage root; the stamp cleared is the admitted segment's."""
+    def test_a_stale_close_on_a_compression_child_is_cleared_on_that_row(self, db: SessionDB) -> None:
+        """The host reopens the row the turn writes to -- the compression tip -- not the lineage root."""
         root = "P_root"
         db.create_session(root, source="tui")
         _admit(db, root)
         _publish(db, root, "C_1", holder=_lease(db, root))
         db.release_session_turn_lease(root, TURN)
         _stamp(db, "C_1", "tui_close", age=60.0)
-        assert db._session_turn_lease_key("C_1") == root
 
+        assert _host_reopen(db, "C_1") == "tui_close"
+        assert db.get_session(root)["end_reason"] == "compression"  # the root's stamp is lineage, untouched
         _admit(db, "C_1", holder=TURN_2)
-        assert _live(db, "C_1")
-        assert db.get_session(root)["end_reason"] == "compression"  # the root's own stamp is lineage, untouched
         _publish(db, "C_1", "C_2", holder=_lease(db, "C_1"))
         assert db.get_session("C_2")["parent_session_id"] == "C_1"
 
-    @pytest.mark.parametrize("reason", ["ws_disconnect", "compression", *BOUNDARIES])
-    def test_admission_leaves_every_other_stamp_alone(self, db: SessionDB, reason: str) -> None:
-        sid = f"S_{reason}"
-        db.create_session(sid, source="tui")
-        _stamp(db, sid, reason, age=60.0)
-        _admit(db, sid)
-        row = db.get_session(sid)
-        assert row["end_reason"] == reason and row["ended_at"] is not None
-
-    def test_admission_leaves_a_superseded_explicit_close_alone(self, db: SessionDB) -> None:
-        parent = "P_superseded_admit"
+    def test_a_stamp_that_lands_mid_turn_costs_that_turn_only(self, db: SessionDB) -> None:
+        """A foreign writer's mis-stamp during the turn cannot be told from a deliberate close, so that
+        rotation fails closed; the host's reopen on the next prompt clears it and the rotation publishes."""
+        parent = "P_mid_turn"
         db.create_session(parent, source="tui")
+        _host_reopen(db, parent)
         _admit(db, parent)
-        _publish(db, parent, "C_first", holder=_lease(db, parent))  # a continuation now exists
+        _stamp(db, parent, "webhook_complete")
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
+            _publish(db, parent, "C_never", holder=_lease(db, parent))
+        assert db.get_session("C_never") is None
+        db.release_compression_lock(parent, HOLDER)
         db.release_session_turn_lease(parent, TURN)
-        db.reopen_session(parent)
-        _stamp(db, parent, "tui_close", age=60.0)
-        _admit(db, parent, holder=TURN_2)
-        assert db.get_session(parent)["end_reason"] == "tui_close"
 
-    def test_a_refused_admission_heals_nothing(self, db: SessionDB) -> None:
-        """Only an ADMITTED turn is evidence; a claim refused because another live holder owns the
-        turn must leave the row exactly as it found it."""
-        parent = "P_busy"
-        db.create_session(parent, source="tui")
-        _admit(db, parent, holder=OTHER_PROCESS)  # another live holder owns the turn
-        _stamp(db, parent, "tui_close", age=60.0)
-        assert not db.try_acquire_session_turn_lease(parent, TURN, ttl_seconds=300.0)
-        assert db.get_session(parent)["end_reason"] == "tui_close"
+        assert _host_reopen(db, parent) == "webhook_complete"
+        _admit(db, parent, holder=TURN_2)
+        _publish(db, parent, "C_next", holder=_lease(db, parent))
+        assert db.get_session(parent)["end_reason"] == "compression"
+        assert db.get_session("C_next")["parent_session_id"] == parent
 
 
 class TestADeliberateCloseIsNeverHealedAtPublication:
     def test_close_during_compression_fails_closed(self, db: SessionDB) -> None:
-        """First probe: lease, then the user closes, then publish."""
+        """First review probe: lease, then the user closes, then publish."""
         parent = "P_closed_mid_compression"
         db.create_session(parent, source="tui")
         _admit(db, parent)
@@ -190,7 +246,7 @@ class TestADeliberateCloseIsNeverHealedAtPublication:
         assert db.get_session(parent)["end_reason"] == "tui_close"  # the user's close survives
 
     def test_close_after_the_turn_was_admitted_fails_closed(self, db: SessionDB) -> None:
-        """Second probe: the turn is running, ``session.close`` stamps after its grace without
+        """Second review probe: the turn is running, ``session.close`` stamps after its grace without
         interrupting the turn thread, and that thread then takes the compression lease."""
         parent = "P_closed_during_turn"
         db.create_session(parent, source="tui")
@@ -203,55 +259,47 @@ class TestADeliberateCloseIsNeverHealedAtPublication:
         assert db.get_session("C_never") is None
         assert db.get_session(parent)["end_reason"] == "tui_close"
 
-    def test_close_during_a_turn_that_began_on_a_stale_stamp_is_recorded_and_wins(self, db: SessionDB) -> None:
-        """Third probe: the turn is admitted on a row carrying the stale stamp this fix heals, then the
-        user closes during the turn. Admission cleared the stale stamp, so the close is recorded
-        (first-stamp-wins would have dropped it) and publication preserves it."""
+    def test_close_during_a_turn_that_began_on_a_stale_stamp_is_not_resurrected(self, db: SessionDB) -> None:
+        """Third review probe, store only: the turn began on the stale stamp this fix targets, the user's
+        close during it is a no-op write under first-stamp-wins, and publication must still refuse."""
         parent = "P_stale_then_closed"
         db.create_session(parent, source="tui")
         _stamp(db, parent, "tui_close", age=60.0)
-        before = time.time()
         _admit(db, parent)
-        assert _live(db, parent)
-        db.end_session(parent, "tui_close")  # the user's close, now an actual write
-        holder = _lease(db, parent)
-
+        db.end_session(parent, "tui_close")  # no-op: the stale stamp already occupies the row
         with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
-            _publish(db, parent, "C_never", holder=holder)
+            _publish(db, parent, "C_never", holder=_lease(db, parent))
         assert db.get_session("C_never") is None
+        assert db.get_session(parent)["end_reason"] == "tui_close"
+
+    def test_after_the_host_reopen_a_close_during_the_turn_is_recorded_and_wins(self, db: SessionDB) -> None:
+        """Third review probe on the host path: the TUI cleared the stale stamp as it started the turn, so
+        the user's close during it is an actual write with a fresh timestamp, and publication preserves it."""
+        parent = "P_host_then_closed"
+        db.create_session(parent, source="tui")
+        _stamp(db, parent, "tui_close", age=60.0)
+        assert _host_reopen(db, parent) == "tui_close"
+        _admit(db, parent)
+        before = time.time()
+        db.end_session(parent, "tui_close")
+        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
+            _publish(db, parent, "C_never", holder=_lease(db, parent))
         row = db.get_session(parent)
         assert row["end_reason"] == "tui_close" and row["ended_at"] >= before, "the fresh close, not the stale one"
 
     @pytest.mark.parametrize("reason", STALE_EXPLICIT_CLOSES)
-    def test_without_an_admitted_turn_a_stale_close_is_not_healed(self, db: SessionDB, reason: str) -> None:
-        parent = f"P_noturn_{reason}"
+    def test_without_the_host_a_stale_close_is_not_healed(self, db: SessionDB, reason: str) -> None:
+        parent = f"P_nohost_{reason}"
         db.create_session(parent, source="tui")
         _stamp(db, parent, reason, age=60.0)
-        holder = _lease(db, parent)  # a compression lease is publication ownership, not evidence
+        _admit(db, parent)
+        holder = _lease(db, parent)  # neither lease is evidence
         with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
             _publish(db, parent, f"C_{reason}", holder=holder)
         with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
             _publish(db, parent, f"C_{reason}")  # lease-less publication: same contract
         assert db.get_session(f"C_{reason}") is None
         assert db.get_session(parent)["end_reason"] == reason
-
-    def test_a_stamp_that_lands_mid_turn_costs_that_turn_only(self, db: SessionDB) -> None:
-        """A foreign writer's mis-stamp during the turn cannot be told from a deliberate close, so that
-        rotation fails closed; the next admitted turn heals it and rotates."""
-        parent = "P_mid_turn"
-        db.create_session(parent, source="tui")
-        _admit(db, parent)
-        _stamp(db, parent, "webhook_complete")
-        with pytest.raises(RuntimeError, match=f"already ended.*{NOT_HEALED}"):
-            _publish(db, parent, "C_never", holder=_lease(db, parent))
-        assert db.get_session("C_never") is None
-        db.release_compression_lock(parent, HOLDER)
-        db.release_session_turn_lease(parent, TURN)
-
-        _admit(db, parent, holder=TURN_2)
-        _publish(db, parent, "C_next", holder=_lease(db, parent))
-        assert db.get_session(parent)["end_reason"] == "compression"
-        assert db.get_session("C_next")["parent_session_id"] == parent
 
 
 class TestLineageOwnedElsewhereStillFailsClosed:
@@ -264,6 +312,7 @@ class TestLineageOwnedElsewhereStillFailsClosed:
         db.release_session_turn_lease(parent, TURN)
         db.reopen_session(parent)
         _stamp(db, parent, "tui_close", age=60.0)
+        assert _host_reopen(db, parent) is None
         _admit(db, parent, holder=TURN_2)
         holder = _lease(db, parent, holder="second-writer")
 
@@ -273,11 +322,12 @@ class TestLineageOwnedElsewhereStillFailsClosed:
         assert db.get_session(parent)["end_reason"] == "tui_close"  # untouched
 
     @pytest.mark.parametrize("reason", BOUNDARIES)
-    def test_boundary_fails_closed_even_after_admission(self, db: SessionDB, reason: str) -> None:
+    def test_boundary_fails_closed_even_after_a_host_reopen(self, db: SessionDB, reason: str) -> None:
         assert reason in _RESET_END_REASONS or reason == "new_session"  # CLI /new is a boundary too
         parent = f"P_{reason}"
         db.create_session(parent, source="tui")
         _stamp(db, parent, reason, age=60.0)
+        assert _host_reopen(db, parent) is None
         _admit(db, parent)
         with pytest.raises(RuntimeError, match=f"already ended.*{reason} boundary"):
             _publish(db, parent, f"C_{reason}", holder=_lease(db, parent))
@@ -288,6 +338,7 @@ class TestLineageOwnedElsewhereStillFailsClosed:
         parent = "P_compression"
         db.create_session(parent, source="tui")
         _stamp(db, parent, "compression", age=60.0)
+        assert _host_reopen(db, parent) is None
         _admit(db, parent)
         with pytest.raises(RuntimeError, match="already ended.*closed by compression"):
             _publish(db, parent, "C_x", holder=_lease(db, parent))
@@ -305,9 +356,10 @@ class TestVerdictIsSharedWithTheAgentGuard:
 
         db.create_session("stale", source="tui")
         _stamp(db, "stale", "tui_close", age=60.0)
-        assert db.compression_parent_deliberately_ended("stale") is True  # not healed until a turn is admitted
         _admit(db, "stale")
-        assert db.compression_parent_deliberately_ended("stale") is False  # healed at admission
+        assert db.compression_parent_deliberately_ended("stale") is True  # admission is not provenance
+        _host_reopen(db, "stale")
+        assert db.compression_parent_deliberately_ended("stale") is False
 
         db.create_session("closed_mid", source="tui")
         _admit(db, "closed_mid")
@@ -317,17 +369,15 @@ class TestVerdictIsSharedWithTheAgentGuard:
         for sid, reason in [("reset", "session_reset"), ("new", "new_session"), ("comp", "compression")]:
             db.create_session(sid, source="tui")
             _stamp(db, sid, reason, age=60.0)
-            _admit(db, sid)
+            _host_reopen(db, sid)
             assert db.compression_parent_deliberately_ended(sid) is True, (sid, reason)
 
         db.create_session("superseded", source="tui")
-        _admit(db, "superseded")
         _publish(db, "superseded", "superseded_child", holder=_lease(db, "superseded"))
         db.release_compression_lock("superseded", HOLDER)
-        db.release_session_turn_lease("superseded", TURN)
         db.reopen_session("superseded")
         _stamp(db, "superseded", "cli_close", age=60.0)
-        _admit(db, "superseded", holder=TURN_2)
+        _host_reopen(db, "superseded")
         assert db.compression_parent_deliberately_ended("superseded") is True
         assert db.compression_parent_deliberately_ended("missing") is False
         assert db.compression_parent_deliberately_ended("") is False
@@ -337,12 +387,12 @@ class TestVerdictIsSharedWithTheAgentGuard:
 
         db.create_session("stale", source="tui")
         _stamp(db, "stale", "tui_close", age=60.0)
-        assert _parent_deliberately_ended(db, "stale") is True
         _admit(db, "stale")
+        assert _parent_deliberately_ended(db, "stale") is True
+        _host_reopen(db, "stale")
         assert _parent_deliberately_ended(db, "stale") is False
         db.create_session("reset", source="tui")
         _stamp(db, "reset", "session_reset", age=60.0)
-        _admit(db, "reset")
         assert _parent_deliberately_ended(db, "reset") is True
 
     def test_agent_guard_fails_open_and_keeps_the_taxonomy_fallback(self) -> None:
@@ -404,13 +454,14 @@ class TestRotationEndToEnd:
         msgs = [{"role": "user", "content": f"m{i}"} for i in range(20)]
         agent._compress_context(list(msgs), "sys", approx_tokens=120_000)
 
-    def test_stale_explicit_close_does_not_wedge_rotation(self, db: SessionDB) -> None:
-        """#106459 end-to-end: the live session's row carries an explicit-close stamp that predates
-        the turn, and auto-compaction still rotates instead of computing and discarding forever."""
+    def test_a_stale_close_cleared_by_the_host_does_not_wedge_rotation(self, db: SessionDB) -> None:
+        """#106459 end-to-end: the live session's row carries an explicit-close stamp that predates the
+        turn; the routing host clears it as the turn starts, and auto-compaction rotates."""
         parent = "PARENT_106459_E2E"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
         _stamp(db, parent, "tui_close", age=60.0)
+        _host_reopen(db, parent)
         self._admit_turn(db, agent, parent)
 
         self._compress(agent)
@@ -420,12 +471,27 @@ class TestRotationEndToEnd:
         child_row = db.get_session(agent.session_id)
         assert child_row is not None and child_row["parent_session_id"] == parent
 
-    def test_close_during_a_turn_that_began_on_a_stale_stamp_aborts_rotation(self, db: SessionDB) -> None:
-        """Third probe end-to-end: stale stamp, admit the turn, the user closes during it, compress."""
-        parent = "PARENT_106459_STALE_THEN_CLOSED"
+    def test_without_the_host_an_admitted_turn_does_not_rotate_over_a_close(self, db: SessionDB) -> None:
+        """The inverse of the previous revision's contract: a turn lease alone never clears the stamp."""
+        parent = "PARENT_106459_ADMIT_ONLY"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
         _stamp(db, parent, "tui_close", age=60.0)
+        self._admit_turn(db, agent, parent)
+
+        self._compress(agent)
+
+        assert agent.session_id == parent
+        assert db.get_session(parent)["end_reason"] == "tui_close"
+        assert db._read_one("SELECT COUNT(*) FROM sessions WHERE parent_session_id = ?", (parent,))[0] == 0
+
+    def test_close_during_a_turn_the_host_reopened_aborts_rotation(self, db: SessionDB) -> None:
+        """Third probe end-to-end on the host path: stale stamp, host reopen, admit, close, compress."""
+        parent = "PARENT_106459_HOST_THEN_CLOSED"
+        db.create_session(parent, source="tui")
+        agent = self._build_agent(db, parent)
+        _stamp(db, parent, "tui_close", age=60.0)
+        _host_reopen(db, parent)
         self._admit_turn(db, agent, parent)
         before = time.time()
         db.end_session(parent, "tui_close")  # session.close during the turn
@@ -471,25 +537,13 @@ class TestRotationEndToEnd:
         assert agent.session_id == parent, "a close made mid-compression must not be resurrected"
         assert db.get_session(parent)["end_reason"] == "tui_close"
 
-    def test_without_an_admitted_turn_a_stale_close_is_not_healed(self, db: SessionDB) -> None:
-        """No turn lease (a caller outside the façade): nothing healed the stamp, so the pre-#106459
-        contract stands and the close is preserved."""
-        parent = "PARENT_106459_NO_TURN"
-        db.create_session(parent, source="tui")
-        agent = self._build_agent(db, parent)
-        _stamp(db, parent, "tui_close", age=60.0)
-
-        self._compress(agent)
-
-        assert agent.session_id == parent
-        assert db.get_session(parent)["end_reason"] == "tui_close"
-
     @pytest.mark.parametrize("reason", ["session_reset", "new_session"])
     def test_boundary_still_aborts_rotation(self, db: SessionDB, reason: str) -> None:
         parent = f"PARENT_106459_{reason}"
         db.create_session(parent, source="tui")
         agent = self._build_agent(db, parent)
         _stamp(db, parent, reason, age=60.0)
+        _host_reopen(db, parent)
         self._admit_turn(db, agent, parent)
 
         self._compress(agent)

--- a/tests/hermes_state/test_88197_automatic_ended_stamp.py
+++ b/tests/hermes_state/test_88197_automatic_ended_stamp.py
@@ -94,7 +94,9 @@ class TestPublishHealsAutomaticStamp:
         assert child_row is not None
         assert child_row["parent_session_id"] == parent
 
-    @pytest.mark.parametrize("reason", ["compression", "session_reset", "tui_close"])
+    # ``tui_close`` with no continuation child is a stale stamp since #106459 and now publishes;
+    # the explicit-close cases live in test_106459_stale_explicit_close_stamp.py.
+    @pytest.mark.parametrize("reason", ["compression", "session_reset"])
     def test_deliberate_boundary_still_fails_closed(
         self, db: SessionDB, reason: str
     ) -> None:

--- a/tests/hermes_state/test_88197_automatic_ended_stamp.py
+++ b/tests/hermes_state/test_88197_automatic_ended_stamp.py
@@ -94,9 +94,7 @@ class TestPublishHealsAutomaticStamp:
         assert child_row is not None
         assert child_row["parent_session_id"] == parent
 
-    # ``tui_close`` with no continuation child is a stale stamp since #106459 and now publishes;
-    # the explicit-close cases live in test_106459_stale_explicit_close_stamp.py.
-    @pytest.mark.parametrize("reason", ["compression", "session_reset"])
+    @pytest.mark.parametrize("reason", ["compression", "session_reset", "tui_close"])
     def test_deliberate_boundary_still_fails_closed(
         self, db: SessionDB, reason: str
     ) -> None:

--- a/tests/tui_gateway/test_106459_routing_provenance_reopen.py
+++ b/tests/tui_gateway/test_106459_routing_provenance_reopen.py
@@ -1,0 +1,324 @@
+"""#106459 routing provenance: the TUI clears a stale explicit-close stamp only for a session it
+still has registered, under ``_sessions_lock`` as it starts a turn, and never once the session has
+been claimed for teardown.
+
+Fourth review probe on #106543: the TUI accepts a prompt and starts a worker before that worker
+reaches ``run_conversation()`` and takes its turn lease, so ``session.close`` can pop the session,
+wait out its grace and stamp ``tui_close`` in between. Clearing the stamp on lease acquisition
+turned that deliberate close back into a live row. The clear now happens in ``_run_prompt_submit``
+while ``_sessions_lock`` is held and the session is still registered -- the lock
+``_pop_session_by_id`` claims teardown under -- and a late lease clears nothing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from tui_gateway import server
+
+TURN = f"pid={os.getpid()}:turn=tui:platform=tui"
+# Captured at import: several tests replace ``threading.Thread`` (module-global) with a synchronous stand-in,
+# and a lock probe must run on a genuinely different thread or an RLock simply re-enters.
+_RealThread = threading.Thread
+
+
+class _ImmediateThread:
+    """Run the turn inside ``start()`` so tests observe its final state synchronously."""
+
+    def __init__(self, target=None, daemon=None, **_kwargs):
+        self._target = target
+
+    def start(self):
+        if self._target is not None:
+            self._target()
+
+    def is_alive(self):
+        return False
+
+    def join(self, timeout=None):
+        return None
+
+
+class _Agent:
+    model = "test-model"
+    provider = "test-provider"
+
+    def __init__(self, session_id: str, db: SessionDB, *, before_lease=None):
+        self.session_id = session_id
+        self._db = db
+        self._before_lease = before_lease
+        self.turns: list = []
+        self.stamp_seen_by_turn: list = []
+
+    def clear_interrupt(self):
+        return None
+
+    def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        if self._before_lease is not None:
+            self._before_lease()
+        # What admit_durable_turn_lease does at the top of the real run_conversation.
+        self._db.try_acquire_session_turn_lease(self.session_id, TURN, ttl_seconds=300.0)
+        self.stamp_seen_by_turn.append(self._db.get_session(self.session_id)["end_reason"])
+        self.turns.append(prompt)
+        return {"final_response": "", "messages": []}
+
+
+def _session(agent: _Agent, **extra) -> dict:
+    return {
+        "agent": agent,
+        "session_key": agent.session_id,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": True,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+        "inflight_turn": None,
+        **extra,
+    }
+
+
+@pytest.fixture
+def db(tmp_path: Path):
+    handle = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield handle
+    finally:
+        handle.close()
+
+
+@pytest.fixture
+def turn_env(monkeypatch, tmp_path, db):
+    """The immediate-prompt harness of tests/test_tui_gateway_server.py, with a real SessionDB."""
+    monkeypatch.setattr(server, "_emit", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
+    monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_a: None)
+    monkeypatch.setattr(server, "_session_cwd", lambda _session: str(tmp_path))
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda *_a, **_k: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_a: {})
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *_a, **_k: None)
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_a: False)
+    monkeypatch.setattr(server, "_voice_tts_enabled", lambda: False)
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    return monkeypatch
+
+
+@pytest.fixture
+def registry():
+    """Sessions registered by a test, removed afterwards."""
+    added: list[str] = []
+
+    def _add(sid: str, session: dict) -> dict:
+        server._sessions[sid] = session
+        added.append(sid)
+        return session
+
+    yield _add
+    for sid in added:
+        server._sessions.pop(sid, None)
+
+
+def _stamp(db: SessionDB, row_id: str, reason: str = "tui_close", *, age: float = 60.0) -> None:
+    db.end_session(row_id, reason)
+    if age:
+        db._write_sql("UPDATE sessions SET ended_at = ? WHERE id = ?", (time.time() - age, row_id))
+
+
+def test_a_registered_session_is_reopened_before_its_turn_starts(turn_env, db, registry):
+    """The #106459 field shape: the TUI keeps accepting prompts on a session whose row carries a
+    stale ``tui_close``. The row must already be clear when the worker runs."""
+    turn_env.setattr(server.threading, "Thread", _ImmediateThread)
+    db.create_session("row-1", source="tui")
+    _stamp(db, "row-1")
+    agent = _Agent("row-1", db)
+    session = registry("ui-1", _session(agent))
+
+    assert server._run_prompt_submit("rid", "ui-1", session, "go") is True
+
+    assert agent.turns == ["go"]
+    assert agent.stamp_seen_by_turn == [None], "the stamp must be cleared before the worker starts"
+    row = db.get_session("row-1")
+    assert row["ended_at"] is None and row["end_reason"] is None
+
+
+@pytest.mark.parametrize("reason", ["session_reset", "new_session", "compression", "ws_disconnect"])
+def test_only_explicit_closes_are_reopened(turn_env, db, registry, reason):
+    turn_env.setattr(server.threading, "Thread", _ImmediateThread)
+    db.create_session("row-2", source="tui")
+    _stamp(db, "row-2", reason)
+    session = registry("ui-2", _session(_Agent("row-2", db)))
+
+    server._run_prompt_submit("rid", "ui-2", session, "go")
+
+    assert db.get_session("row-2")["end_reason"] == reason
+
+
+def test_an_unregistered_session_runs_its_turn_but_keeps_its_stamp(turn_env, db):
+    """``can_start`` also admits a session that is not in the registry; nothing proves it is routed
+    here, so its turn runs as before but its stamp is not cleared."""
+    turn_env.setattr(server.threading, "Thread", _ImmediateThread)
+    db.create_session("row-3", source="tui")
+    _stamp(db, "row-3")
+    agent = _Agent("row-3", db)
+
+    assert server._run_prompt_submit("rid", "ui-3", _session(agent), "go") is True
+
+    assert agent.turns == ["go"]
+    assert agent.stamp_seen_by_turn == ["tui_close"]
+    assert db.get_session("row-3")["end_reason"] == "tui_close"
+
+
+def test_a_session_already_claimed_for_teardown_is_not_reopened(turn_env, db, registry):
+    turn_env.setattr(server.threading, "Thread", _ImmediateThread)
+    db.create_session("row-4", source="tui")
+    _stamp(db, "row-4")
+    agent = _Agent("row-4", db)
+    session = registry("ui-4", _session(agent))
+    assert server._pop_session_by_id("ui-4") is session  # session.close claimed it
+
+    assert server._run_prompt_submit("rid", "ui-4", session, "go") is False
+
+    assert agent.turns == []
+    assert db.get_session("row-4")["end_reason"] == "tui_close"
+
+
+def test_a_close_that_wins_the_race_after_admission_is_not_reopened(turn_env, db, registry):
+    """``_admit_prompt_turn`` checks ``_closing`` under ``history_lock`` only, which does not exclude
+    ``_pop_session_by_id``. A close claimed between admission and the start gate must keep its row's
+    stamp -- the heal belongs under ``_sessions_lock`` with the gate, not in admission."""
+    db.create_session("row-5", source="tui")
+    _stamp(db, "row-5")
+    agent = _Agent("row-5", db)
+    session = registry("ui-5", _session(agent))
+    emit_entered, release_emit = threading.Event(), threading.Event()
+
+    def _blocking_emit(event, *_a, **_k):
+        if event == "message.start":
+            emit_entered.set()
+            assert release_emit.wait(timeout=2.0)
+
+    turn_env.setattr(server, "_emit", _blocking_emit)
+    results: list = []
+    dispatch = threading.Thread(target=lambda: results.append(
+        server._run_prompt_submit("rid", "ui-5", session, "go")))
+    try:
+        dispatch.start()
+        assert emit_entered.wait(timeout=1.0)
+        assert server._pop_session_by_id("ui-5") is session
+    finally:
+        release_emit.set()
+        dispatch.join(timeout=2.0)
+
+    assert results == [False]
+    assert agent.turns == []
+    assert db.get_session("row-5")["end_reason"] == "tui_close"
+
+
+def test_a_late_worker_lease_after_session_close_leaves_the_close(turn_env, db, registry):
+    """Fourth review probe: the prompt is accepted and the worker started, the user closes the session
+    (pop, bounded grace, ``tui_close``) while the worker is still in pre-turn work, and only then does
+    the worker take its turn lease. Nothing re-applies the close afterwards, so it must survive."""
+    db.create_session("row-6", source="tui")
+    worker_waiting, release_worker = threading.Event(), threading.Event()
+
+    def _hold_before_lease():
+        worker_waiting.set()
+        assert release_worker.wait(timeout=5.0)
+
+    agent = _Agent("row-6", db, before_lease=_hold_before_lease)
+    session = registry("ui-6", _session(agent))
+    stamped: list = []
+
+    def _teardown(popped, *, end_reason="tui_close"):
+        db.end_session(popped["agent"].session_id, end_reason)  # what _finalize_session writes
+        stamped.append(end_reason)
+
+    turn_env.setattr(server, "_teardown_session", _teardown)
+    turn_env.setattr(server, "_TURN_SETTLE_BEFORE_CLOSE_SECONDS", 0.2, raising=False)
+    try:
+        assert server._run_prompt_submit("rid", "ui-6", session, "go") is True
+        assert worker_waiting.wait(timeout=2.0)
+        assert server._close_session_by_id("ui-6") is True
+        assert stamped == ["tui_close"]
+    finally:
+        release_worker.set()
+        worker = session.get("_run_thread")
+        if worker is not None:
+            worker.join(timeout=5.0)
+
+    assert agent.turns == ["go"]  # the late worker still runs its turn, as at the merge base
+    assert agent.stamp_seen_by_turn == ["tui_close"]
+    assert db.get_session("row-6")["end_reason"] == "tui_close"
+
+
+def test_the_session_db_is_resolved_before_the_sessions_lock_is_taken(turn_env, db, registry):
+    """Resolving a profile session's handle goes through the state registry; it must not run under the
+    lock that gates every create/close/prompt on this backend."""
+    turn_env.setattr(server.threading, "Thread", _ImmediateThread)
+    db.create_session("row-7", source="tui")
+    _stamp(db, "row-7")
+    session = registry("ui-7", _session(_Agent("row-7", db)))
+    real_session_db = server._session_db
+    lock_free_at_resolution: list[bool] = []
+
+    @contextlib.contextmanager
+    def _probing_session_db(sess):
+        callers = {sys._getframe(depth).f_code.co_name for depth in range(1, 5)}
+        if "_run_prompt_submit" in callers:
+            probe: list[bool] = []
+
+            def _try_lock_from_another_thread():
+                # Acquire and release on the SAME thread: an RLock left owned by a finished thread stays held.
+                got = server._sessions_lock.acquire(timeout=0.5)
+                probe.append(got)
+                if got:
+                    server._sessions_lock.release()
+
+            prober = _RealThread(target=_try_lock_from_another_thread)
+            prober.start()
+            prober.join()
+            lock_free_at_resolution.append(bool(probe and probe[0]))
+        with real_session_db(sess) as handle:
+            yield handle
+
+    turn_env.setattr(server, "_session_db", _probing_session_db)
+
+    assert server._run_prompt_submit("rid", "ui-7", session, "go") is True
+
+    assert lock_free_at_resolution == [True]
+    assert db.get_session("row-7")["end_reason"] is None
+
+
+def test_a_failed_routing_reopen_never_blocks_the_turn(turn_env, db, registry):
+    turn_env.setattr(server.threading, "Thread", _ImmediateThread)
+    db.create_session("row-8", source="tui")
+    _stamp(db, "row-8")
+    agent = _Agent("row-8", db)
+    session = registry("ui-8", _session(agent))
+
+    def _unavailable(*_a, **_k):
+        raise RuntimeError("database is locked")
+
+    turn_env.setattr(db, "reopen_if_explicitly_closed", _unavailable)
+
+    assert server._run_prompt_submit("rid", "ui-8", session, "go") is True
+
+    assert agent.turns == ["go"]
+    assert db.get_session("row-8")["end_reason"] == "tui_close"

--- a/tests/tui_gateway/test_bot_live_owner_delivery.py
+++ b/tests/tui_gateway/test_bot_live_owner_delivery.py
@@ -8,6 +8,7 @@ from tui_gateway.turn_marker import record_turn_start, read_turn_marker
 
 
 def test_refused_input_commits_failed_mailbox_receipt(tmp_path):
+    import contextlib
     import contextvars
     import logging
     import time
@@ -34,6 +35,8 @@ def test_refused_input_commits_failed_mailbox_receipt(tmp_path):
         "_finish_turn": noop, "_clear_inflight_turn": noop,
         "_retire_turn_marker": lambda *args: retired.append(args),
         "_emit_settled_session_info": noop,
+        "_routing_provenance_db": lambda _session: contextlib.nullcontext(None),
+        "_reopen_routed_session_row": noop,
     })
     def terminal(outcome):
         mailbox.complete_delivery(tmp_path, queued["id"], status=outcome["status"],

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
-from hermes_state_common import _RESET_END_REASONS
+from hermes_state_common import _BOUNDARY_END_REASONS
 
 # Hidden from browsing/searching — integrations (HERMES_SESSION_SOURCE=tool), delegate
 # subagent runs, kanban workers are not the user's history.
@@ -36,8 +36,8 @@ _DISCOVER_SEARCH_FIELDS = ("id", "session_id", "role", "snippet", "source", "mod
 _COMPACTION_PREFIXES = ("[CONTEXT COMPACTION", "[CONTEXT SUMMARY]:")
 # /new, /reset, idle/daily expiry and CLI /new ("new_session") end the predecessor WITHOUT
 # carrying its transcript forward — unlike compression continuations and live delegation
-# children. Derived from the gateway set so the two cannot drift.
-_FRESH_RESET_END_REASONS = frozenset(_RESET_END_REASONS) | {"new_session"}
+# children. The store's boundary set, so the two cannot drift.
+_FRESH_RESET_END_REASONS = _BOUNDARY_END_REASONS
 
 
 def _quiet(fn, default, msg, *log_args, with_exc: bool = False):

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -747,6 +747,37 @@ def _finish_turn(sid: str, session: dict, st: _TurnRun) -> None:
     _clear_session_context(scopes.session_tokens)
 
 
+# Bounded so a contended state.db cannot hold ``_sessions_lock``; a skipped heal is retried on the next prompt.
+_ROUTING_REOPEN_PATIENCE_S = 0.5
+
+
+def _routing_provenance_db(session: dict):
+    """The session's own SessionDB for :func:`_reopen_routed_session_row`, or a ``None`` context."""
+    try:
+        return _session_db(session)
+    except Exception:
+        logger.debug("could not resolve the session db for routing provenance", exc_info=True)
+        return contextlib.nullcontext(None)
+
+
+def _reopen_routed_session_row(db, sid: str, session: dict) -> None:
+    """Routing provenance for #106459, called under ``_sessions_lock`` while this backend still has the
+    session registered and is about to start a turn for it: an explicit-close stamp on its row missed a
+    live conversation, so it is cleared (the gateway's #54878 stale-route self-heal, which this backend
+    lacked). ``_pop_session_by_id`` claims teardown under the same lock and sets ``_closing`` before
+    ``_finalize_session`` stamps, so a close of THIS session is either not written yet or already stops
+    the turn -- it is never cleared here. Best-effort: a failure never blocks the turn."""
+    session_id = getattr(session.get("agent"), "session_id", None)  # the compression tip this turn writes
+    if db is None or not session_id:
+        return
+    try:
+        db.reopen_if_explicitly_closed(
+            session_id, provenance=f"TUI session {sid} is still registered and accepting a turn",
+            patience_s=_ROUTING_REOPEN_PATIENCE_S)
+    except Exception:
+        logger.debug("routing-provenance reopen failed for %s", session_id, exc_info=True)
+
+
 def _run_prompt_submit(
     rid, sid: str, session: dict, text: Any, *, display_kind: str | None = None,
     display_metadata: dict | None = None, image_paths: list[str] | None = None,
@@ -842,10 +873,16 @@ def _run_prompt_submit(
             _emit_settled_session_info(sid, session, st.agent)
         _run_post_turn_followups(rid, sid, session, st.result, goal_followup)
     run_thread = threading.Thread(target=run, daemon=True)
-    with _sessions_lock:
+    # The handle is resolved BEFORE _sessions_lock: a profile session opens its own SessionDB through the
+    # state registry, and _sessions_lock gates every create/close/prompt on this backend.
+    with _routing_provenance_db(session) as routing_db, _sessions_lock:
         registered = _sessions.get(sid)
         can_start = not session.get("_closing") and (registered is None or registered is session)
         if can_start:
+            # Only a registered session is proof the conversation is routed here; an unregistered one may
+            # still run its turn, but its stamp stays (#106459).
+            if registered is session:
+                _reopen_routed_session_row(routing_db, sid, session)
             session["_run_thread"] = run_thread
             run_thread.start()
     if not can_start:


### PR DESCRIPTION
## What / Why

An over-limit session could become **permanently uncompressible**. `publish_compression_child()` failed closed on *any* non-automatic `end_reason`, and `end_session()` is first-stamp-wins, so a stale `tui_close` / `cli_close` / `webhook_complete` / `new_session` / gateway-recovery / cron stamp on a still-routed session turned every rotation into "compute the summary, then discard it at publication": the oversized history stayed, the next turn hit `Context length exceeded … Cannot compress further` again, and `/compress` reported "No changes". The agent's pre-flush guard (`_parent_deliberately_ended`) re-implemented the same taxonomy and aborted even earlier, so the two guards had to move together.

The store no longer decides on its own that an explicit close is stale. `_compression_parent_obstacle` (single verdict owner, shared with the agent's pre-flush guard) clears only automatic-cleanup stamps (#88197, unchanged) and fails closed on everything else: an explicit close, a `'compression'` stamp, a boundary (`session_reset`, `session_switch`, `idle`, `daily`, …, and CLI `/new`'s `new_session`, now the shared `_BOUNDARY_END_REASONS`), and an explicit close whose continuation child was already published. A stale explicit close is cleared only by the host that still routes the session, through `SessionDB.reopen_if_explicitly_closed()`: a narrow twin of `reopen_session()` that clears only an explicit close with no published continuation, conditional on the exact stamp it read, and logs the caller's provenance. The TUI — the host in the reporter's log, which kept accepting prompts on a `tui_close`-stamped session — calls it in `_run_prompt_submit` under `_sessions_lock`, in the same critical section as the `can_start` gate and before the turn worker starts, only while the session is still registered and not closing. `_pop_session_by_id` claims teardown under that lock and sets `_closing` before `_finalize_session` stamps, so a close of that session is never cleared. This is the gateway's #54878 stale-route self-heal applied to the TUI's registry. Neither publication nor turn-lease admission can do it safely (details in the review thread): `end_session()` is first-stamp-wins, so a close made during a turn that began on a stale stamp is a no-op write, and a TUI worker can take its turn lease after the host has already closed the session. The agent guard asks the store (`compression_parent_deliberately_ended`, reading through `get_session` so an unreadable row keeps failing open) and retains its taxonomy-only fallback for stand-in stores.

**Known cost, left for a maintainer decision.** A wrong stamp that lands during a turn cannot be told from a deliberate close inside that turn, so that turn's rotation fails closed and the next prompt the host accepts clears it: one discarded summary and one context-length error, only when another writer mis-stamps a live row (#98495 class), instead of the permanent wedge. Relatedly, a session another process closed while this TUI still routes it is reopened by the next turn the TUI starts, as with the gateway's stale-route recovery. Fencing `end_session` by the session turn lease would remove the first cost at its source but changes cross-process close semantics; it is not folded in here and no separate issue is opened until a maintainer picks a direction (details in the review thread).

## Related Issue

Fixes #106459 (facet 1: persistence refuses a still-routed session). Refs #98495 (what stamps live gateway rows in the first place; not addressed here).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Changes Made

- `hermes_state_common.py`: `_BOUNDARY_END_REASONS` (reset reasons + `new_session`); `tools/session_search_tool.py` derives its fresh-reset set from it.
- `hermes_state_compression.py`: `_end_stamp_class` (single taxonomy owner); `reopen_if_explicitly_closed()`, the host-called narrow reopen; `_compression_parent_obstacle` / `compression_parent_deliberately_ended` fail closed on every non-automatic stamp; turn-lease admission is a plain lease claim again.
- `tui_gateway/prompt_turn.py`: the routing-provenance reopen in `_run_prompt_submit`, under `_sessions_lock` for a still-registered session, with the session's handle resolved before the lock, a 0.5 s write patience, and failures never blocking the turn.
- `agent/conversation_compression.py`: `_parent_deliberately_ended` delegates to the store's verdict; taxonomy fallback kept.
- `tests/hermes_state/test_106459_stale_explicit_close_stamp.py` (new, 50 cases): the narrow reopen clears each explicit close and leaves automatic, `compression`, boundary and superseded stamps alone; turn-lease admission clears nothing, including the late-worker lease; a host reopen lets the rotation publish, repeatedly and on a compression child; all four review probes are refused at publication with the close preserved; the verdict matches the agent guard; end to end through `_compress_context`, a host-cleared stale close rotates and an admitted turn alone does not.
- `tests/tui_gateway/test_106459_routing_provenance_reopen.py` (new, 11 cases): a registered stale session is cleared before its worker runs; only explicit reasons; an unregistered session keeps its stamp; a session popped for teardown is refused and not reopened; a close that wins the race between admission and the start gate keeps its stamp; the late-worker probe keeps `tui_close`; the handle is resolved outside `_sessions_lock`; a failed reopen never blocks the turn.
- `tests/tui_gateway/test_bot_live_owner_delivery.py`: the two new helpers are added to the namespace that test builds by hand for `_run_prompt_submit`.

## Non-goals (deliberately out of scope)

- The recovery affordance from the issue's item 2 (after N `Cannot compress further` on one session, offer a one-action escape). That is a surface/UX change across TUI/Desktop and worth its own issue; this PR keeps the state-layer fix self-contained.
- The upstream writer of spurious end stamps on live gateway rows (#98495): this PR makes such a stamp survivable, it does not stop it being written.
- Adoption of the live tip when the parent was genuinely closed by compression: unchanged, still fails closed here and is handled by the existing flush-chokepoint adoption.
- No change to `end_session()` first-stamp-wins semantics or the automatic-reason set; the reset reasons are unchanged, and CLI `new_session` joins them as a boundary through the shared `_BOUNDARY_END_REASONS`. Fencing `end_session()` by the session turn lease (which would remove the one-turn cost above at its source) is left for a maintainer decision.

## How to Test

```bash
cd hermes-agent && uv sync --frozen --extra dev
scripts/run_tests.sh tests/hermes_state/test_106459_stale_explicit_close_stamp.py \
  tests/tui_gateway/test_106459_routing_provenance_reopen.py \
  tests/tui_gateway/test_bot_live_owner_delivery.py \
  tests/hermes_state/test_88197_automatic_ended_stamp.py \
  tests/agent/test_compression_rotation_state.py \
  tests/run_agent/test_compression_closed_adoption.py \
  tests/state/test_compression_lineage_guard.py
```

Results at head `d2c4d908` (base `main` `fd6434b3`) via `scripts/run_tests.sh` with `HERMES_TEST_FILE_RETRIES=0`, over the 22 compression, turn-lease, orphan-sweep and session-search files, all 125 files under `tests/tui_gateway/`, and `tests/test_tui_gateway_server.py`:

| Environment | Result |
| --- | --- |
| macOS arm64, CPython 3.11.15 | 148 files, 2092 passed, 0 failed, 8 skipped |
| macOS arm64, CPython 3.12.13 | 148 files, 2092 passed, 0 failed, 8 skipped |

Mutation check (fifth commit), each against the two new suites; each turns cases red while the rest stay green:

| Mutation | Failures |
| --- | --- |
| reopen an unregistered session too | 1 |
| reopen in `_admit_prompt_turn`, outside `_sessions_lock` | 3 |
| reopen after `run_thread.start()` | 1 |
| the narrow reopen clears any stamp (compression, boundary) | 26 |
| turn-lease admission heals again (the previous revision) | 13 |
| publication heals explicit closes again | 15 |
| the session's handle resolved inside `_sessions_lock` | 1 |

`ruff check` and `git diff --check` pass.

Field check: on current `main` `145c713f` the reporter's shape (a row stamped `tui_close` an hour earlier, a new turn, compression publishes) is still refused. On this head the same row, driven through `_run_prompt_submit` for a session the TUI still has registered, is cleared before the worker runs (`test_a_registered_session_is_reopened_before_its_turn_starts`), and the rotation then publishes (`test_a_stale_close_cleared_by_the_host_does_not_wedge_rotation`).

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have searched existing PRs and issues to ensure this isn't a duplicate (claimed on #106459; no other PR references it)
- [x] My PR only contains changes related to this specific bug fix
- [x] I have run the relevant tests locally (`scripts/run_tests.sh` on the 14 compression-related files; the full suite was not run)
- [x] I have added tests for the behaviour I changed
- [x] Platform tested: macOS 26 arm64 (Python 3.11 and 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




