### PR TITLE
Gateway first turn no longer waits on the Python toolchain probe (#106064, salvage #106075)

### DIFF
--- a/contributors/emails/francip@kortexa.ai
+++ b/contributors/emails/francip@kortexa.ai
@@ -1,0 +1,1 @@
+francip

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -953,7 +953,7 @@ def _warm_turn_machinery_sync() -> int:
     """Synchronously initialize first-turn prerequisites (executor thread); returns the schema count.
 
     Covers the lazy init seen in skeleton turns: ``run_agent`` import graph, tool schemas (+ ``check_fn``
-    TTL cache), context files."""
+    TTL cache), context files, the local Python toolchain probe (#106064)."""
     import run_agent  # noqa: F401  # heavy import graph, cached in sys.modules
     import model_tools
 
@@ -964,6 +964,15 @@ def _warm_turn_machinery_sync() -> int:
         build_context_files_prompt()
     except Exception:
         logger.debug("context-file warm-up failed (non-fatal)", exc_info=True)
+    from hermes_cli.config import load_config_readonly
+
+    agent_cfg = load_config_readonly().get("agent")
+    if not isinstance(agent_cfg, dict) or agent_cfg.get("environment_probe", True):
+        # The resolver owns remote-backend omission, the single worker, its cache and the bounded
+        # wait; calling it here is what the first prompt build would otherwise do on the hot path.
+        from tools.env_probe import get_environment_probe_line
+
+        get_environment_probe_line()
     return len(tool_defs)
 
 

--- a/tests/gateway/test_startup_environment_probe.py
+++ b/tests/gateway/test_startup_environment_probe.py
@@ -1,0 +1,47 @@
+"""The gateway boot warm-up primes the local toolchain probe the first prompt build reads (#106064)."""
+
+import pytest
+
+import model_tools
+from gateway import run as gateway_run
+from tools import env_probe
+from tools.terminal_scope import reset_terminal_scope, set_terminal_scope
+
+
+@pytest.fixture(autouse=True)
+def _probe_cache(monkeypatch):
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **_: [])
+    env_probe._reset_cache_for_tests()
+    yield
+    env_probe._reset_cache_for_tests()
+
+
+def _warm(tmp_path, monkeypatch, agent_section: dict, backend: str) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(f"agent: {agent_section!r}\n", encoding="utf-8")
+    token = set_terminal_scope({"TERMINAL_ENV": backend})
+    try:
+        gateway_run._warm_turn_machinery_sync()
+    finally:
+        reset_terminal_scope(token)
+
+
+def test_warmup_leaves_probe_cached_for_first_prompt(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(env_probe, "_build_probe_line", lambda: calls.append(1) or "Python toolchain: fixture.")
+
+    _warm(tmp_path, monkeypatch, {}, "local")
+
+    assert env_probe._PROBE_DONE.is_set()
+    assert env_probe.get_environment_probe_line() == "Python toolchain: fixture."
+    assert calls == [1]  # single worker; the first turn reuses the cache
+
+
+@pytest.mark.parametrize("agent_section,backend", [({"environment_probe": False}, "local"), ({}, "ssh")])
+def test_warmup_skips_probe_when_disabled_or_remote(tmp_path, monkeypatch, agent_section, backend):
+    monkeypatch.setattr(env_probe, "_build_probe_line", lambda: pytest.fail("host inspected"))
+
+    _warm(tmp_path, monkeypatch, agent_section, backend)
+
+    assert not env_probe._PROBE_DONE.is_set()
+    assert env_probe._PROBE_THREAD is None


### PR DESCRIPTION
The gateway's first inbound turn no longer blocks on the Python/pip toolchain probe: the boot warm-up primes it, so the first system prompt finds the line cached.

- `gateway/run.py::_warm_turn_machinery_sync` now calls `get_environment_probe_line()` after tool schemas + context files, gated on `agent.environment_probe` (default on). The resolver itself owns remote-backend omission (`ssh`/`docker`/… → `""`, host untouched), the single worker, its cache, and the bounded fail-open wait, so nothing is duplicated.
- No `AIAgent` is constructed and no session prompt/memory/tools are frozen at startup; disabled probe or remote terminal backend leaves the host untouched; a slow probe still hits the existing bounded warm-up gate (`HERMES_STARTUP_WARMUP_TIMEOUT`) exactly like the rest of the warm-up.
- `tests/gateway/test_startup_environment_probe.py`: two invariants — enabled+local → probe cached after warm-up (red on main); disabled or remote → host never inspected.

## Live repro

Fresh process, temp `HERMES_HOME` (`agent.environment_probe: true`, `terminal.backend: local`), real python/pip subprocesses; runs `_warm_turn_machinery_sync()` exactly as the boot warm-up does, then constructs an `AIAgent` and builds its first system prompt, timing the wait inside `get_environment_probe_line()` (3 runs each):

| | probe ready after warm-up | probe wait in first prompt build | prompt build |
|---|---|---|---|
| before (origin/main 511633be90e) | False / False / False | 456 / 294 / 235 ms | 464 / 304 / 245 ms |
| after (this branch) | True / True / True | 0 / 0 / 0 ms | 34 / 7 / 8 ms |

Toolchain line present in the prompt in both arms (identical content); provider metadata warm-up (#105999) present in both.

Root cause: `_warm_turn_machinery_sync` warmed imports, tool schemas and context files but never the toolchain probe, so the first `AIAgent` started the worker and its first prompt build waited on it.

## vs #106075

Slim redo of #106075 by @francip — same mechanism and gating, folded into the existing sync warm-up instead of a new `gateway/run_startup_environment.py` module + `asyncio.gather` + second `_log_suppressed` block; 58 lines vs 163. His two behaviour tests are kept as the two invariants; the concurrency/bounded-gate tests are dropped because the probe now rides the already-tested warm-up gate. Contributor email mapping cherry-picked from his PR; `Co-authored-by` on the fix commit.

Credit: @francip (issue #106064 diagnosis, PR #106075).

Closes #106064

## Infographic
![gateway-warm-env-probe](https://v3b.fal.media/files/b/0aa9baaf/wkgoWz29aRVLmrraNN9NW_hFXESrv0.png)
