### PR TITLE
fix(cli): oneshot -t admits portable plugin MCP servers

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -68,8 +68,32 @@ def _build_preloaded_skills_prompt(skills: object = None) -> str | None:
     return skills_prompt or None
 
 
+def _portable_mcp_server_names() -> set[str]:
+    """In-memory portable-plugin MCP names (not written to config.yaml). Empty on any error."""
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+
+        return set(get_plugin_manager().get_portable_mcp_servers())
+    except Exception:
+        return set()
+
+
+def _resolve_mcp_toolset_name(name: str, mcp_names: set[str]) -> str | None:
+    """Exact MCP/portable name, or the unique portable ``ns__server`` whose suffix matches *name*."""
+    if name in mcp_names:
+        return name
+    matches = [full for full in mcp_names if "__" in full and full.rsplit("__", 1)[-1] == name]
+    return matches[0] if len(matches) == 1 else None
+
+
 def _configured_mcp_servers() -> tuple[set[str], set[str]]:
-    """``(enabled, disabled)`` MCP server names from config; both empty on any error."""
+    """``(enabled, disabled)`` MCP server names from config **plus portable plugins**.
+
+    Portable Agent Plugin servers live in PluginManager, not ``mcp_servers`` in
+    config.yaml. ``enabled_mcp_server_names()`` already unions them for the
+    platform_toolsets path; oneshot ``-t`` validation must do the same or
+    ``hermes -z -t <portable>`` exits 2 while a no-``-t`` oneshot admits.
+    """
     try:
         from hermes_cli.config import read_raw_config
         from hermes_cli.tools_config import _parse_enabled_flag
@@ -83,6 +107,7 @@ def _configured_mcp_servers() -> tuple[set[str], set[str]]:
                 continue
             target = enabled if _parse_enabled_flag(server_cfg.get("enabled", True), default=True) else disabled
             target.add(str(name))
+        enabled |= _portable_mcp_server_names() - disabled
         return enabled, disabled
     except Exception:
         return set(), set()
@@ -122,9 +147,17 @@ def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | No
         return None, None
 
     mcp_names, mcp_disabled = _configured_mcp_servers() if unresolved else (set(), set())
-    mcp_valid = [name for name in unresolved if name in mcp_names]
+    mcp_valid: list[str] = []
+    still_unresolved: list[str] = []
+    for name in unresolved:
+        resolved = _resolve_mcp_toolset_name(name, mcp_names)
+        if resolved is not None:
+            mcp_valid.append(resolved)
+        else:
+            still_unresolved.append(name)
+    unresolved = still_unresolved
     disabled = [name for name in unresolved if name in mcp_disabled]
-    unknown = [name for name in unresolved if name not in mcp_names and name not in mcp_disabled]
+    unknown = [name for name in unresolved if name not in mcp_disabled]
     valid = built_in + mcp_valid
 
     if unknown:

--- a/tests/hermes_cli/test_oneshot_explicit_toolsets.py
+++ b/tests/hermes_cli/test_oneshot_explicit_toolsets.py
@@ -1,0 +1,53 @@
+"""Oneshot -t must admit portable plugin MCP servers (not only config.yaml mcp_servers)."""
+
+from unittest.mock import patch
+
+from hermes_cli.oneshot import (
+    _configured_mcp_servers,
+    _resolve_mcp_toolset_name,
+    _validate_explicit_toolsets,
+)
+
+
+PORTABLE = "agent-plugin-rivetflo-csr-runtime-11e814b1__living-runtime"
+
+
+def test_resolve_mcp_toolset_name_exact_and_suffix():
+    names = {PORTABLE, "rivetflo"}
+    assert _resolve_mcp_toolset_name(PORTABLE, names) == PORTABLE
+    assert _resolve_mcp_toolset_name("living-runtime", names) == PORTABLE
+    assert _resolve_mcp_toolset_name("rivetflo", names) == "rivetflo"
+    assert _resolve_mcp_toolset_name("nope", names) is None
+
+
+def test_configured_mcp_servers_unions_portable(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.oneshot._portable_mcp_server_names",
+        lambda: {PORTABLE},
+    )
+    with patch("hermes_cli.config.read_raw_config", return_value={"mcp_servers": {"rivetflo": {}}}):
+        enabled, disabled = _configured_mcp_servers()
+    assert PORTABLE in enabled
+    assert "rivetflo" in enabled
+    assert not disabled
+
+
+def test_validate_explicit_toolsets_accepts_portable_and_short_alias():
+    with patch("hermes_cli.oneshot._configured_mcp_servers", return_value=({PORTABLE}, set())):
+        with patch("toolsets.validate_toolset", return_value=False):
+            with patch("hermes_cli.plugins.discover_plugins"):
+                valid, err = _validate_explicit_toolsets(PORTABLE)
+                assert err is None
+                assert valid == [PORTABLE]
+                valid_short, err_short = _validate_explicit_toolsets("living-runtime")
+                assert err_short is None
+                assert valid_short == [PORTABLE]
+
+
+def test_validate_explicit_toolsets_unknown_still_errors():
+    with patch("hermes_cli.oneshot._configured_mcp_servers", return_value=(set(), set())):
+        with patch("toolsets.validate_toolset", return_value=False):
+            with patch("hermes_cli.plugins.discover_plugins"):
+                valid, err = _validate_explicit_toolsets("living-runtime")
+                assert valid is None
+                assert err and "did not contain any valid toolsets" in err

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -418,7 +418,14 @@ def discover_mcp_tools(allowed_mcp_names: Optional[List[str]] = None) -> List[st
         return []
     if allowed_mcp_names is not None:
         allowed_set = {str(n) for n in allowed_mcp_names}
-        filtered = {name: cfg for name, cfg in servers.items() if name in allowed_set}
+        # Portable Agent Plugin servers are namespaced ``{skill_namespace}__{server_id}``.
+        # ``hermes -z -t living-runtime`` must spawn that namespaced server, not only an
+        # exact key match (built-in toolset names still never match).
+        def _allowed(name: str) -> bool:
+            if name in allowed_set:
+                return True
+            return "__" in name and name.rsplit("__", 1)[-1] in allowed_set
+        filtered = {name: cfg for name, cfg in servers.items() if _allowed(name)}
         if len(filtered) != len(servers):
             logger.debug("MCP discovery filter: spawning %d/%d configured server(s) per --toolsets filter "
                          "(skipped: %s)", len(filtered), len(servers), ",".join(sorted(set(servers) - set(filtered))))


### PR DESCRIPTION
## Summary
Oneshot `-t` validation only consulted `config.yaml` `mcp_servers`, so `hermes -z -t <portable>` exited 2 while the implicit `platform_toolsets` path admitted the same portable Agent Plugin MCP server.

## Changes
- Union in-memory portable plugin MCP names into oneshot validation
- Resolve a unique short suffix such as `living-runtime` to its namespaced `ns__server` key
- Let MCP discovery's explicit filter spawn the matching namespaced server

## Tests
- Added focused coverage in `tests/hermes_cli/test_oneshot_explicit_toolsets.py`
- Local direct smoke: portable union, suffix resolution, and explicit validation pass
- Live canary will be reported separately: `csr-dh-ops`, `hermes -z -t living-runtime`