### PR TITLE
Desktop roster poll and streamed tool events stop doing redundant work (#106133, #106125, salvage #106134, #106126)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -346,6 +346,7 @@ import {
 import { missingRendererAssets } from './renderer-bundle'
 import { loadRendererLoadErrorPage } from './renderer-load-error-page'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { fetchRosterSourceData } from './roster-source-fetch'
 import {
   classifyStoredSecret,
   readSecretStoragePolicy,
@@ -15725,11 +15726,13 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             )
           )
 
-          const body: any = await getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 })
+          const { body, installId } = await fetchRosterSourceData(
+            () => getJsonForBackend(descriptor, '/api/profiles', { timeoutMs: 8_000 }),
+            () => probeConnectionInstallId(connection.id, descriptor)
+          )
 
-          // Cached with a TTL, so the 5s roster poll usually pays zero extra
-          // requests for the backend-identity probe.
-          const installId = await probeConnectionInstallId(connection.id, descriptor)
+          // The install-id probe is TTL-cached, so the 5s roster poll usually
+          // pays zero extra requests; on a miss it runs beside /api/profiles.
 
           const profiles = Array.isArray(body?.profiles)
             ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)

--- a/apps/desktop/electron/roster-source-fetch.test.ts
+++ b/apps/desktop/electron/roster-source-fetch.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { fetchRosterSourceData } from './roster-source-fetch'
+
+test('roster source starts profile and install-id reads together and preserves both results', async () => {
+  let releaseProfiles!: (value: { profiles: Array<{ name: string }> }) => void
+  let releaseInstallId!: (value: string | undefined) => void
+
+  const profiles = new Promise<{ profiles: Array<{ name: string }> }>(resolve => {
+    releaseProfiles = resolve
+  })
+
+  const installId = new Promise<string | undefined>(resolve => {
+    releaseInstallId = resolve
+  })
+
+  const started: string[] = []
+
+  const pending = fetchRosterSourceData(
+    () => {
+      started.push('profiles')
+
+      return profiles
+    },
+    () => {
+      started.push('install-id')
+
+      return installId
+    }
+  )
+
+  assert.deepEqual(started, ['profiles', 'install-id'])
+  releaseInstallId('install-1')
+  releaseProfiles({ profiles: [{ name: 'default' }] })
+  assert.deepEqual(await pending, {
+    body: { profiles: [{ name: 'default' }] },
+    installId: 'install-1'
+  })
+})
+
+test('roster source preserves a profile-read failure after starting the install-id read', async () => {
+  const profilesError = new Error('profiles unavailable')
+  let installIdStarted = false
+
+  await assert.rejects(
+    fetchRosterSourceData(
+      async () => {
+        throw profilesError
+      },
+      async () => {
+        installIdStarted = true
+
+        return undefined
+      }
+    ),
+    profilesError
+  )
+  assert.equal(installIdStarted, true)
+})

--- a/apps/desktop/electron/roster-source-fetch.ts
+++ b/apps/desktop/electron/roster-source-fetch.ts
@@ -1,0 +1,8 @@
+export async function fetchRosterSourceData<T>(
+  fetchProfiles: () => Promise<T>,
+  fetchInstallId: () => Promise<string | undefined>
+): Promise<{ body: T; installId: string | undefined }> {
+  const [body, installId] = await Promise.all([fetchProfiles(), fetchInstallId()])
+
+  return { body, installId }
+}

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -179,10 +179,15 @@ function findToolPartIndex(
     }
   }
 
-  const pendingIndices = parts
-    .map((part, index) => ({ part, index }))
-    .filter(({ part }) => part.type === 'tool-call' && part.toolName === name && part.result === undefined)
-    .map(({ index }) => index)
+  const pendingIndices: number[] = []
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index]
+
+    if (part.type === 'tool-call' && part.toolName === name && part.result === undefined) {
+      pendingIndices.push(index)
+    }
+  }
 
   if (pendingIndices.length === 0) {
     return -1
@@ -279,11 +284,17 @@ function toolResult(
 }
 
 function completeOpenStreamParts(parts: ChatMessagePart[], completedAt: number): ChatMessagePart[] {
-  return parts.map(part =>
-    (part.type === 'text' || part.type === 'reasoning') && part.completedAt === undefined
-      ? ({ ...part, completedAt } as ChatMessagePart)
-      : part
-  )
+  const next = parts.slice()
+
+  for (let index = 0; index < next.length; index += 1) {
+    const part = next[index]
+
+    if ((part.type === 'text' || part.type === 'reasoning') && part.completedAt === undefined) {
+      next[index] = { ...part, completedAt } as ChatMessagePart
+    }
+  }
+
+  return next
 }
 
 export function upsertToolPart(
@@ -325,10 +336,10 @@ export function upsertToolPart(
   } satisfies ChatMessagePart
 
   if (index === -1) {
-    return [...next, base]
+    next.push(base)
+  } else {
+    next[index] = { ...next[index], ...base }
   }
-
-  next[index] = { ...next[index], ...base }
 
   return next
 }

--- a/apps/desktop/src/lib/generated-images.test.ts
+++ b/apps/desktop/src/lib/generated-images.test.ts
@@ -60,6 +60,12 @@ describe('generatedImageEchoSources', () => {
 })
 
 describe('dedupeGeneratedImageEchoesInParts', () => {
+  it('preserves timeline identity when there is nothing to strip', () => {
+    const parts = [{ result: {}, toolName: 'read_file', type: 'tool-call' }]
+
+    expect(dedupeGeneratedImageEchoesInParts(parts)).toBe(parts)
+  })
+
   it('keeps the agent prose while removing the duplicated image', () => {
     expect(
       dedupeGeneratedImageEchoesInParts([

--- a/apps/desktop/src/lib/generated-images.ts
+++ b/apps/desktop/src/lib/generated-images.ts
@@ -68,7 +68,19 @@ export function generatedImageFromResult(result: unknown): string | null {
 
 /** Every path/URL a generated image might appear as in prose, for de-duping. */
 export function generatedImageEchoSources(parts: readonly ToolLike[]): string[] {
-  return unique(parts.flatMap(part => stringFields(imageResult(part) ?? {}, ECHO_KEYS)))
+  // Runs on every streamed tool event over the whole timeline; skip the
+  // per-part array allocations for the (usual) rows that are not image results.
+  const sources: string[] = []
+
+  for (const part of parts) {
+    const result = imageResult(part)
+
+    if (result) {
+      sources.push(...stringFields(result, ECHO_KEYS))
+    }
+  }
+
+  return unique(sources)
 }
 
 /** Strip a generated image out of prose so it only ever shows in the tool slot.
@@ -94,11 +106,13 @@ export function stripGeneratedImageEchoes(text: string, sources: readonly string
 
 /** Strip generated-image echoes from text parts, dropping any part left empty.
  *  The image lives in the tool slot; prose keeps the agent's actual words. */
-export function dedupeGeneratedImageEchoesInParts<T extends TextLike & ToolLike>(parts: readonly T[]): T[] {
+export function dedupeGeneratedImageEchoesInParts<T extends TextLike & ToolLike>(parts: T[]): T[] {
   const sources = generatedImageEchoSources(parts)
 
+  // No echoes to strip: hand back the same array so React and the streaming
+  // reducer see a no-op instead of a fresh identity on every tool event.
   if (!sources.length) {
-    return [...parts]
+    return parts
   }
 
   return parts


### PR DESCRIPTION
Desktop's roster poll no longer waits for `/api/profiles` before probing `/api/status`, and streamed tool events no longer copy the whole assistant timeline three times per event.

## Changes

- **Roster enumeration** (`apps/desktop/electron/main.ts::enumerateRegistryAgentSources`, cherry-picked from #106134 by @Xipong): the `/api/profiles` read and the TTL-cached install-id probe start together and are awaited via a tiny `fetchRosterSourceData` helper. Per-source error isolation is unchanged — `probeConnectionInstallId` still swallows status failures and keeps its TTL/negative-TTL cache, and a profiles failure still rejects only that source.
- **Streaming tool events** (`apps/desktop/src/lib/chat-messages/tool-parts.ts`, `apps/desktop/src/lib/generated-images.ts`; slim redo of #106126, co-authored with @Xipong): the three whole-timeline passes on every `tool.start`/`tool.progress`/`tool.complete` each allocated per part (`map`+spread to close open prose, `map→filter→map` for pending rows, `flatMap` for image-echo sources) and `dedupeGeneratedImageEchoesInParts` returned a fresh copy even when it stripped nothing. They are now single in-place loops, and the no-echo case returns the input array so a no-op stays a no-op for React.

## Live repro

| Path | Before (origin/main) | After (this branch) |
|---|---|---|
| Roster source, loopback HTTP fixture with both endpoints delayed 120 ms (`node roster-probe.cjs`) | `serial: 245.3 ms profiles=default,ops installId=install-abc` | `concurrent: 124.9 ms profiles=default,ops installId=install-abc` |
| Real `useMessageStream` hook (vitest/jsdom), 2,000 `tool.start` + 2,000 `tool.complete` interleaved with text deltas | `total=618ms upsert=190ms dedupe=406ms` | `total=114–138ms upsert=77–97ms dedupe=23–28ms` |
| Same hook, 2,000×2 tool events, no text | `total=252ms` | `total=67–69ms` |

All runs end with `tools=2000 allDone=true` (every row matched its completion).

## vs #106126

The original added a per-stream `Map<toolCallId, index>` plus `WeakMap`/`WeakRef` ownership tracking (~100 LOC of index machinery across the reducer and the hook). Measured on the real hook path it was **not faster than main** (2,000×2: 161–166 ms vs 158–180 ms) because the index only removed one `findIndex` (~8 µs per event on a 4k array) while the allocation-heavy passes and the always-copy dedupe dominated. Fixing those directly gets 4.5× with no new state to invalidate on part removal/reorder/reset, so the index is dropped. First-match `toolCallId` resolution, sparse/no-id contextual correlation and part ordering are byte-for-byte the same logic.

**Root cause:** hot-path helpers were written in allocate-per-row functional style and the image-echo dedupe cloned its input unconditionally, so per-event cost scaled with the whole timeline even when the event touched one row; the roster poll awaited two independent requests one after the other.

## Tests

- `apps/desktop/electron/roster-source-fetch.test.ts` — 2 tests (both start before either resolves; profiles rejection propagates after the probe started).
- `apps/desktop/src/lib/generated-images.test.ts` — 1 new test, red on main: no-echo dedupe preserves array identity.
- Sweep: `npx vitest run --project ui src/lib/ src/app/session/ src/plugins/ src/components/ src/store/` → 501 files / 5,150 tests passed; `npm run typecheck` and `eslint` on touched files clean.

Credit: @Xipong for both reports and both PRs — #106134 is incorporated as-is (re-authored to the account's canonical noreply, `217837358+Xipong@…`, since the PR commit used a noreply id that resolves to a different login); #106126 is superseded by the slimmer redo above with `Co-authored-by`.

Closes #106133
Closes #106125

## Infographic
![desktop-perf-roster-and-tool-events](https://v3b.fal.media/files/b/0aa9bb75/P020FVzwd7yL6aSGQ044B_YAXGLf3z.png)
