### PR TITLE
fix(profiles): copy config-map provider into named profile on model write

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -132,7 +132,9 @@ def _ensure_profile_provider_entry(
 
     Fail-open: no source dict, empty provider, or a same-named dest entry already
     present (keep the profile's local customization). Never invents a built-in
-    ``providers.<name>`` block. Returns the dest entry (existing or copied).
+    ``providers.<name>`` block. ``source_entry`` must be raw yaml (not
+    ``load_config`` expansion) and is deep-copied as-is. Returns the dest entry
+    (existing or copied).
     """
     from hermes_cli.config import find_provider_entry
 
@@ -148,14 +150,9 @@ def _ensure_profile_provider_entry(
         dest_providers = {}
         cfg["providers"] = dest_providers
     stored = source_key if source_key not in (None, "") else provider
-    copied = copy.deepcopy(source_entry)
-    # Raw yaml is preferred, but never persist an expanded secret if one slipped in.
-    api_key = copied.get("api_key")
-    if isinstance(api_key, str):
-        raw_key = api_key.strip()
-        if raw_key and not (raw_key.startswith("${") and raw_key.endswith("}")):
-            copied.pop("api_key", None)
-    dest_providers[stored] = copied
+    # Source is a raw-config snapshot (not load_config expansion): copy as-is,
+    # including inline api_key literals and ${VAR} templates (#88990).
+    dest_providers[stored] = copy.deepcopy(source_entry)
     return dest_providers[stored]
 
 

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -27,7 +27,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from fastapi import APIRouter, HTTPException, Query
 
 from hermes_cli.web_deps import late
-from hermes_cli.web_server_config import _apply_main_model_assignment, _normalize_main_model_assignment
+from hermes_cli.web_server_config import (
+    _apply_main_model_assignment,
+    _normalize_main_model_assignment,
+    _resolve_assignment_credentials,
+)
 from hermes_cli.web_server_gateway import _strip_session_list_rows
 from hermes_cli.web_server_profiles import (
     _fallback_profile_dicts, _hub_action_name, _write_profile_mcp_servers,
@@ -94,14 +98,133 @@ def _profile_setup_command(name: str) -> str:
     return "hermes setup" if name == "default" else f"{name} setup"
 
 
+def _outer_raw_providers() -> Any:
+    """Snapshot ``providers:`` from the caller's current home (before profile scope)."""
+    from hermes_cli.config import read_raw_config
+
+    try:
+        return read_raw_config().get("providers")
+    except Exception:
+        _log.debug("could not read source providers for profile model write", exc_info=True)
+        return None
+
+
+def _lookup_source_provider(source_providers: Any, *names: str) -> Tuple[Any, Optional[Dict[str, Any]]]:
+    """Return the first ``(stored_key, entry)`` matching any of *names* in the source map."""
+    from hermes_cli.config import find_provider_entry
+
+    seen: set[str] = set()
+    for name in names:
+        want = (name or "").strip()
+        if not want or want in seen:
+            continue
+        seen.add(want)
+        stored, entry = find_provider_entry(source_providers, want)
+        if isinstance(entry, dict):
+            return stored, entry
+    return None, None
+
+
+def _ensure_profile_provider_entry(
+    cfg: dict, provider: str, source_key: Any, source_entry: Any,
+) -> Optional[Dict[str, Any]]:
+    """Copy a config-map provider into the target profile when missing.
+
+    Fail-open: no source dict, empty provider, or a same-named dest entry already
+    present (keep the profile's local customization). Never invents a built-in
+    ``providers.<name>`` block. Returns the dest entry (existing or copied).
+    """
+    from hermes_cli.config import find_provider_entry
+
+    if not provider:
+        return None
+    _dest_key, dest_entry = find_provider_entry(cfg.get("providers"), provider)
+    if isinstance(dest_entry, dict):
+        return dest_entry
+    if not isinstance(source_entry, dict):
+        return None
+    dest_providers = cfg.get("providers")
+    if not isinstance(dest_providers, dict):
+        dest_providers = {}
+        cfg["providers"] = dest_providers
+    stored = source_key if source_key not in (None, "") else provider
+    copied = copy.deepcopy(source_entry)
+    # Raw yaml is preferred, but never persist an expanded secret if one slipped in.
+    api_key = copied.get("api_key")
+    if isinstance(api_key, str):
+        raw_key = api_key.strip()
+        if raw_key and not (raw_key.startswith("${") and raw_key.endswith("}")):
+            copied.pop("api_key", None)
+    dest_providers[stored] = copied
+    return dest_providers[stored]
+
+
+def _apply_profile_assignment_credentials(
+    model_cfg: dict, provider: str, dest_entry: Any, source_entry: Any,
+) -> None:
+    """Attach a raw ``key_env`` pointer like the main model-set path; never persist secrets."""
+    _resolve_assignment_credentials(model_cfg, provider, dest_entry)
+    # Target-scope ``read_raw_config()`` cannot see an entry we only just copied
+    # in memory; fall back to the outer-home raw dict (or the copied dest).
+    raw = dest_entry if isinstance(dest_entry, dict) else source_entry
+    if not isinstance(raw, dict):
+        return
+    key_env = str(raw.get("key_env") or "").strip()
+    if key_env and not str(model_cfg.get("key_env") or "").strip():
+        model_cfg["key_env"] = key_env
+        model_cfg.pop("api_key", None)
+    elif isinstance(raw.get("api_key"), str):
+        raw_key = raw["api_key"].strip()
+        if raw_key.startswith("${") and raw_key.endswith("}") and not model_cfg.get("api_key"):
+            model_cfg["api_key"] = raw_key
+
+
 def _write_profile_model(profile_dir: Path, provider: str, model: str) -> None:
     """Write the main model assignment into ``profile_dir``'s config.yaml (HERMES_HOME-scoped);
-    clears stale ``base_url`` / ``context_length`` like ``POST /api/model/set`` does."""
+    clears stale ``base_url`` / ``context_length`` like ``POST /api/model/set`` does.
+
+    Config-map providers (e.g. ``scnet``) are resolved from the caller's current home
+    *before* entering the target profile scope, then copied into the profile when
+    missing so agent init can ``resolve_provider()`` them (#106643).
+    """
     from hermes_cli.config import load_config, save_config
+
+    orig_provider = (provider or "").strip()
+    source_providers = _outer_raw_providers()
+
     with _hermes_home_scope(profile_dir):
         provider, model = _normalize_main_model_assignment(provider, model)
         cfg = load_config()
-        cfg["model"] = _apply_main_model_assignment(cfg.get("model", {}), provider, model)
+        dest_entry: Optional[Dict[str, Any]] = None
+        source_key, source_entry = None, None
+        try:
+            if provider and model:
+                source_key, source_entry = _lookup_source_provider(
+                    source_providers, provider, orig_provider,
+                )
+                dest_entry = _ensure_profile_provider_entry(
+                    cfg, provider, source_key, source_entry,
+                )
+        except Exception:
+            _log.exception(
+                "failed to copy provider %r into profile %s; continuing with model assignment",
+                provider, profile_dir,
+            )
+        base_url = ""
+        if isinstance(dest_entry, dict):
+            base_url = str(dest_entry.get("base_url") or "").strip()
+        model_cfg = _apply_main_model_assignment(
+            cfg.get("model", {}), provider, model, base_url, "",
+        )
+        try:
+            _apply_profile_assignment_credentials(
+                model_cfg, provider, dest_entry, source_entry,
+            )
+        except Exception:
+            _log.debug(
+                "profile assignment credentials skipped for %r", provider, exc_info=True,
+            )
+        cfg["model"] = model_cfg
         save_config(cfg)
 
 

--- a/tests/hermes_cli/test_write_profile_model_copies_provider_entry.py
+++ b/tests/hermes_cli/test_write_profile_model_copies_provider_entry.py
@@ -72,6 +72,37 @@ def test_copies_config_map_provider_from_outer_home(_isolate_hermes_home):
     assert "other" not in (written.get("providers") or {})
 
 
+def test_copies_literal_inline_api_key_without_key_env(_isolate_hermes_home):
+    """A raw inline ``api_key`` (no key_env) is a documented config-map form; copy it as-is."""
+    outer = get_hermes_home()
+    _write_yaml(
+        outer / "config.yaml",
+        {
+            "providers": {
+                "scnet": {
+                    "name": "scnet",
+                    "base_url": "https://api.scnet.cn/api/llm/v1",
+                    "api_key": "sk-test-literal",
+                    "discover_models": True,
+                }
+            }
+        },
+    )
+    profile_dir = _empty_profile_dir(outer)
+
+    _write_profile_model(profile_dir, "scnet", "GLM-5.3-Flash")
+
+    written = _read_yaml(profile_dir / "config.yaml")
+    scnet = (written.get("providers") or {}).get("scnet")
+    assert isinstance(scnet, dict), "target profile must contain providers.scnet"
+    assert scnet.get("api_key") == "sk-test-literal"
+    assert "key_env" not in scnet
+    assert scnet.get("base_url") == "https://api.scnet.cn/api/llm/v1"
+    model = written.get("model") or {}
+    assert isinstance(model, dict)
+    assert model.get("provider") == "scnet"
+
+
 def test_builtin_assignment_does_not_invent_providers_block(_isolate_hermes_home):
     """Built-in registry providers have no config-map entry; do not invent one."""
     outer = get_hermes_home()

--- a/tests/hermes_cli/test_write_profile_model_copies_provider_entry.py
+++ b/tests/hermes_cli/test_write_profile_model_copies_provider_entry.py
@@ -1,0 +1,116 @@
+"""Profile builder must copy a config-map provider into the named profile.
+
+``_write_profile_model`` writes ``model.provider`` / ``model.default`` inside
+the target profile's HERMES_HOME. Custom providers such as ``scnet`` live only
+in the caller's (outer) ``providers:`` map; without copying that entry, agent
+init raises ``Unknown provider 'scnet'``.
+
+Regression for #106643.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from hermes_constants import get_hermes_home
+from hermes_cli.web_routers.profiles import _write_profile_model
+
+_SCNET_ENTRY = {
+    "name": "scnet",
+    "base_url": "https://api.scnet.cn/api/llm/v1",
+    "key_env": "HERMES_CUSTOM_SCNET_API_KEY",
+    "discover_models": True,
+}
+
+
+def _write_yaml(path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _read_yaml(path) -> dict:
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return raw if isinstance(raw, dict) else {}
+
+
+def _empty_profile_dir(outer):
+    profile_dir = outer / "profiles" / "worker"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
+    return profile_dir
+
+
+def test_copies_config_map_provider_from_outer_home(_isolate_hermes_home):
+    """Outer ``providers.scnet`` must land in the target profile config."""
+    outer = get_hermes_home()
+    _write_yaml(
+        outer / "config.yaml",
+        {
+            "providers": {
+                "scnet": dict(_SCNET_ENTRY),
+                "other": {
+                    "name": "other",
+                    "base_url": "https://example.invalid/v1",
+                    "key_env": "HERMES_CUSTOM_OTHER_API_KEY",
+                },
+            }
+        },
+    )
+    profile_dir = _empty_profile_dir(outer)
+
+    _write_profile_model(profile_dir, "scnet", "GLM-5.3-Flash")
+
+    written = _read_yaml(profile_dir / "config.yaml")
+    scnet = (written.get("providers") or {}).get("scnet")
+    assert isinstance(scnet, dict), "target profile must contain providers.scnet"
+    assert scnet.get("base_url") == _SCNET_ENTRY["base_url"]
+    assert scnet.get("key_env") == _SCNET_ENTRY["key_env"]
+    model = written.get("model") or {}
+    assert isinstance(model, dict)
+    assert model.get("provider") == "scnet"
+    # Only the assigned provider is copied — not the rest of the outer map.
+    assert "other" not in (written.get("providers") or {})
+
+
+def test_builtin_assignment_does_not_invent_providers_block(_isolate_hermes_home):
+    """Built-in registry providers have no config-map entry; do not invent one."""
+    outer = get_hermes_home()
+    _write_yaml(outer / "config.yaml", {"model": {"provider": "openrouter", "default": "x"}})
+    profile_dir = _empty_profile_dir(outer)
+
+    _write_profile_model(profile_dir, "openrouter", "anthropic/claude-sonnet-4.6")
+
+    written = _read_yaml(profile_dir / "config.yaml")
+    providers = written.get("providers")
+    assert not providers, f"built-in assignment must not create providers, got {providers!r}"
+
+
+def test_existing_target_provider_entry_is_not_overwritten(_isolate_hermes_home):
+    """A named profile's local providers.scnet customization must be kept."""
+    outer = get_hermes_home()
+    _write_yaml(outer / "config.yaml", {"providers": {"scnet": dict(_SCNET_ENTRY)}})
+    profile_dir = _empty_profile_dir(outer)
+    _write_yaml(
+        profile_dir / "config.yaml",
+        {
+            "providers": {
+                "scnet": {
+                    "name": "keep-local-name",
+                    "base_url": "https://local.example/v1",
+                    "key_env": "LOCAL_SCNET_KEY",
+                    "models": ["kept-model"],
+                }
+            }
+        },
+    )
+
+    _write_profile_model(profile_dir, "scnet", "GLM-5.3-Flash")
+
+    written = _read_yaml(profile_dir / "config.yaml")
+    scnet = (written.get("providers") or {}).get("scnet") or {}
+    assert scnet.get("name") == "keep-local-name"
+    assert scnet.get("models") == ["kept-model"]
+    assert scnet.get("base_url") == "https://local.example/v1"
+    model = written.get("model") or {}
+    assert isinstance(model, dict)
+    assert model.get("provider") == "scnet"


### PR DESCRIPTION
## What does this PR do?

When the dashboard/desktop profile builder assigns a **config-map provider** (e.g. `scnet`) to a named profile, `_write_profile_model` previously wrote only `model.provider` / `model.default` (and credential pointers) inside the target profile's HERMES_HOME. The `providers.<name>` entry that actually defines the endpoint stayed in the caller's home, so agent init failed with `Unknown provider '<name>'`.

This change snapshots the caller's raw `providers:` map **before** entering the profile scope, deep-copies the assigned entry into the target when missing, and attaches a raw `key_env` pointer the same way the main model-set path does.

## Related Issue

Fixes #106643

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_routers/profiles.py`: `_write_profile_model` copies the missing config-map provider from the outer home; fail-open if no source entry / dest already has the key; never invents built-in `providers.*` blocks
- `tests/hermes_cli/test_write_profile_model_copies_provider_entry.py`: focused RED→GREEN coverage (key_env copy, literal inline `api_key` copy, built-in fail-open, existing entry not overwritten)

## How to Test

1. Focused: `./scripts/run_tests.sh tests/hermes_cli/test_write_profile_model_copies_provider_entry.py -q`
2. Proof: outer home has `providers.scnet`; empty named profile; call `_write_profile_model(profile_dir, "scnet", "GLM-5.3-Flash")` → target `config.yaml` contains `providers.scnet` with `base_url` / `key_env` (or literal `api_key`)
3. CONTROL: assigning a built-in provider (`openrouter`) does **not** create a `providers:` block; an existing target `providers.scnet` is not overwritten

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused pytest for the changed path and all listed tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (profile config write path only)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Proof Receipt (focused):
- BEFORE (pre-fix): `test_copies_config_map_provider_from_outer_home` AssertionError — `providers.scnet is None`
- AFTER: 4 passed (copy key_env, copy literal api_key, built-in fail-open, keep existing entry)

Made with [Cursor](https://cursor.com)