### PR TITLE
fix(tools): sandbox builders no longer double-bind env_type

### DIFF
--- a/tests/tools/test_terminal_sandbox_builder_dispatch.py
+++ b/tests/tools/test_terminal_sandbox_builder_dispatch.py
@@ -1,0 +1,54 @@
+"""Regression: sandbox builder dispatch must not double-bind ``env_type``.
+
+https://github.com/NousResearch/hermes-agent/issues/105414
+
+``_create_environment()`` calls every backend builder with ``env_type=`` passed by keyword, but the
+sandbox builders (singularity/daytona/vercel_sandbox) were previously defined via
+``functools.partial(_build_sandbox_env, "singularity")`` — a *positional* binding of the same
+argument. Any sandbox terminal backend therefore crashed with::
+
+    TypeError: _build_sandbox_env() got multiple values for argument 'env_type'
+
+before the environment object was ever constructed. The builders now share the dispatcher's
+keyword-only signature, so this exercises the real dispatch path end to end.
+"""
+
+import pytest
+
+import tools.terminal_tool_backends as backends
+
+SANDBOX_TYPES = ("singularity", "daytona", "vercel_sandbox")
+
+
+class _FakeSandboxEnv:
+    """Stands in for Singularity/Daytona/VercelSandbox (no SDK or container binary needed)."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+@pytest.fixture
+def fake_sandbox_rows(monkeypatch):
+    """Point every sandbox row at the fake env so dispatch runs without real backends."""
+    for env_type in SANDBOX_TYPES:
+        monkeypatch.setitem(backends._SANDBOX_ROWS, env_type,
+                            (lambda: _FakeSandboxEnv, True, lambda cc, kw: {}))
+    yield
+
+
+@pytest.mark.parametrize("env_type", SANDBOX_TYPES)
+def test_sandbox_builder_dispatch_accepts_env_type_keyword(monkeypatch, fake_sandbox_rows, env_type):
+    """Regression: dispatching to a sandbox backend must not raise ``TypeError`` (env_type passed
+    twice). The environment should be constructed with the dispatcher's kwargs intact."""
+    env = backends._create_environment(env_type=env_type, image="img", cwd="/tmp", timeout=5)
+
+    assert isinstance(env, _FakeSandboxEnv)
+    assert env.kwargs["cwd"] == "/tmp"
+    assert env.kwargs["timeout"] == 5
+    assert env.kwargs["image"] == "img"
+
+
+def test_local_builder_unaffected(monkeypatch):
+    """The non-sandbox builders keep working through the same dispatcher."""
+    env = backends._create_environment(env_type="local", image="img", cwd="/tmp", timeout=5)
+    assert env is not None

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -160,17 +160,12 @@ _SANDBOX_ROWS = {
 }
 
 
-def _build_sandbox_env(env_type, *, image, cwd, timeout, cc, task_id, **_):
+def _build_sandbox_env(*, env_type, image, cwd, timeout, cc, task_id, **_):
     cls, with_image, extra = _SANDBOX_ROWS[env_type]
     kwargs = dict(cwd=cwd, timeout=timeout, task_id=task_id, **_resources(cc),
                   **({"image": image} if with_image else {}))
     kwargs.update(extra(cc, kwargs))
     return cls()(**kwargs)
-
-
-_build_singularity_env = functools.partial(_build_sandbox_env, "singularity")
-_build_daytona_env = functools.partial(_build_sandbox_env, "daytona")
-_build_vercel_env = functools.partial(_build_sandbox_env, "vercel_sandbox")
 
 
 def _build_ssh_env(*, cwd, timeout, ssh_config, probe_only=False, **_):
@@ -202,8 +197,10 @@ def _build_plugin_env(*, env_type, image, cwd, timeout, cc, task_id, **_):
 
 
 # Built-in backend -> builder. Anything else is looked up in the plugin registry.
-_ENV_BUILDERS = {"local": _build_local_env, "docker": _build_docker_env, "singularity": _build_singularity_env,
-                 "modal": _build_modal_env, "daytona": _build_daytona_env, "vercel_sandbox": _build_vercel_env,
+# Sandbox backends (singularity/daytona/vercel_sandbox) share _build_sandbox_env and read their
+# own backend key from the env_type kwarg the dispatcher passes to every builder.
+_ENV_BUILDERS = {"local": _build_local_env, "docker": _build_docker_env, "singularity": _build_sandbox_env,
+                 "modal": _build_modal_env, "daytona": _build_sandbox_env, "vercel_sandbox": _build_sandbox_env,
                  "ssh": _build_ssh_env}
 
 


### PR DESCRIPTION
## Summary

Fixes #105414 — dispatching the terminal tool to any sandbox backend (singularity, daytona, vercel_sandbox) crashed with:

```
TypeError: _build_sandbox_env() got multiple values for argument 'env_type'
```

## Root cause

`_create_environment()` calls every builder uniformly with `env_type=` passed **by keyword**, but the sandbox builders were defined as **positional** `functools.partial` bindings:

```python
_build_singularity_env = functools.partial(_build_sandbox_env, "singularity")
```

so calling `builder(env_type=env_type, ...)` bound `env_type` twice. The module's own contract comment (line 102) declares every builder signature as `(*, env_type, ...)` keyword-only — `_build_sandbox_env` and the partial shims were the leftovers of that refactor.

## Change

- `_build_sandbox_env(*, env_type, image, cwd, timeout, cc, task_id, **_):` — `env_type` is now keyword-only, matching sibling builders (`_build_local_env`, `_build_docker_env`, `_build_ssh_env`, `_build_plugin_env`).
- Removed the three `functools.partial` shims; `_ENV_BUILDERS` now maps `"singularity"`, `"daytona"`, `"vercel_sandbox"` directly to the shared `_build_sandbox_env`, which reads its backend key from the `env_type` kwarg the dispatcher already passes.
- No external callers exist for the removed names (verified: only referenced inside this module).

## Tests

New `tests/tools/test_terminal_sandbox_builder_dispatch.py`:

- parametrized over the three sandbox types: dispatch through `_create_environment()` constructs the environment instead of raising `TypeError` (backends stubbed out — no container binary/SDK needed);
- local builder still dispatches fine (no regression).

Verified locally:

- regression test fails on pre-fix code (`TypeError` at the dispatch site) and passes with the fix (sabotage run);
- existing `tests/tools/test_terminal_tool.py`, `test_terminal_tool_requirements.py`, `test_terminal_task_cwd.py`: 32 passed.

## Risk

Low. Pure signature/plumbing change inside `terminal_tool_backends.py`; the dispatch contract (keyword `env_type` to every builder) is unchanged, and non-sandbox builders are untouched.
