### PR TITLE
fix(cron): avoid shell recursion into runtime CLI sources

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -881,6 +881,39 @@ def _read_script_for_scanning(script_path: str) -> str:
 
 # --- recursive walk ---------------------------------------------------------------------------
 
+def _uses_non_shell_interpreter(text: str) -> bool:
+    """Recognize runtime shebangs, not filename extensions (which shells ignore)."""
+    if not text.startswith("#!"):
+        return False
+    first_line = text.partition("\n")[0]
+    if len(first_line) > 4096:
+        return False
+    try:
+        argv = shlex.split(first_line[2:])
+    except ValueError:
+        return False
+    if not argv:
+        return False
+    if _executable_name(argv[0]) == "env":
+        argv = argv[1:]
+        if argv and argv[0] == "-S":
+            argv = argv[1:]
+    return bool(argv) and bool(re.fullmatch(
+        r"(?:bun|node|nodejs|deno|python(?:\d+(?:\.\d+)?)?|ruby|perl)",
+        _executable_name(argv[0]),
+    ))
+
+
+def _explicit_shell_references(command: str, cwd: Optional[str]) -> set[Path]:
+    # Shell invocation overrides the shebang, including for files named *.ts.
+    paths = set()
+    for segment in _iter_command_segments(command):
+        index = _executed_command_index(segment)
+        if index is not None and _executable_name(segment[index]) in _SHELL_EXECUTABLES | {".", "source"}:
+            paths.update(_resolve_lenient(p) for p in _references_at(segment, index, cwd))
+    return paths
+
+
 def _contains_unsafe_gateway_action(
     command: str, *, cwd: Optional[str], depth: int, visited: set[Path], budget: _LifecycleScanBudget,
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
@@ -903,6 +936,7 @@ def _contains_unsafe_gateway_action(
         if recurse(payload, cwd):
             return True
 
+    shell_references = _explicit_shell_references(command, cwd)
     for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
         # Do not touch a FileProvider path even to discover whether the file is hydrated.
         if _on_cloud_path(script_path):
@@ -929,6 +963,14 @@ def _contains_unsafe_gateway_action(
             if unsafe:
                 return True
         if not script_text:
+            continue
+        if resolved not in shell_references and _uses_non_shell_interpreter(script_text):
+            # Preserve literal lifecycle checks without treating imports and language
+            # operators as shell commands and recursively executable paths.
+            if not budget.charge_text(script_text):
+                return _budget_exhausted("text", depth + 1)
+            if _direct_lifecycle_scan(script_text):
+                return True
             continue
         # Relative references inside a script resolve against that script's directory, not the cwd.
         if recurse(script_text, _resolve_script_directory(str(resolved)) or cwd):

--- a/tests/cron/test_lifecycle_guard_runtime_scripts.py
+++ b/tests/cron/test_lifecycle_guard_runtime_scripts.py
@@ -1,0 +1,31 @@
+"""Runtime source text must not become a recursive shell dependency graph."""
+
+import pytest
+
+from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script as guard
+
+
+@pytest.mark.parametrize("shebang", ["#!/usr/bin/env bun", "#!/usr/bin/env -S node", "#!/usr/bin/python3"])
+def test_runtime_entry_does_not_execute_source_references(tmp_path, shebang):
+    dependency = tmp_path / "dependency"
+    dependency.write_text("hermes gateway restart\n")
+    entry = tmp_path / "entry.ts"
+    entry.write_text(f"{shebang}\n// documentation example\n{dependency}\n")
+    link = tmp_path / "cli"
+    link.symlink_to(entry)
+    assert not guard(f"{link} --help", cwd=str(tmp_path))
+    # An explicit shell ignores the shebang: retain recursive protection.
+    assert guard(f"bash {link} --help", cwd=str(tmp_path))
+    assert guard(f"source {link}", cwd=str(tmp_path))
+    assert guard(f"{link} --help; hermes gateway restart", cwd=str(tmp_path))
+    entry.write_text(f"{shebang}\nhermes gateway restart\n")
+    assert guard(f"{link} --help", cwd=str(tmp_path))
+
+
+def test_runtime_entry_remains_bounded(tmp_path, monkeypatch):
+    import cron.lifecycle_guard as module
+
+    entry = tmp_path / "cli"
+    entry.write_text("#!/usr/bin/env bun\n" + "x" * 2048)
+    monkeypatch.setattr(module, "_MAX_LIFECYCLE_SCAN_BYTES", 1024)
+    assert guard(str(entry), cwd=str(tmp_path))

--- a/tools/terminal_tool_guards.py
+++ b/tools/terminal_tool_guards.py
@@ -233,11 +233,12 @@ def gateway_lifecycle_block(
         read_remote_script=lambda p: _read_script_for_guard(env, guard_cwd, p, _MAX_REFERENCED_SCRIPT_BYTES),
     ):
         return _blocked_json(
-            "Blocked: command or referenced script cannot restart, stop, or "
-            "uninstall the gateway from inside the gateway process. The gateway would "
-            "kill this command before it could complete (SIGTERM propagates "
-            "to child processes). Run `hermes gateway restart` from a "
-            "separate shell outside the running gateway.",
+            "Blocked by the gateway lifecycle safety check: a gateway lifecycle action "
+            "was detected, or the command or referenced script could not be safely inspected "
+            "(including scan limits or inaccessible cloud paths). This does not "
+            "necessarily mean the command would restart the gateway. Check the "
+            "lifecycle guard logs for scan-limit details. Actual gateway restart, stop, "
+            "or uninstall commands must run from a separate shell outside the gateway.",
             "error",
         )
     return None


### PR DESCRIPTION
## What does this PR do?

Fix a reproduced false positive where a Bun CLI's `--help` invocation exhausts the lifecycle scanner's byte budget. The scanner follows the executable symlink into TypeScript source and interprets imports, comments and operators as shell script references.

Recognized non-shell runtime shebangs now receive the existing bounded direct lifecycle scan without the recursive shell walk. Explicit `bash file`, `source file`, shell scripts and unknown/no-shebang scripts retain recursive inspection. No product-specific allowlist or help-flag bypass is added. The terminal refusal now acknowledges incomplete inspection and scan limits instead of asserting that every refusal means a gateway restart.

## Related work

Related to #105758, #105765 and #105767. This is a conservative alternative with a reproduced Bun/TypeScript byte-budget case: unlike treating all sources without a POSIX shebang as non-shell, unknown and no-shebang executables retain the existing recursion. It also corrects the terminal diagnostic. Maintainers may prefer folding these changes into the existing work.

## Validation

On macOS arm64, against main at ead7e91dab:

`scripts/run_tests.sh tests/cron/test_lifecycle_guard_runtime_scripts.py tests/cron/test_lifecycle_guard_budget.py tests/hermes_cli/test_gateway_restart_loop.py`

317 passed, 0 failed. The full suite was not run.

The real local Bun CLI help command returns blocked=True on the original scanner and blocked=False with this patch. `hermes gateway restart` remains blocked. Regression fixtures cover symlinked Bun/Node/Python entrypoints, shell-forced execution, compound lifecycle commands, literal lifecycle commands inside runtime sources and size limits.

Prepared with Codex assistance. No new dependencies or configuration options.
