### PR TITLE
fix(update): retire fleet_restart_pending marker when live gateways match expected_sha

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -183,15 +183,52 @@ def _live_fleet_covers_receipt(expected_sha: str | None) -> bool:
         return False
 
 
+def _read_fleet_restart_pending_expected_sha() -> str | None:
+    """Read expected_sha from the fleet_restart_pending marker if present, else None."""
+    path = _fleet_restart_pending_marker_path()
+    try:
+        content = path.read_text(encoding="utf-8")
+        for line in content.splitlines():
+            if line.startswith("expected_sha="):
+                sha = line.split("=", 1)[1].strip()
+                return sha or None
+    except OSError:
+        pass
+    return None
+
+
 def _pending_fleet_restart_needed() -> bool:
     """Reconcile old restart obligations against current, identity-matched gateways."""
     from hermes_cli.update_cmd import _current_checkout_sha
+    from hermes_cli.update_receipt import collect_fleet_versions
 
     # The marker has no runtime inventory and may belong to a newer, killed update
     # than latest.json. An older receipt cannot discharge that unknown obligation.
+    # However, if every live gateway already runs the marker's expected_sha, the
+    # restart obligation is satisfied: retire the marker so we do not spam false
+    # warnings on CLI startup or force-restart a healthy fleet (#106682).
     with suppress(OSError):
         if _fleet_restart_pending_marker_path().is_file():
-            return True
+            expected_sha = _read_fleet_restart_pending_expected_sha()
+            if expected_sha:
+                try:
+                    fleet = collect_fleet_versions()
+                    if fleet and all(
+                        row.get("state") == "current" and row.get("code_sha") == expected_sha
+                        for row in fleet
+                    ):
+                        logger.info(
+                            "fleet_restart_pending retired: all live gateways already run %s",
+                            expected_sha,
+                        )
+                        _clear_fleet_restart_pending_marker()
+                    else:
+                        return True
+                except Exception as exc:
+                    logger.debug("Could not verify fleet restart against marker: %s", exc)
+                    return True
+            else:
+                return True
     if not _receipt_reports_stale_runtime():
         return False
     return not _live_fleet_covers_receipt(_current_checkout_sha())

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -182,6 +182,90 @@ def test_pending_needed_when_marker_exists():
     assert update_cmd._pending_fleet_restart_needed() is False
 
 
+def test_pending_retired_when_live_fleet_matches_marker_expected_sha(monkeypatch):
+    """When all live gateways already run expected_sha, the marker self-heals (#106682)."""
+    sha = "a" * 40
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=sha)
+    marker = update_cmd._fleet_restart_pending_marker_path()
+    assert marker.is_file()
+
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda: [{"profile": "default", "pid": 42, "state": "current", "code_sha": sha}],
+    )
+    assert update_cmd._pending_fleet_restart_needed() is False
+    assert not marker.exists(), "marker must be retired after live fleet verified"
+
+
+def test_pending_needed_when_live_fleet_runs_stale_sha_vs_marker(monkeypatch):
+    """When any live gateway runs an older SHA, restart remains pending (#106682)."""
+    expected = "a" * 40
+    stale = "b" * 40
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=expected)
+    marker = update_cmd._fleet_restart_pending_marker_path()
+
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda: [{"profile": "default", "pid": 42, "state": "current", "code_sha": stale}],
+    )
+    try:
+        assert update_cmd._pending_fleet_restart_needed() is True
+        assert marker.is_file(), "marker must remain when live gateway is stale"
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_pending_needed_when_live_gateway_not_current_vs_marker(monkeypatch):
+    """When a live gateway is in a non-current state, restart remains pending (#106682)."""
+    sha = "a" * 40
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=sha)
+    marker = update_cmd._fleet_restart_pending_marker_path()
+
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda: [{"profile": "default", "pid": 42, "state": "stale", "code_sha": sha}],
+    )
+    try:
+        assert update_cmd._pending_fleet_restart_needed() is True
+        assert marker.is_file()
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_pending_needed_when_no_live_gateways_found_for_marker(monkeypatch):
+    """When no live gateways are found, marker remains pending to allow catch-up (#106682)."""
+    sha = "a" * 40
+    update_cmd._write_fleet_restart_pending_marker(expected_sha=sha)
+    marker = update_cmd._fleet_restart_pending_marker_path()
+
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda: [],
+    )
+    try:
+        assert update_cmd._pending_fleet_restart_needed() is True
+        assert marker.is_file()
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_pending_needed_when_marker_lacks_expected_sha(monkeypatch):
+    """A legacy marker without expected_sha cannot self-heal and remains pending (#106682)."""
+    update_cmd._write_fleet_restart_pending_marker()
+    marker = update_cmd._fleet_restart_pending_marker_path()
+
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda: [{"profile": "default", "pid": 42, "state": "current", "code_sha": "a" * 40}],
+    )
+    try:
+        assert update_cmd._pending_fleet_restart_needed() is True
+        assert marker.is_file()
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+
 def test_pending_needed_when_unfinished_receipt_runtime_sha_skews(monkeypatch):
     disk_sha = "e" * 40
     old_sha = "7" * 40

--- a/tests/hermes_cli/test_update_obligation_identity.py
+++ b/tests/hermes_cli/test_update_obligation_identity.py
@@ -57,7 +57,7 @@ def test_every_owed_identity_requires_current_evidence(monkeypatch, bad):
     directory = home / "logs" / "update_receipts"
     directory.mkdir(parents=True)
     if bad == "marker":
-        (home / "fleet_restart_pending").write_text("expected_sha=new\n")
+        (home / "fleet_restart_pending").write_text("expected_sha=future\n")
     owed = {"kind": "gateway", "profile": "beta", "code_sha": "old"}
     if bad == "wrong-kind":
         owed["kind"] = "serve"
@@ -84,3 +84,22 @@ def test_every_owed_identity_requires_current_evidence(monkeypatch, bad):
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "new")
     monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda: rows)
     assert update_cmd_fleet._pending_fleet_restart_needed()
+
+
+def test_marker_retired_when_live_fleet_matches_expected_sha(monkeypatch):
+    """When running gateways already run the marker's expected_sha, the marker retires (#106682)."""
+    home = get_hermes_home()
+    marker = home / "fleet_restart_pending"
+    marker.write_text("expected_sha=new\n")
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "new")
+    monkeypatch.setattr(
+        update_receipt,
+        "collect_fleet_versions",
+        lambda: [{"profile": "alpha", "pid": 1, "state": "current", "code_sha": "new"}],
+    )
+    assert not update_cmd_fleet._pending_fleet_restart_needed()
+    assert not marker.exists(), (
+        "fleet_restart_pending marker must be retired when live fleet satisfies it"
+    )
+
+


### PR DESCRIPTION
## What does this PR do?

When `hermes update` is interrupted, timed out, or gateways are restarted outside the updater (e.g. via systemd or operator restart), `~/.hermes/fleet_restart_pending` survived indefinitely (#106682). `_pending_fleet_restart_needed()` previously returned `True` solely based on the marker file's presence on disk, ignoring `expected_sha` and live gateway runtime state. This caused:
1. False *"mixed sys.modules"* warnings on every subsequent non-update CLI command (e.g. `hermes config set`, `hermes logs`).
2. Disruptive force-restarts (drain + SIGUSR1 / kill + restart) of healthy, up-to-date production gateways on subsequent `hermes update` invocations.

This PR makes the marker self-healing:
- Extracts `expected_sha` from `fleet_restart_pending`.
- Compares it against the live running gateways via `collect_fleet_versions()` (the same source trusted by the updater's verification stage).
- If all live gateways are verifiably running `expected_sha` with `state == "current"`, logs the retirement, clears the marker file via `_clear_fleet_restart_pending_marker()`, and allows `_pending_fleet_restart_needed()` to settle.
- Fails safe: if no gateways are live, if any gateway is stale/down, or if the marker lacks an `expected_sha` field, the marker is preserved and restart remains pending.

## Related Issue

Fixes #106682

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_fleet.py`:
  - Added `_read_fleet_restart_pending_expected_sha()` to parse `expected_sha` from the marker.
  - In `_pending_fleet_restart_needed()`, check live gateway versions via `collect_fleet_versions()`. If all live gateways are current and match `expected_sha`, log and retire the marker file.
- `tests/hermes_cli/test_update_fleet_restart_pending.py`:
  - Added `test_pending_retired_when_live_fleet_matches_marker_expected_sha`: verifies marker is retired and returns `False` when live fleet matches.
  - Added `test_pending_needed_when_live_fleet_runs_stale_sha_vs_marker`: verifies marker is kept when a live gateway is stale.
  - Added `test_pending_needed_when_live_gateway_not_current_vs_marker`: verifies marker is kept when gateway state is not current.
  - Added `test_pending_needed_when_no_live_gateways_found_for_marker`: verifies marker is kept when no live gateways are found.
  - Added `test_pending_needed_when_marker_lacks_expected_sha`: verifies legacy markers without `expected_sha` remain pending.
- `tests/hermes_cli/test_update_obligation_identity.py`:
  - Updated unfulfilled marker control case (`expected_sha=future`) in `test_every_owed_identity_requires_current_evidence`.
  - Added `test_marker_retired_when_live_fleet_matches_expected_sha`.

## How to Test

Run the test suite:
```bash
scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py tests/hermes_cli/test_update_obligation_identity.py
```
All 37 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
