### PR TITLE
Advisory public-surface step no longer times out the blocking Windows-footguns job (#106103, salvage #106111)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -190,6 +190,9 @@ jobs:
       # decomposition opened with 1,703 such drops that reviewers had to find by hand.
       # Advisory: it never fails the job. The checkout above is depth-1, so deepen both sides until
       # a merge-base exists (the script refuses to report a clean diff without one, by design).
+      # Diff the PR head ref, not the checked-out refs/pull/N/merge commit: that synthetic commit
+      # is recomputed server-side whenever main moves, and once it is unreachable no amount of
+      # deepening ever reaches its parents (run 34285107265: 4 fetches, 4m15s, "no merge-base").
       - name: Public-surface diff vs base (advisory)
         if: github.event_name == 'pull_request'
         continue-on-error: true
@@ -197,11 +200,15 @@ jobs:
         # merge-base) can't consume the blocking job's 5-minute budget and cancel it.
         # continue-on-error already keeps a step *failure* off the job; a step-level
         # timeout keeps a step *overrun* off the job-level timeout the same way.
-        timeout-minutes: 2
+        # Sizing: a --deepen=200 fetch took ~56s and a --deepen=1000 ~67s on the runner, and
+        # main gains ~170 commits/day, so a day-old branch legitimately needs both (~2 min).
+        timeout-minutes: 3
+        env:
+          PR_HEAD: "+refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/origin/pr-head"
         run: |
-          git fetch --no-tags --deepen=200 origin "${{ github.base_ref }}" HEAD
+          git fetch --no-tags --deepen=200 origin "${{ github.base_ref }}" "$PR_HEAD"
           for i in 1 2 3; do
-            git merge-base "origin/${{ github.base_ref }}" HEAD >/dev/null 2>&1 && break
-            git fetch --no-tags --deepen=1000 origin "${{ github.base_ref }}" HEAD
+            git merge-base "origin/${{ github.base_ref }}" origin/pr-head >/dev/null 2>&1 && break
+            git fetch --no-tags --deepen=1000 origin "${{ github.base_ref }}" "$PR_HEAD"
           done
-          python scripts/ci/check_public_surface.py --base "origin/${{ github.base_ref }}" --head HEAD
+          python scripts/ci/check_public_surface.py --base "origin/${{ github.base_ref }}" --head origin/pr-head

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -193,6 +193,11 @@ jobs:
       - name: Public-surface diff vs base (advisory)
         if: github.event_name == 'pull_request'
         continue-on-error: true
+        # Bound the advisory step so a long deepen/fetch (e.g. a distant or missing
+        # merge-base) can't consume the blocking job's 5-minute budget and cancel it.
+        # continue-on-error already keeps a step *failure* off the job; a step-level
+        # timeout keeps a step *overrun* off the job-level timeout the same way.
+        timeout-minutes: 2
         run: |
           git fetch --no-tags --deepen=200 origin "${{ github.base_ref }}" HEAD
           for i in 1 2 3; do


### PR DESCRIPTION
The advisory `Public-surface diff vs base` step can no longer eat the blocking Windows-footguns job's 5-minute budget — it is bounded at 3 minutes, and it now finds a merge-base on the first fetch instead of deepening four times toward a commit it can never reach.

- `timeout-minutes: 3` on the step (PRATHAMESH75's fix from #106111, resized from 2 — see sizing below). GitHub runner semantics: a step timeout sets the step result to `Failed`, then `continue-on-error` is applied to that result (`actions/runner` `StepsRunner.cs`: `Result = TaskResult.Failed` in the timeout catch → `ApplyContinueOnError`), so an overrun ends as a failed-but-continued advisory step and the job keeps going.
- Diff `refs/pull/N/head` instead of the checked-out `HEAD`. The checkout is `refs/pull/N/merge`, a synthetic merge commit GitHub recomputes whenever `main` moves. Once the checked-out SHA is unreachable from any ref, `git fetch --deepen` can never fetch its parents — every iteration of the loop runs to completion and still ends in `no merge-base`. The PR head ref is always reachable, and the merge commit's own content is irrelevant to a symbol diff.
- Sizing: on the runner one `--deepen=200` fetch took ~56s and a `--deepen=1000` ~67s; `main` gains ~170 commits/day, so a day-old branch legitimately needs both (~2 min). 3 min + ~45s of blocking steps still fits the 5-minute job.

## Live repro

| | Observed |
|---|---|
| **Before** (run [34285107265](https://github.com/NousResearch/hermes-agent/actions/runs/34285107265), job 102259026802, `origin/main` workflow) | Blocking steps done at +44s (footguns 9s, compat pointers 25s). Public-surface step 22:18:57 → 22:23:12 = **4m15s**: fetches returned at +56s, +2m03s, +3m11s, +4m15s, then `public-surface: no merge-base between 'origin/main' and 'HEAD'`, exit 2. Job `cancelled` at 5m02s. Checked-out HEAD `5f68d6e` = `Merge 9792fd9 into b1f003e` — `b1f003e` was `main` at that moment; the ref had been recomputed. |
| **Before** (local replay of main's step against that same `5f68d6e`, depth-1) | `no merge-base after deepen=200 (53s); shallow=5f68d6e…` — the merge commit itself stays the shallow boundary; deepening never reaches its parents. |
| **After** (local replay of the branch's step, same `5f68d6e` checkout) | `* [new ref] refs/pull/106080/head -> origin/pr-head`; `loop iterations=1 merge-base=b1f003e…`, 76s total; `check_public_surface.py` → `0 public top-level name(s) dropped … rc=0`. |
| **After** (bounded worst case) | Step killed at 3:00 → step `Failed` → `continue-on-error` → job proceeds; blocking result unaffected. |

Sixteen PR runs on today's main show the step at 10–60s when the merge ref is still current, so the timeout only bites the recomputed-ref case, which the head-ref change also removes.

Root cause: the step diffed the shallow `refs/pull/N/merge` checkout, whose SHA goes unreachable the moment `main` advances, so the `--deepen` loop burned its full budget with no way to succeed while the job-level timeout, not `continue-on-error`, decided the outcome.

Credit: @PRATHAMESH75 for the step-level timeout (#106111, cherry-picked with authorship); @ether-btc for the report and run evidence.

Closes #106103

## Infographic
![ci-lint-public-surface-step-timeout](https://v3b.fal.media/files/b/0aa9babe/9_4M0hR2g9lZM-NB1q94n_JnlT8h12.png)
