### PR TITLE
fix: context metadata provenance and LiteLLM discovery

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -967,12 +967,55 @@ def _resolve_endpoint_context_length(model: str, base_url: str, api_key: str = "
     """Resolve context length from an endpoint's live ``/models`` metadata."""
     endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
     matched = endpoint_metadata.get(model)
-    if not matched and len(endpoint_metadata) == 1:
-        matched = next(iter(endpoint_metadata.values()))
-    elif not matched and model:  # substring match; "" would match EVERY key and poison the window
-        matched = next((entry for key, entry in endpoint_metadata.items() if model in key or key in model), None)
-    context_length = matched.get("context_length") if matched else None
-    return context_length if isinstance(context_length, int) else None
+    if not matched:
+        if len(endpoint_metadata) == 1:
+            matched = next(iter(endpoint_metadata.values()))
+        elif model:
+            # Substring fuzzy match — only meaningful with a non-empty model
+            # name.  An empty string is a substring of EVERY key, which would
+            # "match" whatever model the endpoint happens to list first (e.g.
+            # a 32K embedding model on the Nous portal) and poison the
+            # resolved context length for the whole agent.
+            for key, entry in endpoint_metadata.items():
+                if model in key or key in model:
+                    matched = entry
+                    break
+    if matched:
+        context_length = matched.get("context_length")
+        if isinstance(context_length, int):
+            return context_length
+    # LiteLLM's OpenAI listing may omit cost-map metadata. Only query after
+    # exact membership in the authenticated listing; never fuzzy-authorize.
+    if model in endpoint_metadata:
+        return _query_litellm_model_info(model, base_url, api_key)
+    return None
+
+
+def _query_litellm_model_info(model: str, base_url: str, api_key: str) -> Optional[int]:
+    try:
+        _ensure_requests()
+        base = base_url.rstrip("/")
+        if base.endswith("/v1"):
+            base = base[:-3]
+        headers = {"Authorization": "Bearer " + api_key} if api_key else {}
+        response = requests.get(base + "/model/info", headers=headers,
+                                timeout=(5, 10), verify=_resolve_requests_verify(base_url))
+        try:
+            response.raise_for_status()
+            limits = []
+            for entry in response.json().get("data", []):
+                if entry.get("model_name") != model:
+                    continue
+                value = entry.get("model_info", {}).get("max_input_tokens")
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    limits.append(value)
+            # Advertise the largest route capacity; LiteLLM's enabled pre-call
+            # checks must exclude smaller deployments for that request.
+            return max(limits) if limits else None
+        finally:
+            response.close()
+    except Exception:
+        return None
 
 
 def _get_context_cache_path() -> Path:
@@ -1013,14 +1056,58 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
         return
     key = _context_cache_key(model, base_url)
     cache = _load_context_cache()
-    if cache.get(key) == length:
-        return  # already stored
     cache[key] = length
     try:
-        _write_context_cache(cache)
+        path = _get_context_cache_path()
+        # Atomic write (temp file + fsync + os.replace): a plain truncating
+        # ``open(path, "w")`` leaves the file empty/partial if the process is
+        # killed mid-dump, and the next _load_context_cache() swallows the
+        # resulting YAML error and returns {} — silently wiping EVERY cached
+        # context length. It also exposes torn reads to a concurrent process
+        # reading between truncate and dump-complete.
+        try:
+            old = yaml.safe_load(path.read_text()) or {}
+            observed = old.get("observed_at", {})
+        except Exception:
+            observed = {}
+        observed[key] = time.time()
+        atomic_yaml_write(path, {"context_lengths": cache, "observed_at": observed})
         logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
     except Exception as e:
         logger.debug("Failed to save context length cache: %s", e)
+
+
+def _context_cache_is_fresh(model: str, base_url: str) -> bool:
+    """Legacy caches lack provenance; never treat them as fresh metadata."""
+    try:
+        data = yaml.safe_load(_get_context_cache_path().read_text()) or {}
+        at = data.get("observed_at", {}).get(_context_cache_key(model, base_url))
+        return isinstance(at, (int, float)) and 0 <= time.time() - at < 3600
+    except Exception:
+        return False
+
+
+def _bedrock_catalog_input_limit(model: str) -> Optional[int]:
+    """Input budget is separate from total context; never reserve output twice.
+
+    Prefer the explicit provider input cap when available, otherwise its context.
+    No network in this hot path: picker/catalog refresh owns catalog fetching.
+    """
+    try:
+        from agent.models_dev import fetch_models_dev
+        data = fetch_models_dev(allow_network=False)
+        models = data.get("amazon-bedrock", {}).get("models", {})
+        entry = models.get(model)
+        if not entry:
+            bare = re.sub(r"^(global|us|eu|apac)\.", "", model)
+            entry = models.get(bare)
+        limits = (entry or {}).get("limit", {})
+        value = limits.get("input") or limits.get("context")
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+    except Exception:
+        pass
+    return None
 
 
 def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
@@ -1694,7 +1781,7 @@ def _resolve_bedrock_context_length(model: str, base_url: str) -> Optional[int]:
         return None  # boto3 not installed — fall through to generic resolution
     cache_key_url = base_url or "bedrock://"
     cached = get_cached_context_length(model, cache_key_url)
-    if cached is not None:
+    if cached is not None and _context_cache_is_fresh(model, cache_key_url):
         return cached
     # Region from the base_url host first, then the standard AWS chain. An empty region disables probing (table only).
     _m = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url) if base_url else None
@@ -1702,11 +1789,12 @@ def _resolve_bedrock_context_length(model: str, base_url: str) -> Optional[int]:
     if not region:
         with contextlib.suppress(Exception):
             region = resolve_bedrock_region()
-    ctx = get_bedrock_context_length(model, region=region, probe=bool(region))
-    # Only persist probe-derived values (region present); a pure table fallback must not poison the cache.
-    if ctx and region:
+    from agent.bedrock_adapter import probe_bedrock_context_length
+    ctx = probe_bedrock_context_length(model, region) if region else None
+    if ctx:
         save_context_length(model, cache_key_url, ctx)
-    return ctx
+        return ctx
+    return get_bedrock_context_length(model, region=region, probe=False)
 
 
 def _resolve_custom_endpoint_context_length(model: str, base_url: str, api_key: str, provider: str) -> int:
@@ -1887,8 +1975,18 @@ def get_model_context_length(
     is_bedrock_context = provider == "bedrock" or (
         base_url and base_url_hostname(base_url).startswith("bedrock-runtime.") and base_url_host_matches(base_url, "amazonaws.com")
     )
+    if is_bedrock_context:
+        catalog_limit = _bedrock_catalog_input_limit(model)
+        if catalog_limit:
+            return catalog_limit
+
     # 1. Persistent cache (LM Studio / Codex OAuth excluded — see _skip_persistent_context_cache).
     cached = get_cached_context_length(model, base_url) if base_url and not _skip_persistent_context_cache(base_url, provider) else None
+    if (cached is not None and cached > 0
+            and (is_bedrock_context or provider in {"custom", "litellm"})
+            and not is_local_endpoint(base_url)
+            and not _context_cache_is_fresh(model, base_url)):
+        cached = None
     validated = _validate_cached_context_length(model, base_url, cached, is_bedrock_context, api_key=api_key) if cached is not None else None
     if validated is not None:
         return validated

--- a/tests/test_provider_metadata_provenance.py
+++ b/tests/test_provider_metadata_provenance.py
@@ -1,0 +1,56 @@
+import tempfile,pathlib,time
+from unittest.mock import patch,Mock
+import pytest,yaml
+import agent.model_metadata as m
+import agent.bedrock_adapter as b
+
+@pytest.fixture
+def home(monkeypatch):
+ with tempfile.TemporaryDirectory() as d:
+  monkeypatch.setattr(m,'_get_context_cache_path',lambda:pathlib.Path(d)/'cache.yaml')
+  monkeypatch.setattr(m,'_bedrock_catalog_input_limit',lambda model:None)
+  yield pathlib.Path(d)/'cache.yaml'
+
+def test_failed_probe_not_cached(home):
+ with patch.object(b,'probe_bedrock_context_length',return_value=None) as probe,patch.object(b,'resolve_bedrock_region',return_value='eu-central-1'):
+  assert m.get_model_context_length('not-a-known-model',provider='bedrock')==128000
+  assert not home.exists()
+
+def test_success_probe_cached(home):
+ with patch.object(b,'probe_bedrock_context_length',return_value=500000) as probe,patch.object(b,'resolve_bedrock_region',return_value='eu-central-1'):
+  assert m.get_model_context_length('not-a-known-model',provider='bedrock')==500000
+  assert m.get_model_context_length('not-a-known-model',provider='bedrock')==500000
+  assert probe.call_count==1
+
+def test_catalog_precedes_hand_cache(home):
+ m.save_context_length('new-model','bedrock://',128000)
+ with patch.object(m,'_bedrock_catalog_input_limit',return_value=922000),patch.object(b,'probe_bedrock_context_length') as probe:
+  assert m.get_model_context_length('new-model',provider='bedrock')==922000
+  probe.assert_not_called()
+
+def test_legacy_stale(home):
+ home.write_text(yaml.safe_dump({'context_lengths':{'x@https://x/v1':100}}))
+ assert not m._context_cache_is_fresh('x','https://x/v1')
+
+def test_ttl(home):
+ m.save_context_length('x','https://x/v1',100)
+ assert m._context_cache_is_fresh('x','https://x/v1')
+ with patch.object(m.time,'time',return_value=time.time()+3601):assert not m._context_cache_is_fresh('x','https://x/v1')
+
+def test_info_exact_membership():
+ with patch.object(m,'fetch_endpoint_model_metadata',return_value={'known':{'name':'known'}}),patch.object(m,'_query_litellm_model_info',return_value=1000000) as info:
+  assert m._resolve_endpoint_context_length('known','https://x/v1','key')==1000000
+  assert m._resolve_endpoint_context_length('unknown','https://x/v1','key') is None
+  assert info.call_count==1
+
+def test_info_auth_and_max():
+ m._ensure_requests();r=Mock();r.json.return_value={'data':[{'model_name':'x','model_info':{'max_input_tokens':524288}},{'model_name':'x','model_info':{'max_input_tokens':229376}},{'model_name':'other','model_info':{'max_input_tokens':99999999}}]}
+ with patch.object(m.requests,'get',return_value=r) as get:
+  assert m._query_litellm_model_info('x','https://x/v1','secret')==524288
+  assert get.call_args.kwargs['headers']=={'Authorization':'Bearer secret'}
+  assert get.call_args.args[0]=='https://x/model/info'
+  r.close.assert_called_once()
+
+def test_config_override_keeps_precedence(home):
+ with patch.object(m,'_bedrock_catalog_input_limit',return_value=922000):
+  assert m.get_model_context_length('x',provider='bedrock',config_context_length=200000)==200000


### PR DESCRIPTION
## Problem
Bedrock context detection persists a static fallback when a live probe returns no parsed limit; a configured region is mistaken for provenance. Permanent custom-provider caches mask later metadata changes. LiteLLM /models may omit limits available via authenticated /model/info.

## Changes
Prefer explicit Bedrock catalog input cap (otherwise context), keep request-output budgets unchanged; persist only successful probes; bound relevant persisted caches to one hour, legacy entries stale; exact-membership /model/info fallback.

## Validation
283 targeted tests passed on upstream main e74c4a00. Live checks on installed-base port: eight gateway groups have matching cold/warm values; direct Bedrock catalog resolves without oversized generation probes.

Draft for review: input budget versus total context representation remains intentionally conservative; production port is minimal and separate from the main-based branch. No site-specific endpoints, model lists, or credentials in patch.