### PR TITLE
fix(kanban): explicit scratch/empty project on kanban_create never becomes a project worktree (#106342, salvage #106347)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -63,10 +63,11 @@ def _run_state_kwargs(args: argparse.Namespace, cmd: str) -> tuple[Optional[dict
     return ({} if st is None else {"state_type": st, "state_name": sn}), 0
 
 
-def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
-    """``--workspace`` -> ``(kind, path|None)``: ``scratch``, ``worktree``, ``worktree:<p>``, ``dir:<p>``."""
+def _parse_workspace_flag(value: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """``--workspace`` -> ``(kind, path|None)``: ``scratch``, ``worktree``, ``worktree:<p>``, ``dir:<p>``.
+    Omitted -> ``(None, None)`` so ``create_task`` can tell "default" from an explicit scratch."""
     if not value:
-        return ("scratch", None)
+        return (None, None)
     v = value.strip()
     if v in {"scratch", "worktree"}:
         return (v, None)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1221,7 +1221,7 @@ def _normalize_task_skills(skills: Optional[Iterable[str]]) -> Optional[list[str
 def create_task(
     conn: sqlite3.Connection, *, title: str, body: Optional[str] = None,
     assignee: Optional[str] = None, created_by: Optional[str] = None,
-    workspace_kind: str = "scratch", workspace_path: Optional[str] = None,
+    workspace_kind: Optional[str] = None, workspace_path: Optional[str] = None,
     branch_name: Optional[str] = None, tenant: Optional[str] = None, priority: int = 0,
     parents: Iterable[str] = (), triage: bool = False, idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None, skills: Optional[Iterable[str]] = None,
@@ -1245,6 +1245,8 @@ def create_task(
     dependency edges; an explicit ``session_id`` still wins.
     ``project_source_task_id``: cross-profile fallback when ``project_id`` is not
     in the active profile's projects.db — see ``_resolve_project_link``.
+    ``workspace_kind=None`` (omitted) inherits a project-scoped board's project;
+    an explicit ``"scratch"`` or ``project_id=""`` is a request for no project.
     """
     from hermes_cli.kanban_db_graph import initial_task_state, inherit_creator_origin
     from hermes_cli.kanban_pr_acceptance import validate_contract
@@ -1257,6 +1259,17 @@ def create_task(
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}")
+    # A project-scoped board anchors every new task to its project's repo
+    # (deterministic worktree + branch) without each surface repeating it.
+    # An explicit ``scratch`` (or ``project_id=""``) is a request for no project:
+    # it must not be upgraded to a worktree in the board's repo (#106342).
+    if project_id is None and workspace_kind != "scratch":
+        try:
+            project_id = (_board_meta_for(board).get("project_id") or "").strip() or None
+        except Exception:
+            pass
+    if workspace_kind is None:
+        workspace_kind = "scratch"
     if workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
             f"workspace_kind must be one of {sorted(VALID_WORKSPACE_KINDS)}, "
@@ -1266,14 +1279,6 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
-
-    # A project-scoped board anchors every new task to its project's repo
-    # (deterministic worktree + branch) without each surface repeating it.
-    if project_id is None:
-        try:
-            project_id = (_board_meta_for(board).get("project_id") or "").strip() or None
-        except Exception:
-            pass
 
     project_id, project_obj, project_repo, workspace_kind = _resolve_project_link(
         conn, project_id, project_source_task_id, workspace_kind, workspace_path

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -150,8 +150,9 @@ _SPECS = [
         _arg("--body", help="Optional opening post"),
         _arg("--assignee", help="Profile name to assign"),
         _arg("--parent", action="append", default=[], help="Parent task id (repeatable)"),
-        _arg("--workspace", default="scratch",
-             help="scratch | worktree | worktree:<path> | dir:<path> (default: scratch)"),
+        _arg("--workspace",
+             help="scratch | worktree | worktree:<path> | dir:<path> (default: scratch; "
+                  "an explicit 'scratch' also opts out of a project-scoped board's project)"),
         _arg("--branch", help="Branch name for worktree tasks, e.g. wt/t6-wire"),
         _arg("--project",
              help="Link to a project (id or slug). Anchors the task's "

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -115,7 +115,7 @@ def create_swarm(
     synthesizer_title: str = "Synthesize swarm outputs",
     tenant: Optional[str] = None,
     created_by: str = "swarm-orchestrator",
-    workspace_kind: str = "scratch",
+    workspace_kind: Optional[str] = None,
     workspace_path: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
@@ -166,7 +166,7 @@ def _create_swarm_uncommitted(
     conn: sqlite3.Connection, *, goal: str, workers: Iterable[SwarmWorkerSpec],
     verifier_assignee: str, synthesizer_assignee: str, root_title: Optional[str],
     verifier_title: str, synthesizer_title: str, tenant: Optional[str], created_by: str,
-    workspace_kind: str, workspace_path: Optional[str], priority: int, idempotency_key: Optional[str],
+    workspace_kind: Optional[str], workspace_path: Optional[str], priority: int, idempotency_key: Optional[str],
 ) -> SwarmCreated:
     """Create the swarm graph inside the caller's transaction: planning root
     (``blocked`` until the caller activates it), parallel workers, a verifier

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -355,7 +355,7 @@ class CreateTaskBody(BaseModel):
     assignee: Optional[str] = None
     tenant: Optional[str] = None
     priority: int = 0
-    workspace_kind: str = "scratch"
+    workspace_kind: Optional[str] = None  # None = scratch, or the board project's worktree when scoped
     workspace_path: Optional[str] = None
     parents: list[str] = Field(default_factory=list)
     triage: bool = False

--- a/tests/hermes_cli/test_kanban_board_project.py
+++ b/tests/hermes_cli/test_kanban_board_project.py
@@ -86,3 +86,24 @@ def test_create_task_explicit_project_beats_board(fresh_home, tmp_path):
         assert kb.get_task(conn, tid).project_id == task_proj
     finally:
         conn.close()
+
+
+def test_create_task_explicit_scratch_beats_board(fresh_home, tmp_path):
+    """#106342: every surface (CLI --workspace scratch, dashboard workspace_kind,
+    tool) funnels here; an explicit scratch on a project-scoped board must stay
+    scratch, while an omitted kind still inherits the project worktree."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as pconn:
+        proj_id = pdb.create_project(pconn, name="Widget", primary_path=str(repo))
+
+    kb.create_board("scoped3", name="Scoped3", project_id=proj_id)
+    conn = kbc.connect(board="scoped3")
+    try:
+        scratch = kb.get_task(conn, kb.create_task(
+            conn, title="explicit scratch", board="scoped3", workspace_kind="scratch"))
+        assert (scratch.workspace_kind, scratch.project_id) == ("scratch", None)
+        default = kb.get_task(conn, kb.create_task(conn, title="default", board="scoped3"))
+        assert (default.workspace_kind, default.project_id) == ("worktree", proj_id)
+    finally:
+        conn.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -429,6 +429,43 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+@pytest.mark.parametrize("explicit", [
+    {"workspace_kind": "scratch"},
+    {"project": ""},
+])
+def test_create_explicit_scratch_ignores_ambient_board_project(
+    worker_env, tmp_path, explicit,
+):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import projects_db as pdb
+    from tools import kanban_tools as kt
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as pconn:
+        project_id = pdb.create_project(pconn, name="Ambient", primary_path=str(repo))
+
+    kb.write_board_metadata("default", project_id=project_id)
+    kb.create_board("target", name="Target", project_id="")
+
+    result = json.loads(kt._handle_create({
+        "board": "target",
+        "title": "stay scratch",
+        "assignee": "peer",
+        **explicit,
+    }))
+
+    assert result["ok"] is True
+    assert result["project_id"] is None
+    assert result["workspace_kind"] == "scratch"
+
+    with kbc.connect_closing(board="target") as conn:
+        control = kb.create_task(
+            conn, title="direct scratch", board="target", workspace_kind="scratch")
+        assert kb.get_task(conn, control).project_id is None
+
+
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
     from hermes_cli import kanban_db_connect as kbc

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -429,15 +429,15 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
-@pytest.mark.parametrize("explicit", [
-    {"workspace_kind": "scratch"},
-    {"project": ""},
-])
+@pytest.mark.parametrize("explicit", [{"workspace_kind": "scratch"}, {"project": ""}])
+@pytest.mark.parametrize("target_scoped", [False, True])
 def test_create_explicit_scratch_ignores_ambient_board_project(
-    worker_env, tmp_path, explicit,
+    worker_env, tmp_path, explicit, target_scoped,
 ):
+    """#106342: an explicit scratch / empty project wins over the project the
+    session's current board (and, when scoped, the target board itself) carries.
+    Omitting both still inherits the target board's project."""
     from hermes_cli import kanban_db as kb
-    from hermes_cli import kanban_db_connect as kbc
     from hermes_cli import projects_db as pdb
     from tools import kanban_tools as kt
 
@@ -445,25 +445,17 @@ def test_create_explicit_scratch_ignores_ambient_board_project(
     repo.mkdir()
     with pdb.connect_closing() as pconn:
         project_id = pdb.create_project(pconn, name="Ambient", primary_path=str(repo))
-
     kb.write_board_metadata("default", project_id=project_id)
-    kb.create_board("target", name="Target", project_id="")
+    kb.create_board("target", name="Target", project_id=project_id if target_scoped else "")
 
-    result = json.loads(kt._handle_create({
-        "board": "target",
-        "title": "stay scratch",
-        "assignee": "peer",
-        **explicit,
-    }))
+    def create(**extra):
+        result = json.loads(kt._handle_create(
+            {"board": "target", "title": "card", "assignee": "peer", **extra}))
+        assert result["ok"] is True
+        return result["workspace_kind"], result["project_id"]
 
-    assert result["ok"] is True
-    assert result["project_id"] is None
-    assert result["workspace_kind"] == "scratch"
-
-    with kbc.connect_closing(board="target") as conn:
-        control = kb.create_task(
-            conn, title="direct scratch", board="target", workspace_kind="scratch")
-        assert kb.get_task(conn, control).project_id is None
+    assert create(**explicit) == ("scratch", None)
+    assert create() == (("worktree", project_id) if target_scoped else ("scratch", None))
 
 
 def test_link_happy_path(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -815,15 +815,8 @@ def _handle_create(args: dict, **kw) -> str:
     # mutate review evidence or race its checkout). Project identity is the one safe thing
     # to inherit implicitly (the DB turns it into a fresh per-task worktree).
     workspace_kind, workspace_path = args.get("workspace_kind"), args.get("workspace_path")
-    # See #67567.
-    project_arg_present = "project" in args or "project_id" in args
+    # See #67567. ``project=""`` is an explicit "no project" (no ``or`` collapse, #106342).
     project_id = args["project"] if "project" in args else args.get("project_id")
-    # An explicit scratch request suppresses board project inheritance, while an
-    # explicit project may still intentionally turn scratch into a project worktree.
-    if not project_arg_present and "workspace_kind" in args and workspace_kind == "scratch":
-        project_id = ""
-    workspace_args_omitted = not any(
-        key in args for key in ("project", "project_id", "workspace_kind", "workspace_path"))
     project_source_task_id = None
     triage, skills, goal_mode = (
         _parse_bool_arg(args, "triage"), _coerce_str_list(args.get("skills"), "skills", "skill names"),
@@ -839,16 +832,16 @@ def _handle_create(args: dict, **kw) -> str:
         # The worker/API runtime may be transient; the owning task's origin is durable.
         session_id = (args.get("session_id") or (self_task.session_id if self_task else None)
                       or _current_origin_session_id() or os.environ.get("HERMES_SESSION_ID"))
-        if workspace_args_omitted:
+        if project_id is None and workspace_kind is None and workspace_path is None:
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id
         new_tid = kb.create_task(
             conn, title=str(title).strip(), body=args.get("body"), assignee=str(assignee),
             parents=tuple(parents), tenant=args.get("tenant") or os.environ.get("HERMES_TENANT"),
             priority=_opt_int(args.get("priority"), 0),
-            workspace_kind=str(workspace_kind if workspace_kind is not None else "scratch"),
-            workspace_path=workspace_path, project_id=project_id,
-            # Keep metadata inheritance scoped to the same board DB opened above.
+            workspace_kind=workspace_kind, workspace_path=workspace_path, project_id=project_id,
+            # Board-project inheritance must read the board this call opened, not the
+            # session's current board.
             board=args.get("board"),
             project_source_task_id=project_source_task_id, triage=triage,
             creator_task_id=self_tid,

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -816,7 +816,14 @@ def _handle_create(args: dict, **kw) -> str:
     # to inherit implicitly (the DB turns it into a fresh per-task worktree).
     workspace_kind, workspace_path = args.get("workspace_kind"), args.get("workspace_path")
     # See #67567.
-    project_id = args.get("project") or args.get("project_id")
+    project_arg_present = "project" in args or "project_id" in args
+    project_id = args["project"] if "project" in args else args.get("project_id")
+    # An explicit scratch request suppresses board project inheritance, while an
+    # explicit project may still intentionally turn scratch into a project worktree.
+    if not project_arg_present and "workspace_kind" in args and workspace_kind == "scratch":
+        project_id = ""
+    workspace_args_omitted = not any(
+        key in args for key in ("project", "project_id", "workspace_kind", "workspace_path"))
     project_source_task_id = None
     triage, skills, goal_mode = (
         _parse_bool_arg(args, "triage"), _coerce_str_list(args.get("skills"), "skills", "skill names"),
@@ -832,7 +839,7 @@ def _handle_create(args: dict, **kw) -> str:
         # The worker/API runtime may be transient; the owning task's origin is durable.
         session_id = (args.get("session_id") or (self_task.session_id if self_task else None)
                       or _current_origin_session_id() or os.environ.get("HERMES_SESSION_ID"))
-        if project_id is None and workspace_kind is None and workspace_path is None:
+        if workspace_args_omitted:
             if self_task is not None and self_task.project_id:
                 project_id, project_source_task_id = self_task.project_id, self_task.id
         new_tid = kb.create_task(
@@ -841,6 +848,8 @@ def _handle_create(args: dict, **kw) -> str:
             priority=_opt_int(args.get("priority"), 0),
             workspace_kind=str(workspace_kind if workspace_kind is not None else "scratch"),
             workspace_path=workspace_path, project_id=project_id,
+            # Keep metadata inheritance scoped to the same board DB opened above.
+            board=args.get("board"),
             project_source_task_id=project_source_task_id, triage=triage,
             creator_task_id=self_tid,
             idempotency_key=args.get("idempotency_key"),


### PR DESCRIPTION
`kanban_create` with an explicit `workspace_kind: "scratch"` (or `project: ""`) now lands a scratch card with no project, on every surface — instead of being silently upgraded to a git worktree in the board's project repo.

## What changed

- `hermes_cli/kanban_db.py::create_task` (the one resolver every surface funnels through): board-project inheritance runs only when the caller left `workspace_kind` open (`None`); an explicit `scratch` is a request for no project. `workspace_kind` now defaults to scratch *after* that check.
- `tools/kanban_tools.py::_handle_create`: `project=""` is preserved as an explicit clear (no `or` collapse), `workspace_kind` is passed through unchanged, and inheritance is scoped to the board the call opened (`board=`) rather than the session's current board.
- Same bug class on sibling surfaces, fixed by the same resolver change:
  - CLI `hermes kanban create --workspace scratch` on a project-scoped board produced a project worktree — `--workspace` no longer defaults in argparse, so the resolver can tell "omitted" from "scratch".
  - Dashboard `POST /tasks` with `workspace_kind: "scratch"` did the same — `CreateTaskBody.workspace_kind` defaults to `None`.
  - `kanban_swarm.create_swarm` threads `None` through for consistency.
- Intentional behaviour kept: omitted args still inherit a project-scoped board's project (and a dispatcher-owned worker's `self_task` project); an explicit `project` still turns scratch into a project worktree.

## Validation

Live repro (real imports, temp `HERMES_HOME`, real git repo as the active project's primary path, cwd inside it, session current board project-scoped, target board unscoped):

| Surface / call | Before (origin/main) | After |
|---|---|---|
| tool, no args, target board unscoped | `worktree` / `p_…` (inherited from the *session's* board) | `scratch` / `None` |
| tool, `workspace_kind="scratch"` | `worktree` / `p_…` | `scratch` / `None` |
| tool, `project=""` | `worktree` / `p_…` | `scratch` / `None` |
| tool, `project=""` on a project-scoped board | `worktree` / `p_…` | `scratch` / `None` |
| CLI `--board scoped create --workspace scratch` | `worktree` / `p_…` | `scratch` / `None` |
| dashboard `POST /tasks?board=scoped {workspace_kind: scratch}` | `worktree` / `p_…` | `scratch` / `None` |
| tool/CLI/dashboard, no workspace args on a scoped board (intentional) | `worktree` / `p_…` | unchanged |
| tool/dashboard, explicit `project` (intentional) | `worktree` / `p_…` | unchanged |

- New tests proven red on `origin/main` (5 failed), green with the fix.
- `scripts/run_tests.sh` over `tests/tools/test_kanban*`, `tests/hermes_cli/test_kanban*`, `tests/hermes_cli/test_projects*`, `tests/plugins/test_kanban*`, `tests/cron/`: 1385 + 486 passed. One pre-existing failure on this host, `test_kanban_gateway_restart_handoff.py::test_real_user_systemd_scope_preserves_worker_context` (systemd `--user --scope` receipt; fails identically on plain `origin/main`, unrelated).
- `ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check` clean.

## Root cause

`create_task` inherited the board's `project_id` whenever `project_id is None`, regardless of `workspace_kind`, and every caller collapsed "omitted" into `"scratch"` before reaching it; the tool handler additionally read the *session's* current board (no `board=`) and `or`-collapsed `project=""` into `None`.

Salvages #106347 from @KoNit-K (tool-handler fix and regression test, cherry-picked with authorship; follow-up widens the fix to the shared resolver, CLI and dashboard).
Closes #106342

## Infographic
![kanban-create-honor-explicit-scratch](https://v3b.fal.media/files/b/0aa9bb02/RAkJ2mi6bTQ-q9g6v7h-h_PwNLykKX.png)
