### PR TITLE
fix(slack): bind triggering message to session source

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4352,6 +4352,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_name=user_name,
             thread_id=thread_ts,
             scope_id=str(team_id) if team_id else None,
+            message_id=ts,
             # Workflow/app posts have user=None; flag them so the SLACK_ALLOW_BOTS bypass can
             # authorize them. Same predicate as the drop gate (api_human_users stay human).
             is_bot=self._event_declares_bot_sender(event))

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3807,6 +3807,10 @@ class TestProgressMessageThread:
             "message_id must equal the event ts so _run_agent can use it as "
             "the fallback thread anchor for progress messages"
         )
+        assert source.message_id == "1234567890.000001", (
+            "source.message_id must carry the authenticated triggering Slack ts "
+            "into session-bound tools"
+        )
 
         # Verify that the Slack send() method correctly threads a message
         # when metadata contains thread_id equal to the original ts


### PR DESCRIPTION
## Summary
Slack message events already retain the event `ts` as `MessageEvent.message_id`, but session-bound tools read authenticated context from `SessionSource.message_id`. Set the same Slack event timestamp on the session source so guarded tools can reliably identify the triggering user message.

## Test
`uv run --with pytest --with pytest-asyncio --with aiohttp --with slack-bolt --with slack-sdk pytest tests/gateway/test_slack.py -q -k test_dm_toplevel_progress_uses_message_ts_as_thread`