### PR TITLE
fix(gateway): /review hydrates the persisted transcript on a cache miss

### DIFF
--- a/gateway/slash_commands_goals.py
+++ b/gateway/slash_commands_goals.py
@@ -156,24 +156,70 @@ class GatewayGoalCommandsMixin:
             "elapsed. Lives while the gateway runs — use `hermes cron` for durable schedules."
         )
 
-    def _idle_cached_agent_or_error(self, event: MessageEvent, verb: str):
+    async def _idle_cached_agent_or_error(self, event: MessageEvent, verb: str, *, hydrate: bool = False):
         """``(session_key, cached_agent, None)`` for /refine and /review, or ``(_, _, error_text)``:
-        both need a cached agent from a completed turn and refuse while a run is in flight."""
+        both need an agent from a completed turn and refuse while a run is in flight.
+
+        ``hydrate=True`` (/review only) rebuilds a throwaway agent from the persisted transcript
+        when the RAM agent cache has nothing resident for the session — the cache is a
+        resource-pressure cache (idle TTL, LRU eviction), not the record of what conversation
+        exists, so a cache miss alone must not read as "empty conversation" (#106509)."""
         quick_key = self._session_key_for_source(event.source) if event.source else None
         if not quick_key:
             return None, None, f"{verb.capitalize()} unavailable (no session)."
         if quick_key in self._running_agents:
             return quick_key, None, f"Agent is running — wait for the turn to finish, then /{verb}."
         agent = self._cached_agent_for(quick_key)
+        if agent is None and hydrate:
+            agent = await self._hydrate_persisted_review_agent(event)
         if agent is None:
             return quick_key, None, f"Nothing to {verb} yet — send a message first."
         return quick_key, agent, None
+
+    async def _hydrate_persisted_review_agent(self, event: MessageEvent):
+        """Rebuild a throwaway AIAgent from the persisted transcript for /review's cache-miss
+        fallback. Mirrors ``_build_manual_compression_agent`` (also a throwaway agent built from a
+        persisted session, not the live cache): resolve the session's runtime credentials, then
+        construct a memory/context-free agent seeded with the stored history. Returns None (caller
+        falls back to "nothing to review yet") when there is truly no persisted conversation or
+        credentials cannot be resolved."""
+        source = event.source
+        session_store = getattr(self, "async_session_store", None)
+        if source is None or session_store is None:
+            return None
+        try:
+            session_entry = await session_store.get_or_create_session(source, touch_activity=False)
+            history = await session_store.load_transcript(session_entry.session_id)
+        except Exception:
+            logger.debug("review: persisted-session hydration failed", exc_info=True)
+            return None
+        if not history:
+            return None
+        session_key = self._session_key_for_source(source)
+        model, runtime_kwargs = self._resolve_session_agent_runtime(source=source, session_key=session_key)
+        if not runtime_kwargs.get("api_key"):
+            return None
+        from gateway.run import _platform_config_key
+        platform_key = _platform_config_key(source.platform) if source.platform else None
+        if platform_key is not None:
+            runtime_kwargs["platform"] = platform_key
+        runtime_kwargs["gateway_session_key"] = session_key
+        from run_agent import AIAgent
+        agent = AIAgent(
+            **runtime_kwargs, model=model, max_iterations=1, quiet_mode=True,
+            skip_memory=True, skip_context_files=True, session_id=session_entry.session_id,
+            session_db=getattr(self._session_db, "_db", self._session_db),
+        )
+        agent._session_messages = history
+        agent._print_fn = lambda *a, **kw: None
+        agent._end_session_on_close = False  # this is a read-only peek, not the live session
+        return agent
 
     async def _handle_refine_command(self, event: MessageEvent) -> str:
         """Handle /refine — run the memory/skill review fork on demand, in a daemon thread against a
         snapshot of the cached AIAgent's conversation (live session and prompt cache untouched)."""
         args = (event.get_command_args() or "").strip()
-        _quick_key, agent, error = self._idle_cached_agent_or_error(event, "refine")
+        _quick_key, agent, error = await self._idle_cached_agent_or_error(event, "refine")
         if error:
             return error
         snapshot = list(getattr(agent, "_session_messages", None) or [])
@@ -193,11 +239,22 @@ class GatewayGoalCommandsMixin:
         )
 
     async def _handle_review_command(self, event: MessageEvent) -> str:
+        """Profile-scoping wrapper around /review: the cache-miss fallback resolves runtime
+        credentials (like /compress), which on a multiplexed gateway requires the fail-closed
+        per-profile secret scope that slash dispatch does not install on its own — unscoped, it
+        would raise ``UnscopedSecretError``."""
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return await self._handle_review_command_inner(event)
+        from gateway.run import _profile_runtime_scope
+        with _profile_runtime_scope(self._resolve_profile_home_for_source(event.source)):
+            return await self._handle_review_command_inner(event)
+
+    async def _handle_review_command_inner(self, event: MessageEvent) -> str:
         """Handle /review — spawn an independent reviewer subagent. The approval session-key
         contextvar is only bound during agent turns, so bind it explicitly here or the completion
         event carries no gateway route and never re-enters this chat."""
         args = (event.get_command_args() or "").strip()
-        quick_key, agent, error = self._idle_cached_agent_or_error(event, "review")
+        quick_key, agent, error = await self._idle_cached_agent_or_error(event, "review", hydrate=True)
         if error:
             return error
         snapshot = list(getattr(agent, "_session_messages", None) or [])

--- a/tests/gateway/test_review_command.py
+++ b/tests/gateway/test_review_command.py
@@ -8,7 +8,8 @@ tests/tools/test_async_delegation.py).
 
 import json
 import time
-from unittest.mock import MagicMock
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -138,6 +139,79 @@ async def test_review_command_requires_cached_agent():
     runner._agent_cache = {}
     out = await runner._handle_review_command(_Event())
     assert "send a message first" in out
+
+
+@pytest.mark.asyncio
+async def test_review_command_hydrates_persisted_session_on_cache_miss(monkeypatch):
+    """#106509: a RAM-cache miss (e.g. an evicted agent, or a Telegram forum topic whose live
+    agent isn't resident) must not read as "empty conversation" when SessionDB already holds a
+    transcript for the session. /review should hydrate a throwaway agent from that transcript and
+    still dispatch the reviewer."""
+    import tools.delegate_tool as dt
+    from agent import review_engine as re_mod
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.platforms.event import MessageEvent
+    from gateway.session import SessionEntry, SessionSource
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="c1", chat_type="group", user_id="u1",
+        user_name="tester", thread_id="topic-1",
+    )
+    event = MessageEvent(text="/review check tests", source=source, message_id="m1")
+    history = [
+        {"role": "user", "content": "open a PR"},
+        {"role": "assistant", "content": "PR #5 opened: https://x/pull/5"},
+    ]
+    session_entry = SessionEntry(
+        session_key=SESSION_KEY, session_id="persisted-sess", created_at=datetime.now(),
+        updated_at=datetime.now(), platform=Platform.TELEGRAM, chat_type="group",
+    )
+
+    runner = _make_runner(None)
+    runner._agent_cache = {}
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = history
+    runner._session_db = None
+
+    agent_instance = _make_agent()
+    agent_instance._session_messages = []  # overwritten by hydration below
+
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    built = {}
+
+    def fake_build(**kw):
+        built.update(kw)
+        return fake_child
+
+    monkeypatch.setattr(dt, "_build_child_agent", fake_build)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+    monkeypatch.setattr(
+        dt, "_run_single_child",
+        lambda *a, **k: {
+            "task_index": 0, "status": "completed", "summary": "review done",
+            "api_calls": 1, "duration_seconds": 0.1, "model": "m",
+            "exit_reason": "completed",
+        },
+    )
+    monkeypatch.setattr(re_mod, "_load_review_credentials_cfg", lambda: None)
+
+    with (
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
+        patch("gateway.run._resolve_gateway_model", return_value="test-model"),
+        patch("run_agent.AIAgent", return_value=agent_instance),
+    ):
+        out = await runner._handle_review_command(event)
+
+    assert out == re_mod.format_dispatch_note({"status": "dispatched"})
+    assert "PR #5 opened" in built["context"]
+    runner.session_store.load_transcript.assert_called_once_with("persisted-sess")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes `/review` returning the empty-cache stub ("Nothing to review yet — send a message first.") for a session that already has a persisted conversation, most visibly in a Telegram forum topic whose live agent isn't resident in the RAM agent cache (idle-TTL/LRU eviction, or simply not yet rebuilt after a gateway restart).

`_handle_review_command` (via the shared `_idle_cached_agent_or_error` helper) only ever checked `self._running_agents` and `self._agent_cache`. It never consulted `SessionDB`/the transcript store, so a RAM-cache miss was indistinguishable from "this conversation is empty" — even when the session had a full, persisted transcript.

On a cache miss, `/review` now rebuilds a throwaway `AIAgent` from the persisted transcript (same pattern the existing `/compress` command already uses for its own cache-miss case via `_build_manual_compression_agent`) and dispatches the reviewer against it, instead of bailing out. `/refine` is intentionally left untouched — its memory/skill review fork depends on a fully-configured memory provider that a throwaway, `skip_memory=True` agent doesn't have, so extending the same fallback there would risk a silent no-op rather than a real fix.

## Related Issue

Fixes #106509

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands_goals.py`:
  - `_idle_cached_agent_or_error` is now `async` and takes an opt-in `hydrate: bool = False` flag (`/refine`'s call site is unaffected — it doesn't pass `hydrate=True`, so its behavior is unchanged).
  - New `_hydrate_persisted_review_agent`: on a `/review` cache miss, loads the session's persisted transcript via `async_session_store`, resolves runtime credentials via the existing `_resolve_session_agent_runtime`, and builds a minimal, memory/context-free `AIAgent` seeded with that transcript.
  - `_handle_review_command` is now a profile-scoping wrapper (mirroring `/compress`'s existing wrapper) around a new `_handle_review_command_inner`: the hydration path resolves credentials, which on a multiplexed gateway requires the fail-closed per-profile secret scope that slash-command dispatch does not install on its own.
- `tests/gateway/test_review_command.py`: adds a regression test that drives `/review` through a cache miss with a persisted transcript and asserts the reviewer still dispatches (proven to fail on the pre-fix handler — see below).

## How to Test

Reproduction (from the issue): run a Telegram forum-topic gateway, let a topic's agent idle out of the RAM cache (or restart the gateway), then send `/review` in that topic. Before this change it replies with the 45-character stub instead of dispatching a reviewer, even though the topic has a real transcript.

Automated proof:

```
$ python -m pytest tests/gateway/test_review_command.py -q
.....
5 passed in 1.45s
```

Confirmed the new test fails without the fix (reverted only `gateway/slash_commands_goals.py` via `git checkout HEAD~1 -- gateway/slash_commands_goals.py`, kept the new test):

```
$ python -m pytest tests/gateway/test_review_command.py -q
        ...
>       assert out == re_mod.format_dispatch_note({"status": "dispatched"})
E       AssertionError: assert 'Nothing to r...essage first.' == 'Review start... return here.'
E
E         - Review started. Results will return here.
E         + Nothing to review yet — send a message first.

1 failed, 4 passed in 1.36s
```

Broader regression check (same venv, `scripts/run_tests.sh tests/gateway/`):

```
=== Summary: 797 files, 7939 tests passed, 2 failed, 40 skipped (100% complete) in 346.6s (8 workers) ===
```

The 2 failures are `tests/gateway/test_wecom_callback.py` (`AttributeError: 'NoneType' object has no attribute 'fromstring'`), reproduced identically on unmodified `main` in the same environment — caused by the `defusedxml` (`wecom` extra) not being installed in this sandboxed test venv, unrelated to this change.

Also ran targeted suites for the touched/adjacent code paths:

```
$ python -m pytest tests/gateway/test_review_command.py tests/agent/test_refine_snapshot_isolation.py tests/tools/test_async_delegation.py -q
41 passed, 1 skipped
```

`ruff check gateway/ tests/gateway/test_review_command.py` — all checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the test suite (`scripts/run_tests.sh tests/gateway/`) and it passes (see above; 2 pre-existing, unrelated `wecom` failures)
- [x] I've added tests for my changes
- [x] Tested in a Linux sandbox (Ubuntu-based CI image); not hardware-tested against a live Telegram bot

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

---

Written with AI assistance (Claude Code); reviewed and verified against the real handler code paths, with the included test proven to fail without the fix and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
