### PR TITLE
fix(agent): unentitled Codex primary + fallback no longer oscillate or announce a false restore (#106475, salvage #106482)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1125,7 +1125,7 @@ def restore_primary_runtime(agent) -> bool:
     rt = agent._primary_runtime
     primary_provider = str((rt or {}).get("provider") or "").strip().lower()
     primary_model = str((rt or {}).get("model") or "").strip()
-    from agent.chat_completion_helpers import _is_entitlement_rejected
+    from agent.fallback_cooldown import _is_entitlement_rejected
     if primary_model and _is_entitlement_rejected(agent, primary_provider, primary_model):
         # The primary slug was rejected as unentitled for this account (#106475): restoring
         # here would announce a recovery that was never verified and re-fail every turn.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1124,6 +1124,13 @@ def restore_primary_runtime(agent) -> bool:
         return False  # primary still in rate-limit cooldown, stay on fallback
     rt = agent._primary_runtime
     primary_provider = str((rt or {}).get("provider") or "").strip().lower()
+    primary_model = str((rt or {}).get("model") or "").strip()
+    from agent.chat_completion_helpers import _is_entitlement_rejected
+    if primary_model and _is_entitlement_rejected(agent, primary_provider, primary_model):
+        # The primary slug was rejected as unentitled for this account (#106475): restoring
+        # here would announce a recovery that was never verified and re-fail every turn.
+        # Stay on the fallback; the user sees the terminal entitlement error instead.
+        return False
     primary_runtime_base_url = str((rt or {}).get("base_url") or "")
 
     def _matches_primary(candidate) -> bool:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1712,68 +1712,6 @@ def _rebind_fallback_credential_pool(agent, fb_provider: str, fb_model: str) -> 
             logger.debug("Fallback to %s/%s: could not attach credential pool: %s", fb_provider, fb_model, exc)
 
 
-# Codex ChatGPT-account entitlement 400 — the account can never use the named slug, so with
-# nothing to rotate it is a config error, not a transient failure (#106475).
-_CODEX_ACCOUNT_MODEL_ENTITLEMENT_MARKER = "model is not supported when using codex with a chatgpt account"
-
-
-def _mark_entitlement_rejected_model(agent, api_error) -> bool:
-    """Record a Codex ChatGPT-account 400 that rejects the current model for this account.
-
-    With a single credential there is no pool to rotate (#71970 covers that case), so the
-    (provider, model) pair is treated as dead for the session: the fallback walk skips it and
-    restore_primary_runtime stops switching back — otherwise every turn re-fails on the primary,
-    announces an unverified "Primary model restored", and oscillates forever (#106475).
-    """
-    if getattr(api_error, "status_code", None) != 400:
-        return False
-    pool = getattr(agent, "_credential_pool", None)
-    if pool is not None:
-        try:
-            if len(pool.entries()) > 1:
-                return False  # another account in the pool may be entitled; leave rotation to it
-        except Exception:
-            return False
-    haystack = str(getattr(api_error, "message", "") or api_error).lower()
-    if _CODEX_ACCOUNT_MODEL_ENTITLEMENT_MARKER not in haystack:
-        return False
-    provider = str(getattr(agent, "provider", "") or "").strip().lower()
-    model = str(getattr(agent, "model", "") or "").strip()
-    if not provider or not model:
-        return False
-    rejected = getattr(agent, "_entitlement_rejected_models", None)
-    if rejected is None:
-        rejected = agent._entitlement_rejected_models = set()
-    if (provider, model) in rejected:
-        return True
-    rejected.add((provider, model))
-    logger.warning(
-        "Model entitlement rejection: this account is not entitled to %s via %s; "
-        "treating it as unavailable for this session",
-        model, provider,
-    )
-    agent._buffer_status(
-        f"🚫 This account is not entitled to {model} via {provider}; it will be skipped "
-        "until restart. Switch to an entitled model via /model or `hermes model`."
-    )
-    return True
-
-
-def _is_entitlement_rejected(agent, provider: str, model: str) -> bool:
-    """True when (provider, model) — as configured or normalized — was rejected as unentitled
-    for this account (see _mark_entitlement_rejected_model)."""
-    rejected = getattr(agent, "_entitlement_rejected_models", None) or ()
-    if not rejected:
-        return False
-    if (provider, model) in rejected:
-        return True
-    try:
-        from hermes_cli.model_normalize import normalize_model_for_provider
-        return (provider, normalize_model_for_provider(model, provider)) in rejected
-    except Exception:
-        return False
-
-
 def _fallback_chain_exhausted(agent, reason: "FailoverReason | None") -> bool:
     """Chain exhausted (always False). A non-empty chain walked on a non-rate-limit failure arms a
     short cooldown so next turn's restore_primary_runtime stays gated instead of replaying the whole
@@ -1793,6 +1731,7 @@ def _should_skip_fallback_candidate(agent, fb: dict, fb_key: tuple, fb_provider:
         return True
     if not fb_provider or not fb_model:
         return True
+    from agent.fallback_cooldown import _is_entitlement_rejected
     if _is_entitlement_rejected(agent, fb_provider, fb_model):
         logger.info("Fallback skip: %s/%s was rejected as unentitled for this account", fb_provider, fb_model)
         return True

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1712,6 +1712,68 @@ def _rebind_fallback_credential_pool(agent, fb_provider: str, fb_model: str) -> 
             logger.debug("Fallback to %s/%s: could not attach credential pool: %s", fb_provider, fb_model, exc)
 
 
+# Codex ChatGPT-account entitlement 400 — the account can never use the named slug, so with
+# nothing to rotate it is a config error, not a transient failure (#106475).
+_CODEX_ACCOUNT_MODEL_ENTITLEMENT_MARKER = "model is not supported when using codex with a chatgpt account"
+
+
+def _mark_entitlement_rejected_model(agent, api_error) -> bool:
+    """Record a Codex ChatGPT-account 400 that rejects the current model for this account.
+
+    With a single credential there is no pool to rotate (#71970 covers that case), so the
+    (provider, model) pair is treated as dead for the session: the fallback walk skips it and
+    restore_primary_runtime stops switching back — otherwise every turn re-fails on the primary,
+    announces an unverified "Primary model restored", and oscillates forever (#106475).
+    """
+    if getattr(api_error, "status_code", None) != 400:
+        return False
+    pool = getattr(agent, "_credential_pool", None)
+    if pool is not None:
+        try:
+            if len(pool.entries()) > 1:
+                return False  # another account in the pool may be entitled; leave rotation to it
+        except Exception:
+            return False
+    haystack = str(getattr(api_error, "message", "") or api_error).lower()
+    if _CODEX_ACCOUNT_MODEL_ENTITLEMENT_MARKER not in haystack:
+        return False
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    model = str(getattr(agent, "model", "") or "").strip()
+    if not provider or not model:
+        return False
+    rejected = getattr(agent, "_entitlement_rejected_models", None)
+    if rejected is None:
+        rejected = agent._entitlement_rejected_models = set()
+    if (provider, model) in rejected:
+        return True
+    rejected.add((provider, model))
+    logger.warning(
+        "Model entitlement rejection: this account is not entitled to %s via %s; "
+        "treating it as unavailable for this session",
+        model, provider,
+    )
+    agent._buffer_status(
+        f"🚫 This account is not entitled to {model} via {provider}; it will be skipped "
+        "until restart. Switch to an entitled model via /model or `hermes model`."
+    )
+    return True
+
+
+def _is_entitlement_rejected(agent, provider: str, model: str) -> bool:
+    """True when (provider, model) — as configured or normalized — was rejected as unentitled
+    for this account (see _mark_entitlement_rejected_model)."""
+    rejected = getattr(agent, "_entitlement_rejected_models", None) or ()
+    if not rejected:
+        return False
+    if (provider, model) in rejected:
+        return True
+    try:
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        return (provider, normalize_model_for_provider(model, provider)) in rejected
+    except Exception:
+        return False
+
+
 def _fallback_chain_exhausted(agent, reason: "FailoverReason | None") -> bool:
     """Chain exhausted (always False). A non-empty chain walked on a non-rate-limit failure arms a
     short cooldown so next turn's restore_primary_runtime stays gated instead of replaying the whole
@@ -1730,6 +1792,9 @@ def _should_skip_fallback_candidate(agent, fb: dict, fb_key: tuple, fb_provider:
         logger.debug("Fallback skip: %s previously marked unavailable", fb_key)
         return True
     if not fb_provider or not fb_model:
+        return True
+    if _is_entitlement_rejected(agent, fb_provider, fb_model):
+        logger.info("Fallback skip: %s/%s was rejected as unentitled for this account", fb_provider, fb_model)
         return True
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:

--- a/agent/fallback_cooldown.py
+++ b/agent/fallback_cooldown.py
@@ -1,8 +1,11 @@
-"""Primary rate-limit cooldown arming, shared by fallback switches."""
+"""Primary rate-limit cooldown arming and per-session model rejection markers, shared by the
+fallback walk (chat_completion_helpers) and restore_primary_runtime (agent_runtime_helpers)."""
 import logging
 import time
 
 from agent.error_classifier import FailoverReason
+
+logger = logging.getLogger(__name__)
 
 _RATE_LIMIT_FAILOVER_REASONS = frozenset({FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit})
 
@@ -26,3 +29,56 @@ def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> int | No
     return backoff_seconds
 
 
+# Codex ChatGPT-account entitlement 400 — the account can never use the named slug, so with
+# nothing to rotate it is a config error, not a transient failure (#106475).
+_CODEX_ACCOUNT_MODEL_ENTITLEMENT_MARKER = "model is not supported when using codex with a chatgpt account"
+
+
+def _mark_entitlement_rejected_model(agent, api_error) -> bool:
+    """Record a Codex ChatGPT-account 400 that rejects the current model for this account.
+
+    With a single credential there is no pool to rotate (#71970 covers that case), so the
+    (provider, model) pair is treated as dead for the session: the fallback walk skips it and
+    restore_primary_runtime stops switching back — otherwise every turn re-fails on the primary,
+    announces an unverified "Primary model restored", and oscillates forever (#106475).
+    """
+    if getattr(api_error, "status_code", None) != 400:
+        return False
+    pool = getattr(agent, "_credential_pool", None)
+    if pool is not None and len(pool.entries()) > 1:
+        return False  # another account in the pool may be entitled; leave rotation to it
+    haystack = str(getattr(api_error, "message", "") or api_error).lower()
+    if _CODEX_ACCOUNT_MODEL_ENTITLEMENT_MARKER not in haystack:
+        return False
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    model = str(getattr(agent, "model", "") or "").strip()
+    if not provider or not model:
+        return False
+    rejected = getattr(agent, "_entitlement_rejected_models", None)
+    if rejected is None:
+        rejected = agent._entitlement_rejected_models = set()
+    if (provider, model) in rejected:
+        return True
+    rejected.add((provider, model))
+    logger.warning(
+        "Model entitlement rejection: this account is not entitled to %s via %s; "
+        "treating it as unavailable for this session",
+        model, provider,
+    )
+    agent._buffer_status(
+        f"🚫 This account is not entitled to {model} via {provider}; it will be skipped "
+        "until restart. Switch to an entitled model via /model or `hermes model`."
+    )
+    return True
+
+
+def _is_entitlement_rejected(agent, provider: str, model: str) -> bool:
+    """True when (provider, model) — as configured or normalized — was rejected as unentitled
+    for this account (see _mark_entitlement_rejected_model)."""
+    rejected = getattr(agent, "_entitlement_rejected_models", None) or ()
+    if not rejected:
+        return False
+    if (provider, model) in rejected:
+        return True
+    from hermes_cli.model_normalize import normalize_model_for_provider
+    return (provider, normalize_model_for_provider(model, provider)) in rejected

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -282,6 +282,10 @@ def settle_unrecovered_error(
     ) and not is_context_length_error
 
     if is_client_error:
+        # A Codex ChatGPT-account entitlement 400 names the model: with nothing to rotate the
+        # slug is dead for this account, so record it before the fallback walk runs (#106475).
+        from agent.chat_completion_helpers import _mark_entitlement_rejected_model
+        _mark_entitlement_rejected_model(agent, api_error)
         # Copilot self-heal BEFORE fallback: a stale credential yields a 400
         # ``model_not_available_for_integrator`` / ``model_not_supported``, not a 401.
         # Fresh token + client rebuild, one retry, SAME provider.

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -284,7 +284,7 @@ def settle_unrecovered_error(
     if is_client_error:
         # A Codex ChatGPT-account entitlement 400 names the model: with nothing to rotate the
         # slug is dead for this account, so record it before the fallback walk runs (#106475).
-        from agent.chat_completion_helpers import _mark_entitlement_rejected_model
+        from agent.fallback_cooldown import _mark_entitlement_rejected_model
         _mark_entitlement_rejected_model(agent, api_error)
         # Copilot self-heal BEFORE fallback: a stale credential yields a 400
         # ``model_not_available_for_integrator`` / ``model_not_supported``, not a 401.

--- a/tests/run_agent/test_entitlement_fail_closed.py
+++ b/tests/run_agent/test_entitlement_fail_closed.py
@@ -1,51 +1,30 @@
-"""#106475: with a single credential, a Codex ChatGPT-account entitlement 400 must fail
-closed — the rejected slug is skipped by the fallback walk and restore_primary_runtime
-must not switch back and announce an unverified "Primary model restored" that would
-oscillate forever.
+"""#106475: with a single credential, a Codex ChatGPT-account entitlement 400 must fail closed —
+the rejected slug is skipped by the fallback walk and restore_primary_runtime must not switch back
+and announce an unverified "Primary model restored" that would oscillate forever.
 """
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from agent import chat_completion_helpers
+from agent.fallback_cooldown import _mark_entitlement_rejected_model
 
 from run_agent import AIAgent
 
 # Assembled at runtime so no credential-shaped literal sits in source (scanner guard).
 _TEST_KEY = "test-" + "key-12345678"
-_FALLBACK_KEY = "fallback-" + "key-1234"
 
 
-def _make_tool_defs(*names: str) -> list:
-    return [
-        {
-            "type": "function",
-            "function": {
-                "name": n,
-                "description": f"{n} tool",
-                "parameters": {"type": "object", "properties": {}},
-            },
-        }
-        for n in names
-    ]
-
-
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(fallback_model=None):
     with (
-        patch("model_tools.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("model_tools.get_tool_definitions", return_value=[]),
         patch("model_tools.check_toolset_requirements", return_value={}),
         patch("agent.process_bootstrap.OpenAI"),
         patch("agent.context_compressor.get_model_context_length", return_value=200_000),
         patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
     ):
         agent = AIAgent(
-            api_key=_TEST_KEY,
-            base_url=base_url,
-            provider=provider,
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-            fallback_model=fallback_model,
+            api_key=_TEST_KEY, base_url="https://my-llm.example.com/v1", provider="custom",
+            quiet_mode=True, skip_context_files=True, skip_memory=True, fallback_model=fallback_model,
         )
         agent.client = MagicMock()
         return agent
@@ -54,120 +33,57 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
 def _entitlement_error(model: str) -> SimpleNamespace:
     return SimpleNamespace(
         status_code=400,
-        message=(
-            f"The '{model}' model is not supported when using Codex with a ChatGPT account."
-        ),
+        message=f"The '{model}' model is not supported when using Codex with a ChatGPT account.",
     )
 
 
-def _mock_resolve(base_url="https://fallback.example.com/v1", api_key=_FALLBACK_KEY):
-    mock_client = MagicMock()
-    mock_client.api_key = api_key
-    mock_client.base_url = base_url
-    return mock_client
+def test_marker_fires_only_on_single_credential_entitlement_400_and_fallback_walk_skips_it():
+    agent = _make_agent(fallback_model={"provider": "openai-codex", "model": "openai/gpt-5.6-sol"})
+    agent.provider, agent.model = "openai-codex", "gpt-5.6-sol"
+    for err in (
+        SimpleNamespace(status_code=500, message="server error"),
+        SimpleNamespace(status_code=429, message="rate limited"),
+        SimpleNamespace(status_code=400, message="invalid request body"),
+        SimpleNamespace(status_code=403, message="model is not supported when using Codex with a ChatGPT account."),
+    ):
+        assert _mark_entitlement_rejected_model(agent, err) is False
+    # Multi-credential pool: another account may be entitled — leave it to rotation (#71970).
+    pool = MagicMock()
+    pool.entries.return_value = [object(), object()]
+    agent._credential_pool = pool
+    assert _mark_entitlement_rejected_model(agent, _entitlement_error("gpt-5.6-sol")) is False
+    assert getattr(agent, "_entitlement_rejected_models", None) is None
+
+    agent._credential_pool = None
+    assert _mark_entitlement_rejected_model(agent, _entitlement_error("gpt-5.6-sol")) is True
+    assert agent._entitlement_rejected_models == {("openai-codex", "gpt-5.6-sol")}
+    # The fallback entry names the same slug in vendor-prefixed form: skipped, chain exhausts.
+    with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
+        assert agent._try_activate_fallback() is False
+        resolve.assert_not_called()
 
 
-class TestMarkEntitlementRejectedModel:
-    def test_marks_codex_entitlement_400(self):
-        agent = _make_agent()
-        agent.provider = "openai-codex"
-        agent.model = "gpt-5.6-sol"
-        assert chat_completion_helpers._mark_entitlement_rejected_model(
-            agent, _entitlement_error("gpt-5.6-sol")
-        ) is True
-        assert agent._entitlement_rejected_models == {("openai-codex", "gpt-5.6-sol")}
+def test_restore_primary_runtime_is_gated_on_rejected_primary_slug():
+    fb_client = MagicMock()
+    fb_client.api_key, fb_client.base_url = "fallback-" + "key-1234", "https://fallback.example.com/v1"
 
-    def test_ignores_other_statuses_and_bodies(self):
-        agent = _make_agent()
-        agent.provider = "openai-codex"
-        agent.model = "gpt-5.6-sol"
-        for err in (
-            SimpleNamespace(status_code=500, message="server error"),
-            SimpleNamespace(status_code=429, message="rate limited"),
-            SimpleNamespace(status_code=400, message="invalid request body"),
-            SimpleNamespace(status_code=403, message="model is not supported when using Codex with a ChatGPT account."),
-        ):
-            assert chat_completion_helpers._mark_entitlement_rejected_model(agent, err) is False
-        assert getattr(agent, "_entitlement_rejected_models", None) is None
-
-    def test_multi_credential_pool_is_left_to_rotation(self):
-        agent = _make_agent()
-        agent.provider = "openai-codex"
-        agent.model = "gpt-5.6-sol"
-        pool = MagicMock()
-        pool.entries.return_value = [object(), object()]
-        agent._credential_pool = pool
-        assert chat_completion_helpers._mark_entitlement_rejected_model(
-            agent, _entitlement_error("gpt-5.6-sol")
-        ) is False
-        assert getattr(agent, "_entitlement_rejected_models", None) is None
-
-    def test_single_credential_pool_still_marks(self):
-        agent = _make_agent()
-        agent.provider = "openai-codex"
-        agent.model = "gpt-5.6-sol"
-        pool = MagicMock()
-        pool.entries.return_value = [object()]
-        agent._credential_pool = pool
-        assert chat_completion_helpers._mark_entitlement_rejected_model(
-            agent, _entitlement_error("gpt-5.6-sol")
-        ) is True
-
-
-class TestFallbackWalkSkipsRejectedSlug:
-    def test_rejected_entry_is_skipped_and_chain_exhausts(self):
-        agent = _make_agent(
-            fallback_model={"provider": "openai-codex", "model": "gpt-5.6-sol"},
-        )
-        agent._entitlement_rejected_models = {("openai-codex", "gpt-5.6-sol")}
-        with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
-            assert agent._try_activate_fallback() is False
-            resolve.assert_not_called()
-
-    def test_normalized_slug_form_is_also_skipped(self):
-        agent = _make_agent(
-            fallback_model={"provider": "openai-codex", "model": "openai/gpt-5.6-sol"},
-        )
-        # The runtime (and the marker) recorded the post-normalization slug.
-        agent._entitlement_rejected_models = {("openai-codex", "gpt-5.6-sol")}
-        with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
-            assert agent._try_activate_fallback() is False
-            resolve.assert_not_called()
-
-
-class TestRestoreGate:
-    def test_restore_does_not_switch_back_to_rejected_primary(self):
-        agent = _make_agent(
-            fallback_model={"provider": "zai", "model": "glm-5.2"},
-        )
-        agent._primary_runtime["model"] = "gpt-5.6-sol"
-        agent._primary_runtime["provider"] = "openai-codex"
-        agent._entitlement_rejected_models = {("openai-codex", "gpt-5.6-sol")}
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_resolve(), None)):
+    def _run(rejected_slug):
+        agent = _make_agent(fallback_model={"provider": "zai", "model": "glm-5.2"})
+        agent._primary_runtime["model"], agent._primary_runtime["provider"] = "gpt-5.6-sol", "openai-codex"
+        agent._entitlement_rejected_models = {("openai-codex", rejected_slug)}
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(fb_client, None)):
             assert agent._try_activate_fallback() is True
-        assert agent._fallback_activated is True
-
         emitted = []
         agent._emit_status = emitted.append
         with patch("agent.process_bootstrap.OpenAI", return_value=MagicMock()):
-            assert agent._restore_primary_runtime() is False
+            restored = agent._restore_primary_runtime()
+        return agent, restored, emitted
 
-        # Still on the fallback; no unverified "Primary model restored" claim.
-        assert agent.provider == "zai"
-        assert agent.model == "glm-5.2"
-        assert agent._fallback_activated is True
-        assert emitted == []
+    agent, restored, emitted = _run("gpt-5.6-sol")
+    assert restored is False
+    assert (agent.provider, agent.model, agent._fallback_activated) == ("zai", "glm-5.2", True)
+    assert not any("Primary model restored" in n for n in emitted)
 
-    def test_unrejected_primary_restores_normally(self):
-        agent = _make_agent(
-            fallback_model={"provider": "zai", "model": "glm-5.2"},
-        )
-        agent._entitlement_rejected_models = {("openai-codex", "some-other-slug")}
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_resolve(), None)):
-            assert agent._try_activate_fallback() is True
-
-        emitted = []
-        agent._emit_status = emitted.append
-        with patch("agent.process_bootstrap.OpenAI", return_value=MagicMock()):
-            assert agent._restore_primary_runtime() is True
-        assert any("Primary model restored" in notice for notice in emitted)
+    _, restored, emitted = _run("some-other-slug")
+    assert restored is True
+    assert any("Primary model restored" in n for n in emitted)

--- a/tests/run_agent/test_entitlement_fail_closed.py
+++ b/tests/run_agent/test_entitlement_fail_closed.py
@@ -1,0 +1,173 @@
+"""#106475: with a single credential, a Codex ChatGPT-account entitlement 400 must fail
+closed — the rejected slug is skipped by the fallback walk and restore_primary_runtime
+must not switch back and announce an unverified "Primary model restored" that would
+oscillate forever.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent import chat_completion_helpers
+
+from run_agent import AIAgent
+
+# Assembled at runtime so no credential-shaped literal sits in source (scanner guard).
+_TEST_KEY = "test-" + "key-12345678"
+_FALLBACK_KEY = "fallback-" + "key-1234"
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+    with (
+        patch("model_tools.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+        patch("agent.context_compressor.get_model_context_length", return_value=200_000),
+        patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key=_TEST_KEY,
+            base_url=base_url,
+            provider=provider,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def _entitlement_error(model: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        status_code=400,
+        message=(
+            f"The '{model}' model is not supported when using Codex with a ChatGPT account."
+        ),
+    )
+
+
+def _mock_resolve(base_url="https://fallback.example.com/v1", api_key=_FALLBACK_KEY):
+    mock_client = MagicMock()
+    mock_client.api_key = api_key
+    mock_client.base_url = base_url
+    return mock_client
+
+
+class TestMarkEntitlementRejectedModel:
+    def test_marks_codex_entitlement_400(self):
+        agent = _make_agent()
+        agent.provider = "openai-codex"
+        agent.model = "gpt-5.6-sol"
+        assert chat_completion_helpers._mark_entitlement_rejected_model(
+            agent, _entitlement_error("gpt-5.6-sol")
+        ) is True
+        assert agent._entitlement_rejected_models == {("openai-codex", "gpt-5.6-sol")}
+
+    def test_ignores_other_statuses_and_bodies(self):
+        agent = _make_agent()
+        agent.provider = "openai-codex"
+        agent.model = "gpt-5.6-sol"
+        for err in (
+            SimpleNamespace(status_code=500, message="server error"),
+            SimpleNamespace(status_code=429, message="rate limited"),
+            SimpleNamespace(status_code=400, message="invalid request body"),
+            SimpleNamespace(status_code=403, message="model is not supported when using Codex with a ChatGPT account."),
+        ):
+            assert chat_completion_helpers._mark_entitlement_rejected_model(agent, err) is False
+        assert getattr(agent, "_entitlement_rejected_models", None) is None
+
+    def test_multi_credential_pool_is_left_to_rotation(self):
+        agent = _make_agent()
+        agent.provider = "openai-codex"
+        agent.model = "gpt-5.6-sol"
+        pool = MagicMock()
+        pool.entries.return_value = [object(), object()]
+        agent._credential_pool = pool
+        assert chat_completion_helpers._mark_entitlement_rejected_model(
+            agent, _entitlement_error("gpt-5.6-sol")
+        ) is False
+        assert getattr(agent, "_entitlement_rejected_models", None) is None
+
+    def test_single_credential_pool_still_marks(self):
+        agent = _make_agent()
+        agent.provider = "openai-codex"
+        agent.model = "gpt-5.6-sol"
+        pool = MagicMock()
+        pool.entries.return_value = [object()]
+        agent._credential_pool = pool
+        assert chat_completion_helpers._mark_entitlement_rejected_model(
+            agent, _entitlement_error("gpt-5.6-sol")
+        ) is True
+
+
+class TestFallbackWalkSkipsRejectedSlug:
+    def test_rejected_entry_is_skipped_and_chain_exhausts(self):
+        agent = _make_agent(
+            fallback_model={"provider": "openai-codex", "model": "gpt-5.6-sol"},
+        )
+        agent._entitlement_rejected_models = {("openai-codex", "gpt-5.6-sol")}
+        with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
+            assert agent._try_activate_fallback() is False
+            resolve.assert_not_called()
+
+    def test_normalized_slug_form_is_also_skipped(self):
+        agent = _make_agent(
+            fallback_model={"provider": "openai-codex", "model": "openai/gpt-5.6-sol"},
+        )
+        # The runtime (and the marker) recorded the post-normalization slug.
+        agent._entitlement_rejected_models = {("openai-codex", "gpt-5.6-sol")}
+        with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
+            assert agent._try_activate_fallback() is False
+            resolve.assert_not_called()
+
+
+class TestRestoreGate:
+    def test_restore_does_not_switch_back_to_rejected_primary(self):
+        agent = _make_agent(
+            fallback_model={"provider": "zai", "model": "glm-5.2"},
+        )
+        agent._primary_runtime["model"] = "gpt-5.6-sol"
+        agent._primary_runtime["provider"] = "openai-codex"
+        agent._entitlement_rejected_models = {("openai-codex", "gpt-5.6-sol")}
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_resolve(), None)):
+            assert agent._try_activate_fallback() is True
+        assert agent._fallback_activated is True
+
+        emitted = []
+        agent._emit_status = emitted.append
+        with patch("agent.process_bootstrap.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is False
+
+        # Still on the fallback; no unverified "Primary model restored" claim.
+        assert agent.provider == "zai"
+        assert agent.model == "glm-5.2"
+        assert agent._fallback_activated is True
+        assert emitted == []
+
+    def test_unrejected_primary_restores_normally(self):
+        agent = _make_agent(
+            fallback_model={"provider": "zai", "model": "glm-5.2"},
+        )
+        agent._entitlement_rejected_models = {("openai-codex", "some-other-slug")}
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_resolve(), None)):
+            assert agent._try_activate_fallback() is True
+
+        emitted = []
+        agent._emit_status = emitted.append
+        with patch("agent.process_bootstrap.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+        assert any("Primary model restored" in notice for notice in emitted)


### PR DESCRIPTION
An unentitled Codex primary plus an unentitled Codex fallback now fails closed with one terminal entitlement error instead of alternating "Model fallback" / "Primary model restored" forever with zero delivered answers.

Fixes #106475. Refs #61660, #71970.

## Changes
- `agent/fallback_cooldown.py::_mark_entitlement_rejected_model` — on the non-retryable client-error branch (`agent/turn_api_error.py::settle_unrecovered_error`), a 400 whose body carries the normalized public text `model is not supported when using Codex with a ChatGPT account` records the current `(provider, model)` as dead for the session and emits one user-visible notice pointing at `/model`. Scoped to single-credential pools only: with ≥2 pool entries another account may be entitled, so the decision is left to credential rotation (#71970 / #71973).
- `agent/chat_completion_helpers.py::_should_skip_fallback_candidate` skips rejected entries (configured or normalized slug form) — the walk exhausts instead of re-selecting a dead slug.
- `agent/agent_runtime_helpers.py::restore_primary_runtime` returns `False` when the primary's slug was rejected: the session stays on the current runtime, no unverified "Primary model restored" is announced, and the next turn surfaces the terminal 400 once.
- Marker + predicate live in the topical sibling `agent/fallback_cooldown.py` (the state shared by the fallback walk and the restore gate) rather than appended to the `chat_completion_helpers` facade where the original PR put them; the two `try/except → False` wrappers around `pool.entries()` / `normalize_model_for_provider` (never raises) were dropped. Tests trimmed from 8 to the 2 invariants.

## Validation
| | before (origin/main) | after |
|---|---|---|
| Live repro, turn 1 | primary 400 → fallback 400 → terminal error | same, plus one `🚫 not entitled` notice per slug |
| Live repro, turn 2 (after the 5 s exhausted-chain cooldown) | `✅ Primary model restored …` emitted, chain re-walked, both 400s again | no restore notice, no fallback notice, 1 API call, same terminal error |
| `tests/run_agent/test_entitlement_fail_closed.py` | 2 failed with the marker present but call sites reverted (walk called `resolve_provider_client`; restore returned `True`) | 2 passed |
| `tests/agent/` + `tests/run_agent/` | — | 8788 passed, 1 failed: `test_compression_stall_fallback_78981` — passes alone on this branch and on main, untouched by this diff (isolation flake) |

**Live repro:** in-process harness driving the real `run_conversation` loop with `interruptible_api_call` stubbed to return the entitlement 400 for every model, two turns on one agent — before: turn 2 emits `Primary model restored` and re-walks the chain / after: turn 2 emits nothing but the terminal error. Harness: `/tmp/campaign-0909/codex_entitlement_repro.py` (one-shot, not committed).

**Root cause:** `restore_primary_runtime` switched back to the primary at the start of every turn on the strength of the fallback having also failed, with nothing recording that the account can never use either slug.

## Credits
- @liuhao1024 — fix and tests (PR #106482, cherry-picked with authorship preserved)
- @shivasymbl — report and measurement (#106475)
- @kilhyeonjun — multi-credential rotation half of the same 400 (#71970 / #71973), deliberately left to that PR

## Infographic
![codex-entitlement-fail-closed](https://v3b.fal.media/files/b/0aa9ba7a/0R3hj06OB2TePbSqraoCT_sU1dDJhf.png)
