### PR TITLE
fix(auth): accept valid session tokens in gated WebSocket auth (#106685)

### DIFF
--- a/hermes_cli/web_server_chat.py
+++ b/hermes_cli/web_server_chat.py
@@ -225,10 +225,12 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
     ``credential`` names what was presented so the accept path can log *how*.
 
     Loopback / ``--insecure``: legacy ``?token=`` (constant-time compared).
-    Gated: ``?ticket=`` (browser-minted, single-use, 30s TTL) or ``?internal=``
+    Gated: ``?ticket=`` (browser-minted, single-use, 30s TTL), ``?internal=``
     (process-lifetime, multi-use, only for server-spawned WS clients so the PTY
-    child can reconnect; never injected into the SPA).  The legacy token is
-    rejected in gated mode: a leaked ``_SESSION_TOKEN`` must not grant access.
+    child can reconnect; never injected into the SPA), or ``?token=``
+    (user session access token verified against the dashboard auth session providers,
+    e.g. for Remote desktop connections). The legacy in-process ``_SESSION_TOKEN``
+    is rejected in gated mode: a leaked ``_SESSION_TOKEN`` must not grant access.
     """
     from hermes_cli.web_server import _SESSION_TOKEN, app
     auth_required = bool(getattr(app.state, "auth_required", False))
@@ -266,21 +268,46 @@ def _ws_auth_reason(ws: "WebSocket") -> tuple[Optional[str], str]:
         if protocol_reason == "invalid":
             return "ticket_invalid", "ticket-subprotocol"
         ticket = protocol_ticket or ws.query_params.get("ticket", "")
-        if not ticket:
-            return "no_credential", "none"
+        if ticket:
+            try:
+                _stamp_identity(consume_ticket(ticket))
+                if protocol_ticket:
+                    # Select only the stable public protocol during accept. The
+                    # ticket-bearing protocol is a credential and must never be
+                    # reflected back to the browser or retained after admission.
+                    ws._hermes_ws_subprotocol = _GATEWAY_WS_PROTOCOL
+                    return None, "ticket-subprotocol"
+                return None, "ticket"
+            except TicketInvalid as exc:
+                _reject(str(exc))
+                return "ticket_invalid", "ticket"
 
-        try:
-            _stamp_identity(consume_ticket(ticket))
-            if protocol_ticket:
-                # Select only the stable public protocol during accept. The
-                # ticket-bearing protocol is a credential and must never be
-                # reflected back to the browser or retained after admission.
-                ws._hermes_ws_subprotocol = _GATEWAY_WS_PROTOCOL
-                return None, "ticket-subprotocol"
-            return None, "ticket"
-        except TicketInvalid as exc:
-            _reject(str(exc))
-            return "ticket_invalid", "ticket"
+        token = ws.query_params.get("token", "")
+        if token:
+            from hermes_cli.dashboard_auth.middleware import _verify_access_token
+            session = _verify_access_token(ws, access_token=token, audit=False)
+            if session is not None:
+                _stamp_identity({
+                    "user_id": getattr(session, "user_id", None),
+                    "provider": getattr(session, "provider", None),
+                })
+                audit_log(
+                    AuditEvent.TOKEN_AUTH_SUCCESS,
+                    provider=getattr(session, "provider", None),
+                    user_id=getattr(session, "user_id", None),
+                    ip=(ws.client.host if ws.client else ""),
+                    path=ws.url.path,
+                )
+                return None, "token"
+            audit_log(
+                AuditEvent.TOKEN_AUTH_FAILURE,
+                reason="session_token_invalid",
+                ip=(ws.client.host if ws.client else ""),
+                path=ws.url.path,
+            )
+            return "token_invalid", "token"
+
+        return "no_credential", "none"
 
     token = ws.query_params.get("token", "")
     if not token:

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -19,6 +19,8 @@ import pytest
 
 from fastapi.testclient import TestClient
 
+import time
+
 from hermes_cli import web_server
 import hermes_cli.web_server_chat as _web_server_chat
 from hermes_cli.dashboard_auth import clear_providers, register_provider
@@ -28,7 +30,7 @@ from hermes_cli.dashboard_auth.ws_tickets import (
     internal_ws_credential,
     mint_ticket,
 )
-from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider, _sign
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +269,57 @@ class TestWsAuthOkGated:
         _SESSION_TOKEN (e.g. a leaked log line)."""
         ws = _fake_ws(query={"token": web_server._SESSION_TOKEN})
         assert _web_server_chat._ws_auth_ok(ws) is False
+
+    def test_session_token_accepted_in_gated_mode(self, gated_app):
+        """User session access token via ?token= is accepted in gated mode."""
+        access_token = _sign({
+            "sub": "remote-desktop-user",
+            "email": "user@example.test",
+            "name": "Remote User",
+            "org_id": "org-1",
+            "exp": int(time.time()) + 3600,
+        })
+        ws = _fake_ws(query={"token": access_token}, path="/api/ws")
+        assert _web_server_chat._ws_auth_ok(ws) is True
+        assert ws._hermes_auth_identity == {
+            "user_id": "remote-desktop-user",
+            "provider": "stub",
+        }
+
+    def test_invalid_session_token_rejected_in_gated_mode(self, gated_app):
+        """Bogus token in gated mode fails with token_invalid and audits failure."""
+        ws = _fake_ws(query={"token": "bogus-token"}, path="/api/ws")
+        reason, cred = _web_server_chat._ws_auth_reason(ws)
+        assert reason == "token_invalid"
+        assert cred == "token"
+        assert _web_server_chat._ws_auth_ok(ws) is False
+
+    def test_session_token_audit_logs(self, gated_app, tmp_path, monkeypatch):
+        """Audit log records token_auth_success and token_auth_failure in gated mode."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.dashboard_auth import audit as audit_mod
+
+        if hasattr(audit_mod, "_LOGGER"):
+            monkeypatch.setattr(audit_mod, "_LOGGER", None, raising=False)
+
+        access_token = _sign({
+            "sub": "remote-desktop-user",
+            "email": "user@example.test",
+            "name": "Remote User",
+            "org_id": "org-1",
+            "exp": int(time.time()) + 3600,
+        })
+        ws_ok = _fake_ws(query={"token": access_token}, path="/api/ws")
+        assert _web_server_chat._ws_auth_ok(ws_ok) is True
+
+        ws_bad = _fake_ws(query={"token": "bogus-token"}, path="/api/ws")
+        assert _web_server_chat._ws_auth_ok(ws_bad) is False
+
+        log_file = tmp_path / "logs" / "dashboard-auth.log"
+        if log_file.exists():
+            content = log_file.read_text()
+            assert "token_auth_success" in content
+            assert "token_auth_failure" in content
 
     def test_rejection_audit_logs(self, gated_app, tmp_path, monkeypatch):
         # Point the audit log at a tmp dir so we can read what got written.


### PR DESCRIPTION
### Problem
In gated mode (`auth_required` is `True`), `_ws_auth_reason()` in `hermes_cli/web_server_chat.py` only accepted `?ticket=` (browser single-use tickets) or `?internal=` (server process credentials). Remote clients connecting in token mode (such as Desktop token-mode Remote gateway connections) build URLs like `ws://host:port/api/ws?token=<session-token>` without minting a ticket.

On gated servers, `?token=` fell through to the legacy `_SESSION_TOKEN` check and was rejected with HTTP 403.

### Solution
- In gated mode, validate `?token=` against the configured session-provider stack via `_verify_access_token(ws, access_token=token, audit=False)`.
- On successful verification, stamp `{"user_id": ..., "provider": ...}` onto `ws._hermes_auth_identity` and emit a `token_auth_success` audit event.
- Invalid tokens or legacy in-process `_SESSION_TOKEN` fail verification, emit `token_auth_failure`, and are rejected with `token_invalid`.
- Added unit tests in `tests/hermes_cli/test_dashboard_auth_ws_auth.py` covering valid session token admission, invalid token rejection, and audit log emissions.

Fixes #106685
