### PR TITLE
Desktop MCP polling coalesces reconnect sweeps and keeps log reads single-flight (#106135, #106127, salvage #106136, #106128)

### DIFF
--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -31,6 +31,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
+import { createSerialTask, startCompletionPoll } from '@/lib/completion-poll'
 import { compactNumber } from '@/lib/format'
 import { brandFor } from '@/lib/mcp-brands'
 import { estimateServerTokens, serverUsageCount } from '@/lib/mcp-cost'
@@ -1728,34 +1729,28 @@ function McpLogs({
   // the active profile tears down the old poll (its `cancelled` flag blocks a
   // late setLines) so profile A's logs never flash in B.
   const activeProfile = useStore($activeGatewayProfile)
+  const readLogs = useMemo(() => createSerialTask(getLogs), [])
 
   useEffect(() => {
-    let cancelled = false
+    setLines(null)
 
-    const poll = async () => {
-      try {
+    return startCompletionPoll({
+      delayMs: LOG_POLL_MS,
+      poll: async signal => {
         const response =
           source === 'stdio'
-            ? await getLogs({ file: 'mcp', lines: 500 })
-            : await getLogs({ file: 'agent', lines: 300, search: server ?? 'mcp' })
+            ? await readLogs({ file: 'mcp', lines: 500 }, signal)
+            : await readLogs({ file: 'agent', lines: 300, search: server ?? 'mcp' }, signal)
 
-        if (!cancelled) {
-          setLines(source === 'stdio' && server ? filterStdioSections(response.lines, server) : response.lines)
+        if (signal.aborted) {
+          throw new DOMException('Polling stopped', 'AbortError')
         }
-      } catch {
-        // Backend momentarily unavailable — keep the last tail.
-      }
-    }
 
-    setLines(null)
-    void poll()
-    const timer = window.setInterval(() => void poll(), LOG_POLL_MS)
-
-    return () => {
-      cancelled = true
-      window.clearInterval(timer)
-    }
-  }, [server, source, activeProfile])
+        return source === 'stdio' && server ? filterStdioSections(response.lines, server) : response.lines
+      },
+      publish: setLines
+    })
+  }, [server, source, activeProfile, readLogs])
 
   return <LogTail emptyLabel={emptyLabel} lines={lines} />
 }

--- a/apps/desktop/src/app/skills/mcp-tab.tsx
+++ b/apps/desktop/src/app/skills/mcp-tab.tsx
@@ -31,7 +31,7 @@ import {
   testMcpServer
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
-import { createSerialTask, startCompletionPoll } from '@/lib/completion-poll'
+import { startCompletionPoll } from '@/lib/completion-poll'
 import { compactNumber } from '@/lib/format'
 import { brandFor } from '@/lib/mcp-brands'
 import { estimateServerTokens, serverUsageCount } from '@/lib/mcp-cost'
@@ -1726,31 +1726,26 @@ function McpLogs({
 }) {
   const [lines, setLines] = useState<null | string[]>(null)
   // A profile switch reroutes getLogs to the new backend; keying the effect on
-  // the active profile tears down the old poll (its `cancelled` flag blocks a
-  // late setLines) so profile A's logs never flash in B.
+  // the active profile tears down the old poll (stop suppresses a late
+  // publish) so profile A's logs never flash in B.
   const activeProfile = useStore($activeGatewayProfile)
-  const readLogs = useMemo(() => createSerialTask(getLogs), [])
 
   useEffect(() => {
     setLines(null)
 
     return startCompletionPoll({
       delayMs: LOG_POLL_MS,
-      poll: async signal => {
+      poll: async () => {
         const response =
           source === 'stdio'
-            ? await readLogs({ file: 'mcp', lines: 500 }, signal)
-            : await readLogs({ file: 'agent', lines: 300, search: server ?? 'mcp' }, signal)
-
-        if (signal.aborted) {
-          throw new DOMException('Polling stopped', 'AbortError')
-        }
+            ? await getLogs({ file: 'mcp', lines: 500 })
+            : await getLogs({ file: 'agent', lines: 300, search: server ?? 'mcp' })
 
         return source === 'stdio' && server ? filterStdioSections(response.lines, server) : response.lines
       },
       publish: setLines
     })
-  }, [server, source, activeProfile, readLogs])
+  }, [server, source, activeProfile])
 
   return <LogTail emptyLabel={emptyLabel} lines={lines} />
 }

--- a/apps/desktop/src/lib/completion-poll.test.ts
+++ b/apps/desktop/src/lib/completion-poll.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { createSerialTask, startCompletionPoll } from './completion-poll'
+import { startCompletionPoll } from './completion-poll'
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -37,43 +37,18 @@ describe('startCompletionPoll', () => {
     stop()
   })
 
-  it('cancels stale publication and serializes a replacement lifecycle behind the active request', async () => {
+  it('stop suppresses a late publish and leaves no timer behind', async () => {
     vi.useFakeTimers()
     const first = deferred<string>()
-    const second = deferred<string>()
-    const producer = vi.fn((profile: string) => (profile === 'A' ? first.promise : second.promise))
-    const serial = createSerialTask(producer)
-    const publishA = vi.fn()
-    const publishB = vi.fn()
+    const publish = vi.fn()
 
-    const stopA = startCompletionPoll({
-      delayMs: 2_000,
-      poll: signal => serial('A', signal),
-      publish: publishA
-    })
-
+    const stop = startCompletionPoll({ delayMs: 2_000, poll: () => first.promise, publish })
     await Promise.resolve()
-    stopA()
-
-    const stopB = startCompletionPoll({
-      delayMs: 2_000,
-      poll: signal => serial('B', signal),
-      publish: publishB
-    })
-
-    await Promise.resolve()
-    expect(producer).toHaveBeenCalledTimes(1)
+    stop()
 
     first.resolve('stale')
     await vi.advanceTimersByTimeAsync(0)
-    expect(producer).toHaveBeenCalledTimes(2)
-    expect(publishA).not.toHaveBeenCalled()
-
-    second.resolve('fresh')
-    await vi.advanceTimersByTimeAsync(0)
-    expect(publishB).toHaveBeenCalledWith('fresh')
-
-    stopB()
+    expect(publish).not.toHaveBeenCalled()
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/apps/desktop/src/lib/completion-poll.test.ts
+++ b/apps/desktop/src/lib/completion-poll.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createSerialTask, startCompletionPoll } from './completion-poll'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+describe('startCompletionPoll', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps a slow producer single-flight and resumes cadence after completion', async () => {
+    vi.useFakeTimers()
+    const first = deferred<string>()
+    const poll = vi.fn(() => first.promise)
+    const publish = vi.fn()
+
+    const stop = startCompletionPoll({ delayMs: 2_000, poll, publish })
+    await vi.advanceTimersByTimeAsync(20_000)
+    expect(poll).toHaveBeenCalledTimes(1)
+
+    first.resolve('tail')
+    await Promise.resolve()
+    expect(publish).toHaveBeenCalledWith('tail')
+    await vi.advanceTimersByTimeAsync(1_999)
+    expect(poll).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(poll).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it('cancels stale publication and serializes a replacement lifecycle behind the active request', async () => {
+    vi.useFakeTimers()
+    const first = deferred<string>()
+    const second = deferred<string>()
+    const producer = vi.fn((profile: string) => (profile === 'A' ? first.promise : second.promise))
+    const serial = createSerialTask(producer)
+    const publishA = vi.fn()
+    const publishB = vi.fn()
+
+    const stopA = startCompletionPoll({
+      delayMs: 2_000,
+      poll: signal => serial('A', signal),
+      publish: publishA
+    })
+
+    await Promise.resolve()
+    stopA()
+
+    const stopB = startCompletionPoll({
+      delayMs: 2_000,
+      poll: signal => serial('B', signal),
+      publish: publishB
+    })
+
+    await Promise.resolve()
+    expect(producer).toHaveBeenCalledTimes(1)
+
+    first.resolve('stale')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(producer).toHaveBeenCalledTimes(2)
+    expect(publishA).not.toHaveBeenCalled()
+
+    second.resolve('fresh')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(publishB).toHaveBeenCalledWith('fresh')
+
+    stopB()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/apps/desktop/src/lib/completion-poll.ts
+++ b/apps/desktop/src/lib/completion-poll.ts
@@ -1,50 +1,33 @@
 interface CompletionPollOptions<T> {
   delayMs: number
-  poll: (signal: AbortSignal) => Promise<T>
+  poll: () => Promise<T>
   publish: (value: T) => void
 }
 
-/** Serialize a producer across effect lifecycles without publishing stale work. */
-export function createSerialTask<Args, Result>(
-  task: (args: Args) => Promise<Result>
-): (args: Args, signal: AbortSignal) => Promise<Result> {
-  let tail = Promise.resolve()
-
-  return (args, signal) => {
-    const result = tail.then(() => {
-      if (signal.aborted) {
-        throw new DOMException('Task stopped', 'AbortError')
-      }
-
-      return task(args)
-    })
-
-    tail = result.then(
-      () => undefined,
-      () => undefined
-    )
-
-    return result
-  }
-}
-
-/** Poll immediately, then wait one full cadence after each request settles. */
+/**
+ * Poll immediately, then wait one full cadence AFTER each request settles.
+ *
+ * `setInterval` fires on the wall clock, so a request slower than the cadence
+ * overlaps the next one and a stalled backend piles up concurrent requests.
+ * Rescheduling from settlement keeps the poll single-flight. The returned stop
+ * function drops the pending timer and suppresses a late publish.
+ */
 export function startCompletionPoll<T>({ delayMs, poll, publish }: CompletionPollOptions<T>): () => void {
-  const controller = new AbortController()
+  let stopped = false
   let timer: number | undefined
 
   const run = async () => {
     try {
-      const value = await poll(controller.signal)
+      const value = await poll()
 
-      if (!controller.signal.aborted) {
+      if (!stopped) {
         publish(value)
       }
     } catch {
       // A transient producer failure keeps the previous value visible.
     }
 
-    if (!controller.signal.aborted) {
+    if (!stopped) {
       timer = window.setTimeout(() => void run(), delayMs)
     }
   }
@@ -52,10 +35,7 @@ export function startCompletionPoll<T>({ delayMs, poll, publish }: CompletionPol
   void run()
 
   return () => {
-    controller.abort()
-
-    if (timer !== undefined) {
-      window.clearTimeout(timer)
-    }
+    stopped = true
+    window.clearTimeout(timer)
   }
 }

--- a/apps/desktop/src/lib/completion-poll.ts
+++ b/apps/desktop/src/lib/completion-poll.ts
@@ -1,0 +1,61 @@
+interface CompletionPollOptions<T> {
+  delayMs: number
+  poll: (signal: AbortSignal) => Promise<T>
+  publish: (value: T) => void
+}
+
+/** Serialize a producer across effect lifecycles without publishing stale work. */
+export function createSerialTask<Args, Result>(
+  task: (args: Args) => Promise<Result>
+): (args: Args, signal: AbortSignal) => Promise<Result> {
+  let tail = Promise.resolve()
+
+  return (args, signal) => {
+    const result = tail.then(() => {
+      if (signal.aborted) {
+        throw new DOMException('Task stopped', 'AbortError')
+      }
+
+      return task(args)
+    })
+
+    tail = result.then(
+      () => undefined,
+      () => undefined
+    )
+
+    return result
+  }
+}
+
+/** Poll immediately, then wait one full cadence after each request settles. */
+export function startCompletionPoll<T>({ delayMs, poll, publish }: CompletionPollOptions<T>): () => void {
+  const controller = new AbortController()
+  let timer: number | undefined
+
+  const run = async () => {
+    try {
+      const value = await poll(controller.signal)
+
+      if (!controller.signal.aborted) {
+        publish(value)
+      }
+    } catch {
+      // A transient producer failure keeps the previous value visible.
+    }
+
+    if (!controller.signal.aborted) {
+      timer = window.setTimeout(() => void run(), delayMs)
+    }
+  }
+
+  void run()
+
+  return () => {
+    controller.abort()
+
+    if (timer !== undefined) {
+      window.clearTimeout(timer)
+    }
+  }
+}

--- a/apps/desktop/src/store/mcp-health.test.ts
+++ b/apps/desktop/src/store/mcp-health.test.ts
@@ -117,3 +117,20 @@ it('coalesces reconnects during a sweep into one fresh follow-up sweep', async (
   await flush()
   expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(2)
 })
+
+it.each(['stop', 'disconnect'])('drops the queued sweep on %s', async action => {
+  let release!: (config: Record<string, unknown>) => void
+  mocks.getHermesConfigRecord.mockReturnValueOnce(new Promise(resolve => { release = resolve })).mockResolvedValue({ mcp_servers: {} })
+  startMcpHealthChecker()
+  mocks.gatewayState.set('open')
+  mocks.gatewayState.set('closed')
+  mocks.gatewayState.set('open')
+
+  if (action === 'stop') {stopMcpHealthChecker()}
+  else {mocks.gatewayState.set('closed')}
+
+  release({ mcp_servers: {} })
+  await flush()
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(1)
+})

--- a/apps/desktop/src/store/mcp-health.test.ts
+++ b/apps/desktop/src/store/mcp-health.test.ts
@@ -72,6 +72,8 @@ afterEach(() => {
 })
 
 describe('shouldNotifyOnTransition', () => {
+  // The full previous × next decision table: notify only on a TRANSITION into
+  // a bad state. Rechecks of an already-bad server stay quiet; ok never nudges.
   it.each<[previous: Status | null, next: Status, notify: boolean]>([
     [null, 'ok', false],
     [null, 'needs-auth', true],
@@ -118,19 +120,28 @@ it('coalesces reconnects during a sweep into one fresh follow-up sweep', async (
   expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(2)
 })
 
-it.each(['stop', 'disconnect'])('drops the queued sweep on %s', async action => {
-  let release!: (config: Record<string, unknown>) => void
-  mocks.getHermesConfigRecord.mockReturnValueOnce(new Promise(resolve => { release = resolve })).mockResolvedValue({ mcp_servers: {} })
+it('runs one follow-up when the active sweep fails through the handled config-error path', async () => {
+  let rejectFirst!: (err: Error) => void
+
+  const first = new Promise<Record<string, unknown>>((_resolve, reject) => {
+    rejectFirst = reject
+  })
+
+  mocks.getHermesConfigRecord.mockReturnValueOnce(first).mockResolvedValue({ mcp_servers: {} })
+
   startMcpHealthChecker()
   mocks.gatewayState.set('open')
-  mocks.gatewayState.set('closed')
-  mocks.gatewayState.set('open')
 
-  if (action === 'stop') {stopMcpHealthChecker()}
-  else {mocks.gatewayState.set('closed')}
+  for (let index = 0; index < 12; index += 1) {
+    mocks.gatewayState.set('closed')
+    mocks.gatewayState.set('open')
+  }
 
-  release({ mcp_servers: {} })
-  await flush()
   await flush()
   expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(1)
+
+  rejectFirst(new Error('backend restarting'))
+  await flush()
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(2)
 })

--- a/apps/desktop/src/store/mcp-health.test.ts
+++ b/apps/desktop/src/store/mcp-health.test.ts
@@ -1,10 +1,42 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// The store wires itself to gateway/profile atoms and the REST layer at import
-// time paths; mock the seams (same shape as updates.test.ts) so this test only
-// exercises the pure transition state machine.
+const mocks = vi.hoisted(() => {
+  const makeAtom = <T>(initial: T) => {
+    let value = initial
+    const listeners = new Set<(value: T) => void>()
+
+    return {
+      get: () => value,
+      listen(listener: (value: T) => void) {
+        listeners.add(listener)
+
+        return () => listeners.delete(listener)
+      },
+      set(next: T) {
+        value = next
+
+        for (const listener of listeners) {
+          listener(value)
+        }
+      },
+      subscribe(listener: (value: T) => void) {
+        listener(value)
+
+        return this.listen(listener)
+      }
+    }
+  }
+
+  return {
+    activeProfile: makeAtom('default'),
+    gatewayState: makeAtom<'closed' | 'open'>('closed'),
+    getHermesConfigRecord: vi.fn(),
+    notify: vi.fn()
+  }
+})
+
 vi.mock('@/hermes', () => ({
-  getHermesConfigRecord: vi.fn(),
+  getHermesConfigRecord: mocks.getHermesConfigRecord,
   testMcpServer: vi.fn()
 }))
 
@@ -13,44 +45,75 @@ vi.mock('@/i18n', () => ({
 }))
 
 vi.mock('@/store/notifications', () => ({
-  notify: vi.fn()
+  notify: mocks.notify
 }))
 
 vi.mock('@/store/profile', () => ({
-  $activeGatewayProfile: { get: () => 'default', listen: () => () => {} },
+  $activeGatewayProfile: mocks.activeProfile,
   normalizeProfileKey: (name: string | null | undefined) => (name ?? '').trim() || 'default'
 }))
 
 vi.mock('@/store/session', () => ({
-  $gatewayState: { get: () => 'closed', subscribe: () => () => {} }
+  $gatewayState: mocks.gatewayState
 }))
 
-const { shouldNotifyOnTransition } = await import('./mcp-health')
+const { shouldNotifyOnTransition, startMcpHealthChecker, stopMcpHealthChecker } = await import('./mcp-health')
 
 type Status = 'error' | 'needs-auth' | 'ok'
 
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+afterEach(() => {
+  stopMcpHealthChecker()
+  mocks.gatewayState.set('closed')
+  mocks.activeProfile.set('default')
+  mocks.getHermesConfigRecord.mockReset()
+  mocks.notify.mockReset()
+})
+
 describe('shouldNotifyOnTransition', () => {
-  // The full previous × next decision table: notify only on a TRANSITION into
-  // a bad state. Rechecks of an already-bad server stay quiet; ok never nudges.
   it.each<[previous: Status | null, next: Status, notify: boolean]>([
-    // First observation of the session (previous unknown).
     [null, 'ok', false],
     [null, 'needs-auth', true],
     [null, 'error', true],
-    // Healthy server stays healthy / breaks.
     ['ok', 'ok', false],
     ['ok', 'needs-auth', true],
     ['ok', 'error', true],
-    // Already-broken server: rechecks must NOT re-notify…
     ['needs-auth', 'needs-auth', false],
     ['error', 'error', false],
-    // …but flipping from one bad state to the other is a new transition.
     ['needs-auth', 'error', true],
     ['error', 'needs-auth', true],
-    // Recovery is silent.
     ['needs-auth', 'ok', false],
     ['error', 'ok', false]
   ])('previous=%s next=%s → notify=%s', (previous, next, expected) => {
     expect(shouldNotifyOnTransition(previous, next)).toBe(expected)
   })
+})
+
+it('coalesces reconnects during a sweep into one fresh follow-up sweep', async () => {
+  let releaseFirst!: (config: Record<string, unknown>) => void
+
+  const first = new Promise<Record<string, unknown>>(resolve => {
+    releaseFirst = resolve
+  })
+
+  mocks.getHermesConfigRecord.mockReturnValueOnce(first).mockResolvedValue({ mcp_servers: {} })
+
+  startMcpHealthChecker()
+  mocks.gatewayState.set('open')
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(1)
+
+  for (let index = 0; index < 12; index += 1) {
+    mocks.gatewayState.set('closed')
+    mocks.gatewayState.set('open')
+  }
+
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(1)
+
+  releaseFirst({ mcp_servers: {} })
+  await flush()
+  await flush()
+  expect(mocks.getHermesConfigRecord).toHaveBeenCalledTimes(2)
 })

--- a/apps/desktop/src/store/mcp-health.ts
+++ b/apps/desktop/src/store/mcp-health.ts
@@ -175,6 +175,8 @@ function arm(): void {
 }
 
 function disarm(): void {
+  sweepQueued = false
+
   if (timer !== null) {
     clearInterval(timer)
     timer = null

--- a/apps/desktop/src/store/mcp-health.ts
+++ b/apps/desktop/src/store/mcp-health.ts
@@ -49,8 +49,10 @@ let timer: ReturnType<typeof setInterval> | null = null
 // Bumped on profile switch; in-flight sweeps compare and bail so a slow
 // profile-A probe can't record (or notify) into profile B's state.
 let sweepEpoch = 0
-// Sweeps are chained, never concurrent — sequential probes, no parallel bursts.
-let sweepChain: Promise<void> = Promise.resolve()
+// At most one sweep runs and one follow-up is remembered. Reconnect storms
+// still request a fresh pass, but cannot append an unbounded backlog.
+let sweepInFlight: Promise<void> | null = null
+let sweepQueued = false
 let offGatewayState: (() => void) | null = null
 let offProfile: (() => void) | null = null
 
@@ -143,7 +145,24 @@ async function sweep(): Promise<void> {
 }
 
 function queueSweep(): void {
-  sweepChain = sweepChain.then(sweep, sweep)
+  if (sweepInFlight) {
+    sweepQueued = true
+
+    return
+  }
+
+  sweepInFlight = sweep()
+
+  const settled = () => {
+    sweepInFlight = null
+
+    if (sweepQueued) {
+      sweepQueued = false
+      queueSweep()
+    }
+  }
+
+  sweepInFlight.then(settled, settled)
 }
 
 function arm(): void {


### PR DESCRIPTION
Desktop MCP polling no longer piles up requests: gateway reconnect storms coalesce into one active health sweep plus one pending refresh, and the MCP Logs pane keeps `getLogs` single-flight with the next read scheduled only after the last one settles.

## Changes
- `store/mcp-health.ts::queueSweep` — replaces the unbounded `sweepChain.then(sweep, sweep)` promise chain with an in-flight promise + one `sweepQueued` bit; `disarm` drops the queued intent on disconnect/stop. Settlement runs on both fulfil and reject, so the "one fresh follow-up after settlement, including when the active sweep fails through the handled error path" invariant from #106135 holds.
- `lib/completion-poll.ts::startCompletionPoll` (new, 41 lines) — poll immediately, reschedule one cadence after the request settles; the stop function clears the timer and suppresses a late publish.
- `skills/mcp-tab.tsx::McpLogs` — uses `startCompletionPoll` instead of `setInterval`; `getLogs` is called directly.
- Salvage follow-ups (own commits): dropped `createSerialTask` + the AbortController/AbortError layer from #106128 (a second queue that never forwarded its signal to `getLogs`; the stop flag already suppresses stale publishes), and trimmed tests to two invariants per fix.

## Live repro
Real production modules under the repo vitest harness (jsdom); only the REST helpers / gateway atoms are fixtures. Health checker: `startMcpHealthChecker()` with the first `getHermesConfigRecord` held, 12 closed→open transitions, then release. Log pane: real `McpTab` rendered, `getLogs` never resolves, 20 s of fake-timer cadence.

| Scenario | before (origin/main `511633be90e`) | after (this branch) |
|---|---|---|
| #106135 — 12 reconnects during one held sweep | `config reads = 13` | `config reads = 2` (1 active + 1 follow-up) |
| #106127 — `getLogs` pending across 20 s | `getLogs calls = 11` | `getLogs calls = 1` |

## Validation
- `npx vitest run --project ui src/store/mcp-health.test.ts src/lib/completion-poll.test.ts` → 16 passed. Same test files against origin/main source: 3 failed (11 / 13 / 13 requests) — red→green proven.
- `npx vitest run --project ui src/store src/app/skills src/lib/completion-poll.test.ts` → 125 files, 1509 passed.
- `tsc -p . --noEmit` and `eslint` on touched files: clean.

## Root cause
Both pollers scheduled the next request from the wall clock (`sweepChain.then` per reconnect, `setInterval` per cadence) instead of from the previous request's settlement, so a slow backend turned every trigger into a queued or concurrent request.

## Credit
Both fixes and the tests are by @Xipong (#106136, #106128), cherry-picked with authorship preserved; commits re-authored from `45376891+Xipong@…` to the account's canonical `217837358+Xipong@users.noreply.github.com` noreply (that numeric id belongs to a different GitHub account) — misconfigured local git, not malice. Trim/simplification commits are ours.

Closes #106135
Closes #106127

## Infographic
![desktop-mcp-polling](https://v3b.fal.media/files/b/0aa9ba82/KVEgInZpdeqxcpUgpinS-_OolRTGsZ.png)
