### PR TITLE
Pinned bot-mode sessions no longer vanish from the sidebar (#106171, salvage #106180 + #106188)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2873,8 +2873,10 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
                     db.set_session_title, session_id, "" if body["title"] is None else str(body["title"]))
             except ValueError as exc:
                 return _error_response(str(exc), 400, code="invalid_title")
-        for flag, setter in (("pinned", db.set_session_pinned), ("archived", db.set_session_archived),
-                             ("hidden", db.set_session_hidden)):
+        # Pinned last: set_session_pinned clears hidden, so a pin in the same request
+        # wins over an explicit hidden (same order as the dashboard's _RENAME_FLAG_SETTERS).
+        for flag, setter in (("archived", db.set_session_archived), ("hidden", db.set_session_hidden),
+                             ("pinned", db.set_session_pinned)):
             if flag in body:
                 await asyncio.to_thread(setter, session_id, body[flag])
         if "unread" in body:

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -876,8 +876,13 @@ class SessionSessionsMixin:
         return True
 
     def set_session_pinned(self, session_id: str, pinned: bool) -> bool:
-        """Pin/unpin a session and its compression lineage (pins are exempt from the auto_archive sweep)."""
-        return self._set_lineage_column("pinned", session_id, int(pinned))
+        """Pin/unpin a session and its compression lineage (pins are exempt from the auto_archive sweep).
+        Pinning also clears ``hidden``: a pin means "keep this visible", and a hidden+pinned row is
+        otherwise absent from both the default listing and the pinned back-fill (see #106171)."""
+        result = self._set_lineage_column("pinned", session_id, int(pinned))
+        if pinned:
+            self._set_lineage_column("hidden", session_id, 0)
+        return result
 
     def set_session_hidden(self, session_id: str, hidden: bool) -> bool:
         """Hide/unhide a session and its compression lineage from the default listing; still resumable."""

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -878,10 +878,18 @@ class SessionSessionsMixin:
     def set_session_pinned(self, session_id: str, pinned: bool) -> bool:
         """Pin/unpin a session and its compression lineage (pins are exempt from the auto_archive sweep).
         Pinning also clears ``hidden``: a pin means "keep this visible", and a hidden+pinned row is
-        otherwise absent from both the default listing and the pinned back-fill (see #106171)."""
+        otherwise absent from both the default listing and the pinned back-fill (see #106171).
+        Exempt the canonical Bot Chat (hidden + exact registry title): the desktop contract keeps it
+        hidden and reachable only through the bot row, and unhiding it would also disable the
+        rename guard in ``_set_session_title`` that protects its identity (see review on #106180)."""
         result = self._set_lineage_column("pinned", session_id, int(pinned))
         if pinned:
-            self._set_lineage_column("hidden", session_id, 0)
+            row = self.get_session(session_id)
+            is_canonical_bot_chat = bool(row) and bool(row.get("hidden")) and (
+                (row.get("title") or "") == self.CANONICAL_BOT_CHAT_TITLE
+            )
+            if not is_canonical_bot_chat:
+                self._set_lineage_column("hidden", session_id, 0)
         return result
 
     def set_session_hidden(self, session_id: str, hidden: bool) -> bool:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4448,6 +4448,19 @@ class TestSessionPinAndStaleArchive:
         assert db.set_session_pinned("s1", False) is True
         assert self._pinned(db, "s1") == 0
 
+    def test_pinning_a_hidden_session_makes_it_listable(self, db):
+        """A bot-tile session is born hidden (#106171). Pinning it must clear ``hidden``, or the
+        session is pinned-but-invisible: absent from both the default listing and the back-fill."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(session_id="s1", role="user", content="hi")
+        db.set_session_hidden("s1", True)
+
+        db.set_session_pinned("s1", True)
+
+        assert db.get_session("s1")["hidden"] == 0
+        listed_ids = [s["id"] for s in db.list_sessions_rich(min_message_count=1)]
+        assert "s1" in listed_ids
+
 
 
     # ── pinned back-fill past the page window ─────────────────────────────

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4461,7 +4461,17 @@ class TestSessionPinAndStaleArchive:
         listed_ids = [s["id"] for s in db.list_sessions_rich(min_message_count=1)]
         assert "s1" in listed_ids
 
+    def test_pinning_the_canonical_bot_chat_leaves_it_hidden(self, db):
+        """The canonical Bot Chat (hidden + exact registry title) is desktop-owned and must stay
+        hidden even when pinned, or it leaks into the Sessions sidebar and loses its rename guard
+        (review on #106180). Unlike an ordinary hidden session, pinning must not clear ``hidden``."""
+        db.create_session(session_id="bot1", source="desktop")
+        db.set_session_title("bot1", db.CANONICAL_BOT_CHAT_TITLE)
+        db.set_session_hidden("bot1", True)
 
+        db.set_session_pinned("bot1", True)
+
+        assert db.get_session("bot1")["hidden"] == 1
 
     # ── pinned back-fill past the page window ─────────────────────────────
     def test_pinned_session_survives_the_limit_window(self, db):


### PR DESCRIPTION
Pinning a bot-mode (hidden) session now makes it appear in the Desktop sidebar's Pinned section instead of silently vanishing.

- `hermes_state_sessions.py::set_session_pinned` clears `hidden` across the compression lineage when `pinned=True`. Every pin path (gateway PATCH, dashboard PATCH, `hermes sessions pin`) funnels through this setter, so all three are fixed by one change.
- The canonical Bot Chat (hidden + title exactly `Bot Chat`) is exempt: the desktop contract keeps it hidden and reachable only through the bot row, and unhiding it would also switch off the rename guard in `hermes_state_titles.py::_set_session_title` that protects its identity.
- `gateway/platforms/api_server.py::_handle_patch_session` applies flags `archived → hidden → pinned` (the order the dashboard's `_RENAME_FLAG_SETTERS` already uses), so a `{pinned: true, hidden: true}` body ends visible + pinned instead of re-hiding the row it just pinned.
- Tests: 2 invariant tests in `tests/test_hermes_state.py` (pin unhides + becomes listable; canonical Bot Chat stays hidden). Both proven red on `origin/main`.

**Root cause:** the pin write only ever set `pinned=1`; both the default listing and the `include_pinned` back-fill filter on `s.hidden = 0`, so `pinned=1, hidden=1` was listed nowhere.

## Validation

Live repro with a real `SessionDB` in a temp `HERMES_HOME` (`/tmp/repro_pinned_hidden.py`: create → message → `set_session_hidden(True)` → `set_session_pinned(True)` → `list_sessions_rich(min_message_count=1, include_pinned=True)`):

```
== BEFORE (origin/main 511633be90e)
row: pinned=1 hidden=1
sidebar listing (include_pinned): []
RESULT: INVISIBLE (bug fires)
canonical Bot Chat after pin: hidden=1 in_sidebar=False

== AFTER (979f2973209)
row: pinned=1 hidden=0
sidebar listing (include_pinned): ['bot_tile']
RESULT: VISIBLE
canonical Bot Chat after pin: hidden=1 in_sidebar=False
```

Sabotage: with `origin/main`'s `hermes_state_sessions.py` swapped in, `test_pinning_a_hidden_session_makes_it_listable` fails (`hidden` still 1). With `origin/main`'s PATCH flag order swapped in, a `{pinned: true, hidden: true}` PATCH leaves `hidden=1` (verified against #106188's PATCH test before dropping it).

`scripts/run_tests.sh tests/test_hermes_state.py tests/hermes_state/test_session_hidden.py tests/hermes_state/test_canonical_title_guard.py tests/gateway/test_session_api.py` — green.

## vs #106180 / #106188

Both PRs clear `hidden` in `set_session_pinned`. #106180 is the base (earlier, and the only one that honours the canonical Bot Chat contract). From #106188 this takes the PATCH ordering hunk only. Its `include_pinned` back-fill change (drop the hidden clause so any pinned row lists even while hidden) is **not** taken: it would surface a hidden canonical Bot Chat / room member session into the Sessions sidebar the moment anything pins it, and its "heal legacy rows" motivation is moot — the desktop's pin-sync re-PATCHes `pinned:true` for every locally pinned id on each app launch (`mirrored` is in-memory), so pre-fix `pinned=1, hidden=1` rows self-heal through the write path. Tests trimmed from 6 across both PRs to 2.

Salvage of #106180 by @chelsealong; PATCH ordering from #106188 by @Halldrix.

Closes #106171

## Infographic
![pinned-clears-hidden](https://v3b.fal.media/files/b/0aa9ba99/UXWaU5dg_lkQ9dopFEYZy_dN5RZ7Ow.png)
