### PR TITLE
fix(desktop): HUD edge poll parks while the window is not viewed (#88275, salvage #101987)

### DIFF
--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import { useViewedInterval } from '@/hooks/use-viewed-interval'
 import { chatMessageText } from '@/lib/chat-messages'
 import { $activeSessionAwaitingInput } from '@/store/prompts'
 import { $busy, $messages } from '@/store/session'
@@ -231,7 +232,11 @@ export function HudShell() {
   // hysteresis so the layout can't flutter while it's dragged along the line.
   const [edge, setEdge] = useState<'bottom' | 'top'>('top')
 
-  useEffect(() => {
+  // Viewed-gated (#88275): window position only changes while the user can
+  // see the window, so an ungated 300ms poll keeps the idle renderer hot
+  // forever. useViewedInterval parks the timer when hidden/unfocused and
+  // leading-ticks on return, so a drag is still picked up within one tick.
+  const measureEdge = useCallback(() => {
     // Measured on the WINDOW, and flush-only. Flipping is what lets the bar
     // reach the top of the screen at all: the window's top edge can sit against
     // the menu bar, and the flip moves the composer to that edge. Keying it off
@@ -242,33 +247,33 @@ export function HudShell() {
     const FLIP_ON = 0
     const FLIP_OFF = 4
 
-    const measure = () => {
-      // TRYING IT: the bar stays on top and the transcript always hangs below,
-      // wherever the HUD is parked. Flip the constant to re-enable the
-      // edge-aware layout (the CSS for both orientations is still here).
-      if (HUD_THREAD_ALWAYS_BELOW) {
-        setEdge('top')
+    // TRYING IT: the bar stays on top and the transcript always hangs below,
+    // wherever the HUD is parked. Flip the constant to re-enable the
+    // edge-aware layout (the CSS for both orientations is still here).
+    if (HUD_THREAD_ALWAYS_BELOW) {
+      setEdge('top')
 
-        return
-      }
-
-      // availTop ≈ menu bar / notch inset on macOS; screenY is in full-screen
-      // coordinates, so "parked at the top" means screenY ≈ availTop, not 0.
-      const availTop = (window.screen as { availTop?: number }).availTop ?? 0
-      const topGap = window.screenY - availTop
-
-      setEdge(prev => (topGap <= FLIP_ON ? 'top' : topGap >= FLIP_OFF ? 'bottom' : prev))
+      return
     }
 
-    measure()
-    const timer = setInterval(measure, 300)
-    window.addEventListener('resize', measure)
+    // availTop ≈ menu bar / notch inset on macOS; screenY is in full-screen
+    // coordinates, so "parked at the top" means screenY ≈ availTop, not 0.
+    const availTop = (window.screen as { availTop?: number }).availTop ?? 0
+    const topGap = window.screenY - availTop
+
+    setEdge(prev => (topGap <= FLIP_ON ? 'top' : topGap >= FLIP_OFF ? 'bottom' : prev))
+  }, [])
+
+  useViewedInterval(measureEdge, 300)
+
+  useEffect(() => {
+    measureEdge()
+    window.addEventListener('resize', measureEdge)
 
     return () => {
-      clearInterval(timer)
-      window.removeEventListener('resize', measure)
+      window.removeEventListener('resize', measureEdge)
     }
-  }, [])
+  }, [measureEdge])
 
   const rootRef = useRef<HTMLDivElement | null>(null)
 

--- a/apps/desktop/src/app/hud/hud-shell.viewed-interval.test.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.viewed-interval.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../contrib/wiring', () => ({ WiredPane: () => null }))
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.assign(globalThis, { ResizeObserver: ResizeObserverStub })
+
+import { HudShell } from './hud-shell'
+
+const EDGE_POLL_MS = 300
+
+/** Count callbacks of the edge-measure poll only (the transcript band arms an
+ *  unrelated 500ms mount probe), so the assertion is about this timer. */
+function countEdgePollFires(): { fires: number } {
+  const counter = { fires: 0 }
+  const real = window.setInterval.bind(window)
+
+  vi.spyOn(window, 'setInterval').mockImplementation(((cb: TimerHandler, ms?: number, ...rest: unknown[]) => {
+    if (typeof cb !== 'function' || ms !== EDGE_POLL_MS) {
+      return real(cb, ms, ...rest)
+    }
+
+    return real(
+      () => {
+        counter.fires += 1
+        cb()
+      },
+      ms,
+      ...rest
+    )
+  }) as typeof window.setInterval)
+
+  return counter
+}
+
+let visibility: DocumentVisibilityState = 'visible'
+let focused = true
+
+describe('HudShell edge poll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibility)
+    vi.spyOn(document, 'hasFocus').mockImplementation(() => focused)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // #88275: the window's screen position only moves while someone can see the
+  // window, so the 300ms edge poll must park while the document is hidden and
+  // run while it is viewed — an ungated interval keeps the idle renderer hot.
+  it('parks while the window is hidden and runs while it is viewed', async () => {
+    visibility = 'hidden'
+    focused = false
+    const hidden = countEdgePollFires()
+
+    render(
+      <MemoryRouter>
+        <HudShell />
+      </MemoryRouter>
+    )
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000)
+    })
+
+    expect(hidden.fires).toBe(0)
+
+    cleanup()
+    vi.mocked(window.setInterval).mockRestore()
+
+    visibility = 'visible'
+    focused = true
+    const viewed = countEdgePollFires()
+
+    render(
+      <MemoryRouter>
+        <HudShell />
+      </MemoryRouter>
+    )
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000)
+    })
+
+    expect(viewed.fires).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Outcome

The HUD shell's 300ms window-edge poll now runs only while the HUD window is actually being viewed (visible **and** focused). Hidden or unfocused, the timer is parked; on return it leading-ticks so a drag that happened while parked is picked up within one tick, and the `resize` listener + mount measurement are unchanged.

Based on #101987 by @Finn763 (cherry-picked, authorship preserved). Fixes #88275.

## Why

`HudShell` armed `setInterval(measure, 300)` unconditionally, so an idle, occluded or unfocused HUD kept waking the renderer ~3×/s forever. The window's screen position can only change while the user can see the window, so gating the poll on "viewed" loses nothing.

## What changed

- `apps/desktop/src/app/hud/hud-shell.tsx`: `measure` becomes a stable `useCallback` (`measureEdge`), driven by the existing `useViewedInterval(measureEdge, 300)` hook (already used by two other call sites — no new visibility logic). The mount measurement and `resize` listener stay in a plain effect.
- `apps/desktop/src/app/hud/hud-shell.viewed-interval.test.tsx`: one invariant test — hidden window → 0 edge-poll fires over 3s of fake time; viewed → >0. Proven red against the ungated `setInterval` (10 fires) and green with the fix.

Sibling timers in `src/app/hud` were checked: `composer-drag.ts` uses a one-shot `setTimeout`; `transcript-band.ts` has a 500ms mount probe that clears itself once the viewport exists. Neither is an idle poll, so no widening.

## Measured impact

Same jsdom/fake-timer harness on both sides, 30s of fake time, counting fires of the 300ms edge poll:

| Window state | main | this branch |
|---|---|---|
| visible + focused | 100 | 100 |
| visible + unfocused | 100 | 0 |
| hidden | 100 | 0 |
| return from hidden (fires in the after-return window) | 20 | 10 (incl. leading tick; measure still runs on return) |

## Verification

- `cd apps/desktop && npx vitest run src/app/hud/hud-shell.viewed-interval.test.tsx` — green
- `npx eslint` on both changed files — 0 errors
- `git diff --check` clean
