### PR TITLE
fix(opencode-go): stop pairing reasoning_effort with DeepSeek reasoning_content echo-back on the Go relay (#106648)

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -81,7 +81,15 @@ class OpenCodeGoProfile(ProviderProfile):
                 return {}, {}
             return _thinking_toggle_extras(reasoning_config, re_.KIMI_K2_EFFORTS)
         if _is_deepseek_thinking_model(model):
-            return _thinking_toggle_extras(reasoning_config, re_.DEEPSEEK_V4_EFFORTS, re_.DEEPSEEK_V4_OVERRIDES)
+            # DeepSeek tool-call replays on the Go relay carry reasoning_content echo-back
+            # (model-substring echo rule), and the relay 400s when that echo co-occurs with
+            # any reasoning_effort — keep the explicit off switch, otherwise server default.
+            if (
+                isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            ):
+                return {"thinking": {"type": "disabled"}}, {}
+            return {}, {}
         return {}, {}
 
 

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -170,17 +170,78 @@ class TestOpenCodeGoKimiReasoning:
 
 
 class TestOpenCodeGoDeepSeekThinking:
-    """DeepSeek V4 models use DeepSeek-style thinking controls on OpenCode Go."""
+    """DeepSeek V4 thinking on the Go relay must not pair reasoning_effort with the
+    reasoning_content echo-back the relay rejects (HTTP 400 on the combination)."""
 
-
-    def test_xhigh_and_max_normalize_to_max(self, opencode_go_profile):
-        for effort in ("xhigh", "max"):
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "deepseek-v4-flash",
+            "deepseek/deepseek-v4-pro",
+            "deepseek-reasoner",
+        ],
+    )
+    def test_no_reasoning_effort_on_the_wire(self, opencode_go_profile, model):
+        for effort in ("low", "medium", "high", "xhigh", "max"):
             extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
                 reasoning_config={"enabled": True, "effort": effort},
-                model="deepseek/deepseek-v4-pro",
+                model=model,
             )
             assert extra_body == {}
-            assert top_level == {"reasoning_effort": "max"}
+            assert top_level == {}, (model, effort)
+
+    def test_unset_preserves_server_default(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+            model="deepseek-v4-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_disabled_still_emits_thinking_disabled(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="deepseek-v4-flash",
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    def test_transport_replay_has_no_reasoning_effort(self, opencode_go_profile):
+        """Regression for the relay 400: a DeepSeek tool-call replay (reasoning_content
+        echo-back in history) plus any reasoning_effort value is rejected by the Go
+        relay — the transport must no longer produce that combination."""
+        from agent.message_sanitization import matches_reasoning_echo_family
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        base_url = "https://opencode.ai/zen/go/v1"
+        messages = [
+            {"role": "user", "content": "ping"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": " ",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        ]
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="deepseek-v4-flash",
+            messages=messages,
+            tools=None,
+            provider_profile=opencode_go_profile,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url=base_url,
+        )
+        assert matches_reasoning_echo_family(
+            "deepseek", "opencode-go", "deepseek-v4-flash", base_url
+        ), "deepseek via opencode-go must be an echo family (repro preconditions)"
+        assert "reasoning_effort" not in kwargs
 
 
 class TestOpenCodeGoGLM52Reasoning:
@@ -238,7 +299,7 @@ class TestOpenCodeGoFullKwargsIntegration:
         assert "extra_body" not in kwargs
         assert kwargs["reasoning_effort"] == "high"
 
-    def test_deepseek_thinking_reaches_extra_body_and_top_level(
+    def test_deepseek_thinking_sends_no_effort_at_transport_level(
         self, opencode_go_profile
     ):
         from agent.transports.chat_completions import ChatCompletionsTransport
@@ -252,5 +313,5 @@ class TestOpenCodeGoFullKwargsIntegration:
             base_url="https://opencode.ai/zen/go/v1",
         )
         assert "extra_body" not in kwargs
-        assert kwargs["reasoning_effort"] == "high"
+        assert "reasoning_effort" not in kwargs
 


### PR DESCRIPTION
## Problem (#106648)

Long tool-call sessions on `opencode-go` with DeepSeek thinking models (`deepseek-v4-flash` and friends) die with a bare `HTTP 400` once the history contains `reasoning_content` echo-back replays. The reporter's replay matrix shows the relay rejects the request only when **both** `reasoning_content` echo-back and any `reasoning_effort` value are present.

## Root cause

Two independent policies collide on this provider:

- `agent/message_sanitization.py` `_REASONING_ECHO_RULES` — the `deepseek` echo family matches by **model substring** (`"deepseek"`), regardless of provider, so DeepSeek models served via `opencode-go` correctly get `reasoning_content` echo-back on tool-call replays.
- `plugins/model-providers/opencode-zen/__init__.py` `OpenCodeGoProfile.build_api_kwargs_extras()` — the DeepSeek thinking branch routed through `_thinking_toggle_extras()` and emitted a **top-level `reasoning_effort`** on the chat-completions path.

Repro on main (confirmed before the fix):

```python
ChatCompletionsTransport().build_kwargs(
    model="deepseek-v4-flash", messages=[...replay with reasoning_content...],
    provider_profile=<opencode-go>, reasoning_config={"enabled": True, "effort": "high"},
)  # -> {"reasoning_effort": "high", ...history still carries reasoning_content...}  -> relay 400
```

Note: the `supported_reasoning_efforts()` hook suggested in the issue is consulted by the Responses transport (`agent/transports/codex.py::_profile_declared_efforts`), but DeepSeek models on the Go relay route to **chat_completions** (`hermes_cli/models.py::_OPENCODE_API_MODE_PREFIXES`), where that hook is never called — hence the fix in the Go profile itself.

## Fix

For DeepSeek thinking models on the Go relay, stop emitting `reasoning_effort` entirely (the effort stays at the server default). The explicit `thinking: {"type": "disabled"}` switch is preserved — it is not part of the rejected combination and users rely on it to turn thinking off. Kimi-K2 and GLM-5.2 branches are untouched: neither is in an echo family, so their `reasoning_effort` remains safe.

## Tests

- `TestOpenCodeGoDeepSeekThinking` rewritten: no `reasoning_effort` on the wire for any requested effort across `deepseek-v4-flash` / `deepseek/deepseek-v4-pro` / `deepseek-reasoner`; unset config → server default; `enabled: False` still emits `thinking: disabled`.
- New transport-level regression: a DeepSeek tool-call replay (echo family active) plus `effort: high` must produce kwargs with **no** `reasoning_effort`.
- Full file green locally (32 passed); mutation back to the old branch turns the new tests red.