### PR TITLE
fix(agent): gate execution-guidance tool lines on the session's toolset

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -465,15 +465,39 @@ OPENAI_MODEL_EXECUTION_GUIDANCE = (
 )
 
 
+# Each <mandatory_tool_use>/<act_dont_ask> line above named against the tool(s) it tells the model to reach
+# for. A line is dropped when none of its named tools are in the session's valid_tool_names, so a toolset
+# without terminal/execute_code/etc. isn't told to use them (#106506).
+_EXECUTION_GUIDANCE_LINE_TOOLS = {
+    "- Arithmetic, math, calculations → use terminal or execute_code\n": {"terminal", "execute_code"},
+    "- Hashes, encodings, checksums → use terminal (e.g. sha256sum, base64)\n": {"terminal"},
+    "- Current time, date, timezone → use terminal (e.g. date)\n": {"terminal"},
+    "- System state: OS, CPU, memory, disk, ports, processes → use terminal\n": {"terminal"},
+    "- File contents, sizes, line counts → use read_file, search_files, or terminal\n": {
+        "read_file",
+        "search_files",
+        "terminal",
+    },
+    "- Git history, branches, diffs → use terminal\n": {"terminal"},
+    "- Current facts (weather, news, versions) → use web_search\n": {"web_search"},
+    "- 'What time is it?' → run `date` (don't guess)\n": {"terminal"},
+}
+
+
 def execution_guidance_text(valid_tool_names=None) -> str:
     """OPENAI_MODEL_EXECUTION_GUIDANCE for the session's toolset (cache-safe: the toolset is fixed per session).
 
-    Without web tools (e.g. Blank Slate) the ``web_search`` mentions would dangle, so they are dropped/adjusted.
+    Lines that tell the model to reach for a tool absent from the session's toolset would dangle, so they are
+    dropped/adjusted.
     """
     text = OPENAI_MODEL_EXECUTION_GUIDANCE
-    if valid_tool_names is not None and "web_search" not in valid_tool_names:
-        text = text.replace("- Current facts (weather, news, versions) → use web_search\n", "")
-        text = text.replace("(search_files, web_search, read_file, etc.)", "(search_files, read_file, etc.)")
+    if valid_tool_names is not None:
+        valid_tool_names = set(valid_tool_names)
+        for line, tools in _EXECUTION_GUIDANCE_LINE_TOOLS.items():
+            if not tools & valid_tool_names:
+                text = text.replace(line, "")
+        if "web_search" not in valid_tool_names:
+            text = text.replace("(search_files, web_search, read_file, etc.)", "(search_files, read_file, etc.)")
     return text
 
 

--- a/tests/agent/test_phantom_tool_references.py
+++ b/tests/agent/test_phantom_tool_references.py
@@ -51,6 +51,25 @@ class TestExecutionGuidanceText:
         assert "<missing_context>" in text
         assert "(search_files, read_file, etc.)" in text
 
+    def test_shell_and_file_lines_dropped_on_lean_toolset(self):
+        # #106506: a profile with none of terminal/execute_code/read_file/search_files must not be told to
+        # reach for any of them.
+        from agent.prompt_builder import execution_guidance_text
+        text = execution_guidance_text({"memory", "web_search"})
+        mandatory_block = text.split("<mandatory_tool_use>")[1].split("</mandatory_tool_use>")[0]
+        assert "terminal" not in mandatory_block
+        assert "execute_code" not in mandatory_block
+        assert "read_file" not in mandatory_block
+        assert "search_files" not in mandatory_block
+        # Web tools are present, so their line survives.
+        assert "use web_search" in mandatory_block
+        act_block = text.split("<act_dont_ask>")[1].split("</act_dont_ask>")[0]
+        assert "run `date`" not in act_block
+        # Surrounding structure and unrelated tags survive.
+        assert "<mandatory_tool_use>" in text
+        assert "<act_dont_ask>" in text
+        assert "<missing_context>" in text
+
 
 class TestCodingBriefTodoGating:
     def _brief(self, valid_tool_names):


### PR DESCRIPTION
## What does this PR do?

`execution_guidance_text()` (`agent/prompt_builder.py`) renders
`OPENAI_MODEL_EXECUTION_GUIDANCE` into the system prompt for models in
`EXECUTION_GUIDANCE_MODELS`, and already drops the `web_search` mentions
when a session's `valid_tool_names` doesn't include it. But the
`<mandatory_tool_use>` bullets that point at `terminal`, `execute_code`,
`read_file`, and `search_files`, and the `date` example in
`<act_dont_ask>`, were never gated the same way — they survive verbatim
even on a toolset that has none of those tools.

On a lean profile (e.g. Blank Slate-style toolsets, or a custom
`platform_toolsets` with only a handful of domain tools), the model is
told "use terminal (e.g. date)" or "use read_file, search_files, or
terminal" for things the session can't actually do, calls the
nonexistent tool, and burns a turn on `Tool 'X' does not exist`.

This extends the existing per-line filter (added in #94404 for
`web_search`) to every tool the guidance block names: each line is
dropped when none of the tool(s) it names are present in
`valid_tool_names`, exactly the mechanism the `web_search` case already
used.

## Related Issue

Fixes #106506

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/prompt_builder.py`: `_EXECUTION_GUIDANCE_LINE_TOOLS` maps each
  tool-naming line in `OPENAI_MODEL_EXECUTION_GUIDANCE` to the tool(s) it
  names; `execution_guidance_text()` drops a line when none of its tools
  are in `valid_tool_names` (converted to a set to accept both `list` and
  `set` callers). Behavior for toolsets that include `web_search` and/or
  the shell/file tools is unchanged — this only removes dangling
  references on toolsets that lack them.
- `tests/agent/test_phantom_tool_references.py`: added
  `test_shell_and_file_lines_dropped_on_lean_toolset`, asserting that a
  `{"memory", "web_search"}` toolset's `<mandatory_tool_use>` block
  contains none of `terminal`/`execute_code`/`read_file`/`search_files`
  (while its `web_search` line survives, since that tool is present),
  and that `<act_dont_ask>`'s `date` example is dropped too.

## Test Plan

Confirmed the new test fails without the fix and passes with it:

```
$ git stash push -- agent/prompt_builder.py
$ bash scripts/run_tests.sh tests/agent/test_phantom_tool_references.py -v
...
FAILED tests/agent/test_phantom_tool_references.py::TestExecutionGuidanceText::test_shell_and_file_lines_dropped_on_lean_toolset
========================= 1 failed, 13 passed in 0.46s =========================
$ git stash pop
$ bash scripts/run_tests.sh tests/agent/test_phantom_tool_references.py -v
=== Summary: 1 files, 14 tests passed, 0 failed (100% complete) in 0.7s (8 workers) ===
```

Also green with the fix applied:

```
$ bash scripts/run_tests.sh tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py \
    tests/agent/test_coding_context.py tests/agent/test_phantom_tool_references.py
=== Summary: 4 files, 185 tests passed, 0 failed (100% complete) in 8.9s (8 workers) ===
```

Ran the full `tests/agent/` directory: 8 pre-existing failures across 7
files (`test_auxiliary_transport_autodetect.py`,
`test_auxiliary_named_custom_providers.py`, `test_command_token_source.py`,
`test_fallback_dynamic_credential.py`, `test_nous_portal_anthropic_wire.py`,
`test_set_runtime_main_custom_provider.py`,
`test_vision_routing_31179.py`) — all about Anthropic-SDK/credential
availability in this sandbox, unrelated to `prompt_builder.py`. Verified
identical failures with this change stashed out, on unmodified `main`.

`ruff check agent/prompt_builder.py tests/agent/test_phantom_tool_references.py` — all checks passed.

## AI assistance disclosure

This PR was written by an autonomous Claude Code agent (Claude Sonnet 5) acting on the issue linked above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
