### PR TITLE
fix(tui-gateway): sessionless config.set model no longer rewrites the profile default (#106397, salvage #106405 #106424)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10316,6 +10316,61 @@ def test_config_set_model_once_requires_live_session(monkeypatch):
     assert "/model --once requires a live session" in resp["error"]["message"]
 
 
+def test_config_set_model_sessionless_rejected(monkeypatch):
+    """Sessionless config.set model must 4001 before _apply_model_switch.
+
+    Missing session_id and a stale session_id miss both take the sessionless
+    branch; unscoped values and legacy --global must be rejected the same way
+    so a Desktop client cannot persist model.default before session.create.
+    """
+    called = {"n": 0}
+
+    def boom(*a, **k):
+        called["n"] += 1
+        raise AssertionError("_apply_model_switch must not run")
+
+    monkeypatch.setattr(server, "_apply_model_switch", boom)
+    for value in ["some-model", "some-model --provider openai-codex --global"]:
+        resp = server.handle_request({
+            "id": "1", "method": "config.set",
+            "params": {"key": "model", "value": value},
+        })
+        assert resp["error"]["code"] == 4001
+        assert called["n"] == 0
+
+    resp = server.handle_request({
+        "id": "1", "method": "config.set",
+        "params": {"session_id": "missing-sid", "key": "model", "value": "some-model --global"},
+    })
+    assert resp["error"]["code"] == 4001
+    assert called["n"] == 0
+
+
+def test_config_set_model_live_session_still_applies_switch(monkeypatch):
+    """CONTROL: a live session still reaches _apply_model_switch, including --global."""
+    called = {"raw": []}
+
+    def fake_apply(sid, session, raw, **_kwargs):
+        called["raw"].append(raw)
+        return {"value": "some-model", "warning": "", "scope": "global"}
+
+    server._sessions["sid"] = _session()
+    monkeypatch.setattr(server, "_apply_model_switch", fake_apply)
+    try:
+        resp = server.handle_request({
+            "id": "1", "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "some-model --provider openai-codex --global",
+            },
+        })
+        assert "error" not in resp
+        assert called["raw"] == ["some-model --provider openai-codex --global"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_config_set_model_session_switch_clears_pending_once_restore(monkeypatch):
     class Agent:
         model = "temp/model"

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -141,12 +141,14 @@ def _set_model(rid, params, key, value, session):
                 _persist_live_session_runtime(session)
     else:
         # --once keeps its specific 5001; other sessionless model sets 4001 so
-        # --global cannot persist profile defaults before session.create.
+        # --global cannot persist profile defaults before session.create (#106397:
+        # an older Desktop client sent a fresh-draft pick this way).
         from hermes_cli.model_switch import parse_model_switch_args
         if parse_model_switch_args(str(value)).is_once:
             result = _apply_model_switch("", {"agent": None}, value, confirm_expensive_model=confirmed)
         else:
-            return _err(rid, 4001, "config.set model requires a live session")
+            return _err(rid, 4001, "config.set model requires a live session; "
+                        "use Settings -> Models to change the profile default")
     return _kv(rid, key, result["value"], warning=result["warning"],
                confirm_required=result.get("confirm_required", False),
                confirm_message=result.get("confirm_message", ""), scope=result.get("scope", "session"))

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -140,7 +140,13 @@ def _set_model(rid, params, key, value, session):
             with _session_profile_runtime_scope(session):
                 _persist_live_session_runtime(session)
     else:
-        result = _apply_model_switch("", {"agent": None}, value, confirm_expensive_model=confirmed)
+        # --once keeps its specific 5001; other sessionless model sets 4001 so
+        # --global cannot persist profile defaults before session.create.
+        from hermes_cli.model_switch import parse_model_switch_args
+        if parse_model_switch_args(str(value)).is_once:
+            result = _apply_model_switch("", {"agent": None}, value, confirm_expensive_model=confirmed)
+        else:
+            return _err(rid, 4001, "config.set model requires a live session")
     return _kv(rid, key, result["value"], warning=result["warning"],
                confirm_required=result.get("confirm_required", False),
                confirm_message=result.get("confirm_message", ""), scope=result.get("scope", "session"))


### PR DESCRIPTION
A `config.set model` request that reaches the TUI gateway without a live session (no `session_id`, or a stale one) now fails closed with error `4001` instead of applying the switch against a dummy session — so an older Desktop client sending the legacy `--global` fresh-draft pick can no longer silently rewrite `model.default` / `model.provider` in `config.yaml`.

## Changes
- `tui_gateway/methods_config_set.py::_set_model` — the sessionless branch returns `4001` for every request that is not `--once`; `--once` keeps its existing specific `5001` "/model --once requires a live session" path (@KoNit-K, #106405, cherry-picked with authorship).
- The `4001` message points at the deliberate door: "use Settings -> Models to change the profile default" (the one hunk carried from #106424 by @mkrb84, `Co-authored-by`).
- Two tests in `tests/test_tui_gateway_server.py`: sessionless (missing AND stale `session_id`) unscoped/`--global` → `4001` and `_apply_model_switch` never called; control — a live session with `--global` still reaches `_apply_model_switch`.
- Not carried from #106424: the pre-parse of flags before the session branch. With the guard in place, sessionless `--once --global` already surfaces the canonical `/model --once cannot be combined with --global` through `_apply_model_switch` (verified in-process), so the extra restructuring bought nothing.

Live-session `--global`, `/model --global` from a live session, and Settings → Models (`/api/model/set`) are unchanged.

## Validation
| | before | after |
|---|---|---|
| sessionless `--global` (issue payload), temp `HERMES_HOME` with `model.default: profile-default-model` | `scope: global`, `config.yaml` rewritten to the picked model | `4001`, `config.yaml` byte-identical |
| stale `session_id` + `--global` | same rewrite | `4001`, unchanged |
| sessionless unscoped | `scope: session` (applied against `{"agent": None}`) | `4001` |
| sessionless `--once` | `5001 /model --once requires a live session` | same |
| sessionless `--once --global` | `5001 /model --once cannot be combined with --global` | same |
| `test_config_set_model_sessionless_rejected` on origin/main source | `assert 5001 == 4001` (red) | passes |

Live repro is the real `tui_gateway.server.handle_request` dispatcher (real `switch_model`, real config I/O) in a fresh interpreter, once against an `origin/main` snapshot and once against this branch.

**Root cause:** `_set_model` fell through to `_apply_model_switch("", {"agent": None}, value, ...)` when no session resolved, and the model-switch policy honours `--global` → `_persist_model_switch` writes the profile config. #101287 fixed the current Desktop caller (it returns before any RPC when there is no live session; grep of `apps/desktop` and `ui-tui` shows every remaining `config.set model` caller passes a `session_id`), so the surviving hole was version skew: an older client against a current backend.

Fixes #106397
Refs #90235, #101287

## Credits
- @KoNit-K — PR #106405 (earliest, cherry-picked; the fix and both tests).
- @mkrb84 — reported #106397 with the root cause and proposed fix; PR #106424 (Settings → Models pointer in the error message carried with `Co-authored-by`).

## Infographic
![sessionless-model](https://v3b.fal.media/files/b/0aa9ba34/jj8Bas3tVMBfUC5YMdJ5Y_kIeHV2Z2.png)
