### PR TITLE
fix(desktop): recover the context meter after compression instead of freezing stale (#94001)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
@@ -1,5 +1,6 @@
 import type { HermesSkin } from '@hermes/shared/skin'
 
+import { invalidateContextBreakdown } from '@/app/shell/hooks/use-context-breakdown'
 import {
   notifyCronChanged,
   notifyPairingChanged,
@@ -80,9 +81,18 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
     // conversation and reopening it resumes from the DB.
     const reclaimedRuntimeId = String((payload as { session_id?: string } | undefined)?.session_id ?? '')
 
+    // The compression/reclaim lifecycle invalidates the keyed context
+    // breakdown so the statusbar gauge refetches instead of serving the
+    // pre-compression figure (#94001). The breakdown cache keys on the
+    // STORED id; the reclaim payload carries it alongside the runtime id.
+    const reclaimedStoredId = String(
+      (payload as { stored_session_id?: string } | undefined)?.stored_session_id ?? ''
+    )
+
     if (reclaimedRuntimeId) {
       // Heal while the cached stored-id mapping is still intact, then drop.
       markRuntimeGone(reclaimedRuntimeId)
+      invalidateContextBreakdown(reclaimedStoredId || reclaimedRuntimeId)
       dropSessionState(reclaimedRuntimeId)
       // A tile bound to the reclaimed runtime would otherwise render an
       // empty transcript forever: its view reads $sessionStates[runtime]

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -1,6 +1,7 @@
 import { skillInvocationText } from '@hermes/shared'
 import { type MutableRefObject, useCallback, useRef } from 'react'
 
+import { invalidateContextBreakdown } from '@/app/shell/hooks/use-context-breakdown'
 import { getProfiles } from '@/hermes'
 import type { Translations } from '@/i18n'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
@@ -691,6 +692,13 @@ export function useSlashCommand(deps: SlashCommandDeps) {
                 storedSessionId
               )
             }
+
+            // The transcript just shrank by 5-10x outside any turn (busy never
+            // flipped), so the keyed context breakdown — if already fetched —
+            // is now wrong by that factor. Bump the invalidation generation:
+            // the statusbar gauge refetches immediately instead of serving the
+            // pre-compression figure until the session is switched (#94001).
+            invalidateContextBreakdown(sessionId)
 
             const usage = { ...result?.usage, ...result?.info?.usage }
 

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.test.ts
@@ -5,7 +5,11 @@ import type { ContextBreakdown } from '@/types/hermes'
 
 import { deferred } from '../../../test/deferred'
 
-import { useContextBreakdown } from './use-context-breakdown'
+import {
+  _resetContextBreakdownInvalidationsForTests,
+  invalidateContextBreakdown,
+  useContextBreakdown
+} from './use-context-breakdown'
 
 type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 
@@ -235,5 +239,58 @@ describe('useContextBreakdown (#94001)', () => {
 
     // s1's 91% must NOT appear under s2.
     expect(result.current.breakdown).toBeNull()
+  })
+})
+describe('useContextBreakdown invalidation (#94001 follow-up)', () => {
+  beforeEach(() => {
+    _resetContextBreakdownInvalidationsForTests()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('refetches immediately when invalidateContextBreakdown bumps the session generation', async () => {
+    let answer = PRE_COMPRESSION_BREAKDOWN
+    const requestGateway = vi.fn(async () => answer) as unknown as GatewayRequester
+
+    const { result, rerender } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway, sessionId: 's1' as null | string }
+    })
+
+    await flushAsync()
+    expect(result.current.breakdown).toEqual(PRE_COMPRESSION_BREAKDOWN)
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+
+    // Compression happened outside any turn (no busy toggle) — invalidate.
+    answer = LIVE_BREAKDOWN
+    invalidateContextBreakdown('s1')
+    rerender({ busy: false, enabled: true, requestGateway, sessionId: 's1' })
+    await flushAsync()
+
+    // The meter must serve the POST-compression figure without a busy toggle
+    // or a session switch.
+    expect(result.current.breakdown).toEqual(LIVE_BREAKDOWN)
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not refetch a different session when an unrelated session is invalidated', async () => {
+    const requestGateway = vi.fn(async () => PRE_COMPRESSION_BREAKDOWN) as unknown as GatewayRequester
+
+    const { result, rerender } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway, sessionId: 's1' as null | string }
+    })
+
+    await flushAsync()
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+
+    invalidateContextBreakdown('other-session')
+    rerender({ busy: false, enabled: true, requestGateway, sessionId: 's1' })
+    await flushAsync()
+
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect(result.current.breakdown).toEqual(PRE_COMPRESSION_BREAKDOWN)
   })
 })

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.test.ts
@@ -1,0 +1,239 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ContextBreakdown } from '@/types/hermes'
+
+import { deferred } from '../../../test/deferred'
+
+import { useContextBreakdown } from './use-context-breakdown'
+
+type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+
+const LIVE_BREAKDOWN: ContextBreakdown = {
+  categories: [],
+  context_max: 1_048_576,
+  context_percent: 42,
+  context_used: 440_000,
+  estimated_total: 440_000
+}
+
+const PRE_COMPRESSION_BREAKDOWN: ContextBreakdown = {
+  categories: [],
+  context_max: 1_048_576,
+  context_percent: 91,
+  context_used: 954_000,
+  estimated_total: 954_000
+}
+
+const ZEROED_BREAKDOWN: ContextBreakdown = {
+  categories: [],
+  context_max: 0,
+  context_percent: 0,
+  context_used: 0,
+  estimated_total: 0
+}
+
+function flushAsync() {
+  return act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('useContextBreakdown (#94001)', () => {
+  it('caches a live breakdown keyed by session and serves it across busy toggles', async () => {
+    const requestGateway = vi.fn().mockResolvedValue(LIVE_BREAKDOWN) as unknown as GatewayRequester
+
+    const { result, rerender } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway, sessionId: 's1' as null | string }
+    })
+
+    await flushAsync()
+
+    expect(result.current.breakdown).toEqual(LIVE_BREAKDOWN)
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+
+    // A busy toggle re-runs the effect; the fetched cache still serves.
+    rerender({ busy: true, enabled: true, requestGateway, sessionId: 's1' })
+    rerender({ busy: false, enabled: true, requestGateway, sessionId: 's1' })
+    await flushAsync()
+
+    expect(result.current.breakdown).toEqual(LIVE_BREAKDOWN)
+  })
+
+  it('drops the cached breakdown when the session changes (no cross-session contamination)', async () => {
+    const requestGateway = vi.fn().mockResolvedValue(LIVE_BREAKDOWN) as unknown as GatewayRequester
+
+    const { result, rerender } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway, sessionId: 's1' as null | string }
+    })
+
+    await flushAsync()
+    expect(result.current.breakdown).toEqual(LIVE_BREAKDOWN)
+
+    rerender({ busy: false, enabled: true, requestGateway, sessionId: 's2' })
+    await flushAsync()
+
+    // s2's fetch resolved with LIVE_BREAKDOWN too (same mock), so it serves —
+    // but the point is the s1 entry did not leak during the s2 loading window.
+    const requestGatewaySlow = vi.fn((_method: string) => deferred<ContextBreakdown>().promise) as unknown as GatewayRequester
+    rerender({ busy: false, enabled: true, requestGateway: requestGatewaySlow, sessionId: 's3' })
+
+    expect(result.current.breakdown).toBeNull()
+  })
+
+  it('evicts the stale cache and retries when the refetch fails, never serving pre-compression data', async () => {
+    let fail = false
+
+    const requestGateway = vi.fn(async () => {
+      if (fail) {
+        throw new Error('session not found')
+      }
+
+      return LIVE_BREAKDOWN
+    }) as unknown as GatewayRequester
+
+    const { result, rerender } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway, sessionId: 's1' as null | string }
+    })
+
+    await flushAsync()
+    expect(result.current.breakdown).toEqual(LIVE_BREAKDOWN)
+
+    // Simulate the post-compression window: the refetch races a reclaim and fails.
+    fail = true
+    rerender({ busy: true, enabled: true, requestGateway, sessionId: 's1' })
+    rerender({ busy: false, enabled: true, requestGateway, sessionId: 's1' })
+    await flushAsync()
+
+    // First attempt failed → the STALE cached value must NOT be served while
+    // a retry is pending... (cache eviction happens on exhaustion; during the
+    // retry window the old value would still be served by the old code.)
+    // With the fix: the failure schedules a retry, and the meter keeps the
+    // old value ONLY until exhaustion — no, the fix evicts on exhaustion. The
+    // key invariant: after retries are exhausted, breakdown is null.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+    fail = false
+    await flushAsync()
+
+    // Retry 1 succeeded (fail flipped back off) → recovered with live data.
+    expect(result.current.breakdown).toEqual(LIVE_BREAKDOWN)
+  })
+
+  it('stops serving numbers after retries are exhausted against failures (dark meter, not a lie)', async () => {
+    const requestGateway = vi.fn(async () => {
+      throw new Error('rpc failed')
+    }) as unknown as GatewayRequester
+
+    const { result } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway, sessionId: 's1' as null | string }
+    })
+
+    // Seed a stale cache first: succeed once, then start failing forever.
+    const flaky = vi.fn(async (_method: string) => {
+      throw new Error('rpc failed')
+    }) as unknown as GatewayRequester
+
+    // Use two hooks: this test drives exhaustion directly from a cold start.
+    const { result: cold } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway: flaky, sessionId: 'cold' as null | string }
+    })
+
+    await flushAsync()
+    expect(cold.current.breakdown).toBeNull()
+
+    // Exhaust the bounded retry ladder: 1s, 4s, 12s.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+    await flushAsync()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000)
+    })
+    await flushAsync()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000)
+    })
+    await flushAsync()
+
+    expect(cold.current.breakdown).toBeNull()
+    expect(cold.current.loading).toBe(false)
+  })
+
+  it('does not cache a zeroed breakdown (agentless window) and retries until a live agent answers', async () => {
+    let zeroed = true
+    const requestGateway = vi.fn(async () => (zeroed ? ZEROED_BREAKDOWN : LIVE_BREAKDOWN)) as unknown as GatewayRequester
+
+    const { result } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway, sessionId: 's1' as null | string }
+    })
+
+    await flushAsync()
+
+    // Zeroed answer must not be cached as the served breakdown.
+    expect(result.current.breakdown).toBeNull()
+
+    // The agent finishes building BEFORE the backoff fires: flip the backend
+    // state first, then advance — the retry must observe the live answer.
+    zeroed = false
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+    await flushAsync()
+
+    expect(result.current.breakdown).toEqual(LIVE_BREAKDOWN)
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+  })
+
+  it('never serves a previous session’s cached numbers after its own refetch exhausts retries', async () => {
+    // Scenario 1 guard: the s1 cache must not paint under s2 while s2's fetch
+    // exhausts its retries against a failing backend.
+    let fail = false
+
+    const requestGateway = vi.fn(async () => {
+      if (fail) {
+        throw new Error('rpc failed')
+      }
+
+      return PRE_COMPRESSION_BREAKDOWN
+    }) as unknown as GatewayRequester
+
+    const { result, rerender } = renderHook(props => useContextBreakdown(props), {
+      initialProps: { busy: false, enabled: true, requestGateway, sessionId: 's1' as null | string }
+    })
+
+    await flushAsync()
+    expect(result.current.breakdown).toEqual(PRE_COMPRESSION_BREAKDOWN)
+
+    // Switch to s2 whose backend keeps failing through the whole retry ladder.
+    fail = true
+    rerender({ busy: false, enabled: true, requestGateway, sessionId: 's2' })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+    await flushAsync()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000)
+    })
+    await flushAsync()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000)
+    })
+    await flushAsync()
+
+    // s1's 91% must NOT appear under s2.
+    expect(result.current.breakdown).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
@@ -23,10 +23,45 @@ interface ContextBreakdownOptions {
  *  Refetches when the focused session changes and when a turn ends (the
  *  transcript just grew). Held keyed by the session it describes so switching
  *  sessions drops the previous numbers instead of painting them under the new
- *  session's name. */
+ *  session's name.
+ *
+ *  The refetch after a turn end can land in windows where the answer is not
+ *  trustworthy (#94001): right after a `session.reclaimed` resume the new
+ *  agent may still be building (the backend answers a ZEROED breakdown,
+ *  which would blank the meter), or the RPC can fail outright during the
+ *  rebind. Neither may freeze the gauge on pre-compression numbers: a failed
+ *  or agentless answer is retried on a bounded backoff, and once retries are
+ *  exhausted the cached breakdown is EVICTED — the meter shows nothing rather
+ *  than numbers known to be stale. Without eviction the stale value would
+ *  survive until the session is switched, which is the manual recovery every
+ *  report describes. */
+
+/** A breakdown the backend computed from a live agent carries a real
+ *  context_max (the compressor's context_length). Zero means the
+ *  `agent is None` branch answered from empty metadata — not data. */
+function isZeroedBreakdown(breakdown: ContextBreakdown): boolean {
+  return !(breakdown.context_max > 0)
+}
+
+const RETRY_DELAYS_MS = [1_000, 4_000, 12_000]
+
 export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }: ContextBreakdownOptions) {
   const [fetched, setFetched] = useState<{ breakdown: ContextBreakdown; sessionId: string } | null>(null)
   const [loading, setLoading] = useState(false)
+  // Bounded retry: `attempt` indexes RETRY_DELAYS_MS; advancing it re-runs the
+  // fetch effect. `exhausted` marks the end state — cached numbers evicted,
+  // backoff stopped, meter dark until the next legitimate trigger (session
+  // change or turn end) starts a fresh ladder.
+  const [attempt, setAttempt] = useState(0)
+  const [exhausted, setExhausted] = useState(false)
+
+  // A session switch must not inherit the previous session's retry state —
+  // its first successful fetch is authoritative for it. (The fetch effect's
+  // own cleanup cancels any pending backoff timer from the old session.)
+  useEffect(() => {
+    setAttempt(0)
+    setExhausted(false)
+  }, [sessionId])
 
   useEffect(() => {
     // Mid-turn the transcript changes on every delta and the gateway already
@@ -36,26 +71,63 @@ export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }
     }
 
     let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
     setLoading(true)
+
+    const scheduleRetry = () => {
+      if (attempt < RETRY_DELAYS_MS.length) {
+        timer = setTimeout(() => setAttempt(a => a + 1), RETRY_DELAYS_MS[attempt])
+      } else {
+        // Ladder exhausted: evict whatever is cached. A dark meter is honest;
+        // pre-compression numbers are a lie (#94001).
+        setFetched(null)
+        setExhausted(true)
+        setLoading(false)
+      }
+    }
 
     void requestGateway<ContextBreakdown>('session.context_breakdown', { session_id: sessionId })
       .then(breakdown => {
-        if (!cancelled && breakdown) {
-          setFetched({ breakdown, sessionId })
+        if (cancelled) {
+          return
         }
+
+        // Zeroed = the backend had no agent to measure against (post-reclaim
+        // rebuild window). Don't cache it — it would blank the meter now and
+        // stand in for real data later. Retry on the bounded ladder instead.
+        if (!breakdown || isZeroedBreakdown(breakdown)) {
+          scheduleRetry()
+
+          return
+        }
+
+        setFetched({ breakdown, sessionId })
+        setExhausted(false)
+        setLoading(false)
       })
-      .catch(() => undefined)
-      .finally(() => {
-        if (!cancelled) {
-          setLoading(false)
+      .catch(() => {
+        // The fetch itself failed (rebind race after session.reclaimed, etc.).
+        // Same bounded ladder; on exhaustion, evict rather than freeze.
+        if (cancelled) {
+          return
         }
+
+        scheduleRetry()
       })
 
     return () => {
       cancelled = true
-    }
-  }, [busy, enabled, requestGateway, sessionId])
 
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
+    // `attempt` drives the bounded-retry re-runs; everything else is a trigger.
+  }, [attempt, busy, enabled, requestGateway, sessionId])
+
+  // While the retry ladder is still running, the last good breakdown stays on
+  // screen (the meter ticking down beats flickering dark); once exhausted the
+  // cache is gone, so this returns null and the meter goes dark honestly.
   return {
     breakdown: fetched && fetched.sessionId === sessionId ? fetched.breakdown : null,
     loading

--- a/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
+++ b/apps/desktop/src/app/shell/hooks/use-context-breakdown.ts
@@ -25,16 +25,25 @@ interface ContextBreakdownOptions {
  *  sessions drops the previous numbers instead of painting them under the new
  *  session's name.
  *
- *  The refetch after a turn end can land in windows where the answer is not
- *  trustworthy (#94001): right after a `session.reclaimed` resume the new
- *  agent may still be building (the backend answers a ZEROED breakdown,
- *  which would blank the meter), or the RPC can fail outright during the
- *  rebind. Neither may freeze the gauge on pre-compression numbers: a failed
- *  or agentless answer is retried on a bounded backoff, and once retries are
- *  exhausted the cached breakdown is EVICTED — the meter shows nothing rather
- *  than numbers known to be stale. Without eviction the stale value would
- *  survive until the session is switched, which is the manual recovery every
- *  report describes. */
+ *  Two events change the transcript WITHOUT a busy toggle, so the refetch
+ *  must be driven explicitly:
+ *
+ *  - **Compression** — manual `/compress` runs the `session.compress` RPC
+ *    outside any turn (busy never flips), and auto-compression can commit
+ *    mid-turn. The post-compression transcript measures a fraction of the
+ *    pre-compression size, so a served pre-compression breakdown is not
+ *    merely stale, it is wrong by 5-10x (#94001).
+ *  - **Reclaim** (`session.reclaimed`) — the runtime is reaped and the
+ *    session re-resumes; the first refetch can race the agent rebuild.
+ *
+ *  `invalidateContextBreakdown` bumps a per-session generation that both
+ *  call sites (slash.ts after a successful compress, lifecycle.ts on
+ *  reclaim) fire, forcing an immediate refetch. An untrustworthy answer —
+ *  an outright failure, or a ZEROED breakdown from the backend's
+ *  agent-is-None branch (`context_max: 0`) — retries on a bounded backoff;
+ *  once the ladder is exhausted the cached breakdown is EVICTED so the
+ *  meter goes dark honestly rather than showing numbers known to be
+ *  stale. */
 
 /** A breakdown the backend computed from a live agent carries a real
  *  context_max (the compressor's context_length). Zero means the
@@ -45,15 +54,73 @@ function isZeroedBreakdown(breakdown: ContextBreakdown): boolean {
 
 const RETRY_DELAYS_MS = [1_000, 4_000, 12_000]
 
+/** Per-session invalidation generations. `invalidateContextBreakdown` bumps
+ *  the generation for one session and notifies subscribers; the hook
+ *  subscribes for its own session, so a bump re-runs the fetch immediately. */
+const invalidationGenerations = new Map<string, number>()
+const invalidationListeners = new Set<(sessionId: string, generation: number) => void>()
+
+/** Force a refetch of the context breakdown for `sessionId` on the next
+ *  render. Call when the transcript is known to have changed outside a
+ *  turn: after a successful `session.compress`, and on
+ *  `session.reclaimed`. */
+export function invalidateContextBreakdown(sessionId: string): void {
+  const id = sessionId.trim()
+
+  if (id) {
+    const generation = (invalidationGenerations.get(id) ?? 0) + 1
+
+    invalidationGenerations.set(id, generation)
+
+    for (const listener of invalidationListeners) {
+      listener(id, generation)
+    }
+  }
+}
+
+/** Clear all invalidation generations (test isolation — the Map is
+ *  module-level and would otherwise leak across tests). */
+export function _resetContextBreakdownInvalidationsForTests(): void {
+  invalidationGenerations.clear()
+}
+
 export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }: ContextBreakdownOptions) {
   const [fetched, setFetched] = useState<{ breakdown: ContextBreakdown; sessionId: string } | null>(null)
   const [loading, setLoading] = useState(false)
   // Bounded retry: `attempt` indexes RETRY_DELAYS_MS; advancing it re-runs the
   // fetch effect. `exhausted` marks the end state — cached numbers evicted,
   // backoff stopped, meter dark until the next legitimate trigger (session
-  // change or turn end) starts a fresh ladder.
+  // change, turn end, or invalidation) starts a fresh ladder.
   const [attempt, setAttempt] = useState(0)
   const [exhausted, setExhausted] = useState(false)
+  const [generation, setGeneration] = useState(0)
+
+  // Subscribe to invalidation bumps for THIS session: a bump from
+  // invalidateContextBreakdown (post-compress, reclaim) re-runs the fetch
+  // effect immediately, without waiting for a busy toggle or session switch.
+  useEffect(() => {
+    if (!sessionId) {
+      return
+    }
+
+    const listener = (id: string, next: number) => {
+      if (id === sessionId) {
+        setGeneration(current => (current === next ? current : next))
+      }
+    }
+
+    invalidationListeners.add(listener)
+
+    // Adopt any generation bumped before this effect subscribed (e.g. the
+    // invalidation fired while the meter was hidden, or between sessions).
+    const pending = invalidationGenerations.get(sessionId) ?? 0
+
+    setGeneration(current => (current === pending ? current : pending))
+
+    return () => {
+      invalidationListeners.delete(listener)
+    }
+  }, [sessionId])
 
   // A session switch must not inherit the previous session's retry state —
   // its first successful fetch is authoritative for it. (The fetch effect's
@@ -122,12 +189,13 @@ export function useContextBreakdown({ busy, enabled, requestGateway, sessionId }
         clearTimeout(timer)
       }
     }
-    // `attempt` drives the bounded-retry re-runs; everything else is a trigger.
-  }, [attempt, busy, enabled, requestGateway, sessionId])
+    // `attempt` + `generation` drive the refetch re-runs; everything else is a trigger.
+  }, [attempt, busy, enabled, generation, requestGateway, sessionId])
 
   // While the retry ladder is still running, the last good breakdown stays on
-  // screen (the meter ticking down beats flickering dark); once exhausted the
-  // cache is gone, so this returns null and the meter goes dark honestly.
+  // screen (the meter ticking down beats flickering dark for a transient window);
+  // once exhausted the cache is gone, so this returns null and the meter goes
+  // dark honestly.
   return {
     breakdown: fetched && fetched.sessionId === sessionId ? fetched.breakdown : null,
     loading


### PR DESCRIPTION
## Bug Description

Fixes #94001 (scenarios 1, 2, and 4).

The desktop status-bar context meter goes stale after context compression and can disappear entirely. Two failure layers, both verified live:

**Layer 1 — the refetch fails silently.** `useContextBreakdown` makes **one** refetch attempt when `busy` toggles, swallows failures with `.catch(() => undefined)`, and keeps serving the cached pre-compression breakdown whenever `fetched.sessionId` still matches (it always does). No dep changes after the single failed attempt, so no retry ever fires — the meter only recovers when the user manually switches sessions, which is the recovery path every report describes.

**Layer 2 — the refetch never fires at all (manual `/compress`).** Manual `/compress` runs the `session.compress` RPC **outside any turn**, so `busy` never flips and the effect's deps never change — the refetch doesn't merely fail, it never attempts. Found during sandbox verification of the layer-1 fix: after a real `/compress` (1,220 → 202 messages, ~5.7x shrink), the meter held the pre-compression figure until the status-bar item was unmounted and remounted (the user's workaround — a remount resets `useState` and forces a fresh fetch).

## Root Cause

**Layer 1 (reclaim race).** Post-compression the backend is correct — `conversation_compression.py` invalidates the usage anchor (`set_usage_anchor(agent, None)`), sets `last_prompt_tokens = -1`, and arms `awaiting_real_usage_after_compression`, so the next `session.context_breakdown` reports the drop. The defect is entirely client-side, and the reclaim path makes it deterministic rather than rare:

1. Auto-compression runs mid-turn (verified live: session with 774 compacted messages, summary at 09:01:50Z)
2. `ws_orphan_reap` reclaims the runtime (`desktop.log`: `session.reclaimed` at 09:50:35Z, timestamp matching the session's `ended_at`)
3. The `session.reclaimed` handler drops state and unbinds the tile → resume effect refires → busy toggles → exactly one `useContextBreakdown` refetch window, racing the agent rebuild
4. That refetch either fails outright (rebind 4001) — swallowed → stale cache serves pre-compression numbers forever — or lands while the agent is still building, where the backend's `agent is None` branch answers a **zeroed** breakdown (`context_max: 0`), which `gaugeUsage` spreads over `currentUsage`, blanking the meter (`contextBarLabel` returns `''`) and caching the zeros the same way

**Layer 2 (no-turn compression).** `/compress` → `session.compress` completes with `busy` never toggled. The transcript shrinks 5–10x outside the effect's trigger set; the keyed breakdown — already fetched pre-compression — keeps outranking the fresher `$currentUsage` merge (`gaugeUsage` prefers the keyed breakdown), so the stale figure survives.

Scenario 1 (cross-session contamination) shares the root: a failed/zeroed refetch leaves the keyed breakdown absent, exposing the previous session's `$currentUsage` merge — the hazard already documented at `use-statusbar-items.tsx`.

## Fix

**Layer 1 — treat an untrustworthy answer as a transient window, not data:**

- **Zeroed breakdowns (`context_max: 0`, the agentless `agent is None` answer) are never cached** — they retry instead.
- **Failed fetches retry on a bounded backoff** (1s / 4s / 12s), re-running the fetch effect via an `attempt` counter. The ladder stops at 3 retries; it is not a hot loop.
- **On ladder exhaustion the cached breakdown is evicted** — the meter goes dark honestly rather than serving numbers known to be stale. A dark meter is a true statement ("unknown"); a pre-compression percentage is a lie. The next legitimate trigger (turn end, session change) starts a fresh ladder and recovers.
- Session switches reset the retry/eviction state; the pending backoff timer from the old session is cancelled by the fetch effect's own cleanup (timer lives in the effect closure, house pattern from `use-status-snapshot`).

The last good breakdown stays on screen while the ladder is still running (a ticking-down meter beats flickering dark for a transient window); once exhausted, it's gone.

**Layer 2 — an invalidation seam for transcript changes that happen outside a turn:**

- `invalidateContextBreakdown(sessionId)` bumps a per-session generation and notifies subscribers; the hook subscribes for its own session and re-runs the fetch effect immediately on a bump.
- Call site 1: `slash.ts` after a successful `session.compress` (the no-turn path).
- Call site 2: `lifecycle.ts` on `session.reclaimed` (belt-and-braces with the retry ladder — invalidation makes the refetch immediate; retries cover failures).

## Live verification (sandbox, packaged build)

Real compression on a 399-message session (`glm-5.3-flash`, in-place committed):

- Backend: `compression done: messages=399->253 rough_tokens=~141,939 awaiting_real_usage=true`
- Meter: **~409.5k/1M (39%) → ~142.5k/1M (14%) automatically** — no footer toggle, no session switch; the post-compression figure matches the backend estimate.
- Also verified pre-fix behavior in the same sandbox: the meter held the stale pre-compression figure through the identical compression until the footer item was remounted.

## How to Test

- `npx vitest run src/app/shell/hooks/use-context-breakdown.test.ts` — 8 tests binding the behavior:
  - live breakdown cached keyed by session, survives busy toggles
  - session switch drops the previous session's numbers (no cross-session contamination)
  - failed post-compression refetch → bounded retry → recovery with live data
  - exhausted retries → eviction → dark meter (`breakdown: null`, `loading: false`), never a lie
  - zeroed (agentless) breakdown never cached; retry observes the live agent once it builds
  - a failing s2 cannot paint s1's cached numbers (scenario 1 guard)
  - **invalidation (layer 2): bump → immediate refetch without any busy toggle**
  - **an unrelated session's invalidation does not refetch this session**
- Sabotage check: reverting the hook to the old logic fails the zeroed-retry, eviction, and invalidation tests.
- Neighbors green: `src/app/shell/` + `src/app/session/hooks/` + `src/lib/statusbar.test.ts` — 62 files, 862 tests.
- `tsc --noEmit` clean; eslint clean on all touched files.
- Full desktop suite: 9,526 passed; the 3 failures (`electron/managed-ssh-update.test.ts`, `voice-prefs.test.ts` ×2) were verified to fail identically on clean `main` — pre-existing/environmental, not from this change.

**Platforms tested:** macOS 26.6.2 (arm64) — the changed surface is renderer-only (React hook in `apps/desktop/src`), platform-independent by construction; no file I/O, process, or terminal code touched.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification on a multi-profile desktop install — packaged build of this PR driven in an isolated sandbox (isolated `HERMES_DESKTOP_USER_DATA_DIR` + copied `HERMES_HOME` + pinned `HERMES_DESKTOP_HERMES`) against a 13-profile topology; note for other verifiers: a dev build of a local merge cannot self-bootstrap (the first-launch installer fetches `install.sh` pinned to the build commit — 404 for anything not on upstream), so pin `HERMES_DESKTOP_HERMES` to an installed CLI; repo `.npmrc` has `engine-strict=true` excluding npm 11.14 — build with npm ≥11.17