### PR TITLE
fix(mcp): preserve RFC 9207 iss parameter in dashboard and gateway OAuth callbacks

### DIFF
--- a/apps/desktop/electron/mcp-oauth-callback-ipc.test.ts
+++ b/apps/desktop/electron/mcp-oauth-callback-ipc.test.ts
@@ -42,6 +42,7 @@ test('listen binds a loopback listener and wait resolves with the redirect param
     code: null | string
     error: null | string
     state: null | string
+    iss: null | string
   }>
 
   const res = await fetch(`${redirectUri}?code=abc123&state=st-1`)
@@ -53,10 +54,33 @@ test('listen binds a loopback listener and wait resolves with the redirect param
 
   assert.equal(result.code, 'abc123')
   assert.equal(result.state, 'st-1')
+  assert.equal(result.iss, null)
   assert.equal(result.error, null)
 
   // Listener is one-shot: the port must be closed after the callback.
   await assert.rejects(fetch(`${redirectUri}?code=again&state=st-1`))
+})
+
+test('preserves RFC 9207 iss query parameter when present', async () => {
+  const { id, redirectUri } = (await invoke('hermes:mcp-oauth:listen')) as { id: string; redirectUri: string }
+
+  const waitPromise = invoke('hermes:mcp-oauth:wait', id, 5000) as Promise<{
+    code: null | string
+    error: null | string
+    state: null | string
+    iss: null | string
+  }>
+
+  const res = await fetch(`${redirectUri}?code=auth-code-1&state=st-2&iss=https%3A%2F%2Fauth.example.com`)
+
+  assert.equal(res.status, 200)
+
+  const result = await waitPromise
+
+  assert.equal(result.code, 'auth-code-1')
+  assert.equal(result.state, 'st-2')
+  assert.equal(result.iss, 'https://auth.example.com')
+  assert.equal(result.error, null)
 })
 
 test('non-callback noise (favicon) does not settle the listener', async () => {

--- a/apps/desktop/electron/mcp-oauth-callback-ipc.ts
+++ b/apps/desktop/electron/mcp-oauth-callback-ipc.ts
@@ -42,6 +42,7 @@ interface CallbackResult {
   code: null | string
   error: null | string
   state: null | string
+  iss: null | string
 }
 
 interface PendingListener {
@@ -83,7 +84,7 @@ function dispose(id: string) {
   }
 
   if (!entry.settled) {
-    settle(id, { code: null, error: 'cancelled', state: null })
+    settle(id, { code: null, error: 'cancelled', state: null, iss: null })
   }
 
   pending.delete(id)
@@ -112,6 +113,7 @@ export function registerMcpOauthCallbackIpc() {
       let code: null | string = null
       let state: null | string = null
       let error: null | string = null
+      let iss: null | string = null
 
       try {
         const parsed = new URL(url, 'http://127.0.0.1')
@@ -119,11 +121,12 @@ export function registerMcpOauthCallbackIpc() {
         code = parsed.searchParams.get('code')
         state = parsed.searchParams.get('state')
         error = parsed.searchParams.get('error')
+        iss = parsed.searchParams.get('iss')
       } catch {
         error = 'unparseable callback URL'
       }
 
-      settle(id, { code, error, state })
+      settle(id, { code, error, state, iss })
     })
 
     await new Promise<void>((resolve, reject) => {
@@ -143,7 +146,7 @@ export function registerMcpOauthCallbackIpc() {
     const entry = pending.get(String(id || ''))
 
     if (!entry) {
-      return { code: null, error: 'listener not found', state: null }
+      return { code: null, error: 'listener not found', state: null, iss: null }
     }
 
     if (entry.result) {
@@ -158,7 +161,7 @@ export function registerMcpOauthCallbackIpc() {
 
     const result = await new Promise<CallbackResult>(resolve => {
       const timer = setTimeout(() => {
-        settle(String(id), { code: null, error: 'timeout waiting for OAuth callback', state: null })
+        settle(String(id), { code: null, error: 'timeout waiting for OAuth callback', state: null, iss: null })
       }, timeout)
 
       entry.waiters.push(value => {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -336,7 +336,7 @@ declare global {
         wait: (
           id: string,
           timeoutMs?: number
-        ) => Promise<{ code: null | string; error: null | string; state: null | string }>
+        ) => Promise<{ code: null | string; error: null | string; state: null | string; iss: null | string }>
         cancel: (id: string) => Promise<boolean>
       }
       openPreviewInBrowser?: (url: string) => Promise<void>

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
@@ -80,7 +80,7 @@ describe('Desktop MCP client callback lifecycle', () => {
       const { bridge, api, openExternal, rpc } = harness()
       setApiRequestConnection(connectionId)
       setApiRequestProfile('origin-profile')
-      const callbackResult = { code: 'code-1', state: 'expected', error: null }
+      const callbackResult = { code: 'code-1', state: 'expected', error: null, iss: 'https://idp.example' }
       bridge.wait.mockResolvedValue(callbackResult)
       openExternal.mockImplementation(async () => {
         setApiRequestConnection('other-gateway')

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -276,6 +276,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -291,7 +292,7 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         return HTMLResponse(
             "<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>",

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -88,6 +88,35 @@ def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
     assert flow._callback == ("abc", "expected")
 
 
+def test_oauth_callback_endpoint_preserves_iss_parameter(monkeypatch):
+    import asyncio
+    from hermes_cli import web_server
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+    from starlette.testclient import TestClient
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-iss-test",
+        server_name="cloudflare",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/mcp/oauth/callback/cloudflare",
+    )
+    asyncio.run(
+        flow.publish_authorization_url(
+            "https://mcp.cloudflare.com/authorize?state=cf-state"
+        )
+    )
+    _web_server_mcp._mcp_oauth_flows[flow.flow_id] = flow
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+
+    response = TestClient(web_server.app).get(
+        "/api/mcp/oauth/callback/cloudflare?code=cf-code&state=cf-state&iss=https%3A%2F%2Fmcp.cloudflare.com"
+    )
+
+    assert response.status_code == 200
+    assert flow._callback == ("cf-code", "cf-state", "https://mcp.cloudflare.com")
+
+
 def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, monkeypatch):
     from hermes_cli import web_server
     from tools.mcp_dashboard_oauth import DashboardOAuthFlow

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -100,6 +100,30 @@ def test_mcp_oauth_helpers_use_dashboard_flow_without_loopback_port():
     assert flow.authorization_url == "https://idp.example/authorize?state=state-4"
 
 
+def test_dashboard_flow_preserves_rfc9207_iss_parameter():
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow, dashboard_oauth_flow
+    from tools.mcp_oauth import _make_callback_waiter
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-iss",
+        server_name="cloudflare",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/mcp/oauth/callback/cloudflare",
+    )
+    asyncio.run(flow.publish_authorization_url("https://mcp.cloudflare.com/authorize?state=cf-state"))
+
+    with dashboard_oauth_flow(flow):
+        flow.deliver_callback(code="cf-code", state="cf-state", error=None, iss="https://mcp.cloudflare.com")
+        assert flow._callback == ("cf-code", "cf-state", "https://mcp.cloudflare.com")
+        assert asyncio.run(flow.wait_for_callback()) == ("cf-code", "cf-state", "https://mcp.cloudflare.com")
+
+        result = asyncio.run(_make_callback_waiter(0)())
+        assert result.code == "cf-code"
+        assert result.state == "cf-state"
+        assert result.iss == "https://mcp.cloudflare.com"
+
+
 def test_failed_reauth_rollback_preserves_newer_oauth_state(tmp_path, monkeypatch):
     from tools.mcp_oauth import HermesTokenStorage
 

--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -189,6 +189,13 @@ def test_deliver_callback_accepts_matching_state():
     assert flow._callback == ("abc", "s3cr3tstate")
 
 
+def test_deliver_callback_accepts_and_forwards_iss():
+    flow = _make_session()
+    out = deliver_callback_flow("sess-relay-1", "hosp", code="abc", state="s3cr3tstate", iss="https://mcp.cloudflare.com")
+    assert out == {"ok": True, "session_id": "sess-relay-1"}
+    assert flow._callback == ("abc", "s3cr3tstate", "https://mcp.cloudflare.com")
+
+
 def test_deliver_callback_rejects_state_mismatch():
     _make_session()
     out = deliver_callback_flow("sess-relay-1", "hosp", code="abc", state="WRONG")

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -43,7 +43,7 @@ class DashboardOAuthFlow:
     error: str | None = None
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
-    _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback: tuple[str, str | None] | tuple[str, str | None, str | None] | None = field(default=None, init=False, repr=False)
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = _event_field()
     _callback_ready: threading.Event = _event_field()
@@ -70,7 +70,7 @@ class DashboardOAuthFlow:
             raise RuntimeError(self.error or "MCP OAuth flow ended before authorization")
         return self.authorization_url
 
-    def deliver_callback(self, *, code: str | None, state: str | None, error: str | None) -> None:
+    def deliver_callback(self, *, code: str | None, state: str | None, error: str | None, iss: str | None = None) -> None:
         """Hand the browser redirect to the waiting flow; ``state`` must match exactly."""
         with self._lock:
             if self._callback_ready.is_set():
@@ -80,12 +80,12 @@ class DashboardOAuthFlow:
             if error:
                 self._callback_error = error
             elif code:
-                self._callback = (code, state)
+                self._callback = (code, state, iss) if iss is not None else (code, state)
             else:
                 self._callback_error = "OAuth callback did not include code or error"
             self._callback_ready.set()
 
-    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None] | tuple[str, str | None, str | None]:
         if not await asyncio.to_thread(self._callback_ready.wait, timeout):
             raise TimeoutError("Timed out waiting for MCP OAuth callback")
         if self._callback_error:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -26,7 +26,7 @@ import webbrowser
 from functools import partialmethod
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 from urllib.parse import parse_qs, urlparse
 
 from hermes_constants import secure_parent_dir
@@ -452,7 +452,10 @@ def _authorization_code_result(code: str, state: "str | None", iss: "str | None"
     try:
         from mcp.shared.auth import AuthorizationCodeResult
     except ImportError:  # mcp < 2.0
-        return code, state
+        class AuthorizationCodeResult(NamedTuple):  # type: ignore[no-redef]
+            code: str
+            state: Optional[str] = None
+            iss: Optional[str] = None
     return AuthorizationCodeResult(code=code, state=state, iss=iss)
 
 
@@ -646,8 +649,13 @@ def _make_callback_waiter(port: int, cimd_url: str | None = None, timeout: float
     async def _wait():
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
-            # Dashboard flow speaks the legacy tuple; normalize to one shape.
-            return _authorization_code_result(*await dashboard_flow.wait_for_callback())
+            cb_result = await dashboard_flow.wait_for_callback()
+            if isinstance(cb_result, tuple):
+                code = cb_result[0]
+                state = cb_result[1] if len(cb_result) > 1 else None
+                iss = cb_result[2] if len(cb_result) > 2 else None
+                return _authorization_code_result(code, state, iss)
+            return cb_result
         # The SDK entered the authorization-code flow, so any cached token is unusable. Reject BEFORE
         # binding: binding would block for the full timeout and collide with the TIME_WAIT port on retry.
         # Reject before binding the callback listener in non-interactive contexts. Reaching here means the

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -61,7 +61,7 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             status = 200
             try:
                 flow.deliver_callback(
-                    **{k: (qs.get(k) or [None])[0] for k in ("code", "state", "error")})
+                    **{k: (qs.get(k) or [None])[0] for k in ("code", "state", "error", "iss")})
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400
@@ -255,7 +255,7 @@ def cancel_flow(session_id: str, server_name: str, hermes_home: str) -> Dict[str
 
 def deliver_callback_flow(
     session_id: str, server_name: str, *, code: Optional[str], state: Optional[str],
-    error: Optional[str] = None) -> Dict[str, Any]:
+    error: Optional[str] = None, iss: Optional[str] = None) -> Dict[str, Any]:
     """Relay a client-captured OAuth redirect into a session's flow (remote-backend companion
     to ``start_flow(client_redirect_uri=...)``); ``deliver_callback`` still verifies ``state``
     and rejects replays. Returns ``{ok: true}`` or ``{ok: false, error_message}``."""
@@ -263,7 +263,7 @@ def deliver_callback_flow(
     if rec is None:
         return {"ok": False, "error_message": err}
     try:
-        rec["flow"].deliver_callback(code=code, state=state, error=error)
+        rec["flow"].deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         return {"ok": False, "error_message": str(exc)}
     return {"ok": True, "session_id": session_id}

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1318,11 +1318,11 @@ def _(rid, params: dict) -> dict:
 
 @_mcp_rpc("oauth.callback", _NAME_SESSION)
 def _(rid, params: dict) -> dict:
-    """Relay a client-captured redirect (``code``/``state``/``error``) into a ``client_redirect_uri`` flow."""
-    code, state, error = (str(params.get(k) or "") or None for k in ("code", "state", "error"))
+    """Relay a client-captured redirect (``code``/``state``/``error``/``iss``) into a ``client_redirect_uri`` flow."""
+    code, state, error, iss = (str(params.get(k) or "") or None for k in ("code", "state", "error", "iss"))
     deliver = _tools_mod("tui_gateway.mcp_oauth_sessions").deliver_callback_flow
     return _ok(rid, deliver(
-        _str_arg(params, "session_id"), _str_arg(params, "name"), code=code, state=state, error=error))
+        _str_arg(params, "session_id"), _str_arg(params, "name"), code=code, state=state, error=error, iss=iss))
 
 
 # ─── Plugins ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Summary

Fixes #105895.

When an MCP authorization server advertises `authorization_response_iss_parameter_supported: true` (RFC 9207, e.g. Cloudflare MCP), the MCP SDK validates that the authorization response contains the matching `iss` parameter.

While the local loopback listener captured and passed `iss` into `_authorization_code_result`, the dashboard flow (`DashboardOAuthFlow`), the CLI web router (`/api/mcp/oauth/callback/{server_name:path}`), and the TUI gateway session relay (`deliver_callback_flow` and `@_mcp_rpc("oauth.callback")`) dropped `iss`. As a result, `_authorization_code_result` received `iss=None`, causing OAuth authentication to fail with:
> `Authorization response missing iss parameter advertised by the authorization server`

### Changes

1. **`tools/mcp_dashboard_oauth.py`**:
   - Accept optional `iss: str | None = None` in `DashboardOAuthFlow.deliver_callback()`.
   - Store 3-tuple `(code, state, iss)` when `iss` is provided, while preserving 2-tuple `(code, state)` when `iss is None` for strict backward compatibility with callers asserting 2-tuples.
2. **`tools/mcp_oauth.py`**:
   - Extract `iss` when unpacking `dashboard_flow.wait_for_callback()` results.
   - Provide a `NamedTuple` fallback in `_authorization_code_result` for `mcp < 2.0` environments so attribute access (`.code`, `.state`, `.iss`) behaves identically.
3. **`hermes_cli/web_routers/mcp.py`**:
   - Accept optional `iss: Optional[str] = None` query parameter in `/api/mcp/oauth/callback/{server_name:path}` and forward it to `flow.deliver_callback()`.
4. **`tui_gateway/mcp_oauth_sessions.py` & `tui_gateway/methods_tools.py`**:
   - Forward `iss` in loopback query string parsing, `deliver_callback_flow()`, and the RPC handler `oauth.callback`.
5. **Tests**:
   - Added unit test in `tests/tools/test_mcp_dashboard_oauth.py` verifying `iss` is preserved through dashboard flow.
   - Added unit test in `tests/tui_gateway/test_mcp_oauth_client_callback.py` verifying `iss` forwarding in gateway callback flow.
   - Added route test in `tests/hermes_cli/test_mcp_dashboard_oauth.py` verifying `/api/mcp/oauth/callback/cloudflare?code=...&state=...&iss=...` delivers `iss`.

### Verification

- Ran `pytest tests/tools/test_mcp_dashboard_oauth.py tests/tui_gateway/test_mcp_oauth_client_callback.py tests/hermes_cli/test_mcp_dashboard_oauth.py` -> 30/30 passed.
