### PR TITLE
fix(gateway): prefer session model override in /usage billing route

### DIFF
--- a/gateway/slash_commands_status.py
+++ b/gateway/slash_commands_status.py
@@ -589,13 +589,23 @@ class GatewayStatusCommandsMixin:
         return t("gateway.usage.no_data")
 
     async def _persisted_billing_route(self, source):
-        """``(provider, base_url)`` from the SessionDB row / dominant route when no agent is resident."""
+        """``(provider, base_url)`` from the session /model override, else the
+        SessionDB row / dominant route, when no agent is resident."""
         async def _rows():
             entry = await self.async_session_store.get_or_create_session(source)
             persisted = await self._session_db.get_session(entry.session_id) or {}
             route = await self._session_db.get_dominant_session_model_route(entry.session_id)
-            return persisted, route if isinstance(route, dict) else {}
-        persisted, dominant = await _quiet(_rows, ({}, {}))
+            return entry, persisted, route if isinstance(route, dict) else {}
+        entry, persisted, dominant = await _quiet(_rows, (None, {}, {}))
+        # A /model switch evicts the cached agent, so between turns the dominant
+        # route still names the OLD provider — the explicit override wins.
+        try:
+            _key = getattr(entry, "session_key", None) or self._session_key_for_source(source)
+            _override = ((getattr(self, "_session_model_overrides", {}) or {}).get(_key) or {})
+        except Exception:
+            _override = {}
+        if _override.get("provider"):
+            return _override.get("provider"), _override.get("base_url") or None
         row = dominant if dominant.get("billing_provider") else persisted
         return row.get("billing_provider"), row.get("billing_base_url")
 

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -200,6 +200,57 @@ class TestUsageAccountSection:
         account_call = next(c for c in calls if c["args"] == ("nvidia",))
         assert account_call["kwargs"]["base_url"] == "https://integrate.api.nvidia.com/v1/"
 
+    @pytest.mark.asyncio
+    async def test_usage_command_prefers_session_model_override_over_dominant(self, monkeypatch):
+        """Right after /model (cached agent evicted, no resident agent), /usage must
+        query the override provider, not the stale dominant route."""
+        runner = _make_runner(SK)
+        runner._session_db = AsyncSessionDB(MagicMock())
+        runner._session_db._db.get_session.return_value = {
+            "billing_provider": "new-provider",
+            "billing_base_url": None,
+        }
+        runner._session_db._db.get_dominant_session_model_route.return_value = {
+            "model": "stale-dominant-model",
+            "billing_provider": "stale-provider",
+            "billing_base_url": "https://stale-provider.example.com/v1/",
+        }
+        session_entry = MagicMock(session_id="sess-1", session_key=SK)
+        runner.session_store.get_or_create_session.return_value = session_entry
+        # Production /model write path (legacy view over conversation.model_override).
+        runner._session_model_overrides[SK] = {
+            "model": "switched-model",
+            "provider": "new-provider",
+            "api_key": "",
+            "base_url": "",
+            "api_mode": "",
+            "request_overrides": {},
+            "capabilities": {},
+        }
+
+        calls = []
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+        monkeypatch.setattr(
+            "gateway.slash_commands_status.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands_status.render_account_usage_lines",
+            lambda snapshot, markdown=False: ["account limits"],
+        )
+        monkeypatch.setattr("agent.account_usage.nous_credits_lines", lambda markdown=False: [])
+
+        await runner._handle_usage_command(MagicMock())
+
+        account_call = next(c for c in calls if c["args"] == ("new-provider",))
+        assert account_call["kwargs"]["base_url"] is None
+        assert not [c for c in calls if c["args"] == ("stale-provider",)]
+
 
 class TestUsageReset:
     """`/usage reset [--force]` — banked Codex reset redemption via the gateway."""


### PR DESCRIPTION
## What + why

After `/model` the cached agent is evicted, so with no resident agent `_persisted_billing_route` fell back to the historic dominant route and `/usage` queried the **previous** provider's account block. Same bug class as #77521 (display paths ignoring the explicit session override); the `/status` half is covered by #78310, this covers the `/usage` half. The explicit override now wins; row/dominant order is unchanged when no override exists.

## How to test

`python -m pytest tests/gateway/test_usage_command.py -q` — new test `test_usage_command_prefers_session_model_override_over_dominant` fails on `main` (queries stale dominant provider) and passes with the fix. Full file: 7 passed. `tests/gateway/test_status_command.py`: 10 passed + 1 pre-existing unrelated failure (`test_profile_command_reports_source_stamped_profile`, also fails on clean `main`). `scripts/check-windows-footguns.py`: clean.

## Platforms tested

Windows 11 (direct-pytest workaround per windows-quirks; POSIX wrapper unavailable).

Related: #77521, #78310 (complementary — verified that PR fixes the /status half, see my review there).