### PR TITLE
fix(tools): browser_exec timeout kills the whole CLI process tree instead of orphaning pipe-holders (#106244, salvage #106265)

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -14,6 +14,8 @@ Covers the three seams the integration relies on:
 import json
 import os
 import stat
+import subprocess
+import sys
 import time
 
 import pytest
@@ -1338,3 +1340,80 @@ class TestLightpandaStatusLine:
         out = self._status(monkeypatch, used=False, reason="cloud provider Browserbase is selected")
         assert "NOT in use" in out
         assert "Browserbase" in out
+
+
+class TestTimeoutProcessGroupKill:
+    """#106244: on timeout the whole CLI process group must die. A pipe-holding
+    grandchild (browser_harness daemon / Chrome helper) otherwise keeps communicate()
+    blocked forever, and the wedged call's activity heartbeat pins the session at
+    "now" in the sidebar indefinitely."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_timeout_kills_grandchild_and_returns_promptly(self, tmp_path, monkeypatch):
+        """A grandchild that outlives the direct child and holds the inherited stdout
+        pipe must not keep browser_exec blocked past the timeout (it wedged permanently
+        before the group kill)."""
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {})
+        pid_file = tmp_path / "grandchild.pid"
+        cli = _fake_cli(tmp_path, (
+            "cat > /dev/null\n"
+            "sleep 60 &\n"
+            "echo $! > \"" + str(pid_file) + "\"\n"
+            "sleep 60\n"
+        ))
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        start = time.time()
+        result = json.loads(bu_cli.browser_exec("print(1)", timeout_s=bu_cli._MIN_TIMEOUT_S))
+        elapsed = time.time() - start
+
+        assert "timed out" in result["error"]
+        # Pre-fix, this hangs until the 60s sleeps expire — and forever with a daemon child.
+        assert elapsed < 30
+        # The pipe-holding grandchild died with the group instead of leaking.
+        pid = int(pid_file.read_text().strip())
+        time.sleep(0.5)
+        with pytest.raises(OSError):
+            os.kill(pid, 0)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_gone_group_still_surfaces_timeout(self, monkeypatch):
+        """killpg can race an already-exited group; the timeout must still surface."""
+        waits = []
+
+        class _FakeProc:
+            pid = 424242
+            returncode = None
+
+            def communicate(self, input=None, timeout=None):
+                waits.append(timeout)
+                if input is not None:
+                    raise subprocess.TimeoutExpired("browser-use", timeout)
+                return ("", "")
+
+        monkeypatch.setattr(bu_cli.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+        def _gone_group(pgid, sig):
+            raise ProcessLookupError()
+
+        monkeypatch.setattr(bu_cli.os, "killpg", _gone_group)
+        with pytest.raises(subprocess.TimeoutExpired):
+            bu_cli._run_cli_killing_process_group(["x"], "code", {}, 5)
+        # First wait is the tool timeout, second is the bounded post-kill drain.
+        assert waits == [5, bu_cli._POST_KILL_DRAIN_S]
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
+    def test_post_kill_drain_is_bounded(self, monkeypatch):
+        """If even the post-kill drain misses its deadline, give up instead of wedging."""
+
+        class _StuckProc:
+            pid = 424243
+            returncode = None
+
+            def communicate(self, input=None, timeout=None):
+                raise subprocess.TimeoutExpired("browser-use", timeout)
+
+        monkeypatch.setattr(bu_cli.subprocess, "Popen", lambda *a, **k: _StuckProc())
+        monkeypatch.setattr(bu_cli.os, "killpg", lambda pgid, sig: None)
+        with pytest.raises(subprocess.TimeoutExpired):
+            bu_cli._run_cli_killing_process_group(["x"], "code", {}, 5)

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -1376,7 +1376,6 @@ class TestTimeoutProcessGroupKill:
         with pytest.raises(OSError):
             os.kill(pid, 0)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
     def test_post_kill_drain_is_bounded(self, monkeypatch):
         """If even the post-kill drain misses its deadline, give up instead of wedging."""
 
@@ -1388,6 +1387,6 @@ class TestTimeoutProcessGroupKill:
                 raise subprocess.TimeoutExpired("browser-use", timeout)
 
         monkeypatch.setattr(bu_cli.subprocess, "Popen", lambda *a, **k: _StuckProc())
-        monkeypatch.setattr(bu_cli.os, "killpg", lambda pgid, sig: None)
+        monkeypatch.setattr(bu_cli, "_kill_cli_process_group", lambda proc: None)
         with pytest.raises(subprocess.TimeoutExpired):
             bu_cli._run_cli_killing_process_group(["x"], "code", {}, 5)

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -1377,32 +1377,6 @@ class TestTimeoutProcessGroupKill:
             os.kill(pid, 0)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
-    def test_gone_group_still_surfaces_timeout(self, monkeypatch):
-        """killpg can race an already-exited group; the timeout must still surface."""
-        waits = []
-
-        class _FakeProc:
-            pid = 424242
-            returncode = None
-
-            def communicate(self, input=None, timeout=None):
-                waits.append(timeout)
-                if input is not None:
-                    raise subprocess.TimeoutExpired("browser-use", timeout)
-                return ("", "")
-
-        monkeypatch.setattr(bu_cli.subprocess, "Popen", lambda *a, **k: _FakeProc())
-
-        def _gone_group(pgid, sig):
-            raise ProcessLookupError()
-
-        monkeypatch.setattr(bu_cli.os, "killpg", _gone_group)
-        with pytest.raises(subprocess.TimeoutExpired):
-            bu_cli._run_cli_killing_process_group(["x"], "code", {}, 5)
-        # First wait is the tool timeout, second is the bounded post-kill drain.
-        assert waits == [5, bu_cli._POST_KILL_DRAIN_S]
-
-    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process groups")
     def test_post_kill_drain_is_bounded(self, monkeypatch):
         """If even the post-kill drain misses its deadline, give up instead of wedging."""
 

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -538,7 +538,8 @@ def _run_cli_killing_process_group(cmd, code, env, timeout):
         stdout, stderr = proc.communicate(input=code, timeout=timeout)
     except subprocess.TimeoutExpired:
         with contextlib.suppress(ProcessLookupError, PermissionError):
-            os.killpg(proc.pid, signal.SIGKILL)  # start_new_session=True: pgid == pid
+            # start_new_session=True: pgid == pid; POSIX-only, browser_exec gates this helper behind os.name != "nt".
+            os.killpg(proc.pid, signal.SIGKILL)  # windows-footgun: ok
         try:
             proc.communicate(timeout=_POST_KILL_DRAIN_S)
         except subprocess.TimeoutExpired:

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -516,6 +517,36 @@ def _clamp_timeout(timeout_s: Any) -> int:
         return _DEFAULT_TIMEOUT_S
 
 
+# After a whole-group SIGKILL, every pipe holder is dead, so the drain below is normally
+# instant; the deadline only guards against a process outside the group still holding a pipe.
+_POST_KILL_DRAIN_S = 10.0
+
+
+def _run_cli_killing_process_group(cmd, code, env, timeout):
+    """Run the CLI in its own session and SIGKILL the whole process group on timeout.
+
+    ``subprocess.run`` only kills the direct child on ``TimeoutExpired``; a browser_harness
+    daemon / Chrome helper grandchild inherits the stdout/stderr pipes and keeps them open,
+    so the internal ``communicate()`` blocks on pipe EOF forever and the tool call — plus its
+    activity heartbeat — wedges permanently (#106244).
+    """
+    proc = subprocess.Popen(
+        cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, env=env, start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(input=code, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(ProcessLookupError, PermissionError):
+            os.killpg(proc.pid, signal.SIGKILL)  # start_new_session=True: pgid == pid
+        try:
+            proc.communicate(timeout=_POST_KILL_DRAIN_S)
+        except subprocess.TimeoutExpired:
+            pass
+        raise
+    return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+
+
 def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT_S,
                  task_id: Optional[str] = None, local: bool = False):
     """Run Python code through the browser-use CLI, and return its output"""
@@ -561,10 +592,14 @@ def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT
     timeout = _clamp_timeout(timeout_s)
     started = time.time()
     try:
-        proc = subprocess.run(
-            cmd, input=code, capture_output=True, text=True, timeout=timeout, env=env,
-            **_windows_popen_kwargs(),
-        )
+        if os.name == "nt":
+            proc = subprocess.run(
+                cmd, input=code, capture_output=True, text=True, timeout=timeout, env=env,
+                **_windows_popen_kwargs(),
+            )
+        else:
+            # Plain run() strands the pipe-holding grandchildren above (#106244).
+            proc = _run_cli_killing_process_group(cmd, code, env, timeout)
     except subprocess.TimeoutExpired:
         return tool_error(f"browser-use exec timed out after {timeout}s. The daemon may still be working; retry "
                           f"with a larger timeout_s (max {_MAX_TIMEOUT_S}), or split the work into several calls that "

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -500,14 +500,17 @@ def _route_backend(env: dict, session: str, task_id: Optional[str], local: bool)
     return _resolve_backend_cdp(env, task_id, session_name=session)
 
 
-def _windows_popen_kwargs() -> dict:
-    """Hide the console the .cmd shim would flash on Windows (as browser_tool does)."""
+def _group_popen_kwargs() -> dict:
+    """Popen kwargs starting the CLI in its own process group (a new session on POSIX) so a
+    timeout can take down every process that inherited the capture pipes, not just the CLI
+    child. Windows also hides the console the .cmd shim would flash (as browser_tool does)."""
     def _flags() -> dict:
         from hermes_cli._subprocess_compat import windows_hide_flags
         si = subprocess.STARTUPINFO()
         si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        return {"creationflags": windows_hide_flags(), "startupinfo": si}
-    return _quiet(_flags, {}, "Windows hide-flags unavailable") if os.name == "nt" else {}
+        return {"creationflags": windows_hide_flags() | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+                "startupinfo": si}
+    return _quiet(_flags, {}, "Windows hide-flags unavailable") if os.name == "nt" else {"start_new_session": True}
 
 
 def _clamp_timeout(timeout_s: Any) -> int:
@@ -522,28 +525,38 @@ def _clamp_timeout(timeout_s: Any) -> int:
 _POST_KILL_DRAIN_S = 10.0
 
 
-def _run_cli_killing_process_group(cmd, code, env, timeout):
-    """Run the CLI in its own session and SIGKILL the whole process group on timeout.
+def _kill_cli_process_group(proc) -> None:
+    """SIGKILL the CLI's whole process group (POSIX; ``start_new_session`` made pgid == pid) or,
+    on Windows, its process tree via ``taskkill /T /F`` — the only group-wide kill it offers."""
+    if os.name == "nt":
+        from hermes_cli._subprocess_compat import windows_hide_flags
+        with contextlib.suppress(OSError, subprocess.SubprocessError):
+            subprocess.run(["taskkill", "/T", "/F", "/PID", str(proc.pid)], stdin=subprocess.DEVNULL,
+                           capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=10,
+                           check=False, creationflags=windows_hide_flags())
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(proc.pid, signal.SIGKILL)  # windows-footgun: ok — POSIX only, the nt branch returned above
 
-    ``subprocess.run`` only kills the direct child on ``TimeoutExpired``; a browser_harness
-    daemon / Chrome helper grandchild inherits the stdout/stderr pipes and keeps them open,
-    so the internal ``communicate()`` blocks on pipe EOF forever and the tool call — plus its
-    activity heartbeat — wedges permanently (#106244).
+
+def _run_cli_killing_process_group(cmd, code, env, timeout):
+    """Run the CLI in its own process group and kill the whole group on timeout.
+
+    ``subprocess.run`` only kills the direct child on ``TimeoutExpired``; a grandchild that
+    inherited the stdout/stderr pipes (browser_harness daemon / Chrome helper) is orphaned
+    still holding them, and on Windows ``run()``'s unbounded post-kill ``communicate()`` then
+    blocks on pipe EOF forever — so the tool call, plus its activity heartbeat, wedges (#106244).
     """
     proc = subprocess.Popen(
         cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        text=True, env=env, start_new_session=True,
+        text=True, encoding="utf-8", errors="replace", env=env, **_group_popen_kwargs(),
     )
     try:
         stdout, stderr = proc.communicate(input=code, timeout=timeout)
     except subprocess.TimeoutExpired:
-        with contextlib.suppress(ProcessLookupError, PermissionError):
-            # start_new_session=True: pgid == pid; POSIX-only, browser_exec gates this helper behind os.name != "nt".
-            os.killpg(proc.pid, signal.SIGKILL)  # windows-footgun: ok
-        try:
+        _kill_cli_process_group(proc)
+        with contextlib.suppress(subprocess.TimeoutExpired):
             proc.communicate(timeout=_POST_KILL_DRAIN_S)
-        except subprocess.TimeoutExpired:
-            pass
         raise
     return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
 
@@ -593,14 +606,7 @@ def browser_exec(code: str, session: str = "", timeout_s: int = _DEFAULT_TIMEOUT
     timeout = _clamp_timeout(timeout_s)
     started = time.time()
     try:
-        if os.name == "nt":
-            proc = subprocess.run(
-                cmd, input=code, capture_output=True, text=True, timeout=timeout, env=env,
-                **_windows_popen_kwargs(),
-            )
-        else:
-            # Plain run() strands the pipe-holding grandchildren above (#106244).
-            proc = _run_cli_killing_process_group(cmd, code, env, timeout)
+        proc = _run_cli_killing_process_group(cmd, code, env, timeout)
     except subprocess.TimeoutExpired:
         return tool_error(f"browser-use exec timed out after {timeout}s. The daemon may still be working; retry "
                           f"with a larger timeout_s (max {_MAX_TIMEOUT_S}), or split the work into several calls that "


### PR DESCRIPTION
A `browser_exec` timeout now kills the whole browser-use CLI process tree, so a pipe-holding grandchild can no longer be orphaned past the timeout — and on Windows can no longer wedge the tool worker (and its `tool running: browser_exec` activity heartbeat) forever.

## Changes

- `tools/browser_use_cli.py`
  - `_run_cli_killing_process_group` (from #106265): `Popen` in its own process group, `communicate(timeout)`, on `TimeoutExpired` kill the group then a bounded 10 s drain, re-raise into the existing timeout `tool_error` path.
  - Salvage follow-up: one code path on both platforms. `_group_popen_kwargs` (`start_new_session=True` on POSIX; `CREATE_NEW_PROCESS_GROUP` + hide flags on Windows, replacing the hide-only `_windows_popen_kwargs`), `_kill_cli_process_group` (`os.killpg SIGKILL` / `taskkill /T /F` with the sibling sites' kwarg set), `encoding="utf-8", errors="replace"` on the Popen like every other subprocess call in the file.
- `tests/tools/test_browser_use_cli.py::TestTimeoutProcessGroupKill` — 2 invariants (contributor's 3 trimmed to 2; the dropped one pinned the exact `communicate()` timeout sequence): a real `sleep 60 &` grandchild dies with the group and the timeout error returns promptly; the post-kill drain is bounded. Both red on `origin/main`, green here.

## Validation

| Check | Before (origin/main) | After |
|---|---|---|
| Live repro, Linux: fake CLI forks a pipe-holding grandchild, `browser_exec(timeout_s=5)` | `elapsed=5.7s timeout_error=True grandchild_alive=True` — **grandchild leaked** | `elapsed=5.4s timeout_error=True grandchild_alive=False` |
| E2E through real `registry.dispatch` under `_run_with_activity_heartbeat` | — | timeout error surfaces, heartbeat thread exits, grandchild dead; healthy CLI still returns `exit_code=0` + output |
| `scripts/run_tests.sh tests/tools/test_browser_use_cli.py …` (5 files) | — | 138 passed |
| `check-windows-footguns.py --all`, `check_subprocess_stdin.py`, `check_compat_pointers.py`, `ruff` | — | clean |

Honest note on the mechanism: on POSIX, `subprocess.run()` kills the child and `wait()`s its PID — it does **not** block on the grandchild's pipes (confirmed live above and by @Halldrix on the issue). The permanent-`communicate()` wedge the issue describes is CPython's **Windows** post-kill path (unbounded retry `communicate()`), which is exactly the branch #106265 left on plain `run()`; this salvage covers it. The reporter's macOS wedge is not reproduced by this mechanism and may have another cause (see the report), but the orphaned-grandchild leak is real on every platform and this is the fix at the source. Windows behaviour cannot be live-verified on this Linux host.

Root cause: `subprocess.run(capture_output=True, timeout=…)` only kills the direct child, orphaning any descendant that inherited the capture pipes.

The activity heartbeat in `agent/tool_executor.py` is intentionally unchanged: once the tool call returns, `finally: stop.set()` runs, and capping the heartbeat would weaken the #84491 guarantee that long-running tools keep stamping.

Salvages #106265 from @liuhao1024
Closes #106244

## Infographic
![browser-exec-process-group-kill](https://v3b.fal.media/files/b/0aa9bb68/AO4gg3_T6wZM6G1jn0DOw_jO5IXJkZ.png)
