### PR TITLE
hermes peer dm reaches a hidden Bot Chat that rotated through compression (#106165, salvage #106365)

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -967,6 +967,11 @@ class SessionSessionsMixin:
             ):
                 if key in tip_row:
                     merged[key] = tip_row[key]
+            if merged.get("title") is None:
+                # The title is carried root->tip AFTER the publish transaction; a rotation cut off in
+                # between leaves it on the ended root, and exact-title lookups (`hermes peer dm` ->
+                # canonical "Bot Chat") must still see the lineage under its name (#106165).
+                merged["title"] = s.get("title")
             merged["_lineage_root_id"] = s["id"]
             merged["_lineage_ids"] = chain
             projected.append(merged)
@@ -1089,7 +1094,7 @@ class SessionSessionsMixin:
                 tip.id,
                 tip.source,
                 tip.model,
-                tip.title,
+                COALESCE(tip.title, s.title) AS title,
                 s.started_at AS started_at,
                 tip.ended_at,
                 tip.end_reason,

--- a/tests/gateway/test_peer_dm_hidden_e2e.py
+++ b/tests/gateway/test_peer_dm_hidden_e2e.py
@@ -141,3 +141,40 @@ def test_hidden_lookup_requires_title_filter_e2e(peer_gateway):
     ids = [s["id"] for s in listing["data"]]
     assert peer_gateway.hidden_id not in ids
     assert "ordinary_1" in ids
+
+
+@pytest.fixture()
+def peer_gateway_compressed_hidden(peer_gateway):
+    """Aged Bot Mode footprint: the hidden canonical Bot Chat has a live
+    compression tip (issue #106165). The tip is untitled and hidden via the
+    lineage; the title lives only on the ended root."""
+    db = peer_gateway.db
+    tip_id = db.create_session(
+        "botchat_tip_1", "gateway_botmode", parent_session_id=peer_gateway.hidden_id)
+    db.end_session(peer_gateway.hidden_id, "compression")
+    db.set_session_hidden(peer_gateway.hidden_id, True)  # lineage-hide root+tip
+    peer_gateway.tip_id = tip_id
+    return peer_gateway
+
+
+def test_peer_dm_reaches_compressed_hidden_bot_chat_e2e(
+        peer_gateway_compressed_hidden, monkeypatch, capsys):
+    """Hidden canonical Bot Chat under compression: the peer lookup must still
+    resolve (to the live tip) instead of missing it and colliding with
+    UNIQUE(title) on create (HTTP 400, issue #106165)."""
+    gw = peer_gateway_compressed_hidden
+    monkeypatch.setattr(peer_cmd, "_load_peers", lambda: {"spark": {"url": gw.url}})
+    monkeypatch.setattr(peer_cmd, "_peer_secret", lambda name: API_KEY)
+
+    rc = peer_cmd.cmd_peer(
+        SimpleNamespace(peer_action="dm", target="spark", message="disk status?", json=True)
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reply"] == "e2e reply to: disk status?"
+    assert payload["session_id"] == gw.tip_id
+
+    # No duplicate "Bot Chat" row was minted; the title still lives on the root.
+    assert gw.db.get_session_by_title("Bot Chat")["id"] == gw.hidden_id
+

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1708,6 +1708,21 @@ class TestSessionTitleLineage:
         # The unrelated holder keeps its title.
         assert db.get_session("a")["title"] == "shared"
 
+    def test_projected_tip_inherits_root_title_when_untitled(self, db):
+        """A rotation that ended the root before the title carry ran leaves the name on the
+        root only; the projected lineage row must still surface it (exact-title lookups such as
+        `hermes peer dm` -> canonical "Bot Chat", #106165). A titled tip keeps its own title."""
+        import time as _time
+        self._make_compression_chain(db, _time.time() - 3600)
+        db.set_session_title("root", "Bot Chat")
+
+        rows = db.list_sessions_rich(limit=50, order_by_last_active=True, search_query="Bot Chat")
+        assert [(r["id"], r["title"], r["_lineage_root_id"]) for r in rows] == [("tip", "Bot Chat", "root")]
+
+        db.set_session_title("tip", "renamed tip")
+        rows = db.list_sessions_rich(limit=50, order_by_last_active=True)
+        assert [(r["id"], r["title"]) for r in rows] == [("tip", "renamed tip")]
+
 
 
 class TestSanitizeTitle:


### PR DESCRIPTION
`hermes peer dm` reaches a target whose canonical Bot Chat is hidden **and** has rotated through compression, instead of failing with HTTP 400 `Title already in use`.

- **User-reported** (#106165; the #92854 fix covered a hidden Bot Chat with no continuation).
- `hermes_state_sessions.py::_project_compression_tips` — when the live tip is untitled, the projected lineage row keeps the root's title instead of overwriting it with `None`.
- `hermes_state_sessions.py::list_recent_sessions_bounded` — same `COALESCE(tip.title, s.title)` in the SQL projection (the other lineage→tip projector, used by `session_search`).
- Tests (2): `tests/gateway/test_peer_dm_hidden_e2e.py::test_peer_dm_reaches_compressed_hidden_bot_chat_e2e` (stock `peer dm` client against a real `APIServerAdapter` + real `state.db`, from #106365) and `tests/test_hermes_state.py::TestSessionTitleLineage::test_projected_tip_inherits_root_title_when_untitled` (DB invariant + negative: a titled tip keeps its own title). Both red on `origin/main`, green with the fix.

## Root cause

`_project_compression_tips` copies the tip's `title` over the root's unconditionally; the title is carried root→tip by the agent *after* `publish_compression_child`'s transaction, so a rotation interrupted in between leaves "Bot Chat" on the ended root and `NULL` on the tip — the projected row then fails the handler's exact-title filter, the peer mints a duplicate and the `UNIQUE(title)` guard 400s.

## Validation — live repro (real `APIServerAdapter` on loopback TCP, real SQLite `state.db` under a temp `HERMES_HOME`, stock `hermes peer dm` client; only the model turn stubbed)

`python /tmp/peer_dm_repro.py <worktree> <label>` — hidden `Bot Chat` root ended with `end_reason=compression`, untitled hidden tip:

```
[BEFORE-main] GET /api/sessions?title=Bot%20Chat&include_hidden=1 -> []
Peer 'spark': Peer already has a 'Bot Chat' session but it is hidden and the peer's gateway is too old to expose hidden sessions to this lookup (HTTP 400: Title already in use by session botchat_root). ...
[BEFORE-main] hermes peer dm spark -> rc=1
[BEFORE-main] RESULT: BUG FIRES

[AFTER-fix] GET /api/sessions?title=Bot%20Chat&include_hidden=1 -> [('botchat_tip', 'Bot Chat')]
[AFTER-fix] hermes peer dm spark -> rc=0 out={"peer": "spark", "profile": null, "session_id": "botchat_tip", "reply": "reply to: disk status?"}
[AFTER-fix] Bot Chat rows in state.db: [('botchat_root', 'Bot Chat')]   (no duplicate minted)
[AFTER-fix] RESULT: NEGATIVE (peer dm delivered into the live tip botchat_tip)
```

Sabotage (fix reverted, tests kept): `2 failed, 4 passed` → with fix: `6 passed`.

Premise check: with the normal rotation path (`publish_compression_child` + `_carry_session_state_to_child`) the title *does* land on the tip and the listing already finds it on main; the bug needs the carry to have not run/failed — a real, reachable state (the user hit it), so the fix goes where the title is lost rather than at the HTTP handler.

## Salvage notes

Salvage of #106365 by @Finn763. Kept: the peer-dm e2e regression test (cherry-picked under their authorship). Replaced: the handler-level fallback in `gateway/platforms/api_server.py::_handle_list_sessions` (a second `get_session_by_title` + `get_compression_tip` lookup path with `try/except: pass` and nested `suppress(Exception)`) by the 5-line projection fix — one lookup path, every list consumer (API server, TUI gateway, dashboard, `session_search`) sees the name, no swallowed exceptions. Dropped: the listing-shape test (asserted the same row as the e2e test).

Closes #106165

## Infographic
![peer-dm-compressed-bot-chat](https://v3b.fal.media/files/b/0aa9baad/CjMOyl2uUb7bj0gvKWlNG_9r6nsIeZ.png)
