### PR TITLE
fix(agent): context-overflow stream deaths no longer grow the next request into a death spiral (#106260, salvage #106266)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3246,6 +3246,24 @@ class _StreamingCall(StreamingWaitMonitor):
         Content may be EMPTY on purpose — the loop skips appending an empty stub and
         only sends the nudge (placeholder text leaked into the stitched response)."""
         error = self.result["error"]
+        _cls = None
+        with contextlib.suppress(Exception):
+            from agent.error_classifier import classify_api_error
+            _cls = classify_api_error(
+                error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
+        _reason = getattr(_cls, "reason", None)
+        if _reason == FailoverReason.context_overflow:
+            # #106260: the request already does not fit. Seeding the recovered text as a
+            # continuation stub makes every later request LARGER than the one that just
+            # failed — a death spiral once compression is exhausted or protect_last_n covers
+            # the whole transcript. Re-raise instead so the overflow reaches the normal
+            # context-length recovery (compress + retry, or the #98722 clean-session exit).
+            logger.warning(
+                "Partial stream died on a context-overflow error after %s chars; not seeding a "
+                "continuation stub, routing to context-length recovery: %s",
+                len(getattr(self.agent, "_current_streamed_assistant_text", "") or ""), error)
+            _reset_stale_streak(self.agent)  # deltas fired => provider responsive
+            raise error
         _partial_text = (getattr(self.agent, "_current_streamed_assistant_text", "") or "").strip() or None
         _partial_names = list(self.result.get("partial_tool_names") or [])
         if _partial_names:
@@ -3265,16 +3283,12 @@ class _StreamingCall(StreamingWaitMonitor):
                 "Partial stream delivered before error; returning length-truncated stub with %s chars of "
                 "recovered content so the loop can continue from where the stream died: %s",
                 len(_partial_text or ""), error)
-        # Classify content filtering (MiniMax 1027, Azure content_filter, Anthropic refusal)
-        # before the error is swallowed into the stub: the loop reads the tag and falls back.
+        # Content filtering (MiniMax 1027, Azure content_filter, Anthropic refusal): tag the
+        # stub before the error is swallowed so the loop falls back instead of continuing.
         _stub = _build_partial_stream_stub("assistant", _partial_text, None,
             getattr(self.agent, "model", "unknown"), None, dropped_tool_names=_partial_names)
-        with contextlib.suppress(Exception):
-            from agent.error_classifier import classify_api_error
-            _cls = classify_api_error(
-                error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
-            if _cls.reason == FailoverReason.content_policy_blocked:
-                _stub._content_filter_terminated = True
+        if _reason == FailoverReason.content_policy_blocked:
+            _stub._content_filter_terminated = True
         _reset_stale_streak(self.agent)  # deltas fired => provider responsive: clear the breaker
         return _stub
 

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -1038,3 +1038,61 @@ class TestMergedFinishChunkSurvivesSSEGuard:
         assert response.id != PARTIAL_STREAM_STUB_ID
         assert response.choices[0].finish_reason == "stop"
         assert response.choices[0].message.content == "Hello."
+
+
+class TestContextOverflowPartialNotSeeded:
+    """#106260: a stream that delivered text and then died on a CONTEXT-OVERFLOW error must
+    not become a continuation stub — the recovered text would make every later request
+    larger than the one that just failed. The error is re-raised so the loop's normal
+    context-length recovery (compress + retry / #98722 clean-session exit) owns it."""
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_context_overflow_partial_reraises_instead_of_stub(self, _mock_close, mock_create, monkeypatch):
+        def _overflowing_stream():
+            yield _make_stream_chunk(content="Here's my long partial answer ...")
+            raise RuntimeError("Context length exceeded: max compression attempts (3) reached.")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _overflowing_stream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._current_streamed_assistant_text = "Here's my long partial answer ..."
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        with pytest.raises(RuntimeError, match="Context length exceeded"):
+            agent._interruptible_streaming_api_call({})
+
+    def test_overflow_partial_never_grows_the_next_request(self, loop_agent):
+        """Loop-level invariant: with compression disabled and a provider that overflows on
+        every call, the overflow after partial delivery must end the turn as failed without
+        any request larger than the first — the death spiral is the growth itself."""
+        sizes = []
+        partial = " ".join(f"w{i * 7919 % 100003}" for i in range(400))
+
+        def _create(*_a, **kw):
+            sizes.append(sum(len(str(m.get("content") or "")) for m in kw.get("messages") or []))
+
+            def _gen():
+                yield _make_stream_chunk(content=partial)
+                raise RuntimeError("Context length exceeded: max compression attempts (3) reached.")
+            return _gen()
+
+        loop_agent.stream_delta_callback = lambda _t: None  # real stream consumer -> streaming path
+        loop_agent.client.chat.completions.create.side_effect = _create
+        with (
+            patch("run_agent.AIAgent._create_request_openai_client", return_value=loop_agent.client),
+            patch("run_agent.AIAgent._close_request_openai_client"),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("ask me something")
+
+        assert result.get("failed") is True
+        assert all(s <= sizes[0] for s in sizes), f"request sizes grew across attempts: {sizes}"
+        assert not any(
+            m.get("role") == "assistant" and partial[:30] in str(m.get("content") or "")
+            for m in result["messages"]
+        ), "recovered partial must not be seeded into the transcript after a context overflow"


### PR DESCRIPTION
A streaming turn that dies on a **context-overflow** error after delivering text no longer seeds the recovered partial as a continuation stub — the overflow goes to the normal context-length recovery instead, so each retry can no longer be larger than the one that just failed.

## What changed
- `agent/chat_completion_helpers.py::_StreamingCall._partial_stream_stub` classifies the swallowed error once (existing `classify_api_error` → `FailoverReason.context_overflow`) and **re-raises** it instead of building a `finish_reason=length` stub. The exception reaches `handle_api_error` → `turn_overflow._recover_context_length`: compress + retry while progress is possible, else the existing #98722 `compression_exhausted` clean-session exit. Nothing is appended to the transcript.
- Every other partial-stream death keeps the existing stub: network stall, mid-tool-call drop, content-filter stall, and 413 `payload_too_large` (which keeps its own byte-scored `_recover_payload_too_large` owner).
- The pre-existing content-filter classification reuses the same verdict (one classifier call instead of two).
- 2 invariant tests appended to `tests/run_agent/test_partial_stream_finish_reason.py` (both red on `origin/main`, green here): the streaming call re-raises on a context-overflow partial; the loop never issues a request larger than the first and never persists the partial after an overflow.

## Validation
| Check | Before (origin/main) | After |
|---|---|---|
| Live repro — real `AIAgent`, mocked SSE stream that yields ~70K chars then raises `Context length exceeded: max compression attempts (3) reached.`, compression off | `api_calls=4 request_char_sizes=[1871, 73103, 144335, 215567]`, 1 assistant row carrying the partial, turn ends at the 4-continuation ceiling | `api_calls=1 request_char_sizes=[1871]`, 0 partial rows, `failed=True` |
| Same repro, compression on | same growth | `failed=True compression_exhausted=True` (#98722 gateway reset bit carried) |
| Negative arm — transient `simulated upstream stall` after partial | continuation stub with the partial text | unchanged: continuation stub with the partial text |
| `scripts/run_tests.sh tests/run_agent/` | — | 206 files, 2126 passed, 0 failed |
| `scripts/run_tests.sh tests/agent/` | — | 522 files, 6662 passed, 0 failed (1 file flaky-then-green: `test_compression_stall_fallback_78981.py`, passes 11/11 alone on main and on this branch — unrelated timing flake) |
| ruff / footguns / compat pointers / `git diff --check` | — | clean |

**Root cause:** `_partial_stream_stub()` unconditionally seeded the full recovered text as a length-continuation stub, so after a context-overflow stream death the continuation path appended tens of KB plus a nudge and the next request was strictly larger than the one that had just failed (#106260).

## Salvage notes
- Salvages #106266 from @ca-shrimp (earliest of the cluster, mechanism analysis on the issue; `Co-authored-by` on the commit). That PR added an `_overflow_terminal` stub marker, a new terminal branch in `recover_from_truncation`, a new message constant and `compression_exhausted` plumbing through `partial_result`/`_Trunc.end_turn` (+261/−12). Re-raising into the recovery contract that already owns this error class gets the same outcome with none of that surface: +80/−8 here, 22 net source lines.
- #106275 by @JoaoMarcos44 (+258/−10) is the same marker shape and additionally made HTTP 413 `payload_too_large` terminal, which would bypass `turn_overflow._recover_payload_too_large` (#88960/#47339). Not adopted; the two PRs agree on `context_overflow`, and the 413 scoping was already narrowed in #106266 after review.
- #106264 was closed by its author in favour of #106266.
- Not in scope (design questions raised on the issue): clamping `protect_last_n` so the compressible middle is never empty, and a policy knob for preserving partial content on overflow.

Salvages #106266 from @ca-shrimp
Closes #106260

## Infographic
![stream-stub-overflow-spiral](https://v3b.fal.media/files/b/0aa9babb/UfXXKAkw6Uk3ci3K9Eu-3_RfrUgFEd.png)
