### PR TITLE
feat(telegram): show detached subagent status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3271,6 +3271,26 @@ class GatewayRunner(
     GatewayAgentCacheMixin):
     """Main gateway controller: manages adapter lifecycles, routes messages to/from the agent."""
 
+    _subagent_status_registry_lock = threading.Lock()
+
+    def _prepare_subagent_status_owner(
+        self, *, source, adapter, route_metadata, surface_mode: str, loop,
+    ):
+        """Create a Telegram-only detached-status owner with one shared registry."""
+        if surface_mode == "off" or adapter is None:
+            return None
+        from gateway.subagent_status import SubagentStatusRegistry, create_telegram_subagent_status
+
+        with self._subagent_status_registry_lock:
+            registry = getattr(self, "_subagent_status_registry", None)
+            if registry is None:
+                registry = SubagentStatusRegistry()
+                self._subagent_status_registry = registry
+        pair = create_telegram_subagent_status(
+            source=source, adapter=adapter, route_metadata=route_metadata, loop=loop, registry=registry,
+        )
+        return pair[0] if pair is not None else None
+
     # Class-level defaults so partial construction in tests doesn't blow up on attribute access.
     _busy_input_mode: str = "interrupt"
     _busy_text_mode: str = "interrupt"

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2738,8 +2738,17 @@ class GatewayTurnMixin:
             _cleanup_adapter = None
 
         # The one-slot progress/holder containers shared with the callbacks are TurnContext defaults.
+        _status_surface_mode = disp._display_surface_mode("long_running_notifications", allow_generic=True)
+        _status_owner = self._prepare_subagent_status_owner(
+            source=source,
+            adapter=self._adapter_for_source(source),
+            route_metadata=self._thread_metadata_for_source(source, turn_params.get("event_message_id")),
+            surface_mode=_status_surface_mode,
+            loop=asyncio.get_running_loop(),
+        )
         turn_ctx = TurnContext(
             source=source, message=message, AIAgent=AIAgent, session_key=session_key,
+            subagent_status_owner=_status_owner,
             run_generation=run_generation, _cleanup_progress=_cleanup_progress,
             _run_still_current=self._run_still_current_fn(session_key, run_generation),
             progress_queue=queue.Queue() if disp.needs_progress_queue else None,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1527,7 +1527,7 @@ class TurnRunner:
             # turn so a restart-interrupted turn is recorded WITH its id for drain-window dedup.
             if ctx.inbound_message_id is not None:
                 kwargs["persist_user_platform_id"] = str(ctx.inbound_message_id)
-            return agent.run_conversation(api_message, **kwargs)
+            return self._run_conversation_with_status(agent, api_message, kwargs)
         finally:
             unregister_gateway_notify(session_key)
             # Cancel pending clarify entries so blocked agent threads don't hang past the end of the
@@ -1536,6 +1536,19 @@ class TurnRunner:
                 from tools.clarify_gateway import clear_session
                 clear_session(session_key)
             reset_current_session_key(token)
+
+    def _run_conversation_with_status(self, agent, message, kwargs):
+        """Bind a turn-local detached-status owner only while the parent runs."""
+        from tools.delegation_status import bind_detached_status_owner
+
+        owner = self._ctx.subagent_status_owner
+        try:
+            with bind_detached_status_owner(owner):
+                return agent.run_conversation(message, **kwargs)
+        finally:
+            request_seal = getattr(owner, "request_seal", None)
+            if callable(request_seal):
+                request_seal()
 
     def _finish_stream_consumer(self, result, agent_history, stream_consumer):
         ctx = self._ctx

--- a/gateway/subagent_status.py
+++ b/gateway/subagent_status.py
@@ -1,0 +1,529 @@
+"""Privacy-empty presentation state for detached subagents."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+import time
+from concurrent.futures import Future, TimeoutError as FutureTimeoutError
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Any, Awaitable, Callable
+
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+from tools.delegation_status import (
+    DetachedStatusEvent as SubagentStatusEvent,
+    DetachedStatusPhase as SubagentStatusPhase,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class SubagentStatusRow:
+    ordinal: int
+    phase: SubagentStatusPhase
+    started_at: float
+    finished_at: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SubagentStatusSnapshot:
+    rows: tuple[SubagentStatusRow, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SubagentStatusBatch:
+    batch_id: int
+    start_ordinal: int
+    task_count: int
+
+
+_PHASE_GLYPHS = {
+    SubagentStatusPhase.WAITING: "🚀",
+    SubagentStatusPhase.THINKING: "💭",
+    SubagentStatusPhase.DONE: "✅",
+    SubagentStatusPhase.FAILED: "❌",
+}
+_TERMINAL_PHASES = frozenset(
+    {SubagentStatusPhase.DONE, SubagentStatusPhase.FAILED}
+)
+
+
+class SubagentStatusBoard:
+    """Loop-owned projection of accepted detached batches."""
+
+    def __init__(self) -> None:
+        self._rows: list[SubagentStatusRow] = []
+        self._open_batches: set[int] = set()
+        self._sealed = False
+        self._next_batch_id = 1
+
+    def admit_batch(self, *, task_count: int, at: float) -> SubagentStatusBatch:
+        if self._sealed:
+            raise RuntimeError("status board is sealed")
+        batch = SubagentStatusBatch(
+            batch_id=self._next_batch_id,
+            start_ordinal=len(self._rows) + 1,
+            task_count=task_count,
+        )
+        self._next_batch_id += 1
+        self._open_batches.add(batch.batch_id)
+        self._rows.extend(
+            SubagentStatusRow(
+                ordinal=batch.start_ordinal + index,
+                phase=SubagentStatusPhase.WAITING,
+                started_at=at,
+            )
+            for index in range(task_count)
+        )
+        return batch
+
+    def finalize_batch(
+        self,
+        batch: SubagentStatusBatch,
+        *,
+        outcomes: tuple[SubagentStatusPhase, ...],
+        at: float,
+    ) -> None:
+        if batch.batch_id not in self._open_batches:
+            return
+        if len(outcomes) != batch.task_count:
+            raise ValueError("one outcome is required for every admitted task")
+        for index, outcome in enumerate(outcomes):
+            if outcome not in _TERMINAL_PHASES:
+                raise ValueError("batch outcomes must be terminal")
+            row_index = batch.start_ordinal - 1 + index
+            row = self._rows[row_index]
+            if row.phase in _TERMINAL_PHASES:
+                continue
+            self._rows[row_index] = replace(
+                row, phase=outcome, finished_at=at
+            )
+        self._open_batches.remove(batch.batch_id)
+
+    def observe(
+        self, batch: SubagentStatusBatch, event: SubagentStatusEvent
+    ) -> None:
+        if batch.batch_id not in self._open_batches or event.depth != 1:
+            return
+        if not 0 <= event.task_index < batch.task_count:
+            return
+        row_index = batch.start_ordinal - 1 + event.task_index
+        row = self._rows[row_index]
+        if row.phase in _TERMINAL_PHASES:
+            return
+        finished_at = event.at if event.phase in _TERMINAL_PHASES else None
+        self._rows[row_index] = replace(
+            row, phase=event.phase, finished_at=finished_at
+        )
+
+    def seal(self) -> None:
+        self._sealed = True
+
+    def fail_open_and_seal(self, *, at: float) -> None:
+        self._rows = [
+            row
+            if row.phase in _TERMINAL_PHASES
+            else replace(
+                row,
+                phase=SubagentStatusPhase.FAILED,
+                finished_at=at,
+            )
+            for row in self._rows
+        ]
+        self._open_batches.clear()
+        self._sealed = True
+
+    @property
+    def is_terminal(self) -> bool:
+        return self._sealed and not self._open_batches
+
+    def snapshot(self) -> SubagentStatusSnapshot:
+        return SubagentStatusSnapshot(rows=tuple(self._rows))
+
+
+class _SubagentStatusSink:
+    def __init__(self, owner: "SubagentStatusOwner", batch: SubagentStatusBatch):
+        self._owner = owner
+        self._batch = batch
+
+    def observe(self, event: SubagentStatusEvent) -> None:
+        self._owner._loop.call_soon_threadsafe(
+            self._owner._observe, self._batch, event
+        )
+
+    def finalize(self, outcomes: tuple[SubagentStatusPhase, ...]) -> None:
+        self._owner._loop.call_soon_threadsafe(
+            self._owner._finalize, self._batch, outcomes
+        )
+
+
+class SubagentStatusOwner:
+    def __init__(
+        self,
+        *,
+        loop: asyncio.AbstractEventLoop,
+        on_change: Callable[[SubagentStatusSnapshot, bool], Any],
+        clock: Callable[[], float] = time.monotonic,
+        admission_timeout: float = 5.0,
+        on_first_admission: Callable[["SubagentStatusOwner"], bool] | None = None,
+    ) -> None:
+        self._loop = loop
+        self._on_change = on_change
+        self._clock = clock
+        self._admission_timeout = admission_timeout
+        self._on_first_admission = on_first_admission
+        self._board = SubagentStatusBoard()
+
+    def admit_batch(self, task_count: int) -> _SubagentStatusSink:
+        response: Future[_SubagentStatusSink] = Future()
+
+        def admit_on_loop() -> None:
+            if not response.set_running_or_notify_cancel():
+                return
+            try:
+                sink = self._admit_batch_on_loop(task_count)
+            except BaseException as exc:
+                response.set_exception(exc)
+            else:
+                response.set_result(sink)
+
+        self._loop.call_soon_threadsafe(admit_on_loop)
+        try:
+            return response.result(timeout=self._admission_timeout)
+        except FutureTimeoutError:
+            if response.cancel():
+                raise
+            return response.result()
+
+    def _admit_batch_on_loop(self, task_count: int) -> _SubagentStatusSink:
+        if self._on_first_admission is not None:
+            if not self._on_first_admission(self):
+                raise RuntimeError("detached status registry is closed")
+        batch = self._board.admit_batch(task_count=task_count, at=self._clock())
+        self._notify()
+        return _SubagentStatusSink(self, batch)
+
+    def _observe(
+        self, batch: SubagentStatusBatch, event: SubagentStatusEvent
+    ) -> None:
+        self._board.observe(batch, event)
+        self._notify()
+
+    def _finalize(
+        self,
+        batch: SubagentStatusBatch,
+        outcomes: tuple[SubagentStatusPhase, ...],
+    ) -> None:
+        self._board.finalize_batch(batch, outcomes=outcomes, at=self._clock())
+        self._notify()
+
+    def seal(self) -> None:
+        self._board.seal()
+        self._notify()
+
+    def request_seal(self) -> None:
+        self._loop.call_soon_threadsafe(self.seal)
+
+    def fail_open_and_seal(self) -> None:
+        self._board.fail_open_and_seal(at=self._clock())
+        self._notify()
+
+    def snapshot(self) -> SubagentStatusSnapshot:
+        return self._board.snapshot()
+
+    def _notify(self) -> None:
+        snapshot = self._board.snapshot()
+        if not snapshot.rows:
+            return
+        try:
+            self._on_change(snapshot, self._board.is_terminal)
+        except Exception:
+            logger.warning("Detached status change callback failed", exc_info=True)
+
+
+async def _wait_for_wake(wake: asyncio.Event, delay: float) -> bool:
+    try:
+        await asyncio.wait_for(wake.wait(), timeout=delay)
+        return True
+    except asyncio.TimeoutError:
+        return False
+
+
+class SubagentStatusRegistry:
+    def __init__(self) -> None:
+        self._entries: dict[
+            TelegramSubagentStatusPublisher, SubagentStatusOwner
+        ] = {}
+        self._empty = asyncio.Event()
+        self._empty.set()
+        self._closed = False
+        self._cleanup_tasks: set[asyncio.Task] = set()
+
+    @property
+    def active_count(self) -> int:
+        return len(self._entries)
+
+    @property
+    def cleanup_task_count(self) -> int:
+        return len(self._cleanup_tasks)
+
+    def register(
+        self,
+        owner: SubagentStatusOwner,
+        publisher: "TelegramSubagentStatusPublisher",
+    ) -> bool:
+        if self._closed:
+            return False
+        if publisher in self._entries:
+            return True
+        self._entries[publisher] = owner
+        self._empty.clear()
+        cleanup_task = asyncio.create_task(self._remove_when_closed(publisher))
+        self._cleanup_tasks.add(cleanup_task)
+        cleanup_task.add_done_callback(self._cleanup_tasks.discard)
+        return True
+
+    def close(self) -> None:
+        self._closed = True
+
+    async def _remove_when_closed(
+        self, publisher: "TelegramSubagentStatusPublisher"
+    ) -> None:
+        await publisher.wait_closed()
+        self._entries.pop(publisher, None)
+        if not self._entries:
+            self._empty.set()
+
+    async def wait_empty(self) -> None:
+        await self._empty.wait()
+
+    async def shutdown(self, *, timeout: float) -> None:
+        self.close()
+        entries = list(self._entries.items())
+        for _publisher, owner in entries:
+            owner.seal()
+
+        terminal_budget = min(1.0, max(0.0, timeout * 0.2))
+        grace_budget = max(0.0, timeout - terminal_budget)
+        try:
+            await asyncio.wait_for(self.wait_empty(), timeout=grace_budget)
+            return
+        except asyncio.TimeoutError:
+            pass
+
+        for _publisher, owner in entries:
+            owner.fail_open_and_seal()
+        try:
+            await asyncio.wait_for(self.wait_empty(), timeout=terminal_budget)
+        except asyncio.TimeoutError:
+            await asyncio.gather(
+                *(publisher.cancel() for publisher, _owner in entries),
+                return_exceptions=True,
+            )
+            await self.wait_empty()
+
+
+class _PublicationResult(Enum):
+    SUCCESS = "success"
+    RETRY = "retry"
+    ABANDON = "abandon"
+
+
+class TelegramSubagentStatusPublisher:
+    def __init__(
+        self,
+        *,
+        send: Callable[[str], Awaitable[SendResult]],
+        edit: Callable[[Any, str], Awaitable[SendResult]],
+        clock: Callable[[], float] = time.monotonic,
+        interval: float = 5.0,
+        wait: Callable[[asyncio.Event, float], Awaitable[bool]] = _wait_for_wake,
+    ) -> None:
+        self._send = send
+        self._edit = edit
+        self._clock = clock
+        self._interval = interval
+        self._wait = wait
+        self._latest: SubagentStatusSnapshot | None = None
+        self._message_id: Any = None
+        self._terminal_requested = False
+        self._terminal_edit_attempts = 0
+        self._shutdown_requested = False
+        self._abandoned = False
+        self._wake = asyncio.Event()
+        self._task: asyncio.Task | None = None
+        self._closed = asyncio.Event()
+
+    def notify(
+        self, snapshot: SubagentStatusSnapshot, is_terminal: bool
+    ) -> None:
+        if self._shutdown_requested or self._abandoned or self._closed.is_set():
+            return
+        self._latest = snapshot
+        if is_terminal:
+            self._terminal_requested = True
+            self._wake.set()
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+
+    async def wait_closed(self) -> None:
+        await self._closed.wait()
+
+    async def shutdown(self) -> None:
+        self._shutdown_requested = True
+        self._wake.set()
+        if self._task is None:
+            self._closed.set()
+        await self.wait_closed()
+
+    async def cancel(self) -> None:
+        self._shutdown_requested = True
+        task = self._task
+        if task is None:
+            self._closed.set()
+            return
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    async def _run(self) -> None:
+        try:
+            while self._latest is not None:
+                if self._shutdown_requested:
+                    return
+                snapshot = self._latest
+                terminal = self._terminal_requested
+                terminal_edit = terminal and self._message_id is not None
+                if terminal_edit:
+                    self._terminal_edit_attempts += 1
+                result = await self._publish(snapshot)
+                if result is _PublicationResult.ABANDON:
+                    self._abandoned = True
+                    return
+                if self._shutdown_requested:
+                    return
+                if terminal and result is _PublicationResult.SUCCESS:
+                    return
+                if (
+                    terminal_edit
+                    and result is _PublicationResult.RETRY
+                    and self._terminal_edit_attempts >= 2
+                ):
+                    return
+                await self._wait(self._wake, self._interval)
+                self._wake.clear()
+                if self._shutdown_requested:
+                    return
+        finally:
+            self._closed.set()
+
+    async def _publish(
+        self, snapshot: SubagentStatusSnapshot
+    ) -> _PublicationResult:
+        text = render_subagent_status(snapshot, now=self._clock())
+        try:
+            if self._message_id is None:
+                result = await self._send(text)
+                if not result.success or result.message_id is None:
+                    return _PublicationResult.ABANDON
+                self._message_id = result.message_id
+                return _PublicationResult.SUCCESS
+            result = await self._edit(self._message_id, text)
+            if result.success:
+                return _PublicationResult.SUCCESS
+            if result.retryable and result.retry_after is None:
+                return _PublicationResult.RETRY
+            return _PublicationResult.ABANDON
+        except Exception:
+            logger.warning("Detached Telegram status publication failed", exc_info=True)
+            return _PublicationResult.ABANDON
+
+
+def create_telegram_subagent_status(
+    *,
+    source: Any,
+    adapter: Any,
+    route_metadata: dict | None,
+    loop: asyncio.AbstractEventLoop,
+    clock: Callable[[], float] = time.monotonic,
+    registry: SubagentStatusRegistry | None = None,
+) -> tuple[SubagentStatusOwner, TelegramSubagentStatusPublisher] | None:
+    platform = getattr(getattr(source, "platform", None), "value", None)
+    edit_implementation = getattr(type(adapter), "edit_message", None)
+    if (
+        platform != "telegram"
+        or not callable(getattr(adapter, "edit_message", None))
+        or edit_implementation is BasePlatformAdapter.edit_message
+    ):
+        return None
+
+    descriptor_for_chat = getattr(adapter, "_descriptor_for_chat", None)
+    if callable(descriptor_for_chat):
+        try:
+            descriptor = descriptor_for_chat(str(source.chat_id))
+            supports_op = getattr(descriptor, "supports_op", None)
+            if (
+                str(getattr(descriptor, "platform", "")).lower()
+                != "telegram"
+                or not bool(getattr(descriptor, "supports_edit", False))
+                or not callable(supports_op)
+                or not supports_op("edit")
+            ):
+                return None
+        except Exception:
+            return None
+
+    chat_id = source.chat_id
+    metadata = copy.deepcopy(route_metadata or {})
+    send_metadata = {**metadata, "_interim_send": True}
+    finalize = bool(getattr(adapter, "REQUIRES_EDIT_FINALIZE", False))
+
+    async def send(text: str) -> SendResult:
+        return await adapter.send(chat_id, text, metadata=send_metadata)
+
+    async def edit(message_id: Any, text: str) -> SendResult:
+        return await adapter.edit_message(
+            chat_id, message_id, text, finalize=finalize
+        )
+
+    publisher = TelegramSubagentStatusPublisher(
+        send=send, edit=edit, clock=clock
+    )
+    on_first_admission = None
+    if registry is not None:
+        on_first_admission = lambda owner: registry.register(owner, publisher)
+    owner = SubagentStatusOwner(
+        loop=loop,
+        on_change=publisher.notify,
+        clock=clock,
+        on_first_admission=on_first_admission,
+    )
+    return owner, publisher
+
+
+def _format_elapsed(seconds: float) -> str:
+    whole_seconds = max(0, int(seconds))
+    minutes, remaining = divmod(whole_seconds, 60)
+    if minutes:
+        return f"{minutes}m{remaining:02d}s"
+    return f"{remaining}s"
+
+
+def render_subagent_status(snapshot: SubagentStatusSnapshot, *, now: float) -> str:
+    """Render one compact, plaintext status board."""
+    rows = snapshot.rows
+    done = sum(row.phase in _TERMINAL_PHASES for row in rows)
+    lines = [f"🔀 Subagents · {done}/{len(rows)} done"]
+    for index, row in enumerate(rows):
+        branch = "└" if index == len(rows) - 1 else "├"
+        finished_at = row.finished_at if row.finished_at is not None else now
+        elapsed = _format_elapsed(finished_at - row.started_at)
+        lines.append(
+            f"{branch} #{row.ordinal} {_PHASE_GLYPHS[row.phase]} "
+            f"{row.phase.value} · {elapsed}"
+        )
+    return "\n".join(lines)

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -93,3 +93,7 @@ class TurnContext:
     _native_slack_task_cards: bool = False
     native_tool_start_callback: Optional[Callable] = None
     native_tool_complete_callback: Optional[Callable] = None
+
+    # Privacy-empty detached status owner for this one gateway turn. Bound only
+    # around AIAgent.run_conversation and sealed as the worker returns.
+    subagent_status_owner: Any = None

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1059,6 +1059,49 @@ async def _run_with_agent(
 
 
 @pytest.mark.asyncio
+async def test_run_agent_inner_passes_normalized_route_to_subagent_status_factory(
+    monkeypatch, tmp_path
+):
+    import gateway.run as gateway_run
+
+    captured = []
+
+    def prepare(self, **kwargs):
+        captured.append(kwargs)
+        return None
+
+    class QuietAgent:
+        def __init__(self, **kwargs):
+            self.tools = []
+
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            return {"final_response": "done", "messages": [], "api_calls": 1}
+
+    monkeypatch.setattr(
+        gateway_run.GatewayRunner, "_prepare_subagent_status_owner", prepare
+    )
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QuietAgent,
+        session_id="sess-subagent-status-wiring",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {"long_running_notifications": "generic"}
+                }
+            }
+        },
+    )
+
+    assert result["final_response"] == "done"
+    assert len(captured) == 1
+    assert captured[0]["adapter"] is adapter
+    assert captured[0]["surface_mode"] == "generic"
+    assert captured[0]["route_metadata"]["thread_id"] == "17585"
+
+
+@pytest.mark.asyncio
 async def test_slack_native_progress_correlates_concurrent_duplicate_tools_by_id(
     monkeypatch, tmp_path
 ):

--- a/tests/gateway/test_subagent_status_board.py
+++ b/tests/gateway/test_subagent_status_board.py
@@ -1,0 +1,778 @@
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.subagent_status import (
+    SubagentStatusBoard,
+    SubagentStatusEvent,
+    SubagentStatusOwner,
+    SubagentStatusPhase,
+    SubagentStatusRegistry,
+    SubagentStatusRow,
+    SubagentStatusSnapshot,
+    TelegramSubagentStatusPublisher,
+    create_telegram_subagent_status,
+    render_subagent_status,
+)
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class _ManualCadence:
+    def __init__(self):
+        self.ticks = asyncio.Queue()
+        self.waiting = asyncio.Event()
+
+    async def wait(self, wake, delay):
+        self.waiting.set()
+        wake_task = asyncio.create_task(wake.wait())
+        tick_task = asyncio.create_task(self.ticks.get())
+        done, pending = await asyncio.wait(
+            {wake_task, tick_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in pending:
+            task.cancel()
+        return wake_task in done
+
+    async def tick(self):
+        self.waiting.clear()
+        self.ticks.put_nowait(None)
+        await asyncio.wait_for(self.waiting.wait(), timeout=1)
+
+
+def test_render_subagent_status_counts_all_terminal_rows_and_freezes_elapsed():
+    snapshot = SubagentStatusSnapshot(
+        rows=(
+            SubagentStatusRow(
+                ordinal=1,
+                phase=SubagentStatusPhase.WAITING,
+                started_at=219.0,
+            ),
+            SubagentStatusRow(
+                ordinal=2,
+                phase=SubagentStatusPhase.FAILED,
+                started_at=104.0,
+                finished_at=223.0,
+            ),
+        )
+    )
+
+    assert render_subagent_status(snapshot, now=224.0) == (
+        "🔀 Subagents · 1/2 done\n"
+        "├ #1 🚀 waiting · 5s\n"
+        "└ #2 ❌ failed · 1m59s"
+    )
+
+
+def test_board_stays_open_between_sequential_batches_until_turn_seals():
+    board = SubagentStatusBoard()
+
+    first = board.admit_batch(task_count=2, at=100.0)
+    board.finalize_batch(
+        first,
+        outcomes=(SubagentStatusPhase.DONE, SubagentStatusPhase.FAILED),
+        at=104.0,
+    )
+
+    assert board.is_terminal is False
+
+    second = board.admit_batch(task_count=1, at=105.0)
+    assert tuple(row.ordinal for row in board.snapshot().rows) == (1, 2, 3)
+
+    board.finalize_batch(
+        second,
+        outcomes=(SubagentStatusPhase.DONE,),
+        at=109.0,
+    )
+    assert board.is_terminal is False
+
+    board.seal()
+    assert board.is_terminal is True
+
+
+def test_board_accepts_only_direct_child_events_and_terminal_rows_are_immutable():
+    board = SubagentStatusBoard()
+    batch = board.admit_batch(task_count=1, at=100.0)
+
+    board.observe(
+        batch,
+        SubagentStatusEvent(
+            task_index=0,
+            depth=2,
+            phase=SubagentStatusPhase.THINKING,
+            at=101.0,
+        ),
+    )
+    assert board.snapshot().rows[0].phase is SubagentStatusPhase.WAITING
+
+    board.observe(
+        batch,
+        SubagentStatusEvent(
+            task_index=0,
+            depth=1,
+            phase=SubagentStatusPhase.THINKING,
+            at=102.0,
+        ),
+    )
+    board.observe(
+        batch,
+        SubagentStatusEvent(
+            task_index=0,
+            depth=1,
+            phase=SubagentStatusPhase.DONE,
+            at=103.0,
+        ),
+    )
+    board.observe(
+        batch,
+        SubagentStatusEvent(
+            task_index=0,
+            depth=1,
+            phase=SubagentStatusPhase.THINKING,
+            at=104.0,
+        ),
+    )
+
+    assert board.snapshot().rows[0] == SubagentStatusRow(
+        ordinal=1,
+        phase=SubagentStatusPhase.DONE,
+        started_at=100.0,
+        finished_at=103.0,
+    )
+
+
+def test_batch_reconciliation_closes_missing_events_without_rewriting_terminal_rows():
+    board = SubagentStatusBoard()
+    batch = board.admit_batch(task_count=3, at=100.0)
+    board.observe(
+        batch,
+        SubagentStatusEvent(
+            task_index=0,
+            depth=1,
+            phase=SubagentStatusPhase.DONE,
+            at=102.0,
+        ),
+    )
+    board.observe(
+        batch,
+        SubagentStatusEvent(
+            task_index=1,
+            depth=1,
+            phase=SubagentStatusPhase.THINKING,
+            at=103.0,
+        ),
+    )
+
+    board.finalize_batch(
+        batch,
+        outcomes=(
+            SubagentStatusPhase.DONE,
+            SubagentStatusPhase.DONE,
+            SubagentStatusPhase.FAILED,
+        ),
+        at=110.0,
+    )
+
+    assert board.snapshot().rows == (
+        SubagentStatusRow(1, SubagentStatusPhase.DONE, 100.0, 102.0),
+        SubagentStatusRow(2, SubagentStatusPhase.DONE, 100.0, 110.0),
+        SubagentStatusRow(3, SubagentStatusPhase.FAILED, 100.0, 110.0),
+    )
+
+
+@pytest.mark.asyncio
+async def test_owner_applies_worker_updates_only_on_gateway_loop():
+    loop_thread = threading.get_ident()
+    callback_threads = []
+    terminal_seen = asyncio.Event()
+
+    def on_change(snapshot, is_terminal):
+        callback_threads.append(threading.get_ident())
+        if is_terminal:
+            terminal_seen.set()
+
+    owner = SubagentStatusOwner(
+        loop=asyncio.get_running_loop(), on_change=on_change, clock=lambda: 20.0
+    )
+    sink = await asyncio.to_thread(owner.admit_batch, 1)
+
+    await asyncio.to_thread(
+        sink.observe,
+        SubagentStatusEvent(0, 1, SubagentStatusPhase.THINKING, 21.0),
+    )
+    await asyncio.to_thread(sink.finalize, (SubagentStatusPhase.DONE,))
+    owner.seal()
+
+    await asyncio.wait_for(terminal_seen.wait(), timeout=1)
+    assert callback_threads
+    assert set(callback_threads) == {loop_thread}
+    assert owner.snapshot().rows == (
+        SubagentStatusRow(1, SubagentStatusPhase.DONE, 20.0, 20.0),
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_publisher_sends_once_then_coalesces_edits_and_flushes_terminal():
+    calls = []
+    now = [0.0]
+    cadence = _ManualCadence()
+
+    async def send(text):
+        calls.append(("send", None, text))
+        return SendResult(success=True, message_id="message-1")
+
+    async def edit(message_id, text):
+        calls.append(("edit", message_id, text))
+        return SendResult(success=True, message_id=message_id)
+
+    publisher = TelegramSubagentStatusPublisher(
+        send=send,
+        edit=edit,
+        clock=lambda: now[0],
+        wait=cadence.wait,
+    )
+    waiting = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.WAITING, 0.0),)
+    )
+    publisher.notify(waiting, is_terminal=False)
+    await asyncio.wait_for(cadence.waiting.wait(), timeout=1)
+
+    thinking = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.THINKING, 0.0),)
+    )
+    publisher.notify(thinking, is_terminal=False)
+    now[0] = 5.0
+    await cadence.tick()
+
+    done = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.DONE, 0.0, 6.0),)
+    )
+    publisher.notify(done, is_terminal=True)
+    await asyncio.wait_for(publisher.wait_closed(), timeout=1)
+
+    assert calls == [
+        ("send", None, "🔀 Subagents · 0/1 done\n└ #1 🚀 waiting · 0s"),
+        ("edit", "message-1", "🔀 Subagents · 0/1 done\n└ #1 💭 thinking · 5s"),
+        ("edit", "message-1", "🔀 Subagents · 1/1 done\n└ #1 ✅ done · 6s"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_terminal_retryable_edit_retries_same_message_at_next_cadence():
+    cadence = _ManualCadence()
+    edit_attempts = 0
+
+    async def send(text):
+        return SendResult(success=True, message_id="message-1")
+
+    async def edit(message_id, text):
+        nonlocal edit_attempts
+        edit_attempts += 1
+        if edit_attempts == 1:
+            return SendResult(success=False, retryable=True)
+        return SendResult(success=True, message_id=message_id)
+
+    publisher = TelegramSubagentStatusPublisher(
+        send=send,
+        edit=edit,
+        clock=lambda: 2.0,
+        wait=cadence.wait,
+    )
+    waiting = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.WAITING, 0.0),)
+    )
+    publisher.notify(waiting, is_terminal=False)
+    await asyncio.wait_for(cadence.waiting.wait(), timeout=1)
+    cadence.waiting.clear()
+
+    done = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.DONE, 0.0, 2.0),)
+    )
+    publisher.notify(done, is_terminal=True)
+    await asyncio.wait_for(cadence.waiting.wait(), timeout=1)
+
+    cadence.ticks.put_nowait(None)
+    await asyncio.wait_for(publisher.wait_closed(), timeout=1)
+    assert edit_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_terminal_retryable_edit_stops_after_two_attempts():
+    cadence = _ManualCadence()
+    edit_attempts = 0
+
+    async def send(text):
+        return SendResult(success=True, message_id="message-1")
+
+    async def edit(message_id, text):
+        nonlocal edit_attempts
+        edit_attempts += 1
+        return SendResult(success=False, retryable=True, error="temporary")
+
+    publisher = TelegramSubagentStatusPublisher(
+        send=send,
+        edit=edit,
+        clock=lambda: 5.0,
+        interval=5.0,
+        wait=cadence.wait,
+    )
+    waiting = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.WAITING, 0.0),)
+    )
+    terminal = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.DONE, 0.0, 5.0),)
+    )
+
+    publisher.notify(waiting, is_terminal=False)
+    await asyncio.wait_for(cadence.waiting.wait(), timeout=1)
+    cadence.waiting.clear()
+    publisher.notify(terminal, is_terminal=True)
+    await asyncio.wait_for(cadence.waiting.wait(), timeout=1)
+    cadence.waiting.clear()
+    cadence.ticks.put_nowait(None)
+
+    await asyncio.wait_for(publisher.wait_closed(), timeout=1)
+    assert edit_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_retryable_edit_with_server_delay_is_not_retried():
+    cadence = _ManualCadence()
+    edit_attempts = 0
+
+    async def send(text):
+        return SendResult(success=True, message_id="message-1")
+
+    async def edit(message_id, text):
+        nonlocal edit_attempts
+        edit_attempts += 1
+        return SendResult(
+            success=False,
+            retryable=True,
+            retry_after=3.0,
+            error="flood wait",
+        )
+
+    publisher = TelegramSubagentStatusPublisher(
+        send=send,
+        edit=edit,
+        clock=lambda: 5.0,
+        interval=5.0,
+        wait=cadence.wait,
+    )
+    waiting = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.WAITING, 0.0),)
+    )
+    terminal = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.DONE, 0.0, 5.0),)
+    )
+
+    publisher.notify(waiting, is_terminal=False)
+    await asyncio.wait_for(cadence.waiting.wait(), timeout=1)
+    publisher.notify(terminal, is_terminal=True)
+
+    await asyncio.wait_for(publisher.wait_closed(), timeout=1)
+    assert edit_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_publisher_shutdown_waits_for_entered_send_and_prohibits_future_calls():
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = []
+
+    async def send(text):
+        calls.append("send")
+        entered.set()
+        await release.wait()
+        return SendResult(success=True, message_id="message-1")
+
+    async def edit(message_id, text):
+        calls.append("edit")
+        return SendResult(success=True, message_id=message_id)
+
+    publisher = TelegramSubagentStatusPublisher(send=send, edit=edit)
+    snapshot = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.WAITING, 0.0),)
+    )
+    publisher.notify(snapshot, is_terminal=False)
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    shutdown_task = asyncio.create_task(publisher.shutdown())
+    release.set()
+    await asyncio.wait_for(shutdown_task, timeout=1)
+
+    publisher.notify(snapshot, is_terminal=True)
+    assert calls == ["send"]
+
+
+@pytest.mark.asyncio
+async def test_factory_pins_route_metadata_for_initial_send():
+    calls = []
+
+    class Adapter:
+        async def send(self, chat_id, content, metadata=None):
+            calls.append((chat_id, content, metadata))
+            return SendResult(success=True, message_id="message-1")
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            raise AssertionError("terminal first publication must not edit")
+
+    route_metadata = {"message_thread_id": 17}
+    pair = create_telegram_subagent_status(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        adapter=Adapter(),
+        route_metadata=route_metadata,
+        loop=asyncio.get_running_loop(),
+        clock=lambda: 4.0,
+    )
+    assert pair is not None
+    _owner, publisher = pair
+    route_metadata["message_thread_id"] = 99
+
+    snapshot = SubagentStatusSnapshot(
+        (SubagentStatusRow(1, SubagentStatusPhase.DONE, 0.0, 4.0),)
+    )
+    publisher.notify(snapshot, is_terminal=True)
+    await asyncio.wait_for(publisher.wait_closed(), timeout=1)
+
+    assert calls == [
+        (
+            "chat-1",
+            "🔀 Subagents · 1/1 done\n└ #1 ✅ done · 4s",
+            {"message_thread_id": 17, "_interim_send": True},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_factory_uses_relay_per_chat_edit_capability():
+    class Adapter:
+        def __init__(self, descriptor):
+            self.descriptor = descriptor
+
+        def _descriptor_for_chat(self, chat_id):
+            return self.descriptor
+
+        async def send(self, chat_id, content, metadata=None):
+            return SendResult(success=True, message_id="message-1")
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            return SendResult(success=True, message_id=message_id)
+
+    def descriptor(platform, supports_edit, supports_op):
+        return SimpleNamespace(
+            platform=platform,
+            supports_edit=supports_edit,
+            supports_op=lambda op: supports_op,
+        )
+
+    source = SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1")
+    loop = asyncio.get_running_loop()
+
+    for rejected in (
+        descriptor("discord", True, True),
+        descriptor("telegram", False, True),
+        descriptor("telegram", True, False),
+    ):
+        assert create_telegram_subagent_status(
+            source=source,
+            adapter=Adapter(rejected),
+            route_metadata=None,
+            loop=loop,
+        ) is None
+
+    assert create_telegram_subagent_status(
+        source=source,
+        adapter=Adapter(descriptor("telegram", True, True)),
+        route_metadata=None,
+        loop=loop,
+    ) is not None
+
+
+@pytest.mark.asyncio
+async def test_factory_rejects_native_adapter_without_edit_override():
+    class Adapter:
+        edit_message = BasePlatformAdapter.edit_message
+
+        async def send(self, chat_id, content, metadata=None):
+            return SendResult(success=True, message_id="message-1")
+
+    assert create_telegram_subagent_status(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        adapter=Adapter(),
+        route_metadata=None,
+        loop=asyncio.get_running_loop(),
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_registry_tracks_only_accepted_owner_once():
+    class Adapter:
+        async def send(self, chat_id, content, metadata=None):
+            return SendResult(success=True, message_id="message-1")
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            return SendResult(success=True, message_id=message_id)
+
+    registry = SubagentStatusRegistry()
+    pair = create_telegram_subagent_status(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        adapter=Adapter(),
+        route_metadata=None,
+        loop=asyncio.get_running_loop(),
+        registry=registry,
+    )
+    assert pair is not None
+    owner, publisher = pair
+    assert registry.active_count == 0
+
+    await asyncio.to_thread(owner.admit_batch, 1)
+    await asyncio.to_thread(owner.admit_batch, 1)
+    assert registry.active_count == 1
+
+    await publisher.shutdown()
+    await asyncio.wait_for(registry.wait_empty(), timeout=1)
+    assert registry.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_registry_retains_cleanup_waiter_until_publisher_closes():
+    async def send(text):
+        return SendResult(success=True, message_id="message-1")
+
+    async def edit(message_id, text):
+        return SendResult(success=True, message_id=message_id)
+
+    loop = asyncio.get_running_loop()
+    registry = SubagentStatusRegistry()
+    publisher = TelegramSubagentStatusPublisher(send=send, edit=edit)
+    owner = SubagentStatusOwner(
+        loop=loop,
+        on_change=publisher.notify,
+    )
+
+    assert registry.register(owner, publisher) is True
+    assert registry.cleanup_task_count == 1
+
+    await publisher.shutdown()
+    await registry.wait_empty()
+    await asyncio.sleep(0)
+    assert registry.cleanup_task_count == 0
+
+
+@pytest.mark.asyncio
+async def test_closed_registry_refuses_first_admission_without_retention():
+    calls = []
+
+    class Adapter:
+        async def send(self, chat_id, content, metadata=None):
+            calls.append("send")
+            return SendResult(success=True, message_id="message-1")
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            return SendResult(success=True, message_id=message_id)
+
+    registry = SubagentStatusRegistry()
+    pair = create_telegram_subagent_status(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        adapter=Adapter(),
+        route_metadata=None,
+        loop=asyncio.get_running_loop(),
+        registry=registry,
+    )
+    assert pair is not None
+    owner, _publisher = pair
+
+    registry.close()
+    with pytest.raises(RuntimeError, match="registry is closed"):
+        await asyncio.to_thread(owner.admit_batch, 1)
+
+    assert registry.active_count == 0
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_closed_registry_refuses_later_batch_on_active_owner():
+    class Adapter:
+        async def send(self, chat_id, content, metadata=None):
+            return SendResult(success=True, message_id="message-1")
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            return SendResult(success=True, message_id=message_id)
+
+    registry = SubagentStatusRegistry()
+    pair = create_telegram_subagent_status(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        adapter=Adapter(),
+        route_metadata=None,
+        loop=asyncio.get_running_loop(),
+        registry=registry,
+    )
+    assert pair is not None
+    owner, publisher = pair
+
+    await asyncio.to_thread(owner.admit_batch, 1)
+    registry.close()
+    with pytest.raises(RuntimeError, match="registry is closed"):
+        await asyncio.to_thread(owner.admit_batch, 1)
+
+    await publisher.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_registry_shutdown_allows_completion_during_grace():
+    calls = []
+    sent = asyncio.Event()
+
+    class Adapter:
+        async def send(self, chat_id, content, metadata=None):
+            calls.append(("send", content))
+            sent.set()
+            return SendResult(success=True, message_id="message-1")
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            calls.append(("edit", content))
+            return SendResult(success=True, message_id=message_id)
+
+    registry = SubagentStatusRegistry()
+    pair = create_telegram_subagent_status(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        adapter=Adapter(),
+        route_metadata=None,
+        loop=asyncio.get_running_loop(),
+        clock=lambda: 9.0,
+        registry=registry,
+    )
+    assert pair is not None
+    owner, _publisher = pair
+
+    sink = await asyncio.to_thread(owner.admit_batch, 1)
+    await asyncio.wait_for(sent.wait(), timeout=1)
+    shutdown = asyncio.create_task(registry.shutdown(timeout=1))
+    await asyncio.sleep(0)
+    await asyncio.to_thread(sink.finalize, (SubagentStatusPhase.DONE,))
+    await shutdown
+
+    assert registry.active_count == 0
+    assert calls == [
+        ("send", "🔀 Subagents · 0/1 done\n└ #1 🚀 waiting · 0s"),
+        ("edit", "🔀 Subagents · 1/1 done\n└ #1 ✅ done · 0s"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_registry_shutdown_cancels_publisher_after_bound():
+    entered = asyncio.Event()
+    never = asyncio.Event()
+
+    class Adapter:
+        async def send(self, chat_id, content, metadata=None):
+            entered.set()
+            await never.wait()
+            return SendResult(success=True, message_id="message-1")
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            raise AssertionError("send never produced an editable message")
+
+    registry = SubagentStatusRegistry()
+    pair = create_telegram_subagent_status(
+        source=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        adapter=Adapter(),
+        route_metadata=None,
+        loop=asyncio.get_running_loop(),
+        registry=registry,
+    )
+    assert pair is not None
+    owner, _publisher = pair
+
+    await asyncio.to_thread(owner.admit_batch, 1)
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    await asyncio.wait_for(registry.shutdown(timeout=0.01), timeout=1)
+
+    assert registry.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_sealing_unadmitted_owner_stays_inert():
+    changes = []
+    owner = SubagentStatusOwner(
+        loop=asyncio.get_running_loop(),
+        on_change=lambda snapshot, terminal: changes.append((snapshot, terminal)),
+    )
+
+    owner.request_seal()
+    await asyncio.sleep(0)
+
+    assert changes == []
+
+
+def test_timed_out_admission_cannot_execute_later():
+    loop = asyncio.new_event_loop()
+    changes = []
+    owner = SubagentStatusOwner(
+        loop=loop,
+        on_change=lambda snapshot, terminal: changes.append((snapshot, terminal)),
+        admission_timeout=0.01,
+    )
+    try:
+        with pytest.raises(TimeoutError):
+            owner.admit_batch(1)
+        loop.run_until_complete(asyncio.sleep(0))
+        assert changes == []
+    finally:
+        loop.close()
+
+
+def test_gateway_runner_prepares_inert_owner_only_when_surface_enabled():
+    from gateway.run import GatewayRunner
+
+    class Adapter:
+        async def send(self, chat_id, content, metadata=None):
+            return SendResult(success=True, message_id="message-1")
+
+        async def edit_message(
+            self, chat_id, message_id, content, *, finalize=False
+        ):
+            return SendResult(success=True, message_id=message_id)
+
+    runner = object.__new__(GatewayRunner)
+    source = SimpleNamespace(platform=Platform.TELEGRAM, chat_id="chat-1")
+    loop = asyncio.new_event_loop()
+    try:
+        assert runner._prepare_subagent_status_owner(
+            source=source,
+            adapter=Adapter(),
+            route_metadata=None,
+            surface_mode="off",
+            loop=loop,
+        ) is None
+        assert not hasattr(runner, "_subagent_status_registry")
+
+        owner = runner._prepare_subagent_status_owner(
+            source=source,
+            adapter=Adapter(),
+            route_metadata=None,
+            surface_mode="generic",
+            loop=loop,
+        )
+        assert owner is not None
+        assert runner._subagent_status_registry.active_count == 0
+    finally:
+        loop.close()

--- a/tests/gateway/test_turn_context.py
+++ b/tests/gateway/test_turn_context.py
@@ -18,6 +18,7 @@ import pytest
 from gateway.config import Platform
 from gateway.session import SessionSource
 from gateway.turn_context import TurnContext
+from tools.delegation_status import get_detached_status_owner
 
 
 def _make_runner(ctx):
@@ -68,6 +69,30 @@ class TestTurnRunner:
         ctx = TurnContext(progress_queue=queue_mod.Queue())
         runner = _make_runner(ctx)  # stub adapter resolver returns None
         assert asyncio.run(runner.send_progress_messages()) is None
+
+    def test_run_conversation_binds_owner_only_for_call_and_requests_seal(self):
+        sealed = []
+
+        class Owner:
+            def request_seal(self):
+                sealed.append(True)
+
+        owner = Owner()
+
+        class Agent:
+            def run_conversation(self, message, **kwargs):
+                assert get_detached_status_owner() is owner
+                return {"final_response": message}
+
+        ctx = TurnContext(subagent_status_owner=owner)
+        runner = _make_runner(ctx)
+
+        assert get_detached_status_owner() is None
+        assert runner._run_conversation_with_status(Agent(), "hello", {}) == {
+            "final_response": "hello"
+        }
+        assert get_detached_status_owner() is None
+        assert sealed == [True]
 
     def test_normal_response_preserves_compression_exhausted(self):
         """A non-empty exhaustion response must still reach auto-reset consumers."""

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -498,6 +498,67 @@ def test_list_async_delegations_exposes_live_activity(monkeypatch):
         gate.set()
 
 
+def test_stalled_batch_finalizes_status_when_completion_publication_fails(monkeypatch):
+    from tools.delegation_status import DetachedStatusPhase
+
+    outcomes = []
+    delegation_id = "deleg_stalled_status"
+    with ad._records_lock:
+        ad._records[delegation_id] = {
+            "delegation_id": delegation_id,
+            "status": "stalling",
+            "is_batch": True,
+            "goals": ["one", "two"],
+            "dispatched_at": time.time() - 5,
+            "completed_at": None,
+            "interrupt_fn": None,
+            "progress_fn": None,
+            "status_finalize_fn": outcomes.append,
+        }
+
+    def fail_publication(*args, **kwargs):
+        raise RuntimeError("queue failed")
+
+    monkeypatch.setattr(ad, "_push_batch_completion_event", fail_publication)
+
+    with pytest.raises(RuntimeError, match="queue failed"):
+        ad._finalize_stalled(delegation_id)
+
+    assert outcomes == [
+        (DetachedStatusPhase.FAILED, DetachedStatusPhase.FAILED)
+    ]
+
+
+def test_malformed_batch_result_cannot_strand_finalization(monkeypatch):
+    from tools.delegation_status import DetachedStatusPhase
+
+    outcomes = []
+    delegation_id = "deleg_malformed_status"
+    with ad._records_lock:
+        ad._records[delegation_id] = {
+            "delegation_id": delegation_id,
+            "status": "running",
+            "is_batch": True,
+            "goals": ["one"],
+            "dispatched_at": time.time(),
+            "completed_at": None,
+            "interrupt_fn": None,
+            "progress_fn": None,
+            "status_finalize_fn": outcomes.append,
+        }
+
+    monkeypatch.setattr(ad, "_push_batch_completion_event", lambda *a, **k: None)
+    ad._finalize_batch(
+        delegation_id,
+        {"results": [None]},
+        "completed",
+    )
+
+    assert outcomes == [(DetachedStatusPhase.FAILED,)]
+    with ad._records_lock:
+        assert ad._records[delegation_id]["status"] == "completed"
+
+
 def test_in_tool_stall_uses_higher_threshold(monkeypatch):
     """A frozen child inside a tool gets the in-tool ceiling, not the idle one."""
     _fast_stale_monitor(monkeypatch, idle=0.1, in_tool=10.0, grace=0.1)
@@ -648,6 +709,169 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert "the real task" in text
 
 
+def test_background_status_admits_before_worker_and_finalizes_from_results(monkeypatch):
+    from unittest.mock import MagicMock
+
+    import tools.delegate_tool as dt
+    from tools.delegation_status import (
+        DetachedStatusPhase,
+        bind_detached_status_owner,
+        get_detached_status_owner,
+    )
+
+    child_gate = threading.Event()
+    worker_started = threading.Event()
+    worker_owner_values = []
+
+    class Sink:
+        def __init__(self):
+            self.outcomes = []
+
+        def observe(self, event):
+            pass
+
+        def finalize(self, outcomes):
+            self.outcomes.append(outcomes)
+
+    sink = Sink()
+
+    class Owner:
+        def __init__(self):
+            self.admissions = []
+
+        def admit_batch(self, task_count):
+            assert worker_started.is_set() is False
+            self.admissions.append(task_count)
+            return sink
+
+    owner = Owner()
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "sess"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+    fake_child = MagicMock()
+    fake_child._delegate_role = "leaf"
+    fake_child._subagent_id = "s1"
+    fake_child.tool_progress_callback = None
+
+    def gated_child(task_index, goal, child=None, parent_agent=None, **kwargs):
+        worker_owner_values.append(get_detached_status_owner())
+        worker_started.set()
+        child_gate.wait(timeout=10)
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "m",
+            "exit_reason": "completed",
+        }
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kwargs: fake_child)
+    monkeypatch.setattr(dt, "_run_single_child", gated_child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+
+    try:
+        with bind_detached_status_owner(owner):
+            result = json.loads(
+                dt.delegate_task(
+                    goal="status task",
+                    background=True,
+                    parent_agent=parent,
+                )
+            )
+        assert result["status"] == "dispatched"
+        assert owner.admissions == [1]
+        assert worker_started.wait(timeout=2)
+        assert worker_owner_values == [None]
+    finally:
+        child_gate.set()
+
+    event = _drain_for(result["delegation_id"])
+    assert event is not None
+    assert sink.outcomes == [(DetachedStatusPhase.DONE,)]
+
+
+def test_accepted_background_dispatch_installs_structural_event_tee(monkeypatch):
+    from unittest.mock import MagicMock
+
+    import tools.delegate_tool as dt
+    from tools.delegation_status import (
+        DetachedStatusPhase,
+        bind_detached_status_owner,
+    )
+
+    class Sink:
+        def __init__(self):
+            self.events = []
+
+        def observe(self, event):
+            self.events.append(event)
+
+        def finalize(self, outcomes):
+            pass
+
+    sink = Sink()
+
+    class Owner:
+        def admit_batch(self, task_count):
+            assert task_count == 1
+            return sink
+
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.session_id = "sess"
+    parent._interrupt_requested = False
+    parent._active_children = []
+    parent._active_children_lock = None
+    child = MagicMock()
+    child._delegate_role = "leaf"
+    child._subagent_id = "s1"
+    child.tool_progress_callback = None
+
+    def emitting_child(
+        task_index, goal, child=None, parent_agent=None, **kwargs
+    ):
+        assert child is not None
+        callback = child.tool_progress_callback
+        callback("subagent.start", preview="private goal")
+        callback("_thinking", "private reasoning")
+        callback("subagent.complete", status="completed", summary="private result")
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": "private result",
+        }
+
+    creds = {
+        "model": "m", "provider": None, "base_url": None, "api_key": None,
+        "api_mode": None, "command": None, "args": None,
+    }
+    monkeypatch.setattr(dt, "_build_child_agent", lambda **kwargs: child)
+    monkeypatch.setattr(dt, "_run_single_child", emitting_child)
+    monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
+
+    with bind_detached_status_owner(Owner()):
+        result = json.loads(
+            dt.delegate_task(
+                goal="status task", background=True, parent_agent=parent
+            )
+        )
+    assert _drain_for(result["delegation_id"]) is not None
+    assert [(event.task_index, event.depth, event.phase) for event in sink.events] == [
+        (0, 1, DetachedStatusPhase.WAITING),
+        (0, 1, DetachedStatusPhase.THINKING),
+        (0, 1, DetachedStatusPhase.DONE),
+    ]
+
+
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     """TUI async delegation must route to the live/compressed agent id.
 
@@ -740,6 +964,91 @@ def test_concurrent_dispatch_respects_capacity():
     statuses = sorted(r["status"] for r in results)
     assert statuses == ["dispatched", "rejected"]
     gate.set()
+
+
+def test_batch_persistence_failure_rolls_back_before_worker_submission(monkeypatch):
+    worker_started = threading.Event()
+
+    def runner():
+        worker_started.set()
+        return {"results": []}
+
+    def fail_persistence(record):
+        raise RuntimeError("disk failed")
+
+    monkeypatch.setattr(ad, "_persist_dispatch", fail_persistence)
+
+    with pytest.raises(RuntimeError, match="disk failed"):
+        ad.dispatch_async_delegation_batch(
+            goals=["persist me"],
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="",
+            runner=runner,
+            max_async_children=1,
+        )
+
+    assert ad.active_count() == 0
+    assert worker_started.is_set() is False
+
+
+def test_partial_persistence_failure_removes_durable_record(monkeypatch):
+    delegation_id = "deleg_partial_persistence"
+
+    def fail_pruning():
+        raise RuntimeError("prune failed")
+
+    monkeypatch.setattr(ad, "_prune_durable_records", fail_pruning)
+
+    with pytest.raises(RuntimeError, match="prune failed"):
+        ad.dispatch_async_delegation_batch(
+            goals=["persist me"],
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="",
+            runner=lambda: {"results": []},
+            max_async_children=1,
+            delegation_id=delegation_id,
+        )
+
+    with ad._DB_LOCK, ad._transaction() as conn:
+        row = conn.execute(
+            "SELECT 1 FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        ).fetchone()
+    assert row is None
+
+
+def test_single_persistence_failure_rolls_back_before_worker_submission(monkeypatch):
+    worker_started = threading.Event()
+
+    def runner():
+        worker_started.set()
+        return {"status": "completed", "summary": "done"}
+
+    def fail_persistence(record):
+        raise RuntimeError("disk failed")
+
+    monkeypatch.setattr(ad, "_persist_dispatch", fail_persistence)
+
+    with pytest.raises(RuntimeError, match="disk failed"):
+        ad.dispatch_async_delegation(
+            goal="persist me",
+            context=None,
+            toolsets=None,
+            role="leaf",
+            model="m",
+            session_key="",
+            runner=runner,
+            max_async_children=1,
+        )
+
+    assert ad.active_count() == 0
+    assert worker_started.is_set() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1344,6 +1344,39 @@ class TestChildCredentialLeasing(unittest.TestCase):
         child._swap_credential.assert_called_once_with(leased_entry)
         child._credential_pool.release_lease.assert_called_once_with("cred-b")
 
+    def test_run_single_child_clears_gateway_status_owner(self):
+        from tools.delegate_tool import _run_single_child
+        from tools.delegation_status import (
+            bind_detached_status_owner,
+            get_detached_status_owner,
+        )
+
+        owner = object()
+        child = MagicMock()
+        child._credential_pool = None
+
+        def run_conversation(**kwargs):
+            self.assertIsNone(get_detached_status_owner())
+            return {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+
+        child.run_conversation.side_effect = run_conversation
+        with bind_detached_status_owner(owner):
+            result = _run_single_child(
+                task_index=0,
+                goal="nested work",
+                child=child,
+                parent_agent=_make_mock_parent(),
+            )
+            self.assertIs(get_detached_status_owner(), owner)
+
+        self.assertEqual(result["status"], "completed")
+
     def test_run_single_child_releases_lease_after_failure(self):
         from tools.delegate_tool import _run_single_child
 

--- a/tests/tools/test_delegation_status.py
+++ b/tests/tools/test_delegation_status.py
@@ -1,0 +1,167 @@
+from dataclasses import fields
+from typing import Any
+
+from tools.delegation_status import (
+    DetachedStatusEvent,
+    DetachedStatusPhase,
+    attach_detached_status_sink,
+    bind_detached_status_owner,
+    get_detached_status_owner,
+)
+
+
+def test_detached_status_contract_is_privacy_empty_and_turn_scoped():
+    owner = object()
+
+    assert get_detached_status_owner() is None
+    with bind_detached_status_owner(owner):
+        assert get_detached_status_owner() is owner
+        assert tuple(field.name for field in fields(DetachedStatusEvent)) == (
+            "task_index",
+            "depth",
+            "phase",
+            "at",
+        )
+        assert DetachedStatusEvent(
+            task_index=0,
+            depth=1,
+            phase=DetachedStatusPhase.WAITING,
+            at=10.0,
+        ).phase is DetachedStatusPhase.WAITING
+    assert get_detached_status_owner() is None
+
+
+def test_structural_tee_preserves_display_callback_without_copying_content():
+    class Child:
+        def __init__(self):
+            self.tool_progress_callback: Any = None
+
+    class Sink:
+        def __init__(self):
+            self.events = []
+
+        def observe(self, event):
+            self.events.append(event)
+
+    child = Child()
+    display_events = []
+    child.tool_progress_callback = (
+        lambda event_type, *args, **kwargs: display_events.append(
+            (event_type, args, kwargs)
+        )
+    )
+    sink = Sink()
+
+    attach_detached_status_sink(child, sink, task_index=2, clock=lambda: 42.0)
+    child.tool_progress_callback(
+        "subagent.start", preview="secret goal", model="secret model"
+    )
+    child.tool_progress_callback("_thinking", "secret reasoning", depth=2)
+    child.tool_progress_callback(
+        "subagent.complete", summary="secret summary", status="failed"
+    )
+
+    assert [event[0] for event in display_events] == [
+        "subagent.start",
+        "_thinking",
+        "subagent.complete",
+    ]
+    assert sink.events == [
+        DetachedStatusEvent(2, 1, DetachedStatusPhase.WAITING, 42.0),
+        DetachedStatusEvent(2, 2, DetachedStatusPhase.THINKING, 42.0),
+        DetachedStatusEvent(2, 1, DetachedStatusPhase.FAILED, 42.0),
+    ]
+
+
+def test_display_callback_failure_does_not_block_structural_status():
+    class Child:
+        def __init__(self):
+            self.tool_progress_callback: Any = None
+
+    class Sink:
+        def __init__(self):
+            self.events = []
+
+        def observe(self, event):
+            self.events.append(event)
+
+    child = Child()
+
+    def broken_display(*args, **kwargs):
+        raise RuntimeError("display broke")
+
+    child.tool_progress_callback = broken_display
+    sink = Sink()
+    attach_detached_status_sink(child, sink, task_index=0, clock=lambda: 7.0)
+
+    child.tool_progress_callback("_thinking", "private reasoning")
+
+    assert sink.events == [
+        DetachedStatusEvent(0, 1, DetachedStatusPhase.THINKING, 7.0)
+    ]
+
+
+def test_reasoning_tool_and_progress_events_project_as_thinking():
+    class Child:
+        def __init__(self):
+            self.tool_progress_callback: Any = None
+
+    class Sink:
+        def __init__(self):
+            self.events = []
+
+        def observe(self, event):
+            self.events.append(event)
+
+    child = Child()
+    sink = Sink()
+    attach_detached_status_sink(child, sink, task_index=1, clock=lambda: 8.0)
+
+    event_types = (
+        "_thinking",
+        "reasoning.available",
+        "tool.started",
+        "tool.completed",
+        "subagent_progress",
+        "delegate.task_thinking",
+        "delegate.tool_started",
+        "delegate.tool_completed",
+        "delegate.task_progress",
+    )
+    for event_type in event_types:
+        child.tool_progress_callback(event_type)
+
+    assert [event.phase for event in sink.events] == [
+        DetachedStatusPhase.THINKING for _ in event_types
+    ]
+
+
+def test_only_explicit_success_completion_projects_as_done():
+    class Child:
+        def __init__(self):
+            self.tool_progress_callback: Any = None
+
+    class Sink:
+        def __init__(self):
+            self.events = []
+
+        def observe(self, event):
+            self.events.append(event)
+
+    child = Child()
+    sink = Sink()
+    attach_detached_status_sink(child, sink, task_index=0, clock=lambda: 9.0)
+
+    statuses = ("completed", "success", "failed", "error", "timeout", "stalled", "cancelled")
+    for status in statuses:
+        child.tool_progress_callback("subagent.complete", status=status)
+
+    assert [event.phase for event in sink.events] == [
+        DetachedStatusPhase.DONE,
+        DetachedStatusPhase.DONE,
+        DetachedStatusPhase.FAILED,
+        DetachedStatusPhase.FAILED,
+        DetachedStatusPhase.FAILED,
+        DetachedStatusPhase.FAILED,
+        DetachedStatusPhase.FAILED,
+    ]

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -183,6 +183,22 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
     _prune_durable_records()
 
 
+def _persist_dispatch_or_rollback(delegation_id: str, record: Dict[str, Any]) -> None:
+    """Persistence is part of admission: never leave an active ghost on failure."""
+    try:
+        _persist_dispatch(record)
+    except Exception:
+        with _records_lock:
+            if _records.get(delegation_id) is record:
+                _records.pop(delegation_id, None)
+        try:
+            with _DB_LOCK, _transaction() as conn:
+                conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
+        except Exception:
+            logger.warning("Failed to remove partially persisted async delegation %s", delegation_id, exc_info=True)
+        raise
+
+
 def _prune_durable_records() -> None:
     """Bound terminal history, preferring delivered records for deletion."""
     cutoff = time.time() - _DURABLE_RETENTION_SECONDS
@@ -589,7 +605,7 @@ def _dispatch(
             return {"status": "rejected", "error": capacity_error}
         _records[delegation_id] = record
         live_units = sum(1 for r in _records.values() if r.get("status") in _LIVE_STATES)
-    _persist_dispatch(record)
+    _persist_dispatch_or_rollback(delegation_id, record)
     # Units of one call share a slot, so live units can exceed slots: size the pool by units or a
     # unit queues behind a full pool and the stale monitor kills it before its child ever starts.
     executor = _get_executor(max(max_async_children, live_units))
@@ -791,6 +807,60 @@ def push_task_failure_notice(delegation_id: str, entry: Dict[str, Any], *, n_tas
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
         logger.error("Async delegation batch %s: failed to enqueue task failure notice: %s", delegation_id, exc)
+
+
+def _finalize_status_projection(record: Dict[str, Any], combined: Dict[str, Any]) -> None:
+    callback = record.get("status_finalize_fn")
+    if not callable(callback):
+        return
+    from tools.delegation_status import DetachedStatusPhase
+    task_count = len(record.get("goals") or ())
+    outcomes = [DetachedStatusPhase.FAILED] * task_count
+    for entry in combined.get("results") or ():
+        if isinstance(entry, dict) and isinstance(entry.get("task_index"), int):
+            index = entry["task_index"]
+            if 0 <= index < task_count and entry.get("status") in {"completed", "success"}:
+                outcomes[index] = DetachedStatusPhase.DONE
+    callback(tuple(outcomes))
+
+
+def _push_batch_completion_event(record: Dict[str, Any], combined: Dict[str, Any], status: str) -> None:
+    _push_completion_event(record, combined, status)
+
+
+def _finalize_batch(delegation_id: str, combined: Dict[str, Any], status: str) -> None:
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is None or record.get("status") not in _ACTIVE_STATES:
+            return
+        record.update(status="finalizing", completed_at=time.time(), interrupt_fn=None, progress_fn=None)
+        snapshot = dict(record)
+    try:
+        _push_batch_completion_event(snapshot, combined, status)
+    finally:
+        _finalize_status_projection(snapshot, combined)
+        with _records_lock:
+            if delegation_id in _records:
+                _records[delegation_id]["status"] = status
+            _prune_completed_locked()
+
+
+def _finalize_stalled(delegation_id: str) -> None:
+    with _records_lock:
+        record = _records.get(delegation_id)
+        if record is None or record.get("status") not in _ACTIVE_STATES:
+            return
+        record.update(status="finalizing", completed_at=time.time(), interrupt_fn=None, progress_fn=None)
+        snapshot = dict(record)
+    result = {"results": [], "error": "stalled", "total_duration_seconds": 0.0}
+    try:
+        _push_batch_completion_event(snapshot, result, "stalled")
+    finally:
+        _finalize_status_projection(snapshot, result)
+        with _records_lock:
+            if delegation_id in _records:
+                _records[delegation_id]["status"] = "stalled"
+            _prune_completed_locked()
 
 
 # ── Stale monitor ───────────────────────────────────────────────────────────

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -655,7 +655,8 @@ class _ChildRun:
         def _run_with_thread_capture():
             worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+            from tools.delegation_status import bind_detached_status_owner
+            with delegated_child_context(str(getattr(child, "session_id", "") or "")), bind_detached_status_owner(None):
                 return child.run_conversation(
                     user_message=self.goal, task_id=self.child_task_id, stream_callback=self.relay_text,
                 )

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -344,6 +344,26 @@ def _dispatch_unit(unit: _Batch, unit_id: Optional[str], slot_key: Optional[str]
     """Hand ONE unit to the async registry; the runner joins on that unit's children only."""
     from tools.async_delegation import dispatch_async_delegation_batch
     child_agents = [c for (_, _, c) in unit.children]
+    from tools.delegation_status import attach_detached_status_sink, get_detached_status_owner, DetachedStatusPhase
+
+    owner = get_detached_status_owner()
+    sink = owner.admit_batch(len(unit.children)) if owner is not None else None
+    if sink is not None:
+        for task_index, _task, child in unit.children:
+            attach_detached_status_sink(child, sink, task_index=task_index)
+
+    def _runner():
+        from tools.delegation_status import bind_detached_status_owner
+        with bind_detached_status_owner(None):
+            result = _execute_and_aggregate(unit, honor_parent_interrupt=False)
+        if sink is not None:
+            outcomes = tuple(
+                DetachedStatusPhase.DONE if entry.get("status") in {"completed", "success"}
+                else DetachedStatusPhase.FAILED
+                for entry in result.get("results") or ()
+            )
+            sink.finalize(outcomes)
+        return result
 
     def _interrupt():
         for c in child_agents:
@@ -354,7 +374,7 @@ def _dispatch_unit(unit: _Batch, unit_id: Optional[str], slot_key: Optional[str]
         goals=[t["goal"] for t in unit.task_list], context=unit.context,
         toolsets=None,  # metadata for the completion block only; subagents inherit the parent's toolsets
         role=unit.top_role, model=unit.creds["model"],
-        runner=lambda: _execute_and_aggregate(unit, honor_parent_interrupt=False),
+        runner=_runner,
         interrupt_fn=_interrupt, delegation_id=unit_id, slot_key=slot_key,
         task_indexes=[i for (i, _, _) in unit.children] if len(unit.children) < len(unit.task_list) else None,
         progress_fn=lambda: _batch_progress_token(child_agents), **routing,

--- a/tools/delegation_status.py
+++ b/tools/delegation_status.py
@@ -1,0 +1,100 @@
+"""Channel-neutral, privacy-empty detached status contracts."""
+
+from __future__ import annotations
+
+import contextvars
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Iterator
+
+
+class DetachedStatusPhase(str, Enum):
+    WAITING = "waiting"
+    THINKING = "thinking"
+    DONE = "done"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class DetachedStatusEvent:
+    task_index: int
+    depth: int
+    phase: DetachedStatusPhase
+    at: float
+
+
+_THINKING_EVENTS = frozenset(
+    {
+        "_thinking",
+        "reasoning.available",
+        "tool.started",
+        "tool.completed",
+        "subagent_progress",
+        "delegate.task_thinking",
+        "delegate.tool_started",
+        "delegate.tool_completed",
+        "delegate.task_progress",
+    }
+)
+
+
+_DETACHED_STATUS_OWNER: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+    "hermes_detached_status_owner", default=None
+)
+
+
+def get_detached_status_owner() -> object | None:
+    return _DETACHED_STATUS_OWNER.get()
+
+
+def attach_detached_status_sink(
+    child: Any,
+    sink: Any,
+    *,
+    task_index: int,
+    clock: Callable[[], float] = time.monotonic,
+) -> None:
+    display_callback = getattr(child, "tool_progress_callback", None)
+
+    def _tee(event_type: Any, *args: Any, **kwargs: Any) -> None:
+        if display_callback is not None:
+            try:
+                display_callback(event_type, *args, **kwargs)
+            except Exception:
+                pass
+
+        name = getattr(event_type, "value", event_type)
+        if name == "subagent.start":
+            phase = DetachedStatusPhase.WAITING
+        elif name in _THINKING_EVENTS:
+            phase = DetachedStatusPhase.THINKING
+        elif name == "subagent.complete":
+            phase = (
+                DetachedStatusPhase.DONE
+                if kwargs.get("status") in ("completed", "success")
+                else DetachedStatusPhase.FAILED
+            )
+        else:
+            return
+        depth = kwargs.get("depth", 1)
+        sink.observe(
+            DetachedStatusEvent(
+                task_index=task_index,
+                depth=depth if isinstance(depth, int) else 1,
+                phase=phase,
+                at=clock(),
+            )
+        )
+
+    child.tool_progress_callback = _tee
+
+
+@contextmanager
+def bind_detached_status_owner(owner: object | None) -> Iterator[None]:
+    token = _DETACHED_STATUS_OWNER.set(owner)
+    try:
+        yield
+    finally:
+        _DETACHED_STATUS_OWNER.reset(token)


### PR DESCRIPTION
Supersedes the stale draft implementation in #90677 and preserves its contributor history while porting it onto current `main`.

This adds an origin-aware detached-subagent status board for Telegram/forum topics, with lifecycle isolation, privacy-safe progress projection, atomic dispatch persistence, and failure/stall finalization.

Verification: 201 focused tests passed via `scripts/run_tests.sh`; compilation and `git diff --check` passed. One macOS child-session database path assertion is a pre-existing baseline failure: it fails unchanged on current `main` as well as this branch (`/tmp` versus `/private/tmp`).

No gateway, account setting, or default local installation was modified.

Refs #90608 and #90677.