### PR TITLE
fix(mcp): a stdio server dying mid-call no longer replays the tool call (Refs #106421, salvage #106440)

### DIFF
--- a/tests/tools/test_mcp_stdio_fastfail_reconnect.py
+++ b/tests/tools/test_mcp_stdio_fastfail_reconnect.py
@@ -9,15 +9,17 @@ subprocess (#95626 added the reconnect signal).
 Signalling alone still lost the call: a gateway restart kills every MCP stdio
 child, and the first call from a surviving agent session (or a cron run
 spanning the restart) failed in 0.00s while the subprocess was respawned
-seconds later. Both fast-fail sites now respawn AND retry once:
+seconds later. Both fast-fail sites request a respawn, but only a call that
+has not reached the server is safe to retry:
 
-- pre-call gate (children already dead when the call arrives);
-- mid-call watcher race (children die while the RPC is in flight).
+- pre-call gate (children already dead when the call arrives): retry once;
+- mid-call watcher race (children die while the RPC is in flight): report an
+  uncertain outcome without replaying a possibly completed side effect.
 
-Both must recover transparently, and both must stop after ONE retry so a
-server that keeps dying parks via run()'s rapid-drop budget instead of
-hot-cycling respawns forever. The error text must never claim a timeout —
-that wording is what misdirected the original investigation.
+The pre-call path must stop after ONE retry so a server that keeps dying parks
+via run()'s rapid-drop budget instead of hot-cycling respawns forever. The
+error text must never claim a timeout — that wording is what misdirected the
+original investigation.
 """
 
 import asyncio
@@ -131,19 +133,22 @@ def test_precall_dead_children_respawn_and_retry(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv-dead")
 
 
-def test_midcall_child_exit_respawn_and_retry(monkeypatch, tmp_path):
-    """Subprocess dies while the RPC is in flight → respawn and retry once,
-    so the caller still gets its result."""
+def test_midcall_child_exit_reconnects_without_replay(monkeypatch, tmp_path):
+    """An in-flight side effect may have completed, so reconnect but do not replay it."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     from tools import mcp_tool
     from tools.mcp_tool_handlers import _make_tool_handler
 
     alive = {"v": True}
+    effects = {"n": 0}
 
     async def _hanging_call(*a, **kw):
+        effects["n"] += 1
+        alive["v"] = False
         await asyncio.sleep(30)
 
     async def _good_call(*a, **kw):
+        effects["n"] += 1
         return _success_result()
 
     async def _watch_children():
@@ -167,12 +172,12 @@ def test_midcall_child_exit_respawn_and_retry(monkeypatch, tmp_path):
     _mcp_loop._ensure_mcp_loop()
     try:
         handler = _make_tool_handler("srv-midcall", "tool1", 10.0)
-        # The child dies once the RPC is in flight.
-        alive["v"] = False
         parsed = json.loads(handler({}))
-        assert "error" not in parsed, parsed
-        assert parsed["result"] == "ok", parsed
+        assert parsed["outcome_uncertain"] is True, parsed
+        assert "may have completed" in parsed["error"], parsed
+        assert "did not replay" in parsed["error"], parsed
         assert server._reconnect_event.set_calls == 1
+        assert effects["n"] == 1, "the replacement session must not repeat an uncertain side effect"
     finally:
         _cleanup(mcp_tool, "srv-midcall")
 

--- a/tests/tools/test_mcp_stdio_fastfail_reconnect.py
+++ b/tests/tools/test_mcp_stdio_fastfail_reconnect.py
@@ -182,51 +182,51 @@ def test_midcall_child_exit_reconnects_without_replay(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv-midcall")
 
 
-def test_precall_respawn_retry_dying_midcall_is_uncertain_without_replay(monkeypatch, tmp_path):
-    """A safe pre-call retry becomes uncertain if its replacement dies after dispatch."""
+def test_sdk_first_transport_close_midcall_is_uncertain_without_replay(monkeypatch, tmp_path):
+    """The SDK usually notices the closed pipe before the 250 ms child watcher does and raises a
+    transport-closure error. On a stdio server that is the same ambiguous mid-call death: it must
+    surface as uncertain, never reach the session-expired recoverer, which would replay the call."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    anyio = pytest.importorskip("anyio")
     from tools import mcp_tool
     from tools.mcp_tool_handlers import _make_tool_handler
 
-    alive = {"v": False}
     effects = {"n": 0}
 
-    async def _never_dispatched(*a, **kw):
-        raise AssertionError("the original dead child must not receive the call")
-
-    async def _effect_then_die(*a, **kw):
+    async def _effect_then_pipe_closes(*a, **kw):
         effects["n"] += 1
-        alive["v"] = False
-        await asyncio.sleep(30)
+        raise anyio.ClosedResourceError
+
+    async def _good_call(*a, **kw):
+        effects["n"] += 1
+        return _success_result()
 
     async def _watch_children():
-        while alive["v"]:
-            await asyncio.sleep(0.05)
+        await asyncio.sleep(30)  # the watcher loses the race
 
     def _respawn(server):
-        alive["v"] = True
         new_session = MagicMock()
-        new_session.call_tool = _effect_then_die
+        new_session.call_tool = _good_call
         server.session = new_session
         server._ready.set()
 
     server = _install_stub_server(
-        mcp_tool, "srv-retry-midcall", _never_dispatched,
-        children_dead=lambda: not alive["v"],
+        mcp_tool, "srv-sdk-first", _effect_then_pipe_closes,
+        children_dead=lambda: False,
         on_reconnect=_respawn,
     )
     server._watch_stdio_children = _watch_children
+    server._is_http = lambda: False
     _mcp_loop._ensure_mcp_loop()
     try:
-        handler = _make_tool_handler("srv-retry-midcall", "tool1", 10.0)
+        handler = _make_tool_handler("srv-sdk-first", "tool1", 10.0)
         parsed = json.loads(handler({}))
         assert parsed["outcome_uncertain"] is True, parsed
-        assert "may have completed" in parsed["error"], parsed
         assert "did not replay" in parsed["error"], parsed
         assert server._reconnect_event.set_calls == 1
-        assert effects["n"] == 1, "the uncertain retry must not be invoked a third time"
+        assert effects["n"] == 1, "the session-expired recoverer must not replay an in-flight stdio call"
     finally:
-        _cleanup(mcp_tool, "srv-retry-midcall")
+        _cleanup(mcp_tool, "srv-sdk-first")
 
 
 def test_dead_child_never_returning_is_not_reported_as_a_timeout(

--- a/tests/tools/test_mcp_stdio_fastfail_reconnect.py
+++ b/tests/tools/test_mcp_stdio_fastfail_reconnect.py
@@ -182,6 +182,53 @@ def test_midcall_child_exit_reconnects_without_replay(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv-midcall")
 
 
+def test_precall_respawn_retry_dying_midcall_is_uncertain_without_replay(monkeypatch, tmp_path):
+    """A safe pre-call retry becomes uncertain if its replacement dies after dispatch."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _make_tool_handler
+
+    alive = {"v": False}
+    effects = {"n": 0}
+
+    async def _never_dispatched(*a, **kw):
+        raise AssertionError("the original dead child must not receive the call")
+
+    async def _effect_then_die(*a, **kw):
+        effects["n"] += 1
+        alive["v"] = False
+        await asyncio.sleep(30)
+
+    async def _watch_children():
+        while alive["v"]:
+            await asyncio.sleep(0.05)
+
+    def _respawn(server):
+        alive["v"] = True
+        new_session = MagicMock()
+        new_session.call_tool = _effect_then_die
+        server.session = new_session
+        server._ready.set()
+
+    server = _install_stub_server(
+        mcp_tool, "srv-retry-midcall", _never_dispatched,
+        children_dead=lambda: not alive["v"],
+        on_reconnect=_respawn,
+    )
+    server._watch_stdio_children = _watch_children
+    _mcp_loop._ensure_mcp_loop()
+    try:
+        handler = _make_tool_handler("srv-retry-midcall", "tool1", 10.0)
+        parsed = json.loads(handler({}))
+        assert parsed["outcome_uncertain"] is True, parsed
+        assert "may have completed" in parsed["error"], parsed
+        assert "did not replay" in parsed["error"], parsed
+        assert server._reconnect_event.set_calls == 1
+        assert effects["n"] == 1, "the uncertain retry must not be invoked a third time"
+    finally:
+        _cleanup(mcp_tool, "srv-retry-midcall")
+
+
 def test_dead_child_never_returning_is_not_reported_as_a_timeout(
     monkeypatch, tmp_path,
 ):

--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -196,8 +196,14 @@ def test_call_tool_handler_rebuilds_configured_server_transport(
         handler = _make_tool_handler("resumed", "health", 10.0)
         parsed = json.loads(handler({}))
 
-        assert parsed == {"result": "reconnected"}
-        assert call_count["n"] == 2
+        if expected_route == "stdio":
+            # A stdio pipe closing after dispatch is an ambiguous mid-call death: the transport
+            # is rebuilt for future calls, but the call itself is not replayed (#106440).
+            assert parsed["outcome_uncertain"] is True, parsed
+            assert call_count["n"] == 1
+        else:
+            assert parsed == {"result": "reconnected"}
+            assert call_count["n"] == 2
         assert routes == [expected_route, expected_route]
         assert configs == [transport_config, transport_config]
         assert len(sessions) == 2

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -334,7 +334,19 @@ async def _call_tool_racing_stdio_death(server, server_name: str, tool_name: str
                 f"MCP stdio subprocess for '{server_name}' exited mid-call",
                 in_flight=True,
             )
-        return await rpc_task
+        try:
+            return await rpc_task
+        except Exception as exc:
+            # The SDK usually sees the closed pipe before the 250 ms watcher poll does. On a stdio
+            # server a transport-closure error after dispatch is the same ambiguous mid-call death;
+            # it must not fall through to the session-expired recoverer, which replays the call.
+            _is_http = getattr(server, "_is_http", None)
+            if callable(_is_http) and _is_http() is False and _is_session_expired_error(exc):
+                raise _StdioChildExited(
+                    f"MCP stdio subprocess for '{server_name}' closed its transport mid-call",
+                    in_flight=True,
+                ) from exc
+            raise
     finally:
         watch_task.cancel()
         if not rpc_task.done():

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -33,6 +33,9 @@ _STDIO_NO_RESPAWN_MSG = (
 _STDIO_DIED_AGAIN_MSG = (
     "MCP server '{s}' respawned its stdio subprocess and it exited again immediately. The server is not starting "
     "cleanly — do NOT retry this tool; ask the user to check the server's command and its stderr log.")
+_STDIO_OUTCOME_UNCERTAIN_MSG = (
+    "MCP server '{s}' lost its stdio subprocess after the tool call began. The operation may have completed, so "
+    "Hermes did not replay it. Do NOT retry automatically; inspect the external state first.")
 
 
 def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
@@ -187,11 +190,19 @@ def _handle_session_expired_and_retry(server_name: str, exc: BaseException, retr
 class _StdioChildExited(RuntimeError):
     """Stdio subprocess gone when (or while) a call ran. Deliberately NOT a TimeoutError."""
 
+    def __init__(self, message: str, *, in_flight: bool):
+        super().__init__(message)
+        self.in_flight = in_flight
+
 
 def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry_call, op_description: str):
-    """Respawn a dead stdio child and retry once; None if not our error. Never spawns itself: it
-    sets ``_reconnect_event`` and waits, so spawn frequency stays governed by ``run()``'s
-    rapid-drop budget. Single-shot: a child that dies again reports and stops.
+    """Respawn a dead stdio child; retry once only when it was dead before dispatch.
+
+    A mid-call exit is ambiguous: the server may have applied a side effect before its
+    response pipe disappeared. Reconnect for future calls but never replay that operation.
+    None means this is not our error. This function never spawns itself: it sets
+    ``_reconnect_event`` and waits, so spawn frequency stays governed by ``run()``'s rapid-drop
+    budget. A pre-dispatch retry whose child dies again reports and stops.
 
     Why retrying here cannot hot-cycle respawns: this function never spawns anything. It sets
     ``_reconnect_event`` (one signal, same as before) and waits for the server task to publish a fresh
@@ -203,13 +214,20 @@ def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry
     reconnected = False
     srv = _lookup_reconnectable_server(server_name)
     if srv is not None:
-        logger.info("MCP server '%s': %s found the stdio subprocess dead (%s); respawning and retrying once.",
-                    server_name, op_description, exc)
+        action = "reconnecting without replay" if exc.in_flight else "respawning and retrying once"
+        logger.info("MCP server '%s': %s found the stdio subprocess dead (%s); %s.",
+                    server_name, op_description, exc, action)
         if _mcp_loop_running():
             reconnected = _loop._signal_reconnect_and_wait(
                 server_name, srv, op_description=op_description, timeout=_core._STDIO_RESPAWN_WAIT_SEC)
         else:  # No MCP loop to wait on (non-async adapters, tests): still request the respawn.
             _loop._signal_reconnect(srv)
+    if exc.in_flight:
+        return _strike(
+            server_name,
+            _STDIO_OUTCOME_UNCERTAIN_MSG.format(s=server_name),
+            outcome_uncertain=True,
+        )
     if not reconnected:
         return _strike(server_name, _STDIO_NO_RESPAWN_MSG.format(s=server_name, t=_core._STDIO_RESPAWN_WAIT_SEC))
     try:
@@ -283,12 +301,16 @@ async def _call_tool_racing_stdio_death(server, server_name: str, tool_name: str
     """``session.call_tool`` that fails fast when the stdio child is/gets dead: pre-call (a dead
     child must not hold the slot for the full timeout) and mid-call (race against
     ``_watch_stdio_children``). Both raise :class:`_StdioChildExited` for the respawn path, which
-    owns the reconnect signal. callable()/``is True`` because MagicMock attributes are truthy."""
+    owns the reconnect signal; only pre-call failure is safe to replay. callable()/``is True``
+    because MagicMock attributes are truthy."""
     # Fast-fail (#81995): a stdio subprocess that is already dead must not own this call slot — fail
     # immediately instead of waiting out the full tool timeout on a transport nobody will ever answer.
     _stdio_dead = getattr(server, "_stdio_children_dead", None)
     if callable(_stdio_dead) and _stdio_dead() is True:
-        raise _StdioChildExited(f"MCP stdio subprocess for '{server_name}' had already exited when the call was dispatched")
+        raise _StdioChildExited(
+            f"MCP stdio subprocess for '{server_name}' had already exited when the call was dispatched",
+            in_flight=False,
+        )
     _call_coro = server.session.call_tool(tool_name, arguments=args)
     _watch_children = getattr(server, "_watch_stdio_children", None)
     if not (inspect.iscoroutinefunction(_watch_children) and asyncio.iscoroutine(_call_coro)):
@@ -302,7 +324,10 @@ async def _call_tool_racing_stdio_death(server, server_name: str, tool_name: str
         done, _pending = await asyncio.wait({rpc_task, watch_task}, return_when=asyncio.FIRST_COMPLETED)
         if watch_task in done and not rpc_task.done():
             rpc_task.cancel()
-            raise _StdioChildExited(f"MCP stdio subprocess for '{server_name}' exited mid-call")
+            raise _StdioChildExited(
+                f"MCP stdio subprocess for '{server_name}' exited mid-call",
+                in_flight=True,
+            )
         return await rpc_task
     finally:
         watch_task.cancel()

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -236,6 +236,12 @@ def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry
         # Died again right after respawn: broken server; run()'s budget takes it to the park.
         logger.warning("MCP server '%s': %s stdio subprocess exited again right after respawn (%s); not retrying "
                        "further.", server_name, op_description, retry_exc)
+        if retry_exc.in_flight:
+            return _strike(
+                server_name,
+                _STDIO_OUTCOME_UNCERTAIN_MSG.format(s=server_name),
+                outcome_uncertain=True,
+            )
         return _strike(server_name, _STDIO_DIED_AGAIN_MSG.format(s=server_name))
     except Exception as retry_exc:
         logger.warning("MCP %s/%s retry after stdio respawn failed: %s", server_name, op_description, retry_exc)


### PR DESCRIPTION
After a stdio MCP server dies while a tool call is in flight, Hermes no longer replays the call — it reconnects for future calls and returns an explicit `outcome_uncertain` error, so a non-idempotent action (a charge, a send, a delete) is never applied twice; a call that never reached the server is still retried once.

## Changes

- `tools/mcp_tool_handlers.py::_StdioChildExited` carries `in_flight`; `_handle_stdio_child_exited_and_retry` retries once only when the child was dead **before** dispatch, and returns `_STDIO_OUTCOME_UNCERTAIN_MSG` + `outcome_uncertain: true` (no replay) when the child died after dispatch — including when the one safe retry itself dies mid-call (@100yenadmin, salvaged from #106440).
- `_call_tool_racing_stdio_death`: a session-expired-class transport error (`ClosedResourceError`, "Connection closed", …) raised by an already-dispatched RPC on a **stdio** server is re-raised as `_StdioChildExited(in_flight=True)`. Without this the SDK sees the closed pipe before the 250 ms child watcher, the error skips the stdio recoverer and `_handle_session_expired_and_retry` replays the call — the P1 raised in review of #106440, and what the live repro actually hits. HTTP servers keep their session-expired retry (our commit).
- Tests trimmed to the salvage bar: the contributor's third regression (a watcher-race variant) is replaced by the SDK-first regression; `test_mcp_tool_session_expired.py[stdio]` updated to the new contract (HTTP arm unchanged).

## Validation

| | before (origin/main) | after |
|---|---|---|
| Live repro — real stdio child (`fake_mcp_server.py`) applies a side effect then `os._exit(0)` without replying | **2 effects**, result `MCP call failed: MCPError: Connection closed` (replayed via session-expired recovery) | **1 effect**, result `outcome_uncertain: true` + "Hermes did not replay it" |
| Live repro — child SIGKILLed **before** dispatch | 1 effect, `{"result": "charged"}` | unchanged: 1 effect, `{"result": "charged"}` (never-sent → retried once) |
| `tests/tools/test_mcp_stdio_fastfail_reconnect.py` with `origin/main` handlers | 2 failed / 3 passed | 5 passed |
| Contributor's commits alone | `test_sdk_first_transport_close_midcall_is_uncertain_without_replay` FAILED (2 effects live) | passes |
| `tests/tools/test_mcp*.py` + other MCP-touching test files | — | 61 files 680 passed + 13 files 311 passed |

Live repro was run in-process with the real MCP loop, `register_mcp_servers`, registry dispatch and a real subprocess, temp `HERMES_HOME`.

**Root cause:** #100987's respawn-and-retry treated "child dead before dispatch" and "child died during the RPC" identically, and the session-expired recoverer independently retried any transport-closure error regardless of transport, so an in-flight stdio call whose side effect may have landed was re-sent.

Refs #106421 (generic MCP correction discovered there; nothing about device control is implemented here — the issue stays open).

## Credits

- @100yenadmin — PR #106440: diagnosis, the `in_flight` split and the uncertain-outcome contract (two commits cherry-picked with authorship).
- @andrexibiza — review on #106440 identifying the SDK-first race that the third commit here closes.

## Infographic
![mcp-no-replay](https://v3b.fal.media/files/b/0aa9ba69/n528lhlVk9ZZ0W9LYW62R_yeMuQmxO.png)
