### PR TITLE
fix(desktop): stamp YouTube embed Referer in the session chat embeds actually use

### DIFF
--- a/apps/desktop/electron/embed-referer.test.ts
+++ b/apps/desktop/electron/embed-referer.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for electron/embed-referer.ts — the YouTube Referer stamp for chat
+ * embeds. Chat embeds are plain iframes in the window's default session and
+ * the production renderer loads from a file:// URL (no Referer is sent), so
+ * YouTube's embed player rejects the config request with error 153 unless the
+ * session listener stamps one in. The stamp must also survive composition with
+ * the default-session listener that applies remote gateway headers: Electron
+ * keeps a single listener per webRequest hook, so both behaviors live in one.
+ *
+ * Run with: vitest run --project electron embed-referer
+ */
+
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+type PartitionListener = (
+  details: { url: string; requestHeaders?: Record<string, string> },
+  callback: (result: { requestHeaders?: Record<string, string> }) => void
+) => void
+
+const partitionListeners = new Map<string, PartitionListener>()
+
+vi.mock('electron', () => ({
+  session: {
+    fromPartition: (name: string) => ({
+      webRequest: {
+        onBeforeSendHeaders: (listener: PartitionListener) => {
+          partitionListeners.set(name, listener)
+        }
+      }
+    })
+  }
+}))
+
+const { installEmbedReferer, stampEmbedRefererHeaders, withEmbedRefererStamp } = await import(
+  './embed-referer'
+)
+
+function partitionListener(name: string): PartitionListener {
+  const listener = partitionListeners.get(name)
+
+  assert.ok(listener, `onBeforeSendHeaders listener installed for ${name}`)
+
+  return listener!
+}
+
+const YOUTUBE_HOSTS = [
+  'https://www.youtube.com/watch?v=9MVqxnIb98Y',
+  'https://www.youtube-nocookie.com/embed/9MVqxnIb98Y?modestbranding=1&rel=0',
+  'https://rr3---sn-npoe7ney.googlevideo.com/videoplayback?Id=o-AH',
+  'https://i.ytimg.com/vi/9MVqxnIb98Y/hqdefault.jpg',
+  'https://www.youtubei.googleapis.com/youtubei/v1/player?key=AIza'
+]
+
+test('stampEmbedRefererHeaders adds the YouTube referer for every YouTube host', () => {
+  for (const url of YOUTUBE_HOSTS) {
+    assert.equal(
+      stampEmbedRefererHeaders(url, { Accept: '*/*' }).Referer,
+      'https://www.youtube.com/',
+      `expected stamp for ${url}`
+    )
+  }
+})
+
+test('stampEmbedRefererHeaders keeps unrelated headers as they were', () => {
+  const stamped = stampEmbedRefererHeaders(YOUTUBE_HOSTS[0], { Accept: '*/*', 'X-Test': 'a' })
+
+  assert.equal(stamped.Accept, '*/*')
+  assert.equal(stamped['X-Test'], 'a')
+})
+
+test('stampEmbedRefererHeaders never overrides an existing Referer', () => {
+  const stamped = stampEmbedRefererHeaders(YOUTUBE_HOSTS[0], { Referer: 'https://example.com/' })
+
+  assert.equal(stamped.Referer, 'https://example.com/')
+  assert.equal('referer' in stamped, false)
+})
+
+test('stampEmbedRefererHeaders honors a lowercase referer instead of adding one', () => {
+  const stamped = stampEmbedRefererHeaders(YOUTUBE_HOSTS[0], { referer: 'https://example.com/' })
+
+  assert.equal(stamped.referer, 'https://example.com/')
+  assert.equal('Referer' in stamped, false)
+})
+
+test('stampEmbedRefererHeaders leaves non-YouTube hosts completely untouched', () => {
+  const original = { Accept: '*/*' }
+
+  assert.equal(stampEmbedRefererHeaders('https://example.com/video', original), original)
+
+  // Substring matches must not fool the host test either.
+  assert.equal(
+    stampEmbedRefererHeaders('https://notyoutube.com/embed/x', original),
+    original
+  )
+  assert.equal(
+    stampEmbedRefererHeaders('https://youtube.com.evil.io/embed/x', original),
+    original
+  )
+})
+
+test('stampEmbedRefererHeaders tolerates unparseable URLs', () => {
+  const original = { Accept: '*/*' }
+
+  assert.equal(stampEmbedRefererHeaders('not a url', original), original)
+})
+
+test('installEmbedRefererForSession stamps through the session listener', () => {
+  installEmbedReferer()
+
+  const listener = partitionListener('persist:hermes-embed')
+
+  let result: { requestHeaders?: Record<string, string> } = {}
+  listener({ url: YOUTUBE_HOSTS[1], requestHeaders: { Accept: '*/*' } }, (r) => {
+    result = r
+  })
+
+  assert.equal(result.requestHeaders?.Referer, 'https://www.youtube.com/')
+})
+
+test('withEmbedRefererStamp applies the stamp after the wrapped listener', () => {
+  const calls: string[] = []
+
+  const wrapped = withEmbedRefererStamp((details, callback) => {
+    calls.push(details.url)
+
+    // The remote-headers listener reports no changes for non-gateway URLs.
+    callback({})
+  })
+
+  let result: { requestHeaders?: Record<string, string> } = {}
+  wrapped({ url: YOUTUBE_HOSTS[1], requestHeaders: { Accept: '*/*' } }, (r) => {
+    result = r
+  })
+
+  assert.equal(calls.length, 1)
+  assert.equal(result.requestHeaders?.Accept, '*/*')
+  assert.equal(result.requestHeaders?.Referer, 'https://www.youtube.com/')
+})
+
+test('withEmbedRefererStamp preserves headers merged by the wrapped listener', () => {
+  const wrapped = withEmbedRefererStamp((details, callback) => {
+    callback({ requestHeaders: { ...details.requestHeaders, Authorization: 'Bearer t' } })
+  })
+
+  let result: { requestHeaders?: Record<string, string> } = {}
+  wrapped({ url: YOUTUBE_HOSTS[1], requestHeaders: { Accept: '*/*' } }, (r) => {
+    result = r
+  })
+
+  assert.equal(result.requestHeaders?.Authorization, 'Bearer t')
+  assert.equal(result.requestHeaders?.Referer, 'https://www.youtube.com/')
+})
+
+test('withEmbedRefererStamp leaves non-YouTube requests to the wrapped listener alone', () => {
+  const wrapped = withEmbedRefererStamp((_details, callback) => {
+    callback({})
+  })
+
+  let result: { requestHeaders?: Record<string, string> } | undefined
+  wrapped({ url: 'https://gateway.internal/api', requestHeaders: { Accept: '*/*' } }, (r) => {
+    result = r
+  })
+
+  // No requestHeaders in the result means "no changes" — the wrapper must not
+  // turn that into an empty header replacement or add anything itself.
+  assert.deepEqual(result, {})
+})

--- a/apps/desktop/electron/embed-referer.ts
+++ b/apps/desktop/electron/embed-referer.ts
@@ -6,37 +6,101 @@ const EMBED_REFERER = 'https://www.youtube.com/'
 const YOUTUBE_REFERER_HOST_RE =
   /(^|\.)(youtube\.com|youtube-nocookie\.com|googlevideo\.com|ytimg\.com|youtubei\.googleapis\.com)$/i
 
-function installEmbedRefererForSession(embedSession) {
+/**
+ * YouTube rejects embed player config requests that arrive without a Referer
+ * (player error 153). Chat embeds are plain iframes in the window session, and
+ * the production renderer loads from a file:// URL, so the browser sends none.
+ */
+function stampEmbedRefererHeaders(
+  url: string,
+  headers: Record<string, string>
+): Record<string, string> {
+  let host = ''
+
+  try {
+    host = new URL(url).hostname
+  } catch {
+    host = ''
+  }
+
+  if (!YOUTUBE_REFERER_HOST_RE.test(host)) {
+    return headers
+  }
+
+  if (headers.Referer || headers.referer) {
+    return headers
+  }
+
+  return { ...headers, Referer: EMBED_REFERER }
+}
+
+/**
+ * Compose the referer stamp onto another session listener. Electron keeps a
+ * single listener per webRequest hook, so the default-session listener that
+ * applies remote gateway headers must also carry the stamp. The stamp has to
+ * run on the listener's RESULT (a wrapped listener reporting no header changes
+ * would otherwise drop it again), while requests the stamp does not apply to
+ * keep the listener's exact callback semantics — an empty requestHeaders value
+ * means "replace all headers", not "no changes".
+ */
+function withEmbedRefererStamp(
+  listener: (
+    details: EmbedRequestDetails,
+    callback: (result: { requestHeaders?: Record<string, string> }) => void
+  ) => void
+) {
+  return (
+    details: EmbedRequestDetails,
+    callback: (result: { requestHeaders?: Record<string, string> }) => void
+  ) => {
+    listener(details, (result) => {
+      if (result.requestHeaders) {
+        callback({ requestHeaders: stampEmbedRefererHeaders(details.url, result.requestHeaders) })
+
+        return
+      }
+
+      const base = details.requestHeaders ?? {}
+      const stamped = stampEmbedRefererHeaders(details.url, base)
+
+      if (stamped === base) {
+        callback(result)
+
+        return
+      }
+
+      callback({ requestHeaders: stamped })
+    })
+  }
+}
+
+interface EmbedRequestDetails {
+  url: string
+  requestHeaders?: Record<string, string>
+}
+
+interface EmbedSession {
+  webRequest: {
+    onBeforeSendHeaders: (
+      listener: (
+        details: EmbedRequestDetails,
+        callback: (result: { requestHeaders?: Record<string, string> }) => void
+      ) => void
+    ) => void
+  }
+}
+
+function installEmbedRefererForSession(embedSession: EmbedSession | undefined) {
   if (!embedSession) {
     return
   }
 
   embedSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    let host = ''
-
-    try {
-      host = new URL(details.url).hostname
-    } catch {
-      host = ''
-    }
-
-    if (!YOUTUBE_REFERER_HOST_RE.test(host)) {
-      callback({ requestHeaders: details.requestHeaders })
-
-      return
-    }
-
-    const headers = { ...details.requestHeaders }
-
-    if (!headers.Referer && !headers.referer) {
-      headers.Referer = EMBED_REFERER
-    }
-
-    callback({ requestHeaders: headers })
+    callback({ requestHeaders: stampEmbedRefererHeaders(details.url, details.requestHeaders ?? {}) })
   })
 }
 
-/** Stamp Referer on YouTube requests in the embed webview partition only. */
+/** Stamp Referer on YouTube requests in the embed webview partition. */
 function installEmbedReferer() {
   try {
     installEmbedRefererForSession(session.fromPartition(EMBED_SESSION_PARTITION))
@@ -45,4 +109,4 @@ function installEmbedReferer() {
   }
 }
 
-export { installEmbedReferer }
+export { installEmbedReferer, stampEmbedRefererHeaders, withEmbedRefererStamp }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -169,7 +169,7 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
-import { installEmbedReferer } from './embed-referer'
+import { installEmbedReferer, withEmbedRefererStamp } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import {
   buildTerminalScript,
@@ -9259,9 +9259,11 @@ function installRemoteHeaderRules() {
   }
 
   remoteHeaderRulesInstalled = true
-  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    applyRemoteRequestHeaders(details, callback, headersForRemoteRequest)
-  })
+  session.defaultSession.webRequest.onBeforeSendHeaders(
+    withEmbedRefererStamp((details, callback) => {
+      applyRemoteRequestHeaders(details, callback, headersForRemoteRequest)
+    })
+  )
 }
 
 // Validate + normalize the per-profile remote overrides map read from disk.


### PR DESCRIPTION
## Summary

Chat embeds are plain `<iframe>`s rendered in the main window's default session (`youtube-embed.tsx`, `frame-embed.tsx`), and the production renderer loads from a `file://` URL, so `window.location.origin` is `null` and `strict-origin-when-cross-origin` sends no Referer — YouTube's embed player then rejects the config request with error 153. The existing Referer stamp in `electron/embed-referer.ts` was wired only to the `persist:hermes-embed` partition, which nothing in the tree references; no chat embed ever ran in it.

There is a second trap the wiring has to respect: `installRemoteHeaderRules` (electron/main.ts) installs its own `session.defaultSession.webRequest.onBeforeSendHeaders` listener, and Electron keeps a **single listener per webRequest hook** — stamping onto `defaultSession` separately would be silently replaced (or would eat the remote gateway headers in the reverse order).

Fix:

- Extract the stamp into a pure helper `stampEmbedRefererHeaders(url, headers)` (adds `Referer: https://www.youtube.com/` for the YouTube host family, only when absent) and reuse it from the embed-partition installer.
- Add `withEmbedRefererStamp(listener)` and compose it **into** the existing default-session listener in `installRemoteHeaderRules`, so remote gateway headers and the referer stamp coexist in the single listener slot. The stamp runs on the listener's result; requests the stamp does not apply to keep the wrapped listener's exact callback semantics (an empty `requestHeaders` value means "replace all headers", not "no changes").

## Testing

- `npx vitest run embed-referer --project electron` — 10 passed (10)
- `npx tsc --build tsconfig.electron.json` — clean
- `eslint --fix` on the three touched files — 0 problems
- Mutation checks (each red, then restored to 10/10 green): host gate disabled → 3 failed; no-op passthrough removed → 1 failed; stamp dropped from wrapper result → 1 failed

Fixes #106596