### PR TITLE
Context-overflow after partial streaming ends the turn instead of growing the request (#106260, salvage #106266)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3267,42 +3267,37 @@ class _StreamingCall(StreamingWaitMonitor):
             logger.warning(
                 "Partial stream dropped tool call(s) %s after %s chars of text; surfaced warning to user: %s",
                 _partial_names, len(_partial_text or ""), error)
-        else:
-            logger.warning(
-                "Partial stream delivered before error; returning length-truncated stub with %s chars of "
-                "recovered content so the loop can continue from where the stream died: %s",
-                len(_partial_text or ""), error)
-        # Classify content filtering (MiniMax 1027, Azure content_filter, Anthropic refusal)
-        # before the error is swallowed into the stub: the loop reads the tag and falls back.
+        # Classify the error before it is swallowed into the stub: the loop reads the
+        # content-filter tag and falls back; a context overflow must not be continued at all.
         _cls = None
         with contextlib.suppress(Exception):
             from agent.error_classifier import classify_api_error
             _cls = classify_api_error(
                 error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
-        # #106260: a context-overflow error after partial delivery must NOT seed a
-        # continuation stub with the recovered text — the transcript already cannot fit
-        # (compression failed or protect_last_n covers it), and appending tens of KB only
-        # makes every later request larger. Return an EMPTY stub marked terminal: the loop
-        # ends the turn via the recovery contract instead of continuing into the same
-        # overflow. Scope is deliberately context_overflow ONLY: payload_too_large (413)
-        # has its own byte-scored recovery owner (turn_overflow._recover_payload_too_large,
-        # #88960/#47339) that must not be bypassed (review P1, andrexibiza).
+        _reset_stale_streak(self.agent)  # deltas fired => provider responsive: clear the breaker
+        # #106260: continuing after a context-overflow error re-sends a larger request into the
+        # same overflow. Return an EMPTY stub marked terminal so the loop ends the turn instead.
+        # Scope is context_overflow ONLY: payload_too_large (413) has its own byte-scored recovery
+        # owner (turn_overflow._recover_payload_too_large, #88960/#47339) that must not be bypassed.
         if _cls is not None and _cls.reason == FailoverReason.context_overflow:
             logger.warning(
                 "Partial stream ended on a context-overflow error after %s chars; "
                 "NOT seeding a continuation stub (transcript is already over budget): %s",
                 len(_partial_text or ""), error,
             )
-            _reset_stale_streak(self.agent)
             return _build_partial_stream_stub(
                 "assistant", None, None, getattr(self.agent, "model", "unknown"), None,
                 dropped_tool_names=_partial_names, overflow_terminal=True,
             )
+        if not _partial_names:
+            logger.warning(
+                "Partial stream delivered before error; returning length-truncated stub with %s chars of "
+                "recovered content so the loop can continue from where the stream died: %s",
+                len(_partial_text or ""), error)
         _stub = _build_partial_stream_stub("assistant", _partial_text, None,
             getattr(self.agent, "model", "unknown"), None, dropped_tool_names=_partial_names)
         if _cls is not None and _cls.reason == FailoverReason.content_policy_blocked:
             _stub._content_filter_terminated = True
-        _reset_stale_streak(self.agent)  # deltas fired => provider responsive: clear the breaker
         return _stub
 
     def run(self):

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2174,11 +2174,17 @@ def cleanup_task_resources(agent, task_id: str) -> None:
 
 
 def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, usage_obj, *,
-    dropped_tool_names=None):
+    dropped_tool_names=None, overflow_terminal=False):
     """Stub for an SSE stream that ended without ``finish_reason`` after
     delivering content. Tagged ``PARTIAL_STREAM_STUB_ID`` + ``FINISH_REASON_LENGTH``
     so the loop enters its continuation/retry path instead of accepting
-    truncated output as a complete turn (#32086)."""
+    truncated output as a complete turn (#32086).
+
+    ``overflow_terminal`` (``full_content=None``): the stream died on a
+    context-overflow error. Seeding the recovered text as a continuation stub
+    would grow every later request into the same overflow (#106260); the loop
+    treats the marker as terminal and ends the turn via the recovery contract.
+    """
     return SimpleNamespace(
         id=PARTIAL_STREAM_STUB_ID,
         model=model_name,
@@ -2190,6 +2196,7 @@ def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, u
         )],
         usage=usage_obj,
         _dropped_tool_names=dropped_tool_names or None,
+        _overflow_terminal=overflow_terminal,
     )
 
 
@@ -3267,14 +3274,33 @@ class _StreamingCall(StreamingWaitMonitor):
                 len(_partial_text or ""), error)
         # Classify content filtering (MiniMax 1027, Azure content_filter, Anthropic refusal)
         # before the error is swallowed into the stub: the loop reads the tag and falls back.
-        _stub = _build_partial_stream_stub("assistant", _partial_text, None,
-            getattr(self.agent, "model", "unknown"), None, dropped_tool_names=_partial_names)
+        _cls = None
         with contextlib.suppress(Exception):
             from agent.error_classifier import classify_api_error
             _cls = classify_api_error(
                 error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
-            if _cls.reason == FailoverReason.content_policy_blocked:
-                _stub._content_filter_terminated = True
+        # #106260: a context-overflow / payload-too-large error after partial delivery must NOT
+        # seed a continuation stub with the recovered text — the transcript already cannot fit
+        # (compression failed or protect_last_n covers it), and appending tens of KB only makes
+        # every later request larger. Return an EMPTY stub marked terminal: the loop ends the
+        # turn via the recovery contract instead of continuing into the same overflow.
+        if _cls is not None and _cls.reason in (
+            FailoverReason.context_overflow, FailoverReason.payload_too_large,
+        ):
+            logger.warning(
+                "Partial stream ended on a context-overflow error after %s chars; "
+                "NOT seeding a continuation stub (transcript is already over budget): %s",
+                len(_partial_text or ""), error,
+            )
+            _reset_stale_streak(self.agent)
+            return _build_partial_stream_stub(
+                "assistant", None, None, getattr(self.agent, "model", "unknown"), None,
+                dropped_tool_names=_partial_names, overflow_terminal=True,
+            )
+        _stub = _build_partial_stream_stub("assistant", _partial_text, None,
+            getattr(self.agent, "model", "unknown"), None, dropped_tool_names=_partial_names)
+        if _cls is not None and _cls.reason == FailoverReason.content_policy_blocked:
+            _stub._content_filter_terminated = True
         _reset_stale_streak(self.agent)  # deltas fired => provider responsive: clear the breaker
         return _stub
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3279,14 +3279,15 @@ class _StreamingCall(StreamingWaitMonitor):
             from agent.error_classifier import classify_api_error
             _cls = classify_api_error(
                 error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
-        # #106260: a context-overflow / payload-too-large error after partial delivery must NOT
-        # seed a continuation stub with the recovered text — the transcript already cannot fit
-        # (compression failed or protect_last_n covers it), and appending tens of KB only makes
-        # every later request larger. Return an EMPTY stub marked terminal: the loop ends the
-        # turn via the recovery contract instead of continuing into the same overflow.
-        if _cls is not None and _cls.reason in (
-            FailoverReason.context_overflow, FailoverReason.payload_too_large,
-        ):
+        # #106260: a context-overflow error after partial delivery must NOT seed a
+        # continuation stub with the recovered text — the transcript already cannot fit
+        # (compression failed or protect_last_n covers it), and appending tens of KB only
+        # makes every later request larger. Return an EMPTY stub marked terminal: the loop
+        # ends the turn via the recovery contract instead of continuing into the same
+        # overflow. Scope is deliberately context_overflow ONLY: payload_too_large (413)
+        # has its own byte-scored recovery owner (turn_overflow._recover_payload_too_large,
+        # #88960/#47339) that must not be bypassed (review P1, andrexibiza).
+        if _cls is not None and _cls.reason == FailoverReason.context_overflow:
             logger.warning(
                 "Partial stream ended on a context-overflow error after %s chars; "
                 "NOT seeding a continuation stub (transcript is already over budget): %s",

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -32,9 +32,9 @@ _FIRST_TRUNCATED_FINAL = "First response truncated due to output length limit"
 # continuation — the transcript already cannot fit, and appending the partial stub grows every
 # later request into the same overflow. End the turn via the recovery contract instead.
 _CONTEXT_OVERFLOW_PARTIAL_FINAL = (
-    "The conversation exceeded the model's context window and compression could "
-    "not recover it, so the partial response was not continued. Start a new "
-    "session (or /new) to continue with a clean transcript."
+    "The request no longer fits the model's context window, so the partial "
+    "response was not continued. Continue in a fresh session (/new; gateway "
+    "chats are reset automatically)."
 )
 
 _THINKING_EXHAUSTED = (
@@ -345,18 +345,23 @@ def recover_from_truncation(
     # #106260: a context-overflow error after partial delivery must not seed a
     # continuation. _partial_stream_stub marks such stubs _overflow_terminal and
     # leaves content empty; continuing would only re-send a larger request into
-    # the same overflow (compression already failed / protect_last_n covers it).
+    # the same overflow. The stub path never raises, so this class never reached
+    # recover_from_overflow's compress-and-retry on main either — ending the turn
+    # replaces a growth loop, not a compression attempt.
     if getattr(st.response, "_overflow_terminal", False):
         agent._flush_status_buffer()
         agent._vprint(
             f"{agent.log_prefix}⚠️ Stream ended on a context-overflow error after "
-            "partial delivery — not continuing (the transcript is already over "
-            "budget).",
+            "partial delivery — not continuing (the request no longer fits the model's "
+            "context window).",
             force=True,
         )
+        # Prior tool batches can leave a tool-result tail; this path never reaches
+        # finalize_turn (same as the truncated-tool-call terminal above).
+        close_interrupted_tool_sequence(st.messages, _CONTEXT_OVERFLOW_PARTIAL_FINAL)
         # Carry the #98722 typed exhaustion bit so the gateway resets/moves future
         # input to a clean session instead of leaving this bloated one authoritative
-        # for the next turn (review P1, andrexibiza).
+        # for the next turn.
         return st.end_turn(
             _CONTEXT_OVERFLOW_PARTIAL_FINAL,
             error=_CONTEXT_OVERFLOW_PARTIAL_FINAL,

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -73,11 +73,12 @@ def normalize_response_for_agent(agent: Any, response: Any) -> Any:
 
 def partial_result(
     messages: List[Dict[str, Any]], api_call_count: int, final_response: str,
-    error: Optional[str] = None, *, failed: bool = False,
+    error: Optional[str] = None, *, failed: bool = False, compression_exhausted: bool = False,
 ) -> Dict[str, Any]:
     """Typed incomplete-turn result (``partial`` unless ``failed``); ``error`` defaults to
-    ``final_response``."""
-    return {
+    ``final_response``. ``compression_exhausted`` carries the #98722 typed bit the gateway
+    consumes to reset/move future input to a clean session (see run_turn.py)."""
+    result = {
         "final_response": final_response,
         "messages": messages,
         "api_calls": api_call_count,
@@ -85,6 +86,9 @@ def partial_result(
         ("failed" if failed else "partial"): True,
         "error": final_response if error is None else error,
     }
+    if compression_exhausted:
+        result["compression_exhausted"] = True
+    return result
 
 
 @dataclass
@@ -129,16 +133,20 @@ class _Trunc(TruncationVerdict):
     def end_turn(
         self, final_response: str, error: Optional[str] = None, *,
         result_messages: Optional[List[Dict[str, Any]]] = None, cleanup: bool = True,
-        failed: bool = False,
+        failed: bool = False, compression_exhausted: bool = False,
     ) -> TruncationVerdict:
-        """Persist and end the turn as partial (or ``failed``)."""
+        """Persist and end the turn as partial (or ``failed``).
+
+        ``compression_exhausted`` forwards the #98722 typed bit so the gateway can
+        move future input off a bloated session (run_turn.py consumes it).
+        """
         agent = self.agent
         if cleanup:
             agent._cleanup_task_resources(self.effective_task_id)
         agent._persist_session(self.messages, self.conversation_history)
         return self.done("return", partial_result(
             self.messages if result_messages is None else result_messages, self.api_call_count,
-            final_response, error, failed=failed,
+            final_response, error, failed=failed, compression_exhausted=compression_exhausted,
         ))
 
     @property
@@ -346,10 +354,14 @@ def recover_from_truncation(
             "budget).",
             force=True,
         )
+        # Carry the #98722 typed exhaustion bit so the gateway resets/moves future
+        # input to a clean session instead of leaving this bloated one authoritative
+        # for the next turn (review P1, andrexibiza).
         return st.end_turn(
             _CONTEXT_OVERFLOW_PARTIAL_FINAL,
             error=_CONTEXT_OVERFLOW_PARTIAL_FINAL,
             failed=True,
+            compression_exhausted=True,
         )
 
     _trunc_msg = normalize_response_for_agent(agent, response)

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -28,6 +28,14 @@ _CONTINUABLE_MODES = {"chat_completions", "bedrock_converse", "anthropic_message
 _THINK_TAG_RE = re.compile(r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)[^>]*>', re.IGNORECASE)
 _TRUNCATED_FINAL = "Response truncated due to output length limit"
 _FIRST_TRUNCATED_FINAL = "First response truncated due to output length limit"
+# #106260: a stream that died on a context-overflow error after partial delivery must not seed a
+# continuation — the transcript already cannot fit, and appending the partial stub grows every
+# later request into the same overflow. End the turn via the recovery contract instead.
+_CONTEXT_OVERFLOW_PARTIAL_FINAL = (
+    "The conversation exceeded the model's context window and compression could "
+    "not recover it, so the partial response was not continued. Start a new "
+    "session (or /new) to continue with a clean transcript."
+)
 
 _THINKING_EXHAUSTED = (
     "💭 Reasoning exhausted the output token budget — no visible response was produced.",
@@ -325,6 +333,24 @@ def recover_from_truncation(
         f"{agent.log_prefix}⚠️  Response truncated (finish_reason='length') - model hit max output tokens",
         force=True,
     )
+
+    # #106260: a context-overflow error after partial delivery must not seed a
+    # continuation. _partial_stream_stub marks such stubs _overflow_terminal and
+    # leaves content empty; continuing would only re-send a larger request into
+    # the same overflow (compression already failed / protect_last_n covers it).
+    if getattr(st.response, "_overflow_terminal", False):
+        agent._flush_status_buffer()
+        agent._vprint(
+            f"{agent.log_prefix}⚠️ Stream ended on a context-overflow error after "
+            "partial delivery — not continuing (the transcript is already over "
+            "budget).",
+            force=True,
+        )
+        return st.end_turn(
+            _CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            error=_CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            failed=True,
+        )
 
     _trunc_msg = normalize_response_for_agent(agent, response)
     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None

--- a/tests/run_agent/test_overflow_partial_terminal_106260.py
+++ b/tests/run_agent/test_overflow_partial_terminal_106260.py
@@ -86,6 +86,36 @@ class TestOverflowTerminalStub:
         assert response.choices[0].message.content is None
 
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_payload_too_large_partial_is_not_made_terminal(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Review P1 (andrexibiza): payload_too_large (413) has its own byte-scored
+        recovery owner and must NOT be collapsed into the context-overflow terminal
+        contract — the partial keeps its normal continuation stub."""
+        def _overflowing_stream():
+            yield _make_stream_chunk(content="some media-heavy partial output ...")
+            raise RuntimeError(
+                "Request payload too large (413): 5MB exceeds the 4MB limit"
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _overflowing_stream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._current_streamed_assistant_text = "some media-heavy partial output ..."
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert getattr(response, "_overflow_terminal", False) is False
+        # The recovered text is preserved for the normal continuation path.
+        assert response.choices[0].message.content == "some media-heavy partial output ..."
+
+
 class TestRecoverFromTruncationOverflowTerminal:
     def _mock_agent(self):
         agent = MagicMock()
@@ -127,6 +157,9 @@ class TestRecoverFromTruncationOverflowTerminal:
         result = verdict.result or {}
         assert result.get("failed") is True
         assert result.get("final_response") == _CONTEXT_OVERFLOW_PARTIAL_FINAL
+        # #98722 typed bit: the gateway consumes this to reset/move future input
+        # to a clean session instead of leaving the bloated one authoritative.
+        assert result.get("compression_exhausted") is True
         # No fragment or nudge was appended to the transcript.
         assert result.get("messages") == []
 

--- a/tests/run_agent/test_overflow_partial_terminal_106260.py
+++ b/tests/run_agent/test_overflow_partial_terminal_106260.py
@@ -40,21 +40,6 @@ def _make_stream_chunk(content=None, finish_reason=None):
 
 
 class TestOverflowTerminalStub:
-    def test_build_stub_carries_marker_and_empty_content(self):
-        from agent.chat_completion_helpers import _build_partial_stream_stub
-
-        stub = _build_partial_stream_stub(
-            "assistant", None, None, "test/model", None, overflow_terminal=True)
-        assert stub._overflow_terminal is True
-        assert stub.id == PARTIAL_STREAM_STUB_ID
-        assert stub.choices[0].finish_reason == FINISH_REASON_LENGTH
-        assert stub.choices[0].message.content is None
-
-        normal = _build_partial_stream_stub(
-            "assistant", "some text", None, "test/model", None)
-        assert getattr(normal, "_overflow_terminal", False) is False
-        assert normal.choices[0].message.content == "some text"
-
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
     def test_partial_stream_overflow_error_returns_terminal_stub(
@@ -145,9 +130,18 @@ class TestRecoverFromTruncationOverflowTerminal:
         )
 
         agent = self._mock_agent()
+        # The overflow fired right after a tool batch: the transcript tail is a
+        # raw tool result, which strict providers reject as tool -> user.
+        messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": None,
+             "tool_calls": [{"id": "c1", "type": "function",
+                             "function": {"name": "read_file", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "c1", "content": "big file"},
+        ]
         verdict = recover_from_truncation(
             agent, self._response(), FINISH_REASON_LENGTH, MagicMock(),
-            messages=[], conversation_history=None, api_kwargs={},
+            messages=messages, conversation_history=None, api_kwargs={},
             api_call_count=0, effective_task_id=None, current_turn_user_idx=None,
             length_continue_retries=0, truncated_response_parts=[],
             truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
@@ -160,25 +154,9 @@ class TestRecoverFromTruncationOverflowTerminal:
         # #98722 typed bit: the gateway consumes this to reset/move future input
         # to a clean session instead of leaving the bloated one authoritative.
         assert result.get("compression_exhausted") is True
-        # No fragment or nudge was appended to the transcript.
-        assert result.get("messages") == []
-
-    def test_normal_stub_is_not_treated_as_terminal(self):
-        from agent.turn_truncation import (
-            _CONTEXT_OVERFLOW_PARTIAL_FINAL,
-            recover_from_truncation,
-        )
-
-        agent = self._mock_agent()
-        verdict = recover_from_truncation(
-            agent, self._response(overflow_terminal=False), FINISH_REASON_LENGTH,
-            MagicMock(),
-            messages=[], conversation_history=None, api_kwargs={},
-            api_call_count=0, effective_task_id=None, current_turn_user_idx=None,
-            length_continue_retries=0, truncated_response_parts=["recovered text"],
-            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
-        )
-        # Not the overflow-terminal final; the normal continuation path runs
-        # (no early return with the overflow message).
-        result = (verdict.result or {}) if verdict.action == "return" else None
-        assert result is None or result.get("final_response") != _CONTEXT_OVERFLOW_PARTIAL_FINAL
+        # The interrupted tool tail is closed so the next user turn alternates;
+        # no fragment or nudge was appended.
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"] == _CONTEXT_OVERFLOW_PARTIAL_FINAL
+        assert len(messages) == 4
+        assert result.get("messages") is messages

--- a/tests/run_agent/test_overflow_partial_terminal_106260.py
+++ b/tests/run_agent/test_overflow_partial_terminal_106260.py
@@ -1,0 +1,151 @@
+"""Regression tests for #106260: a context-overflow error after partial stream
+delivery must NOT seed a continuation stub with the recovered text.
+
+Seeding tens of KB of partial content as a length-continuation stub makes every
+later request larger, so a session whose transcript cannot fit (compression
+failed / protect_last_n covers it) loops forever growing the context. The stub
+is instead marked terminal (content empty) and the loop ends the turn via the
+recovery contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+
+
+def _make_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+def _make_stream_chunk(content=None, finish_reason=None):
+    delta = SimpleNamespace(content=content, tool_calls=None,
+                            reasoning_content=None, reasoning=None)
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=None, usage=None)
+
+
+class TestOverflowTerminalStub:
+    def test_build_stub_carries_marker_and_empty_content(self):
+        from agent.chat_completion_helpers import _build_partial_stream_stub
+
+        stub = _build_partial_stream_stub(
+            "assistant", None, None, "test/model", None, overflow_terminal=True)
+        assert stub._overflow_terminal is True
+        assert stub.id == PARTIAL_STREAM_STUB_ID
+        assert stub.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert stub.choices[0].message.content is None
+
+        normal = _build_partial_stream_stub(
+            "assistant", "some text", None, "test/model", None)
+        assert getattr(normal, "_overflow_terminal", False) is False
+        assert normal.choices[0].message.content == "some text"
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_partial_stream_overflow_error_returns_terminal_stub(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """A stream that delivered text then hit the provider's
+        maximum-context-length error must return an EMPTY stub marked terminal,
+        not a continuation stub carrying the recovered text (#106260)."""
+        def _overflowing_stream():
+            yield _make_stream_chunk(content="Here's my long partial answer ...")
+            raise RuntimeError(
+                "This model's maximum context length is 128000 tokens. "
+                "However, you requested 140000 tokens."
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _overflowing_stream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._current_streamed_assistant_text = "Here's my long partial answer ..."
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert getattr(response, "_overflow_terminal", False) is True
+        # The recovered text must not be seeded for continuation.
+        assert response.choices[0].message.content is None
+
+
+class TestRecoverFromTruncationOverflowTerminal:
+    def _mock_agent(self):
+        agent = MagicMock()
+        agent._vprint = MagicMock()
+        agent._flush_status_buffer = MagicMock()
+        agent._cleanup_task_resources = MagicMock()
+        agent._persist_session = MagicMock()
+        return agent
+
+    def _response(self, overflow_terminal=True, content="recovered text"):
+        return SimpleNamespace(
+            id=PARTIAL_STREAM_STUB_ID,
+            _overflow_terminal=overflow_terminal,
+            _dropped_tool_names=None,
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(role="assistant", content=content,
+                                        tool_calls=None, reasoning_content=None),
+                finish_reason=FINISH_REASON_LENGTH,
+            )],
+        )
+
+    def test_overflow_terminal_stub_ends_turn_without_continuation(self):
+        from agent.turn_truncation import (
+            _CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            recover_from_truncation,
+        )
+
+        agent = self._mock_agent()
+        verdict = recover_from_truncation(
+            agent, self._response(), FINISH_REASON_LENGTH, MagicMock(),
+            messages=[], conversation_history=None, api_kwargs={},
+            api_call_count=0, effective_task_id=None, current_turn_user_idx=None,
+            length_continue_retries=0, truncated_response_parts=[],
+            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
+        )
+
+        assert verdict.action == "return"
+        result = verdict.result or {}
+        assert result.get("failed") is True
+        assert result.get("final_response") == _CONTEXT_OVERFLOW_PARTIAL_FINAL
+        # No fragment or nudge was appended to the transcript.
+        assert result.get("messages") == []
+
+    def test_normal_stub_is_not_treated_as_terminal(self):
+        from agent.turn_truncation import (
+            _CONTEXT_OVERFLOW_PARTIAL_FINAL,
+            recover_from_truncation,
+        )
+
+        agent = self._mock_agent()
+        verdict = recover_from_truncation(
+            agent, self._response(overflow_terminal=False), FINISH_REASON_LENGTH,
+            MagicMock(),
+            messages=[], conversation_history=None, api_kwargs={},
+            api_call_count=0, effective_task_id=None, current_turn_user_idx=None,
+            length_continue_retries=0, truncated_response_parts=["recovered text"],
+            truncated_tool_call_retries=0, retry_count=0, compression_attempts=0,
+        )
+        # Not the overflow-terminal final; the normal continuation path runs
+        # (no early return with the overflow message).
+        result = (verdict.result or {}) if verdict.action == "return" else None
+        assert result is None or result.get("final_response") != _CONTEXT_OVERFLOW_PARTIAL_FINAL


### PR DESCRIPTION
A streamed response that dies on a context-overflow error after partial text was delivered now ends the turn (and the gateway resets the session) instead of re-sending an ever-larger request into the same overflow.

Salvage of #106266 by @ca-shrimp (both commits cherry-picked, authorship preserved) plus one follow-up commit. Closes #106260.

## Who hits this
Long sessions on any provider that streams the first tokens and then rejects the request with a context-length error (OpenAI-compatible "maximum context length is N tokens", Anthropic "prompt is too long", etc.). Because the stub path returns instead of raising, `recover_from_overflow` (compress-and-retry) never runs; main seeded a length-continuation stub carrying the recovered text, so every retry was larger than the last — the growth loop in #106260.

## Changes
- `agent/chat_completion_helpers.py` (contributor): when the classified error is `context_overflow`, `_partial_stream_stub` returns an EMPTY stub flagged `_overflow_terminal`; `payload_too_large` (413) keeps its own byte-scored recovery owner (`turn_overflow._recover_payload_too_large`) and is not affected.
- `agent/turn_truncation.py` (contributor): the flagged stub ends the turn `failed=True` with the `compression_exhausted` bit from #98722, so `gateway/run_turn.py` moves the next message to a clean session.
- Follow-up (ours):
  - close the interrupted tool tail (`close_interrupted_tool_sequence`) on this terminal, mirroring the truncated-tool-call terminal above it — the path never reaches `finalize_turn`, so a transcript that overflowed right after a tool batch otherwise ends on a raw tool result that strict providers reject on the next user turn (`tool -> user`);
  - classify once before either log (an overflow no longer emits "so the loop can continue" followed by the contradicting "NOT seeding a continuation stub");
  - user-facing final says what happened ("no longer fits the model's context window") rather than "compression could not recover it" (this path never reached compression);
  - test file trimmed to the three tests that bind behaviour.

## Validation
| Check | Result |
|---|---|
| `tests/run_agent/{test_overflow_partial_terminal_106260,test_partial_stream_finish_reason,test_streaming,test_first_chunk_at_hook,test_continuation_ceiling_wedge}.py` | 87 passed |
| `tests/gateway/test_35809_auto_reset_clean_context.py`, `tests/agent/test_send_path_history_isolation.py` | passed |
| Mutation: `turn_truncation.py` reverted to the contributor commit | tail-close assertion fails; restored → green |
| Consumers traced | `compression_exhausted` readers (`run_turn.py:1530/1568`, `run_turn_runner.py`, `tui_gateway/prompt_turn.py`) already handle this dict shape from `conversation_loop`/`turn_overflow`; no new consumer |
| Content=None stub | nothing before the `_overflow_terminal` check in `recover_from_truncation` reads content or appends to `truncated_response_parts` |

Review threads on #106266 (andrexibiza): the `compression_exhausted` bit is carried (contributor's second commit), the 413 scope is preserved, and the tool-tail gap raised there is what the follow-up closes.
