### PR TITLE
fix(picker): Nous picker reads pricing cache-only, no live catalog fetch on /model open (#74514, salvage #102099)

### DIFF
--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -416,7 +416,9 @@ def _nous_picker_model_ids(curated: dict, force_fresh_nous_tier: bool) -> list:
             union_with_portal_paid_recommendations,
         )
         from hermes_cli.auth import get_provider_auth_state
-        pricing = get_pricing_for_provider("nous") or {}
+        # Cache-only: both Portal unions below discard the pricing map (``model_ids, _ = ...``);
+        # only the appended ids matter, so a live catalog fetch here buys nothing but latency.
+        pricing = get_pricing_for_provider("nous", cached_only=True) or {}
         try:
             portal = (get_provider_auth_state("nous") or {}).get("portal_base_url", "") or ""
         except Exception:

--- a/tests/hermes_cli/test_nous_picker_pricing_cached_only.py
+++ b/tests/hermes_cli/test_nous_picker_pricing_cached_only.py
@@ -1,0 +1,22 @@
+"""The Nous picker row never starts a pricing fetch: the picker only uses the ids the Portal
+unions append, and a cold pricing cache must not hold the picker open (salvage of #102099)."""
+
+import hermes_cli.models_pricing as mp
+from hermes_cli import model_switch_providers as msp
+
+
+def test_nous_picker_model_ids_reads_pricing_cache_only(monkeypatch):
+    seen: list[bool] = []
+
+    def fake_pricing(provider, *, force_refresh=False, cached_only=False):
+        seen.append(cached_only)
+        return {}
+
+    monkeypatch.setattr(mp, "get_pricing_for_provider", fake_pricing)
+    # Keep the sibling Portal calls off the network; only the pricing call shape is under test.
+    monkeypatch.setattr("hermes_cli.models.check_nous_free_tier", lambda **kw: False)
+    monkeypatch.setattr("hermes_cli.models.fetch_nous_recommended_models", lambda *a, **kw: None)
+    monkeypatch.setattr(mp, "nous_policy_allowed_ids", lambda **kw: None)
+
+    assert msp._nous_picker_model_ids({"nous": ["nous/a"]}, False) == ["nous/a"]
+    assert seen == [True]


### PR DESCRIPTION
## perf(picker): read Nous pricing cache-only when building the picker row

Opening the model picker no longer pays a live Nous `/v1/models` round-trip when the pricing cache is cold. `_nous_picker_model_ids` (hermes_cli/model_switch_providers.py) fetched pricing only to hand it to `union_with_portal_*`, which discard the map (`model_ids, _ = ...`); the picker uses just the appended ids. It now reads `get_pricing_for_provider("nous", cached_only=True)` — the same cache the background pricing prewarm (#101685) fills for later opens.

Based on #102099 by @finn763.

**WHO/WHEN:** every `/model` open (CLI, TUI, desktop, dashboard) with Nous credentials and no resident pricing entry — first open per process, and every open after the 5-min `_NOUS_CATALOG_TTL_SECONDS` expiry. **WHY** it existed: #102099 targeted `hermes_cli/model_switch.py`, which 3b1ecfc0a1 decomposed into `model_switch_providers.py` two days later; this re-derives the one-line change at the live call site (the original hunk no longer applies).

Scope note: when the org carries a Nous model policy, `nous_policy_allowed_ids()` in the same function still fetches the catalog — that read is load-bearing (it narrows the list to policy) and shares the pricing cache entry, so it is unchanged. `web_routers/models.py::_nous_recommended_default` and `model_setup_flows.py::_model_flow_nous` keep their live pricing reads because they partition by tier with the map.

## Measured impact

`_nous_picker_model_ids(curated, False)` with the pricing HTTP layer stubbed to a 2 s reply and an empty pricing cache (3 runs, median; Portal recommendation + policy calls stubbed to no-ops so only the pricing path is timed):

| | main (9e6c4100cb) | branch | Δ |
|---|---|---|---|
| cold call wall time | 2007.6 ms | 0.1 ms | −99.99 % |
| pricing HTTP calls per open | 1 | 0 | −1 |

## Tests

One invariant test (`tests/hermes_cli/test_nous_picker_pricing_cached_only.py`): the picker path calls `get_pricing_for_provider` with `cached_only=True` and still yields the curated list. Mutation-checked: reverting the production line fails the test.

## Verification

- `scripts/run_tests.sh` on the new test + `test_list_picker_providers.py`, `test_nous_policy_surfaces.py`, `test_picker_prewarm.py`: 24 passed.
- `ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check`: clean.
