### PR TITLE
fix(bedrock): stop the context probe escalating on throttles, and treat an accepted tier as a floor

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -964,7 +964,10 @@ _WORDS_PER_TOKEN = 0.9  # conservative: ensures the padded prompt clears the tie
 def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
     """Discover a model's real context window by provoking a length error — the only authoritative source
     ("prompt is too long: 1300032 tokens > 1000000 maximum"); length validation runs before inference so the
-    probe costs nothing. An accepted tier is a safe lower bound; None (no creds/network/unparseable) → static table."""
+    probe costs nothing. An accepted tier is a safe lower bound; None (no creds/network/unparseable) → static table.
+    Escalating to a larger tier is only for failures that say nothing about size — a throttle or a
+    numberless overflow is terminal, because the next tier uploads more to learn the same nothing."""
+    from agent.error_classifier import FailoverReason, classify_api_error
     from agent.model_metadata import parse_context_limit_from_error
     try:
         client = _get_bedrock_runtime_client(region)
@@ -986,7 +989,17 @@ def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
             if limit and limit >= 1024:
                 logger.info("Probed Bedrock context window for %s: %s tokens", model_id, f"{limit:,}")
                 return limit
-            # Opaque server error / auth / throttle at this tier — try the next.
+            # Nothing parseable. Two shapes make a larger tier pointless or actively harmful, and the
+            # classifier the retry loop already uses names both: a throttle ("Too many tokens, please
+            # wait before trying again" — arriving after boto3 has already spent its own retries) and a
+            # numberless overflow ("Input is too long for requested model.", what Converse answers once
+            # the padding is far past the window). Escalating either one re-uploads a bigger prompt to
+            # be told the same thing.
+            if classify_api_error(exc).reason in (FailoverReason.rate_limit, FailoverReason.context_overflow):
+                logger.debug("Bedrock context probe for %s stopped at the ~%s-token tier: %s",
+                             model_id, f"{tier_tokens:,}", last_error[:200])
+                break
+            # Opaque server error / auth at this tier — try the next.
     logger.debug("Bedrock context probe for %s returned no parseable limit: %s", model_id, last_error[:200])
     return None
 

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -975,6 +975,7 @@ def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
         logger.debug("Bedrock context probe skipped for %s: %s", model_id, exc)
         return None
     last_error = ""
+    accepted_floor = 0
     for tier_tokens in _BEDROCK_PROBE_TIERS:
         oversized = "data " * int(tier_tokens / _WORDS_PER_TOKEN)
         try:
@@ -982,7 +983,10 @@ def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
                             inferenceConfig={"maxTokens": 8})
             logger.debug("Bedrock context probe for %s accepted ~%s-token prompt; "
                          "window is at least that", model_id, f"{tier_tokens:,}")
-            return tier_tokens
+            # A tier that fits bounds the window from below only; a rejection is what quotes the
+            # number. So record the floor and step up — this is the outcome the tier ladder exists
+            # for, and returning here is why a 2M model used to probe as 1,300,000.
+            accepted_floor = tier_tokens
         except Exception as exc:
             last_error = str(exc)
             limit = parse_context_limit_from_error(last_error)
@@ -1000,8 +1004,23 @@ def probe_bedrock_context_length(model_id: str, region: str) -> Optional[int]:
                              model_id, f"{tier_tokens:,}", last_error[:200])
                 break
             # Opaque server error / auth at this tier — try the next.
+    if accepted_floor:
+        # Every tier fit, so all the probe learned is ">= the top tier". Reporting that floor as the
+        # window is how a 3.5M model gets pinned to 2.2M, and callers that persist probe results keep
+        # the number. Answer only when the floor is genuinely more than the static table knows.
+        if accepted_floor > _static_bedrock_context_length(model_id):
+            return accepted_floor
+        logger.debug("Bedrock context probe for %s accepted ~%s tokens, no more than the static table "
+                     "already knows; deferring to it", model_id, f"{accepted_floor:,}")
+        return None
     logger.debug("Bedrock context probe for %s returned no parseable limit: %s", model_id, last_error[:200])
     return None
+
+
+def _static_bedrock_context_length(model_id: str) -> int:
+    """Longest-substring match in ``BEDROCK_CONTEXT_LENGTHS``, else the default. Never touches the network."""
+    matches = [key for key in BEDROCK_CONTEXT_LENGTHS if key in model_id.lower()]
+    return BEDROCK_CONTEXT_LENGTHS[max(matches, key=len)] if matches else BEDROCK_DEFAULT_CONTEXT_LENGTH
 
 
 def get_bedrock_context_length(model_id: str, region: str = "", probe: bool = True) -> int:
@@ -1009,8 +1028,7 @@ def get_bedrock_context_length(model_id: str, region: str = "", probe: bool = Tr
     only: a stale substring match silently caps the window (a 1M Opus pinned to 200K via "opus-4")."""
     if probe and region and (probed := probe_bedrock_context_length(model_id, region)):
         return probed
-    matches = [key for key in BEDROCK_CONTEXT_LENGTHS if key in model_id.lower()]
-    return BEDROCK_CONTEXT_LENGTHS[max(matches, key=len)] if matches else BEDROCK_DEFAULT_CONTEXT_LENGTH
+    return _static_bedrock_context_length(model_id)
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1056,6 +1056,41 @@ class TestBedrockContextProbe:
             assert probe_bedrock_context_length("some.unlisted-model", "us-east-1") == 200_000
         assert client.converse.call_count == 2
 
+    def test_accepted_tier_escalates_to_read_the_real_window(self):
+        # A tier that fits only proves "at least this much". The next tier is what
+        # makes Bedrock quote the number, so a 2M model must resolve to 2M and not
+        # to the 1,300,000 the first tier would have reported.
+        from agent.bedrock_adapter import probe_bedrock_context_length
+        client = self._client_with(
+            {"usage": {"inputTokens": 1_444_444}},
+            Exception("This model\'s maximum context length is 2000000 tokens. "
+                      "Please reduce the length of the prompt"))
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=client):
+            assert probe_bedrock_context_length("some.unlisted-model", "us-east-1") == 2_000_000
+        assert client.converse.call_count == 2
+
+    def test_accepted_floor_does_not_mask_a_larger_table_value(self):
+        # Both tiers fit, so the probe knows only ">= 2.2M". Measured on Llama 4
+        # Scout, which accepts 2,222,258 tokens against a real 3,500,000 window:
+        # answering with the floor would cap it at two thirds, and a caller that
+        # persists probe results (agent/model_metadata.py) would keep that.
+        from agent.bedrock_adapter import BEDROCK_CONTEXT_LENGTHS, probe_bedrock_context_length
+        client = self._client_with(
+            {"usage": {"inputTokens": 1_444_444}}, {"usage": {"inputTokens": 2_444_444}})
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=client), \
+                patch.dict(BEDROCK_CONTEXT_LENGTHS, {"test.wide-window": 5_000_000}):
+            assert probe_bedrock_context_length("test.wide-window-v1:0", "us-east-1") is None
+
+    def test_accepted_floor_answers_when_the_table_knows_less(self):
+        # For a model the table has never heard of, the floor is still the best
+        # thing available -- without it the caller falls to the 128K default.
+        from agent.bedrock_adapter import probe_bedrock_context_length
+        client = self._client_with(
+            {"usage": {"inputTokens": 1_444_444}}, {"usage": {"inputTokens": 2_444_444}})
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=client):
+            assert probe_bedrock_context_length("some.unlisted-model", "us-east-1") == 2_200_000
+        assert client.converse.call_count == 2
+
 
     def test_probe_returns_none_when_client_unavailable(self):
         from agent.bedrock_adapter import probe_bedrock_context_length

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1012,6 +1012,50 @@ class TestBedrockContextProbe:
         client.converse.side_effect = Exception(message)
         return client
 
+    def _client_with(self, *outcomes):
+        """Client whose successive converse() calls yield *outcomes* (a response dict or an Exception)."""
+        client = MagicMock()
+        client.converse.side_effect = list(outcomes)
+        return client
+
+    def test_throttle_at_a_tier_does_not_escalate(self):
+        # Measured against Converse: a 12.2 MB tier-2 payload came back as
+        # "ThrottlingException ... Too many tokens, please wait before trying
+        # again." after boto3 had already burned its four internal retries.
+        # Uploading a still larger prompt is the one reaction that cannot help.
+        from agent.bedrock_adapter import probe_bedrock_context_length
+        client = self._client_raising(
+            "An error occurred (ThrottlingException) when calling the Converse operation "
+            "(reached max retries: 4): Too many tokens, please wait before trying again.")
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=client):
+            assert probe_bedrock_context_length("some.unlisted-model", "us-east-1") is None
+        assert client.converse.call_count == 1
+
+    def test_numberless_overflow_does_not_escalate(self):
+        # The other shape an over-padded prompt gets back, with no window in it.
+        # A bigger payload returns the identical sentence.
+        from agent.bedrock_adapter import probe_bedrock_context_length
+        client = self._client_raising(
+            "An error occurred (ValidationException) when calling the Converse "
+            "operation: Input is too long for requested model.")
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=client):
+            assert probe_bedrock_context_length("some.unlisted-model", "us-east-1") is None
+        assert client.converse.call_count == 1
+
+    def test_opaque_server_error_still_escalates(self):
+        # The ladder exists for this case, so it has to keep working: an
+        # InternalServerException says nothing about length, and the next tier is
+        # what turns it into a parseable answer.
+        from agent.bedrock_adapter import probe_bedrock_context_length
+        client = self._client_with(
+            Exception("An error occurred (InternalServerException) when calling the "
+                      "Converse operation: Internal server error"),
+            Exception("This model\'s maximum context length is 200000 tokens. "
+                      "Please reduce the length of the prompt"))
+        with patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=client):
+            assert probe_bedrock_context_length("some.unlisted-model", "us-east-1") == 200_000
+        assert client.converse.call_count == 2
+
 
     def test_probe_returns_none_when_client_unavailable(self):
         from agent.bedrock_adapter import probe_bedrock_context_length


### PR DESCRIPTION
## What does this PR do?

Two independent bugs in `probe_bedrock_context_length` (`agent/bedrock_adapter.py:964`), one commit each. Both were found by pointing the probe at real Converse endpoints and reading what came back.

**1. The probe escalates to a bigger payload on failures where that cannot help.** The `except` branch falls through to the next, larger tier whenever the rejection carries no parseable window. Two of the shapes Bedrock actually returns make that upload pointless or actively harmful:

```
ThrottlingException ... Too many tokens, please wait before trying again.
ValidationException ... Input is too long for requested model.
```

**2. An accepted tier is returned as the window when it is only a floor.** `_BEDROCK_PROBE_TIERS = (1_300_000, 2_200_000)` ascends, and the loop did `return tier_tokens` on the first acceptance. So every model whose window exceeds the first tier probed as exactly `1,300,000`, and the second tier — the whole point of a ladder — was never reached on the acceptance path.

## Related Issue

No issue.

This replaces my own **#98522**, which I am closing. That PR is 6,737 commits behind and does not merge (`bedrock_adapter.py` has been touched 21 times over its base), so it needs rewriting rather than rebasing. But there is a second reason I would rather state than quietly carry forward: **its central claim is wrong, and I only found that out by measuring.** #98522's docstring says

> the error shape is a property of the model, not of the payload size, so a bigger prompt returns the identical error

That is not what Bedrock does. Same model, same region, different padding:

| target | outcome |
|---|---|
| 2,200,000 | `This model's maximum context length is 1048576 tokens. Please reduce the length of the prompt` |
| 5,000,000 | `Input is too long for requested model.` — no number |

The shape **does** follow payload size, and it degrades as the payload grows. That happens to make #98522's `break` the right behaviour, but for the opposite reason to the one it gives, and a reviewer accepting it would be accepting a false premise. #98522 also returned the largest accepted tier as the answer, which is bug 2 above, not a fix for it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Commit 1 — `stop the context probe escalating after a throttle or a numberless overflow`** (`agent/bedrock_adapter.py` `+15/-2`, `tests/…` `+44/-0`)

Classify the failure before escalating, and stop on `rate_limit` or `context_overflow`. An opaque `InternalServerException` still steps up, which is what the ladder's own comment says it is for.

I deliberately did **not** build this on `classify_bedrock_error` / `THROTTLE_PATTERNS` further down this same file. `COMPAT_MANIFEST.md:178-184` lists `THROTTLE_PATTERNS`, `OVERLOAD_PATTERNS`, `CONTEXT_OVERFLOW_PATTERNS`, `classify_bedrock_error` and `is_context_overflow_error` all as `restored-def … (deleted; BASE body restored)` inside the revert-scheduled plugin-compat block, and `grep` finds no non-compat caller of `classify_bedrock_error` in the tree. So this uses the live classifier instead — `agent/error_classifier.py`, whose module docstring is explicit that the retry loop should consult it "instead of re-matching strings itself", and whose `_RATE_LIMIT_PATTERNS` comment already names this exact Bedrock throttle message. No new patterns, no new constants, and `agent/error_classifier.py` imports nothing from `bedrock_adapter`, so there is no cycle.

**Commit 2 — `treat an accepted probe tier as a floor, not the window`** (`agent/bedrock_adapter.py` `+21/-3`, `tests/…` `+35/-0`)

- An accepted tier records `accepted_floor` and steps up. A rejection at the next tier quotes the real number, so a 2M-window model now resolves to `2,000,000` instead of `1,300,000`.
- If every tier is accepted, the floor is compared against the static table before being reported. When the table knows more, return `None` and let it answer; the floor is still returned for a model the table has never seen, which would otherwise drop to the 128K default.
- The table lookup moves into `_static_bedrock_context_length` so the probe and `get_bedrock_context_length` share one resolver instead of two copies of the longest-substring match.

Total: 2 files, `+115/-5`, two commits. No signature changes; `get_bedrock_context_length`'s behaviour is identical for every input that does not reach the probe.

## Why the two belong in one PR

Commit 2 is what makes the throttle reachable. Today a wide model accepts tier 1 and returns immediately, so tier 2 is never sent. Once acceptance escalates, the second call is a 12.2 MB upload — and that is precisely the call that came back throttled in my measurement, after 256 s, with boto3 having already spent its four internal retries. Landing commit 2 without commit 1 would mean a wide model can get throttled and then answer by uploading more. They also touch adjacent lines of the same function, so as separate PRs the second would go stale against the first.

They are still two commits, independently coherent, if you would rather take only one.

## Known cost, stated up front

**Commit 2 makes a second probe call for models wider than the first tier, and an accepted probe is billed.** A rejected probe is free — length validation runs before inference — but an acceptance bills the padded input. Per probe, worst case goes from ~1.44M input tokens (tier 1 only) to ~3.9M (both tiers). It buys the exact window instead of a floor, and it only happens for models whose window exceeds ~1.44M actual tokens. #104128 (@rodrigogs) is adding a negative memo so a repeatedly-failing probe stops re-sending these payloads at all, which bounds the repetition; the two changes compose and do not conflict (see below).

## How to Test

```bash
# the six new tests against the old implementation
git checkout 9e6c4100cb                        # this PR's base
git checkout fix/bedrock-probe-escalation-and-floor -- tests/agent/test_bedrock_adapter.py
pytest tests/agent/test_bedrock_adapter.py -q -p no:randomly \
       -k "throttle or numberless or opaque_server or accepted"
#  -> 5 failed, 1 passed
#     e.g. AssertionError: assert 1300000 == 2200000

git checkout fix/bedrock-probe-escalation-and-floor
pytest tests/agent/test_bedrock_adapter.py -q -p no:randomly
#  -> 84 passed   (78 on base + 6)
```

Five of the six fail on base. The sixth, `test_opaque_server_error_still_escalates`, **passes on base by design** — it is a regression guard for the escalation that must survive, not evidence of a bug. I would rather say that than present 6/6.

Every Bedrock and consumer suite on this branch: `test_bedrock_adapter.py` 84, `test_bedrock_integration.py` 35, `test_bedrock_1m_context.py` 2, `test_bedrock_empty_text_blocks.py` 3, `test_bedrock_interrupt_post_worker.py` 2, `test_bedrock_transport_replay.py` 2, `test_model_metadata.py` 121, `test_model_metadata_local_ctx.py` 37, and `test_error_classifier.py` 140 — all passed.

`ruff check .` passes repo-wide.

## Relationship to the other two open PRs in this area

Both verified with a real three-way merge against this branch's head, not assumed:

| | files | `git merge-tree` vs this branch |
|---|---|---|
| #106492 (mine, Llama 4 table rows) | `bedrock_adapter.py`, `test_bedrock_adapter.py` | **clean** |
| #104128 (@rodrigogs, probe caching) | `model_metadata.py`, `test_model_metadata.py` | **clean**, no file overlap |

**#106492 is the PR that asked for this.** Its *Known limitation* section says the Scout row only takes effect on the no-region path, because the probe returns `1,300,000` for a 3.5M model, and offers to send the probe fix separately. This is that PR. Either can land first: with only this one, Scout's table value is still 128K so the floor `1,300,000` wins and nothing changes; with only #106492, the region path still answers `1,300,000`; with both, it answers `3,500,000`.

**#104128 matters for the design, not the diff.** It reworks `_resolve_bedrock_context_length` to call `probe_bedrock_context_length` directly and `save_context_length` the result. That is why commit 2 puts the floor-vs-table comparison **inside the probe** rather than in `get_bedrock_context_length` — under #104128 a fix in the getter would be bypassed on that path, and the truncated `1,300,000` would be persisted. Returning `None` when the table knows more also respects #104128's stated invariant that only a probed value may be cached.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — two commits, both `fix(bedrock): ...`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — `probe_bedrock_context_length` and `BEDROCK_PROBE_TIERS` return only #104128 (different file, different problem), my own #98522 (being closed) and my own #106492
- [x] My PR contains **only** changes related to this fix (2 files, two commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — partially; the note below is why
- [x] I've added tests for my changes — 6, five of which fail on base
- [x] I've tested on my platform: Amazon Linux 2023 x86_64, CPython 3.11.14

**What I ran, and what I could not.** The complete `tests/agent/` directory on both sides, so the number is attributable:

| | `tests/agent/` |
|---|---|
| base `9e6c4100cb` | 32 failed, 6621 passed, 31 skipped |
| this branch | 32 failed, **6627 passed**, 31 skipped |

`+6 passed` — exactly the tests this PR adds — and the failing set is **identical**: `diff` of the sorted `FAILED` lines is empty. Those 32 are pre-existing on `main` in my environment; 18 of them are the three `test_auxiliary_*` files, the rest are skill-command / provider-resolution cases. Nothing that reads a context window.

I did **not** get a whole-`tests/` run: my box hits 36 collection errors from optional dependencies I don't have (`aiohttp` and the acp/gateway stack), and the remainder exceeds my remote-execution time ceiling. Rather than tick the box on a number I can't attribute, it stays unticked with the scoped run shown above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the docstring and the two comment blocks in the probe are the documentation for this behaviour; no `docs/` change applies
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — N/A, no platform-conditional code
- [x] Tool descriptions/schemas — N/A, no tool behaviour change

## Screenshots / Logs

Measured 2026-09-09 against `bedrock-runtime` `Converse` from my own AWS account, padding with the production expression `"data " * int(target / _WORDS_PER_TOKEN)` — so these are the exact payloads the tiers send. Actual tokens land at ≈1.111 per target unit.

**The two tiers against models of known width:**

| model | table window | target (= tier) | payload | outcome |
|---|---|---|---|---|
| `us.meta.llama3-3-70b-instruct-v1:0` | 131,072 | 1,300,000 | 7.2 MB | rejected, **parseable** — `maximum context length is 131072 tokens` |
| `us.meta.llama3-3-70b-instruct-v1:0` | 131,072 | 2,200,000 | 12.2 MB | rejected, **parseable** — same number |
| `us.meta.llama4-maverick-17b-instruct-v1:0` | 1,048,576 | 2,200,000 | 12.2 MB | rejected, **parseable** — `maximum context length is 1048576 tokens` |
| `us.meta.llama4-scout-17b-instruct-v1:0` | 3,500,000 | 2,200,000 | 12.2 MB | **`ThrottlingException` … `Too many tokens, please wait before trying again.` after 256.0 s, `reached max retries: 4`** |

That last row is the one commit 1 exists for, and it is not a contrived case: Scout accepts tier 1, so under commit 2 it always proceeds to this call.

Two things worth recording, since both cost me a wrong reading first:

- **Inside the current tiers, length rejections are parseable.** I expected to find the numberless shape here and did not. It needs a far larger overshoot: a 5,000,000-token target (27.8 MB) returns `Input is too long for requested model.` for both Llama 4 models in both `us-east-1` and `us-east-2`. So the numberless shape is what escalation *produces*, which is the argument against escalating into it — and it is why I could not reproduce the error string my own #98522 quoted.
- **A throttle raises exactly like a length rejection.** Earlier in this measurement, three results I first recorded as rejections were `Too many tokens, please wait before trying again`, which carries no window at all. Only `classify_api_error` separating `rate_limit` from `context_overflow` distinguishes them.

**The live classifier's verdicts on the measured strings**, since the whole fix rests on them (`agent/error_classifier.py`, no network):

| measured string | `classify_api_error(...).reason` |
|---|---|
| `ThrottlingException … Too many tokens, please wait before trying again.` | `rate_limit` → stop |
| `ValidationException … Input is too long for requested model.` | `context_overflow` → stop |
| `ValidationException … maximum context length is 131072 tokens …` | `context_overflow` (never reached — parsed and returned first) |
| `InternalServerException … Internal server error` | `unknown` → escalate, as before |

**Commit 2 is provably behaviour-preserving on today's table.** Computed by importing the module at this PR's base: `BEDROCK_CONTEXT_LENGTHS` has 28 entries taking five distinct values — 128,000 / 200,000 / 272,000 / 300,000 / 1,000,000 — so its maximum is `1,000,000`, below the `1,300,000` first tier. The new floor-vs-table comparison therefore cannot change any lookup that resolves against `main` as it stands. It starts mattering with the `3,500,000` Scout row in #106492.

The probe path this affects is `_resolve_bedrock_context_length` (`agent/model_metadata.py:1687`), which calls `get_bedrock_context_length(model, region=region, probe=bool(region))` at `:1705`. The no-region caller at `:1670` never reaches the probe and is untouched.
