### PR TITLE
feat(desktop): expose native session splits through plugin SDK

### DIFF
--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -11,6 +11,8 @@
  *     when either is empty.
  *   - `tab` (⌘/⌃-click / ⌘-Enter / session refs) — focus if already on screen,
  *     else open as a stacked session tab (never steals main from under you).
+ *   - `split` — focus if already on screen, else open a native edge split
+ *     beside the focused chat zone (right by default), never spending main.
  *   - `window` (⇧⌘-click) — pop into its own window; falls back to `tab` when
  *     the bridge has no session-window support.
  */
@@ -22,13 +24,14 @@ import {
   focusOpenSession,
   openSessionTile,
   reuseBlankDraftTile,
-  setSessionTileWorkspaceScope
+  setSessionTileWorkspaceScope,
+  type SplitDir
 } from '@/store/session-states'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import { $workspaceIsPage, sessionRoute } from './routes'
 
-export type OpenSessionIntent = 'in-place' | 'main' | 'stack' | 'tab' | 'window'
+export type OpenSessionIntent = 'in-place' | 'main' | 'stack' | 'tab' | 'window' | 'split'
 
 export type OpenSessionNavigate = (to: string, options?: { replace?: boolean }) => void
 
@@ -77,13 +80,14 @@ export function openSessionIntentFromModifiers(
 
 /**
  * @param navigate Required for `in-place` (route into main when not on screen).
- *   `tab` / `window` ignore it — pass a no-op when you don't have a router handle.
+ *   `tab` / `split` / `window` ignore it — pass a no-op when you don't have a router handle.
  */
 export function openSession(
   storedSessionId: string,
   navigate: OpenSessionNavigate,
   intent: OpenSessionIntent = 'in-place',
-  workspaceScope: OpenSessionWorkspaceScope = { workspaceMode: 'sessions' }
+  workspaceScope: OpenSessionWorkspaceScope = { workspaceMode: 'sessions' },
+  splitDirection: SplitDir = 'right'
 ): void {
   if (!storedSessionId) {
     return
@@ -128,6 +132,15 @@ export function openSession(
   if (resolved === 'stack') {
     spendBlankDraft = mainChatOccupied($activeSessionId.get(), $selectedStoredSessionId.get())
     resolved = spendBlankDraft ? 'tab' : 'in-place'
+  }
+
+  if (resolved === 'split') {
+    // Opening is not a drag: an existing conversation keeps its placement.
+    if (!focusOpenSession(storedSessionId, workspaceScope)) {
+      openSessionTile(storedSessionId, splitDirection, undefined, undefined, workspaceScope)
+    }
+
+    return
   }
 
   if (resolved === 'tab') {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -96,7 +96,8 @@ import {
   $sessionTiles,
   dropTilesForProfile,
   focusWorkspaceOwnerSessionTile,
-  sessionTileDelegate
+  sessionTileDelegate,
+  type SplitDir
 } from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
 import type { PaginatedSessions, UsageStats } from '@/types/hermes'
@@ -347,6 +348,9 @@ export interface PluginOpenSessionOptions {
   forceResume?: boolean
   hydrationTimeoutMs?: number
   intent?: OpenSessionIntent
+  /** Edge beside the focused chat zone; defaults to right. Only used with
+   *  intent: 'split'. Already-open conversations are focused, not moved. */
+  splitDirection?: SplitDir
   keepAllProfilesScope?: boolean
   profile?: null | string
   route?: PluginProfileRoute
@@ -848,7 +852,7 @@ export const host = {
     const profile = (explicitRoute?.profile ?? options.profile ?? '').trim()
     const targetProfile = normalizeProfileKey(profile || $activeGatewayProfile.get())
 
-    // A local bot open passes only `profile` (no cross-connection route), but
+    // A local bot or split open passes only `profile` (no cross-connection route), but
     // its RPCs STILL have to reach that profile's own local gateway while chrome
     // stays on the launch profile. Synthesize a local owner route from the
     // profile so the persisted tile carries it — the session-request router
@@ -865,7 +869,7 @@ export const host = {
 
     const ownerRoute =
       explicitRoute ??
-      (options.workspaceMode === 'bots' && profile && localConnectionId
+      ((options.workspaceMode === 'bots' || options.intent === 'split') && profile && localConnectionId
         ? { connectionId: localConnectionId, mode: 'local' as const, profile: targetProfile }
         : null)
 
@@ -995,7 +999,20 @@ export const host = {
 
           const intent = options.intent ?? 'in-place'
 
-          if (options.workspaceMode === 'bots') {
+          if (intent === 'split') {
+            openSession(
+              storedSessionId,
+              navigate,
+              intent,
+              {
+                ownerRoute: ownerRoute ?? undefined,
+                workspaceMode: options.workspaceMode ?? 'sessions',
+                workspaceOwnerKey: options.workspaceOwnerKey,
+                workspaceTabTitle: options.tabTitle
+              },
+              options.splitDirection
+            )
+          } else if (options.workspaceMode === 'bots') {
             openSession(storedSessionId, navigate, intent, {
               ownerRoute: ownerRoute ?? undefined,
               workspaceMode: 'bots',

--- a/apps/desktop/src/sdk/open-session-split.test.ts
+++ b/apps/desktop/src/sdk/open-session-split.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest'
+
+import { watchSessionTiles } from '@/app/chat/session-tile'
+import { findGroupOfPane, group } from '@/components/pane-shell/tree/model'
+import * as tree from '@/components/pane-shell/tree/store'
+import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
+import { registry } from '@/contrib/registry'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { $activeGatewayProfile } from '@/store/profile'
+import * as session from '@/store/session'
+import * as states from '@/store/session-states'
+import { openSessionInNewWindow } from '@/store/windows'
+
+import { host } from './index'
+
+// Only the backend/window boundaries are replaced; SDK routing, session stores,
+// native tile registration, layout adoption and hydration checks are production.
+vi.mock(import('@/store/gateway'), async importOriginal => ({
+  ...(await importOriginal()),
+  activeGatewayConnectionId: () => 'local',
+  openGatewayForAgent: vi.fn(async () => undefined),
+  openGatewayForProfile: vi.fn(async () => undefined)
+}))
+vi.mock(import('@/store/windows'), async importOriginal => ({
+  ...(await importOriginal()),
+  canOpenSessionWindow: () => true,
+  openSessionInNewWindow: vi.fn()
+}))
+
+beforeAll(() => {
+  const dispose = registry.register({
+    area: 'panes',
+    data: { placement: 'main', uncloseable: true },
+    id: 'workspace',
+    render: () => null,
+    title: 'Chat'
+  })
+
+  tree.watchContributedPanes()
+  watchSessionTiles()
+
+  return dispose
+})
+
+function resetState() {
+  for (const tile of states.$sessionTiles.get()) {
+    states.discardSessionTile(tile.storedSessionId)
+  }
+
+  states.clearAllSessionStates()
+  setWorkspaceScope('sessions')
+  session.$sessions.set([])
+  session.$selectedStoredSessionId.set(null)
+  session.$activeSessionId.set(null)
+  session.$messages.set([])
+  tree.$layoutTree.set(null)
+  tree.$activeTreeGroup.set(null)
+  tree.$activePresetId.set('default')
+  window.localStorage.clear()
+  window.location.hash = '#/c/main-chat'
+  vi.clearAllMocks()
+}
+
+beforeEach(resetState)
+afterEach(resetState)
+
+function setupMain() {
+  tree.declareDefaultTree(group(['workspace'], { active: 'workspace', id: 'main' }))
+  session.$selectedStoredSessionId.set('main-chat')
+  session.$activeSessionId.set('main-runtime')
+}
+
+it('splits at each requested edge without replacing main or duplicating/relocating an open conversation', async () => {
+  const route = {
+    connectionId: 'remote-a',
+    mode: 'remote' as const,
+    profile: 'writer',
+    targetProfile: 'backend-writer'
+  }
+
+  const originalProfile = $activeGatewayProfile.get()
+
+  for (const splitDirection of [undefined, 'right', 'left', 'top', 'bottom'] as const) {
+    resetState()
+    setupMain()
+    await host.openSession('side-chat', { intent: 'split', route, splitDirection })
+
+    const layout = tree.$layoutTree.get()!
+    const side = findGroupOfPane(layout, 'session-tile:side-chat')
+    const main = findGroupOfPane(layout, 'workspace')!
+    expect(side).not.toBeNull()
+    expect(side!.id).not.toBe(main.id)
+    expect(layout.type).toBe('split')
+
+    if (layout.type !== 'split') {
+      throw new Error('Expected a native split')
+    }
+
+    const direction = splitDirection ?? 'right'
+    expect(layout.orientation).toBe(direction === 'left' || direction === 'right' ? 'row' : 'column')
+    expect(layout.children.map(child => child.id)).toEqual(
+      direction === 'left' || direction === 'top' ? [side!.id, main.id] : [main.id, side!.id]
+    )
+    expect(states.sessionTileOwnerRoute('side-chat')).toEqual(route)
+    expect(states.openTileGatewayScopes()).toContain('conn:remote-a::writer')
+    expect(session.$selectedStoredSessionId.get()).toBe('main-chat')
+    expect(session.$activeSessionId.get()).toBe('main-runtime')
+    expect(window.location.hash).toBe('#/c/main-chat')
+    expect(openSessionInNewWindow).not.toHaveBeenCalled()
+    expect($activeGatewayProfile.get()).toBe(originalProfile)
+
+    const tiles = states.$sessionTiles.get()
+    await host.openSession('side-chat', { intent: 'split', splitDirection: 'left' })
+    expect(states.$sessionTiles.get()).toEqual(tiles)
+    expect(tree.$activeTreeGroup.get()).toBe(side!.id)
+    expect(states.$focusedStoredSessionId.get()).toBe('side-chat')
+    expect(findGroupOfPane(tree.$layoutTree.get()!, 'session-tile:side-chat')!.id).toBe(side!.id)
+
+    await host.openSession('main-chat', { intent: 'split' })
+    expect(states.$sessionTiles.get()).toEqual(tiles)
+    expect(states.$focusedStoredSessionId.get()).toBe('main-chat')
+  }
+})
+
+it('awaits the split tile runtime through the existing hydration seam, not the healthy main runtime', async () => {
+  setupMain()
+  let finishResume!: (runtimeId: string) => void
+
+  const resumeTile = vi.fn(
+    () =>
+      new Promise<string>(resolve => {
+        finishResume = resolve
+      })
+  )
+
+  states.setSessionTileDelegate({
+    archiveSession: vi.fn(),
+    branchSession: vi.fn(),
+    deleteSession: vi.fn(),
+    executeSlash: vi.fn(),
+    interruptSession: vi.fn(),
+    resumeTile,
+    submitToSession: vi.fn(),
+    updateSession: vi.fn()
+  })
+  let hydrated = false
+
+  const opening = host
+    .openSession('side-chat', { awaitHydration: true, intent: 'split', profile: 'writer' })
+    .then(() => {
+      hydrated = true
+    })
+
+  await vi.waitFor(() => expect(resumeTile).toHaveBeenCalledWith('side-chat', { refreshTranscript: true }))
+  expect(states.sessionTileOwnerRoute('side-chat')).toEqual({ connectionId: 'local', mode: 'local', profile: 'writer' })
+  finishResume('side-runtime')
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(hydrated).toBe(false)
+  // Deliver the gateway's binding via the real state seam. Main stays intact.
+  states.publishSessionState('side-runtime', createClientSessionState('side-chat'))
+  states.patchSessionTile('side-chat', { runtimeId: 'side-runtime' })
+  await opening
+  expect(hydrated).toBe(true)
+  expect(session.$activeSessionId.get()).toBe('main-runtime')
+  expect(session.$selectedStoredSessionId.get()).toBe('main-chat')
+  expect(states.$sessionTiles.get().find(tile => tile.storedSessionId === 'side-chat')?.runtimeId).toBe('side-runtime')
+  expect(window.location.hash).toBe('#/c/main-chat')
+})

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -499,9 +499,10 @@ ctx.os.openExternal(url)                   // OS default handler (browser, mail,
 ctx.os.revealPath(path)                    // reveal in Finder / Explorer → Promise<boolean>
 ctx.os.writeClipboard(text)                // system clipboard → Promise<boolean>
 host.navigate('/route')                    // hash-route navigation
-host.openSession(id, { profile?, intent? }) // open a stored session core-style;
-                                           //   profile: soft-swap to that profile's backend first
-                                           //   intent: 'in-place' (default) | 'stack' | 'tab' | 'window'
+host.openSession(id, { profile?, intent?, splitDirection? }) // Promise<void>; open a stored session
+                                           //   profile: dial its backend; keep chrome's profile by default
+                                           //   intent: 'in-place' (default) | 'main' | 'stack' | 'tab' | 'window' | 'split'
+                                           //   splitDirection: 'right' (default) | 'left' | 'top' | 'bottom'
 host.newChat(profile?)                     // fresh chat draft, optionally in another profile
 host.openWorkspace(id, { render, title?, minWidth?, onClose? })
                                            // dock a plugin-rendered tab into the MAIN
@@ -517,6 +518,38 @@ host.requestProfile<T>(route, method, params?)   // registry-routed RPC; no fore
 host.requestProfile<T>(profile, method, params?) // legacy v1/local overload
 host.request<T>(method, params?)           // active-gateway JSON-RPC — the real power
 ```
+
+### Open an existing session in a native split
+
+```ts
+import { host } from '@hermes/plugin-sdk'
+
+await host.openSession(storedSessionId, { intent: 'split' }) // right-hand split
+await host.openSession(otherStoredSessionId, { intent: 'split', splitDirection: 'bottom' })
+```
+
+`split` uses the built-in session pane, transcript, and composer in the current
+window. It does not create or branch a session, replace the main conversation,
+open a new window, or require a plugin-rendered chat UI. Pass a **stored session
+id**, not a runtime id. A new pane docks against the native session-tab target
+(the hovered chat zone, then focused chat zone, then main workspace).
+
+Like `tab`, `split` focuses a conversation already open in main or a tile
+(including compression-lineage aliases) instead of duplicating or relocating it.
+It does not spend a blank main view or draft tab. `splitDirection` only affects
+`intent: 'split'`; omitting it splits to the right. Default, `main`, `stack`,
+`tab`, and `window` behavior is unchanged, including the `window` fallback to
+`tab` when session windows are unavailable.
+
+Existing `profile` / `route` and workspace ownership options apply to split
+panes too. The owner is retained for session RPC routing and the pane's gateway
+lifetime. `awaitHydration`, `expectHistory`, `forceResume`, and hydration
+timeout/retry options use the same native tile hydration path as tab opens;
+without `awaitHydration`, resolution does not mean the transcript has loaded.
+
+This option requires a Desktop build that supports the `split` intent. Merely
+checking for `host.openSession` is not sufficient on older builds; do not send
+this intent to them, since they may treat it as an in-place open.
 
 `host.request` is the same JSON-RPC the app itself uses (sessions, config, skills,
 cron, kanban, …). `host.requestProfile` accepts a descriptor from


### PR DESCRIPTION
## What does this PR do?

Lets Desktop plugins open an existing native session in an in-window split:

```ts
await host.openSession(storedSessionId, { intent: 'split' }) // right
await host.openSession(storedSessionId, { intent: 'split', splitDirection: 'bottom' })
```

The concrete consumer is a `/side` brainstorming plugin that leaves the main conversation visible. Session creation, model choice, context retrieval, and the command itself stay outside this PR. Desktop already has native split-session panes; this exposes that existing capability rather than introducing a second chat renderer.

## Related Issue

Fixes #106713.

## Type of Change

- [x] New feature — additive Desktop SDK capability.

## Changes Made

- `apps/desktop/src/app/open-session.ts`: add a `split` intent and edge direction, using `openSessionTile`. Existing conversations are focused in place, not duplicated or relocated; main is never spent for a split.
- `apps/desktop/src/sdk/index.ts`: pass split placement and owner scope through `host.openSession`. Preserve the owning route for cross-profile split panes and reuse the existing tile hydration path.
- `apps/desktop/src/sdk/open-session-split.test.ts`: two invariant tests drive the real SDK, session stores, native tile registration, and layout adoption. They cover edge placement, main preservation, repeated opens, route retention, and waiting for the side runtime rather than the main runtime.
- `website/docs/developer-guide/desktop-plugin-sdk.md`: document API, focus/placement semantics, hydration, and older-build limitations.

Existing default/main/stack/tab/window calls are unchanged. `splitDirection` is ignored unless `intent` is `split`. Placement uses the existing native session-tab target (hovered chat zone, focused chat zone, then main). An already-open chat keeps its position.

## How to Test

Run from `apps/desktop`:

```sh
node ../../node_modules/vitest/vitest.mjs run src/sdk/open-session-split.test.ts src/sdk/index.test.ts src/sdk/plugin-open-session-plan.test.ts src/app/open-session.test.ts src/store/session-states.test.ts src/store/session-request-router.test.ts
npm run typecheck
node ../../node_modules/eslint/bin/eslint.js src/app/open-session.ts src/sdk/index.ts src/sdk/open-session-split.test.ts
node ../../node_modules/prettier/bin/prettier.cjs --check src/app/open-session.ts src/sdk/index.ts src/sdk/open-session-split.test.ts
```

Verified on Windows: **6 files / 147 tests passed**, renderer/Electron/E2E typechecks passed, changed-file ESLint and formatting passed, and `git diff --check` passed. The implementation pass also ran the full Desktop lint command successfully (warnings in untouched files).

Negative control: temporarily disabling the new split branch caused both new tests to fail (no split pane; no side-runtime resume). Restoring it and rerunning the six-file suite returned all 147 tests to green.

Tests use jsdom with transport/window boundaries replaced; **no live Electron/backend session test was performed**. No model requests or user sessions were created. Tested base: `ae65399d8f635d90334d3d1de16d49e8d48ef85e`.

## Checklist

- [x] Read the Contributing Guide and Desktop guidance.
- [x] Conventional commit; focused feature scope.
- [x] Checked existing issues and PRs for overlap.
- [x] Added behavior tests and demonstrated a failing negative control.
- [x] Tested on Windows 11 with an isolated workspace dependency install.
- [x] Updated SDK documentation; no config keys, backend tools, dependencies, or lockfiles changed.
- [ ] Full Python suite — not run; this is a Desktop TypeScript/docs change.
- [ ] Live Electron/backend verification — not performed.

## Compatibility

The new intent requires a Desktop build containing this change. Older SDKs may treat an unknown intent as in-place navigation, so checking only for `host.openSession` is not sufficient. The docs call this out; this PR does not install a consumer plugin or change released Desktop behavior.
