### PR TITLE
fix(gateway): macOS restart/stop of an unloaded launchd job no longer leaks raw launchctl stderr (#106273, salvage #106272)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4042,9 +4042,10 @@ def launchd_stop():
     _mark_planned_stop()
     # bootout unloads the definition so KeepAlive doesn't respawn; `hermes gateway start` re-bootstraps.
     try:
-        subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
+        # Captured: an already-unloaded job (3/113/125) is handled below, so launchctl's own
+        # "Boot-out failed: 3" must not print around the ✓ line; e.stderr stays on the raised error.
+        subprocess.run(["launchctl", "bootout", target], check=True, timeout=90, **_CAPTURE_TEXT)
     except subprocess.CalledProcessError as e:
-        # Job already unloaded (3/113/125) or domain unmanageable (5/125): fall through to the PID-based kill.
         # Job already unloaded (3/113/125), or the domain can't be managed at all (5/125, macOS 26+
         # detached-fallback process, issue #23387) — in both cases just fall through to the PID-based kill
         # below.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3530,7 +3530,11 @@ def _launchctl_bootstrap(domain: str, plist_path, label: str, *, timeout: int = 
         if exc.returncode != _LAUNCHCTL_BOOTSTRAP_EIO:
             raise
         # Stale registration — bootout the leftover label and bootstrap once more.
-        subprocess.run(["launchctl", "bootout", f"{domain}/{label}"], check=False, timeout=timeout)
+        # Captured: the bootout is best-effort (a drained job may already be
+        # unloaded), so its expected 3/113/125 stderr must not leak to the terminal.
+        subprocess.run(
+            ["launchctl", "bootout", f"{domain}/{label}"],
+            check=False, timeout=timeout, **_CAPTURE_TEXT)
         subprocess.run(bootstrap, check=True, timeout=timeout)
 
 
@@ -3912,7 +3916,8 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     # Bootout/bootstrap so launchd reads the new definition; bootstrap can fail silently under load
     # during a drain, and KeepAlive can't revive an unregistered job.
-    subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
+    # Captured: best-effort (the job may already be unloaded), keep expected noise off the terminal.
+    subprocess.run(["launchctl", "bootout", target], check=False, timeout=90, **_CAPTURE_TEXT)
     _reload_budget = _launchd_reload_budget()
     # Wait out the old gateway's drain first so the budget isn't burned on guaranteed EIO ("already loaded").
     if gateway_pid is not None and not _wait_for_pid_exit(gateway_pid, _reload_budget):
@@ -3972,7 +3977,10 @@ def launchd_install(force: bool = False):
 
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{get_launchd_label()}"], check=False, timeout=90)
+    # Captured: uninstalling an already-unloaded job is fine — don't print Boot-out failed: 3.
+    subprocess.run(
+        ["launchctl", "bootout", f"{_launchd_domain()}/{get_launchd_label()}"],
+        check=False, timeout=90, **_CAPTURE_TEXT)
     if plist_path.exists():
         plist_path.unlink()
         print(f"✓ Removed {plist_path}")
@@ -4129,7 +4137,9 @@ def launchd_restart():
                 print("⚠ launchd did not revive the gateway after its graceful exit — forcing restart")
             else:
                 print(f"⚠ Gateway drain timed out after {wait_budget:.0f}s — forcing launchd restart")
-        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+        # Captured: an unloaded job (3/113/125) is the expected case below, which
+        # prints its own ↻ line — and e.stderr feeds the update_cmd failure diagnostic.
+        subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90, **_CAPTURE_TEXT)
         _launchd_ok("✓ Service restarted")
     except subprocess.CalledProcessError as e:
         if not _launchd_error_indicates_unloaded(e):
@@ -4139,7 +4149,9 @@ def launchd_restart():
         print("↻ launchd job was unloaded; reloading")
         try:
             # After a drain the job is usually still registered (bootstrap would hit EIO): boot it out first.
-            subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
+            # Captured: best-effort (the job may already be unloaded after the drain),
+            # so an expected Boot-out failed: 3 must not leak past the ↻ line below.
+            subprocess.run(["launchctl", "bootout", target], check=False, timeout=90, **_CAPTURE_TEXT)
             plist_path = str(get_launchd_plist_path())
             subprocess.run(["launchctl", "bootstrap", _launchd_domain(), plist_path], check=True, timeout=30)
             subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2463,6 +2463,71 @@ class TestLaunchctlBootstrapEioRetry:
         assert excinfo.value.returncode == 5
 
 
+class TestLaunchdUnloadedJobStderrStaysOffTerminal:
+    """#106273: against an UNLOADED job, ``launchctl bootout`` / ``kickstart -k`` exit 3 and print
+    ``Could not find service ...`` / ``Boot-out failed: 3`` on fd 2. Those exits are the *handled*
+    case, so a real launchctl child (fake binary on PATH, real fd inheritance) must leave the
+    terminal's stderr empty while the CLI's own status lines print. ``capfd`` reads fd 2, so an
+    inherited-stderr regression fires even though ``subprocess.run`` never touches ``sys.stderr``."""
+
+    @pytest.fixture
+    def fake_launchctl(self, tmp_path, monkeypatch):
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        script = bin_dir / "launchctl"
+        # bootout exits $FAKE_BOOTOUT_RC (default 3 = unloaded); `kickstart -k` is the unloaded 3;
+        # bootstrap / plain kickstart / print succeed. Every invocation is logged for the caller.
+        script.write_text(
+            "#!/bin/sh\n"
+            'echo "$@" >> "$FAKE_LAUNCHCTL_LOG"\n'
+            'case "$1" in\n'
+            '  bootout) echo "Boot-out failed: ${FAKE_BOOTOUT_RC:-3}: No such process" >&2; exit "${FAKE_BOOTOUT_RC:-3}" ;;\n'
+            '  kickstart) if [ "$2" = "-k" ]; then echo "Could not find service in domain for user gui: 501" >&2; exit 3; fi ;;\n'
+            "esac\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o755)
+        log = tmp_path / "calls.log"
+        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+        monkeypatch.setenv("FAKE_LAUNCHCTL_LOG", str(log))
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: tmp_path / "ai.hermes.gateway.plist")
+        monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+        monkeypatch.setattr(gateway_cli, "_mark_planned_stop", lambda *a, **k: None)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda *a, **k: True)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: None)
+        return log
+
+    def test_restart_of_unloaded_job_reloads_without_launchctl_noise(self, fake_launchctl, capfd):
+        gateway_cli.launchd_restart()
+
+        out, err = capfd.readouterr()
+        assert "↻ launchd job was unloaded; reloading" in out
+        assert "✓ Service restarted" in out
+        assert err == ""
+        verbs = [line.split()[0] for line in fake_launchctl.read_text(encoding="utf-8").splitlines()]
+        assert verbs == ["kickstart", "bootout", "bootstrap", "kickstart"]
+
+    def test_stop_of_unloaded_job_is_quiet_but_a_real_bootout_failure_keeps_stderr(
+        self, fake_launchctl, capfd, monkeypatch
+    ):
+        gateway_cli.launchd_stop()
+        out, err = capfd.readouterr()
+        assert "✓ Service stopped" in out
+        assert err == ""
+
+        # Unexpected exit code: not swallowed, and the captured stderr rides on the exception for
+        # the caller's diagnostic instead of having been printed raw by launchctl.
+        monkeypatch.setenv("FAKE_BOOTOUT_RC", "1")
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            gateway_cli.launchd_stop()
+        assert excinfo.value.returncode == 1
+        assert "Boot-out failed: 1" in excinfo.value.stderr
+        assert capfd.readouterr().err == ""
+
+
 class TestRetryLaunchctlBootstrapUntilRegistered:
     """`_retry_launchctl_bootstrap_until_registered` — salvage of #53277.
 


### PR DESCRIPTION
`hermes gateway restart` / `hermes gateway stop` / `hermes update` on macOS no longer print raw `launchctl` errors (`Could not find service … in domain for user gui: 501`, `Boot-out failed: 3: No such process`) around the CLI's own `↻` / `✓` status lines when the launchd job is already unloaded.

## Changes

- **`hermes_cli/gateway.py`** (@thedavidweng's commit, picked verbatim): the four best-effort `launchctl bootout` calls (`_launchctl_bootstrap` EIO recovery, `refresh_launchd_plist_if_needed`, `launchd_uninstall`, `launchd_restart` reload path) and the `kickstart -k` in `launchd_restart` now pass the file's shared `_CAPTURE_TEXT` kwargs (`capture_output=True, text=True, encoding="utf-8", errors="replace"`). Expected exits 3/113/125 stay silent; the `kickstart -k` failure still raises with `e.stderr` populated for the `update_cmd_fleet` "Gateway restart failed: …" diagnostic.
- **Follow-up (mine)** — widened to the one remaining sibling with the same bug class: `launchd_stop()` boots out with `check=True` and already handles 3/113/125 and 5/125 by falling through to the PID kill, yet inherited stderr, so `hermes gateway stop` against an unloaded job printed `Boot-out failed: 3` next to `✓ Service stopped`. Same kwargs; an unexpected exit still raises with the captured stderr attached (not swallowed).
- **Tests** (mine, replacing the contributor's two `capture_output is True` kwarg assertions on a mocked `subprocess.run`): `TestLaunchdUnloadedJobStderrStaysOffTerminal` — two invariant tests that put a real fake `launchctl` on `PATH` (exits 3 + prints the macOS messages on fd 2) and read fd 2 through `capfd`. Host-independent: `launchd_restart` / `launchd_stop` are not platform-guarded, so no `macos_only` marker is needed.

## Validation

Fake `launchctl` on PATH, real `hermes_cli.gateway` functions in a fresh subprocess (fd inheritance is real, not mocked). Not run on real macOS (no Mac host here); the fake reproduces the issue's exact exit code and stderr text.

| Surface | Before (origin/main) | After |
|---|---|---|
| `launchd_restart()` unloaded job | stdout `↻ launchd job was unloaded; reloading \| ✓ Service restarted`, **stderr** `Could not find service … gui: 501 \| Boot-out failed: 3: No such process` | same stdout, stderr empty |
| `launchd_stop()` unloaded job | stdout `✓ Service stopped`, **stderr** `Boot-out failed: 3: No such process` | same stdout, stderr empty |
| `launchd_uninstall()` unloaded job | stdout `✓ Service uninstalled`, **stderr** `Boot-out failed: 3: No such process` | same stdout, stderr empty |
| `launchd_stop()` bootout exit 1 (unexpected) | raises `CalledProcessError` | still raises; `e.stderr` contains `Boot-out failed: 1` and nothing hits the terminal |

- New tests: red on origin/main (`assert err == ""` fails with the launchctl text), green here.
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_restart_loop.py tests/hermes_cli/test_subprocess_stdin_guard.py` → 404 passed; full `tests/hermes_cli/` directory run in the report.
- `ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `check_subprocess_stdin.py`, `git diff --check`: clean.

**Root cause:** the best-effort `bootout` / `kickstart -k` calls whose failure is the *handled* case ran without stderr capture, so launchctl wrote its complaint straight to the inherited terminal fd.

Salvages #106272 from @thedavidweng
Closes #106273

## Infographic
![launchd-bootout-stderr](https://v3b.fal.media/files/b/0aa9bacb/EzP5QcIQSNy8xtDt5Q-yK_bwUiFE7O.png)
