### PR TITLE
fix(openviking): accept `~` and reject cross-user URIs in viking_forget

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -168,9 +168,10 @@ memory URI.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
-`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md` (any
-explicit user id works; `viking://~/...` input is passed through untouched for
-deployments where the server expands the home alias). Files
+`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`, or the
+`viking://~/...` self alias. Under `viking://user/...` the user id is required
+and must match the calling identity; the uid-less `viking://user/memories/...`
+and `viking://user/peers/...` shorthands are deprecated and rejected. Files
 directly under `memories/`, such as `viking://user/default/memories/profile.md`,
 are also allowed because OpenViking supports them. The tool rejects directories,
 resources, skills, sessions, generated summary files, and URIs with query

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -490,7 +490,7 @@ def _is_windows_absolute_path(value: str) -> bool:
     return len(value) >= 3 and value[0].isalpha() and value[1] == ":" and value[2] in {"/", "\\"}
 
 
-def _validate_forget_memory_uri(raw_uri: Any) -> tuple[Optional[str], Optional[str]]:
+def _validate_forget_memory_uri(raw_uri: Any, *, user_space: Optional[str] = None) -> tuple[Optional[str], Optional[str]]:
     uri = raw_uri.strip() if isinstance(raw_uri, str) else ""
     if not uri:
         return None, "uri is required"
@@ -502,11 +502,17 @@ def _validate_forget_memory_uri(raw_uri: Any) -> tuple[Optional[str], Optional[s
     if uri.endswith("/") or not uri.endswith(".md"):
         return None, "viking_forget only deletes concrete .md memory files"
     parts = [part for part in uri[len("viking://") :].split("/") if part]
-    # ``memories`` segment index for the user / user-uid / peer / uid-peer layouts.
-    memories_idx = next((idx for idx, peer_at in ((1, None), (2, None), (3, 1), (4, 2))
-                         if parts[:1] == ["user"] and len(parts) > idx and parts[idx] == "memories" and (peer_at is None or parts[peer_at] == "peers")), None)
+    # ``memories`` index for ``<scope>/[peers/<agent>/]memories/``; under ``user`` the uid is
+    # required, since the uid-less shorthands are deprecated upstream.
+    offsets = ((1, None), (3, 1)) if parts[:1] == ["~"] else ((2, None), (4, 2)) if parts[:1] == ["user"] else ()
+    memories_idx = next((idx for idx, peer_at in offsets
+                         if len(parts) > idx and parts[idx] == "memories" and (peer_at is None or parts[peer_at] == "peers")), None)
     if memories_idx is None or len(parts) < memories_idx + 2:
         return None, "viking_forget only deletes user memory file URIs"
+    # An explicit uid can name someone else's space; the server answers PERMISSION_DENIED either way.
+    if parts[0] == "user" and user_space and parts[1] != user_space:
+        return None, (f"viking_forget only deletes your own memories; use viking://user/{user_space}/... "
+                      "or viking://~/... instead")
     if uri.rsplit("/", 1)[-1] in _GENERATED_MEMORY_SUMMARY_FILENAMES:
         return None, "viking_forget cannot delete generated memory summary files"
     return uri, None
@@ -2635,7 +2641,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
         })
 
     def _tool_forget(self, args: dict) -> str:
-        uri, error = _validate_forget_memory_uri(args.get("uri"))
+        # _resolve_user_space, not _user_space: its "default" fallback is a guess, not an identity.
+        uri, error = _validate_forget_memory_uri(args.get("uri"), user_space=_resolve_user_space(self._client))
         if error:
             return tool_error(error)
         result = self._unwrap_result(self._client.delete("/api/v1/fs", params={"uri": uri, "recursive": False}))

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -12,6 +12,7 @@ from hermes_cli import __version__ as _HERMES_VERSION
 from plugins.memory.openviking import (
     OpenVikingMemoryProvider,
     _VikingClient,
+    _validate_forget_memory_uri,
 )
 
 _EXPECTED_USER_AGENT = f"openviking-memory-hermes/{_HERMES_VERSION}"
@@ -728,6 +729,56 @@ def test_get_tool_schemas_omits_profile_and_keeps_narrow_forget_tools():
     assert "viking_forget" in names
 
 
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "viking://user/zayn/memories/profile.md",
+        "viking://user/zayn/memories/preferences/mem_abc123.md",
+        "viking://user/zayn/peers/hermes/memories/preferences/mem_abc123.md",
+        # Self alias.
+        "viking://~/memories/profile.md",
+        "viking://~/memories/preferences/mem_abc123.md",
+        "viking://~/peers/hermes/memories/preferences/mem_abc123.md",
+    ],
+)
+def test_validate_forget_memory_uri_accepts_canonical(uri):
+    assert _validate_forget_memory_uri(uri) == (uri, None)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        # Deprecated uid-less shorthands.
+        "viking://user/memories/preferences/mem_abc123.md",
+        "viking://user/peers/hermes/memories/preferences/mem_abc123.md",
+        # Non-memory scopes and generated summaries.
+        "viking://user/zayn/sessions/s1/mem_abc123.md",
+        "viking://resources/docs/note.md",
+        "viking://user/zayn/memories/preferences/.abstract.md",
+        # Directories, non-markdown, query/fragment.
+        "viking://user/zayn/memories/preferences/",
+        "viking://user/zayn/memories/preferences/mem_abc123.txt",
+        "viking://user/zayn/memories/preferences/mem_abc123.md?force=1",
+    ],
+)
+def test_validate_forget_memory_uri_rejects_non_canonical(uri):
+    resolved, error = _validate_forget_memory_uri(uri)
+    assert resolved is None and error
+
+
+def test_validate_forget_memory_uri_rejects_other_user_space():
+    mine = "viking://user/zayn/memories/preferences/mem_abc123.md"
+    theirs = "viking://user/someone-else/memories/preferences/mem_abc123.md"
+
+    assert _validate_forget_memory_uri(mine, user_space="zayn") == (mine, None)
+    assert _validate_forget_memory_uri("viking://~/memories/preferences/mem_abc123.md", user_space="zayn")[1] is None
+
+    resolved, error = _validate_forget_memory_uri(theirs, user_space="zayn")
+    assert resolved is None and "your own memories" in error
+    # Unverified identity leaves the check to the server rather than blocking a legitimate delete.
+    assert _validate_forget_memory_uri(theirs, user_space=None) == (theirs, None)
+
+
 def test_viking_client_delete_uses_identity_headers(monkeypatch):
     client = _VikingClient(
         "https://example.com",
@@ -744,18 +795,18 @@ def test_viking_client_delete_uses_identity_headers(monkeypatch):
         return SimpleNamespace(
             status_code=200,
             text="",
-            json=lambda: {"status": "ok", "result": {"uri": "viking://~/memories/x.md"}},
+            json=lambda: {"status": "ok", "result": {"uri": "viking://user/zayn/memories/x.md"}},
             raise_for_status=lambda: None,
         )
 
     monkeypatch.setattr(client._httpx, "delete", capture_delete)
 
-    assert client.delete("/api/v1/fs", params={"uri": "viking://~/memories/x.md"}) == {
+    assert client.delete("/api/v1/fs", params={"uri": "viking://user/zayn/memories/x.md"}) == {
         "status": "ok",
-        "result": {"uri": "viking://~/memories/x.md"},
+        "result": {"uri": "viking://user/zayn/memories/x.md"},
     }
     assert captured["url"] == "https://example.com/api/v1/fs"
-    assert captured["kwargs"]["params"] == {"uri": "viking://~/memories/x.md"}
+    assert captured["kwargs"]["params"] == {"uri": "viking://user/zayn/memories/x.md"}
     assert captured["kwargs"]["headers"]["Authorization"] == "Bearer test-key"
     assert captured["kwargs"]["headers"]["X-OpenViking-Actor-Peer"] == "hermes"
     assert captured["kwargs"]["headers"]["User-Agent"] == _EXPECTED_USER_AGENT


### PR DESCRIPTION
`viking_forget` gated deletes on a positional whitelist that hardcoded `user` as the first segment:

```python
memories_idx = next((idx for idx, peer_at in ((1, None), (2, None), (3, 1), (4, 2))
                     if parts[:1] == ["user"] and ...
```

Two problems:

1. **`viking://~/...` was rejected client-side.** `viking_search` and `viking_read` can return a `~` URI that `viking_forget` then refuses. Meanwhile offsets `(1, None)` and `(3, 1)` accepted the uid-less `viking://user/memories/...` and `viking://user/peers/...` shorthands, both deprecated upstream (the latter removed in #4196).

2. **An explicit uid went through unchecked.** `viking://user/<someone-else>/memories/x.md` was forwarded as a DELETE. The server answers `PERMISSION_DENIED`, so nothing is lost, but the gate should not forward it.

## Changes

- Offsets are selected by scope: `~` → `(1, None), (3, 1)`, `user` → `(2, None), (4, 2)`. The uid-less shorthands no longer match.
- Under `user`, the uid must equal the resolved identity. `_tool_forget` passes `_resolve_user_space(...)`, not `_user_space(...)` — the latter falls back to a literal `"default"`, which is a guess and must not be compared against a uid. A failed probe yields `None` and leaves the check to the server.

Resulting behaviour, with the identity resolved as `zayn`:

```
PASS    viking://~/memories/preferences/mem_a.md
PASS    viking://~/peers/hermes/memories/preferences/mem_a.md
PASS    viking://user/zayn/memories/preferences/mem_a.md
PASS    viking://user/zayn/peers/hermes/memories/preferences/mem_a.md
REJECT  viking://user/other/peers/hermes/memories/preferences/mem_a.md
REJECT  viking://user/memories/preferences/mem_a.md
REJECT  viking://user/peers/hermes/memories/preferences/mem_a.md
```

The write path is untouched — it keeps emitting explicit-uid URIs.

## Tests

`_validate_forget_memory_uri` had no coverage. Added cases for the accepted scopes, the deprecated shorthands, cross-user URIs, and the unverified-identity path.

```
tests/plugins/memory/test_openviking_provider.py tests/openviking_plugin/  ->  127 passed
```

Pre-existing failures elsewhere in `tests/plugins/memory/` (`test_hindsight_provider.py`, `test_mem0_v3.py`, and a collection error in `test_holographic_auto_extract.py`) are unrelated and identical before and after this change.
