### PR TITLE
fix(responses): skip empty-content assistant fallback for strict relays

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -494,7 +494,13 @@ def _chat_messages_to_responses_input(
         emit(message_items, msg)
         if not message_items:
             # Every reasoning item needs a following item (else missing_following_item), hence the "" fallback.
-            fallback = content_parts or (content_text if content_text.strip() else "" if reasoning_items else None)
+            # Strict relays (e.g. Volcengine Coding Plan /responses) instead reject an empty-content
+            # assistant item with HTTP 400 "missing input.content" while accepting a reasoning item
+            # with no following message. Only synthesize the "" fallback for OpenAI-family endpoints
+            # (xai/github/codex or unknown); "other:*" relays get none.
+            needs_following = current_issuer_kind in ("xai_responses", "github_responses", "codex_backend") or not current_issuer_kind
+            fallback = content_parts or (content_text if content_text.strip()
+                                         else ("" if (reasoning_items and needs_following) else None))
             if fallback is not None:
                 emit([{"role": "assistant", "content": fallback}], msg)
         emit(_replay_tool_call_items(msg, start_index=len(items)), msg)


### PR DESCRIPTION
## Problem

Tool-calling turns on Volcengine Coding Plan `/responses` (model `doubao-seed-evolving`, a Codex-protocol endpoint) fail with:

```
HTTP 400: The request failed because it is missing `input.content` parameter.
```

and fall back to another model mid-turn.

## Root cause

`_chat_messages_to_responses_input` synthesizes `{"role": "assistant", "content": ""}` (empty-string content) when an assistant message has no text but carries replayed `codex_reasoning_items`. That `""` fallback exists because OpenAI-family endpoints require a non-reasoning item after a reasoning item (`missing_following_item`).

Strict relays — Volcengine Coding Plan is one — reject the empty-string content item outright, while accepting a replayed reasoning item **with no following message at all** (verified live: reasoning-only, reasoning+`function_call`, and reasoning+`function_call_output` all pass; `content: ""` and `content: []` both 400).

## Fix

Only synthesize the `""` fallback for OpenAI-family issuers (`xai_responses`, `github_responses`, `codex_backend`, or unknown). For `other:*` issuers (custom OpenAI-compatible `/responses` endpoints), emit nothing — their own encrypted reasoning blobs replay standalone.

Behavior for OpenAI/xAI/GitHub/Codex endpoints is unchanged (they keep the `""` fallback).

## Verification

- Reproduced with a real 607-message session (761 input items) against the live Volcengine endpoint: before the fix the full input 400s; after the fix it returns OK.
- `py_compile` clean.
