### PR TITLE
fix(computer_use): gate element_token and scroll x/y on the live driver schema

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2272,6 +2272,69 @@ class TestElementTokenAttachment:
         assert backend._snapshot_tokens == {1: "snap2:1", 2: "snap2:2"}
 
 
+class TestSchemaIsTheInputGate:
+    """Current cua-driver (0.25.0) publishes no per-tool `capabilities[]` on tools/list but keeps
+    `additionalProperties: false` AND refuses a bare `element_index` (`snapshot_id_required`).
+    The live input schema — not the capability vocabulary — decides what the wrapper may send.
+    Drives the REAL `_CuaDriverSession` gate against a tools/list of that shape.
+    """
+
+    def _backend_with_live_session(self, tool_schemas):
+        from tools.computer_use.cua_backend import CuaDriverBackend
+        from tools.computer_use.cua_backend_session import _AsyncBridge, _CuaDriverSession
+
+        session = _CuaDriverSession(_AsyncBridge())
+        session._capabilities = {name: set() for name in tool_schemas}  # tools listed, no vocabulary
+        session._tool_schemas = tool_schemas
+        calls = []
+
+        def call_tool(name, args, **_):
+            calls.append((name, dict(args)))
+            return {"data": "ok", "images": [], "image_mime_types": [], "structuredContent": None, "isError": False}
+
+        session.call_tool = call_tool
+        backend = CuaDriverBackend()
+        backend._session = session
+        backend._active_pid, backend._active_window_id = 111, 222
+        return backend, calls
+
+    def test_element_token_rides_along_when_only_the_schema_declares_it(self):
+        backend, calls = self._backend_with_live_session({
+            "click": {"additionalProperties": False,
+                      "properties": {"element_index": {}, "element_token": {}, "snapshot_id": {}}},
+        })
+        backend._snapshot_tokens = {5: "s0001:5"}
+        backend.click(element=5)
+        (name, args), = calls
+        assert name == "click" and args["element_index"] == 5
+        assert args["element_token"] == "s0001:5"
+
+    def test_element_token_withheld_when_neither_schema_nor_capability_accepts_it(self):
+        backend, calls = self._backend_with_live_session({
+            "click": {"additionalProperties": False, "properties": {"element_index": {}}},
+        })
+        backend._snapshot_tokens = {5: "s0001:5"}
+        backend.click(element=5)
+        (_, args), = calls
+        assert "element_token" not in args
+
+    def test_scroll_coordinates_follow_the_live_schema(self):
+        backend, calls = self._backend_with_live_session({
+            "scroll": {"additionalProperties": False,
+                       "properties": {"direction": {}, "amount": {}, "x": {}, "y": {}}},
+        })
+        backend.scroll(direction="down", x=50, y=60)
+        (_, args), = calls
+        assert (args["x"], args["y"]) == (50, 60)
+
+        backend, calls = self._backend_with_live_session({
+            "scroll": {"additionalProperties": False, "properties": {"direction": {}, "amount": {}}},
+        })
+        backend.scroll(direction="down", x=50, y=60)
+        (_, args), = calls
+        assert "x" not in args and "y" not in args
+
+
 class TestSessionLifecycle:
     """Surface gap (audit June 2026): Hermes never declared a cua-driver
     session, so the agent-cursor overlay was inert and per-run state

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -354,10 +354,11 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
 
     def _action(self, name: str, args: Dict[str, Any], *, inject_session: bool = True) -> ActionResult:
         # Attach the snapshot's `element_token` to an `element_index` call so a superseded snapshot yields an explicit
-        # 'stale' error. Gated on the per-tool capability: older drivers (`additionalProperties: false`) must never see it.
+        # 'stale' error. Gated on the live schema (or the older capability vocabulary): drivers whose schema lacks it
+        # (`additionalProperties: false`) must never see it; current drivers REQUIRE it alongside element_index.
         idx = args.get("element_index")
         token = self._snapshot_tokens.get(idx) if isinstance(idx, int) else None
-        if token and self._session.supports_capability("accessibility.element_tokens", tool=name):
+        if token and self._session.accepts_input(name, "element_token", capability="accessibility.element_tokens"):
             args["element_token"] = token
         if inject_session:  # setdefault preserves any explicit session a caller already supplied
             args.setdefault("session", self._session_id)

--- a/tools/computer_use/cua_backend_input.py
+++ b/tools/computer_use/cua_backend_input.py
@@ -134,10 +134,10 @@ class _InputMixin:
         args.update(direction=direction, amount=max(1, min(50, amount)))
         # An element without a known window_id is not an addressing form here; scrolling then falls through
         # to the coordinate form or the bare window. Some driver schemas reject x/y on scroll: only send
-        # coordinates when the driver advertises support; otherwise it scrolls the targeted window
-        # (window_id is still sent for routing).
+        # coordinates when the live schema (or the older capability vocabulary) accepts them; otherwise it
+        # scrolls the targeted window (window_id is still sent for routing).
         xy = lambda: ({"x": x, "y": y}  # noqa: E731
-                      if self._session.supports_capability("input.scroll.coordinates", tool="scroll") else {})
+                      if self._session.accepts_input("scroll", "x", capability="input.scroll.coordinates") else {})
         refusal = self._pointer_args("scroll", args, (
             ("element scroll", {"element_index": element}
              if element is not None and self._active_window_id is not None else None),

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -373,6 +373,14 @@ class _CuaDriverSession:
         properties = schema.get("properties") if isinstance(schema, dict) else None
         return isinstance(properties, dict) and property_name in properties
 
+    def accepts_input(self, tool: str, property_name: str, capability: Optional[str] = None) -> bool:
+        """The driver takes *property_name* on *tool*: the live schema declares it, or the tool advertises
+        *capability*. The schema is the ground truth — current cua-driver (0.25.0) publishes no per-tool
+        capability lists on tools/list while `additionalProperties: false` still rejects undeclared args, so
+        a capability-only gate silently drops arguments the driver now requires (`snapshot_id_required`)."""
+        return self.supports_input_property(tool, property_name) or (
+            capability is not None and self.supports_capability(capability, tool=tool))
+
     @property
     def capabilities_discovered(self) -> bool:
         """tools/list populated the map; when False ``_has_tool`` is untrustworthy."""


### PR DESCRIPTION
## What does this PR do?

On a fresh install, every `computer_use` element action (`click(element=N)`, `scroll`, `set_value`) is refused by cua-driver with `snapshot_id_required: click: bare element_index is not accepted; pass element_token, or snapshot_id together with element_index`.

Root cause: current cua-driver (0.25.0 — what `hermes computer-use install` / the Hermes installer pull today) publishes **no per-tool `capabilities[]`** on `tools/list`, yet its input tool schemas declare `element_token` / `snapshot_id` / `x` / `y` with `additionalProperties: false`, and it now *requires* a token alongside `element_index`. Hermes only attached the token when the driver advertised `accessibility.element_tokens` (`tools/computer_use/cua_backend.py` `_action`), so the 200 tokens `capture()` had just cached were never sent. `scroll` had the same shape of gate on `input.scroll.coordinates` for `x`/`y`.

Fix: the live schema is the ground truth. `_CuaDriverSession.accepts_input(tool, property, capability=None)` accepts a property when the tool's schema declares it, falling back to the capability vocabulary for older drivers. Both call sites use it. Drivers whose schema lacks the property still never see it (the original `additionalProperties: false` concern is preserved). No tool-schema or behaviour change for the model.

## Related Issue

None found (searched open PRs/issues for `snapshot_id_required` / `element_token`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend_session.py` — new `accepts_input()` beside the existing `supports_input_property()` seam.
- `tools/computer_use/cua_backend.py` — `_action` attaches `element_token` via `accepts_input(name, "element_token", capability="accessibility.element_tokens")`.
- `tools/computer_use/cua_backend_input.py` — `scroll` sends `x`/`y` via `accepts_input("scroll", "x", capability="input.scroll.coordinates")`.
- `tests/tools/test_computer_use.py` — `TestSchemaIsTheInputGate`: three invariant tests driving the **real** `_CuaDriverSession` gate against a tools/list of the current shape (schema declares the property, empty capability set): token rides along; token withheld when neither schema nor capability accepts it; scroll x/y follow the schema. Red on base (`KeyError: 'element_token'`, `KeyError: 'x'`), green with the fix.

## How to Test

1. Ubuntu 24.04 (arm64 here, headless Sway, `computer_use.native_wayland: true`), `hermes computer-use install` → cua-driver 0.25.0; `hermes computer-use doctor` all green.
2. On `main`: `capture()` then `click(element=<button index>)` → `ok: false`, `snapshot_id_required`.
3. With this PR: same call → `Clicked element [7] (pid …)` (gedit's Open dialog opens); `set_value` on the text view lands; `scroll(coordinate=…)` forwards `x`/`y`.
4. `scripts/run_tests.sh tests/tools/test_computer_use*.py` → 16 files, 247 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs
- [x] Only changes related to this fix
- [x] Tests pass (`scripts/run_tests.sh tests/tools/test_computer_use*.py`)
- [x] Tests added (invariant tests, proven red on base)
- [x] Tested on my platform: Ubuntu 24.04 aarch64 (DGX Spark), headless Sway/Wayland, cua-driver 0.25.0

### Documentation & Housekeeping

- [x] Docs — N/A (internal gate; no user-facing behaviour or config change)
- [x] `cli-config.yaml.example` — N/A
- [x] `AGENTS.md` — N/A
- [x] Cross-platform: the gate is platform-independent (reads the driver's own tools/list); macOS/Windows drivers of the same version have the same schema shape
- [x] Tool descriptions/schemas — N/A (unchanged)
