### PR TITLE
TUI gateway reconnect replay no longer holds unbounded payload bytes (#106139, salvage #106140)

### DIFF
--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -186,6 +186,19 @@ def test_oversized_event_marks_gap_even_with_empty_buffer(monkeypatch):
     assert not event_replay.is_truncated("s1", 1)
     assert not event_replay.is_truncated("s1", 2)
 
+    # The gap watermark never moves backwards: a small frame after an oversized one must
+    # not hide the hole the oversized frame left.
+    reset_replay_state()
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_MAX", 1)
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 1000)
+    monkeypatch.setattr(event_replay, "_REPLAY_PROCESS_BYTES_MAX", 1000)
+    event_replay._stamp_event(_frame("s"))
+    large = _frame("s")
+    large["params"]["payload"] = {"data": "x" * 2000}
+    event_replay._stamp_event(large)
+    event_replay._stamp_event(_frame("s"))
+    assert event_replay.is_truncated("s", 1)
+
 
 def test_truncation_detection_semantics():
     """The RPC handler's truncated flag: gap between last_seen and buffer start."""
@@ -204,14 +217,3 @@ def test_truncation_detection_semantics():
     assert event_replay.is_truncated("s1", 5)
     # Unknown session: nothing evicted, nothing truncated.
     assert not event_replay.is_truncated("nope", 0)
-
-
-def test_oversized_gap_watermark_never_moves_backwards(monkeypatch):
-    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_MAX", 1)
-    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 1000)
-    event_replay._stamp_event(_frame("s"))
-    large = _frame("s")
-    large["params"]["payload"] = {"data": "x" * 2000}
-    event_replay._stamp_event(large)
-    event_replay._stamp_event(_frame("s"))
-    assert event_replay.is_truncated("s", 1)

--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -204,3 +204,14 @@ def test_truncation_detection_semantics():
     assert event_replay.is_truncated("s1", 5)
     # Unknown session: nothing evicted, nothing truncated.
     assert not event_replay.is_truncated("nope", 0)
+
+
+def test_oversized_gap_watermark_never_moves_backwards(monkeypatch):
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_MAX", 1)
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 1000)
+    event_replay._stamp_event(_frame("s"))
+    large = _frame("s")
+    large["params"]["payload"] = {"data": "x" * 2000}
+    event_replay._stamp_event(large)
+    event_replay._stamp_event(_frame("s"))
+    assert event_replay.is_truncated("s", 1)

--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -135,6 +135,58 @@ def test_concurrent_stamping_never_drops_or_duplicates_seq():
     assert replay_stats()["events"] == 8 * 200
 
 
+def test_byte_budget_evicts_payloads_and_preserves_gap_semantics(monkeypatch):
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 700)
+    monkeypatch.setattr(event_replay, "_REPLAY_PROCESS_BYTES_MAX", 5_000)
+
+    first = _frame("s1", "tool.complete")
+    first["params"]["payload"] = {"result": "x" * 400}
+    second = _frame("s1", "tool.complete")
+    second["params"]["payload"] = {"result": "y" * 400}
+    event_replay._stamp_event(first)
+    event_replay._stamp_event(second)
+
+    stats = replay_stats()
+    assert stats["bytes"] <= stats["max_bytes_per_session"]
+    assert [event["seq"] for event in events_since("s1", 0)] == [2]
+    assert event_replay.is_truncated("s1", 0)
+
+    reset_replay_state()
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 1_000)
+    monkeypatch.setattr(event_replay, "_REPLAY_PROCESS_BYTES_MAX", 700)
+    first = _frame("s1", "tool.complete")
+    first["params"]["payload"] = {"result": "x" * 400}
+    event_replay._stamp_event(first)
+    other = _frame("s2", "tool.complete")
+    other["params"]["payload"] = {"result": "y" * 400}
+    event_replay._stamp_event(other)
+
+    stats = replay_stats()
+    assert stats["bytes"] <= stats["max_bytes_process"]
+    assert events_since("s1", 0) == []
+    assert event_replay.is_truncated("s1", 0)
+    assert [event["seq"] for event in events_since("s2", 0)] == [1]
+
+
+def test_oversized_event_marks_gap_even_with_empty_buffer(monkeypatch):
+    monkeypatch.setattr(event_replay, "_REPLAY_BUFFER_BYTES_MAX", 300)
+    monkeypatch.setattr(event_replay, "_REPLAY_PROCESS_BYTES_MAX", 300)
+
+    oversized = _frame("s1", "tool.complete")
+    oversized["params"]["payload"] = {"result": "x" * 1000}
+    event_replay._stamp_event(oversized)
+
+    assert events_since("s1", 0) == []
+    assert event_replay.is_truncated("s1", 0)
+    assert not event_replay.is_truncated("s1", 1)
+
+    event_replay._stamp_event(_frame("s1"))
+    assert [event["seq"] for event in events_since("s1", 0)] == [2]
+    assert event_replay.is_truncated("s1", 0)
+    assert not event_replay.is_truncated("s1", 1)
+    assert not event_replay.is_truncated("s1", 2)
+
+
 def test_truncation_detection_semantics():
     """The RPC handler's truncated flag: gap between last_seen and buffer start."""
     # Overflow the ring so the oldest events are genuinely evicted.

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -77,14 +77,14 @@ def _stamp_event(obj: dict) -> None:
             evicted_seq, _event, evicted_size = buf.popleft()
             _replay_buffer_bytes[sid] -= evicted_size
             _replay_total_bytes -= evicted_size
-            _replay_evicted_through[sid] = evicted_seq
+            _replay_evicted_through[sid] = max(_replay_evicted_through.get(sid, 0), evicted_seq)
         while _replay_total_bytes > _REPLAY_PROCESS_BYTES_MAX:
             for evict_sid, evict_buf in _replay_buffers.items():
                 if evict_buf:
                     evicted_seq, _event, evicted_size = evict_buf.popleft()
                     _replay_buffer_bytes[evict_sid] -= evicted_size
                     _replay_total_bytes -= evicted_size
-                    _replay_evicted_through[evict_sid] = evicted_seq
+                    _replay_evicted_through[evict_sid] = max(_replay_evicted_through.get(evict_sid, 0), evicted_seq)
                     break
 
 

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -5,7 +5,10 @@ Every event frame through :func:`server.write_json` (hence ``_emit``) gets a per
 with its last seen seq and gets everything newer. Invariants: stdio TUI unaffected (``seq`` only on
 event frames; Ink ignores unknown keys); one lock guards counters + buffers, and write_json already
 serializes per-transport writes so stamping cannot reorder frames; memory bound =
-_REPLAY_BUFFER_MAX events x _REPLAY_SESSIONS_MAX sessions, oldest session evicted FIFO.
+_REPLAY_BUFFER_MAX events AND _REPLAY_BUFFER_BYTES_MAX serialized bytes per session,
+_REPLAY_PROCESS_BYTES_MAX bytes across at most _REPLAY_SESSIONS_MAX sessions, oldest evicted
+FIFO. Evicted or never-retained (oversized) frames leave a truncation watermark so a
+reconnecting client refetches instead of trusting a replay with holes.
 """
 
 from __future__ import annotations
@@ -20,9 +23,13 @@ from collections import OrderedDict, deque
 # epoch lets clients detect the restart and reset their watermarks.
 _REPLAY_EPOCH = uuid.uuid4().hex
 
-# Count limits protect control-frame churn; byte limits protect large tool results.
+# A long turn emits ~hundreds of token events; 512 covers minutes of streaming plus
+# all control events. Desktop users rarely exceed a dozen live chats.
 _REPLAY_BUFFER_MAX = 512
 _REPLAY_SESSIONS_MAX = 64
+# A ring may legitimately hold many bounded 64 KiB tool results (512 of them ≈ 32 MiB per
+# session, ×64 sessions before any cap); bound the serialized bytes so replay memory cannot
+# scale with payload size without limit.
 _REPLAY_BUFFER_BYTES_MAX = 4 * 1024 * 1024
 _REPLAY_PROCESS_BYTES_MAX = 64 * 1024 * 1024
 
@@ -51,13 +58,15 @@ def _stamp_event(obj: dict) -> None:
     if not sid:
         # Session-less global events (skin.changed etc.) are re-fetchable via their own RPCs.
         return
+    # Sizing stays OUTSIDE the lock (same rule as transport.write) so one large payload cannot
+    # stall other threads' frames; ``seq`` is not stamped yet, a few bytes off a MiB budget.
+    size = len(json.dumps(params, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8", errors="surrogatepass"))
     with _replay_lock:
         global _replay_total_bytes
         seq = _replay_next_seq.get(sid, 0) + 1
         _replay_next_seq[sid] = seq
         params["seq"] = seq
-        size = len(json.dumps(params, ensure_ascii=False, separators=(",", ":")).encode(
-            "utf-8", errors="surrogatepass"))
         buf = _replay_buffers.get(sid)
         if buf is None:
             buf = _replay_buffers[sid] = deque()

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -10,6 +10,7 @@ _REPLAY_BUFFER_MAX events x _REPLAY_SESSIONS_MAX sessions, oldest session evicte
 
 from __future__ import annotations
 
+import json
 import threading
 import uuid
 from collections import OrderedDict, deque
@@ -19,15 +20,18 @@ from collections import OrderedDict, deque
 # epoch lets clients detect the restart and reset their watermarks.
 _REPLAY_EPOCH = uuid.uuid4().hex
 
-# A long turn emits ~hundreds of token events; 512 covers minutes of streaming plus
-# all control events. Desktop users rarely exceed a dozen live chats.
+# Count limits protect control-frame churn; byte limits protect large tool results.
 _REPLAY_BUFFER_MAX = 512
 _REPLAY_SESSIONS_MAX = 64
+_REPLAY_BUFFER_BYTES_MAX = 4 * 1024 * 1024
+_REPLAY_PROCESS_BYTES_MAX = 64 * 1024 * 1024
 
 _replay_lock = threading.Lock()
-# sid -> deque of (seq, params dict) — the bare event (type/session_id/seq/payload),
-# the exact shape the client's dispatch path consumes.
+# sid -> deque of (seq, params dict, serialized bytes).
 _replay_buffers: "OrderedDict[str, deque]" = OrderedDict()
+_replay_buffer_bytes: dict[str, int] = {}
+_replay_evicted_through: dict[str, int] = {}
+_replay_total_bytes = 0
 _replay_next_seq: dict[str, int] = {}
 
 
@@ -48,16 +52,40 @@ def _stamp_event(obj: dict) -> None:
         # Session-less global events (skin.changed etc.) are re-fetchable via their own RPCs.
         return
     with _replay_lock:
+        global _replay_total_bytes
         seq = _replay_next_seq.get(sid, 0) + 1
         _replay_next_seq[sid] = seq
         params["seq"] = seq
+        size = len(json.dumps(params, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8", errors="surrogatepass"))
         buf = _replay_buffers.get(sid)
         if buf is None:
-            buf = _replay_buffers[sid] = deque(maxlen=_REPLAY_BUFFER_MAX)
+            buf = _replay_buffers[sid] = deque()
+            _replay_buffer_bytes[sid] = 0
             while len(_replay_buffers) > _REPLAY_SESSIONS_MAX:
-                _oldest_sid, _oldest_buf = _replay_buffers.popitem(last=False)
-                _replay_next_seq.pop(_oldest_sid, None)
-        buf.append((seq, params))
+                oldest_sid, oldest_buf = _replay_buffers.popitem(last=False)
+                _replay_total_bytes -= _replay_buffer_bytes.pop(oldest_sid, 0)
+                _replay_next_seq.pop(oldest_sid, None)
+                _replay_evicted_through.pop(oldest_sid, None)
+        if size > _REPLAY_BUFFER_BYTES_MAX or size > _REPLAY_PROCESS_BYTES_MAX:
+            _replay_evicted_through[sid] = seq
+            return
+        buf.append((seq, params, size))
+        _replay_buffer_bytes[sid] += size
+        _replay_total_bytes += size
+        while len(buf) > _REPLAY_BUFFER_MAX or _replay_buffer_bytes[sid] > _REPLAY_BUFFER_BYTES_MAX:
+            evicted_seq, _event, evicted_size = buf.popleft()
+            _replay_buffer_bytes[sid] -= evicted_size
+            _replay_total_bytes -= evicted_size
+            _replay_evicted_through[sid] = evicted_seq
+        while _replay_total_bytes > _REPLAY_PROCESS_BYTES_MAX:
+            for evict_sid, evict_buf in _replay_buffers.items():
+                if evict_buf:
+                    evicted_seq, _event, evicted_size = evict_buf.popleft()
+                    _replay_buffer_bytes[evict_sid] -= evicted_size
+                    _replay_total_bytes -= evicted_size
+                    _replay_evicted_through[evict_sid] = evicted_seq
+                    break
 
 
 def events_since(sid: str, last_seen: int) -> list[dict]:
@@ -68,15 +96,14 @@ def events_since(sid: str, last_seen: int) -> list[dict]:
     """
     with _replay_lock:
         buf = _replay_buffers.get(sid or "")
-        return [event for seq, event in buf if seq > last_seen] if buf else []
+        return [event for seq, event, _size in buf if seq > last_seen] if buf else []
 
 
 def is_truncated(sid: str, last_seen: int) -> bool:
     """True when events between *last_seen* and the ring's oldest retained seq were
     evicted — the client must refetch history instead of trusting the replay."""
     with _replay_lock:
-        buf = _replay_buffers.get(sid or "")
-        return bool(buf) and last_seen + 1 < buf[0][0]
+        return last_seen < _replay_evicted_through.get(sid or "", 0)
 
 
 def latest_seq(sid: str) -> int:
@@ -88,8 +115,12 @@ def latest_seq(sid: str) -> int:
 def reset_replay_state() -> None:
     """Test hook."""
     with _replay_lock:
+        global _replay_total_bytes
         _replay_buffers.clear()
+        _replay_buffer_bytes.clear()
+        _replay_evicted_through.clear()
         _replay_next_seq.clear()
+        _replay_total_bytes = 0
 
 
 def replay_stats() -> dict:
@@ -97,5 +128,8 @@ def replay_stats() -> dict:
     with _replay_lock:
         return {
             "sessions": len(_replay_buffers),
-            "events": sum(len(b) for b in _replay_buffers.values()),
-            "max_per_session": _REPLAY_BUFFER_MAX}
+            "events": sum(len(buffer) for buffer in _replay_buffers.values()),
+            "bytes": _replay_total_bytes,
+            "max_per_session": _REPLAY_BUFFER_MAX,
+            "max_bytes_per_session": _REPLAY_BUFFER_BYTES_MAX,
+            "max_bytes_process": _REPLAY_PROCESS_BYTES_MAX}


### PR DESCRIPTION
The TUI gateway's reconnect replay ring now bounds retained payload **bytes** (4 MiB per session, 64 MiB per process), so a burst of large tool results no longer pins tens of MiB per session in memory, and any byte-evicted or oversized frame reports `truncated: true` so a reconnecting client refetches instead of trusting a replay with holes.

- `tui_gateway/event_replay.py::_stamp_event` tracks the serialized size of every retained frame; per-session (`_REPLAY_BUFFER_BYTES_MAX`) and process-wide (`_REPLAY_PROCESS_BYTES_MAX`) budgets evict oldest-first alongside the existing 512-frame count cap.
- Frames larger than a budget are never retained; they only advance the per-session eviction watermark, so the gap is still reported.
- `is_truncated` now reads the eviction watermark (`_replay_evicted_through`) instead of inferring a gap from the oldest retained frame; the watermark is monotonic, so an empty-after-eviction buffer no longer reports a complete replay.
- Follow-up (ours): the sizing `json.dumps` runs **outside** `_replay_lock`, matching the documented `transport.py::write` invariant that serialization never holds a lock and blocks other threads' frames; WHY comments on the byte ceilings and a module docstring that states the bound in bytes.
- `replay_stats()` additionally reports `bytes`, `max_bytes_per_session`, `max_bytes_process` (additive, debug surface).
- Tests trimmed to two invariants (byte-budget eviction with gap semantics; oversized frame marks a gap on an empty buffer + monotonic watermark), proven red on `origin/main` (`2 failed, 9 passed`) and green on this branch (`11 passed`).

## Live repro

Real module, no mocks: stamp 512 unique 64 KiB `tool.complete` frames for one session via `_stamp_event`, then measure what the ring retains (`/tmp/gateway-state-a/repro_replay_bytes.py <repo>`).

| | `origin/main` (before) | this branch (after) |
|---|---|---|
| retained payload bytes | `32.04 MiB over 512 frames` | `3.94 MiB over 63 frames` |
| `is_truncated('s1', 0)` | `False` (client told the replay is complete) | `True` |
| `is_truncated('s1', 511)` | `False` | `False` |
| `len(events_since('s1', 0))` | `512` | `63` |

Root cause: the ring bounded frame **count** (`deque(maxlen=512)`), not payload bytes, and truncation was inferred from the oldest retained frame, so an evicted-but-empty buffer reported a complete replay.

## Tests

| Suite | Result |
|---|---|
| `scripts/run_tests.sh tests/test_tui_gateway_event_replay.py` | 11 passed |
| `scripts/run_tests.sh tests/tui_gateway/` | 124 files, 1094 passed |
| `apps/shared` vitest `src/json-rpc-gateway-replay.test.ts` (client replay path, response shape unchanged) | 8 passed |

## Design note

Server-side contract change, flagged for maintainer awareness: `session.events.since` now reports `truncated: true` for byte-budget evictions and oversized frames too, not only for count-cap evictions. `apps/shared/src/json-rpc-gateway.ts::fetchReplay` does not read `truncated` today, and the Desktop refetches session state on reconnect via `resetTileRuntimeBindings` / `refreshSessions` regardless, so no client change is required for correctness. The response shape of `session.events.since` (`events` / `latest_seq` / `truncated` / `count` / `epoch`) is unchanged.

Salvaged from #106140 by @Xipong (cherry-picked, authorship preserved).

Closes #106139

## Infographic

![replay-ring-byte-cap](https://v3b.fal.media/files/b/0aa9ba8c/q2yzjlUlNQnPqLstLWOEv_ox9v870O.png)
