### PR TITLE
fix(tui_gateway): a stalled WebSocket send no longer blocks every later event and RPC reply (#106369, salvage #106372)

### DIFF
--- a/tests/tui_gateway/test_ws_send_timeout.py
+++ b/tests/tui_gateway/test_ws_send_timeout.py
@@ -1,38 +1,34 @@
-"""A stalled ``send_text`` must not hold the writer lock forever (#106369).
+"""A stalled ``send_text`` must have a bounded lifetime (#106369).
 
-Without a send deadline, socket backpressure parks ``_safe_send_many`` inside
-``_send_lock`` and ``_closed`` never latches, so reconnect recovery cannot
-start. With the fix, a stalled send times out, latches the transport closed,
-and a queued second batch returns immediately instead of blocking forever.
+``_safe_send_many`` awaits the socket while holding the connection-wide ``_send_lock``. Without a
+deadline, one send parked by socket backpressure trapped every later event and RPC reply behind the
+lock on an apparently open connection, so reconnect recovery never started.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 
-import tui_gateway.ws as ws_mod
 from tui_gateway.ws import WSTransport
 
 
 class _StalledWS:
-    """``send_text`` never completes — models socket backpressure."""
+    """``send_text`` never completes (kernel backpressure); ``close`` is observable."""
 
     def __init__(self) -> None:
-        self.sent: list[str] = []
+        self.closed_with: list[int] = []
         self._release = asyncio.Event()
 
     async def send_text(self, line: str) -> None:
-        await self._release.wait()  # never set during the test
-        self.sent.append(line)
+        await self._release.wait()
 
     async def close(self, code: int = 1000) -> None:
+        self.closed_with.append(code)
         self._release.set()
 
 
 class _FastWS:
-    """``send_text`` completes immediately — guards against the timeout
-    breaking the happy path."""
-
     def __init__(self) -> None:
         self.sent: list[str] = []
 
@@ -40,54 +36,36 @@ class _FastWS:
         self.sent.append(line)
 
 
-def test_stalled_send_latches_closed() -> None:
+def test_stalled_send_closes_socket_and_releases_queued_reply(monkeypatch):
+    # raising=False: on a base without the deadline the test must fail on the SYMPTOM (sends never terminate).
+    monkeypatch.setattr("tui_gateway.ws._WS_SEND_DEADLINE_S", 0.05, raising=False)
+
     async def _run() -> None:
-        loop = asyncio.get_running_loop()
         ws = _StalledWS()
-        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
-        orig = ws_mod._WS_WRITE_TIMEOUT_S
-        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
-        try:
-            await transport._safe_send_many(["first"])
-        finally:
-            ws_mod._WS_WRITE_TIMEOUT_S = orig
-        assert transport.closed is True, "stalled send must latch the transport closed"
-        assert ws.sent == [], "the stalled frame must not be recorded as sent"
+        transport = WSTransport(ws, asyncio.get_running_loop(), peer="127.0.0.1:1")
+        progress = asyncio.create_task(transport.write_async({"method": "event", "params": {"type": "tool.progress"}}))
+        await asyncio.sleep(0)  # progress is now inside send_text, holding _send_lock
+        reply = asyncio.create_task(transport.write_async({"id": "submit", "result": {"status": "streaming"}}))
+        # The loop stays responsive; both sends must still terminate within the deadline (not the 2s cap).
+        results = await asyncio.wait_for(asyncio.gather(progress, reply), timeout=2.0)
+        assert results == [False, False], "a send that missed the deadline must report failure, not success"
+        assert transport.closed, "the transport must latch closed so handle_ws teardown/reconnect can run"
+        await asyncio.sleep(0)  # let the scheduled close task run
+        assert ws.closed_with == [1011], "the stalled socket must be closed, not left half-open"
 
     asyncio.run(_run())
 
 
-def test_queued_batch_returns_immediately_after_timeout() -> None:
+def test_progress_then_final_ordering_preserved_on_healthy_socket():
     async def _run() -> None:
-        loop = asyncio.get_running_loop()
-        ws = _StalledWS()
-        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
-        orig = ws_mod._WS_WRITE_TIMEOUT_S
-        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
-        try:
-            await transport._safe_send_many(["first"])
-            # _closed is now True; the second batch must not queue on _send_lock.
-            await transport._safe_send_many(["second"])
-        finally:
-            ws_mod._WS_WRITE_TIMEOUT_S = orig
-        assert transport.closed is True
-        assert ws.sent == []
-
-    asyncio.run(_run())
-
-
-def test_normal_send_completes_within_timeout() -> None:
-    async def _run() -> None:
-        loop = asyncio.get_running_loop()
         ws = _FastWS()
-        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
-        orig = ws_mod._WS_WRITE_TIMEOUT_S
-        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
-        try:
-            await transport._safe_send_many(["a", "b", "c"])
-        finally:
-            ws_mod._WS_WRITE_TIMEOUT_S = orig
-        assert transport.closed is False, "a fast send must not latch the transport closed"
-        assert ws.sent == ["a", "b", "c"]
+        transport = WSTransport(ws, asyncio.get_running_loop(), peer="127.0.0.1:1")
+        assert await transport.write_async({"method": "event", "params": {"type": "tool.progress"}})
+        assert await transport.write_async({"method": "event", "params": {"type": "message.complete"}})
+        assert await transport.write_async({"id": "submit", "result": {"status": "done"}})
+        assert not transport.closed
+        assert [json.loads(s).get("params", {}).get("type", "reply") for s in ws.sent] == [
+            "tool.progress", "message.complete", "reply",
+        ]
 
     asyncio.run(_run())

--- a/tests/tui_gateway/test_ws_send_timeout.py
+++ b/tests/tui_gateway/test_ws_send_timeout.py
@@ -1,0 +1,93 @@
+"""A stalled ``send_text`` must not hold the writer lock forever (#106369).
+
+Without a send deadline, socket backpressure parks ``_safe_send_many`` inside
+``_send_lock`` and ``_closed`` never latches, so reconnect recovery cannot
+start. With the fix, a stalled send times out, latches the transport closed,
+and a queued second batch returns immediately instead of blocking forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import tui_gateway.ws as ws_mod
+from tui_gateway.ws import WSTransport
+
+
+class _StalledWS:
+    """``send_text`` never completes — models socket backpressure."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self._release = asyncio.Event()
+
+    async def send_text(self, line: str) -> None:
+        await self._release.wait()  # never set during the test
+        self.sent.append(line)
+
+    async def close(self, code: int = 1000) -> None:
+        self._release.set()
+
+
+class _FastWS:
+    """``send_text`` completes immediately — guards against the timeout
+    breaking the happy path."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send_text(self, line: str) -> None:
+        self.sent.append(line)
+
+
+def test_stalled_send_latches_closed() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _StalledWS()
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        orig = ws_mod._WS_WRITE_TIMEOUT_S
+        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
+        try:
+            await transport._safe_send_many(["first"])
+        finally:
+            ws_mod._WS_WRITE_TIMEOUT_S = orig
+        assert transport.closed is True, "stalled send must latch the transport closed"
+        assert ws.sent == [], "the stalled frame must not be recorded as sent"
+
+    asyncio.run(_run())
+
+
+def test_queued_batch_returns_immediately_after_timeout() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _StalledWS()
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        orig = ws_mod._WS_WRITE_TIMEOUT_S
+        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
+        try:
+            await transport._safe_send_many(["first"])
+            # _closed is now True; the second batch must not queue on _send_lock.
+            await transport._safe_send_many(["second"])
+        finally:
+            ws_mod._WS_WRITE_TIMEOUT_S = orig
+        assert transport.closed is True
+        assert ws.sent == []
+
+    asyncio.run(_run())
+
+
+def test_normal_send_completes_within_timeout() -> None:
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        ws = _FastWS()
+        transport = WSTransport(ws, loop, peer="127.0.0.1:1")
+        orig = ws_mod._WS_WRITE_TIMEOUT_S
+        ws_mod._WS_WRITE_TIMEOUT_S = 0.05
+        try:
+            await transport._safe_send_many(["a", "b", "c"])
+        finally:
+            ws_mod._WS_WRITE_TIMEOUT_S = orig
+        assert transport.closed is False, "a fast send must not latch the transport closed"
+        assert ws.sent == ["a", "b", "c"]
+
+    asyncio.run(_run())

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -183,7 +183,15 @@ class WSTransport:
                     return
                 payload = _sanitize_ws_text(line)
                 try:
-                    await self._ws.send_text(payload)
+                    await asyncio.wait_for(self._ws.send_text(payload), timeout=_WS_WRITE_TIMEOUT_S)
+                except asyncio.TimeoutError as exc:
+                    # A stalled send_text (socket backpressure) must not hold the writer lock forever.
+                    # Unlike the loop-stall case in write(), this means the socket itself is unresponsive:
+                    # latch closed so queued batches bail and reconnect recovery can start. See #106369.
+                    self._closed = True
+                    _log.warning("ws send timed out peer=%s timeout=%ss error_type=%s error=%s",
+                                 self._peer, _WS_WRITE_TIMEOUT_S, type(exc).__name__, exc)
+                    return
                 except UnicodeEncodeError as exc:
                     # A single illegal UTF-8 frame (lone surrogate) must not tear down the socket.
                     _log.warning("ws send skipped invalid utf-8 frame peer=%s error=%s", self._peer, exc)

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -58,6 +58,13 @@ def _sanitize_ws_text(text: str) -> str:
 # Max seconds a pool-dispatched handler blocks waiting for the loop to flush a WS frame before we
 # give up waiting (the transport is NOT marked dead).
 _WS_WRITE_TIMEOUT_S = 10.0
+# Max seconds one send_text may await the socket once it is actually running on the loop. A healthy
+# socket returns from send_text without waiting (the frame lands in the transport buffer); only kernel
+# backpressure parks it, so a GIL/loop stall cannot start this clock. Deliberately 3x the worker wait
+# above and under the client's 45s heartbeat deadline (apps/shared json-rpc-gateway): a peer that
+# cannot drain ~48 KiB in 30s is gone, and closing here starts its reconnect instead of leaving every
+# later frame and RPC reply parked behind the writer lock (#106369).
+_WS_SEND_DEADLINE_S = 30.0
 _WS_LOG_PAYLOAD_PREVIEW = 240
 
 # Per-token streaming frames are coalesced: buffered and flushed as a batch on a short timer instead
@@ -183,14 +190,16 @@ class WSTransport:
                     return
                 payload = _sanitize_ws_text(line)
                 try:
-                    await asyncio.wait_for(self._ws.send_text(payload), timeout=_WS_WRITE_TIMEOUT_S)
-                except asyncio.TimeoutError as exc:
-                    # A stalled send_text (socket backpressure) must not hold the writer lock forever.
-                    # Unlike the loop-stall case in write(), this means the socket itself is unresponsive:
-                    # latch closed so queued batches bail and reconnect recovery can start. See #106369.
+                    await asyncio.wait_for(self._ws.send_text(payload), timeout=_WS_SEND_DEADLINE_S)
+                except asyncio.TimeoutError:
+                    # The loop is responsive (the timer fired) but the socket never drained: unlike the
+                    # loop-stall wait in write(), this is a dead peer. Latch under the writer lock so queued
+                    # batches bail, and close the socket so handle_ws's read loop ends and its teardown
+                    # (session detach/reap, client reconnect) runs. See #106369.
                     self._closed = True
-                    _log.warning("ws send timed out peer=%s timeout=%ss error_type=%s error=%s",
-                                 self._peer, _WS_WRITE_TIMEOUT_S, type(exc).__name__, exc)
+                    _log.warning("ws send deadline exceeded (socket stalled, loop responsive) peer=%s deadline=%ss — closing",
+                                 self._peer, _WS_SEND_DEADLINE_S)
+                    self._loop.create_task(self._close_stalled_socket())
                     return
                 except UnicodeEncodeError as exc:
                     # A single illegal UTF-8 frame (lone surrogate) must not tear down the socket.
@@ -207,6 +216,14 @@ class WSTransport:
         if self._token_flush_handle is not None:
             self._token_flush_handle.cancel()
             self._token_flush_handle = None
+
+    async def _close_stalled_socket(self) -> None:
+        """Close the peer socket after a send deadline so ``handle_ws``'s ``receive_text`` unblocks and its
+        disconnect teardown runs. The server library bounds this (websockets ``close_timeout`` → abort)."""
+        try:
+            await self._ws.close(code=1011)
+        except Exception as exc:  # noqa: BLE001 - the peer is already gone; teardown is what matters
+            _log.debug("ws close after send deadline failed peer=%s error=%s", self._peer, exc)
 
 
 def _ws_peer_label(ws: Any) -> str:


### PR DESCRIPTION
A WebSocket send that the peer never drains now terminates after 30 s, closes the socket, and lets the Desktop/dashboard reconnect — instead of parking every later event and RPC reply behind the writer lock on a connection that still looks open.

Fixes #106369. Salvage of #106372 by @gaoanze888 (cherry-picked, authorship preserved) plus a maintainer follow-up.

## Changes
- `tui_gateway/ws.py::WSTransport._safe_send_many` — the actual `await self._ws.send_text(...)` is wrapped in `asyncio.wait_for` (from #106372). On timeout it latches `_closed` under the writer lock so queued batches bail (#106372), and **closes the socket with 1011** so `handle_ws`'s `receive_text` unblocks and the normal disconnect teardown (unregister live transport, detach/reap sessions, client reconnect + replay) runs (follow-up).
- New `_WS_SEND_DEADLINE_S = 30.0`, separate from the 10 s `_WS_WRITE_TIMEOUT_S` the PR reused (follow-up). The 10 s constant is the worker-side wait for the *loop* to run the send and deliberately never marks the transport dead (#48445 / #55545: GIL-heavy turns stall the loop >10 s routinely). The new clock is different in kind: `wait_for` starts it only when the coroutine actually runs on the loop, and a healthy socket returns from `send_text` without waiting, so only real kernel backpressure can consume it. Verified a loop stall 3× the deadline does not trip it on 3.11/3.12/3.13. 30 s = 3× the worker wait and under the client's 45 s heartbeat deadline (`apps/shared` `json-rpc-gateway`). The issue's request "do not mark dead at the 10 s worker wait" is honoured.
- Diagnostic distinguishes the two stalls: `ws send deadline exceeded (socket stalled, loop responsive)` vs `write()`'s existing `ws write slow (loop stalled …)`.
- `contributors/emails/gaoanze888@gmail.com` mapping.

## Dropped from #106372 (shape gates)
- Tests trimmed 3 → 2 in my own commit (`test_ws_send_timeout.py`): one invariant per behaviour class, using the issue's own two-queued-`write_async` shape. The contributor's `_closed`-only assertions did not check that the socket gets closed or that the queued RPC reply is released.

## Validation
| | Before (origin/main) | After (this branch) |
|---|---|---|
| Issue's repro script (stalled `send_text`, loop responsive) | `sends STILL pending after 2.0s (unbounded); transport.closed=False` | `sends terminated on their own after 0.40s; closed=[1011]; transport.closed=True` (deadline set to 0.5 s for the run) |
| `tests/tui_gateway/test_ws_send_timeout.py` | `test_stalled_send_closes_socket_and_releases_queued_reply` FAILS on the symptom (2 s cap `TimeoutError`, sends never terminate) | 2 passed |
| `tests/tui_gateway/` + `tests/test_tui_gateway_ws.py` (mirror dirs, incl. replay tests) | — | 126 files, 1103 passed, 0 failed |
| E2E: real uvicorn + Starlette WS, two `websockets.sync` clients, one never reads (kernel backpressure), writes from a worker thread, deadline 2 s | — | stuck peer: `write()` returns False after 2.19 s, transport closed, endpoint teardown ran (after websockets' own 10 s close handshake bound × 3 stages, ~30 s); healthy peer: all 71 frames in order, final RPC reply delivered, never closed |

**Live repro:** before — both queued sends pending indefinitely, socket never closed / after — sends fail within the deadline, socket closed 1011, transport closed.

Root cause: `_safe_send_many` held the connection-wide `_send_lock` across an unbounded `await send_text()`, so one send parked by socket backpressure trapped every later frame behind the lock while `_closed` stayed False and no teardown path could ever observe the dead peer.

## Credits
- @gaoanze888 — #106372, the fix (cherry-picked as author).
- @zhangweiooy — #106369, report with the deterministic in-process repro used as the live repro here, and the design constraints (bound the actual await, close on failure, do not trip at the 10 s worker wait, distinguish loop-stall vs socket-stall).

## Infographic
![ws-send-deadline](https://v3b.fal.media/files/b/0aa9bb1d/RTNsbrtxPTpxWa-MDIBvG_mYPIXBUl.png)
