### PR TITLE
fix(bedrock): give claude-opus-5 its own context-window entry

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -935,8 +935,9 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude: 1M GA vs 200K. The 1M entries must match agent/model_metadata.py
     # DEFAULT_CONTEXT_LENGTHS or context compresses early.
     **dict.fromkeys((
-        "anthropic.claude-fable-5", "anthropic.claude-fable", "anthropic.claude-sonnet-5", "anthropic.claude-opus-4-8",
-        "anthropic.claude-opus-4-7", "anthropic.claude-opus-4-6", "anthropic.claude-sonnet-4-6",
+        "anthropic.claude-fable-5", "anthropic.claude-fable", "anthropic.claude-opus-5", "anthropic.claude-sonnet-5",
+        "anthropic.claude-opus-4-8", "anthropic.claude-opus-4-7", "anthropic.claude-opus-4-6",
+        "anthropic.claude-sonnet-4-6",
     ), 1_000_000),
     **dict.fromkeys((
         "anthropic.claude-sonnet-4-5", "anthropic.claude-haiku-4-5", "anthropic.claude-opus-4", "anthropic.claude-sonnet-4",

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -993,6 +993,35 @@ class TestBedrockContextLength:
         assert get_bedrock_context_length("unknown.model-v1:0") == BEDROCK_DEFAULT_CONTEXT_LENGTH
 
 
+    def test_opus_5_is_not_treated_as_an_unknown_model(self):
+        # "anthropic.claude-opus-4" is not a substring of "...claude-opus-5", so without an entry of
+        # its own opus-5 matched nothing in the table and took the branch above - a 1M model driven
+        # on BEDROCK_DEFAULT_CONTEXT_LENGTH, an eighth of its window.
+        # Measured: Converse rejects a 1,444,500-token prompt with "> 1000000 maximum" for
+        # us.anthropic.claude-opus-5 and global.anthropic.claude-opus-5, in us-east-1 and us-east-2.
+        from agent.bedrock_adapter import get_bedrock_context_length
+        for model_id in ("us.anthropic.claude-opus-5", "global.anthropic.claude-opus-5"):
+            assert get_bedrock_context_length(model_id, probe=False) == 1_000_000
+        # The key must also survive a dated/versioned suffix, which is how Bedrock spells most IDs.
+        # This one is synthetic - the two above are the IDs the API actually lists today.
+        assert get_bedrock_context_length("us.anthropic.claude-opus-5-20260101-v1:0", probe=False) == 1_000_000
+
+
+    def test_every_1m_claude_in_the_generic_table_resolves_to_1m_here(self):
+        # The table states this as a requirement on itself: "The 1M entries must match
+        # agent/model_metadata.py DEFAULT_CONTEXT_LENGTHS or context compresses early."  Scoped to
+        # Claude deliberately - Bedrock really does serve less than the generic table for the OpenAI
+        # models (272K vs 1,050,000), so a blanket cross-table assert would be wrong.  Dotted keys
+        # are skipped: Bedrock model IDs spell versions with dashes, never dots.
+        from agent.bedrock_adapter import get_bedrock_context_length
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+        one_m = [k for k, v in DEFAULT_CONTEXT_LENGTHS.items()
+                 if v == 1_000_000 and k.startswith("claude") and "." not in k]
+        assert one_m, "no 1M Claude keys in the generic table - this guard would pass vacuously"
+        resolved = {k: get_bedrock_context_length("us.anthropic." + k, probe=False) for k in one_m}
+        assert {k: v for k, v in resolved.items() if v != 1_000_000} == {}
+
+
     def test_no_region_skips_probe_uses_table(self):
         # Default call (no region) must NOT hit the network — returns the
         # static table value.  Guards backward compatibility for callers that


### PR DESCRIPTION
## What does this PR do?

Adds `anthropic.claude-opus-5` to `BEDROCK_CONTEXT_LENGTHS` at `1_000_000`. Today it is absent, and because the table matches by **longest substring**, absent does not mean "falls back to the closest Claude" — it means no match at all:

```python
matches = [key for key in BEDROCK_CONTEXT_LENGTHS if key in model_id.lower()]
return BEDROCK_CONTEXT_LENGTHS[max(matches, key=len)] if matches else BEDROCK_DEFAULT_CONTEXT_LENGTH
```

`"anthropic.claude-opus-4"` is not a substring of `"anthropic.claude-opus-5"`, so `us.anthropic.claude-opus-5` resolves to `BEDROCK_DEFAULT_CONTEXT_LENGTH` — **128,000 for a model that serves 1,000,000**. It is the "unknown Bedrock model" default, applied to a current flagship.

The fix is one key. I'm sending it because the table already says it should be there:

```python
    # Anthropic Claude: 1M GA vs 200K. The 1M entries must match agent/model_metadata.py
    # DEFAULT_CONTEXT_LENGTHS or context compresses early.
```

`agent/model_metadata.py` has `"claude-opus-5": 1000000`. Of the eight 1M Claude keys in that table, opus-5 was the only one with no Bedrock counterpart — so this is the stated invariant being restored, not a new number being proposed.

`get_bedrock_context_length`'s own docstring anticipates this class of bug (*"a stale substring match silently caps the window (a 1M Opus pinned to 200K via 'opus-4')"*). opus-5 is the sharper version of it: not a stale match, no match.

## Related Issue

No issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`agent/bedrock_adapter.py` `+3/-2` — `"anthropic.claude-opus-5"` added to the 1M tuple, which reflows the tuple across three lines instead of two. No other change; no comment edit, since the existing comment is the justification.

`tests/agent/test_bedrock_adapter.py` `+29/-0` — two tests in `TestBedrockContextLength`:

- **`test_opus_5_is_not_treated_as_an_unknown_model`** asserts 1,000,000 for `us.anthropic.claude-opus-5` and `global.anthropic.claude-opus-5` (the two IDs Bedrock lists today) plus one synthetic dated ID, labelled as synthetic in the comment, to pin the substring behaviour for whatever suffix the versioned release carries.
- **`test_every_1m_claude_in_the_generic_table_resolves_to_1m_here`** is the regression guard for the invariant above: every `claude*` key worth 1,000,000 in `DEFAULT_CONTEXT_LENGTHS` must resolve to 1,000,000 through `get_bedrock_context_length`. It is deliberately **scoped to Claude** — a blanket cross-table assert would be wrong, because Bedrock genuinely serves less than the generic table for the OpenAI models (`openai.gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`: 272,000 on Bedrock vs 1,050,000 generic). Dotted keys are skipped; Bedrock IDs spell versions with dashes. There's a non-vacuity assert so the guard can't quietly degrade to an empty loop.

Both tests pass `probe=False`, so nothing touches the network.

## How to Test

```bash
pytest tests/agent/test_bedrock_adapter.py -q -p no:randomly
#  -> 80 passed

git checkout <base> -- agent/bedrock_adapter.py
pytest tests/agent/test_bedrock_adapter.py -q -p no:randomly
#  -> 2 failed, 78 passed
```

Both failures are behavioural, not import errors — the guard reports `AssertionError: assert {'claude-opus-5': 128000} == {}`, which is the defect stated as data.

| suite | result |
|---|---|
| `test_bedrock_adapter.py` + `test_model_metadata.py` + `test_bedrock_integration.py` | **236 passed** |

Those are the only test files in the tree that reference `get_bedrock_context_length` or `BEDROCK_CONTEXT_LENGTHS`, plus the generic-table suite this change is keyed to. `ruff check .` passes repo-wide.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — one commit, `fix(bedrock): ...`
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — **no. I ticked this without running the search, and this PR is a duplicate of #75824, #83071 and #92273. Unticked rather than left standing as a false claim; see the closing comment.**
- [x] My PR contains **only** changes related to this fix (2 files, 1 commit)
- [ ] I've run `pytest tests/ -q` and all tests pass — no; see below
- [x] I've added tests for my changes — 2, both failing on base
- [x] I've tested on my platform: Amazon Linux 2023 x86_64, CPython 3.11.14

No whole-`tests/` run: my box hits collection errors from optional dependencies I don't have (`aiohttp`, the acp/gateway stack), and the remainder exceeds my remote-execution budget. Rather than tick that box on a number I can't attribute, it stays unticked with the scoped runs above.

### Documentation & Housekeeping

- [x] Documentation — N/A, one table entry; the existing comment already states the rule it satisfies
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, no platform-conditional code
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Measured today against live Converse from my own AWS account, `us-east-1` and `us-east-2`, by sending an oversized prompt so the API states its own limit — the same technique `probe_bedrock_context_length` uses, and free, because length validation runs before inference:

```
us.anthropic.claude-opus-5      -> prompt is too long: 1444500 tokens > 1000000 maximum
global.anthropic.claude-opus-5  -> prompt is too long: 1444500 tokens > 1000000 maximum
```

I probed the rest of the Anthropic block the same way rather than only the row I'm changing, so this PR isn't resting on a single reading:

| model | measured | table today |
|---|---|---|
| `claude-opus-5` | **1,000,000** | **128,000 (default)** |
| `claude-opus-4-7` | 1,000,000 | 1,000,000 |
| `claude-opus-4-6` | 1,000,000 | 1,000,000 |
| `claude-sonnet-4-6` | 1,000,000 | 1,000,000 |
| `claude-haiku-4-5` | 200,000 | 200,000 |

Every other row agrees. Two I could not measure and am not claiming anything about: `claude-fable-5` returned `data retention mode 'default' is not available for this model` and `claude-sonnet-4-5` returned `Input is too long for requested model` with no number in it — both account/config conditions on my side, not evidence about the models.

Two things worth flagging so nobody has to discover them in review:

**The live probe hides this on one path and not the other.** `get_bedrock_context_length` probes first when it is given a `region`, and the probe's first tier is 1,300,000 tokens — above opus-5's real 1M window, so it gets a parseable rejection and returns the right answer. The wrong 128,000 is what you get on the no-region path (`get_bedrock_context_length(model_id)`), when boto3 or credentials are unavailable, or when the probe is throttled. That is the same "static table is the fallback that has to be right" shape as the Llama 4 rows in my #106492.

**This does not conflict with my own #106492**, which corrects the Llama 4 rows in the same table. I placed these two tests above `test_no_region_skips_probe_uses_table` instead of at the end of the class, because #106492 appends there and the two would have collided. `git merge-tree` across the two branches reports zero conflicts, in both files. Either can be taken first, in either order.