### PR TITLE
fix(state): live replay keeps compression summary separate from the next user turn (#106352, salvage #106353)

### DIFF
--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -784,14 +784,16 @@ class SessionMessagesMixin:
         """Load messages in OpenAI format. ``include_compacted`` (deduped display history) is for DISPLAY reads
         only: the model-fed restore must not regrow what compaction summarized away. ``repair_alternation``
         repairs the loaded list for LIVE REPLAY callers (a durable ``user;user`` pair would re-trigger the
-        per-request repair forever); the stored transcript is never mutated."""
+        per-request repair forever), preserving summary markers before repair so derivative context
+        cannot merge with an original user turn; the stored transcript is never mutated."""
         rows = self._fetch_conversation_rows(
             self._resume_lineage_ids(session_id) if include_ancestors else [session_id],
             self._active_clause(include_inactive, include_compacted), with_session_id=False)
         if include_compacted:
             rows = self._dedupe_display_generations(rows)
         return self._rows_to_conversation(rows, session_id=session_id, include_ancestors=include_ancestors,
-            repair_alternation=repair_alternation, include_row_ids=include_row_ids)
+            repair_alternation=repair_alternation, include_row_ids=include_row_ids,
+            include_summary_markers=repair_alternation)
 
     def _dedupe_replayed_user(self, messages, msg, exact_user_clones) -> Tuple[bool, Any]:
         """Ancestor-lineage dedupe of one decoded user *msg* -> ``(skip, exact_clone_key)``. Rotation

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -327,6 +327,34 @@ def test_compressed_summary_marker_survives_restart_via_resume_history(tmp_path)
     assert all("_compressed_summary" not in m for m in plain)
 
 
+def test_live_replay_preserves_summary_boundary_without_changing_display(tmp_path):
+    from hermes_state import SessionDB
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    db.create_session("summary-replay", source="telegram")
+    db.append_message("summary-replay", "user", "Derivative context", _compressed_summary=True)
+    db.append_message("summary-replay", "user", "Original request")
+    db.append_message("summary-replay", "assistant", "Original answer")
+    db.create_session("plain-replay", source="telegram")
+    db.append_message("plain-replay", "user", "First request")
+    db.append_message("plain-replay", "user", "Second request")
+
+    reopened = SessionDB(db_path)
+    display_before = reopened.get_messages_as_conversation("summary-replay")
+    replay = reopened.get_messages_as_conversation("summary-replay", repair_alternation=True)
+    assert [m["content"] for m in replay] == [
+        "Derivative context", "Original request", "Original answer"
+    ]
+    assert replay[0].get("_compressed_summary") is True
+    assert all("_compressed_summary" not in m for m in replay[1:])
+    assert reopened.get_messages_as_conversation("summary-replay") == display_before
+    assert all("_compressed_summary" not in m for m in display_before)
+    plain = reopened.get_messages_as_conversation("plain-replay", repair_alternation=True)
+    assert [m["content"] for m in plain] == ["First request\n\nSecond request"]
+    assert all("_compressed_summary" not in m for m in plain)
+
+
 def test_compressed_summary_column_is_added_to_legacy_databases(tmp_path):
     """Pre-upgrade databases gain the marker column via declarative reconcile.
 


### PR DESCRIPTION
Live replay no longer merges a persisted compression summary into the user's next request: `SessionDB.get_messages_as_conversation(..., repair_alternation=True)` now keeps the durable `_compressed_summary` marker so alternation repair recognizes the summary carrier and leaves the boundary intact.

Reachability: code-path-reachable on every live-replay caller (gateway `session_transcript.get_session_history`, CLI resume, ACP resume, TUI lineage-overflow resume, `turn_facade_lease`) — the same durable shape `get_resume_conversations` already handled.

## Changes

- `hermes_state_messages.py::get_messages_as_conversation` — pass `include_summary_markers=repair_alternation` to `_rows_to_conversation`. Display reads (`repair_alternation=False`) stay marker-free, byte-identical to before.
- `tests/agent/test_pre_compress_checkpoint_contract.py` — one invariant test: replay keeps three messages with the marker on the summary only; default display read unchanged; two genuine consecutive user rows still merge.

## Validation

| Check | Before (origin/main `511633be90e`) | After |
|---|---|---|
| Live repro: temp `SessionDB`, rows `user[_compressed_summary] / user / assistant`, reopen, `repair_alternation=True` | `[('Derivative context\n\nOriginal request', None), ('Original answer', None)]` — **BUG FIRES** | `[('Derivative context', True), ('Original request', None), ('Original answer', None)]` |
| Default display read of the same session | 3 rows, marker-free | 3 rows, marker-free (unchanged) |
| Genuine `user;user` pair with `repair_alternation=True` | merges to one message | still merges to one message |
| New test on base (sabotage) | `1 failed` | passes |
| `scripts/run_tests.sh tests/agent/test_pre_compress_checkpoint_contract.py tests/hermes_state/ tests/state/` | — | green |
| `tests/test_hermes_state.py` | `TestFTS5Search::test_search_projection_skips_context_enrichment_queries` fails on pristine `origin/main` (pre-existing, FTS search, untouched here) | 260 passed, that one deselected |

Root cause: `_rows_to_conversation` only decodes the `_compressed_summary` column when `include_summary_markers` is set, and `get_messages_as_conversation` never set it, so `_merge_consecutive_users` (`agent/agent_runtime_helpers.py`) could not tell the summary carrier from a plain user row and merged them.

Salvage notes: single commit cherry-picked verbatim under the contributor's identity (mapping already present in `scripts/release.py`); no conflicts, no follow-up changes needed.

Salvages #106353 from @100yenadmin
Closes #106352

## Infographic
![replay-summary-markers](https://v3b.fal.media/files/b/0aa9ba2f/s5y_LIsh3Obk0Jg2G-wP8_FS6zU7FB.png)
