### PR TITLE
fix(kanban): make PR acceptance gh-compatible

### DIFF
--- a/hermes_cli/kanban_pr_acceptance.py
+++ b/hermes_cli/kanban_pr_acceptance.py
@@ -19,6 +19,22 @@ class _GitHubRulesUnavailable(RuntimeError):
     """The rules endpoint could not be read (as opposed to no rules existing)."""
 
 
+def _rules_endpoint_has_no_required_checks(exc: subprocess.CalledProcessError) -> bool:
+    """Recognize GitHub's plan-gated rules response without masking auth errors.
+
+    GitHub returns HTTP 403 for private repositories whose plan cannot expose
+    the rules endpoint.  That is an auditable lack of rules data, not proof of
+    required checks; unlike a real permission failure, the response explicitly
+    identifies the unavailable feature (usually with an upgrade hint).
+    """
+    detail = " ".join(filter(None, (exc.stderr, exc.stdout))).lower()
+    return (
+        "upgrade to github pro" in detail
+        or "feature unavailable" in detail
+        or "branch protection rules are not available" in detail
+    )
+
+
 def validate_contract(value: str | None) -> str:
     if value is None or value == "local-only":
         return "local-only"
@@ -87,6 +103,11 @@ def collect_acceptance(contract: str, published_pr: str | None) -> dict:
             # not evidence that the repository has no required checks.
             stderr = (exc.stderr or "").lower()
             if "404" in stderr or "not found" in stderr:
+                rules = []
+            elif _rules_endpoint_has_no_required_checks(exc):
+                # The rules API is plan-gated for some private repositories.
+                # Treat only its explicit feature-unavailable response as a
+                # no-required-checks result; generic 403 remains infra.
                 rules = []
             else:
                 raise _GitHubRulesUnavailable from exc

--- a/hermes_cli/kanban_pr_acceptance.py
+++ b/hermes_cli/kanban_pr_acceptance.py
@@ -8,10 +8,15 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+from typing import Any
 from urllib.parse import quote
 
 _REPO = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 _PR = re.compile(r"https://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/pull/([1-9][0-9]*)")
+
+
+class _GitHubRulesUnavailable(RuntimeError):
+    """The rules endpoint could not be read (as opposed to no rules existing)."""
 
 
 def validate_contract(value: str | None) -> str:
@@ -22,15 +27,28 @@ def validate_contract(value: str | None) -> str:
     return value
 
 
-def _api(endpoint: str, *, query: str | None = None, paginate: bool = False):
+def _api(endpoint: str, *, query: str | None = None, paginate: bool = False) -> Any:
     command = ["gh", "api", endpoint, "--hostname", "github.com"]
     if query is not None:
         command += ["-f", "query=" + query]
     if paginate:
-        command += ["--paginate", "--slurp"]
+        # Do not use --slurp: older and vendor-patched gh releases reject it.
+        # gh emits one complete JSON document per page without that flag.
+        command += ["--paginate"]
     result = subprocess.run(command, stdin=subprocess.DEVNULL, capture_output=True,
                             text=True, timeout=30, check=True)
-    value = json.loads(result.stdout)
+    if paginate:
+        decoder = json.JSONDecoder()
+        value, index = [], 0
+        while index < len(result.stdout):
+            while index < len(result.stdout) and result.stdout[index].isspace():
+                index += 1
+            if index == len(result.stdout):
+                break
+            page, index = decoder.raw_decode(result.stdout, index)
+            value.append(page)
+    else:
+        value = json.loads(result.stdout)
     if isinstance(value, dict) and value.get("errors"):
         raise ValueError("GitHub returned incomplete GraphQL evidence")
     return value
@@ -38,7 +56,7 @@ def _api(endpoint: str, *, query: str | None = None, paginate: bool = False):
 
 def collect_acceptance(contract: str, published_pr: str | None) -> dict:
     receipt = {"ok": False, "classification": "missing", "head_sha": None,
-               "pr_url": published_pr, "checks": [],
+               "merge_sha": None, "pr_url": published_pr, "checks": [],
                "recovery": "Fix required failures, rerun infrastructure checks or wait, then retry completion. "
                            "Use kanban_block if human input is needed; receipts remain on the task event log."}
     try:
@@ -61,21 +79,51 @@ def collect_acceptance(contract: str, published_pr: str | None) -> dict:
             raise ValueError("PR is closed or current head is unavailable")
         protection = (pr.get("baseRef") or {}).get("branchProtectionRule") or {}
         required = {(r["context"], (r.get("app") or {}).get("databaseId")) for r in protection.get("requiredStatusChecks", [])}
-        rules = _api(f"repos/{repo}/rules/branches/{quote(branch, safe='')}?per_page=100", paginate=True)
+        try:
+            rules = _api(f"repos/{repo}/rules/branches/{quote(branch, safe='')}?per_page=100", paginate=True)
+        except subprocess.CalledProcessError as exc:
+            # A branch with no active rules commonly returns 404. That is a
+            # valid, auditable policy result; 401/403 and other failures are
+            # not evidence that the repository has no required checks.
+            stderr = (exc.stderr or "").lower()
+            if "404" in stderr or "not found" in stderr:
+                rules = []
+            else:
+                raise _GitHubRulesUnavailable from exc
         for page in rules:
-            for rule in page:
+            page_rules = page if isinstance(page, list) else [page]
+            for rule in page_rules:
                 if rule["type"] == "required_status_checks":
                     required.update((r["context"], r.get("integration_id"))
                                     for r in rule["parameters"]["required_status_checks"])
         receipt["required"] = [{"context": c, "app_id": a} for c, a in sorted(required, key=str)]
         if not required:
-            receipt["detail"] = "No repository-required checks are configured; explicitly use a local-only contract for non-CI tasks."
+            # A merged PR is immutable evidence even when the repository has
+            # no required-check policy. Open PRs still need required checks.
+            current = _api(f"repos/{repo}/pulls/{number}")
+            if (current.get("head", {}).get("sha") != sha
+                    or current.get("base", {}).get("ref") != branch
+                    or (current.get("state") == "closed" and not current.get("merged"))):
+                receipt.update(classification="stale",
+                               detail="PR head/base changed while collecting evidence; retry.")
+                return receipt
+            merge_sha = current.get("merge_commit_sha")
+            if current.get("merged") and re.fullmatch(r"[0-9a-f]{40}", merge_sha or ""):
+                receipt.update(ok=True, classification="no_required_checks",
+                               merge_sha=merge_sha,
+                               detail="PR merged; repository has no required status-check policy.")
+                return receipt
+            receipt["classification"] = "no_required_checks"
+            receipt["detail"] = "No repository-required checks are configured; merge evidence is required."
             return receipt
         pages = _api(f"repos/{repo}/commits/{sha}/check-runs?per_page=100&filter=latest", paginate=True)
-        runs = [run for page in pages for run in page["check_runs"]]
-        if len({r["id"] for r in runs}) != pages[0]["total_count"]:
+        runs = [run for page in pages
+                for run in (page["check_runs"] if isinstance(page, dict) else page[0]["check_runs"])]
+        first_page = pages[0] if isinstance(pages[0], dict) else pages[0][0]
+        if len({r["id"] for r in runs}) != first_page["total_count"]:
             raise ValueError("Incomplete check-run pagination")
-        statuses = [{**s, "sha": sha} for page in _api(f"repos/{repo}/commits/{sha}/statuses?per_page=100", paginate=True) for s in page]
+        statuses = [{**s, "sha": sha} for page in _api(f"repos/{repo}/commits/{sha}/statuses?per_page=100", paginate=True)
+                    for s in (page if isinstance(page, list) else [page])]
         outcomes = []
         for context, app_id in sorted(required, key=str):
             matching = [r for r in runs if r["name"] == context and
@@ -100,10 +148,16 @@ def collect_acceptance(contract: str, published_pr: str | None) -> dict:
         if current["head"]["sha"] != sha or current["base"]["ref"] != branch or (current["state"] == "closed" and not current.get("merged")):
             receipt.update(classification="stale", detail="PR head/base changed while collecting evidence; retry.")
             return receipt
+        if current.get("merged"):
+            receipt["merge_sha"] = current.get("merge_commit_sha")
+            if not re.fullmatch(r"[0-9a-f]{40}", receipt["merge_sha"] or ""):
+                receipt.update(classification="infra", detail="Merged PR has no immutable merge SHA.")
+                return receipt
         receipt["classification"] = next((x for x in outcomes if x != "success"), "missing" if not outcomes else "success")
         receipt["ok"] = receipt["classification"] == "success"
         return receipt
-    except (OSError, subprocess.SubprocessError, ValueError, KeyError, TypeError, IndexError):
+    except (OSError, subprocess.SubprocessError, ValueError, KeyError, TypeError, IndexError,
+            _GitHubRulesUnavailable):
         # Never persist gh stderr (credentials/host details); the failed phase is actionable.
         receipt.update(classification="infra", detail="GitHub acceptance evidence unavailable or incomplete; check gh authentication/API access and retry.")
         return receipt

--- a/hermes_cli/kanban_pr_acceptance.py
+++ b/hermes_cli/kanban_pr_acceptance.py
@@ -35,6 +35,18 @@ def _rules_endpoint_has_no_required_checks(exc: subprocess.CalledProcessError) -
     )
 
 
+def _rules_endpoint_reports_unprotected_branch(exc: subprocess.CalledProcessError) -> bool:
+    """Recognize the rules API's explicit no-rules 404 response.
+
+    A generic 404 is deliberately not enough: GitHub also uses it when a
+    repository or branch is inaccessible.  The rules endpoint documents
+    ``Branch not protected`` as the no-protection response, so only that
+    explicit message may be treated as an empty policy result.
+    """
+    detail = " ".join(filter(None, (exc.stderr, exc.stdout))).lower()
+    return "branch not protected" in detail
+
+
 def validate_contract(value: str | None) -> str:
     if value is None or value == "local-only":
         return "local-only"
@@ -98,11 +110,10 @@ def collect_acceptance(contract: str, published_pr: str | None) -> dict:
         try:
             rules = _api(f"repos/{repo}/rules/branches/{quote(branch, safe='')}?per_page=100", paginate=True)
         except subprocess.CalledProcessError as exc:
-            # A branch with no active rules commonly returns 404. That is a
-            # valid, auditable policy result; 401/403 and other failures are
-            # not evidence that the repository has no required checks.
-            stderr = (exc.stderr or "").lower()
-            if "404" in stderr or "not found" in stderr:
+            # Only GitHub's explicit no-protection response is evidence of an
+            # empty policy.  Generic 404s can mean an inaccessible repository
+            # or branch and must remain infrastructure failures.
+            if _rules_endpoint_reports_unprotected_branch(exc):
                 rules = []
             elif _rules_endpoint_has_no_required_checks(exc):
                 # The rules API is plan-gated for some private repositories.

--- a/tests/hermes_cli/test_kanban_pr_acceptance.py
+++ b/tests/hermes_cli/test_kanban_pr_acceptance.py
@@ -9,6 +9,7 @@ import pytest
 
 from hermes_cli import kanban_db as kb
 from hermes_cli.kanban_db_connect import connect
+from hermes_cli import kanban_pr_acceptance as acceptance
 
 
 @pytest.fixture
@@ -25,7 +26,8 @@ def github(tmp_path, monkeypatch):
                     "baseRef": {"branchProtectionRule": {"requiredStatusChecks": [
                         {"context": "required", "app": {"databaseId": 1}}]}}}}}}
             elif "/rules/branches/" in self.path:
-                value = [[]]
+                value = [{"type": "required_status_checks", "parameters": {
+                    "required_status_checks": [{"context": "required", "integration_id": 1}]}}]
             elif "/check-runs" in self.path:
                 run = {"id": 42, "name": "required", "head_sha": sha,
                        "app": {"id": 1}, "status": "in_progress" if state["conclusion"] == "pending" else "completed", "conclusion": state["conclusion"],
@@ -33,15 +35,15 @@ def github(tmp_path, monkeypatch):
                 if state.get("stale"):
                     run["head_sha"] = "b" * 40
                 runs = [] if state.get("missing") else [run]
-                value = [{"total_count": 100 + len(runs), "check_runs": [
+                value = {"total_count": 100 + len(runs), "check_runs": [
                     {**run, "id": 1000 + i, "name": "optional", "conclusion": "skipped"}
-                    for i in range(100)]}, {"total_count": 100 + len(runs), "check_runs": runs}]
+                    for i in range(100)] + runs}
                 if state.get("race"):
                     state["race"]()
                 if state.get("head_change"):
                     state["head"] = "b" * 40
             elif "/statuses" in self.path:
-                value = [[]]
+                value = []
             elif "/pulls/" in self.path:
                 value = {"head": {"sha": sha}, "base": {"ref": "main"}, "state": "open"}
             else:
@@ -129,3 +131,124 @@ def test_acceptance_receipts_and_terminal_write_share_run_ownership(github):
             assert kb.get_task(conn, tid).status != "done"
             assert conn.execute("SELECT count(*) FROM task_events WHERE task_id=? AND kind='pr_acceptance'", (tid,)).fetchone()[0] == 0
             github.pop("race")
+
+
+def test_paginated_api_does_not_require_slurp(monkeypatch):
+    calls = []
+
+    class Result:
+        stdout = '{"page": 1}\n{"page": 2}\n'
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return Result()
+
+    monkeypatch.setattr(acceptance.subprocess, "run", run)
+    assert acceptance._api("repos/acme/repo/rules", paginate=True) == [{"page": 1}, {"page": 2}]
+    assert "--paginate" in calls[0]
+    assert "--slurp" not in calls[0]
+
+
+def test_paginated_api_preserves_single_page_documents(monkeypatch):
+    payloads = [
+        "[{\"type\": \"required_status_checks\"}]\n",
+        "{\"total_count\": 1, \"check_runs\": []}\n",
+        "[{\"context\": \"required\"}]\n",
+    ]
+
+    class Result:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def run(command, **kwargs):
+        return Result(payloads.pop(0))
+
+    monkeypatch.setattr(acceptance.subprocess, "run", run)
+    assert acceptance._api("rules", paginate=True) == [[{"type": "required_status_checks"}]]
+    assert acceptance._api("check-runs", paginate=True) == [{"total_count": 1, "check_runs": []}]
+    assert acceptance._api("statuses", paginate=True) == [[{"context": "required"}]]
+
+
+def test_single_page_rest_payloads_are_classified_correctly(monkeypatch):
+    sha = "a" * 40
+    responses = iter([
+        {"data": {"repository": {"pullRequest": {
+            "headRefOid": sha, "baseRefName": "main", "state": "OPEN",
+            "baseRef": {"branchProtectionRule": {"requiredStatusChecks": []}},
+        }}}},
+        [[{"type": "required_status_checks", "parameters": {
+            "required_status_checks": [{"context": "required", "integration_id": 1}]}}]],
+        [{"total_count": 1, "check_runs": [{
+            "id": 42, "name": "required", "head_sha": sha, "app": {"id": 1},
+            "status": "completed", "conclusion": "success"}]}],
+        [[{"context": "required", "id": 7, "sha": sha, "state": "success"}]],
+        {"head": {"sha": sha}, "base": {"ref": "main"}, "state": "open"},
+    ])
+    monkeypatch.setattr(acceptance, "_api", lambda *args, **kwargs: next(responses))
+
+    receipt = acceptance.collect_acceptance(
+        "acme/repo", "https://github.com/acme/repo/pull/7")
+    assert receipt["ok"] is True
+    assert receipt["checks"][0]["classification"] == "success"
+
+
+@pytest.mark.parametrize("merge_sha", [None, "not-a-sha", "b" * 39, "B" * 40])
+def test_no_required_checks_requires_immutable_merge_sha(monkeypatch, merge_sha):
+    sha = "a" * 40
+    responses = iter([
+        {"data": {"repository": {"pullRequest": {
+            "headRefOid": sha, "baseRefName": "main", "state": "MERGED",
+            "baseRef": {"branchProtectionRule": {"requiredStatusChecks": []}},
+        }}}},
+        [],
+        {"head": {"sha": sha}, "base": {"ref": "main"},
+         "state": "closed", "merged": True, "merge_commit_sha": merge_sha},
+    ])
+    monkeypatch.setattr(acceptance, "_api", lambda *args, **kwargs: next(responses))
+    receipt = acceptance.collect_acceptance(
+        "acme/repo", "https://github.com/acme/repo/pull/7")
+    assert receipt["ok"] is (merge_sha == "b" * 40)
+    assert receipt["classification"] == "no_required_checks"
+    assert receipt["merge_sha"] == (merge_sha if merge_sha == "b" * 40 else None)
+
+
+def test_no_required_checks_is_distinct_from_api_failure(monkeypatch):
+    sha = "a" * 40
+
+    def denied(*args, **kwargs):
+        if "rules/branches" in args[0]:
+            raise acceptance.subprocess.CalledProcessError(
+                1, "gh", stderr="HTTP 403: Resource not accessible")
+        return {"data": {"repository": {"pullRequest": {
+            "headRefOid": sha, "baseRefName": "main", "state": "MERGED",
+            "baseRef": {"branchProtectionRule": {"requiredStatusChecks": []}},
+        }}}}
+
+    monkeypatch.setattr(acceptance, "_api", denied)
+    denied_receipt = acceptance.collect_acceptance(
+        "acme/repo", "https://github.com/acme/repo/pull/7")
+    assert denied_receipt["ok"] is False
+    assert denied_receipt["classification"] == "infra"
+
+
+@pytest.mark.parametrize("mismatch", ["head", "base"])
+def test_no_required_checks_rejects_head_or_base_race(monkeypatch, mismatch):
+    sha = "a" * 40
+    current = {"head": {"sha": sha}, "base": {"ref": "main"},
+               "state": "closed", "merged": True,
+               "merge_commit_sha": "b" * 40}
+    current[mismatch] = {"sha": "c" * 40} if mismatch == "head" else {"ref": "release"}
+    responses = iter([
+        {"data": {"repository": {"pullRequest": {
+            "headRefOid": sha, "baseRefName": "main", "state": "MERGED",
+            "baseRef": {"branchProtectionRule": {"requiredStatusChecks": []}},
+        }}}},
+        [],
+        current,
+    ])
+    monkeypatch.setattr(acceptance, "_api", lambda *args, **kwargs: next(responses))
+
+    receipt = acceptance.collect_acceptance(
+        "acme/repo", "https://github.com/acme/repo/pull/7")
+    assert receipt["ok"] is False
+    assert receipt["classification"] == "stale"

--- a/tests/hermes_cli/test_kanban_pr_acceptance.py
+++ b/tests/hermes_cli/test_kanban_pr_acceptance.py
@@ -231,6 +231,31 @@ def test_no_required_checks_is_distinct_from_api_failure(monkeypatch):
     assert denied_receipt["classification"] == "infra"
 
 
+def test_plan_gated_rules_endpoint_falls_back_to_no_required_checks(monkeypatch):
+    sha = "a" * 40
+    responses = iter([
+        {"data": {"repository": {"pullRequest": {
+            "headRefOid": sha, "baseRefName": "main", "state": "MERGED",
+            "baseRef": {"branchProtectionRule": {"requiredStatusChecks": []}},
+        }}}},
+        {"head": {"sha": sha}, "base": {"ref": "main"},
+         "state": "closed", "merged": True, "merge_commit_sha": "b" * 40},
+    ])
+
+    def plan_gated(*args, **kwargs):
+        if "rules/branches" in args[0]:
+            raise acceptance.subprocess.CalledProcessError(
+                1, "gh", stderr="HTTP 403: Upgrade to GitHub Pro to enable this feature")
+        return next(responses)
+
+    monkeypatch.setattr(acceptance, "_api", plan_gated)
+    receipt = acceptance.collect_acceptance(
+        "acme/repo", "https://github.com/acme/repo/pull/7")
+    assert receipt["ok"] is True
+    assert receipt["classification"] == "no_required_checks"
+    assert receipt["merge_sha"] == "b" * 40
+
+
 @pytest.mark.parametrize("mismatch", ["head", "base"])
 def test_no_required_checks_rejects_head_or_base_race(monkeypatch, mismatch):
     sha = "a" * 40

--- a/tests/hermes_cli/test_kanban_pr_acceptance.py
+++ b/tests/hermes_cli/test_kanban_pr_acceptance.py
@@ -256,6 +256,41 @@ def test_plan_gated_rules_endpoint_falls_back_to_no_required_checks(monkeypatch)
     assert receipt["merge_sha"] == "b" * 40
 
 
+@pytest.mark.parametrize(
+    ("message", "is_no_rules"),
+    [("HTTP 404: Branch not protected", True),
+     ("HTTP 404: Not Found", False),
+     ("HTTP 404: Repository not found", False)],
+)
+def test_rules_404_requires_explicit_unprotected_branch_response(message, is_no_rules):
+    error = acceptance.subprocess.CalledProcessError(1, "gh", stderr=message)
+    assert acceptance._rules_endpoint_reports_unprotected_branch(error) is is_no_rules
+
+
+def test_inaccessible_rules_404_cannot_false_success(monkeypatch):
+    sha = "a" * 40
+    responses = iter([
+        {"data": {"repository": {"pullRequest": {
+            "headRefOid": sha, "baseRefName": "main", "state": "MERGED",
+            "baseRef": {"branchProtectionRule": {"requiredStatusChecks": []}},
+        }}}},
+        {"head": {"sha": sha}, "base": {"ref": "main"},
+         "state": "closed", "merged": True, "merge_commit_sha": "b" * 40},
+    ])
+
+    def inaccessible(*args, **kwargs):
+        if "rules/branches" in args[0]:
+            raise acceptance.subprocess.CalledProcessError(
+                1, "gh", stderr="HTTP 404: Repository not found")
+        return next(responses)
+
+    monkeypatch.setattr(acceptance, "_api", inaccessible)
+    receipt = acceptance.collect_acceptance(
+        "acme/repo", "https://github.com/acme/repo/pull/7")
+    assert receipt["ok"] is False
+    assert receipt["classification"] == "infra"
+
+
 @pytest.mark.parametrize("mismatch", ["head", "base"])
 def test_no_required_checks_rejects_head_or_base_race(monkeypatch, mismatch):
     sha = "a" * 40

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -61,9 +61,10 @@ dashboard completion. It reads classic branch protection and active ruleset
 required contexts, paginates exact-head check runs and legacy statuses, then
 re-reads the PR head/base. Optional failed/skipped telemetry does not veto accepted
 required checks. Missing, pending, failed, cancelled, timed-out, stale, skipped or
-neutral **required** evidence cannot complete the card. Neither can zero-run
-acceptance, unreadable policy or GitHub API failures. A repository without required
-checks needs a local-only contract. `gh` must be authenticated with read access to
+neutral **required** evidence cannot complete the card. A merged PR from a repository
+with no required-check policy is accepted with explicit `no_required_checks` evidence;
+an open PR still cannot complete without required checks. Unreadable policy, auth
+failures, and other GitHub API failures remain infrastructure failures. `gh` must be authenticated with read access to
 the repository's checks and rules; no remote writes are performed by this gate.
 
 Rejection retains the active card and workspace. Durable `pr_acceptance` events


### PR DESCRIPTION
Kanban task: t_bb4f751c

## Kanban Task
https://mc.solobot.cloud/tasks?task=t_bb4f751c

- replace fragile gh api --paginate --slurp usage with compatibility-safe page parsing
- distinguish no required checks from auth/API failures, including plan-gated rules responses
- accept merged PRs with immutable merge SHA evidence
- add deterministic acceptance tests and update docs

Focused tests pass: scripts/run_tests.sh tests/hermes_cli/test_kanban_pr_acceptance.py -q
Affected tests pass: scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_review_surfaces.py -q