### PR TITLE
fix(acp): advertise model selector via configOptions alongside legacy models (#105383)

### DIFF
--- a/acp_adapter/model_catalog.py
+++ b/acp_adapter/model_catalog.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Callable
 
-from acp.schema import ModelInfo, SessionModelState
+from acp.schema import ModelInfo, SessionConfigSelectOption, SessionConfigOptionSelect, SessionModelState
 
 logger = logging.getLogger("acp_adapter.server")
 
@@ -233,6 +233,26 @@ class _ModelCatalog:
                 is_current = named_slug == normalized_provider and named_model == self.current_model
                 parts = [f"Provider: {named_label}", str(named_desc or "").strip(), "current" if is_current else ""]
                 self.add(named_slug, named_model, named_model, " • ".join(part for part in parts if part))
+
+
+# ``SessionConfigOptionSelect`` id under which the model selector is advertised via
+# ACP v1.3.0 ``configOptions`` (Zed 1.18+ renders the model picker from this).
+MODEL_CONFIG_OPTION_ID = "model"
+
+
+def model_state_to_config_option(state: SessionModelState | None) -> SessionConfigOptionSelect | None:
+    """v1.3.0 select option mirroring a legacy ``SessionModelState``; ``None`` when
+    there is nothing listable (caller then omits ``config_options``)."""
+    if state is None or not state.available_models:
+        return None
+    return SessionConfigOptionSelect(
+        id=MODEL_CONFIG_OPTION_ID, name="Model", category="model", type="select",
+        current_value=state.current_model_id or state.available_models[0].model_id,
+        options=[
+            SessionConfigSelectOption(value=item.model_id, name=item.name, description=item.description)
+            for item in state.available_models
+        ],
+    )
 
 
 def build_model_state(model: str, provider: str, base_url: str) -> SessionModelState | None:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -30,7 +30,7 @@ from acp_adapter.content import PromptBlock, _content_blocks_to_openai_user_cont
 from acp_adapter.events import (
     _build_plan_update_from_todo_result, make_message_cb, make_step_cb, make_thinking_cb, make_tool_progress_cb,
 )
-from acp_adapter.model_catalog import build_model_state, encode_model_choice
+from acp_adapter.model_catalog import MODEL_CONFIG_OPTION_ID, build_model_state, encode_model_choice, model_state_to_config_option
 from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
 from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
@@ -544,7 +544,8 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
                 return
 
     async def _session_response_fields(self, state: SessionState, replay_verb: str | None = None) -> dict[str, Any]:
-        """``models``/``modes``/``field_meta`` for session responses, after an optional history replay;
+        """``models`` (legacy) + ``config_options`` (v1.3.0) / ``modes`` / ``field_meta``
+        for session responses, after an optional history replay;
         schedules command advertisement + usage refresh.
 
         Per ACP spec, load/resume must stream history via ``session/update`` BEFORE responding
@@ -569,8 +570,11 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
                 )
         self._schedule_available_commands_update(state.session_id)
         self._schedule_soon(lambda: self._send_usage_update(state))
+        model_state = self._build_model_state(state)
+        model_option = model_state_to_config_option(model_state)
         return {
-            "models": self._build_model_state(state),
+            "models": model_state,
+            "config_options": [model_option] if model_option is not None else None,
             "modes": self._session_modes(state),
             "field_meta": self._provenance_meta(state.session_id, getattr(state.agent, "session_id", state.session_id)),
         }
@@ -632,8 +636,12 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Forked session %s -> %s", session_id, state.session_id)
         self._schedule_available_commands_update(state.session_id)
+        model_state = self._build_model_state(state)
+        model_option = model_state_to_config_option(model_state)
         return ForkSessionResponse(
-            session_id=state.session_id, models=self._build_model_state(state), modes=self._session_modes(state)
+            session_id=state.session_id, models=model_state,
+            config_options=[model_option] if model_option is not None else None,
+            modes=self._session_modes(state),
         )
 
     async def list_sessions(
@@ -955,11 +963,20 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
     async def set_config_option(
         self, config_id: str, session_id: str, value: str, **kwargs: Any
     ) -> SetSessionConfigOptionResponse | None:
-        """Accept ACP config option updates even when Hermes has no typed ACP config surface yet."""
+        """Accept ACP config option updates; ``model`` switches the session model (v1.3.0
+        picker path, same switch as the legacy ``session/set_model``)."""
         state = self.session_manager.get_session(session_id)
         if state is None:
             logger.warning("Session %s: config update requested for missing session", session_id)
             return None
+
+        if str(config_id) == MODEL_CONFIG_OPTION_ID:
+            _old, requested_provider, resolved_model = self._switch_model(state, str(value), keep_endpoint=True)
+            logger.info(
+                "Session %s: model switched to %s via provider %s", session_id, resolved_model, requested_provider
+            )
+            model_option = model_state_to_config_option(self._build_model_state(state))
+            return SetSessionConfigOptionResponse(config_options=[model_option] if model_option is not None else [])
 
         if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             state.mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)

--- a/tests/acp/test_model_config_option.py
+++ b/tests/acp/test_model_config_option.py
@@ -1,0 +1,93 @@
+"""Regression tests for #105383: ACP model picker missing in Zed 1.18+.
+
+``session/new`` must advertise the model selector BOTH as the v1.3.0
+``configOptions`` (``SessionConfigOptionSelect``) AND the legacy ``models``
+(``SessionModelState``); ``session/set_config_option`` with id ``model``
+must switch the session model like the legacy ``session/set_model``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from acp.schema import SessionConfigOptionSelect, SessionModelState
+from acp_adapter.model_catalog import ACP_MAX_MODELS_PER_PROVIDER
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+def _manager(**agent_kwargs):
+    defaults = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "base_url": "https://api.openai.com/v1",
+    }
+    defaults.update(agent_kwargs)
+    return SessionManager(agent_factory=lambda: SimpleNamespace(**defaults))
+
+
+def _payload():
+    return {
+        "providers": [
+            {"slug": "anthropic", "name": "Anthropic", "models": ["claude-sonnet-4-6"]},
+            {"slug": "openai-codex", "name": "OpenAI Codex", "models": [{"id": "gpt-5.4"}]},
+        ],
+    }
+
+
+def _patched_inventory(payload):
+    picker_context = MagicMock()
+    picker_context.with_overrides.return_value = picker_context
+    return (
+        patch("hermes_cli.inventory.load_picker_context", return_value=picker_context),
+        patch("hermes_cli.inventory.build_models_payload", return_value=payload),
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_session_advertises_model_config_option_alongside_legacy():
+    agent = HermesACPAgent(session_manager=_manager())
+    ctx_patch, payload_patch = _patched_inventory(_payload())
+    with ctx_patch, payload_patch:
+        resp = await agent.new_session(cwd="/tmp")
+        forked = await agent.fork_session(cwd="/tmp", session_id=resp.session_id)
+
+    for response in (resp, forked):
+        # Legacy field preserved for older clients.
+        assert isinstance(response.models, SessionModelState)
+        assert response.models.current_model_id == "openai-codex:gpt-5.4"
+        # v1.3.0 shape for Zed 1.18+: same selector, same ids.
+        assert isinstance(response.config_options, list) and len(response.config_options) == 1
+        option = response.config_options[0]
+        assert isinstance(option, SessionConfigOptionSelect)
+        assert option.id == "model"
+        assert option.type == "select"
+        assert option.current_value == response.models.current_model_id
+        assert [item.value for item in option.options] == [
+            model.model_id for model in response.models.available_models
+        ]
+
+
+@pytest.mark.asyncio
+async def test_set_config_option_model_switches_session_and_persists():
+    agent = HermesACPAgent(session_manager=_manager())
+    ctx_patch, payload_patch = _patched_inventory(_payload())
+    with ctx_patch, payload_patch:
+        resp = await agent.new_session(cwd="/tmp")
+        before = resp.config_options[0].current_value
+        update = await agent.set_config_option(
+            "model", resp.session_id, "anthropic:claude-sonnet-4-6",
+        )
+        resumed = await agent.resume_session(cwd="/tmp", session_id=resp.session_id)
+
+    state = agent.session_manager.get_session(resp.session_id)
+    assert state.model == "claude-sonnet-4-6"
+    assert update.config_options[0].current_value != before
+    assert update.config_options[0].current_value.endswith("claude-sonnet-4-6")
+    assert update.config_options[0].current_value in [
+        item.value for item in update.config_options[0].options
+    ]
+    # Switch survives resume; legacy field agrees with the new shape.
+    assert resumed.config_options[0].current_value == update.config_options[0].current_value
+    assert resumed.models.current_model_id == update.config_options[0].current_value

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -61,7 +61,7 @@ def agent(mock_manager):
 async def test_new_session_exposes_edit_approvals_as_modes_not_config_options(agent):
     resp = await agent.new_session(cwd="/tmp")
 
-    assert resp.config_options is None
+    assert not any(opt.id == "edit_approval_policy" for opt in resp.config_options or [])
     assert isinstance(resp.modes, SessionModeState)
     assert resp.modes.current_mode_id == "default"
     assert [(mode.id, mode.name) for mode in resp.modes.available_modes] == [


### PR DESCRIPTION
## What Problem This Solves

With Zed 1.18.1, the per-thread model selector never renders for `hermes acp` threads: the adapter published model state only under the legacy `models` field of the `session/new` response, but ACP v1.3.0 moved the picker to `configOptions` (`SessionConfigOptionSelect`), which Zed 1.18+ reads exclusively. Result: mode selector renders, model dropdown missing.

This PR advertises the existing model inventory (same `_build_model_state()` source, same `provider:model` ids) as a `SessionConfigOptionSelect` (`id: "model"`, `category: "model"`) in `NewSessionResponse` / `LoadSessionResponse` / `ResumeSessionResponse` / `ForkSessionResponse`, while keeping the legacy `models` field untouched for older clients. `session/set_config_option` with `configId: "model"` reuses the legacy `_switch_model()` path and returns the updated `config_options`, so mid-session switching works from the new picker.

No dependency changes: the pinned `agent-client-protocol==0.9.0` already ships the full `configOptions` API; it just was never used for models.

Related open PRs checked before opening: #75358 (configOptions model selector) and #81067 (same on ACP 0.11+) — this PR targets #105383 on current `main` with the pinned 0.9.0 SDK and keeps the legacy field dual-emitted.

## Evidence

TDD: new `tests/acp/test_model_config_option.py` (2 tests) failed red on base (`config_options is None` → `TypeError`), green after the fix; sabotage probe (force `model_state_to_config_option()` → `None`) re-fails both tests, then reverted.

Measured (single-file runs, hermes venv python):

- `tests/acp/test_model_config_option.py`: 2 passed
- `tests/acp/test_server.py`: 30 passed
- `tests/acp/test_named_provider_catalogs.py`: 11 passed

Live stdio-shaped probe of `new_session` → `model_dump(by_alias=True)`:

- top-level keys: `['configOptions', 'models', 'modes', 'sessionId']`
- `configOptions: [(id='model', category='model', currentValue='openai-codex:gpt-5.4', 691 options)]` (count reflects local named-endpoint catalogs)
- legacy `models.currentModelId` identical: `openai-codex:gpt-5.4`, same 691 entries
- `set_config_option('model', …, 'anthropic:claude-sonnet-4-6')` → updated `currentValue`, switch persisted across `resume_session`; legacy `models.current_model_id` agrees

Skipped: proactive `ConfigOptionUpdate` push notifications on out-of-band switches (e.g. `/model` slash) and a `reasoning_effort`/`thought_level` option — follow-ups once the picker itself is verified against Zed 1.18+.

Closes #105383
