### PR TITLE
feat(approval): let pre_tool_call approve directives set the displayed command

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1753,6 +1753,7 @@ class _PreToolCallDirective:
     action: Optional[str] = None
     message: Optional[str] = None
     rule_key: Optional[str] = None
+    display_target: Optional[str] = None
     modified_args: Optional[Dict[str, Any]] = None
 
 
@@ -1774,8 +1775,9 @@ def _get_pre_tool_call_directive_details(
     middleware_trace: Optional[List[Dict[str, Any]]] = None,
 ) -> _PreToolCallDirective:
     """Check ``pre_tool_call`` hooks for ``{"action": "block", "message"}`` (veto; message becomes
-    the tool result) or ``{"action": "approve", "message", "rule_key"?}`` (escalate ANY tool to the
-    human-approval gate; ``rule_key`` picks the ``[a]lways`` allowlist grain). First valid directive
+    the tool result) or ``{"action": "approve", "message", "rule_key"?, "display_target"?}``
+    (escalate ANY tool to the human-approval gate; ``rule_key`` picks the ``[a]lways`` allowlist
+    grain, ``display_target`` is what the approval UI shows as the command). First valid directive
     wins; irrelevant returns are ignored."""
     allowed = getattr(_thread_tool_whitelist, "allowed", None)
     if allowed is not None and tool_name not in allowed:
@@ -1810,7 +1812,10 @@ def _get_pre_tool_call_directive_details(
             continue
         rule_key = result.get("rule_key") if action == "approve" else None
         rule_key = (rule_key.strip() or None) if isinstance(rule_key, str) else None
-        return _PreToolCallDirective(action=action, message=message, rule_key=rule_key, modified_args=modified_args)
+        display_target = result.get("display_target") if action == "approve" else None
+        display_target = (display_target.strip() or None) if isinstance(display_target, str) else None
+        return _PreToolCallDirective(action=action, message=message, rule_key=rule_key,
+                                     display_target=display_target, modified_args=modified_args)
     return _PreToolCallDirective(modified_args=modified_args)
 
 
@@ -1857,7 +1862,8 @@ def _resolve_block_from_details(
             approval_tokens = set_current_observability_context(
                 turn_id=turn_id, tool_call_id=tool_call_id, session_id=session_id)
         try:
-            result = request_tool_approval(tool_name, details.message or "", rule_key=details.rule_key or tool_name)
+            result = request_tool_approval(tool_name, details.message or "", rule_key=details.rule_key or tool_name,
+                                           display_target=details.display_target or "")
         finally:
             if approval_tokens is not None:
                 with suppress(Exception):

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1447,6 +1447,43 @@ class TestResolvePreToolBlock:
             "rule_key": "write_file:ssh",
         }
 
+    def test_approve_passes_display_target_to_gate(self, monkeypatch):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        seen = {}
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "approve", "message": "why", "rule_key": "k",
+                 "display_target": "  kubectl delete pod x  "}
+            ],
+        )
+
+        def _approve(tool_name, reason, **kwargs):
+            seen["display_target"] = kwargs.get("display_target")
+            return {"approved": True, "message": None}
+
+        monkeypatch.setattr("tools.approval.request_tool_approval", _approve)
+        assert resolve_pre_tool_block("terminal", {}) is None
+        assert seen == {"display_target": "kubectl delete pod x"}
+
+    def test_approve_without_display_target_passes_empty(self, monkeypatch):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        seen = {}
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "approve", "message": "why", "display_target": 42}],
+        )
+
+        def _approve(tool_name, reason, **kwargs):
+            seen["display_target"] = kwargs.get("display_target")
+            return {"approved": True, "message": None}
+
+        monkeypatch.setattr("tools.approval.request_tool_approval", _approve)
+        assert resolve_pre_tool_block("terminal", {}) is None
+        assert seen == {"display_target": ""}  # non-string ignored → synthetic label
+
 
     def test_approve_gate_exception_fails_closed(self, monkeypatch):
         from hermes_cli.plugins import resolve_pre_tool_block

--- a/tests/tools/test_request_tool_approval.py
+++ b/tests/tools/test_request_tool_approval.py
@@ -156,6 +156,39 @@ class TestRequestToolApproval:
         res = request_tool_approval("terminal", "any", rule_key="my-rule")
         assert res["pattern_key"] == "plugin_rule:my-rule"
 
+    def test_display_target_defaults_to_synthetic_label(self, monkeypatch):
+        seen = {}
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(tools_approval_context, "_is_gateway_approval_context", lambda: False)
+
+        def _prompt(command, *a, **k):
+            seen["command"] = command
+            return "deny"
+
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", _prompt)
+        monkeypatch.setattr(approval_prompt, "prompt_dangerous_approval", _prompt)
+        request_tool_approval("terminal", "any", rule_key="my-rule")
+        assert seen["command"] == "<terminal> (plugin approval rule)"
+
+    def test_display_target_is_shown_as_command_but_not_keyed(self, monkeypatch):
+        """A plugin that knows the real command can show it; the allowlist grain stays rule_key."""
+        seen = {}
+        monkeypatch.setattr(approval, "_is_interactive_cli", lambda: True)
+        monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+        monkeypatch.setattr(tools_approval_context, "_is_gateway_approval_context", lambda: False)
+
+        def _prompt(command, *a, **k):
+            seen["command"] = command
+            return "deny"
+
+        monkeypatch.setattr(approval, "prompt_dangerous_approval", _prompt)
+        monkeypatch.setattr(approval_prompt, "prompt_dangerous_approval", _prompt)
+        res = request_tool_approval("terminal", "mutates prod", rule_key="kubectl-prod",
+                                    display_target="kubectl --context prod delete pod x")
+        assert seen["command"] == "kubectl --context prod delete pod x"
+        assert res["pattern_key"] == "plugin_rule:kubectl-prod"
+
     def test_no_human_non_cron_fails_closed(self, monkeypatch):
         """Non-interactive, non-gateway, NON-cron context blocks (fail-closed)
         — a plugin-flagged action never runs ungated without a human."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -927,7 +927,8 @@ def check_dangerous_command(command: str, env_type: str,
     )
 
 
-def request_tool_approval(tool_name: str, reason: str, *, rule_key: str = "", approval_callback=None) -> dict:
+def request_tool_approval(tool_name: str, reason: str, *, rule_key: str = "", display_target: str = "",
+                          approval_callback=None) -> dict:
     """Escalate an arbitrary tool call to the human-approval gate.
 
     Entry point for a plugin ``pre_tool_call`` hook returning ``{"action": "approve", ...}``:
@@ -936,7 +937,10 @@ def request_tool_approval(tool_name: str, reason: str, *, rule_key: str = "", ap
     the LLM cannot skip it. Cron honors ``approvals.cron_mode``; any OTHER non-interactive
     non-gateway context fails CLOSED. ``rule_key`` controls the ``[a]lways`` allowlist grain;
     when empty it is ``tool_name`` + a hash of ``reason`` so DISTINCT reasons on the same tool
-    persist independently. Returns the ``check_dangerous_command`` result shape.
+    persist independently. ``display_target`` is what the approval UI shows as the *command*
+    (the expandable box on the desktop card, the code block in gateway clients); when empty a
+    synthetic ``<tool> (plugin approval rule)`` label is shown. It is display-only: it never
+    affects the allowlist key. Returns the ``check_dangerous_command`` result shape.
     """
     description = reason or f"Plugin requires approval for {tool_name}"
     if not rule_key:
@@ -944,9 +948,10 @@ def request_tool_approval(tool_name: str, reason: str, *, rule_key: str = "", ap
     subject = f"Tool '{tool_name}' requires approval ({description})"
     return _run_approval_gate(
         # Namespaced so plugin-rule approvals share the allowlist machinery without ever colliding with a real
-        # command pattern key; the display target is a synthetic label for the display/allowlist layer.
+        # command pattern key; the display target is a synthetic label for the display/allowlist layer unless
+        # the plugin supplied the real one.
         pattern_key=f"plugin_rule:{rule_key}", description=description,
-        display_target=f"<{tool_name}> (plugin approval rule)", approval_callback=approval_callback,
+        display_target=display_target or f"<{tool_name}> (plugin approval rule)", approval_callback=approval_callback,
         subject=subject, advice="Find an alternative approach.",
         autoapprove_log_prefix=f"plugin-escalated tool call '{tool_name}' in non-interactive non-gateway context",
         fail_closed_when_no_human=True,

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -549,10 +549,11 @@ def my_callback(tool_name: str, args: dict, task_id: str, **kwargs):
 ```python
 return {"action": "block", "message": "Reason the tool call was blocked"}
 # or
-return {"action": "approve", "message": "Why approval is required", "rule_key": "optional:scope"}
+return {"action": "approve", "message": "Why approval is required", "rule_key": "optional:scope",
+        "display_target": "optional: what the approval UI shows as the command"}
 ```
 
-The first valid directive wins (Python plugins registered first, then shell hooks). `block` requires a non-empty `message` and short-circuits the tool with that text as the error returned to the model. `approve` escalates the call to the existing human-approval gate; `message` and `rule_key` are optional, and denial, timeout, or gate error fails closed. Other return values are ignored, so existing observer-only callbacks keep working unchanged.
+The first valid directive wins (Python plugins registered first, then shell hooks). `block` requires a non-empty `message` and short-circuits the tool with that text as the error returned to the model. `approve` escalates the call to the existing human-approval gate; `message`, `rule_key` and `display_target` are optional, and denial, timeout, or gate error fails closed. Without `display_target` the approval UI shows a synthetic `<tool> (plugin approval rule)` label in place of the command, so a plugin that knows the exact command (or file path) should pass it — display only, it never affects the allowlist key. Other return values are ignored, so existing observer-only callbacks keep working unchanged.
 
 **Return value — rewrite the tool's arguments:**
 


### PR DESCRIPTION
## What does this PR do?

A plugin that escalates a tool call via a `pre_tool_call` `{"action": "approve"}` directive cannot influence what the approval UI shows as the **command**. `request_tool_approval()` hardcodes `display_target=f"<{tool_name}> (plugin approval rule)"`, so the desktop card's expandable "Command" box and the gateway code block show a placeholder — even when the plugin knows the exact command and put it in `message`, which the desktop clamps to one truncated line.

This adds an optional `display_target` to the approve directive and threads it through `_PreToolCallDirective` → `request_tool_approval(display_target=...)`. Absent, empty, or non-string values keep today's synthetic label, so existing hooks are unaffected. It is **display only**: the allowlist key stays `plugin_rule:<rule_key>`, and the gateway path already redacts the displayed command via `redact_sensitive_text` before painting it.

This is orthogonal to #62092 / #62411, which fix the *desktop* side by rendering `description`; this PR fixes the *API* side so the Command box can carry the real command.

## Related Issue

Refs #62402 (does not fully close it — the desktop rendering half is #62092)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/approval.py`: `request_tool_approval()` gains `display_target: str = ""`; falls back to the existing label.
- `hermes_cli/plugins.py`: `_PreToolCallDirective.display_target`; parsed from the hook return (stripped, non-string ignored) and passed to the gate.
- `tests/tools/test_request_tool_approval.py`: default label kept; explicit target shown as command while `pattern_key` stays `plugin_rule:<rule_key>`.
- `tests/hermes_cli/test_plugins.py`: directive parsing → gate kwarg, incl. whitespace strip and non-string fallback.
- `website/docs/user-guide/features/hooks.md`: documents the new field.

## How to Test

1. In a plugin, return `{"action": "approve", "message": "why", "rule_key": "k", "display_target": "kubectl --context prod delete pod x"}` from `pre_tool_call`.
2. Trigger the tool in the desktop app / a gateway client — the Command box / code block now shows the given text instead of `<terminal> (plugin approval rule)`.
3. `pytest tests/tools/test_request_tool_approval.py tests/hermes_cli/test_plugins.py tests/tools/test_approval.py -q` → all pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (see comment below for the full-suite result)
- [x] I've added tests for my changes
- [x] I've tested on my platform: CachyOS (Arch) Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/hooks.md`, docstrings)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure Python string plumbing)
- [x] Tool descriptions/schemas — N/A
