### PR TITLE
fix(gateway): keep attachments recoverable after delivery crashes

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -1,6 +1,6 @@
-"""Durable delivery-obligation ledger for gateway final responses (rows in the shared ``state.db``;
+"""Durable delivery-obligation ledger for complete gateway responses (rows in shared ``state.db``;
 WAL, owner pid + process-start liveness, bounded retention) so a crash between finalize and
-platform ACK cannot lose a response silently. Checkpoints: record_obligation() 'pending' before
+platform ACK cannot lose text or attachments silently. Checkpoints: record_obligation() 'pending' before
 any send | mark_attempting() 'attempting' right before the await | mark_delivered() 'delivered'
 only on SendResult.success | mark_failed() 'failed' on a definitive rejection. Crash semantics
 (never silently resend an ambiguous send): pending = never started, redeliver plainly; attempting
@@ -13,6 +13,7 @@ best-effort: ledger failures must never block a send; callers wrap every call in
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -172,12 +173,16 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             owner_pid INTEGER,
             owner_started_at INTEGER,
             last_error TEXT,
-            adapter_profile TEXT
+            adapter_profile TEXT,
+            attachment_manifest TEXT
         )"""
     )
-    if "adapter_profile" not in {row[1] for row in conn.execute("PRAGMA table_info(delivery_obligations)")}:
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(delivery_obligations)")}
+    for column in ("adapter_profile", "attachment_manifest"):
+        if column in columns:
+            continue
         try:
-            conn.execute("ALTER TABLE delivery_obligations ADD COLUMN adapter_profile TEXT")
+            conn.execute(f"ALTER TABLE delivery_obligations ADD COLUMN {column} TEXT")
         except sqlite3.OperationalError as exc:
             # Concurrent first-use connections can both observe the old schema.
             if "duplicate column" not in str(exc).lower():
@@ -245,14 +250,39 @@ def _owner_alive(pid: Any, started_at: Any) -> bool:
         return True
 
 
-def compute_obligation_id(session_key: str, message_ref: str, content: str) -> str:
+def _encode_attachment_manifest(manifest: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not manifest:
+        return None
+    return json.dumps(manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _decode_attachment_manifest(raw: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+        return value if isinstance(value, dict) else None
+    except (TypeError, ValueError):
+        logger.warning("delivery obligation contains an invalid attachment manifest")
+        return None
+
+
+def compute_obligation_id(
+    session_key: str, message_ref: str, content: str, *,
+    attachment_manifest: Optional[Dict[str, Any]] = None,
+) -> str:
     """Stable id: same turn + same content re-records idempotently, while distinct threads/topics on one
     chat never collide (session_key carries platform/chat/thread; ``message_ref`` = inbound message id)."""
-    return hashlib.sha256(f"{session_key}|{message_ref}|{content}".encode("utf-8", "replace")).hexdigest()[:24]
+    material = f"{session_key}|{message_ref}|{content}"
+    encoded_manifest = _encode_attachment_manifest(attachment_manifest)
+    if encoded_manifest:
+        material += f"|{encoded_manifest}"
+    return hashlib.sha256(material.encode("utf-8", "replace")).hexdigest()[:24]
 
 
 def record_obligation(*, obligation_id: str, session_key: str, platform: str, chat_id: str,
-                      thread_id: Optional[str], content: str, adapter_profile: Optional[str] = None) -> None:
+                      thread_id: Optional[str], content: str, adapter_profile: Optional[str] = None,
+                      attachment_manifest: Optional[Dict[str, Any]] = None) -> None:
     """Record a final response as owed to the platform (state='pending')."""
     now, (pid, started) = time.time(), _owner_stamp()
     with _DB_LOCK, _transaction() as conn:
@@ -260,10 +290,11 @@ def record_obligation(*, obligation_id: str, session_key: str, platform: str, ch
             """INSERT OR REPLACE INTO delivery_obligations
                (obligation_id, session_key, platform, chat_id, thread_id,
                 content, state, attempts, created_at, updated_at,
-                owner_pid, owner_started_at, adapter_profile)
-               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?)""",
+                owner_pid, owner_started_at, adapter_profile, attachment_manifest)
+               VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?, ?, ?)""",
             (obligation_id, session_key, platform, str(chat_id), str(thread_id) if thread_id else None,
-             content, now, now, pid, started, str(adapter_profile).strip() if adapter_profile else "default"))
+             content, now, now, pid, started, str(adapter_profile).strip() if adapter_profile else "default",
+             _encode_attachment_manifest(attachment_manifest)))
     _prune()
 
 
@@ -309,7 +340,8 @@ def _update_state(obligation_id: str, state: str, error: str = "") -> None:
             (state, time.time(), error[:500] if error else None, obligation_id))
 
 
-def _claimed_row(oid, session_key, platform, chat_id, thread_id, content, attempts, profile, *,
+def _claimed_row(oid, session_key, platform, chat_id, thread_id, content, attachment_manifest,
+                 attempts, profile, *,
                  needs_marker: bool, runtime: bool = False, flood: bool = False,
                  last_error: Optional[str] = None) -> Dict[str, Any]:
     """Claimed-row dict handed back for redelivery. A marked row names its own cause: ``flood`` (a reply
@@ -318,8 +350,12 @@ def _claimed_row(oid, session_key, platform, chat_id, thread_id, content, attemp
     restart marker default. ``last_error`` is the row's pre-claim error, carried so a runtime claim that is
     released unsent goes back to ``failed`` with the same error and keeps its retry eligibility."""
     marker = FLOOD_MARKER if flood else (RECONNECTED_MARKER if runtime else None)
+    decoded_manifest = _decode_attachment_manifest(attachment_manifest)
     return {"obligation_id": oid, "session_key": session_key, "platform": platform, "chat_id": chat_id,
-            "thread_id": thread_id, "content": content, "needs_marker": needs_marker,
+            "thread_id": thread_id, "content": content,
+            "attachment_manifest": decoded_manifest or {},
+            "attachment_manifest_valid": decoded_manifest is not None,
+            "needs_marker": needs_marker,
             **({"marker": marker} if needs_marker and marker else {}), "profile": profile,
             **({"runtime_recovery": True} if runtime else {}),
             **({"last_error": last_error} if last_error else {}), "attempts": attempts + 1}
@@ -349,12 +385,13 @@ def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Opt
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
             """SELECT obligation_id, session_key, platform, chat_id, thread_id,
-                      content, state, attempts, created_at,
+                      content, attachment_manifest, state, attempts, created_at,
                       owner_pid, owner_started_at, adapter_profile, last_error, updated_at
                FROM delivery_obligations
                WHERE state IN ('pending', 'attempting', 'failed')"""
         ).fetchall()
-        for (oid, session_key, platform, chat_id, thread_id, content, state, attempts, created_at,
+        for (oid, session_key, platform, chat_id, thread_id, content, attachment_manifest,
+             state, attempts, created_at,
              owner_pid, owner_started_at, adapter_profile, last_error, updated_at) in rows:
             if _owner_alive(owner_pid, owner_started_at):
                 continue  # a live gateway still owns this row
@@ -397,9 +434,10 @@ def sweep_recoverable(now: Optional[float] = None, *, deliverable_platforms: Opt
                 # pending = never started, redeliver plainly; anything else (crashed mid-await, other
                 # rejection, a flood refusal whose earlier chunks the platform may have accepted) carries
                 # the marker.
-                claimed.append(_claimed_row(oid, session_key, platform, chat_id, thread_id, content, attempts,
-                                            adapter_profile or "default", needs_marker=state != "pending",
-                                            flood=flood_row))
+                claimed.append(_claimed_row(
+                    oid, session_key, platform, chat_id, thread_id, content, attachment_manifest,
+                    attempts, adapter_profile or "default", needs_marker=state != "pending",
+                    flood=flood_row))
     return claimed
 
 
@@ -423,11 +461,12 @@ def sweep_failed_for_runtime(platform: str, now: Optional[float] = None, *,
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
             """SELECT obligation_id, session_key, platform, chat_id, thread_id,
-                      content, attempts, created_at, owner_pid,
+                      content, attachment_manifest, attempts, created_at, owner_pid,
                       owner_started_at, last_error, adapter_profile, updated_at
                FROM delivery_obligations
                WHERE state='failed' AND platform=?""", (platform,)).fetchall()
-        for (oid, session_key, row_platform, chat_id, thread_id, content, attempts, created_at,
+        for (oid, session_key, row_platform, chat_id, thread_id, content, attachment_manifest,
+             attempts, created_at,
              owner_pid, owner_started_at, last_error, adapter_profile, updated_at) in rows:
             # Exact process-start matching prevents PID reuse from stealing work.
             if (adapter_profile != expected_profile or owner_pid != pid or owner_started_at != started
@@ -454,9 +493,10 @@ def sweep_failed_for_runtime(platform: str, now: Optional[float] = None, *,
                 # The failed send's ack may have been lost (reconnect) or its earlier chunks accepted
                 # (flood): every runtime redelivery carries a marker. The pre-claim error rides along so a
                 # claim released unsent keeps its flood retry eligibility.
-                claimed.append(_claimed_row(oid, session_key, row_platform, chat_id, thread_id, content,
-                                            attempts, adapter_profile, needs_marker=True, runtime=True,
-                                            flood=is_flood_error(last_error), last_error=last_error))
+                claimed.append(_claimed_row(
+                    oid, session_key, row_platform, chat_id, thread_id, content, attachment_manifest,
+                    attempts, adapter_profile, needs_marker=True, runtime=True,
+                    flood=is_flood_error(last_error), last_error=last_error))
     return claimed
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2567,11 +2567,12 @@ class BasePlatformAdapter(ABC):
 
     async def send_multiple_images(
         self, chat_id: str, images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """Send ``(url, alt)`` images (``http(s)://`` or ``file://``) one by one (GIFs via
         ``send_animation``, local files via ``send_image_file``); override to bundle natively
         (Signal)."""
         from urllib.parse import unquote as _unquote
+        outcome = SendResult(success=True)
         for image_url, alt_text in images:
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
@@ -2588,8 +2589,13 @@ class BasePlatformAdapter(ABC):
                     chat_id=chat_id, **url_kw, caption=alt_text or None, metadata=metadata)
                 if not img_result.success:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                    if outcome.success:
+                        outcome = img_result
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+                if outcome.success:
+                    outcome = SendResult(success=False, error=str(img_err))
+        return outcome
 
     async def send_image(
         self, chat_id: str, image_url: str, caption: Optional[str] = None,
@@ -3706,7 +3712,7 @@ class BasePlatformAdapter(ABC):
 
     async def _deliver_media_attachments(
         self, chat_id: str, media_files: list, local_files: list, *,
-        force_document_attachments: bool, human_delay: float, metadata: Dict[str, Any]) -> bool:
+        force_document_attachments: bool, human_delay: float, metadata: Dict[str, Any]) -> SendResult:
         """Deliver MEDIA-tag files and detected local files by type: images batched via
         ``send_multiple_images`` unless ``[[as_document]]``; otherwise audio → send_voice (MEDIA
         tags only, never bare local files), video → send_video, else send_document. Every failure is
@@ -3717,12 +3723,12 @@ class BasePlatformAdapter(ABC):
             return Path(path).suffix.lower() in _IMAGE_EXTS and not force_document_attachments
         _image_paths = [p for p, is_voice in media_files if not is_voice and _as_image(p)]
         _image_paths += [p for p in local_files if _as_image(p)]
-        succeeded = True
+        outcome = SendResult(success=True)
         if _image_paths:
-            succeeded = await self._send_image_batch(
+            outcome = await self._send_image_batch(
                 chat_id, [(f"file://{_quote(p)}", "") for p in _image_paths], metadata, human_delay)
 
-        async def _send_one(path: str, *, is_voice: bool, media_tag: bool) -> bool:
+        async def _send_one(path: str, *, is_voice: bool, media_tag: bool) -> SendResult:
             """MEDIA-tag files (``media_tag``) may route to send_voice; bare local files never
             do."""
             ext = Path(path).suffix.lower()
@@ -3738,7 +3744,7 @@ class BasePlatformAdapter(ABC):
                 logger.warning("[%s] Failed to send %s (%s): %s", self.name,
                                "media" if media_tag else "local file", ext, result.error)
                 await self._notify_media_delivery_failure(chat_id, path, is_voice=is_voice, metadata=metadata)
-            return bool(result.success)
+            return result
         queue = [(p, v, True) for p, v in media_files if v or not _as_image(p)]
         if queue:
             logger.info("[%s] Delivering %d non-image MEDIA attachment(s)", self.name, len(queue))
@@ -3747,26 +3753,30 @@ class BasePlatformAdapter(ABC):
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
             try:
-                succeeded = await _send_one(
-                    path, is_voice=is_voice, media_tag=media_tag) and succeeded
+                result = await _send_one(path, is_voice=is_voice, media_tag=media_tag)
+                if outcome.success and not result.success:
+                    outcome = result
             except Exception as err:
-                succeeded = False
+                if outcome.success:
+                    outcome = SendResult(success=False, error=str(err))
                 if media_tag:
                     logger.warning("[%s] Error sending media: %s", self.name, err)
                 else:
                     logger.error("[%s] Error sending local file %s: %s", self.name, path, err)
-        return succeeded
+        return outcome
 
     async def _send_image_batch(
-        self, chat_id: str, images: list, metadata: Dict[str, Any], human_delay: float) -> bool:
+        self, chat_id: str, images: list, metadata: Dict[str, Any], human_delay: float) -> SendResult:
         """Batch-send images; report whether dispatch completed so the ledger can retain failures."""
         try:
             result = await self.send_multiple_images(
                 chat_id=chat_id, images=images, metadata=metadata, human_delay=human_delay)
-            return bool(getattr(result, "success", True))
+            # External adapters predating the result contract return None. Bundled implementations
+            # return SendResult so their failures remain represented in the delivery obligation.
+            return result if isinstance(result, SendResult) else SendResult(success=True)
         except Exception as batch_err:
             logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
-            return False
+            return SendResult(success=False, error=str(batch_err))
 
     @staticmethod
     def _attachment_manifest(extracted: "_ExtractedResponse") -> Dict[str, Any]:
@@ -3782,18 +3792,19 @@ class BasePlatformAdapter(ABC):
 
     async def _deliver_attachment_manifest(
         self, chat_id: str, manifest: Dict[str, Any], metadata: Dict[str, Any],
-    ) -> bool:
+    ) -> SendResult:
         """Deliver a persisted attachment manifest through the same routes as the live turn."""
         human_delay = self._get_human_delay()
         images = manifest.get("images") or []
-        succeeded = True
+        outcome = SendResult(success=True)
         if images:
             logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
-            succeeded = await self._send_image_batch(chat_id, images, metadata, human_delay)
-        return await self._deliver_media_attachments(
+            outcome = await self._send_image_batch(chat_id, images, metadata, human_delay)
+        media_outcome = await self._deliver_media_attachments(
             chat_id, manifest.get("media_files") or [], manifest.get("local_files") or [],
             force_document_attachments=bool(manifest.get("force_document_attachments")),
-            human_delay=human_delay, metadata=metadata) and succeeded
+            human_delay=human_delay, metadata=metadata)
+        return outcome if not outcome.success else media_outcome
 
     async def send_final_ledgered(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any], *,
@@ -3821,15 +3832,22 @@ class BasePlatformAdapter(ABC):
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
         is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable,
         delivery_adapter: Optional["BasePlatformAdapter"] = None,
+        *, ledgered_elsewhere: bool = False,
     ) -> SendResult:
-        """Send the final text on the CURRENT transport (a reconnect may have replaced
-        this adapter); the complete-response caller owns the ledger transaction."""
-        delivery_adapter = delivery_adapter or self._final_delivery_adapter(event.source)
-        logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
-                    len(text_content), event.source.chat_id)
-        result = await delivery_adapter._send_with_retry(
-            chat_id=event.source.chat_id, content=text_content,
-            reply_to=_reply_anchor_for_event(event), metadata=metadata)
+        """Send final text through the ordinary ledger path unless a complete-response
+        obligation already brackets this text together with its attachments."""
+        if ledgered_elsewhere:
+            delivery_adapter = delivery_adapter or self._final_delivery_adapter(event.source)
+            logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
+                        len(text_content), event.source.chat_id)
+            result = await delivery_adapter._send_with_retry(
+                chat_id=event.source.chat_id, content=text_content,
+                reply_to=_reply_anchor_for_event(event), metadata=metadata)
+        else:
+            result, delivery_adapter = await self.send_final_ledgered(
+                event, session_key, text_content, metadata,
+                reply_to=_reply_anchor_for_event(event),
+                is_ephemeral_response=is_ephemeral_response)
         record_delivery(result)
         if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
             delivery_adapter._schedule_ephemeral_delete(
@@ -3853,18 +3871,18 @@ class BasePlatformAdapter(ABC):
         return _thread_metadata
 
     async def _deliver_attachments(self, event: MessageEvent, extracted: "_ExtractedResponse",
-                                   metadata: Dict[str, Any], *, anything_sent: bool) -> bool:
+                                   metadata: Dict[str, Any], *, anything_sent: bool) -> SendResult:
         """Send extracted image URLs, MEDIA files and bare local files (human-paced),
         then fail loudly if a non-empty response produced nothing deliverable."""
         manifest = self._attachment_manifest(extracted)
-        succeeded = await self._deliver_attachment_manifest(
+        outcome = await self._deliver_attachment_manifest(
             event.source.chat_id, manifest, metadata)
         if not (anything_sent or manifest) and extracted.pre_extract.strip():
             logger.error("[%s] response_delivery_dropped: non-empty response "
                          "(%d chars) produced no delivered message or attachment "
                          "for %s (empty after extract, recovery yielded nothing).", self.name,
                          len(extracted.pre_extract), event.source.chat_id)
-        return succeeded
+        return outcome
 
     def _start_typing_refresh(self, event: MessageEvent, interrupt_event: asyncio.Event,
                               metadata: Optional[dict]) -> Optional[asyncio.Task]:
@@ -4022,23 +4040,25 @@ class BasePlatformAdapter(ABC):
                     _text_result = await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
                         is_ephemeral_response, _ephemeral_ttl, _record_delivery,
-                        delivery_adapter=_delivery_adapter)
+                        delivery_adapter=_delivery_adapter, ledgered_elsewhere=True)
                     _text_delivered = bool(getattr(_text_result, "success", False))
-                _attachments_delivered = await _delivery_adapter._deliver_attachments(
+                _attachment_result = await _delivery_adapter._deliver_attachments(
                     event, extracted, _final_thread_metadata,
                     anything_sent=delivery_attempted or _tts_caption_delivered)
                 if _attachment_manifest:
-                    _record_delivery(SendResult(
-                        success=_attachments_delivered,
-                        error="" if _attachments_delivered else "attachment delivery failed"))
+                    _record_delivery(_attachment_result)
                 if _obligation_id is not None:
-                    _complete_delivery = _text_delivered and _attachments_delivered
-                    _failure = getattr(_text_result, "error", "") if not _text_delivered else ""
+                    _complete_delivery = _text_delivered and _attachment_result.success
+                    _failure = _text_result if not _text_delivered else _attachment_result
                     await self._finalize_delivery_obligation(
                         _obligation_id,
                         SendResult(
                             success=_complete_delivery,
-                            error=_failure or ("" if _complete_delivery else "attachment delivery failed")),
+                            error="" if _complete_delivery else str(getattr(_failure, "error", "") or "send failed"),
+                            retryable=bool(getattr(_failure, "retryable", False)),
+                            retry_after=getattr(_failure, "retry_after", None),
+                            error_kind=getattr(_failure, "error_kind", None),
+                        ),
                         event, _delivery_adapter)
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             # Clean up the per-turn streaming-TTS flag.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3639,7 +3639,9 @@ class BasePlatformAdapter(ABC):
 
     async def _record_delivery_obligation(
         self, event: MessageEvent, session_key: str, text_content: str,
-        delivery_adapter: "BasePlatformAdapter", is_ephemeral_response: bool) -> Optional[str]:
+        attachment_manifest: Dict[str, Any], delivery_adapter: "BasePlatformAdapter",
+        is_ephemeral_response: bool,
+    ) -> Optional[str]:
         """Ledger the final response BEFORE the send so a crash before platform ACK redelivers on
         next boot; best-effort, skips slash-command and ephemeral replies. Returns the obligation id
         or None."""
@@ -3658,12 +3660,13 @@ class BasePlatformAdapter(ABC):
             if _ledger_id is None:
                 _ledger_id = getattr(event, "message_id", "")
             obligation_id = compute_obligation_id(
-                session_key, str(_ledger_id or ""), text_content)
+                session_key, str(_ledger_id or ""), text_content,
+                attachment_manifest=attachment_manifest)
             await asyncio.to_thread(
                 record_obligation, obligation_id=obligation_id, session_key=session_key,
                 platform=str(getattr(source.platform, "value", source.platform)),
                 chat_id=source.chat_id, thread_id=getattr(source, "thread_id", None),
-                content=text_content,
+                content=text_content, attachment_manifest=attachment_manifest,
                 adapter_profile=getattr(delivery_adapter, "_owner_profile", None))
             await asyncio.to_thread(mark_attempting, obligation_id)
             return obligation_id
@@ -3702,8 +3705,8 @@ class BasePlatformAdapter(ABC):
             logger.debug("delivery ledger update failed", exc_info=True)
 
     async def _deliver_media_attachments(
-        self, event: MessageEvent, media_files: list, local_files: list, *,
-        force_document_attachments: bool, human_delay: float, metadata: Dict[str, Any]) -> None:
+        self, chat_id: str, media_files: list, local_files: list, *,
+        force_document_attachments: bool, human_delay: float, metadata: Dict[str, Any]) -> bool:
         """Deliver MEDIA-tag files and detected local files by type: images batched via
         ``send_multiple_images`` unless ``[[as_document]]``; otherwise audio → send_voice (MEDIA
         tags only, never bare local files), video → send_video, else send_document. Every failure is
@@ -3714,12 +3717,12 @@ class BasePlatformAdapter(ABC):
             return Path(path).suffix.lower() in _IMAGE_EXTS and not force_document_attachments
         _image_paths = [p for p, is_voice in media_files if not is_voice and _as_image(p)]
         _image_paths += [p for p in local_files if _as_image(p)]
+        succeeded = True
         if _image_paths:
-            await self._send_image_batch(
-                event, [(f"file://{_quote(p)}", "") for p in _image_paths], metadata, human_delay)
-        chat_id = event.source.chat_id
+            succeeded = await self._send_image_batch(
+                chat_id, [(f"file://{_quote(p)}", "") for p in _image_paths], metadata, human_delay)
 
-        async def _send_one(path: str, *, is_voice: bool, media_tag: bool) -> None:
+        async def _send_one(path: str, *, is_voice: bool, media_tag: bool) -> bool:
             """MEDIA-tag files (``media_tag``) may route to send_voice; bare local files never
             do."""
             ext = Path(path).suffix.lower()
@@ -3735,6 +3738,7 @@ class BasePlatformAdapter(ABC):
                 logger.warning("[%s] Failed to send %s (%s): %s", self.name,
                                "media" if media_tag else "local file", ext, result.error)
                 await self._notify_media_delivery_failure(chat_id, path, is_voice=is_voice, metadata=metadata)
+            return bool(result.success)
         queue = [(p, v, True) for p, v in media_files if v or not _as_image(p)]
         if queue:
             logger.info("[%s] Delivering %d non-image MEDIA attachment(s)", self.name, len(queue))
@@ -3743,21 +3747,53 @@ class BasePlatformAdapter(ABC):
             if human_delay > 0:
                 await asyncio.sleep(human_delay)
             try:
-                await _send_one(path, is_voice=is_voice, media_tag=media_tag)
+                succeeded = await _send_one(
+                    path, is_voice=is_voice, media_tag=media_tag) and succeeded
             except Exception as err:
+                succeeded = False
                 if media_tag:
                     logger.warning("[%s] Error sending media: %s", self.name, err)
                 else:
                     logger.error("[%s] Error sending local file %s: %s", self.name, path, err)
+        return succeeded
 
     async def _send_image_batch(
-        self, event: MessageEvent, images: list, metadata: Dict[str, Any], human_delay: float) -> None:
-        """Batch-send images; a failure is logged (never raised) so other attachments still go."""
+        self, chat_id: str, images: list, metadata: Dict[str, Any], human_delay: float) -> bool:
+        """Batch-send images; report whether dispatch completed so the ledger can retain failures."""
         try:
-            await self.send_multiple_images(
-                chat_id=event.source.chat_id, images=images, metadata=metadata, human_delay=human_delay)
+            result = await self.send_multiple_images(
+                chat_id=chat_id, images=images, metadata=metadata, human_delay=human_delay)
+            return bool(getattr(result, "success", True))
         except Exception as batch_err:
             logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
+            return False
+
+    @staticmethod
+    def _attachment_manifest(extracted: "_ExtractedResponse") -> Dict[str, Any]:
+        """JSON-safe attachment payload persisted before any part of the response is sent."""
+        if not (extracted.images or extracted.media_files or extracted.local_files):
+            return {}
+        return {
+            "images": [list(image) for image in extracted.images],
+            "media_files": [list(media) for media in extracted.media_files],
+            "local_files": list(extracted.local_files),
+            "force_document_attachments": bool(extracted.force_document_attachments),
+        }
+
+    async def _deliver_attachment_manifest(
+        self, chat_id: str, manifest: Dict[str, Any], metadata: Dict[str, Any],
+    ) -> bool:
+        """Deliver a persisted attachment manifest through the same routes as the live turn."""
+        human_delay = self._get_human_delay()
+        images = manifest.get("images") or []
+        succeeded = True
+        if images:
+            logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
+            succeeded = await self._send_image_batch(chat_id, images, metadata, human_delay)
+        return await self._deliver_media_attachments(
+            chat_id, manifest.get("media_files") or [], manifest.get("local_files") or [],
+            force_document_attachments=bool(manifest.get("force_document_attachments")),
+            human_delay=human_delay, metadata=metadata) and succeeded
 
     async def send_final_ledgered(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any], *,
@@ -3774,7 +3810,7 @@ class BasePlatformAdapter(ABC):
         logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
                     len(text_content), event.source.chat_id)
         obligation_id = await self._record_delivery_obligation(
-            event, session_key, text_content, delivery_adapter, is_ephemeral_response)
+            event, session_key, text_content, {}, delivery_adapter, is_ephemeral_response)
         result = await delivery_adapter._send_with_retry(
             chat_id=event.source.chat_id, content=text_content, reply_to=reply_to, metadata=metadata)
         if obligation_id is not None:
@@ -3783,14 +3819,22 @@ class BasePlatformAdapter(ABC):
 
     async def _send_final_text(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
-        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable) -> None:
-        """Normal-lane final: the ledger bracket plus the message-id owner's ephemeral delete."""
-        result, delivery_adapter = await self.send_final_ledgered(
-            event, session_key, text_content, metadata,
-            reply_to=_reply_anchor_for_event(event), is_ephemeral_response=is_ephemeral_response)
+        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable,
+        delivery_adapter: Optional["BasePlatformAdapter"] = None,
+    ) -> SendResult:
+        """Send the final text on the CURRENT transport (a reconnect may have replaced
+        this adapter); the complete-response caller owns the ledger transaction."""
+        delivery_adapter = delivery_adapter or self._final_delivery_adapter(event.source)
+        logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
+                    len(text_content), event.source.chat_id)
+        result = await delivery_adapter._send_with_retry(
+            chat_id=event.source.chat_id, content=text_content,
+            reply_to=_reply_anchor_for_event(event), metadata=metadata)
         record_delivery(result)
         if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
-            delivery_adapter._schedule_ephemeral_delete(event.source.chat_id, result.message_id, ephemeral_ttl)
+            delivery_adapter._schedule_ephemeral_delete(
+                event.source.chat_id, result.message_id, ephemeral_ttl)
+        return result
 
     async def _notify_turn_error(self, event: MessageEvent, e: BaseException) -> Optional[dict]:
         """Tell the user a turn failed rather than leaving radio silence (last resort:
@@ -3809,23 +3853,18 @@ class BasePlatformAdapter(ABC):
         return _thread_metadata
 
     async def _deliver_attachments(self, event: MessageEvent, extracted: "_ExtractedResponse",
-                                   metadata: Dict[str, Any], *, anything_sent: bool) -> None:
+                                   metadata: Dict[str, Any], *, anything_sent: bool) -> bool:
         """Send extracted image URLs, MEDIA files and bare local files (human-paced),
         then fail loudly if a non-empty response produced nothing deliverable."""
-        human_delay = self._get_human_delay()
-        images, media_files, local_files = extracted.images, extracted.media_files, extracted.local_files
-        if images:
-            logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
-            await self._send_image_batch(event, images, metadata, human_delay)
-        await self._deliver_media_attachments(
-            event, media_files, local_files,
-            force_document_attachments=extracted.force_document_attachments,
-            human_delay=human_delay, metadata=metadata)
-        if not (anything_sent or images or local_files or media_files) and extracted.pre_extract.strip():
+        manifest = self._attachment_manifest(extracted)
+        succeeded = await self._deliver_attachment_manifest(
+            event.source.chat_id, manifest, metadata)
+        if not (anything_sent or manifest) and extracted.pre_extract.strip():
             logger.error("[%s] response_delivery_dropped: non-empty response "
                          "(%d chars) produced no delivered message or attachment "
                          "for %s (empty after extract, recovery yielded nothing).", self.name,
                          len(extracted.pre_extract), event.source.chat_id)
+        return succeeded
 
     def _start_typing_refresh(self, event: MessageEvent, interrupt_event: asyncio.Event,
                               metadata: Optional[dict]) -> Optional[asyncio.Task]:
@@ -3955,6 +3994,11 @@ class BasePlatformAdapter(ABC):
                 text_content, media_files = extracted.text_content, extracted.media_files
                 # Final content gets notify=True; typing metadata stays unmarked (thread-strict).
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _delivery_adapter = self._final_delivery_adapter(event.source)
+                _attachment_manifest = self._attachment_manifest(extracted)
+                _obligation_id = await self._record_delivery_obligation(
+                    event, session_key, text_content, _attachment_manifest,
+                    _delivery_adapter, is_ephemeral_response)
                 _tts_paths, _tts_requested_path = [], None
                 if self._wants_auto_tts(
                         event, session_key, interrupt_event, text_content, media_files):
@@ -3972,13 +4016,30 @@ class BasePlatformAdapter(ABC):
                 if not _tts_paths and _tts_requested_path is not None:
                     with contextlib.suppress(OSError):
                         os.remove(_tts_requested_path)
+                _text_delivered = not text_content or _tts_caption_delivered
+                _text_result = None
                 if text_content and not _tts_caption_delivered:
-                    await self._send_final_text(
+                    _text_result = await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
-                        is_ephemeral_response, _ephemeral_ttl, _record_delivery)
-                await self._deliver_attachments(
+                        is_ephemeral_response, _ephemeral_ttl, _record_delivery,
+                        delivery_adapter=_delivery_adapter)
+                    _text_delivered = bool(getattr(_text_result, "success", False))
+                _attachments_delivered = await _delivery_adapter._deliver_attachments(
                     event, extracted, _final_thread_metadata,
                     anything_sent=delivery_attempted or _tts_caption_delivered)
+                if _attachment_manifest:
+                    _record_delivery(SendResult(
+                        success=_attachments_delivered,
+                        error="" if _attachments_delivered else "attachment delivery failed"))
+                if _obligation_id is not None:
+                    _complete_delivery = _text_delivered and _attachments_delivered
+                    _failure = getattr(_text_result, "error", "") if not _text_delivered else ""
+                    await self._finalize_delivery_obligation(
+                        _obligation_id,
+                        SendResult(
+                            success=_complete_delivery,
+                            error=_failure or ("" if _complete_delivery else "attachment delivery failed")),
+                        event, _delivery_adapter)
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             # Clean up the per-turn streaming-TTS flag.
             self._streaming_tts_completed_turns.discard(self._streaming_tts_turn_key(

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -781,11 +781,11 @@ class SignalAdapter(BasePlatformAdapter):
         return file_path, None, None
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
-                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """Send a batch of images via chunked Signal RPC calls. Alt texts are dropped (one shared body
         per send); bad images are skipped with a warning; ``human_delay`` is ignored (scheduler paces)."""
         if not images:
-            return
+            return SendResult(success=True)
         scheduler = get_scheduler()
         logger.info("Signal send_multiple_images: received %d image(s) for %s — scheduler state: %s", len(images),
                     chat_id[:30], scheduler.state())
@@ -802,22 +802,29 @@ class SignalAdapter(BasePlatformAdapter):
         if not attachments:
             logger.error("Signal: no valid images in batch of %d (download=%d missing=%d oversize=%d)", len(images),
                          skipped["download"], skipped["missing"], skipped["oversize"])
-            return
+            return SendResult(success=False, error="No valid images in batch")
         logger.info("Signal send_multiple_images: %d/%d images valid, sending in chunks", len(attachments), len(images))
         base_params = await self._with_target({"account": self.account, "message": ""}, chat_id)
         per = SIGNAL_MAX_ATTACHMENTS_PER_MSG
         att_batches = [attachments[i:i + per] for i in range(0, len(attachments), per)]
         n_batches = len(att_batches)
+        outcome = (SendResult(success=False, error="Some images could not be prepared")
+                   if len(attachments) != len(images) else SendResult(success=True))
         for idx, att_batch in enumerate(att_batches, start=1):
             n = len(att_batch)
             estimated = scheduler.estimate_wait(n)
             logger.debug("Signal batch %d/%d: %d attachments, estimated wait=%.1fs", idx, n_batches, n, estimated)
             if estimated >= SIGNAL_BATCH_PACING_NOTICE_THRESHOLD:
                 await self._notify_batch_pacing(chat_id, idx, n_batches, estimated)
-            await self._send_attachment_batch(scheduler, dict(base_params, attachments=att_batch), n,
-                                              f"{idx}/{n_batches}")
+            result = await self._send_attachment_batch(
+                scheduler, dict(base_params, attachments=att_batch), n, f"{idx}/{n_batches}")
+            if outcome.success and not result.success:
+                outcome = result
+        return outcome
 
-    async def _send_attachment_batch(self, scheduler, params: Dict[str, Any], n: int, label: str) -> None:
+    async def _send_attachment_batch(
+        self, scheduler, params: Dict[str, Any], n: int, label: str,
+    ) -> SendResult:
         """Send one attachment batch with rate-limit pacing and a single transient retry. Tokens are
         deducted only on validated success (None = server never accepted it); 429s feed the scheduler."""
         send_timeout, max_attempts = _signal_send_timeout(n), SIGNAL_RATE_LIMIT_MAX_ATTEMPTS
@@ -832,7 +839,7 @@ class SignalAdapter(BasePlatformAdapter):
                 if attempt >= max_attempts:
                     logger.error("Signal: rate-limit retries exhausted on batch %s (%d attachments lost, "
                                  "server retry_after=%s)", label, n, retry_after)
-                    return
+                    return SendResult(success=False, error=str(e), retryable=True)
                 logger.warning("Signal: rate-limited on batch %s (attempt %d/%d, server retry_after=%s); "
                                "scheduler will pace the retry", label, attempt, max_attempts, retry_after)
                 continue
@@ -843,11 +850,11 @@ class SignalAdapter(BasePlatformAdapter):
                 await scheduler.report_rpc_duration(duration, n)
                 logger.info("Signal batch %s: %d attachments sent in %.1fs (attempt %d/%d)", label, n, duration,
                             attempt, max_attempts)
-                return
+                return SendResult(success=True)
             logger.error("Signal: RPC send failed for batch %s (%d attachments, attempt %d/%d, rpc_duration=%.1fs)%s",
                          label, n, attempt, max_attempts, duration, f": {err_msg}" if result is not None else "")
             if attempt >= max_attempts:
-                return
+                return SendResult(success=False, error=err_msg or "Signal RPC send failed")
             logger.info("Signal: retrying batch %s after %.1fs backoff", label, 2.0 ** attempt)
             await asyncio.sleep(2.0 ** attempt)
 

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -379,16 +379,36 @@ class GatewayStartupMixin:
             if adapter is None:
                 continue
             content = row["content"]
+            attachment_manifest = row.get("attachment_manifest") or {}
             if row.get("needs_marker"):
                 content = row.get("marker", RECOVERED_MARKER) + content
             metadata = {"thread_id": row["thread_id"]} if row.get("thread_id") else None
-            try:
-                result = await adapter.send(chat_id=row["chat_id"], content=content, metadata=metadata)
-            except Exception as send_err:
-                logger.warning("obligation %s: redelivery send raised: %s", row["obligation_id"], send_err)
-                result = None
+            result = None
+            text_succeeded = not content
+            if content:
+                try:
+                    result = await adapter.send(
+                        chat_id=row["chat_id"], content=content, metadata=metadata)
+                    text_succeeded = bool(getattr(result, "success", False))
+                except Exception as send_err:
+                    logger.warning(
+                        "obligation %s: redelivery send raised: %s",
+                        row["obligation_id"], send_err)
+            attachments_succeeded = True
+            if not row.get("attachment_manifest_valid", True):
+                attachments_succeeded = False
+            elif attachment_manifest:
+                try:
+                    attachments_succeeded = await adapter._deliver_attachment_manifest(
+                        row["chat_id"], attachment_manifest, metadata)
+                except Exception as attachment_err:
+                    attachments_succeeded = False
+                    logger.warning(
+                        "obligation %s: attachment redelivery raised: %s",
+                        row["obligation_id"], attachment_err)
+            complete = text_succeeded and attachments_succeeded
             with _log_suppressed(logging.DEBUG, "delivery ledger update failed", exc_info=True):
-                if result is not None and getattr(result, "success", False):
+                if complete:
                     await asyncio.to_thread(mark_delivered, row["obligation_id"])
                     redelivered += 1
                     logger.info(
@@ -396,8 +416,11 @@ class GatewayStartupMixin:
                         row["platform"], row["chat_id"], row["obligation_id"], row["attempts"],
                     )
                 else:
+                    error = str(getattr(result, "error", "") or "")
+                    if not attachments_succeeded:
+                        error = "attachment delivery failed"
                     await asyncio.to_thread(
-                        mark_failed, row["obligation_id"], str(getattr(result, "error", "") or "send failed")
+                        mark_failed, row["obligation_id"], error or "send failed"
                     )
         # Whatever is still waiting on a flood penalty (adopted at boot, skipped as not yet due, refused
         # again just now) gets a timer, so no flood-refused reply waits for the next restart.

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -394,13 +394,15 @@ class GatewayStartupMixin:
                     logger.warning(
                         "obligation %s: redelivery send raised: %s",
                         row["obligation_id"], send_err)
+            attachment_result = None
             attachments_succeeded = True
             if not row.get("attachment_manifest_valid", True):
                 attachments_succeeded = False
             elif attachment_manifest:
                 try:
-                    attachments_succeeded = await adapter._deliver_attachment_manifest(
+                    attachment_result = await adapter._deliver_attachment_manifest(
                         row["chat_id"], attachment_manifest, metadata)
+                    attachments_succeeded = bool(getattr(attachment_result, "success", False))
                 except Exception as attachment_err:
                     attachments_succeeded = False
                     logger.warning(
@@ -418,7 +420,7 @@ class GatewayStartupMixin:
                 else:
                     error = str(getattr(result, "error", "") or "")
                     if not attachments_succeeded:
-                        error = "attachment delivery failed"
+                        error = str(getattr(attachment_result, "error", "") or "attachment delivery failed")
                     await asyncio.to_thread(
                         mark_failed, row["obligation_id"], error or "send failed"
                     )

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2967,20 +2967,27 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         thread_channel, thread_id, starter_msg, message_id = self._forum_thread_parts(thread)
         if file is not None or files:
             attachments = getattr(starter_msg, "attachments", None) or []
-            if not attachments:
+            submitted_count = 1 if file is not None else len(files or [])
+            if len(attachments) != submitted_count:
                 filename = ""
                 if file is not None:
                     filename = getattr(file, "filename", "") or ""
                 elif files:
                     filename = getattr(files[0], "filename", "") or ""
+                received_count = len(attachments)
                 logger.warning(
-                    "[%s] Forum thread %s starter has no attachments for %s", self.name, thread_id,
-                    filename or "file",
+                    "[%s] Forum thread %s starter attached %d of %d files for %s", self.name,
+                    thread_id, received_count, submitted_count, filename or "file",
+                )
+                receipt = (
+                    f"attached {received_count} of {submitted_count} files"
+                    if received_count
+                    else f"attached no files (0 of {submitted_count})"
                 )
                 return SendResult(
                     success=False,
                     error=(
-                        "Discord created the forum thread but attached no files"
+                        f"Discord created the forum thread but {receipt}"
                         + (f" ({filename})" if filename else "")
                     ),
                     message_id=message_id or None,

--- a/plugins/platforms/discord/adapter_media.py
+++ b/plugins/platforms/discord/adapter_media.py
@@ -145,11 +145,23 @@ class DiscordMediaMixin:
                     self.name, len(files), chunk_idx + 1, len(chunks),
                 )
                 if self._is_forum_parent(channel):
-                    await self._forum_post_file(
+                    result = await self._forum_post_file(
                         channel, content=(content or "").strip(), files=files,
                     )
+                    if outcome.success and not result.success:
+                        outcome = result
                 else:
-                    await channel.send(content=content, files=files)
+                    msg = await channel.send(content=content, files=files)
+                    attachments = getattr(msg, "attachments", None) or []
+                    if len(attachments) != len(files) and outcome.success:
+                        outcome = SendResult(
+                            success=False,
+                            error=(
+                                "Discord accepted the message but attached "
+                                f"{len(attachments)} of {len(files)} files"
+                            ),
+                            message_id=str(getattr(msg, "id", "") or "") or None,
+                        )
             except Exception as e:
                 logger.warning(
                     "[%s] Multi-image Discord send failed (chunk %d/%d), falling back to per-image: %s",

--- a/plugins/platforms/discord/adapter_media.py
+++ b/plugins/platforms/discord/adapter_media.py
@@ -65,33 +65,32 @@ class DiscordMediaMixin:
     async def send_multiple_images(
         self, chat_id: str, images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0,
-    ) -> None:
+    ) -> SendResult:
         """Send images as one Discord message (<=10 attachments): URLs are downloaded and uploaded
         inline (bare links don't render); on chunk failure the remainder uses the per-image loop."""
         from plugins.platforms.discord.adapter import _prompt_target_id, _image_ext_from_content_type, _read_url_image_with_redirect_guard, is_safe_url
 
         if not self._client:
-            return
+            return SendResult(success=False, error="Not connected")
         if not images:
-            return
+            return SendResult(success=True)
         try:
             import discord as _discord_mod
             import io as _io
             from urllib.parse import unquote as _unquote
         except Exception:  # pragma: no cover
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         try:
             channel = await self._resolve_channel(_prompt_target_id(chat_id, metadata))
             if not channel:
                 logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
-                return
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
         except Exception as e:
             logger.warning("[%s] Failed to resolve channel for multi-image send: %s", self.name, e)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         CHUNK = 10
         chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
+        outcome = SendResult(success=True)
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
@@ -135,6 +134,8 @@ class DiscordMediaMixin:
                         except Exception as dl_err:
                             logger.warning("[%s] Download failed for %s: %s", self.name, image_url[:80], dl_err)
                             continue
+                if len(files) != len(chunk) and outcome.success:
+                    outcome = SendResult(success=False, error="Some images could not be prepared")
                 if not files:
                     continue
                 # Use the first caption if any (Discord only has one message body for the group)
@@ -154,13 +155,17 @@ class DiscordMediaMixin:
                     "[%s] Multi-image Discord send failed (chunk %d/%d), falling back to per-image: %s",
                     self.name, chunk_idx + 1, len(chunks), e, exc_info=True,
                 )
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback = await super().send_multiple_images(
+                    chat_id, chunk, metadata, human_delay=human_delay)
+                if outcome.success and not fallback.success:
+                    outcome = fallback
             finally:
                 if aiohttp_session is not None:
                     try:
                         await aiohttp_session.close()
                     except Exception:
                         pass
+        return outcome
 
 
     async def send_voice(

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -717,12 +717,12 @@ class EmailAdapter(BasePlatformAdapter):
         return await self.send(chat_id, f"{caption or ''}\n\nImage: {image_url}".strip(), reply_to)
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
-                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+                                   metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """One email per batch: local files attached, URL images linked in the body (no remote download); base-class fallback on failure."""
         if not images:
-            return
+            return SendResult(success=True)
         from urllib.parse import unquote as _unquote
-        body_parts, local_paths = [], []
+        body_parts, local_paths, missing = [], [], False
         for image_url, alt_text in images:
             if alt_text:
                 body_parts.append(alt_text)
@@ -732,13 +732,19 @@ class EmailAdapter(BasePlatformAdapter):
                 local_paths.append(local_path)
             else:
                 logger.warning("[Email] Skipping missing image: %s", local_path)
+                missing = True
         if not local_paths and not body_parts:
-            return
+            return SendResult(success=False, error="No valid images in batch")
         try:
-            await asyncio.get_running_loop().run_in_executor(None, self._send_email_with_attachments, chat_id, "\n\n".join(body_parts), local_paths)
+            message_id = await asyncio.get_running_loop().run_in_executor(
+                None, self._send_email_with_attachments, chat_id,
+                "\n\n".join(body_parts), local_paths)
+            return SendResult(
+                success=not missing, message_id=message_id,
+                error="Some images were missing" if missing else None)
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
 
     def _send_email_with_attachments(self, to_addr: str, body: str, file_paths: List[str]) -> str:
         """Send an email with multiple file attachments via SMTP (unattachable files are skipped)."""

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -698,16 +698,11 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
-    def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]], *, lenient: bool) -> str:
-        """Send a reply with attachments; *lenient* logs-and-skips unattachable files instead of raising."""
+    def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]]) -> str:
+        """Send a reply with attachments, failing before SMTP if any file cannot be attached."""
         msg, msg_id, _ = self._new_reply(to_addr, body)
         for path, name in files:
-            try:
-                _attach_file(msg, path, name)
-            except Exception as e:
-                if not lenient:
-                    raise
-                logger.warning("[Email] Failed to attach %s: %s", path, e)
+            _attach_file(msg, path, name)
         self._smtp_send(msg)
         return msg_id
 
@@ -743,12 +738,12 @@ class EmailAdapter(BasePlatformAdapter):
                 success=not missing, message_id=message_id,
                 error="Some images were missing" if missing else None)
         except Exception as e:
-            logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
-            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
+            logger.error("[Email] Multi-image send failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
 
     def _send_email_with_attachments(self, to_addr: str, body: str, file_paths: List[str]) -> str:
-        """Send an email with multiple file attachments via SMTP (unattachable files are skipped)."""
-        msg_id = self._send_with_files(to_addr, body, [(Path(f), Path(f).name) for f in file_paths], lenient=True)
+        """Send an email with multiple file attachments via SMTP."""
+        msg_id = self._send_with_files(to_addr, body, [(Path(f), Path(f).name) for f in file_paths])
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
         return msg_id
 
@@ -759,7 +754,7 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _send_email_with_attachment(self, to_addr: str, body: str, file_path: str, file_name: Optional[str] = None) -> str:
         """Send an email with a single file attachment via SMTP (raises if unattachable)."""
-        return self._send_with_files(to_addr, body, [(Path(file_path), file_name or Path(file_path).name)], lenient=False)
+        return self._send_with_files(to_addr, body, [(Path(file_path), file_name or Path(file_path).name)])
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1478,11 +1478,12 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def send_multiple_images(
         self, chat_id: str, images: list[tuple[str, str]], metadata: Optional[Dict[str, Any]] = None,
-        human_delay: float = 0.0) -> None:
+        human_delay: float = 0.0) -> SendResult:
         if not images:
-            return
+            return SendResult(success=True)
         from urllib.parse import unquote as _unquote
         total = len(images)
+        outcome = SendResult(success=True)
         for idx, (image_url, alt_text) in enumerate(images, start=1):
             if human_delay > 0 and idx > 1:
                 await asyncio.sleep(human_delay)
@@ -1494,6 +1495,9 @@ class MatrixAdapter(BasePlatformAdapter):
                 result = await self.send_image(chat_id=chat_id, image_url=image_url, caption=caption, metadata=metadata)
             if not result.success:
                 logger.warning("Matrix: failed to send image %d/%d: %s", idx, total, result.error)
+                if outcome.success:
+                    outcome = result
+        return outcome
 
     async def send_document(
         self, chat_id: str, file_path: str, caption: Optional[str] = None, file_name: Optional[str] = None,

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -398,12 +398,13 @@ class MattermostAdapter(BasePlatformAdapter):
         return file_data, _url_filename(image_url, f"image_{index}.png"), ct
 
     async def send_multiple_images(self, chat_id: str, images: List[Tuple[str, str]],
-                                   metadata: _Metadata = None, human_delay: float = 0.0) -> None:
+                                   metadata: _Metadata = None, human_delay: float = 0.0) -> SendResult:
         """Send a batch of images as one post; chunked at Mattermost's 5-``file_ids`` cap, each chunk
         falling back to the base per-image loop on failure."""
         if not images:
-            return
+            return SendResult(success=True)
         chunks = [images[i:i + 5] for i in range(0, len(images), 5)]  # Mattermost post file_ids cap
+        outcome = SendResult(success=True)
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
@@ -415,6 +416,8 @@ class MattermostAdapter(BasePlatformAdapter):
                     loaded = await self._load_batch_image(image_url, len(file_ids))
                     if loaded is not None and (fid := await self._upload_file(chat_id, *loaded)):
                         file_ids.append(fid)
+                if len(file_ids) != len(chunk) and outcome.success:
+                    outcome = SendResult(success=False, error="Some images could not be prepared")
                 if not file_ids:
                     continue
                 logger.info("Mattermost: sending %d image(s) as single post (chunk %d/%d)",
@@ -422,11 +425,18 @@ class MattermostAdapter(BasePlatformAdapter):
                 data = await self._post_message(chat_id, "\n".join(caption_parts), None, metadata, file_ids)
                 if not data or "id" not in data:
                     logger.warning("Mattermost: multi-image post failed, falling back")
-                    await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                    fallback = await super().send_multiple_images(
+                        chat_id, chunk, metadata, human_delay=human_delay)
+                    if outcome.success and not fallback.success:
+                        outcome = fallback
             except Exception as e:
                 logger.warning("Mattermost: multi-image send failed (chunk %d/%d), falling back: %s",
                                chunk_idx + 1, len(chunks), e, exc_info=True)
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback = await super().send_multiple_images(
+                    chat_id, chunk, metadata, human_delay=human_delay)
+                if outcome.success and not fallback.success:
+                    outcome = fallback
+        return outcome
 
     # --- WebSocket ---
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2657,31 +2657,33 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def send_multiple_images(
         self, chat_id: str, images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+        metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> SendResult:
         """Send a batch of images as one message via ``files_upload_v2(file_uploads=...)`` (10 per
         call, Slack cap) instead of N posts; falls back to the base per-image loop on failure."""
         if self._suppressed_ignored(chat_id, "multi-image upload in"):
-            return
+            return SendResult(success=False, error="Delivery suppressed")
         if not self._app:
-            return
+            return SendResult(success=False, error="Not connected")
         if not images:
-            return
+            return SendResult(success=True)
         chat_id = await self._dm_target(chat_id, metadata)
         try:
             from urllib.parse import unquote as _unquote
             from tools.url_safety import create_ssrf_safe_async_client, is_safe_url as _is_safe_url
         except Exception:
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         thread_ts = self._resolve_thread_ts(None, metadata)
         CHUNK = 10
         chunks = [images[i : i + CHUNK] for i in range(0, len(images), CHUNK)]
+        outcome = SendResult(success=True)
         for chunk_idx, chunk in enumerate(chunks):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
             try:
                 file_uploads, initial_comment_parts = await self._collect_image_uploads(
                     chunk, _unquote, _is_safe_url, create_ssrf_safe_async_client)
+                if len(file_uploads) != len(chunk) and outcome.success:
+                    outcome = SendResult(success=False, error="Some images could not be prepared")
                 if not file_uploads:
                     continue
                 initial_comment = "\n".join(initial_comment_parts) if initial_comment_parts else ""
@@ -2696,8 +2698,11 @@ class SlackAdapter(BasePlatformAdapter):
                 logger.warning(
                     "[Slack] Multi-image files_upload_v2 failed (chunk %d/%d), falling back to per-image: %s",
                     chunk_idx + 1, len(chunks), e, exc_info=True)
-                await super().send_multiple_images(
+                fallback = await super().send_multiple_images(
                     chat_id, chunk, metadata, human_delay=human_delay)
+                if outcome.success and not fallback.success:
+                    outcome = fallback
+        return outcome
 
     @staticmethod
     async def _collect_image_uploads(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4642,24 +4642,27 @@ class TelegramAdapter(BasePlatformAdapter):
                     os.unlink(_transcoded_voice_path)
 
     async def send_multiple_images(
-        self, chat_id: str, images: List[tuple], metadata: Optional[Dict[str, Any]] = None, human_delay: float = 0.0) -> None:
+        self, chat_id: str, images: List[tuple], metadata: Optional[Dict[str, Any]] = None,
+        human_delay: float = 0.0,
+    ) -> SendResult:
         """Send images as Telegram albums (``send_media_group``, 10 per chunk). Animated GIFs can't join a
         media group (need ``send_animation``) so they go via the base per-image path, as does a failed chunk."""
         if not self._bot or not images:
-            return
+            return SendResult(success=not images, error=None if not images else "Not connected")
         try:
             from telegram import InputMediaPhoto
         except Exception as exc:  # pragma: no cover - missing SDK
             logger.warning("[%s] InputMediaPhoto unavailable, falling back to per-image send: %s", self.name, exc)
-            await super().send_multiple_images(chat_id, images, metadata, human_delay)
-            return
+            return await super().send_multiple_images(chat_id, images, metadata, human_delay)
         is_anim = lambda url: not url.startswith("file://") and self._is_animation_url(url)  # noqa: E731
         animations = [img for img in images if is_anim(img[0])]
         photos = [img for img in images if not is_anim(img[0])]
+        outcome = SendResult(success=True)
         if animations:
-            await super().send_multiple_images(chat_id, animations, metadata, human_delay=human_delay)
+            outcome = await super().send_multiple_images(
+                chat_id, animations, metadata, human_delay=human_delay)
         if not photos:
-            return
+            return outcome
         from urllib.parse import unquote as _unquote
         CHUNK = 10  # Telegram's album limit
         chunks = [photos[i:i + CHUNK] for i in range(0, len(photos), CHUNK)]
@@ -4679,6 +4682,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         source = open(local_path, "rb")
                         opened_files.append(source)
                     media.append(InputMediaPhoto(media=source, caption=self._caption_1024(alt_text)))
+                if len(media) != len(chunk) and outcome.success:
+                    outcome = SendResult(success=False, error="Some images could not be prepared")
                 if not media:
                     continue
                 logger.info("[%s] Sending media group of %d photo(s) (chunk %d/%d)", self.name, len(media), chunk_idx + 1, len(chunks))
@@ -4696,11 +4701,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning(
                     "[%s] send_media_group failed (chunk %d/%d), falling back to per-image: %s", self.name,
                     chunk_idx + 1, len(chunks), _redact_telegram_error_text(e), exc_info=True)
-                await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
+                fallback = await super().send_multiple_images(
+                    chat_id, chunk, metadata, human_delay=human_delay)
+                if outcome.success and not fallback.success:
+                    outcome = fallback
             finally:
                 for fh in opened_files:
                     with contextlib.suppress(Exception):
                         fh.close()
+        return outcome
 
     async def send_image_file(
         self, chat_id: str, image_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None,

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway import delivery_ledger as dl
+from gateway.platforms.base import SendResult
 
 
 @pytest.fixture(autouse=True)
@@ -412,7 +413,9 @@ class TestGatewayRedeliverySweep:
         _record(content=content, attachment_manifest=manifest)
         _orphan("ob-1")
         adapter = self._adapter()
-        adapter._deliver_attachment_manifest = AsyncMock(return_value=True)
+        adapter._deliver_attachment_manifest = AsyncMock(
+            return_value=SendResult(success=True)
+        )
         runner = self._runner(adapter)
 
         assert await runner._redeliver_pending_obligations() == 1

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -38,6 +38,7 @@ def _record(oid="ob-1", session_key="agent:main:slack:channel:C1", **kw):
         chat_id=kw.get("chat_id", "C1"),
         thread_id=kw.get("thread_id", "171.001"),
         content=kw.get("content", "the final answer"),
+        attachment_manifest=kw.get("attachment_manifest"),
         adapter_profile=kw.get("adapter_profile"),
     )
 
@@ -124,6 +125,7 @@ class TestSchemaMigration:
             conn.close()
 
         assert "adapter_profile" in columns
+        assert "attachment_manifest" in columns
 
 
 class TestStateMachine:
@@ -141,6 +143,10 @@ class TestObligationId:
         assert a != dl.compute_obligation_id("sk1:threadB", "msg1", "hello")
         assert a != dl.compute_obligation_id("sk1", "msg2", "hello")
         assert a != dl.compute_obligation_id("sk1", "msg1", "other")
+        assert a != dl.compute_obligation_id(
+            "sk1", "msg1", "hello",
+            attachment_manifest={"images": [["https://example.test/chart.png", "chart"]]},
+        )
         assert len(a) == 24
 
 
@@ -393,6 +399,29 @@ class TestGatewayRedeliverySweep:
         runner._async_session_store.clear_resume_pending.assert_awaited_once_with(
             "agent:main:slack:channel:C1"
         )
+
+    @pytest.mark.parametrize("content", ["the final answer", ""])
+    @pytest.mark.asyncio
+    async def test_complete_attachment_obligation_redelivers(self, content):
+        manifest = {
+            "images": [["https://example.test/chart.png", "chart"]],
+            "media_files": [["C:/media/photo.png", False]],
+            "local_files": [],
+            "force_document_attachments": False,
+        }
+        _record(content=content, attachment_manifest=manifest)
+        _orphan("ob-1")
+        adapter = self._adapter()
+        adapter._deliver_attachment_manifest = AsyncMock(return_value=True)
+        runner = self._runner(adapter)
+
+        assert await runner._redeliver_pending_obligations() == 1
+
+        assert adapter.send.await_count == bool(content)
+        adapter._deliver_attachment_manifest.assert_awaited_once_with(
+            "C1", manifest, {"thread_id": "171.001"}
+        )
+        assert _row("ob-1")["state"] == "delivered"
 
     @pytest.mark.asyncio
     async def test_startup_redelivery_uses_persisted_transport_owner(self):

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -9,6 +9,7 @@ block the send.
 
 import asyncio
 import threading
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -66,6 +67,23 @@ def _rows():
             """SELECT obligation_id, state, content, adapter_profile
                FROM delivery_obligations"""
         ).fetchall()
+
+
+def _last_error():
+    with dl._connect() as conn:
+        row = conn.execute(
+            "SELECT last_error FROM delivery_obligations"
+        ).fetchone()
+    return row[0] if row else None
+
+
+def _allowed_media_path(tmp_path, monkeypatch, name="report.pdf"):
+    root = tmp_path / "media-cache"
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"attachment")
+    monkeypatch.setattr("gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS", (root,))
+    return Path(path).resolve()
 
 
 def _blocking_probe():
@@ -149,6 +167,64 @@ class TestProducerHook:
         assert _rows()[0][3] == "reviewer"
         runner._redeliver_failed_obligations_for_platform.assert_awaited_once_with(
             Platform.SLACK, profile="reviewer"
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_image_keeps_complete_obligation_recoverable(self):
+        adapter = _Adapter()
+        adapter.send_image = AsyncMock(
+            return_value=SendResult(success=False, error="image upload failed")
+        )
+
+        await _run(adapter, _event(), response="![chart](https://example.test/chart.png)")
+
+        assert _rows()[0][1] == "failed"
+        assert _last_error() == "image upload failed"
+
+    @pytest.mark.asyncio
+    async def test_attachment_degradation_triggers_replacement_redelivery(
+        self, tmp_path, monkeypatch,
+    ):
+        adapter = _Adapter()
+        adapter._owner_profile = "reviewer"
+        replacement = _Adapter()
+        replacement._owner_profile = "reviewer"
+        runner = MagicMock()
+        runner._adapter_for_source.side_effect = [adapter, replacement]
+        runner._redeliver_failed_obligations_for_platform = AsyncMock(return_value=1)
+        adapter.gateway_runner = runner
+        adapter.send_document = AsyncMock(return_value=SendResult(
+            success=False, error="send_path_degraded", retryable=True,
+        ))
+        media = _allowed_media_path(tmp_path, monkeypatch)
+
+        await _run(adapter, _event(), response=f"MEDIA:{media}")
+
+        assert _rows()[0][1] == "failed"
+        assert _last_error() == "send_path_degraded"
+        runner._redeliver_failed_obligations_for_platform.assert_awaited_once_with(
+            Platform.SLACK, profile="reviewer"
+        )
+
+    @pytest.mark.asyncio
+    async def test_attachment_flood_failure_arms_runtime_timer(
+        self, tmp_path, monkeypatch,
+    ):
+        adapter = _Adapter()
+        runner = MagicMock()
+        runner._schedule_flood_redelivery = MagicMock()
+        adapter.gateway_runner = runner
+        adapter.send_document = AsyncMock(return_value=SendResult(
+            success=False, error="flood_control:60", retry_after=60,
+        ))
+        media = _allowed_media_path(tmp_path, monkeypatch)
+
+        await _run(adapter, _event(), response=f"MEDIA:{media}")
+
+        assert _rows()[0][1] == "failed"
+        assert _last_error() == "flood_control:60"
+        runner._schedule_flood_redelivery.assert_called_once_with(
+            Platform.SLACK, profile=None
         )
 
 

--- a/tests/gateway/test_discord_attachment_receipts.py
+++ b/tests/gateway/test_discord_attachment_receipts.py
@@ -1,9 +1,11 @@
 """Media targets and receipts must describe the attachment, not a fallback notice."""
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
 from plugins.platforms.discord.adapter import DiscordAdapter
 
 
@@ -61,3 +63,38 @@ async def test_failed_upload_never_becomes_successful_text_notice(tmp_path, meth
     assert not result.success
     assert "upload rejected" in result.error
     assert not client.uploads
+
+
+@pytest.mark.asyncio
+async def test_image_batch_requires_complete_attachment_receipt(tmp_path):
+    adapter = DiscordAdapter(PlatformConfig())
+    adapter._client = client = Client()
+    path = tmp_path / "media.bin"
+    path.write_bytes(b"attachment bytes")
+
+    async def send_without_attachments(**kwargs):
+        client.uploads.extend(kwargs["files"])
+        return SimpleNamespace(id=444, attachments=[])
+
+    client.send = send_without_attachments
+    result = await adapter.send_multiple_images("222", [(f"file://{path}", "caption")])
+
+    assert not result.success
+    assert "attached 0 of 1 files" in result.error
+
+
+@pytest.mark.asyncio
+async def test_image_batch_propagates_failed_forum_receipt(tmp_path):
+    adapter = DiscordAdapter(PlatformConfig())
+    adapter._client = Client()
+    adapter._is_forum_parent = lambda _channel: True
+    adapter._forum_post_file = AsyncMock(
+        return_value=SendResult(success=False, error="Discord forum starter contained no files")
+    )
+    path = tmp_path / "media.bin"
+    path.write_bytes(b"attachment bytes")
+
+    result = await adapter.send_multiple_images("222", [(f"file://{path}", "caption")])
+
+    assert not result.success
+    assert result.error == "Discord forum starter contained no files"

--- a/tests/gateway/test_discord_attachment_receipts.py
+++ b/tests/gateway/test_discord_attachment_receipts.py
@@ -98,3 +98,34 @@ async def test_image_batch_propagates_failed_forum_receipt(tmp_path):
 
     assert not result.success
     assert result.error == "Discord forum starter contained no files"
+
+
+@pytest.mark.asyncio
+async def test_image_batch_rejects_partial_forum_starter_receipt(tmp_path):
+    adapter = DiscordAdapter(PlatformConfig())
+    adapter._client = Client()
+    adapter._is_forum_parent = lambda _channel: True
+    adapter._resolve_channel = AsyncMock(
+        return_value=SimpleNamespace(
+            id=222,
+            create_thread=AsyncMock(
+                return_value=SimpleNamespace(
+                    id=777,
+                    message=SimpleNamespace(id=800, attachments=[SimpleNamespace()]),
+                    thread=SimpleNamespace(id=777, send=AsyncMock()),
+                )
+            ),
+        )
+    )
+    paths = [tmp_path / "first.png", tmp_path / "second.png"]
+    for path in paths:
+        path.write_bytes(b"attachment bytes")
+
+    result = await adapter.send_multiple_images(
+        "222", [(f"file://{path}", "caption") for path in paths]
+    )
+
+    assert not result.success
+    assert "attached 1 of 2 files" in result.error
+    assert result.message_id == "800"
+    assert result.raw_response == {"thread_id": "777"}

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -431,6 +431,32 @@ class TestSendMethods(unittest.TestCase):
         finally:
             os.unlink(tmp_path)
 
+    def test_image_batch_fails_when_attachment_construction_fails(self):
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(b"image bytes")
+            tmp_path = f.name
+
+        try:
+            with patch(
+                "plugins.platforms.email.adapter._attach_file",
+                side_effect=OSError("attachment encoder failed"),
+            ), patch.object(adapter, "_smtp_send") as smtp_send:
+                result = asyncio.run(
+                    adapter.send_multiple_images(
+                        "user@test.com", [(f"file://{tmp_path}", "image")]
+                    )
+                )
+
+            self.assertFalse(result.success)
+            self.assertIn("attachment encoder failed", result.error)
+            smtp_send.assert_not_called()
+        finally:
+            os.unlink(tmp_path)
+
 
     def test_get_chat_info(self):
         """get_chat_info should return email address as chat info."""

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -88,6 +88,35 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_document.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_media_only_response_records_attachment_obligation_before_delivery(
+    tmp_path, monkeypatch,
+):
+    from gateway import delivery_ledger as dl
+
+    adapter = _MediaRoutingAdapter()
+    event = _event()
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{media_file}")
+    adapter.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="doc")
+    )
+    recorded = []
+    monkeypatch.setattr(dl, "ledger_enabled", lambda: True)
+    monkeypatch.setattr(dl, "record_obligation", lambda **kwargs: recorded.append(kwargs))
+    monkeypatch.setattr(dl, "mark_attempting", lambda _oid: None)
+    monkeypatch.setattr(dl, "mark_delivered", lambda _oid: None)
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert len(recorded) == 1
+    assert recorded[0]["content"] == ""
+    assert recorded[0]["attachment_manifest"]["media_files"] == [
+        [str(media_file), False]
+    ]
+    adapter.send_document.assert_awaited_once()
+
+
 def _fake_runner(thread_meta):
     """Build a fake GatewayRunner-like object with the helper methods needed by
     _deliver_media_from_response."""


### PR DESCRIPTION
## What does this PR do?

Gateway crash recovery now preserves the complete final response instead of recovering text while silently dropping its attachments. Delivery obligations persist a canonical attachment manifest, media-only replies create obligations, and a row is settled only after both text and attachment delivery finish.

### Symptom

If the gateway exits after recording or sending final text but before attachment delivery completes, startup recovery sends only the text and marks the obligation delivered. Replies containing only media previously created no obligation at all.

### Impact

Users can permanently lose generated images, documents, audio, or video after a gateway crash even though recovery reports the response as delivered.

### Bug Cause

**Trigger:** `gateway/platforms/base.py` / `_process_message_background`

**Causal chain:**
1. Response extraction separates final text from image, MEDIA, and local-file attachments.
2. The delivery ledger records and settles only `text_content`; attachment delivery runs afterward outside the obligation.
3. Startup redelivery reads only `content`, so a crash can recover text without the owed files, while media-only responses leave no recoverable row.

**Why it is wrong:** The durable obligation represents only one part of a multi-part response but marks that partial representation delivered as if it covered the complete response.

**Working sibling / contrast:** Text-only responses were already represented and redelivered correctly. This change keeps that legacy row shape compatible while adding manifests only when attachments exist.

**Ruled out:** Resume regeneration cannot reliably repair this because claimed ledger sessions clear `resume_pending` before redelivery, and media-only turns may have no applicable resume marker.

### Fix

Persist a canonical JSON manifest for extracted images, MEDIA files, local files, and document-routing intent. Include the manifest in obligation identity, record it before delivery starts, route live and recovered manifests through the same attachment dispatcher, and settle the row only when all response parts succeed. Existing databases migrate additively and legacy text-only rows decode as an empty manifest.

## Related Issue

Closes #106668

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/delivery_ledger.py` - persist, migrate, identify, and claim attachment manifests.
- `gateway/platforms/base.py` - ledger complete responses and share live/recovery attachment dispatch.
- `gateway/run_startup.py` - redeliver persisted attachments and settle only complete recovery.
- `tests/gateway/test_delivery_ledger.py` - cover text-plus-media and media-only recovery contracts.
- `tests/gateway/test_tts_media_routing.py` - prove media-only live turns record an obligation before delivery.

## How to Test

1. Run the delivery-ledger suite, including simulated dead-owner recovery for text-plus-media and media-only rows.
2. Run the normal media-routing tests that prove media-only replies are recorded before file delivery.

```bash
scripts/run_tests.sh tests/gateway/test_delivery_ledger.py
scripts/run_tests.sh tests/gateway/test_tts_media_routing.py -k 'base_adapter_routes_voice_tagged or media_only_response_records'
```

Local result: 38 delivery-ledger tests passed; 2 focused media-routing tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and migration are covered by code docstrings and tests
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; the manifest uses JSON and existing platform adapter methods
- [x] Tool descriptions and schemas are N/A; no model tool behavior changed

## Screenshots / Logs

N/A - automated crash-recovery tests exercise the affected state and send paths.
