### PR TITLE
fix(agent): fall back to Luna Reserve (gpt-reserve) on Codex quota exhaustion

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1033,6 +1033,11 @@ def _init_fallback_chain(agent, fallback_model):
 
     # Ordered backups tried when the primary is exhausted (legacy single-dict or list).
     agent._fallback_chain = _fallback_entries(fallback_model)
+    # Luna Reserve: when the primary is Codex OAuth, prepend gpt-reserve so a regular-allowance
+    # 429 (classified upstream_rate_limit) falls back to the account's separate reserve quota
+    # instead of jumping straight to other providers. Same helper as switch_model's _finish_switch.
+    from agent.agent_runtime_helpers import _prepend_codex_reserve_entry
+    _prepend_codex_reserve_entry(agent)
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2065,6 +2065,26 @@ def _build_primary_runtime_snapshot(agent, api_mode) -> Dict[str, Any]:
     return rt
 
 
+def _prepend_codex_reserve_entry(agent) -> None:
+    """Prepend Luna Reserve (gpt-reserve) to the fallback chain for Codex OAuth primaries.
+
+    A regular-allowance 429 (classified upstream_rate_limit) then falls back to the
+    account's separate reserve quota instead of jumping straight to other providers.
+    Same credential, same endpoint — the backend_identity skip guard passes because
+    the model differs. No-op for non-Codex primaries or when already present.
+    """
+    if (getattr(agent, "provider", "") or "").strip().lower() != "openai-codex":
+        return
+    from hermes_cli.codex_models import CODEX_RESERVE_MODEL
+    reserve_entry = {"provider": "openai-codex", "model": CODEX_RESERVE_MODEL}
+    if not any(
+        (e.get("provider") or "").strip().lower() == "openai-codex"
+        and (e.get("model") or "").strip() == CODEX_RESERVE_MODEL
+        for e in agent._fallback_chain
+    ):
+        agent._fallback_chain.insert(0, reserve_entry)
+
+
 def _finish_switch(agent, new_provider, old_norm, new_norm) -> None:
     """Post-switch bookkeeping: fallback reset/prune, request_overrides, billing route."""
     agent._fallback_activated = False
@@ -2080,7 +2100,10 @@ def _finish_switch(agent, new_provider, old_norm, new_norm) -> None:
             if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
         ]
     agent._fallback_chain = fallback_chain
-    agent._fallback_model = fallback_chain[0] if fallback_chain else None
+    # A switch TO Codex must re-arm the reserve rung (the prune above may have dropped it);
+    # a switch AWAY leaves it pruned.
+    _prepend_codex_reserve_entry(agent)
+    agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
     # Apply the switched-to provider's request_overrides (custom_providers extra_body).
     try:
         _apply_switched_provider_request_overrides(agent, new_provider)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2077,12 +2077,14 @@ def _prepend_codex_reserve_entry(agent) -> None:
         return
     from hermes_cli.codex_models import CODEX_RESERVE_MODEL
     reserve_entry = {"provider": "openai-codex", "model": CODEX_RESERVE_MODEL}
+    chain = getattr(agent, "_fallback_chain", None) or []
     if not any(
         (e.get("provider") or "").strip().lower() == "openai-codex"
         and (e.get("model") or "").strip() == CODEX_RESERVE_MODEL
-        for e in agent._fallback_chain
+        for e in chain
     ):
-        agent._fallback_chain.insert(0, reserve_entry)
+        chain.insert(0, reserve_entry)
+        agent._fallback_chain = chain
 
 
 def _finish_switch(agent, new_provider, old_norm, new_norm) -> None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1978,18 +1978,23 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
     return _creds_pair(creds)
 
 
-def _read_codex_access_token() -> Optional[str]:
-    """Valid, non-expired Codex OAuth access token; an exhausted pool falls back to the profile's auth.json token."""
+def _read_codex_access_token(allow_cooldown: bool = False) -> Optional[str]:
+    """Valid, non-expired Codex OAuth access token; an exhausted pool falls back to the profile's auth.json token.
+
+    ``allow_cooldown`` bypasses pool cooldown for the Luna Reserve path only: gpt-reserve
+    is a separate metered model on the SAME credential, so a cooldown on the regular
+    allowance must not block it. Other callers (image_gen, aux tasks) keep the old
+    behavior — a benched credential resolves to None and fails clean.
+    """
     pool_present, entry = _select_pool_entry("openai-codex")
     if pool_present:
         token = _pool_runtime_api_key(entry)
         if token:
             return token
     # Pool entries in cooldown (regular quota exhausted) still carry the SAME credential
-    # that serves Luna Reserve (gpt-reserve) — the reserve is a separate metered model on
-    # the same OAuth account, so a cooldown on the regular allowance must not block it.
-    # DEAD entries (revoked/re-authed) are skipped: their tokens are unusable.
-    if pool_present:
+    # that serves Luna Reserve (gpt-reserve). DEAD entries (revoked/re-authed) are
+    # skipped: their tokens are unusable.
+    if pool_present and allow_cooldown:
         try:
             from agent.credential_pool import STATUS_DEAD, load_pool
             pool = load_pool("openai-codex")
@@ -4529,7 +4534,11 @@ def _resolve_openai_codex_branch(req: _ResolveRequest) -> _ResolveResult:
     no_token_msg = "resolve_provider_client: openai-codex requested but no Codex OAuth token found (run: hermes model)"
     if req.raw_codex:
         # Raw OpenAI client for callers needing responses.stream() (main agent loop).
-        codex_token = _read_codex_access_token()
+        # allow_cooldown only for the Luna Reserve model: gpt-reserve shares the
+        # credential with the benched regular allowance.
+        codex_token = _read_codex_access_token(
+            allow_cooldown=(model or "").strip().lower() == "gpt-reserve"
+        )
         if not codex_token:
             logger.warning(no_token_msg)
             return None, None

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1985,6 +1985,22 @@ def _read_codex_access_token() -> Optional[str]:
         token = _pool_runtime_api_key(entry)
         if token:
             return token
+    # Pool entries in cooldown (regular quota exhausted) still carry the SAME credential
+    # that serves Luna Reserve (gpt-reserve) — the reserve is a separate metered model on
+    # the same OAuth account, so a cooldown on the regular allowance must not block it.
+    # DEAD entries (revoked/re-authed) are skipped: their tokens are unusable.
+    if pool_present:
+        try:
+            from agent.credential_pool import STATUS_DEAD, load_pool
+            pool = load_pool("openai-codex")
+            for e in pool.entries():
+                if getattr(e, "last_status", None) == STATUS_DEAD:
+                    continue
+                token = _pool_runtime_api_key(e)
+                if token:
+                    return token
+        except Exception as exc:
+            logger.debug("Could not read Codex pool entries for reserve fallback: %s", exc)
     try:
         from hermes_cli.auth import _read_codex_tokens
         access_token = _read_codex_tokens().get("tokens", {}).get("access_token")

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4536,8 +4536,9 @@ def _resolve_openai_codex_branch(req: _ResolveRequest) -> _ResolveResult:
         # Raw OpenAI client for callers needing responses.stream() (main agent loop).
         # allow_cooldown only for the Luna Reserve model: gpt-reserve shares the
         # credential with the benched regular allowance.
+        from hermes_cli.codex_models import CODEX_RESERVE_MODEL
         codex_token = _read_codex_access_token(
-            allow_cooldown=(model or "").strip().lower() == "gpt-reserve"
+            allow_cooldown=(model or "").strip().lower() == CODEX_RESERVE_MODEL
         )
         if not codex_token:
             logger.warning(no_token_msg)

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -677,6 +677,14 @@ def _status_429(c: _Ctx) -> Verdict:
         upstream = _extract_upstream_provider_name(c.body)
         ctx = {"upstream_provider": upstream} if upstream else {}
         return _v(_R.upstream_rate_limit, should_fallback=True, error_context=ctx)
+    # Codex OAuth quota wall: the account's REGULAR allowance is exhausted but the
+    # credential is healthy — Luna Reserve (gpt-reserve) is a separate metered model
+    # on the same credential. Route to upstream_rate_limit so the pool skips rotation
+    # and the fallback chain (which prepends gpt-reserve for Codex primaries) takes
+    # over instead of benching the credential for hours.
+    if c.provider_slug == "openai-codex" and c.code == "usage_limit_reached":
+        return _v(_R.upstream_rate_limit, should_fallback=True,
+                  error_context={"upstream_provider": "openai-codex"})
     # Quota walls as 429 (Anthropic ``usage_limit_reached``, "quota", billing
     # phrases) are billing ONLY when the body is not itself a rate-limit phrase
     # ("Rate limit exceeded" contains "limit exceeded") and carries no reset/

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1443,6 +1443,9 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.3-codex-spark": 128_000, "gpt-5.2-codex": 272_000, "gpt-5.4-mini": 272_000,
     "gpt-5.6-sol": 272_000, "gpt-5.6-terra": 272_000, "gpt-5.6-luna": 272_000, "gpt-daybreak-blue-latest": 272_000,
     "gpt-5.5": 272_000, "gpt-5.4": 272_000, "gpt-5.2": 272_000, "gpt-5": 272_000,
+    # Luna Reserve (gpt-reserve) is a fallback model on the same Codex OAuth credential; the
+    # backend serves it with the same 272K window as the 5.6 family.
+    "gpt-reserve": 272_000,
 }
 # Codex OAuth advertises 272K for these families but ACCEPTS ~900K+ (verified live; gpt-5.5 and
 # gpt-5.4-mini genuinely reject >272K). 900K keeps ≥11K margin. OPT-IN ONLY via explicit ``-900k``

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -49,6 +49,11 @@ _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     # gates real availability by ChatGPT Pro entitlement.
     ("gpt-5.3-codex-spark", ("gpt-5.3-codex",))]
 
+# Luna Reserve: separate metered model on the same Codex OAuth credential, served when the
+# regular allowance is exhausted. Backend lists it visibility:hidden (never in the picker)
+# but accepts it on the wire; the fallback chain prepends it for Codex primaries.
+CODEX_RESERVE_MODEL = "gpt-reserve"
+
 
 def _dedupe(model_ids) -> List[str]:
     """Order-preserving dedupe."""

--- a/tests/agent/test_codex_reserve_fallback.py
+++ b/tests/agent/test_codex_reserve_fallback.py
@@ -82,7 +82,18 @@ def test_read_codex_token_uses_pool_entry_in_cooldown():
         patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
         patch("agent.credential_pool.load_pool", return_value=pool),
     ):
-        assert _read_codex_access_token() == "reserve-token"
+        assert _read_codex_access_token(allow_cooldown=True) == "reserve-token"
+
+
+def test_read_codex_token_does_not_bypass_cooldown_by_default():
+    """Other callers (image_gen, aux) keep the old behavior: benched → None."""
+    entry = SimpleNamespace(runtime_api_key="reserve-token", access_token="")
+    pool = SimpleNamespace(entries=lambda: [entry])
+    with (
+        patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
+        patch("agent.credential_pool.load_pool", return_value=pool),
+    ):
+        assert _read_codex_access_token() is None
 
 
 def test_read_codex_token_skips_dead_pool_entries():
@@ -94,7 +105,7 @@ def test_read_codex_token_skips_dead_pool_entries():
         patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
         patch("agent.credential_pool.load_pool", return_value=pool),
     ):
-        assert _read_codex_access_token() == "live-token"
+        assert _read_codex_access_token(allow_cooldown=True) == "live-token"
 
 
 def test_read_codex_token_prefers_available_pool_selection():

--- a/tests/agent/test_codex_reserve_fallback.py
+++ b/tests/agent/test_codex_reserve_fallback.py
@@ -1,0 +1,103 @@
+"""Tests for Luna Reserve (gpt-reserve) fallback wiring.
+
+Covers: the fallback-chain prepend for Codex OAuth primaries (agent_init) and
+the pool-cooldown bypass in the Codex token reader (auxiliary_client) so a
+regular-allowance 429 can still reach the reserve quota on the same credential.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.agent_init import _init_fallback_chain
+from agent.auxiliary_client import _read_codex_access_token
+
+
+def _make_agent(provider="openai-codex"):
+    return SimpleNamespace(
+        provider=provider,
+        _fallback_chain=[],
+        _fallback_index=0,
+        _fallback_activated=False,
+        quiet_mode=True,
+    )
+
+
+def test_reserve_prepended_for_codex_primary():
+    agent = _make_agent()
+    _init_fallback_chain(agent, [{"provider": "nous", "model": "upstage/solar-pro4:free"}])
+    assert agent._fallback_chain[0] == {"provider": "openai-codex", "model": "gpt-reserve"}
+    assert agent._fallback_chain[1] == {"provider": "nous", "model": "upstage/solar-pro4:free"}
+
+
+def test_reserve_not_duplicated_when_already_configured():
+    agent = _make_agent()
+    _init_fallback_chain(agent, [{"provider": "openai-codex", "model": "gpt-reserve"}])
+    assert agent._fallback_chain.count({"provider": "openai-codex", "model": "gpt-reserve"}) == 1
+
+
+def test_reserve_not_added_for_non_codex_primary():
+    agent = _make_agent(provider="nous")
+    _init_fallback_chain(agent, [{"provider": "openrouter", "model": "x/model"}])
+    assert all(e.get("model") != "gpt-reserve" for e in agent._fallback_chain)
+
+
+def test_reserve_keeps_configured_chain_order():
+    agent = _make_agent()
+    _init_fallback_chain(agent, [{"provider": "openrouter", "model": "x/model"}])
+    assert [e["model"] for e in agent._fallback_chain] == ["gpt-reserve", "x/model"]
+
+
+def test_reserve_rearmed_after_switch_to_codex():
+    """A /model switch TO Codex must re-arm the reserve rung.
+
+    The prune drops entries targeting the OLD provider (nous) — the user just
+    rejected it — so the chain after the switch is the reserve rung alone.
+    """
+    from agent.agent_runtime_helpers import _finish_switch
+
+    agent = _make_agent(provider="openai-codex")
+    agent._fallback_chain = [{"provider": "nous", "model": "upstage/solar-pro4:free"}]
+    _finish_switch(agent, "openai-codex", "nous", "openai-codex")
+    assert agent._fallback_chain == [{"provider": "openai-codex", "model": "gpt-reserve"}]
+
+
+def test_reserve_pruned_after_switch_away_from_codex():
+    """A /model switch AWAY from Codex leaves the reserve pruned."""
+    from agent.agent_runtime_helpers import _finish_switch
+
+    agent = _make_agent(provider="nous")
+    agent._fallback_chain = [
+        {"provider": "openai-codex", "model": "gpt-reserve"},
+        {"provider": "nous", "model": "upstage/solar-pro4:free"},
+    ]
+    _finish_switch(agent, "nous", "openai-codex", "nous")
+    assert all(e.get("model") != "gpt-reserve" for e in agent._fallback_chain)
+
+
+def test_read_codex_token_uses_pool_entry_in_cooldown():
+    """A pool entry benched for the regular quota still serves the reserve model."""
+    entry = SimpleNamespace(runtime_api_key="reserve-token", access_token="")
+    pool = SimpleNamespace(entries=lambda: [entry])
+    with (
+        patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
+        patch("agent.credential_pool.load_pool", return_value=pool),
+    ):
+        assert _read_codex_access_token() == "reserve-token"
+
+
+def test_read_codex_token_skips_dead_pool_entries():
+    """Revoked (DEAD) entries must not serve the reserve — their tokens are unusable."""
+    dead = SimpleNamespace(runtime_api_key="dead-token", access_token="", last_status="dead")
+    live = SimpleNamespace(runtime_api_key="live-token", access_token="", last_status="exhausted")
+    pool = SimpleNamespace(entries=lambda: [dead, live])
+    with (
+        patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
+        patch("agent.credential_pool.load_pool", return_value=pool),
+    ):
+        assert _read_codex_access_token() == "live-token"
+
+
+def test_read_codex_token_prefers_available_pool_selection():
+    entry = SimpleNamespace(runtime_api_key="selected-token", access_token="")
+    with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, entry)):
+        assert _read_codex_access_token() == "selected-token"

--- a/tests/agent/test_codex_reserve_fallback.py
+++ b/tests/agent/test_codex_reserve_fallback.py
@@ -112,3 +112,72 @@ def test_read_codex_token_prefers_available_pool_selection():
     entry = SimpleNamespace(runtime_api_key="selected-token", access_token="")
     with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, entry)):
         assert _read_codex_access_token() == "selected-token"
+
+
+def _fallback_agent():
+    """Minimal agent for try_activate_fallback: chain [gpt-reserve, openrouter]."""
+    return SimpleNamespace(
+        provider="openai-codex",
+        model="gpt-5.6-luna",
+        base_url="",
+        requested_provider="openai-codex",
+        api_mode="codex_responses",
+        _fallback_chain=[
+            {"provider": "openai-codex", "model": "gpt-reserve"},
+            {"provider": "openrouter", "model": "x/model"},
+        ],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _unavailable_fallback_keys=None,
+        _config_context_length=None,
+        _reasoning_echo_flag=False,
+        _provider_fallback_active=False,
+        _provider_fallback_route=None,
+        _pending_fallback_notice=None,
+        _rate_limited_until=0,
+        runtime_capabilities=None,
+        quiet_mode=True,
+        _buffer_status=lambda notice: None,
+        _anthropic_prompt_cache_policy=lambda **kw: (False, False),
+        _ensure_lmstudio_runtime_loaded=lambda: None,
+    )
+
+
+def test_reserve_exhausted_advances_to_next_provider():
+    """When the reserve rung cannot resolve (quota gone / provider unconfigured),
+    try_activate_fallback must advance to the next provider in the chain — the
+    reserve must not block the fallback (bot review point 2)."""
+    from agent.chat_completion_helpers import try_activate_fallback
+
+    agent = _fallback_agent()
+    client_mock = SimpleNamespace(base_url="https://openrouter.ai/v1")
+
+    def _resolve(provider, model=None, **kw):
+        if provider == "openai-codex":
+            return None, None  # reserve unavailable → skip
+        return client_mock, model
+
+    with (
+        patch("agent.fallback_cooldown._arm_rate_limit_cooldown", return_value=None),
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve),
+        patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+        patch("agent.chat_completion_helpers._fallback_api_mode_resolved", return_value="chat_completions"),
+        patch("agent.chat_completion_helpers._rebind_fallback_credential_pool"),
+        patch("agent.client_lifecycle._swap_fallback_clients"),
+        patch("agent.agent_runtime_helpers.sync_credential_pool_entry_id"),
+        patch("agent.chat_completion_helpers._update_fallback_context_compressor"),
+        patch("agent.chat_completion_helpers._reresolve_fallback_reasoning_config"),
+        patch("agent.chat_completion_helpers._rescope_fallback_extra_body"),
+        patch("agent.chat_completion_helpers.rewrite_prompt_model_identity"),
+        patch("agent.chat_completion_helpers._reset_stale_streak"),
+        patch("agent.native_compaction.resolve_native_compaction_capabilities", return_value={}),
+    ):
+        assert try_activate_fallback(agent) is True
+
+    # Advanced past the reserve to the next provider.
+    assert agent.provider == "openrouter"
+    assert agent.model == "x/model"
+    assert agent._fallback_index == 2
+    assert agent._fallback_activated is True
+    # The reserve rung was marked unavailable, not silently retried forever.
+    assert ("openai-codex", "gpt-reserve", "") in agent._unavailable_fallback_keys

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1322,6 +1322,36 @@ class TestOpenRouterUpstreamRateLimit:
         assert result.error_context.get("upstream_provider") == "DeepSeek"
 
 
+class TestCodexUsageLimitReserve:
+    """Codex OAuth regular-allowance 429 → upstream_rate_limit (Luna Reserve path).
+
+    The account's regular quota is exhausted but the credential is healthy:
+    gpt-reserve (Luna Reserve) is a separate metered model on the SAME credential.
+    Classifying as upstream_rate_limit skips pool rotation/cooldown so the
+    fallback chain (which prepends gpt-reserve for Codex primaries) takes over.
+    """
+
+    def test_codex_usage_limit_429_classified_as_upstream_rate_limit(self):
+        e = MockAPIError(
+            "The usage limit has been reached",
+            status_code=429,
+            body={
+                "error": {
+                    "type": "usage_limit_reached",
+                    "message": "The usage limit has been reached",
+                    "plan_type": "plus",
+                    "resets_at": 1788970089,
+                    "resets_in_seconds": 10068,
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openai-codex", model="gpt-5.6-luna")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+        assert result.error_context.get("upstream_provider") == "openai-codex"
+
+
     def test_account_level_429_still_rotates_credential(self):
         """A real account-level 429 (no upstream wrapper) → rate_limit, rotates."""
         e = MockAPIError(


### PR DESCRIPTION
## Summary

When the regular Codex OAuth allowance is exhausted, the backend returns `HTTP 429` with `usage_limit_reached`. Hermes classified this as billing/rate-limit, which benched the credential for hours — even when the account has **Luna Reserve** (`gpt-reserve`) available: a separate, metered model on the **same** OAuth credential that the Codex CLI switches to automatically when the regular quota runs out.

This PR makes Hermes do the same: on a Codex `usage_limit_reached` 429, the credential stays healthy and the fallback chain tries `gpt-reserve` first (same account, separate quota) before jumping to external fallback providers.

## Problem

- `agent/error_classifier.py` classified Codex `usage_limit_reached` (429) as `rate_limit`/`billing` → credential pool rotation + multi-hour cooldown, even though the account had reserve quota left.
- The fallback chain never contained `gpt-reserve` — the backend lists it with `visibility: hidden`, so it was filtered out of the model catalog and never considered as a fallback.
- `_read_codex_access_token()` could not read pool entries in cooldown, so even a correctly-armed reserve fallback would have failed to obtain the token.

## Changes

- **`agent/error_classifier.py`**: route `openai-codex` + `usage_limit_reached` to `upstream_rate_limit` (credential healthy, fall back — don't bench). The pool skips rotation; the fallback chain takes over.
- **`agent/agent_init.py` / `agent/agent_runtime_helpers.py`**: prepend `gpt-reserve` to the fallback chain for Codex OAuth primaries — at agent init **and** after `/model` switches (the switch path rebuilds the chain and previously dropped the reserve rung).
- **`agent/auxiliary_client.py`**: `_read_codex_access_token()` reads pool entries even when in cooldown (the reserve shares the credential), skipping `DEAD` (revoked) entries.
- **`hermes_cli/codex_models.py`**: `CODEX_RESERVE_MODEL = "gpt-reserve"` constant.
- **`agent/model_metadata.py`**: 272K context window for `gpt-reserve`.

## How to test

1. Exhaust the regular Codex allowance (or use an account with `gpt-reserve` available — check `/status` in Codex CLI for `gpt-reserve Weekly limit`).
2. Run: `hermes chat -q "ping" --oneshot -m gpt-5.6-luna --provider openai-codex`
3. Expected: `⚠️ Model fallback: gpt-5.6-luna via openai-codex unavailable (rate limit); using gpt-reserve via openai-codex.` followed by a normal response — **not** a quota error, and **not** a jump to an external fallback provider.
4. Also verify the `/model` path: start a session on another provider, `/model gpt-5.6-luna` (Codex), send a message → same reserve fallback.

## Platforms

Tested on macOS (M4). The change is platform-agnostic (no OS-specific code); `scripts/check-windows-footguns.py` passes on all touched files.

## Related

Closes the same symptom as #95066 (Codex `usage_limit_reached` never reaches the fallback chain) and adds the reserve rung that issue does not know about. The Codex CLI behavior this mirrors is documented in OpenAI's [Luna Reserve help article](https://help.openai.com/en/articles/20001499-luna-reserve-in-codex-and-chatgpt-work).
