### PR TITLE
fix(models): list Opus 5 and Fable 5.1 on the native Anthropic picker

### DIFF
--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -200,7 +200,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "minimax-oauth": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
     "minimax-cn": list(_MINIMAX_MODELS),
     "anthropic": [
-        "claude-fable-5", "claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6",
+        "claude-fable-5.1", "claude-fable-5", "claude-opus-5", "claude-sonnet-5",
+        "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6",
         "claude-sonnet-4-6", "claude-opus-4-5-20251101", "claude-sonnet-4-5-20250929",
         "claude-opus-4-20250514", "claude-sonnet-4-20250514", "claude-haiku-4-5-20251001",
     ],

--- a/tests/hermes_cli/test_anthropic_picker_curated.py
+++ b/tests/hermes_cli/test_anthropic_picker_curated.py
@@ -16,18 +16,38 @@ from unittest.mock import patch
 from hermes_cli import models as M
 
 
+def test_anthropic_native_list_keeps_aggregator_flagships():
+    """Native Anthropic must list the same current flagships OpenRouter/Nous already ship.
+
+    Aggregator catalogs get the new aliases first; the native curated list is what
+    `/model` falls back to when live `/v1/models` lags or 401s. Newest-first order
+    is the contract that keeps Fable 5.1 / Opus 5 from hiding behind older 4.x ids.
+    """
+    or_ids = {mid for mid, _ in M.OPENROUTER_MODELS}
+    native = M._PROVIDER_MODELS["anthropic"]
+    for slug in ("claude-fable-5.1", "claude-opus-5"):
+        assert f"anthropic/{slug}" in or_ids
+        assert slug in native
+    assert native.index("claude-fable-5.1") < native.index("claude-fable-5")
+    assert native.index("claude-opus-5") < native.index("claude-opus-4-8")
+
+
 def test_anthropic_curated_alias_survives_when_live_omits_it():
     """A curated alias missing from /v1/models still surfaces (first)."""
     curated = M._PROVIDER_MODELS["anthropic"]
+    assert "claude-fable-5.1" in curated  # sanity: newest Fable alias is curated
     assert "claude-fable-5" in curated  # sanity: the alias is curated
+    assert "claude-opus-5" in curated  # sanity: native flagship matches aggregators
     assert "claude-sonnet-5" in curated  # newest Sonnet alias is curated
 
-    # Live catalog the API would actually return — no fable-5.
+    # Live catalog the API would actually return — no fable-5.1 / opus-5.
     live = ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
     with patch.object(M, "_fetch_anthropic_models", return_value=live):
         result = M.provider_model_ids("anthropic")
 
+    assert "claude-fable-5.1" in result
     assert "claude-fable-5" in result
+    assert "claude-opus-5" in result
     assert "claude-sonnet-5" in result
     # Curated order is preserved at the front.
     assert result[:len(curated)] == list(curated)
@@ -48,7 +68,8 @@ def test_anthropic_merge_dedupes_overlap_and_appends_live_only():
     # Live-only entry is preserved (discovery still works for unknown models).
     assert "claude-future-9-99" in result
     # Curated entries lead, live-only trails.
-    assert result.index("claude-fable-5") < result.index("claude-future-9-99")
+    assert result.index("claude-fable-5.1") < result.index("claude-future-9-99")
+    assert result.index("claude-opus-5") < result.index("claude-future-9-99")
 
 
 def test_anthropic_falls_back_to_curated_when_live_unavailable():
@@ -57,4 +78,6 @@ def test_anthropic_falls_back_to_curated_when_live_unavailable():
         result = M.provider_model_ids("anthropic")
 
     assert result == list(M._PROVIDER_MODELS["anthropic"])
+    assert "claude-fable-5.1" in result
+    assert "claude-opus-5" in result
     assert "claude-fable-5" in result


### PR DESCRIPTION
## Summary
- Native Anthropic `/model` falls back to `_PROVIDER_MODELS["anthropic"]` when live `/v1/models` lags or 401s (Claude Pro/Max OAuth). That list still stopped at Fable 5 / Sonnet 5, so Opus 5 and Fable 5.1 never appeared even though both already work when addressed directly and already ship on OpenRouter / Nous.
- Adds `claude-fable-5.1` and `claude-opus-5` to the native Anthropic curated list, newest-first, so the merge/fallback path surfaces them the same way it already surfaces Fable 5.

Older attempts (#91678, #102688) patched `hermes_cli/models.py` after the catalog moved to `models_catalog_static.py`, so they cannot land.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_anthropic_picker_curated.py` — 4 passed
- [x] New relationship test is red on the pre-fix catalog (`claude-fable-5.1` / `claude-opus-5` absent) and green after the list update
- [ ] In `/model` with an Anthropic API key (and with OAuth if available): Opus 5 and Fable 5.1 show in the Anthropic list without needing OpenRouter/Nous
- [ ] Selecting either id still starts a session (`hermes --provider anthropic -m claude-opus-5` / `claude-fable-5.1`)