### PR TITLE
fix(cron): a killed manual run no longer blocks the next one for 5 minutes (dead-owner fire_claim reclaim)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2062,13 +2062,35 @@ def trigger_job(job_id: str, extra_prompt: Optional[str] = None) -> Optional[Dic
     })
 
 
+def _claim_owner_is_dead(claim: Dict[str, Any]) -> bool:
+    """True when the claim's ``by`` names a process on THIS host that provably no longer exists.
+    ``_machine_id()`` stamps ``host:pid[:token]``; a foreign host, an explicit HERMES_MACHINE_ID,
+    or any liveness-probe failure returns False (fail safe: only a proven death shortens the TTL)."""
+    parts = str(claim.get("by") or "").split(":")
+    if len(parts) < 2 or not parts[1].isdigit():
+        return False
+    try:
+        import socket
+        if parts[0] != socket.gethostname():
+            return False
+        from gateway.status import _pid_exists
+        return not _pid_exists(int(parts[1]))
+    except Exception:
+        return False
+
+
 def _claim_is_live(claim: Any, now: datetime, ttl_seconds: float) -> bool:
-    """True for a well-formed claim aged within ``[0, ttl)``: future-dated (clock/TZ skew) or
-    malformed claims count as stale so they can never wedge a job."""
+    """True for a well-formed claim aged within ``[0, ttl)`` whose owner is not provably dead:
+    future-dated (clock/TZ skew) or malformed claims count as stale so they can never wedge a
+    job, and a same-host owner pid that has exited releases the claim immediately instead of
+    after the TTL (a killed ``hermes cron run`` otherwise blocks the next manual run for the
+    full window with "already being fired")."""
     if not isinstance(claim, dict) or not claim.get("at"):
         return False
     claimed_at = _parse_aware(claim["at"])
-    return claimed_at is not None and 0 <= (now - claimed_at).total_seconds() < ttl_seconds
+    if claimed_at is None or not (0 <= (now - claimed_at).total_seconds() < ttl_seconds):
+        return False
+    return not _claim_owner_is_dead(claim)
 
 
 _REARM_RECURRING_ERROR = (

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -294,3 +294,34 @@ def test_manual_claim_still_refuses_a_paused_job(temp_home):
 
     assert claim_job_for_fire(job["id"], manual=True) is False
     assert get_job(job["id"]).get("paused_at") is not None
+
+
+def test_fresh_claim_from_a_dead_same_host_owner_is_reclaimable(temp_home):
+    """A claim younger than the TTL whose owner pid (same host) has exited is stale at once: a
+    ``hermes cron run`` killed mid-flight must not block the next manual run for the whole TTL
+    with "already being fired". A live owner's fresh claim still blocks."""
+    import os
+    import socket
+    import subprocess
+    import sys
+
+    from cron.jobs import claim_job_for_fire, create_job, load_jobs, save_jobs
+
+    jid = create_job(prompt="x", schedule="every 5m", name="s")["id"]
+    assert claim_job_for_fire(jid) is True
+
+    # Live same-host owner (this process) → still blocked.
+    jobs = load_jobs()
+    job = next(j for j in jobs if j["id"] == jid)
+    job["fire_claim"]["by"] = f"{socket.gethostname()}:{os.getpid()}:tok"
+    save_jobs(jobs)
+    assert claim_job_for_fire(jid) is False
+
+    # Owner that has provably exited → reclaimable despite the fresh timestamp.
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait()
+    jobs = load_jobs()
+    job = next(j for j in jobs if j["id"] == jid)
+    job["fire_claim"]["by"] = f"{socket.gethostname()}:{child.pid}:tok"
+    save_jobs(jobs)
+    assert claim_job_for_fire(jid) is True


### PR DESCRIPTION
A `hermes cron run` (or scheduler tick) that dies mid-flight no longer blocks the next manual run for the full 5-minute claim TTL: a `fire_claim` whose same-host owner pid has exited is treated as stale immediately.

## Symptom

- Kill a `hermes cron run <id>` mid-run (timeout, Ctrl-C, OOM). The job record keeps a `fire_claim` stamped `host:pid:token`.
- Every `hermes cron run <id>` / `cronjob run` in the next 5 minutes fails with **"Job is already being fired by the scheduler; not run again."** even though nothing is running.
- Seen live 2026-09-09 during the post-outage catch-up on Teknium's box: two killed manual runs of `openhands-pr-scout` each left a dead-pid claim; retries were refused until the claim was cleared by hand.

## Change (+56/−3, `cron/jobs.py` + 1 test)

- `_claim_is_live()` now also consults a new `_claim_owner_is_dead()`: when the claim's `by` parses as `<this-host>:<pid>[:token]` and `gateway.status._pid_exists(pid)` is False, the claim is stale regardless of age.
- Fail safe by construction: foreign host, explicit `HERMES_MACHINE_ID` (no pid), or any probe exception → unchanged TTL behaviour.
- Mirrors what the executions table already does for its rows (`cron/executions.py::_owner_is_live`, #86721); the job-record claim was the one lease without dead-owner reclaim.

| | Before | After |
|---|---|---|
| Owner pid gone, claim 30 s old | refused for up to 5 min | reclaimed at once |
| Owner alive, claim 30 s old | refused | refused |
| Claim from another host, pid gone | refused (TTL) | refused (TTL) |
| Claim > TTL | reclaimed | reclaimed |

## Validation

- **Live repro:** new invariant test `test_fresh_claim_from_a_dead_same_host_owner_is_reclaimable` RED on base (`assert claim_job_for_fire(jid) is True` fails on the dead-owner step), GREEN on branch.
- `scripts/run_tests.sh tests/cron/ tests/tools/test_cronjob*.py` → 105 files, 1347 passed, 0 failed.
- E2E (real store in a temp `HERMES_HOME`, real exited child pid, through `tools.cronjob_tools._claim_for_manual_run`): dead owner → claimed; live owner (this pid) → "already being fired"; foreign host with dead pid → still blocked.
- ruff, windows-footguns, compat-pointers, `git diff --check` clean.

## Infographic

![Cron fire claim: dead owner releases at once](https://v3b.fal.media/files/b/0aa9c162/GroLlR-gb2yaQkisuNRkY_iWbghrFn.png)
