### PR TITLE
fix(desktop): stamp YouTube Referer on the default session too

### DIFF
--- a/apps/desktop/electron/embed-referer.test.ts
+++ b/apps/desktop/electron/embed-referer.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for electron/embed-referer.ts — stamping a YouTube Referer header so
+ * the inline embed iframe doesn't fail with error 153 (see #106596).
+ *
+ * Run with: vitest run --project electron embed-referer
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+function fakeSession() {
+  let handler: ((details: unknown, callback: (result: unknown) => void) => void) | undefined
+
+  return {
+    webRequest: {
+      onBeforeSendHeaders: vi.fn((fn: typeof handler) => {
+        handler = fn
+      })
+    },
+    sendHeaders: (url: string, requestHeaders: Record<string, string> = {}) => {
+      let result: { requestHeaders: Record<string, string> } | undefined
+
+      handler!({ url, requestHeaders }, (r: unknown) => {
+        result = r as { requestHeaders: Record<string, string> }
+      })
+
+      return result!.requestHeaders
+    }
+  }
+}
+
+const defaultSession = fakeSession()
+const embedPartitionSession = fakeSession()
+
+vi.mock('electron', () => ({
+  session: {
+    defaultSession,
+    fromPartition: vi.fn(() => embedPartitionSession)
+  }
+}))
+
+const { installEmbedReferer } = await import('./embed-referer')
+
+describe('installEmbedReferer', () => {
+  it('stamps a YouTube Referer on the default session, not just the embed partition', () => {
+    installEmbedReferer()
+
+    const headers = defaultSession.sendHeaders('https://www.youtube-nocookie.com/embed/abc123')
+
+    expect(headers.Referer).toBe('https://www.youtube.com/')
+  })
+
+  it('still stamps the embed webview partition session', () => {
+    installEmbedReferer()
+
+    const headers = embedPartitionSession.sendHeaders('https://www.youtube-nocookie.com/embed/abc123')
+
+    expect(headers.Referer).toBe('https://www.youtube.com/')
+  })
+
+  it('leaves non-YouTube requests untouched', () => {
+    installEmbedReferer()
+
+    const headers = defaultSession.sendHeaders('https://example.com/thing')
+
+    expect(headers.Referer).toBeUndefined()
+  })
+})

--- a/apps/desktop/electron/embed-referer.test.ts
+++ b/apps/desktop/electron/embed-referer.test.ts
@@ -7,6 +7,8 @@
 
 import { describe, expect, it, vi } from 'vitest'
 
+import { applyRemoteRequestHeaders } from './remote-ws-headers'
+
 function fakeSession() {
   let handler: ((details: unknown, callback: (result: unknown) => void) => void) | undefined
 
@@ -17,10 +19,10 @@ function fakeSession() {
       })
     },
     sendHeaders: (url: string, requestHeaders: Record<string, string> = {}) => {
-      let result: { requestHeaders: Record<string, string> } | undefined
+      let result: { requestHeaders?: Record<string, string> } | undefined
 
       handler!({ url, requestHeaders }, (r: unknown) => {
-        result = r as { requestHeaders: Record<string, string> }
+        result = r as { requestHeaders?: Record<string, string> }
       })
 
       return result!.requestHeaders
@@ -38,30 +40,93 @@ vi.mock('electron', () => ({
   }
 }))
 
-const { installEmbedReferer } = await import('./embed-referer')
+const { installEmbedReferer, withEmbedReferer } = await import('./embed-referer')
 
-describe('installEmbedReferer', () => {
-  it('stamps a YouTube Referer on the default session, not just the embed partition', () => {
-    installEmbedReferer()
-
-    const headers = defaultSession.sendHeaders('https://www.youtube-nocookie.com/embed/abc123')
+describe('withEmbedReferer', () => {
+  it('stamps a Referer for known YouTube hosts', () => {
+    const headers = withEmbedReferer('https://www.youtube-nocookie.com/embed/abc123', {})
 
     expect(headers.Referer).toBe('https://www.youtube.com/')
   })
 
-  it('still stamps the embed webview partition session', () => {
+  it('does not override an existing Referer', () => {
+    const headers = withEmbedReferer('https://www.youtube.com/watch?v=abc123', { Referer: 'https://custom/' })
+
+    expect(headers.Referer).toBe('https://custom/')
+  })
+
+  it('leaves non-YouTube requests untouched', () => {
+    const headers = withEmbedReferer('https://example.com/thing', { 'X-Foo': 'bar' })
+
+    expect(headers).toEqual({ 'X-Foo': 'bar' })
+  })
+})
+
+describe('installEmbedReferer', () => {
+  it('stamps the embed webview partition session', () => {
     installEmbedReferer()
 
     const headers = embedPartitionSession.sendHeaders('https://www.youtube-nocookie.com/embed/abc123')
 
-    expect(headers.Referer).toBe('https://www.youtube.com/')
+    expect(headers!.Referer).toBe('https://www.youtube.com/')
   })
 
-  it('leaves non-YouTube requests untouched', () => {
+  it('does not register a handler on the default session', () => {
+    defaultSession.webRequest.onBeforeSendHeaders.mockClear()
+
     installEmbedReferer()
+
+    // Composed into main.ts's installRemoteHeaderRules() listener instead —
+    // Electron only allows a single onBeforeSendHeaders listener per session,
+    // so a second listener registered here would silently replace, or be
+    // replaced by, that one.
+    expect(defaultSession.webRequest.onBeforeSendHeaders).not.toHaveBeenCalled()
+  })
+})
+
+describe('default session composition (mirrors main.ts installRemoteHeaderRules)', () => {
+  // Reproduces the exact registration main.ts performs: a single
+  // onBeforeSendHeaders listener on session.defaultSession that runs the
+  // remote-gateway header logic and then layers the embed Referer on top,
+  // since registering installEmbedReferer's own listener there as well
+  // would just be discarded by whichever of the two registers last.
+  function installComposedDefaultSessionHandler(headersForRemoteRequest: (url: string) => Record<string, string>) {
+    defaultSession.webRequest.onBeforeSendHeaders((details: any, callback: any) => {
+      applyRemoteRequestHeaders(
+        details,
+        (result: { requestHeaders?: Record<string, string> }) => {
+          const requestHeaders = withEmbedReferer(details.url, result.requestHeaders ?? details.requestHeaders)
+
+          callback({ requestHeaders })
+        },
+        headersForRemoteRequest
+      )
+    })
+  }
+
+  it('still stamps the YouTube Referer when no remote headers apply (the common case)', () => {
+    installComposedDefaultSessionHandler(() => ({}))
+
+    const headers = defaultSession.sendHeaders('https://www.youtube-nocookie.com/embed/abc123')
+
+    expect(headers!.Referer).toBe('https://www.youtube.com/')
+  })
+
+  it('stamps the Referer alongside remote-gateway headers when in remote mode', () => {
+    installComposedDefaultSessionHandler(() => ({ Authorization: 'Bearer token' }))
+
+    const headers = defaultSession.sendHeaders('https://www.youtube-nocookie.com/embed/abc123')
+
+    expect(headers!.Referer).toBe('https://www.youtube.com/')
+    expect(headers!.Authorization).toBe('Bearer token')
+  })
+
+  it('leaves non-YouTube requests governed only by the remote-gateway headers', () => {
+    installComposedDefaultSessionHandler(() => ({ Authorization: 'Bearer token' }))
 
     const headers = defaultSession.sendHeaders('https://example.com/thing')
 
-    expect(headers.Referer).toBeUndefined()
+    expect(headers!.Referer).toBeUndefined()
+    expect(headers!.Authorization).toBe('Bearer token')
   })
 })

--- a/apps/desktop/electron/embed-referer.ts
+++ b/apps/desktop/electron/embed-referer.ts
@@ -6,41 +6,46 @@ const EMBED_REFERER = 'https://www.youtube.com/'
 const YOUTUBE_REFERER_HOST_RE =
   /(^|\.)(youtube\.com|youtube-nocookie\.com|googlevideo\.com|ytimg\.com|youtubei\.googleapis\.com)$/i
 
+function withEmbedReferer(url: string, requestHeaders: Record<string, string> = {}) {
+  let host = ''
+
+  try {
+    host = new URL(url).hostname
+  } catch {
+    host = ''
+  }
+
+  if (!YOUTUBE_REFERER_HOST_RE.test(host)) {
+    return requestHeaders
+  }
+
+  if (requestHeaders.Referer || requestHeaders.referer) {
+    return requestHeaders
+  }
+
+  return { ...requestHeaders, Referer: EMBED_REFERER }
+}
+
 function installEmbedRefererForSession(embedSession) {
   if (!embedSession) {
     return
   }
 
   embedSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    let host = ''
-
-    try {
-      host = new URL(details.url).hostname
-    } catch {
-      host = ''
-    }
-
-    if (!YOUTUBE_REFERER_HOST_RE.test(host)) {
-      callback({ requestHeaders: details.requestHeaders })
-
-      return
-    }
-
-    const headers = { ...details.requestHeaders }
-
-    if (!headers.Referer && !headers.referer) {
-      headers.Referer = EMBED_REFERER
-    }
-
-    callback({ requestHeaders: headers })
+    callback({ requestHeaders: withEmbedReferer(details.url, details.requestHeaders) })
   })
 }
 
 /**
- * Stamp Referer on YouTube requests in both the embed webview partition and
- * the default session, since the YouTube iframe embed renders as a plain
- * iframe in the main window's default session, not a webview on the embed
- * partition.
+ * Stamp Referer on YouTube requests in the embed webview partition.
+ *
+ * The default session also needs this (the YouTube iframe embed renders
+ * there as a plain iframe, not a webview on the embed partition), but
+ * Electron's webRequest.onBeforeSendHeaders only allows a single listener
+ * per session — registering here would silently replace, or be replaced
+ * by, main.ts's installRemoteHeaderRules() listener on the same session.
+ * So the default-session stamping is composed into that listener via
+ * withEmbedReferer() instead of registered here; see main.ts.
  */
 function installEmbedReferer() {
   try {
@@ -48,12 +53,6 @@ function installEmbedReferer() {
   } catch {
     // Non-fatal: embeds still render; YouTube may show referer errors.
   }
-
-  try {
-    installEmbedRefererForSession(session.defaultSession)
-  } catch {
-    // Non-fatal: embeds still render; YouTube may show referer errors.
-  }
 }
 
-export { installEmbedReferer }
+export { installEmbedReferer, withEmbedReferer }

--- a/apps/desktop/electron/embed-referer.ts
+++ b/apps/desktop/electron/embed-referer.ts
@@ -36,10 +36,21 @@ function installEmbedRefererForSession(embedSession) {
   })
 }
 
-/** Stamp Referer on YouTube requests in the embed webview partition only. */
+/**
+ * Stamp Referer on YouTube requests in both the embed webview partition and
+ * the default session, since the YouTube iframe embed renders as a plain
+ * iframe in the main window's default session, not a webview on the embed
+ * partition.
+ */
 function installEmbedReferer() {
   try {
     installEmbedRefererForSession(session.fromPartition(EMBED_SESSION_PARTITION))
+  } catch {
+    // Non-fatal: embeds still render; YouTube may show referer errors.
+  }
+
+  try {
+    installEmbedRefererForSession(session.defaultSession)
   } catch {
     // Non-fatal: embeds still render; YouTube may show referer errors.
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -169,7 +169,7 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
-import { installEmbedReferer } from './embed-referer'
+import { installEmbedReferer, withEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import {
   buildTerminalScript,
@@ -9260,7 +9260,15 @@ function installRemoteHeaderRules() {
 
   remoteHeaderRulesInstalled = true
   session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    applyRemoteRequestHeaders(details, callback, headersForRemoteRequest)
+    applyRemoteRequestHeaders(
+      details,
+      (result) => {
+        const requestHeaders = withEmbedReferer(details.url, result.requestHeaders ?? details.requestHeaders)
+
+        callback({ requestHeaders })
+      },
+      headersForRemoteRequest
+    )
   })
 }
 


### PR DESCRIPTION
Fixes #106596

## What changed and why

YouTube embeds in the desktop chat render the player chrome but fail to play with "Error 153 - Video player configuration error".

`installEmbedReferer()` (`apps/desktop/electron/embed-referer.ts`) only installed the Referer-stamping `webRequest.onBeforeSendHeaders` handler on the `persist:hermes-embed` session partition. But the YouTube iframe embed (`apps/desktop/src/components/assistant-ui/embeds/youtube-embed.tsx`) is a plain `<iframe>` rendered in the main window's **default session** — nothing in the renderer references the `persist:hermes-embed` partition. Combined with the production renderer loading via `pathToFileURL(...)`, `window.location.origin` is `null`, so with `referrerPolicy="strict-origin-when-cross-origin"` no Referer is sent at all and no `origin` param is set (deliberately, per the comment in `youtube-embed.tsx`, for non-http(s) origins). YouTube now rejects embed config requests that arrive with neither, producing error 153.

**Revision:** an earlier version of this fix just added a second `session.defaultSession.webRequest.onBeforeSendHeaders(...)` registration inside `installEmbedReferer()`. That handler was a no-op in the shipped app: Electron's `onBeforeSendHeaders` allows only one listener per session, and `app.whenReady()` in `main.ts` calls `installRemoteHeaderRules()` immediately after `installEmbedReferer()`, which unconditionally re-registers on the same `session.defaultSession`, silently discarding the Referer handler before any real request used it (see review discussion for the mechanical repro).

The fix now composes both concerns into the single listener Electron permits:
- `embed-referer.ts` exports a pure `withEmbedReferer(url, requestHeaders)` helper that stamps `Referer: https://www.youtube.com/` onto YouTube-domain requests (and leaves everything else untouched). `installEmbedReferer()` still uses it to install a handler on the `persist:hermes-embed` partition directly.
- `main.ts`'s `installRemoteHeaderRules()` — the function that actually owns `session.defaultSession.webRequest.onBeforeSendHeaders` — now calls `withEmbedReferer()` on the headers produced by `applyRemoteRequestHeaders()` before invoking the callback, so the default session gets both remote-gateway headers (when configured) and the YouTube Referer, from one registration.

## How to test

Rewrote `apps/desktop/electron/embed-referer.test.ts` to cover:
- `withEmbedReferer()` directly (stamps YouTube hosts, doesn't override an existing Referer, leaves other hosts untouched).
- `installEmbedReferer()` only registers on the embed partition, not on `session.defaultSession` (guards against reintroducing the double-registration bug).
- A "default session composition" suite that mirrors `main.ts`'s actual `installRemoteHeaderRules()` registration (composing `applyRemoteRequestHeaders` + `withEmbedReferer` into one `onBeforeSendHeaders` listener), asserting the Referer lands both when no remote headers apply (the common case) and when remote-gateway headers are present, and that non-YouTube requests are unaffected.

Confirmed the new tests fail without the source change (`git checkout HEAD~1 -- apps/desktop/electron/embed-referer.ts apps/desktop/electron/main.ts`, kept the new test file):

```
 Test Files  1 failed (1)
      Tests  7 failed | 1 passed (8)
```

(6 failures are `withEmbedReferer is not a function` / the composed-session tests, since the old source doesn't export it or compose it into `installRemoteHeaderRules`; 1 is the new "does not register a handler on the default session" assertion, since the old code did.)

And passes with the fix restored:

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Also ran:
- `npx eslint electron/embed-referer.ts electron/embed-referer.test.ts electron/main.ts electron/remote-ws-headers.ts` — clean
- `npx tsc -p tsconfig.electron.json --noEmit` — clean
- `npx vitest run --project electron` (full electron suite) — `153 passed | 2 skipped`, `2151 passed | 6 skipped`, no regressions

## What platforms tested on

Linux (CI-equivalent unit/typecheck/lint environment). This is a session-wiring fix with no platform-specific code path; the existing partition-only path was already cross-platform.

## AI assistance disclosure

This change was written with Claude Code (Anthropic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
