### PR TITLE
fix(cron): scan python script operand, not interpreter binary (#105427)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -108,6 +108,17 @@ _LAUNCHCTL_LIFECYCLE_VERBS_RE = re.compile(
 _HERMES_GATEWAY_LABEL_RE = re.compile(r"(?i)\bhermes[.\-]?gateway\b")
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
+# Python interpreter basenames: when one of these executes a script file
+# (`/abs/python3 /abs/snapshot.py`), the INTERPRETER is not a shell script and
+# must not be size-checked as one; the SCRIPT operand is what gets scanned.
+# Deliberately narrow (python only): matching is positional, never a blanket
+# name exemption — `sh python3-oversized` still fails closed via the shell
+# branch. See #105427.
+_PYTHON_INTERPRETER_RE = re.compile(r"(?i)^python(\d+(\.\d+)*)?w?(\.exe)?$")
+# Python options taking a separate value (`-W ignore snapshot.py`).
+_PYTHON_OPTIONS_WITH_VALUES = frozenset({"-W", "-X"})
+# Long option taking a separate value (`--check-hash-based-pycs always`).
+_PYTHON_LONG_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs"})
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _SHELL_COMMAND_FLAGS = {"-c", "--command"}
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
@@ -692,6 +703,43 @@ def _iter_option_values(segment: list[str], start: int, option: str) -> Iterator
             yield token[len(prefix):]
 
 
+def _python_script_operand(segment: list[str], index: int) -> Optional[str]:
+    """Script file a Python interpreter executes, or None when there is none.
+
+    Returns None for `-c`/`-m` (payload/module, covered by the direct regex, no
+    file to scan) and for `-`/stdin. Used positionally: only when the
+    executable itself is a python interpreter. Never a name exemption.
+    """
+    args = segment[index + 1 :]
+    pos = 0
+    while pos < len(args):
+        token = args[pos]
+        if token == "--":
+            pos += 1
+            break
+        if token in ("-c", "-m"):
+            return None
+        if token in _PYTHON_OPTIONS_WITH_VALUES:
+            pos += 2
+            continue
+        if token in _PYTHON_LONG_OPTIONS_WITH_VALUES:
+            pos += 2
+            continue
+        if token.startswith("--") and "=" not in token:
+            pos += 1
+            continue
+        if token.startswith("-") and token != "-":
+            pos += 1
+            continue
+        break
+    if pos >= len(args):
+        return None
+    candidate = args[pos]
+    if candidate in ("-", "-c", "-m"):
+        return None
+    return candidate
+
+
 def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterator[Path]:
     """Yield the scripts the token at *index* executes, if any."""
     if index >= len(segment):
@@ -724,6 +772,23 @@ def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterat
         if arg_index < len(arguments) and arguments[arg_index] not in _SHELL_COMMAND_FLAGS:
             yield from _resolved_or_nothing(arguments[arg_index], cwd)
         return
+
+    if _PYTHON_INTERPRETER_RE.match(executable_name):
+        operand = _python_script_operand(segment, index)
+        if operand is not None:
+            # Interpreter position with a script payload: scan the SCRIPT, never
+            # the interpreter binary. Fail-closed preserved: the script itself is
+            # still size/content-checked; `sh <python-named-file>` still blocks
+            # via the shell branch above.
+            yield from _resolved_or_nothing(operand, cwd)
+            return
+        if any(token in ("-c", "-m") for token in segment[index + 1 :]):
+            # `-c` payload is covered by the direct regex; `-m` is a module, not
+            # a file. No file to scan, and the interpreter binary itself is never
+            # a shell script.
+            return
+        # No script operand and no -c/-m (bare `--version`, REPL, ...): fall
+        # through so direct execution of a file named python* is still scanned.
 
     # A bare "/" is pathlib's division operator in Python sources, not an executable; resolving it
     # hits the filesystem root and fails the regular-file check, hard-blocking innocent .py scripts.

--- a/tests/hermes_cli/test_105427_lifecycle_interpreter.py
+++ b/tests/hermes_cli/test_105427_lifecycle_interpreter.py
@@ -1,0 +1,89 @@
+"""Regression for #105427: interpreter binary vs script classification."""
+from pathlib import Path
+from cron import lifecycle_guard as guard
+
+
+def test_python_directory_literal_is_not_a_shell_command(tmp_path):
+    data = tmp_path / "market-data"
+    data.mkdir()
+    script = tmp_path / "snapshot.py"
+    script.write_text("from pathlib import Path\nROOT = Path(" + repr(data.as_posix()) + ")\n")
+    source = script.read_text()
+    assert not guard.contains_gateway_lifecycle_command(source)
+    assert not guard.contains_launchctl_submit_command(source)
+    guard.check_gateway_lifecycle("Read-only public snapshot.", str(script))
+
+
+def test_large_absolute_interpreter_is_not_a_shell_script(tmp_path):
+    interp = tmp_path / "python3"
+    interp.write_bytes(b"\x00" * (guard._MAX_REFERENCED_SCRIPT_BYTES + 1))
+    script = tmp_path / "snapshot.py"
+    script.write_text('print("snapshot")\n')
+    cmd = interp.as_posix() + " " + script.as_posix()
+    assert not guard.contains_gateway_lifecycle_command_or_referenced_script(cmd, cwd=str(tmp_path))
+
+
+def test_quoted_absolute_interpreter_is_not_a_shell_script(tmp_path):
+    interp = tmp_path / "python3"
+    interp.write_bytes(b"\x00" * (guard._MAX_REFERENCED_SCRIPT_BYTES + 1))
+    script = tmp_path / "snapshot.py"
+    script.write_text('print("snapshot")\n')
+    cmd = '"' + interp.as_posix() + '" "' + script.as_posix() + '"'
+    assert not guard.contains_gateway_lifecycle_command_or_referenced_script(cmd, cwd=str(tmp_path))
+
+
+def test_wrapped_interpreter_is_not_a_shell_script(tmp_path):
+    interp = tmp_path / "python3"
+    interp.write_bytes(b"\x00" * (guard._MAX_REFERENCED_SCRIPT_BYTES + 1))
+    script = tmp_path / "snapshot.py"
+    script.write_text('print("snapshot")\n')
+    cmd = "sudo " + interp.as_posix() + " " + script.as_posix()
+    assert not guard.contains_gateway_lifecycle_command_or_referenced_script(cmd, cwd=str(tmp_path))
+
+
+def test_real_direct_lifecycle_command_stays_blocked():
+    try:
+        guard.check_gateway_lifecycle("hermes gateway restart")
+    except guard.GatewayLifecycleBlocked:
+        return
+    raise AssertionError("direct lifecycle not blocked")
+
+
+def test_referenced_shell_restart_stays_blocked(tmp_path):
+    script = tmp_path / "restart.sh"
+    script.write_text("#!/bin/sh\nhermes gateway stop\n")
+    assert guard.contains_gateway_lifecycle_command_or_referenced_script(
+        "sh " + script.as_posix(), cwd=str(tmp_path))
+
+
+def test_actual_oversized_shell_script_stays_fail_closed(tmp_path):
+    script = tmp_path / "large.sh"
+    script.write_bytes(b"#" * (guard._MAX_REFERENCED_SCRIPT_BYTES + 1))
+    assert guard.contains_gateway_lifecycle_command_or_referenced_script(
+        "sh " + script.as_posix(), cwd=str(tmp_path))
+
+
+def test_oversized_file_named_python_as_shell_arg_stays_fail_closed(tmp_path):
+    # `sh python3-oversized`: explicitly supplied AS the shell script -> still blocked.
+    # Proves the fix is positional, not a name exemption.
+    payload = tmp_path / "python3"
+    payload.write_bytes(b"#" * (guard._MAX_REFERENCED_SCRIPT_BYTES + 1))
+    assert guard.contains_gateway_lifecycle_command_or_referenced_script(
+        "sh " + payload.as_posix(), cwd=str(tmp_path))
+
+
+def test_python_script_arg_with_lifecycle_stays_blocked(tmp_path):
+    # sabotage: interpreter is benign, script payload is evil -> must still block.
+    interp = tmp_path / "python3"
+    interp.write_bytes(b"\x7fELF" + b"\x00" * 64)
+    evil = tmp_path / "evil.py"
+    evil.write_text('import os\nos.system("hermes gateway restart")\n')
+    cmd = interp.as_posix() + " " + evil.as_posix()
+    assert guard.contains_gateway_lifecycle_command_or_referenced_script(cmd, cwd=str(tmp_path))
+
+
+def test_python_c_payload_with_lifecycle_stays_blocked(tmp_path):
+    interp = tmp_path / "python3"
+    interp.write_bytes(b"\x7fELF" + b"\x00" * 64)
+    cmd = interp.as_posix() + ' -c "hermes gateway restart"'
+    assert guard.contains_gateway_lifecycle_command_or_referenced_script(cmd, cwd=str(tmp_path))


### PR DESCRIPTION
## What Problem This Solves

`cron/lifecycle_guard.py` treated an absolute Python interpreter binary in executable position as a referenced shell script (`_references_at`: any token containing `/`). An oversized interpreter (`1 MiB + 1` portable stand-in; real `python3` was 17 MB in the report) failed the referenced-script size check, so a benign `<interp> <snapshot.py>` collector was rejected as a gateway-lifecycle risk. Worse, the real script operand was never scanned, so `<interp> <evil.py>` with a lifecycle payload was missed entirely (bypass).

Fix: when the executable basename matches a Python interpreter (`python`, `python3`, `python3.11`, `pythonw`, `python.exe`, …), scan the script operand instead of the interpreter binary. `-c`/`-m` yield nothing (payload covered by the direct regex; module is not a file). With no operand and no `-c`/`-m`, fall through to the generic scan so direct execution of a file named `python*` stays fail-closed. `sh <file-named-python>` still blocks via the shell branch — positional, never a name exemption. The directory-literal case from the report already passes on current main via the `.py` direct-scan branch (#77131) plus directories-as-nothing-to-scan (#86753); covered by a regression test here.

## Evidence

New suite `tests/hermes_cli/test_105427_lifecycle_interpreter.py`: **10 passed** (was 6 passed / 4 failed before the fix — 3 benign `<interp> <script>` shapes blocked plus 1 evil `<interp> <evil.py>` missed).

Python-adjacent upstream guards still green: `test_python_script_with_pathlib_division_not_blocked`, `test_python_script_with_literal_lifecycle_command_still_blocked`, `test_absolute_path_binary_does_not_crash_guard`, `test_command_referencing_elf_binary_returns_false` — **4 passed**.

No new failures: `tests/hermes_cli/test_gateway_restart_loop.py` is **61 failed / 236 passed both before and after** this change (all 61 are pre-existing Windows backslash-path failures, verified by stashing the fix and re-running); `tests/cron/test_lifecycle_guard_budget.py` is **3 failed / 13 passed both before and after** (same pre-existing Windows failures).

Sabotage controls in the new suite (all passing): evil `evil.py` via interpreter still blocked, `-c "hermes gateway restart"` still blocked, oversized `sh <file-named-python>` still fail-closed.

Closes #105427
