### PR TITLE
fix(browser): restore the instant immutable read for real-profile auth copies

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -393,7 +393,22 @@ _SQLITE_AUTH_DBS = frozenset({"Cookies", "Login Data", "Login Data For Account",
 
 
 def _copy_auth_file(src_file: str, dst_file: str) -> bool:
-    """Copy auth state; refuse a DB that cannot be snapshotted consistently within five seconds."""
+    """Copy auth state; refuse a DB that cannot be snapshotted consistently.
+
+    Two-tier read against a live browser, both bounded by the five-second
+    backup deadline:
+
+    1. The instant immutable=1 read — a committed snapshot of a file another
+       process owns. On POSIX this never blocks, even under the owning
+       browser's exclusive write lock, so an open Chrome cannot stall the
+       launch. Skipped when the source carries a non-empty ``-wal`` sidecar:
+       immutable ignores committed WAL frames, so a WAL-mode source must
+       coordinate instead.
+    2. The bounded coordinated online-backup (``mode=ro`` source) for
+       WAL-mode sources — and as the fallback whenever tier 1 cannot read.
+
+    Both write through SQLite so a torn journal never half-lands; the copy
+    fails closed only when both tiers fail."""
     os.makedirs(os.path.dirname(dst_file), exist_ok=True)
     try:
         if os.path.basename(src_file) in _SQLITE_AUTH_DBS:
@@ -403,11 +418,26 @@ def _copy_auth_file(src_file: str, dst_file: str) -> bool:
                 if _status != sqlite3.SQLITE_DONE and time.monotonic() >= deadline:
                     raise TimeoutError("auth database backup exceeded five seconds")
 
-            # SQLite must coordinate both ends: immutable ignores committed source WAL,
-            # while replacing only the destination file can replay its abandoned WAL.
-            # Connection busy timeouts do not bound backup's retry loop; its callback does.
+            src_uri = Path(src_file).resolve().as_uri()
+            src_wal = f"{src_file}-wal"
+            # Tier 1: instant committed-snapshot read (POSIX: lock-free even
+            # while the browser writes; Windows: open fails -> tier 2).
+            if not (os.path.exists(src_wal) and os.path.getsize(src_wal) > 0):
+                try:
+                    with contextlib.closing(sqlite3.connect(
+                            src_uri + "?immutable=1", uri=True, timeout=0.0)) as source:
+                        with contextlib.closing(sqlite3.connect(dst_file, timeout=0.0)) as out:
+                            source.backup(out, pages=256, progress=check_deadline, sleep=0.1)
+                    return True
+                except (OSError, sqlite3.Error):
+                    logger.debug("real-profile: immutable snapshot of %s failed; "
+                                 "falling back to coordinated backup", src_file)
+            # Tier 2: SQLite must coordinate both ends: immutable ignores
+            # committed source WAL, while replacing only the destination file
+            # can replay its abandoned WAL. Connection busy timeouts do not
+            # bound backup's retry loop; its callback does.
             with contextlib.closing(sqlite3.connect(
-                    Path(src_file).resolve().as_uri() + "?mode=ro", uri=True, timeout=0.0)) as source:
+                    src_uri + "?mode=ro", uri=True, timeout=0.0)) as source:
                 with contextlib.closing(sqlite3.connect(dst_file, timeout=0.0)) as out:
                     source.backup(out, pages=256, progress=check_deadline, sleep=0.1)
         else:

--- a/tests/tools/test_browser_real_profile.py
+++ b/tests/tools/test_browser_real_profile.py
@@ -1093,17 +1093,32 @@ class TestWindowsLockedProfileCopy:
                  str(src), str(dst)],
                 capture_output=True, text=True, timeout=15, stdin=subprocess.DEVNULL)
             assert result.returncode == 0, result.stderr
-            assert result.stdout.strip() == "False"
+            if locked == "source" and sys.platform != "win32":
+                # POSIX: the immutable committed-snapshot read succeeds under the
+                # writer's exclusive lock and carries the last COMMITTED state —
+                # the property real-profile launching depends on so an open
+                # browser cannot stall or fail the copy (Sep 2026 regression:
+                # refusing here broke every launch while Chrome was running).
+                assert result.stdout.strip() == "True"
+            else:
+                # Locked destination, or any lock on Windows: the copy must
+                # refuse rather than overwrite or hang.
+                assert result.stdout.strip() == "False"
         finally:
             holder.rollback()
             holder.close()
-        with sqlite3.connect(dst) as conn:
-            assert conn.execute("select x from cookies").fetchall() == [(99,)]
-        conn.close()
-        assert bc._copy_auth_file(str(src), str(dst)) is True
-        with sqlite3.connect(dst) as conn:
-            assert conn.execute("select x from cookies").fetchall() == [(7,)]
-        conn.close()
+        if locked == "source" and sys.platform != "win32":
+            with sqlite3.connect(dst) as conn:
+                assert conn.execute("select x from cookies").fetchall() == [(7,)]
+            conn.close()
+        else:
+            with sqlite3.connect(dst) as conn:
+                assert conn.execute("select x from cookies").fetchall() == [(99,)]
+            conn.close()
+            assert bc._copy_auth_file(str(src), str(dst)) is True
+            with sqlite3.connect(dst) as conn:
+                assert conn.execute("select x from cookies").fetchall() == [(7,)]
+            conn.close()
 
     def test_copy_auth_file_preserves_source_wal_not_abandoned_destination_wal(self, tmp_path):
         import sqlite3


### PR DESCRIPTION
## What does this PR do?

Restores instant (non-blocking) source reads for real-profile auth database copies, so launching the real-profile browser works reliably on POSIX while the user's browser is open and actively writing.

`browser.use_real_profile: true` snapshots the live browser's auth databases into the Hermes copy on every launch. 58d6d5223a removed the `immutable=1` source read and kept only the coordinated `mode=ro` online-backup. On POSIX, SQLite's busy timeout does not cover lock negotiation, so when the live browser holds an exclusive lock on `Cookies` / `Web Data` / `Login Data For Account`, the backup cannot start; the five-second progress-callback deadline fires per busy database, and the snapshot fails closed:

    browser.use_real_profile is on, but could not read the 'chrome' profile's
    login data (N database(s) unavailable). Close chrome and retry, or turn
    browser.use_real_profile off.

Observed in production: 3 busy databases x 5 s ~= 17 s per attempt, then failure — on a machine where the identical operation completed in ~1 s before the commit. The practical effect is that real-profile browsing only works when the user's browser happens to be closed or idle at the moment of launch, which inverts the feature's intent: the snapshot copy exists precisely so the agent browser and the user's browser can run concurrently.

The code removed by 58d6d5223a documented this exact hazard in a comment deleted along with the `immutable=1` path:

    # With a live Chrome on macOS, mode=ro WITHOUT immutable=1 blocks inside
    # lock negotiation and NEVER returns: sqlite's busy timeout does not cover
    # lock negotiation, so `timeout=5` cannot rescue it. immutable=1 reads
    # instantly and is what we want anyway — a committed snapshot of a file
    # another process owns, not coordinated writes.

## Root cause

`_copy_auth_file()` opens the source with `mode=ro` and relies on the backup progress-callback deadline to bound lock negotiation. Lock negotiation is not bounded by the connection busy timeout, so a writer-held lock converts directly into a per-database timeout. `_profile_is_locked()` intentionally never trips on POSIX, so the cost is paid at the mirror step on every attempt.

Two secondary observations:

1. The error text advises "turn browser.use_real_profile off", which discards the snapshot store on the next launch (consent off path). An agent following that advice destroys the working copy and any logins it holds, turning a transient read failure into data loss for the session.
2. The commit's reason for dropping `immutable=1` — "immutable ignores committed source WAL" — is correct but scoped to WAL-mode sources. Chrome's auth databases on macOS are rollback-journal (no non-empty `-wal` sidecar alongside `Cookies` / `Login Data` / `Web Data` in a default profile), so the instant read loses nothing for exactly the files this path exists to copy. Removing the only non-blocking read mode to protect against a condition that does not apply to these files regressed the common case (browser open, mid-write) from sub-second success to guaranteed failure.

## The fix: two-tier read

Keeps 58d6d5223a's destination-side discipline (no file replacement, bounded backups, fail closed) and restores the instant read as tier 1:

1. If the source has no non-empty `-wal` sidecar, snapshot it via `immutable=1` — never blocks on POSIX even under the writer's exclusive lock; reads the last committed state.
2. Otherwise (WAL-mode source, or tier 1 could not open the file, e.g. Windows sharing violations), fall back to the existing bounded coordinated `mode=ro` backup.

Both tiers write through SQLite into the destination and share the same five-second deadline callback; the copy still fails closed only when both tiers fail, preserving the "never launch silently signed-out" invariant.

## Measurements

- Rollback-journal source holding an exclusive lock (simulated live writer, `BEGIN EXCLUSIVE` then copy):
  - pre-58d6d5223a code: succeeds in ~0.00 s, committed rows intact
  - post-58d6d5223a code: `TimeoutError` at ~5.1 s, returns `False`
  - this branch: succeeds in ~0.00 s, committed rows intact
- Full real-profile snapshot against a live, actively-used Chrome on macOS (this branch): ~1.1 s total, all auth databases copied, source profile identity and full cookie set present in the copy (~17 s then failure on the parent commit).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/browser_connect.py` — `_copy_auth_file()` gains the two-tier source read (immutable tier 1 with `-wal` sidecar guard, coordinated tier 2 fallback); both tiers bounded by the same deadline callback; docstring updated.
- `tests/tools/test_browser_real_profile.py` — `test_copy_auth_file_bounds_locks_without_overwriting` now asserts the POSIX locked-source contract (copy succeeds with committed state) while keeping the locked-destination and Windows refusal branches unchanged; the WAL-fidelity test (`test_copy_auth_file_preserves_source_wal_not_abandoned_destination_wal`) passes unchanged because the sidecar guard routes WAL sources to the coordinated tier.

## How to Test

1. `python -m pytest tests/tools/test_browser_real_profile.py -q` — 82/82 pass on this branch.
2. Red/green: on the parent commit, hold `BEGIN EXCLUSIVE` on a rollback-journal `Cookies` fixture and call `_copy_auth_file(src, dst)` — it returns `False` after ~5 s; on this branch the same call returns `True` in ~0.00 s with the committed rows intact.
3. Live check on macOS: with Chrome running and actively used, trigger a real-profile launch; the snapshot completes in ~1 s instead of failing after ~17 s.

## Related Issue

Related: #105754 (the destination-hang fix this builds on), #96659

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #105763 (salvage of #105754) fixed the destination-side hang and is the parent of this regression; no open PR restores the source-side instant read
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/tools/test_browser_real_profile.py` 82/82 via `scripts/run_tests.sh`)
- [x] I've added tests for my changes (amended the locked-source expectation; WAL and destination-lock tests unchanged and passing)
- [x] I've tested on my platform: macOS 15.5 (arm64)