### PR TITLE
fix(models): curated OpenRouter catalog persists to disk so a cold process opens the picker instantly (salvage #96099)

### DIFF
--- a/contributors/emails/hyperion@bathaeedunne.com
+++ b/contributors/emails/hyperion@bathaeedunne.com
@@ -1,0 +1,2 @@
+yavarb
+# PR #96099 salvage

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -146,6 +146,52 @@ def _custom_provider_ssl_context(base_url: str):
 
 # Process-lifetime picker lists refreshed from the live catalogs (see fetch_*_models).
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
+
+# On-disk TTL for the curated OpenRouter picker catalog. The in-memory
+# ``_openrouter_catalog_cache`` is per-process, so without a disk cache every
+# cold picker open re-downloads the full ~686KB /api/v1/models catalog
+# (~1.4-7s). Persisting the *curated* result (post-filter) lets fresh
+# processes serve the picker from disk within the TTL instead.
+_OPENROUTER_CATALOG_DISK_TTL = 3600.0  # 1h, matches provider-models cache
+
+
+def _openrouter_catalog_disk_path() -> "Path":
+    """Disk path for the persisted curated OpenRouter catalog."""
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "cache" / "openrouter_curated_catalog.json"
+
+
+def _read_openrouter_catalog_disk() -> list[tuple[str, str]] | None:
+    """Return the last-known-good curated catalog from disk if fresh, else None."""
+    try:
+        path = _openrouter_catalog_disk_path()
+        with open(path, encoding="utf-8") as fh:
+            obj = json.load(fh)
+        if time.time() - float(obj.get("fetched_at", 0)) > _OPENROUTER_CATALOG_DISK_TTL:
+            return None
+        items = obj.get("curated")
+        if not isinstance(items, list):
+            return None
+        out: list[tuple[str, str]] = []
+        for it in items:
+            if isinstance(it, (list, tuple)) and len(it) == 2:
+                out.append((str(it[0]), str(it[1])))
+        return out or None
+    except Exception:
+        return None
+
+
+def _write_openrouter_catalog_disk(curated: list[tuple[str, str]]) -> None:
+    """Persist the curated catalog so the next cold picker open is instant."""
+    try:
+        path = _openrouter_catalog_disk_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"fetched_at": time.time(), "curated": [list(c) for c in curated]}, fh)
+        os.replace(tmp, path)
+    except Exception as exc:
+        logger.debug("openrouter curated catalog disk write failed: %s", exc)
 _ai_gateway_catalog_cache: list[tuple[str, str]] | None = None
 
 
@@ -473,6 +519,14 @@ def fetch_openrouter_models(
     if _openrouter_catalog_cache is not None and not force_refresh:
         return list(_openrouter_catalog_cache)
 
+    # Cold process: serve from the persisted disk cache when fresh so the
+    # picker doesn't re-download the full ~686KB catalog on every open.
+    if not force_refresh:
+        disk = _read_openrouter_catalog_disk()
+        if disk:
+            _openrouter_catalog_cache = disk
+            return list(disk)
+
     # Remote catalog manifest first, in-repo snapshot when unreachable; the live /v1/models filter
     # (tool support, free pricing) is applied on top either way.
     try:
@@ -514,6 +568,7 @@ def fetch_openrouter_models(
     if not curated[0][1]:
         curated[0] = (curated[0][0], "recommended")
     _openrouter_catalog_cache = curated
+    _write_openrouter_catalog_disk(curated)
     return list(curated)
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -147,49 +147,46 @@ def _custom_provider_ssl_context(base_url: str):
 # Process-lifetime picker lists refreshed from the live catalogs (see fetch_*_models).
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
 
-# On-disk TTL for the curated OpenRouter picker catalog. The in-memory
-# ``_openrouter_catalog_cache`` is per-process, so without a disk cache every
-# cold picker open re-downloads the full ~686KB /api/v1/models catalog
-# (~1.4-7s). Persisting the *curated* result (post-filter) lets fresh
-# processes serve the picker from disk within the TTL instead.
-_OPENROUTER_CATALOG_DISK_TTL = 3600.0  # 1h, matches provider-models cache
+# The in-memory ``_openrouter_catalog_cache`` is per-process, so without a disk cache every cold
+# picker open re-downloads the full ~686KB /api/v1/models catalog. The *curated* result
+# (post-filter) is persisted under the same TTL the catalog manifest uses, so both layers go
+# stale together.
 
 
-def _openrouter_catalog_disk_path() -> "Path":
-    """Disk path for the persisted curated OpenRouter catalog."""
+def _openrouter_catalog_disk_ttl() -> float:
+    from hermes_cli.model_catalog import DEFAULT_TTL_MINUTES
+
+    return DEFAULT_TTL_MINUTES * 60.0
+
+
+def _openrouter_catalog_disk_path() -> Path:
     from hermes_constants import get_hermes_home
+
     return get_hermes_home() / "cache" / "openrouter_curated_catalog.json"
 
 
 def _read_openrouter_catalog_disk() -> list[tuple[str, str]] | None:
-    """Return the last-known-good curated catalog from disk if fresh, else None."""
-    try:
-        path = _openrouter_catalog_disk_path()
-        with open(path, encoding="utf-8") as fh:
-            obj = json.load(fh)
-        if time.time() - float(obj.get("fetched_at", 0)) > _OPENROUTER_CATALOG_DISK_TTL:
-            return None
-        items = obj.get("curated")
-        if not isinstance(items, list):
-            return None
-        out: list[tuple[str, str]] = []
-        for it in items:
-            if isinstance(it, (list, tuple)) and len(it) == 2:
-                out.append((str(it[0]), str(it[1])))
-        return out or None
-    except Exception:
+    """Fresh curated catalog from disk, or None (missing, corrupt, expired, or empty)."""
+    obj = _read_json_cache(_openrouter_catalog_disk_path())
+    if obj is None:
         return None
+    try:
+        if time.time() - float(obj.get("fetched_at", 0)) > _openrouter_catalog_disk_ttl():
+            return None
+    except (TypeError, ValueError):
+        return None
+    items = obj.get("curated")
+    if not isinstance(items, list):
+        return None
+    out = [(str(it[0]), str(it[1])) for it in items if isinstance(it, (list, tuple)) and len(it) == 2]
+    return out or None
 
 
 def _write_openrouter_catalog_disk(curated: list[tuple[str, str]]) -> None:
-    """Persist the curated catalog so the next cold picker open is instant."""
     try:
-        path = _openrouter_catalog_disk_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump({"fetched_at": time.time(), "curated": [list(c) for c in curated]}, fh)
-        os.replace(tmp, path)
+        _write_json_cache(
+            _openrouter_catalog_disk_path(),
+            {"fetched_at": time.time(), "curated": [list(c) for c in curated]})
     except Exception as exc:
         logger.debug("openrouter curated catalog disk write failed: %s", exc)
 _ai_gateway_catalog_cache: list[tuple[str, str]] | None = None

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -154,9 +154,10 @@ _openrouter_catalog_cache: list[tuple[str, str]] | None = None
 
 
 def _openrouter_catalog_disk_ttl() -> float:
-    from hermes_cli.model_catalog import DEFAULT_TTL_MINUTES
+    """Same TTL as the catalog manifest this list is filtered from (honours ``model_catalog.ttl_minutes``)."""
+    from hermes_cli.model_catalog import refresh_interval_seconds
 
-    return DEFAULT_TTL_MINUTES * 60.0
+    return refresh_interval_seconds()
 
 
 def _openrouter_catalog_disk_path() -> Path:

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -1,6 +1,8 @@
 """Tests for the hermes_cli models module."""
 
 import json
+import pytest
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Thread
 from unittest.mock import patch, MagicMock
@@ -1519,3 +1521,54 @@ class TestLocalOllamaModelDiscovery:
 
         assert result.success is True
         assert result.api_key == "no-key-required"
+
+
+class TestOpenRouterCatalogDiskCache:
+    """A cold process must serve the curated OpenRouter picker list from disk within the TTL and
+    fall through to the live fetch when the snapshot is expired or corrupt."""
+
+    @pytest.fixture(autouse=True)
+    def _reset(self, monkeypatch):
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        yield
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+
+    @staticmethod
+    def _install_network(monkeypatch, calls):
+        payload = {"data": [{"id": "a/one", "supported_parameters": ["tools"],
+                             "pricing": {"prompt": "0", "completion": "0"}}]}
+
+        def fake_index(url, timeout, opener):
+            calls.append(url)
+            return payload["data"], {m["id"]: m for m in payload["data"]}
+
+        monkeypatch.setattr(_models_mod, "_fetch_live_catalog_index", fake_index)
+        monkeypatch.setattr("hermes_cli.model_catalog.get_curated_openrouter_models",
+                            lambda: [("a/one", "")])
+
+    def test_fresh_snapshot_serves_cold_process_without_network(self, monkeypatch, tmp_path):
+        calls = []
+        self._install_network(monkeypatch, calls)
+        first = fetch_openrouter_models()
+        assert calls and _models_mod._openrouter_catalog_disk_path().is_file()
+
+        _models_mod._openrouter_catalog_cache = None  # simulate a fresh process
+        calls.clear()
+        assert fetch_openrouter_models() == first
+        assert calls == []
+
+    def test_expired_or_corrupt_snapshot_falls_through_to_fetch(self, monkeypatch, tmp_path):
+        calls = []
+        self._install_network(monkeypatch, calls)
+        path = _models_mod._openrouter_catalog_disk_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        stale = time.time() - _models_mod._openrouter_catalog_disk_ttl() - 1
+        path.write_text(json.dumps({"fetched_at": stale, "curated": [["old/model", ""]]}))
+        assert fetch_openrouter_models() == [("a/one", "free")]
+        assert len(calls) == 1
+
+        _models_mod._openrouter_catalog_cache = None
+        path.write_text("{not json")
+        assert fetch_openrouter_models() == [("a/one", "free")]
+        assert len(calls) == 2


### PR DESCRIPTION
Based on #96099 by @yavarb (re-derived onto current main after the picker module split; contributor authorship preserved on the commit).

## Problem

`fetch_openrouter_models()` keeps the curated picker list only in `_openrouter_catalog_cache`, a per-process dict. Every cold process (CLI start, desktop backend, TUI) re-downloads and re-filters the full OpenRouter `/api/v1/models` catalog before the model picker can open.

## Fix

Persist the *curated* (post-filter) list to `<hermes_home>/cache/openrouter_curated_catalog.json` after a successful live refresh and serve a fresh cold process from that snapshot. `force_refresh=True` still bypasses it; an expired, corrupt or missing snapshot falls through to the live fetch unchanged.

Relative to the original PR, on top of the cherry-pick:

- the snapshot TTL is `model_catalog.DEFAULT_TTL_MINUTES` (the manifest's TTL) instead of a separate 1h literal, so both layers go stale together;
- read/write go through the existing `_read_json_cache` / `_write_json_cache` helpers (atomic `atomic_json_write`, parent dir creation) instead of a hand-rolled tmp+replace;
- the `validate_requested_model` `:nitro`/`:floor` hunk is dropped — `hermes_cli/models_validate.py` already treats routing suffixes as request-time modifiers on main.

Composes with #101685, which made pricing lookup non-blocking: that removed the pricing stall, this removes the catalog download from the cold path.

## Measured impact

`fetch_openrouter_models()` with the HTTP layer patched to sleep 1s and return 600 models, fresh interpreter per run, same temp `HERMES_HOME` for the 1st and 2nd process, 3 runs:

| tree | 1st process | 2nd process |
|---|---|---|
| main | 1003 / 1016 / 1027 ms | 1018 / 1026 / 1020 ms |
| this branch | 1023 / 1025 / 1013 ms | 0.1 / 0.1 / 0.1 ms |

## Tests

Two invariants in `tests/hermes_cli/test_models.py`: a fresh process with a valid snapshot makes zero catalog requests; an expired or corrupt snapshot falls through to the fetch. Mutation check: disabling the disk read turns the first test red. `scripts/run_tests.sh tests/hermes_cli/test_models.py` 80 passed; ruff, `check_compat_pointers.py`, `git diff --check` clean.
