### PR TITLE
feat(stt): transcribe Cantonese-English voice locally with SenseVoice

### DIFF
--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # :mod:`tools.transcription_tools`** (TestBuiltinSync fails on drift); importing it
 # directly would be a circular import.
 _BUILTIN_NAMES = frozenset({
-    "local", "local_command", "groq", "openai", "mistral", "xai", "elevenlabs", "deepinfra",
+    "local", "local_command", "sensevoice", "groq", "openai", "mistral", "xai", "elevenlabs", "deepinfra",
 })
 
 

--- a/apps/desktop/src/api/config.ts
+++ b/apps/desktop/src/api/config.ts
@@ -83,9 +83,9 @@ export function getHermesConfigDefaults(): Promise<HermesConfigRecord> {
   })
 }
 
-export function getHermesConfigSchema(profile?: null | string): Promise<ConfigSchemaResponse> {
-  return hermesApi<ConfigSchemaResponse>({
-    ...profileScoped(profile),
+export function getHermesConfigSchema(profile?: ProfileScope): Promise<ConfigSchemaResponse> {
+  return window.hermesDesktop.api<ConfigSchemaResponse>({
+    ...capabilityScoped(profile),
     path: '/api/config/schema'
   })
 }

--- a/apps/desktop/src/api/system.ts
+++ b/apps/desktop/src/api/system.ts
@@ -217,10 +217,10 @@ export function setTtsLease(lease: string, active: boolean): Promise<AudioTtsLea
   })
 }
 
-export function getElevenLabsVoices(profile?: null | string): Promise<ElevenLabsVoicesResponse> {
-  return hermesApi<ElevenLabsVoicesResponse>({
+export function getElevenLabsVoices(profile?: ProfileScope): Promise<ElevenLabsVoicesResponse> {
+  return window.hermesDesktop.api<ElevenLabsVoicesResponse>({
     path: '/api/audio/elevenlabs/voices',
-    ...profileScoped(profile)
+    ...capabilityScoped(profile)
   })
 }
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -248,9 +248,10 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   'terminal.backend': ['local', 'docker', 'singularity', 'modal', 'daytona', 'ssh'],
   'stt.elevenlabs.model_id': ['scribe_v2', 'scribe_v1'],
   'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3'],
+  'stt.sensevoice.backend': ['cpu', 'cuda', 'vulkan'],
   // Speech-to-text backends — kept in sync with the stt block in
-  // hermes_cli/config.py (local/groq/openai/mistral/elevenlabs).
-  'stt.provider': ['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'],
+  // hermes_cli/config.py (local/sensevoice/groq/openai/mistral/elevenlabs).
+  'stt.provider': ['local', 'sensevoice', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'],
   // OpenAI TTS voices — the union across models (per the OpenAI TTS API
   // docs). Model-specific narrowing happens in enumOptionsFor():
   // tts-1 / tts-1-hd support 9 voices; gpt-4o-mini-tts supports all 13.
@@ -370,7 +371,10 @@ export const FREE_INPUT_KEYS = new Set([
   'tts.kittentts.voice',
   'tts.piper.voice',
   'tts.deepinfra.model',
-  'tts.deepinfra.voice'
+  'tts.deepinfra.voice',
+  'stt.sensevoice.binary',
+  'stt.sensevoice.model',
+  'stt.sensevoice.vad_model'
 ])
 
 export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
@@ -736,6 +740,11 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.deepinfra.voice',
       'stt.local.model',
       'stt.local.language',
+      'stt.sensevoice.binary',
+      'stt.sensevoice.model',
+      'stt.sensevoice.vad_model',
+      'stt.sensevoice.backend',
+      'stt.sensevoice.timeout_seconds',
       'stt.openai.model',
       'stt.groq.model',
       'stt.mistral.model',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -197,7 +197,7 @@ describe('settings helpers', () => {
 
     it('renders a dropdown for the STT provider including xAI (Grok)', () => {
       const opts = enumOptionsFor('stt.provider', 'local', config)
-      expect(opts).toEqual(['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'])
+      expect(opts).toEqual(['local', 'sensevoice', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'])
     })
 
     it('renders dropdowns for per-backend model/device sub-fields', () => {
@@ -319,6 +319,7 @@ describe('settings helpers', () => {
             // both are built-in STT names omitted from ENUM_OPTIONS['stt.provider']
             local_command: { type: 'command', command: 'curl …' },
             deepinfra: { type: 'command', command: 'curl …' },
+            SENSEVOICE: { type: 'command', command: 'llama-funasr-sensevoice …' },
             myasr: { type: 'command', command: 'curl …' }
           }
         }
@@ -327,6 +328,7 @@ describe('settings helpers', () => {
       const opts = enumOptionsFor('stt.provider', 'local', shadowing)
       expect(opts).not.toContain('local_command')
       expect(opts).not.toContain('deepinfra')
+      expect(opts).not.toContain('SENSEVOICE')
       expect(opts).toContain('myasr')
     })
   })

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -274,6 +274,7 @@ const BUILTIN_TTS_PROVIDERS = new Set([
 const BUILTIN_STT_PROVIDERS = new Set([
   'local',
   'local_command',
+  'sensevoice',
   'groq',
   'openai',
   'mistral',

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -65,6 +65,7 @@ vi.mock('@/hermes', () => ({
   getHermesConfigRecord: () => getHermesConfigRecord(),
   getHermesConfigSchema: () => getHermesConfigSchema(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
+  saveHermesConfigRecord: (config: unknown, profile?: unknown) => saveHermesConfig(config, profile),
   getElevenLabsVoices: () => getElevenLabsVoices(),
   // @/store/profile (pulled in transitively via use-config-record's
   // normalizeProfileKey import) calls this at module-init; the full-replacement
@@ -198,6 +199,46 @@ describe('ToolsetConfigPanel', () => {
     await waitFor(() => expect(saveHermesConfig).toHaveBeenCalled(), { timeout: 3000 })
     const saved = saveHermesConfig.mock.calls.at(-1)?.[0] as Record<string, Record<string, Record<string, string>>>
     expect(saved.tts.openai.voice).toBe('marin')
+  })
+
+  it('renders every local SenseVoice setup field in the STT provider row', async () => {
+    getToolsetConfig.mockResolvedValue(
+      config({
+        name: 'stt',
+        providers: [
+          {
+            name: 'SenseVoice',
+            badge: 'local · free',
+            tag: 'Cantonese + English GGUF',
+            env_vars: [],
+            post_setup: null,
+            requires_nous_auth: false,
+            is_active: false,
+            status: 'needs_setup',
+            stt_provider: 'sensevoice'
+          }
+        ]
+      })
+    )
+    getHermesConfigRecord.mockResolvedValue({
+      stt: {
+        sensevoice: {
+          binary: 'llama-funasr-sensevoice',
+          model: 'sense-voice-small.gguf',
+          vad_model: 'fsmn-vad.gguf',
+          backend: 'cpu',
+          timeout_seconds: 120
+        }
+      }
+    })
+
+    render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="stt" />)
+
+    expect(await screen.findByDisplayValue('llama-funasr-sensevoice')).toBeTruthy()
+    expect(screen.getByDisplayValue('sense-voice-small.gguf')).toBeTruthy()
+    expect(screen.getByDisplayValue('fsmn-vad.gguf')).toBeTruthy()
+    expect(screen.getByText('Cpu')).toBeTruthy()
+    expect(screen.getByDisplayValue('120')).toBeTruthy()
   })
 
   it('renders no inline voice fields for rows without tts_provider (older backend)', async () => {

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -62,11 +62,18 @@ vi.mock('@/hermes', () => ({
   getActionStatus: (name: string, lines?: number) => getActionStatus(name, lines),
   startOAuthLogin: (providerId: string) => startOAuthLogin(providerId),
   pollOAuthSession: (providerId: string, sessionId: string) => pollOAuthSession(providerId, sessionId),
-  getHermesConfigRecord: () => getHermesConfigRecord(),
-  getHermesConfigSchema: () => getHermesConfigSchema(),
+  getHermesConfigRecord: (profile?: unknown) => getHermesConfigRecord(profile),
+  getHermesConfigSchema: (profile?: unknown) => getHermesConfigSchema(profile),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
   saveHermesConfigRecord: (config: unknown, profile?: unknown) => saveHermesConfig(config, profile),
-  getElevenLabsVoices: () => getElevenLabsVoices(),
+  getElevenLabsVoices: (profile?: unknown) => getElevenLabsVoices(profile),
+  profileScopeKey: (scope?: string | { connectionId?: string; profile?: string }) => {
+    if (scope && typeof scope === 'object') {
+      return `${scope.connectionId ?? ''}::${scope.profile ?? 'default'}`
+    }
+
+    return scope ?? 'default'
+  },
   // @/store/profile (pulled in transitively via use-config-record's
   // normalizeProfileKey import) calls this at module-init; the full-replacement
   // mock must provide it or the module graph throws on load.
@@ -202,6 +209,7 @@ describe('ToolsetConfigPanel', () => {
   })
 
   it('renders every local SenseVoice setup field in the STT provider row', async () => {
+    const profile = { connectionId: 'homelab', profile: 'voice-bot' }
     getToolsetConfig.mockResolvedValue(
       config({
         name: 'stt',
@@ -221,6 +229,7 @@ describe('ToolsetConfigPanel', () => {
       })
     )
     getHermesConfigRecord.mockResolvedValue({
+      unrelated: { concurrent_setting: 'stale' },
       stt: {
         sensevoice: {
           binary: 'llama-funasr-sensevoice',
@@ -232,13 +241,47 @@ describe('ToolsetConfigPanel', () => {
       }
     })
 
-    render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="stt" />)
+    render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} profile={profile} toolset="stt" />)
 
     expect(await screen.findByDisplayValue('llama-funasr-sensevoice')).toBeTruthy()
     expect(screen.getByDisplayValue('sense-voice-small.gguf')).toBeTruthy()
     expect(screen.getByDisplayValue('fsmn-vad.gguf')).toBeTruthy()
     expect(screen.getByText('Cpu')).toBeTruthy()
     expect(screen.getByDisplayValue('120')).toBeTruthy()
+    expect(getHermesConfigRecord).toHaveBeenCalledWith(profile)
+    expect(getHermesConfigSchema).toHaveBeenCalledWith(profile)
+
+    fireEvent.change(screen.getByDisplayValue('sense-voice-small.gguf'), { target: { value: 'sense-voice-v2.gguf' } })
+    await waitFor(() => expect(saveHermesConfig).toHaveBeenCalled(), { timeout: 3000 })
+    expect(saveHermesConfig).toHaveBeenLastCalledWith(
+      { stt: { sensevoice: { model: 'sense-voice-v2.gguf' } } },
+      profile
+    )
+  })
+
+  it('scopes dynamic ElevenLabs voices to the selected connection and profile', async () => {
+    const profile = { connectionId: 'homelab', profile: 'voice-bot' }
+    getToolsetConfig.mockResolvedValue(
+      config({
+        providers: [
+          {
+            name: 'ElevenLabs',
+            badge: 'paid',
+            tag: 'Most natural voices',
+            env_vars: [],
+            post_setup: null,
+            requires_nous_auth: false,
+            is_active: false,
+            tts_provider: 'elevenlabs'
+          }
+        ]
+      })
+    )
+
+    render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} profile={profile} toolset="tts" />)
+
+    await screen.findByText('ElevenLabs Voice')
+    expect(getElevenLabsVoices).toHaveBeenCalledWith(profile)
   })
 
   it('renders no inline voice fields for rows without tts_provider (older backend)', async () => {

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -890,7 +890,12 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange, profile }: Too
                   // Voice/model settings for this backend (tts.<key>.*) —
                   // the same fields Settings → Voice renders, inline so the
                   // Capabilities panel is a complete setup surface.
-                  <VoiceProviderFields providerKey={provider.tts_provider} section="tts" />
+                  <VoiceProviderFields profile={profile} providerKey={provider.tts_provider} section="tts" />
+                )}
+                {toolset === 'stt' && provider.stt_provider && (
+                  // Local model/runtime settings for this backend — setup must
+                  // be complete before the provider-select endpoint activates it.
+                  <VoiceProviderFields profile={profile} providerKey={provider.stt_provider} section="stt" />
                 )}
                 {MODEL_CATALOG_TOOLSETS.has(toolset) && (
                   <ModelCatalogPicker

--- a/apps/desktop/src/app/settings/voice-provider-fields.test.ts
+++ b/apps/desktop/src/app/settings/voice-provider-fields.test.ts
@@ -10,6 +10,13 @@ describe('voiceProviderKeys', () => {
     expect(voiceProviderKeys('tts', 'openai')).toEqual(['tts.openai.model', 'tts.openai.voice'])
     expect(voiceProviderKeys('tts', 'elevenlabs')).toEqual(['tts.elevenlabs.voice_id', 'tts.elevenlabs.model_id'])
     expect(voiceProviderKeys('tts', 'edge')).toEqual(['tts.edge.voice'])
+    expect(voiceProviderKeys('stt', 'sensevoice')).toEqual([
+      'stt.sensevoice.binary',
+      'stt.sensevoice.model',
+      'stt.sensevoice.vad_model',
+      'stt.sensevoice.backend',
+      'stt.sensevoice.timeout_seconds'
+    ])
   })
 
   it('covers every built-in TTS provider the Capabilities picker offers', () => {
@@ -54,7 +61,10 @@ describe('voice field option coverage', () => {
       'tts.elevenlabs.voice_id',
       'tts.edge.voice',
       'tts.xai.voice_id',
-      'tts.piper.voice'
+      'tts.piper.voice',
+      'stt.sensevoice.binary',
+      'stt.sensevoice.model',
+      'stt.sensevoice.vad_model'
     ]) {
       expect(FREE_INPUT_KEYS.has(key), key).toBe(true)
     }

--- a/apps/desktop/src/app/settings/voice-provider-fields.tsx
+++ b/apps/desktop/src/app/settings/voice-provider-fields.tsx
@@ -5,6 +5,7 @@ import {
   getElevenLabsVoices,
   getHermesConfigSchema,
   type ProfileScope,
+  profileScopeKey,
   saveHermesConfigRecord
 } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -15,7 +16,7 @@ import { hermesConfigCacheWriter, useHermesConfigRecord } from '../hooks/use-con
 
 import { ConfigField } from './config-field'
 import { SECTIONS } from './constants'
-import { enumOptionsFor, getNested, inferFieldSchema, setNested } from './helpers'
+import { diffConfig, enumOptionsFor, getNested, inferFieldSchema, setNested } from './helpers'
 
 // The curated voice keys (Settings → Voice) are the single source of which
 // per-provider fields exist; both the Voice settings page and the
@@ -47,8 +48,8 @@ export function VoiceProviderFields({ section, providerKey, profile }: VoiceProv
   const { data: loadedConfig } = useHermesConfigRecord(profile)
 
   const { data: schemaResponse } = useQuery({
-    queryKey: ['hermes-config-schema'],
-    queryFn: () => getHermesConfigSchema(),
+    queryKey: profile == null ? ['hermes-config-schema'] : ['hermes-config-schema', profileScopeKey(profile)],
+    queryFn: () => getHermesConfigSchema(profile),
     staleTime: 5 * 60 * 1000
   })
 
@@ -57,11 +58,14 @@ export function VoiceProviderFields({ section, providerKey, profile }: VoiceProv
   // config-settings.tsx's autosave loop.
   const [config, setConfig] = useState<HermesConfigRecord | null>(null)
   const seeded = useRef(false)
+  const configBaselineRef = useRef<HermesConfigRecord | null>(null)
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
 
   // eslint-disable-next-line no-restricted-syntax -- one-shot config seed flag, not an atom mirror
   useEffect(() => {
     if (loadedConfig && !seeded.current) {
       seeded.current = true
+      configBaselineRef.current = loadedConfig
       setConfig(loadedConfig)
     }
   }, [loadedConfig])
@@ -69,15 +73,30 @@ export function VoiceProviderFields({ section, providerKey, profile }: VoiceProv
   const saveVersionRef = useRef(0)
   const [saveVersion, setSaveVersion] = useState(0)
 
+  // eslint-disable-next-line no-restricted-syntax -- autosave bookkeeping refs, not an atom mirror
   useEffect(() => {
     if (!config || saveVersion === 0) {
       return
     }
 
+    const snapshot = config
+
     const timeout = window.setTimeout(() => {
-      void saveHermesConfigRecord(config, profile)
-        .then(() => hermesConfigCacheWriter(profile)(config))
-        .catch(err => notifyError(err, t.settings.config.autosaveFailed))
+      saveQueueRef.current = saveQueueRef.current.then(async () => {
+        try {
+          const patch = diffConfig(configBaselineRef.current ?? {}, snapshot)
+          const result = await saveHermesConfigRecord(patch, profile)
+
+          if (!result.ok) {
+            throw new Error(t.settings.config.autosaveFailed)
+          }
+
+          configBaselineRef.current = snapshot
+          hermesConfigCacheWriter(profile)(snapshot)
+        } catch (err) {
+          notifyError(err, t.settings.config.autosaveFailed)
+        }
+      })
     }, 550)
 
     return () => window.clearTimeout(timeout)
@@ -97,7 +116,7 @@ export function VoiceProviderFields({ section, providerKey, profile }: VoiceProv
 
     let cancelled = false
 
-    getElevenLabsVoices()
+    getElevenLabsVoices(profile)
       .then(result => {
         if (cancelled || !result.available) {
           return
@@ -114,7 +133,7 @@ export function VoiceProviderFields({ section, providerKey, profile }: VoiceProv
       })
 
     return () => void (cancelled = true)
-  }, [wantsElevenLabs])
+  }, [profile, wantsElevenLabs])
 
   if (keys.length === 0 || !config) {
     return null

--- a/apps/desktop/src/app/settings/voice-provider-fields.tsx
+++ b/apps/desktop/src/app/settings/voice-provider-fields.tsx
@@ -1,12 +1,17 @@
 import { useQuery } from '@tanstack/react-query'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { getElevenLabsVoices, getHermesConfigSchema, saveHermesConfig } from '@/hermes'
+import {
+  getElevenLabsVoices,
+  getHermesConfigSchema,
+  type ProfileScope,
+  saveHermesConfigRecord
+} from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
 import type { HermesConfigRecord } from '@/types/hermes'
 
-import { setHermesConfigCache, useHermesConfigRecord } from '../hooks/use-config-record'
+import { hermesConfigCacheWriter, useHermesConfigRecord } from '../hooks/use-config-record'
 
 import { ConfigField } from './config-field'
 import { SECTIONS } from './constants'
@@ -26,14 +31,20 @@ export function voiceProviderKeys(section: 'tts' | 'stt', providerKey: string): 
 /**
  * Inline voice/model settings for one TTS (or STT) provider, rendered inside
  * the Capabilities → toolset config panel underneath the provider's API-key
- * fields. Reads and writes the same `tts.<provider>.*` config keys as
+ * fields. Reads and writes the same `<section>.<provider>.*` config keys as
  * Settings → Voice (shared ConfigField renderer + enum/free-input rules), with
  * the same debounced autosave through the shared config cache.
  */
-export function VoiceProviderFields({ section, providerKey }: { section: 'tts' | 'stt'; providerKey: string }) {
+interface VoiceProviderFieldsProps {
+  section: 'tts' | 'stt'
+  providerKey: string
+  profile?: ProfileScope
+}
+
+export function VoiceProviderFields({ section, providerKey, profile }: VoiceProviderFieldsProps) {
   const { t } = useI18n()
   const keys = useMemo(() => voiceProviderKeys(section, providerKey), [section, providerKey])
-  const { data: loadedConfig } = useHermesConfigRecord()
+  const { data: loadedConfig } = useHermesConfigRecord(profile)
 
   const { data: schemaResponse } = useQuery({
     queryKey: ['hermes-config-schema'],
@@ -64,14 +75,14 @@ export function VoiceProviderFields({ section, providerKey }: { section: 'tts' |
     }
 
     const timeout = window.setTimeout(() => {
-      void saveHermesConfig(config)
-        .then(() => setHermesConfigCache(config))
+      void saveHermesConfigRecord(config, profile)
+        .then(() => hermesConfigCacheWriter(profile)(config))
         .catch(err => notifyError(err, t.settings.config.autosaveFailed))
     }, 550)
 
     return () => window.clearTimeout(timeout)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- copy is stable; avoid re-scheduling autosave on locale change
-  }, [config, saveVersion])
+  }, [config, saveVersion, profile])
 
   // ElevenLabs cloned/library voices from the live account, when available —
   // mirrors the Settings → Voice dynamic voice list.

--- a/apps/desktop/src/hermes-capability-scope.test.ts
+++ b/apps/desktop/src/hermes-capability-scope.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  getElevenLabsVoices,
   getHermesConfigRecord,
+  getHermesConfigSchema,
   getMcpCatalog,
   getSkillContent,
   getSkills,
@@ -77,6 +79,8 @@ describe('capability helpers are connection-scoped', () => {
   it('object scopes pin every read and write to the named connection', () => {
     void getSkills({ connectionId: 'homelab', profile: 'inbox-bot' })
     void getToolsets({ connectionId: 'homelab', profile: 'inbox-bot' })
+    void getHermesConfigSchema({ connectionId: 'homelab', profile: 'inbox-bot' })
+    void getElevenLabsVoices({ connectionId: 'homelab', profile: 'inbox-bot' })
     void getSkillContent('arxiv', { connectionId: 'homelab', profile: 'inbox-bot' })
     void setSkillEnabled('arxiv', false, { connectionId: 'homelab', profile: 'inbox-bot' })
     void setToolsetEnabled('browser', true, { connectionId: 'homelab', profile: 'inbox-bot' })

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1109,6 +1109,9 @@ export interface ToolProvider {
    *  provider's voice/model settings (tts.<key>.*). Absent on other toolsets
    *  and older backends. */
   tts_provider?: string
+  /** STT toolset only: the provider key written to stt.provider. Doubles as
+   *  the config section holding local model/runtime settings. */
+  stt_provider?: string
   /** Web toolset only: capabilities this backend can serve. Search-only
    *  providers (ddgs, brave-free) report ['search']. */
   capabilities?: WebCapability[]

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1496,7 +1496,8 @@ platform_toolsets:
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.
-# Providers: local (free, faster-whisper) | groq (free tier) | openai (Whisper API) | mistral (Voxtral Transcribe)
+# Providers: local (free, faster-whisper) | sensevoice (free, local GGUF) | groq (free tier) |
+# openai (Whisper API) | mistral (Voxtral Transcribe)
 # Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
 stt:
   enabled: true
@@ -1528,7 +1529,7 @@ stt:
   #   openai / groq          -> `prompt`, forwarded unchanged
   #   mistral                -> `prompt`, forwarded unchanged
   #   deepinfra              -> OpenAI-compatible `prompt`, unchanged
-  #   local_command/xai/
+  #   local_command/sensevoice/xai/
   #   elevenlabs             -> unsupported; DEBUG log, then continue
   #   plugin providers       -> `prompt` in `**extra`; plugin owns limits
   # prompt: "Hermes, Teknium, Nous Research, kanban"
@@ -1543,6 +1544,12 @@ stt:
     # no_speech_prob_threshold: 0.6  # drop a segment only if no_speech_prob > this...
     # logprob_threshold: -1.0       # ...AND avg_logprob < this (both must hit — quiet real speech survives)
     # unload_after_idle_seconds: 0  # 0=never unload (default); e.g. 300 releases the model after 5min idle (frees VRAM on GPU; next voice message reloads it)
+  # sensevoice:
+  #   binary: "llama-funasr-sensevoice"  # executable on PATH or absolute path
+  #   model: "/path/to/sensevoice-small-q8.gguf"  # required GGUF model
+  #   vad_model: "/path/to/fsmn-vad.gguf"  # optional, recommended for long audio
+  #   backend: "cpu"          # cpu | cuda | vulkan; must match the runtime build
+  #   timeout_seconds: 300
   language: "en"               # GLOBAL language hint for every STT provider (per-provider language wins). Set "" for auto-detect.
   # groq:
   #   model: "whisper-large-v3-turbo"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1063,8 +1063,8 @@ DEFAULT_CONFIG = {
         # Echo the raw transcript of gateway voice messages back as a 🎙️ message.
         "echo_transcripts": True,
         # No seeded "provider": a stored value counts as an explicit user pick; unset = autodetect
-        # ladder. Valid: "local" (faster-whisper) | "groq" | "openai" | "mistral" | "elevenlabs" |
-        # "deepinfra". Global language hint unless a per-provider language overrides it. "en"
+        # ladder. Valid: "local" (faster-whisper) | "sensevoice" | "groq" | "openai" | "mistral" |
+        # "elevenlabs" | "deepinfra". Global language hint unless a per-provider language overrides it. "en"
         # because Whisper auto-detect misreads short/accented clips; "" = auto; or "es", "zh", ...
         "language": "en",
         # Client-side ffmpeg silence trim before cloud upload (local whisper uses VAD): silence
@@ -1084,6 +1084,13 @@ DEFAULT_CONFIG = {
             "no_speech_prob_threshold": 0.6,
             "logprob_threshold": -1.0,
             "unload_after_idle_seconds": 0,  # 0 = never; e.g. 300 frees the model after 5min
+        },
+        "sensevoice": {
+            "binary": "llama-funasr-sensevoice",  # executable name on PATH or absolute path
+            "model": "",  # required path to sensevoice-small-*.gguf
+            "vad_model": "",  # optional path to fsmn-vad.gguf for long audio
+            "backend": "cpu",  # cpu, cuda, or vulkan (matching the installed runtime build)
+            "timeout_seconds": 300,
         },
         "groq": {
             # whisper-large-v3, whisper-large-v3-turbo, distil-whisper-large-v3-en

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -267,11 +267,10 @@ def _local_stt_backend_available() -> bool:
 def _sensevoice_backend_available(stt_cfg: Dict[str, object]) -> bool:
     """True when the selected SenseVoice binary and GGUF model are usable."""
     try:
-        from tools.transcription_sensevoice import _configured_file, _sensevoice_binary
+        from tools.transcription_sensevoice import _sensevoice_config_error
 
         cfg = stt_cfg.get("sensevoice") or {}
-        model = _configured_file(cfg.get("model"))
-        return bool(_sensevoice_binary(cfg.get("binary")) and model and model.is_file())
+        return _sensevoice_config_error(cfg) is None
     except Exception:
         return False
 

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -242,7 +242,7 @@ _PROVIDER_LABELS = {
     }),
     "stt": ("local", {
         "openai": "OpenAI Whisper", "groq": "Groq Whisper", "mistral": "Mistral Voxtral Transcribe",
-        "local": "Local faster-whisper",
+        "local": "Local faster-whisper", "sensevoice": "SenseVoice local",
     }),
 }
 
@@ -260,6 +260,18 @@ def _local_stt_backend_available() -> bool:
         from tools.transcription_tools import _HAS_FASTER_WHISPER
 
         return bool(_HAS_FASTER_WHISPER)
+    except Exception:
+        return False
+
+
+def _sensevoice_backend_available(stt_cfg: Dict[str, object]) -> bool:
+    """True when the selected SenseVoice binary and GGUF model are usable."""
+    try:
+        from tools.transcription_sensevoice import _configured_file, _sensevoice_binary
+
+        cfg = stt_cfg.get("sensevoice") or {}
+        model = _configured_file(cfg.get("model"))
+        return bool(_sensevoice_binary(cfg.get("binary")) and model and model.is_file())
     except Exception:
         return False
 
@@ -357,6 +369,7 @@ def _audio_features(
     # status never flags it "tool disabled".
     stt_available = bool({
         "local": _local_stt_backend_available() and not stt_gw, "openai": managed["stt"] or direct_openai_stt,
+        "sensevoice": _sensevoice_backend_available(stt_cfg) and not stt_gw,
         "groq": _any_env("GROQ_API_KEY") and not stt_gw, "mistral": _any_env("MISTRAL_API_KEY") and not stt_gw,
     }.get(stt_current, False))
     stt = _state(

--- a/hermes_cli/setup_summary.py
+++ b/hermes_cli/setup_summary.py
@@ -152,6 +152,15 @@ def _stt_row(config, feats):
     if stt_feature is not None and stt_feature.managed_by_nous:
         return ("Speech-to-Text (OpenAI via Nous subscription)", True, None)
     provider = _setup.cfg_get(config, "stt", "provider", default="local") or "local"
+    if provider == "sensevoice":
+        from hermes_cli.nous_subscription import _sensevoice_backend_available
+
+        ok = _sensevoice_backend_available(_setup.cfg_get(config, "stt", default={}) or {})
+        return (
+            "Speech-to-Text (SenseVoice local)" if ok else "Speech-to-Text (SenseVoice — not configured)",
+            ok,
+            None if ok else "set stt.sensevoice.binary and stt.sensevoice.model in config.yaml",
+        )
     return _voice_provider_status("Speech-to-Text", provider, _STT_SUMMARY_ROWS, _STT_SUMMARY_DEFAULT)
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -249,6 +249,8 @@ TOOL_CATEGORIES = {
         "providers": [
             _row("Local Whisper", "★ recommended · free", "faster-whisper on-device, no API key", stt_provider="local",
                  post_setup="faster_whisper"),
+            _row("SenseVoice", "local · free", "Cantonese + English GGUF; configure binary and model paths",
+                 stt_provider="sensevoice"),
             _row("Nous Subscription", "subscription", "Managed OpenAI transcription billed to your subscription",
                  stt_provider="openai", **_NOUS, managed_nous_feature="stt",
                  override_env_vars=["VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY"]),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -250,7 +250,7 @@ TOOL_CATEGORIES = {
             _row("Local Whisper", "★ recommended · free", "faster-whisper on-device, no API key", stt_provider="local",
                  post_setup="faster_whisper"),
             _row("SenseVoice", "local · free", "Cantonese + English GGUF; configure binary and model paths",
-                 stt_provider="sensevoice"),
+                 stt_provider="sensevoice", config_setup="sensevoice"),
             _row("Nous Subscription", "subscription", "Managed OpenAI transcription billed to your subscription",
                  stt_provider="openai", **_NOUS, managed_nous_feature="stt",
                  override_env_vars=["VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY"]),

--- a/hermes_cli/tools_config_providers.py
+++ b/hermes_cli/tools_config_providers.py
@@ -171,6 +171,12 @@ def provider_readiness_status(provider: dict, config: dict, *, features=None, is
     if provider.get("env_vars", []):
         return "ready" if _provider_env_ready(provider) else "needs_keys"
 
+    if provider.get("config_setup") == "sensevoice":
+        from tools.transcription_sensevoice import _sensevoice_config_error
+
+        stt_cfg = config.get("stt") if isinstance(config.get("stt"), dict) else {}
+        return "ready" if _sensevoice_config_error(stt_cfg.get("sensevoice")) is None else "needs_setup"
+
     managed_feature = provider.get("managed_nous_feature")
     if provider.get("requires_nous_auth") or managed_feature:
         if features is None:
@@ -648,6 +654,37 @@ def _configure_stt_model(stt_provider: str, config: dict) -> None:
     _print_success(f"  STT model set to: {chosen}")
 
 
+def _configure_sensevoice(config: dict) -> bool:
+    """Collect the non-secret local runtime settings required by SenseVoice."""
+    from hermes_cli.tools_config import _cfg_section, _prompt_choice
+    from tools.transcription_sensevoice import _DEFAULT_BINARY
+
+    existing = config.get("stt", {}).get("sensevoice", {})
+    existing = existing if isinstance(existing, dict) else {}
+    model = _prompt("  SenseVoiceSmall GGUF model path", str(existing.get("model") or ""))
+    if not model:
+        _print_warning("  SenseVoice not configured — a GGUF model path is required.")
+        return False
+    binary = _prompt("  SenseVoice runtime executable", str(existing.get("binary") or _DEFAULT_BINARY))
+    vad_model = _prompt("  FSMN-VAD GGUF model path (optional)", str(existing.get("vad_model") or ""))
+    backends = ["cpu", "cuda", "vulkan"]
+    current_backend = str(existing.get("backend") or "cpu").strip().lower()
+    backend = backends[_prompt_choice(
+        "  Select SenseVoice backend:", backends,
+        backends.index(current_backend) if current_backend in backends else 0,
+    )]
+    cfg = _cfg_section(_cfg_section(config, "stt"), "sensevoice")
+    cfg.update({"model": model, "binary": binary or _DEFAULT_BINARY, "backend": backend})
+    if vad_model:
+        cfg["vad_model"] = vad_model
+    else:
+        cfg.pop("vad_model", None)
+    return True
+
+
+_PROVIDER_CONFIGURATORS = {"sensevoice": _configure_sensevoice}
+
+
 # Provider-row marker key -> config section it selects into.
 _PROVIDER_MARKER_SECTIONS = {
     "tts_provider": "tts", "stt_provider": "stt", "browser_provider": "browser", "web_backend": "web",
@@ -890,6 +927,9 @@ def _configure_provider(provider: dict, config: dict, *, force_fresh: bool = Tru
     if not _nous_provider_gate(provider, config, managed_feature, force_fresh=force_fresh):
         return
 
+    config_setup = provider.get("config_setup")
+    if config_setup and not _PROVIDER_CONFIGURATORS[config_setup](config):
+        return
     _print_provider_selection(provider, managed_feature, reconfigure=reconfigure)
     # Shared with the GUI provider-select endpoint (apply_provider_selection): one source of truth for config writes.
     _write_provider_config(provider, config, managed_feature=managed_feature)
@@ -897,7 +937,10 @@ def _configure_provider(provider: dict, config: dict, *, force_fresh: bool = Tru
     if not env_vars:
         if provider.get("post_setup"):
             _run_post_setup(provider["post_setup"])
-        _print_success(f"  {provider['name']} - no configuration needed!")
+        if config_setup:
+            _print_success(f"  {provider['name']} configured!")
+        else:
+            _print_success(f"  {provider['name']} - no configuration needed!")
         if managed_feature:
             _print_info("  Requests for this tool will be billed to your Nous subscription.")
         _finish_provider_selection(provider, config, managed_feature)

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -376,10 +376,11 @@ async def get_toolset_config(name: str, profile: Optional[str] = None):
                         # row's backend key + capabilities for per-capability selection.
                         row["web_backend"] = prov["web_backend"]
                         row["capabilities"] = web_provider_capabilities(prov["web_backend"])
-                    if name == "tts" and prov.get("tts_provider"):
-                        # Key written to tts.provider; doubles as the config section
-                        # (tts.<key>.*) holding the provider's voice/model settings.
-                        row["tts_provider"] = prov["tts_provider"]
+                    provider_marker = f"{name}_provider"
+                    if name in {"stt", "tts"} and prov.get(provider_marker):
+                        # Key written to <toolset>.provider; doubles as the config
+                        # section holding this provider's voice/model settings.
+                        row[provider_marker] = prov[provider_marker]
                     providers.append(row)
             payload = {
                 "name": name, "has_category": cat is not None, "providers": providers,
@@ -485,7 +486,8 @@ async def select_toolset_provider(
     entitlement (``needs_nous_auth`` + ``feature``): the GUI has no inline
     login, so an unentitled selection would write config and never activate.
     """
-    from hermes_cli.tools_config import apply_provider_selection, web_provider_capabilities
+    from hermes_cli.tools_config import (
+        apply_provider_selection, provider_readiness_status, web_provider_capabilities)
     from hermes_cli.nous_subscription import (
         MANAGED_FEATURE_COVERAGE_CATEGORY, get_nous_subscription_features)
 
@@ -521,6 +523,11 @@ async def select_toolset_provider(
                         raise _bad_request(f"{body.provider} does not support {body.capability}")
                     _dict_section(config, "web")[f"{body.capability}_backend"] = backend
                 else:
+                    prov = _provider_row(config)
+                    if prov is not None and prov.get("config_setup"):
+                        status = provider_readiness_status(prov, config)
+                        if status == "needs_setup":
+                            raise _bad_request(f"Configure {body.provider} before selecting it")
                     try:
                         apply_provider_selection(name, body.provider, config)
                     except KeyError as exc:

--- a/hermes_cli/web_server_config.py
+++ b/hermes_cli/web_server_config.py
@@ -103,8 +103,11 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     ),
     # "mistral" temporarily removed — mistralai PyPI package quarantined
     # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-    "stt.provider": _select("Speech-to-text provider", "local", "groq", "openai", "xai", "elevenlabs"),
+    "stt.provider": _select(
+        "Speech-to-text provider", "local", "sensevoice", "groq", "openai", "xai", "elevenlabs"
+    ),
     "stt.local.model": _select("Local faster-whisper model size", "tiny", "base", "small", "medium", "large-v3"),
+    "stt.sensevoice.backend": _select("SenseVoice execution backend", "cpu", "cuda", "vulkan"),
     "stt.groq.model": _select(
         "Groq Whisper model", "whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en"
     ),

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -3,6 +3,8 @@
 import shutil
 import sys
 
+import pytest
+
 from hermes_cli.nous_account import NousPortalAccountInfo, NousToolAccessInfo
 from hermes_cli import nous_subscription as ns
 from tools import tool_backend_helpers
@@ -17,6 +19,24 @@ _POOL_COVERAGE = {
     "browser-use": True,
     "modal": True,
 }
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"vad_model": "missing-vad.gguf"},
+        {"backend": "bogus"},
+    ],
+)
+def test_sensevoice_readiness_rejects_runtime_invalid_config(tmp_path, extra):
+    binary = tmp_path / "llama-funasr-sensevoice"
+    binary.write_bytes(b"binary")
+    binary.chmod(0o755)
+    model = tmp_path / "sensevoice.gguf"
+    model.write_bytes(b"GGUF")
+    cfg = {"binary": str(binary), "model": str(model), **extra}
+
+    assert ns._sensevoice_backend_available({"sensevoice": cfg}) is False
 
 
 def _account(*, logged_in: bool, paid: bool | None = None) -> NousPortalAccountInfo:

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -20,6 +20,7 @@ from hermes_cli.tools_config import (  # noqa: E402
     STT_MODEL_CATALOG,
     TOOL_CATEGORIES,
     _checklist_toolset_keys,
+    _configure_provider,
     _configure_stt_model,
     _is_provider_active,
     _write_provider_config,
@@ -80,6 +81,34 @@ class TestConfigWrites:
         apply_provider_selection("stt", "SenseVoice", config)
 
         assert config["stt"]["provider"] == "sensevoice"
+
+    def test_terminal_sensevoice_selection_requires_model_before_activation(self, capsys):
+        config = {}
+
+        with patch("hermes_cli.tools_config_providers._prompt", return_value=""):
+            _configure_provider(_stt_provider_named("SenseVoice"), config)
+
+        assert config.get("stt", {}).get("provider") is None
+        assert "GGUF model path is required" in capsys.readouterr().out
+
+    def test_terminal_sensevoice_selection_persists_local_runtime_settings(self):
+        config = {}
+
+        with patch(
+            "hermes_cli.tools_config_providers._prompt",
+            side_effect=["model.gguf", "sensevoice-bin", "vad.gguf"],
+        ), patch("hermes_cli.tools_config._prompt_choice", return_value=2):
+            _configure_provider(_stt_provider_named("SenseVoice"), config)
+
+        assert config["stt"] == {
+            "provider": "sensevoice",
+            "sensevoice": {
+                "model": "model.gguf",
+                "binary": "sensevoice-bin",
+                "vad_model": "vad.gguf",
+                "backend": "vulkan",
+            },
+        }
 
 
 class TestActiveDetection:

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -75,6 +75,12 @@ class TestConfigWrites:
             apply_provider_selection("stt", "OpenAI", config)
         assert config["stt"]["provider"] == "openai"
 
+    def test_sensevoice_is_selectable_as_local_stt(self):
+        config = {}
+        apply_provider_selection("stt", "SenseVoice", config)
+
+        assert config["stt"]["provider"] == "sensevoice"
+
 
 class TestActiveDetection:
     def test_active_matches_config(self):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2833,6 +2833,25 @@ class TestNewEndpoints:
         else:
             assert data["active_provider"] is None
 
+    def test_sensevoice_requires_setup_before_api_activation(self):
+        """Capabilities exposes SenseVoice settings and cannot activate an unusable row."""
+        from hermes_cli.config import load_config
+
+        data = self.client.get("/api/tools/toolsets/stt/config").json()
+        sensevoice = next(p for p in data["providers"] if p["name"] == "SenseVoice")
+        assert sensevoice["stt_provider"] == "sensevoice"
+        assert sensevoice["status"] == "needs_setup"
+
+        before = load_config()["stt"].get("provider")
+        resp = self.client.put(
+            "/api/tools/toolsets/stt/provider",
+            json={"provider": "SenseVoice"},
+        )
+
+        assert resp.status_code == 400
+        assert "Configure SenseVoice before selecting it" in resp.json()["detail"]
+        assert load_config()["stt"].get("provider") == before
+
     def test_get_toolset_config_reports_truthful_provider_status(self, monkeypatch):
         """Each provider row carries a server-computed readiness `status`.
 

--- a/tests/tools/test_stt_cloud_trim.py
+++ b/tests/tools/test_stt_cloud_trim.py
@@ -7,7 +7,7 @@ silence isn't uploaded, billed per audio-minute, or hallucinated on.
 
 Contract under test:
 
-1. Trim runs only for built-in CLOUD providers — never local/local_command,
+1. Trim runs only for built-in CLOUD providers — never local/local_command/sensevoice,
    never command-type or plugin providers.
 2. Best-effort semantics: disabled config, missing ffmpeg/ffprobe, trim
    failure, mostly-silence result, or <10% saving all mean "upload the
@@ -36,7 +36,7 @@ if "faster_whisper" not in sys.modules:
     faster_whisper_stub.__spec__ = ModuleSpec("faster_whisper", loader=None)
     sys.modules["faster_whisper"] = faster_whisper_stub
 
-from tools.transcription_common import BUILTIN_STT_PROVIDERS, CLOUD_STT_PROVIDERS
+from tools.transcription_common import BUILTIN_STT_PROVIDERS, CLOUD_STT_PROVIDERS, LOCAL_STT_PROVIDERS
 from tools.transcription_audio import (
     _cloud_trim_settings,
     _CLOUD_TRIM_KEEP_MS_DEFAULT,
@@ -86,13 +86,12 @@ def _write_wav(path: Path, segments) -> str:
 
 class TestProviderGating:
     def test_cloud_set_excludes_local_providers(self):
-        assert "local" not in CLOUD_STT_PROVIDERS
-        assert "local_command" not in CLOUD_STT_PROVIDERS
+        assert not CLOUD_STT_PROVIDERS & LOCAL_STT_PROVIDERS
 
     def test_cloud_set_covers_every_remote_builtin(self):
         # Invariant: every built-in that is not local-ish uploads audio and
         # must get the trim. New built-ins are cloud unless proven otherwise.
-        assert CLOUD_STT_PROVIDERS == BUILTIN_STT_PROVIDERS - {"local", "local_command"}
+        assert CLOUD_STT_PROVIDERS == BUILTIN_STT_PROVIDERS - LOCAL_STT_PROVIDERS
 
     def test_local_provider_never_trims(self, tmp_path):
         wav = _write_wav(tmp_path / "a.wav", [("tone", 1)])

--- a/tests/tools/test_stt_sensevoice.py
+++ b/tests/tools/test_stt_sensevoice.py
@@ -1,0 +1,64 @@
+"""SenseVoiceSmall GGUF provider contracts."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tools import transcription_tools
+
+
+def test_sensevoice_dispatches_locally_with_configured_gguf(tmp_path, monkeypatch):
+    audio = tmp_path / "voice.wav"
+    audio.write_bytes(b"RIFF")
+    model = tmp_path / "sensevoice-small-q8.gguf"
+    model.write_bytes(b"GGUF")
+    vad = tmp_path / "fsmn-vad.gguf"
+    vad.write_bytes(b"GGUF")
+    binary = tmp_path / "llama-funasr-sensevoice"
+    binary.write_bytes(b"binary")
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured.update(command=command, kwargs=kwargs)
+        return SimpleNamespace(stdout="粵語 mixed English\n", stderr="")
+
+    config = {
+        "provider": "sensevoice",
+        "sensevoice": {
+            "binary": str(binary),
+            "model": str(model),
+            "vad_model": str(vad),
+            "backend": "cpu",
+        },
+    }
+    monkeypatch.setattr(transcription_tools, "_load_stt_config", lambda: config)
+    with patch("tools.transcription_sensevoice._run_quiet", side_effect=fake_run):
+        result = transcription_tools.transcribe_audio(str(audio))
+
+    assert result == {
+        "success": True,
+        "transcript": "粵語 mixed English",
+        "provider": "sensevoice",
+    }
+    assert captured["command"] == [
+        str(binary), "-m", str(model), "-a", str(audio),
+        "--vad", str(vad), "--backend", "cpu",
+    ]
+    assert captured["kwargs"]["timeout"] == 300
+    assert "OPENAI_API_KEY" not in captured["kwargs"]["env"]
+
+
+def test_sensevoice_reports_missing_model_before_spawning(tmp_path, monkeypatch):
+    audio = tmp_path / "voice.wav"
+    audio.write_bytes(b"RIFF")
+    config = {
+        "provider": "sensevoice",
+        "sensevoice": {"binary": "llama-funasr-sensevoice", "model": ""},
+    }
+    monkeypatch.setattr(transcription_tools, "_load_stt_config", lambda: config)
+
+    with patch("tools.transcription_sensevoice._run_quiet") as run:
+        result = transcription_tools.transcribe_audio(str(audio))
+
+    assert result["success"] is False
+    assert "stt.sensevoice.model" in result["error"]
+    run.assert_not_called()

--- a/tests/tools/test_stt_sensevoice.py
+++ b/tests/tools/test_stt_sensevoice.py
@@ -1,9 +1,13 @@
 """SenseVoiceSmall GGUF provider contracts."""
 
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from tools import transcription_tools
+from tools.transcription_sensevoice import _sensevoice_binary
 
 
 def test_sensevoice_dispatches_locally_with_configured_gguf(tmp_path, monkeypatch):
@@ -15,6 +19,7 @@ def test_sensevoice_dispatches_locally_with_configured_gguf(tmp_path, monkeypatc
     vad.write_bytes(b"GGUF")
     binary = tmp_path / "llama-funasr-sensevoice"
     binary.write_bytes(b"binary")
+    binary.chmod(0o755)
     captured = {}
 
     def fake_run(command, **kwargs):
@@ -62,3 +67,13 @@ def test_sensevoice_reports_missing_model_before_spawning(tmp_path, monkeypatch)
     assert result["success"] is False
     assert "stt.sensevoice.model" in result["error"]
     run.assert_not_called()
+
+
+@pytest.mark.linux_only
+def test_sensevoice_rejects_non_executable_explicit_binary(tmp_path):
+    binary = tmp_path / "llama-funasr-sensevoice"
+    binary.write_bytes(b"binary")
+    binary.chmod(0o644)
+
+    assert os.access(binary, os.X_OK) is False
+    assert _sensevoice_binary(str(binary)) is None

--- a/tests/tools/test_stt_sensevoice.py
+++ b/tests/tools/test_stt_sensevoice.py
@@ -21,10 +21,18 @@ def test_sensevoice_dispatches_locally_with_configured_gguf(tmp_path, monkeypatc
     binary.write_bytes(b"binary")
     binary.chmod(0o755)
     captured = {}
+    for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        monkeypatch.setenv(name, f"secret-{name}")
 
     def fake_run(command, **kwargs):
         captured.update(command=command, kwargs=kwargs)
-        return SimpleNamespace(stdout="粵語 mixed English\n", stderr="")
+        return SimpleNamespace(
+            stdout=(
+                "1\n00:00:00,000 --> 00:00:01,000\nhello\n\n"
+                "2\n00:00:01,000 --> 00:00:02,000\nworld\n"
+            ),
+            stderr="",
+        )
 
     config = {
         "provider": "sensevoice",
@@ -41,15 +49,18 @@ def test_sensevoice_dispatches_locally_with_configured_gguf(tmp_path, monkeypatc
 
     assert result == {
         "success": True,
-        "transcript": "粵語 mixed English",
+        "transcript": "hello world",
         "provider": "sensevoice",
     }
     assert captured["command"] == [
         str(binary), "-m", str(model), "-a", str(audio),
-        "--vad", str(vad), "--backend", "cpu",
+        "--vad", str(vad), "--srt", "--backend", "cpu",
     ]
     assert captured["kwargs"]["timeout"] == 300
     assert "OPENAI_API_KEY" not in captured["kwargs"]["env"]
+    assert not {
+        "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+    } & captured["kwargs"]["env"].keys()
 
 
 def test_sensevoice_reports_missing_model_before_spawning(tmp_path, monkeypatch):

--- a/tools/transcription_common.py
+++ b/tools/transcription_common.py
@@ -43,9 +43,10 @@ GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-lar
 # The plugin hook from issue #30398-style follow-up rejects plugins registering under any of these names;
 # the dispatcher in ``transcribe_audio`` short-circuits them defensively as well.
 BUILTIN_STT_PROVIDERS = frozenset({
-    "local", "local_command", "groq", "openai", "mistral", "xai", "elevenlabs", "deepinfra"})
+    "local", "local_command", "sensevoice", "groq", "openai", "mistral", "xai", "elevenlabs", "deepinfra"})
 # Built-in providers that upload audio to a remote API.
-CLOUD_STT_PROVIDERS = frozenset(BUILTIN_STT_PROVIDERS - {"local", "local_command"})
+LOCAL_STT_PROVIDERS = frozenset({"local", "local_command", "sensevoice"})
+CLOUD_STT_PROVIDERS = frozenset(BUILTIN_STT_PROVIDERS - LOCAL_STT_PROVIDERS)
 
 
 def _error_result(error: str, **extra: Any) -> Dict[str, Any]:

--- a/tools/transcription_sensevoice.py
+++ b/tools/transcription_sensevoice.py
@@ -1,0 +1,91 @@
+"""Offline SenseVoiceSmall transcription through the FunASR GGUF runtime."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from tools.transcription_audio import _prepare_local_audio, _run_quiet
+from tools.transcription_common import (
+    _config_number, _error_result, _log_prompt_unsupported, _ok_result,
+    _process_error_detail,
+)
+
+
+_DEFAULT_BINARY = "llama-funasr-sensevoice"
+_SUPPORTED_BACKENDS = frozenset({"cpu", "cuda", "vulkan"})
+logger = logging.getLogger("tools.transcription_tools")
+
+
+def _configured_file(value: Any) -> Optional[Path]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return Path(value.strip()).expanduser()
+
+
+def _sensevoice_binary(value: Any) -> Optional[str]:
+    configured = value.strip() if isinstance(value, str) and value.strip() else _DEFAULT_BINARY
+    path = Path(configured).expanduser()
+    return str(path) if path.is_file() else shutil.which(configured)
+
+
+def _transcribe_sensevoice(
+    file_path: str, model_name: str, *, language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run ``llama-funasr-sensevoice`` with user-supplied GGUF weights."""
+    from tools.transcription_tools import _load_stt_config
+
+    if language:
+        logger.debug("STT provider 'sensevoice' does not support language hints — using auto-detection")
+    if prompt:
+        _log_prompt_unsupported("STT provider 'sensevoice'")
+    cfg = (_load_stt_config().get("sensevoice") or {})
+    model = _configured_file(model_name)
+    if model is None:
+        return _error_result(
+            "SenseVoice requires stt.sensevoice.model to point to a SenseVoiceSmall GGUF file")
+    if not model.is_file():
+        return _error_result(f"SenseVoice GGUF model not found: {model}")
+    binary = _sensevoice_binary(cfg.get("binary"))
+    if not binary:
+        return _error_result(
+            "SenseVoice runtime not found. Install llama-funasr-sensevoice or set "
+            "stt.sensevoice.binary to its path")
+    vad_model = _configured_file(cfg.get("vad_model"))
+    if vad_model is not None and not vad_model.is_file():
+        return _error_result(f"SenseVoice VAD GGUF model not found: {vad_model}")
+    backend = str(cfg.get("backend") or "cpu").strip().lower()
+    if backend not in _SUPPORTED_BACKENDS:
+        return _error_result(
+            f"Unsupported SenseVoice backend {backend!r}; choose cpu, cuda, or vulkan")
+
+    timeout = max(_config_number(cfg, "timeout_seconds", 300, int), 1)
+    try:
+        with tempfile.TemporaryDirectory(prefix="hermes-sensevoice-") as work_dir:
+            prepared_input, prep_error = _prepare_local_audio(file_path, work_dir)
+            if prep_error:
+                return _error_result(prep_error)
+            command = [binary, "-m", str(model), "-a", prepared_input]
+            if vad_model is not None:
+                command.extend(("--vad", str(vad_model)))
+            command.extend(("--backend", backend))
+            from tools.environments.local import hermes_subprocess_env
+            result = _run_quiet(
+                command, timeout=timeout,
+                env=hermes_subprocess_env(inherit_credentials=False),
+            )
+        transcript = result.stdout.strip()
+        if not transcript:
+            return _error_result("SenseVoice completed but produced no transcript")
+        return _ok_result(transcript, "sensevoice")
+    except subprocess.TimeoutExpired:
+        return _error_result(f"SenseVoice transcription timed out after {timeout} seconds")
+    except subprocess.CalledProcessError as exc:
+        return _error_result(f"SenseVoice transcription failed: {_process_error_detail(exc)}")
+    except OSError as exc:
+        return _error_result(f"SenseVoice runtime failed to start: {exc}")

--- a/tools/transcription_sensevoice.py
+++ b/tools/transcription_sensevoice.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import subprocess
 import tempfile
@@ -30,7 +31,33 @@ def _configured_file(value: Any) -> Optional[Path]:
 def _sensevoice_binary(value: Any) -> Optional[str]:
     configured = value.strip() if isinstance(value, str) and value.strip() else _DEFAULT_BINARY
     path = Path(configured).expanduser()
-    return str(path) if path.is_file() else shutil.which(configured)
+    if path.is_file():
+        if os.name != "nt" and not os.access(path, os.X_OK):
+            return None
+        return str(path)
+    return shutil.which(configured)
+
+
+def _sensevoice_config_error(cfg: Any, *, model_name: Any = None) -> Optional[str]:
+    """Return why a SenseVoice config cannot run, without spawning the runtime."""
+    cfg = cfg if isinstance(cfg, dict) else {}
+    model = _configured_file(cfg.get("model") if model_name is None else model_name)
+    if model is None:
+        return "SenseVoice requires stt.sensevoice.model to point to a SenseVoiceSmall GGUF file"
+    if not model.is_file():
+        return f"SenseVoice GGUF model not found: {model}"
+    if not _sensevoice_binary(cfg.get("binary")):
+        return (
+            "SenseVoice runtime not found. Install llama-funasr-sensevoice or set "
+            "stt.sensevoice.binary to its path"
+        )
+    vad_model = _configured_file(cfg.get("vad_model"))
+    if vad_model is not None and not vad_model.is_file():
+        return f"SenseVoice VAD GGUF model not found: {vad_model}"
+    backend = str(cfg.get("backend") or "cpu").strip().lower()
+    if backend not in _SUPPORTED_BACKENDS:
+        return f"Unsupported SenseVoice backend {backend!r}; choose cpu, cuda, or vulkan"
+    return None
 
 
 def _transcribe_sensevoice(
@@ -46,23 +73,14 @@ def _transcribe_sensevoice(
         _log_prompt_unsupported("STT provider 'sensevoice'")
     cfg = (_load_stt_config().get("sensevoice") or {})
     model = _configured_file(model_name)
-    if model is None:
-        return _error_result(
-            "SenseVoice requires stt.sensevoice.model to point to a SenseVoiceSmall GGUF file")
-    if not model.is_file():
-        return _error_result(f"SenseVoice GGUF model not found: {model}")
+    config_error = _sensevoice_config_error(cfg, model_name=model_name)
+    if config_error:
+        return _error_result(config_error)
+    assert model is not None
     binary = _sensevoice_binary(cfg.get("binary"))
-    if not binary:
-        return _error_result(
-            "SenseVoice runtime not found. Install llama-funasr-sensevoice or set "
-            "stt.sensevoice.binary to its path")
+    assert binary is not None
     vad_model = _configured_file(cfg.get("vad_model"))
-    if vad_model is not None and not vad_model.is_file():
-        return _error_result(f"SenseVoice VAD GGUF model not found: {vad_model}")
     backend = str(cfg.get("backend") or "cpu").strip().lower()
-    if backend not in _SUPPORTED_BACKENDS:
-        return _error_result(
-            f"Unsupported SenseVoice backend {backend!r}; choose cpu, cuda, or vulkan")
 
     timeout = max(_config_number(cfg, "timeout_seconds", 300, int), 1)
     try:

--- a/tools/transcription_sensevoice.py
+++ b/tools/transcription_sensevoice.py
@@ -60,6 +60,18 @@ def _sensevoice_config_error(cfg: Any, *, model_name: Any = None) -> Optional[st
     return None
 
 
+def _parse_srt_transcript(output: str) -> str:
+    segments = []
+    for block in output.replace("\r\n", "\n").split("\n\n"):
+        lines = [line.strip() for line in block.splitlines()]
+        timestamp = next((index for index, line in enumerate(lines) if "-->" in line), None)
+        if timestamp is not None:
+            text = " ".join(line for line in lines[timestamp + 1:] if line)
+            if text:
+                segments.append(text)
+    return " ".join(segments)
+
+
 def _transcribe_sensevoice(
     file_path: str, model_name: str, *, language: Optional[str] = None,
     prompt: Optional[str] = None,
@@ -90,14 +102,23 @@ def _transcribe_sensevoice(
                 return _error_result(prep_error)
             command = [binary, "-m", str(model), "-a", prepared_input]
             if vad_model is not None:
-                command.extend(("--vad", str(vad_model)))
+                command.extend(("--vad", str(vad_model), "--srt"))
             command.extend(("--backend", backend))
             from tools.environments.local import hermes_subprocess_env
+            child_env = {
+                key: value
+                for key, value in hermes_subprocess_env(inherit_credentials=False).items()
+                if not key.upper().startswith("AWS_")
+            }
             result = _run_quiet(
                 command, timeout=timeout,
-                env=hermes_subprocess_env(inherit_credentials=False),
+                env=child_env,
             )
-        transcript = result.stdout.strip()
+        transcript = (
+            _parse_srt_transcript(result.stdout)
+            if vad_model is not None
+            else result.stdout.strip()
+        )
         if not transcript:
             return _error_result("SenseVoice completed but produced no transcript")
         return _ok_result(transcript, "sensevoice")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Speech-to-text transcription used by the gateway for voice messages.
 
-Built-in providers: local (faster-whisper, default/free), local_command, groq, openai
+Built-in providers: local (faster-whisper, default/free), local_command, sensevoice, groq, openai
 (also serves the managed ``nous`` selection), mistral, xai, elevenlabs, deepinfra; plus
 user-declared command providers and plugin providers. ``transcribe_audio(path)`` returns
 ``{"success", "transcript", "error"?, "provider"?}``. This module owns provider resolution,
@@ -22,7 +22,7 @@ from utils import is_truthy_value
 from tools.transcription_common import (
     BUILTIN_STT_PROVIDERS, CLOUD_STT_PROVIDERS, DEFAULT_ELEVENLABS_STT_MODEL,
     DEFAULT_GROQ_STT_MODEL, DEFAULT_LOCAL_MODEL, DEFAULT_MISTRAL_STT_MODEL, DEFAULT_PROVIDER,
-    DEFAULT_STT_MODEL, LOCAL_STT_COMMAND_ENV, LOCAL_STT_LANGUAGE_ENV, _error_result,
+    DEFAULT_STT_MODEL, LOCAL_STT_COMMAND_ENV, LOCAL_STT_LANGUAGE_ENV, LOCAL_STT_PROVIDERS, _error_result,
     _get_stt_section, _ok_result)
 from tools.transcription_audio import (
     _convert_caf_to_wav, _prepare_audio_for_transcription, _trim_silence_for_cloud_stt,
@@ -31,6 +31,7 @@ from tools.transcription_local import (
     _get_idle_unload_seconds, _has_local_command, _join_confident_segments,
     _load_local_whisper_model, _looks_like_cuda_lib_error, _normalize_local_model,
     _transcribe_local_command, _try_lazy_install_stt, build_local_transcribe_kwargs)
+from tools.transcription_sensevoice import _transcribe_sensevoice
 # The ``_transcribe_<provider>`` handlers are looked up in this module's globals by _dispatch_stt_provider.
 from tools.transcription_cloud import (  # noqa: F401  (handlers dispatched via globals())
     _has_xai_stt_credentials, _resolve_openai_audio_client_config, _transcribe_deepinfra,
@@ -137,7 +138,7 @@ def _has_openai_audio_backend() -> bool:
 
 def _is_local_stt_provider(provider: str, stt_config: Dict[str, Any]) -> bool:
     """Whether *provider* is exempt from Hermes's remote upload cap."""
-    return (provider or "").lower().strip() in {"local", "local_command"}
+    return (provider or "").lower().strip() in LOCAL_STT_PROVIDERS
 
 
 # ---- Provider resolution ------------------------------------------------
@@ -443,6 +444,7 @@ def _transcribe_prepared_audio(
 _BUILTIN_MODEL_KEYS = {
     "local": ("local", "model", DEFAULT_LOCAL_MODEL, False),
     "local_command": ("local", "model", DEFAULT_LOCAL_MODEL, False),
+    "sensevoice": ("sensevoice", "model", "", False),
     "groq": ("groq", "model", DEFAULT_GROQ_STT_MODEL, True),
     "openai": ("openai", "model", DEFAULT_STT_MODEL, False),
     "mistral": ("mistral", "model", DEFAULT_MISTRAL_STT_MODEL, False),

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -460,8 +460,9 @@ See `agent/tts_provider.py` for the full ABC including docstrings.
 Voice messages sent on Telegram, Discord, WhatsApp, Slack, or Signal are automatically transcribed and injected as text into the conversation. The agent sees the transcript as normal text.
 
 | Provider | Quality | Cost | API Key |
-|----------|---------|------|---------| 
+|----------|---------|------|---------|
 | **Local Whisper** (default) | Good | Free | None needed |
+| **SenseVoiceSmall GGUF** | Best for Cantonese + English mixing | Free | None needed |
 | **Groq Whisper API** | Good–Best | Free tier | `GROQ_API_KEY` |
 | **OpenAI Whisper API** | Good–Best | Paid | `VOICE_TOOLS_OPENAI_KEY` or `OPENAI_API_KEY` |
 
@@ -474,11 +475,16 @@ Local transcription works out of the box when `faster-whisper` is installed. If 
 ```yaml
 # In ~/.hermes/config.yaml
 stt:
-  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra"
+  provider: "local"           # "local" | "sensevoice" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra"
   language: "en"              # Global language hint applied to every provider unless a per-provider language overrides it; set "" to restore auto-detect
   local:
     model: "base"             # tiny, base, small, medium, large-v3
-    language: ""              # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
+    language: ""              # optional ISO 639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
+  sensevoice:
+    binary: "llama-funasr-sensevoice"  # executable on PATH or an absolute path
+    model: "/path/to/sensevoice-small-q8.gguf"
+    vad_model: "/path/to/fsmn-vad.gguf"  # optional; recommended for long audio
+    backend: "cpu"            # cpu, cuda, or vulkan; must match the runtime build
   groq:
     language: ""              # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
   openai:
@@ -501,6 +507,8 @@ stt:
 | `small` | ~500 MB | Medium | Better |
 | `medium` | ~1.5 GB | Slower | Great |
 | `large-v3` | ~3 GB | Slowest | Best |
+
+**SenseVoiceSmall GGUF** — Runs [SenseVoiceSmall](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) fully offline through FunASR's [`llama-funasr-sensevoice`](https://github.com/modelscope/FunASR/tree/main/runtime/llama.cpp) binary. It is optimized for multilingual and code-mixed speech, including Cantonese (`yue`) plus English. Download a matching runtime binary and GGUF model, set `stt.provider: sensevoice`, and configure the paths shown above. The optional FSMN-VAD GGUF segments long recordings. Hermes sends credentials neither to the process nor over the network.
 
 **Groq API** — Requires `GROQ_API_KEY`. Good cloud fallback when you want a free hosted STT option. Set `stt.groq.language` (or the global `HERMES_LOCAL_STT_LANGUAGE` env var) to skip Whisper's auto-detect and reduce latency on known-language audio.
 


### PR DESCRIPTION
## What does this PR do?

Adds SenseVoiceSmall as a first-class offline STT provider for Cantonese, English, and code-mixed voice messages. Hermes invokes the FunASR GGUF runtime directly, keeps audio local, and exposes the provider across CLI and desktop configuration surfaces.

### Motivation

Local faster-whisper can be inaccurate for Cantonese and Cantonese-English mixed speech. SenseVoiceSmall provides a local GGUF alternative without sending voice recordings to a third-party API.

### Behavior

Set `stt.provider: sensevoice`, then configure the `llama-funasr-sensevoice` binary and SenseVoiceSmall GGUF model paths. An optional FSMN-VAD model handles long recordings, and CPU, CUDA, and Vulkan runtime builds are supported. Hermes validates configuration before spawning the runtime and removes credentials from the child environment.

Automatic runtime/model downloads, emotion/event tag surfacing, and persistent server mode are not included.

## Related Issue

Closes #106561

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/transcription_sensevoice.py` - run SenseVoiceSmall through the local FunASR GGUF binary with model, VAD, backend, timeout, and error handling.
- `tools/transcription_tools.py` - register SenseVoice as a local built-in STT provider and dispatch public transcription calls to it.
- `hermes_cli/` and `apps/desktop/` - expose SenseVoice selection, configuration fields, and readiness reporting.
- `cli-config.yaml.example` and `website/docs/user-guide/features/tts.md` - document installation and configuration.
- `tests/` - cover public dispatch, configuration errors, provider selection, local/cloud classification, and desktop settings.

## How to Test

1. Configure `stt.provider: sensevoice`, `stt.sensevoice.binary`, and `stt.sensevoice.model` with a FunASR runtime and GGUF model.
2. Send a Cantonese-English voice message through a gateway platform or record one in CLI voice mode.
3. Run the automated regression suites:

```bash
scripts/run_tests.sh tests/tools/test_stt_sensevoice.py tests/tools/test_stt_cloud_trim.py tests/agent/test_transcription_registry.py tests/hermes_cli/test_stt_picker.py tests/hermes_cli/test_setup_summary_provider_warning.py -q
cd apps/desktop && npx vitest run src/app/settings/helpers.test.ts src/app/settings/voice-provider-fields.test.ts
```

Local result: 55 Python tests and 48 desktop tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A
