### PR TITLE
fix(projects): preserve Windows drive roots when normalizing folders

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -106,9 +106,8 @@ def _now() -> int:
 
 
 def _normalize_path(path: str) -> str:
-    """Absolute, user-expanded, separator-normalized path (no trailing sep)."""
-    p = os.path.abspath(os.path.expanduser(str(path).strip()))
-    return p.rstrip("/\\") or p
+    """Absolute, user-expanded, normalized path, preserving root separators."""
+    return os.path.abspath(os.path.expanduser(str(path).strip()))
 
 
 def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:

--- a/tests/hermes_cli/test_projects_cli.py
+++ b/tests/hermes_cli/test_projects_cli.py
@@ -57,5 +57,21 @@ def test_rename_and_archive(tmp_path):
         assert len(pdb.list_projects(conn)) == 1
 
 
+@pytest.mark.windows_only
+def test_drive_root_project_stays_absolute(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    root = tmp_path.anchor
+    assert _run(["create", "Drive", root]) == 0
+
+    with pdb.connect_closing() as conn:
+        project = pdb.get_project(conn, "drive")
+        assert project.primary_path == root
+        assert [folder.path for folder in project.folders] == [root]
+        assert pdb.find_by_primary_path(conn, root).id == project.id
+        assert pdb.find_by_primary_path(conn, str(tmp_path)) is None
+
+    # A drive root must not resolve to cwd and falsely claim a child folder.
+    assert _run(["create", "Child", str(tmp_path)]) == 0
+
 
 


### PR DESCRIPTION
## What does this PR do?

Creating a project with a Windows drive root such as `D:\` stores `D:` instead. That is drive-relative: later primary-folder lookup can miss the root project or incorrectly claim the current directory belongs to it, preventing a child project from being created.

`os.path.abspath()` already normalizes trailing separators while preserving roots. Remove the subsequent `rstrip()` from the shared project-path normalizer and add one regression test through the real project argument parser, command handlers, and isolated SQLite database.

## Related Issue

Found by inspection and reproduced on main at `ead7e91dabf1e963796ec834b196984a2fa44ff4`. No matching issue or PR found in all-state searches for `drive root`, `projects drive root`, `projects rstrip`, and `projects_db root`. Related PRs #63262 and #65030 concern frontend path identity and Unicode normalization, not this backend drive-root truncation.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/projects_db.py`: preserve root separators by relying on the existing standard-library normalization.
- `tests/hermes_cli/test_projects_cli.py`: verify a drive-root project stays absolute, root lookup succeeds, and creating a child project is not rejected as a duplicate. Marked `windows_only` for native Windows CI.

## How to Test

In a disposable `HERMES_HOME`, from a non-root directory on drive D:

```powershell
hermes project create Drive D:\
hermes project show drive
hermes project create Child "$PWD"
```

Before: primary folder is `D:` and the child can be rejected as already belonging to `drive`. After: primary folder is `D:\` and the child succeeds.

Run through the canonical runner (Git Bash on Windows):

```bash
bash scripts/run_tests.sh tests/hermes_cli/test_projects_cli.py tests/hermes_cli/test_projects_db.py -j 2 --file-retries 0
```

Native Windows, Python 3.11.15, pytest 9.1.1:

- Original main with the new regression: 7 passed, 3 failed. The regression fails with `assert 'D:' == 'D:\\'`.
- With the fix: 8 passed, 2 failed; all 3 project CLI tests pass.
- The same 2 existing DB tests fail on both revisions: `test_create_get_list` and `test_per_profile_isolation` expect literal POSIX paths on Windows (`/tmp/hermes`, `/a/scanned`). No changes to those tests.
- Windows-footgun check on changed files, plugin-compat pointer check, and `git diff --check` pass.

The full repository suite was not run. Tests use an isolated home and database. The patch prevents new path truncation; it does not migrate previously stored drive-relative paths.

## Checklist

- [x] Read the contributing guide and searched existing PRs.
- [x] Conventional commit; one logical fix; no unrelated changes.
- [x] Added a behavior regression test, proven red on the original code.
- [x] Tested on native Windows.
- [ ] Full test suite passes — not run; focused results and existing failures documented above.
- [x] Documentation/config/schema/architecture updates: not applicable beyond the normalizer docstring.

Prepared with Codex assistance; reproduction and test results were reviewed before submission.
