### PR TITLE
fix(sessions): clear hidden flag when pinning and include pinned in sidebar (#106171)

### DIFF
--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -877,6 +877,10 @@ class SessionSessionsMixin:
 
     def set_session_pinned(self, session_id: str, pinned: bool) -> bool:
         """Pin/unpin a session and its compression lineage (pins are exempt from the auto_archive sweep)."""
+        if pinned:
+            # Pinning expresses explicit intent to keep/display the session in the sidebar.
+            # Clear hidden so a bot-mode or plumbing session becomes visible (#106171).
+            self._set_lineage_column("hidden", session_id, 0)
         return self._set_lineage_column("pinned", session_id, int(pinned))
 
     def set_session_hidden(self, session_id: str, hidden: bool) -> bool:
@@ -1183,7 +1187,7 @@ class SessionSessionsMixin:
             archived_only=archived_only, include_archived=include_archived,
         )
         if not include_hidden:
-            where_clauses.append("s.hidden = 0")
+            where_clauses.append("(s.hidden = 0 OR s.pinned = 1)" if include_pinned else "s.hidden = 0")
         where_sql = _where_sql(where_clauses)
         base_where_params = list(params)  # pinned back-fill reuses the WHERE before LIMIT/OFFSET
         # Shared projection head of the three list queries (whitespace is part of the SQL text).

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4448,6 +4448,24 @@ class TestSessionPinAndStaleArchive:
         assert db.set_session_pinned("s1", False) is True
         assert self._pinned(db, "s1") == 0
 
+    def test_pinning_clears_hidden_and_survives_sidebar_filter(self, db):
+        """Pinning a hidden bot-mode session clears hidden and shows in sidebar (issue #106171)."""
+        db.create_session(session_id="bot1", source="cli")
+        db.set_session_hidden("bot1", True)
+        assert db.get_session("bot1")["hidden"] == 1
+
+        # Pinning clears the hidden flag
+        assert db.set_session_pinned("bot1", True) is True
+        assert db.get_session("bot1")["hidden"] == 0
+        assert db.get_session("bot1")["pinned"] == 1
+
+        # Even if a row somehow had both hidden=1 and pinned=1, include_pinned includes it
+        db.set_session_hidden("bot1", True)
+        assert db.get_session("bot1")["hidden"] == 1
+        sessions = db.list_sessions_rich(include_hidden=False, include_pinned=True)
+        session_ids = [s["id"] for s in sessions]
+        assert "bot1" in session_ids
+
 
 
     # ── pinned back-fill past the page window ─────────────────────────────


### PR DESCRIPTION
### Problem
Sessions created from Bot Mode workspace tiles are initially assigned `hidden = 1` in `state.db`. When an operator or user subsequently pins the session, `set_session_pinned(session_id, True)` mirrored `pinned = 1` to the database but never cleared `hidden`.

Because `list_sessions_rich()` hard-filtered `WHERE s.hidden = 0`, the pinned session was excluded from both the main session list and the Pinned section, causing the conversation to disappear from the sidebar.

### Solution
- In `SessionDB.set_session_pinned(session_id, pinned)`: when `pinned` is `True`, explicitly clear `hidden` (`self._set_lineage_column("hidden", session_id, 0)`). Pinning is an unambiguous signal that the session should remain visible and accessible.
- In `SessionDB.list_sessions_rich()`: when `include_pinned=True` (requested by sidebar views), use `(s.hidden = 0 OR s.pinned = 1)` so pinned rows are never suppressed by the hidden filter.
- Added regression test `test_pinning_clears_hidden_and_survives_sidebar_filter` in `tests/test_hermes_state.py`.

Fixes #106171
