### PR TITLE
feat(plugin-catalog): add netbox and rustpush-imessage community entries (salvage #105969, #101577)

### DIFF
--- a/plugin-catalog/hermes-plugin-netbox.yaml
+++ b/plugin-catalog/hermes-plugin-netbox.yaml
@@ -1,0 +1,21 @@
+name: hermes-plugin-netbox
+repo: https://github.com/andrewvieyra/hermes-plugin-netbox
+sha: 8ff1fc408e765294664e6ed96c4a5a437b76ceef
+description: 'NetBox change management: query DCIM/IPAM objects, build a reviewed field-level diff, apply
+  with a journal and roll back.'
+maintainer: andrewvieyra
+tier: community
+docs_url: https://github.com/andrewvieyra/hermes-plugin-netbox
+platforms: []
+capabilities:
+  provides_tools:
+  - netbox_query
+  - netbox_plan
+  - netbox_apply
+  - netbox_rollback
+  - netbox_plans
+  provides_hooks: []
+  provides_middleware: []
+  requires_env:
+  - NETBOX_URL
+  - NETBOX_TOKEN

--- a/plugin-catalog/hermes-rustpush-imessage.yaml
+++ b/plugin-catalog/hermes-rustpush-imessage.yaml
@@ -1,0 +1,14 @@
+name: hermes-rustpush-imessage
+repo: https://github.com/boobutler/hermes-rustpush-imessage
+sha: 695f74755cbcdbcd742baa51021fdb96a78ac10e
+description: Local-only iMessage platform plugin backed by a launchd-supervised OpenBubbles RustPush sidecar
+  over a same-user Unix socket.
+maintainer: boobutler
+tier: community
+docs_url: https://github.com/boobutler/hermes-rustpush-imessage
+platforms: []
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []


### PR DESCRIPTION
## Summary
Two community entries for the plugin catalog (landed in #69446), re-targeted from their community-index submissions after the index was retired. Credit to the original submitters: **@andrewvieyra** (#105969) and **@boobutler** (#101577).

| Entry | Repo @ pin | Declared |
|---|---|---|
| `hermes-plugin-netbox` | andrewvieyra/hermes-plugin-netbox @ `8ff1fc4` | 5 tools (`netbox_query/plan/apply/rollback/plans`), env `NETBOX_URL`, `NETBOX_TOKEN` |
| `hermes-rustpush-imessage` | boobutler/hermes-rustpush-imessage @ `695f747` | platform adapter, no tools/hooks |

## Validation
| Check | Result |
|---|---|
| `scripts/validate_plugin_catalog.py plugin-catalog/` | 10 files valid |
| `hermes plugins validate` on each repo cloned at the pinned SHA | both pass (declared == registered) |
| Pin maturity | netbox 2026-09-08, rustpush 2026-09-02 — under the 2-week guideline; both are the authors' first published release, admitted on that basis. Flag if you'd rather wait. |

Not included from the same batch: **inline-platform** (#102873) registers an `inline` tool it doesn't declare; **researchcraft** (#104042) registers undeclared `modal_run`/`runpod_run` and its `image_generate` collides with the built-in tool name. Both authors get a comment with the exact `validate` output.

## Infographic
![catalog-community-batch](https://v3b.fal.media/files/b/0aa9c0fc/hfMDogCnpWAVtO5jjeV6m_T7RIQsvT.png)
