### PR TITLE
fix: heal stale non-automatic end stamps on still-routed sessions (#106459)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2897,6 +2897,21 @@ def _parent_deliberately_ended(session_db: Any, session_id: str) -> bool:
         return False
 
 
+def _end_stamp_contradicted_by_live_traffic(session_db: Any, session_id: str) -> bool:
+    """Stale-stamp read (#106459): a non-automatic end stamp on a row still being driven
+    (traffic inside the heal window, no continuation child) is contradicted by the router,
+    so the pre-flush abort below must not fire — the authoritative in-transaction heal in
+    publish_compression_child clears it under the verified compression lease. Fails CLOSED:
+    an unreadable predicate must not widen the deliberate-end abort."""
+    pred = getattr(type(session_db), "end_stamp_contradicted_by_live_traffic", None)
+    if not callable(pred):
+        return False
+    try:
+        return bool(pred(session_db, session_id))
+    except Exception:
+        return False
+
+
 def _carry_session_state_to_child(agent: Any, old_session_id: str, old_title: Any) -> None:
     """Migrate /goal, /heartbeat, /loop state and the title from the parent to the child.
     Each lookup is a flat per-session read with no parent walk, so state would silently die at the boundary. The title
@@ -2945,7 +2960,11 @@ def _publish_rotated_compaction(
     # The flush is durable and NOT rolled back on abort: a deliberately-ended parent
     # fails publish forever, so check that before writing. Automatic end stamps are
     # healed by publish (don't abort); the lease is re-acquirable (don't check it).
-    if _parent_deliberately_ended(agent._session_db, old_session_id):
+    # A non-automatic stamp contradicted by live traffic (row still driven, no
+    # continuation child) is stale (#106459) — publish heals it in-transaction, so
+    # don't abort here either; only a quiet, unforked deliberate boundary aborts.
+    if _parent_deliberately_ended(agent._session_db, old_session_id) and not _end_stamp_contradicted_by_live_traffic(
+            agent._session_db, old_session_id):
         raise RuntimeError(f"Compression parent already ended: {old_session_id}")
     # Foreign-tail ceiling: the flush below writes OUR rows (already in handoff);
     # rows above the start watermark up to this MAX(id) are foreign appends.

--- a/hermes_state_compression.py
+++ b/hermes_state_compression.py
@@ -22,6 +22,14 @@ _COOLDOWN_ROW_SQL = (
     "SELECT compression_failure_cooldown_until, compression_failure_error FROM sessions WHERE id = ?"
 )
 
+# A non-automatic end stamp is stale when the row still received conversation traffic this
+# recently (#106459: a transient/erroneous end stamp wedged compression into a permanent
+# "Cannot compress further" death loop — every turn summarized fine, then publish refused,
+# then the oversized history overflowed again). Generous window: a deliberate boundary
+# (session reset/switch) re-routes subsequent turns to a NEW row within minutes, so a
+# stamped row driven by live turns this fresh is not a boundary anyone acted on.
+_STAMP_HEAL_ACTIVITY_WINDOW_SECONDS = 900.0
+
 # One forward step of get_compression_chain: the preferred continuation child of ``?``.
 _CHAIN_STEP_SQL = f"""
                     SELECT child.id
@@ -155,6 +163,71 @@ class SessionCompressionMixin:
             return updated.rowcount == 1
         return bool(self._execute_write(_do))
 
+    def _continuation_child_exists(self, conn, session_id: str) -> bool:
+        """Whether any non-branch/non-delegate/non-tool child row hangs off *session_id*
+        (continuation marker of a real boundary — a deliberate end usually forks one)."""
+        child = conn.execute(
+            """
+            SELECT 1
+            FROM sessions
+            WHERE parent_session_id = ?
+            """
+            + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="")
+            + """
+            LIMIT 1
+            """,
+            (session_id, session_id, session_id),
+        ).fetchone()
+        return child is not None
+
+    def end_stamp_contradicted_by_live_traffic(self, session_id: str, window_seconds: float = None) -> bool:
+        """Read-only stale-stamp predicate (#106459). True when the row is stamped ended
+        with a NON-automatic reason yet the boundary is contradicted by observable
+        liveness: no continuation child was published from it and the row still received
+        conversation traffic inside *window_seconds*. The router driving a row the stamp
+        claims is over is the same contradiction #88197 already heals for automatic
+        stamps, under stricter guards — the authoritative heal runs inside
+        ``publish_compression_child``'s transaction, where the compression lease is
+        re-verified; this read only lets the pre-flush guard skip an abort it would
+        otherwise regret (the flush is durable and not rolled back)."""
+        if not session_id:
+            return False
+        window = _STAMP_HEAL_ACTIVITY_WINDOW_SECONDS if window_seconds is None else window_seconds
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                f"""
+                SELECT ended_at, end_reason, ({_sql_session_last_active("sessions")}) AS last_active
+                FROM sessions WHERE id = ?
+                """,
+                (session_id,),
+            ).fetchone()
+            if row is None or row["ended_at"] is None or is_automatic_end_reason(row["end_reason"]):
+                return False
+            if self._continuation_child_exists(conn, session_id):
+                return False
+            try:
+                last_active = float(row["last_active"])
+            except (TypeError, ValueError):
+                return False
+            return last_active >= time.time() - window
+
+    def _heal_stale_parent_end_stamp(self, conn, parent_session_id: str, last_active: Any, now: float) -> bool:
+        """Transaction-side twin of :meth:`end_stamp_contradicted_by_live_traffic`. The
+        caller must already hold a verified live compression lease (publish does, before
+        this runs). Clears the stamp only when no continuation child exists and the row
+        was driven within the heal window; anything else fails closed."""
+        if self._continuation_child_exists(conn, parent_session_id):
+            return False
+        try:
+            if float(last_active) < now - _STAMP_HEAL_ACTIVITY_WINDOW_SECONDS:
+                return False
+        except (TypeError, ValueError):
+            return False
+        conn.execute(
+            "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
+            (parent_session_id,))
+        return True
+
     def _publish_child_session_row(self, conn, parent, *, parent_session_id, child_session_id, source,
                                    model, model_config, system_prompt, cwd, profile_name) -> None:
         """INSERT the compression child's ``sessions`` row copied from *parent*. Same contract as
@@ -215,8 +288,10 @@ class SessionCompressionMixin:
             parent = conn.execute(
                 """SELECT ended_at, end_reason, cwd, git_branch, git_repo_root,
                           user_id, session_key, chat_id, chat_type,
-                          thread_id, display_name, origin_json, profile_name
-                   FROM sessions WHERE id = ?""",
+                          thread_id, display_name, origin_json, profile_name,
+                          ({_sql_last_active}) AS _last_active
+                   FROM sessions WHERE id = ?""".format(
+                       _sql_last_active=_sql_session_last_active("sessions")),
                 (parent_session_id,),
             ).fetchone()
             if parent is None:
@@ -225,12 +300,20 @@ class SessionCompressionMixin:
                 # An AUTOMATIC end stamp (tui_shutdown, ws_disconnect, orphan reap, idle/LRU
                 # evict) is stale by construction — this lease holder is still continuing the
                 # conversation, and left alone it wedges rotation forever. Clear it; the closure
-                # UPDATE below re-stamps end_reason='compression'. Deliberate boundaries fail closed.
+                # UPDATE below re-stamps end_reason='compression'. A NON-automatic stamp gets one
+                # stricter liveness check (#106459): no continuation child and the row still
+                # received traffic inside the heal window means the boundary is contradicted by
+                # the router still driving it — the lease holder above is mid-rotation on a
+                # session the stamp claims is over, so heal and proceed. A quiet or forked row
+                # is a real boundary and fails closed.
                 if not is_automatic_end_reason(parent["end_reason"]):
-                    raise RuntimeError(f"Compression parent already ended: {parent_session_id}")
-                conn.execute(
-                    "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
-                    (parent_session_id,))
+                    if not self._heal_stale_parent_end_stamp(
+                            conn, parent_session_id, parent["_last_active"], time.time()):
+                        raise RuntimeError(f"Compression parent already ended: {parent_session_id}")
+                else:
+                    conn.execute(
+                        "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
+                        (parent_session_id,))
             if not messages:
                 raise RuntimeError("Compression child handoff must not be empty")
             self._publish_child_session_row(

--- a/tests/state/test_compression_stale_end_stamp_heal.py
+++ b/tests/state/test_compression_stale_end_stamp_heal.py
@@ -1,0 +1,170 @@
+"""Regression tests: a stale non-automatic end stamp on a still-routed session must not
+permanently wedge compression (#106459).
+
+Failure shape from the field (support-confirmed agent.log): a gateway-driven session row
+carried a non-automatic ``ended_at`` stamp. Compression summarized fine (~60s), then
+publish refused with "Compression parent already ended", the oversized history stayed,
+and every later turn died with "Context length exceeded ... Cannot compress further" —
+manual /compress no-ops through the same path, so the session was unrecoverable.
+
+The heal clears the stamp only when the boundary is contradicted by observable liveness:
+no continuation child was published from it and the row still received conversation
+traffic inside the heal window. Quiet or forked deliberate boundaries still fail closed.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_errors import CompressionSessionBusyError
+
+_OLD_ACTIVITY_AGE = 900.0 * 4
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield session_db
+    finally:
+        session_db.close()
+
+
+def _seed_lock(db: SessionDB, session_id: str, holder: str = "compressor", *, expired: bool = False) -> None:
+    now = time.time()
+    db._conn.execute(
+        "INSERT INTO compression_locks (session_id, holder, acquired_at, expires_at) VALUES (?, ?, ?, ?)",
+        (session_id, holder, now, (now - 10.0) if expired else (now + 300.0)),
+    )
+    db._conn.commit()
+
+
+def _ended_parent(
+    db: SessionDB,
+    session_id: str = "parent",
+    end_reason: str = "session_switch",
+    *,
+    activity_age: float = 5.0,
+) -> None:
+    """Row stamped ended with *end_reason*; its freshest observable activity is *activity_age*
+    seconds old (both ``last_activity_at`` and the message timestamp are backdated so the
+    freshest-of expression is deterministic)."""
+    now = time.time()
+    stale_ts = now - activity_age
+    db.create_session(session_id, source="test")
+    db.append_message(session_id, "user", "before split", timestamp=stale_ts)
+    db.end_session(session_id, end_reason)
+    db._conn.execute("UPDATE sessions SET last_activity_at = ? WHERE id = ?", (stale_ts, session_id))
+    db._conn.commit()
+
+
+def _publish(db: SessionDB, *, parent: str = "parent", holder: str = "compressor") -> None:
+    _seed_lock(db, parent, holder)
+    db.publish_compression_child(
+        parent_session_id=parent,
+        child_session_id=f"{parent}-child",
+        source="test",
+        messages=[{"role": "user", "content": "compressed summary"}],
+        compression_lock_holder=holder,
+        require_compression_lease=True,
+    )
+
+
+class TestStaleEndStampHealOnPublish:
+    def test_stale_nonautomatic_stamp_with_live_traffic_publishes(self, db: SessionDB) -> None:
+        """#106459: the router still drives the row (fresh traffic), nobody forked from the
+        boundary, and this writer holds the live lease — the stamp is stale; publish heals
+        and completes instead of discarding the compression work."""
+        _ended_parent(db, activity_age=5.0)
+
+        _publish(db)
+
+        child = db.get_session("parent-child")
+        assert child is not None
+        assert child["parent_session_id"] == "parent"
+        parent = db.get_session("parent")
+        assert parent["end_reason"] == "compression"
+        assert parent["ended_at"] is not None
+
+    def test_quiet_deliberate_boundary_still_fails_closed(self, db: SessionDB) -> None:
+        """A deliberate boundary nobody acted on since (no traffic inside the heal window)
+        must keep refusing publication."""
+        _ended_parent(db, activity_age=_OLD_ACTIVITY_AGE)
+
+        with pytest.raises(RuntimeError, match="Compression parent already ended"):
+            _publish(db)
+
+        parent = db.get_session("parent")
+        assert parent["end_reason"] == "session_switch"
+        assert db.get_session("parent-child") is None
+
+    def test_forked_deliberate_boundary_still_fails_closed(self, db: SessionDB) -> None:
+        """A continuation child hanging off the boundary means another path owns the
+        lineage — recent traffic alone must not widen the heal."""
+        _ended_parent(db, activity_age=5.0)
+        db.create_session("adopted", source="test", parent_session_id="parent")
+
+        with pytest.raises(RuntimeError, match="Compression parent already ended"):
+            _publish(db)
+
+        assert db.get_session("parent")["end_reason"] == "session_switch"
+
+    def test_automatic_stamp_heal_unchanged(self, db: SessionDB) -> None:
+        """The #88197 automatic-stamp heal keeps working: an automatic stamp on a live-
+        lease rotation clears without the traffic/child guards."""
+        _ended_parent(db, end_reason="ws_disconnect", activity_age=_OLD_ACTIVITY_AGE)
+
+        _publish(db)
+
+        assert db.get_session("parent-child") is not None
+        assert db.get_session("parent")["end_reason"] == "compression"
+
+    def test_lost_lease_still_fails_busy(self, db: SessionDB) -> None:
+        """The heal must not bypass the lease gate: a stale stamp with a foreign/expired
+        lease still raises CompressionSessionBusyError before any stamp is touched."""
+        _ended_parent(db, activity_age=5.0)
+        _seed_lock(db, "parent", holder="someone-else")
+
+        with pytest.raises(CompressionSessionBusyError):
+            db.publish_compression_child(
+                parent_session_id="parent",
+                child_session_id="parent-child",
+                source="test",
+                messages=[{"role": "user", "content": "compressed summary"}],
+                compression_lock_holder="compressor",
+                require_compression_lease=True,
+            )
+
+        assert db.get_session("parent")["end_reason"] == "session_switch"
+
+
+class TestReadPredicate:
+    def test_contradicted_by_live_traffic_true(self, db: SessionDB) -> None:
+        _ended_parent(db, activity_age=5.0)
+        assert db.end_stamp_contradicted_by_live_traffic("parent") is True
+
+    def test_contradicted_by_live_traffic_false_when_quiet(self, db: SessionDB) -> None:
+        _ended_parent(db, activity_age=_OLD_ACTIVITY_AGE)
+        assert db.end_stamp_contradicted_by_live_traffic("parent") is False
+
+    def test_contradicted_by_live_traffic_false_when_forked(self, db: SessionDB) -> None:
+        _ended_parent(db, activity_age=5.0)
+        db.create_session("adopted", source="test", parent_session_id="parent")
+        assert db.end_stamp_contradicted_by_live_traffic("parent") is False
+
+    def test_contradicted_by_live_traffic_false_for_automatic_and_live_rows(self, db: SessionDB) -> None:
+        """The predicate targets non-automatic stamps only; live rows and automatic stamps
+        take their existing paths."""
+        assert db.end_stamp_contradicted_by_live_traffic("missing") is False
+        db.create_session("live", source="test")
+        assert db.end_stamp_contradicted_by_live_traffic("live") is False
+        _ended_parent(db, end_reason="ws_disconnect", activity_age=5.0)
+        assert db.end_stamp_contradicted_by_live_traffic("parent") is False
+
+    def test_custom_window_narrows_the_predicate(self, db: SessionDB) -> None:
+        _ended_parent(db, activity_age=600.0)
+        assert db.end_stamp_contradicted_by_live_traffic("parent", 900.0) is True
+        assert db.end_stamp_contradicted_by_live_traffic("parent", 60.0) is False


### PR DESCRIPTION
Closes #106459

## Problem

A non-automatic end stamp on a still-routed session row wedges compression rotation permanently: the summary gets generated, the commit aborts with `Compression parent already ended` (failure_class=session_split_failed), the oversized history rolls back, and the next turn hits `Context length exceeded`. `/compress` takes the same path, so there is no recovery. The #88197 heal only covers automatic reasons; non-automatic stamps have no way out.

## Fix

Keep failing closed for real deliberate boundaries, but treat the stamp as stale when observable liveness contradicts it — all three guards must hold:

1. no continuation child published from the boundary,
2. the row still received traffic within a generous window (900s),
3. the writer holds a live compression lease.

## Tests

New `tests/state/test_compression_stale_end_stamp_heal.py`: 10 tests, RED (6 failures) on base → GREEN on this branch, including 4 fail-closed regressions guarding that quiet rows and forked boundaries are still refused.