### PR TITLE
fix(gateway): fail closed on missing edit transport

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -157,6 +157,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     server. The mixin comes first so its ``format_message`` overrides the base one."""
 
     splits_long_messages = True  # send() chunks via truncate_message()
+    # Meta's Cloud API has no message-edit endpoint.  Declaring that explicitly keeps
+    # the streaming runner from attaching an edit consumer whose undelivered state
+    # makes final-delivery ownership ambiguous.
+    SUPPORTS_MESSAGE_EDITING = False
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP_CLOUD)

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2363,7 +2363,16 @@ class GatewayTurnMixin:
                 _adapter.pause_typing_for_chat(_chat_id)
         # Non-editing platforms (QQ, WeChat) skip streaming — the partial first message could never
         # be updated — unless they have a native-streaming transport (WeCom msgtype "stream").
-        _adapter_supports_edit = getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)
+        # Fail closed on capability drift: inheriting BasePlatformAdapter.edit_message means
+        # the adapter has no edit transport, even if an omitted/stale declaration defaults to
+        # True.  Otherwise the stream consumer can claim a turn it cannot update and leave
+        # final-delivery ownership ambiguous.
+        _edit_impl = getattr(type(adapter), "edit_message", None)
+        _adapter_supports_edit = (
+            getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True) is True
+            and _edit_impl is not None
+            and _edit_impl is not BasePlatformAdapter.edit_message
+        )
         _adapter_supports_native_stream = bool(getattr(adapter, "SUPPORTS_NATIVE_STREAMING", False))
         if not _adapter_supports_edit and not _adapter_supports_native_stream and on_missing_cursor == "raise":
             raise RuntimeError("skip streaming for non-editable platform")

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform, PlatformConfig, StreamingConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
@@ -65,6 +65,25 @@ def _make_event(text="hello", chat_id="c1", user_id="u1"):
         ),
         message_id="m1",
     )
+
+
+def test_misdeclared_edit_capability_without_implementation_fails_closed():
+    """A stale True capability must not activate the inherited no-op edit path."""
+    from gateway.run import GatewayRunner
+
+    class MisdeclaredEditingAdapter(StubAdapter):
+        SUPPORTS_MESSAGE_EDITING = True
+
+    adapter = MisdeclaredEditingAdapter()
+    source = SimpleNamespace(platform=Platform.DISCORD, chat_type="dm")
+
+    with pytest.raises(RuntimeError, match="non-editable platform"):
+        GatewayRunner.__new__(GatewayRunner)._build_stream_consumer_config(
+            source,
+            StreamingConfig(),
+            adapter,
+            on_missing_cursor="raise",
+        )
 
 
 # ===================================================================
@@ -319,4 +338,3 @@ class TestFinalContentDeliveredSuppression:
             response["already_sent"] = True
 
         assert response.get("already_sent") is True
-

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -123,6 +124,23 @@ def _mock_httpx_response(status_code: int, json_body: dict):
     resp.json = MagicMock(return_value=json_body)
     resp.text = json.dumps(json_body)
     return resp
+
+
+def test_non_editing_transport_keeps_final_delivery_out_of_stream_consumer():
+    """The Cloud API cannot edit, so normal final-send keeps sole ownership."""
+    from gateway.config import StreamingConfig
+    from gateway.run import GatewayRunner
+
+    adapter = _make_adapter()
+    source = SimpleNamespace(platform=Platform.WHATSAPP_CLOUD, chat_type="dm")
+
+    with pytest.raises(RuntimeError, match="non-editable platform"):
+        GatewayRunner.__new__(GatewayRunner)._build_stream_consumer_config(
+            source,
+            StreamingConfig(),
+            adapter,
+            on_missing_cursor="raise",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1399,4 +1417,3 @@ class TestReplyContextResolution:
         assert event.reply_to_message_id is None
         assert event.reply_to_text is None
         assert event.reply_to_is_own_message is False
-


### PR DESCRIPTION
## What\n- mark the WhatsApp Cloud API adapter as non-editable\n- derive streaming edit capability from a concrete dit_message override, so stale or omitted capability metadata cannot attach an unusable consumer\n- cover both the WhatsApp regression and the generic misdeclared-adapter contract\n\n## Why\nThe WhatsApp Cloud API has no edit endpoint, but the adapter inherited the gateway's optimistic editing default. Text-streaming setup therefore attached a consumer that could not own final delivery, producing duplicate-risk warnings and potentially exposing a partial-plus-final delivery path. The normal final-send lane should remain the sole owner for this adapter.\n\n## Verification\n- red-first: the WhatsApp capability regression failed before the fix\n- scripts/run_tests.sh tests/gateway/test_whatsapp_cloud.py tests/gateway/test_duplicate_reply_suppression.py -j 2 -q — 54 passed\n- uff check on all changed Python files\n- scripts/check-windows-footguns.py --diff origin/main\n- git diff --check\n\nNo live messages or provider calls were made.