### PR TITLE
fix(tui_gateway): carry live subagent ownership through prompt.submit and queued-prompt reattach

### DIFF
--- a/tests/tui_gateway/test_subagent_snapshot.py
+++ b/tests/tui_gateway/test_subagent_snapshot.py
@@ -224,3 +224,73 @@ def test_reattach_does_not_adopt_foreign_or_retired_generations(runtime):
         assert call("subagent.steer", via=new, subagent_id=sid, text="deny")["result"]["status"] == "rejected"
         assert not call("subagent.interrupt", via=new, subagent_id=sid)["result"]["found"]
     assert effects == []
+
+
+def test_prompt_submit_reattach_transfers_child_ownership(runtime, monkeypatch):
+    """prompt.submit is one of the four reattach sites named by de25545dce ("fan session events out
+    instead of rebinding the transport slot"); only session.resume and session.activate were later
+    taught to carry live subagent ownership across the attach (see _rebind_live_transport). A prompt
+    sent right after a reconnect used to attach the new transport WITHOUT transferring ownership, so
+    subagent.list/steer/interrupt kept authorizing only the stale transport."""
+    from tools.delegate_tool_child_run import _register_child
+
+    server, owner, old, call = runtime
+    new = type("Transport", (), {"write": lambda self, frame: True})()
+    steered, stopped = [], []
+    child = SimpleNamespace(_subagent_id="child", _delegate_depth=1, model="test",
+                            steer=lambda text: steered.append(text) or True,
+                            hard_interrupt=lambda text: stopped.append(text))
+    _register_child(child, None, "owned", owner_session_id="ui-owner",
+                    owner_transport=old, owner_session_record=owner)
+
+    owner["transport"] = server._detached_ws_transport
+    owner["history_lock"] = threading.Lock()
+    owner["running"] = True  # forces the busy-return path immediately after the reattach block
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *a: None)
+    monkeypatch.setattr(server, "_legacy_group_fence_error", lambda *a: None)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a: False)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {})
+    monkeypatch.setattr(server, "_handle_busy_submit", lambda *a, **kw: {"result": {"status": "queued"}})
+
+    response = call("prompt.submit", text="continue", via=new)
+    assert response["result"]["status"] == "queued"
+    assert server._session_transport_contains(owner, new)
+
+    assert {row["subagent_id"] for row in call("subagent.list", via=new)["result"]["subagents"]} == {"child"}
+    assert call("subagent.steer", via=new, subagent_id="child", text="hi")["result"]["status"] == "queued"
+    assert call("subagent.interrupt", via=new, subagent_id="child")["result"]["found"]
+    assert steered == ["hi"] and len(stopped) == 1
+
+
+def test_queued_prompt_drain_reattach_transfers_child_ownership(runtime, monkeypatch):
+    """The queued-prompt drain is the fourth de25545dce reattach site (see the test above) and was
+    left on the same stale-ownership footing as prompt.submit: _drain_queued_prompt pinned the
+    drained turn's transport with a bare attach, never transferring live subagent ownership."""
+    from tools.delegate_tool_child_run import _register_child
+
+    server, owner, old, call = runtime
+    new = type("Transport", (), {"write": lambda self, frame: True})()
+    steered, stopped = [], []
+    child = SimpleNamespace(_subagent_id="child", _delegate_depth=1, model="test",
+                            steer=lambda text: steered.append(text) or True,
+                            hard_interrupt=lambda text: stopped.append(text))
+    _register_child(child, None, "owned", owner_session_id="ui-owner",
+                    owner_transport=old, owner_session_record=owner)
+
+    owner["transport"] = server._detached_ws_transport
+    owner["history_lock"] = threading.Lock()
+    owner["running"] = False
+    owner["_closing"] = False
+    owner["queued_prompt"] = {"text": "continue", "transport": new}
+    owner["queued_prompts"] = []
+    owner["_queued_prompt_generation"] = 0
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *a: False)
+
+    assert server._drain_queued_prompt(1, "ui-owner", owner) is True
+    assert server._session_transport_contains(owner, new)
+
+    assert {row["subagent_id"] for row in call("subagent.list", via=new)["result"]["subagents"]} == {"child"}
+    assert call("subagent.steer", via=new, subagent_id="child", text="hi")["result"]["status"] == "queued"
+    assert call("subagent.interrupt", via=new, subagent_id="child")["result"]["found"]
+    assert steered == ["hi"] and len(stopped) == 1

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -577,8 +577,8 @@ def _(rid, params: dict) -> dict:
         if (refusal := _reattach_refusal(rid, sid, session)) is not None:
             return refusal
         if (t := current_transport()) is not None:
-            _attach_session_transport(session, t)
-            _cancel_ws_orphan_reap(sid)
+            with session["history_lock"]:
+                _rebind_live_transport(sid, session, t)
     # Claim the turn against a possibly-running session (busy/queued reply, else fall
     # through once ``running`` is observed False).  The provider interrupt happens after
     # history_lock is released (a non-interruptible tool may hold it); if the old turn

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -293,7 +293,7 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
         # whole drained turn. A peer that disconnected while its prompt sat in the queue is skipped: the
         # prompt still runs, only the dead pin is dropped.
         if queued_transport is not None and not _transport_is_dead(queued_transport):
-            _attach_session_transport(session, queued_transport)
+            _rebind_live_transport(sid, session, queued_transport)
     use_compute_host = _session_uses_compute_host(session)
     with session["history_lock"]:
         if int(session.get("_queued_prompt_generation", 0)) != queue_generation:


### PR DESCRIPTION
## Summary

`de25545dce` ("fan session events out instead of rebinding the transport slot") turned `prompt.submit`, `session.resume`, `session.activate`, and the queued-prompt drain into the four attach sites of the fan-out transport architecture, all originally calling `_attach_session_transport`.

A later commit taught `_rebind_live_transport` (a thin wrapper around `_attach_session_transport`) to also transfer live subagent ownership (`owner_transport` on `_active_subagents` records) across an attach — but it was only wired into `session.resume` (`methods_session.py`) and `session.activate` (`methods_session.py`). `prompt.submit` (`methods_prompt.py`) and the queued-prompt drain (`session_auto_continue.py::_drain_queued_prompt`) kept calling the bare `_attach_session_transport`.

Effect: a client that reattaches through `prompt.submit` or the queued-prompt drain keeps streaming the session correctly (session-slot membership is fine), but loses control of any subagent spawned under that session — `subagent.list` returns `[]`, `subagent.tail`/`steer`/`interrupt` reject, because those RPCs authorize against the subagent record's `owner_transport`, which stays pinned to the pre-reattach (stale) transport.

`_drain_queued_prompt`'s own comment ("ATTACHED, not rebound: a mid-turn prompt from a second client used to silence the first for the whole drained turn") explains why it uses *attach* semantics rather than the old single-slot *rebind* — but that reasoning is about `_attach_session_transport`'s fan-out behavior, which `_rebind_live_transport` still delegates to unchanged. `_rebind_live_transport` only adds ownership bookkeeping on top; it does not reintroduce the old displacing rebind, so switching to it here is safe and keeps the exact same fan-out semantics.

## Fix

Route both remaining sites through `_rebind_live_transport`, mirroring the `resume`/`activate` call shape exactly (attach under `session["history_lock"]`, matching the function's own documented precondition).

## Test plan

- [x] Added two regression tests to `tests/tui_gateway/test_subagent_snapshot.py`, mirroring the file's existing `_rebind_live_transport` coverage: `test_prompt_submit_reattach_transfers_child_ownership` drives the real `prompt.submit` RPC through `server.dispatch`, and `test_queued_prompt_drain_reattach_transfers_child_ownership` drives `_drain_queued_prompt` directly. Both register a live subagent child, reattach through the fixed call site, and assert `subagent.list`/`steer`/`interrupt` succeed against the new transport.
- [x] Mutation-verify: reverted just the two production lines and confirmed both new tests fail (`subagent.list` returns `set()` instead of `{'child'}`); restored the fix and confirmed they pass again.
- [x] `tests/tui_gateway/test_subagent_snapshot.py` — 7 passed (isolated).
- [x] Broader regression sweep — `test_subagent_snapshot.py`, `test_ws_orphan_races.py`, `test_auto_continue.py`, `test_multi_client_fanout.py`, `test_attach_does_not_wait_for_agent.py`, `test_session_control.py`, `test_bot_live_owner_delivery.py`, `test_shared_session_delivery.py` — 83 passed, 8 skipped (pre-existing, unrelated skips).
- [x] Full `tests/tui_gateway/` suite (1082 tests, one pre-existing collection error unrelated to this change — missing `aiohttp`) — same 3 failures occur with or without this fix (confirmed by re-running the full suite with the fix stashed), i.e. pre-existing test-order pollution unrelated to these files.
- [x] `ruff check` clean on all three changed files.
