### PR TITLE
fix(browser): terminate real-profile Chrome on last session cleanup

### DIFF
--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -1052,3 +1052,74 @@ class TestWindowsLockedProfileCopy:
         dst, err = bc.snapshot_real_profile("chrome", src=str(root))
         assert dst is None
         assert err and "login data" in err.lower() and "close" in err.lower()
+
+
+class TestRealProfileChromeReapedOnSessionCleanup:
+    """The real-profile browser is launched directly (not by agent-browser),
+    so an ``agent-browser close`` only detaches from it via CDP — the process
+    itself used to stay alive until process exit (atexit), which never fires
+    on a long-lived externally-supervised gateway. _cleanup_single_browser_session
+    must now terminate it once the last real-profile-backed session is gone.
+    """
+
+    def _session(self, real_profile: bool):
+        return {
+            "session_name": "s1",
+            "bb_session_id": None,
+            "cdp_url": None,
+            "features": {"local": True, "real_profile": real_profile},
+        }
+
+    def test_terminates_when_last_real_profile_session_closes(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_active_sessions", {"task1": self._session(True)})
+        monkeypatch.setattr(bt, "_session_last_activity", {"task1": 0.0})
+        monkeypatch.setattr(bt, "_run_browser_command", lambda *a, **k: None)
+        monkeypatch.setattr(bt, "_maybe_stop_recording", lambda *a, **k: None)
+        monkeypatch.setattr(bt, "_session_has_expired", lambda *a, **k: False)
+        monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: "/tmp/nonexistent-abc")
+        terminate_calls = []
+        monkeypatch.setattr(bt, "_terminate_real_profile_chrome", lambda: terminate_calls.append(1))
+        monkeypatch.setattr(bt, "_real_profile_cdp_cache", {"cdp": "http://127.0.0.1:1/json"})
+
+        bt._cleanup_single_browser_session("task1")
+
+        assert terminate_calls == [1]
+        assert "cdp" not in bt._real_profile_cdp_cache
+
+    def test_does_not_terminate_while_another_real_profile_session_active(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_active_sessions", {
+            "task1": self._session(True),
+            "task2": self._session(True),
+        })
+        monkeypatch.setattr(bt, "_session_last_activity", {"task1": 0.0, "task2": 0.0})
+        monkeypatch.setattr(bt, "_run_browser_command", lambda *a, **k: None)
+        monkeypatch.setattr(bt, "_maybe_stop_recording", lambda *a, **k: None)
+        monkeypatch.setattr(bt, "_session_has_expired", lambda *a, **k: False)
+        monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: "/tmp/nonexistent-abc")
+        terminate_calls = []
+        monkeypatch.setattr(bt, "_terminate_real_profile_chrome", lambda: terminate_calls.append(1))
+
+        bt._cleanup_single_browser_session("task1")
+
+        assert terminate_calls == []
+        assert "task2" in bt._active_sessions
+
+    def test_non_real_profile_session_never_touches_terminate(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_active_sessions", {"task1": self._session(False)})
+        monkeypatch.setattr(bt, "_session_last_activity", {"task1": 0.0})
+        monkeypatch.setattr(bt, "_run_browser_command", lambda *a, **k: None)
+        monkeypatch.setattr(bt, "_maybe_stop_recording", lambda *a, **k: None)
+        monkeypatch.setattr(bt, "_session_has_expired", lambda *a, **k: False)
+        monkeypatch.setattr(bt, "_socket_safe_tmpdir", lambda: "/tmp/nonexistent-abc")
+        terminate_calls = []
+        monkeypatch.setattr(bt, "_terminate_real_profile_chrome", lambda: terminate_calls.append(1))
+
+        bt._cleanup_single_browser_session("task1")
+
+        assert terminate_calls == []

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -5905,9 +5905,27 @@ def _cleanup_single_browser_session(task_id: str) -> None:
                 logger.warning("agent-browser close failed for task %s: %s", task_id, e)
 
         # Now remove from tracking under lock
+        was_real_profile = (session_info.get("features") or {}).get("real_profile")
         with _cleanup_lock:
             _active_sessions.pop(task_id, None)
             _session_last_activity.pop(task_id, None)
+            other_real_profile_sessions = any(
+                (info.get("features") or {}).get("real_profile")
+                for info in _active_sessions.values()
+            )
+
+        # The real-profile browser is launched directly (not by agent-browser)
+        # and the "close" command above only detaches from it via CDP — the
+        # process itself keeps running (see _terminate_real_profile_chrome's
+        # docstring). Previously that only happened via atexit, which never
+        # fires on a long-lived externally-supervised gateway, so idle
+        # real-profile sessions leaked a full Chrome process indefinitely.
+        # Terminate it here too, once the last real-profile-backed session
+        # this reaper knows about is gone.
+        if was_real_profile and not other_real_profile_sessions:
+            _terminate_real_profile_chrome()
+            with _real_profile_cdp_lock:
+                _real_profile_cdp_cache.pop("cdp", None)
 
         # Cloud mode: close the cloud browser session via provider API.
         # Local sidecars have bb_session_id=None so this no-ops for them.


### PR DESCRIPTION
Fixes #106601

## Bug

`browser.use_real_profile` launches the user's actual Chromium directly and has `agent-browser` attach to it over CDP, instead of spawning it as an `agent-browser`-managed daemon. `_cleanup_single_browser_session()` always issues an `agent-browser close`, but for a real-profile session that only detaches the CDP connection — the process itself keeps running, per `_terminate_real_profile_chrome()`'s own docstring:

> "agent-browser only ATTACHED to them, so its own session cleanup never kills them"

The only call site that actually killed the process was `_emergency_cleanup_all_sessions()`, registered via `atexit`. That never fires on a long-lived, externally-supervised gateway (`gateway run --external-supervisor`) — exactly the deployment mode a persistent bot with its own logged-in browser identity is meant to run in. Every real-profile session such a gateway ever created leaked its Chrome process for the gateway's entire lifetime.

Observed in the wild: a gateway with `use_real_profile: true` accumulated a Chrome process tree pinned at 90–130% CPU, still alive after ~3 days of continuous uptime, only reaped manually.

## Fix

Session-level activity tracking already threads real-profile sessions through the normal `_active_sessions` / `_session_last_activity` machinery — `_create_local_session()` tags the session `features: {"real_profile": True}`, and the periodic inactivity reaper already knows exactly when such a session goes idle. It just never acted on the underlying process.

`_cleanup_single_browser_session()` now checks, after popping the session, whether it was real-profile-backed and whether any other currently-active session still is (the underlying browser is shared/cached across tasks via `_real_profile_cdp_cache`, so it should only be torn down once nothing references it). If so, it calls the existing `_terminate_real_profile_chrome()` and clears `_real_profile_cdp_cache["cdp"]`, so a later request cleanly relaunches — `_real_profile_cdp()` already re-validates liveness via `_cdp_http_ready()` before reuse, so this doesn't change the reuse/relaunch contract at all.

Small, additive diff — no changes to the default (non-real-profile) path.

## Testing

Added three cases to `tests/tools/test_browser_real_profile.py`:
- last real-profile session closing terminates the Chrome process and clears the CDP cache
- termination is skipped while another real-profile session is still active
- a non-real-profile session closing never touches the new code path

`pytest` wasn't present in the shipped venv on my machine, so I also verified these three scenarios with a standalone script driving `_cleanup_single_browser_session` directly — all pass. Happy to adjust the tests to match your preferred fixtures/mocking style if they don't fit the existing suite's conventions.

## Note

This closes the idle-timeout leak. A gateway *crash* (rather than a clean process lifetime) still bypasses `_cleanup_single_browser_session()` entirely, so a crash-orphaned real-profile Chrome process isn't covered by this fix — `_reap_orphaned_browser_sessions()` only scans `agent-browser` daemon socket dirs today, not directly-launched real-profile processes. Flagged this in the original issue as a possible follow-up; happy to take a stab at it in a separate PR if that's wanted.