### PR TITLE
fix(dashboard): chat input no longer repeats the last character after page navigation (#106403, salvage #106445)

### DIFF
--- a/web/src/lib/pty-mobile-input.test.ts
+++ b/web/src/lib/pty-mobile-input.test.ts
@@ -70,6 +70,26 @@ describe("normalizePtyMobileInput", () => {
   });
 });
 
+describe("normalizePtyMobileInput with a stale tracked line", () => {
+  it("emits deletes sized to the stale tracker unless the tracker was reset", () => {
+    // #106403: the tracked line survives a dashboard tab switch while the
+    // TUI composer moves on. A re-emitted word inside the replacement
+    // window is then rewritten against the stale snapshot — the DELETE
+    // count is the tracker's length, not the composer's, so the composer
+    // ends up with repeated characters ("hel" + 3×DEL + "hello" over a
+    // composer holding "hello" leaves "hehello"). Clearing the tracker on
+    // deactivation makes the same input pass through untouched.
+    const stale = normalizePtyMobileInput("hello", "hel", true);
+    expect(stale.normalized).toBe(true);
+    expect(stale.data).toBe("\x7f".repeat("hel".length) + "hello");
+
+    const reset = normalizePtyMobileInput("hello", "", true);
+    expect(reset.normalized).toBe(false);
+    expect(reset.data).toBe("hello");
+    expect(reset.nextLine).toBe("hello");
+  });
+});
+
 describe("updatePtyInputLine", () => {
   it("tracks printable text, delete, and submit", () => {
     expect(updatePtyInputLine("", "abc")).toBe("abc");

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -205,16 +205,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   useEffect(() => {
     setHasActivated((prev) => latchChatActivation(prev, isActive));
   }, [isActive]);
-
-  // Clear mobile-input tracking refs when the tab is hidden so stale state
-  // from a previous /chat visit doesn't cause the mobile-replacement logic
-  // to misfire on the next activation (#106403: repeated last character).
-  useEffect(() => {
-    if (!isActive) {
-      ptyInputLineRef.current = "";
-      mobileReplacementInputUntilRef.current = 0;
-    }
-  }, [isActive]);
   const [searchParams, setSearchParams] = useSearchParams();
   // Lazy-init: the missing-token check happens at construction so the effect
   // body doesn't have to setState (React 19's set-state-in-effect rule).
@@ -307,6 +297,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     setPtyState("connecting");
     setReconnectNonce((n) => n + 1);
   }, [clearReconnectTimer, searchParams, setSearchParams]);
+  // Clear mobile-input tracking refs when the tab is hidden so stale state
+  // from a previous /chat visit doesn't cause the mobile-replacement logic
+  // to misfire on the next activation (#106403: repeated last character).
+  useEffect(() => {
+    if (!isActive) {
+      ptyInputLineRef.current = "";
+      mobileReplacementInputUntilRef.current = 0;
+    }
+  }, [isActive]);
   // Raw state for the mobile side-sheet + a derived value that force-
   // closes whenever the chat tab isn't active.  The *derived* value is
   // what side-effects (body-scroll lock, keydown listener, portal render)

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -205,6 +205,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   useEffect(() => {
     setHasActivated((prev) => latchChatActivation(prev, isActive));
   }, [isActive]);
+
+  // Clear mobile-input tracking refs when the tab is hidden so stale state
+  // from a previous /chat visit doesn't cause the mobile-replacement logic
+  // to misfire on the next activation (#106403: repeated last character).
+  useEffect(() => {
+    if (!isActive) {
+      ptyInputLineRef.current = "";
+      mobileReplacementInputUntilRef.current = 0;
+    }
+  }, [isActive]);
   const [searchParams, setSearchParams] = useSearchParams();
   // Lazy-init: the missing-token check happens at construction so the effect
   // body doesn't have to setState (React 19's set-state-in-effect rule).


### PR DESCRIPTION
The dashboard chat input no longer repeats the last typed character after navigating to another dashboard page and back.

Fixes #106403
Refs #106487 (desktop CJK IME text garbled through the same mobile-replacement normalization path — a separate premise; not touched here)

## Changes

- `web/src/pages/ChatPage.tsx` — new `useEffect([isActive])` that resets `ptyInputLineRef` / `mobileReplacementInputUntilRef` when the chat tab deactivates, mirroring what `reconnectPty` / `startFreshPty` / `startFreshDashboardChat` already do on their own resets. (cherry-picked from #106445 by @kokhlo, authorship preserved)
- Follow-up commit: the effect is declared **after** those three callbacks. Declared above them (as in #106445) the React Compiler `react-hooks/immutability` lint treats the two refs as effect-owned and flags the six pre-existing assignments in the callbacks as errors — that is what turned the `JS & TS checks` job red on the original PR. Placement alone fixes it; eslint on the file is back to main's 0 errors / 3 warnings, no suppressions added.
- One pure-function vitest in `web/src/lib/pty-mobile-input.test.ts` (`normalizePtyMobileInput with a stale tracked line`): a stale tracker `"hel"` turns an in-window `"hello"` into `3×DEL + "hello"` (leaves `"hehello"` in a composer that already holds `"hello"`); with the tracker reset the same input passes through untouched.

## Root cause

`<ChatPage/>` stays mounted (hidden) on every dashboard route, so the flat input-line tracker that drives the mobile-replacement heuristic (`web/src/lib/pty-mobile-input.ts::normalizePtyMobileInput`) survives the tab switch while the TUI composer moves on; the next keystroke inside the 350 ms replacement window is rewritten against the stale snapshot with a DELETE count sized to the stale line, leaving repeated characters in the composer.

## Validation

| | before | after |
|---|---|---|
| Pure-function repro (`normalizePtyMobileInput("hello", "hel", true)`) | `data = "\x7f\x7f\x7fhello"` → composer holding `hello` becomes `hehello` | tracker reset → `data = "hello"`, `normalized: false` |
| `web` eslint on `ChatPage.tsx` | #106445 placement: 6 errors (`react-hooks/immutability`) | 0 errors / 3 warnings (= main) |
| `npm run check` in `web/` (tsc + vitest + eslint) | — | 40 files / 296 tests passed, 0 lint errors |

The new test asserts the normalizer's stale-state behaviour; it is not red-on-base by construction (the fix lives in the React effect, not in the pure function). No React effect test was added. Live browser repro against a running dashboard was **skipped** — the symptom is reproduced through the pure normalization path above; the issue reporter confirmed the original diff works ("thanks. it works.").

## Credits

- @kokhlo — diagnosis on #106403 and the fix (#106445, cherry-picked with authorship preserved)
- @kirankurianphilip — report and confirmation on #106403

## Infographic
![dash-repeat-char](https://v3b.fal.media/files/b/0aa9baa9/7YX1ToPnYm_n5uV9dqxmu_XKA7OZyK.png)
