### PR TITLE
test(gateway): tests can no longer spawn a real gateway runtime (39 detached 'gateway restart' orphans squatted :8644 for 6 days)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1001,6 +1001,7 @@ def _ensure_current_event_loop(request):
 # delivery is harmless.
 
 _LIVE_SYSTEM_GUARD_BYPASS_MARK = "live_system_guard_bypass"
+_GATEWAY_LOOKALIKE_MARK = "spawns_gateway_lookalike"
 _REQUIRES_WAL_MARK = "requires_wal"
 
 
@@ -1152,6 +1153,12 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
         f"{_LIVE_SYSTEM_GUARD_BYPASS_MARK}: bypass the live-system guard "
         "(only for tests that genuinely need real os.kill / subprocess "
         "behaviour — e.g. PTY tests that signal their own child).",
+    )
+    config.addinivalue_line(
+        "markers",
+        f"{_GATEWAY_LOOKALIKE_MARK}: the test spawns and reaps its own stub "
+        "child whose argv matches the gateway runtime matcher; only the "
+        "real-gateway spawn check is lifted, os.kill stays guarded.",
     )
     config.addinivalue_line(
         "markers",
@@ -1319,6 +1326,7 @@ def _live_system_guard(request, monkeypatch):
     import subprocess as _subprocess
 
     test_pid = _os.getpid()
+    lookalike_ok = request.node.get_closest_marker(_GATEWAY_LOOKALIKE_MARK) is not None
     # Capture the test process's existing children at fixture start —
     # any *new* children spawned by the test are also allowlisted via
     # the live psutil walk below. Static set keeps the fast path cheap.
@@ -1544,6 +1552,28 @@ def _live_system_guard(request, monkeypatch):
                 "@pytest.mark.live_system_guard_bypass if genuinely "
                 "needed (e.g. an integration test testing the update "
                 "flow against a dedicated throwaway repo)."
+            )
+        # Block spawning a REAL gateway runtime (``python -m hermes_cli.main
+        # gateway run|start|restart``). ``_spawn_hermes_action`` launches it
+        # with start_new_session=True, so it outlives the pytest worker; the
+        # child inherits the pytest-tmp HERMES_HOME, resolves the DEVELOPER's
+        # ``hermes-gateway`` systemd unit (a tmp home hashes to no profile
+        # suffix), restarts the live gateway, and the survivors squat the
+        # webhook port. 2026-09-03: 39 such orphans lived 6 days after a
+        # sibling refactor moved the spawn seam and left tests patching the
+        # facade. The canonical matcher, never an argv substring.
+        from gateway.status import _gateway_command_subcommand
+        if not lookalike_ok and _gateway_command_subcommand(cmd_str) in ("run", "start", "restart"):
+            raise RuntimeError(
+                f"tests/conftest.py live-system guard: blocked "
+                f"subprocess.{name}({cmd!r}) — this would spawn a REAL "
+                "hermes gateway runtime that outlives the test (it is "
+                "detached), restarts the developer's live gateway, and "
+                "holds the webhook port. Patch the spawn seam where "
+                "production reads it (hermes_cli.web_server_gateway."
+                "_spawn_hermes_action), or mark with "
+                "@pytest.mark.spawns_gateway_lookalike a test that spawns "
+                "and reaps its own stub child."
             )
 
     def _wrap_subprocess(name, real):

--- a/tests/hermes_cli/test_cross_profile_kill_refusal.py
+++ b/tests/hermes_cli/test_cross_profile_kill_refusal.py
@@ -95,6 +95,9 @@ class TestRecordedGatewayHomeConflicts:
         )
 
 
+# The lookalike's argv ("<stub> gateway run") is what the guard's real-gateway spawn check matches;
+# the child is a sleep stub the test kills in ``finally``, never a runtime.
+@pytest.mark.spawns_gateway_lookalike
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock harness")
 class TestCrossProfileStopRefusal:
     def test_stop_profile_gateway_refuses_other_profiles_pid(
@@ -163,6 +166,7 @@ class TestCrossProfileStopRefusal:
             proc.wait(timeout=10)
 
 
+@pytest.mark.spawns_gateway_lookalike
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX flock harness")
 class TestProfileDeleteStopRefusal:
     def test_stop_gateway_process_refuses_other_profiles_pid(

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -80,6 +80,9 @@ def test_prepare_skips_interactive_xpc_zero_even_for_gateway_argv():
     )
 
 
+# The child is ``python -c <record argv>`` carrying a "gateway run" tail as inert data, which is
+# exactly what the guard's real-gateway spawn check matches; it exits at once.
+@pytest.mark.spawns_gateway_lookalike
 def test_main_injects_flag_into_stale_gateway_child(tmp_path, monkeypatch):
     """Stale plist inner argv must grow --external-supervisor in the grandchild."""
     monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway-butler")

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -3,6 +3,8 @@
 import re
 import sys
 
+import pytest
+
 from gateway.restart import EXTERNAL_GATEWAY_SUPERVISOR_ENV
 from hermes_cli import stderr_timestamp
 

--- a/tests/hermes_cli/test_venv_holder_windows_live.py
+++ b/tests/hermes_cli/test_venv_holder_windows_live.py
@@ -30,9 +30,12 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    sys.platform != "win32", reason="live Windows venv-holder E2E"
-)
+pytestmark = [
+    pytest.mark.skipif(sys.platform != "win32", reason="live Windows venv-holder E2E"),
+    # ``_spawn`` sleepers carry a "gateway run" argv tail as inert data (the guard's real-gateway
+    # spawn check matches it); every child is ``_kill``ed by the test.
+    pytest.mark.spawns_gateway_lookalike,
+]
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import sys
 import types
 
 import pytest
@@ -290,6 +291,32 @@ def test_subprocess_killall_hermes_blocked():
 
 
 
+
+
+# ──────────────────── real gateway runtime spawn ─────────────────
+
+
+def test_subprocess_popen_real_gateway_restart_blocked():
+    """``python -m hermes_cli.main gateway restart`` is a detached child that
+    inherits the pytest-tmp HERMES_HOME, resolves the developer's real
+    ``hermes-gateway`` unit, and outlives the test (39 six-day orphans squatted
+    the webhook port, 2026-09-03). Blocked at the spawn primitive."""
+    with pytest.raises(RuntimeError, match="live-system guard"):
+        subprocess.Popen(
+            [sys.executable, "-m", "hermes_cli.main", "gateway", "restart"],
+            start_new_session=True,
+        )
+
+
+def test_subprocess_run_gateway_status_passes_through():
+    """Only lifecycle verbs are blocked: ``gateway status`` (and every other
+    read-only subcommand) must still spawn — via the canonical matcher, not an
+    argv substring."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import sys; print(sys.argv[1:])", "-m", "hermes_cli.main", "gateway", "status"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
 
 
 # ──────────────────── bypass marker ─────────────────────────────


### PR DESCRIPTION
Tests can no longer spawn a real `hermes gateway run|start|restart` runtime: the live-system guard in `tests/conftest.py` rejects the spawn at the subprocess primitive, so an unintercepted dashboard-restart seam fails the test instead of restarting the developer's gateway and leaving detached orphans.

**Incident:** on 2026-09-03 a refactor moved `_spawn_hermes_action` from the `hermes_cli.web_server` facade to `hermes_cli.web_server_gateway` about ten minutes before the tests were repointed; runs in that window patched a name production never read, spawned real `gateway restart` children (`start_new_session=True`, so they outlive pytest), and 39 of them lived for six days. One was still bound to `0.0.0.0:8644` on 2026-09-09 and blocked the restored production gateway's webhook adapter.

## Root cause

`@patch("hermes_cli.web_server._spawn_hermes_action")` applied to the facade while `web_server._spawn_gateway_restart` reads `_gateway_mod._spawn_hermes_action` from the sibling — the patch applied, intercepted nothing, and the test passed while the real child ran. The child inherits the pytest-tmp `HERMES_HOME`, which is not a profile and yields no service suffix, so `get_service_name()` resolves the developer's real `hermes-gateway` unit.

## Changes

- `tests/conftest.py` — `_live_system_guard._check_subprocess_cmd` blocks any subprocess primitive (Popen/run/call/check_*/os.system/os.popen/pty.spawn/asyncio) whose command line `gateway.status._gateway_command_subcommand` classifies as `run`, `start` or `restart`. Canonical matcher; no argv substrings, so `gateway status`, `gateway --help`, `serve`, `kanban` pass through. Error message points at the correct seam (`hermes_cli.web_server_gateway._spawn_hermes_action`).
- New marker `spawns_gateway_lookalike` lifts only this check (os.kill stays guarded) for the three files that deliberately spawn and reap a stub child with a gateway-shaped argv: `test_cross_profile_kill_refusal.py` (flock holders), `test_stderr_timestamp.py` (`python -c` recorder with an inert `gateway run` tail), `test_venv_holder_windows_live.py` (sleepers; Windows lane).
- `tests/test_live_system_guard_self_test.py` — two canaries: `gateway restart` Popen is blocked; `gateway status` passes through.

No production code changed. The current tests on `origin/main` already patch the right module (`4fde117f4ba` repointed them), so today's suite is clean — this PR makes the class of mistake fail loudly next time a seam moves.

## Validation

| Check | Before | After |
|---|---|---|
| Unpatched `_spawn_hermes_action(["gateway","restart"])` from a test (scratch file, origin/main) | real child spawned; production gateway restarted (MainPID 136820 → 1689090, `NRestarts=1`) | `RuntimeError: live-system guard: blocked subprocess.Popen(... 'gateway', 'restart')`; MainPID unchanged; 0 survivors |
| Stale facade-patching test file from `5f1feb5344c` replayed on this branch | (on 09-03 tree) real spawn | fails at the facade `AttributeError`, no spawn |
| `pgrep` for `hermes_cli.main gateway` with `HERMES_HOME` under `/tmp/pytest-of-*` after each candidate file (`test_spawn_gateway_restart_{reap,cooldown}`, `test_dashboard_admin_endpoints`, `test_web_routers_tools_install_on_enable`, `test_web_server_profile_unification`, `test_session_hygiene`) | 0 on current main (already repointed) | 0 |
| `ss -ltnp \| grep 8644` | production pid only | production pid only |
| `scripts/run_tests.sh tests/hermes_cli/ tests/gateway/ tests/hermes_state/ tests/test_live_system_guard*.py` | — | 17497 passed, 175 skipped; 2 failures pre-existing on `origin/main` and unrelated (`test_live_system_guard.py::test_argv_arguments_are_not_treated_as_executables` and `test_update_head_moved_gate.py::test_update_success_when_head_moves` both trip the out-of-tree `~/.hermes/pytest_live_guard.py` plugin on this machine's tmp path containing `hermes`; not present in CI) |
| `ruff check --fix`, `check-windows-footguns --all`, `check_compat_pointers`, `check_subprocess_stdin`, `git diff --check` | — | clean |

Production gateway (`systemctl --user is-active hermes-gateway`) active throughout.

## Production follow-up (not in this PR)

A `gateway restart` child launched with a non-profile `HERMES_HOME` (any temp dir, not just pytest) resolves the *default* `hermes-gateway` unit and restarts it. `_profile_suffix()` hashes such homes for the service *name*, but `get_systemd_unit_path()` is looked up by that name only when it exists — worth a guard that refuses `systemd_restart`/`stop_profile_gateway` when `HERMES_HOME` is a temp path (the same predicate `_refuse_temp_home_service_write` already uses for unit writes).

## Infographic

![tests can no longer spawn a real gateway](https://v3b.fal.media/files/b/0aa9bc5a/LmI-1MUDuJXRR64ecTt5M_u9XIyT24.png)
