### PR TITLE
fix(mcp): SO_REUSEADDR on adopted OAuth callback reservations (Errno 98 after consent)

### DIFF
--- a/tests/tools/test_mcp_oauth_port_reentry.py
+++ b/tests/tools/test_mcp_oauth_port_reentry.py
@@ -1,0 +1,125 @@
+"""A completed OAuth callback flow on a pinned port must not wedge the next flow (#73997).
+
+`hermes mcp login` against servers with a pinned callback port (CIMD or a configured
+``oauth.redirect_port``) failed with ``Errno 98 Address already in use`` on the SECOND
+authorization attempt — right after the user had consented and the code WAS delivered.
+
+Mechanism (verified empirically, mcp 2.0.0, Linux): the consent tab often holds its side
+of the callback connection open past the waiter's ``server_close()`` (the waiter polls the
+result at 0.5s and closes the listener as soon as the code lands, while the browser is
+still sending/receiving). The server then performs the ACTIVE close of the accepted
+connection, leaving it in TIME_WAIT (or FIN-WAIT while the peer drains). On the adopted-
+reservation path (pinned ports) the listener socket came from ``_bind_reserved``, which
+set no ``SO_REUSEADDR`` — and Linux only honours a ``SO_REUSEADDR`` rebind against a
+TIME_WAIT socket when the socket that created that TIME_WAIT itself had the flag set.
+The next flow's bind on the same pinned port therefore fails for the whole ~60s window
+and the re-entered authorization is lost.
+"""
+
+import asyncio
+import socket
+import threading
+import time
+
+import pytest
+
+pytest.importorskip(
+    "mcp.client.auth.oauth2",
+    reason="MCP SDK 1.26.0+ required for OAuth support",
+)
+
+import tools.mcp_oauth as mod
+from tools.mcp_oauth import _make_callback_handler, _make_callback_waiter
+
+# Port mechanics use a free port rather than the real CIMD range: test files run as
+# concurrent subprocesses and the pinned range is bound for real by _pick_cimd_port.
+
+
+def _hit_callback_when_ready(url: str, timeout: float = 15.0, hold_open: float = 1.2) -> None:
+    """Consent tab: GET the callback once it answers and hold the socket open (late close)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            s = socket.create_connection((socket.parse_ns(f"//{url.split('/')[2]}").host
+                                          if False else "127.0.0.1",
+                                          int(url.split(":")[2].split("/")[0])), timeout=5)
+            break
+        except OSError:
+            time.sleep(0.01)
+    else:
+        raise AssertionError(f"callback listener never came up: {url}")
+    s.sendall(b"GET /callback?code=abc123&state=xyz HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n")
+    time.sleep(hold_open)  # browser tab lingers past the waiter's server_close()
+    try:
+        s.recv(4096)
+    except OSError:
+        pass
+    s.close()
+
+
+def _complete_flow_on(port: int) -> None:
+    """One full callback flow: reserve -> adopt/listen -> consent round-trip -> waiter's finally."""
+    assert mod._bind_reserved(port) == port
+    waiter = _make_callback_waiter(port)
+
+    async def _drive():
+        threading.Thread(
+            target=_hit_callback_when_ready,
+            args=(f"http://127.0.0.1:{port}/callback?code=abc123&state=xyz",),
+            daemon=True,
+        ).start()
+        return await asyncio.wait_for(waiter(), timeout=20)
+
+    outcome = asyncio.run(_drive())
+    assert outcome.code == "abc123"
+
+
+@pytest.fixture
+def private_port():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+class TestCompletedFlowPortIsImmediatelyReusable:
+    """The port a completed flow listened on is rebindable by the next flow immediately."""
+
+    def test_second_flow_after_completed_flow_binds_the_same_pinned_port(
+        self, private_port, monkeypatch
+    ):
+        """RED on base: the adopted reserved socket carries no SO_REUSEADDR, so the TIME_WAIT
+        its completed connection leaves behind makes the next bind fail EADDRINUSE for the
+        full kernel window — the 'port already in use' failure right after successful consent.
+        """
+        port = private_port
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        monkeypatch.setattr(mod, "_raise_if_non_interactive", lambda lead: None)
+
+        _complete_flow_on(port)
+
+        # Flow B (re-entry / next login attempt) starts immediately on the SAME port.
+        assert mod._bind_reserved(port) == port  # must not raise
+        handler_cls, _result = _make_callback_handler()
+        server = mod._start_callback_server(port, handler_cls)  # EADDRINUSE on base
+        try:
+            assert server.server_address[1] == port
+        finally:
+            server.server_close()
+
+    def test_completed_flow_releases_the_port_for_a_plain_bind(self, private_port, monkeypatch):
+        """The waiter's finally must leave the port bindable (SO_REUSEADDR on) immediately,
+        even when the consent tab holds its connection open past server_close."""
+        port = private_port
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        monkeypatch.setattr(mod, "_raise_if_non_interactive", lambda lead: None)
+
+        _complete_flow_on(port)
+
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            probe.bind(("127.0.0.1", port))  # EADDRINUSE on base
+        finally:
+            probe.close()

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -118,8 +118,20 @@ _MAX_RESERVED_SOCKETS = 8
 def _bind_reserved(port: int) -> int | None:
     """Bind ``127.0.0.1:port`` (0 = ephemeral) and park it until the waiter adopts it; None if taken.
     The cap evicts ephemeral parks only: losing a pinned CIMD port (the only ones the published
-    document declares) mid-flow would reopen the race."""
+    document declares) mid-flow would reopen the race.
+
+    SO_REUSEADDR is set BEFORE binding: once the waiter adopts this socket it becomes the
+    callback listener, and if the consent tab holds its connection open past the waiter's
+    ``server_close()`` the server-side close is the active one — leaving the connection in
+    TIME_WAIT keyed to this socket. Linux only allows a ``SO_REUSEADDR`` rebind against a
+    TIME_WAIT socket when the socket that created that TIME_WAIT itself had the flag set,
+    so a listener adopted from a plain (flag-less) socket wedges the port against the next
+    flow for the whole kernel window (#73997): the re-entered authorization right after a
+    successful consent dies with ``Errno 98``. The raw-bind path sets the same flag via
+    ``allow_reuse_address`` in ``_start_callback_server``; this keeps the adopted path equal.
+    """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     try:
         sock.bind(("127.0.0.1", port))
     except OSError:


### PR DESCRIPTION
# Fix MCP OAuth login: completed flow wedges its pinned callback port (Errno 98 on re-entry)

Fixes #73997. Same failure class as #99442, #103633 (second authorization block + errno 98 after consent; the code is delivered but no token lands).

## Symptom

`hermes mcp login <server>` against an OAuth server with a pinned callback port (CIMD's 27890–27894, or a configured `oauth.redirect_port`) aborts right after the user completes consent:

```
✗ Authentication failed: OAuth callback port 27890 is already in use ([Errno 98] Address already in use).
  Close any other in-progress login, or set a free `oauth.redirect_port` in the server config, then retry.
```

The consent IS granted and the authorization code IS delivered to the callback listener — then a second `MCP OAuth: authorization required.` block prints and the flow dies. No token file is written.

Reproduced 4× on 2026-09-09 against `https://mcp.fanvue.com/mcp` (single process, one flow, two authorization URLs, exit with errno 98):

```
  MCP OAuth: authorization required.
  Open this URL in your browser:
    https://auth.mcp.fanvue.com/oauth2/auth?...&redirect_uri=http%3A%2F%2F127.0.0.1%3A27890%2Fcallback&state=Fa0tm2...
  (Browser opened automatically.)

  Or paste the redirect URL here (or the ``?code=...&state=...`` portion) and press Enter. ...

  MCP OAuth: authorization required.          <- re-entry, new state
  Open this URL in your browser:
    https://auth.mcp.fanvue.com/oauth2/auth?...&state=YryMD9Zz...

  ✗ Authentication failed: OAuth callback port 27890 is already in use ([Errno 98] Address already in use).
```

The authorization server itself is healthy (RFC 8414 metadata served; the re-entry is client-side).

## Root cause (two halves, one defect)

**Half 1 — why the second bind fails (Hermes side, this PR).**

`_bind_reserved()` (`tools/mcp_oauth.py`) parked the selection-time reservation socket WITHOUT `SO_REUSEADDR`. When the callback waiter adopts that socket (`_start_callback_server()` pops it from `_reserved_sockets` and swaps it in as `server.socket`), the resulting listener — and the accepted callback connection's TIME_WAIT state after close — carries NO reuse flag. On Linux, a bind with `SO_REUSEADDR` against a TIME_WAIT socket succeeds only when the socket that created that TIME_WAIT itself had the flag set. The raw-bind path (explicit `oauth.redirect_port`) sets `allow_reuse_address = True` before `server_bind()`; the adopted path (pinned CIMD ports — the default for every CIMD-eligible server) does not, so the port stays un-rebindable for the full ~60s kernel window.

Empirically isolated (Linux, same process): a completed callback flow whose consent tab holds its connection open past the waiter's `server_close()` (the waiter polls the result at 0.5s; a real browser tab closes late) leaves the server side doing the active close → `TIME-WAIT` on the pinned port → the immediate rebind via `_start_callback_server()` raises `OSError 98`; the same flow on a listener that had `SO_REUSEADDR` set rebinds instantly. Red→green is exactly this delta.

**Half 2 — why the flow re-enters authorization at all (SDK side, NOT patched here).**

After the callback delivers the code, the SDK's `async_auth_flow` (mcp 2.0.0, `mcp/client/auth/oauth2.py`) runs the token exchange (`_handle_token_response`, line ~747). When the exchange fails — e.g. a transient 4xx from the provider, an `invalid_client` (issue #73997's case), or any non-2xx — the raised `OAuthTokenError` propagates to the transport layer, and the surrounding reconnect machinery retries the connection; a retried 401 makes the SDK call `_perform_authorization()` again (second authorization URL). With the retry now fixed (Half 1), the second flow binds successfully and can complete; with a genuinely terminal exchange error (bad credentials), the second flow surfaces the provider's real error instead of a bogus port-in-use. No Hermes-side retry loop exists (`_reauth_oauth_server` runs a single probe). An upstream SDK change is NOT required; the SDK's re-entry is legitimate OAuth retry behavior that must simply be allowed to rebind — which is what this PR restores.

## Fix

One line + rationale comment: set `SO_REUSEADDR` on the reservation socket in `_bind_reserved()` before binding, so a listener adopted from the reservation matches the raw-bind path's `allow_reuse_address` behavior.

Invariants preserved:
- **#22161 TOCTOU reservation guard**: untouched — the socket is still bound-but-not-listening from selection until adoption.
- **#44588/#34260 concurrent-flow isolation**: untouched — per-flow closures and per-port waiters unchanged.
- **#57836 non-interactive fail-fast**: untouched — both `_raise_if_non_interactive` boundaries unchanged.
- **No-park-on-auth-failure**: untouched — nothing in the park/reconnect ladder changed.
- `_pick_cimd_port` still holds pinned sockets until adoption; eviction cap still never evicts pinned ports.

## Test evidence

`tests/tools/test_mcp_oauth_port_reentry.py` (2 invariant tests, both RED on base, GREEN with the fix — run via `scripts/run_tests.sh`):

```
RED on base (unpatched):
✗ test_second_flow_after_completed_flow_binds_the_same_pinned_port — assert None == 42647
  (mod._bind_reserved(port) returned None: the reservation bind hit the TIME_WAIT port, EADDRINUSE)
✗ test_completed_flow_releases_the_port_for_a_plain_bind — OSError: [Errno 98] Address already in use

GREEN with fix:
✓ tests/tools/test_mcp_oauth_port_reentry.py (2✓)

Full OAuth + MCP surface after the fix:
✓ 10 files, 258 tests passed (test_mcp_oauth 59✓, test_mcp_cimd 50✓, test_mcp_tool 101✓,
  test_mcp_oauth_manager, test_mcp_oauth_integration, test_mcp_oauth_bidirectional,
  test_mcp_oauth_user_agent, test_mcp_oauth_metadata, test_mcp_oauth_cold_load_expiry,
  test_mcp_oauth_port_reentry) — 0 failed
```

The tests complete a REAL callback round-trip (reserve → adopt → HTTP GET with the consent-tab-late-close shape → waiter's finally) and then require the same pinned port to accept the next flow immediately — the behavior contract from #73997, not a change-detector.

## No SDK change required

Verified against the installed `mcp 2.0.0`: the SDK's re-entry into `_perform_authorization()` after a failed exchange is by design (retry with fresh authorization); once Hermes' pinned-port listener is re-bindable, that retry completes or surfaces the provider's real error. Do not patch the SDK in place.