### PR TITLE
fix(state): give the stale-FTS deferral an exit when the holder is permanent

### DIFF
--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -464,16 +464,40 @@ class SessionSchemaMixin:
             row = None
         parsed = safe_json_loads(row[0]) if row else None
         record = parsed if isinstance(parsed, dict) else {}
+        # Permanence is a property of a SPECIFIC holder set, not of the clock.
+        # If the set changed, the previous history describes different processes
+        # and must not be inherited -- otherwise holder A's accrued hour lets a
+        # freshly-arrived holder B skip the wait entirely.
+        holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
+        previous_pids = record.get("holder_pids")
+        if not isinstance(previous_pids, list):
+            previous_pids = None
+        else:
+            try:
+                previous_pids = sorted({int(p) for p in previous_pids})
+            except (TypeError, ValueError):
+                previous_pids = None
+        holder_set_changed = (
+            previous_pids is not None
+            and previous_pids != holder_pids
+            # Two empty sets are not a change. An unprovable scan filters to an
+            # empty holder_pids, so treating empty-vs-empty as a change would
+            # silently reset the history of a genuinely stuck holder on every
+            # single deferral.
+            and not (not previous_pids and not holder_pids)
+        )
         try:
             first_seen = float(record.get("first_seen", now))
             attempts = int(record.get("attempts", 0)) + 1
         except (TypeError, ValueError):
             first_seen, attempts = now, 1
+        if holder_set_changed:
+            first_seen, attempts = now, 1
         if first_seen > now or first_seen < 0:
             first_seen = now
         diagnostic = {
             "first_seen": first_seen, "last_seen": now, "attempts": attempts,
-            "holder_pids": sorted({pid for pid, _path in foreign_holders if pid > 0}),
+            "holder_pids": holder_pids,
         }
         cursor.execute(
             "INSERT INTO state_meta (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -489,7 +513,13 @@ class SessionSchemaMixin:
                     "state.db FTS rebuild deferrals; checking holders again.", reaped, attempts,
                 )
                 foreign_holders = self._foreign_state_db_holders()
-            if foreign_holders and attempts < _FTS_HOLDER_FUTILE_ATTEMPTS:
+            # Suppressed once the futility exit takes over, since that path logs
+            # its own ERROR -- but an unprovable holder never reaches that exit,
+            # so it must keep getting the actionable message.
+            if foreign_holders and (
+                attempts < _FTS_HOLDER_FUTILE_ATTEMPTS
+                or any(pid <= 0 for pid, _path in foreign_holders)
+            ):
                 logger.error(
                     "state.db FTS repair remains blocked after %d deferrals "
                     "by holder(s) %s. Stopping the Desktop backend "
@@ -500,6 +530,24 @@ class SessionSchemaMixin:
                 )
         if not foreign_holders:
             return False
+        # An unknown holder (pid < 0) is the "could not prove quiescence"
+        # sentinel from foreign_state_db_holders(): a failed /proc or open-file
+        # scan, or psutil missing. Its own docstring says structural maintenance
+        # must not assume quiescence in that state, and it is exactly what the
+        # rebuild flock CANNOT speak for -- fts_rebuild_admission serializes
+        # cooperating FTS rebuilders, it is no evidence that an uninspectable
+        # process or an unlinked SQLite generation is gone. So the futility exit
+        # is unavailable here: keep deferring, fail closed, forever if need be.
+        # The visible-PID case is the one this exit was written for.
+        uninspectable = [h for h in foreign_holders if h[0] <= 0]
+        if uninspectable:
+            logger.warning(
+                "state.db FTS repair stays deferred after %d deferrals: holder state "
+                "could not be proven (%s). The futility exit needs identifiable "
+                "holders; an unprovable scan is not something the rebuild lock can "
+                "serialize against.", attempts, uninspectable,
+            )
+            return True
         if attempts >= _FTS_HOLDER_FUTILE_ATTEMPTS and now - first_seen >= _FTS_HOLDER_FUTILE_SECONDS:
             # Proven-futile wait: proceed under the rebuild flock rather than
             # deferring forever while canonical writes keep failing. See the

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -443,7 +443,9 @@ class SessionSchemaMixin:
 
     # ── Stale-FTS recovery ─────────────────────────────────────────────────
 
-    def _defer_stale_fts_for_holders(self, cursor: sqlite3.Cursor, foreign_holders) -> bool:
+    def _defer_stale_fts_for_holders(
+        self, cursor: sqlite3.Cursor, foreign_holders, remaining=None
+    ) -> bool:
         """Record a deferral diagnostic for the foreign processes holding the DB; True = defer
         (holders remain). After ``_FTS_HOLDER_ESCALATE_ATTEMPTS`` deferrals spanning
         ``_FTS_HOLDER_ESCALATE_SECONDS``, provably inactive orphan Desktop backends are
@@ -468,24 +470,29 @@ class SessionSchemaMixin:
         # If the set changed, the previous history describes different processes
         # and must not be inherited -- otherwise holder A's accrued hour lets a
         # freshly-arrived holder B skip the wait entirely.
-        holder_pids = sorted({pid for pid, _path in foreign_holders if pid > 0})
-        previous_pids = record.get("holder_pids")
-        if not isinstance(previous_pids, list):
-            previous_pids = None
-        else:
-            try:
-                previous_pids = sorted({int(p) for p in previous_pids})
-            except (TypeError, ValueError):
-                previous_pids = None
-        holder_set_changed = (
-            previous_pids is not None
-            and previous_pids != holder_pids
-            # Two empty sets are not a change. An unprovable scan filters to an
-            # empty holder_pids, so treating empty-vs-empty as a change would
-            # silently reset the history of a genuinely stuck holder on every
-            # single deferral.
-            and not (not previous_pids and not holder_pids)
-        )
+        def _identity(holders):
+            """Positive-PID identity of a holder list, plus whether it moved."""
+            pids = sorted({pid for pid, _path in holders if pid > 0})
+            prev = record.get("holder_pids")
+            if not isinstance(prev, list):
+                prev = None
+            else:
+                try:
+                    prev = sorted({int(p) for p in prev})
+                except (TypeError, ValueError):
+                    prev = None
+            changed = (
+                prev is not None
+                and prev != pids
+                # Two empty sets are not a change. An unprovable scan filters to
+                # an empty pid set, so treating empty-vs-empty as a change would
+                # silently reset the history of a genuinely stuck holder on
+                # every single deferral.
+                and not (not prev and not pids)
+            )
+            return pids, changed
+
+        holder_pids, holder_set_changed = _identity(foreign_holders)
         try:
             first_seen = float(record.get("first_seen", now))
             attempts = int(record.get("attempts", 0)) + 1
@@ -513,6 +520,27 @@ class SessionSchemaMixin:
                     "state.db FTS rebuild deferrals; checking holders again.", reaped, attempts,
                 )
                 foreign_holders = self._foreign_state_db_holders()
+                # The rescan may describe a different process than the one the
+                # window was accrued against: A reaped, restarted B present. Re-
+                # derive the identity and restart the window if it moved, or B
+                # inherits A's hour and is authorized on its first deferral.
+                holder_pids, rescan_changed = _identity(foreign_holders)
+                if rescan_changed:
+                    first_seen, attempts = now, 1
+                cursor.execute(
+                    "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    (
+                        FTS_REBUILD_DEFERRAL_KEY,
+                        json.dumps(
+                            {
+                                "first_seen": first_seen, "last_seen": now,
+                                "attempts": attempts, "holder_pids": holder_pids,
+                            },
+                            sort_keys=True,
+                        ),
+                    ),
+                )
             # Suppressed once the futility exit takes over, since that path logs
             # its own ERROR -- but an unprovable holder never reaches that exit,
             # so it must keep getting the actionable message.
@@ -522,12 +550,20 @@ class SessionSchemaMixin:
             ):
                 logger.error(
                     "state.db FTS repair remains blocked after %d deferrals "
-                    "by holder(s) %s. Stopping the Desktop backend "
-                    "(`systemctl --user stop hermes-serve`) leaves the gateway as the sole "
-                    "holder and lets its own retry tick rebuild without gateway downtime; "
-                    "note that tick backs off to hourly, so allow up to an hour. "
+                    "by holder(s) %s. Stop the listed holder(s) through whatever "
+                    "supervisor launched them (on a default Linux install the "
+                    "Desktop backend is `systemctl --user stop hermes-serve`); "
+                    "this process then becomes the sole holder and its own retry "
+                    "tick rebuilds without stopping the gateway. Note that tick "
+                    "backs off to hourly, so allow up to an hour. "
                     "`hermes doctor` reports this degraded state.", attempts, foreign_holders,
                 )
+        if remaining is not None:
+            # Hand the caller the holder list as it stands AFTER any reap, so it
+            # can distinguish "blocker is gone" from "blocker is permanent"
+            # without a third scan (an extra scan also breaks callers that stub
+            # _foreign_state_db_holders with a finite sequence).
+            remaining[:] = list(foreign_holders)
         if not foreign_holders:
             return False
         # An unknown holder (pid < 0) is the "could not prove quiescence"
@@ -573,7 +609,8 @@ class SessionSchemaMixin:
         Fails closed: holders or a lost admission race leave the breadcrumb set."""
         foreign_holders = self._foreign_state_db_holders()
         if foreign_holders:
-            if self._defer_stale_fts_for_holders(cursor, foreign_holders):
+            remaining = []
+            if self._defer_stale_fts_for_holders(cursor, foreign_holders, remaining):
                 return False
             # Proceeding past a proven-permanent holder (see
             # _defer_stale_fts_for_holders): probe the rebuild authority instead
@@ -581,7 +618,14 @@ class SessionSchemaMixin:
             # acquire here would add the full admission budget to every startup
             # of a database in this state -- and the stale breadcrumb already
             # guarantees the retry, so waiting buys nothing.
-            timeout_seconds = 0.0
+            #
+            # But that method also returns False after a successful reap, where
+            # the blocker is simply gone. Re-scan to tell the two apart: giving
+            # up the startup budget there would let transient lock contention
+            # postpone a repair that could have completed now, extending the
+            # write-loss window for no reason.
+            if remaining:
+                timeout_seconds = 0.0
         with fts_rebuild_admission(self.db_path, timeout_seconds=timeout_seconds) as admitted:
             if not admitted:
                 logger.warning(

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -32,6 +32,31 @@ logger = logging.getLogger("hermes_state")
 
 _FTS_HOLDER_ESCALATE_ATTEMPTS = 3
 _FTS_HOLDER_ESCALATE_SECONDS = 60.0
+# Deferring on a foreign holder is cheap and correct while the holder might go
+# away. It stops being either when the holder is another *supervised* service
+# sharing this HERMES_HOME (a gateway alongside `hermes serve`): that holder is
+# a fixed property of the deployment, the orphan reap above deliberately will
+# not touch it, and every deferral leaves the FTS index detached while the
+# messages_fts triggers keep failing canonical writes. Waiting forever is not
+# the safe choice there -- it is silent, unbounded transcript loss (#106393:
+# five days, 292 deferrals, all of it logged and none of it repaired).
+#
+# So the deferral gets an exit condition. Once the same holder set has blocked
+# this many attempts across this much wall time, the wait is proven futile and
+# the rebuild proceeds -- NOT by ignoring safety, but because the safety for
+# this particular operation is `fts_rebuild_admission` (a cross-process flock),
+# not holder absence. `_recover_stale_fts_locked` is one BEGIN IMMEDIATE write
+# transaction over SQL DDL/DML; it never unlinks or replaces the WAL sidecars.
+# The corruption that motivated the holder gate (#90806, #90950) came from
+# file-level surgery -- sidecar unlink, journal_mode flips -- which lives in
+# hermes_state_repair.py behind its own `_live_writer_holds_db` gate and is
+# untouched by this. Concurrent *rebuilds* remain impossible via the flock.
+#
+# Thresholds are deliberately well past any transient peer: with the doubling
+# backoff in `retry_deferred_fts_recovery` (60s -> 3600s cap) this is several
+# hours of a genuinely stuck holder, not a restarting one.
+_FTS_HOLDER_FUTILE_ATTEMPTS = 10
+_FTS_HOLDER_FUTILE_SECONDS = 3600.0
 # retry_deferred_fts_recovery cadence: startup paid the full admission wait once; later
 # retries are non-blocking probes whose spacing doubles up to the cap.
 _FTS_STALE_RETRY_SECONDS = 60.0
@@ -422,7 +447,14 @@ class SessionSchemaMixin:
         """Record a deferral diagnostic for the foreign processes holding the DB; True = defer
         (holders remain). After ``_FTS_HOLDER_ESCALATE_ATTEMPTS`` deferrals spanning
         ``_FTS_HOLDER_ESCALATE_SECONDS``, provably inactive orphan Desktop backends are
-        reaped and the holders re-checked."""
+        reaped and the holders re-checked.
+
+        Returns False (proceed with the rebuild) once the holders have proven permanent --
+        ``_FTS_HOLDER_FUTILE_ATTEMPTS`` deferrals spanning ``_FTS_HOLDER_FUTILE_SECONDS``.
+        A holder that survives the orphan reap is a supervised peer that will never leave,
+        and deferring to it forever means canonical writes keep failing through the
+        ``messages_fts`` triggers indefinitely (#106393). The rebuild's own safety is the
+        cross-process ``fts_rebuild_admission`` flock, which still applies."""
         now = time.time()
         try:
             row = cursor.execute(
@@ -457,14 +489,28 @@ class SessionSchemaMixin:
                     "state.db FTS rebuild deferrals; checking holders again.", reaped, attempts,
                 )
                 foreign_holders = self._foreign_state_db_holders()
-            if foreign_holders:
+            if foreign_holders and attempts < _FTS_HOLDER_FUTILE_ATTEMPTS:
                 logger.error(
                     "state.db FTS repair remains blocked after %d deferrals "
-                    "by holder(s) %s. Stop the listed processes, then run "
-                    "`hermes sessions optimize-storage` with the gateway stopped. "
+                    "by holder(s) %s. Stopping the Desktop backend "
+                    "(`systemctl --user stop hermes-serve`) leaves the gateway as the sole "
+                    "holder and lets its own retry tick rebuild without gateway downtime; "
+                    "note that tick backs off to hourly, so allow up to an hour. "
                     "`hermes doctor` reports this degraded state.", attempts, foreign_holders,
                 )
         if not foreign_holders:
+            return False
+        if attempts >= _FTS_HOLDER_FUTILE_ATTEMPTS and now - first_seen >= _FTS_HOLDER_FUTILE_SECONDS:
+            # Proven-futile wait: proceed under the rebuild flock rather than
+            # deferring forever while canonical writes keep failing. See the
+            # _FTS_HOLDER_FUTILE_* rationale above.
+            logger.error(
+                "state.db FTS repair blocked by holder(s) %s for %d deferrals over %.1fh; "
+                "the holders look permanent (supervised peers are never reaped), so proceeding "
+                "with the rebuild under the cross-process rebuild lock instead of deferring "
+                "again. This is a single write transaction and performs no WAL surgery.",
+                foreign_holders, attempts, (now - first_seen) / 3600.0,
+            )
             return False
         logger.warning(
             "Deferred stale state.db FTS rebuild while foreign processes "
@@ -478,8 +524,16 @@ class SessionSchemaMixin:
         bounds the admission wait (None = full startup budget, ``0`` = non-blocking retry).
         Fails closed: holders or a lost admission race leave the breadcrumb set."""
         foreign_holders = self._foreign_state_db_holders()
-        if foreign_holders and self._defer_stale_fts_for_holders(cursor, foreign_holders):
-            return False
+        if foreign_holders:
+            if self._defer_stale_fts_for_holders(cursor, foreign_holders):
+                return False
+            # Proceeding past a proven-permanent holder (see
+            # _defer_stale_fts_for_holders): probe the rebuild authority instead
+            # of waiting on it. The holder is not going away, so a blocking
+            # acquire here would add the full admission budget to every startup
+            # of a database in this state -- and the stale breadcrumb already
+            # guarantees the retry, so waiting buys nothing.
+            timeout_seconds = 0.0
         with fts_rebuild_admission(self.db_path, timeout_seconds=timeout_seconds) as admitted:
             if not admitted:
                 logger.warning(

--- a/tests/state/test_fts_permanent_holder_deadlock.py
+++ b/tests/state/test_fts_permanent_holder_deadlock.py
@@ -68,7 +68,14 @@ def _seed_stale_db(tmp_path, monkeypatch):
     return db_path
 
 
-def _write_deferral(db_path, *, attempts, age_seconds, now):
+def _write_deferral(db_path, *, attempts, age_seconds, now, holder_pids=(4242,)):
+    """Seed the deferral breadcrumb.
+
+    `holder_pids` must match the holder the code will actually see: production
+    compares the persisted set against the live scan and restarts the counters
+    when they differ, so seeding a fictional PID would silently exercise the
+    holder-changed path instead of the futility path.
+    """
     raw = sqlite3.connect(str(db_path))
     raw.execute(
         "INSERT INTO state_meta (key, value) VALUES (?, ?) "
@@ -79,7 +86,7 @@ def _write_deferral(db_path, *, attempts, age_seconds, now):
                 "first_seen": now - age_seconds,
                 "last_seen": now,
                 "attempts": attempts,
-                "holder_pids": [4242],
+                "holder_pids": sorted(holder_pids),
             }),
         ),
     )
@@ -104,11 +111,182 @@ def _pin_unreapable_holder(monkeypatch, db_path):
     )
 
 
+class TestUnprovableHolderStaysFailClosed:
+    """The futility exit must never fire on a holder we could not identify.
+
+    `foreign_state_db_holders()` returns `(-1, "open-file scan failed: ...")`
+    when a /proc or open-file scan fails, or `(-1, "open-file scan
+    unavailable")` when psutil is missing. Its docstring is explicit that
+    structural maintenance must not assume quiescence in that state.
+
+    That is precisely what `fts_rebuild_admission` cannot speak for: the flock
+    serializes cooperating FTS rebuilders, it is not evidence that an
+    uninspectable process -- or a process holding an unlinked SQLite generation
+    -- has gone away. So an unknown holder keeps deferring past the threshold,
+    forever if necessary, rather than trading a hang for possible corruption.
+    """
+
+    @pytest.mark.parametrize(
+        "sentinel",
+        [
+            pytest.param((-1, "open-file scan failed: boom"), id="scan-failed"),
+            pytest.param((-1, "open-file scan unavailable"), id="psutil-missing"),
+        ],
+    )
+    def test_unknown_holder_past_the_threshold_still_defers(
+        self, tmp_path, monkeypatch, sentinel
+    ):
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 1_000_000.0
+        # Well past both thresholds; only the holder's identity differs.
+        # holder_pids=() because production filters pid > 0, so a (-1, ...)
+        # scan persists an EMPTY set. Seeding a fictional pid here would take
+        # the holder-changed reset path and never reach the fail-closed branch.
+        _write_deferral(
+            db_path,
+            attempts=FUTILE_ATTEMPTS * 5,
+            age_seconds=FUTILE_SECONDS * 5,
+            now=now,
+            holder_pids=(),
+        )
+        monkeypatch.setattr(
+            SessionDB, "_foreign_state_db_holders", lambda self: [sentinel], raising=False,
+        )
+        monkeypatch.setattr(
+            SessionDB, "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [], raising=False,
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True, (
+                "an unprovable holder must not reach the futility exit"
+            )
+            assert _meta_value(db_path, FTS_STALE_KEY) == "1"
+            # The history must be INTACT, not reset: an unchanged holder set
+            # that is merely unprovable keeps accruing, and the exit declines
+            # anyway. This is what distinguishes the fail-closed guard from the
+            # holder-identity reset -- without the guard, this same state
+            # reaches the exit and rebuilds.
+            raw = _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY)
+            assert raw is not None
+            record = json.loads(raw)
+            assert record["attempts"] > FUTILE_ATTEMPTS, (
+                f"deferral history was reset (attempts={record['attempts']}), so this "
+                "case is exercising the identity-change path, not the guard"
+            )
+            assert now - record["first_seen"] > FUTILE_SECONDS, (
+                "first_seen was reset, so the futility thresholds were not actually met"
+            )
+            # Canonical writes stay available while deferred.
+            reopened.append_message("s1", "user", "still writable while unprovable")
+        finally:
+            reopened.close()
+
+    def test_unknown_holder_mixed_with_a_known_one_still_defers(
+        self, tmp_path, monkeypatch
+    ):
+        """One unprovable entry poisons the whole set, not just its own row."""
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 1_000_000.0
+        # The known pid 4242 is what production persists for this mixed set
+        # (the -1 entry is filtered out), so the identity check must agree and
+        # the test must fail closed on the unprovable entry alone.
+        _write_deferral(
+            db_path, attempts=FUTILE_ATTEMPTS * 5, age_seconds=FUTILE_SECONDS * 5, now=now,
+            holder_pids=(4242,),
+        )
+        monkeypatch.setattr(
+            SessionDB, "_foreign_state_db_holders",
+            lambda self: [(4242, str(db_path) + "-wal"), (-1, "open-file scan failed: x")],
+            raising=False,
+        )
+        monkeypatch.setattr(
+            SessionDB, "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [], raising=False,
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True
+            # Same distinction as above: the history must survive, proving the
+            # guard declined rather than the identity check resetting it.
+            raw = _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY)
+            assert raw is not None
+            record = json.loads(raw)
+            assert record["attempts"] > FUTILE_ATTEMPTS
+            assert now - record["first_seen"] > FUTILE_SECONDS
+        finally:
+            reopened.close()
+
+
+class TestPermanenceBelongsToAHolderSet:
+    """Accrued futility must not transfer from one holder to another.
+
+    #106393's contract is "the SAME holder set has blocked N consecutive
+    deferrals". Without comparing the persisted `holder_pids` against the
+    current scan, holder A's accumulated hour lets a freshly-arrived holder B
+    skip the wait on its very first deferral.
+    """
+
+    def test_a_new_holder_resets_the_accrued_history(self, tmp_path, monkeypatch):
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 1_000_000.0
+        # Holder A (pid 4242) accrued more than enough history to be futile.
+        _write_deferral(
+            db_path, attempts=FUTILE_ATTEMPTS, age_seconds=FUTILE_SECONDS, now=now
+        )
+        # ...but the holder present NOW is B (pid 7777).
+        monkeypatch.setattr(
+            SessionDB, "_foreign_state_db_holders",
+            lambda self: [(7777, str(db_path) + "-wal")], raising=False,
+        )
+        monkeypatch.setattr(
+            SessionDB, "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [], raising=False,
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True, (
+                "holder B inherited holder A's futility history"
+            )
+            # The breadcrumb must now describe B, with the counters restarted.
+            raw = _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY)
+            assert raw is not None, "the deferral breadcrumb was not written"
+            record = json.loads(raw)
+            assert record["holder_pids"] == [7777]
+            assert record["attempts"] == 1
+            assert record["first_seen"] == now
+        finally:
+            reopened.close()
+
+    def test_the_same_holder_keeps_its_history(self, tmp_path, monkeypatch):
+        """Control for the test above: an unchanged set must still reach the exit."""
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 1_000_000.0
+        _write_deferral(
+            db_path, attempts=FUTILE_ATTEMPTS, age_seconds=FUTILE_SECONDS, now=now
+        )
+        _pin_unreapable_holder(monkeypatch, db_path)   # same pid 4242 as seeded
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is False
+            assert _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY) is None
+        finally:
+            reopened.close()
+
+
 class TestPermanentHolderExitCondition:
     def test_holder_not_yet_proven_permanent_is_still_deferred_to(self, tmp_path, monkeypatch):
         """Below the futility threshold nothing changes: the holder wins, cheaply."""
         db_path = _seed_stale_db(tmp_path, monkeypatch)
-        now = 10_000.0
+        now = 1_000_000.0
         # One attempt short, and one second short, of proven-futile.
         _write_deferral(
             db_path,
@@ -131,7 +309,7 @@ class TestPermanentHolderExitCondition:
     def test_proven_permanent_holder_no_longer_blocks_the_rebuild(self, tmp_path, monkeypatch):
         """Past the threshold the rebuild proceeds and the breadcrumbs are cleared."""
         db_path = _seed_stale_db(tmp_path, monkeypatch)
-        now = 10_000.0
+        now = 1_000_000.0
         _write_deferral(
             db_path,
             attempts=FUTILE_ATTEMPTS,
@@ -155,7 +333,7 @@ class TestPermanentHolderExitCondition:
     def test_futility_needs_both_attempts_and_elapsed_time(self, tmp_path, monkeypatch):
         """Many fast retries are not proof of permanence; the clock must agree too."""
         db_path = _seed_stale_db(tmp_path, monkeypatch)
-        now = 10_000.0
+        now = 1_000_000.0
         _write_deferral(
             db_path,
             attempts=FUTILE_ATTEMPTS * 10,
@@ -178,7 +356,7 @@ class TestPermanentHolderExitCondition:
         authority. With the flock unavailable the rebuild must still defer.
         """
         db_path = _seed_stale_db(tmp_path, monkeypatch)
-        now = 10_000.0
+        now = 1_000_000.0
         _write_deferral(
             db_path,
             attempts=FUTILE_ATTEMPTS,
@@ -214,7 +392,7 @@ class TestPermanentHolderExitCondition:
         the acquire must be a probe: the breadcrumb guarantees the retry.
         """
         db_path = _seed_stale_db(tmp_path, monkeypatch)
-        now = 10_000.0
+        now = 1_000_000.0
         _write_deferral(
             db_path,
             attempts=FUTILE_ATTEMPTS,
@@ -314,12 +492,15 @@ def test_rebuild_under_a_live_second_process_keeps_the_database_intact(tmp_path,
 
         time.sleep(0.5)  # let the peer commit before the rebuild starts
 
-        now = 10_000.0
+        now = 1_000_000.0
+        # Seed the history against the peer's REAL pid. Using a fictional one
+        # would take the holder-changed reset path and never test futility.
         _write_deferral(
             db_path,
             attempts=FUTILE_ATTEMPTS,
             age_seconds=FUTILE_SECONDS,
             now=now,
+            holder_pids=(peer.pid,),
         )
         monkeypatch.setattr(
             SessionDB, "_reap_inactive_orphan_desktop_holders",

--- a/tests/state/test_fts_permanent_holder_deadlock.py
+++ b/tests/state/test_fts_permanent_holder_deadlock.py
@@ -222,6 +222,112 @@ class TestUnprovableHolderStaysFailClosed:
             reopened.close()
 
 
+class TestReapRescanReestablishesIdentity:
+    """A reap that swaps the holder must not hand its window to the newcomer.
+
+    The A->B protection runs before the orphan reap. If the reap removes A and
+    the rescan returns a different positive-PID B, every downstream variable
+    still describes A -- so the futility check can authorize B on its first
+    deferral using A's accrued hour.
+    """
+
+    def test_holder_swapped_by_the_reap_restarts_the_window(self, tmp_path, monkeypatch):
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 1_000_000.0
+        # A has earned the full futility window.
+        _write_deferral(
+            db_path,
+            attempts=FUTILE_ATTEMPTS * 5,
+            age_seconds=FUTILE_SECONDS * 5,
+            now=now,
+            holder_pids=(4242,),
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        scans = iter([
+            [(4242, str(db_path) + "-wal")],   # pre-reap: A
+            [(7777, str(db_path) + "-wal")],   # post-reap rescan: B, a different process
+        ])
+        monkeypatch.setattr(
+            SessionDB, "_foreign_state_db_holders",
+            lambda self: next(scans, [(7777, str(db_path) + "-wal")]),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            SessionDB, "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [4242],
+            raising=False,
+        )
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True, (
+                "B inherited A's window and was authorized on its first deferral"
+            )
+            raw = _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY)
+            assert raw is not None
+            record = json.loads(raw)
+            assert record["holder_pids"] == [7777], (
+                "the persisted identity must describe the post-reap holder"
+            )
+            assert record["attempts"] == 1, (
+                f"the window must restart for B (attempts={record['attempts']})"
+            )
+            assert record["first_seen"] == now
+        finally:
+            reopened.close()
+
+
+class TestReapClearedKeepsTheStartupBudget:
+    """`_defer_stale_fts_for_holders` returns False for two different outcomes.
+
+    Proven permanence means the holder is staying, so probing the rebuild lock
+    non-blocking is right. A successful reap means the blocker is gone -- there
+    the startup admission budget must survive, or transient contention postpones
+    a repair that could have finished now.
+    """
+
+    def test_reap_cleared_holders_still_waits_for_admission(self, tmp_path, monkeypatch):
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 1_000_000.0
+        _write_deferral(
+            db_path, attempts=3, age_seconds=120.0, now=now, holder_pids=(4242,),
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        scans = iter([
+            [(4242, str(db_path) + "-wal")],   # pre-reap
+            [],                                # post-reap rescan: gone
+        ])
+        monkeypatch.setattr(
+            SessionDB, "_foreign_state_db_holders",
+            lambda self: next(scans, []), raising=False,
+        )
+        monkeypatch.setattr(
+            SessionDB, "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [4242],
+            raising=False,
+        )
+
+        seen = {}
+        real = hermes_state_schema.fts_rebuild_admission
+
+        def spy(db, *, timeout_seconds=None):
+            seen["timeout"] = timeout_seconds
+            return real(db, timeout_seconds=timeout_seconds)
+
+        monkeypatch.setattr(hermes_state_schema, "fts_rebuild_admission", spy)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert seen.get("timeout") != 0.0, (
+                "the reap-cleared path must keep the startup admission budget, "
+                f"got timeout_seconds={seen.get('timeout')!r}"
+            )
+        finally:
+            reopened.close()
+
+
 class TestPermanenceBelongsToAHolderSet:
     """Accrued futility must not transfer from one holder to another.
 

--- a/tests/state/test_fts_permanent_holder_deadlock.py
+++ b/tests/state/test_fts_permanent_holder_deadlock.py
@@ -1,0 +1,358 @@
+"""A permanently-held state.db must not defer its FTS repair forever.
+
+Deferring a stale-FTS rebuild while another process holds state.db is correct
+while that holder might leave. When the holder is a supervised peer sharing one
+HERMES_HOME -- a gateway alongside `hermes serve` -- it never leaves, the orphan
+reap deliberately will not touch it, and every deferral keeps the FTS index
+detached while the messages_fts triggers fail canonical writes. In #106393 that
+ran for five days and 292 deferrals, losing every transcript in the window while
+the process stayed healthy and the remedy was logged each time.
+
+These tests pin the invariants of the exit condition, not its current numbers:
+a holder that has not yet proven permanent is still deferred to, one that has is
+not, and the rebuild's real safety (the cross-process rebuild flock) still holds
+in both cases.
+"""
+
+import contextlib
+import json
+import multiprocessing
+import os
+import sqlite3
+import time
+
+import pytest
+
+import hermes_state_schema
+from hermes_state import SessionDB
+from hermes_state_common import FTS_REBUILD_DEFERRAL_KEY, FTS_STALE_KEY
+
+# Read the thresholds through getattr so an unpatched tree fails on BEHAVIOR
+# (the rebuild never runs) rather than on an AttributeError at collection time.
+# A test that errors before it exercises anything proves nothing about the bug.
+FUTILE_ATTEMPTS = getattr(hermes_state_schema, "_FTS_HOLDER_FUTILE_ATTEMPTS", 10)
+FUTILE_SECONDS = getattr(hermes_state_schema, "_FTS_HOLDER_FUTILE_SECONDS", 3600.0)
+
+
+def _corrupt_fts(db_path):
+    raw = sqlite3.connect(str(db_path))
+    raw.execute("UPDATE messages_fts_data SET block = X'DEADBEEFDEADBEEFDEADBEEFDEADBEEF'")
+    raw.commit()
+    raw.close()
+
+
+def _meta_value(db_path, key):
+    raw = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        row = raw.execute("SELECT value FROM state_meta WHERE key = ?", (key,)).fetchone()
+        return row[0] if row else None
+    finally:
+        raw.close()
+
+
+def _seed_stale_db(tmp_path, monkeypatch):
+    """A closed state.db with a detached, stale FTS index and one live session."""
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    if not db._fts_enabled:
+        db.close()
+        pytest.skip("FTS5 unavailable in this build")
+    db.create_session("s1", source="test")
+    db.append_message("s1", "user", "seed calibration row")
+    _corrupt_fts(db_path)
+    monkeypatch.setattr(
+        db, "rebuild_fts", lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt"))
+    )
+    db.append_message("s1", "user", "written while fts was failing")
+    db.close()
+    return db_path
+
+
+def _write_deferral(db_path, *, attempts, age_seconds, now):
+    raw = sqlite3.connect(str(db_path))
+    raw.execute(
+        "INSERT INTO state_meta (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (
+            FTS_REBUILD_DEFERRAL_KEY,
+            json.dumps({
+                "first_seen": now - age_seconds,
+                "last_seen": now,
+                "attempts": attempts,
+                "holder_pids": [4242],
+            }),
+        ),
+    )
+    raw.commit()
+    raw.close()
+
+
+def _pin_unreapable_holder(monkeypatch, db_path):
+    """A holder that is real and that the orphan reap refuses to touch.
+
+    This is the supervised-peer shape: `_reap_inactive_orphan_desktop_holders`
+    returns nothing for it, exactly as it does for a systemd-managed
+    `hermes serve` (non-orphan ppid, not an ephemeral backend, live clients).
+    """
+    monkeypatch.setattr(
+        SessionDB, "_foreign_state_db_holders",
+        lambda self: [(4242, str(db_path) + "-wal")], raising=False,
+    )
+    monkeypatch.setattr(
+        SessionDB, "_reap_inactive_orphan_desktop_holders",
+        lambda self, holders, *, min_age_seconds: [], raising=False,
+    )
+
+
+class TestPermanentHolderExitCondition:
+    def test_holder_not_yet_proven_permanent_is_still_deferred_to(self, tmp_path, monkeypatch):
+        """Below the futility threshold nothing changes: the holder wins, cheaply."""
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 10_000.0
+        # One attempt short, and one second short, of proven-futile.
+        _write_deferral(
+            db_path,
+            attempts=FUTILE_ATTEMPTS - 2,
+            age_seconds=FUTILE_SECONDS - 1,
+            now=now,
+        )
+        _pin_unreapable_holder(monkeypatch, db_path)
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True
+            assert _meta_value(db_path, FTS_STALE_KEY) == "1"
+            # Canonical writes must stay available while deferred.
+            reopened.append_message("s1", "user", "still writable while deferred")
+        finally:
+            reopened.close()
+
+    def test_proven_permanent_holder_no_longer_blocks_the_rebuild(self, tmp_path, monkeypatch):
+        """Past the threshold the rebuild proceeds and the breadcrumbs are cleared."""
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 10_000.0
+        _write_deferral(
+            db_path,
+            attempts=FUTILE_ATTEMPTS,
+            age_seconds=FUTILE_SECONDS,
+            now=now,
+        )
+        _pin_unreapable_holder(monkeypatch, db_path)
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is False
+            assert _meta_value(db_path, FTS_STALE_KEY) is None
+            assert _meta_value(db_path, FTS_REBUILD_DEFERRAL_KEY) is None
+            # The rebuild is only useful if search actually works afterwards,
+            # including for rows written while the index was detached.
+            assert reopened.search_messages("written while fts was failing")
+        finally:
+            reopened.close()
+
+    def test_futility_needs_both_attempts_and_elapsed_time(self, tmp_path, monkeypatch):
+        """Many fast retries are not proof of permanence; the clock must agree too."""
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 10_000.0
+        _write_deferral(
+            db_path,
+            attempts=FUTILE_ATTEMPTS * 10,
+            age_seconds=1.0,  # a restart loop, not a permanent holder
+            now=now,
+        )
+        _pin_unreapable_holder(monkeypatch, db_path)
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True
+        finally:
+            reopened.close()
+
+    def test_rebuild_flock_still_fails_closed_for_a_permanent_holder(self, tmp_path, monkeypatch):
+        """The safety that replaces holder-absence must be load-bearing.
+
+        Proven futility removes the holder gate, NOT the cross-process rebuild
+        authority. With the flock unavailable the rebuild must still defer.
+        """
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 10_000.0
+        _write_deferral(
+            db_path,
+            attempts=FUTILE_ATTEMPTS,
+            age_seconds=FUTILE_SECONDS,
+            now=now,
+        )
+        _pin_unreapable_holder(monkeypatch, db_path)
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        @contextlib.contextmanager
+        def _never_admitted(db_path, *, timeout_seconds=None):
+            yield False
+
+        monkeypatch.setattr(hermes_state_schema, "fts_rebuild_admission", _never_admitted)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True
+            assert _meta_value(db_path, FTS_STALE_KEY) == "1"
+        finally:
+            reopened.close()
+
+    def test_proceeding_past_a_permanent_holder_never_waits_on_the_flock(
+        self, tmp_path, monkeypatch
+    ):
+        """Opening a permanently-blocked db must not inherit the admission budget.
+
+        Before the exit condition existed, a database in this state returned at
+        the holder gate and never reached `fts_rebuild_admission`. Now it does
+        reach it, so a contended flock would add the full startup budget
+        (_FTS_REBUILD_LOCK_TIMEOUT_SECONDS, 120s) to every open -- measured at
+        120.1s before this was fixed. The holder is permanent by definition, so
+        the acquire must be a probe: the breadcrumb guarantees the retry.
+        """
+        db_path = _seed_stale_db(tmp_path, monkeypatch)
+        now = 10_000.0
+        _write_deferral(
+            db_path,
+            attempts=FUTILE_ATTEMPTS,
+            age_seconds=FUTILE_SECONDS,
+            now=now,
+        )
+        _pin_unreapable_holder(monkeypatch, db_path)
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        seen_timeouts = []
+        real_admission = hermes_state_schema.fts_rebuild_admission
+
+        @contextlib.contextmanager
+        def _recording_admission(path, *, timeout_seconds=None):
+            seen_timeouts.append(timeout_seconds)
+            with real_admission(path, timeout_seconds=timeout_seconds) as admitted:
+                yield admitted
+
+        monkeypatch.setattr(hermes_state_schema, "fts_rebuild_admission", _recording_admission)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert seen_timeouts, "the rebuild never reached the admission authority"
+            # Non-blocking probe, not the startup budget (None) and not a wait.
+            assert seen_timeouts[0] == 0.0, (
+                f"proceeding past a permanent holder waited on the flock "
+                f"(timeout={seen_timeouts[0]!r}); a contended lock would stall startup"
+            )
+        finally:
+            reopened.close()
+
+
+def _peer_writer(db_path, ready, stop, wrote, errors):
+    """A second OS process holding the db read-write and committing throughout."""
+    conns = []
+    for _ in range(3):
+        conn = sqlite3.connect(str(db_path), timeout=30)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("SELECT count(*) FROM messages").fetchone()
+        conns.append(conn)
+    ready.set()
+    i = 0
+    while not stop.is_set():
+        conn = conns[i % len(conns)]
+        try:
+            conn.execute(
+                "INSERT INTO messages(session_id, role, content, timestamp) VALUES (?,?,?,?)",
+                ("peer", "user", f"peer calibration row {i}", time.time()),
+            )
+            conn.commit()
+            with wrote.get_lock():
+                wrote.value += 1
+        except sqlite3.Error:
+            with errors.get_lock():
+                errors.value += 1
+        i += 1
+        time.sleep(0.004)
+    for conn in conns:
+        conn.close()
+
+
+@pytest.mark.linux_only
+def test_rebuild_under_a_live_second_process_keeps_the_database_intact(tmp_path, monkeypatch):
+    """E2E: the claim that makes the exit condition safe, against a real process.
+
+    The holder gate was added because file-level surgery (WAL sidecar unlink,
+    journal_mode flips) corrupts a live-WAL database under a concurrent holder
+    (#90806, #90950). The stale-FTS rebuild does none of that -- it is one
+    BEGIN IMMEDIATE transaction of SQL DDL/DML. This exercises that difference
+    for real: a separate process holds the database and commits rows for the
+    whole rebuild, and afterwards the database must be intact, no committed row
+    may be missing, and search must work.
+    """
+    db_path = _seed_stale_db(tmp_path, monkeypatch)
+    before = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    baseline = before.execute("SELECT count(*) FROM messages").fetchone()[0]
+    before.close()
+
+    ctx = multiprocessing.get_context("spawn")
+    ready, stop = ctx.Event(), ctx.Event()
+    wrote, errors = ctx.Value("i", 0), ctx.Value("i", 0)
+    peer = ctx.Process(target=_peer_writer, args=(db_path, ready, stop, wrote, errors))
+    peer.start()
+    try:
+        assert ready.wait(timeout=30), "peer process never became ready"
+
+        # The peer must really be a foreign holder, or this proves nothing.
+        held = set()
+        for fd in os.listdir(f"/proc/{peer.pid}/fd"):
+            try:
+                target = os.readlink(f"/proc/{peer.pid}/fd/{fd}")
+            except OSError:
+                continue
+            if os.path.basename(target).startswith("state.db"):
+                held.add(os.path.basename(target))
+        assert held, "peer is not holding state.db; the test would be vacuous"
+
+        time.sleep(0.5)  # let the peer commit before the rebuild starts
+
+        now = 10_000.0
+        _write_deferral(
+            db_path,
+            attempts=FUTILE_ATTEMPTS,
+            age_seconds=FUTILE_SECONDS,
+            now=now,
+        )
+        monkeypatch.setattr(
+            SessionDB, "_reap_inactive_orphan_desktop_holders",
+            lambda self, holders, *, min_age_seconds: [], raising=False,
+        )
+        monkeypatch.setattr(hermes_state_schema.time, "time", lambda: now)
+
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is False, "rebuild did not run under the live holder"
+            time.sleep(0.5)  # peer keeps writing across the schema change
+        finally:
+            reopened.close()
+    finally:
+        stop.set()
+        peer.join(timeout=30)
+        if peer.is_alive():  # pragma: no cover - defensive
+            peer.terminate()
+            peer.join(timeout=10)
+
+    peer_rows = wrote.value
+    assert peer_rows > 0, "peer never committed; the test would be vacuous"
+    assert errors.value == 0, f"peer writes failed during the rebuild: {errors.value}"
+
+    check = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        assert check.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        total = check.execute("SELECT count(*) FROM messages").fetchone()[0]
+        assert total == baseline + peer_rows, "committed rows were lost across the rebuild"
+        # Every row is indexed, including those committed mid-rebuild.
+        assert check.execute("SELECT count(*) FROM messages_fts").fetchone()[0] == total
+        assert check.execute(
+            "SELECT count(*) FROM messages_fts WHERE messages_fts MATCH 'calibration'"
+        ).fetchone()[0] > 0
+    finally:
+        check.close()


### PR DESCRIPTION
## What does this PR do?

Gives the stale-FTS rebuild deferral an exit condition when the blocking holder
is permanent, so a supervised peer sharing one `HERMES_HOME` can no longer
convert a recoverable FTS corruption into indefinite, silent transcript loss.

Deferring while another process holds `state.db` is right while that holder
might leave. It is not right when the holder is a second supervised service (a
gateway alongside `hermes serve` on a remote node): that holder is a fixed
property of the deployment, the orphan reap in
`_reap_inactive_orphan_desktop_holders` deliberately will not touch it, and
every deferral leaves the FTS index detached while the `messages_fts` triggers
keep failing **every** canonical `messages` INSERT.

On the reporting host that ran for five days and 292 deferrals. The gateway
answered messages the whole time, `systemctl is-active` stayed green, the
liveness heartbeat kept pinging, and `MAX(timestamp)` on `messages` was five
days stale. Every session transcript in the window is gone. The repair logged
its own remedy 292 times and could never run it.

This is the gap left by #93155 / #93191. That issue's diagnosis was exactly
right — *"the defect is that deferral has no exit condition"* — but the fix gave
an exit only for **orphan** Desktop backends, and #93155 explicitly classifies a
"busy peer" as a holder that *should* defer. Correct for a transient peer;
for a permanent one, "defer" means "never repair."

### Why this is safe

The holder gate is not the safety mechanism for this operation, and removing it
here does not remove any safety:

- **Concurrent rebuilds remain impossible.** `_recover_stale_fts` still admits
  through `fts_rebuild_admission`, the cross-process `flock` that exists
  precisely to serialize structural rebuilds (`hermes_state_common.py`), and
  still fails closed. A test asserts the rebuild is refused when that flock is
  unavailable, so the replacement guard is load-bearing rather than decorative.
- **No file-level surgery is involved.** `_recover_stale_fts_locked` is one
  `BEGIN IMMEDIATE` transaction of SQL DDL/DML. It never unlinks or replaces the
  WAL sidecars and never flips `journal_mode`. The corruption that motivated the
  holder gate (#90806, #90950) came from exactly that kind of surgery, which
  lives in `hermes_state_repair.py` behind its own `_live_writer_holds_db` gate
  and is untouched by this PR.
- **Transient holders behave exactly as before.** The exit needs 10 deferrals
  *and* an hour of wall time. With the doubling backoff in
  `retry_deferred_fts_recovery` (60s → 3600s cap) that is several hours of a
  genuinely stuck holder, not a restarting one. A restart loop with many fast
  retries does not qualify, and there is a test for that.
- **The orphan-reap predicate is unchanged.** `_is_inactive_orphan_desktop_holder`
  is correct and stays as-is; force-killing a live service with connected
  clients would be a worse bug than the one being fixed. The point is that "this
  holder must not be killed" and "therefore retry forever while writes fail" are
  two different conclusions.

## Related Issue

Fixes #106393

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_schema.py`
  - Add `_FTS_HOLDER_FUTILE_ATTEMPTS` / `_FTS_HOLDER_FUTILE_SECONDS` with the
    rationale for why proceeding is safe for this specific operation.
  - `_defer_stale_fts_for_holders` returns `False` (proceed) once the holders
    have proven permanent, logging at ERROR with the holder set, the deferral
    count and the elapsed hours.
  - Suppress the pre-existing "remains blocked" ERROR once the futility branch
    takes over, so the two do not alternate on every retry.
  - Reword that ERROR's remediation. The old text (`stop the listed processes,
    then run hermes sessions optimize-storage with the gateway stopped`) cannot
    be followed from inside a gateway-hosted session: stopping the gateway kills
    the session running the command, and a separate `optimize-storage` process
    makes the gateway *its* foreign holder, so the same gate fails again. The
    new text points at stopping only the Desktop backend, which leaves the
    gateway as the sole holder and lets its own retry tick repair with no
    gateway downtime — and warns that the tick backs off to hourly, because the
    resulting wait reads as failure and invites something more destructive.
- `tests/state/test_fts_permanent_holder_deadlock.py` — new.

## How to Test

Reproduction (this is the shape a remote node with a Desktop client has by
default):

1. Run `hermes-gateway.service` and `hermes-serve.service` under
   `systemd --user` against one `HERMES_HOME`, with the Desktop app connected so
   the backend has established clients.
2. Get the FTS index into the stale state (`state_meta.fts_stale = 1`).
3. Watch `state_meta.fts_rebuild_deferral` and the log. Before this PR the
   `attempts` counter climbs forever, `MAX(timestamp)` on `messages` stops
   advancing, and the gateway logs one `disk=0` "Persisted transcript lagged"
   WARNING per turn while still replying normally.

Automated:

```bash
scripts/run_tests.sh tests/state/test_fts_permanent_holder_deadlock.py -q
```

The five tests cover: a holder below the threshold is still deferred to (with
canonical writes available); a proven-permanent holder no longer blocks the
rebuild and search works afterwards; futility requires attempts **and** elapsed
time; the rebuild flock still fails closed for a permanent holder; and an E2E
case that spawns a real second process holding `state.db` + `-wal` + `-shm`
(asserted via `/proc/<pid>/fd`) and committing rows throughout the rebuild, then
requires `integrity_check` ok, no committed row lost, and every row indexed
including those written mid-rebuild.

Verified RED before GREEN: on unpatched `main` the two behavioral tests fail
with `rebuild did not run under the live holder`, while the three that assert
preserved behavior pass. The thresholds are read via `getattr` with defaults so
an unpatched tree fails on behavior rather than erroring at import.

Field rehearsal on the reporting host, against a WAL-safe copy of its real
`state.db` (14,180 messages, 127 sessions) with the production failure state
injected and a real second process attached:

```
PEER_PRE_ERR (expected, this is the bug) DatabaseError:
    fts5: corrupt structure record for table "messages_fts"
Rebuilt stale state.db FTS indexes from canonical messages and restored sync triggers.
live foreign holder pid 429442 holds: ['state.db', 'state.db-shm', 'state.db-wal']

fts_stale after   : False
after repair      : 229 rows written, 0 errors
integrity_check   : ok
foreign_key_check : 0 violations
messages          : 14421 (baseline 14180 + peer 241)
messages_fts      : 14421
breadcrumbs left  : none
search worked     : True
```

The peer's pre-repair write errors are the bug itself — the corrupt index
rejecting writes through its triggers, which is the production data loss. After
the rebuild lands under the live holder, the peer writes cleanly.

Platform tested: Ubuntu 24.04.4 LTS (kernel 6.17, x86_64), Python 3.11.15,
SQLite 3.53.1.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite (`scripts/run_tests.sh`); see the note below — 90 pre-existing failures, none introduced by this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS (kernel 6.17.0-1019-aws, x86_64)

Note on the suite: the full `scripts/run_tests.sh` run is
**46,200 passed / 90 failed / 413 skipped** in 6890s. All 90 failures pre-date
this change; I verified that rather than assuming it, because 27 files failing
is too many to wave through:

- The 27 failing files, re-run on clean `main` in a separate checkout, give
  89 + 1 = **90** — the same count.
- The only failing file inside the subsystem this PR touches is
  `tests/test_hermes_state.py`, and it is **260 passed / 1 failed on both**
  `main` and this branch, with the same test name
  (`TestFTS5Search::test_search_projection_skips_context_enrichment_queries`).
- Comparing failing test *names* rather than counts leaves three that appear on
  this branch and not in the baseline list
  (`test_moa_loop_mode::test_references_run_in_parallel`,
  `test_lazy_secrets_dispatch::...::test_update_check_clean`,
  `test_zombie_process_cleanup::...::test_timed_out_child_keeps_relay_session_until_its_turn_exits`).
  Run on their own they are **51/51 green on both** `main` and this branch, so
  they are ordering/timing flakes under the 4-worker full-suite run, not
  regressions.

Targeted suites, all green on this branch: 6/6 new tests, and 601/601 across
`tests/state/`, `tests/hermes_state/`, the gateway session-DB files,
`test_state_db_malformed_repair.py` and `test_state_db_stats.py`.

Lint: `ruff check .` passes. `ty` on `hermes_state_schema.py` reports 51
diagnostics on this branch and 51 on `main` — identical when compared by
diagnostic text, so nothing new; the new test file reports none.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring for `_defer_stale_fts_for_holders`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; thresholds are internal constants, not behavioral settings users tune)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — the changed logic is pure arithmetic on the existing deferral record and is platform-independent; `fts_rebuild_admission` already handles `msvcrt` vs `flock`. The E2E test is marked `linux_only` because it reads `/proc/<pid>/fd`; the four unit tests run everywhere.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
