### PR TITLE
kanban promote refuses undone parents instead of a false --force success (#106195, salvage #75354)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1013,13 +1013,13 @@ def _cmd_promote(args: argparse.Namespace) -> int:
     author = _profile_author()
     # Dedupe while preserving order; positional task_id always first.
     ids = list(dict.fromkeys(_bulk_ids(args)))
-    dry_run, force = bool(args.dry_run), bool(args.force)
+    dry_run = bool(args.dry_run)
 
     results: list[dict[str, object]] = []
     with kbc.connect_closing() as conn:
         for tid in ids:
-            ok, err = kb.promote_task(conn, tid, actor=author, reason=reason, force=force, dry_run=dry_run)
-            results.append({"task_id": tid, "promoted": ok, "dry_run": dry_run, "forced": force,
+            ok, err = kb.promote_task(conn, tid, actor=author, reason=reason, dry_run=dry_run)
+            results.append({"task_id": tid, "promoted": ok, "dry_run": dry_run,
                             "reason": reason, "error": err})
 
     failed = [r for r in results if not r["promoted"]]

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3173,11 +3173,11 @@ def request_changes(
 
 def promote_task(
     conn: sqlite3.Connection, task_id: str, *, actor: str, reason: Optional[str] = None,
-    force: bool = False, dry_run: bool = False,
+    dry_run: bool = False,
 ) -> tuple[bool, Optional[str]]:
     """Operator promotion ``todo``/``blocked`` -> ``ready`` with an audit event.
-    Refused while a parent is unfinished unless ``force``; ``dry_run`` only
-    validates. Returns ``(ok, reason)``."""
+    Refused while a parent is unfinished; ``dry_run`` only validates.
+    Returns ``(ok, reason)``."""
     cur_status = _task_status(conn, task_id)
     if cur_status is None:
         return False, f"task {task_id} not found"
@@ -3188,18 +3188,22 @@ def promote_task(
             f"'todo' or 'blocked'"
         )
 
-    if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?", (task_id,),
-        ).fetchall()
-        unsatisfied = [p["id"] for p in parents if p["status"] not in ("done", "archived")]
-        if unsatisfied:
-            return False, (
-                f"unsatisfied parent dependencies: "
-                f"{', '.join(unsatisfied)} (use --force to override)"
-            )
+    # No override: claim_task demotes ready -> todo on an undone parent whichever
+    # writer set 'ready', so a forced promotion would only report a success the
+    # first claim silently reverts (#106195). The dependency itself is the knob.
+    parents = conn.execute(
+        "SELECT t.id, t.status FROM tasks t "
+        "JOIN task_links l ON l.parent_id = t.id "
+        "WHERE l.child_id = ?", (task_id,),
+    ).fetchall()
+    unsatisfied = [p["id"] for p in parents if p["status"] not in ("done", "archived")]
+    if unsatisfied:
+        return False, (
+            f"unsatisfied parent dependencies: {', '.join(unsatisfied)} "
+            f"(the ready -> running claim re-checks parents, so promotion cannot "
+            f"bypass them; complete the parents or drop the link with "
+            f"`hermes kanban unlink <parent_id> {task_id}`)"
+        )
 
     if dry_run:
         return True, None
@@ -3211,9 +3215,7 @@ def promote_task(
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
-        _append_event(
-            conn, task_id, "promoted_manual", {"actor": actor, "reason": reason, "forced": force},
-        )
+        _append_event(conn, task_id, "promoted_manual", {"actor": actor, "reason": reason})
 
     return True, None
 

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -328,7 +328,6 @@ _SPECS = [
         _TASK_ID,
         _arg("reason", nargs="*", help="Audit-trail reason (recorded on the task_events row)"),
         _bulk_ids("promote"),
-        _arg("--force", action="store_true", help="Promote even if parent dependencies are not yet done/archived"),
         _arg("--dry-run", action="store_true", help="Validate the promotion without mutating state"),
         _arg("--json", dest="json", action="store_true", help="Emit machine-readable JSON result"),
     ], help="Manually move one or more todo/blocked tasks to ready (recovery path)"),

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -64,10 +64,22 @@ def test_promote_stuck_todo_succeeds(conn):
     assert kb.get_task(conn, child).status == "ready"
 
 
+def test_promote_refuses_undone_parent_and_names_the_real_remedy(conn):
+    # #106195: promotion must never report a 'ready' that the first claim reverts.
+    child, (parent,) = _stuck_todo(conn, parents_done=False)
+    ok, err = kb.promote_task(conn, child, actor="tester", reason="recovery")
+    assert not ok
+    assert parent in err and "--force" not in err and f"unlink <parent_id> {child}" in err
+    assert kb.get_task(conn, child).status == "todo"
+    assert kb.claim_task(conn, child) is None  # still gated; nothing pretended
 
 
-
-
+def test_cli_promote_has_no_force_flag(kanban_home):
+    from hermes_cli import kanban_parser
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    kanban_parser.build_parser(parser.add_subparsers(dest="command"))
+    with pytest.raises(SystemExit):
+        parser.parse_args(["kanban", "promote", "t_x", "--force"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`hermes kanban promote` now refuses a task whose parents are unfinished and says how to actually unblock it, instead of `--force` printing `Promoted <id> -> ready` for a transition the first claim silently reverts.

## Changes
- `promote_task` / `hermes kanban promote`: `--force` removed (parser flag, CLI handler, `force=` kwarg, the `forced` event field nothing read).
- Refusal message states that the `ready -> running` claim re-checks parents (so promotion cannot bypass them) and names the working remedies: complete the parents or `hermes kanban unlink <parent_id> <id>`.
- Two invariant tests in `tests/hermes_cli/test_kanban_promote.py`: refusal on an undone parent leaves the task in `todo` with no fake `ready` (red on main: 1 failed / 3 passed with main's `kanban_db.py` swapped in), and `--force` no longer parses.

## Root cause
`promote --force` wrote `status='ready'`, but `claim_task` is the deliberate single enforcement point ("never ready -> running with an undone parent, whichever writer set 'ready'", cda20eec0c0) and demotes back to `todo` with `claim_rejected {parents_not_done}` — so the override had no honest outcome, only a success line that the next human claim or dispatcher tick undid.

## Why refuse rather than honor the force at claim time
`complete_task` and `request_review` re-check the same `_parents_satisfied` predicate. Live probe on a subgoal driven to `running` past the gate: `complete_task -> False`, `request_review -> (False, 'parent dependencies are not satisfied')`. A consume-at-claim authorization (#75354's design) would let the child *start* but never *finish*; the dependency edge is the real knob, and `unlink` already exists for it.

## Live repro (real board DB in a temp `HERMES_HOME`, real `hermes_cli` imports)
Setup: `running` goal parent + `todo` subgoal with `parents=[goal]`.

**Before (origin/main 511633be90e)** — `/tmp/repro_106195.py`:
```
$ hermes kanban promote --force t_a8b55d77 recovery
  rc=0 stdout='Promoted t_a8b55d77 -> ready: recovery' stderr=''
  status after promote: ready
$ hermes kanban claim t_a8b55d77
  claim_task -> None
  status after claim: todo
  events: created -> promoted_manual {forced: True} -> claim_rejected {reason: parents_not_done}
```

**After (this branch)** — `/tmp/repro_106195_after.py`, exact user argv through the real parser:
```
$ hermes kanban promote --force t_86d0e4a9 recovery
  rc=2 stderr='hermes: error: unrecognized arguments: --force'
$ hermes kanban promote t_86d0e4a9 recovery
  rc=1 stderr='cannot promote t_86d0e4a9: unsatisfied parent dependencies: t_02f46811 (the ready -> running claim re-checks parents, so promotion cannot bypass them; complete the parents or drop the link with `hermes kanban unlink <parent_id> t_86d0e4a9`)'
  status after promote attempts: todo
  claim_task -> None
  events: created -> claim_rejected
```

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_promote.py` → 4 passed.
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py` → 333 passed, 1 failed: `test_kanban_gateway_restart_handoff.py::test_real_user_systemd_scope_preserves_worker_context`, which fails identically on an untouched `origin/main` checkout (host systemd-scope receipt; unrelated).
- ruff, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check` clean. No docs reference `promote --force`.

## Credit
Slimmer redo of #75354 by @vyacheslavk, who traced the promote -> claim gap; direction differs (refuse at promote rather than persist a consumable authorization) because the completion gates make a forced claim a dead end. Live-trace confirmations by @kokhlo and @liuhao1024 on the issue.

Closes #106195

## Infographic
![kanban-promote-no-false-force](https://v3b.fal.media/files/b/0aa9ba87/X6eNXyag6k3pUbgW4sg3u_SPraroId.png)
