### PR TITLE
fix(cron): do not hold fire fence during heartbeat save_jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2596,7 +2596,7 @@ def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -9,8 +9,14 @@ E2E-over-mocks discipline for file-touching code.
 """
 import threading
 import time
+from pathlib import Path
 
 import pytest
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX
+    fcntl = None
 
 
 @pytest.fixture
@@ -325,3 +331,118 @@ def test_fresh_claim_from_a_dead_same_host_owner_is_reclaimable(temp_home):
     job["fire_claim"]["by"] = f"{socket.gethostname()}:{child.pid}:tok"
     save_jobs(jobs)
     assert claim_job_for_fire(jid) is True
+
+
+def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event):
+    """Hold an exclusive flock on *path* from a separate fd until released.
+
+    flock locks are per-open-file-description, so a second open() in the SAME
+    process contends exactly like another process would.
+    """
+    fd = open(path, "a+", encoding="utf-8")
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        held.set()
+        release.wait(timeout=30)
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        fd.close()
+
+
+def test_heartbeat_fire_claim_missing_job_returns_false(temp_home):
+    import cron.jobs as jobs
+
+    assert jobs.heartbeat_fire_claim("nope-does-not-exist", expected_owner="anyone") is False
+
+
+@pytest.mark.skipif(fcntl is None, reason="flock semantics are POSIX-only")
+def test_heartbeat_does_not_pin_fire_fence_while_jobs_lock_contended(temp_home, monkeypatch):
+    """Correct-owner heartbeat must not hold fire_fence across a .jobs.lock wait.
+
+    Contended path: another thread holds ``.jobs.lock`` while the owner calls
+    ``heartbeat_fire_claim``; concurrently ``mark_job_run`` needs the fire fence.
+
+    PRE-FIX: heartbeat wraps ``_with_job`` in ``_under_fire_fence``, so the
+    flock wait keeps fire_fence held and ``mark_job_run`` fails closed (False).
+    POST-FIX: heartbeat only CAS-refreshes via ``_with_job``; mark can take the
+    fence and succeed (or at least is not fence-blocked by the heartbeat).
+    """
+    from datetime import datetime, timedelta
+
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="fence-hostage")
+    jid = job["id"]
+    assert jobs.claim_job_for_fire(jid) is True
+    claimed = jobs.get_job(jid)["fire_claim"]
+    owner = claimed["by"]
+    claimed_at = datetime.fromisoformat(claimed["at"])
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: claimed_at + timedelta(seconds=30))
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.8)
+
+    lock_path = jobs._jobs_lock_file()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch()
+
+    release = threading.Event()
+    held = threading.Event()
+    heartbeat_waiting_on_jobs_lock = threading.Event()
+    results = {}
+    real_acquire = jobs._acquire_flock
+    real_refresh = jobs._refresh_claim
+
+    def wrapped_acquire(lock_fd, timeout):
+        name = Path(getattr(lock_fd, "name", "") or "").name
+        if name == ".jobs.lock":
+            heartbeat_waiting_on_jobs_lock.set()
+        return real_acquire(lock_fd, timeout)
+
+    def wrapped_refresh(job_list, claim, expected_owner):
+        ok = real_refresh(job_list, claim, expected_owner)
+        if ok:
+            results["refreshed_at"] = claim.get("at")
+            results["refreshed_by"] = claim.get("by")
+        return ok
+
+    monkeypatch.setattr(jobs, "_acquire_flock", wrapped_acquire)
+    monkeypatch.setattr(jobs, "_refresh_claim", wrapped_refresh)
+
+    holder = threading.Thread(
+        target=_hold_jobs_flock, args=(lock_path, release, held), daemon=True,
+    )
+    holder.start()
+    assert held.wait(timeout=5), "test holder failed to take .jobs.lock"
+
+    def run_heartbeat():
+        results["heartbeat"] = jobs.heartbeat_fire_claim(jid, expected_owner=owner)
+
+    def run_mark():
+        results["mark"] = jobs.mark_job_run(jid, True, expected_fire_owner=owner)
+
+    try:
+        hb_thread = threading.Thread(target=run_heartbeat)
+        hb_thread.start()
+        assert heartbeat_waiting_on_jobs_lock.wait(timeout=5), (
+            "heartbeat never reached the .jobs.lock wait inside _with_job/save_jobs"
+        )
+
+        mark_thread = threading.Thread(target=run_mark)
+        mark_thread.start()
+        mark_thread.join(timeout=8)
+        hb_thread.join(timeout=8)
+        assert mark_thread.is_alive() is False
+        assert hb_thread.is_alive() is False
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert results.get("heartbeat") is True
+    assert results.get("refreshed_by") == owner
+    assert results.get("refreshed_at") != claimed["at"]
+    assert results.get("mark") is True, (
+        "mark_job_run failed closed while heartbeat held fire_fence across the "
+        ".jobs.lock wait (heartbeat must not wrap _with_job in _under_fire_fence)"
+    )


### PR DESCRIPTION
## What does this PR do?

`heartbeat_fire_claim` was wrapping `_with_job` in `_under_fire_fence`, so a heartbeat that blocked on the global `.jobs.lock` inside `save_jobs` kept the per-job fire fence held. Concurrent `mark_job_run` then timed out on the fence and fail-closed a job that had already completed successfully.

Heartbeat only CAS-refreshes `fire_claim.at` via `_refresh_claim`. `_with_job` already provides `_jobs_lock` for that mutation, so the fire fence is unnecessary and harmful here. `mark_job_run` and `claim_job_for_fire` still use `_under_fire_fence`.

## Related Issue

Fixes #106737

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `cron/jobs.py`: `heartbeat_fire_claim` returns `_with_job(...)` only (no `_under_fire_fence`)
- `tests/cron/test_claim_job_for_fire.py`: contended `.jobs.lock` + concurrent `mark_job_run` regression; missing-job fail-open coverage

## How to Test

```bash
# Focused suite (includes new contention RED→GREEN probe)
./scripts/run_tests.sh tests/cron/test_claim_job_for_fire.py -q
# → 18 passed

# Contended probe alone (pre-fix fails; post-fix passes)
./scripts/run_tests.sh tests/cron/test_claim_job_for_fire.py -k 'heartbeat_does_not_pin_fire_fence or heartbeat_fire_claim_missing' -q
```

Proof on base `42d28d64f0`: contention test FAILED (`mark_job_run` False + fire-fence timeout log). After fix: same suite GREEN.

## Review follow-up

Self-review P0=0 (Detection / Fail-open / Forbidden / RED evidence / diff scope). Independent review skipped: 2 files, <200 lines, no auth/crypto/state.db.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(cron): ...`)
- [x] Searched existing PRs for duplicates
- [x] PR contains only changes related to this fix
- [x] Relevant tests run locally
- [x] Added tests for the change
- [x] Tested on macOS (darwin)

### Documentation & Housekeeping
- [x] Docs N/A
- [x] cli-config N/A
- [x] Cross-platform: contention probe is POSIX-flock `skipif`; production change is lock-nesting only
- [x] Tool schemas N/A

Made with [Cursor](https://cursor.com)