### PR TITLE
feat(desktop): optionally wrap the tab strip onto more rows

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -23,7 +23,13 @@ import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/p
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $reasoningCollapsedByDefault, setReasoningCollapsedByDefault } from '@/store/reasoning-disclosure'
 import { $sessionListDensity, type SessionListDensity, setSessionListDensity } from '@/store/session-list-density'
-import { $tabStripDefault, setTabStripDefault, type TabStripDefault } from '@/store/tabstrip-prefs'
+import {
+  $tabStripDefault,
+  $tabStripWrap,
+  setTabStripDefault,
+  setTabStripWrap,
+  type TabStripDefault
+} from '@/store/tabstrip-prefs'
 import { $retiredTips, $tipsEnabled, resetTips, setTipsEnabled } from '@/store/tips'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $toursEnabled, setToursEnabled } from '@/store/tours'
@@ -397,6 +403,7 @@ export function AppearanceSettings() {
   const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
   const sessionListDensity = useStore($sessionListDensity)
   const tabStripDefault = useStore($tabStripDefault)
+  const tabStripWrap = useStore($tabStripWrap)
   const zoomPercent = useStore($zoomPercent)
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
@@ -659,6 +666,13 @@ export function AppearanceSettings() {
             }
             description={a.tabStripDesc}
             title={a.tabStripTitle}
+          />
+
+          <ToggleRow
+            checked={tabStripWrap}
+            description={a.tabStripWrapDesc}
+            label={a.tabStripWrapTitle}
+            onChange={setTabStripWrap}
           />
 
           {/* Linux has neither half of this setting (see TRANSLUCENCY_SUPPORTED),

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tab-strip-scroll.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tab-strip-scroll.ts
@@ -53,7 +53,12 @@ export function tabStripScrollLeft({
 }
 
 /** Scroll `activeId`'s tab into view whenever the activation or the tab set
- *  changes. `last` drives the "+"-follows-the-final-tab case. */
+ *  changes. `last` drives the "+"-follows-the-final-tab case.
+ *
+ *  `enabled` is false on a WRAPPED strip: there is no horizontal overflow to
+ *  correct, and writing `scrollLeft` on a `flex-wrap` container is a silent
+ *  no-op that would leave a tab on row three just as unreachable. Rows are the
+ *  reveal mechanism there — every tab is already on screen. */
 export function useActiveTabVisible(
   scrollerRef: RefObject<HTMLDivElement | null>,
   activeId: string,

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -1,6 +1,6 @@
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { registry } from '@/contrib/registry'
 
@@ -8,6 +8,23 @@ import type { GroupNode } from '../model'
 import { $treeDragging, NEW_SESSION_DRAG, SESSION_TILE_DRAG } from '../store'
 
 import { TreeGroup } from './tree-group'
+
+// jsdom ships no ResizeObserver, and a zone that renders a header strip
+// measures it (the strip's height is no longer the constant 28px once tabs can
+// wrap onto more rows).
+//
+// beforeEach, not beforeAll: this file's afterEach calls `vi.unstubAllGlobals()`,
+// so a one-time stub survives only the first test and every later one that
+// renders a header would throw.
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+})
 
 let root: null | Root = null
 let container: HTMLDivElement | null = null

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -31,6 +31,7 @@ import { useI18n } from '@/i18n'
 import { useKeybindHint } from '@/lib/keybinds/use-keybind-hint'
 import { cn } from '@/lib/utils'
 import { closeAllOpenSessionTiles } from '@/store/session-states'
+import { $tabStripWrap } from '@/store/tabstrip-prefs'
 
 import { $layoutEditMode } from '../../edit-mode'
 import { useWindowControlsOverlap } from '../../geometry'
@@ -239,6 +240,8 @@ export function TreeGroup({
   // missing on an inactive tile tab whose zone-active was the uncloseable
   // workspace).
   const [menuPane, setMenuPane] = useState<string | undefined>(undefined)
+  // App-wide: overflow the strip onto more rows instead of scrolling one.
+  const tabStripWrap = useStore($tabStripWrap)
   const panes = useContributions('panes')
   // Coarse drag flag only (set once at drag start/end). The per-frame drop
   // HINT lives in ZoneDropOverlay so a moving pointer re-renders the tiny
@@ -353,11 +356,21 @@ export function TreeGroup({
   // Keep the activated tab — and, on the last one, the trailing "+" — inside
   // the strip's scroll window. Opening a tab past the right edge otherwise
   // left both the new tab and the button that made it out of view.
+  //
+  // A wrapped strip has no scroll window: every tab is on screen by row, so the
+  // effect is disabled rather than writing a scrollLeft that does nothing.
   useActiveTabVisible(tabsRef, activeId, {
-    enabled: headerVisible,
+    enabled: headerVisible && !tabStripWrap,
     last: shown[shown.length - 1] === activeId,
     tabCount: shown.length
   })
+
+  // The header's real height. A single-row strip is always 28px, but a wrapped
+  // one grows with its tab count, so the edit veil (which starts below the
+  // header) has to MEASURE instead of assuming. Only the veil reads this, and
+  // it only renders in edit mode — so the observer is wired to the strip that
+  // exists either way and costs one entry per zone.
+  const headerHeight = useStripHeight(stripRef, headerVisible)
 
   // Zone-menu close targets read the layout tree, but this component must NOT
   // subscribe to it: `useStore($layoutTree)` here wires every zone — and
@@ -527,6 +540,10 @@ export function TreeGroup({
                 <StripDropCaret groupId={node.id} stripRef={stripRef} />
               </>
             }
+            // A MINIMIZED zone never wraps: it IS its strip, and the tracks it
+            // sizes against (MINIMIZED_TRACK / COLLAPSED_ZONE_PX) are one row
+            // thick, so a second row would overflow the collapsed rail.
+            wrap={tabStripWrap && !node.minimized}
           >
             {shown.map(paneId => {
               const isActive = paneId === activeId && !node.minimized
@@ -735,7 +752,7 @@ export function TreeGroup({
             className="absolute inset-x-0 bottom-0 z-50 flex cursor-grab items-center justify-center outline-1 -outline-offset-2 outline-dashed backdrop-blur-[2px]"
             onPointerDown={e => startPaneDrag(activeId, e, undefined, undefined, active?.title ?? activeId)}
             style={{
-              top: headerVisible ? 28 : 0,
+              top: headerHeight,
               background:
                 'color-mix(in srgb, var(--ui-accent) 6%, color-mix(in srgb, var(--ui-bg-chrome) 55%, transparent))',
               outlineColor: 'color-mix(in srgb, var(--ui-accent) 55%, transparent)'
@@ -759,6 +776,44 @@ export function TreeGroup({
 // ---------------------------------------------------------------------------
 // Tab-strip insertion caret
 // ---------------------------------------------------------------------------
+
+/**
+ * The header strip's measured height, for anything that positions against it.
+ *
+ * A single-row strip is a constant 28px and was hardcoded as one; a WRAPPED
+ * strip grows a row per overflow, so the constant became a lie that let the
+ * edit veil cover its own tabs. Measured, not derived from the tab count: rows
+ * are decided by the browser's flex line-breaking against the zone's width, and
+ * re-deriving that here would be a second, wrong copy of the layout algorithm.
+ *
+ * Falls back to 0 when there is no header, which is what a hidden strip's
+ * consumers want anyway.
+ */
+function useStripHeight(stripRef: RefObject<HTMLDivElement | null>, headerVisible: boolean): number {
+  const [height, setHeight] = useState(0)
+
+  useEffect(() => {
+    const strip = stripRef.current
+
+    if (!headerVisible || !strip) {
+      setHeight(0)
+
+      return
+    }
+
+    // ResizeObserver, not a layout effect: a wrap line appears when the ZONE
+    // resizes (a sash drag, a window resize), with no React render of this
+    // component to hang a measurement off.
+    const observer = new ResizeObserver(() => setHeight(strip.getBoundingClientRect().height))
+
+    observer.observe(strip)
+    setHeight(strip.getBoundingClientRect().height)
+
+    return () => observer.disconnect()
+  }, [headerVisible, stripRef])
+
+  return height
+}
 
 /**
  * The insertion divider for a stack drop: a 2px vertical line at the slot the

--- a/apps/desktop/src/components/ui/pane-tab.test.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { PaneTab, PaneTabLabel } from './pane-tab'
+import { PaneTab, PaneTabLabel, PaneTabStrip } from './pane-tab'
 
 afterEach(cleanup)
 
@@ -201,5 +201,91 @@ describe('PaneTab hover close button', () => {
     )
 
     expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+  })
+})
+
+describe('PaneTabStrip overflow', () => {
+  // The strip has exactly two overflow behaviours and they are mutually
+  // exclusive: scroll one row (default) or wrap onto several. Asserted as a
+  // contract between the prop and the two properties that actually decide it —
+  // the list's wrapping and the bar's height being a floor vs a fixed value —
+  // rather than by freezing the full class string, which churns on every
+  // restyle.
+
+  const listOf = (): HTMLElement => screen.getByRole('tablist')
+  const barOf = (): HTMLElement => listOf().parentElement!
+  const classes = (el: HTMLElement): string[] => el.className.split(/\s+/).filter(Boolean)
+
+  it('scrolls a single row by default — the strip stays exactly one tab tall', () => {
+    render(
+      <PaneTabStrip>
+        <PaneTab>
+          <PaneTabLabel>one</PaneTabLabel>
+        </PaneTab>
+      </PaneTabStrip>
+    )
+
+    expect(classes(listOf())).toContain('overflow-x-auto')
+    expect(classes(listOf())).not.toContain('flex-wrap')
+    // Fixed height, not a floor: a scrolling strip can never grow a second row.
+    expect(classes(barOf())).toContain('h-7')
+    expect(classes(barOf())).not.toContain('min-h-7')
+  })
+
+  it('wraps onto more rows when asked, and stops scrolling', () => {
+    render(
+      <PaneTabStrip wrap>
+        <PaneTab>
+          <PaneTabLabel>one</PaneTabLabel>
+        </PaneTab>
+      </PaneTabStrip>
+    )
+
+    expect(classes(listOf())).toContain('flex-wrap')
+    // Both halves matter: a wrapping list inside a fixed-height bar clips the
+    // rows it just created instead of showing them.
+    expect(classes(listOf())).not.toContain('overflow-x-auto')
+    expect(classes(barOf())).toContain('min-h-7')
+    expect(classes(barOf())).not.toContain('h-7')
+  })
+
+  it('pins a wrapped tab to ONE row — height:100% would resolve against the whole bar', () => {
+    const { rerender } = render(
+      <PaneTabStrip wrap>
+        <PaneTab>
+          <PaneTabLabel>one</PaneTabLabel>
+        </PaneTab>
+      </PaneTabStrip>
+    )
+
+    // The var the tab's height reads. Set here, a tab is one row tall; unset,
+    // it falls back to 100% and stretches to every row in the bar.
+    expect(classes(barOf())).toContain('[--pane-tab-h:1.75rem]')
+
+    rerender(
+      <PaneTabStrip>
+        <PaneTab>
+          <PaneTabLabel>one</PaneTabLabel>
+        </PaneTab>
+      </PaneTabStrip>
+    )
+
+    // Unwrapped strips must NOT declare it: the fallback is what keeps a
+    // single-row tab filling a bar whose height it does not know.
+    expect(classes(barOf())).not.toContain('[--pane-tab-h:1.75rem]')
+  })
+
+  it('keeps trailing chrome one row tall so the chevron stays on the first row', () => {
+    render(
+      <PaneTabStrip trailing={<button type="button">chevron</button>} wrap>
+        <PaneTab>
+          <PaneTabLabel>one</PaneTabLabel>
+        </PaneTab>
+      </PaneTabStrip>
+    )
+
+    const trailing = screen.getByText('chevron').parentElement!
+
+    expect(classes(trailing)).toContain('h-7')
   })
 })

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -26,7 +26,14 @@ const TAB =
 
 // Full height: with the strip's rule removed there is no last-pixel row to
 // leave uncovered, so tabs fill the bar and no sliver of gutter shows through.
-const TAB_HORIZONTAL = 'h-full min-w-0 max-w-48 not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'
+//
+// `--pane-tab-h` is that height, and it exists for ONE reason: `height: 100%`
+// resolves against the flex CONTAINER, not the wrap line, so on a wrapped strip
+// every tab would stretch to the full multi-row bar. The wrapped strip pins the
+// var to one row; unset (every other strip) it falls back to 100% and nothing
+// about the single-row geometry changes.
+const TAB_HORIZONTAL =
+  'h-[var(--pane-tab-h,100%)] min-w-0 max-w-48 not-first:border-l not-first:border-l-(--ui-stroke-quaternary)'
 
 // A closeable tab's floor: 8px label inset + the ~19px opaque ✕ chip, so the
 // shortest labels (FILES, REVIEW) clear the chip and pass under nothing but the
@@ -37,7 +44,7 @@ const TAB_VERTICAL =
   'w-full max-h-48 justify-center not-first:border-t not-first:border-t-(--ui-stroke-quaternary) [writing-mode:vertical-rl]'
 
 const TAB_ACTIVE =
-  'h-full text-foreground [--tab-surface:var(--pane-tab-active-bg,var(--ui-editor-surface-background))]'
+  'h-[var(--pane-tab-h,100%)] text-foreground [--tab-surface:var(--pane-tab-active-bg,var(--ui-editor-surface-background))]'
 
 // Horizontal only: the active tab is the sole seam on the strip — a
 // theme-primary underline drawn as an inset shadow in its own last pixel row,
@@ -260,6 +267,10 @@ interface PaneTabStripProps extends React.ComponentProps<'div'> {
   listRef?: React.Ref<HTMLDivElement>
   /** Non-scrolling trailing chrome pinned to the right (the minimize chevron). */
   trailing?: React.ReactNode
+  /** Overflow onto more rows instead of scrolling one. The bar stops being a
+   *  fixed 28px and grows with its content, so every consumer that positions
+   *  against the header must MEASURE it rather than assume a row. */
+  wrap?: boolean
 }
 
 /**
@@ -272,7 +283,7 @@ interface PaneTabStripProps extends React.ComponentProps<'div'> {
  * `data-zone-tabstrip`, drop carets) ride on the usual div props.
  */
 export const PaneTabStrip = React.forwardRef<HTMLDivElement, PaneTabStripProps>(function PaneTabStrip(
-  { children, className, listRef, trailing, ...props },
+  { children, className, listRef, trailing, wrap = false, ...props },
   ref
 ) {
   return (
@@ -280,21 +291,34 @@ export const PaneTabStrip = React.forwardRef<HTMLDivElement, PaneTabStripProps>(
       // Strip and active tab both sit on the sidebar surface, so the bar reads
       // as one piece of chrome with the titlebar above it. No bottom rule — the
       // active tab's primary underline is the only seam.
+      //
+      // Wrapped: `min-h-7` instead of `h-7`. The bar keeps a single row's height
+      // as its FLOOR (an empty or one-row strip is pixel-identical to the
+      // scrolling form) and grows a row at a time from there. `items-start`
+      // stops a short row from stretching its tabs to the full bar height.
       className={cn(
-        'group/pane-header relative flex h-7 shrink-0 select-none bg-(--ui-sidebar-surface-background) [-webkit-app-region:no-drag] [--pane-tab-active-bg:var(--ui-sidebar-surface-background)]',
+        'group/pane-header relative flex shrink-0 select-none bg-(--ui-sidebar-surface-background) [-webkit-app-region:no-drag] [--pane-tab-active-bg:var(--ui-sidebar-surface-background)]',
+        wrap ? 'min-h-7 items-start [--pane-tab-h:1.75rem]' : 'h-7',
         className
       )}
       ref={ref}
       {...props}
     >
       <div
-        className="flex min-w-0 flex-1 overflow-x-auto overflow-y-hidden overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className={cn(
+          'flex min-w-0 flex-1',
+          wrap
+            ? 'flex-wrap'
+            : 'overflow-x-auto overflow-y-hidden overscroll-x-contain [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
+        )}
         ref={listRef}
         role="tablist"
       >
         {children}
       </div>
-      {trailing}
+      {/* Trailing chrome keeps a full row's height so the chevron stays centred
+          on the FIRST row rather than drifting to the middle of a tall bar. */}
+      <div className={cn('flex shrink-0', wrap && 'h-7')}>{trailing}</div>
     </div>
   )
 })

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -595,6 +595,9 @@ export const en: Translations = {
       tabStripAuto: 'Auto',
       tabStripAlways: 'Always',
       tabStripNever: 'Never',
+      tabStripWrapTitle: 'Wrap Tabs',
+      tabStripWrapDesc:
+        'Overflow tabs onto more rows instead of scrolling one. Costs transcript height; useful when the window is too narrow for the tabs you keep open.',
       terminalFontTitle: 'Terminal Font',
       terminalFontDesc:
         'Choose an installed font for Desktop terminals. Nerd Fonts render Powerlevel10k and shell icons; leave blank to use bundled JetBrains Mono.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -422,6 +422,9 @@ export const ja = defineLocale({
       tabStripAuto: '自動',
       tabStripAlways: '常に表示',
       tabStripNever: '表示しない',
+      tabStripWrapTitle: 'タブを折り返す',
+      tabStripWrapDesc:
+        'タブを1行でスクロールする代わりに複数行に折り返します。トランスクリプトの高さを消費しますが、ウィンドウ幅がタブ数に対して狭い場合に便利です。',
       terminalFontTitle: 'ターミナルフォント',
       terminalFontDesc:
         'Desktop のターミナルで使用するインストール済みフォントを選びます。Nerd Font は Powerlevel10k とシェルアイコンを表示できます。空欄では内蔵の JetBrains Mono を使用します。',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -584,6 +584,9 @@ export const ru = defineLocale({
       tabStripAuto: 'Авто',
       tabStripAlways: 'Всегда',
       tabStripNever: 'Никогда',
+      tabStripWrapTitle: 'Перенос вкладок',
+      tabStripWrapDesc:
+        'Переносить вкладки на несколько рядов вместо прокрутки одного. Занимает место у переписки; полезно, когда окно слишком узкое для открытых вкладок.',
       terminalFontTitle: 'Шрифт терминала',
       terminalFontDesc:
         'Выберите установленный шрифт для терминалов приложения. Nerd Fonts отображают Powerlevel10k и иконки оболочки; оставьте пустым, чтобы использовать встроенный JetBrains Mono.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -488,6 +488,8 @@ export interface Translations {
       tabStripAuto: string
       tabStripAlways: string
       tabStripNever: string
+      tabStripWrapTitle: string
+      tabStripWrapDesc: string
       terminalFontTitle: string
       terminalFontDesc: string
       terminalFontPlaceholder: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -411,6 +411,9 @@ export const zhHant = defineLocale({
       tabStripAuto: '自動',
       tabStripAlways: '一律',
       tabStripNever: '永不',
+      tabStripWrapTitle: '換行分頁',
+      tabStripWrapDesc:
+        '讓分頁換到多列顯示，而不是在單列中捲動。會佔用對話區高度；當視窗寬度不足以顯示所有分頁時很有用。',
       terminalFontTitle: '終端機字型',
       terminalFontDesc:
         '選擇已安裝的字型用於桌面端終端機。Nerd Font 可正確顯示 Powerlevel10k 與 Shell 圖示；留空則使用內建的 JetBrains Mono。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -581,6 +581,9 @@ export const zh: Translations = {
       tabStripAuto: '自动',
       tabStripAlways: '始终',
       tabStripNever: '从不',
+      tabStripWrapTitle: '换行标签页',
+      tabStripWrapDesc:
+        '让标签页换到多行显示，而不是在一行内滚动。会占用对话区高度；当窗口宽度不足以显示所有标签页时很有用。',
       terminalFontTitle: '终端字体',
       terminalFontDesc:
         '选择已安装的字体用于桌面端终端。Nerd Font 可正确显示 Powerlevel10k 和 Shell 图标；留空则使用内置的 JetBrains Mono。',

--- a/apps/desktop/src/store/tabstrip-prefs.ts
+++ b/apps/desktop/src/store/tabstrip-prefs.ts
@@ -1,7 +1,8 @@
 import type { TabStripMode } from '@/components/pane-shell/tree/model'
-import { type Codec, persistentAtom } from '@/lib/persisted'
+import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
 
 const TAB_STRIP_DEFAULT_STORAGE_KEY = 'hermes.desktop.tabStripDefault'
+const TAB_STRIP_WRAP_STORAGE_KEY = 'hermes.desktop.tabStripWrap'
 
 /** What a zone does when it has made no choice of its own. */
 export type TabStripDefault = 'auto' | TabStripMode
@@ -35,4 +36,24 @@ export function effectiveTabStripMode(zoneMode: TabStripMode | undefined): TabSt
   const fallback = $tabStripDefault.get()
 
   return fallback === 'auto' ? undefined : fallback
+}
+
+/**
+ * Wrap an overflowing strip onto more rows instead of scrolling it.
+ *
+ * This is deliberately NOT a fourth `TabStripMode`. Visibility ("is there a
+ * strip") and overflow ("what does a full strip do") are separate questions:
+ * the mode ladder in `strip-visibility.ts` protects a pane's last handle, and
+ * folding wrapping into it would make "hide" and "wrap" contend for one slot on
+ * a zone that may not survive either answer. Wrapping is app-wide because the
+ * reason to want it — a window too narrow for the working set, tiled by the WM
+ * — is a property of the window, not of one zone.
+ *
+ * Off by default: rows are bought with transcript height, which is the wrong
+ * trade in a tall window and the right one only when the width is fixed.
+ */
+export const $tabStripWrap = persistentAtom<boolean>(TAB_STRIP_WRAP_STORAGE_KEY, false, Codecs.bool)
+
+export function setTabStripWrap(value: boolean) {
+  $tabStripWrap.set(value)
 }


### PR DESCRIPTION
## Summary

An overflowing tab strip scrolls horizontally. That is the right overflow when the window can grow — but in a window whose width is **fixed by the window manager** (a tiling layout, or a FancyZones zone sized for one sidebar plus one pane), the width will never change, so tabs past the edge stay out of view and the strip becomes a list you page through rather than a set you can see.

Splitting the zone is the existing answer, and it does give a second strip — but it also halves the surface the tabs belong to, which is exactly what a fixed-width layout cannot spare.

This adds **Wrap Tabs** (Settings → Appearance, **off by default**): the strip keeps one row's height as its floor and grows a row at a time as tabs overflow.

## Design notes

**Deliberately not a fourth `TabStripMode`.** Visibility ("is there a strip") and overflow ("what does a full strip do") are separate questions. The mode ladder in `strip-visibility.ts` exists to protect a pane's *last handle*; folding wrapping into it would make "hide" and "wrap" contend for one slot on a zone that may not survive either answer. `strip-visibility.ts` is untouched by this PR.

**App-wide rather than per-zone**, because the reason to want it — a window too narrow for the working set — is a property of the window, not of one zone.

## Three places the single-row assumption was baked in

- **Tab height was `h-full`**, which resolves against the flex *container*, not the wrap line — so on a wrapped strip every tab stretched to the full multi-row bar. Now `h-[var(--pane-tab-h,100%)]`, pinned to one row only when wrapping. Unset everywhere else, so single-row geometry is unchanged.
- **`TreeGroup` positioned the edit-mode veil at a hardcoded `top: 28`.** Now measured via `ResizeObserver`. Rows are decided by the browser's flex line-breaking against the zone's width; re-deriving that from the tab count would be a second, wrong copy of the layout algorithm.
- **`MINIMIZED_TRACK` / `COLLAPSED_ZONE_PX` size a minimized zone as one row.** A minimized zone *is* its strip, so it never wraps — both constants stay true, guarded by `wrap={tabStripWrap && !node.minimized}`.

`useActiveTabVisible` is disabled when wrapped: there is no horizontal overflow to correct, and writing `scrollLeft` on a `flex-wrap` container is a silent no-op that would leave a tab on row three just as unreachable.

## Test plan

- `vitest run --project ui src/components/pane-shell/ src/components/ui/ src/app/settings/` — **625 passed / 87 files**
- `tsc -p tsconfig.json --noEmit` — no errors in touched files
- `eslint` on all changed files — clean
- 4 new tests in `pane-tab.test.tsx` cover: wrap swaps the scroller for `flex-wrap`, the default stays `h-7` + `overflow-x-auto`, `--pane-tab-h` pins the row height, and trailing chrome keeps one row's height.
- Added a `ResizeObserver` stub to `tree-group.test.tsx` (`beforeEach`, since that file's `afterEach` calls `vi.unstubAllGlobals()`).

Built and running on Windows 11 (Electron 40, packaged via `npm run builder`) in a fixed-width FancyZones zone, which is the case that motivated it.

## Notes for review

- Default is off; with the setting off, the rendered strip markup is unchanged.
- All five locales with existing `tabStrip*` keys were updated (`en`, `ru`, `zh`, `zh-hant`, `ja`), plus the `types.ts` contract. `ar.ts` has no `tabStrip*` keys and falls back to English, so it was left alone.
