### PR TITLE
fix(kanban): park forced review cards via review_hold; close stale running rows (#101638)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -716,8 +716,13 @@ def _cmd_claim(args: argparse.Namespace) -> int:
             existing = kb.get_task(conn, args.task_id)
             if existing is None:
                 return _err(f"no such task: {args.task_id}")
-            return _err(f"cannot claim {args.task_id}: status={existing.status} "
-                        f"lock={existing.claim_lock or '(none)'}")
+            if existing.status == "review":
+                # Explicit human pull unparks a held review card (#101638)
+                # and claims it for review in one step.
+                task = kb.claim_review_task(conn, args.task_id, ttl_seconds=args.ttl, force=True)
+            if task is None:
+                return _err(f"cannot claim {args.task_id}: status={existing.status} "
+                            f"lock={existing.claim_lock or '(none)'}")
         workspace = kbw.resolve_workspace(task)
         kbw.set_workspace_path(conn, task.id, str(workspace))
     print(f"Claimed {task.id}\nWorkspace: {workspace}")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -710,6 +710,8 @@ class Task:
     # done / budget exhausted (-> kanban_block); ``goal_max_turns`` None -> goals default.
     goal_mode: bool = False
     goal_max_turns: Optional[int] = None
+    # Review-lane park flag (#101638); True = dispatcher must not auto-claim.
+    review_hold: bool = False
     session_id: Optional[str] = None         # originating HERMES_SESSION_ID; NULL from CLI/dashboard
     # VALID_BLOCK_KINDS or None (legacy); kept across unblock so a same-kind re-block reads as a loop.
     block_kind: Optional[str] = None
@@ -731,6 +733,7 @@ class Task:
             last_failure_error=g("last_failure_error", g("last_spawn_error")),
             skills=skills_value,
             goal_mode=bool(g("goal_mode")),
+            review_hold=bool(g("review_hold")),
             block_recurrences=int(g("block_recurrences") or 0),
         )
 
@@ -941,7 +944,15 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Review-lane park flag (#101638). Set when ``request_review`` overrides
+    -- a live claim via ``force=True`` (operator parking: "wait for a human /
+    -- dependency, do NOT auto-spawn a reviewer"). Meaningful only while
+    -- ``status = 'review'``: ``claim_review_task`` refuses held cards and
+    -- the dispatcher skips them in the review lane. Cleared on a normal
+    -- worker handoff (``expected_run_id``), an explicit human claim
+    -- (``force=True``), or when the card leaves review. 0 = dispatch-hot.
+    review_hold          INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2159,11 +2170,17 @@ def claim_task(
 
 def claim_review_task(
     conn: sqlite3.Connection, task_id: str, *, ttl_seconds: Optional[int] = None,
-    claimer: Optional[str] = None,
+    claimer: Optional[str] = None, force: bool = False,
 ) -> Optional[Task]:
     """Atomic ``review -> running`` (None when lost). Parents are re-checked
     (one may have reopened meanwhile) and a NEW run tracks the reviewer
-    separately from the implementer."""
+    separately from the implementer.
+
+    A parked card (``review_hold``, set by a forced ``request_review`` over a
+    live claim — #101638) is refused unless ``force`` (explicit human pull,
+    which unparks). A leaked open run from a dead worker is reclaimed in the
+    same txn, mirroring :func:`claim_task`.
+    """
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
@@ -2179,6 +2196,22 @@ def claim_review_task(
                     {"reason": "parent_reopened", "source_status": "review"},
                 )
             return None
+        hold = conn.execute(
+            "SELECT COALESCE(review_hold, 0) FROM tasks WHERE id = ? AND status = 'review'",
+            (task_id,),
+        ).fetchone()
+        if hold and hold[0] and not force:
+            return None
+        if force:
+            # ponytail: single-row flag clear; a lane column beats an event scan.
+            conn.execute(
+                "UPDATE tasks SET review_hold = 0 WHERE id = ? AND status = 'review'",
+                (task_id,),
+            )
+        # Close a leaked prior run so the CAS below doesn't strand it.
+        _reclaim_dangling_run(
+            conn, task_id, statuses=("review",), now=now, note="invariant recovery on review re-claim",
+        )
         run_id = _claim_and_open_run(
             conn, task_id, "review", lock, expires, now, event_extra={"source_status": "review"},
         )
@@ -3046,18 +3079,27 @@ def request_review(
             *(() if reviewer is None else (reviewer,)), task_id,
             *(() if expected_run_id is None else (int(expected_run_id),)),
         )
+        # #101638: force-overriding a LIVE claim parks the card in review —
+        # the operator takes the handoff out of the dispatch loop ("wait for
+        # a human/dependency"). A normal worker handoff (ownership proof via
+        # ``expected_run_id``, or a move from ``ready``) stays dispatch-hot.
+        forced_park = bool(
+            force and expected_run_id is None
+            and trow["status"] == "running" and trow["claim_lock"] is not None
+        )
         cur = conn.execute(
             """
             UPDATE tasks
                SET status        = 'review',
                    claim_lock    = NULL,
                    claim_expires = NULL,
-                   worker_pid    = NULL
+                   worker_pid    = NULL,
+                   review_hold   = ?
             """ + assignee_sql + """
              WHERE id = ?
                AND status IN ('running', 'ready')
             """ + run_guard,
-            params,
+            (int(forced_park), *params),
         )
         if cur.rowcount != 1:
             return _ret(
@@ -3075,6 +3117,7 @@ def request_review(
                 "summary": _first_line(summary, 400) or None,
                 "implementer": implementer,
                 "reviewer": reviewer,
+                **({"forced": True} if forced_park else {}),
             },
             run_id=run_id,
         )
@@ -3312,7 +3355,8 @@ def reopen_review_task(conn: sqlite3.Connection, task_id: str) -> bool:
             # consecutive_failures deliberately PRESERVED: review reopen is not
             # a success signal; only complete_task resets the breaker (#35072).
             "UPDATE tasks SET status = ?, current_run_id = NULL, "
-            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+            "review_hold = 0 "
             + (", assignee = ?" if implementer else "")
             + " WHERE id = ? AND status = 'review'",
             params,

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -813,6 +813,8 @@ _LATER_TASK_COLUMNS = (
     # Typed block reason (VALID_BLOCK_KINDS); NULL = generic human blocker.
     ("block_kind", "block_kind TEXT"),
     ("block_recurrences", "block_recurrences INTEGER NOT NULL DEFAULT 0"),
+    # Review-lane park flag: 0 = dispatch-hot (pre-column behaviour).
+    ("review_hold", "review_hold INTEGER NOT NULL DEFAULT 0"),
 )
 
 _NOTIFY_SUB_COLUMNS = (

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -315,6 +315,12 @@ def _terminate_reclaimed_worker(
         info["terminated"] = True
         return info
     except OSError:
+        # Windows raises OSError (winerror 87) — not ProcessLookupError —
+        # for a dead pid (#101638). A pid that no longer exists is gone
+        # regardless of errno; only a still-alive pid defers the reclaim.
+        if not _kb._pid_alive(pid):
+            info["terminated"] = True
+            return info
         return info
 
     if _poll_worker_exit(pid):
@@ -1229,7 +1235,8 @@ def _profile_exists_fn() -> Optional[Callable[[str], bool]]:
 def _has_spawnable(conn: sqlite3.Connection, status: str) -> bool:
     rows = conn.execute(
         "SELECT DISTINCT assignee FROM tasks "
-        "WHERE status = ? AND assignee IS NOT NULL AND claim_lock IS NULL",
+        "WHERE status = ? AND assignee IS NOT NULL AND claim_lock IS NULL"
+        + (" AND COALESCE(review_hold, 0) = 0" if status == "review" else ""),
         (status,),
     ).fetchall()
     if not rows:
@@ -1709,10 +1716,13 @@ def _tick_spawn_budget(
 
 
 def _lane_rows(conn: sqlite3.Connection, status: str) -> list[sqlite3.Row]:
-    """Unclaimed rows of one lane in dispatch order."""
+    """Unclaimed rows of one lane in dispatch order. Parked review cards
+    (``review_hold``, #101638) are not dispatch sources — the operator parked
+    them for a human/dependency, so the dispatcher never enumerates them."""
+    hold_filter = " AND COALESCE(review_hold, 0) = 0" if status == "review" else ""
     return conn.execute(
         "SELECT id, assignee FROM tasks "
-        f"WHERE status = '{status}' AND claim_lock IS NULL "
+        f"WHERE status = '{status}' AND claim_lock IS NULL{hold_filter} "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
 

--- a/tests/hermes_cli/test_kanban_review_hold.py
+++ b/tests/hermes_cli/test_kanban_review_hold.py
@@ -1,0 +1,200 @@
+"""#101638: review-lane hold + stale-run reclaim.
+
+* ``request-review --force`` over a live claim parks the card: the dispatcher
+  must not re-claim it on the next tick (``review_hold`` guard in the shared
+  ``claim_review_task`` path + review lane enumeration skips held cards).
+* A normal worker handoff (``expected_run_id``) is NOT a park: review dispatch
+  proceeds unchanged.
+* ``claim_review_task`` reclaims a dangling open run in the same txn
+  (mirrors ``claim_task``), so dead workers leave no stale ``running`` rows.
+* ``release_stale_claims`` closes the stale run row in the same txn that
+  re-queues the task (baseline pin for part (b)).
+* An explicit human ``kanban claim`` on a held review card unparks it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _dispatch_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    import hermes_cli.config as cfgmod
+    import hermes_cli.profiles as profmod
+
+    monkeypatch.setattr(profmod, "profile_exists", lambda name: True)
+    monkeypatch.setattr(
+        cfgmod, "load_config",
+        lambda *args, **kwargs: {"kanban": {"review_dispatch": True}},
+    )
+
+
+def _open_runs(conn, tid: str):
+    return conn.execute(
+        "SELECT id, status, outcome, ended_at FROM task_runs "
+        "WHERE task_id = ? AND ended_at IS NULL",
+        (tid,),
+    ).fetchall()
+
+
+def _events(conn, tid: str, kind: str):
+    return [
+        (json.loads(r["payload"]) if r["payload"] else None)
+        for r in conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = ? ORDER BY id",
+            (tid, kind),
+        ).fetchall()
+    ]
+
+
+def test_force_request_review_parks_card_dispatcher_leaves_it(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The issue's scenario: park via force, next tick must not spawn."""
+    _dispatch_stubs(monkeypatch)
+    spawned: list[str] = []
+
+    def spawn(task, workspace, board=None):
+        spawned.append(task.id)
+        return 12345
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="park me", assignee="worker")
+        kb.claim_task(conn, tid)
+        ok, _ = kb.request_review(conn, tid, summary="waiting on human", force=True, with_reason=True)
+        assert ok is True
+        task = kb.get_task(conn, tid)
+        assert task is not None and task.status == "review"
+        assert bool(task.review_hold) is True
+
+        # Direct claim path also refuses a parked card.
+        assert kb.claim_review_task(conn, tid) is None
+        assert kb.get_task(conn, tid).status == "review"
+
+        res = kbd.dispatch_once(conn, spawn_fn=spawn)
+        assert tid not in [s[0] for s in res.spawned]
+        assert tid not in spawned
+        assert kb.get_task(conn, tid).status == "review"
+
+
+def test_normal_handoff_still_dispatches(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker handoff with ownership proof is not a park: reviewer spawns."""
+    _dispatch_stubs(monkeypatch)
+
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="review me", assignee="reviewer")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert kb.request_review(conn, tid, summary="done", expected_run_id=claimed.current_run_id) is True
+        task = kb.get_task(conn, tid)
+        assert task is not None and task.status == "review"
+        assert bool(task.review_hold) is False
+
+        res = kbd.dispatch_once(conn, dry_run=True)
+        assert tid in [s[0] for s in res.spawned]
+
+
+def test_claim_review_task_reclaims_dangling_run(kanban_home: Path) -> None:
+    """Dead worker's leaked open run closes in the claim txn (cf. claim_task)."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="dangling", assignee="reviewer")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        leaked_run_id = int(claimed.current_run_id)
+        # Simulate a host-level death mid-handoff: task sits in review while
+        # the implementer run row is still open (ended_at IS NULL).
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'review', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
+                (tid,),
+            )
+        assert len(_open_runs(conn, tid)) == 1
+
+        got = kb.claim_review_task(conn, tid)
+        assert got is not None
+        assert got.status == "running"
+        # The leaked row is terminal now; only the fresh reviewer run is open.
+        leaked = conn.execute(
+            "SELECT status, outcome, ended_at FROM task_runs WHERE id = ?",
+            (leaked_run_id,),
+        ).fetchone()
+        assert leaked["ended_at"] is not None
+        assert leaked["outcome"] == "reclaimed"
+        still_open = _open_runs(conn, tid)
+        assert len(still_open) == 1
+        assert int(still_open[0]["id"]) != leaked_run_id
+
+
+def test_release_stale_claims_closes_run_row(kanban_home: Path) -> None:
+    """Reclaim re-queues AND stamps the stale run terminal in one txn."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="stale", assignee="worker")
+        claimed = kb.claim_task(conn, tid, ttl_seconds=1)
+        assert claimed is not None
+        run_id = int(claimed.current_run_id)
+        # Expire the claim and ensure the worker looks dead (no such pid).
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET claim_expires = 1, worker_pid = ? WHERE id = ?",
+                (4199999, tid),
+            )
+
+        n = kb.release_stale_claims(conn)
+        assert n == 1
+        task = kb.get_task(conn, tid)
+        assert task is not None and task.current_run_id is None
+        assert task.status in ("ready", "review")
+        run = conn.execute(
+            "SELECT status, outcome, ended_at FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        assert run["ended_at"] is not None
+        assert run["outcome"] == "reclaimed"
+        assert _events(conn, tid, "reclaimed")
+
+
+def test_human_claim_unparks_held_card(kanban_home: Path) -> None:
+    """Explicit human pull (``kanban claim`` path) clears the hold."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="held", assignee="reviewer")
+        kb.claim_task(conn, tid)
+        ok, _ = kb.request_review(conn, tid, summary="parked", force=True, with_reason=True)
+        assert ok is True
+        assert bool(kb.get_task(conn, tid).review_hold) is True
+
+        got = kb.claim_review_task(conn, tid, force=True)
+        assert got is not None
+        assert got.status == "running"
+        assert bool(kb.get_task(conn, tid).review_hold) is False
+
+
+def test_reopen_clears_hold(kanban_home: Path) -> None:
+    """Leaving review via reopen drops the hold bit with the lane."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="held", assignee="worker")
+        kb.claim_task(conn, tid)
+        ok, _ = kb.request_review(conn, tid, summary="parked", force=True, with_reason=True)
+        assert ok is True
+        assert kb.reopen_review_task(conn, tid) is True
+        task = kb.get_task(conn, tid)
+        assert task is not None and task.status in ("ready", "todo")
+        assert bool(task.review_hold) is False


### PR DESCRIPTION
## What Problem This Solves

#101638 reports two kanban gaps:

1. `kanban request-review --force` over a live claim is meant as operator parking ("wait for a human/dependency"), but the dispatcher treats the review lane as dispatch-hot: the next tick re-claims via `claim_review_task` and spawns a reviewer (~11s later, then duplicates).
2. A dead worker leaves its `task_runs` row in `running` (`ended_at IS NULL`); reclaim re-queues the card but the stale row lingers and confuses outcome-based logic (`check_respawn_guard` latest-run lookup, completion summaries).

Changes (branch `fix/101638-kanban-review`, 5 files):

- `review_hold` column on `tasks` (schema + `_LATER_TASK_COLUMNS` backfill, default 0 = dispatch-hot). `request_review(force=True)` over a live `running` claim sets it (park); a normal worker handoff via `expected_run_id` does not.
- `claim_review_task` refuses held cards unless `force=True` (explicit human pull, which unparks); dispatcher review-lane enumeration (`_lane_rows`, `_has_spawnable`) skips held cards; `reopen_review_task` clears the hold on lane exit; `kanban claim` on a held review card unparks via `force=True`.
- `claim_review_task` reclaims a dangling open run in-claim-txn (mirrors `claim_task`), so no stale `running` rows on review re-claim.
- Windows reclaim fix in `_terminate_reclaimed_worker`: `os.kill` on a dead pid raises `OSError` (winerror 87), not `ProcessLookupError` — verified live (`OSError(22, winerror 87)`, `_pid_exists == False`). The old `except OSError: return` left `terminated=False`, so `_worker_survived_termination` was true and `release_stale_claims` deferred forever (claim extended, `n == 0`). Now a non-existent pid counts as terminated; only a still-alive pid defers.

## Evidence

Target file `tests/hermes_cli/test_kanban_review_hold.py` (6 tests: force-park holds, normal handoff dispatches, review re-claim closes dangling run, `release_stale_claims` closes stale run, human claim unparks, reopen clears hold):

- With fix: `6 passed in 2.53s`
- Sabotage (tracked source stashed, test file kept): `6 failed` — confirms the tests pin the fix, then `git stash pop` restored and re-verified `6 passed`.

Adjacent regression (single files only):

- `tests/hermes_cli/test_kanban_review_lifecycle.py`: `19 passed in 6.82s`
- `tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py`: `2 passed in 1.38s`

Closes #101638
