### PR TITLE
fix(codex): Azure Foundry rejects replayed reasoning from more than one response; classify and prune

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -717,7 +717,10 @@ def _classify_400(c: _Ctx) -> Verdict:
     # overflow because "encrypted content … could not be verified" trips it.
     if code == "invalid_encrypted_content" or "invalid_encrypted_content" in msg or (
         "encrypted content for item" in msg and "could not be verified" in msg
-    ) or "could not decrypt the provided encrypted_content" in msg:
+    ) or "could not decrypt the provided encrypted_content" in msg or (
+        # Azure Foundry (gpt-6-astra) rejects replayed reasoning from several prior responses this way (#105369).
+        "conflicting authenticated continuation identities" in msg
+    ):
         return _V_INVALID_ENCRYPTED
     # Reasoning-mandatory route rejecting a disable (GLM-5.3 on Nous Portal / OpenRouter). Deterministic
     # for the request shape, but the only bad field is ``reasoning: {enabled: false}`` — the loop drops

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -405,6 +405,17 @@ def _is_post_tool_replay(messages: Optional[list[dict[str, Any]]]) -> bool:
     return False
 
 
+def _is_azure_responses(params: dict[str, Any]) -> bool:
+    """True for any Azure-hosted Responses endpoint: the ``azure-foundry`` provider, a resource-level
+    ``*.openai.azure.com`` host, or the project-scoped ``*.services.ai.azure.com`` gateway."""
+    from utils import base_url_host_matches
+
+    if str(params.get("provider") or "").strip().lower() == "azure-foundry":
+        return True
+    base_url = str(params.get("base_url") or "")
+    return base_url_host_matches(base_url, "openai.azure.com") or base_url_host_matches(base_url, "services.ai.azure.com")
+
+
 def _newest_reasoning_only(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Copy of ``messages`` keeping ``codex_reasoning_items`` only on the newest assistant row that has any.
     Foundry rejects a request that replays encrypted reasoning from more than one prior response (HTTP 400
@@ -554,12 +565,13 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
-        is_azure_foundry = _is_azure_foundry_responses(params)
         # Foundry 400s on encrypted-reasoning replay only in the post-tool follow-up turn.
         replay_encrypted_reasoning = bool(params.get("replay_encrypted_reasoning", True)) and not (
-            is_azure_foundry and _is_post_tool_replay(payload_messages)
+            _is_azure_foundry_responses(params) and _is_post_tool_replay(payload_messages)
         )
-        if is_azure_foundry and replay_encrypted_reasoning:
+        # Own predicate: #101243 may narrow _is_azure_foundry_responses to the project gateway, and the
+        # multi-item rejection happens on resource-level hosts too.
+        if replay_encrypted_reasoning and _is_azure_responses(params):
             payload_messages = _newest_reasoning_only(payload_messages)
         # One predicate decides whether context_management goes out AND whether the converter may replay a checkpoint.
         context_management = params.get("context_management")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -405,6 +405,28 @@ def _is_post_tool_replay(messages: Optional[list[dict[str, Any]]]) -> bool:
     return False
 
 
+def _newest_reasoning_only(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Copy of ``messages`` keeping ``codex_reasoning_items`` only on the newest assistant row that has any.
+    Foundry rejects a request that replays encrypted reasoning from more than one prior response (HTTP 400
+    "Conflicting authenticated continuation identities", #105369). ``compaction`` checkpoints stay everywhere."""
+    out: list[dict[str, Any]] = []
+    newest_kept = False
+    for msg in reversed(messages):
+        items = msg.get("codex_reasoning_items") if isinstance(msg, dict) and msg.get("role") == "assistant" else None
+        if isinstance(items, list) and any(isinstance(i, dict) and i.get("type") != "compaction" for i in items):
+            if newest_kept:
+                checkpoints = [i for i in items if isinstance(i, dict) and i.get("type") == "compaction"]
+                msg = dict(msg)
+                if checkpoints:
+                    msg["codex_reasoning_items"] = checkpoints
+                else:
+                    msg.pop("codex_reasoning_items")
+            newest_kept = True
+        out.append(msg)
+    out.reverse()
+    return out
+
+
 def _native_compaction_active(context_management: Any) -> bool:
     """True only when the caller's eligibility gate produced a non-empty payload.
 
@@ -532,10 +554,13 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        is_azure_foundry = _is_azure_foundry_responses(params)
         # Foundry 400s on encrypted-reasoning replay only in the post-tool follow-up turn.
         replay_encrypted_reasoning = bool(params.get("replay_encrypted_reasoning", True)) and not (
-            _is_azure_foundry_responses(params) and _is_post_tool_replay(payload_messages)
+            is_azure_foundry and _is_post_tool_replay(payload_messages)
         )
+        if is_azure_foundry and replay_encrypted_reasoning:
+            payload_messages = _newest_reasoning_only(payload_messages)
         # One predicate decides whether context_management goes out AND whether the converter may replay a checkpoint.
         context_management = params.get("context_management")
         native_compaction_active = _native_compaction_active(context_management)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -774,6 +774,21 @@ class TestClassifyApiError:
         e = MockAPIError("Error code: 400 - " + body["message"], status_code=400, body=body)
         assert classify_api_error(e, provider=provider, model="gpt-5.5").reason == expected
 
+    def test_azure_conflicting_continuation_identities_is_invalid_encrypted_content(self):
+        """Azure Foundry's wording for a rejected encrypted-reasoning replay (#105369); ``code`` is the
+        generic ``invalid_value``, so the message decides."""
+        message = "Conflicting authenticated continuation identities."
+        e = MockAPIError(
+            f"Error code: 400 - {{'error': {{'message': '{message}', 'type': 'invalid_request_error', "
+            "'param': 'input', 'code': 'invalid_value'}}",
+            status_code=400,
+            body={"error": {"message": message, "type": "invalid_request_error", "param": "input", "code": "invalid_value"}},
+        )
+        result = classify_api_error(e, provider="azure-foundry", model="gpt-6-astra")
+        assert result.reason == FailoverReason.invalid_encrypted_content
+        assert result.retryable is True
+        assert result.should_fallback is False
+
     # ── Reasoning-mandatory route rejecting a disable ──
 
     def test_reasoning_mandatory_400_is_retryable_not_format_error(self):

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -383,6 +383,75 @@ class TestCodexBuildKwargs:
         assert "function_call_output" in item_types
         assert kw.get("include") == ["reasoning.encrypted_content"]
 
+    @classmethod
+    def _two_turn_messages(cls):
+        """Two answered turns, each assistant row sealed by its own response, then a fresh user message."""
+        return [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": "one",
+                "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "sealed-1", "summary": []}],
+            },
+            {"role": "user", "content": "second"},
+            {
+                "role": "assistant",
+                "content": "two",
+                "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "sealed-2", "summary": []}],
+            },
+            {"role": "user", "content": "third"},
+        ]
+
+    def test_azure_foundry_new_turn_replays_only_newest_reasoning(self, transport):
+        """Two sealed prior responses on the wire is the 400 "Conflicting authenticated
+        continuation identities" shape (#105369); one is accepted."""
+        kw = transport.build_kwargs(
+            model="gpt-6-astra",
+            messages=self._two_turn_messages(),
+            tools=[],
+            provider="azure-foundry",
+            base_url="https://placeholder.openai.azure.com/openai/v1",
+            replay_encrypted_reasoning=True,
+        )
+        reasoning = [item for item in kw["input"] if item.get("type") == "reasoning"]
+        assert [item["encrypted_content"] for item in reasoning] == ["sealed-2"]
+        assert kw.get("include") == ["reasoning.encrypted_content"]
+        assistant_text = [item for item in kw["input"] if item.get("role") == "assistant"]
+        assert len(assistant_text) == 2
+
+    def test_default_responses_new_turn_replays_all_reasoning(self, transport):
+        """Non-Azure Responses endpoints keep cross-turn reasoning replay."""
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=self._two_turn_messages(), tools=[], replay_encrypted_reasoning=True,
+        )
+        reasoning = [item for item in kw["input"] if item.get("type") == "reasoning"]
+        assert [item["encrypted_content"] for item in reasoning] == ["sealed-1", "sealed-2"]
+
+    def test_azure_foundry_newest_reasoning_pruning_leaves_canonical_messages_untouched(self, transport):
+        messages = self._two_turn_messages()
+        transport.build_kwargs(
+            model="gpt-6-astra", messages=messages, tools=[], provider="azure-foundry",
+            base_url="https://placeholder.openai.azure.com/openai/v1", replay_encrypted_reasoning=True,
+        )
+        assert messages[1]["codex_reasoning_items"][0]["encrypted_content"] == "sealed-1"
+        assert messages[3]["codex_reasoning_items"][0]["encrypted_content"] == "sealed-2"
+
+    def test_newest_reasoning_only_keeps_compaction_checkpoints(self):
+        from agent.transports.codex import _newest_reasoning_only
+
+        checkpoint = {"type": "compaction", "encrypted_content": "ckpt", "summary": []}
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "one", "codex_reasoning_items": [checkpoint, self._reasoning_item()]},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "two", "codex_reasoning_items": [self._reasoning_item()]},
+            {"role": "user", "content": "third"},
+        ]
+        pruned = _newest_reasoning_only(messages)
+        assert pruned[1]["codex_reasoning_items"] == [checkpoint]
+        assert pruned[3]["codex_reasoning_items"] == [self._reasoning_item()]
+        assert len(messages[1]["codex_reasoning_items"]) == 2
+
     def test_azure_foundry_post_tool_replay_suppresses_reasoning_items(self, transport):
         """The rejected payload shape drops reasoning, keeps tool continuity."""
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -419,6 +419,19 @@ class TestCodexBuildKwargs:
         assistant_text = [item for item in kw["input"] if item.get("role") == "assistant"]
         assert len(assistant_text) == 2
 
+    @pytest.mark.parametrize("base_url", [
+        "https://placeholder.openai.azure.com/openai/v1",
+        "https://placeholder.services.ai.azure.com/api/projects/placeholder/openai/v1",
+    ])
+    def test_azure_host_without_provider_replays_only_newest_reasoning(self, transport, base_url):
+        """Both Azure hosts are detected without ``provider``; the rejection is not gateway-specific."""
+        kw = transport.build_kwargs(
+            model="gpt-6-astra", messages=self._two_turn_messages(), tools=[], base_url=base_url,
+            replay_encrypted_reasoning=True,
+        )
+        reasoning = [item for item in kw["input"] if item.get("type") == "reasoning"]
+        assert [item["encrypted_content"] for item in reasoning] == ["sealed-2"]
+
     def test_default_responses_new_turn_replays_all_reasoning(self, transport):
         """Non-Azure Responses endpoints keep cross-turn reasoning replay."""
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary

On Azure Foundry, `gpt-6-astra` returns HTTP 400 "Conflicting authenticated continuation identities" on the first request of every turn after the first, and the session never recovers. Fixes #105369.

## What the endpoint rejects

That request replays the encrypted `reasoning` item of every earlier response. I replayed the persisted items of a failed session against the resource-level endpoint. Any one item alone returns 200. Any two together return 400. Restoring the stripped `rs_` ids changes nothing, so #67667 does not cover this case. In-turn calls never hit it: `_is_post_tool_replay` already suppresses replay on Azure when the request ends on a tool result. The background review named in the issue is coincident; one failed session had no review between its turns.

## Transport

On Azure Foundry, `build_kwargs` keeps `codex_reasoning_items` only on the newest assistant row that has any. `include` still requests `reasoning.encrypted_content`, `compaction` checkpoints stay on every row, and the canonical messages are not mutated. Other Responses endpoints are unchanged. The gate is its own predicate, provider `azure-foundry` or either Azure host, so narrowing `_is_azure_foundry_responses` in #101243 does not switch it off.

## Classifier

The message now maps to `invalid_encrypted_content`. The existing recovery in `turn_recovery` strips the replay state and retries once, instead of aborting as a non-retryable client error.

## Validation

I rebuilt the failing session from `state.db` through the transport and sent both payloads live. Unpatched: 5 reasoning items, 400. Patched: 1 item, 200. The transport, classifier and codex request suites pass, 326 tests.

> [!IMPORTANT]
> Verified against `*.openai.azure.com/openai/v1` only. #101243 targets a different 400, `invalid_payload`, on the project-scoped gateway. A one-item control passes on both endpoints, so it cannot show that an endpoint tolerates multi-item replay.

## Follow-up

`auxiliary_client.py` converts messages for Responses without this pruning. This PR does not touch it.
