### PR TITLE
tool_search: a query no tool answers returns nothing, not five tools sharing one word

### DIFF
--- a/tests/tools/test_deferral_fixes.py
+++ b/tests/tools/test_deferral_fixes.py
@@ -268,10 +268,9 @@ class TestSourceNameIndexing:
             defs = [_td("mcp__linear__create_issue", "Create an issue."),
                     _td("mcp__slack__post_message", "Post a message.")]
             catalog = build_catalog(defs)
-            hits = search_catalog(catalog, "mcp message")
-            # Before the fix "mcp" BM25-matched both docs, so both came
-            # back and the order was decided by document length, not by
-            # the term the model actually meant.
+            # The prefix is in no document, so it can never match or rank.
+            assert all("mcp" not in e._tokens for e in catalog)
+            hits = search_catalog(catalog, "message")
             assert [h.name for h in hits] == ["mcp__slack__post_message"]
         finally:
             for n in names:
@@ -310,9 +309,11 @@ class TestSourceNameIndexing:
             for name in names:
                 registry.deregister(name)
 
-    def test_substring_fallback_covers_token_misses(self):
-        """"hub" is a substring of github but never a token — the fallback
-        (not BM25) must return the github tools."""
+    def test_unknown_token_returns_nothing(self):
+        """A token no document carries is the query's rarest token, so it gates and nothing
+        is admitted: an empty group, not `limit` tools sharing a common word. The old
+        name-substring fallback ("hub" -> github_*) is gone with it; the substring path
+        admitted tools that matched no query token at all."""
         from tools.registry import registry
 
         names = [
@@ -323,9 +324,9 @@ class TestSourceNameIndexing:
             defs = [_td("github_create_issue", "Create an issue."),
                     _td("github_merge_pr", "Merge a pull request.")]
             catalog = build_catalog(defs)
-            hits = search_catalog(catalog, "hub")
-            assert {h.name for h in hits} == {"github_create_issue", "github_merge_pr"}
             assert search_catalog(catalog, "zzzz") == []
+            assert search_catalog(catalog, "hub") == []
+            assert search_catalog(catalog, "create zzzz issue") == []
         finally:
             for n in names:
                 registry.deregister(n)

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -247,7 +247,7 @@ class TestThresholdGate:
 
 
 # ---------------------------------------------------------------------------
-# Retrieval (BM25 + substring fallback)
+# Retrieval (BM25, rarest-token admission)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/tools/test_tool_search_multiquery.py
+++ b/tests/tools/test_tool_search_multiquery.py
@@ -78,13 +78,24 @@ class TestStemming:
         assert "mq_linear_create_issue" in names
         assert "mq_linear_list_issues" in names
 
-    def test_substring_fallback_still_uses_raw_name(self, issue_defs):
-        """Fallback matches the unstemmed tool name, unchanged by stemming."""
+    def test_rarest_query_token_gates_admission(self, issue_defs):
+        """A document that lacks the query's rarest token is not a result, however many
+        common tokens it shares. In this catalog 'issue' and 'linear' are each in two tools
+        and 'slack' in one, so 'slack' gates: the two linear tools share two of the three
+        query tokens and still do not come back."""
         from tools.tool_search import build_catalog, search_catalog
 
         catalog = build_catalog(issue_defs)
-        names = [h.name for h in search_catalog(catalog, "post_mess", limit=5)]
+        names = [h.name for h in search_catalog(catalog, "linear issue slack", limit=5)]
         assert names == ["mq_slack_post_message"]
+
+    def test_token_no_document_carries_admits_nothing(self, issue_defs):
+        """'send gmail email' against a catalog with no gmail tool returns nothing rather
+        than five tools that merely share 'message' or 'email'."""
+        from tools.tool_search import build_catalog, search_catalog
+
+        catalog = build_catalog(issue_defs)
+        assert search_catalog(catalog, "post gmail message", limit=5) == []
 
     def test_single_token_stems_are_cached(self):
         from tools.tool_search_catalog import _stem, _tokenize

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -347,7 +347,9 @@ def _shared_tool_record(entry: CatalogEntry) -> Dict[str, Any]:
     except (TypeError, KeyError, AttributeError):
         required = []
     return {"source": entry.source, "source_name": entry.source_name,
-            "description": (entry.description or "")[:400],  # cap chatty MCP descriptions
+            # 500 keeps 9 in 10 vendor tool descriptions whole and every first
+            # sentence (measured p90 575, first-sentence max 329 over 353 tools).
+            "description": (entry.description or "")[:500],
             "required": [r[:64] for r in (required if isinstance(required, list) else [])
                          if isinstance(r, str)][:32]}
 

--- a/tools/tool_search_catalog.py
+++ b/tools/tool_search_catalog.py
@@ -143,25 +143,37 @@ def _corpus_stats(catalog: List[CatalogEntry]) -> _CorpusStats:
     return doc_lengths, avg_dl, dict(doc_freq), len(catalog)
 
 
+def _gate_token(query_tokens: List[str], doc_freq: Dict[str, int], n_docs: int) -> str:
+    """The query token with the highest IDF: the word that names the intent. ``send``,
+    ``read``, ``create`` sit in dozens of tool documents and separate nothing; ``gmail``,
+    ``github``, ``incident`` sit in a few and separate everything. A document without this
+    token answered a different question, however many common tokens it shares."""
+    def _idf(token: str) -> float:
+        df = doc_freq.get(token, 0)
+        return math.log(1 + (n_docs - df + 0.5) / (df + 0.5))
+    return max(query_tokens, key=_idf)
+
+
 def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5, *,
                    corpus_stats: Optional[_CorpusStats] = None) -> List[CatalogEntry]:
     """Top-``limit`` catalog entries for ``query`` by BM25 (exact name match ranks first).
-    Falls back to a name-substring match only when NO query token appears in any document
-    (e.g. "hub" vs ``github_*``); the IDF variant is strictly positive, so a hit anywhere
-    suppresses the fallback."""
+
+    Admission is by the query's rarest token (:func:`_gate_token`), not by ``score > 0``:
+    BM25 is additive over the tokens a document shares with the query, so on a large catalog
+    ``score > 0`` admits one-token matches and fills every slot with them (measured: "send
+    gmail email" returned 5 incident tools that only shared ``email``). A token no document
+    carries admits nothing; the caller's empty-group hint tells the model to retry without it."""
     query_tokens = _tokenize(query) if catalog and limit > 0 else []
     if not query_tokens:
         return []
     corpus_stats = corpus_stats or _corpus_stats(catalog)
-    scored: List[Tuple[float, CatalogEntry]] = []
+    gate = _gate_token(query_tokens, corpus_stats[2], corpus_stats[3])
     exact_name = query.strip().lower()
-    for entry in catalog:
-        s = (float("inf") if entry.name.lower() == exact_name
-             else _bm25_score(query_tokens, entry._tokens, *corpus_stats))
-        if s > 0:
-            scored.append((s, entry))
-    if not scored:
-        scored = [(0.1, entry) for entry in catalog if query.lower() in entry.name.lower()]
+    scored = [
+        (float("inf") if entry.name.lower() == exact_name
+         else _bm25_score(query_tokens, entry._tokens, *corpus_stats), entry)
+        for entry in catalog
+        if entry.name.lower() == exact_name or gate in entry._tokens]
     scored.sort(key=lambda x: x[0], reverse=True)
     return [e for _, e in scored[:limit]]
 

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -179,10 +179,13 @@ to any progressive-disclosure design, not specific to this implementation:
   finds that server's tools even when a tool's own name doesn't carry
   the service), description, and parameter names, with Snowball
   stemming (English) applied to both the index and the query so
-  morphological variants match ("issues" finds `create_issue`). Falls
-  back to a literal substring match on the tool name when no query
-  token matches any document (e.g. searching `"hub"` where the token is
-  `github`).
+  morphological variants match ("issues" finds `create_issue`). A tool is
+  a result only if it contains the query's rarest token (the one in the
+  fewest tool documents, so the word that names the intent: `gmail`,
+  `github`, `incident`, not `send` or `create`). A query whose rarest
+  token appears in no tool returns an empty group with the connected
+  sources and a retry hint, instead of `limit` tools that share one
+  common word.
 - **Parallel execution unwraps the bridge.** The batch planner decides
   concurrency on the *underlying* tool of a `tool_call`, not on the
   literal bridge name — so an MCP server opted in via


### PR DESCRIPTION
`tool_search` is the model's search over tools kept out of its prompt. It used to fill every result list to `limit` (default 5) even when the only link between a result and the query was one common word such as `email`. It now returns no results, plus a hint on how to retry, when the query's most specific word matches no tool.

## The problem

Hermes holds back MCP server tools and a few event-triggered core tools ("deferred" tools) so their schemas do not ride in every prompt. The model finds them with `tool_search`. With one or two MCP servers this worked. With a real install (6 servers, 311 deferred tools) every search returned exactly `limit` names, and for queries the catalog could not answer, all of them were wrong.

Live, on `main`, catalog of 311 tools:

| query | what came back |
|---|---|
| `send gmail email` | `create_incident`, `escalate_incident`, `team_members`, `video_analyze`, `remove_team_member` |
| `read google calendar events` | `on_call_event`, `on_call_events`, `on_call`, `remove_release`, `incident_timeline` |
| `linear create issue` | `create_issue_label`, `save_issue_label`, `link_error_issue`, `save_issue`, `list_issue_statuses` (correct) |

The first two rows are wrong in the same way. No tool in this catalog knows "gmail" or "google". Each result shares one word with the query (`email`, `calendar`, `event`) and nothing else. The model reads five names as five candidates and picks one.

<!-- before-and-after:start -->
| Before (tool_search, 311-tool catalog) | After (tool_search, 311-tool catalog) |
|:---:|:---:|
| ![Before](https://github.com/user-attachments/assets/0a131811-1566-4b13-a3f8-b1f761b081b7) | ![After](https://github.com/user-attachments/assets/e921f14d-c5b7-48b0-a374-5c20c1d29f3b) |

<!-- before-and-after:end -->

## Why it happened

The search scores each tool with BM25, a standard text-ranking formula: a rare word counts for more than a common one, and a match counts for more in a short description than in a long one. Two properties of BM25 caused the bad rows:

1. **The score adds up over the words a tool shares with the query.** Words the tool lacks cost nothing. A tool that matches only `email` scores as if the query had been just "email".
2. **BM25 ranks. It does not judge.** It says which tool is most like the query, never whether any tool is like the query. The old rule kept every tool with a score above zero, that is, every tool sharing at least one word with the query, then returned the top `limit`. With 311 tools, at least five always share some word with any realistic query, so the list was always full.

```mermaid
flowchart LR
    Q["query: send gmail email"] --> T["tokens: send, gmail, email"]
    T --> B["before: keep any tool<br/>sharing one word"]
    T --> A["after: keep only tools<br/>containing the rarest word"]
    B --> B1["5 tools sharing 'email'"]
    A --> A1["rarest word = gmail<br/>in 0 tools"]
    A1 --> A2["empty group + retry hint"]
```

## What changes

A tool is now a result only if its indexed text (name, server name, description, parameter names) contains the query's **rarest token**: the query word found in the fewest tools. In this catalog, generic verbs (`send`, `read`, `create`, `list`) appear in dozens of tools, so they are almost never the rarest word; service and object names (`gmail`, `github`, `incident`, `railway`) appear in one server's tools, so they usually are. Ranking among the tools that pass is unchanged (BM25, exact name first). The gate is `_gate_token` in `tools/tool_search_catalog.py`.

If the rarest word is in no tool at all, nothing passes and the group comes back empty with the existing `available_sources` list and hint ("retry with the service name plus a concrete action"). The model retries with a word the catalog knows, or concludes the capability is not local.

The name-substring fallback (`"hub"` matched `github_*` when no token matched) is deleted. It admitted tools that matched no query word at all, the same defect in a smaller form.

### The one open question

When the rarest query word matches no tool, should the search return nothing (strict) or fall back to the rarest word that does match something (lenient)? This PR is strict, so `list google calendar events tomorrow` returns nothing because `tomorrow` appears in no tool; the model gets the hint and retries without it. Lenient would answer that query, and would also answer `order pizza` with Shopify order tools because `order` is the rarest known word. On the 25-query benchmark below, strict returned 2 wrong names across the 4 queries that have no correct answer; lenient returned 7. Strict was chosen because the empty group already carries the recovery path. Switching is one line in `_gate_token`.

### Also in this PR: description clip 400 to 500 characters

Each result carries a truncated description so the model can choose without a second call. Across 353 third-party tool descriptions (the connector catalog served by the managed tool gateway, captured 2026-09-09), a 500-character clip leaves 91% untruncated and never cuts a first sentence (longest first sentence: 329 characters). The 400-character clip left 82% untruncated.

## What the model experiences

| query | before | after |
|---|---|---|
| `send gmail email` (no gmail tool local) | 5 unrelated tools | empty group, sources listed, retry hint |
| `read google calendar events` | 5 unrelated tools | empty group, sources listed, retry hint |
| `linear create issue` | 5 linear tools | same 5 linear tools |
| `betterstack incident` | 5 incident tools | same 5 incident tools |
| `zzzz` | 5 tools via substring or one-word match | empty group |

I wrote 25 queries and labelled by hand which catalog tools are correct answers for each (5 connector-only intents, 5 local-only, 5 served by both, 5 single vague verbs, 5 with no correct answer). Against the same 311-tool catalog, the share of returned names that were correct (precision at 5) went from 0.18 to 0.43, and the total number of wrong names across all 25 queries fell from 102 to 66. The queries, labels, and catalog snapshot are not in this PR; a companion PR adds them to `hermes-toolbench` (the separate benchmark repo) so the numbers can be re-run offline.

## What this does not do

- It does not weight tool names above descriptions. Measured on the same 25 queries, a 4:1 name weight on top of this rule moved precision from 0.425 to 0.433. Not worth the code.
- It does not help one-word queries (`read`, `create`). A one-word query's rarest token is itself; the top 5 by BM25 is the honest answer.
- It does not touch connectors (remote tools from the managed tool gateway). That fix stacks on this one in the connectors branch.

## How to test

```bash
scripts/run_tests.sh tests/tools/test_tool_search.py tests/tools/test_tool_search_multiquery.py tests/tools/test_deferral_fixes.py
```

129 pass. New behaviour tests: `test_rarest_query_token_gates_admission`, `test_token_no_document_carries_admits_nothing`, `test_unknown_token_returns_nothing`. The fallback test they replace pinned the deleted behaviour.

The before/after tables and screenshots come from the same probe run against `main` and this branch on one machine's real install (6 MCP servers, 311 deferred tools).
