### PR TITLE
Media-only replies report SUCCESS on every platform, not ❌ (#106153, salvage #106167)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2567,11 +2567,14 @@ class BasePlatformAdapter(ABC):
 
     async def send_multiple_images(
         self, chat_id: str, images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """Send ``(url, alt)`` images (``http(s)://`` or ``file://``) one by one (GIFs via
         ``send_animation``, local files via ``send_image_file``); override to bundle natively
-        (Signal)."""
+        (Signal). Returns success when at least one image was delivered — the outcome
+        the turn-level delivery tracker records. Overrides that batch natively but
+        still return ``None`` are legacy: the caller records nothing for them."""
         from urllib.parse import unquote as _unquote
+        delivered = False
         for image_url, alt_text in images:
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
@@ -2588,8 +2591,15 @@ class BasePlatformAdapter(ABC):
                     chat_id=chat_id, **url_kw, caption=alt_text or None, metadata=metadata)
                 if not img_result.success:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                else:
+                    delivered = True
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+        if not images:
+            return SendResult(success=False, error="no images to send")
+        return SendResult(
+            success=delivered,
+            error=None if delivered else "all images failed to send")
 
     async def send_image(
         self, chat_id: str, image_url: str, caption: Optional[str] = None,
@@ -3703,11 +3713,12 @@ class BasePlatformAdapter(ABC):
 
     async def _deliver_media_attachments(
         self, event: MessageEvent, media_files: list, local_files: list, *,
-        force_document_attachments: bool, human_delay: float, metadata: Dict[str, Any]) -> None:
+        force_document_attachments: bool, human_delay: float, metadata: Dict[str, Any],
+        record_delivery: Callable) -> None:
         """Deliver MEDIA-tag files and detected local files by type: images batched via
         ``send_multiple_images`` unless ``[[as_document]]``; otherwise audio → send_voice (MEDIA
         tags only, never bare local files), video → send_video, else send_document. Every failure is
-        reported."""
+        reported. Each send feeds ``record_delivery`` so media-only turns report SUCCESS."""
         from urllib.parse import quote as _quote
 
         def _as_image(path: str) -> bool:
@@ -3716,10 +3727,11 @@ class BasePlatformAdapter(ABC):
         _image_paths += [p for p in local_files if _as_image(p)]
         if _image_paths:
             await self._send_image_batch(
-                event, [(f"file://{_quote(p)}", "") for p in _image_paths], metadata, human_delay)
+                event, [(f"file://{_quote(p)}", "") for p in _image_paths], metadata, human_delay,
+                record_delivery)
         chat_id = event.source.chat_id
 
-        async def _send_one(path: str, *, is_voice: bool, media_tag: bool) -> None:
+        async def _send_one(path: str, *, is_voice: bool, media_tag: bool) -> SendResult:
             """MEDIA-tag files (``media_tag``) may route to send_voice; bare local files never
             do."""
             ext = Path(path).suffix.lower()
@@ -3735,6 +3747,7 @@ class BasePlatformAdapter(ABC):
                 logger.warning("[%s] Failed to send %s (%s): %s", self.name,
                                "media" if media_tag else "local file", ext, result.error)
                 await self._notify_media_delivery_failure(chat_id, path, is_voice=is_voice, metadata=metadata)
+            return result
         queue = [(p, v, True) for p, v in media_files if v or not _as_image(p)]
         if queue:
             logger.info("[%s] Delivering %d non-image MEDIA attachment(s)", self.name, len(queue))
@@ -3743,21 +3756,31 @@ class BasePlatformAdapter(ABC):
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
             try:
-                await _send_one(path, is_voice=is_voice, media_tag=media_tag)
+                record_delivery(await _send_one(path, is_voice=is_voice, media_tag=media_tag))
             except Exception as err:
+                record_delivery(SendResult(success=False, error=str(err)))
                 if media_tag:
                     logger.warning("[%s] Error sending media: %s", self.name, err)
                 else:
                     logger.error("[%s] Error sending local file %s: %s", self.name, path, err)
 
     async def _send_image_batch(
-        self, event: MessageEvent, images: list, metadata: Dict[str, Any], human_delay: float) -> None:
-        """Batch-send images; a failure is logged (never raised) so other attachments still go."""
+        self, event: MessageEvent, images: list, metadata: Dict[str, Any], human_delay: float,
+        record_delivery: Callable) -> None:
+        """Batch-send images; a failure is logged (never raised) so other attachments still go.
+        The batch result feeds ``record_delivery`` so media-only turns report their real
+        outcome instead of FAILURE."""
         try:
-            await self.send_multiple_images(
+            result = await self.send_multiple_images(
                 chat_id=event.source.chat_id, images=images, metadata=metadata, human_delay=human_delay)
         except Exception as batch_err:
             logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
+            record_delivery(SendResult(success=False, error=str(batch_err)))
+            return
+        # Legacy native-batch overrides return None instead of a SendResult:
+        # ``record_delivery(None)`` records nothing, so their outcome stays as before
+        # until they migrate to the SendResult contract.
+        record_delivery(result)
 
     async def send_final_ledgered(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any], *,
@@ -3809,18 +3832,20 @@ class BasePlatformAdapter(ABC):
         return _thread_metadata
 
     async def _deliver_attachments(self, event: MessageEvent, extracted: "_ExtractedResponse",
-                                   metadata: Dict[str, Any], *, anything_sent: bool) -> None:
+                                   metadata: Dict[str, Any], *, anything_sent: bool,
+                                   record_delivery: Callable) -> None:
         """Send extracted image URLs, MEDIA files and bare local files (human-paced),
-        then fail loudly if a non-empty response produced nothing deliverable."""
+        then fail loudly if a non-empty response produced nothing deliverable. Attachment
+        results feed ``record_delivery`` so the turn outcome reflects them."""
         human_delay = self._get_human_delay()
         images, media_files, local_files = extracted.images, extracted.media_files, extracted.local_files
         if images:
             logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
-            await self._send_image_batch(event, images, metadata, human_delay)
+            await self._send_image_batch(event, images, metadata, human_delay, record_delivery)
         await self._deliver_media_attachments(
             event, media_files, local_files,
             force_document_attachments=extracted.force_document_attachments,
-            human_delay=human_delay, metadata=metadata)
+            human_delay=human_delay, metadata=metadata, record_delivery=record_delivery)
         if not (anything_sent or images or local_files or media_files) and extracted.pre_extract.strip():
             logger.error("[%s] response_delivery_dropped: non-empty response "
                          "(%d chars) produced no delivered message or attachment "
@@ -3978,7 +4003,8 @@ class BasePlatformAdapter(ABC):
                         is_ephemeral_response, _ephemeral_ttl, _record_delivery)
                 await self._deliver_attachments(
                     event, extracted, _final_thread_metadata,
-                    anything_sent=delivery_attempted or _tts_caption_delivered)
+                    anything_sent=delivery_attempted or _tts_caption_delivered,
+                    record_delivery=_record_delivery)
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             # Clean up the per-turn streaming-TTS flag.
             self._streaming_tts_completed_turns.discard(self._streaming_tts_turn_key(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2571,8 +2571,8 @@ class BasePlatformAdapter(ABC):
         """Send ``(url, alt)`` images (``http(s)://`` or ``file://``) one by one (GIFs via
         ``send_animation``, local files via ``send_image_file``); override to bundle natively
         (Signal). Returns success when at least one image was delivered — the outcome
-        the turn-level delivery tracker records. Overrides that batch natively but
-        still return ``None`` are legacy: the caller records nothing for them."""
+        the turn-level delivery tracker records; every override must return the same
+        aggregate, or a media-only turn on that platform reports FAILURE (#106153)."""
         from urllib.parse import unquote as _unquote
         delivered = False
         for image_url, alt_text in images:
@@ -3777,9 +3777,6 @@ class BasePlatformAdapter(ABC):
             logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
             record_delivery(SendResult(success=False, error=str(batch_err)))
             return
-        # Legacy native-batch overrides return None instead of a SendResult:
-        # ``record_delivery(None)`` records nothing, so their outcome stays as before
-        # until they migrate to the SendResult contract.
         record_delivery(result)
 
     async def send_final_ledgered(

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -781,11 +781,12 @@ class SignalAdapter(BasePlatformAdapter):
         return file_path, None, None
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
-                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """Send a batch of images via chunked Signal RPC calls. Alt texts are dropped (one shared body
-        per send); bad images are skipped with a warning; ``human_delay`` is ignored (scheduler paces)."""
+        per send); bad images are skipped with a warning; ``human_delay`` is ignored (scheduler paces).
+        Returns success when at least one batch was accepted, so media-only turns report SUCCESS."""
         if not images:
-            return
+            return SendResult(success=False, error="no images to send")
         scheduler = get_scheduler()
         logger.info("Signal send_multiple_images: received %d image(s) for %s — scheduler state: %s", len(images),
                     chat_id[:30], scheduler.state())
@@ -802,24 +803,30 @@ class SignalAdapter(BasePlatformAdapter):
         if not attachments:
             logger.error("Signal: no valid images in batch of %d (download=%d missing=%d oversize=%d)", len(images),
                          skipped["download"], skipped["missing"], skipped["oversize"])
-            return
+            return SendResult(success=False, error="no valid images in batch")
         logger.info("Signal send_multiple_images: %d/%d images valid, sending in chunks", len(attachments), len(images))
         base_params = await self._with_target({"account": self.account, "message": ""}, chat_id)
         per = SIGNAL_MAX_ATTACHMENTS_PER_MSG
         att_batches = [attachments[i:i + per] for i in range(0, len(attachments), per)]
         n_batches = len(att_batches)
+        delivered = False
         for idx, att_batch in enumerate(att_batches, start=1):
             n = len(att_batch)
             estimated = scheduler.estimate_wait(n)
             logger.debug("Signal batch %d/%d: %d attachments, estimated wait=%.1fs", idx, n_batches, n, estimated)
             if estimated >= SIGNAL_BATCH_PACING_NOTICE_THRESHOLD:
                 await self._notify_batch_pacing(chat_id, idx, n_batches, estimated)
-            await self._send_attachment_batch(scheduler, dict(base_params, attachments=att_batch), n,
-                                              f"{idx}/{n_batches}")
+            if await self._send_attachment_batch(scheduler, dict(base_params, attachments=att_batch), n,
+                                                 f"{idx}/{n_batches}"):
+                delivered = True
+        return SendResult(
+            success=delivered,
+            error=None if delivered else "all Signal attachment batches failed")
 
-    async def _send_attachment_batch(self, scheduler, params: Dict[str, Any], n: int, label: str) -> None:
+    async def _send_attachment_batch(self, scheduler, params: Dict[str, Any], n: int, label: str) -> bool:
         """Send one attachment batch with rate-limit pacing and a single transient retry. Tokens are
-        deducted only on validated success (None = server never accepted it); 429s feed the scheduler."""
+        deducted only on validated success (None = server never accepted it); 429s feed the scheduler.
+        Returns True when the server accepted the batch."""
         send_timeout, max_attempts = _signal_send_timeout(n), SIGNAL_RATE_LIMIT_MAX_ATTEMPTS
         for attempt in range(1, max_attempts + 1):
             await scheduler.acquire(n)
@@ -832,7 +839,7 @@ class SignalAdapter(BasePlatformAdapter):
                 if attempt >= max_attempts:
                     logger.error("Signal: rate-limit retries exhausted on batch %s (%d attachments lost, "
                                  "server retry_after=%s)", label, n, retry_after)
-                    return
+                    return False
                 logger.warning("Signal: rate-limited on batch %s (attempt %d/%d, server retry_after=%s); "
                                "scheduler will pace the retry", label, attempt, max_attempts, retry_after)
                 continue
@@ -843,13 +850,14 @@ class SignalAdapter(BasePlatformAdapter):
                 await scheduler.report_rpc_duration(duration, n)
                 logger.info("Signal batch %s: %d attachments sent in %.1fs (attempt %d/%d)", label, n, duration,
                             attempt, max_attempts)
-                return
+                return True
             logger.error("Signal: RPC send failed for batch %s (%d attachments, attempt %d/%d, rpc_duration=%.1fs)%s",
                          label, n, attempt, max_attempts, duration, f": {err_msg}" if result is not None else "")
             if attempt >= max_attempts:
-                return
+                return False
             logger.info("Signal: retrying batch %s after %.1fs backoff", label, 2.0 ** attempt)
             await asyncio.sleep(2.0 ** attempt)
+        return False
 
     async def _notify_batch_pacing(self, chat_id: str, next_batch_idx: int, total_batches: int, wait_s: float) -> None:
         """Tell the user about an inter-batch pacing wait over the notice threshold (best-effort)."""

--- a/plugins/platforms/discord/adapter_media.py
+++ b/plugins/platforms/discord/adapter_media.py
@@ -65,33 +65,32 @@ class DiscordMediaMixin:
     async def send_multiple_images(
         self, chat_id: str, images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0,
-    ) -> None:
+    ) -> SendResult:
         """Send images as one Discord message (<=10 attachments): URLs are downloaded and uploaded
         inline (bare links don't render); on chunk failure the remainder uses the per-image loop."""
         from plugins.platforms.discord.adapter import _prompt_target_id, _image_ext_from_content_type, _read_url_image_with_redirect_guard, is_safe_url
 
         if not self._client:
-            return
+            return SendResult(success=False, error="Not connected")
         if not images:
-            return
+            return SendResult(success=False, error="no images to send")
         try:
             import discord as _discord_mod
             import io as _io
             from urllib.parse import unquote as _unquote
         except Exception:  # pragma: no cover
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         try:
             channel = await self._resolve_channel(_prompt_target_id(chat_id, metadata))
             if not channel:
                 logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
-                return
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         CHUNK = 10
         chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
+        delivered = False
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
@@ -149,18 +148,21 @@ class DiscordMediaMixin:
                     )
                 else:
                     await channel.send(content=content, files=files)
+                delivered = True
             except Exception as e:
                 logger.warning(
                     "[%s] Multi-image Discord send failed (chunk %d/%d), falling back to per-image: %s",
                     self.name, chunk_idx + 1, len(chunks), e, exc_info=True,
                 )
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback = await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                delivered = delivered or fallback.success
             finally:
                 if aiohttp_session is not None:
                     try:
                         await aiohttp_session.close()
                     except Exception:
                         pass
+        return SendResult(success=delivered, error=None if delivered else "all images failed to send")
 
 
     async def send_voice(

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -717,10 +717,10 @@ class EmailAdapter(BasePlatformAdapter):
         return await self.send(chat_id, f"{caption or ''}\n\nImage: {image_url}".strip(), reply_to)
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
-                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """One email per batch: local files attached, URL images linked in the body (no remote download); base-class fallback on failure."""
         if not images:
-            return
+            return SendResult(success=False, error="no images to send")
         from urllib.parse import unquote as _unquote
         body_parts, local_paths = [], []
         for image_url, alt_text in images:
@@ -733,12 +733,13 @@ class EmailAdapter(BasePlatformAdapter):
             else:
                 logger.warning("[Email] Skipping missing image: %s", local_path)
         if not local_paths and not body_parts:
-            return
+            return SendResult(success=False, error="no valid images in batch")
         try:
-            await asyncio.get_running_loop().run_in_executor(None, self._send_email_with_attachments, chat_id, "\n\n".join(body_parts), local_paths)
+            message_id = await asyncio.get_running_loop().run_in_executor(None, self._send_email_with_attachments, chat_id, "\n\n".join(body_parts), local_paths)
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
+        return SendResult(success=True, message_id=message_id)
 
     def _send_email_with_attachments(self, to_addr: str, body: str, file_paths: List[str]) -> str:
         """Send an email with multiple file attachments via SMTP (unattachable files are skipped)."""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1478,11 +1478,12 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def send_multiple_images(
         self, chat_id: str, images: list[tuple[str, str]], metadata: Optional[Dict[str, Any]] = None,
-        human_delay: float = 0.0) -> None:
+        human_delay: float = 0.0) -> SendResult:
         if not images:
-            return
+            return SendResult(success=False, error="no images to send")
         from urllib.parse import unquote as _unquote
         total = len(images)
+        delivered = False
         for idx, (image_url, alt_text) in enumerate(images, start=1):
             if human_delay > 0 and idx > 1:
                 await asyncio.sleep(human_delay)
@@ -1494,6 +1495,8 @@ class MatrixAdapter(BasePlatformAdapter):
                 result = await self.send_image(chat_id=chat_id, image_url=image_url, caption=caption, metadata=metadata)
             if not result.success:
                 logger.warning("Matrix: failed to send image %d/%d: %s", idx, total, result.error)
+            delivered = delivered or result.success
+        return SendResult(success=delivered, error=None if delivered else "all images failed to send")
 
     async def send_document(
         self, chat_id: str, file_path: str, caption: Optional[str] = None, file_name: Optional[str] = None,

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -398,12 +398,13 @@ class MattermostAdapter(BasePlatformAdapter):
         return file_data, _url_filename(image_url, f"image_{index}.png"), ct
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
-                                   metadata: _Metadata = None, human_delay: float = 0.0) -> None:
+                                   metadata: _Metadata = None, human_delay: float = 0.0) -> SendResult:
         """Send a batch of images as one post; chunked at Mattermost's 5-``file_ids`` cap, each chunk
         falling back to the base per-image loop on failure."""
         if not images:
-            return
+            return SendResult(success=False, error="no images to send")
         chunks = [images[i:i + 5] for i in range(0, len(images), 5)]  # Mattermost post file_ids cap
+        delivered = False
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
@@ -420,13 +421,18 @@ class MattermostAdapter(BasePlatformAdapter):
                 logger.info("Mattermost: sending %d image(s) as single post (chunk %d/%d)",
                             len(file_ids), chunk_idx + 1, len(chunks))
                 data = await self._post_message(chat_id, "\n".join(caption_parts), None, metadata, file_ids)
-                if not data or "id" not in data:
+                if data and "id" in data:
+                    delivered = True
+                else:
                     logger.warning("Mattermost: multi-image post failed, falling back")
-                    await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                    fallback = await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                    delivered = delivered or fallback.success
             except Exception as e:
                 logger.warning("Mattermost: multi-image send failed (chunk %d/%d), falling back: %s",
                                chunk_idx + 1, len(chunks), e, exc_info=True)
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback = await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                delivered = delivered or fallback.success
+        return SendResult(success=delivered, error=None if delivered else "all images failed to send")
 
     # --- WebSocket ---
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2657,25 +2657,25 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def send_multiple_images(
         self, chat_id: str, images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """Send a batch of images as one message via ``files_upload_v2(file_uploads=...)`` (10 per
         call, Slack cap) instead of N posts; falls back to the base per-image loop on failure."""
         if self._suppressed_ignored(chat_id, "multi-image upload in"):
-            return
+            return SendResult(success=False, error="ignored_channel")
         if not self._app:
-            return
+            return SendResult(success=False, error="Not connected")
         if not images:
-            return
+            return SendResult(success=False, error="no images to send")
         chat_id = await self._dm_target(chat_id, metadata)
         try:
             from urllib.parse import unquote as _unquote
             from tools.url_safety import create_ssrf_safe_async_client, is_safe_url as _is_safe_url
         except Exception:
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         thread_ts = self._resolve_thread_ts(None, metadata)
         CHUNK = 10
         chunks = [images[i : i + CHUNK] for i in range(0, len(images), CHUNK)]
+        delivered = False
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
@@ -2692,12 +2692,15 @@ class SlackAdapter(BasePlatformAdapter):
                     channel=chat_id, file_uploads=file_uploads, initial_comment=initial_comment,
                     thread_ts=thread_ts)
                 self._record_uploaded_file_thread(chat_id, thread_ts, metadata)
+                delivered = True
             except Exception as e:
                 logger.warning(
                     "[Slack] Multi-image files_upload_v2 failed (chunk %d/%d), falling back to per-image: %s",
                     chunk_idx + 1, len(chunks), e, exc_info=True)
-                await super().send_multiple_images(
+                fallback = await super().send_multiple_images(
                     chat_id, chunk, metadata, human_delay=human_delay)
+                delivered = delivered or fallback.success
+        return SendResult(success=delivered, error=None if delivered else "all images failed to send")
 
     @staticmethod
     async def _collect_image_uploads(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4642,24 +4642,27 @@ class TelegramAdapter(BasePlatformAdapter):
                     os.unlink(_transcoded_voice_path)
 
     async def send_multiple_images(
-        self, chat_id: str, images: List[tuple], metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+        self, chat_id: str, images: List[tuple], metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """Send images as Telegram albums (``send_media_group``, 10 per chunk). Animated GIFs can't join a
         media group (need ``send_animation``) so they go via the base per-image path, as does a failed chunk."""
-        if not self._bot or not images:
-            return
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        if not images:
+            return SendResult(success=False, error="no images to send")
         try:
             from telegram import InputMediaPhoto
         except Exception as exc:  # pragma: no cover - missing SDK
             logger.warning("[%s] InputMediaPhoto unavailable, falling back to per-image send: %s", self.name, exc)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         is_anim = lambda url: not url.startswith("file://") and self._is_animation_url(url)  # noqa: E731
         animations = [img for img in images if is_anim(img[0])]
         photos = [img for img in images if not is_anim(img[0])]
+        delivered = False
         if animations:
-            await super().send_multiple_images(chat_id, animations, metadata, human_delay=human_delay)
+            anim_result = await super().send_multiple_images(chat_id, animations, metadata, human_delay=human_delay)
+            delivered = anim_result.success
         if not photos:
-            return
+            return SendResult(success=delivered, error=None if delivered else "all images failed to send")
         from urllib.parse import unquote as _unquote
         CHUNK = 10  # Telegram's album limit
         chunks = [photos[i:i + CHUNK] for i in range(0, len(photos), CHUNK)]
@@ -4692,15 +4695,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._send_with_dm_topic_reply_anchor_retry(
                     self._bot.send_media_group, {**send_kwargs, "media": media}, metadata, reply_to_id,
                     "media group", reset_media=_reset_opened_files)
+                delivered = True
             except Exception as e:
                 logger.warning(
                     "[%s] send_media_group failed (chunk %d/%d), falling back to per-image: %s", self.name,
                     chunk_idx + 1, len(chunks), _redact_telegram_error_text(e), exc_info=True)
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback = await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                delivered = delivered or fallback.success
             finally:
                 for fh in opened_files:
                     with contextlib.suppress(Exception):
                         fh.close()
+        return SendResult(success=delivered, error=None if delivered else "all images failed to send")
 
     async def send_image_file(
         self, chat_id: str, image_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None,

--- a/tests/gateway/test_media_only_outcome.py
+++ b/tests/gateway/test_media_only_outcome.py
@@ -1,0 +1,120 @@
+"""Regression tests for #106153 — media-only turns reported FAILURE.
+
+``_process_message_background`` fed its ``on_processing_complete`` outcome from
+``delivery_attempted``/``delivery_succeeded``, which only text/TTS sends
+populated. A turn replying with just ``MEDIA:<path>`` delivered the attachment
+fine but computed ``processing_ok = False`` (no text attempted, non-empty
+response), so Signal swapped the 👀 reaction for ❌ instead of ✅.
+
+The attachment path now feeds the same tracker, so a delivered media-only
+turn reports SUCCESS and a failed one still reports FAILURE.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    SendResult,
+)
+from gateway.platforms.event import MessageEvent, MessageType, ProcessingOutcome
+from gateway.session import SessionSource, build_session_key
+
+
+class _MediaOutcomeAdapter(BasePlatformAdapter):
+    """Base-loop adapter (no ``send_multiple_images`` override) that records
+    the turn outcome via the production ``on_processing_complete`` hook."""
+
+    def __init__(self, *, image_ok: bool = True):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.SIGNAL)
+        self._image_ok = image_ok
+        self.outcomes: list = []
+        self.images_sent: list = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="msg-1")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def send_image_file(self, chat_id, image_path, caption=None,
+                              reply_to=None, metadata=None, **kwargs) -> SendResult:
+        self.images_sent.append(str(image_path))
+        if self._image_ok:
+            return SendResult(success=True, message_id="img-1")
+        return SendResult(success=False, error="boom")
+
+    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        self.outcomes.append(outcome)
+
+
+async def _hold_typing(_chat_id, interval=2.0, metadata=None, stop_event=None):
+    if stop_event is not None:
+        await stop_event.wait()
+    else:
+        await asyncio.Event().wait()
+
+
+def _allowed_image(tmp_path, monkeypatch, name: str = "photo.png"):
+    root = tmp_path / "media-cache"
+    f = root / name
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 64)
+    monkeypatch.setattr("gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS", (root,))
+    return f.resolve()
+
+
+def _make_event() -> MessageEvent:
+    return MessageEvent(
+        text="send the photo",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.SIGNAL, chat_id="111", chat_type="dm"),
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_only_success_reports_success(tmp_path, monkeypatch):
+    """Delivered media-only turn must report SUCCESS (was FAILURE → ❌)."""
+    png = _allowed_image(tmp_path, monkeypatch)
+    adapter = _MediaOutcomeAdapter(image_ok=True)
+    adapter._keep_typing = _hold_typing
+
+    async def handler(_event):
+        return f"MEDIA:{png}"
+
+    adapter.set_message_handler(handler)
+    event = _make_event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert adapter.images_sent == [str(png)]
+    assert adapter.outcomes == [ProcessingOutcome.SUCCESS]
+
+
+@pytest.mark.asyncio
+async def test_media_only_failure_still_reports_failure(tmp_path, monkeypatch):
+    """A media-only turn whose attachment failed must still report FAILURE."""
+    png = _allowed_image(tmp_path, monkeypatch)
+    adapter = _MediaOutcomeAdapter(image_ok=False)
+    adapter._keep_typing = _hold_typing
+
+    async def handler(_event):
+        return f"MEDIA:{png}"
+
+    adapter.set_message_handler(handler)
+    event = _make_event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert adapter.images_sent == [str(png)]
+    assert adapter.outcomes == [ProcessingOutcome.FAILURE]


### PR DESCRIPTION
A media-only reply (`MEDIA:<path>` and nothing else) whose attachment is delivered now ends the turn as `ProcessingOutcome.SUCCESS`, so Signal's reaction swaps 👀 → ✅ instead of ❌ — on every platform, not just Signal.

Salvage of #106167 by @Halldrix (cherry-picked, authorship preserved), with the contract completed across all `send_multiple_images` overrides. Sibling PR #106173 by @liuhao1024 fixes the same bug by the same mechanism; #106167 was opened first and its version is smaller, so it is the base — @liuhao1024's analysis matched and is credited below.

## Changes

- `gateway/platforms/base.py` — `_deliver_attachments` / `_deliver_media_attachments` / `_send_image_batch` take the turn's `_record_delivery` and feed every attachment result (image batch, voice, video, document, and exception failures) into it. Base `send_multiple_images` returns an aggregate `SendResult` (any image delivered = success). *(Halldrix)*
- `gateway/platforms/signal.py` — `_send_attachment_batch` returns `bool`; `send_multiple_images` rolls batches into a `SendResult`. *(Halldrix)*
- `plugins/platforms/{discord,email,matrix,mattermost,slack,telegram}` — the six native-batch overrides return the same aggregate `SendResult` (chunk success or per-image fallback success). Without this, `_record_delivery(None)` recorded nothing and a media-only turn on those platforms still reported FAILURE; it also left the base `-> SendResult` contradicted by six `-> None` overrides (#106192's lived case). *(follow-up commit)*
- `tests/gateway/test_media_only_outcome.py` — 2 invariant tests through the real `_process_message_background`: delivered media-only → SUCCESS; failed media-only → FAILURE.

Dropped from #106167: commit `d8beb2f` (annotate base `-> Optional[SendResult]`) — superseded by making the overrides honest instead of widening the annotation.

## Root cause

`processing_ok = delivery_succeeded if delivery_attempted else not bool(response)` is fed only by `_send_final_text` and `_play_tts_file`; attachment delivery never called `_record_delivery`, so a non-empty media-only response with no text send resolved to FAILURE regardless of the attachment result.

## Validation

Live repro (`/tmp/repro_106153.py <repo> <label>`: fresh interpreter, temp `HERMES_HOME`, real `BasePlatformAdapter._process_message_background` with a fake Signal-like adapter whose `send_multiple_images` returns success/failure, handler returns only `MEDIA:<png>`):

```
[origin/main]     send_multiple_images succeeds on media-only reply -> batches=1 outcome=FAILURE (expected SUCCESS) BUG FIRES
[origin/main]     send_multiple_images fails on media-only reply    -> batches=1 outcome=FAILURE (expected FAILURE) OK
[fix-fa6cc87323b] send_multiple_images succeeds on media-only reply -> batches=1 outcome=SUCCESS (expected SUCCESS) OK
[fix-fa6cc87323b] send_multiple_images fails on media-only reply    -> batches=1 outcome=FAILURE (expected FAILURE) OK
```

Sabotage: `test_media_only_success_reports_success` run against origin/main → `1 failed, 1 passed` (`assert [FAILURE] == [SUCCESS]`).

| Check | Before (origin/main) | After |
|---|---|---|
| `ty check` on the 8 touched files (`uv tool run ty` 0.0.79) | 241 diagnostics / 20 `invalid-method-override` | 241 / 20 — diagnostic set byte-identical (`diff` empty). Intermediate head with only the base widened: 246 / 25 |
| `scripts/run_tests.sh` 14 media/adapter files | — | 643 passed, 0 failed, 1 skipped |
| `scripts/run_tests.sh tests/gateway/ tests/plugins/platforms/` | — | 8094 passed, 0 failed, 43 skipped (2 pre-existing flaky files unrelated to this diff: `test_browser_control_broker_hardening.py`, `test_session_hygiene.py`, both pass on retry) |
| ruff / footguns / compat pointers / `git diff --check` | — | clean |

## Credits

Salvage of #106167 by @Halldrix. Co-credit @liuhao1024 (#106173, same diagnosis and mechanism, opened 23 min later). Reported by @krizano with the exact root cause.

Closes #106153
Refs #106192

## Infographic
![signal-media-only-outcome](https://v3b.fal.media/files/b/0aa9ba78/0a1t3lIu0C6x9JH9Fqf5m_4besv7Dx.png)
