### PR TITLE
fix(desktop): keep pre-compression transcript reachable after in-place /compress (#105256)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -776,6 +776,56 @@ describe('usePromptActions /compress', () => {
     expect(renderedText).toContain('sure, here is the summary')
   })
 
+  it('keeps pre-compression messages reachable after the transcript rewrite (#105256)', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string, _params?: Record<string, unknown>, _timeoutMs?: number) => {
+      if (method === 'session.compress') {
+        return {
+          removed: 2,
+          summary: { headline: 'Compressed: 4 → 2 messages' },
+          messages: [
+            { role: 'user', content: 'summarized context' },
+            { role: 'assistant', content: 'sure, here is the summary' }
+          ]
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={[
+          { id: 'pre-1', role: 'user', parts: [textPart('pre-compression user turn')], timestamp: 0 },
+          { id: 'pre-2', role: 'assistant', parts: [textPart('pre-compression assistant reply')], timestamp: 1 }
+        ]}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    // The transcript was replaced with the post-compress history.
+    const finalMessages = seeds[seeds.length - 1]?.messages as Array<{ parts?: Array<{ text?: string }> }>
+
+    const renderedText = (finalMessages ?? [])
+      .flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+      .join('\n')
+
+    expect(renderedText).toContain('summarized context')
+    expect(renderedText).toContain('sure, here is the summary')
+    // Active-session scrollback: the pre-compression segment stays in the
+    // transcript so scrolling up still reaches it.
+    expect(renderedText).toContain('pre-compression user turn')
+    expect(renderedText).toContain('pre-compression assistant reply')
+    expect(renderedText.indexOf('pre-compression user turn')).toBeLessThan(renderedText.indexOf('summarized context'))
+  })
+
   it('uses the compute-host response transcript and success output', async () => {
     const seeds: Record<string, unknown>[] = []
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -1,6 +1,7 @@
 import { skillInvocationText } from '@hermes/shared'
 import { type MutableRefObject, useCallback, useRef } from 'react'
 
+import { mergeOlderTranscriptPage } from '@/app/chat/transcript-backfill'
 import { getProfiles } from '@/hermes'
 import type { Translations } from '@/i18n'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
@@ -684,10 +685,18 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             // toChatMessages handles it directly. updateSessionState only
             // publishes for the active runtime, guarding against a late result
             // clobbering the foreground after a session switch.
+            // The pre-compression segment stays reachable in the active
+            // session (#105256): the rewrite shares no anchor with the live
+            // transcript, so grafting would drop everything before the
+            // summary. Prepend it instead (deduped by row/message id), keeping
+            // the post-compress history authoritative for overlapping rows.
             if (Array.isArray(result?.messages)) {
               updateSessionState(
                 sessionId,
-                state => ({ ...state, messages: toChatMessages(result.messages!) }),
+                state => ({
+                  ...state,
+                  messages: mergeOlderTranscriptPage(toChatMessages(result.messages!), state.messages)
+                }),
                 storedSessionId
               )
             }


### PR DESCRIPTION
## What Problem This Solves

Desktop, active session: after an in-place context compression (manual `/compress`), scrolling up no longer reveals the earlier messages. The `/compress` handler in `apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts` replaced the in-memory transcript wholesale with the RPC's post-compress `messages` (summary + carried-forward tail). The rewrite shares no anchor with the live transcript, so everything before the summary became unreachable in that session — the exact symptom of #105256 (distinct from #79565, which covers session *switch*; switch paths are untouched by this change).

Fix: apply the post-compress history with `mergeOlderTranscriptPage` (existing helper from `app/chat/transcript-backfill`, already used for backfill grafts), so the pre-compression segment is prepended — deduped by row/message id, post-compress rows authoritative on overlap — instead of dropped. The transcript window / "Show earlier" paging then pages through the pre-compression segment as before. Auto-compaction mid-turn already preserved scrollback (it skips the post-turn hydrate via `compactedTurnRef`); session-switch hydration still replaces, unchanged.

## Evidence

- New regression test `keeps pre-compression messages reachable after the transcript rewrite (#105256)` in `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx`:
  - RED before fix: `expect(renderedText).toContain('pre-compression user turn')` fails; final transcript holds only `summarized context` / `sure, here is the summary` / `/compress` output lines.
  - GREEN after fix: pre-compression turns present and ordered before the summary.
  - Sabotage check: temporarily reverting `slash.ts` to the plain replace makes the new test fail again (`1 failed | 132 skipped`); re-applying the fix restores green.
- Suites (run from `apps/desktop`, `vitest --pool=threads`):
  - `use-prompt-actions/index.test.tsx` + `utils.test.ts`: 187 passed.
  - `app/chat/transcript-backfill.test.ts`: 20 passed.
- `npm run typecheck` (renderer + electron + e2e projects): clean, exit 0.
- Switch-path guard preserved: `does not clobber the foreground transcript when compression resolves after a session switch` still passes — late results still publish only to their invocation-time session id.

Closes #105256
