### PR TITLE
fix(gateway): preserve original user text for automatic titles

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1434,12 +1434,16 @@ def _run_conversation_turn(
     persist_user_platform_id: Optional[str] = None,
     turn_author: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    title_user_message: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Run a complete conversation with tool calling until completion; returns the result dict.
 
     ``stream_callback``: per-text-delta callback (TTS). ``persist_user_message``: clean text to
     store when ``user_message`` carries API-only synthetic prefixes; timestamp / platform id are
-    stored as metadata (platform id lets restart drain recovery dedup). ``persist_user_display_*``:
+    stored as metadata (platform id lets restart drain recovery dedup).
+    ``title_user_message``: optional pre-injection text for titles only (None uses the
+    model-facing message; an empty string suppresses titling for this turn).
+    ``persist_user_display_*``:
     display-only event rendering; the model still receives the message unchanged."""
     if moa_config is None:
         user_message, moa_config, persist_user_message = _decode_inline_moa_turn(
@@ -1478,6 +1482,7 @@ def _run_conversation_turn(
             # MoA turns append per-call aggregated context to the API copy of the
             # user message, so no byte-stable api_content sidecar can be stamped.
             moa_active=bool(moa_config),
+            title_user_message=title_user_message,
         )
     except PreflightCompressionTimedOut as _preflight_timeout_exc:
         return _preflight_timeout_result(agent, _preflight_timeout_exc, conversation_history)
@@ -1584,6 +1589,7 @@ def run_conversation(
     persist_user_platform_id: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
     turn_author: Optional[Dict[str, Any]] = None,
+    title_user_message: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Run one turn (see ``_run_conversation_turn``) and export the current-turn boundary.
 
@@ -1608,6 +1614,7 @@ def run_conversation(
         persist_user_platform_id=persist_user_platform_id,
         moa_config=moa_config,
         turn_author=turn_author,
+        title_user_message=title_user_message,
     )
     return export_current_turn_boundary(agent, result, user_message)
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -152,7 +152,9 @@ def append_notes_to_multimodal_content(content: Any, notes: str) -> bool:
 _UNTITLED_PLATFORMS = frozenset({"cron", "subagent"})
 
 
-def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
+def _maybe_title_session_at_turn_start(
+    agent: Any, messages: List[Any], title_user_message: Optional[str] = None,
+) -> None:
     """Kick off auto-titling for the session's first user message; never fatal."""
     session_db = getattr(agent, "_session_db", None)
     session_id = getattr(agent, "session_id", None)
@@ -165,11 +167,14 @@ def _maybe_title_session_at_turn_start(agent: Any, messages: List[Any]) -> None:
         from agent.title_generator import maybe_auto_title
 
         # Turn's user message as text; image-only turns yield "" and are skipped.
-        user_text = ""
-        for msg in reversed(messages or []):
-            if isinstance(msg, dict) and msg.get("role") == "user":
-                user_text = flatten_message_text(msg.get("content")).strip()
-                break
+        if title_user_message is not None:
+            user_text = title_user_message.strip()
+        else:
+            user_text = ""
+            for msg in reversed(messages or []):
+                if isinstance(msg, dict) and msg.get("role") == "user":
+                    user_text = flatten_message_text(msg.get("content")).strip()
+                    break
         if not user_text:
             return
         # The session row is created lazily; force it now or the title write matches
@@ -858,6 +863,7 @@ def build_turn_context(
     restore_or_build_system_prompt,
     install_safe_stdio, sanitize_surrogates, summarize_user_message_for_log, set_session_context,
     set_current_write_origin, ra, moa_active: bool=False,
+    title_user_message: Optional[str]=None,
 ) -> TurnContext:
     """Run the once-per-turn setup and return the loop's input context.
 
@@ -1000,7 +1006,7 @@ def build_turn_context(
 
     # Title the session now: the row exists and titling depends only on the user's ask,
     # so it runs concurrently with the turn. Daemon thread, no-op once titled.
-    _maybe_title_session_at_turn_start(agent, messages)
+    _maybe_title_session_at_turn_start(agent, messages, title_user_message)
 
     return TurnContext(
         user_message=user_message, original_user_message=original_user_message, messages=messages,

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -28,6 +28,7 @@ class TurnFacadeMixin:
         persist_user_platform_id: Optional[str]=None, moa_config: Optional[dict[str, Any]]=None,
         turn_author: Optional[Dict[str, Any]] = None,
         relay_metadata: Optional[Dict[str, Any]] = None,
+        title_user_message: Optional[str]=None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review shares this session_id for cache parity: fence review startup or interrupt
@@ -137,6 +138,7 @@ class TurnFacadeMixin:
                         persist_user_display_metadata=persist_user_display_metadata,
                         persist_user_platform_id=persist_user_platform_id, moa_config=moa_config,
                         turn_author=turn_author,
+                        title_user_message=title_user_message,
                     )
                 finally:
                     # Post-loop relay/task finalization must not receive a late refresh interrupt;

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1831,6 +1831,7 @@ class GatewayTurnMixin:
         persist_user_display_kind: Optional[str]
         persistence_session_id: Optional[str] = None
         persistence_owner: Optional[str] = None
+        title_user_message: Optional[str] = None
 
     async def _hmwa_prepare_turn(self, event, source, session_entry, session_key, _quick_key, run_generation):
         """Everything between session resolution and the agent run: session open, task-local env,
@@ -1858,6 +1859,10 @@ class GatewayTurnMixin:
         turn_sidecar_notes: List[str] = []
         if _was_auto_reset:
             await self._hmwa_deliver_auto_reset_notice(session_entry, source, turn_sidecar_notes)
+
+        # Keep human text separate from skills, sender metadata, and other model context.
+        # With no text (e.g. voice-only), retain the existing enriched-message title fallback.
+        title_user_message = event.text or None
 
         # Auto-load bound skill(s) only on NEW sessions; ongoing ones carry the content in history.
         _auto = getattr(event, "auto_skill", None)
@@ -1922,6 +1927,7 @@ class GatewayTurnMixin:
         return self._PreparedTurn(
             history, context_prompt, message_text, persist_user_message, persist_user_timestamp,
             persist_user_display_kind, session_entry.session_id, owner,
+            title_user_message=title_user_message,
         ), _session_env_tokens
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
@@ -1975,6 +1981,7 @@ class GatewayTurnMixin:
                 run_generation=run_generation, event_message_id=self._reply_anchor_for_event(event),
                 inbound_message_id=str(event.message_id) if event.message_id else None,
                 channel_prompt=event.channel_prompt, moa_config=getattr(event, "_moa_config", None),
+                title_user_message=prepared.title_user_message,
                 persist_user_message=prepared.persist_user_message,
                 persist_user_timestamp=prepared.persist_user_timestamp,
                 persist_user_display_kind=prepared.persist_user_display_kind,
@@ -3820,6 +3827,7 @@ class GatewayTurnMixin:
         persist_user_message: Optional[Any] = None, persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None, message_type: Optional[str] = None,
         persist_user_display_metadata: Optional[dict] = None,
+        title_user_message: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Run the agent; returns the full run_conversation result dict.
 
@@ -3840,6 +3848,7 @@ class GatewayTurnMixin:
             session_id=session_id, _interrupt_depth=_interrupt_depth,
             event_message_id=event_message_id, inbound_message_id=inbound_message_id,
             channel_prompt=channel_prompt, moa_config=moa_config,
+            title_user_message=title_user_message,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
             persist_user_display_kind=persist_user_display_kind,

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1519,6 +1519,8 @@ class TurnRunner:
                 # Sent on every transport: a provider gating durable writes needs the bot flag in a DM too.
                 kwargs["turn_author"] = {"id": ctx.source.user_id or None, "name": ctx.source.user_name or None,
                                          "is_bot": bool(getattr(ctx.source, "is_bot", False))}
+            if ctx.title_user_message is not None:
+                kwargs["title_user_message"] = ctx.title_user_message
             if persist_user_message_override is not None:
                 kwargs["persist_user_message"] = persist_user_message_override
             elif observed_group_context:

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -51,6 +51,7 @@ class TurnContext:
     # Raw inbound platform id (not the event_message_id reply anchor); stamped on the user turn.
     inbound_message_id: Optional[str] = None
     moa_config: Optional[dict] = None
+    title_user_message: Optional[str] = None
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None
     # display_kind of the persisted user row for a self-injected turn; DB-only, never sent.

--- a/tests/agent/test_title_input.py
+++ b/tests/agent/test_title_input.py
@@ -1,0 +1,58 @@
+"""Title-only input must not change history, eligibility, or fallback behavior."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from agent.turn_context import _maybe_title_session_at_turn_start
+
+
+@pytest.mark.parametrize("override, content, expected", [
+    (None, "Ordinary request", "Ordinary request"),
+    ("Actual question", "Injected model context", "Actual question"),
+    ("  Actual question  ", "Injected model context", "Actual question"),
+    ("", "Injected model context", None),
+    ("   ", "Injected model context", None),
+    (None, [{"type": "text", "text": "Image caption"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}}], "Image caption"),
+    (None, [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}}], None),
+])
+def test_title_input_override_is_optional_and_history_is_unchanged(monkeypatch, override, content, expected):
+    agent = SimpleNamespace(_session_db=Mock(), session_id="test", _session_db_created=True)
+    messages = [{"role": "user", "content": content}]
+    original = deepcopy(messages)
+    title = Mock()
+    monkeypatch.setattr("agent.title_generator.maybe_auto_title", title)
+
+    _maybe_title_session_at_turn_start(agent, messages, override)
+
+    assert messages == original
+    if expected is None:
+        title.assert_not_called()
+    else:
+        assert title.call_args.args[2] == expected
+        assert title.call_args.kwargs["conversation_history"] is messages
+
+
+@pytest.mark.parametrize("text, titleable", [("/help", True), ("[CONTEXT COMPACTION] synthetic handoff", False)])
+def test_title_override_preserves_existing_control_message_eligibility(monkeypatch, text, titleable):
+    agent = SimpleNamespace(_session_db=Mock(), session_id="test", _session_db_created=True)
+    start = Mock()
+    monkeypatch.setattr("agent.title_generator.threading", SimpleNamespace(Thread=start))
+
+    _maybe_title_session_at_turn_start(agent, [{"role": "user", "content": "injected context"}], text)
+
+    assert start.called is titleable
+
+
+@pytest.mark.parametrize("platform", ["cron", "subagent", "CRON"])
+def test_title_override_cannot_enable_titling_for_machine_runs(monkeypatch, platform):
+    agent = SimpleNamespace(_session_db=Mock(), session_id="test", platform=platform)
+    title = Mock()
+    monkeypatch.setattr("agent.title_generator.maybe_auto_title", title)
+
+    _maybe_title_session_at_turn_start(agent, [], "Actual question")
+
+    title.assert_not_called()

--- a/tests/gateway/test_auto_skill_title_input.py
+++ b/tests/gateway/test_auto_skill_title_input.py
@@ -1,0 +1,141 @@
+"""Title input is user intent, not the gateway's model-facing skill payload."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent import title_generator
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionEntry
+from gateway.turn_context import TurnContext
+from run_agent import AIAgent
+
+
+class _TurnObserved(BaseException):
+    """Stop after the real prologue, before any main-model network request."""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("skills", [[], "alpha", ["alpha"], ["alpha", "beta"]])
+async def test_gateway_titles_original_request_without_changing_model_input(tmp_path, monkeypatch, skills):
+    question = "Why does my connection pool exhaust after a deployment?"
+    names = [skills] if isinstance(skills, str) else skills
+    payloads = {name: f"# {name}\n" + (f"Follow {name} procedures.\n" * 100) for name in names}
+    monkeypatch.setattr("agent.skill_commands._load_skill_payload", lambda name, **kw: (
+        {"name": name, "content": payloads[name]}, tmp_path / name, name,
+    ))
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
+    source = SessionSource(platform=Platform.DISCORD, chat_id="channel", user_id="user", user_name="Example")
+    event = MessageEvent(text=question, source=source, auto_skill=skills,
+                         channel_context="[Discord channel context: synthetic metadata]")
+    entry = SessionEntry(session_id="title-test", session_key="discord:title-test",
+                         created_at=datetime(2026, 1, 1), updated_at=datetime(2026, 1, 1))
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.adapters = {}
+    runner._get_proxy_url = lambda: None
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    runner._hmwa_resolve_session = AsyncMock(return_value=(source, entry, entry.session_key))
+    runner._hmwa_open_session = AsyncMock(return_value=(False, True))
+    runner._set_session_env = lambda context: {}
+    runner._clear_session_env = lambda tokens: None
+    runner._pinned_session_context_prompt = lambda *args: ""
+    runner._hmwa_acquire_turn_lease = AsyncMock()
+    runner._mark_durable_active_turn = AsyncMock()
+    runner.session_store = object()
+    runner._async_session_store = SimpleNamespace(_store=runner.session_store, load_transcript=AsyncMock(return_value=[]))
+    runner._hmwa_run_session_hygiene = AsyncMock(return_value=[])
+    runner._hmwa_first_contact_notes = AsyncMock()
+    runner._voice_channel_sidecar_note = lambda *args: None
+    runner._consume_pending_native_image_paths = lambda key: []
+    runner._adapter_for_source = lambda source: None
+    runner._bind_adapter_run_generation = lambda *args: None
+    async def propagate_error(exc, *args):
+        raise exc
+    runner._hmwa_agent_error_reply = propagate_error
+
+    from hermes_state import SessionDB
+    db = SessionDB(tmp_path / "state.db")
+    agent = AIAgent(session_db=db, model="test-model", api_key="test-key", base_url="http://127.0.0.1:1/v1",
+                    platform="discord", session_id=entry.session_id, enabled_toolsets=[],
+                    quiet_mode=True, skip_memory=True, skip_context_files=True)
+    agent.compression_enabled = False
+    title_inputs, title_requests, model_inputs = [], [], []
+
+    def title_request(**kwargs):
+        title_requests.append(kwargs["messages"][-1]["content"])
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content='{"title": "Diagnose connection pool exhaustion"}'))])
+
+    def title_at_turn_start(db, sid, text, **kwargs):
+        title_inputs.append(text)
+        title_generator.generate_title(text)
+
+    monkeypatch.setattr(title_generator, "maybe_auto_title", title_at_turn_start)
+    monkeypatch.setattr(title_generator, "call_llm", title_request)
+
+    def observe_model(agent, messages):
+        model_inputs.append(messages[-1]["content"])
+        raise _TurnObserved
+
+    monkeypatch.setattr("agent.conversation_loop.begin_iteration", observe_model)
+
+    defaults = TurnContext()
+    display = SimpleNamespace(**{name: getattr(defaults, name) for name in runner._DISPLAY_TO_TURN_CTX})
+    display.platform_key = "discord"
+    display.resolve_display_setting = lambda *args: False
+    runner._run_agent_display_settings = lambda source: display
+
+    def run_without_delivery(ctx, worker, *args):
+        # Execute at the existing wiring seam: real _run_agent_inner/context/agent
+        # forwarding, without starting the executor or platform delivery tasks.
+        worker._native_image_run_message = lambda: ctx.message
+        worker._run_conversation_with_approval(agent, [], None, ctx.persist_user_message, ctx.persist_user_timestamp)
+
+    runner._run_agent_bind_turn_wiring = run_without_delivery
+    runner._run_agent = runner._run_agent_inner
+    try:
+        with pytest.raises(_TurnObserved):
+            await runner._handle_message_with_agent(event, source, entry.session_key, 1)
+        assert title_inputs == [question]
+        assert title_requests == [question]
+        # Both independent per-turn carriers must survive the gateway/facade/loop
+        # handoff: title text must not displace upstream memory author attribution.
+        assert agent._turn_author == {"id": "user", "name": "Example", "is_bot": False}
+        assert question in model_inputs[0]
+        for payload in payloads.values():
+            assert payload in model_inputs[0]
+        if skills:
+            assert model_inputs[0].index(question) > title_generator.MAX_TITLE_INPUT_CHARS
+        stored = [row["content"] for row in db.get_messages(entry.session_id) if row["role"] == "user"]
+        assert stored and question in stored[0]
+        for payload in payloads.values():
+            assert payload in stored[0]
+        # The ordinary Discord metadata is still model-facing, too.
+        assert model_inputs[0] != question
+        # The cached agent must not reuse this title override on a later caller
+        # that does not supply one.
+        with pytest.raises(_TurnObserved):
+            agent.run_conversation("Explain transaction isolation")
+        assert title_inputs[-1] == "Explain transaction isolation"
+        assert title_requests[-1] == "Explain transaction isolation"
+        # Relay metadata belongs to upstream's facade, while title input belongs
+        # to the conversation prologue. Both must survive the same admission.
+        from agent import relay_runtime
+        from unittest.mock import Mock
+        begin_turn = Mock(wraps=relay_runtime.SESSION_COORDINATOR.begin_turn)
+        monkeypatch.setattr(relay_runtime.SESSION_COORDINATOR, "begin_turn", begin_turn)
+        metadata = {"source": "title-regression"}
+        with pytest.raises(_TurnObserved):
+            agent.run_conversation("Enriched relay request", relay_metadata=metadata,
+                                   title_user_message="Original relay request")
+        assert begin_turn.call_args.kwargs["metadata"] is metadata
+        assert title_inputs[-1] == "Original relay request"
+        assert model_inputs[-1] == "Enriched relay request"
+    finally:
+        agent.close()
+        db.close()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1330,6 +1330,12 @@ If you do not want Hermes to auto-generate titles after the first exchange, set
 `auxiliary.title_generation.enabled: false`. Manual titles still work through
 `/title` and `hermes sessions rename`.
 
+In the local messaging gateway, text messages supply their original request to
+session titling, before channel-bound skills and platform context are added.
+The main model and conversation history still retain the full skill content.
+Attachment-only turns retain the existing enriched-message title fallback.
+This affects new title generation; it does not repair previously named sessions.
+
 ### Stream-only endpoints
 
 Some OpenAI-compatible endpoints reject non-streaming chat requests outright (e.g. Tencent Copilot returns HTTP 400 `"Non-stream chat request is currently not supported"`). Interactive chat already streams, but auxiliary tasks (title generation, compression, vision) use non-streaming calls and would fail on every attempt. Hermes always treats `copilot.tencent.com` as stream-only; for any other such endpoint, list a URL substring under `auxiliary.stream_only_base_urls`:


### PR DESCRIPTION
## Summary

Preserve the original text of a local gateway request for session titling before
auto-loaded skills and platform metadata are injected. Carry an optional
`title_user_message` through the existing turn contexts and agent entrypoint;
only the title consumer uses it. Main-model input and persisted conversation
content keep the full skills unchanged.

This avoids arbitrary parsing/stripping of skill documents and does not change
title models, truncation limits or Discord rename mechanics. The existing
eligibility and instant-title functions now receive the same original user text
as the model-backed title generator; their rules are unchanged. A text caption
is used on caption-plus-attachment turns; attachment-only local turns retain
the existing fallback. An explicit empty override suppresses titling for that
turn. The value is per-call, not mutable state on a cached agent.

## Reproduction

1. Configure a Discord channel with automatic threads/title renaming and one or
   more `channel_skill_bindings` pointing at synthetic skills with more than
   1,000 characters of instructions.
2. Start a new session with an ordinary question, e.g.
   `Why does my connection pool exhaust after a deployment?`
3. Before this change, the gateway prepends those skills and Discord context to
   the question. The title generator receives that expanded message and its
   1,000-character input window does not contain the actual question. The title
   therefore tends to describe the skills rather than the request.
4. After this change, the auxiliary title request receives the question while
   the main model and persisted history still contain all skill bodies.

## Related work

Refs #48359, specifically its existing Discord gateway reproduction:
https://github.com/NousResearch/hermes-agent/issues/48359#issuecomment-5520444985

#4946 identified the same root cause at older call sites; this is an independent
implementation against the current split turn-start pipeline, not an import of
that patch. #71843 covers explicit slash-skill invocation, and #48380 targets
the Desktop/ACP path. Neither covers this local gateway auto-loading boundary.
This PR does not claim to close every surface of #48359.

## Verification

- Deterministic unchanged-upstream RED: all four gateway regression variants fail
  at the real title-input assertion (ordinary Discord metadata, scalar binding,
  one binding and multiple long bindings).
- Canonical focused run: **108 passed across 10 files**, exit 0, with no file retries.
- Tests exercise gateway preparation, local worker/context forwarding and the
  real agent turn-start path into the auxiliary title request. They verify full
  skill content in the model-facing message and persisted history, fallback and
  control-message eligibility, excluded machine platforms, and no stale override
  on subsequent use of the same agent.
- Ruff critical correctness checks and `git diff --check` passed.
- Full canonical run (`bash scripts/run_tests.sh -j 4 --file-retries 0`):
  **46,363 passed, 23 failed, 434 skipped** across 3,881 files. This is not a
  green full-suite claim. All 23 failing IDs have unchanged-base attribution:
  22 reproduce directly on the upstream base in the same isolated environment;
  the concurrent-close/WAL timing assertion also reproduces on unchanged base
  and candidate under the same controlled schedule. No unexplained failed ID
  remains in this run. The timing probe does not reconstruct the original run's
  exact scheduling and is not counted as a passing test.
- Independent read-only review of the frozen candidate passed.

No live Discord messages or model calls are needed for these synthetic tests.
Remote proxy/ACP title protocols and previously generated titles are out of scope.
