### PR TITLE
fix(bedrock): give bedrock_converse an iteration-limit summary builder

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2095,7 +2095,38 @@ def _chat_summary_attempt(agent, api_messages: list, api_request_id: str):
     return _attempt
 
 
-_SUMMARY_ATTEMPT_BUILDERS = {"codex_responses": _codex_summary_attempt, "anthropic_messages": _anthropic_summary_attempt}
+def _bedrock_summary_no_client(reason, kind="openai"):
+    """``make_client`` for the bedrock summary dispatch — never invoked. The ``bedrock_converse``
+    branch of ``_dispatch_nonstreaming_api_request`` calls ``_bedrock_converse_call`` and owns its own
+    boto3 client. Raise rather than return None so a refactor that does start calling it here fails
+    loudly instead of handing None to an SDK."""
+    raise AssertionError(
+        f"bedrock summary dispatch asked for a {kind!r} client (reason={reason!r}); "
+        "bedrock_converse owns its own boto3 client")
+
+
+def _bedrock_summary_attempt(agent, api_messages: list, api_request_id: str):
+    """Summary over Converse — the api_mode this table used to omit, which sent Bedrock sessions to
+    ``_chat_summary_attempt`` and its opening ``_ensure_primary_openai_client()``. With no OpenAI
+    client that raised and ``handle_max_iterations``'s ``except Exception`` turned it into the
+    "couldn't summarize" string; with one configured it was worse — a chat.completions request
+    carrying the whole conversation, addressed to ``agent.base_url`` with a Bedrock ``modelId``.
+    Dispatching through ``_dispatch_nonstreaming_api_request`` keeps per-api_mode routing in the one
+    place that helper promises and inherits its cachePoint-rejection and stale-connection recovery;
+    ``tools_for_api=[]`` suppresses ``toolConfig``, mirroring the ``pop("tools")`` in the codex
+    builder above, because the summary prompt tells the model not to call more tools."""
+    def _attempt(retry_count: int) -> str:
+        bedrock_kwargs = agent._build_api_kwargs(api_messages, tools_for_api=[])
+        response = _managed_summary_call(
+            agent, api_request_id, bedrock_kwargs,
+            lambda request: _dispatch_nonstreaming_api_request(agent, request, make_client=_bedrock_summary_no_client),
+            retry_count=retry_count)
+        return _summary_text(agent, response)
+    return _attempt
+
+
+_SUMMARY_ATTEMPT_BUILDERS = {"codex_responses": _codex_summary_attempt, "anthropic_messages": _anthropic_summary_attempt,
+                             "bedrock_converse": _bedrock_summary_attempt}
 
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:

--- a/tests/agent/test_bedrock_iteration_limit_summary.py
+++ b/tests/agent/test_bedrock_iteration_limit_summary.py
@@ -1,0 +1,161 @@
+"""Iteration-limit summary must work on api_mode='bedrock_converse'.
+
+``_SUMMARY_ATTEMPT_BUILDERS`` named ``codex_responses`` and ``anthropic_messages`` and nothing
+else, so ``bedrock_converse`` fell through to ``_chat_summary_attempt``, which opens with
+``_ensure_primary_openai_client()``. A Bedrock session has no OpenAI credentials, so that raised,
+the wrapping ``except Exception`` in ``handle_max_iterations`` swallowed it, and the user got
+
+    I reached the maximum iterations (N) but couldn't summarize. Error: ...
+
+instead of a summary — every single time the iteration limit was hit. These tests drive the real
+``BedrockTransport`` and the real ``normalize_converse_response`` so they cover the actual wiring
+(kwargs shape, sentinel keys, response normalization), stubbing only the boto3 client.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _converse_reply(text):
+    """A minimal but real-shaped ``bedrock-runtime.converse()`` response."""
+    return {
+        "output": {"message": {"role": "assistant", "content": [{"text": text}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 11, "outputTokens": 3, "totalTokens": 14},
+    }
+
+
+class _FakeBedrockClient:
+    """Records every ``converse()`` call and replies from a scripted list."""
+
+    def __init__(self, *replies):
+        self.replies = list(replies)
+        self.calls = []
+
+    def converse(self, **kwargs):
+        self.calls.append(kwargs)
+        if len(self.calls) <= len(self.replies):
+            return self.replies[len(self.calls) - 1]
+        return self.replies[-1]
+
+
+@pytest.fixture
+def bedrock_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        # Unroutable on purpose. Post-fix nothing here leaves the process, but the PRE-fix path
+        # really did reach agent.base_url over the network — that is the defect this file exists
+        # for. Port 9 (discard) refuses instantly, so the demonstration that these tests fail
+        # without the fix stays deterministic and offline instead of depending on a real endpoint.
+        base_url="http://127.0.0.1:9/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cached_system_prompt = "SYS"
+    agent.api_mode = "bedrock_converse"
+    agent.model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    agent._bedrock_region = "us-east-2"
+    return agent
+
+
+def _run(agent, client, messages=None):
+    """Drive handle_max_iterations with a stubbed bedrock runtime client."""
+    from agent.chat_completion_helpers import handle_max_iterations
+    from agent.transports.bedrock import BedrockTransport
+
+    if messages is None:
+        messages = [{"role": "user", "content": "q1"}, {"role": "assistant", "content": "a1"}]
+    with patch.object(agent, "_get_transport", return_value=BedrockTransport()), \
+         patch("agent.bedrock_adapter._get_bedrock_runtime_client", return_value=client):
+        return handle_max_iterations(agent, messages, 5), messages
+
+
+class TestBedrockIterationLimitSummary:
+    def test_summary_is_produced_over_converse(self, bedrock_agent):
+        """The regression: a Bedrock session gets a real summary, not the 'couldn't summarize'
+        error string."""
+        client = _FakeBedrockClient(_converse_reply("SUMMARY"))
+        out, _ = _run(bedrock_agent, client)
+
+        assert out == "SUMMARY"
+        assert "couldn't summarize" not in out
+        assert len(client.calls) == 1
+
+    def test_no_openai_client_is_ever_built(self, bedrock_agent):
+        """The pre-fix path did not merely fail — it built an OpenAI-wire request carrying the
+        whole conversation and addressed it to ``agent.base_url`` with a Bedrock modelId, i.e. it
+        sent a Bedrock user's conversation to a non-Bedrock endpoint. Make touching that client
+        fatal rather than merely unused."""
+        client = _FakeBedrockClient(_converse_reply("SUMMARY"))
+
+        def _boom(*a, **kw):
+            raise AssertionError("bedrock summary must not build an OpenAI client")
+
+        with patch.object(bedrock_agent, "_ensure_primary_openai_client", side_effect=_boom):
+            out, _ = _run(bedrock_agent, client)
+
+        assert out == "SUMMARY"
+
+    def test_converse_kwargs_are_well_formed(self, bedrock_agent):
+        """The dispatch must receive transport-built kwargs and strip both sentinel keys before
+        they reach boto3, which rejects unknown params."""
+        client = _FakeBedrockClient(_converse_reply("SUMMARY"))
+        _run(bedrock_agent, client)
+
+        sent = client.calls[0]
+        assert sent["modelId"] == bedrock_agent.model
+        assert "__bedrock_converse__" not in sent
+        assert "__bedrock_region__" not in sent
+        # Converse takes the system prompt in its own top-level field, never as role='system'.
+        assert all(m["role"] != "system" for m in sent["messages"])
+
+    def test_summary_offers_no_tools(self, bedrock_agent):
+        """The summary prompt says 'without calling any more tools' — sending toolConfig invites
+        the model to do exactly that."""
+        bedrock_agent.tools = [{
+            "type": "function",
+            "function": {
+                "name": "read_file", "description": "read a file",
+                "parameters": {"type": "object", "properties": {"path": {"type": "string"}}},
+            },
+        }]
+        client = _FakeBedrockClient(_converse_reply("SUMMARY"))
+        _run(bedrock_agent, client)
+
+        assert "toolConfig" not in client.calls[0]
+
+    def test_empty_first_reply_falls_through_to_the_retry_path(self, bedrock_agent):
+        """Bedrock needs the branch in *both* paths: an empty summary retries once, and that retry
+        must not land on the OpenAI branch either."""
+        client = _FakeBedrockClient(_converse_reply(""), _converse_reply("SECOND-TRY"))
+
+        def _boom(*a, **kw):
+            raise AssertionError("bedrock summary retry must not build an OpenAI client")
+
+        with patch.object(bedrock_agent, "_ensure_primary_openai_client", side_effect=_boom):
+            out, _ = _run(bedrock_agent, client)
+
+        assert out == "SECOND-TRY"
+        assert len(client.calls) == 2
+
+    def test_summary_is_appended_to_history(self, bedrock_agent):
+        """A successful summary is the turn's assistant message, so downstream persistence and the
+        next turn's prefix both see it."""
+        client = _FakeBedrockClient(_converse_reply("SUMMARY"))
+        _, messages = _run(bedrock_agent, client)
+
+        assert messages[-1]["role"] == "assistant"
+        assert messages[-1]["content"] == "SUMMARY"
+
+    def test_make_client_hook_is_fatal_not_silent(self):
+        """``_dispatch_nonstreaming_api_request``'s bedrock branch never calls ``make_client``.
+        Pin that contract so a refactor which starts calling it cannot quietly pass None to an
+        SDK."""
+        from agent.chat_completion_helpers import _bedrock_summary_no_client
+
+        with pytest.raises(AssertionError, match="own boto3 client"):
+            _bedrock_summary_no_client("some_reason", kind="openai")


### PR DESCRIPTION
## What does this PR do?

Adds the missing `bedrock_converse` entry to `_SUMMARY_ATTEMPT_BUILDERS` in `agent/chat_completion_helpers.py`, so the iteration-limit summary runs over Converse instead of falling through to the OpenAI-wire path.

The table names `codex_responses` and `anthropic_messages` and nothing else:

```python
_SUMMARY_ATTEMPT_BUILDERS = {"codex_responses": _codex_summary_attempt, "anthropic_messages": _anthropic_summary_attempt}
...
        build_attempt = _SUMMARY_ATTEMPT_BUILDERS.get(agent.api_mode, _chat_summary_attempt)
```

so `bedrock_converse` gets `_chat_summary_attempt`, whose first statement is

```python
        summary_client = agent._ensure_primary_openai_client(reason=...)
```

A Bedrock session has no OpenAI client, so that raises, the wrapping `except Exception` in `handle_max_iterations` swallows it, and the user gets `I reached the maximum iterations (N) but couldn't summarize. Error: ...` — every time the limit is hit.

**The failure mode is worse when the agent does hold OpenAI-compatible credentials**, which is the common setup since a `base_url`/`api_key` pair is usually configured even for Bedrock users. Then that branch does not fail early: it builds a `chat.completions` request carrying the entire conversation, addressed to `agent.base_url`, with a Bedrock `modelId`. A Bedrock user's conversation leaves the process for a non-Bedrock host.

## Related Issue

No issue.

**This replaces my own #98564, which I am closing.** Same fix, same tests, without the refactor. #98564 was `+494/-216` because it also extracted 221 lines out of `chat_completion_helpers.py` into a new `agent/chat_completion_helpers_iteration_limit.py`. That extraction was most of the diff and it was a judgement call, not a requirement — the fix proper is one function, one guard, and one dict key. A reviewer asked to cherry-pick a 710-line-churn change to fix a missing dict entry is being asked for the wrong trade, and in a queue this size that is my problem to fix, not theirs. So: same behaviour, `+193/-1`, no new module, no moved lines.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`agent/chat_completion_helpers.py` `+32/-1` — two functions added immediately after `_chat_summary_attempt`, and `bedrock_converse` added to the table:

- **`_bedrock_summary_attempt`** dispatches through the existing `_dispatch_nonstreaming_api_request` rather than calling `converse()` here, so per-`api_mode` routing stays in the one place that helper's docstring promises, and this path inherits its cachePoint-rejection (#97281) and stale-connection recovery for free. Kwargs come from the existing `agent._build_api_kwargs(api_messages, tools_for_api=[])`, so no `toolConfig` is sent — mirroring `codex_kwargs.pop("tools", None)` in the codex builder three functions up, because the summary prompt tells the model not to call more tools.
- **`_bedrock_summary_no_client`** is the `make_client` argument, and it **raises**. `_dispatch_nonstreaming_api_request`'s bedrock branch is `return _bedrock_converse_call(api_kwargs, stream=False)` — it never calls `make_client`. Raising rather than returning `None` means a future refactor that does start calling it fails loudly instead of handing `None` to an SDK.

Both the initial call and the retry go through the same `attempt` closure `handle_max_iterations` already invokes twice, so they cannot diverge the way two hand-written branches could.

`tests/agent/test_bedrock_iteration_limit_summary.py` `+161/-0` — 7 tests driving the real `BedrockTransport` and the real `normalize_converse_response`, stubbing only the boto3 client.

No signature changes. Every other `api_mode` resolves to exactly the same builder as before.

## How to Test

```bash
pytest tests/agent/test_bedrock_iteration_limit_summary.py -q -p no:randomly
#  -> 7 passed

# against unpatched code
git checkout <base> -- agent/chat_completion_helpers.py
pytest tests/agent/test_bedrock_iteration_limit_summary.py -q -p no:randomly
#  -> 7 failed
```

**Being precise about that 7.** Six are behavioural failures — the summary comes back as the `couldn't summarize` string, or the `_ensure_primary_openai_client` tripwire fires. The seventh, `test_make_client_hook_is_fatal_not_silent`, fails with `ImportError: cannot import name '_bedrock_summary_no_client'`, which only proves the symbol is new. I'd rather say that than present 7/7 as seven reproductions.

The six behavioural failures also emit `Failed to get summary response: Connection error` and `Auxiliary: marking nous unhealthy (payment / credit error)`. That is the second half of the defect showing up as a test artefact: the unpatched path genuinely tries to leave the process. The fixture points `base_url` at `http://127.0.0.1:9/v1` — port 9 is discard, so it refuses instantly and the demonstration stays offline and deterministic. Nothing in this PR's own test run touches the network.

Suites run on this branch:

| suite | result |
|---|---|
| `test_bedrock_iteration_limit_summary.py` | 7 passed |
| `test_bedrock_adapter.py` | 78 passed |
| `test_bedrock_integration.py` | 35 passed |
| `test_api_content_sidecar.py` | 27 passed |
| `test_turn_finalizer_cleanup_guard.py` | 4 passed |
| `test_turn_finalizer_final_response_persistence.py` | 8 passed |
| `test_turn_finalizer_iteration_limit_exit.py` | 9 passed |
| `test_verification_continuation_budget.py` | 7 passed |
| `tests/run_agent/test_run_agent.py` | 1 failed, 283 passed |

Those last eight files are every test in the tree that mentions `handle_max_iterations` or `_SUMMARY_ATTEMPT_BUILDERS`, plus the Bedrock suites. **The one failure is pre-existing**, not caused by this change: `TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client` fails identically on the unmodified base in the same environment — I ran the same file in a clean worktree at the base commit to check rather than assuming.

`ruff check .` passes repo-wide.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — one commit, `fix(bedrock): ...`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — `_SUMMARY_ATTEMPT_BUILDERS` and `handle_max_iterations` return only my own #98564, which this replaces and which I'm closing
- [x] My PR contains **only** changes related to this fix (2 files, 1 commit)
- [ ] I've run `pytest tests/ -q` and all tests pass — no; see below
- [x] I've added tests for my changes — 7, six of which fail behaviourally on base
- [x] I've tested on my platform: Amazon Linux 2023 x86_64, CPython 3.11.14

I did not get a whole-`tests/` run: my box hits collection errors from optional dependencies I don't have (`aiohttp` and the acp/gateway stack), and the remainder exceeds my remote-execution time budget. Rather than tick that box on a number I can't attribute, it stays unticked with the scoped runs above.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the two docstrings are the documentation for this behaviour; no `docs/` change applies
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — N/A, no platform-conditional code
- [x] Tool descriptions/schemas — N/A; the change *removes* tools from one request, which is the point

## Screenshots / Logs

One thing I want to attribute rather than restate as fresh evidence. The claim that the unpatched path actually reaches `agent.base_url` was measured on **2026-08-30** while preparing #98564: with the fixture pointed at a real endpoint, the pre-fix run returned `Error code: 401 - {'error': {'message': 'Missing Authentication header'}}` — i.e. the conversation had left the process for a non-Bedrock host. I have not re-run that against a live endpoint for this PR; the committed fixture deliberately cannot. Today's evidence for that half is the offline `Connection error` above, which shows the attempt but not where it would have landed.

Everything else here was measured against `main` today.
