### PR TITLE
fix(feishu): hot-reload per-group group_rules without a gateway restart

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3285,17 +3285,50 @@ class FeishuAdapter(BasePlatformAdapter):
         return None
 
     def _require_mention_for(self, chat_id: str) -> bool:
-        rule = self._group_rules.get(chat_id) if chat_id else None
+        rule = self._effective_group_rule(chat_id)
         if rule and rule.require_mention is not None:
             return rule.require_mention
         return self._require_mention
+
+    def _effective_group_rule(self, chat_id: str) -> Optional[FeishuGroupRule]:
+        """Boot-time rule overlaid with the hot-reload entry for this chat.
+
+        Hot entries mirror the config.yaml group_rules shape and override per field,
+        so a one-key edit (e.g. ``{"require_mention": false}``) cannot silently drop
+        the rest of an existing rule. Missing keys keep the boot-time value.
+        """
+        if not chat_id:
+            return None
+        boot = self._group_rules.get(chat_id)
+        try:
+            from plugins.platforms.feishu.feishu_group_rules import load_group_rules
+
+            hot = load_group_rules().get(chat_id)
+        except Exception:
+            logger.exception("[Feishu] Failed to load hot-reload group rules")
+            return boot
+        if not hot:
+            return boot
+        if boot is None:
+            return FeishuGroupRule(
+                policy=str(hot.get("policy", "open")).strip().lower(),
+                allowlist=set(hot.get("allowlist", ())),
+                blacklist=set(hot.get("blacklist", ())),
+                require_mention=hot.get("require_mention"),
+            )
+        return FeishuGroupRule(
+            policy=hot.get("policy", boot.policy),
+            allowlist=set(hot.get("allowlist", boot.allowlist)),
+            blacklist=set(hot.get("blacklist", boot.blacklist)),
+            require_mention=hot.get("require_mention", boot.require_mention),
+        )
 
     def _allow_group_message(self, sender_id: Any, chat_id: str = "", *, is_bot: bool = False) -> bool:
         """Per-group policy gate for non-DM traffic."""
         sender_ids = {getattr(sender_id, "open_id", None), getattr(sender_id, "user_id", None)} - {None}
         if sender_ids and self._admins and (sender_ids & self._admins):
             return True
-        rule = self._group_rules.get(chat_id) if chat_id else None
+        rule = self._effective_group_rule(chat_id)
         if rule:
             policy, allowlist, blacklist = rule.policy, rule.allowlist, rule.blacklist
         else:

--- a/plugins/platforms/feishu/feishu_group_rules.py
+++ b/plugins/platforms/feishu/feishu_group_rules.py
@@ -1,0 +1,80 @@
+"""Feishu per-group admission rules hot-reload: ~/.hermes/feishu_group_rules.json.
+
+Entries use the same shape as ``platforms.feishu.extra.group_rules`` in config.yaml
+(policy / allowlist / blacklist / require_mention) and overlay the boot-time rules
+per chat at admission time, so flipping a group's gating no longer needs a gateway
+restart. Malformed entries are skipped with a warning (the last valid state keeps
+serving), mirroring the feishu_comment_rules.json mtime-cached hot reload.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from hermes_constants import get_hermes_home
+from plugins.platforms.feishu.feishu_comment_rules import _MtimeCache
+
+logger = logging.getLogger(__name__)
+
+# Resolved at import time: this module is lazy-imported by the adapter's admission
+# path, long after profile/HERMES_HOME overrides have been applied, so freezing is safe.
+GROUP_RULES_FILE = get_hermes_home() / "feishu_group_rules.json"
+
+_group_rules_cache = _MtimeCache(GROUP_RULES_FILE)
+
+_VALID_POLICIES = ("open", "allowlist", "blacklist", "admin_only", "disabled")
+
+
+def _validate_entry(chat_id: str, raw: Any) -> Dict[str, Any]:
+    """Normalize one rule entry; raises ValueError on a shape we refuse to guess."""
+    if not isinstance(raw, dict):
+        raise ValueError(f"entry for {chat_id!r} is not an object")
+    entry: Dict[str, Any] = {}
+    if "policy" in raw:
+        policy = str(raw["policy"]).strip().lower()
+        if policy not in _VALID_POLICIES:
+            raise ValueError(f"entry for {chat_id!r} has unknown policy {policy!r}")
+        entry["policy"] = policy
+    for key in ("allowlist", "blacklist"):
+        if key in raw:
+            values = raw[key]
+            if not isinstance(values, (list, tuple)):
+                raise ValueError(f"entry for {chat_id!r} has non-list {key}")
+            entry[key] = {str(u).strip() for u in values if str(u).strip()}
+    if "require_mention" in raw:
+        value = raw["require_mention"]
+        entry["require_mention"] = value is True or value == 1 or value == "true"
+    return entry
+
+
+def load_group_rules() -> Dict[str, Dict[str, Any]]:
+    """Read hot-reload group rules (mtime-cached); malformed entries are skipped."""
+    rules: Dict[str, Dict[str, Any]] = {}
+    for chat_id, raw in _group_rules_cache.load().items():
+        try:
+            rules[str(chat_id)] = _validate_entry(chat_id, raw)
+        except ValueError as exc:
+            logger.warning("[Feishu-GroupRules] Skipping %s", exc)
+    return rules
+
+
+def _main() -> int:
+    """Print the effective hot-reload rules (debugging aid for operators)."""
+    rules = load_group_rules()
+    if not rules:
+        print(f"No hot-reload group rules loaded (file: {GROUP_RULES_FILE})")
+        return 0
+    for chat_id, entry in sorted(rules.items()):
+        fields = ", ".join(
+            f"{key}={sorted(value) if isinstance(value, set) else value!r}"
+            for key, value in entry.items()
+        )
+        print(f"  {chat_id}: {fields}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/gateway/test_feishu_group_rules.py
+++ b/tests/gateway/test_feishu_group_rules.py
@@ -1,0 +1,185 @@
+"""Hot-reload tests for feishu_group_rules (per-chat overlay on boot-time group_rules)."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from plugins.platforms.feishu.feishu_comment_rules import _MtimeCache
+from plugins.platforms.feishu.feishu_group_rules import (
+    GROUP_RULES_FILE,
+    _validate_entry,
+    load_group_rules,
+)
+from tests.gateway.feishu_helpers import make_adapter_skeleton, make_sender
+
+
+class TestValidateEntry(unittest.TestCase):
+    def test_full_entry_normalized(self):
+        entry = _validate_entry(
+            "oc_1",
+            {
+                "policy": "Allowlist",
+                "allowlist": ["ou_a", " ou_b ", ""],
+                "blacklist": ["ou_x"],
+                "require_mention": "false",
+            },
+        )
+        self.assertEqual(entry["policy"], "allowlist")
+        self.assertEqual(entry["allowlist"], {"ou_a", "ou_b"})
+        self.assertEqual(entry["blacklist"], {"ou_x"})
+        self.assertIs(entry["require_mention"], False)
+
+    def test_partial_entry_keeps_only_present_keys(self):
+        entry = _validate_entry("oc_1", {"require_mention": True})
+        self.assertEqual(entry, {"require_mention": True})
+
+    def test_unknown_policy_raises(self):
+        with self.assertRaises(ValueError):
+            _validate_entry("oc_1", {"policy": "yolo"})
+
+    def test_non_list_allowlist_raises(self):
+        with self.assertRaises(ValueError):
+            _validate_entry("oc_1", {"allowlist": "ou_a"})
+
+    def test_non_object_entry_raises(self):
+        with self.assertRaises(ValueError):
+            _validate_entry("oc_1", ["policy"])
+
+
+class TestLoadGroupRules(unittest.TestCase):
+    def _write(self, path: Path, payload) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+
+    def test_malformed_entries_skipped_valid_served(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "group_rules.json"
+            self._write(
+                path,
+                {
+                    "oc_good": {"policy": "open", "require_mention": False},
+                    "oc_bad_policy": {"policy": "nope"},
+                    "oc_bad_list": {"allowlist": "ou_a"},
+                    "oc_not_object": True,
+                },
+            )
+            with (
+                patch(
+                    "plugins.platforms.feishu.feishu_group_rules.GROUP_RULES_FILE", path
+                ),
+                patch(
+                    "plugins.platforms.feishu.feishu_group_rules._group_rules_cache",
+                    _MtimeCache(path),
+                ),
+            ):
+                rules = load_group_rules()
+        self.assertEqual(list(rules), ["oc_good"])
+        self.assertIs(rules["oc_good"]["require_mention"], False)
+
+    def test_missing_file_yields_no_rules(self):
+        with (
+            patch(
+                "plugins.platforms.feishu.feishu_group_rules.GROUP_RULES_FILE",
+                Path("/nonexistent/g.json"),
+            ),
+            patch(
+                "plugins.platforms.feishu.feishu_group_rules._group_rules_cache",
+                _MtimeCache(Path("/nonexistent/g.json")),
+            ),
+        ):
+            self.assertEqual(load_group_rules(), {})
+
+    def test_edit_reread_on_mtime_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "group_rules.json"
+            self._write(path, {"oc_1": {"require_mention": True}})
+            os.utime(path, (1_000_000, 1_000_000))
+            with (
+                patch(
+                    "plugins.platforms.feishu.feishu_group_rules.GROUP_RULES_FILE", path
+                ),
+                patch(
+                    "plugins.platforms.feishu.feishu_group_rules._group_rules_cache",
+                    _MtimeCache(path),
+                ),
+            ):
+                self.assertIs(load_group_rules()["oc_1"]["require_mention"], True)
+                self._write(path, {"oc_1": {"require_mention": False}})
+                os.utime(path, (2_000_000, 2_000_000))
+                self.assertIs(load_group_rules()["oc_1"]["require_mention"], False)
+
+
+class TestEffectiveGroupRule(unittest.TestCase):
+    def _adapter(self, **kwargs):
+        from plugins.platforms.feishu.adapter import FeishuGroupRule
+
+        adapter = make_adapter_skeleton(group_policy="allowlist")
+        adapter._group_rules = {
+            "oc_1": FeishuGroupRule(
+                policy="allowlist",
+                allowlist={"ou_alice"},
+                blacklist=set(),
+                require_mention=True,
+            ),
+        }
+        return adapter
+
+    def test_hot_require_mention_flips_mention_gate_without_restart(self):
+        adapter = self._adapter()
+        self.assertTrue(adapter._require_mention_for("oc_1"))
+        with patch(
+            "plugins.platforms.feishu.feishu_group_rules.load_group_rules",
+            return_value={"oc_1": {"require_mention": False}},
+        ):
+            self.assertFalse(adapter._require_mention_for("oc_1"))
+        # Overlay is read per admission: reverting the file restores boot behavior.
+        self.assertTrue(adapter._require_mention_for("oc_1"))
+
+    def test_partial_hot_entry_merges_into_boot_rule(self):
+        adapter = self._adapter()
+        with patch(
+            "plugins.platforms.feishu.feishu_group_rules.load_group_rules",
+            return_value={"oc_1": {"require_mention": False}},
+        ):
+            sender = make_sender(open_id="ou_alice")
+            self.assertTrue(adapter._allow_group_message(sender.sender_id, "oc_1"))
+            stranger = make_sender(open_id="ou_charlie")
+            self.assertFalse(adapter._allow_group_message(stranger.sender_id, "oc_1"))
+
+    def test_hot_entry_can_add_rule_for_unknown_chat(self):
+        adapter = self._adapter()
+        with patch(
+            "plugins.platforms.feishu.feishu_group_rules.load_group_rules",
+            return_value={"oc_new": {"policy": "disabled"}},
+        ):
+            sender = make_sender(open_id="ou_anyone")
+            self.assertFalse(adapter._allow_group_message(sender.sender_id, "oc_new"))
+        # Without the file, the chat falls back to the default policy.
+        self.assertFalse(adapter._allow_group_message(sender.sender_id, "oc_new"))
+
+    def test_hot_loader_failure_keeps_boot_rules(self):
+        adapter = self._adapter()
+        with patch(
+            "plugins.platforms.feishu.feishu_group_rules.load_group_rules",
+            side_effect=RuntimeError("boom"),
+        ):
+            self.assertTrue(adapter._require_mention_for("oc_1"))
+            sender = make_sender(open_id="ou_alice")
+            self.assertTrue(adapter._allow_group_message(sender.sender_id, "oc_1"))
+
+    def test_empty_chat_id_never_touches_hot_rules(self):
+        adapter = self._adapter()
+        with patch(
+            "plugins.platforms.feishu.feishu_group_rules.load_group_rules"
+        ) as loader:
+            self.assertIsNone(adapter._effective_group_rule(""))
+            loader.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a mtime-cached hot-reload overlay for per-group admission rules: `~/.hermes/feishu_group_rules.json` mirrors the `platforms.feishu.extra.group_rules` shape (`policy` / `allowlist` / `blacklist` / `require_mention`) and overlays the boot-time rules per chat at admission time, so flipping a group's gating no longer needs a gateway restart (#106694).
- New module `plugins/platforms/feishu/feishu_group_rules.py` reuses the proven `_MtimeCache` from `feishu_comment_rules.py` (stat-per-access, re-read on mtime change). Malformed entries are skipped with a warning, mirroring the comment-rules loader.
- Adapter gains `_effective_group_rule()` (`adapter.py`): boot rule overlaid **per field** — a one-key hot entry (e.g. `{"require_mention": false}`) cannot silently drop the rest of an existing rule; entries can also add rules for chats that have none. `_require_mention_for` and `_allow_group_message` now resolve through it. Loader failure is fail-soft (boot rules keep serving). `config.yaml` remains the boot/persistence source.

## Testing
- `python -m pytest tests/gateway/test_feishu_group_rules.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_feishu.py tests/gateway/test_feishu_comment_rules.py -q` → **99 passed, 18 skipped** (unchanged skips, all pre-existing).
- New suite covers: partial hot entry merges into boot rule (mention gate + policy gate), rule for unknown chat, edit re-read on mtime change, malformed entries skipped, missing file, loader failure keeps boot rules, empty chat id never touches the hot file.
- Mutation checks: disabling the overlay (`return boot` early) → mention-gate test fails; removing entry validation → malformed-entry test fails. Both restored, suite green.

Fixes #106694