### PR TITLE
fix(dashboard-auth): scope global provider registration by owning profile

### DIFF
--- a/hermes_cli/dashboard_auth/registry.py
+++ b/hermes_cli/dashboard_auth/registry.py
@@ -96,7 +96,7 @@ def list_session_providers() -> List[DashboardAuthProvider]:
     return [p for p in list_providers() if getattr(p, "supports_session", True)]
 
 
-def register_global_provider(provider: DashboardAuthProvider, *, scope: Optional[str] = None) -> None:
+def register_global_provider(provider: DashboardAuthProvider, *, scope: Optional[str] = None) -> bool:
     """Register a host-owned provider in the process-global slot (upsert). The registry is shared
     across every profile one dashboard process serves, so these outlive any per-home plugin
     manager: always targets ``_providers`` (never a per-home overlay), so a forced plugin
@@ -107,7 +107,8 @@ def register_global_provider(provider: DashboardAuthProvider, *, scope: Optional
     provider) rather than upserted — otherwise background plugin discovery for another profile
     (e.g. the dashboard UI following the machine's sticky active profile) can silently replace the
     provider actively validating an unrelated, already-authenticated Dashboard's sessions with one
-    signed for a different profile (#106608).
+    signed for a different profile (#106608). Returns whether the registration took effect, so the
+    caller can tell an operator apart from a silent no-op.
 
     Pairs with ``unregister_global_provider`` for teardown of the exact object still current (#91701).
     """
@@ -119,10 +120,11 @@ def register_global_provider(provider: DashboardAuthProvider, *, scope: Optional
             _log.warning(
                 "dashboard-auth: refusing to replace provider %r (owned by profile %r) with one "
                 "registered for profile %r", provider.name, owner, scope)
-            return
+            return False
         _providers[provider.name] = provider
         _provider_owners[provider.name] = scope
     _log_registered("global provider ", provider)
+    return True
 
 
 def unregister_global_provider(name: str, provider: DashboardAuthProvider) -> bool:

--- a/hermes_cli/dashboard_auth/registry.py
+++ b/hermes_cli/dashboard_auth/registry.py
@@ -14,6 +14,9 @@ _log = logging.getLogger(__name__)
 _lock = threading.Lock()
 _providers: dict[str, DashboardAuthProvider] = {}
 _scoped_providers: dict[str, dict[str, DashboardAuthProvider]] = {}
+# Profile (scope_key) that currently owns each name in ``_providers`` — see
+# ``register_global_provider``.
+_provider_owners: dict[str, Optional[str]] = {}
 
 
 def _merged(scope: Optional[str] = None) -> dict[str, DashboardAuthProvider]:
@@ -93,18 +96,32 @@ def list_session_providers() -> List[DashboardAuthProvider]:
     return [p for p in list_providers() if getattr(p, "supports_session", True)]
 
 
-def register_global_provider(provider: DashboardAuthProvider) -> None:
+def register_global_provider(provider: DashboardAuthProvider, *, scope: Optional[str] = None) -> None:
     """Register a host-owned provider in the process-global slot (upsert). The registry is shared
     across every profile one dashboard process serves, so these outlive any per-home plugin
-    manager: always targets ``_providers`` (never a per-home overlay) and *replaces* a same-name
-    entry instead of raising, so a forced plugin re-discovery (e.g. after a password change)
-    rotates the provider in place. Pairs with ``unregister_global_provider``.
+    manager: always targets ``_providers`` (never a per-home overlay), so a forced plugin
+    re-discovery (e.g. after a password change) rotates the provider in place.
+
+    ``scope`` identifies the profile whose plugin manager is registering. A same-name provider
+    from a DIFFERENT scope than the one already holding the name is refused (warn, keep the live
+    provider) rather than upserted — otherwise background plugin discovery for another profile
+    (e.g. the dashboard UI following the machine's sticky active profile) can silently replace the
+    provider actively validating an unrelated, already-authenticated Dashboard's sessions with one
+    signed for a different profile (#106608).
 
     Pairs with ``unregister_global_provider`` for teardown of the exact object still current (#91701).
     """
     assert_protocol_compliance(type(provider))
     with _lock:
+        owner = _provider_owners.get(provider.name)
+        if (provider.name in _providers and owner is not None and scope is not None
+                and owner != scope):
+            _log.warning(
+                "dashboard-auth: refusing to replace provider %r (owned by profile %r) with one "
+                "registered for profile %r", provider.name, owner, scope)
+            return
         _providers[provider.name] = provider
+        _provider_owners[provider.name] = scope
     _log_registered("global provider ", provider)
 
 
@@ -114,6 +131,7 @@ def unregister_global_provider(name: str, provider: DashboardAuthProvider) -> bo
     with _lock:
         if _providers.get(name) is provider:
             _providers.pop(name, None)
+            _provider_owners.pop(name, None)
             return True
     return False
 
@@ -123,3 +141,4 @@ def clear_providers() -> None:
     with _lock:
         _providers.clear()
         _scoped_providers.clear()
+        _provider_owners.clear()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -755,10 +755,17 @@ class PluginContext:
             # the WHOLE process, permanently disabling sign-in until restart (#91701). The handle still
             # disposes explicitly (identity- conditional), and a forced re-discovery rotates the provider in
             # place via the upsert.
-            register_global_provider(provider, scope=self._manager.scope_key)
+            registered = register_global_provider(provider, scope=self._manager.scope_key)
         except (TypeError, ValueError) as e:
             logger.warning("Plugin '%s' failed to register dashboard-auth provider %r: %s",
                            self.manifest.name, getattr(provider, "name", "?"), e)
+            return
+        if not registered:
+            # Refused: another profile's plugin manager already owns this name (#106608). The
+            # operator needs an actionable signal, not a silent no-op that looks like success.
+            logger.warning(
+                "Plugin '%s' dashboard-auth provider %r NOT registered: name owned by another "
+                "profile", self.manifest.name, registry_name)
             return
         handle = self._track("dashboard_auth_provider", registry_name,
                              lambda: unregister_global_provider(registry_name, provider), persistent=True)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -755,7 +755,7 @@ class PluginContext:
             # the WHOLE process, permanently disabling sign-in until restart (#91701). The handle still
             # disposes explicitly (identity- conditional), and a forced re-discovery rotates the provider in
             # place via the upsert.
-            register_global_provider(provider)
+            register_global_provider(provider, scope=self._manager.scope_key)
         except (TypeError, ValueError) as e:
             logger.warning("Plugin '%s' failed to register dashboard-auth provider %r: %s",
                            self.manifest.name, getattr(provider, "name", "?"), e)

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -290,3 +290,30 @@ def test_same_profile_rediscovery_still_rotates_in_place():
 
     live = get_provider("basic")
     assert live.tag == "new"
+
+
+def test_owner_eviction_releases_name_for_other_profile():
+    """The name is not stuck forever if its owner dies without unregistering.
+
+    ``_provider_owners`` is only cleared by an identity-matched
+    ``unregister_global_provider`` call. If profile-a's manager is torn down
+    without ever making that call directly, the routine re-discovery eviction
+    path (``_evict_stale_persistent_registrations``) is what still reaches it
+    (via the tracked handle's release callback) — so a legitimate profile-b
+    registration is not locked out until process restart.
+    """
+    owner_manager, owner_ctx = _real_ctx(scope_key="profile-a")
+    owner_ctx.register_dashboard_auth_provider(_Basic("owner"))
+
+    owner_manager.unload()
+    owner_manager._evict_stale_persistent_registrations()
+    assert get_provider("basic") is None
+
+    _other_manager, other_ctx = _real_ctx(scope_key="profile-b")
+    other_ctx.register_dashboard_auth_provider(_Basic("legit"))
+
+    live = get_provider("basic")
+    assert live is not None and live.tag == "legit", (
+        "a different profile could not reclaim a name whose owner died "
+        "without unregistering"
+    )

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -115,8 +115,8 @@ class _Basic(DashboardAuthProvider):
         return None
 
 
-def _real_ctx() -> tuple[PluginManager, PluginContext]:
-    manager = PluginManager(scope_key=hermes_home_key())
+def _real_ctx(scope_key: str | None = None) -> tuple[PluginManager, PluginContext]:
+    manager = PluginManager(scope_key=scope_key or hermes_home_key())
     manifest = PluginManifest(name="basic", version="0.0.1", kind="backend")
     return manager, PluginContext(manifest=manifest, manager=manager)
 
@@ -255,3 +255,38 @@ def test_persistent_dispose_is_idempotent_after_targeted_unload():
     assert manager._persistent_carryover == []
     manager._evict_stale_persistent_registrations()
     assert get_provider("basic") is None
+
+
+# ---------------------------------------------------------------------------
+# #106608: an isolated Dashboard's auth provider must stay bound to its
+# launch profile. Background plugin discovery for a DIFFERENT profile (e.g.
+# the dashboard UI following the machine's sticky active profile) must not
+# clobber it with a same-name provider signed for that other profile.
+# ---------------------------------------------------------------------------
+
+
+def test_other_profile_registration_does_not_replace_owner():
+    """A different scope registering the same name is refused, not upserted."""
+    owner_manager, owner_ctx = _real_ctx(scope_key="profile-a")
+    owner_provider = _Basic("owner")
+    owner_ctx.register_dashboard_auth_provider(owner_provider)
+
+    _other_manager, other_ctx = _real_ctx(scope_key="profile-b")
+    other_ctx.register_dashboard_auth_provider(_Basic("intruder"))
+
+    live = get_provider("basic")
+    assert live is owner_provider, (
+        "a same-name provider registered for a different profile replaced "
+        "the provider validating this process's live sessions"
+    )
+    assert live.tag == "owner"
+
+
+def test_same_profile_rediscovery_still_rotates_in_place():
+    """A same-scope re-registration (e.g. password change) still upserts."""
+    manager, ctx = _real_ctx(scope_key="profile-a")
+    ctx.register_dashboard_auth_provider(_Basic("old"))
+    ctx.register_dashboard_auth_provider(_Basic("new"))
+
+    live = get_provider("basic")
+    assert live.tag == "new"


### PR DESCRIPTION
## Summary

Fixes #106608.

An isolated Dashboard's Basic Auth login could be immediately invalidated after a successful sign-in when the machine's sticky active profile differed from the Dashboard's launch profile. During page bootstrap, the UI's `ProfileProvider` follows the sticky active profile, which triggers plugin discovery for that OTHER profile in the same process. That discovery re-registers a same-name (`basic`) dashboard-auth provider through `register_dashboard_auth_provider()` → `register_global_provider()`, which upserted unconditionally into the process-global `_providers` registry — clobbering the provider that actually validated the live Dashboard's session cookies. Since no signing secret was configured, the replacement provider generated a *different* signing key, so the original session's cookies immediately failed verification (401), even though nothing about the cookie or the process had changed.

This is a follow-up gap in the fix for #91701 / #93271: those fixes correctly kept the registry from being *emptied* on routine per-home plugin-manager teardown, but didn't address a *different* profile's discovery overwriting the entry in place.

## Fix

`register_global_provider()` now tracks which profile (`scope_key`) owns each registered name. A same-name registration from a **different** profile than the current owner is refused (logged, existing provider kept) instead of upserted. A same-profile re-registration (e.g. rotating the provider after a password change, or a routine re-discovery of the *same* profile) still upserts and rotates the provider in place exactly as before — no change to that path.

`hermes_cli/plugins.py`'s `register_dashboard_auth_provider()` now passes the registering `PluginManager`'s immutable `scope_key` through to `register_global_provider()`.

No change was needed on the read side (`get_provider` / `list_session_providers`): they already read the same process-global `_providers` map, so once cross-profile writes stop clobbering the entry, verification works correctly again.

## Test plan

Added two tests to `tests/hermes_cli/test_dashboard_auth_plugin_hook.py`:

- `test_other_profile_registration_does_not_replace_owner` — two `PluginManager`s with different `scope_key`s both register a provider named `basic`; asserts the second (different-profile) registration is refused and the original owner's provider instance is still live. This reproduces #106608.
- `test_same_profile_rediscovery_still_rotates_in_place` — same `scope_key` registering twice still upserts, preserving the password-change / forced-rediscovery behavior from #91701.

Confirmed the new regression test fails without the fix (`git checkout HEAD~1 -- hermes_cli/dashboard_auth/registry.py hermes_cli/plugins.py`, rerun):

```
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_plugin_hook.py -q
...........F.
FAILED tests/hermes_cli/test_dashboard_auth_plugin_hook.py::test_other_profile_registration_does_not_replace_owner
AssertionError: a same-name provider registered for a different profile replaced the provider validating this process's live sessions
1 failed, 12 passed in 0.30s
```

With the fix restored, the full suite passes:

```
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_plugin_hook.py -q
=== Summary: 1 files, 13 tests passed, 0 failed (100% complete) in 0.5s (8 workers) ===

$ scripts/run_tests.sh tests/plugins/dashboard_auth/ tests/hermes_cli/test_dashboard_auth_plugin_hook.py -q
=== Summary: 6 files, 124 tests passed, 0 failed (100% complete) in 3.4s (8 workers) ===

$ scripts/run_tests.sh tests/hermes_cli/test_plugins*.py -q
=== Summary: 8 files, 159 tests passed, 0 failed (100% complete) in 6.1s (8 workers) ===

$ ruff check hermes_cli/dashboard_auth/registry.py hermes_cli/plugins.py tests/hermes_cli/test_dashboard_auth_plugin_hook.py
All checks passed!
```

---
This change was authored with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
