### PR TITLE
fix(security): allow tilde-path executables through Tirith scanning

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -11,7 +11,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import tools.tirith_security as _tirith_mod
-from tools.tirith_security import check_command_security, ensure_installed
+from tools.tirith_security import (
+    _expand_leading_tilde_executable,
+    check_command_security,
+    ensure_installed,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -48,6 +52,35 @@ def _mock_run(returncode=0, stdout="", stderr=""):
 
 def _json_stdout(findings=None, summary=""):
     return json.dumps({"findings": findings or [], "summary": summary})
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("~/bin/tool --help", "/home/alice/bin/tool --help"),
+        ("  ~/bin/tool", "  /home/alice/bin/tool"),
+        ("~bob/bin/tool $(dynamic)", "/home/bob/bin/tool $(dynamic)"),
+        ("'~/bin/tool' --help", "'~/bin/tool' --help"),
+        (r"\~/bin/tool", r"\~/bin/tool"),
+        ("echo ~/bin/tool", "echo ~/bin/tool"),
+    ],
+)
+def test_expand_leading_tilde_executable_preserves_command_syntax(command, expected):
+    homes = {"~": "/home/alice", "~bob": "/home/bob"}
+    with patch("tools.tirith_security.os.path.expanduser", side_effect=lambda value: homes.get(value, value)):
+        assert _expand_leading_tilde_executable(command) == expected
+
+
+@patch("tools.tirith_security.subprocess.run")
+@patch("tools.tirith_security._load_security_config")
+def test_check_expands_tilde_executable_before_scanning(mock_cfg, mock_run):
+    mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                             "tirith_timeout": 5, "tirith_fail_open": True}
+    mock_run.return_value = _mock_run(0, _json_stdout())
+    with patch("tools.tirith_security.is_platform_supported", return_value=True), \
+         patch("tools.tirith_security.os.path.expanduser", return_value="/home/alice"):
+        check_command_security("~/bin/tool --help")
+    assert mock_run.call_args.args[0][-1] == "/home/alice/bin/tool --help"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -11,6 +11,8 @@ import json
 import logging
 import os
 import platform
+import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -463,6 +465,9 @@ _EXIT_ACTIONS = {0: "allow", 1: "block", 2: "warn"}
 _NO_DETAILS_SUMMARY = {
     "block": "security issue detected (details unavailable)",
     "warn": "security warning detected (details unavailable)"}
+_LEADING_TILDE_EXECUTABLE = re.compile(
+    r"^[ \t]*(?P<home>~[^/ \t\r\n'\"\\$`;&|(){}<>]*)(?=/)"
+)
 
 
 def _verdict(action: str, summary: str = "", findings: list | None = None) -> dict:
@@ -477,6 +482,22 @@ def _crash(fail_open: bool, open_summary: str, closed_summary: str) -> dict:
     """An operational failure: count it toward the circuit breaker, then fail open/closed."""
     _record_tirith_crash()
     return _fail(fail_open, open_summary, closed_summary)
+
+
+def _expand_leading_tilde_executable(command: str) -> str:
+    """Resolve a bare tilde home prefix on the first command word.
+
+    Tirith 0.4.1 mistakes that deterministic shell expansion for a dynamic
+    executable body. Quoted, escaped, and non-leading tildes are left alone;
+    all syntax after the home prefix remains available to the scanner.
+    """
+    if not (match := _LEADING_TILDE_EXECUTABLE.match(command)):
+        return command
+    home = match.group("home")
+    expanded = os.path.expanduser(home)
+    if expanded == home:
+        return command
+    return command[:match.start("home")] + shlex.quote(expanded) + command[match.end("home"):]
 
 
 def check_command_security(command: str) -> dict:
@@ -501,7 +522,8 @@ def check_command_security(command: str) -> dict:
         return _fail(fail_open, "tirith path unavailable", "tirith path unavailable (fail-closed)")
     try:
         result = subprocess.run(
-            [tirith_path, "check", "--json", "--non-interactive", "--shell", "posix", "--", command],
+            [tirith_path, "check", "--json", "--non-interactive", "--shell", "posix", "--",
+             _expand_leading_tilde_executable(command)],
             capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
             stdin=subprocess.DEVNULL)
     except OSError as exc:


### PR DESCRIPTION
## What does this PR do?

Commands that invoke a binary through a leading `~/` or resolvable `~user/` path no longer get blocked by Tirith as an incomplete nested command. Hermes now resolves only the bare leading home prefix before scanning and leaves every remaining shell token intact, so pipes, substitutions, and other dynamic syntax remain visible to Tirith.

### Symptom

Tirith 0.4.1 reports HIGH `analysis_incomplete` findings for a simple command such as `~/bin/tool --help`, while the equivalent absolute executable path passes.

### Impact

Legitimate commands copied from tool output or documentation can be blocked in unattended agent modes even when the command has no pipe, subshell, substitution, or redirection.

### Bug Cause

**Trigger:** `tools/tirith_security.py:526` / `check_command_security()` passing a command whose first bare token starts with `~/` or a resolvable `~user/` prefix.

**Causal chain:**
1. Hermes forwards the original command text directly to `tirith check --shell posix`.
2. Tirith 0.4.1 treats the leading tilde executable as an unresolved nested executable body.
3. Hermes receives Tirith's block exit code and prevents the otherwise simple command from running.

**Why it is wrong:** A bare leading tilde home prefix is deterministically resolved by the POSIX shell before execution. Treating that prefix as dynamic command construction produces a false positive.

**Working sibling / contrast:** Replacing the same prefix with its resolved absolute home directory makes the identical command pass Tirith analysis.

**Ruled out:** Arguments and path depth are not the trigger; minimal argument-free paths reproduce the finding, and an absolute-path control does not.

### Fix

Resolve only a shell-expandable tilde home prefix on the first command word before invoking Tirith. Quoted, escaped, unknown-user, and non-leading tildes remain unchanged. The suffix is preserved byte-for-byte, including command substitutions and other syntax that Tirith must continue to inspect.

## Related Issue

Closes #106714

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tirith_security.py` - normalize a resolvable leading tilde executable prefix at the Tirith boundary.
- `tests/tools/test_tirith_security.py` - cover eligible prefixes, excluded forms, preserved dynamic syntax, and subprocess integration.

## How to Test

1. Run the focused tilde regression tests.
2. Confirm all eligible and excluded command forms preserve the expected scanner input.

```bash
scripts/run_tests.sh tests/tools/test_tirith_security.py -k tilde
```

Result: 8 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (unit tests; Tirith has no Windows build)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is internal and covered by the function docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated regression coverage exercises the scanner command boundary directly.
