### PR TITLE
fix(dashboard): all-profiles project tree scans single-flight instead of once per poller (#102674, salvage #102676)

### DIFF
--- a/contributors/emails/moken627-hub@users.noreply.github.com
+++ b/contributors/emails/moken627-hub@users.noreply.github.com
@@ -1,0 +1,2 @@
+moken627-hub
+# PR #102676 salvage

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -557,6 +557,7 @@ def _merge_profile_tree(
 
 
 @sessions_router.get("/api/profiles/projects/tree")
+@_sidebar_singleflight_cache
 def get_profiles_projects_tree(preview_limit: int = 3, session_limit: int = 2000):
     """Project tree for every profile at once, for the all-profiles sidebar.
 

--- a/tests/hermes_cli/test_profiles_sidebar_cache.py
+++ b/tests/hermes_cli/test_profiles_sidebar_cache.py
@@ -172,6 +172,21 @@ class SidebarCacheTests(unittest.TestCase):
 
         self.assertEqual(inspect.signature(wrapped), inspect.signature(scan))
 
+    def test_heavy_sidebar_endpoints_are_all_single_flight_wrapped(self):
+        # HostHighCPU on a 2-vCore box: /api/profiles/projects/tree was the
+        # one heavy sidebar endpoint left uncoalesced, so every Desktop poll
+        # re-ran the full 50-profile fan-out. Any new heavy sidebar endpoint
+        # must carry the wrapper too — this pins the existing two.
+        for endpoint in (
+            profiles.get_profiles_sessions_sidebar,
+            profiles.get_profiles_projects_tree,
+        ):
+            self.assertTrue(
+                callable(getattr(endpoint, "cache_clear", None)),
+                f"{endpoint.__name__} lost its @_sidebar_singleflight_cache "
+                "wrapper — concurrent Desktop polls will re-scan every profile",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/hermes_cli/test_profiles_sidebar_cache.py
+++ b/tests/hermes_cli/test_profiles_sidebar_cache.py
@@ -172,20 +172,37 @@ class SidebarCacheTests(unittest.TestCase):
 
         self.assertEqual(inspect.signature(wrapped), inspect.signature(scan))
 
-    def test_heavy_sidebar_endpoints_are_all_single_flight_wrapped(self):
-        # HostHighCPU on a 2-vCore box: /api/profiles/projects/tree was the
-        # one heavy sidebar endpoint left uncoalesced, so every Desktop poll
-        # re-ran the full 50-profile fan-out. Any new heavy sidebar endpoint
-        # must carry the wrapper too — this pins the existing two.
-        for endpoint in (
-            profiles.get_profiles_sessions_sidebar,
-            profiles.get_profiles_projects_tree,
-        ):
-            self.assertTrue(
-                callable(getattr(endpoint, "cache_clear", None)),
-                f"{endpoint.__name__} lost its @_sidebar_singleflight_cache "
-                "wrapper — concurrent Desktop polls will re-scan every profile",
-            )
+    def test_projects_tree_coalesces_concurrent_scans_and_returns_copies(self):
+        # /api/profiles/projects/tree fans out over every profile's state.db; desktop
+        # background sync + sidebar refreshes overlap identical requests. One scan must
+        # serve the whole burst, and no two callers may share the same payload object.
+        workers = 8
+        entered = threading.Event()
+        release = threading.Event()
+        scans = 0
+        scans_lock = threading.Lock()
+
+        def fake_read(name, home, errors, fn):
+            nonlocal scans
+            with scans_lock:
+                scans += 1
+            entered.set()
+            self.assertTrue(release.wait(timeout=2))
+            return None
+
+        with mock.patch.object(profiles, "_profile_targets", return_value=[("default", Path("/nonexistent"))]), \
+                mock.patch.object(profiles, "_read_profile_db", side_effect=fake_read), \
+                ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(profiles.get_profiles_projects_tree) for _ in range(workers)]
+            self.assertTrue(entered.wait(timeout=1))
+            time.sleep(0.05)
+            release.set()
+            results = [future.result(timeout=2) for future in futures]
+
+        self.assertEqual(scans, 1)
+        self.assertEqual(len({id(r) for r in results}), workers)
+        self.assertEqual(results, [results[0]] * workers)
+        self.assertEqual(results[0]["projects"], [])
 
 
 if __name__ == "__main__":

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -15,30 +15,13 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _cold_sidebar_singleflight_caches():
-    """Force a cold single-flight cache around every test in this file.
-
-    Both sidebar endpoints are wrapped in ``_sidebar_singleflight_cache``
-    (5s TTL). Each test builds a fresh tmp profile set, so a warm entry from
-    a previous test — same default query params, different disk state — would
-    answer with another test's payload. Clearing before and after keeps every
-    request cold without disabling the caching the endpoints rely on.
-    """
+def _uncached_sidebar_endpoints(monkeypatch):
+    """Both sidebar endpoints sit behind ``_sidebar_singleflight_cache`` (5s TTL). Every
+    test here builds a fresh tmp profile set under the same default query params, so a warm
+    entry would answer with another test's payload. TTL 0 makes each request cold."""
     from hermes_cli.web_routers import profiles as profiles_routes
 
-    endpoints = (
-        profiles_routes.get_profiles_sessions_sidebar,
-        profiles_routes.get_profiles_projects_tree,
-    )
-    for endpoint in endpoints:
-        clear = getattr(endpoint, "cache_clear", None)
-        if clear is not None:
-            clear()
-    yield
-    for endpoint in endpoints:
-        clear = getattr(endpoint, "cache_clear", None)
-        if clear is not None:
-            clear()
+    monkeypatch.setattr(profiles_routes, "_SIDEBAR_CACHE_TTL_SECONDS", 0.0)
 
 
 @pytest.fixture

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -14,6 +14,33 @@ Two behaviors that only show up with more than one profile on disk:
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _cold_sidebar_singleflight_caches():
+    """Force a cold single-flight cache around every test in this file.
+
+    Both sidebar endpoints are wrapped in ``_sidebar_singleflight_cache``
+    (5s TTL). Each test builds a fresh tmp profile set, so a warm entry from
+    a previous test — same default query params, different disk state — would
+    answer with another test's payload. Clearing before and after keeps every
+    request cold without disabling the caching the endpoints rely on.
+    """
+    from hermes_cli.web_routers import profiles as profiles_routes
+
+    endpoints = (
+        profiles_routes.get_profiles_sessions_sidebar,
+        profiles_routes.get_profiles_projects_tree,
+    )
+    for endpoint in endpoints:
+        clear = getattr(endpoint, "cache_clear", None)
+        if clear is not None:
+            clear()
+    yield
+    for endpoint in endpoints:
+        clear = getattr(endpoint, "cache_clear", None)
+        if clear is not None:
+            clear()
+
+
 @pytest.fixture
 def profiles_on_disk(tmp_path, monkeypatch, _isolate_hermes_home):
     """An isolated default home plus one named profile, each with a state.db."""


### PR DESCRIPTION
perf(dashboard): single-flight the all-profiles project tree

Based on #102676 by @moken627-hub (cherry-picked, authorship preserved).

Fixes #102674

## Problem

`GET /api/profiles/projects/tree` fans out over every profile's `state.db` and rebuilds the project
tree per profile on every call. The desktop hits it from background sync **and** the sidebar
(`refreshProjectTree`), so bursts of identical requests overlap in the AnyIO worker pool and each
one repeats the full scan. Its sibling `GET /api/profiles/sessions` has been behind
`_sidebar_singleflight_cache` since f0cfe5a56f; this route was the one heavy sidebar endpoint left
uncoalesced.

## Change

- `hermes_cli/web_routers/profiles.py`: decorate `get_profiles_projects_tree` with the existing
  `_sidebar_singleflight_cache` (one line). Same 5s TTL / single-flight / copy-on-hit semantics as
  the sessions sidebar; payloads carrying `errors[]` are still never cached.
- Dropped from the original PR: the `read_user_config_raw` memo in `hermes_cli/config.py`. That
  function is documented as uncached by contract (write-back round-trips), and once the tree
  response itself is cached the per-profile config re-parse happens once per TTL rather than once
  per poller, so the memo no longer buys anything.
- Tests: one invariant (8 concurrent tree requests run the scan once and each caller gets its own
  copy) replacing an attribute-presence check; the scope suite disables the TTL via
  `_SIDEBAR_CACHE_TTL_SECONDS = 0` instead of calling a clear hook the decorator never exposed.

## Measured impact

Temp `HERMES_HOME`, 6 profiles (default + 5), each with a config.yaml, 100 `SKILL.md`, and a
`state.db` with 30 sessions across 5 folders. 10 concurrent `get_profiles_projects_tree()` calls via
`asyncio.gather` over `run_in_threadpool`; `_build_project_tree` invocations counted; 3 runs each
(cache cold per run).

| | main (9e6c4100cb) | this branch |
|---|---|---|
| `_build_project_tree` calls per 10-request burst | 60 / 60 / 60 | 6 / 6 / 6 |
| burst wall time | 758 / 313 / 330 ms | 92 / 55 / 21 ms |

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_profiles_sidebar_cache.py tests/hermes_cli/test_profiles_sidebar_scope.py` — 18 passed.
- Mutation: removing the decorator line turns the new single-flight test red (60 scans instead of 1); restoring it goes green.
- `ruff check`, `scripts/check_compat_pointers.py`, `git diff --check` clean.
