### PR TITLE
fix(dashboard): escape hermes-update from the dashboard's own systemd cgroup

### DIFF
--- a/hermes_cli/web_routers/actions.py
+++ b/hermes_cli/web_routers/actions.py
@@ -226,7 +226,9 @@ async def update_hermes():
 
     action_id = secrets.token_hex(16)
     with http_failure("Failed to spawn hermes update", 500, "Failed to start update"):
-        proc = _spawn_hermes_action(["update"], "hermes-update", env_overrides={"HERMES_ACTION_ID": action_id})
+        proc = _spawn_hermes_action(
+            ["update"], "hermes-update", env_overrides={"HERMES_ACTION_ID": action_id}, escape_cgroup=True,
+        )
     return {"ok": True, "pid": proc.pid, "name": "hermes-update", "action_id": action_id}
 
 

--- a/hermes_cli/web_server_gateway.py
+++ b/hermes_cli/web_server_gateway.py
@@ -322,10 +322,51 @@ def _dashboard_spawn_executable() -> str:
     return sys.executable
 
 
+def _dashboard_is_systemd_managed() -> bool:
+    """Whether THIS dashboard process is itself the main process of a systemd unit."""
+    if sys.platform == "win32":
+        return False
+    from hermes_cli.main_dashboard import _get_systemd_service_for_pid
+    return _get_systemd_service_for_pid(os.getpid()) is not None
+
+
+def _cgroup_escaped_argv_and_env(
+    cmd: List[str], env: Dict[str, str]
+) -> Tuple[List[str], Dict[str, str]]:
+    """Wrap *cmd* in a ``systemd-run --user --scope`` transient unit, when that escape is
+    actually usable; *cmd*/*env* unchanged otherwise (never raises, never blocks the spawn).
+
+    A dashboard-triggered ``hermes update`` is normally a plain child of the dashboard's own
+    process, sharing its systemd cgroup (``start_new_session`` only creates a new POSIX
+    session, not a new cgroup). When the update's own post-update phase restarts that same
+    unit, ``KillMode=control-group`` SIGKILLs the update child right along with it — before it
+    can finalize the receipt or clear its markers, since a SIGKILL never runs Python's
+    ``finally`` blocks. Placing the child in its own transient scope first keeps it alive
+    through that restart. See #106592.
+    """
+    import shutil
+    from tools.process_registry import _systemd_run_user_scope_available, systemd_user_bus_env
+    if not _systemd_run_user_scope_available():
+        return cmd, env
+    systemd_run = shutil.which("systemd-run")
+    if not systemd_run:
+        return cmd, env
+    return (
+        [systemd_run, "--user", "--scope", "--quiet", "--collect", "--", *cmd],
+        systemd_user_bus_env(env),
+    )
+
+
 def _spawn_hermes_action(
-    subcommand: List[str], name: str, *, env_overrides: Optional[Dict[str, str]] = None
+    subcommand: List[str], name: str, *, env_overrides: Optional[Dict[str, str]] = None,
+    escape_cgroup: bool = False,
 ) -> subprocess.Popen:
-    """Spawn ``hermes <subcommand>`` detached (via ``hermes_cli.main``) and record the handle."""
+    """Spawn ``hermes <subcommand>`` detached (via ``hermes_cli.main``) and record the handle.
+
+    *escape_cgroup*: this action's own effects (e.g. restarting the dashboard's systemd unit)
+    could SIGKILL the spawned child before it finishes — place it outside that cgroup first.
+    See :func:`_cgroup_escaped_argv_and_env`.
+    """
     from hermes_cli.web_server import PROJECT_ROOT
     _ACTION_LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_file = open(_ACTION_LOG_DIR / _ACTION_LOG_FILES[name], "ab", buffering=0)
@@ -339,6 +380,8 @@ def _spawn_hermes_action(
     action_env = {**os.environ, "HERMES_NONINTERACTIVE": "1"}
     action_env.pop("_HERMES_GATEWAY", None)
     detach = {"creationflags": windows_detach_flags()} if sys.platform == "win32" else {"start_new_session": True}
+    if escape_cgroup and sys.platform != "win32" and _dashboard_is_systemd_managed():
+        cmd, action_env = _cgroup_escaped_argv_and_env(cmd, action_env)
     proc = subprocess.Popen(
         cmd, cwd=str(PROJECT_ROOT), stdin=subprocess.DEVNULL, stdout=log_file, stderr=subprocess.STDOUT,
         env={**action_env, **(env_overrides or {})}, **detach,

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -1039,6 +1039,120 @@ def test_spawn_hermes_action_scrubs_gateway_loop_guard_env(monkeypatch, tmp_path
 
 
 # ---------------------------------------------------------------------------
+# _spawn_hermes_action cgroup escape for dashboard-triggered updates (#106592)
+# ---------------------------------------------------------------------------
+
+def _patched_spawn(monkeypatch, tmp_path):
+    """Isolate _spawn_hermes_action's module state and capture the Popen argv/env."""
+    import hermes_cli.web_server as ws
+
+    monkeypatch.setattr(_web_server_gateway, "_ACTION_LOG_DIR", tmp_path)
+    monkeypatch.setattr(_web_server_gateway, "_ACTION_PROCS", {})
+
+    captured = {}
+
+    class _FakeProc:
+        pid = 1234
+
+    def _fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env")
+        return _FakeProc()
+
+    monkeypatch.setattr(ws.subprocess, "Popen", _fake_popen)
+    return captured
+
+
+def test_spawn_hermes_action_escapes_cgroup_when_dashboard_is_systemd_managed(monkeypatch, tmp_path):
+    """A dashboard-triggered ``hermes update`` must not share the dashboard's own systemd
+    cgroup: the update's post-update phase restarts that unit, and ``KillMode=control-group``
+    would SIGKILL the update mid-run — before its ``finally`` block can finalize the receipt
+    or clear its markers (#106592)."""
+    captured = _patched_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(_web_server_gateway, "_dashboard_is_systemd_managed", lambda: True)
+    monkeypatch.setattr(
+        _web_server_gateway, "_cgroup_escaped_argv_and_env",
+        lambda cmd, env: (["systemd-run", "--user", "--scope", "--quiet", "--collect", "--", *cmd],
+                           {**env, "DBUS_SESSION_BUS_ADDRESS": "unix:path=/fake/bus"}),
+    )
+
+    _web_server_gateway._spawn_hermes_action(
+        ["update"], "hermes-update", env_overrides={"HERMES_ACTION_ID": "a" * 32}, escape_cgroup=True,
+    )
+
+    assert captured["cmd"][:5] == ["systemd-run", "--user", "--scope", "--quiet", "--collect"]
+    assert captured["cmd"][-1] == "update"
+    assert captured["env"]["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/fake/bus"
+
+
+def test_spawn_hermes_action_skips_escape_when_dashboard_is_not_systemd_managed(monkeypatch, tmp_path):
+    """A dashboard NOT running as a systemd unit has nothing to escape from — the child must
+    spawn exactly as before, with no ``systemd-run`` wrapper."""
+    captured = _patched_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(_web_server_gateway, "_dashboard_is_systemd_managed", lambda: False)
+
+    def _fail_if_called(cmd, env):
+        raise AssertionError("cgroup escape must not be attempted when not systemd-managed")
+
+    monkeypatch.setattr(_web_server_gateway, "_cgroup_escaped_argv_and_env", _fail_if_called)
+
+    _web_server_gateway._spawn_hermes_action(
+        ["update"], "hermes-update", env_overrides={"HERMES_ACTION_ID": "a" * 32}, escape_cgroup=True,
+    )
+
+    assert captured["cmd"][0] != "systemd-run"
+
+
+def test_spawn_hermes_action_default_does_not_escape_cgroup(monkeypatch, tmp_path):
+    """Every OTHER action (gateway start/stop, skills install, ...) keeps today's plain
+    spawn: only callers that opt in with ``escape_cgroup=True`` risk the extra hop."""
+    captured = _patched_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(_web_server_gateway, "_dashboard_is_systemd_managed", lambda: True)
+
+    def _fail_if_called(cmd, env):
+        raise AssertionError("cgroup escape must not be attempted unless escape_cgroup=True")
+
+    monkeypatch.setattr(_web_server_gateway, "_cgroup_escaped_argv_and_env", _fail_if_called)
+
+    _web_server_gateway._spawn_hermes_action(["gateway", "restart"], "gateway-restart")
+
+    assert captured["cmd"][0] != "systemd-run"
+
+
+def test_cgroup_escaped_argv_wraps_command_when_scope_usable(monkeypatch):
+    """The real escape helper: when ``systemd-run --user --scope`` is usable, prefix the
+    command with it and merge in the reachable-bus env instead of dropping it."""
+    import tools.process_registry as _process_registry
+
+    monkeypatch.setattr(_process_registry, "_systemd_run_user_scope_available", lambda: True)
+    monkeypatch.setattr(
+        _process_registry, "systemd_user_bus_env", lambda env: {**env, "DBUS_SESSION_BUS_ADDRESS": "unix:path=/fake"},
+    )
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run" if name == "systemd-run" else None)
+
+    cmd, env = _web_server_gateway._cgroup_escaped_argv_and_env(["python", "-m", "hermes_cli.main", "update"], {})
+
+    assert cmd == [
+        "/usr/bin/systemd-run", "--user", "--scope", "--quiet", "--collect", "--",
+        "python", "-m", "hermes_cli.main", "update",
+    ]
+    assert env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/fake"
+
+
+def test_cgroup_escaped_argv_falls_back_when_scope_unusable(monkeypatch):
+    """No reachable user D-Bus session (common for system services/containers, #70716's exact
+    failure mode) must degrade to the plain command, not raise or hang the spawn."""
+    import tools.process_registry as _process_registry
+
+    monkeypatch.setattr(_process_registry, "_systemd_run_user_scope_available", lambda: False)
+
+    cmd, env = _web_server_gateway._cgroup_escaped_argv_and_env(["python", "-m", "hermes_cli.main", "update"], {"X": "1"})
+
+    assert cmd == ["python", "-m", "hermes_cli.main", "update"]
+    assert env == {"X": "1"}
+
+
+# ---------------------------------------------------------------------------
 # Desktop lifespan reaps orphan gateways at serve startup (#77276)
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1350,8 +1350,8 @@ class TestWebServerEndpoints:
 
         calls = []
 
-        def fake_spawn(subcommand, name, *, env_overrides=None):
-            calls.append((subcommand, name, env_overrides))
+        def fake_spawn(subcommand, name, *, env_overrides=None, escape_cgroup=False):
+            calls.append((subcommand, name, env_overrides, escape_cgroup))
             return Proc()
 
         monkeypatch.setattr(_web_server_files, "_dashboard_local_update_managed_externally", lambda: False)
@@ -1371,7 +1371,7 @@ class TestWebServerEndpoints:
             "action_id": "a" * 32,
         }
         assert calls == [
-            (["update"], "hermes-update", {"HERMES_ACTION_ID": "a" * 32})
+            (["update"], "hermes-update", {"HERMES_ACTION_ID": "a" * 32}, True)
         ]
 
     def test_update_hermes_reuses_running_action(self, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #106592.

A dashboard-triggered `hermes update` (the Desktop "Update backend" button)
spawns via `_spawn_hermes_action(["update"], "hermes-update", ...)` with
`start_new_session=True`. That only creates a new POSIX session — not a new
systemd cgroup — so the update child stays inside `hermes-dashboard.service`'s
cgroup.

When run as a system-level `hermes-dashboard.service` with the systemd
default `KillMode=control-group`, the update's own post-update phase restarts
that same unit (`_finish_dashboard_update_cleanup` → `_restart_managed_dashboard_service`
→ `systemctl restart hermes-dashboard.service`). That restart SIGKILLs
*every* process in the unit's cgroup, including the update child that just
issued the restart command — before it reaches `finalize_update_receipt()`
or clears `.hermes-update-in-progress` / `fleet_restart_pending`
(`hermes_cli/main.py`'s `cmd_update()` wraps the whole run in a
`try/except/else/finally`, but a SIGKILL never runs a `finally` block).

Observable effect (matches the issue's reproduction): the code update and
gateway/dashboard restart succeed, but Desktop reports "Backend update
failed", and subsequent CLI commands warn that a previous update never
finished restarting the gateways, because the markers and the receipt were
never finalized.

## Fix

Mirrors the cgroup-escape pattern the codebase already uses for the
analogous gateway-restart-recovery case
(`hermes_cli/update_abort_recovery.py::_run_fresh_recovery_process`, which
wraps its child in `systemd-run --user --scope` when running under a
gateway's systemd unit) and reuses the already-shipped, tested
`systemd-run --user --scope` availability probe and D-Bus env synthesis from
`tools/process_registry.py` (used today to keep memory-heavy local
executors out of the gateway's cgroup, #70716).

- `hermes_cli/web_server_gateway.py`
  - `_dashboard_is_systemd_managed()` — is *this* dashboard process itself
    the main process of a systemd unit (via the existing
    `main_dashboard._get_systemd_service_for_pid`)?
  - `_cgroup_escaped_argv_and_env()` — wraps a command in
    `systemd-run --user --scope --quiet --collect --` and merges in a
    reachable user-bus env, but only when the probe proves the escape is
    actually usable; returns the input unchanged otherwise (no `systemd-run`
    binary, no reachable user D-Bus session). Never raises, never blocks
    the spawn — degrading to today's (buggy-report but functional) spawn is
    always safe.
  - `_spawn_hermes_action(..., escape_cgroup=False)` — new opt-in kwarg;
    every existing caller (gateway start/stop, skills/mcp install,
    gateway-restart) is untouched.
- `hermes_cli/web_routers/actions.py` — `POST /api/hermes/update` now passes
  `escape_cgroup=True` when spawning `hermes-update`, the one action whose
  own effects can kill its own spawning process.

## Test plan

Added 5 tests to `tests/hermes_cli/test_dashboard_admin_endpoints.py`
covering: the escape firing when the dashboard is systemd-managed, the
escape being skipped when it isn't, every other action staying unescaped by
default, and the real `_cgroup_escaped_argv_and_env` helper both wrapping
the command when the scope is usable and falling back cleanly when it
isn't (no reachable user bus — the same failure mode #70716 already
guards against elsewhere).

Proved the new tests fail without the fix:

```
$ git stash push -- hermes_cli/web_server_gateway.py hermes_cli/web_routers/actions.py
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_admin_endpoints.py -q
...
5 failed, 42 passed in 4.17s
FAILED ...::test_spawn_hermes_action_escapes_cgroup_when_dashboard_is_systemd_managed
FAILED ...::test_spawn_hermes_action_skips_escape_when_dashboard_is_not_systemd_managed
FAILED ...::test_spawn_hermes_action_default_does_not_escape_cgroup
FAILED ...::test_cgroup_escaped_argv_wraps_command_when_scope_usable
FAILED ...::test_cgroup_escaped_argv_falls_back_when_scope_unusable
$ git stash pop
```

With the fix restored:

```
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_admin_endpoints.py tests/hermes_cli/test_web_server.py -q
=== Summary: 2 files, 235 tests passed, 0 failed (100% complete) in 16.7s (8 workers) ===
```

Also ran the wider blast radius (update/dashboard/gateway-restart/process-registry
suites) to check for regressions:

```
$ scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/hermes_cli/test_update_stale_dashboard.py \
    tests/hermes_cli/test_update_serve_generation_recovery.py tests/hermes_cli/test_web_routers_tools_install_on_enable.py \
    tests/hermes_cli/test_spawn_gateway_restart_cooldown.py tests/hermes_cli/test_spawn_gateway_restart_reap.py \
    tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_web_server_skills_profiles.py \
    tests/tools/test_process_registry.py tests/hermes_cli/test_dashboard_admin_endpoints.py -q
=== Summary: 10 files, 489 tests passed, 0 failed, 7 skipped (100% complete) in 22.6s (8 workers) ===
```

(One pre-existing test, `test_update_hermes_spawns_with_action_id`, needed
its `fake_spawn` signature and asserted call-args tuple updated for the new
`escape_cgroup` kwarg — included in this PR.)

`ruff check` on all touched files: all checks passed.

Manually verified the escape mechanism itself works on a real host (this
sandbox happens to run inside `system.slice/hosted-compute-agent.service`,
so `systemd-run --user --scope` was actually exercised, not just mocked):

```
$ timeout 10 systemd-run --user --scope --quiet --collect -- /bin/sh -c 'echo escaped-ok'
escaped-ok
```

## AI assistance disclosure

This PR was written with AI assistance (Claude Code / Anthropic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
