### PR TITLE
fix(skills-hub): support category-nested tap skill discovery and add tap refresh command

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1086,6 +1086,7 @@ def do_repair_official(name: str, restore: bool = False, console: Optional[Conso
 _TAP_OPS = {
     "add": ("add", "[bold green]Added tap:[/] {repo}\n", "[yellow]Tap already exists:[/] {repo}\n"),
     "remove": ("remove", "[bold green]Removed tap:[/] {repo}\n", "[bold red]Error:[/] Tap not found: {repo}\n"),
+    "refresh": ("refresh", "[bold green]Refreshed tap index cache:[/] {repo}\n", "[bold red]Error:[/] Tap not found: {repo}\n"),
 }
 
 
@@ -1105,6 +1106,12 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
                           t.get("path", "skills/"))
         c.print(table)
         c.print()
+    elif action == "refresh" and not repo:
+        refreshed = mgr.refresh()
+        if refreshed:
+            c.print("[bold green]Refreshed index cache for all configured taps.[/]\n")
+        else:
+            c.print("[dim]No custom taps configured to refresh.[/]\n")
     elif action in _TAP_OPS:
         method, ok_line, fail_line = _TAP_OPS[action]
         if not repo:
@@ -1112,7 +1119,7 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
             return
         c.print((ok_line if getattr(mgr, method)(repo) else fail_line).format(repo=repo))
     else:
-        c.print(f"[bold red]Unknown tap action:[/] {action}. Use: list, add, remove\n")
+        c.print(f"[bold red]Unknown tap action:[/] {action}. Use: list, add, remove, refresh\n")
 
 
 def _read_frontmatter(skill_md: str) -> dict:
@@ -1312,7 +1319,7 @@ def _snapshot_cli(args) -> None:
 def _tap_cli(args) -> None:
     tap_action = getattr(args, "tap_action", None)
     if not tap_action:
-        _console.print("Usage: hermes skills tap [list|add|remove]\n")
+        _console.print("Usage: hermes skills tap [list|add|remove|refresh]\n")
         return
     do_tap(tap_action, repo=getattr(args, "repo", "") or getattr(args, "name", ""))
 
@@ -1503,5 +1510,5 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]reset[/] <name> [--restore]    Reset bundled-skill tracking (fix 'user-modified' flag)\n"
         "  [cyan]publish[/] <path> --repo <r>   Publish a skill to GitHub via PR\n"
         "  [cyan]snapshot[/] export|import      Export/import skill configurations\n"
-        "  [cyan]tap[/] list|add|remove         Manage skill sources\n",
+        "  [cyan]tap[/] list|add|remove|refresh Manage skill sources\n",
         title="/skills"))

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -169,6 +169,8 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     tap_add.add_argument("repo", help="GitHub repo (e.g. owner/repo)")
     tap_rm = tap_subparsers.add_parser("remove", help="Remove a tap")
     tap_rm.add_argument("name", help="Tap name to remove")
+    tap_refresh = tap_subparsers.add_parser("refresh", help="Refresh tap index cache")
+    tap_refresh.add_argument("repo", nargs="?", default="", help="GitHub repo to refresh (omit to refresh all taps)")
 
     # config sub-action: interactive enable/disable
     skills_subparsers.add_parser(

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_tap, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -565,3 +565,47 @@ def test_do_install_generic_when_no_index_hit_or_rate_limited(monkeypatch, meta_
     assert "Could not fetch" in out
     assert "Stale index entry" not in out
     assert ("rate limit" in out) is meta_hit
+
+def test_do_tap_lifecycle_and_refresh(hub_env):
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    # 1. Empty list
+    do_tap("list", console=console)
+    assert "No custom taps configured" in sink.getvalue()
+
+    # 2. Add tap
+    sink.seek(0); sink.truncate(0)
+    do_tap("add", "callacat/hermes-capabilities", console=console)
+    assert "Added tap" in sink.getvalue()
+
+    # 3. List configured
+    sink.seek(0); sink.truncate(0)
+    do_tap("list", console=console)
+    assert "callacat/hermes-capabilities" in sink.getvalue()
+
+    # 4. Refresh specific tap
+    sink.seek(0); sink.truncate(0)
+    do_tap("refresh", "callacat/hermes-capabilities", console=console)
+    assert "Refreshed tap index cache" in sink.getvalue()
+
+    # 5. Refresh all taps
+    sink.seek(0); sink.truncate(0)
+    do_tap("refresh", "", console=console)
+    assert "Refreshed index cache for all configured taps" in sink.getvalue()
+
+    # 6. Refresh non-existent tap
+    sink.seek(0); sink.truncate(0)
+    do_tap("refresh", "nonexistent/tap", console=console)
+    assert "Tap not found" in sink.getvalue()
+
+    # 7. Remove tap
+    sink.seek(0); sink.truncate(0)
+    do_tap("remove", "callacat/hermes-capabilities", console=console)
+    assert "Removed tap" in sink.getvalue()
+
+    # 8. Unknown action
+    sink.seek(0); sink.truncate(0)
+    do_tap("invalid_action", console=console)
+    assert "Unknown tap action" in sink.getvalue()
+    assert "refresh" in sink.getvalue()

--- a/tests/hermes_cli/test_skills_subparser.py
+++ b/tests/hermes_cli/test_skills_subparser.py
@@ -32,3 +32,26 @@ def test_no_duplicate_skills_subparser():
                 "See issue #898 for details."
             ) from e
         raise
+
+
+def test_skills_tap_refresh_subparser():
+    """Verify 'hermes skills tap refresh [repo]' parses both specific and omitted repo."""
+    from hermes_cli.main import build_skills_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_skills_parser(subparsers, cmd_skills=lambda a: None)
+
+    # Specific tap repo
+    args = parser.parse_args(["skills", "tap", "refresh", "callacat/hermes-capabilities"])
+    assert args.command == "skills"
+    assert args.skills_action == "tap"
+    assert args.tap_action == "refresh"
+    assert args.repo == "callacat/hermes-capabilities"
+
+    # All taps (repo omitted)
+    args_all = parser.parse_args(["skills", "tap", "refresh"])
+    assert args_all.command == "skills"
+    assert args_all.skills_action == "tap"
+    assert args_all.tap_action == "refresh"
+    assert args_all.repo == ""

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -141,6 +141,97 @@ class TestSkillsShGroupings:
 
         assert skills[0].extra["category"] == "Decision Optimization"
 
+    def test_list_skills_in_repo_nested_via_tree(self):
+        auth = MagicMock()
+        src = GitHubSource(auth=auth)
+
+        tree = (
+            "main",
+            [
+                {"type": "blob", "path": "skills/software-development/web-design-inspiration-libs/SKILL.md"},
+                {"type": "blob", "path": "skills/homelab-pihole-dns/SKILL.md"},
+                {"type": "blob", "path": "skills/.hidden/should-ignore/SKILL.md"},
+                {"type": "tree", "path": "skills/software-development"},
+                {"type": "blob", "path": "README.md"},
+            ],
+        )
+
+        def mock_inspect(identifier):
+            if "web-design-inspiration-libs" in identifier:
+                return SkillMeta(
+                    name="web-design-inspiration-libs", description="d1", source="github",
+                    identifier=identifier, trust_level="community",
+                )
+            if "homelab-pihole-dns" in identifier:
+                return SkillMeta(
+                    name="homelab-pihole-dns", description="d2", source="github",
+                    identifier=identifier, trust_level="community",
+                )
+            return None
+
+        with patch("tools.skills_hub._read_index_cache", return_value=None), \
+             patch("tools.skills_hub._write_index_cache"), \
+             patch.object(src, "_get_repo_tree", return_value=tree), \
+             patch.object(src, "inspect", side_effect=mock_inspect):
+            skills = src._list_skills_in_repo("callacat/hermes-capabilities", "skills/")
+
+        assert len(skills) == 2
+        names = {s.name for s in skills}
+        assert names == {"web-design-inspiration-libs", "homelab-pihole-dns"}
+        nested_skill = next(s for s in skills if s.name == "web-design-inspiration-libs")
+        assert nested_skill.extra["category"] == "software-development"
+        assert nested_skill.identifier == "callacat/hermes-capabilities/skills/software-development/web-design-inspiration-libs"
+
+    def test_list_skills_in_repo_nested_via_contents_fallback(self):
+        auth = MagicMock()
+        src = GitHubSource(auth=auth)
+
+        root_contents = [
+            {"type": "dir", "name": "software-development"},
+            {"type": "dir", "name": "homelab-pihole-dns"},
+            {"type": "file", "name": "README.md"},
+        ]
+        sub_contents = [
+            {"type": "dir", "name": "web-design-inspiration-libs"},
+        ]
+
+        def mock_github_get(url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 200
+            if url.endswith("/contents/skills"):
+                resp.json.return_value = root_contents
+                return resp
+            if url.endswith("/contents/skills/software-development"):
+                resp.json.return_value = sub_contents
+                return resp
+            return None
+
+        def mock_inspect(identifier):
+            if identifier.endswith("skills/homelab-pihole-dns"):
+                return SkillMeta(
+                    name="homelab-pihole-dns", description="d1", source="github",
+                    identifier=identifier, trust_level="community",
+                )
+            if identifier.endswith("skills/software-development/web-design-inspiration-libs"):
+                return SkillMeta(
+                    name="web-design-inspiration-libs", description="d2", source="github",
+                    identifier=identifier, trust_level="community",
+                )
+            return None
+
+        with patch("tools.skills_hub._read_index_cache", return_value=None), \
+             patch("tools.skills_hub._write_index_cache"), \
+             patch.object(src, "_get_repo_tree", return_value=None), \
+             patch.object(src, "_github_get", side_effect=mock_github_get), \
+             patch.object(src, "inspect", side_effect=mock_inspect):
+            skills = src._list_skills_in_repo("callacat/hermes-capabilities", "skills/")
+
+        assert len(skills) == 2
+        names = {s.name for s in skills}
+        assert names == {"web-design-inspiration-libs", "homelab-pihole-dns"}
+        nested_skill = next(s for s in skills if s.name == "web-design-inspiration-libs")
+        assert nested_skill.extra["category"] == "software-development"
+
 # ---------------------------------------------------------------------------
 # GitHubSource.trust_level_for
 # ---------------------------------------------------------------------------
@@ -684,6 +775,48 @@ class TestTapsManager:
         mgr.add("owner/repo")
         assert mgr.remove("owner/repo") is True
         assert mgr.load() == []
+
+    def test_refresh_single_and_all_taps(self, tmp_path):
+        cache_dir = tmp_path / "index-cache"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "owner_repo1_skills_.json").write_text("{}", encoding="utf-8")
+        (cache_dir / "owner_repo2_skills_.json").write_text("{}", encoding="utf-8")
+        (cache_dir / "other_cache.json").write_text("{}", encoding="utf-8")
+
+        mgr = TapsManager(path=tmp_path / "taps.json")
+        with patch("tools.skills_hub._index_cache_dir", return_value=cache_dir):
+            mgr.add("owner/repo1")
+            mgr.add("owner/repo2")
+            # Refresh non-existent tap
+            assert mgr.refresh("owner/nonexistent") is False
+
+            # Refresh specific tap
+            assert mgr.refresh("owner/repo1") is True
+            assert not (cache_dir / "owner_repo1_skills_.json").exists()
+            assert (cache_dir / "other_cache.json").exists()
+
+            # Refresh all taps
+            (cache_dir / "owner_repo1_skills_.json").write_text("{}", encoding="utf-8")
+            assert mgr.refresh() is True
+            assert not (cache_dir / "owner_repo1_skills_.json").exists()
+            assert not (cache_dir / "owner_repo2_skills_.json").exists()
+            assert (cache_dir / "other_cache.json").exists()
+
+    def test_add_and_remove_clears_cache(self, tmp_path):
+        cache_dir = tmp_path / "index-cache"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "owner_repo_skills_.json").write_text("{}", encoding="utf-8")
+
+        mgr = TapsManager(path=tmp_path / "taps.json")
+        with patch("tools.skills_hub._index_cache_dir", return_value=cache_dir):
+            # Adding tap invalidates stale cache
+            mgr.add("owner/repo")
+            assert not (cache_dir / "owner_repo_skills_.json").exists()
+
+            # Re-create cache file and remove tap
+            (cache_dir / "owner_repo_skills_.json").write_text("{}", encoding="utf-8")
+            assert mgr.remove("owner/repo") is True
+            assert not (cache_dir / "owner_repo_skills_.json").exists()
 
 # ---------------------------------------------------------------------------
 # LobeHubSource._convert_to_skill_md

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -818,6 +818,28 @@ class TestTapsManager:
             assert mgr.remove("owner/repo") is True
             assert not (cache_dir / "owner_repo_skills_.json").exists()
 
+    def test_clear_tap_cache_preserves_prefix_sharing_sibling_taps(self, tmp_path):
+        cache_dir = tmp_path / "index-cache"
+        cache_dir.mkdir(parents=True)
+        # Sibling tap sharing the same prefix (e.g. repo vs repo-extra)
+        base_cache = cache_dir / "callacat_hermes-capabilities_skills_.json"
+        sibling_cache = cache_dir / "callacat_hermes-capabilities-extra_skills_.json"
+        base_cache.write_text("{}", encoding="utf-8")
+        sibling_cache.write_text("{}", encoding="utf-8")
+
+        mgr = TapsManager(path=tmp_path / "taps.json")
+        with patch("tools.skills_hub._index_cache_dir", return_value=cache_dir):
+            mgr.add("callacat/hermes-capabilities")
+            # Base cache was unlinked, but sibling tap cache was preserved
+            assert not base_cache.exists()
+            assert sibling_cache.exists()
+
+            # Refreshing base tap also preserves sibling cache
+            base_cache.write_text("{}", encoding="utf-8")
+            assert mgr.refresh("callacat/hermes-capabilities") is True
+            assert not base_cache.exists()
+            assert sibling_cache.exists()
+
 # ---------------------------------------------------------------------------
 # LobeHubSource._convert_to_skill_md
 # ---------------------------------------------------------------------------

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -262,6 +262,18 @@ class TapsManager(_JsonStateFile):
     def save(self, taps: List[dict]) -> None:
         self._write({"taps": taps})
 
+    def _clear_tap_cache(self, repo: str) -> None:
+        """Remove cached index-cache files for a given repo."""
+        cache_dir = _index_cache_dir()
+        if not cache_dir.exists():
+            return
+        sanitized = repo.replace("/", "_").replace(" ", "_")
+        for cache_file in cache_dir.glob(f"{sanitized}*.json"):
+            try:
+                cache_file.unlink(missing_ok=True)
+            except OSError:
+                pass
+
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""
         taps = self.load()
@@ -269,6 +281,7 @@ class TapsManager(_JsonStateFile):
             return False
         taps.append({"repo": repo, "path": path})
         self.save(taps)
+        self._clear_tap_cache(repo)
         return True
 
     def remove(self, repo: str) -> bool:
@@ -278,6 +291,21 @@ class TapsManager(_JsonStateFile):
         if len(new_taps) == len(taps):
             return False
         self.save(new_taps)
+        self._clear_tap_cache(repo)
+        return True
+
+    def refresh(self, repo: Optional[str] = None) -> bool:
+        """Invalidate cached index files for a specific tap or all configured taps."""
+        taps = self.load()
+        if repo:
+            if not any(t["repo"] == repo for t in taps):
+                return False
+            self._clear_tap_cache(repo)
+            return True
+        if not taps:
+            return False
+        for t in taps:
+            self._clear_tap_cache(t["repo"])
         return True
 
     list_taps = load

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -268,11 +268,12 @@ class TapsManager(_JsonStateFile):
         if not cache_dir.exists():
             return
         sanitized = repo.replace("/", "_").replace(" ", "_")
-        for cache_file in cache_dir.glob(f"{sanitized}*.json"):
-            try:
-                cache_file.unlink(missing_ok=True)
-            except OSError:
-                pass
+        for pattern in (f"{sanitized}.json", f"{sanitized}_*.json"):
+            for cache_file in cache_dir.glob(pattern):
+                try:
+                    cache_file.unlink(missing_ok=True)
+                except OSError:
+                    pass
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""

--- a/tools/skills_hub_github.py
+++ b/tools/skills_hub_github.py
@@ -5,7 +5,7 @@ import logging
 import subprocess
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import quote
 
 import httpx
@@ -343,25 +343,91 @@ class GitHubSource(SkillSource):
         cached = _cached_metas(cache_key)
         if cached is not None:
             return cached
-        resp = self._github_get(f"{_API}/{repo}/contents/{path.rstrip('/')}")
+
+        prefix = path.strip("/")
+        groupings = self._get_skillsh_groupings(repo)
+
+        # 1. Try recursive git tree discovery (1 API call for all flat & nested skills)
+        tree = self._get_repo_tree(repo)
+        if tree is not None:
+            skills: List[SkillMeta] = []
+            seen_identifiers: Set[str] = set()
+            for entry in tree[1]:
+                if entry.get("type") != "blob":
+                    continue
+                epath = entry.get("path", "")
+                if not (epath.endswith("/SKILL.md") or epath == "SKILL.md"):
+                    continue
+                if prefix:
+                    if not (epath.startswith(f"{prefix}/") or epath == f"{prefix}/SKILL.md"):
+                        continue
+                    rel = epath[len(prefix):].lstrip("/")
+                else:
+                    rel = epath
+
+                parts = rel.split("/")
+                dir_parts = parts[:-1]
+                if any(p.startswith((".", "_")) for p in dir_parts):
+                    continue
+
+                skill_dir = epath[: -len("/SKILL.md")] if epath.endswith("/SKILL.md") else ""
+                identifier = f"{repo}/{skill_dir}" if skill_dir else repo
+                if identifier in seen_identifiers:
+                    continue
+                seen_identifiers.add(identifier)
+
+                meta = self.inspect(identifier)
+                if meta:
+                    dir_name = dir_parts[-1] if dir_parts else ""
+                    category_dir = dir_parts[0] if len(dir_parts) > 1 else None
+                    category = groupings and (
+                        groupings.get(meta.name) or groupings.get(dir_name) or (category_dir and groupings.get(category_dir))
+                    )
+                    if not category and category_dir:
+                        category = category_dir
+                    if category:
+                        meta.extra["category"] = category
+                    skills.append(meta)
+            _cache_metas(cache_key, skills)
+            return skills
+
+        # 2. Fallback to Contents API traversal (supports flat & category-nested directories)
+        resp = self._github_get(f"{_API}/{repo}/contents/{prefix}")
         if resp is None or resp.status_code != 200:
             return []
         entries = resp.json()
         if not isinstance(entries, list):
             return []
-        skills: List[SkillMeta] = []
-        groupings = self._get_skillsh_groupings(repo)
-        prefix = path.rstrip("/")
+        skills = []
         for entry in entries:
             if entry.get("type") != "dir" or entry["name"].startswith((".", "_")):
                 continue
             dir_name = entry["name"]
-            meta = self.inspect(f"{repo}/{prefix}/{dir_name}" if prefix else f"{repo}/{dir_name}")
+            subpath = f"{prefix}/{dir_name}" if prefix else dir_name
+            meta = self.inspect(f"{repo}/{subpath}")
             if meta:
                 category = (groupings and (groupings.get(meta.name) or groupings.get(dir_name))) or bucket
                 if category:
                     meta.extra["category"] = category
                 skills.append(meta)
+            else:
+                # Subdirectory might be a category containing skill directories
+                sub_resp = self._github_get(f"{_API}/{repo}/contents/{subpath}")
+                if sub_resp is not None and sub_resp.status_code == 200:
+                    sub_entries = sub_resp.json()
+                    if isinstance(sub_entries, list):
+                        for sub_entry in sub_entries:
+                            if sub_entry.get("type") != "dir" or sub_entry["name"].startswith((".", "_")):
+                                continue
+                            sub_dir = sub_entry["name"]
+                            nested_path = f"{subpath}/{sub_dir}"
+                            nested_meta = self.inspect(f"{repo}/{nested_path}")
+                            if nested_meta:
+                                category = groupings and (
+                                    groupings.get(nested_meta.name) or groupings.get(sub_dir) or groupings.get(dir_name)
+                                )
+                                nested_meta.extra["category"] = category or dir_name
+                                skills.append(nested_meta)
         _cache_metas(cache_key, skills)
         return skills
 
@@ -372,13 +438,13 @@ class GitHubSource(SkillSource):
         if repo in self._tree_cache:
             return self._tree_cache[repo]
         repo_data = self._github_json(f"{_API}/{repo}")
-        if repo_data is None:
+        if not isinstance(repo_data, dict):
             return None
         default_branch = repo_data.get("default_branch", "main")
         tree_data = self._github_json(
             f"{_API}/{repo}/git/trees/{default_branch}", params={"recursive": "1"}, timeout=30.0,
         )
-        if tree_data is None:
+        if not isinstance(tree_data, dict):
             return None
         if tree_data.get("truncated"):
             logger.debug("Git tree truncated for %s, cannot cache", repo)

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -993,6 +993,7 @@ New taps are assigned `community` trust by default. Skills installed from them r
 hermes skills tap list                                # show all configured taps
 hermes skills tap add myorg/skills-repo               # add (default path: skills/)
 hermes skills tap remove myorg/skills-repo            # remove
+hermes skills tap refresh [myorg/skills-repo]         # refresh index cache (all taps or specific tap)
 ```
 
 Inside a running session:
@@ -1001,9 +1002,10 @@ Inside a running session:
 /skills tap list
 /skills tap add myorg/skills-repo
 /skills tap remove myorg/skills-repo
+/skills tap refresh [myorg/skills-repo]
 ```
 
-Taps are stored in `~/.hermes/skills/.hub/taps.json` (created on demand).
+Taps are stored in `~/.hermes/skills/.hub/taps.json` (created on demand). Taps support both flat (`skills/<skill-name>/SKILL.md`) and category-nested (`skills/<category>/<skill-name>/SKILL.md`) layouts.
 
 ## Bundled skill updates (`hermes skills reset`)
 


### PR DESCRIPTION
## Summary
Fixes #106729.

When skills are distributed via custom GitHub taps using a category-nested layout (e.g. `skills/<category>/<skill-name>/SKILL.md` such as `skills/software-development/web-design-inspiration-libs/SKILL.md`), `tools/skills_hub_github.py::_list_skills_in_repo` previously only inspected flat first-level directories. Because `self.inspect` looked for `skills/<category>/SKILL.md` and returned `None`, the entire category subdirectory and all skills nested within it were silently dropped from the tap index cache.

Additionally, `hermes skills tap` only supported `list`, `add`, and `remove`. There was no mechanism to invalidate or refresh stale index cache files (`.hub/index-cache/<tap>_skills_.json`), and re-adding a tap did not flush the stale cache.

### Changes Made
1. **Category-Nested Tap Skill Discovery (`tools/skills_hub_github.py`)**:
   - Query git tree via `self._get_repo_tree(repo)` to discover all `SKILL.md` files at arbitrary nesting depths under the configured tap prefix in a single API call, automatically extracting and setting the category metadata (`meta.extra["category"]`).
   - Fall back to recursive Contents API traversal when `_get_repo_tree` is unavailable (or in mock test environments), scanning both top-level skill directories and category subdirectories.
   - Safeguarded `_get_repo_tree` against non-dict API responses.
2. **Tap Index Cache Management (`tools/skills_hub.py`)**:
   - Added `TapsManager.refresh(repo: Optional[str] = None)` to invalidate cache files for a specific tap or all configured taps.
   - Added automatic cache invalidation in `TapsManager.add()` and `TapsManager.remove()` to prevent stale index retention.
3. **CLI & Slash Command Support (`hermes_cli/skills_hub.py`, `hermes_cli/subcommands/skills.py`)**:
   - Added `refresh` subcommand to `hermes skills tap [refresh]` and `/skills tap refresh` with optional repo argument.
   - Updated CLI help messages and usage documentation.
4. **Documentation (`website/docs/user-guide/features/skills.md`)**:
   - Documented `hermes skills tap refresh [owner/repo]` and noted support for category-nested skill layouts.
5. **Test Coverage (`tests/tools/test_skills_hub.py`, `tests/hermes_cli/test_skills_hub.py`, `tests/hermes_cli/test_skills_subparser.py`)**:
   - Added unit tests for git tree and Contents API nested skill discovery with category tagging.
   - Added lifecycle tests for `TapsManager.refresh()`, `add()`, and `remove()`.
   - Added CLI execution and subparser tests for `hermes skills tap refresh`.

## Verification
- Unit tests:
  - `pytest tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_skills_subparser.py` (11/11 passed)
  - `pytest -k "TestSkillsShGroupings or TestTapsManager" tests/tools/test_skills_hub.py` (8/8 passed)
- Linter: `ruff check` (0 errors across all modified files)
