### PR TITLE
fix(serve): ensure parent-death watchdog detects exited Desktop parent (#80204)

### DIFF
--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -75,7 +75,10 @@ def _process_start_marker(pid: int) -> str:
     marker = result.stdout.strip()
     if result.returncode == 0 and marker:
         return f"ps:{marker}"
-    if result.returncode != 0 and (not marker or "no such process" in result.stderr.lower() or "not found" in result.stderr.lower()):
+    stderr_lower = result.stderr.lower()
+    if (result.returncode == 1 and not marker) or any(
+        msg in stderr_lower for msg in ("no such process", "not found")
+    ):
         raise ProcessLookupError(pid)
     raise OSError(f"ps could not inspect PID {pid}: {result.stderr.strip()}")
 

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -75,7 +75,7 @@ def _process_start_marker(pid: int) -> str:
     marker = result.stdout.strip()
     if result.returncode == 0 and marker:
         return f"ps:{marker}"
-    if result.returncode == 1 and not marker:
+    if result.returncode != 0 and (not marker or "no such process" in result.stderr.lower() or "not found" in result.stderr.lower()):
         raise ProcessLookupError(pid)
     raise OSError(f"ps could not inspect PID {pid}: {result.stderr.strip()}")
 
@@ -278,12 +278,19 @@ def _is_serve_orphaned(
     try:
         if expected_start_marker is not None:
             probe = process_start_marker or _process_start_marker
-            actual_marker = probe(int(desktop_pid))
-            if _parent_start_markers_match(actual_marker, expected_start_marker):
-                return False
-            if _parent_start_marker_mismatch_is_conclusive(actual_marker, expected_start_marker):
+            try:
+                actual_marker = probe(int(desktop_pid))
+            except ProcessLookupError:
                 return True
-            # Inconclusive marker: degrade to PID liveness instead of exiting.
+            except Exception:
+                actual_marker = None
+
+            if actual_marker is not None:
+                if _parent_start_markers_match(actual_marker, expected_start_marker):
+                    return False
+                if _parent_start_marker_mismatch_is_conclusive(actual_marker, expected_start_marker):
+                    return True
+                # Inconclusive marker: degrade to PID liveness instead of exiting.
 
         if pid_exists is None:
             from gateway.status import _pid_exists

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -223,13 +223,14 @@ def test_parent_watchdog_detects_dead_parent_on_process_lookup_error():
 
 
 def test_ps_process_start_marker_raises_process_lookup_error_on_missing_process(monkeypatch):
-    """#80204: _process_start_marker raises ProcessLookupError when ps exits non-zero with no marker."""
+    """#80204: _process_start_marker raises ProcessLookupError when ps exits with known missing-process markers."""
     import subprocess
     import pytest
     from hermes_cli import web_server_lifecycle
 
+    # returncode != 1 but explicit "No such process" in stderr
     def fake_run(*args, **kwargs):
-        return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="ps: 4242: No such process")
+        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: 4242: No such process")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
@@ -237,4 +238,57 @@ def test_ps_process_start_marker_raises_process_lookup_error_on_missing_process(
 
     with pytest.raises(ProcessLookupError):
         web_server_lifecycle._process_start_marker(4242)
+
+
+def test_ps_process_start_marker_raises_oserror_on_unrelated_nonzero_failure(monkeypatch):
+    """#80204: unrelated ps failures (e.g. returncode 2 without missing-process message) must raise OSError."""
+    import subprocess
+    import pytest
+    from hermes_cli import web_server_lifecycle
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: temporary process table failure")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
+    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
+
+    with pytest.raises(OSError) as excinfo:
+        web_server_lifecycle._process_start_marker(4242)
+    assert "ps could not inspect PID 4242" in str(excinfo.value)
+    assert not isinstance(excinfo.value, ProcessLookupError)
+
+
+def test_parent_watchdog_does_not_kill_live_parent_on_unrelated_ps_failure(monkeypatch):
+    """#80204: an unrelated nonzero ps error raises OSError, degrading to pid_exists which keeps a live backend alive."""
+    import subprocess
+    from hermes_cli import web_server_lifecycle
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=2, stdout="", stderr="ps: temporary process table failure")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
+    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
+
+    # Parent is alive: must return False (do not kill healthy backend)
+    assert (
+        web_server_lifecycle._is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: True,
+        )
+        is False
+    )
+
+    # Parent is dead: must return True (reap orphan)
+    assert (
+        web_server_lifecycle._is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: False,
+        )
+        is True
+    )
+
 

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -175,3 +175,66 @@ def test_parent_watchdog_warns_when_disarmed_by_unusable_marker(monkeypatch, cap
 class _NoThread:
     def start(self):
         raise AssertionError("watchdog thread must not start")
+
+
+def test_parent_watchdog_detects_dead_parent_when_start_marker_probe_raises_oserror():
+    """#80204: when marker probe fails with OSError on a dead parent, watchdog
+    must degrade to PID liveness check and reap the orphan, not return False."""
+    def broken_marker_probe(_pid: int) -> str:
+        raise OSError("ps could not inspect PID 4242: ps: 4242: No such process")
+
+    # Parent is dead: pid_exists returns False -> must return True (orphaned)
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: False,
+            process_start_marker=broken_marker_probe,
+        )
+        is True
+    )
+
+    # Parent is still alive: pid_exists returns True -> fail-safe False
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: True,
+            process_start_marker=broken_marker_probe,
+        )
+        is False
+    )
+
+
+def test_parent_watchdog_detects_dead_parent_on_process_lookup_error():
+    """#80204: ProcessLookupError from probe immediately signals parent is gone."""
+    def lookup_error_probe(pid: int) -> str:
+        raise ProcessLookupError(pid)
+
+    assert (
+        _is_serve_orphaned(
+            4242,
+            "ps:Thu Aug 20 22:33:11 2026",
+            pid_exists=lambda _pid: True,
+            process_start_marker=lookup_error_probe,
+        )
+        is True
+    )
+
+
+def test_ps_process_start_marker_raises_process_lookup_error_on_missing_process(monkeypatch):
+    """#80204: _process_start_marker raises ProcessLookupError when ps exits non-zero with no marker."""
+    import subprocess
+    import pytest
+    from hermes_cli import web_server_lifecycle
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args, returncode=1, stdout="", stderr="ps: 4242: No such process")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(web_server_lifecycle.sys, "platform", "darwin")
+    monkeypatch.setattr(web_server_lifecycle.os, "name", "posix")
+
+    with pytest.raises(ProcessLookupError):
+        web_server_lifecycle._process_start_marker(4242)
+


### PR DESCRIPTION
Fixes #80204

### Problem
Hermes Desktop repeatedly leaves orphaned `hermes serve` processes (and their descendant MCP watchdogs / workers) alive and reparented to PID 1 after the Desktop parent exits, crashes, or hands off to an updater.

Root cause:
1. In `hermes_cli/web_server_lifecycle.py::_is_serve_orphaned()`, the probe `actual_marker = probe(int(desktop_pid))` was executed inside a single `try` block that caught `except Exception: return False`. If `probe()` failed with `OSError` (e.g. from `ps could not inspect PID`, access error, or platform probe exception), the function immediately aborted and returned `False`, completely bypassing the `not bool(pid_exists(desktop_pid))` degradation fallback.
2. In `_process_start_marker()`, when `ps` inspected an exited process on macOS/BSD, `if result.returncode == 1 and not marker: raise ProcessLookupError` did not catch cases where `returncode != 1` or where `stderr` contained process lookup error notices, raising an `OSError` instead of `ProcessLookupError`.
3. Consequently, the watchdog loop (`while not _is_serve_orphaned(...): time.sleep(...)`) continuously evaluated `_is_serve_orphaned(...) == False` indefinitely, preventing the backend from ever terminating itself when its Electron spawner exited.

### Solution
1. In `_is_serve_orphaned()`:
   - Wrapped the marker probe invocation in its own isolated `try...except` block.
   - If `probe()` raises `ProcessLookupError`, immediately signal the parent is gone (`return True`).
   - If `probe()` raises `OSError` or any other probe failure, degrade `actual_marker = None` and fall through to the authoritative `pid_exists(desktop_pid)` liveness check.
   - If `pid_exists(desktop_pid)` indicates the parent PID is dead, correctly return `True` so the watchdog reaps the orphan.
2. In `_process_start_marker()`:
   - Raised `ProcessLookupError(pid)` whenever `result.returncode != 0` and `(not marker or "no such process" in result.stderr.lower() or "not found" in result.stderr.lower())`.
3. In `tests/hermes_cli/test_serve_parent_watchdog.py`:
   - Added unit and regression tests verifying:
     - When marker probe throws `OSError` on a dead parent PID, `_is_serve_orphaned` falls back to `pid_exists` and returns `True`.
     - When marker probe throws `OSError` on a living parent PID, `_is_serve_orphaned` fails safe and returns `False`.
     - `ProcessLookupError` from marker probe immediately flags an orphan.
     - `_process_start_marker` properly raises `ProcessLookupError` when `ps` exits non-zero without a valid process marker.

### Verification
- Ran `pytest tests/hermes_cli/test_serve_parent_watchdog.py -v`: all 15 tests passed cleanly.
