### PR TITLE
fix(config): make platform_toolsets validation MCP-aware (#78102)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1395,8 +1395,23 @@ def _warn_invalid_platform_toolsets(results: Dict[str, Any], quiet: bool) -> Non
         from hermes_cli.toolset_validation import validate_platform_toolsets
         from hermes_cli.toolset_scope import toolset_allowed_for_platform
 
+        raw = read_raw_config()
+        try:
+            from hermes_cli.tools_config import enabled_mcp_server_names
+
+            mcp_names = enabled_mcp_server_names(raw)
+
+            def _mcp_ok(name: str) -> bool:
+                # Bare and mcp-<server> forms both name an enabled MCP server; no_mcp is the
+                # reserved sentinel that disables the MCP allowlist (see _merge_mcp_servers).
+                return (name in mcp_names
+                        or (name.startswith("mcp-") and name[4:] in mcp_names)
+                        or name == "no_mcp")
+        except Exception:
+            _mcp_ok = None
         for w in validate_platform_toolsets(
-                read_raw_config().get("platform_toolsets"), validate_toolset, toolset_allowed_for_platform):
+                raw.get("platform_toolsets"), validate_toolset, toolset_allowed_for_platform,
+                is_valid_mcp_server=_mcp_ok):
             results["warnings"].append(w)
             if not quiet:
                 print(f"  ⚠ {w}")

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -31,13 +31,24 @@ def _platform_default_is_valid(
 def validate_platform_toolsets(
     platform_toolsets: object, is_valid_toolset: Callable[[str], bool],
     is_allowed_for_platform: Callable[[str, str], bool] = toolset_allowed_for_platform,
+    is_valid_mcp_server: Callable[[str], bool] | None = None,
 ) -> List[str]:
     """Return human-readable warnings for a ``platform_toolsets`` mapping.
     Reports: a toolset name ``is_valid_toolset`` rejects (suggesting ``hermes-<platform>`` when that
     would have been valid); a non-empty mapping resolving to zero valid toolsets (agent would start with
     no tools); a platform with no valid toolsets, checked per-platform because the global net is
     suppressed once any platform is valid; and non-list platform values, which fall back to the platform
-    default. ``is_valid_toolset`` is injected so this does no registry imports or I/O."""
+    default. ``is_valid_toolset`` is injected so this does no registry imports or I/O.
+
+    MCP server names are a legitimate ``platform_toolsets`` entry: the listed names form a per-platform
+    MCP allowlist (see ``tools_config._merge_mcp_servers`` and ``_save_platform_tools``, which preserve
+    them). The runtime registers the ``mcp-<server>`` alias only after MCP discovery
+    (``tools/mcp_tool_registration.py``), so in a fresh interpreter (update CLI / config migration)
+    the registry is empty and ``is_valid_toolset`` rejects every MCP name. ``is_valid_mcp_server`` is
+    the injected predicate covering that case: True when ``name`` is an enabled MCP server or the
+    ``mcp-<server>`` prefixed form of one (None disables the check). An MCP-validated name counts as
+    valid for the zero-toolset safety nets, so a platform list consisting only of MCP names does not
+    warn."""
     warnings: List[str] = []
     if not isinstance(platform_toolsets, dict) or not platform_toolsets:
         return warnings
@@ -69,6 +80,12 @@ def validate_platform_toolsets(
             if not isinstance(name, str) or not name:
                 continue
             if not is_valid_toolset(name):
+                if is_valid_mcp_server is not None and is_valid_mcp_server(name):
+                    # MCP allowlist entry (bare server name or mcp-<server> form): valid, and it
+                    # must count toward the zero-toolset safety nets.
+                    valid_count += 1
+                    platform_valid_count += 1
+                    continue
                 hint = f" — did you mean '{default}'?" if default_valid else ""
                 warnings.append(f"platform '{platform}' references unknown toolset '{name}'{hint}")
             elif is_allowed_for_platform(name, str(platform)):

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -197,3 +197,105 @@ def test_populated_platforms_produce_no_empty_list_warning():
     cfg = {"cli": ["hermes-cli"], "telegram": ["hermes-telegram"]}
     warnings = validate_platform_toolsets(cfg, _is_valid)
     assert warnings == []
+
+
+# --- MCP-awareness (#78102): platform_toolsets legitimately holds MCP server names ---
+# (per-platform MCP allowlist; see tools_config._merge_mcp_servers / _save_platform_tools).
+
+
+def test_bare_mcp_server_name_accepted_via_predicate():
+    cfg = {"telegram": ["linear", "web"]}
+    warnings = validate_platform_toolsets(
+        cfg, _is_valid, is_valid_mcp_server=lambda n: n in {"linear"})
+    # 'linear' is not a toolset, but the MCP predicate vouches for it: no warning at all.
+    assert not any("telegram" in w for w in warnings)
+
+
+def test_prefixed_mcp_server_name_accepted_via_predicate():
+    cfg = {"cli": ["mcp-codegraph", "hermes-cli"]}
+    warnings = validate_platform_toolsets(
+        cfg, _is_valid, is_valid_mcp_server=lambda n: n in {"mcp-codegraph"})
+    assert not any("unknown toolset 'mcp-codegraph'" in w for w in warnings)
+    assert not any("zero valid toolsets" in w for w in warnings)
+
+
+def test_mcp_only_platform_list_does_not_trip_zero_valid_safety_net():
+    # Both names are MCP allowlist entries, neither is a toolset: the platform has tools
+    # (the MCP allowlist), so neither the per-platform nor the global net may fire.
+    cfg = {"telegram": ["linear", "fellow"]}
+    warnings = validate_platform_toolsets(
+        cfg, _is_valid, is_valid_mcp_server=lambda n: n in {"linear", "fellow"})
+    assert warnings == []
+
+
+def test_mixed_list_flags_only_the_genuinely_unknown_name():
+    cfg = {"cli": ["hermes-cli", "linear", "bogus"]}
+    warnings = validate_platform_toolsets(
+        cfg, _is_valid, is_valid_mcp_server=lambda n: n in {"linear"})
+    assert [w for w in warnings if "unknown toolset" in w] == [
+        w for w in warnings if "'bogus'" in w
+    ]
+    assert len(warnings) == 1
+
+
+def test_mcp_names_still_warn_without_predicate():
+    # Legacy callers pass no predicate (explicit None = the default): behavior is
+    # unchanged, MCP names keep warning.
+    cfg = {"telegram": ["linear"]}
+    warnings = validate_platform_toolsets(cfg, _is_valid, is_valid_mcp_server=None)
+    assert any("unknown toolset 'linear'" in w for w in warnings)
+
+
+def test_config_validator_accepts_mcp_names_and_no_mcp_sentinel(monkeypatch):
+    # Caller-level: _warn_invalid_platform_toolsets must build the MCP predicate from the
+    # raw config, so bare MCP names and the no_mcp sentinel pass without warnings.
+    import hermes_cli.config as config_mod
+
+    cfg = {
+        "mcp_servers": {
+            "linear": {"transport": "stdio"},
+            "fellow": {"transport": "stdio"},
+        },
+        "platform_toolsets": {"telegram": ["web", "linear", "fellow", "no_mcp"]},
+    }
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: cfg)
+    results = {"warnings": []}
+    config_mod._warn_invalid_platform_toolsets(results, quiet=True)
+    assert results["warnings"] == []
+
+
+def test_config_validator_still_flags_bogus_name_alongside_mcp_names(monkeypatch):
+    # The predicate widens acceptance, never blinds it: an unknown name still warns.
+    import hermes_cli.config as config_mod
+
+    cfg = {
+        "mcp_servers": {
+            "linear": {"transport": "stdio"},
+            "fellow": {"transport": "stdio"},
+        },
+        "platform_toolsets": {"telegram": ["web", "linear", "fellow", "no_mcp", "bogus"]},
+    }
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: cfg)
+    results = {"warnings": []}
+    config_mod._warn_invalid_platform_toolsets(results, quiet=True)
+    assert len(results["warnings"]) == 1
+    assert "unknown toolset 'bogus'" in results["warnings"][0]
+
+
+def test_config_validator_flags_mcp_name_of_disabled_server(monkeypatch):
+    # A disabled MCP server's name is not in the allowlist: the warning is genuinely
+    # useful there (its tools are silently absent at runtime), so it must fire.
+    import hermes_cli.config as config_mod
+
+    cfg = {
+        "mcp_servers": {
+            "linear": {"transport": "stdio", "enabled": False},
+        },
+        "platform_toolsets": {"telegram": ["linear"]},
+    }
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: cfg)
+    results = {"warnings": []}
+    config_mod._warn_invalid_platform_toolsets(results, quiet=True)
+    # The unknown-name warning fires (plus the zero-valid safety nets, since nothing
+    # in the list is valid) — the disabled server is not vouched for.
+    assert any("unknown toolset 'linear'" in w for w in results["warnings"])


### PR DESCRIPTION
## What does this PR do?

`validate_platform_toolsets()` in `hermes_cli/toolset_validation.py` now accepts an optional injected `is_valid_mcp_server` predicate, and the config-migration caller in `hermes_cli/config.py` passes one built from the raw config. This stops `hermes update` and `hermes doctor` config validation from warning `platform 'telegram' references unknown toolset 'linear'` for names that are legitimate MCP server entries.

A `platform_toolsets` list is a per-platform MCP allowlist, not just a list of toolset names. Three code paths agree on that contract:

- `tools_config._merge_mcp_servers()` intersects bare server names from `platform_toolsets` with the enabled MCP servers to form the allowlist.
- `tools_config._save_platform_tools()` explicitly preserves MCP server names when the `hermes tools` picker saves a platform list.
- `tools/mcp_tool_registration.py` registers a `server_name -> mcp-<server_name>` alias at runtime, but only after MCP discovery.

The validator ran in a fresh interpreter (update CLI, config migration) where the tool registry is empty, so `validate_toolset()` rejected every MCP name and the migration path warned on each one. The `no_mcp` sentinel false-warned for the same reason: `_merge_mcp_servers()` documents it as the reserved value that disables the allowlist, but `validate_toolset("no_mcp")` is False.

The fix keeps the file's existing dependency-injection shape: `is_valid_mcp_server(name)` is True for an enabled MCP server name or its `mcp-<server>` prefixed form, injected by the caller so `toolset_validation.py` still does no registry imports or I/O. An MCP-validated name also counts toward both zero-valid-toolset safety nets, so a platform list consisting only of MCP names does not trip the "agent will have no tools" warning (it has tools: the allowlist). Corruption detection is intact. A name that is neither a toolset nor a valid MCP form still warns with the existing hint, and a disabled MCP server's name still warns because its tools are genuinely absent at runtime. The predicate build in `config.py` degrades to `None` on failure, so validation falls back to current behavior instead of crashing migration.

## Related Issue

Fixes #78102

This covers the `toolset_validation.py` half of that issue (the unknown-toolset warnings from the `hermes update` / `hermes doctor` config validation path). The other half, the cli.py constructor warning around lines 4461-4468 that flags `mcp-<server>` names at startup, is not touched here. Related false-positive-class issues not addressed by this PR: #95529 and #91757 (plugin toolsets flagged before discovery).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/toolset_validation.py`: new optional `is_valid_mcp_server` parameter on `validate_platform_toolsets()`; an MCP-validated name increments both valid counters and emits no warning; docstring documents the MCP allowlist contract and why the registry is empty in fresh interpreters.
- `hermes_cli/config.py`: `_warn_invalid_platform_toolsets()` reads the raw config once, builds the predicate from `enabled_mcp_server_names()` (bare name, `mcp-` prefixed form, and the `no_mcp` sentinel), passes it to the validator, and falls back to `None` on any predicate-build failure.
- `tests/hermes_cli/test_toolset_validation.py`: 8 new tests covering bare and prefixed MCP names, MCP-only lists versus the zero-valid safety nets, mixed lists, the no-predicate legacy path, and caller-level wiring (including the disabled-server and bogus-name cases).

## How to Test

1. Put an enabled MCP server name in `platform_toolsets` (bare or `mcp-` prefixed), or the `no_mcp` sentinel, e.g. `platform_toolsets: {telegram: [web, linear, no_mcp]}` with `linear` enabled under `mcp_servers`.
2. Run `hermes update` or `hermes doctor` so the config validation path executes.
3. Before this PR, the migration output includes `references unknown toolset 'linear'` with the `did you mean 'hermes-telegram'?` hint. After, no warning fires for the MCP name or the sentinel. A genuinely unknown name still warns.
4. Unit tests: `pytest tests/hermes_cli/test_toolset_validation.py -q` (20 passed; 12 existing plus 8 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the focused suites in a minimal PR venv instead: `test_toolset_validation.py` 20 passed, `test_tools_config.py` 52 passed, 6 skipped; full-suite run on the supported matrix left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15, Python 3.14 PR venv (focused suites)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): the `validate_platform_toolsets()` docstring documents the new parameter and the MCP allowlist contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys (N/A: no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (N/A: pure logic, no OS-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior (N/A)

## Screenshots / Logs

Non-vacuity check (repo discipline): with the `toolset_validation.py` change temporarily reverted, the new tests fail; with it restored, all 20 pass.

```
$ .venv-pr/bin/python -m pytest tests/hermes_cli/test_toolset_validation.py -q
20 passed in 0.39s

# validator change reverted (temporarily):
FAILED test_bare_mcp_server_name_accepted_via_predicate
FAILED test_mcp_names_still_warn_without_predicate
... 6 of the 8 new tests fail
```

`test_tools_config.py` (neighbor suite): 52 passed, 6 skipped on this branch.

Drafted with AI assistance (OpenCode SWE subagent on GLM model); reviewed by Abhishek Sharma.
