### PR TITLE
fix(kanban): reject phantom reviewers and profile placeholders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,402 @@
+name: CI
+
+# Orchestrator workflow. Runs ``detect-changes`` once, then conditionally
+# calls the sub-workflows that a PR can actually affect. A final
+# ``all-checks-pass`` gate job aggregates results so branch protection only
+# needs to require a single check.
+#
+# Sub-workflows are triggered via ``workflow_call`` and keep their own job
+# definitions, matrices, and concurrency settings. They no longer have
+# ``push:`` / ``pull_request:`` triggers of their own — everything flows
+# through this file.
+#
+# SECURITY: this workflow runs PR-controlled actions, workflows, and code.
+# Do not add ``secrets: inherit`` or GitHub App credentials here. Trusted
+# main-only automation uses protected environments in its own workflows.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write # needed by lint (PR comment) + supply-chain review_status
+  actions: read # needed by osv-scanner (SARIF upload)
+  security-events: write # needed by osv-scanner (SARIF upload)
+  packages: write # needed by docker build
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────
+  # detect: run the classifier once. Every downstream job reads its outputs
+  # to decide whether to run. On push/dispatch the classifier fails open
+  # (all lanes true) so post-merge validation is never weakened.
+  # ─────────────────────────────────────────────────────────────────────
+  detect:
+    name: Detect affected areas
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      python: ${{ steps.classify.outputs.python }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+      site: ${{ steps.classify.outputs.site }}
+      scan: ${{ steps.classify.outputs.scan }}
+      deps: ${{ steps.classify.outputs.deps }}
+      npm_lock: ${{ steps.classify.outputs.npm_lock }}
+      docker_meta: ${{ steps.classify.outputs.docker_meta }}
+      mcp_catalog: ${{ steps.classify.outputs.mcp_catalog }}
+      ci_review: ${{ steps.classify.outputs.ci_review }}
+      ci_review_files: ${{ steps.classify.outputs.ci_review_files }}
+      event_name: ${{ github.event_name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Detect affected areas
+        id: classify
+        uses: ./.github/actions/detect-changes
+        with:
+          github-token: ${{ github.token }}
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Lane-gated sub-workflows. Each runs in parallel after detect finishes.
+  # Skipped workflows (if condition is false) don't spin up runners.
+  # ─────────────────────────────────────────────────────────────────────
+  tests:
+    name: Python tests
+    needs: detect
+    if: needs.detect.outputs.python == 'true'
+    uses: ./.github/workflows/tests.yml
+    with:
+      slice_count: 8
+
+  lint:
+    name: Python lints
+    needs: detect
+    if: needs.detect.outputs.python == 'true'
+    uses: ./.github/workflows/lint.yml
+    with:
+      event_name: ${{ needs.detect.outputs.event_name }}
+
+  js-tests:
+    name: JS & TS checks
+    needs: detect
+    if: needs.detect.outputs.frontend == 'true'
+    uses: ./.github/workflows/js-tests.yml
+
+  e2e-desktop:
+    name: Desktop E2E
+    needs: detect
+    if: needs.detect.outputs.python == 'true' || needs.detect.outputs.frontend == 'true'
+    uses: ./.github/workflows/e2e-desktop.yml
+
+  docs-site:
+    name: Docs Site
+    needs: detect
+    if: needs.detect.outputs.site == 'true'
+    uses: ./.github/workflows/docs-site-checks.yml
+
+  history-check:
+    name: Deny unrelated histories
+    needs: detect
+    if: needs.detect.outputs.event_name == 'pull_request'
+    uses: ./.github/workflows/history-check.yml
+
+  contributor-check:
+    name: Check contributors
+    needs: detect
+    if: needs.detect.outputs.python == 'true'
+    uses: ./.github/workflows/contributor-check.yml
+
+  uv-lockfile:
+    name: Check uv.lock
+    needs: detect
+    uses: ./.github/workflows/uv-lockfile-check.yml
+
+  infographic-check:
+    name: Check no committed infographics
+    needs: detect
+    uses: ./.github/workflows/infographic-check.yml
+
+  lockfile-diff:
+    name: package-lock.json diff
+    needs: detect
+    if: needs.detect.outputs.event_name == 'pull_request' && needs.detect.outputs.npm_lock == 'true'
+    uses: ./.github/workflows/lockfile-diff.yml
+
+  docker-lint:
+    name: Lint Docker scripts
+    needs: detect
+    if: needs.detect.outputs.docker_meta == 'true'
+    uses: ./.github/workflows/docker-lint.yml
+
+  docker:
+    name: Build&Test Docker image
+    needs: detect
+    # Trusted main pushes run docker.yml directly so its container-publish
+    # environment secrets never cross this reusable-workflow call. PR runs
+    # remain build/test-only and secret-free.
+    if: needs.detect.outputs.event_name == 'pull_request' && (needs.detect.outputs.python == 'true' || needs.detect.outputs.frontend == 'true' || needs.detect.outputs.docker_meta == 'true')
+    uses: ./.github/workflows/docker.yml
+
+  supply-chain:
+    name: Supply-chain scan
+    needs: detect
+    if: needs.detect.outputs.event_name == 'pull_request' && (needs.detect.outputs.scan == 'true' || needs.detect.outputs.deps == 'true')
+    uses: ./.github/workflows/supply-chain-audit.yml
+    with:
+      event_name: ${{ needs.detect.outputs.event_name }}
+      scan: ${{ needs.detect.outputs.scan == 'true' }}
+      deps: ${{ needs.detect.outputs.deps == 'true' }}
+
+  review-labels:
+    name: Review label gate
+    needs: [detect, supply-chain]
+    if: always() && needs.detect.outputs.event_name == 'pull_request' && (needs.detect.outputs.ci_review == 'true' || needs.detect.outputs.mcp_catalog == 'true' || needs.supply-chain.outputs.critical_findings == 'true')
+    uses: ./.github/workflows/review-labels.yml
+    with:
+      ci_review: ${{ needs.detect.outputs.ci_review == 'true' }}
+      ci_review_files: ${{ needs.detect.outputs.ci_review_files }}
+      mcp_catalog: ${{ needs.detect.outputs.mcp_catalog == 'true' }}
+      supply_chain: ${{ needs.supply-chain.outputs.critical_findings == 'true' }}
+
+  osv-scanner:
+    name: OSV scan
+    uses: ./.github/workflows/osv-scanner.yml
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Live-updating PR review comment.
+  #
+  # A single ``comment-live`` job polls the GitHub Actions API every 15s
+  # for job statuses in this run, re-assembles the review comment from
+  # whatever results are available, and upserts it via the
+  # ``<!-- hermes-ci-review-bot -->`` marker.
+  #
+  # When the visible job set goes quiet, the poller waits 10 seconds and polls
+  # once more so downstream jobs created by an aggregate gate get included.
+  # ─────────────────────────────────────────────────────────────────────
+  comment-live:
+    name: CI review comment (live)
+    needs: [detect, review-labels, lockfile-diff, supply-chain, osv-scanner, uv-lockfile, history-check, contributor-check, e2e-desktop]
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Run live comment poller
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Commit info for the review comment header.
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMIT_MESSAGE: ${{ github.event.pull_request.head.commit.message }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}
+          # Structured review statuses from workflow_call jobs.
+          # Each job outputs a JSON array of {source, results: [...]} objects
+          # that the assembler renders directly — no hardcoded job-name
+          # matching. We merge all available outputs into one array.
+          REVIEW_STATUSES: ${{ toJSON(needs.*.outputs.review_status) }}
+        run: |
+          set -uo pipefail
+
+          # REVIEW_STATUSES is a JSON array of strings (some may be empty
+          # when a job was skipped). Parse each string and merge into one
+          # flat array for the assembler.
+          python3 - <<'PYEOF'
+          import json, os, sys
+
+          raw = os.environ.get("REVIEW_STATUSES", "")
+          merged = []
+          if raw:
+              try:
+                  arr = json.loads(raw)
+              except (json.JSONDecodeError, TypeError):
+                  arr = []
+              for item in arr:
+                  if not item:
+                      continue
+                  try:
+                      statuses = json.loads(item)
+                  except (json.JSONDecodeError, TypeError):
+                      continue
+                  if isinstance(statuses, list):
+                      merged.extend(statuses)
+
+          # Write merged array to a temp file the poller reads.
+          with open("/tmp/review_statuses.json", "w") as f:
+              json.dump(merged, f)
+          print(f"Merged {len(merged)} review status entries")
+          PYEOF
+
+          python3 scripts/ci/live_comment.py \
+            --interval 15 \
+            --timeout 2100 \
+            --review-statuses-file /tmp/review_statuses.json
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Gate: runs after everything. ``if: always()`` ensures it reports a
+  # status even when some deps were skipped. Only actual ``failure``
+  # results cause it to fail; ``skipped`` is treated as success.
+  #
+  # Branch protection should require ONLY this check.
+  #
+  # Outputs ``needs-json`` — a compact ``{job_name: result}`` dict — so
+  # the live comment poller can list failed jobs in the PR comment.
+  # ─────────────────────────────────────────────────────────────────────
+  all-checks-pass:
+    name: All required checks pass
+    needs:
+      - detect
+      - tests
+      - lint
+      - js-tests
+      - e2e-desktop
+      - docs-site
+      - history-check
+      - contributor-check
+      - uv-lockfile
+      - lockfile-diff
+      - docker-lint
+      - supply-chain
+      - review-labels
+      - osv-scanner
+      # comment-live is a polling job — it doesn't block the gate.
+      # we don't require docker to pass rn because it's so slow lol
+      # - docker
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      needs-json: ${{ steps.evaluate.outputs.needs-json }}
+    steps:
+      - name: Evaluate job results
+        id: evaluate
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | python3 -c "
+          import json, sys
+          needs = json.load(sys.stdin)
+          # Emit compact {job_name: result} for the comment assembler.
+          compact = {name: info['result'] for name, info in needs.items()}
+          print(f'needs-json={json.dumps(compact)}')
+          with open('$GITHUB_OUTPUT', 'a') as f:
+              f.write(f'needs-json={json.dumps(compact)}\n')
+          failed = [name for name, info in needs.items() if info['result'] == 'failure']
+          for name, info in sorted(needs.items()):
+              result = info['result']
+              icon = '✅' if result in ('success', 'skipped') else '❌'
+              print(f'{icon} {name}: {result}')
+          if failed:
+              print(f'::error::{len(failed)} job(s) failed: {\", \".join(failed)}')
+              sys.exit(1)
+          print('All checks passed (or were skipped)')
+          "
+
+  # ─────────────────────────────────────────────────────────────────────
+  # CI timing report: collect per-job/step durations from the GitHub API,
+  # cache them on main (as a baseline), and on PRs generate an HTML diff
+  # report with a gantt chart + per-step breakdown. The report is uploaded
+  # as an artifact and a markdown summary is written to $GITHUB_STEP_SUMMARY.
+  #
+  # The live comment poller can read the standalone review-status artifact
+  # after the HTML report is uploaded, so its link points straight at that report.
+  # ─────────────────────────────────────────────────────────────────────
+  ci-timings:
+    name: CI timing report
+    needs: [all-checks-pass, docker]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore baseline cache (PR only)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ci-timings-baseline.json
+          # Prefix-match: exact key will never hit (run_id differs), so
+          # restore-keys finds the most recent baseline from main.
+          key: ci-timings-baseline-never-exact
+          restore-keys: |
+            ci-timings-baseline-
+
+      - name: Collect timings and generate report
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/ci/timings_report.py \
+            --baseline ci-timings-baseline.json \
+            --output ci-timings-report.html \
+            --json-out ci-timings.json \
+            --summary-out ci-timings-summary.md
+
+      - name: Upload HTML report
+        # Advisory report — artifact-service blips must not fail the job.
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        id: ci-timings-html
+        with:
+          name: ci-timings-report
+          path: ci-timings-report.html
+          retention-days: 14
+
+      - name: Build linked review status
+        if: hashFiles('ci-timings.json') != ''
+        env:
+          CI_TIMINGS_REPORT_URL: ${{ steps.ci-timings-html.outputs.artifact-url }}
+        run: |
+          python3 scripts/ci/timings_report.py \
+            --from-json ci-timings.json \
+            --baseline ci-timings-baseline.json \
+            --review-status-out review-status.json \
+            --review-status-only
+
+      - name: Upload review status
+        if: hashFiles('review-status.json') != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ci-timings-review-status
+          path: review-status.json
+          retention-days: 14
+
+      - name: Output summary
+        env:
+          REPORT_URL: ${{ steps.ci-timings-html.outputs.artifact-url}}
+        run: |
+          {
+            echo "# CI Timing report"
+            echo "[View the full interactive report]($REPORT_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"
+          cat ci-timings-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Save baseline cache (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          # Degraded runs (API rate-limited) produce no ci-timings.json —
+          # skip rather than fail, and never cache an empty baseline.
+          if [ -f ci-timings.json ]; then
+            cp ci-timings.json ci-timings-baseline.json
+          else
+            echo "No timings JSON this run — skipping baseline update"
+          fi
+
+      - name: Upload baseline to cache (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && hashFiles('ci-timings-baseline.json') != ''
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ci-timings-baseline.json
+          key: ci-timings-baseline-${{ github.run_id }}

--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -33,7 +33,6 @@ jobs:
           if [ -z "$NEW_EMAILS" ]; then
             echo "No new commits to check."
             echo "review_status=[]" >> "$GITHUB_OUTPUT"
-            echo "review_status=[]" > review-status.json
             exit 0
           fi
 
@@ -68,8 +67,6 @@ jobs:
             echo -e "$MISSING"
             echo ""
             echo "Add a mapping file (do NOT edit AUTHOR_MAP in release.py):"
-            echo "  python3 scripts/audit_pr_attribution.py --fix   # auto-resolve + create files"
-            echo "or manually:"
             echo -e "$MISSING" | while read -r line; do
               email=$(echo "$line" | sed 's/^ *//' | cut -d' ' -f1)
               [ -z "$email" ] && continue
@@ -81,28 +78,14 @@ jobs:
 
             # Emit review_status for unmapped emails
             DETAIL=$(echo -e "$MISSING" | sed '/^$/d; s/^  //')
-            HOW_TO_FIX=$'Run from the PR branch:\n```\npython3 scripts/audit_pr_attribution.py --fix\ngit add contributors && git commit -m "chore: map contributor emails" && git push\n```\nOr map one email manually (do NOT edit AUTHOR_MAP in release.py):\n```\npython3 scripts/add_contributor.py <email> <github-username>\n```\nTo find the GitHub username for an email:\n```\ngh api \'search/users?q=EMAIL+in:email\' --jq \'.items[0].login\'\n```\n'
+            HOW_TO_FIX=$'Add mappings to scripts/release.py AUTHOR_MAP:\n```\n"<email>": "<github-username>",\n```\nTo find the GitHub username for an email:\n```\ngh api \'search/users?q=EMAIL+in:email\' --jq \'.items[0].login\'\n```\n'
             REVIEW_STATUS=$(jq -nc \
               --arg detail "$DETAIL" \
               --arg how_to_fix "$HOW_TO_FIX" \
               '[{"source":"contributor attribution","results":[{"kind":"action_required","title":"Unmapped contributor email(s)","summary":"New contributor email(s) are not in AUTHOR_MAP.","detail":$detail,"how_to_fix":$how_to_fix}]}]')
             echo "review_status=$REVIEW_STATUS" >> "$GITHUB_OUTPUT"
-            echo "review_status=$REVIEW_STATUS" > review-status.json
 
             exit 1
           else
             echo "✅ All contributor emails are mapped."
-            echo "review_status=[]" >> "$GITHUB_OUTPUT"
-            echo "review_status=[]" > review-status.json
           fi
-
-      - name: Upload review status artifact
-        if: always() && steps.check-emails.outcome != 'skipped'
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: review-status-contributor-check
-          path: review-status.json
-          retention-days: 1
-          overwrite: true
-          if-no-files-found: ignore

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -65,13 +65,9 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: 26
+          node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
-
-      - name: grab npm 12
-        run: |
-          npm i -g npm@12
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -188,61 +184,6 @@ jobs:
           if [ -f website/build/llms-full.txt ]; then
             cp website/build/llms-full.txt _site/llms-full.txt
           fi
-
-      # Pages serves exactly the newest artifact, so each deploy used to delete
-      # the previous build's content-hashed JS/CSS while edge caches (Vercel →
-      # Fastly, max-age=300 + stale-while-revalidate=3600) kept serving HTML
-      # that referenced it — every asset request 404'd for up to ~65 minutes
-      # after each deploy. With push-triggered deploys landing every ~15-30
-      # minutes, the docs were in that broken window most of the day (search,
-      # being pure client JS, died first). Fix: keep a rolling pool of prior
-      # builds' hashed assets and union-merge it into every artifact so stale
-      # HTML keeps resolving. Hashed filenames are content-addressed, so a
-      # collision is by definition the identical file — the merge never
-      # overwrites current-build output (cp --update=none).
-      - name: Restore asset retention pool
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: _asset_retention
-          key: docs-asset-retention-${{ github.run_id }}
-          restore-keys: |
-            docs-asset-retention-
-
-      - name: Merge retained assets from previous deploys
-        run: |
-          set -euo pipefail
-          ASSET_DIRS="assets zh-Hans/assets"
-          mkdir -p _asset_retention
-          # 1) Add this build's hashed assets to the pool (fresh mtimes, so
-          #    assets still shipped by current builds never age out).
-          for d in $ASSET_DIRS; do
-            if [ -d "_site/docs/$d" ]; then
-              mkdir -p "_asset_retention/$d"
-              cp -a "_site/docs/$d/." "_asset_retention/$d/"
-            fi
-          done
-          # 2) Drop pool entries no build has produced for 14 days — far
-          #    beyond any edge-cache or open-tab horizon.
-          find _asset_retention -type f -mtime +14 -delete
-          find _asset_retention -type d -empty -delete
-          # 3) Union-merge the pool into the artifact; --update=none keeps the
-          #    current build authoritative for any path it produced.
-          for d in $ASSET_DIRS; do
-            if [ -d "_asset_retention/$d" ]; then
-              mkdir -p "_site/docs/$d"
-              cp -R --update=none "_asset_retention/$d/." "_site/docs/$d/"
-            fi
-          done
-          echo "retention pool:" && du -sh _asset_retention
-          echo "deployed assets:" && du -sh _site/docs/assets
-
-      - name: Save asset retention pool
-        # Always save under a fresh key (caches are immutable); restore-keys
-        # prefix matching picks the newest on the next run.
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
-        with:
-          path: _asset_retention
-          key: docs-asset-retention-${{ github.run_id }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,19 +1,16 @@
 name: Docker Build, Test, and Publish
 
 on:
-  # This workflow owns its own triggers. ci.yml does not call it.
-  # A reusable-workflow call eeps the caller run in progress for that full time.
-  # GitHub refuses  ``gh run rerun`` on a run that is still in progress.
-  # Thus one slow advisory job blocked every rerun of the fast required jobs. A separate
-  # run reruns and cancels independently.
-  #
-  # Trusted main pushes resolve the environment-scoped Docker Hub secrets in
-  # this same workflow, never across a workflow boundary.
-  pull_request:
+  # Trusted main pushes run this workflow directly so environment-scoped
+  # Docker Hub secrets are resolved by the top-level workflow, never across
+  # a reusable-workflow boundary.
   push:
     branches: [main]
   release:
     types: [published]
+  # CI calls this only for untrusted PR build/test coverage. Those runs never
+  # reach the protected publish or merge jobs below.
+  workflow_call:
 
 permissions:
   contents: read
@@ -30,60 +27,22 @@ env:
   IMAGE_NAME: nousresearch/hermes-agent
 
 jobs:
-  # Classify the PR's changed files. ci.yml used to gate the docker call on
-  # its own ``detect`` outputs; now that this workflow triggers itself, it
-  # runs the same composite action. On push and release the classifier fails
-  # open (every lane true), so post-merge validation is never weakened.
-  detect:
-    name: Detect affected areas
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      build: ${{ steps.gate.outputs.build }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Detect affected areas
-        id: classify
-        uses: ./.github/actions/detect-changes
-        with:
-          github-token: ${{ github.token }}
-
-      - name: Decide whether to build
-        id: gate
-        env:
-          # The docker lane derives from python_prod (not python: the image
-          # copies installed code, never tests/, so tests-only PRs skip the
-          # build), frontend and docker_meta. classify_changes.py owns the
-          # formula so this gate and the nix lane cannot drift apart.
-          DOCKER: ${{ steps.classify.outputs.docker }}
-        run: |
-          set -euo pipefail
-          if [ "$DOCKER" = "true" ]; then
-            echo "build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "build=false" >> "$GITHUB_OUTPUT"
-          fi
-
   # Build and test the image for each architecture. This job runs PR code,
   # so it must remain secret-free. Publishing happens in the separate,
   # protected publish job after these tests pass.
   build:
-    needs: [detect]
-    if: github.repository == 'NousResearch/hermes-agent' && needs.detect.outputs.build == 'true'
+    if: github.repository == 'NousResearch/hermes-agent'
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest-32-core
+            runner: ubuntu-latest
             platform: linux/amd64
             cache-from: type=gha,scope=docker-amd64
             cache-to: type=gha,mode=max,scope=docker-amd64
-          # arm64 builds on the native arm64 larger runner. A build of
-          # linux/arm64 on an x64 host uses emulation.
           - arch: arm64
-            runner: ubuntu-latest-32-arm-core
+            runner: ubuntu-24.04-arm
             platform: linux/arm64
             cache-from: type=gha,scope=docker-arm64
             cache-to: type=gha,mode=max,scope=docker-arm64
@@ -94,22 +53,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Reject profile exports in the build context
-        run: python3 scripts/ci/check_profile_archive_boundary.py
-
-      # Retry once on transient Docker Hub / buildkit pull failures
-      # (connection reset, auth token timeout, rate limiting). The action
-      # generates a unique builder name per invocation so the retry doesn't
-      # collide with the failed first attempt. A genuine persistent failure
-      # still fails the job — only the first attempt has continue-on-error.
-      # Refs: docker/setup-buildx-action#510
       - name: Set up Docker Buildx
-        id: buildx
-        continue-on-error: true
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Set up Docker Buildx (retry)
-        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Build once, load into the local daemon for testing.  Cached
@@ -144,16 +88,9 @@ jobs:
       # ---------------------------------------------------------------------
       - name: Install uv (for docker tests)
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
 
       - name: Set up Python 3.11 (for docker tests)
-        uses: ./.github/actions/retry
-        with:
-          command: uv python install 3.11
+        run: uv python install 3.11
 
       - name: Install Python dependencies (for docker tests)
         # ``dev`` extra pulls in pytest, pytest-asyncio —
@@ -174,11 +111,7 @@ jobs:
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
         run: |
-          # Each of these tests drives a container, so the docker daemon sets
-          # the limit and not the processor. This caps the workers. The
-          # default from run_tests.sh is cpu_count*2, which starts 64
-          # containers together on the 32-core amd64 runner.
-          HERMES_TEST_WORKERS=$(nproc) scripts/run_tests.sh tests/docker/ --file-timeout 600
+          scripts/run_tests.sh tests/docker/ --file-timeout 600
 
   # ---------------------------------------------------------------------------
   # Rebuild and push each architecture only after the unprivileged build/test
@@ -193,13 +126,12 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: ubuntu-latest-32-core
+            runner: ubuntu-latest
             platform: linux/amd64
             cache-from: type=gha,scope=docker-amd64
             cache-to: type=gha,mode=max,scope=docker-amd64
-          # Native arm64 for the same reason as the build matrix above.
           - arch: arm64
-            runner: ubuntu-latest-32-arm-core
+            runner: ubuntu-24.04-arm
             platform: linux/arm64
             cache-from: type=gha,scope=docker-arm64
             cache-to: type=gha,mode=max,scope=docker-arm64
@@ -209,18 +141,7 @@ jobs:
       - name: Checkout trusted source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Reject profile exports in the build context
-        run: python3 scripts/ci/check_profile_archive_boundary.py
-
-      # Retry once on transient Docker Hub / buildkit pull failures.
-      # See build job for rationale; same pattern.
       - name: Set up Docker Buildx
-        id: buildx
-        continue-on-error: true
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Set up Docker Buildx (retry)
-        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
@@ -282,15 +203,7 @@ jobs:
           pattern: digest-*
           merge-multiple: true
 
-      # Retry once on transient Docker Hub / buildkit pull failures.
-      # See build job for rationale; same pattern.
       - name: Set up Docker Buildx
-        id: buildx
-        continue-on-error: true
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
-      - name: Set up Docker Buildx (retry)
-        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub

--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -15,13 +15,9 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 26
+          node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
-
-      - name: grab npm 12
-        run: |
-          npm i -g npm@12
 
       - name: Install website dependencies
         uses: ./.github/actions/retry
@@ -49,8 +45,5 @@ jobs:
         working-directory: website
 
       - name: Build Docusaurus
-        # Build only the default (en) locale in CI — the full bilingual
-        # build runs in deploy-site.yml on push-to-main / release.
-        # Same pattern Docusaurus uses internally (build:fast --locale en).
-        run: npm run build:fast
+        run: npm run build
         working-directory: website

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -17,10 +17,7 @@ concurrency:
 jobs:
   e2e:
     name: Playwright E2E (Linux)
-    # This job builds the renderer and the electron bundle, then drives a real
-    # Electron app under xvfb. vite, tsc and the Playwright workers all scale
-    # with the core count.
-    runs-on: ubuntu-latest-32-core
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
       review_status: ${{ steps.review-status.outputs.review_status }}
@@ -42,13 +39,8 @@ jobs:
       # ── Node ───────────────────────────────────────────────────────────
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 26
+          node-version: 22
           cache: npm
-
-      - name: grab npm 12
-        run: |
-          npm i -g npm@12
-
       # Full npm ci (not --ignore-scripts): electron's postinstall
       # downloads the binary we launch, and node-pty's native build is
       # needed for the terminal pane.
@@ -60,21 +52,12 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
         with:
-          # Pin the uv version: unpinned, setup-uv resolves "latest" by
-          # fetching a manifest from raw.githubusercontent.com on EVERY job —
-          # a transient fetch failure fails the whole job (2026-07-28 slice-5
-          # incident). Pinned, the binary downloads directly; no manifest hop.
-          version: '0.9.28'
           enable-cache: true
           cache-dependency-glob: |
             pyproject.toml
             uv.lock
-
       - name: Set up Python 3.11
-        uses: ./.github/actions/retry
-        with:
-          command: uv python install 3.11
-
+        run: uv python install 3.11
       - name: Install Python dependencies
         uses: ./.github/actions/retry
         with:
@@ -118,11 +101,11 @@ jobs:
               npx playwright test --reporter=list
           fi
         env:
-          CI: 'true'
+          CI: "true"
           # Ensure no real API keys leak into the test env.
-          OPENROUTER_API_KEY: ''
-          OPENAI_API_KEY: ''
-          NOUS_API_KEY: ''
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
 
       # ── Save updated baselines to cache (main only) ───────────────────
       - name: Save updated baselines to cache
@@ -187,18 +170,6 @@ jobs:
             cat /tmp/e2e-review-status.json
             echo '__E2E_REVIEW_STATUS__'
           } >> "$GITHUB_OUTPUT"
-          cp /tmp/e2e-review-status.json review-status.json
-
-      - name: Upload review status artifact
-        if: always() && steps.review-status.outcome != 'skipped'
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: review-status-e2e-desktop
-          path: apps/desktop/review-status.json
-          retention-days: 1
-          overwrite: true
-          if-no-files-found: ignore
 
       # The trusted workflow_run publisher consumes only this flat, bounded
       # artifact. It turns selected images into GitHub attachment URLs; it

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -44,7 +44,6 @@ jobs:
           if ! BASE=$(git merge-base origin/main HEAD 2>/dev/null) || [ -z "$BASE" ]; then
             STATUS='[{"source":"unrelated histories","results":[{"kind":"action_required","title":"Unrelated histories","summary":"This PR has no common ancestor with main.","detail":"","how_to_fix":"Rebase your changes onto current main:\n```\ngit fetch origin main\ngit checkout -b fix-branch origin/main\n# re-apply your changes (cherry-pick, copy files, etc.)\ngit push -f origin fix-branch\n```\n"}]}]'
             echo "review_status=${STATUS}" >> "$GITHUB_OUTPUT"
-            echo "review_status=${STATUS}" > review-status.json
             echo ""
             echo "::error::This PR has no common ancestor with main."
             echo ""
@@ -67,15 +66,3 @@ jobs:
           fi
           echo "::notice::Common ancestor with main: $BASE"
           echo "review_status=[]" >> "$GITHUB_OUTPUT"
-          echo "review_status=[]" > review-status.json
-
-      - name: Upload review status artifact
-        if: always() && steps.merge-base-check.outcome != 'skipped'
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: review-status-history-check
-          path: review-status.json
-          retention-days: 1
-          overwrite: true
-          if-no-files-found: ignore

--- a/.github/workflows/js-autofix.yml
+++ b/.github/workflows/js-autofix.yml
@@ -67,12 +67,8 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 26
+          node-version: 22
           cache: npm
-
-      - name: grab npm 12
-        run: |
-          npm i -g npm@12
 
       # --ignore-scripts: eslint only needs TS sources + eslint packages.
       - uses: ./.github/actions/retry
@@ -89,33 +85,20 @@ jobs:
       - name: Produce patch
         id: produce-patch
         run: |
-          # Exclude every file that the dep-version-gate ruleset guards
-          # (package manifests, eslint configs, workflow files). A patch
-          # that contains one of these files makes the bot PR wait for a
-          # team review, and auto-merge then stops. The check step in
-          # typecheck.yml still reports their lint errors.
-          # The (glob) magic makes "**/" also match files at the repo
-          # root, which plain pathspec wildcards do not.
-          EXCLUDES=(
-            ':(exclude,glob)**/package.json'
-            ':(exclude,glob)**/package-lock.json'
-            ':(exclude,glob)**/eslint.config.*'
-            ':(exclude,glob).github/**'
-          )
-          if git diff --quiet -- . "${EXCLUDES[@]}"; then
+          if git diff --quiet; then
             echo "No fixes needed."
             echo "has-fixes=false" >> "$GITHUB_OUTPUT"
             # Empty patch signals "nothing to do" to apply-patch.
             : > js-fix.patch
           else
-            git diff -- . "${EXCLUDES[@]}" > js-fix.patch
+            git diff > js-fix.patch
             echo "has-fixes=true" >> "$GITHUB_OUTPUT"
             echo "Patch size: $(wc -c < js-fix.patch) bytes"
 
             # Reject patches that touch anything outside JS/TS/JSON sources.
             # `npm run fix` should only ever modify those; anything else means
             # eslint/prettier or a plugin went rogue and we refuse to ship it.
-            BAD=$(git diff --name-only -- . "${EXCLUDES[@]}" | grep -vE '\.(js|cjs|mjs|ts|tsx|json)$' || true)
+            BAD=$(git diff --name-only | grep -vE '\.(js|cjs|mjs|ts|tsx|json)$' || true)
             if [ -n "$BAD" ]; then
               echo "::error::Refusing to upload patch — touches disallowed files:"
               echo "$BAD"

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -5,79 +5,65 @@ on:
   workflow_call:
 
 jobs:
-  check:
-    name: JS & TS checks
-    # One 32-core job replaces a 14-leg matrix. The matrix spread about 612s
-    # of check payload over 4-core runners. It paid about 371s of repeated
-    # setup to do it: 14 checkouts, 14 node installs, 14 node_modules
-    # restores.
-    #
-    # One larger runner installs one time. vitest, tsc and eslint each size
-    # their own worker pool from the core count.
-    runs-on: ubuntu-latest-32-core
-    timeout-minutes: 30
+  workspaces:
+    name: List npm workspaces
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      checks: ${{ steps.set-matrix.outputs.checks }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 26
+          node-version: 22
           cache: npm
-
-      - name: grab npm 12
-        run: |
-          # No-op once the bundled npm is already 12.x — saves ~5-15s/job and
-          # keeps the installed major aligned with the npm12 cache-key tag.
-          npm --version | grep -q '^12\.' || npm i -g npm@12
-
-      # The ``cache: npm`` option of ``setup-node`` caches only the ~/.npm
-      # tarball cache. The job then extracts the full workspace node_modules
-      # again and runs the postinstalls again, which includes the Electron
-      # binary fetch. This caches the installed tree itself, keyed on the
-      # lockfile, and skips ``npm ci`` on an exact hit. There are no
-      # restore-keys: a partial hit leaves a stale tree, so anything other
-      # than an exact lockfile match reinstalls from the start.
-      #
-      # This install runs WITH scripts, so the tree holds the postinstall
-      # artifacts. The postinstall of electron unpacks its binary into
-      # node_modules/electron/dist, which is inside the cached tree.
-      #
-      # The ~/.cache/electron download cache stays out of the key on purpose.
-      # ``npm ci`` is skipped on a hit, so nothing reads that cache. It only
-      # makes the archive larger.
-      - name: Restore node_modules
-        id: node-modules-cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: |
-            node_modules
-            apps/*/node_modules
-            ui-tui/node_modules
-            ui-tui/packages/*/node_modules
-            tests-js/node_modules
-            web/node_modules
-          key: node-modules-scripts-${{ runner.os }}-node26-npm12-${{ hashFiles('package-lock.json') }}
-
       - uses: ./.github/actions/retry
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        with:
+          command: npm ci --ignore-scripts
+      - id: set-matrix
+        run: |
+          node -e '
+          const { execSync } = require("child_process");
+          const pkgs = JSON.parse(execSync("npm query .workspace", { encoding: "utf-8" }));
+          if (pkgs.length === 0) {
+            console.error("::error::Workspace discovery produced an empty package list — refusing to emit a zero-length matrix (would skip all JS/TS checks silently).");
+            process.exit(1);
+          }
+          const checks = [];
+          for (const pkg of pkgs) {
+            const scripts = pkg.scripts || {};
+            const subs = Object.keys(scripts).filter(s => /^check:.+$/.test(s));
+            if (subs.length > 0) {
+              for (const script of subs) {
+                checks.push({ package: pkg.location, script });
+              }
+            } else if (scripts.check) {
+              checks.push({ package: pkg.location, script: "check" });
+            }
+          }
+          if (checks.length === 0) {
+            console.error("::error::No check scripts found in any workspace package.");
+            process.exit(1);
+          }
+          process.stdout.write("checks=" + JSON.stringify(checks) + "\n");
+          ' >> "$GITHUB_OUTPUT"
+
+  check:
+    name: ${{ matrix.package }} / ${{ matrix.script }}
+    needs: workspaces
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.workspaces.outputs.checks) }}
+      fail-fast: false # report all failures, not just the first one
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+      - uses: ./.github/actions/retry
         with:
           command: npm ci
-
-      # Every check runs at the same time. The step fails only after all of
-      # them finish. There are two reasons this is not ``npm run --ws check``.
-      #
-      #   * ``--ws`` is serial and stops at the first workspace that fails. A
-      #     run then reports one failure, where the matrix this replaced
-      #     reported every failure together.
-      #   * The unit of work is a CHECK, and not a workspace. apps/desktop is
-      #     most of the payload, and its own ``check`` is a serial && chain.
-      #     A spread across workspaces alone leaves that chain as the long
-      #     pole. This expands the ``check:*`` sub-scripts of a package, so
-      #     its lint, ui, electron and plugin suites all run together. That
-      #     is the same selection rule the old matrix job used.
-      #
-      # Discovery is ``npm query .workspace``. A new package or a new
-      # ``check:*`` script needs no change here. An empty list is an error and
-      # not an empty run, because an empty run reports green after it checks
-      # nothing.
-      - name: Run all workspace checks
-        run: node .github/scripts/run-workspace-checks.mjs
+      - run: npm run --prefix ${{ matrix.package }} ${{ matrix.script }}

--- a/.github/workflows/label-rerun.yml
+++ b/.github/workflows/label-rerun.yml
@@ -2,16 +2,13 @@ name: Label rerun
 
 # When the ``ci-reviewed`` label is added to a PR, rerun all failed jobs in
 # the latest CI run. This re-evaluates ``review-labels`` (which now sees the
-# label) and GitHub reruns the dependent ``all-checks-pass`` gate.
+# label) and GitHub automatically reruns dependent jobs (``comment-live``,
+# ``all-checks-pass``) — so the review comment gets updated too.
 #
-# ``gh run rerun`` only works on a completed run. Thus this waits when the
-# run is still in progress. The wait is now short. The two slowest jobs are
-# the 40-minute comment poller and the 45-minute image build. Each one moved
-# to its own workflow, so a CI run ends when its required jobs end.
-#
-# The review comment updates without help. The poller in
-# ci-review-comment.yml watches the CI run through the API. It gets the
-# rerun results.
+# If the CI run is still in progress when the label is added, we wait for it
+# to finish before rerunning (``gh run rerun`` only works on completed runs).
+# The wait can be long (20+ min for a full CI run), but it's better than
+# silently failing and leaving the reviewer stuck.
 
 on:
   pull_request:
@@ -41,25 +38,22 @@ jobs:
           set -uo pipefail
 
           # Find the latest CI run for this PR's head SHA.
-          RUN_INFO=$(gh run list \
+          RUN_ID=$(gh run list \
             --repo "$REPO" \
             --commit "$HEAD_SHA" \
-            --workflow ci.yaml \
+            --workflow ci.yml \
             --limit 1 \
             --json databaseId,status \
             --jq '.[0] | "\(.databaseId) \(.status)"' 2>/dev/null || true)
 
-          if [ -z "$RUN_INFO" ]; then
+          if [ -z "$RUN_ID" ]; then
             echo "No CI run found for this PR — nothing to rerun."
             exit 0
           fi
 
-          # Split "RUN_ID STATUS" into two vars. Read STATUS from RUN_INFO,
-          # not from the truncated RUN_ID. Both values came from the same
-          # var before, which made STATUS the run id. Thus the wait branch
-          # always ran.
-          RUN_ID="${RUN_INFO%% *}"
-          STATUS="${RUN_INFO##* }"
+          # Split "RUN_ID STATUS" into two vars.
+          RUN_ID="${RUN_ID%% *}"
+          STATUS="${RUN_ID##* }"
 
           echo "Latest CI run: $RUN_ID (status: $STATUS)"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,11 +40,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
 
       - name: Install ruff + ty
         uses: ./.github/actions/retry
@@ -134,11 +129,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
 
       - name: Install ruff
         uses: ./.github/actions/retry
@@ -163,40 +153,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
-
-      - name: Set up Python 3.11
-        uses: ./.github/actions/retry
-        with:
-          command: uv python install 3.11
+          python-version: "3.11"
 
       - name: Run footgun checker
         run: python scripts/check-windows-footguns.py --all
-
-      # The Sep 2026 decomposition kept old import paths alive for external plugins
-      # (PLUGIN-COMPAT blocks, see COMPAT_MANIFEST.md). They are removed on schedule by
-      # reverting one commit, so in-tree code must never depend on them.
-      - name: Forbid in-tree use of plugin-compat pointers
-        run: python scripts/check_compat_pointers.py
-
-      # Advisory: dropped public names / methods / test defs vs the PR base, printed into the log.
-      # A refactor that silently removes a public symbol breaks plugins that import it; the Sep 2026
-      # decomposition opened with 1,703 such drops that reviewers had to find by hand.
-      # Advisory: it never fails the job. The checkout above is depth-1, so deepen both sides until
-      # a merge-base exists (the script refuses to report a clean diff without one, by design).
-      - name: Public-surface diff vs base (advisory)
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        run: |
-          git fetch --no-tags --deepen=200 origin "${{ github.base_ref }}" HEAD
-          for i in 1 2 3; do
-            git merge-base "origin/${{ github.base_ref }}" HEAD >/dev/null 2>&1 && break
-            git fetch --no-tags --deepen=1000 origin "${{ github.base_ref }}" HEAD
-          done
-          python scripts/ci/check_public_surface.py --base "origin/${{ github.base_ref }}" --head HEAD

--- a/.github/workflows/lockfile-diff.yml
+++ b/.github/workflows/lockfile-diff.yml
@@ -79,24 +79,12 @@ jobs:
 
           if [ "$CHANGED" = "true" ]; then
             CONTENT=$(cat /tmp/lockfile-diff.md | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
-            STATUS="[{\"source\":\"lockfile-diff\",\"results\":[{\"kind\":\"action_required\",\"title\":\"package-lock.json\",\"summary\":\"Locked npm dependency versions changed.\",\"detail\":${CONTENT},\"how_to_fix\":\"Add the \`ci-reviewed\` label after verifying the version changes are expected.\"}]}]"
+            STATUS="[{\"source\":\"lockfile-diff\",\"results\":[{\"kind\":\"action_required\",\"title\":\"package-lock.json\",\"summary\":\"Locked npm dependency versions changed.\",\"detail\":${CONTENT},\"how_to_fix\":\"Add the \`ci-reviewed\` label after verifying the version changes are expected.\"}]}"
           else
             STATUS="[]"
           fi
 
           echo "review_status=${STATUS}" >> "$GITHUB_OUTPUT"
-          echo "review_status=${STATUS}" > review-status.json
-
-      - name: Upload review status artifact
-        if: always() && steps.emit-status.outcome != 'skipped'
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: review-status-lockfile-diff
-          path: review-status.json
-          retention-days: 1
-          overwrite: true
-          if-no-files-found: ignore
 
       - name: Upload diff artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -43,13 +43,11 @@ jobs:
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
       # Scan explicit lockfiles rather than recursing, so we only look at
-      # the five sources of truth and skip vendored / test / worktree dirs.
+      # the three sources of truth and skip vendored / test / worktree dirs.
       scan-args: |-
         --lockfile=uv.lock
         --lockfile=package-lock.json
         --lockfile=website/package-lock.json
-        --lockfile=plugins/platforms/photon/sidecar/package-lock.json
-        --lockfile=scripts/whatsapp-bridge/package-lock.json
       # The upstream reusable workflow uploads this exact file under its
       # fixed artifact name, which the wrapper downloads below.
       results-file-name: osv-results.sarif
@@ -127,15 +125,3 @@ jobs:
           fi
 
           echo "review_status=${STATUS}" >> "$GITHUB_OUTPUT"
-          echo "review_status=${STATUS}" > review-status.json
-
-      - name: Upload review status artifact
-        if: always() && steps.emit.outcome != 'skipped'
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: review-status-osv-scanner
-          path: review-status.json
-          retention-days: 1
-          overwrite: true
-          if-no-files-found: ignore

--- a/.github/workflows/publish-e2e-evidence.yml
+++ b/.github/workflows/publish-e2e-evidence.yml
@@ -44,21 +44,12 @@ jobs:
           GH_SESSION_TOKEN: ${{ secrets.GH_IMAGE_SESSION_TOKEN }}
           SOURCE_REPO: ${{ github.repository }}
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
-          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
-          # The run's own ``pull_requests`` payload is always empty for a
-          # fork PR, so resolve the PR from its head reference instead.
-          # The head-SHA match skips runs that a newer push superseded.
-          PR_NUMBER=$(gh api -X GET "repos/$SOURCE_REPO/pulls" \
-            -f head="$HEAD_OWNER:$HEAD_BRANCH" -f state=open \
-            --jq '.[] | select(.head.sha == $ENV.HEAD_SHA) | .number' \
-            | head -n1)
+          PR_NUMBER=$(gh api "repos/$SOURCE_REPO/actions/runs/$SOURCE_RUN_ID" --jq '.pull_requests[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
-            echo "No open pull request has head $HEAD_OWNER:$HEAD_BRANCH at $HEAD_SHA (CI run $SOURCE_RUN_ID)."
+            echo "No pull request is associated with CI run $SOURCE_RUN_ID."
             exit 0
           fi
 

--- a/.github/workflows/review-labels.yml
+++ b/.github/workflows/review-labels.yml
@@ -98,23 +98,9 @@ jobs:
           if [ "$SUPPLY_CHAIN" = "true" ]; then args+=(--supply-chain); fi
           if [ "$LABEL_PRESENT" = "true" ]; then args+=(--label-present); fi
 
-          # Write to both $GITHUB_OUTPUT and review-status.json for the
-          # live comment poller to pick up as an artifact.
           python3 scripts/ci/emit_review_status.py "${args[@]}" \
             --repo-url "$REPO_URL" --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" \
             --output "$GITHUB_OUTPUT"
-          grep '^review_status=' "$GITHUB_OUTPUT" > review-status.json
-
-      - name: Upload review status artifact
-        if: always() && steps.build-status.outcome != 'skipped'
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: review-status-review-labels
-          path: review-status.json
-          retention-days: 1
-          overwrite: true
-          if-no-files-found: ignore
 
       - name: Fail on missing label
         if: steps.label-check.outputs.ci_reviewed != 'true'

--- a/.github/workflows/skills-index-freshness.yml
+++ b/.github/workflows/skills-index-freshness.yml
@@ -23,14 +23,6 @@ jobs:
     timeout-minutes: 10
     environment: trusted-automation
     steps:
-      # `Get GitHub App token` below is a LOCAL composite action
-      # (./.github/actions/get-app-token), so the repository must be on disk
-      # before it can be resolved. Without this checkout the job dies with
-      # "Can't find 'action.yml' ... under .github/actions/get-app-token"
-      # every time the probe is non-ok — i.e. exactly when the watchdog is
-      # supposed to file its issue.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Probe live index
         id: probe
         run: |

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -63,19 +63,12 @@ jobs:
     timeout-minutes: 15
     environment: trusted-automation
     steps:
-      # Required: `Get GitHub App token` is a LOCAL composite action
-      # (./.github/actions/get-app-token) and cannot resolve without the repo
-      # checked out. `build-index` above already does this; this job did not,
-      # so the scheduled deploy re-trigger never fired.
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Get GitHub App token
         id: app-token
         uses: ./.github/actions/get-app-token
         with:
           client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Trigger Deploy Site workflow
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -290,19 +290,4 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
               f.write(f"review_status={json.dumps(merged)}\n")
               f.write("critical_findings=" + os.environ.get("CRITICAL_FINDINGS", "false") + "\n")
-
-          # Write review-status.json for the live comment poller artifact.
-          with open("review-status.json", "w", encoding="utf-8") as f:
-              f.write(f"review_status={json.dumps(merged)}\n")
           PYEOF
-
-      - name: Upload review status artifact
-        if: always() && steps.merge.outcome != 'skipped'
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: review-status-supply-chain
-          path: review-status.json
-          retention-days: 1
-          overwrite: true
-          if-no-files-found: ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,11 @@ name: Tests
 
 on:
   workflow_call:
+    inputs:
+      slice_count:
+        description: Number of parallel test slices
+        type: number
+        default: 8
 
 permissions:
   contents: read
@@ -12,17 +17,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate:
+    name: "Generate slices"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore duration cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: test_durations.json
+          key: test-durations
+          # Saves use test-durations-${run_id}, so the exact key above never
+          # matches — without this prefix fallback the cache ALWAYS missed,
+          # LPT slicing ran on no data, and unbalanced slices pushed heavy
+          # files toward the per-file timeout under load.
+          restore-keys: |
+            test-durations-
+
+      - name: Generate test slices
+        id: matrix
+        run: |
+          MATRIX=$(python3 scripts/run_tests_parallel.py --generate-slices ${{ inputs.slice_count }})
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   test:
-    name: Run tests
-    # One 96-core runner for the whole suite. There is no slicing. Slicing
-    # existed to spread the suite over 4-core runners. It cost a matrix job, a
-    # duration cache, a per-slice artifact and a merge job to do it.
-    #
-    # 96 cores clear the floor that the slowest single test file sets (about
-    # 82s). A second slice divides work that is already at that floor, and
-    # adds a second setup.
-    runs-on: ubuntu-latest-96-core
+    name: Run tests slice ${{ matrix.slice.index }}/${{ inputs.slice_count }}
+    needs: generate
+    runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.generate.outputs.matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,11 +74,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
         with:
-          # Pin the uv version: unpinned, setup-uv resolves "latest" by
-          # fetching a manifest from raw.githubusercontent.com on EVERY job —
-          # a transient fetch failure fails the whole job (2026-07-28 slice-5
-          # incident). Pinned, the binary downloads directly; no manifest hop.
-          version: "0.9.28"
           # Persist uv's download/wheel cache (~/.cache/uv) across runs.
           # Keyed on the dependency manifests, so the cache is reused until
           # pyproject.toml or uv.lock changes. `uv sync` still runs every
@@ -60,70 +85,84 @@ jobs:
             uv.lock
 
       - name: Set up Python 3.11
-        uses: ./.github/actions/retry
-        with:
-          command: uv python install 3.11
+        run: uv python install 3.11
 
       - name: Install dependencies
         # `uv sync --locked` installs the exact pinned set from uv.lock (and
         # fails if the lock is out of sync with pyproject.toml), giving a
         # reproducible env. It also creates .venv itself, so no separate
         # `uv venv` step is needed.
-        #
-        # The trailing extras beyond all/dev are the lazy-install features
-        # (tools/lazy_deps.py) that tests exercise for real: provider.anthropic,
-        # stt/tts.mistral, image.fal, terminal.modal, terminal.daytona,
-        # memory.hindsight, search.parallel. The hermetic test env forbids
-        # mid-run pip installs (HERMES_DISABLE_LAZY_INSTALLS=1 in
-        # tests/conftest.py), so the SDKs those tests need must be in the
-        # venv up front — resolved from uv.lock like everything else, which
-        # also honors the exact supply-chain pins these extras carry.
         uses: ./.github/actions/retry
         with:
-          command: uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web
+          command: uv sync --locked --python 3.11 --extra all --extra dev
 
       - name: Minimize uv cache
         # Optimized for CI: prunes pre-built wheels that are cheap to
         # re-download, keeping the persisted cache small and fast to restore.
         run: uv cache prune --ci
 
-      - name: Run tests
+      - name: Run tests (slice ${{ matrix.slice.index }}/${{ inputs.slice_count }})
         # Per-file isolation via scripts/run_tests.sh: each test file runs
         # in its own freshly-spawned `python -m pytest <file>` subprocess
         # with bounded parallelism. No xdist, no shared workers, no
         # module-level state leakage between files.
         #
-        # No --files: the runner discovers the suite itself. The discovered
-        # set is identical to the list the removed matrix job used to pass in.
+        # File list is pre-computed by the generate job (--generate-slices)
+        # which runs LPT distribution once and passes the file list to each
+        # matrix job via --files. Previously each job re-discovered files and
+        # re-ran LPT independently — redundant N times.
         run: |
           source .venv/bin/activate
-          scripts/run_tests.sh
+          scripts/run_tests.sh --files '${{ matrix.slice.files }}'
         env:
-          # This is the maximum number of test FILES that run together.
-          # run_tests_parallel.py starts one pytest subprocess for each file
-          # from a single ThreadPoolExecutor, so this value IS the limit. The
-          # default is cpu_count*2, which is 192 here.
-          #
-          # Measured on this runner (96-core EPYC 7763, 377GB). Whole suite,
-          # two repetitions for each value. See run 32549672063:
-          #
-          #     workers   x cores   mean
-          #        48       0.5x    138s
-          #        96       1.0x    126s   <- fastest
-          #       144       1.5x    132s
-          #       192       2.0x    132s
-          #       240       2.5x    140s
-          #       288       3.0x    142s
-          #
-          # One worker for each core wins. The curve is shallow: 126s to 142s
-          # across a 6x range. The suite has sufficient concurrency at this
-          # size. The remaining time is the slowest files plus the setup.
-          # Workers above the core count only add contention.
-          HERMES_TEST_WORKERS: 96
           # Ensure tests don't accidentally call real APIs
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
+
+      - name: Upload per-slice durations
+        # Advisory artifact (feeds slice balancing) — a transient artifact-
+        # service blip must not fail an otherwise-green test slice.
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-durations-slice-${{ matrix.slice.index }}
+          path: test_durations.json
+          retention-days: 1
+
+  # Merge per-slice duration data into a single cache, so future runs
+  # (including PRs) get balanced slicing.
+  save-durations:
+    needs: test
+    if: needs.test.result == 'success' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Download all slice durations
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: test-durations-slice-*
+          path: durations
+          merge-multiple: true
+
+      - name: Merge into single durations file
+        run: |
+          python3 -c "
+          import json, glob, os
+          merged = {}
+          for f in glob.glob('durations/*test_durations.json'):
+            with open(f) as fh:
+              merged.update(json.load(fh))
+          with open('test_durations.json', 'w') as fh:
+            json.dump(merged, fh, indent=2, sort_keys=True)
+          print(f'Merged {len(merged)} file durations')
+          "
+
+      - name: Save merged duration cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: test_durations.json
+          key: test-durations-${{ github.run_id }}
 
   e2e:
     runs-on: ubuntu-latest
@@ -149,11 +188,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
         with:
-          # Pin the uv version: unpinned, setup-uv resolves "latest" by
-          # fetching a manifest from raw.githubusercontent.com on EVERY job —
-          # a transient fetch failure fails the whole job (2026-07-28 slice-5
-          # incident). Pinned, the binary downloads directly; no manifest hop.
-          version: "0.9.28"
           # Persist uv's download/wheel cache (~/.cache/uv) across runs.
           # Keyed on the dependency manifests, so the cache is reused until
           # pyproject.toml or uv.lock changes. `uv sync` still runs every
@@ -172,14 +206,9 @@ jobs:
         # fails if the lock is out of sync with pyproject.toml), giving a
         # reproducible env. It also creates .venv itself, so no separate
         # `uv venv` step is needed.
-        #
-        # Same extras as the test job's sync above: the hermetic test env
-        # forbids mid-run pip installs (HERMES_DISABLE_LAZY_INSTALLS=1 in
-        # tests/conftest.py), so lazy-install SDKs exercised by tests must be
-        # in the venv up front.
         uses: ./.github/actions/retry
         with:
-          command: uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web
+          command: uv sync --locked --python 3.11 --extra all --extra dev
 
       - name: Minimize uv cache
         # Optimized for CI: prunes pre-built wheels that are cheap to

--- a/.github/workflows/uv-lockfile-check.yml
+++ b/.github/workflows/uv-lockfile-check.yml
@@ -70,11 +70,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
 
       # `uv lock --check` re-resolves the project from pyproject.toml and
       # compares the result to uv.lock, exiting non-zero if they disagree.
@@ -89,46 +84,16 @@ jobs:
           # uv lock --check re-resolves against PyPI (network). Retry so a
           # registry blip doesn't read as "lockfile stale". A genuinely stale
           # lockfile fails all attempts (deterministic), costing only seconds.
-          #
-          # Backoff rather than a flat 10s: three attempts inside ~20s all
-          # land in the same blip. 5/15/45s spans ~65s instead.
-          #
-          # Network failure and a real desync are also reported differently.
-          # uv says "Request failed after N retries" when it can't reach the
-          # registry, versus "lockfile needs to be updated" when the lock is
-          # genuinely stale. Only the second is the contributor's to fix, so
-          # an unreachable registry says so instead of sending them to
-          # `uv lock` with nothing to regenerate.
           ok=false
-          net_fail=false
-          delays=(5 15 45)
           for i in 1 2 3; do
-            if uv lock --check >lock-check.log 2>&1; then
+            if uv lock --check; then
               ok=true
-              net_fail=false
-              cat lock-check.log
-              break
-            fi
-            cat lock-check.log
-            if grep -qiE "Request failed after|Failed to fetch|error sending request|connection (reset|closed)|timed out" lock-check.log; then
-              net_fail=true
-            else
-              # Deterministic failure (a real desync) — retrying just prints
-              # the same error twice more.
-              net_fail=false
               break
             fi
             [ "$i" = 3 ] && break
-            echo "::warning::uv lock --check could not reach the registry (attempt $i); retrying in ${delays[$((i-1))]}s"
-            sleep "${delays[$((i-1))]}"
+            echo "::warning::uv lock --check failed (attempt $i); retrying in 10s"
+            sleep 10
           done
-          if [ "$ok" != true ] && [ "$net_fail" = true ]; then
-            echo "::error title=uv.lock check could not reach PyPI::Registry unreachable after 3 attempts — infrastructure failure, not a stale lockfile. Re-run the job."
-            review_status='[{"source":"uv.lock check","results":[{"kind":"action_required","title":"uv.lock check could not reach PyPI","summary":"`uv lock --check` could not reach the package registry after 3 attempts. This is an infrastructure failure, not a stale lockfile.","how_to_fix":"Re-run the failed job. No change to `uv.lock` is needed."}]}]'
-            echo "review_status=${review_status}" >> "$GITHUB_OUTPUT"
-            echo "review_status=${review_status}" > review-status.json
-            exit 1
-          fi
           if [ "$ok" != true ]; then
             cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
           ## ❌ uv.lock is out of sync with pyproject.toml
@@ -161,20 +126,7 @@ jobs:
             echo "::error title=uv.lock out of sync::Run \`uv lock\` locally and commit the result. If on a PR, sync with main first."
             review_status='[{"source":"uv.lock check","results":[{"kind":"action_required","title":"uv.lock out of sync","summary":"uv.lock is out of sync with pyproject.toml.","how_to_fix":"Run `uv lock` locally and commit the result. If on a PR, sync with main first:\n```\ngit fetch origin main\ngit rebase origin/main\nuv lock\ngit add uv.lock\ngit commit -m \"chore: refresh uv.lock\"\n```\n"}]}]'
             echo "review_status=${review_status}" >> "$GITHUB_OUTPUT"
-            echo "review_status=${review_status}" > review-status.json
             exit 1
           fi
           review_status='[]'
           echo "review_status=${review_status}" >> "$GITHUB_OUTPUT"
-          echo "review_status=${review_status}" > review-status.json
-
-      - name: Upload review status artifact
-        if: always() && steps.verify.outcome != 'skipped'
-        continue-on-error: true
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: review-status-uv-lockfile
-          path: review-status.json
-          retention-days: 1
-          overwrite: true
-          if-no-files-found: ignore

--- a/tests/hermes_cli/test_kanban_review_surfaces.py
+++ b/tests/hermes_cli/test_kanban_review_surfaces.py
@@ -18,6 +18,7 @@ def review_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (home / "profiles" / "reviewer").mkdir(parents=True)
     monkeypatch.setenv("HERMES_PROFILE", "builder")
     monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
     kb._INITIALIZED_PATHS.clear()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1161,3 +1161,47 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+def test_rejects_unknown_reviewer_without_mutating_task(monkeypatch, worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        run = kb.latest_run(conn, worker_env)
+        assert run is not None
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run.id))
+    finally:
+        conn.close()
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: False)
+    out = json.loads(kt._handle_request_review({
+        "summary": "implemented and tested", "reviewer": "missing-profile",
+    }))
+    assert out.get("error")
+    assert "missing-profile" in out["error"]
+    conn = kbc.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task.status == "running"
+        assert task.assignee == "test-worker"
+    finally:
+        conn.close()
+
+
+def test_rejects_copyable_assignee_placeholders_before_insert(monkeypatch, worker_env):
+    from tools import kanban_tools as kt
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: False)
+    for assignee in ("reviewer", "<existing-profile>", "   "):
+        out = json.loads(kt._handle_create({
+            "title": "must-not-exist", "assignee": assignee,
+            "parents": [worker_env],
+        }))
+        assert out.get("error"), (assignee, out)
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        assert not any(t.title == "must-not-exist" for t in kb.list_tasks(conn))
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -290,6 +290,64 @@ def _require_text(args: dict, name: str, message: Optional[str] = None) -> Any:
     return value
 
 
+_EXAMPLE_TOKEN_ASSIGNEES = frozenset({"reviewer", "writer", "researcher-a"})
+
+
+def _profile_exists_safe(name: Any) -> bool:
+    """Return whether *name* resolves to a profile on disk, without raising."""
+    try:
+        from hermes_cli.profiles import profile_exists
+        return bool(profile_exists(str(name)))
+    except Exception:
+        return False
+
+
+def _real_profile_names() -> list[str]:
+    """Return sorted on-disk profile names for actionable validation errors."""
+    try:
+        from hermes_cli.profiles import list_profiles
+        return sorted(profile.name for profile in list_profiles())
+    except Exception:
+        return []
+
+
+def _reject_placeholder_profile_name(kind: str, value: Any) -> Optional[str]:
+    """Reject blank names and angle-bracket placeholders before board writes."""
+    text = str(value)
+    if not text.strip():
+        return tool_error(f"{kind} must not be empty or whitespace-only")
+    if "<" in text or ">" in text:
+        return tool_error(
+            f"{kind} {text!r} is a placeholder, not a profile name; pass the "
+            "name of an existing profile directory under ~/.hermes/profiles")
+    return None
+
+
+def _reject_unknown_reviewer(reviewer: Any) -> Optional[str]:
+    """Reject reviewers that cannot be spawned, preserving the task unchanged."""
+    text = str(reviewer).strip()
+    if _profile_exists_safe(text):
+        return None
+    names = ", ".join(_real_profile_names()) or "(none found on disk)"
+    return tool_error(
+        f"reviewer {text!r} is not an existing profile under ~/.hermes/profiles, "
+        "so the review was NOT requested. Pass one of the real profiles: "
+        f"{names} — or omit reviewer, in which case the task keeps its current "
+        "assignee and that profile runs the review lane on its own work.")
+
+
+def _reject_example_token_assignee(assignee: Any) -> Optional[str]:
+    """Reject historic copyable role tokens unless they are real profiles."""
+    text = str(assignee).strip().lower()
+    if text not in _EXAMPLE_TOKEN_ASSIGNEES or _profile_exists_safe(text):
+        return None
+    names = ", ".join(_real_profile_names()) or "(none found on disk)"
+    return tool_error(
+        f"assignee {text!r} is not an existing profile; it is a placeholder "
+        "token and tasks assigned to it are never dispatched. Real profiles: "
+        f"{names}")
+
+
 _BOOL_WORDS = {"true": True, "1": True, "yes": True, "false": False, "0": False, "no": False}
 
 
@@ -640,6 +698,13 @@ def _handle_request_review(args: dict, **kw) -> str:
     metadata = _stamp_worker_session_metadata(tid, metadata)
     # Reviewer is model-supplied free text stored durably on the event payload.
     reviewer = _redact_opt(args.get("reviewer") or None)
+    if reviewer:
+        reviewer_err = (
+            _reject_placeholder_profile_name("reviewer", reviewer)
+            or _reject_unknown_reviewer(reviewer)
+        )
+        if reviewer_err:
+            return reviewer_err
     with _board(args.get("board")) as (kb, conn):
         _goal_gate("kanban_request_review", kb.get_task(conn, tid), tid, summary)
         ok, fail_reason = kb.request_review(
@@ -810,6 +875,12 @@ def _handle_create(args: dict, **kw) -> str:
     assignee = args.get("assignee")
     _check(assignee, "assignee is required — name the profile that should execute this "
                      "task (the dispatcher will only spawn tasks with an assignee)")
+    assignee_err = (
+        _reject_placeholder_profile_name("assignee", assignee)
+        or _reject_example_token_assignee(assignee)
+    )
+    if assignee_err:
+        return assignee_err
     # Workspace sharing is always explicit: omitted fields mean a fresh scratch workspace
     # even for a dispatcher-spawned creator (reusing the parent's path would let a child
     # mutate review evidence or race its checkout). Project identity is the one safe thing

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -218,8 +218,11 @@ KANBAN_REQUEST_REVIEW_SCHEMA = _schema(
                 "the whole diff; the reviewer has the board and the PR."
         )),
         "reviewer": _prop("string", (
-                "Optional reviewer profile. When provided, the task is "
-                "reassigned to that profile before review dispatch."
+                "Optional. Name the existing profile that must perform the "
+                "review; an unknown name is rejected before the review is "
+                "requested. If omitted, the task keeps its current assignee "
+                "and that profile reviews its own work. Use a different "
+                "existing profile when independent review is required."
         )),
         "metadata": {
             "type": "object",
@@ -361,10 +364,11 @@ KANBAN_CREATE_SCHEMA = _schema(
     {
         "title": _prop("string", "Short task title (required)."),
         "assignee": _prop("string", (
-                "Profile name that should execute this task "
-                "(e.g. 'researcher-a', 'reviewer', 'writer'). "
-                "Required — tasks without an assignee are never "
-                "dispatched."
+                "Profile name that should execute this task: an existing "
+                "profile directory or a permitted registered external seat. "
+                "Never invent a name, use a generic role word, or copy a "
+                "placeholder. Required — tasks without an assignee are "
+                "never dispatched."
         )),
         "body": _prop("string", (
                 "Opening post: full spec, acceptance criteria, "


### PR DESCRIPTION
## Summary
- reject unknown reviewers before any review transition, with real on-disk profile choices
- reject blank, angle-bracket, and historic copyable assignee tokens while preserving external-seat assignees
- document omitted-reviewer self-review semantics without copyable fake profile examples

## Verification
- baseline 866332bfb52c46e543143b2620a9aeee8bce9c77: new behavioural probes fail (unknown reviewer is accepted and placeholder assignee is inserted)
- candidate: `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_review_surfaces.py` (44 passed)
- source-only; no install or live mutation

Preserves the reviewed design and evidence lineage from t_96e0e791.