### PR TITLE
fix(desktop): route project writes to the live profile in All profiles

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -13,8 +13,10 @@ import {
   $projectsRpcAvailable,
   $projectTree,
   $worktreeRefreshToken,
+  addProjectFolder,
   ALL_PROJECTS,
   createProject,
+  deleteProject,
   enterProject,
   exitProjectScope,
   fetchProjectSessions,
@@ -27,7 +29,8 @@ import {
   refreshWorktrees,
   resolveNewSessionCwd,
   scanAndRecordRepos,
-  startWorkInRepo
+  startWorkInRepo,
+  updateProject
 } from './projects'
 import {
   $removedSessionIds,
@@ -496,6 +499,78 @@ describe('createProject', () => {
       'sidebar.projects.staleBackend'
     )
     expect($projectsRpcAvailable.get()).toBe(false)
+  })
+})
+
+describe('project writes while viewing all profiles', () => {
+  const project = {
+    folders: [],
+    id: 'p_1',
+    name: 'Warsongs',
+    primary_path: '/srv/ws',
+    color: null as null | string,
+    icon: null as null | string
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    $activeProjectId.set(null)
+    $projectsRpcAvailable.set(null)
+    $projects.set([project])
+    $projectTree.set([
+      { id: project.id, label: project.name, path: project.primary_path, color: null, icon: null, repos: [], sessionCount: 0 }
+    ])
+    $activeGatewayProfile.set('default')
+    setShowAllProfiles(false)
+  })
+
+  afterEach(() => {
+    setShowAllProfiles(false)
+    $activeGatewayProfile.set('default')
+  })
+
+  it.each(['default', 'coder'])('updates appearance in the active %s profile without leaving All profiles', async profile => {
+    const request = vi.fn().mockResolvedValue({})
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+    $activeGatewayProfile.set(profile)
+    setShowAllProfiles(true)
+
+    await expect(updateProject(project.id, { color: '#ff0000' })).resolves.toBeUndefined()
+
+    expect(request).toHaveBeenCalledWith(
+      'projects.update',
+      expect.objectContaining({ profile, id: project.id, color: '#ff0000' })
+    )
+    expect($profileScope.get()).toBe(ALL_PROFILES)
+    expect($projects.get()).toEqual([expect.objectContaining({ id: project.id, color: '#ff0000' })])
+  })
+
+  it.each(['default', 'coder'])('adds a folder in the active %s profile without leaving All profiles', async profile => {
+    const request = vi.fn().mockResolvedValue({})
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+    $activeGatewayProfile.set(profile)
+    setShowAllProfiles(true)
+
+    await expect(addProjectFolder(project.id, '/srv/ws/extra')).resolves.toBeUndefined()
+
+    expect(request).toHaveBeenCalledWith(
+      'projects.add_folder',
+      expect.objectContaining({ profile, id: project.id, path: '/srv/ws/extra' })
+    )
+    expect($profileScope.get()).toBe(ALL_PROFILES)
+  })
+
+  it.each(['default', 'coder'])('deletes a project in the active %s profile without leaving All profiles', async profile => {
+    const request = vi.fn().mockResolvedValue({ active_id: null, projects: [], scoped_session_ids: [] })
+    activeGateway.mockReturnValue({ connectionState: 'open', request } as never)
+    $activeGatewayProfile.set(profile)
+    setShowAllProfiles(true)
+
+    await expect(deleteProject(project.id)).resolves.toBeUndefined()
+
+    expect(request).toHaveBeenCalledWith('projects.delete', expect.objectContaining({ profile, id: project.id }))
+    expect($profileScope.get()).toBe(ALL_PROFILES)
+    expect($projects.get()).toEqual([])
   })
 })
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -285,6 +285,17 @@ export function projectProfile(): null | string {
   return $profileScope.get() === ALL_PROFILES || profile === ALL_PROFILES ? null : profile
 }
 
+// All profiles filters the sidebar. Writes still belong to the live gateway profile.
+function writableProjectProfile(): string {
+  const profile = normalizeProfileKey($activeGatewayProfile.get())
+
+  if (!profile || profile === ALL_PROFILES) {
+    throw new Error('Projects are unavailable while viewing all profiles')
+  }
+
+  return profile
+}
+
 function projectParams(
   params: Record<string, unknown> = {},
   profile: null | string = projectProfile()
@@ -878,7 +889,7 @@ export async function createProject(input: CreateProjectInput): Promise<ProjectI
   try {
     // All profiles filters the sidebar, not the owner of a new project.
     // Capture the live route so reconnecting cannot retarget the write.
-    const context = await activeProjectsContext(normalizeProfileKey($activeGatewayProfile.get()))
+    const context = await activeProjectsContext(writableProjectProfile())
 
     res = await gatewayRequestOn<{ project: ProjectInfo | null }>(
       context.gateway,
@@ -961,6 +972,7 @@ export async function updateProject(
   id: string,
   patch: { name?: string; color?: null | string; icon?: null | string }
 ): Promise<void> {
+  const context = await activeProjectsContext(writableProjectProfile())
   const snap = snapshotProjects()
 
   $projectTree.set(
@@ -980,14 +992,18 @@ export async function updateProject(
   // Backend treats null/undefined as "leave unchanged"; "" clears (stores NULL).
   // Map explicit null → "" so "no color"/"no icon" actually clear.
   await persistOrRollback(snap, () =>
-    gatewayRequest(
+    gatewayRequestOn(
+      context.gateway,
       'projects.update',
-      projectParams({
-        id,
-        ...patch,
-        ...(patch.color === null && { color: '' }),
-        ...(patch.icon === null && { icon: '' })
-      })
+      projectParams(
+        {
+          id,
+          ...patch,
+          ...(patch.color === null && { color: '' }),
+          ...(patch.icon === null && { icon: '' })
+        },
+        context.profile
+      )
     )
   )
 }
@@ -1029,6 +1045,7 @@ export async function addProjectFolder(
   path: string,
   opts: { label?: string; isPrimary?: boolean } = {}
 ): Promise<void> {
+  const context = await activeProjectsContext(writableProjectProfile())
   const snap = snapshotProjects()
   const trimmed = path.trim()
 
@@ -1059,9 +1076,10 @@ export async function addProjectFolder(
   }
 
   await persistOrRollback(snap, () =>
-    gatewayRequest(
+    gatewayRequestOn(
+      context.gateway,
       'projects.add_folder',
-      projectParams({ id, path, label: opts.label, is_primary: opts.isPrimary ?? false })
+      projectParams({ id, path, label: opts.label, is_primary: opts.isPrimary ?? false }, context.profile)
     )
   )
   reconcileProjects()
@@ -1086,6 +1104,7 @@ function openSessionBelongsToProject(projectId: string, projects: ProjectInfo[])
 // clicked (the entered-scope effect exits if you deleted the project you were
 // inside), reconciling from the server payload. A failed delete restores both.
 export async function deleteProject(id: string): Promise<void> {
+  const context = await activeProjectsContext(writableProjectProfile())
   const snap = snapshotProjects()
   // Capture membership BEFORE removal — the project's folders (which determine
   // ownership) are gone once it's dropped from the cache.
@@ -1105,13 +1124,26 @@ export async function deleteProject(id: string): Promise<void> {
   }
 
   await persistOrRollback(snap, async () => {
-    applyPayload(await gatewayRequest<ProjectsPayload>('projects.delete', projectParams({ id })))
+    applyPayload(
+      await gatewayRequestOn<ProjectsPayload>(
+        context.gateway,
+        'projects.delete',
+        projectParams({ id }, context.profile)
+      )
+    )
   })
   void refreshProjectTree()
 }
 
 export async function setActiveProject(id: null | string): Promise<void> {
-  const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', projectParams({ id }))
+  const context = await activeProjectsContext(writableProjectProfile())
+
+  const res = await gatewayRequestOn<{ active_id: null | string }>(
+    context.gateway,
+    'projects.set_active',
+    projectParams({ id }, context.profile)
+  )
+
   $activeProjectId.set(res.active_id ?? null)
 }
 


### PR DESCRIPTION
## Bug Description

With **Show all profiles** on, project Appearance (and rename, add-folder, delete) throws `Projects are unavailable while viewing all profiles` before RPC. The picker paints, then rolls back. Households that keep All profiles on for Bots cannot change color/icon.

Related to #94738. Create already works in this view via #106189.

## Root Cause

`projectProfile()` is `null` while All profiles is a sidebar filter. Default `projectParams()` throws. `createProject` already captures `$activeGatewayProfile` instead. Other writes still used the read-scope helper.

## Fix

- Add `writableProjectProfile()` (live gateway profile, never All profiles).
- Route `updateProject`, `addProjectFolder`, `deleteProject`, and `setActiveProject` through `activeProjectsContext(writableProjectProfile())`, same as create.
- Keep `projectProfile()` for reads.

This is the opposite of #96272 (hide the menus). After this lands, hiding is unnecessary.

## How to Verify

1. Turn **Show all profiles** on.
2. Open a project kebab → Appearance. Pick a color.
3. The color stays. All profiles stays on.
4. Rename, Add folder, and Delete also persist.

## Test Plan

- [x] Added regression tests for update / add-folder / delete while All profiles is on
- [x] `npx vitest run --project ui src/store/projects.test.ts` → 50 passed
- [x] `npx eslint src/store/projects.ts src/store/projects.test.ts` → clean

## Risk Assessment

Low — write RPCs already take `profile`. Create already used this route. Reads still refuse All profiles as a write target.

## AI assistance disclosure

Implementation and verification used Hermes Agent. Reported commands ran on this branch.