### PR TITLE
kanban_request_review rejects unknown reviewer profiles instead of parking the task (#106163, salvage #97429)

### DIFF
--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -20,6 +20,8 @@ def review_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_PROFILE", "builder")
     monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    # kanban_request_review now rejects reviewers that are not installed profiles (#106163).
+    (home / "profiles" / "reviewer").mkdir(parents=True)
     kb._INITIALIZED_PATHS.clear()
     kb.init_db()
     with kbc.connect() as conn:

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -164,6 +164,77 @@ def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
         conn.close()
 
 
+def test_request_review_rejects_missing_profile_without_mutation(
+    monkeypatch, worker_env, tmp_path
+):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    profiles_root = tmp_path / ".hermes" / "profiles"
+    (profiles_root / "verifier").mkdir(parents=True)
+    before_conn = kb.connect()
+    try:
+        before_task = kb.get_task(before_conn, worker_env)
+        assert before_task is not None
+        before_runs = kb.list_runs(before_conn, worker_env)
+        before_events = kb.list_events(before_conn, worker_env)
+    finally:
+        before_conn.close()
+    monkeypatch.setenv(
+        "HERMES_KANBAN_RUN_ID", str(before_task.current_run_id)
+    )
+
+    out = json.loads(kt._handle_request_review({
+        "summary": "Ready for review.",
+        "reviewer": "reviewer",
+    }))
+
+    assert "error" in out
+    assert "reviewer" in out["error"]
+    assert "verifier" in out["error"]
+    after_conn = kb.connect()
+    try:
+        after_task = kb.get_task(after_conn, worker_env)
+        assert after_task is not None
+        assert after_task.status == before_task.status == "running"
+        assert after_task.assignee == before_task.assignee == "test-worker"
+        assert after_task.current_run_id == before_task.current_run_id
+        assert kb.list_runs(after_conn, worker_env) == before_runs
+        assert kb.list_events(after_conn, worker_env) == before_events
+    finally:
+        after_conn.close()
+
+
+def test_request_review_accepts_installed_profile(monkeypatch, worker_env, tmp_path):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    profiles_root = tmp_path / ".hermes" / "profiles"
+    (profiles_root / "verifier").mkdir(parents=True)
+    conn = kb.connect()
+    try:
+        running = kb.get_task(conn, worker_env)
+        assert running is not None
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(running.current_run_id))
+
+    out = json.loads(kt._handle_request_review({
+        "summary": "Ready for review.",
+        "reviewer": "verifier",
+    }))
+
+    assert out["ok"] is True
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        assert task.status == "review"
+        assert task.assignee == "verifier"
+    finally:
+        conn.close()
+
+
 def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     """Goal-mode tasks must pass the auxiliary judge before completion.
     Regression for #38367: workers bypassing the judge via early kanban_complete."""

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -164,75 +164,44 @@ def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
         conn.close()
 
 
-def test_request_review_rejects_missing_profile_without_mutation(
-    monkeypatch, worker_env, tmp_path
-):
+def test_request_review_rejects_unknown_reviewer_without_mutation(monkeypatch, worker_env, tmp_path):
+    """#106163: a non-profile ``reviewer`` (e.g. the literal "reviewer") must be
+    refused with an error the model sees, leaving the task running under the
+    implementer — never parked in ``review`` on an assignee nobody can spawn."""
     from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
     from tools import kanban_tools as kt
 
-    profiles_root = tmp_path / ".hermes" / "profiles"
-    (profiles_root / "verifier").mkdir(parents=True)
-    before_conn = kb.connect()
-    try:
-        before_task = kb.get_task(before_conn, worker_env)
-        assert before_task is not None
-        before_runs = kb.list_runs(before_conn, worker_env)
-        before_events = kb.list_events(before_conn, worker_env)
-    finally:
-        before_conn.close()
-    monkeypatch.setenv(
-        "HERMES_KANBAN_RUN_ID", str(before_task.current_run_id)
-    )
+    (tmp_path / ".hermes" / "profiles" / "verifier").mkdir(parents=True)
+    with kbc.connect() as conn:
+        before = kb.get_task(conn, worker_env)
+        before_events = kb.list_events(conn, worker_env)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(before.current_run_id))
 
-    out = json.loads(kt._handle_request_review({
-        "summary": "Ready for review.",
-        "reviewer": "reviewer",
-    }))
+    out = json.loads(kt._handle_request_review({"summary": "Ready for review.", "reviewer": "reviewer"}))
 
-    assert "error" in out
-    assert "reviewer" in out["error"]
-    assert "verifier" in out["error"]
-    after_conn = kb.connect()
-    try:
-        after_task = kb.get_task(after_conn, worker_env)
-        assert after_task is not None
-        assert after_task.status == before_task.status == "running"
-        assert after_task.assignee == before_task.assignee == "test-worker"
-        assert after_task.current_run_id == before_task.current_run_id
-        assert kb.list_runs(after_conn, worker_env) == before_runs
-        assert kb.list_events(after_conn, worker_env) == before_events
-    finally:
-        after_conn.close()
+    assert "'reviewer'" in out["error"] and "verifier" in out["error"]
+    with kbc.connect() as conn:
+        after = kb.get_task(conn, worker_env)
+        assert (after.status, after.assignee, after.current_run_id) == ("running", "test-worker", before.current_run_id)
+        assert kb.list_events(conn, worker_env) == before_events
 
 
 def test_request_review_accepts_installed_profile(monkeypatch, worker_env, tmp_path):
     from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
     from tools import kanban_tools as kt
 
-    profiles_root = tmp_path / ".hermes" / "profiles"
-    (profiles_root / "verifier").mkdir(parents=True)
-    conn = kb.connect()
-    try:
-        running = kb.get_task(conn, worker_env)
-        assert running is not None
-    finally:
-        conn.close()
-    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(running.current_run_id))
+    (tmp_path / ".hermes" / "profiles" / "verifier").mkdir(parents=True)
+    with kbc.connect() as conn:
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(kb.get_task(conn, worker_env).current_run_id))
 
-    out = json.loads(kt._handle_request_review({
-        "summary": "Ready for review.",
-        "reviewer": "verifier",
-    }))
+    out = json.loads(kt._handle_request_review({"summary": "Ready for review.", "reviewer": "verifier"}))
 
     assert out["ok"] is True
-    conn = kb.connect()
-    try:
+    with kbc.connect() as conn:
         task = kb.get_task(conn, worker_env)
-        assert task is not None
-        assert task.status == "review"
-        assert task.assignee == "verifier"
-    finally:
-        conn.close()
+        assert (task.status, task.assignee) == ("review", "verifier")
 
 
 def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -640,6 +640,15 @@ def _handle_request_review(args: dict, **kw) -> str:
     metadata = _stamp_worker_session_metadata(tid, metadata)
     # Reviewer is model-supplied free text stored durably on the event payload.
     reviewer = _redact_opt(args.get("reviewer") or None)
+    if reviewer:
+        from hermes_cli.profiles import list_profile_names, profile_exists
+
+        if not profile_exists(reviewer):
+            alternatives = ", ".join(list_profile_names()) or "none"
+            return tool_error(
+                f"reviewer profile {reviewer!r} is not installed. "
+                f"Installed profiles: {alternatives}"
+            )
     with _board(args.get("board")) as (kb, conn):
         _goal_gate("kanban_request_review", kb.get_task(conn, tid), tid, summary)
         ok, fail_reason = kb.request_review(

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -643,12 +643,11 @@ def _handle_request_review(args: dict, **kw) -> str:
     if reviewer:
         from hermes_cli.profiles import list_profile_names, profile_exists
 
-        if not profile_exists(reviewer):
-            alternatives = ", ".join(list_profile_names()) or "none"
-            return tool_error(
-                f"reviewer profile {reviewer!r} is not installed. "
-                f"Installed profiles: {alternatives}"
-            )
+        # A non-profile reviewer would park the card in `review` on an assignee
+        # the dispatcher can never spawn (#106163).
+        _check(profile_exists(reviewer),
+               f"reviewer profile {reviewer!r} is not installed. "
+               f"Installed profiles: {', '.join(list_profile_names())}")
     with _board(args.get("board")) as (kb, conn):
         _goal_gate("kanban_request_review", kb.get_task(conn, tid), tid, summary)
         ok, fail_reason = kb.request_review(


### PR DESCRIPTION
`kanban_request_review(reviewer=<non-profile string>)` now returns a tool error naming the installed profiles and leaves the task running under its implementer, instead of parking the card in `review` on an assignee the dispatcher can never spawn.

Salvage of #97429 by @auroracapital (earliest fix, same mechanism). Composed against #106214 by @gaoanze888 — see "Why the tool layer" below.

## Changes
- `tools/kanban_tools.py::_handle_request_review` — when the model passes an explicit `reviewer`, validate it with `hermes_cli.profiles.profile_exists` **before** any board write; reject via the module's `_check` idiom with `reviewer profile 'X' is not installed. Installed profiles: default, ...` so the model can self-correct. Omitting `reviewer` (review inherits the implementer / prior-reviewer provenance) is unchanged.
- `tests/tools/test_kanban_tools.py` — 2 invariant tests: unknown reviewer → error, task `(status, assignee, run_id)` and event log byte-identical to before (proven red without the fix); installed profile → `review` with that assignee.
- Dropped from #97429: the `kanban_diagnostics.py` `review_reopened` hunk + its tests (that loop was already replaced by `_latest_event_ts` on main, and the hunk is unrelated to #106163). Commit re-authored from the placeholder identity `regen <regen@local>` to @auroracapital's GitHub noreply address.

## Why the tool layer (vs #106214's DB guard)
#106214 puts the same `profile_exists` check inside `hermes_cli/kanban_db.py::request_review`. That primitive is also the chokepoint for `hermes kanban request-review --reviewer` and the dashboard's drag-to-review with `force=True` — operator surfaces where a non-profile assignee (an external / human review lane pulling via `claim_task`) is a documented board shape (`website/docs/user-guide/features/kanban-worker-lanes.md`; the dispatcher already buckets those as `skipped_nonspawnable` rather than erroring). Gating the DB forced #106214 to monkeypatch `profile_exists → True` in five unrelated test fixtures. The model-facing tool wrapper is the only surface where a typo'd string is a bug rather than an operator decision, so the guard lives there — one file, no fixture churn.

## Validation — live repro (real board DB, temp `HERMES_HOME`, only named profile `zn-worker-fast`, task claimed by it, worker calls the tool handler with `reviewer="reviewer"`)

Script: `python /tmp/kanban_reviewer_repro.py <worktree> <label>` (purges `tools*`/`hermes*` from `sys.modules`, real imports, real SQLite).

**Before (origin/main):**
```
[main] tool result: {"ok": true, "task_id": "t_e371e77f", "run_id": 1, "status": "review"}
[main] task status=review assignee='reviewer' profile_exists(assignee)=False
[main] events: ['created', 'claimed', 'review_requested']
[main] BUG FIRES: task parked in review on nonexistent profile
```

**After (this branch):**
```
[fix] tool result: {"error": "reviewer profile 'reviewer' is not installed. Installed profiles: default, zn-worker-fast"}
[fix] task status=running assignee='zn-worker-fast' profile_exists(assignee)=True
[fix] events: ['created', 'claimed']
[fix] NEGATIVE: task untouched, error surfaced
```

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_kanban_tools.py` | 34 passed, 0 failed |
| Sabotage (fix hunk reverted, new tests run) | `test_request_review_rejects_unknown_reviewer_without_mutation` FAILED, accept-test passed → the test bites |
| `ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check` | clean |

**Root cause:** the tool handler forwarded model-supplied free text straight into the DB's `assignee` column with no check that it names a spawnable profile.

Closes #106163

## Infographic
![kanban-reviewer-guard](https://v3b.fal.media/files/b/0aa9baa0/6YwScNqaVZSbeUzcIjXmX_aqOtXWqv.png)
