### PR TITLE
fix(update): retire fleet_restart_pending when live gateways match expected_sha

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -183,14 +183,73 @@ def _live_fleet_covers_receipt(expected_sha: str | None) -> bool:
         return False
 
 
+def _marker_expected_sha(text: str) -> str | None:
+    """Parse ``expected_sha=`` from a ``fleet_restart_pending`` body.
+
+    Missing or empty values cannot be verified and must fail open.
+    """
+    for line in text.splitlines():
+        if line.startswith("expected_sha="):
+            value = line.split("=", 1)[1].strip()
+            return value or None
+    return None
+
+
+def _live_fleet_covers_marker_sha(expected_sha: str) -> bool:
+    """True when every live gateway row vouches for *expected_sha*.
+
+    Fail open (False) when the probe is empty, raises, or any live row cannot
+    vouch — empty ``code_sha``, SHA mismatch, or an explicitly stale row.
+    A receipt is not required; live ``code_sha`` is the discharge evidence.
+    """
+    if not expected_sha:
+        return False
+    from hermes_cli.update_receipt import collect_fleet_versions
+
+    try:
+        fleet = collect_fleet_versions()
+    except Exception as exc:
+        logger.debug("Could not probe live fleet for pending marker: %s", exc)
+        return False
+    if not fleet:
+        return False
+    vouched = False
+    for row in fleet:
+        if not isinstance(row, dict):
+            return False
+        code_sha = row.get("code_sha")
+        if not code_sha:
+            return False
+        if str(code_sha) != str(expected_sha):
+            return False
+        if row.get("state") == "stale":
+            return False
+        vouched = True
+    return vouched
+
+
 def _pending_fleet_restart_needed() -> bool:
     """Reconcile old restart obligations against current, identity-matched gateways."""
     from hermes_cli.update_cmd import _current_checkout_sha
 
-    # The marker has no runtime inventory and may belong to a newer, killed update
-    # than latest.json. An older receipt cannot discharge that unknown obligation.
+    # Marker may belong to a newer, killed update than latest.json. An older
+    # receipt cannot discharge that unknown obligation — but a live fleet
+    # already running expected_sha can (#106682).
     with suppress(OSError):
-        if _fleet_restart_pending_marker_path().is_file():
+        path = _fleet_restart_pending_marker_path()
+        if path.is_file():
+            try:
+                body = path.read_text(encoding="utf-8")
+            except OSError:
+                return True
+            expected = _marker_expected_sha(body)
+            if expected and _live_fleet_covers_marker_sha(expected):
+                logger.info(
+                    "Retiring fleet_restart_pending: live gateways match expected_sha=%s",
+                    expected,
+                )
+                _clear_fleet_restart_pending_marker()
+                return False
             return True
     if not _receipt_reports_stale_runtime():
         return False

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -176,10 +176,41 @@ def test_marker_round_trip_under_hermes_home():
 
 
 def test_pending_needed_when_marker_exists():
+    # No expected_sha: cannot verify live fleet, so fail-open (marker existence ⇒ pending).
     update_cmd._write_fleet_restart_pending_marker()
     assert update_cmd._pending_fleet_restart_needed() is True
     update_cmd._clear_fleet_restart_pending_marker()
     assert update_cmd._pending_fleet_restart_needed() is False
+
+
+def test_marker_with_expected_sha_cleared_when_live_fleet_matches(monkeypatch):
+    update_cmd._write_fleet_restart_pending_marker(expected_sha="AAA")
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **k: [{"profile": "default", "code_sha": "AAA", "state": "current"}],
+    )
+    assert update_cmd._pending_fleet_restart_needed() is False
+    assert not update_cmd._fleet_restart_pending_marker_path().exists()
+
+
+def test_marker_still_pending_when_live_fleet_sha_mismatches(monkeypatch):
+    update_cmd._write_fleet_restart_pending_marker(expected_sha="AAA")
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **k: [{"profile": "default", "code_sha": "BBB", "state": "current"}],
+    )
+    assert update_cmd._pending_fleet_restart_needed() is True
+    assert update_cmd._fleet_restart_pending_marker_path().is_file()
+
+
+def test_marker_fail_open_when_no_live_fleet(monkeypatch):
+    update_cmd._write_fleet_restart_pending_marker(expected_sha="AAA")
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **k: [],
+    )
+    assert update_cmd._pending_fleet_restart_needed() is True
+    assert update_cmd._fleet_restart_pending_marker_path().is_file()
 
 
 def test_pending_needed_when_unfinished_receipt_runtime_sha_skews(monkeypatch):

--- a/tests/hermes_cli/test_update_obligation_identity.py
+++ b/tests/hermes_cli/test_update_obligation_identity.py
@@ -57,7 +57,9 @@ def test_every_owed_identity_requires_current_evidence(monkeypatch, bad):
     directory = home / "logs" / "update_receipts"
     directory.mkdir(parents=True)
     if bad == "marker":
-        (home / "fleet_restart_pending").write_text("expected_sha=new\n")
+        # No expected_sha: cannot verify live fleet, so the marker still
+        # fail-opens even when successors would cover the receipt (#106682).
+        (home / "fleet_restart_pending").write_text("started=1\npid=1\n")
     owed = {"kind": "gateway", "profile": "beta", "code_sha": "old"}
     if bad == "wrong-kind":
         owed["kind"] = "serve"


### PR DESCRIPTION
## What does this PR do?

`fleet_restart_pending` was treated as an open obligation solely because the marker file existed. Only the updater cleared it. When gateways were restarted by an operator, agent fallback, or a timeout-killed updater before bookkeeping finished, the marker survived indefinitely: every non-`update` CLI launch printed a false mixed-`sys.modules` warning, and the next `hermes update` force-restarted an already-current fleet.

This PR keeps writing the marker after pull, but `_pending_fleet_restart_needed()` now compares the marker's `expected_sha` against live gateway rows from `collect_fleet_versions()` (the same `code_sha` surface the updater verify stage trusts). When every live row vouches for that SHA, the marker is retired (self-heal) and warning/catch-up no-op. Missing `expected_sha`, empty/failed fleet probes, or any unvouched/mismatched row fail open and preserve the old pending behavior.

## Related Issue

Fixes #106682

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `hermes_cli/update_cmd_fleet.py`: parse marker `expected_sha`; `_live_fleet_covers_marker_sha()`; clear marker when live fleet matches
- `tests/hermes_cli/test_update_fleet_restart_pending.py`: match/self-heal, mismatch, empty-fleet fail-open
- `tests/hermes_cli/test_update_obligation_identity.py`: keep expected_sha-less marker as fail-open pending

## How to Test

```
HERMES_PYTHON=<venv-python> scripts/run_tests.sh \
  tests/hermes_cli/test_update_fleet_restart_pending.py \
  tests/hermes_cli/test_update_obligation_identity.py
# -> 2 files, 34 passed
```

Proof receipt: pre-fix, `test_marker_with_expected_sha_cleared_when_live_fleet_matches` failed (`assert True is False`); post-fix focused suite GREEN.

## Review follow-up

- Does not require an update receipt to discharge the marker (receipts are often absent in the field).
- Empty fleet / empty `code_sha` / probe errors fail open and keep the marker.
- Does not change marker write-after-pull or warning copy.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(update): ...`)
- [x] Searched existing PRs for duplicates
- [x] Only changes related to this fix
- [x] Ran relevant tests locally
- [x] Added tests for the change
- [x] Tested on: macOS (focused suite)

### Documentation & Housekeeping
- [x] Docs — N/A
- [x] cli-config.yaml.example — N/A
- [x] Cross-platform impact considered (marker + local gateway_state probe)
- [x] Tool schemas — N/A

Made with [Cursor](https://cursor.com)