### PR TITLE
fix(cron): pass workdir to agent pre-run scripts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1967,7 +1967,12 @@ def _prepare_job_prompt(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path, cancel_event=cancel_event)
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job,
+            script_path,
+            workdir=_resolve_job_workdir(job, job_id),
+            cancel_event=cancel_event,
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info("Job '%s' (ID: %s): wakeAgent=false, skipping agent run", job_name, job_id)

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -320,3 +320,34 @@ class TestRunJobTerminalCwd:
         assert observed["terminal_cwd_during_run"] == baseline
         assert os.environ["TERMINAL_CWD"] == baseline
         assert get_session_cwd(observed["task_id"]) is None
+
+    def test_agent_prerun_script_receives_configured_workdir(
+        self, monkeypatch, tmp_path
+    ):
+        import cron.scheduler as sched
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        def run_script(job, script_path, workdir=None, cancel_event=None):
+            observed["script_workdir"] = workdir
+            return True, '{"wakeAgent": false}'
+
+        monkeypatch.setattr(
+            sched, "_run_job_script_with_claim_heartbeat", run_script
+        )
+        success, *_ = sched.run_job(
+            {
+                "id": "agent-script-workdir",
+                "name": "agent-script-workdir",
+                "prompt": "Review the project.",
+                "script": "collect.py",
+                "workdir": str(workdir),
+                "schedule_display": "manual",
+            }
+        )
+
+        assert success is True
+        assert observed["script_workdir"] == str(workdir)


### PR DESCRIPTION
## Summary
- pass the configured cron workdir to pre-run scripts for script-plus-agent jobs
- reuse the existing workdir validation already used by no-agent jobs
- add a regression proving the script runner receives the configured project directory

## Reproduction
A cron job with `script`, `workdir`, and `no_agent: false` launched its pre-run script from `HERMES_HOME/scripts`, while the later agent run used the configured workdir. Scripts that fail closed on repository identity therefore refused valid jobs.

## Tests
- focused regression: passed
- affected modules: 39 passed, 1 skipped
- unrelated existing Windows failure: `test_tilde_expands` assumes changing `HOME` changes `Path.expanduser("~")`; Windows uses the profile directory