### PR TITLE
fix(gateway): preserve follow-ups during stop command handoff

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3372,7 +3372,9 @@ class BasePlatformAdapter(ABC):
     def _session_task_is_stale(self, session_key: str) -> bool:
         """True if the recorded owner task for ``session_key`` has exited. No owner task at all is
         NOT stale (guards installed outside handle_message, as tests do, must not be healed)."""
-        done = getattr(self._session_tasks.get(session_key), "done", None)
+        # A command owns the guard until its reply and cancellation finish, even if the old turn exits.
+        owner = getattr(self._active_sessions.get(session_key), "_hermes_command_task", None)
+        done = getattr(owner or self._session_tasks.get(session_key), "done", None)
         return bool(done and done())
 
     def _heal_stale_session_lock(self, session_key: str) -> bool:
@@ -3447,7 +3449,11 @@ class BasePlatformAdapter(ABC):
         self, session_key: str, command_guard: asyncio.Event) -> None:
         """Tail of /stop, /new, /reset: release the command-scoped guard, then
         spawn a fresh processing task for any follow-up queued meanwhile."""
+        if self._active_sessions.get(session_key) is not command_guard:
+            return
         await self._flush_text_debounce_now(session_key)
+        if self._active_sessions.get(session_key) is not command_guard:
+            return
         pending_event = self._pending_messages.pop(session_key, None)
         self._release_session_guard(session_key, guard=command_guard)
         if pending_event is not None:
@@ -3460,21 +3466,29 @@ class BasePlatformAdapter(ABC):
         logger.debug("[%s] Command '/%s' bypassing active-session guard for %s", self.name, cmd, session_key)
         current_guard = self._active_sessions.get(session_key)
         command_guard = asyncio.Event()
+        setattr(command_guard, "_hermes_command_task", asyncio.current_task())
         self._active_sessions[session_key] = command_guard
         try:
             # Send BEFORE cancelling so cancellation side effects can't drop the "/new"
             # confirmation.
             await self._dispatch_inline_reply(event, log_cmd=cmd)
+            if self._active_sessions.get(session_key) is not command_guard:
+                return
             await self.cancel_session_processing(session_key, release_guard=False, discard_pending=False)
-        except Exception:
-            # On failure restore the original guard so the session isn't left half-reset.
+            await self._drain_pending_after_session_command(session_key, command_guard)
+        except (Exception, asyncio.CancelledError):
+            # Restore the preceding live owner, which may itself be a command awaiting its reply.
             if self._active_sessions.get(session_key) is command_guard:
-                if session_key in self._session_tasks and current_guard is not None:
+                owner = (getattr(current_guard, "_hermes_command_task", None)
+                         or self._session_tasks.get(session_key))
+                if owner is not None and not owner.done() and current_guard is not None:
                     self._active_sessions[session_key] = current_guard
                 else:
-                    self._release_session_guard(session_key, guard=command_guard)
+                    self._session_tasks.pop(session_key, None)
+                    await self._drain_pending_after_session_command(session_key, command_guard)
             raise
-        await self._drain_pending_after_session_command(session_key, command_guard)
+        finally:
+            delattr(command_guard, "_hermes_command_task")
 
     async def handle_message(self, event: MessageEvent) -> None:
         """Process an incoming message; returns quickly by spawning a background
@@ -3903,6 +3917,8 @@ class BasePlatformAdapter(ABC):
         drop: re-queue it if another task already owns the session (drain handoff), else spawn the
         drain task and leave it the guard. Nothing pending: release the guard only if we still own
         it."""
+        if getattr(self._active_sessions.get(session_key), "_hermes_command_task", None) is not None:
+            return
         late_pending = self._pending_messages.pop(session_key, None)
         current_task = asyncio.current_task()
         if late_pending is not None:
@@ -3987,16 +4003,6 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook(
                 "on_processing_complete", event,
                 ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE)
-            # Force-flush an unfired debounce timer so this task hands off to a fresh drain task.
-            # Clear the Event BEFORE the stop-typing await so concurrent inbound sees a live guard.
-            await self._flush_text_debounce_now(session_key)
-            if session_key in self._pending_messages:
-                pending_event = self._pending_messages.pop(session_key)
-                logger.debug("[%s] Processing queued follow-up message", self.name)
-                self._clear_session_guard(session_key)
-                await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
-                self._spawn_drain_task(pending_event, session_key)
-                return  # Drain task owns the session now.
         except asyncio.CancelledError:
             expected = asyncio.current_task() in self._expected_cancelled_tasks
             await self._run_processing_hook(
@@ -4011,16 +4017,16 @@ class BasePlatformAdapter(ABC):
             if isinstance(e, (SystemExit, KeyboardInterrupt)):
                 raise
         finally:
-            # Stop typing BEFORE the post-delivery callback: a stuck callback must not keep it
-            # alive.
-            await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
-            await self._fire_post_delivery_callback(session_key, interrupt_event)
-            # Callback work or a late refresh may have recreated typing — one final bounded stop.
-            await self._stop_typing_refresh(
-                event.source.chat_id, None, metadata=_thread_metadata, stop_attempts=1)
-            # Flush any timer that missed the in-band drain, then reconcile ownership.
-            await self._flush_text_debounce_now(session_key)
-            self._finish_session_task(session_key, interrupt_event)
+            try:
+                # Stop typing before callbacks, then clear any refresh they recreated.
+                await self._stop_typing_refresh(event.source.chat_id, typing_task, metadata=_thread_metadata)
+                await self._fire_post_delivery_callback(session_key, interrupt_event)
+                await self._stop_typing_refresh(
+                    event.source.chat_id, None, metadata=_thread_metadata, stop_attempts=1)
+            finally:
+                # Cleanup cancellation must not strand input that is still owned by this session.
+                await self._flush_text_debounce_now(session_key)
+                self._finish_session_task(session_key, interrupt_event)
 
     def _spawn_drain_task(self, pending_event: MessageEvent, session_key: str) -> None:
         """Hand the session to a fresh task for a queued follow-up — never recurse (chained

--- a/tests/gateway/test_pending_drain_no_recursion.py
+++ b/tests/gateway/test_pending_drain_no_recursion.py
@@ -180,7 +180,8 @@ async def test_normal_path_releases_session_guard():
 
 
 @pytest.mark.asyncio
-async def test_drain_task_cancellation_releases_session():
+@pytest.mark.parametrize("cancel_during", ["handler", "callback"])
+async def test_drain_task_cancellation_releases_session(cancel_during):
     """If the in-band drain task is cancelled (e.g. user sent ``/stop``
     mid-drain), the session guard and task registry must still get
     cleaned up — the cancelled drain task's own ``finally`` runs and
@@ -196,6 +197,11 @@ async def test_drain_task_cancellation_releases_session():
 
     turn_started = asyncio.Event()
     drain_hit_handler = asyncio.Event()
+    drain_task_holder = []
+
+    async def post_delivery():
+        drain_hit_handler.set()
+        await asyncio.Event().wait()
 
     async def handler(event):
         if event.text == "M0":
@@ -203,12 +209,16 @@ async def test_drain_task_cancellation_releases_session():
             adapter._pending_messages[sk] = _make_event(text="M1")
             turn_started.set()
             return "ok"
-        # M1 is the drained follow-up — hang so we can cancel the drain task.
+        if event.text == "M2":
+            return "follow-up reply"
+        drain_task_holder.append(asyncio.current_task())
+        if cancel_during == "callback":
+            adapter.register_post_delivery_callback(sk, post_delivery)
+            adapter._pending_messages[sk] = _make_event(text="M2")
+            return "ok"
+        # Hold M1 until the test cancels it, independently of scheduler speed.
         drain_hit_handler.set()
-        try:
-            await asyncio.sleep(0.2)
-        except asyncio.CancelledError:
-            raise
+        await asyncio.Event().wait()
 
     adapter._message_handler = handler
 
@@ -218,7 +228,7 @@ async def test_drain_task_cancellation_releases_session():
     await asyncio.wait_for(drain_hit_handler.wait(), timeout=2)
 
     # Cancel the drain task mid-handler.
-    drain_task = adapter._session_tasks.get(sk)
+    drain_task = drain_task_holder[0]
     assert drain_task is not None, "in-band drain did not install a drain task"
     assert not drain_task.done(), "drain task finished before we could cancel"
     drain_task.cancel()
@@ -239,6 +249,10 @@ async def test_drain_task_cancellation_releases_session():
         "cancelled drain task did not release _session_tasks[sk] — "
         "stale-lock detection will treat the dead task as alive"
     )
+    if cancel_during == "callback":
+        assert any(call.kwargs.get("content") == "follow-up reply"
+                   for call in adapter._send_with_retry.call_args_list)
+        assert sk not in adapter._pending_messages
 
 
 @pytest.mark.asyncio
@@ -261,10 +275,14 @@ async def test_late_arrival_drain_still_fires_when_no_in_band_drain():
 
     results: list[str] = []
     original_stop_typing = getattr(adapter, "stop_typing", None)
+    injected = False
 
     async def injecting_stop_typing(chat_id):
-        # Simulate a message landing during the cleanup awaits.
-        adapter._pending_messages[sk] = _make_event(text="late")
+        nonlocal injected
+        # One late arrival, not a self-replenishing queue on every cleanup.
+        if not injected:
+            injected = True
+            adapter._pending_messages[sk] = _make_event(text="late")
         if original_stop_typing:
             await original_stop_typing(chat_id)
 
@@ -293,3 +311,4 @@ async def test_late_arrival_drain_still_fires_when_no_in_band_drain():
         "late-arrival drain did not spawn a drain task — a message that "
         "landed during cleanup awaits was silently dropped"
     )
+    assert results == ["first", "late"]

--- a/tests/gateway/test_session_command_handoff.py
+++ b/tests/gateway/test_session_command_handoff.py
@@ -1,0 +1,239 @@
+"""Follow-ups belong to the command handoff, not the previous task's cleanup."""
+
+import asyncio
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.event import MessageEvent
+from gateway.session import SessionSource, build_session_key
+
+
+async def wait(event):
+    await asyncio.wait_for(event.wait(), timeout=5)
+
+
+class HandoffAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, typing_indicator=False), Platform.TELEGRAM)
+        self._busy_text_mode = ""
+        self.sent = []
+        self.begin_first = asyncio.Event()
+        self.begin_first.set()
+        self.entered = asyncio.Event()
+        self.finish = asyncio.Event()
+        self.cleaning = asyncio.Event()
+        self.finish_cleanup = asyncio.Event()
+        self.followup_started = asyncio.Event()
+        self.finish_followup = asyncio.Event()
+        self.command_sends = {}
+        self.first_task = None
+
+    async def connect(self, **kwargs):
+        raise AssertionError("Offline adapter must not connect")
+
+    async def disconnect(self):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        if content in self.command_sends:
+            entered, release = self.command_sends[content]
+            entered.set()
+            await wait(release)
+        return SendResult(success=True, message_id=str(len(self.sent)))
+
+    async def _stop_typing_refresh(self, *args, **kwargs):
+        if asyncio.current_task() is self.first_task:
+            self.cleaning.set()
+            await wait(self.finish_cleanup)
+        await super()._stop_typing_refresh(*args, **kwargs)
+
+    async def _process_message_background(self, event, session_key):
+        if event.text == "first":
+            await wait(self.begin_first)
+        await super()._process_message_background(event, session_key)
+
+    def event(self, text):
+        return MessageEvent(text=text, message_id=text, source=SessionSource(
+            platform=Platform.TELEGRAM, chat_id="handoff", chat_type="dm",
+        ))
+
+    async def settle(self):
+        for _ in range(10):
+            tasks = list(self._background_tasks)
+            if not tasks:
+                return
+            await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), 5)
+        raise AssertionError("Adapter tasks did not finish")
+
+    async def cleanup(self, commands):
+        for gate in (self.begin_first, self.finish, self.finish_cleanup, self.finish_followup):
+            gate.set()
+        for _, release in self.command_sends.values():
+            release.set()
+        await asyncio.wait_for(asyncio.gather(*commands, return_exceptions=True), 5)
+        await self.settle()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("command", "command_exit"), [
+    ("/stop", "reply"), ("/new", "reply"), ("/reset", "reply"),
+    ("/stop", "cancel"), ("/stop", "raise"),
+])
+@pytest.mark.parametrize("arrival", ["scheduled", "handler", "cleanup", "finished", "cancel"])
+async def test_command_owns_followups_until_handoff(command, command_exit, arrival, caplog):
+    adapter = HandoffAdapter()
+    key = build_session_key(adapter.event("first").source)
+    ack_started, ack_release = asyncio.Event(), asyncio.Event()
+    adapter.command_sends["command reply"] = (ack_started, ack_release)
+    followup_admissions = []
+    command_task = None
+
+    async def handler(event):
+        if event.text == command:
+            if command_exit == "raise":
+                ack_started.set()
+                await wait(ack_release)
+                raise RuntimeError("command failed")
+            return "command reply"
+        if event.text == "first":
+            adapter.entered.set()
+            await wait(adapter.finish)
+            return None
+        assert command_task is not None
+        followup_admissions.append(command_task.done())
+        adapter.followup_started.set()
+        await wait(adapter.finish_followup)
+        return "follow-up reply"
+
+    adapter._message_handler = handler
+    try:
+        if arrival == "scheduled":
+            adapter.begin_first.clear()
+        await adapter.handle_message(adapter.event("first"))
+        adapter.first_task = adapter._session_tasks[key]
+        if arrival != "scheduled":
+            await wait(adapter.entered)
+        command_task = asyncio.create_task(adapter.handle_message(adapter.event(command)))
+        await wait(ack_started)
+        if arrival == "scheduled":
+            adapter.begin_first.set()
+            await wait(adapter.entered)
+        if arrival in {"cleanup", "finished"}:
+            adapter.finish.set()
+            await wait(adapter.cleaning)
+        if arrival == "finished":
+            adapter.finish_cleanup.set()
+            await asyncio.wait_for(adapter.first_task, 5)
+        followup = adapter.event("next")
+        await adapter.handle_message(followup)
+        assert followup._gateway_accepted
+        adapter.finish_cleanup.set()
+        if arrival != "cancel" and not (arrival == "scheduled" and command_exit != "reply"):
+            adapter.finish.set()
+            await asyncio.wait_for(adapter.first_task, 5)
+        if command_exit == "cancel":
+            command_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await command_task
+            adapter.finish.set()
+        else:
+            ack_release.set()
+            await asyncio.wait_for(command_task, 5)
+            if command_exit == "raise":
+                adapter.finish.set()
+                assert "command failed" in caplog.text
+        adapter.finish_followup.set()
+        await adapter.settle()
+
+        assert followup_admissions == [True], "Follow-up ran before the command handed off"
+        replies = [] if command_exit == "raise" else ["command reply"]
+        assert adapter.sent == replies + ["follow-up reply"]
+        assert key not in adapter._pending_messages
+        assert key not in adapter._active_sessions
+        assert key not in adapter._session_tasks
+    finally:
+        await adapter.cleanup([command_task] if command_task else [])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("old_turn_done", [False, True])
+@pytest.mark.parametrize("newer_exit", ["reply", "raise", "cancel"])
+async def test_overlapping_commands_preserve_followup_ownership(old_turn_done, newer_exit, caplog):
+    adapter = HandoffAdapter()
+    key = build_session_key(adapter.event("first").source)
+    first_ack, release_first_ack = asyncio.Event(), asyncio.Event()
+    next_ack, release_next_ack = asyncio.Event(), asyncio.Event()
+    adapter.command_sends = {
+        "stop reply": (first_ack, release_first_ack),
+        "reset reply": (next_ack, release_next_ack),
+    }
+    commands = []
+    admissions = []
+
+    async def handler(event):
+        if event.text == "/stop":
+            return "stop reply"
+        if event.text == "/reset":
+            if newer_exit != "reply":
+                next_ack.set()
+                await wait(release_next_ack)
+                raise RuntimeError("newer command failed")
+            return "reset reply"
+        if event.text == "first":
+            adapter.entered.set()
+            await wait(adapter.finish)
+            return None
+        owner = commands[1] if newer_exit == "reply" else commands[0]
+        admissions.append(owner.done())
+        adapter.followup_started.set()
+        await wait(adapter.finish_followup)
+        return "follow-up reply"
+
+    adapter._message_handler = handler
+    try:
+        await adapter.handle_message(adapter.event("first"))
+        adapter.first_task = adapter._session_tasks[key]
+        await wait(adapter.entered)
+        commands.append(asyncio.create_task(adapter.handle_message(adapter.event("/stop"))))
+        await wait(first_ack)
+        commands.append(asyncio.create_task(adapter.handle_message(adapter.event("/reset"))))
+        await wait(next_ack)
+        if old_turn_done:
+            adapter.finish.set()
+            adapter.finish_cleanup.set()
+            await asyncio.wait_for(adapter.first_task, 5)
+        await adapter.handle_message(adapter.event("next"))
+        adapter.finish_cleanup.set()
+        if newer_exit == "cancel":
+            commands[1].cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await commands[1]
+        else:
+            release_next_ack.set()
+            await asyncio.wait_for(commands[1], 5)
+            if newer_exit == "raise":
+                assert "newer command failed" in caplog.text
+        if newer_exit != "reply":
+            release_first_ack.set()
+            await asyncio.wait_for(commands[0], 5)
+        await wait(adapter.followup_started)
+        followup_task = adapter._session_tasks.get(key)
+        assert followup_task is not None, "Follow-up lost its processing owner"
+        release_first_ack.set()
+        await asyncio.wait_for(commands[0], 5)
+        assert not followup_task.cancelled()
+        adapter.finish_followup.set()
+        await adapter.settle()
+        assert admissions == [True]
+        replies = ["reset reply"] if newer_exit == "reply" else []
+        assert adapter.sent == ["stop reply"] + replies + ["follow-up reply"]
+        assert key not in adapter._active_sessions
+        assert key not in adapter._session_tasks
+    finally:
+        await adapter.cleanup(commands)


### PR DESCRIPTION
## What does this PR do?

A follow-up arriving while `/stop`, `/new`, or `/reset` sends its acknowledgement can be started by the old turn's cleanup, then cancelled when the command resumes. If the old turn has already exited, stale-lock recovery can also admit the follow-up before the command finishes.

Keep command ownership until handoff finishes, preserving acknowledgement-before-cancellation. Failed commands restore the previous live owner or hand off pending input if none remains. Cleanup cancellation cannot strand that input, and an older command cannot cancel a newer turn.

## Type of Change

- [x] Bug fix

## Changes Made

- `gateway/platforms/base.py`: use the existing guard to track command ownership and hand off pending input after cleanup, including cancellation paths.
- `tests/gateway/test_session_command_handoff.py`: cover task-start/cleanup races, command exceptions and cancellation, and overlapping commands.
- `tests/gateway/test_pending_drain_no_recursion.py`: cover cancellation during the delivery callback and make the late-arrival fixture inject only one message.

## How to Test

```bash
bash scripts/run_tests.sh -j 2 --file-retries 0 \
  tests/gateway/test_session_command_handoff.py \
  tests/gateway/test_pending_drain_no_recursion.py
```

Both test files pass: **36 tests**. Of the 31 new handoff cases, 27 fail against unmodified main (`ee7fc3bc06`) and four preserve existing behavior. The expanded drain tests also pass on the baseline. An offline check with the real GatewayRunner, AIAgent loop and SQLite confirms that the follow-up is persisted and delivered, using controlled model responses and transport.

<details>
<summary>Broader validation</summary>

Across the same 106 Gateway test files, the baseline passes **999 tests** and the fix passes **1,000**, including the added callback-cancellation case. Both skip eight tests. The new handoff test file is excluded from this selection.

Selection: `tests/gateway/**/test_*.py` files matching the following expression, excluding `test_session_command_handoff.py`:

```text
_active_sessions|_session_tasks|_pending_messages|cancel_session_processing|_process_message_background|_dispatch_active_session_command|_finish_session_task|_spawn_drain_task
```

Run through `scripts/run_tests.sh -j 2 --file-retries 0 --file-timeout 180` on macOS, using isolated homes, short physical temporary paths and test-process-only suppression of macOS proxy discovery. The latter two settings avoid unrelated log-path truncation and inherited-proxy assertions reproduced on the baseline; explicit proxy environment variables remain enabled.

Skips are seven Linux/Windows-only cases and one optional `aiohttp_socks` case. The full repository suite, native Linux/Windows suites and live Telegram/provider connections were not tested.

Full-repository Ruff, Windows-footgun and compatibility-pointer checks and `git diff --check` pass. Type-diagnostic signatures and counts in the two existing files match baseline (55 in `base.py`, two in the drain test), ignoring line-number shifts. The new handoff test has no diagnostics.

</details>

## Checklist

- [x] Read the contributing guide and checked related PRs.
- [x] Changes are limited to command handoff and its regression tests.
- [x] Added failing-before behavioral tests and verified the fix on macOS.
