### PR TITLE
fix(cli): heal the OpenCode base_url when the adopted model changes t…

### DIFF
--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -251,8 +251,10 @@ class CLIModelSwitchMixin:
                 current_model = canonical
                 changed = True
 
-        def _adopt_with_mode(normalize, api_mode_of, notice) -> bool:
-            """Provider families that also own the wire protocol: adopt id, then sync api_mode."""
+        def _adopt_with_mode(normalize, api_mode_of, notice, normalize_base_url=None) -> bool:
+            """Provider families that also own the wire protocol: adopt id, sync api_mode, and —
+            for families whose endpoint shape follows the wire — heal base_url through
+            ``normalize_base_url(api_mode, base_url)`` so the pair can never disagree."""
             nonlocal changed
             try:
                 _adopt(normalize(current_model), notice)
@@ -260,6 +262,14 @@ class CLIModelSwitchMixin:
                 if resolved_mode != self.api_mode:
                     self.api_mode = resolved_mode
                     changed = True
+                # Unconditional, not gated on the mode having just changed: the URL may already be
+                # desynced from an earlier adopt that moved the wire and left it behind (#105947).
+                current_base = getattr(self, "base_url", "") or ""
+                if normalize_base_url is not None and current_base:
+                    healed = normalize_base_url(self.api_mode, current_base)
+                    if healed and healed != current_base:
+                        self.base_url = healed
+                        changed = True
             except Exception:
                 pass
             return changed
@@ -284,13 +294,21 @@ class CLIModelSwitchMixin:
 
         from hermes_cli.models import opencode_provider_family
         if opencode_provider_family(resolved_provider) is not None:
-            from hermes_cli.models import normalize_opencode_model_id, opencode_model_api_mode
+            from hermes_cli.models import (
+                normalize_opencode_base_url, normalize_opencode_model_id, opencode_model_api_mode)
             return _adopt_with_mode(
                 lambda m: normalize_opencode_model_id(resolved_provider, m),
                 lambda m: opencode_model_api_mode(resolved_provider, m),
                 lambda new: (
                     f"Stripped provider prefix from '{current_model}'; "
-                    f"using '{new}' for {resolved_provider}."))
+                    f"using '{new}' for {resolved_provider}."),
+                # OpenCode's endpoint shape follows the wire: /v1 is stripped for
+                # anthropic_messages (the Anthropic SDK prepends its own) and must be re-appended
+                # for chat/codex models. Without healing it here, a session that passed through a
+                # Claude/Qwen model keeps the stripped URL and every later chat_completions model
+                # POSTs to https://opencode.ai/zen/chat/completions — the marketing site, 404 with
+                # an HTML body (#105947).
+                lambda mode, url: normalize_opencode_base_url(resolved_provider, mode, url))
 
         if resolved_provider != "openai-codex":
             return changed

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -238,6 +238,56 @@ class TestNormalizeModelForProvider:
         assert cli.model == "claude-sonnet-4-6"
         assert cli.api_mode == "anthropic_messages"
 
+    # -- #105947: OpenCode base_url must follow the adopted wire ---------------
+    #
+    # OpenCode's endpoint shape is a function of api_mode: `/v1` is stripped for
+    # anthropic_messages (the Anthropic SDK prepends its own `/v1/messages`) and carried for
+    # chat/codex models. `_adopt_with_mode` moved api_mode but left base_url behind, so a
+    # session that passed through a Claude/Qwen model kept the stripped URL and every later
+    # chat_completions model POSTed to https://opencode.ai/zen/chat/completions — the
+    # marketing site, answering 404 with an HTML body instead of a JSON API error.
+
+    def test_opencode_chat_model_heals_stripped_base_url(self):
+        """Adopting a chat_completions model re-appends the `/v1` the anthropic wire stripped."""
+        cli = _make_cli(model="opencode-zen/mimo-v2.5-free")
+        cli.api_mode = "anthropic_messages"
+        cli.base_url = "https://opencode.ai/zen"
+        changed = cli._normalize_model_for_provider("opencode-zen")
+        assert changed is True
+        assert cli.model == "mimo-v2.5-free"
+        assert cli.api_mode == "chat_completions"
+        assert cli.base_url == "https://opencode.ai/zen/v1"
+
+    def test_opencode_claude_strips_v1_from_base_url(self):
+        """The other direction: the Anthropic SDK prepends its own `/v1`, so ours must go."""
+        cli = _make_cli(model="opencode-zen/claude-sonnet-4-6")
+        cli.api_mode = "chat_completions"
+        cli.base_url = "https://opencode.ai/zen/v1"
+        changed = cli._normalize_model_for_provider("opencode-zen")
+        assert changed is True
+        assert cli.api_mode == "anthropic_messages"
+        assert cli.base_url == "https://opencode.ai/zen"
+
+    def test_opencode_heals_base_url_when_mode_already_matches(self):
+        """Healing is unconditional: the URL can be desynced from an EARLIER adopt, so a
+        no-op mode (and a model needing no prefix strip) must still repair it."""
+        cli = _make_cli(model="mimo-v2.5-free")
+        cli.api_mode = "chat_completions"
+        cli.base_url = "https://opencode.ai/zen"
+        changed = cli._normalize_model_for_provider("opencode-zen")
+        assert changed is True
+        assert cli.api_mode == "chat_completions"
+        assert cli.base_url == "https://opencode.ai/zen/v1"
+
+    def test_opencode_custom_proxy_base_url_untouched(self):
+        """A custom OPENCODE_*_BASE_URL proxy is not an opencode.ai host — never re-shape it."""
+        cli = _make_cli(model="opencode-zen/mimo-v2.5-free")
+        cli.api_mode = "anthropic_messages"
+        cli.base_url = "https://proxy.internal/zen"
+        cli._normalize_model_for_provider("opencode-zen")
+        assert cli.api_mode == "chat_completions"
+        assert cli.base_url == "https://proxy.internal/zen"
+
     def test_default_model_replaced(self):
         """No model configured (empty default) gets swapped for codex."""
         import cli as _cli_mod


### PR DESCRIPTION
## What does this PR do?

`_adopt_with_mode()` in `hermes_cli/cli_model_switch_mixin.py` syncs `api_mode` for provider families that own their wire protocol — but leaves `base_url` in whatever shape the **previous** mode required.

For OpenCode those two are not independent. `normalize_opencode_base_url()` strips `/v1` for `anthropic_messages` (the Anthropic SDK prepends its own `/v1/messages`) and carries it for chat/codex models; its docstring already states the transform **"Must be SYMMETRIC"**. `_adopt_with_mode()` only ever did half of it:

```python
resolved_mode = api_mode_of(current_model)
if resolved_mode != self.api_mode:
    self.api_mode = resolved_mode   # wire moves
    changed = True                  # base_url does not
```

So a session that passes through a Claude/Qwen model on `opencode-zen` keeps the stripped `https://opencode.ai/zen`, and every later `chat_completions` model POSTs to `https://opencode.ai/zen/chat/completions` — the marketing site, which answers **404 with an HTML body** instead of a JSON API error.

That matches #105947 exactly: the runtime resolver returns the correct `/zen/v1` all the way through (`opencode_zen_free_runtime()` → `normalize_opencode_base_url()`), yet the client is built with `/zen`, and the failure shows up on a `chat_completions` model. The URL was never corrupted downstream of the resolver — the CLI moved the wire without re-shaping the URL to match.

This is the same class of bug as the *"only minimax works on opencode-go"* regression already covered in `TestOpenCodeBaseUrlNormalization`, one layer up: there the normalizer itself was missing, here it exists and is correct but is never called on this path.

### Why this approach

Healing runs **unconditionally**, not gated on the mode having just changed — the URL can already be desynced from an *earlier* adopt that moved the wire and left it behind, which is the steady state a resumed session lands in. Gating it on `resolved_mode != self.api_mode` would leave exactly the reported case unfixed.

The normalizer is injected rather than hardcoded, so `_adopt_with_mode()` stays generic: Copilot (the other caller) passes nothing and is entirely unaffected.

## Related Issue

Fixes #105947

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/cli_model_switch_mixin.py` — `_adopt_with_mode()` takes an optional `normalize_base_url(api_mode, base_url)` callable and applies it on every adopt; the OpenCode branch passes `normalize_opencode_base_url(resolved_provider, ...)`.
- `tests/hermes_cli/test_codex_models.py` — four regression tests in `TestNormalizeModelForProvider`.

Scope guarantees:

- Custom `OPENCODE_*_BASE_URL` proxies are untouched — `normalize_opencode_base_url()` only re-shapes `opencode.ai` hosts, and there is a test pinning that.
- Copilot passes no normalizer; its behavior is unchanged.
- An empty/unset `base_url` is skipped, so nothing is fabricated for callers that never had one.

## How to Test

Reproduction of the reported failure, and proof the fix closes it:

```bash
# 3 of the 4 new tests fail on main, pass with this patch
git stash push hermes_cli/cli_model_switch_mixin.py   # revert the fix, keep the tests
pytest tests/hermes_cli/test_codex_models.py -k TestNormalizeModelForProvider -q
#   3 failed, 4 passed
git stash pop
pytest tests/hermes_cli/test_codex_models.py -k TestNormalizeModelForProvider -q
#   7 passed
```

The three that flip are the bug: a stripped `/zen` is not re-healed when a `chat_completions` model is adopted (both when the mode flips and when it already matches). The fourth (`test_opencode_custom_proxy_base_url_untouched`) passes either way by design — it is the guard against over-reaching onto self-hosted proxies.

Suites run locally (Linux, Python 3.11.15):

| Command | Result |
| --- | --- |
| `pytest tests/hermes_cli/test_codex_models.py tests/hermes_cli/test_model_validation.py -q` | 67 passed |
| `pytest` over the 7 OpenCode / model-switch suites (`test_model_switch_opencode_anthropic.py`, `test_opencode_zen_free_keyless.py`, `test_opencode_go_flat_namespace.py`, `test_custom_opencode_family_runtime.py`, `test_model_normalize.py`, `test_runtime_provider_resolution.py`, `test_25106_global_switch_persists_base_url_api_mode.py`) | 114 passed |
| `ruff check` on both changed files (repo-pinned config) | All checks passed |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not claimed.** I ran the targeted suites in the table above (181 tests, all passing) plus `ruff`; I did not run the entire `tests/` tree locally. Leaving this to CI.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (x86_64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the `_adopt_with_mode()` docstring now states the base_url contract; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, pure string/URL normalization with no platform-dependent behavior

---
_Generated by [Claude Code](https://claude.ai/code)_
