### PR TITLE
Desktop stops repeating SSH uname probes, wsl.exe distro spawns, transcript re-serialisation and live-status requests (#106131 #106129 #106123 #106098, salvage #106132 #106130 #106124 #106099)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10712,6 +10712,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     const lifecycle = platform.os === 'Windows' ? connectWindowsRemote : remoteLifecycle.connect
     result = await lifecycle({
       ssh,
+      platform,
       profile: resolveRemoteSshDashboardProfile(sshConfig.remoteProfile, profile),
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -999,7 +999,14 @@ test('connect() spawns fresh when there is no lockfile, adopts the served token'
     [/cat .*\.log/, 'HERMES_DASHBOARD_READY port=51999\n']
   ])
 
-  const result = await connect(connectDeps(ssh, { adoptServedToken: async () => 'the-served-token' }))
+  const result = await connect(
+    connectDeps(ssh, {
+      adoptServedToken: async () => 'the-served-token',
+      platform: { os: 'Linux', arch: 'x86_64' }
+    })
+  )
+
+  assert.equal(ssh.calls.filter(command => command === 'uname -s; uname -m').length, 0)
   assert.equal(result.reused, false)
   assert.equal(result.remotePort, 51999)
   assert.equal(result.localPort, 50001)

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -1396,7 +1396,7 @@ async function connect(deps) {
   const log = msg => rememberLog(`[ssh-lifecycle] ${msg}`)
 
   assertBootstrapNotSuperseded(signal)
-  const platform = await probeRemotePlatform(ssh)
+  const platform = deps.platform ?? (await probeRemotePlatform(ssh))
   log(`remote platform ${platform.os}/${platform.arch}`)
   const hermesHome = await probeRemoteHermesHome(ssh)
   await assertRemoteInstallUpdateClear(ssh, hermesHome)

--- a/apps/desktop/electron/wsl-path-bridge.test.ts
+++ b/apps/desktop/electron/wsl-path-bridge.test.ts
@@ -39,13 +39,22 @@ test('parseDefaultDistro strips the default-marker and blank lines', () => {
 
 // ── wslPosixToWindowsAccessible ──────────────────────────────────────
 
-test('wslPosixToWindowsAccessible maps a drvfs mount to its Windows drive', () => {
-  assert.equal(wslPosixToWindowsAccessible('/mnt/c/Users/alex', 'Ubuntu'), 'C:\\Users\\alex')
-  assert.equal(wslPosixToWindowsAccessible('/mnt/d', 'Ubuntu'), 'D:\\')
-})
+test('wslPosixToWindowsAccessible resolves a distro only for paths that need a UNC share', () => {
+  let distroProbes = 0
 
-test('wslPosixToWindowsAccessible maps an in-distro POSIX path to a UNC share', () => {
-  assert.equal(wslPosixToWindowsAccessible('/home/alex/proj', 'Ubuntu'), '\\\\wsl.localhost\\Ubuntu\\home\\alex\\proj')
+  const resolveDistro = () => {
+    distroProbes += 1
+
+    return 'Ubuntu'
+  }
+
+  assert.equal(wslPosixToWindowsAccessible('/mnt/c/Users/alex', undefined, resolveDistro), 'C:\\Users\\alex')
+  assert.equal(distroProbes, 0)
+  assert.equal(
+    wslPosixToWindowsAccessible('/home/alex/proj', undefined, resolveDistro),
+    '\\\\wsl.localhost\\Ubuntu\\home\\alex\\proj'
+  )
+  assert.equal(distroProbes, 1)
 })
 
 test('wslPosixToWindowsAccessible leaves non-absolute / already-Windows paths alone', () => {

--- a/apps/desktop/electron/wsl-path-bridge.ts
+++ b/apps/desktop/electron/wsl-path-bridge.ts
@@ -133,7 +133,11 @@ function wslUncBase(distro: string): string {
  * (drvfs mount), any other absolute POSIX path → `\\wsl.localhost\<distro>\...`.
  * Non-absolute or already-Windows paths pass through.
  */
-export function wslPosixToWindowsAccessible(posixPath: string, distro: string = resolveDefaultWslDistro()): string {
+export function wslPosixToWindowsAccessible(
+  posixPath: string,
+  distro?: string,
+  resolveDistro: () => string = resolveDefaultWslDistro
+): string {
   const value = String(posixPath || '').trim()
   const normalized = value.replace(/\\/g, '/')
 
@@ -151,7 +155,7 @@ export function wslPosixToWindowsAccessible(posixPath: string, distro: string = 
 
   const relative = normalized.replace(/^\/+/, '').replace(/\//g, '\\')
 
-  return `${wslUncBase(distro)}\\${relative}`
+  return `${wslUncBase(distro ?? resolveDistro())}\\${relative}`
 }
 
 /** Native folder dialog `defaultPath`: open a WSL cwd in the Windows picker. */
@@ -174,7 +178,7 @@ export function resolvePickerDefaultPath(
   const value = String(defaultPath).trim()
 
   return value.startsWith('/') && !WIN_DRIVE_RE.test(value)
-    ? wslPosixToWindowsAccessible(value, distro ?? resolveDefaultWslDistro())
+    ? wslPosixToWindowsAccessible(value, distro)
     : defaultPath
 }
 
@@ -191,6 +195,6 @@ export function resolveLocalReadPath(dirPath: string, distro?: string, profile?:
   }
 
   return IS_WINDOWS && value.startsWith('/') && !WIN_DRIVE_RE.test(value)
-    ? wslPosixToWindowsAccessible(value, distro ?? resolveDefaultWslDistro())
+    ? wslPosixToWindowsAccessible(value, distro)
     : value
 }

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -69,22 +69,6 @@ describe('useBackgroundSync profile-scoped session refresh', () => {
     expect(request).toHaveBeenCalledTimes(2)
   })
 
-  it('discards a queued old-connection refresh when the connection changes', async () => {
-    let rejectOld!: (reason: Error) => void
-    const oldRequest = new Promise<{ sessions: [] }>((_, reject) => { rejectOld = reject })
-    const request = vi.fn().mockReturnValueOnce(oldRequest).mockResolvedValue({ sessions: [] })
-    const hook = render('default', 'first', async () => undefined, request)
-    await act(async () => { $sessionsChangeTick.set(1) })
-    hook.rerender({ connectionId: 'second', profile: 'default' })
-    await act(async () => undefined)
-    expect(request).toHaveBeenCalledTimes(2)
-    await act(async () => { rejectOld(new Error('old connection closed')) })
-    expect(request).toHaveBeenCalledTimes(2)
-    hook.unmount()
-    await act(async () => { $sessionsChangeTick.set(2) })
-    expect(request).toHaveBeenCalledTimes(2)
-  })
-
   it('refreshes the session list after the active gateway profile changes', async () => {
     const refreshSessions = vi.fn(async () => undefined)
     const hook = render('default', 'local', refreshSessions)

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -9,7 +9,12 @@ import { useBackgroundSync } from './use-background-sync'
 const noop = () => undefined
 const requestGateway = async () => ({ sessions: [] })
 
-function render(activeGatewayProfile: string, activeConnectionId: string, refreshSessions: () => Promise<void>) {
+function render(
+  activeGatewayProfile: string,
+  activeConnectionId: string,
+  refreshSessions: () => Promise<void>,
+  gatewayRequest = requestGateway
+) {
   return renderHook(
     ({ connectionId, profile }: { connectionId: string; profile: string }) => {
       useBackgroundSync({
@@ -26,7 +31,7 @@ function render(activeGatewayProfile: string, activeConnectionId: string, refres
         refreshHermesConfig: noop,
         refreshMessagingSessions: noop,
         refreshSessions,
-        requestGateway
+        requestGateway: gatewayRequest
       })
     },
     { initialProps: { connectionId: activeConnectionId, profile: activeGatewayProfile } }
@@ -45,6 +50,39 @@ describe('useBackgroundSync profile-scoped session refresh', () => {
   afterEach(() => {
     cleanup()
     vi.useRealTimers()
+  })
+
+  it('coalesces change ticks while the live status request is pending', async () => {
+    $changeEventsAvailable.set(true)
+    let release!: (value: { sessions: [] }) => void
+    const pending = new Promise<{ sessions: [] }>(resolve => { release = resolve })
+    const request = vi.fn(() => pending)
+    render('default', 'local', async () => undefined, request)
+    await act(async () => undefined)
+
+    for (let tick = 1; tick <= 8; tick += 1) {
+      await act(async () => { $sessionsChangeTick.set(tick) })
+    }
+
+    expect(request).toHaveBeenCalledTimes(1)
+    await act(async () => { release({ sessions: [] }) })
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('discards a queued old-connection refresh when the connection changes', async () => {
+    let rejectOld!: (reason: Error) => void
+    const oldRequest = new Promise<{ sessions: [] }>((_, reject) => { rejectOld = reject })
+    const request = vi.fn().mockReturnValueOnce(oldRequest).mockResolvedValue({ sessions: [] })
+    const hook = render('default', 'first', async () => undefined, request)
+    await act(async () => { $sessionsChangeTick.set(1) })
+    hook.rerender({ connectionId: 'second', profile: 'default' })
+    await act(async () => undefined)
+    expect(request).toHaveBeenCalledTimes(2)
+    await act(async () => { rejectOld(new Error('old connection closed')) })
+    expect(request).toHaveBeenCalledTimes(2)
+    hook.unmount()
+    await act(async () => { $sessionsChangeTick.set(2) })
+    expect(request).toHaveBeenCalledTimes(2)
   })
 
   it('refreshes the session list after the active gateway profile changes', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -575,7 +575,6 @@ export function useBackgroundSync({
 }: BackgroundSyncParams): void {
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
-  const sessionsChangeTick = useStore($sessionsChangeTick)
   const activeTranscriptBusy = useStore($busy)
   const activeTranscriptRefreshPendingRef = useRef<string | null>(null)
   // Tile reconcile state (#93942 slice 1): shared sequence guard + per-tile
@@ -682,9 +681,16 @@ export function useBackgroundSync({
 
     let cancelled = false
     let inFlight = false
+    let refreshPending = false
 
     const refreshLiveStatuses = async () => {
+      if (cancelled) {
+        return
+      }
+
       if (inFlight) {
+        refreshPending = true
+
         return
       }
 
@@ -701,8 +707,15 @@ export function useBackgroundSync({
         // still work as before; leave the current sidebar state untouched.
       } finally {
         inFlight = false
+
+        if (refreshPending && !cancelled) {
+          refreshPending = false
+          void refreshLiveStatuses()
+        }
       }
     }
+
+    const unsubscribe = $sessionsChangeTick.listen(() => void refreshLiveStatuses())
 
     const dispose = visiblePoll(
       changeEventsAvailable ? LIVE_SESSION_STATUS_BACKSTOP_INTERVAL_MS : LIVE_SESSION_STATUS_POLL_INTERVAL_MS,
@@ -713,11 +726,12 @@ export function useBackgroundSync({
 
     return () => {
       cancelled = true
+      unsubscribe()
       dispose()
     }
-    // sessionsChangeTick: each sessions.changed broadcast re-seeds immediately
-    // via the effect re-run (already coalesced to 2s server-side).
-  }, [activeGatewayProfile, changeEventsAvailable, gatewayState, requestGateway, sessionsChangeTick])
+    // Keep the in-flight guard alive across change ticks; a slow response must
+    // not create a new request (and invalidate the old result) on every tick.
+  }, [activeConnectionId, activeGatewayProfile, changeEventsAvailable, gatewayState, requestGateway])
 
   // sessions.changed also means the *stored* list may have new rows (a cron
   // run's session, an inbound messaging turn creating a thread). The full list

--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import type { ChatMessage } from '@/lib/chat-messages'
@@ -62,6 +62,41 @@ describe('SessionStateCache', () => {
     owners.set('stored-d', 'runtime-d')
     cache.prune()
     expect(owners.get('stored-a')).toBe('runtime-new-owner')
+  })
+
+  it('does not remeasure unchanged warm transcripts on repeated stream flushes', () => {
+    const stringify = vi.spyOn(JSON, 'stringify')
+
+    const cache = new SessionStateCache(
+      { isReferenced: () => false, onEvict: () => undefined },
+      { maxBytes: Number.POSITIVE_INFINITY, maxCount: 24 }
+    )
+
+    for (let index = 0; index < 24; index += 1) {
+      cache.set(`runtime-${index}`, settled(`stored-${index}`, 'x'.repeat(4096)))
+    }
+
+    for (let flush = 0; flush < 10; flush += 1) {
+      cache.prune()
+    }
+
+    expect(stringify).toHaveBeenCalledTimes(24)
+    stringify.mockRestore()
+  })
+
+  it('never measures a pinned active transcript while streaming', () => {
+    const cache = new SessionStateCache({ isReferenced: () => true, onEvict: () => undefined })
+    const state = settled('active', 'stream')
+    const stringify = vi.spyOn(JSON, 'stringify')
+    try {
+      for (let flush = 0; flush < 20; flush += 1) {
+        cache.set('active', { ...state, messages: [...state.messages] })
+        cache.prune()
+      }
+      expect(stringify).not.toHaveBeenCalled()
+    } finally {
+      stringify.mockRestore()
+    }
   })
 
   it('uses transcript bytes as well as count', () => {

--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -84,21 +84,6 @@ describe('SessionStateCache', () => {
     stringify.mockRestore()
   })
 
-  it('never measures a pinned active transcript while streaming', () => {
-    const cache = new SessionStateCache({ isReferenced: () => true, onEvict: () => undefined })
-    const state = settled('active', 'stream')
-    const stringify = vi.spyOn(JSON, 'stringify')
-    try {
-      for (let flush = 0; flush < 20; flush += 1) {
-        cache.set('active', { ...state, messages: [...state.messages] })
-        cache.prune()
-      }
-      expect(stringify).not.toHaveBeenCalled()
-    } finally {
-      stringify.mockRestore()
-    }
-  })
-
   it('uses transcript bytes as well as count', () => {
     const evicted: string[] = []
 

--- a/apps/desktop/src/app/session/session-state-cache.ts
+++ b/apps/desktop/src/app/session/session-state-cache.ts
@@ -45,6 +45,7 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
   readonly #maxBytes: number
   readonly #maxCount: number
   readonly #recency = new Map<string, number>()
+  readonly #transcriptWeights = new WeakMap<ClientSessionState['messages'], number>()
   #clock = 0
 
   constructor(callbacks: SessionStateCacheCallbacks, limits: SessionStateCacheLimits = {}) {
@@ -91,7 +92,7 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
         continue
       }
 
-      const weight = transcriptBytes(state)
+      const weight = this.#weight(state)
       candidates.push({ bytes: weight, runtimeId, state, touched: this.#recency.get(runtimeId) ?? 0 })
       bytes += weight
     }
@@ -143,6 +144,19 @@ export class SessionStateCache extends Map<string, ClientSessionState> {
       !hasDraftOrInFlightMessage(state) &&
       !this.#callbacks.isReferenced(runtimeId, state)
     )
+  }
+
+  #weight(state: ClientSessionState): number {
+    const cached = this.#transcriptWeights.get(state.messages)
+
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const weight = transcriptBytes(state)
+    this.#transcriptWeights.set(state.messages, weight)
+
+    return weight
   }
 
   #touch(runtimeId: string): void {


### PR DESCRIPTION
Four small Desktop hot paths stop doing redundant work: the POSIX SSH bootstrap probes `uname` once instead of twice, converting a `/mnt/<drive>` WSL path no longer spawns `wsl.exe -l -q`, the warm-transcript cache stops re-serialising unchanged transcripts on every prune, and `sessions.changed` ticks coalesce behind an in-flight `session.active_list` request instead of restarting it.

## Symptoms (one per issue)

- **#106131 — SSH bootstrap runs `uname -s; uname -m` twice.** `bootstrapSshConnectionInner` detects the platform to pick a lifecycle, then `remoteLifecycle.connect` probes it again. On Windows Desktop every `ssh.exec` is its own SSH process, so that is a full extra round-trip before the first real lifecycle command.
- **#106129 — `/mnt/<drive>` conversions spawn `wsl.exe`.** `wslPosixToWindowsAccessible`'s default parameter evaluated `resolveDefaultWslDistro()` (a synchronous `wsl.exe -l -q` with a 2 s timeout) even when the path maps to a plain drive letter that never needs the distro name.
- **#106123 — `SessionStateCache.prune()` re-`JSON.stringify`s every warm transcript.** Every stream flush calls `set()` + `prune()`; with 24 unchanged warm transcripts each prune serialised all 24 again (240 serialisations across 10 prunes).
- **#106098 — `useBackgroundSync` recreates the `session.active_list` effect per tick.** `sessionsChangeTick` was an effect dependency, so each `sessions.changed` tore the effect down (resetting `inFlight`) and fired a fresh request while the previous one was still pending — the single-flight guard never applied across ticks.

## Changes

- `electron/main.ts` passes the already-detected `platform` into `remoteLifecycle.connect`; `connect` uses `deps.platform ?? probeRemotePlatform(ssh)` so direct callers keep their probe.
- `electron/wsl-path-bridge.ts`: the distro is resolved lazily only on the UNC branch (`distro ?? resolveDistro()`); `resolvePickerDefaultPath` / `resolveLocalReadPath` stop pre-resolving it.
- `src/app/session/session-state-cache.ts`: byte weights are memoised in a `WeakMap` keyed by the immutable `messages` array, measured only when an entry reaches the eviction-candidate path.
- `src/app/contrib/hooks/use-background-sync.ts`: the effect subscribes to `$sessionsChangeTick` directly; a tick during an in-flight request sets `refreshPending` and one follow-up refresh runs when it settles. `activeConnectionId` joins the deps so a connection switch still restarts the loop.
- Follow-up commits (ours): trim to one red-on-main invariant test per fix (the dropped companions passed on main without their fixes), and map Xipong's second noreply email for release attribution.

## Live repro

Real-module probes (vitest, production modules, no mocks of the code under test; `wsl.exe` spawn observed via the `node:child_process` seam on a `win32`-faked platform):

| Probe | before (origin/main) | after (this branch) |
|---|---|---|
| `uname` execs across `detectRemotePlatform` + `connect` on one POSIX bootstrap | `uname_execs=2` | `uname_execs=1` |
| `wsl.exe` spawns converting `/mnt/c/Users/alex` → `C:\Users\alex` | `wsl_exe_spawns=1` | `wsl_exe_spawns=0` |
| `JSON.stringify` calls, 24 warm transcripts × 10 prunes | `stringify_calls=240` | `stringify_calls=24` |
| `session.active_list` requests fired across 8 ticks while one is pending | `requests=9` | `requests=1` |

Contributor fixtures: all four red on `origin/main`, green after each pick.

## Root cause

Each site recomputed something already known to its caller — the detected platform, the default distro, a transcript's byte weight, or an in-flight request — because the value lived in a scope that was torn down or never threaded through.

## Validation

- `npx vitest run --project electron electron/remote-lifecycle.test.ts electron/wsl-path-bridge.test.ts` — 104 passed
- `npx vitest run --project ui src/app/session/session-state-cache.test.ts src/app/contrib/hooks/use-background-sync.test.tsx` — 19 passed
- `npm run typecheck` (all three tsconfigs) — clean; `eslint` on the touched files — clean
- `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check` — clean

Credit: all four fixes authored by @Xipong (cherry-picked with authorship preserved from #106132, #106130, #106124, #106099).

Closes #106131
Closes #106129
Closes #106123
Closes #106098

## Infographic
![desktop-small-polish](https://v3b.fal.media/files/b/0aa9ba94/E5RiIXrtDXcTgMkBCc2Yi_jYNLP1T3.png)
