### PR TITLE
feat(image_gen): support GPT Image 2.5 in Codex OAuth provider

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -5,7 +5,8 @@ optional GPT Image 2.5 Flare/Sunburst quality variants), routed through the Code
 Responses API ``image_generation`` tool, so no ``OPENAI_API_KEY`` is needed. Output
 is PNG; source images travel as Responses ``input_image`` parts. Selected catalog
 ids are sent as ``tools[0].model`` (quality from catalog meta) and are never rewritten
-to ``gpt-image-2``.
+to ``gpt-image-2`` by Hermes. Codex may normalize the model even on HTTP success;
+server-reported tool metadata is preserved separately, not treated as engine identity.
 
 Do NOT reintroduce an "account capability" classifier keyed on ``Tool choice
 'image_generation' not found in 'tools' parameter``: that 400 is a request-shape
@@ -63,7 +64,7 @@ MODELS = {
     },
 }
 
-# Hosts the ``image_generation`` tool call; catalog ``api_model`` does the image work.
+# Hosts ``image_generation``; catalog ``api_model`` requests (not verifies) an image model.
 _CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
@@ -323,12 +324,29 @@ def _iter_sse_json(response: Any):
         yield payload
 
 
+def _extract_reported_image_model(event: Dict[str, Any]) -> Optional[str]:
+    """Read only image-tool metadata, never the host model or arbitrary output text."""
+    response = event.get("response")
+    tools = response.get("tools") if isinstance(response, dict) else None
+    if not isinstance(tools, list):
+        return None
+    for tool in tools:
+        if isinstance(tool, dict) and tool.get("type") == "image_generation":
+            model = tool.get("model")
+            if isinstance(model, str) and model.strip():
+                return model
+    return None
+
+
 def _collect_image_b64(
     token: str, *, prompt: str, size: str, quality: str, api_model: str = API_MODEL,
     input_images: Optional[List[Dict[str, str]]] = None
 ) -> Optional[Dict[str, str]]:
-    """Stream a Codex Responses image_generation call → ``{"b64", "source": "final"|"partial"}`` or
-    ``None``. A partial is kept only when no final arrives; callers must not treat it as success."""
+    """Collect image bytes and optional ``reported_model`` from the same response stream.
+
+    A partial is kept only when no final arrives; callers must not treat it as success.
+    Reported tool configuration is not verified image-engine identity.
+    """
     import httpx
     from agent.codex_headers import codex_cloudflare_headers
 
@@ -344,6 +362,7 @@ def _collect_image_b64(
 
     final_b64: Optional[str] = None
     partial_b64: Optional[str] = None
+    reported_model: Optional[str] = None
     with httpx.Client(timeout=timeout, headers=headers) as http:
         with http.stream("POST", f"{_CODEX_BASE_URL}/responses", json=payload) as response:
             try:
@@ -355,11 +374,15 @@ def _collect_image_b64(
                     f"{_summarize_error_body(exc.response.text)}"
                 ) from exc
             for event in _iter_sse_json(response):
+                reported_model = _extract_reported_image_model(event) or reported_model
                 result_b64, event_partial = _extract_image_candidates(event)
                 final_b64 = result_b64 or final_b64
                 partial_b64 = event_partial or partial_b64
     if final_b64:
-        return {"b64": final_b64, "source": "final"}
+        result = {"b64": final_b64, "source": "final"}
+        if reported_model is not None:
+            result["reported_model"] = reported_model
+        return result
     return {"b64": partial_b64, "source": "partial"} if partial_b64 else None
 
 
@@ -386,7 +409,8 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             "env_vars": [],
             "post_setup_hint": (
                 "Sign in with `hermes auth codex` (or `hermes setup` → Codex) "
-                "if you haven't already. No API key needed."),
+                "if you haven't already. No API key needed. The selected image model "
+                "is a request; Hermes cannot confirm the exact image variant on Codex."),
         }
 
     def capabilities(self) -> Dict[str, Any]:
@@ -476,6 +500,12 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
             extra={
                 "size": size, "quality": meta["quality"], "input_image_count": len(input_images),
                 "image_source": image_source, "requested_size": size, "pixel_size": pixel_size,
+                "requested_model": api_model, "reported_model": collected.get("reported_model"),
+                "model_selection_verified": False,
+                "model_selection_note": (
+                    "Exact image model unverified. 'model' is the configured selection; "
+                    "'requested_model' is the sent image-tool model; 'reported_model' is "
+                    "server-reported tool configuration, not proof of the image engine."),
             })
 
 

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -11,9 +11,9 @@ server-reported tool metadata is preserved separately, not treated as engine ide
 Do NOT reintroduce an "account capability" classifier keyed on ``Tool choice
 'image_generation' not found in 'tools' parameter``: that 400 is a request-shape
 rejection for every account, fixed by omitting tool_choice (``_build_responses_payload``);
-any remaining HTTP error must surface verbatim. Unknown/unsupported image-model
-rejections are labeled as compatibility ``api_error`` and must not silently fall
-through to another provider.
+any remaining HTTP error must surface verbatim as ``api_error`` and must not
+silently fall through to another provider. Error text alone does not identify
+whether the host model, image model, or another parameter was rejected.
 """
 
 from __future__ import annotations
@@ -98,25 +98,6 @@ def _summarize_error_body(body: str) -> str:
     except (TypeError, ValueError):
         pass
     return text[:_MAX_ERROR_BODY_CHARS]
-
-
-def _is_unsupported_image_model_error(message: str) -> bool:
-    """True when Codex rejected the image_generation tool's ``model`` (not request-shape)."""
-    text = (message or "").lower()
-    if "tool choice" in text:
-        return False
-    needles = (
-        "unknown model",
-        "unsupported model",
-        "model is not supported",
-        "invalid model",
-        "unrecognized model",
-        "model_not_found",
-        "model does not exist",
-        "does not have access to model",
-        "unknown or invalid model",
-    )
-    return any(needle in text for needle in needles)
 
 
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
@@ -459,12 +440,6 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
                         attempt + 1, attempts)
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
-            message = str(exc)
-            if _is_unsupported_image_model_error(message):
-                return fail(
-                    f"Codex image_generation compatibility error: the backend rejected "
-                    f"model {api_model!r}. {exc} The selected image model was not rewritten.",
-                    "api_error")
             return fail(f"OpenAI image generation via Codex auth failed: {exc}", "api_error")
 
         if not collected or not collected.get("b64"):

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -1,13 +1,18 @@
 """OpenAI image generation — ChatGPT/Codex OAuth variant.
 
-Same catalog/tiers as the ``openai`` plugin (``gpt-image-2`` low/medium/high), routed
-through the Codex Responses API ``image_generation`` tool, so no ``OPENAI_API_KEY`` is
-needed. Output is PNG; source images travel as Responses ``input_image`` parts.
+Same catalog/tiers as the ``openai`` plugin (``gpt-image-2`` low/medium/high plus
+optional GPT Image 2.5 Flare/Sunburst quality variants), routed through the Codex
+Responses API ``image_generation`` tool, so no ``OPENAI_API_KEY`` is needed. Output
+is PNG; source images travel as Responses ``input_image`` parts. Selected catalog
+ids are sent as ``tools[0].model`` (quality from catalog meta) and are never rewritten
+to ``gpt-image-2``.
 
 Do NOT reintroduce an "account capability" classifier keyed on ``Tool choice
 'image_generation' not found in 'tools' parameter``: that 400 is a request-shape
 rejection for every account, fixed by omitting tool_choice (``_build_responses_payload``);
-any remaining HTTP error must surface verbatim.
+any remaining HTTP error must surface verbatim. Unknown/unsupported image-model
+rejections are labeled as compatibility ``api_error`` and must not silently fall
+through to another provider.
 """
 
 from __future__ import annotations
@@ -38,7 +43,27 @@ logger = logging.getLogger(__name__)
 # so it stays diagnosable. See issues #19505, #49008 and #31335.
 _MAX_ERROR_BODY_CHARS = 500
 
-# Hosts the ``image_generation`` tool call; ``API_MODEL`` does the image work.
+# Same picker catalog as the API-key OpenAI plugin: GPT Image 2 quality tiers plus
+# GPT Image 2.5 Flare/Sunburst (``auto`` has no suffix; other qualities are suffixed).
+MODELS = {
+    **{key: {**meta, "api_model": API_MODEL} for key, meta in GPT_IMAGE_2_TIERS.items()},
+    **{
+        model if quality == "auto" else f"{model}-{quality}": {
+            "display": f"GPT Image 2.5 {name} ({quality.title()})",
+            "speed": speed,
+            "strengths": strengths,
+            "api_model": model,
+            "quality": quality,
+        }
+        for model, name, speed, strengths in (
+            ("gpt-image-2.5-flare", "Flare", "Fast", "Everyday image generation and editing"),
+            ("gpt-image-2.5-sunburst", "Sunburst", "Slower", "Precision generation and editing"),
+        )
+        for quality in ("auto", "low", "medium", "high", "xhigh", "max")
+    },
+}
+
+# Hosts the ``image_generation`` tool call; catalog ``api_model`` does the image work.
 _CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
@@ -74,9 +99,28 @@ def _summarize_error_body(body: str) -> str:
     return text[:_MAX_ERROR_BODY_CHARS]
 
 
+def _is_unsupported_image_model_error(message: str) -> bool:
+    """True when Codex rejected the image_generation tool's ``model`` (not request-shape)."""
+    text = (message or "").lower()
+    if "tool choice" in text:
+        return False
+    needles = (
+        "unknown model",
+        "unsupported model",
+        "model is not supported",
+        "invalid model",
+        "unrecognized model",
+        "model_not_found",
+        "model does not exist",
+        "does not have access to model",
+        "unknown or invalid model",
+    )
+    return any(needle in text for needle in needles)
+
+
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return resolve_static_model(
-        GPT_IMAGE_2_TIERS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex")
+        MODELS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex")
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -174,11 +218,12 @@ def _normalize_input_images(
 
 
 def _build_responses_payload(
-    *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None
+    *, prompt: str, size: str, quality: str, api_model: str = API_MODEL,
+    input_images: Optional[List[Dict[str, str]]] = None
 ) -> Dict[str, Any]:
     """Responses body for an image_generation call. No ``tool_choice``: Codex rejects every shape
     for forcing the hosted tool (looks it up as a *function* name), so the host model decides,
-    nudged by ``instructions``."""
+    nudged by ``instructions``. ``api_model`` is the catalog's image-tool model id (never rewritten)."""
     content: List[Dict[str, Any]] = [{"type": "input_text", "text": prompt}, *(input_images or [])]
     return {
         "model": _CODEX_CHAT_MODEL,
@@ -187,7 +232,7 @@ def _build_responses_payload(
         "input": [{"type": "message", "role": "user", "content": content}],
         "tools": [{
             "type": "image_generation",
-            "model": API_MODEL,
+            "model": api_model,
             "size": size,
             "quality": quality,
             "output_format": "png",
@@ -279,7 +324,8 @@ def _iter_sse_json(response: Any):
 
 
 def _collect_image_b64(
-    token: str, *, prompt: str, size: str, quality: str, input_images: Optional[List[Dict[str, str]]] = None
+    token: str, *, prompt: str, size: str, quality: str, api_model: str = API_MODEL,
+    input_images: Optional[List[Dict[str, str]]] = None
 ) -> Optional[Dict[str, str]]:
     """Stream a Codex Responses image_generation call → ``{"b64", "source": "final"|"partial"}`` or
     ``None``. A partial is kept only when no final arrives; callers must not treat it as success."""
@@ -293,7 +339,7 @@ def _collect_image_b64(
         "Content-Type": "application/json",
     })
     payload = _build_responses_payload(
-        prompt=prompt, size=size, quality=quality, input_images=input_images)
+        prompt=prompt, size=size, quality=quality, api_model=api_model, input_images=input_images)
     timeout = httpx.Timeout(300.0, connect=30.0, read=300.0, write=30.0, pool=30.0)
 
     final_b64: Optional[str] = None
@@ -318,11 +364,11 @@ def _collect_image_b64(
 
 
 class OpenAICodexImageGenProvider(StaticImageGenProvider):
-    """gpt-image-2 routed through ChatGPT/Codex OAuth instead of an API key."""
+    """gpt-image-2 / 2.5 routed through ChatGPT/Codex OAuth instead of an API key."""
 
     provider_id = "openai-codex"
     label = "OpenAI (Codex auth)"
-    models = GPT_IMAGE_2_TIERS
+    models = MODELS
     default_model_id = DEFAULT_MODEL
     price = "varies"
 
@@ -333,7 +379,10 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
         return {
             "name": "OpenAI (Codex auth)",
             "badge": "free",
-            "tag": "gpt-image-2 via ChatGPT/Codex OAuth — no API key required; supports text and image inputs",
+            "tag": (
+                "GPT Image 2 / 2.5 Flare / Sunburst via ChatGPT/Codex OAuth — "
+                "no API key required; supports text and image inputs"
+            ),
             "env_vars": [],
             "post_setup_hint": (
                 "Sign in with `hermes auth codex` (or `hermes setup` → Codex) "
@@ -368,12 +417,13 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
         except Exception as exc:
             return fail(f"Invalid image input for Codex image editing: {exc}", "invalid_image_input")
 
+        api_model = meta.get("api_model", API_MODEL)
         try:
             collected: Optional[Dict[str, str]] = None
             for attempt in range(attempts):
                 collected = _collect_image_b64(
                     token, prompt=prompt, size=size, quality=meta["quality"],
-                    input_images=input_images or None)
+                    api_model=api_model, input_images=input_images or None)
                 if collected and collected.get("source") == "final" and collected.get("b64"):
                     break
                 if attempt < _NONFINAL_RETRIES:
@@ -385,6 +435,12 @@ class OpenAICodexImageGenProvider(StaticImageGenProvider):
                         attempt + 1, attempts)
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
+            message = str(exc)
+            if _is_unsupported_image_model_error(message):
+                return fail(
+                    f"Codex image_generation compatibility error: the backend rejected "
+                    f"model {api_model!r}. {exc} The selected image model was not rewritten.",
+                    "api_error")
             return fail(f"OpenAI image generation via Codex auth failed: {exc}", "api_error")
 
         if not collected or not collected.get("b64"):

--- a/plugins/image_gen/openai-codex/plugin.yaml
+++ b/plugins/image_gen/openai-codex/plugin.yaml
@@ -1,5 +1,5 @@
 name: openai-codex
 version: 1.0.0
-description: "OpenAI image generation backed by ChatGPT/Codex OAuth (gpt-image-2 via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
+description: "OpenAI image generation backed by ChatGPT/Codex OAuth (GPT Image 2 and GPT Image 2.5 Flare/Sunburst via the Responses image_generation tool). Saves generated images to $HERMES_HOME/cache/images/."
 author: NousResearch
 kind: backend

--- a/tests/plugins/image_gen/test_codex_image_review_integration.py
+++ b/tests/plugins/image_gen/test_codex_image_review_integration.py
@@ -1,0 +1,127 @@
+"""Offline integration review of Codex image selection and error attribution.
+
+Real bundled discovery, config, tool dispatcher, provider, SSE and image saving;
+only OAuth-token lookup and HTTP transport are replaced. Fixtures are synthetic,
+not evidence of live OpenAI engine selection.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+from tools import image_generation_tool as tool
+
+PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+@pytest.fixture
+def codex_route(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+        "image_gen": {"provider": "openai-codex"},
+    }))
+    provider = tool._get_plugin_provider("openai-codex", force=True)
+    assert provider is not None
+    module = sys.modules[type(provider).__module__]
+    assert module.__file__ is not None
+    assert Path(module.__file__).resolve().is_relative_to(Path(__file__).resolve().parents[3])
+    monkeypatch.setattr(module, "_read_codex_access_token", lambda: "synthetic-review-token")
+    return tmp_path, provider
+
+
+@pytest.mark.parametrize("failure", ["host-model", "size", "image-model"])
+def test_backend_error_does_not_reassign_blame(codex_route, monkeypatch, failure):
+    home, provider = codex_route
+    requests = []
+    messages = []
+
+    def respond(request):
+        assert str(request.url) == "https://chatgpt.com/backend-api/codex/responses"
+        payload = json.loads(request.content)
+        requests.append(payload)
+        host = payload["model"]
+        image_model = payload["tools"][0]["model"]
+        status, param, message = {
+            "host-model": (404, "model", f"Unknown model: {host}"),
+            "size": (400, "tools[0].size", "Invalid model parameters: size is unsupported"),
+            "image-model": (400, "tools[0].model", f"Unknown model: {image_model} is not supported"),
+        }[failure]
+        messages.append(message)
+        return httpx.Response(status, json={"error": {
+            "message": message, "type": "invalid_request_error", "param": param,
+        }})
+
+    real_client = httpx.Client
+    monkeypatch.setattr(httpx, "Client", lambda *a, **kw: real_client(
+        *a, transport=httpx.MockTransport(respond), **kw,
+    ))
+    result = json.loads(tool._handle_image_generate({"prompt": "A blue circle."}))
+    assert len(requests) == 1
+    assert result["success"] is False
+    assert result["error_type"] == "api_error"
+    assert messages[0] in result["error"]
+    assert not result.get("image")
+    if failure != "image-model":
+        image_model = requests[0]["tools"][0]["model"]
+        assert f"backend rejected model {image_model!r}" not in result["error"], result["error"]
+
+
+@pytest.mark.parametrize("requested", ["gpt-image-2.5-flare", "gpt-image-2.5-sunburst"])
+@pytest.mark.parametrize("editing", [False, True], ids=["generate", "edit"])
+def test_configured_selection_and_unverified_echo_survive_tool_dispatch(
+    codex_route, monkeypatch, requested, editing,
+):
+    home, provider = codex_route
+    config_path = home / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"image_gen": {
+        "provider": "openai-codex", "model": requested,
+        "openai-codex": {"model": requested},
+    }}))
+    original_config = config_path.read_bytes()
+    requests = []
+    reported = "opaque-backend-image-alias"
+    events = [{"type": "response.completed", "response": {
+        "tools": [{"type": "image_generation", "model": reported}],
+        "output": [{"type": "image_generation_call", "status": "completed",
+                    "result": base64.b64encode(PNG).decode()}],
+    }}]
+    wire = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+
+    def respond(request):
+        assert str(request.url) == "https://chatgpt.com/backend-api/codex/responses"
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, text=wire, headers={"content-type": "text/event-stream"})
+
+    real_client = httpx.Client
+    monkeypatch.setattr(httpx, "Client", lambda *a, **kw: real_client(
+        *a, transport=httpx.MockTransport(respond), **kw,
+    ))
+    args = {"prompt": "A blue circle.", "aspect_ratio": "square"}
+    if editing:
+        source = home / "reference.png"
+        source.write_bytes(PNG)
+        args["image_url"] = str(source)
+    result = json.loads(tool._handle_image_generate(args))
+    assert len(requests) == 1
+    assert requests[0]["tools"][0]["model"] == requested
+    parts = requests[0]["input"][0]["content"]
+    assert any(part["type"] == "input_image" for part in parts) is editing
+    assert result["success"] is True
+    assert result["model"] == requested
+    assert result["requested_model"] == requested
+    assert result["reported_model"] == reported
+    assert result["model_selection_verified"] is False
+    assert Path(result["image"]).read_bytes() == PNG
+    assert config_path.read_bytes() == original_config

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -399,7 +399,7 @@ class TestGenerate:
         # The account-entitlement misdiagnosis must not come back.
         assert "not enabled for the current Codex account" not in result["error"]
         assert result["error_type"] != "capability_unsupported"
-        # Model-compatibility labeling is only for unknown/unsupported image models.
+        # Do not infer account entitlement or image-model rejection from error prose.
         assert "compatibility" not in result["error"].lower()
 
 
@@ -611,7 +611,7 @@ class TestGptImage25Payload:
         assert result["model"] == "gpt-image-2-medium"
         assert captured["tools"][0]["model"] == "gpt-image-2"
 
-    def test_unsupported_model_http_error_is_compatibility_api_error_not_fallback(
+    def test_unsupported_model_http_error_is_preserved_as_api_error_not_fallback(
         self, provider, monkeypatch, tmp_path
     ):
         """Unknown/unsupported model from Codex must surface; never silently switch providers."""
@@ -648,9 +648,9 @@ class TestGptImage25Payload:
         result = provider.generate("a cat")
         assert seen["json"]["tools"][0]["model"] == "gpt-image-2.5-flare"
         assert result["success"] is False
-        assert result["error_type"] in ("compatibility", "api_error")
+        assert result["error_type"] == "api_error"
         err = result["error"].lower()
-        assert "compatibility" in err
+        assert "Unknown model: gpt-image-2.5-flare is not supported" in result["error"]
         assert "gpt-image-2.5-flare" in result["error"]
         assert "unknown model" in err or "not supported" in err
         assert "not enabled for the current Codex account" not in result["error"]

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -61,7 +61,8 @@ class TestMetadata:
 
     def test_list_models_three_tiers(self, provider):
         ids = [m["id"] for m in provider.list_models()]
-        assert ids == ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"]
+        # GPT Image 2 three-tier catalog remains the leading entries; 2.5 variants follow.
+        assert ids[:3] == ["gpt-image-2-low", "gpt-image-2-medium", "gpt-image-2-high"]
 
     def test_setup_schema_has_no_required_env_vars(self, provider):
         schema = provider.get_setup_schema()
@@ -127,13 +128,13 @@ class TestGenerate:
 
         captured = {}
 
-        def _collect(token, *, prompt, size, quality, input_images=None):
-            captured.update(codex_plugin._build_responses_payload(
-                prompt=prompt,
-                size=size,
-                quality=quality,
-                input_images=input_images,
-            ))
+        def _collect(token, **kwargs):
+            payload_kwargs = {
+                k: kwargs[k]
+                for k in ("prompt", "size", "quality", "input_images", "api_model")
+                if k in kwargs
+            }
+            captured.update(codex_plugin._build_responses_payload(**payload_kwargs))
             return {"b64": _b64_png(), "source": "final"}
 
         monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
@@ -397,6 +398,8 @@ class TestGenerate:
         # The account-entitlement misdiagnosis must not come back.
         assert "not enabled for the current Codex account" not in result["error"]
         assert result["error_type"] != "capability_unsupported"
+        # Model-compatibility labeling is only for unknown/unsupported image models.
+        assert "compatibility" not in result["error"].lower()
 
 
 class TestRequestShape:
@@ -449,6 +452,210 @@ class TestRequestShape:
         # Body is capped, but the actionable wire message still reaches the user.
         assert "tools' parameter" in message
         assert len(message) < len(body)
+
+
+# ── GPT Image 2.5 Flare / Sunburst (issue #106708) ──────────────────────────
+
+
+_GPT_IMAGE_25_MODELS = ("gpt-image-2.5-flare", "gpt-image-2.5-sunburst")
+_GPT_IMAGE_25_QUALITIES = ("auto", "low", "medium", "high", "xhigh", "max")
+_GPT_IMAGE_25_IDS = tuple(
+    model if quality == "auto" else f"{model}-{quality}"
+    for model in _GPT_IMAGE_25_MODELS
+    for quality in _GPT_IMAGE_25_QUALITIES
+)
+
+
+def _catalog_id(api_model: str, quality: str) -> str:
+    return api_model if quality == "auto" else f"{api_model}-{quality}"
+
+
+def _set_codex_model(tmp_path, model_id: str) -> None:
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"image_gen": {"openai-codex": {"model": model_id}}})
+    )
+
+
+def _capture_payload(captured: dict):
+    """Record ``_collect_image_b64`` kwargs and the Responses payload they produce."""
+
+    def _collect(token, **kwargs):
+        captured["collect_kwargs"] = kwargs
+        payload_kwargs = {
+            "prompt": kwargs["prompt"],
+            "size": kwargs["size"],
+            "quality": kwargs["quality"],
+            "input_images": kwargs.get("input_images"),
+        }
+        import inspect
+
+        params = inspect.signature(codex_plugin._build_responses_payload).parameters
+        if "api_model" in params and kwargs.get("api_model"):
+            payload_kwargs["api_model"] = kwargs["api_model"]
+        captured.update(codex_plugin._build_responses_payload(**payload_kwargs))
+        return {"b64": _b64_png(), "source": "final"}
+
+    return _collect
+
+
+class TestGptImage25Catalog:
+    def test_list_models_includes_flare_and_sunburst_quality_variants(self, provider):
+        ids = [m["id"] for m in provider.list_models()]
+        for model_id in _GPT_IMAGE_25_IDS:
+            assert model_id in ids
+        # GPT Image 2 three-tier catalog is retained (CONTROL).
+        assert "gpt-image-2-low" in ids
+        assert "gpt-image-2-medium" in ids
+        assert "gpt-image-2-high" in ids
+
+    def test_picker_ids_match_resolvable_catalog(self, provider):
+        ids = [m["id"] for m in provider.list_models()]
+        assert set(ids) == set(provider.models)
+        assert provider.default_model() in ids
+        assert provider.default_model() == "gpt-image-2-medium"
+
+
+class TestGptImage25Payload:
+    def test_flare_text_to_image_sends_api_model_not_gpt_image_2(
+        self, provider, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        _set_codex_model(tmp_path, "gpt-image-2.5-flare")
+        captured = {}
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _capture_payload(captured))
+
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2.5-flare"
+        assert captured["tools"][0]["model"] == "gpt-image-2.5-flare"
+        assert captured["tools"][0]["quality"] == "auto"
+        assert captured["collect_kwargs"].get("api_model") == "gpt-image-2.5-flare"
+        # Must not silently rewrite to GPT Image 2.
+        assert captured["tools"][0]["model"] != "gpt-image-2"
+
+    def test_sunburst_edit_with_reference_image_sends_api_model(
+        self, provider, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        _set_codex_model(tmp_path, "gpt-image-2.5-sunburst")
+        source = tmp_path / "ref.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+        captured = {}
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _capture_payload(captured))
+
+        result = provider.generate(
+            "edit this", image_url=str(source), reference_image_urls=[str(source)]
+        )
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2.5-sunburst"
+        assert captured["tools"][0]["model"] == "gpt-image-2.5-sunburst"
+        assert captured["tools"][0]["quality"] == "auto"
+        content = captured["input"][0]["content"]
+        image_parts = [part for part in content if part.get("type") == "input_image"]
+        assert len(image_parts) >= 1
+        assert captured["tools"][0]["model"] != "gpt-image-2"
+
+    def test_gpt_image_2_medium_default_payload_still_gpt_image_2(
+        self, provider, monkeypatch
+    ):
+        """CONTROL: default catalog selection must keep sending gpt-image-2."""
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _capture_payload(captured))
+
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-medium"
+        assert captured["tools"][0]["model"] == "gpt-image-2"
+        assert captured["tools"][0]["quality"] == "medium"
+
+    @pytest.mark.parametrize("api_model,quality", [
+        (model, quality)
+        for model in _GPT_IMAGE_25_MODELS
+        for quality in _GPT_IMAGE_25_QUALITIES
+    ])
+    def test_quality_variant_reaches_image_generation_tool(
+        self, provider, monkeypatch, tmp_path, api_model, quality
+    ):
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        tier = _catalog_id(api_model, quality)
+        _set_codex_model(tmp_path, tier)
+        captured = {}
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _capture_payload(captured))
+
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert result["model"] == tier
+        assert result["quality"] == quality
+        assert captured["tools"][0]["model"] == api_model
+        assert captured["tools"][0]["quality"] == quality
+
+    def test_unknown_model_id_falls_through_to_gpt_image_2_medium(
+        self, provider, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        _set_codex_model(tmp_path, "not-a-real-image-model")
+        captured = {}
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _capture_payload(captured))
+
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-medium"
+        assert captured["tools"][0]["model"] == "gpt-image-2"
+
+    def test_unsupported_model_http_error_is_compatibility_api_error_not_fallback(
+        self, provider, monkeypatch, tmp_path
+    ):
+        """Unknown/unsupported model from Codex must surface; never silently switch providers."""
+        import httpx
+
+        monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        _set_codex_model(tmp_path, "gpt-image-2.5-flare")
+
+        body = json.dumps({
+            "error": {
+                "message": "Unknown model: gpt-image-2.5-flare is not supported",
+                "type": "invalid_request_error",
+            }
+        })
+
+        seen = {}
+
+        def _handler(request):
+            seen["json"] = json.loads(request.content)
+            return httpx.Response(400, text=body, request=request)
+
+        real_client = httpx.Client
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            lambda *args, **kwargs: real_client(
+                transport=httpx.MockTransport(_handler),
+                headers=kwargs.get("headers"),
+                timeout=kwargs.get("timeout"),
+            ),
+        )
+
+        result = provider.generate("a cat")
+        assert seen["json"]["tools"][0]["model"] == "gpt-image-2.5-flare"
+        assert result["success"] is False
+        assert result["error_type"] in ("compatibility", "api_error")
+        err = result["error"].lower()
+        assert "compatibility" in err
+        assert "gpt-image-2.5-flare" in result["error"]
+        assert "unknown model" in err or "not supported" in err
+        assert "not enabled for the current Codex account" not in result["error"]
+        # Must not silently retarget OPENAI_API_KEY or FAL.
+        assert "OPENAI_API_KEY" not in result["error"]
+        assert " fal" not in err
 
 
 # ── Plugin entry point ──────────────────────────────────────────────────────

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -656,6 +657,116 @@ class TestGptImage25Payload:
         # Must not silently retarget OPENAI_API_KEY or FAL.
         assert "OPENAI_API_KEY" not in result["error"]
         assert " fal" not in err
+
+
+def _mock_codex_stream(monkeypatch, responses, requests):
+    """Replace only HTTP transport; keep request construction, SSE parsing and saving real."""
+    import httpx
+
+    streams = iter(responses)
+
+    def respond(request):
+        assert str(request.url) == f"{codex_plugin._CODEX_BASE_URL}/responses"
+        requests.append(json.loads(request.content))
+        wire = "".join(f"data: {json.dumps(event)}\n\n" for event in next(streams))
+        return httpx.Response(200, text=wire, headers={"content-type": "text/event-stream"})
+
+    real_client = httpx.Client
+    monkeypatch.setattr(httpx, "Client", lambda *args, **kwargs: real_client(
+        transport=httpx.MockTransport(respond), **kwargs,
+    ))
+
+
+@pytest.mark.parametrize("model_id", [
+    "gpt-image-2-medium", *[f"{model}-low" for model in _GPT_IMAGE_25_MODELS],
+])
+@pytest.mark.parametrize("with_reference", [False, True], ids=["generate", "edit"])
+@pytest.mark.parametrize("report", ["alias", "echo", "missing"])
+@pytest.mark.parametrize("metadata_event", ["response.created", "response.completed"])
+def test_success_separates_requested_model_from_unverified_server_report(
+    provider, monkeypatch, tmp_path, model_id, with_reference, report, metadata_event,
+):
+    monkeypatch.delenv("OPENAI_IMAGE_MODEL", raising=False)
+    monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+    _set_codex_model(tmp_path, model_id)
+    original_config = (tmp_path / "config.yaml").read_bytes()
+    api_model = codex_plugin.MODELS[model_id]["api_model"]
+    reported = {"alias": "gpt-image-2-codex", "echo": api_model, "missing": None}[report]
+    tools = [{"type": "function", "name": "unrelated", "model": "not-the-image-model"}]
+    if reported is not None:
+        tools.append({"type": "image_generation", "model": reported})
+    events: list[dict[str, Any]] = [
+        {"type": "response.created", "response": {"model": "host-model"}},
+        {"type": "response.completed", "response": {
+            "model": "host-model", "output": [{
+                "type": "image_generation_call", "status": "completed", "result": _b64_png(),
+            }],
+        }},
+    ]
+    for event in events:
+        if event["type"] == metadata_event:
+            event["response"]["tools"] = tools
+    requests = []
+    _mock_codex_stream(monkeypatch, [events], requests)
+    kwargs = {}
+    if with_reference:
+        source = tmp_path / "reference.png"
+        source.write_bytes(bytes.fromhex(_PNG_HEX))
+        kwargs["image_url"] = str(source)
+
+    result = provider.generate("A blue circle on white.", **kwargs)
+
+    assert len(requests) == 1  # A model label must not cause retries or a provider switch.
+    assert requests[0]["tools"][0]["model"] == api_model
+    content = requests[0]["input"][0]["content"]
+    assert any(part["type"] == "input_image" for part in content) == with_reference
+    assert result["success"] is True
+    assert Path(result["image"]).read_bytes() == bytes.fromhex(_PNG_HEX)
+    assert result["provider"] == "openai-codex"
+    assert result["model"] == model_id  # Preserve the existing catalog-selection field.
+    assert result["requested_model"] == api_model
+    assert result["reported_model"] == reported
+    # Even an echoed tool configuration is not verified image-engine identity.
+    assert result["model_selection_verified"] is False
+    assert "unverified" in result["model_selection_note"].lower()
+    assert not result.get("error")
+    assert (tmp_path / "config.yaml").read_bytes() == original_config
+
+
+@pytest.mark.parametrize("created_tools,completed_tools,expected", [
+    ([{"type": "image_generation", "model": "initial-label"}],
+     [{"type": "image_generation", "model": "final-label"}], "final-label"),
+    ([{"type": "image_generation", "model": "initial-label"}], None, "initial-label"),
+    (None, None, None),
+    (None, {"type": "image_generation", "model": "not-a-tools-list"}, None),
+    (None, [None, {"type": "image_generation", "model": {"unexpected": "object"}}], None),
+    (None, [{"type": "image_generation", "model": "   "}], None),
+])
+def test_reported_model_belongs_to_successful_attempt_not_a_previous_partial(
+    provider, monkeypatch, created_tools, completed_tools, expected,
+):
+    monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+    partial_attempt = [{"type": "response.created", "response": {"tools": [
+        {"type": "image_generation", "model": "discarded-attempt-label"},
+    ]}}, {"type": "response.image_generation_call.partial_image", "partial_image_b64": _b64_png()}]
+    final_attempt = [
+        {"type": "response.created", "response": {"tools": created_tools}},
+        {"type": "response.completed", "response": {
+            "model": "host-model", "tools": completed_tools,
+            "output": [{"type": "image_generation_call", "result": _b64_png()}],
+        }},
+    ]
+    requests = []
+    _mock_codex_stream(monkeypatch, [partial_attempt, final_attempt], requests)
+
+    result = provider.generate("A blue circle on white.")
+
+    assert len(requests) == 2
+    assert result["success"] is True
+    assert result["image_source"] == "final"
+    assert Path(result["image"]).read_bytes() == bytes.fromhex(_PNG_HEX)
+    assert result["reported_model"] == expected
+    assert result["model_selection_verified"] is False
 
 
 # ── Plugin entry point ──────────────────────────────────────────────────────

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -62,7 +62,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
 | `image_gen/openai` | image backend | OpenAI GPT Image 2 and 2.5 Flare/Sunburst generation and editing (API key) |
-| `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
+| `image_gen/openai-codex` | image backend | OpenAI GPT Image 2 and 2.5 Flare/Sunburst via Codex OAuth |
 | `image_gen/xai` | image backend | xAI `grok-2-image` backend |
 | `hermes-achievements` | dashboard tab | Steam-style collectible badges generated from your real Hermes session history |
 | `kanban/dashboard` | dashboard tab | Kanban board UI for the multi-agent dispatcher — tasks, comments, fan-out, board switching. See [Kanban Multi-Agent](./kanban.md). |

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -200,9 +200,11 @@ tool (`tools[0].model`) together with the catalog quality. It does not rewrite
 `gpt-image-2-medium` default are unchanged. Text-to-image and reference-image
 edits both use Responses `input_image` parts.
 
-Codex backend support for 2.5 is best-effort: if the hosted tool rejects an
-unknown or unsupported model, Hermes surfaces a compatibility `api_error` and
-does **not** silently fall back to `OPENAI_API_KEY` or FAL. If you need
+Codex backend support for 2.5 is best-effort: if the backend rejects a request,
+Hermes preserves its error message in an `api_error` and does **not** silently
+fall back to `OPENAI_API_KEY` or FAL. Host-model availability, image-model
+support, and invalid parameters are separate failures; error prose alone is
+not used to blame the selected image model. If you need
 deterministic 2.5 routing, use the **OpenAI** API-key provider or **FAL**.
 
 ## Usage
@@ -268,8 +270,8 @@ invoke the tool, the call fails with `empty_response`. Whether the hosted
 image tool is reachable at all has also been reported to vary between
 accounts. GPT Image 2.5 Flare/Sunburst are selectable in this provider and are
 forwarded to the tool's `model` field, but the Codex backend may still reject
-an unknown or unsupported model; that surfaces as a compatibility error rather
-than a Hermes-side rewrite or provider switch. The backend can also return a
+an unknown or unsupported model; Hermes preserves that rejection as an
+`api_error` rather than rewriting the selection or switching providers. The backend can also return a
 successful image with a different or opaque tool model label, such as
 `gpt-image-2-codex`. HTTP success does not confirm Flare/Sunburst selection, and
 an opaque label does not establish that GPT Image 2.5 is unavailable.

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -182,10 +182,28 @@ does not estimate 2.5 token consumption. See the official
 [Flare](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare) and
 [Sunburst](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst) docs.
 
-The **OpenAI (Codex auth)** provider remains separate: its backend can accept
-an image-model value without honoring that selection, so a successful image
-alone does not verify Flare or Sunburst routing. These selections are offered
-through the direct OpenAI API provider and FAL, not as verified Codex-auth selections.
+## OpenAI (Codex auth): GPT Image 2.5
+
+The **OpenAI (Codex auth)** provider now offers the same optional GPT Image 2.5
+Flare and Sunburst catalog as the API-key provider — including `auto` (no suffix)
+and `-low` / `-medium` / `-high` / `-xhigh` / `-max` quality variants. Select them
+through `hermes tools` → Image Generation → OpenAI (Codex auth), or set:
+
+```bash
+hermes config set image_gen.provider openai-codex
+hermes config set image_gen.openai-codex.model gpt-image-2.5-flare
+```
+
+Hermes sends the selected API model id on the Codex Responses `image_generation`
+tool (`tools[0].model`) together with the catalog quality. It does not rewrite
+2.5 selections to `gpt-image-2`. Existing GPT Image 2 tiers and the
+`gpt-image-2-medium` default are unchanged. Text-to-image and reference-image
+edits both use Responses `input_image` parts.
+
+Codex backend support for 2.5 is best-effort: if the hosted tool rejects an
+unknown or unsupported model, Hermes surfaces a compatibility `api_error` and
+does **not** silently fall back to `OPENAI_API_KEY` or FAL. If you need
+deterministic 2.5 routing, use the **OpenAI** API-key provider or **FAL**.
 
 ## Usage
 
@@ -231,7 +249,7 @@ Two inputs drive the edit:
 | **OpenAI** (GPT Image 2 / 2.5 Flare / Sunburst) | ✓ | up to 16 | `images.edit()` |
 | **xAI** (Grok Imagine) | ✓ | 1 | `/v1/images/edits` (`grok-imagine-image-quality`) |
 | **Krea** (`Krea 2`) | ✓ | up to 10 | reference-guided generation (`image_style_references`) |
-| **OpenAI (Codex auth)** | ✓ | up to 16 | Codex Responses `image_generation` tool with `input_image` content parts |
+| **OpenAI (Codex auth)** (GPT Image 2 / 2.5 Flare / Sunburst) | ✓ | up to 16 | Codex Responses `image_generation` tool with `input_image` content parts |
 | **OpenRouter** (Image API models) | ✓ | up to 14–16 (per model) | `input_references` on `POST /images/generations`; chat-served models use `image_url` content parts (up to 3) |
 
 FAL models with an editing endpoint: `flux-2/klein/9b`, `flux-2-pro`,
@@ -248,8 +266,12 @@ backend rejects every `tool_choice` shape for hosted tools, so the request
 relies on instructions to steer the model. When the host model declines to
 invoke the tool, the call fails with `empty_response`. Whether the hosted
 image tool is reachable at all has also been reported to vary between
-accounts. If you need image generation to work deterministically, configure
-the **OpenAI** (API key), **FAL**, or **xAI** backend instead.
+accounts. GPT Image 2.5 Flare/Sunburst are selectable in this provider and are
+forwarded to the tool's `model` field, but the Codex backend may still reject
+an unknown or unsupported model; that surfaces as a compatibility error rather
+than a silent rewrite or provider switch. If you need image generation to work
+deterministically, configure the **OpenAI** (API key), **FAL**, or **xAI**
+backend instead.
 
 :::
 

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -269,9 +269,30 @@ image tool is reachable at all has also been reported to vary between
 accounts. GPT Image 2.5 Flare/Sunburst are selectable in this provider and are
 forwarded to the tool's `model` field, but the Codex backend may still reject
 an unknown or unsupported model; that surfaces as a compatibility error rather
-than a silent rewrite or provider switch. If you need image generation to work
-deterministically, configure the **OpenAI** (API key), **FAL**, or **xAI**
-backend instead.
+than a Hermes-side rewrite or provider switch. The backend can also return a
+successful image with a different or opaque tool model label, such as
+`gpt-image-2-codex`. HTTP success does not confirm Flare/Sunburst selection, and
+an opaque label does not establish that GPT Image 2.5 is unavailable.
+
+Successful Codex tool results distinguish:
+
+- `model`: the configured catalog selection, retained for compatibility.
+- `requested_model`: the image-tool model sent to Codex, without the catalog's
+  quality suffix (quality is sent separately).
+- `reported_model`: the last nonempty image-generation model string observed in
+  `response.tools` in the successful attempt, or `null` if none was reported.
+  This is tool-configuration metadata, **not verified image-engine identity**;
+  even a label matching the request may merely echo its configuration.
+- `model_selection_verified`: `false`; `model_selection_note` explains the
+  uncertainty. Hermes does not infer a mapping from an opaque backend alias.
+
+Missing or different model metadata does not discard a usable final image,
+trigger another request, or switch providers. For example: "Image generated
+successfully. Flare was requested, but the service reported `gpt-image-2-codex`;
+the exact image variant is unverified."
+
+If you need a different image-generation interface, configure the **OpenAI**
+(API key), **FAL**, or **xAI** backend explicitly instead.
 
 :::
 


### PR DESCRIPTION
## What does this PR do?

Adds GPT Image 2.5 Flare/Sunburst (plus quality variants) to the `openai-codex` image provider so ChatGPT/Codex OAuth can select them. Existing GPT Image 2 tiers remain the default. When the Codex backend rejects an unsupported image model id, the provider returns a clear compatibility/api_error instead of silently routing through the API-key or FAL backends.

### Symptom

Adds GPT Image 2.5 Flare/Sunburst (plus quality variants) to the `openai-codex` image provider so ChatGPT/Codex OAuth can select them. Existing GPT Image 2 tiers remain the default. When the Codex backend rejects an unsupported image model id, the provider returns a clear compatibility/api_error instead of silently routing through the API-key or FAL backends.


Fixes #106708


- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)


- `plugins/image_gen/openai-codex/__init__.py` — extend catalog with 2.5 models; pass `api_model` into the Responses `image_generation` tool; narrow unsupported-model HTTP classification
- `plugins/image_gen/openai-codex/plugin.yaml` — describe 2.5 support
- `tests/plugins/image_gen/test_openai_codex_provider.py` — catalog/payload RED→GREEN coverage for flare/sunburst, edit path, GPT Image 2 control, and tool_choice 400 fail-open
- `website/docs/user-guide/features/image-generation.md` + `built-in-plugins.md` — document Codex OAuth 2.5 availability and backend limits


1. `scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py -q`
2. Confirm default still resolves to `gpt-image-2-medium` with `tools[0].model == gpt-image-2`
3. Set `image_gen.openai-codex.model` to `gpt-image-2.5-flare` / `gpt-image-2.5-sunburst` and confirm payload `tools[0].model` matches



- [x] I've read the Contributing Guide
- [x] My commit messages follow Convention

### Impact

Adds GPT Image 2.5 Flare/Sunburst (plus quality variants) to the `openai-codex` image provider so ChatGPT/Codex OAuth can select them. Existing GPT Image 2 tiers remain the default.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Adds GPT Image 2.5 Flare/Sunburst (plus quality variants) to the `openai-codex` image provider so ChatGPT/Codex OAuth can select them. Existing GPT Image 2 tiers remain the default. When the Codex backend rejects an unsupported image model id, the provider returns a clear compatibility/api_error instead of silently routing through the API-key or FAL backends.

## Related Issue

Fixes #106708

## Type of Change

- ✅ Feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py` — extend catalog with 2.5 models; pass `api_model` into the Responses `image_generation` tool; narrow unsupported-model HTTP classification
- `plugins/image_gen/openai-codex/plugin.yaml` — describe 2.5 support
- `tests/plugins/image_gen/test_openai_codex_provider.py` — catalog/payload RED→GREEN coverage for flare/sunburst, edit path, GPT Image 2 control, and tool_choice 400 fail-open
- `website/docs/user-guide/features/image-generation.md` + `built-in-plugins.md` — document Codex OAuth 2.5 availability and backend limits

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ `scripts/run_tests.sh tests/plugins/image_gen/test_openai_codex_provider.py -q`
- ✅ Confirm default still resolves to `gpt-image-2-medium` with `tools[0].model == gpt-image-2`
- ✅ Set `image_gen.openai-codex.model` to `gpt-image-2.5-flare` / `gpt-image-2.5-sunburst` and confirm payload `tools[0].model` matches

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

