### PR TITLE
fix(models): unreachable custom endpoint stops re-paying connect timeouts on every picker open (#81123, salvage #102364)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2106,6 +2106,35 @@ def github_model_reasoning_efforts(
     return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
 
 
+# Negative cache: monotonic timestamp of the last fully-failed probe, keyed
+# by ``host:port`` so both URL candidates (``/v1`` + root) share one entry.
+# Without this, an unreachable endpoint (TCP blackhole — SYN draws no reply,
+# so every attempt burns its full connect timeout) makes every picker open /
+# chat turn re-pay the timeout per candidate, and the sequential stalls stack
+# past 10s while the Desktop sits on a spinner with no error (#81123). Short
+# TTL collapses the burst but still picks up recovery without a restart.
+# Mirrors _deepinfra_catalog_neg_cache.
+_probe_neg_cache: dict[str, float] = {}
+_PROBE_NEG_TTL = 60.0  # seconds
+
+
+def _probe_neg_key(base_url: str) -> Optional[str]:
+    """Return a ``host:port`` key for *base_url*, or None if it has no host."""
+    normalized = (base_url or "").strip().lower()
+    if not normalized:
+        return None
+    url = normalized if "://" in normalized else f"http://{normalized}"
+    try:
+        parsed = urllib.parse.urlparse(url)
+        host = parsed.hostname or ""
+        if not host:
+            return None
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except Exception:
+        return None
+    return f"{host}:{port}"
+
+
 def _probe_result(
     models, probed_url, resolved_base_url, suggested_base_url=None, used_fallback=False
 ) -> dict[str, Any]:
@@ -2137,6 +2166,14 @@ def probe_api_models(
         candidates.append((alternate_base, True))
 
     tried: list[str] = []
+    # ponytail: short-TTL negative cache; full re-probe once it expires.
+    _neg_key = _probe_neg_key(normalized)
+    if _neg_key is not None:
+        _neg_seen = _probe_neg_cache.get(_neg_key)
+        if _neg_seen is not None and (time.monotonic() - _neg_seen) < _PROBE_NEG_TTL:
+            return _probe_result(
+                None, normalized.rstrip("/") + "/models", normalized,
+                alternate_base if alternate_base != normalized else None)
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
     if urllib.parse.urlparse(normalized).hostname == "generativelanguage.googleapis.com":
         headers["X-Goog-Api-Client"] = f"hermes-agent/{_HERMES_VERSION}"
@@ -2169,6 +2206,9 @@ def probe_api_models(
         return _probe_result(
             [m.get("id", "") for m in data.get("data", [])], url, candidate_base.rstrip("/"),
             alternate_base if alternate_base != candidate_base else normalized, is_fallback)
+
+    if _neg_key is not None:
+        _probe_neg_cache[_neg_key] = time.monotonic()
     return _probe_result(
         None, tried[0] if tried else normalized.rstrip("/") + "/models", normalized,
         alternate_base if alternate_base != normalized else None)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2119,20 +2119,11 @@ _PROBE_NEG_TTL = 60.0  # seconds
 
 
 def _probe_neg_key(base_url: str) -> Optional[str]:
-    """Return a ``host:port`` key for *base_url*, or None if it has no host."""
-    normalized = (base_url or "").strip().lower()
-    if not normalized:
-        return None
-    url = normalized if "://" in normalized else f"http://{normalized}"
-    try:
-        parsed = urllib.parse.urlparse(url)
-        host = parsed.hostname or ""
-        if not host:
-            return None
-        port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    except Exception:
-        return None
-    return f"{host}:{port}"
+    """``host:port`` for *base_url* (both URL candidates share one entry), or None without a host."""
+    from utils import base_url_origin
+
+    _, host, port = base_url_origin(base_url)
+    return f"{host}:{port}" if host else None
 
 
 def _probe_result(
@@ -2166,7 +2157,6 @@ def probe_api_models(
         candidates.append((alternate_base, True))
 
     tried: list[str] = []
-    # ponytail: short-TTL negative cache; full re-probe once it expires.
     _neg_key = _probe_neg_key(normalized)
     if _neg_key is not None:
         _neg_seen = _probe_neg_cache.get(_neg_key)
@@ -2196,11 +2186,17 @@ def probe_api_models(
     _ssl_context = _custom_provider_ssl_context(normalized)
     if _ssl_context is not None:
         _open_kwargs["ssl_context"] = _ssl_context
+    reachable = False
     for candidate_base, is_fallback in candidates:
         url = candidate_base.rstrip("/") + "/models"
         tried.append(url)
         try:
             data = _get_json(url, timeout=timeout, headers=headers, **_open_kwargs)
+        except urllib.error.HTTPError:
+            # The host answered: an auth/404 failure is not unreachability, and a user fixing
+            # their key must not be served a cached "no models" for the next TTL window.
+            reachable = True
+            continue
         except Exception:
             continue
         if _neg_key is not None:
@@ -2209,7 +2205,7 @@ def probe_api_models(
             [m.get("id", "") for m in data.get("data", [])], url, candidate_base.rstrip("/"),
             alternate_base if alternate_base != candidate_base else normalized, is_fallback)
 
-    if _neg_key is not None:
+    if _neg_key is not None and not reachable:
         _probe_neg_cache[_neg_key] = time.monotonic()
     return _probe_result(
         None, tried[0] if tried else normalized.rstrip("/") + "/models", normalized,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2203,6 +2203,8 @@ def probe_api_models(
             data = _get_json(url, timeout=timeout, headers=headers, **_open_kwargs)
         except Exception:
             continue
+        if _neg_key is not None:
+            _probe_neg_cache.pop(_neg_key, None)
         return _probe_result(
             [m.get("id", "") for m in data.get("data", [])], url, candidate_base.rstrip("/"),
             alternate_base if alternate_base != candidate_base else normalized, is_fallback)

--- a/tests/agent/test_custom_provider_ca_probes.py
+++ b/tests/agent/test_custom_provider_ca_probes.py
@@ -239,6 +239,14 @@ class TestMetadataProbeThreadsProviderCA:
 class TestCatalogProbeThreadsSSLContext:
     """End-to-end: the urllib catalog probe carries the provider SSL context."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_probe_neg_cache(self):
+        import hermes_cli.models as models
+
+        models._probe_neg_cache.clear()
+        yield
+        models._probe_neg_cache.clear()
+
     def test_probe_api_models_passes_ssl_context(self, clean_env, real_ca):
         import hermes_cli.models as models
 

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -378,3 +378,37 @@ class TestSalvageFollowups:
             out = mod.cached_fetch_api_models("sk-key", "https://gw.example.com/v1")
         assert out == ["live-models"]
         live.assert_called_once()
+
+
+class TestProbeApiModelsNegativeCache:
+    """#81123: a fully-failed /models probe must degrade fast, not re-burn
+    connect timeouts per URL candidate on every picker open."""
+
+    def _fail(self, req, **kw):
+        raise TimeoutError("connect timed out")
+
+    def test_repeat_failure_skips_network(self, monkeypatch):
+        import hermes_cli.models as mod
+
+        monkeypatch.setattr(mod, "_probe_neg_cache", {})
+        monkeypatch.setattr(mod, "_urlopen_model_catalog_request", self._fail)
+        r1 = mod.probe_api_models("", "https://blackhole.invalid/v1", timeout=1.0)
+        calls = []
+        monkeypatch.setattr(
+            mod, "_urlopen_model_catalog_request",
+            lambda req, **kw: calls.append(req.full_url) or self._fail(req, **kw),
+        )
+        r2 = mod.probe_api_models("", "https://blackhole.invalid/v1/", timeout=1.0)
+        assert (r1["models"], r2["models"]) == (None, None)
+        assert calls == []  # /v1 + root share one host:port entry
+        assert r2["probed_url"] == "https://blackhole.invalid/v1/models"
+
+    def test_expired_entry_reprobes(self, monkeypatch):
+        import hermes_cli.models as mod
+
+        old = time.monotonic() - mod._PROBE_NEG_TTL - 1
+        monkeypatch.setattr(mod, "_probe_neg_cache", {"blackhole.invalid:443": old})
+        monkeypatch.setattr(mod, "_urlopen_model_catalog_request", self._fail)
+        out = mod.probe_api_models("", "https://blackhole.invalid/v1", timeout=1.0)
+        assert out["models"] is None
+        assert mod._probe_neg_cache["blackhole.invalid:443"] > old

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -384,13 +384,20 @@ class TestProbeApiModelsNegativeCache:
     """#81123: a fully-failed /models probe must degrade fast, not re-burn
     connect timeouts per URL candidate on every picker open."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_probe_neg_cache(self):
+        import hermes_cli.models as mod
+
+        mod._probe_neg_cache.clear()
+        yield
+        mod._probe_neg_cache.clear()
+
     def _fail(self, req, **kw):
         raise TimeoutError("connect timed out")
 
-    def test_repeat_failure_skips_network(self, monkeypatch):
+    def test_repeat_failure_within_ttl_skips_network(self, monkeypatch):
         import hermes_cli.models as mod
 
-        monkeypatch.setattr(mod, "_probe_neg_cache", {})
         monkeypatch.setattr(mod, "_urlopen_model_catalog_request", self._fail)
         r1 = mod.probe_api_models("", "https://blackhole.invalid/v1", timeout=1.0)
         calls = []
@@ -403,12 +410,30 @@ class TestProbeApiModelsNegativeCache:
         assert calls == []  # /v1 + root share one host:port entry
         assert r2["probed_url"] == "https://blackhole.invalid/v1/models"
 
-    def test_expired_entry_reprobes(self, monkeypatch):
+    def test_expired_entry_reprobes_and_success_clears_it(self, monkeypatch):
         import hermes_cli.models as mod
 
+        key = "blackhole.invalid:443"
         old = time.monotonic() - mod._PROBE_NEG_TTL - 1
-        monkeypatch.setattr(mod, "_probe_neg_cache", {"blackhole.invalid:443": old})
+        mod._probe_neg_cache[key] = old
         monkeypatch.setattr(mod, "_urlopen_model_catalog_request", self._fail)
         out = mod.probe_api_models("", "https://blackhole.invalid/v1", timeout=1.0)
         assert out["models"] is None
-        assert mod._probe_neg_cache["blackhole.invalid:443"] > old
+        assert mod._probe_neg_cache[key] > old  # expiry re-probed and re-recorded
+
+        mod._probe_neg_cache[key] = old  # expired again: the real probe runs
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "m1"}]}'
+
+        monkeypatch.setattr(mod, "_urlopen_model_catalog_request", lambda req, **kw: _Resp())
+        ok = mod.probe_api_models("", "https://blackhole.invalid/v1", timeout=1.0)
+        assert ok["models"] == ["m1"]
+        assert key not in mod._probe_neg_cache  # recovery is not masked by the stale entry

--- a/tests/hermes_cli/test_cached_fetch_api_models.py
+++ b/tests/hermes_cli/test_cached_fetch_api_models.py
@@ -410,6 +410,19 @@ class TestProbeApiModelsNegativeCache:
         assert calls == []  # /v1 + root share one host:port entry
         assert r2["probed_url"] == "https://blackhole.invalid/v1/models"
 
+    def test_http_error_from_a_reachable_host_is_not_cached_as_unreachable(self, monkeypatch):
+        import urllib.error
+
+        import hermes_cli.models as mod
+
+        def _unauthorized(req, **kw):
+            raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, None)
+
+        monkeypatch.setattr(mod, "_urlopen_model_catalog_request", _unauthorized)
+        assert mod.probe_api_models("bad-key", "https://reachable.invalid/v1", timeout=1.0)["models"] is None
+        # The host answered; a corrected key must probe again immediately.
+        assert "reachable.invalid:443" not in mod._probe_neg_cache
+
     def test_expired_entry_reprobes_and_success_clears_it(self, monkeypatch):
         import hermes_cli.models as mod
 


### PR DESCRIPTION
Based on #102364 by @Finn763 (cherry-picked, authorship preserved).

Fixes #81123

## Problem

`probe_api_models()` tries two URL candidates (`base` and `base±/v1`) against a custom endpoint. When the host is a TCP blackhole every candidate burns its full connect timeout, and nothing remembers the failure — so every picker open / chat turn re-pays ~2× the timeout while the desktop sits on a spinner.

## Fix

Short-TTL (60s) in-memory negative cache keyed by `host:port` (so both candidates share one entry), mirroring the existing `_deepinfra_catalog_neg_cache` pattern:

- a fully-failed probe records `time.monotonic()`;
- a probe within the TTL returns the same `models: None` result immediately with zero network calls;
- expiry re-probes; a **successful** probe pops the entry (added on top of the original PR so recovery is never masked by a stale mark).

## Measured impact

`probe_api_models("", "http://10.255.255.1:9/v1", timeout=1.0)` called twice in one process, fresh interpreter per run, 3 runs each:

| tree | 1st call | 2nd call |
|---|---|---|
| main | 2051 / 2046 / 2058 ms | 2076 / 2076 / 2036 ms |
| this branch | 2032 / 2056 / 2055 ms | 0.0 / 0.1 / 0.1 ms |

## Tests

Two invariant tests in `tests/hermes_cli/test_cached_fetch_api_models.py` (autouse fixture clears the module cache): a second failure within the TTL makes no network call and `/v1` + root share the entry; an expired entry re-probes and re-records, and a success clears it. Mutation check: disabling the early return turns the first test red.

`scripts/run_tests.sh tests/hermes_cli/test_cached_fetch_api_models.py` (26 passed) and `tests/agent/test_custom_provider_ca_probes.py` green; ruff, `check_compat_pointers.py`, `git diff --check` clean.
