### PR TITLE
fix(a2a): do not fail inbound tasks on observation timeout

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -334,7 +334,9 @@ class A2AAdapter(BasePlatformAdapter):
         """Background thread that fails orphaned tasks (keeps them queryable)."""
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL):
             try:
-                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT):
+                with self._pending_lock:
+                    live = set(self._pending)
+                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT, skip_ids=live):
                     logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, _ORPHAN_TIMEOUT)
                     protocol.metrics.tasks_failed += 1
             except Exception:
@@ -595,15 +597,37 @@ class A2AAdapter(BasePlatformAdapter):
         return state, reply
 
     @staticmethod
-    def _await_future(fut: Future, deadline: float, keepalive, on_timeout: tuple[str, str]) -> tuple[str, str]:
-        """Block until ``fut`` resolves or ``deadline`` passes (-> ``on_timeout``). ``keepalive`` runs
-        every _SSE_KEEPALIVE seconds while waiting; if it raises, the client is gone and we stop."""
+    def _await_future(
+        fut: Future,
+        deadline: float,
+        keepalive,
+        on_timeout: tuple[str, str],
+        *,
+        persist_after_deadline: bool = False,
+    ) -> tuple[str, str]:
+        """Block until ``fut`` resolves. Subscribe/watch may return ``on_timeout`` at the
+        deadline. Inbound ``message/send`` keeps waiting: observation timeout is not
+        TASK_STATE_FAILED (A2A §3.1.3). ``keepalive`` runs every _SSE_KEEPALIVE seconds;
+        if it raises, the client is gone and we stop."""
+        logged_observation_timeout = False
         while True:
+            remaining = deadline - time.time()
+            if keepalive:
+                wait = _SSE_KEEPALIVE
+            elif remaining > 0:
+                wait = remaining
+            else:
+                wait = _SSE_KEEPALIVE if persist_after_deadline else max(0.0, remaining)
             try:
-                return fut.result(timeout=_SSE_KEEPALIVE if keepalive else max(0.0, deadline - time.time()))
+                return fut.result(timeout=wait)
             except FuturesTimeout:
-                if time.time() >= deadline:
+                if time.time() >= deadline and not persist_after_deadline:
                     return on_timeout
+                if persist_after_deadline and remaining <= 0 and not logged_observation_timeout:
+                    logger.info(
+                        "A2A: observation window elapsed; task stays non-terminal until the session replies"
+                    )
+                    logged_observation_timeout = True
                 if keepalive:
                     try:
                         keepalive()
@@ -613,8 +637,13 @@ class A2AAdapter(BasePlatformAdapter):
                 return on_timeout
 
     def _await_reply(self, pending: dict, keepalive=None) -> tuple[str, str]:
-        return self._await_future(pending["future"], pending["started"] + _reply_timeout(), keepalive,
-                                  (protocol.STATE_FAILED, "[agent did not reply in time]"))
+        return self._await_future(
+            pending["future"],
+            pending["started"] + _reply_timeout(),
+            keepalive,
+            (protocol.STATE_FAILED, "[agent did not reply in time]"),
+            persist_after_deadline=True,
+        )
 
     def _rpc_message_send(self, req_id: Any, params: dict, peer: str, agent: Optional[dict] = None, v1_response: bool = False) -> dict:
         task, pending = self._prepare_task(params, peer, agent=agent)

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -14,7 +14,7 @@ from collections import OrderedDict, defaultdict, deque
 from concurrent.futures import Future
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Collection, Optional
 
 from gateway.platforms._shared import coerce_port as _coerce_int
 
@@ -414,10 +414,19 @@ class TaskStore:
         next_offset = offset + page_size if offset + page_size < total else 0
         return (page, next_offset, total) if with_total else (page, next_offset)
 
-    def fail_orphans(self, timeout_seconds: int = 300) -> list[str]:
+    def fail_orphans(
+        self,
+        timeout_seconds: int = 300,
+        skip_ids: Optional[Collection[str]] = None,
+    ) -> list[str]:
+        skip = set(skip_ids or ())
         with self._lock:
-            stale = [tid for tid, rec in self._tasks.items()
-                     if rec["state"] not in TERMINAL_STATES and time.time() - rec["created_at"] > timeout_seconds]
+            stale = [
+                tid for tid, rec in self._tasks.items()
+                if tid not in skip
+                and rec["state"] not in TERMINAL_STATES
+                and time.time() - rec["created_at"] > timeout_seconds
+            ]
         return [tid for tid in stale if self.complete(tid, STATE_FAILED, "[task orphaned — no reply produced]")]
 
     def _trim_locked(self) -> None:

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -498,6 +498,10 @@ class TestTaskStore:
         assert store.get("t-new")["state"] == protocol.STATE_SUBMITTED
         # Second sweep does nothing (already terminal).
         assert store.fail_orphans(timeout_seconds=300) == []
+        store.create("t-live", "c1", "p")
+        store._tasks["t-live"]["created_at"] = time.time() - 600
+        assert store.fail_orphans(timeout_seconds=300, skip_ids={"t-live"}) == []
+        assert store.get("t-live")["state"] == protocol.STATE_SUBMITTED
 
     def test_list_newest_first_with_filters(self):
         store = protocol.TaskStore()

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -16,6 +16,7 @@ import json
 import os
 import socket
 import threading
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import Future
@@ -1727,3 +1728,40 @@ class TestMultiplexConstructionScope:
         assert adapter.port == 9111
         assert adapter.agent_name == "default-profile-agent"
         assert adapter._agents[""]["description"] == "Default profile's own agent."
+
+
+# --------------------------------------------------------------------------
+# Observation timeout is not a terminal A2A state (§3.1.3 / #1237)
+# --------------------------------------------------------------------------
+
+class TestObservationTimeoutNotFailed:
+    def test_await_reply_keeps_waiting_after_deadline_then_completes(self, monkeypatch):
+        """A live session that answers late must not be TASK_STATE_FAILED."""
+        monkeypatch.setenv("A2A_REPLY_TIMEOUT", "0.05")
+        adapter = _bare_adapter()
+        fut = Future()
+        pending = {"future": fut, "started": time.time() - 1.0}
+
+        def complete_late():
+            time.sleep(0.2)
+            fut.set_result((protocol.STATE_COMPLETED, "late answer"))
+
+        thread = threading.Thread(target=complete_late)
+        thread.start()
+        state, reply = adapter._await_reply(pending)
+        thread.join(timeout=2)
+        assert (state, reply) == (protocol.STATE_COMPLETED, "late answer")
+        assert state != protocol.STATE_FAILED
+
+    def test_watchdog_skips_tasks_with_live_waiters(self):
+        adapter = _bare_adapter()
+        adapter.tasks.create("task-live", "ctx", "peer")
+        adapter.tasks._tasks["task-live"]["created_at"] = time.time() - 600
+        adapter._add_pending("task-live", "ctx")
+        with adapter._pending_lock:
+            live = set(adapter._pending)
+        failed = adapter.tasks.fail_orphans(timeout_seconds=300, skip_ids=live)
+        rec = adapter.tasks.get("task-live")
+        assert failed == []
+        assert rec is not None
+        assert rec["state"] != protocol.STATE_FAILED


### PR DESCRIPTION
## Bug Description

Inbound A2A `message/send` waits on `_await_future`, then returns `TASK_STATE_FAILED` with `[agent did not reply in time]` when `A2A_REPLY_TIMEOUT` elapses. The live session is still composing. Abel's seat then shows that string (120× today) and he reads Hermes/James session stores by hand. Observation timeout is not a terminal state (A2A §3.1.3). Governance #1237.

Same family as stale PR #96983. That head predates the `_await_future` refactor on current `main` (`9e6c4100cb`). This cut reconstructs the invariant there.

## Root Cause

`_await_reply` called `_await_future(..., on_timeout=(STATE_FAILED, "[agent did not reply in time]"))`. Past the deadline the wait is `max(0, remaining)` (a 0s wait), then FAILED. `fail_orphans` could also fail a working task that still had a live pending waiter.

## Fix

- After the observation window, keep waiting on the same future with a positive interval (`_SSE_KEEPALIVE`). Late `complete()` still lands.
- `fail_orphans(..., skip_ids=live pending)` so a live waiter is not orphaned.
- `tasks/subscribe` still uses `on_timeout` (current record). Profile-CLI subprocess timeout is unchanged.

## How to Verify

```
python -m pytest tests/plugins/test_a2a_plugin.py::TestObservationTimeoutNotFailed tests/plugins/test_a2a_phase23.py::TestTaskStore::test_fail_orphans tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py -q
```

152 passed. Sabotage: restore `timeout=max(0.0, remaining)` plus the FAILED return → late-complete test RED; restore GREEN.

## Test Plan

- [x] Late reply after deadline → `TASK_STATE_COMPLETED`, not failed
- [x] Watchdog skip live pending ids
- [x] Existing `fail_orphans` still fails true orphans
- [x] `test_a2a_plugin.py` + `test_a2a_phase23.py` 152 passed

## Risk Assessment

Holding `message/send` threads now wait until the agent actually replies (or a real failure / client disconnect). Callers that already treat HTTP timeout as local observation keep `GetTask` as working and can receive a late push. PR ≠ merge ≠ live gateway.

## Exclusions

- No Seed change (893/895 Path-B already on Abel 8.0.28).
- No bounce of Hermes/James gateways (Hermes's seat).
- Pingpong cap (`A2A_MAX_PINGPONG_TURNS`) is a separate named change for Hermes to apply.