### PR TITLE
fix(gateway): foreign HERMES_HOME no longer resolves to the default hermes-gateway systemd unit (temp-home harness uninstalled the production gateway)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1949,16 +1949,21 @@ def _profile_name_from_home(home: Path, default: Path) -> str | None:
 
 
 def _profile_suffix() -> str:
-    """Service-name suffix for HERMES_HOME: "" for the default root, the profile name for
-    ``<root>/profiles/<name>``, else a short hash of the path."""
+    """Service-name suffix for HERMES_HOME: "" for the platform-native default home (``~/.hermes``), the
+    profile name for ``<root>/profiles/<name>``, else a short hash of the path.
+
+    The bare name is reserved for the NATIVE default, not ``get_default_hermes_root()``: that helper
+    treats any HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself",
+    which let a temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall
+    the production gateway. Service names are host-wide identities; only the real default home owns the
+    bare one."""
     import hashlib
-    from hermes_constants import get_default_hermes_root
+    from hermes_constants import _get_platform_default_hermes_home, get_default_hermes_root
     home = get_hermes_home().resolve()
-    default = get_default_hermes_root().resolve()
-    if home == default:
+    if home == _get_platform_default_hermes_home().resolve():
         return ""
-    # Fallback: short hash for arbitrary HERMES_HOME paths
-    return _profile_name_from_home(home, default) or hashlib.sha256(str(home).encode()).hexdigest()[:8]
+    name = _profile_name_from_home(home, get_default_hermes_root().resolve())
+    return name or hashlib.sha256(str(home).encode()).hexdigest()[:8]
 
 
 def _profile_arg(hermes_home: str | None = None, default_root: str | Path | None = None) -> str:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1385,7 +1385,7 @@ def _s6_gateway_snapshot(gateway_pids: tuple[int, ...]) -> GatewayRuntimeSnapsho
     from hermes_cli.service_manager import detect_service_manager, get_service_manager
     if detect_service_manager() != "s6":
         return None
-    service_name = f"gateway-{_profile_suffix() or 'default'}"
+    service_name = f"gateway-{_current_profile_name()}"
     mgr = get_service_manager()
     service_installed = service_running = False
     try:
@@ -1964,6 +1964,14 @@ def _profile_suffix() -> str:
         return ""
     name = _profile_name_from_home(home, get_default_hermes_root().resolve())
     return name or hashlib.sha256(str(home).encode()).hexdigest()[:8]
+
+
+def _current_profile_name() -> str:
+    """Profile id relative to the profile ROOT: ``default`` for the root itself (Docker's ``/opt/data``
+    included), ``<name>`` for ``<root>/profiles/<name>``, else the service hash. s6 slots and the
+    multiplexer ask which PROFILE this is; ``_profile_suffix()`` answers which HOST SERVICE this is."""
+    from hermes_constants import profile_name_for_home
+    return profile_name_for_home(get_hermes_home()) or _profile_suffix()
 
 
 def _profile_arg(hermes_home: str | None = None, default_root: str | Path | None = None) -> str:
@@ -4282,7 +4290,7 @@ def named_profile_served_by_running_multiplexer(profile_name: str | None = None)
     See #97120.
     """
     try:
-        suffix = profile_name if profile_name is not None else _profile_suffix()
+        suffix = profile_name if profile_name is not None else _current_profile_name()
     except Exception:
         return False
     if not suffix or suffix == "default":
@@ -4339,7 +4347,7 @@ def _guard_named_profile_under_multiplexer(force: bool = False) -> None:
     if force:
         return
     try:
-        suffix = _profile_suffix()
+        suffix = _current_profile_name()
     except Exception:
         return
     if not named_profile_served_by_running_multiplexer():
@@ -5688,8 +5696,7 @@ def _dispatch_via_service_manager_if_s6(action: str, profile: str | None = None)
     if detect_service_manager() != "s6":
         return False
     if profile is None:
-        # _profile_suffix() is "" for the default root; the default gateway is gateway-default.
-        profile = _profile_suffix() or "default"
+        profile = _current_profile_name()  # root home (Docker /opt/data included) is gateway-default
     mgr = get_service_manager()
     if action not in ("start", "stop", "restart"):
         return False

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3218,8 +3218,24 @@ def _systemd_scope_preamble(
     return system
 
 
+def _systemd_unit_belongs_to_current_home(system: bool = False) -> bool:
+    """False (with a warning) when the installed unit pins a HERMES_HOME other than this process's: the
+    service name then resolved to ANOTHER install's gateway, and stop/disable/unlink would take it down."""
+    _sync_hermes_home_from_systemd_unit(system=system)  # sudo strips HERMES_HOME; adopt the unit's first
+    unit_home = _hermes_home_from_systemd_unit_file(system=system)
+    if unit_home is None or Path(unit_home).expanduser().resolve() == get_hermes_home().resolve():
+        return True
+    print_warning(
+        f"Refusing to remove {get_systemd_unit_path(system=system)}: it runs HERMES_HOME={unit_home}, "
+        f"but this process has HERMES_HOME={get_hermes_home()}"
+    )
+    return False
+
+
 def systemd_uninstall(system: bool = False):
     system = _systemd_scope_preamble("uninstall", system, require_installed=False)
+    if not _systemd_unit_belongs_to_current_home(system):
+        return
     _run_systemctl(["stop", get_service_name()], system=system, check=False, timeout=90)
     _run_systemctl(["disable", get_service_name()], system=system, check=False, timeout=30)
 

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -192,12 +192,14 @@ def uninstall_gateway_service():
 
 def _remove_systemd_gateway() -> bool:
     """Linux: uninstall systemd services (both user and system scopes)."""
-    from hermes_cli.gateway import _systemctl_cmd, get_service_name, get_systemd_unit_path
+    from hermes_cli.gateway import (
+        _systemctl_cmd, _systemd_unit_belongs_to_current_home, get_service_name, get_systemd_unit_path,
+    )
     svc_name = get_service_name()
     removed_any = False
     for is_system, scope in ((False, "user"), (True, "system")):
         unit_path = get_systemd_unit_path(system=is_system)
-        if not unit_path.exists():
+        if not unit_path.exists() or not _systemd_unit_belongs_to_current_home(is_system):
             continue
         try:
             if is_system and os.geteuid() != 0:  # windows-footgun: ok — Linux-only systemd path

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -186,6 +186,38 @@ class TestRequireServiceInstalled:
         gateway_cli._require_service_installed("start")
 
 
+class TestServiceIdentityForForeignHome:
+    """A HERMES_HOME that is neither ``~/.hermes`` nor ``~/.hermes/profiles/<name>`` must never resolve to
+    the default profile's ``hermes-gateway`` unit (a temp-home harness uninstalled the production gateway)."""
+
+    @pytest.fixture
+    def machine_home(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: home)
+        return home
+
+    def test_foreign_home_gets_its_own_unit(self, machine_home, tmp_path, monkeypatch):
+        foreign = tmp_path / "elsewhere"
+        foreign.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(foreign))
+
+        default_unit = machine_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+        assert gateway_cli.get_service_name() != "hermes-gateway"
+        assert gateway_cli.get_systemd_unit_path() != default_unit
+        assert gateway_cli.get_systemd_unit_path().parent == default_unit.parent
+
+    def test_default_and_named_profile_homes_keep_their_names(self, machine_home, monkeypatch):
+        default_home = machine_home / ".hermes"
+        (default_home / "profiles" / "alpha").mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        assert gateway_cli.get_service_name() == "hermes-gateway"
+
+        monkeypatch.setenv("HERMES_HOME", str(default_home / "profiles" / "alpha"))
+        assert gateway_cli.get_service_name() == "hermes-gateway-alpha"
+
+
 class TestGetCronDrainTimeout:
     def test_missing_config_falls_back_to_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -218,6 +218,25 @@ class TestServiceIdentityForForeignHome:
         assert gateway_cli.get_service_name() == "hermes-gateway-alpha"
 
 
+class TestUninstallRefusesForeignUnit:
+    """systemd_uninstall must not stop/disable/unlink a unit pinned to another HERMES_HOME."""
+
+    def test_unit_for_other_home_is_left_alone(self, tmp_path, monkeypatch, capsys):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text('[Service]\nEnvironment="HERMES_HOME=/somewhere/else"\n', encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "mine"))
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "_systemd_scope_preamble", lambda *a, **k: False)
+        calls = []
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", lambda args, **k: calls.append(args))
+
+        gateway_cli.systemd_uninstall(system=False)
+
+        assert unit_path.exists()
+        assert calls == []
+        assert "/somewhere/else" in capsys.readouterr().out
+
+
 class TestGetCronDrainTimeout:
     def test_missing_config_falls_back_to_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)


### PR DESCRIPTION
A process whose `HERMES_HOME` is neither `~/.hermes` nor `~/.hermes/profiles/<name>` now gets its own hashed `hermes-gateway-<8hex>` service identity, and `gateway uninstall` refuses to touch a unit that belongs to another home — so a temp-home harness can no longer install over, stop, or delete the default profile's production gateway.

## Incident (why this matters)

2026-09-02: a refactor parity harness ran `HERMES_HOME=$(mktemp -d) python -c '... uninstall_gateway_service()'`. It resolved to the REAL `~/.config/systemd/user/hermes-gateway.service`, ran `systemctl --user stop/disable`, unlinked the unit and daemon-reloaded. With no unit left, `Restart=` had nothing to revive: every cron job (60) and every messaging platform was dead for 6.5 days.

## Root cause (one sentence)

`_profile_suffix()` compared `HERMES_HOME` against `get_default_hermes_root()`, which by design treats *any* home outside `~/.hermes` (Docker `/opt/data`, a `mktemp` dir) as "the root itself", so the equality short-circuited to the bare name and the documented `sha256(path)[:8]` fallback was unreachable dead code.

## Before / after

| `HERMES_HOME` | before (origin/main) | after |
|---|---|---|
| `~/.hermes` | `hermes-gateway.service` | `hermes-gateway.service` (unchanged) |
| `~/.hermes/profiles/alpha` | `hermes-gateway-alpha.service` | `hermes-gateway-alpha.service` (unchanged) |
| `/tmp/xyz` (mktemp) | **`hermes-gateway.service`** ← production unit | `hermes-gateway-b88549e8.service` |
| `/opt/data` (Docker root) | `hermes-gateway.service` | `hermes-gateway-<hash>.service` (see Docker below) |

Same rule feeds `get_launchd_label()` / `get_launchd_plist_path()` and the Windows Scheduled-Task name — all derive from `_profile_suffix()`, so the whole class is fixed at one site.

## Changes (3 commits)

- **`hermes_cli/gateway.py::_profile_suffix`** — bare name only when `HERMES_HOME == _get_platform_default_hermes_home()` (`~/.hermes`); profile name for `<root>/profiles/<name>`; hash otherwise. Docstring now says why.
- **`_current_profile_name()`** (new, 6 LOC) — the three callers that asked `_profile_suffix() or "default"` as a *profile id* (s6 `gateway-<profile>` slot in `_s6_gateway_snapshot` / `_dispatch_via_service_manager_if_s6`, and the multiplexer probes `named_profile_served_by_running_multiplexer` / `_guard_named_profile_under_multiplexer`) now use `hermes_constants.profile_name_for_home()` so a Docker root stays `gateway-default` under s6 and a hash is never mistaken for a profile name.
- **Uninstall guard** — `systemd_uninstall()` and `uninstall._remove_systemd_gateway()` call `_systemd_unit_belongs_to_current_home()`, which reuses the existing `_hermes_home_from_systemd_unit_file` parser; when the unit's `Environment="HERMES_HOME=…"` names another home it warns with both paths and leaves the unit (no stop/disable/unlink). Units without the line are removed as before.

## Sibling resolvers audited

| Site | Verdict |
|---|---|
| `gateway.py::_profile_arg` | not the bug — it only emits `--profile <name>` for `<root>/profiles/<name>`; a foreign home correctly yields `""` (no `-p`), unit `ExecStart` still pins `HERMES_HOME` explicitly |
| `gateway.py::get_launchd_plist_path` / `get_launchd_label` / `gateway_windows.get_task_name` | derive from `_profile_suffix()` → fixed by commit 1 |
| `gateway.py::_scan_gateway_pids::_matches_current_profile` | matches by explicit `HERMES_HOME=` on argv / `-p`, not by service name — a foreign home does not claim the default gateway's PIDs; unchanged |
| `uninstall.py::_is_default_hermes_home` | gates *profile discovery* (`list_profiles`), not service identity; discovery of siblings for a Docker root is intended; unchanged |
| `gateway_enroll.py::_warn_if_secondary_multiplex_profile`, `update_cmd.py::_invalidate_update_cache`, `update_cmd_deps.py`, `profiles.py::_get_default_hermes_home` | root-relative *storage* lookups where "root = HERMES_HOME in Docker" is the documented intent (#7170); untouched, as is `_get_profiles_root()` |
| `gateway/status.py::_profile_label_for_home` | labels a root home `"default"` for lock diagnostics; informational only, not a service path; unchanged |

## Docker decision

The official image supervises gateways with **s6** (`docker/s6-rc.d`, `hermes_cli/service_manager.py`, `gateway-<profile>` slots), never systemd/launchd; `hermes gateway install` inside a container prints Docker guidance and exits 0 (`test_install_in_container_prints_docker_guidance`). `grep` of `Dockerfile`, `docker/`, `scripts/`, `install.sh` finds no hardcoded `hermes-gateway` unit name. So option (a): a Docker/custom root now gets a hashed *host* service suffix (irrelevant inside the container), while its *profile id* stays `default` via `_current_profile_name()` so the s6 slot name is unchanged (`gateway-default`). Docs already describe this rule (`messaging/index.md`: "other installations use `hermes-gateway-<hash>`").

## Validation

- **Live repro (pure path functions only, nothing invoked against systemd):** before — `HERMES_HOME=$(mktemp -d) python -c 'print(get_service_name(), get_systemd_unit_path())'` → `hermes-gateway /home/<user>/.config/systemd/user/hermes-gateway.service`. After → `hermes-gateway-81868c41 …/hermes-gateway-81868c41.service`.
- **Tests (proved RED on origin/main in a second worktree, GREEN here):** `TestServiceIdentityForForeignHome` (2) and `TestUninstallRefusesForeignUnit` (1) in `tests/hermes_cli/test_gateway_service.py`. On base: `assert 'hermes-gateway' != 'hermes-gateway'` and the foreign unit was unlinked.
- **Suites:** 19 files / 500 passed (all gateway service, s6, launchd fleet, multiplex, profiles, uninstall, status, constants files referencing `_profile_suffix` / `get_service_name` / `get_systemd_unit_path`) + 5 uninstall files / 22 passed. `ruff`, `check-windows-footguns --all`, `check_compat_pointers`, `git diff --check` clean.
- **E2E (real imports, `hermes*` purged from `sys.modules`, mocked `Path.home`, temp `HERMES_HOME`):** foreign home → unit under mocked `~/.config/systemd/user/hermes-gateway-<8hex>.service`; `<mockhome>/.hermes` → bare; `profiles/alpha` → `-alpha`; Docker-shaped root → hashed service, `_current_profile_name()=="default"`. Guard: unit file with `Environment="HERMES_HOME=/somewhere/else"` at the resolved path + patched `subprocess.run` → `systemd_uninstall(system=False)` left the file in place and issued **zero** systemctl calls; with a matching home it proceeded (stop/disable/unlink/daemon-reload). `uninstall._remove_systemd_gateway()` likewise returned `False` and kept the file.
- Production gateway verified `systemctl --user is-active hermes-gateway` → `active` after every step.

## Infographic

![one home, one service](https://v3b.fal.media/files/b/0aa9bc1f/mlkenhGuBzJw4WJeq7uxD_QKo07qLn.png)
