### PR TITLE
fix(desktop): tile owner keyed by a stable scalar so sessions.changed ticks stop re-rendering tiles (#104094, salvage #104111)

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-owner.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-owner.test.ts
@@ -70,29 +70,6 @@ describe('tileOwnerRoute', () => {
   })
 })
 
-describe('ownerRouteKey', () => {
-  it('encodes a route into a stable scalar identity', () => {
-    expect(ownerRouteKey({ connectionId: 'local', profile: 'default' })).toBe('local\u0000default\u0000')
-  })
-
-  it('returns the same key across calls for identical fields (reference stability)', () => {
-    const a = ownerRouteKey({ connectionId: 'local', profile: 'tech-review', targetProfile: 'tech-review' })
-    const b = ownerRouteKey({ connectionId: 'local', profile: 'tech-review', targetProfile: 'tech-review' })
-
-    expect(a).toBe(b)
-  })
-
-  it('distinguishes a targetProfile from a bare profile', () => {
-    expect(ownerRouteKey({ connectionId: 'local', profile: 'default' })).not.toBe(
-      ownerRouteKey({ connectionId: 'local', profile: 'default', targetProfile: 'tech-review' })
-    )
-  })
-
-  it('returns null for an unresolved route', () => {
-    expect(ownerRouteKey(undefined)).toBeNull()
-  })
-})
-
 describe('tileOwnerRoute key stability under session-list churn', () => {
   it('keeps the current tile key when an UNRELATED row changes (sessions.changed tick)', () => {
     const tiles = [tile({ storedSessionId: 'mine' })]
@@ -115,5 +92,11 @@ describe('tileOwnerRoute key stability under session-list churn', () => {
     ).not.toBe(
       ownerRouteKey(tileOwnerRoute(tiles, [row({ connection_id: 'remote', id: 'mine', profile: 'default' })], 'mine'))
     )
+    // A target profile is part of the owner identity too, and an unresolved
+    // owner has no key at all.
+    expect(ownerRouteKey({ connectionId: 'local', profile: 'default' })).not.toBe(
+      ownerRouteKey({ connectionId: 'local', profile: 'default', targetProfile: 'tech-review' })
+    )
+    expect(ownerRouteKey(undefined)).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/session-tile-owner.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-owner.test.ts
@@ -4,7 +4,7 @@ import { _resetSessionOwnerHintsForTests, setSessionOwnerHint } from '@/store/se
 import type { SessionTile } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
-import { tileOwnerRoute } from './session-tile-owner'
+import { ownerRouteKey, tileOwnerRoute } from './session-tile-owner'
 
 const row = (over: Partial<SessionInfo>): SessionInfo => over as SessionInfo
 
@@ -67,5 +67,53 @@ describe('tileOwnerRoute', () => {
   it('is undefined for an untagged session, preserving ambient routing', () => {
     expect(tileOwnerRoute([], [row({ id: 's1' })], 's1')).toBeUndefined()
     expect(tileOwnerRoute([], [], 'missing')).toBeUndefined()
+  })
+})
+
+describe('ownerRouteKey', () => {
+  it('encodes a route into a stable scalar identity', () => {
+    expect(ownerRouteKey({ connectionId: 'local', profile: 'default' })).toBe('local\u0000default\u0000')
+  })
+
+  it('returns the same key across calls for identical fields (reference stability)', () => {
+    const a = ownerRouteKey({ connectionId: 'local', profile: 'tech-review', targetProfile: 'tech-review' })
+    const b = ownerRouteKey({ connectionId: 'local', profile: 'tech-review', targetProfile: 'tech-review' })
+
+    expect(a).toBe(b)
+  })
+
+  it('distinguishes a targetProfile from a bare profile', () => {
+    expect(ownerRouteKey({ connectionId: 'local', profile: 'default' })).not.toBe(
+      ownerRouteKey({ connectionId: 'local', profile: 'default', targetProfile: 'tech-review' })
+    )
+  })
+
+  it('returns null for an unresolved route', () => {
+    expect(ownerRouteKey(undefined)).toBeNull()
+  })
+})
+
+describe('tileOwnerRoute key stability under session-list churn', () => {
+  it('keeps the current tile key when an UNRELATED row changes (sessions.changed tick)', () => {
+    const tiles = [tile({ storedSessionId: 'mine' })]
+    const mine = { connection_id: 'local', id: 'mine', profile: 'default' }
+    // The only difference is an unrelated row's last_active moving — exactly
+    // what a sessions.changed broadcast republishes for every profile.
+    const rowsBefore: SessionInfo[] = [row({ id: 'other-session', last_active: 100 }), row(mine)]
+    const rowsAfter: SessionInfo[] = [row({ id: 'other-session', last_active: 9_999 }), row(mine)]
+
+    expect(ownerRouteKey(tileOwnerRoute(tiles, rowsBefore, 'mine'))).toBe(
+      ownerRouteKey(tileOwnerRoute(tiles, rowsAfter, 'mine'))
+    )
+  })
+
+  it('changes the key when THIS tile owner actually re-homes', () => {
+    const tiles = [tile({ storedSessionId: 'mine' })]
+
+    expect(
+      ownerRouteKey(tileOwnerRoute(tiles, [row({ connection_id: 'local', id: 'mine', profile: 'default' })], 'mine'))
+    ).not.toBe(
+      ownerRouteKey(tileOwnerRoute(tiles, [row({ connection_id: 'remote', id: 'mine', profile: 'default' })], 'mine'))
+    )
   })
 })

--- a/apps/desktop/src/app/chat/session-tile-owner.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-owner.test.ts
@@ -4,7 +4,7 @@ import { _resetSessionOwnerHintsForTests, setSessionOwnerHint } from '@/store/se
 import type { SessionTile } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
-import { ownerRouteKey, tileOwnerRoute } from './session-tile-owner'
+import { ownerRouteFromKey, ownerRouteKey, tileOwnerRoute } from './session-tile-owner'
 
 const row = (over: Partial<SessionInfo>): SessionInfo => over as SessionInfo
 
@@ -98,5 +98,15 @@ describe('tileOwnerRoute key stability under session-list churn', () => {
       ownerRouteKey({ connectionId: 'local', profile: 'default', targetProfile: 'tech-review' })
     )
     expect(ownerRouteKey(undefined)).toBeNull()
+
+    // The component rebuilds the route from the key; encoder and decoder must round-trip.
+    for (const route of [
+      { connectionId: 'local', profile: 'default' },
+      { connectionId: 'local', profile: 'default', targetProfile: 'tech-review' }
+    ]) {
+      expect(ownerRouteFromKey(ownerRouteKey(route))).toEqual(route)
+    }
+
+    expect(ownerRouteFromKey(null)).toBeUndefined()
   })
 })

--- a/apps/desktop/src/app/chat/session-tile-owner.ts
+++ b/apps/desktop/src/app/chat/session-tile-owner.ts
@@ -56,3 +56,14 @@ export function ownerRouteKey(route: SessionOwnerRoute | undefined): string | nu
 
   return `${route.connectionId}\u0000${route.profile}\u0000${route.targetProfile ?? ''}`
 }
+
+/** Inverse of `ownerRouteKey`; the two live together so the field order cannot drift. */
+export function ownerRouteFromKey(key: string | null): SessionOwnerRoute | undefined {
+  if (!key) {
+    return undefined
+  }
+
+  const [connectionId, profile, targetProfile] = key.split('\u0000')
+
+  return { connectionId, profile, ...(targetProfile ? { targetProfile } : {}) }
+}

--- a/apps/desktop/src/app/chat/session-tile-owner.ts
+++ b/apps/desktop/src/app/chat/session-tile-owner.ts
@@ -35,3 +35,24 @@ export function tileOwnerRoute(
     ...(owner.targetProfile ? { targetProfile: owner.targetProfile } : {})
   }
 }
+
+/**
+ * Stable scalar identity for a resolved tile owner route.
+ *
+ * `tileOwnerRoute` builds a fresh object on every call, so a component that
+ * derives the route through `useMemo` over a whole `$sessions` array re-creates
+ * it (and everything keyed on it) whenever the list is republished — which
+ * happens on every `sessions.changed` tick even when this tile's own row never
+ * moved (multi-profile / Bots setups tick every ~2s). Encoding the route as a
+ * string lets components subscribe through `useStoreSelector`/`useStoresSelector`
+ * instead: `Object.is` bails out when the owner fields are unchanged, so
+ * unrelated list churn stops at the subscription instead of re-rendering the
+ * tile's chat shell.
+ */
+export function ownerRouteKey(route: SessionOwnerRoute | undefined): string | null {
+  if (!route) {
+    return null
+  }
+
+  return `${route.connectionId}\u0000${route.profile}\u0000${route.targetProfile ?? ''}`
+}

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -35,6 +35,7 @@ import { transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { NEW_SESSION_TITLE, sessionTitle } from '@/lib/chat-runtime'
+import { useStoresSelector } from '@/lib/use-session-slice'
 import { transcribeAudioClientDirect } from '@/lib/voice-client-direct'
 import { createComposerAttachmentScope, draftTitleFor } from '@/store/composer'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
@@ -51,7 +52,7 @@ import {
   sessionPinId
 } from '@/store/session'
 import { isSessionRemovalPending } from '@/store/session-removal'
-import { requestForSessionProfile } from '@/store/session-request-router'
+import { requestForSessionProfile, type SessionOwnerRoute } from '@/store/session-request-router'
 import {
   $sessionStates,
   $sessionTileDelegateRevision,
@@ -71,7 +72,7 @@ import { SessionDraftTitle } from './session-draft-title'
 import { startSessionDrag } from './session-drag'
 import { SessionStatusDot } from './session-status-dot'
 import { useSessionTileActions } from './session-tile-actions'
-import { tileOwnerRoute } from './session-tile-owner'
+import { ownerRouteKey, tileOwnerRoute } from './session-tile-owner'
 import { type SessionView, SessionViewProvider } from './session-view'
 import { SessionContextMenu } from './sidebar/session-actions-menu'
 import { lastVisibleMessageIsUser } from './thread-loading'
@@ -189,15 +190,39 @@ function TileChat({
   // NOT on every render: this component re-renders per streamed token, and the
   // lookup spreads three arrays before scanning them.
   const tiles = useStore($sessionTiles)
-  const sessionRows = useStore($sessions)
-  const cronRows = useStore($cronSessions)
-  const messagingRows = useStore($messagingSessions)
 
-  const ownerRoute = useMemo(() => {
-    const rows = cronRows.length || messagingRows.length ? [...sessionRows, ...cronRows, ...messagingRows] : sessionRows
+  // The route is derived through a SCALAR key instead of a `$sessions` array
+  // subscription: `$sessions` is republished whenever ANY row's last_active
+  // moves (a sessions.changed tick — multi-profile / Bots setups tick every
+  // ~2s), and `tileOwnerRoute` returns a fresh object per call, so a plain
+  // useMemo over the array would re-create the route — and with it
+  // `requestTileGateway`, `selectModel` and the model menu, all of which feed
+  // the memo'd ChatView — on every unrelated tick. The key only changes when
+  // THIS tile's owner fields change, so unrelated list churn stops at the
+  // `Object.is` bail-out and the tile's chat shell stays still.
+  const ownerKey = useStoresSelector(
+    [$sessionTiles, $sessions, $cronSessions, $messagingSessions],
+    () => {
+      const sessionRows = $sessions.get()
+      const cronRows = $cronSessions.get()
+      const messagingRows = $messagingSessions.get()
 
-    return tileOwnerRoute(tiles, rows, storedSessionId)
-  }, [cronRows, messagingRows, sessionRows, storedSessionId, tiles])
+      const rows =
+        cronRows.length || messagingRows.length ? [...sessionRows, ...cronRows, ...messagingRows] : sessionRows
+
+      return ownerRouteKey(tileOwnerRoute($sessionTiles.get(), rows, storedSessionId))
+    }
+  )
+
+  const ownerRoute = useMemo<SessionOwnerRoute | undefined>(() => {
+    if (!ownerKey) {
+      return undefined
+    }
+
+    const [connectionId, profile, targetProfile] = ownerKey.split('\u0000')
+
+    return { connectionId, profile, ...(targetProfile ? { targetProfile } : {}) }
+  }, [ownerKey])
 
   const requestTileGateway = useCallback(
     <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal): Promise<T> =>

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -52,7 +52,7 @@ import {
   sessionPinId
 } from '@/store/session'
 import { isSessionRemovalPending } from '@/store/session-removal'
-import { requestForSessionProfile, type SessionOwnerRoute } from '@/store/session-request-router'
+import { requestForSessionProfile } from '@/store/session-request-router'
 import {
   $sessionStates,
   $sessionTileDelegateRevision,
@@ -72,7 +72,7 @@ import { SessionDraftTitle } from './session-draft-title'
 import { startSessionDrag } from './session-drag'
 import { SessionStatusDot } from './session-status-dot'
 import { useSessionTileActions } from './session-tile-actions'
-import { ownerRouteKey, tileOwnerRoute } from './session-tile-owner'
+import { ownerRouteFromKey, ownerRouteKey, tileOwnerRoute } from './session-tile-owner'
 import { type SessionView, SessionViewProvider } from './session-view'
 import { SessionContextMenu } from './sidebar/session-actions-menu'
 import { lastVisibleMessageIsUser } from './thread-loading'
@@ -186,11 +186,6 @@ function TileChat({
   const queryClient = useQueryClient()
 
   // Owner ladder, same as useSessionTileActions (session-tile-actions.ts:99-103).
-  // Recomputed when the tile store or any owner-bearing session list changes,
-  // NOT on every render: this component re-renders per streamed token, and the
-  // lookup spreads three arrays before scanning them.
-  const tiles = useStore($sessionTiles)
-
   // The route is derived through a SCALAR key instead of a `$sessions` array
   // subscription: `$sessions` is republished whenever ANY row's last_active
   // moves (a sessions.changed tick — multi-profile / Bots setups tick every
@@ -214,15 +209,7 @@ function TileChat({
     }
   )
 
-  const ownerRoute = useMemo<SessionOwnerRoute | undefined>(() => {
-    if (!ownerKey) {
-      return undefined
-    }
-
-    const [connectionId, profile, targetProfile] = ownerKey.split('\u0000')
-
-    return { connectionId, profile, ...(targetProfile ? { targetProfile } : {}) }
-  }, [ownerKey])
+  const ownerRoute = useMemo(() => ownerRouteFromKey(ownerKey), [ownerKey])
 
   const requestTileGateway = useCallback(
     <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal): Promise<T> =>


### PR DESCRIPTION
## Outcome

A `sessions.changed` tick that only moves an unrelated session's `last_active` no longer re-renders every open chat tile. `TileChat` now derives its owner route through a stable scalar key (`connectionId\0profile\0targetProfile`) via `useStoresSelector`, so unrelated `$sessions` / `$cronSessions` / `$messagingSessions` republishes stop at the `Object.is` bail-out instead of rebuilding `ownerRoute`, `requestTileGateway`, `selectModel` and the model menu that feed the memo'd `ChatView`. A real re-home (connection or profile change for this tile) still propagates.

Based on #104111 by @Inspired-by-Atmosphere (cherry-picked, authorship preserved).

## Why

`tileOwnerRoute` returns a fresh object per call, and the previous `useMemo` depended on the whole `$sessions` array — which is republished every ~2s under multi-profile / Bots setups. Every open tile therefore re-rendered its chat shell on every tick, mid-stream, for rows it does not own.

## What changed

- `apps/desktop/src/app/chat/session-tile-owner.ts`: `ownerRouteKey(route)` — encodes exactly the three fields `tileOwnerRoute` emits (`connectionId`, `profile`, `targetProfile?`; it never emits `mode`), `null` for an unresolved owner. `\0` cannot appear in connection ids or profile keys, so the split round-trips losslessly.
- `apps/desktop/src/app/chat/session-tile.tsx`: `TileChat` subscribes with `useStoresSelector([...], () => ownerRouteKey(tileOwnerRoute(...)))` (existing helper; the `.get()` reads are inside the selector, which is re-run on every listened store change, so they are reactive) and rebuilds the route object from the key only when the key changes. The remaining `useStore($sessionTiles)` is left as-is — tile lifecycle events are low-frequency.
- `session-tile-owner.test.ts`: the contributor's four `ownerRouteKey` snapshot-style tests are folded into the two behavioural invariants that matter — unrelated row churn keeps the key identical; a genuine re-home (connection, or target profile) changes it and an unresolved owner has no key.

## Measured impact

jsdom render bench, one tile, N = 200 `$sessions` republishes where only an unrelated row's `last_active` changes (same harness, both wirings side by side):

| wiring | tile re-renders | ownerRoute identity changes | derivation runs |
|---|---|---|---|
| before (useMemo over the arrays) | 200 | 200 | 200 |
| after (selector + scalar key) | 0 | 0 | 200 (cheap: find + string build, no render) |

A real re-home after the churn still changed the route exactly once on the new path.

## Verification

- `cd apps/desktop && npx vitest run src/app/chat/session-tile-owner.test.ts` — 8/8 green
- Mutation: dropping `targetProfile` from the key → re-home invariant red; restored → green
- `npx eslint` on the three changed files — 0 errors; `git diff --check` clean
