### PR TITLE
fix(skills): point github skill helpers at the consolidated scripts path

### DIFF
--- a/skills/software-development/github/references/auth.md
+++ b/skills/software-development/github/references/auth.md
@@ -47,33 +47,55 @@ Tell the user to go to: **https://github.com/settings/tokens**
 - Set expiration (90 days is a good default)
 - Copy the token — it won't be shown again
 
-**Step 2: Configure git to store the token**
+**Step 2: Configure git to hold the token**
+
+Prefer the OS keychain-backed helper — the token lands in the system
+credential store instead of a plaintext file:
 
 ```bash
-# Set up the credential helper to cache credentials
-# "store" saves to ~/.git-credentials in plaintext (simple, persistent)
-git config --global credential.helper store
+# macOS
+git config --global credential.helper osxkeychain
+# Linux (GNOME; requires libsecret)
+git config --global credential.helper libsecret
+# Windows (ships with Git for Windows)
+git config --global credential.helper manager
+```
 
-# Now do a test operation that triggers auth — git will prompt for credentials
-# Username: <their-github-username>
-# Password: <paste the personal access token, NOT their GitHub password>
+If no keychain is available, the in-memory cache keeps the token out of
+disk-backed state for the session:
+
+```bash
+# Cache in memory for 8 hours (28800 seconds); nothing is written to disk
+git config --global credential.helper 'cache --timeout=28800'
+```
+
+**Last resort — plaintext store:** `store` saves the token unencrypted to
+`~/.git-credentials`, readable by anything with the user's file access. Use
+it only when the user explicitly accepts that trade-off (e.g. a throwaway
+container):
+
+```bash
+git config --global credential.helper store
+```
+
+Whichever helper is set, prime it with one test operation — git prompts for
+credentials once (Username: their GitHub username, Password: the personal
+access token, NOT their GitHub password):
+
+```bash
 git ls-remote https://github.com/<their-username>/<any-repo>.git
 ```
 
 After entering credentials once, they're saved and reused for all future operations.
 
-**Alternative: cache helper (credentials expire from memory)**
+**Avoid tokens in remote URLs.** `https://<username>:<token>@github.com/...`
+copies the token into `.git/config`, `git remote -v` output, shell history,
+and every tool that reads the remote URL. Use the credential helper or a
+`GITHUB_TOKEN` env var instead. If a token-bearing URL is already configured,
+scrub it:
 
 ```bash
-# Cache in memory for 8 hours (28800 seconds) instead of saving to disk
-git config --global credential.helper 'cache --timeout=28800'
-```
-
-**Alternative: set the token directly in the remote URL (per-repo)**
-
-```bash
-# Embed token in the remote URL (avoids credential prompts entirely)
-git remote set-url origin https://<username>:<token>@github.com/<owner>/<repo>.git
+git remote set-url origin https://github.com/<owner>/<repo>.git
 ```
 
 **Step 3: Configure git identity**
@@ -108,8 +130,10 @@ ls -la ~/.ssh/id_*.pub 2>/dev/null || echo "No SSH keys found"
 **Step 2: Generate a key if needed**
 
 ```bash
-# Generate an ed25519 key (modern, secure, fast)
-ssh-keygen -t ed25519 -C "their-email@example.com" -f ~/.ssh/id_ed25519 -N ""
+# Generate an ed25519 key (modern, secure, fast). Let ssh-keygen prompt for
+# a passphrase interactively — a passphrase-less key is single-factor access
+# to the account. Only pass -N "" if the user explicitly opts in knowing that.
+ssh-keygen -t ed25519 -C "their-email@example.com" -f ~/.ssh/id_ed25519
 
 # Display the public key for them to add to GitHub
 cat ~/.ssh/id_ed25519.pub
@@ -259,11 +283,11 @@ curl -s -H "Authorization: token $GITHUB_TOKEN" \
 
 ### Extracting the Token from Git Credentials
 
-If git credentials are already configured (via credential.helper store), the token can be extracted:
+If git credentials are already configured (via a configured credential helper), the token can be extracted:
 
 ```bash
 # Read from git credential store
-uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py"
+uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py"
 ```
 
 ### Helper: Detect Auth Method
@@ -280,7 +304,7 @@ elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && 
   export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
   echo "AUTH_METHOD=curl"
 elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-  export GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+  export GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
   echo "AUTH_METHOD=curl"
 else
   echo "AUTH_METHOD=none"
@@ -298,6 +322,6 @@ fi
 | `remote: Permission to X denied` | Token may lack `repo` scope — regenerate with correct scopes |
 | `fatal: Authentication failed` | Cached credentials may be stale — run `git credential reject` then re-authenticate |
 | `ssh: connect to host github.com port 22: Connection refused` | Try SSH over HTTPS port: add `Host github.com` with `Port 443` and `Hostname ssh.github.com` to `~/.ssh/config` |
-| Credentials not persisting | Check `git config --global credential.helper` — must be `store` or `cache` |
+| Credentials not persisting | Check `git config --global credential.helper` — should be a keychain helper (`osxkeychain`/`libsecret`/`manager`) or `cache` |
 | Multiple GitHub accounts | Use SSH with different keys per host alias in `~/.ssh/config`, or per-repo credential URLs |
 | `gh: command not found` + no sudo | Use git-only Method 1 above — no installation needed |

--- a/skills/software-development/github/references/code-review.md
+++ b/skills/software-development/github/references/code-review.md
@@ -4,7 +4,7 @@ Perform code reviews on local changes before pushing, or review open PRs on GitH
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
+- Authenticated with GitHub (see `references/auth.md`)
 - Inside a git repository
 
 ### Setup (for PR interactions)
@@ -18,7 +18,7 @@ else
     if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
       GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     fi
   fi
 fi
@@ -322,7 +322,7 @@ When the user asks you to "review PR #N", "look at this PR", or gives you a PR U
 ### Step 1: Set up environment
 
 ```bash
-source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
+source "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/gh-env.sh"
 # Or run the inline setup block from the top of this skill
 ```
 

--- a/skills/software-development/github/references/github-api-cheatsheet.md
+++ b/skills/software-development/github/references/github-api-cheatsheet.md
@@ -6,7 +6,7 @@ All requests need: `-H "Authorization: token $GITHUB_TOKEN"`
 
 Use the `gh-env.sh` helper to set `$GITHUB_TOKEN`, `$GH_OWNER`, `$GH_REPO` automatically:
 ```bash
-source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
+source "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/gh-env.sh"
 ```
 
 ## Repositories

--- a/skills/software-development/github/references/issues.md
+++ b/skills/software-development/github/references/issues.md
@@ -4,7 +4,7 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
+- Authenticated with GitHub (see `references/auth.md`)
 - Inside a git repo with a GitHub remote, or specify the repo explicitly
 
 ### Setup
@@ -18,7 +18,7 @@ else
     if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
       GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     fi
   fi
 fi

--- a/skills/software-development/github/references/pr-workflow.md
+++ b/skills/software-development/github/references/pr-workflow.md
@@ -4,7 +4,7 @@ Complete guide for managing the PR lifecycle. Each section shows the `gh` way fi
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
+- Authenticated with GitHub (see `references/auth.md`)
 - Inside a git repository with a GitHub remote
 
 ### Quick Auth Detection
@@ -20,7 +20,7 @@ else
     if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
       GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     fi
   fi
 fi

--- a/skills/software-development/github/references/repo-management.md
+++ b/skills/software-development/github/references/repo-management.md
@@ -4,7 +4,7 @@ Create, clone, fork, configure, and manage GitHub repositories. Each section sho
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
+- Authenticated with GitHub (see `references/auth.md`)
 
 ### Setup
 
@@ -17,7 +17,7 @@ else
     if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
       GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     fi
   fi
 fi

--- a/skills/software-development/github/scripts/gh-env.sh
+++ b/skills/software-development/github/scripts/gh-env.sh
@@ -2,7 +2,7 @@
 # GitHub environment detection helper for Hermes Agent skills.
 #
 # Usage (via terminal tool):
-#   source skills/github/github-auth/scripts/gh-env.sh
+#   source "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/gh-env.sh"
 #
 # After sourcing, these variables are set:
 #   GH_AUTH_METHOD  - "gh", "curl", or "none"
@@ -29,7 +29,7 @@ elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && 
         GH_AUTH_METHOD="curl"
     fi
 elif [ -f "$HOME/.git-credentials" ]; then
-    GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+    GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     if [ -n "$GITHUB_TOKEN" ]; then
         GH_AUTH_METHOD="curl"
     fi
@@ -61,6 +61,6 @@ unset _remote_url
 echo "GitHub Auth: $GH_AUTH_METHOD"
 [ -n "$GH_USER" ]       && echo "User: $GH_USER"
 [ -n "$GH_OWNER_REPO" ] && echo "Repo: $GH_OWNER_REPO"
-[ "$GH_AUTH_METHOD" = "none" ] && echo "⚠ Not authenticated — see github-auth skill"
+[ "$GH_AUTH_METHOD" = "none" ] && echo "⚠ Not authenticated — see references/auth.md of the github skill"
 
 export GH_AUTH_METHOD GITHUB_TOKEN GH_USER GH_OWNER GH_REPO GH_OWNER_REPO

--- a/tests/skills/test_github_skill.py
+++ b/tests/skills/test_github_skill.py
@@ -128,3 +128,34 @@ def test_issue_to_pr_not_a_router():
     steps = re.findall(r"^### \d+\..*?(?=^### \d+\.|^## |\Z)", body, re.MULTILINE | re.DOTALL)
     routing = [s for s in steps if re.match(r"^### \d+\.[^\n]*\n+Load `", s)]
     assert len(routing) == 0, "steps must not open by delegating to another skill"
+
+
+def test_no_stale_split_skill_helper_paths():
+    """The consolidated skill must not reference the removed split layout.
+
+    The pre-consolidation layout (${HERMES_HOME}/skills/github/github-auth/...)
+    no longer exists after the six github-* skills merged; any reference to it
+    resolves to nothing on a clean profile.
+    """
+    for p in sorted(SKILL_DIR.rglob("*")):
+        if p.is_file() and p.suffix in (".md", ".sh"):
+            content = p.read_text(encoding="utf-8")
+            for marker in ("skills/github/", "github-auth/"):
+                assert marker not in content, (
+                    f"stale split-skill path {marker!r} survived in {p}"
+                )
+
+
+def test_referenced_helper_scripts_exist():
+    """Every scripts/<name> helper a bundled file names must ship beside it."""
+    scanned = [
+        SKILL_PATH,
+        *sorted((SKILL_DIR / "references").glob("*.md")),
+        SKILL_DIR / "scripts" / "gh-env.sh",
+    ]
+    for p in scanned:
+        content = p.read_text(encoding="utf-8")
+        for name in sorted(set(re.findall(r"scripts/([A-Za-z0-9_.-]+)", content))):
+            assert (SKILL_DIR / "scripts" / name).is_file(), (
+                f"{p.name} references helper scripts/{name} that does not exist"
+            )


### PR DESCRIPTION
## Summary

The consolidated `github` skill still pointed several workflows at helper paths from the removed split-skill layout. On `main` (verified), six files invoked `${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/…`, which has not existed since the six `github-*` skills merged into `skills/software-development/github/`:

- `references/auth.md` — `git-credential-token.py` ×2 (token extraction + detect-auth fallback chain)
- `references/issues.md`, `references/pr-workflow.md`, `references/repo-management.md` — detect-auth fallback chain
- `references/code-review.md` — fallback chain + `source …/gh-env.sh`
- `references/github-api-cheatsheet.md` — `source …/gh-env.sh`
- `scripts/gh-env.sh` — the helper **itself** re-invoked `git-credential-token.py` through the dead path, and its usage comment / "see github-auth skill" note were stale

On a clean profile every one of these resolves to nothing: the curl fallback chain silently degrades to `AUTH_METHOD=none` (or an empty token) with no signal.

**Fix:** repoint all of the above to `${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/` (the category subtree is preserved verbatim on install — verified against a live profile), and fix the stale `github-auth` pointers to the merged reference. Also live-tested `source gh-env.sh` on a real profile: `GitHub Auth: gh / User: kokhlo / Repo: …`.

**Auth-safety pass over `references/auth.md`** (the second half of the issue):

- keychain-backed helpers (`osxkeychain`/`libsecret`/`manager`) are now the default for git-only PAT setups; in-memory `cache` second; plaintext `credential.helper store` demoted to an explicitly-flagged last resort
- the "token in remote URL" snippet is replaced by an avoid-note + scrub command (token-bearing URLs leak into `.git/config`, `git remote -v`, shell history)
- `ssh-keygen -N ""` is no longer the recipe: interactive passphrase by default, empty passphrase only as an informed opt-in
- the device-flow and `hosts.yml` escapes stay, strictly gated behind their documented PTY/keyring-hang pitfalls (they are contingency paths, not recommendations)

## Tests

Two regression tests in `tests/skills/test_github_skill.py`:

- `test_no_stale_split_skill_helper_paths` — no `.md`/`.sh` file under the skill tree may contain `skills/github/` or `github-auth/` (mutation-verified: re-injecting the dead path fails the test)
- `test_referenced_helper_scripts_exist` — every `scripts/<name>` a bundled file mentions must exist in the skill tree (mutation-verified: renaming the helper to a nonexistent file fails the test)

```
$ env -u HERMES_YOLO_MODE .venv/bin/python -m pytest tests/skills/test_github_skill.py -q
13 passed in 0.37s
$ bash -n skills/software-development/github/scripts/gh-env.sh  # ok
$ ruff check tests/skills/test_github_skill.py                  # All checks passed!
```

`generate-skill-docs.py` output for this skill is unchanged by the diff (verified by running the generator — only pre-existing cross-platform path drift unrelated to this change appears).

Fixes #106671