### PR TITLE
fix(state): opening state.db no longer takes the write lock when nothing needs writing (salvage #101881)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -916,13 +916,31 @@ class SessionDB(
         token = uuid.uuid4().hex
         try:
             with self._lock:
-                self._conn.execute(
-                    "INSERT OR IGNORE INTO state_meta (key, value) VALUES (?, ?)",
-                    (_STATE_DB_GENERATION_KEY, token),
-                )
+                # Read before writing. The stamp is minted once per FILE, so
+                # every open after the first one used to issue an
+                # INSERT OR IGNORE that could not insert anything — and a
+                # write statement takes the database write lock even when it
+                # changes nothing. With a sibling process holding that lock
+                # the no-op INSERT blocks for the full busy timeout (~1s at
+                # the timeout=1.0 this connection is opened with) and the
+                # whole block is then abandoned by the handler below, so the
+                # stamp was LOST precisely when contention made it slowest.
+                # state_meta is keyed by TEXT PRIMARY KEY, so the probe is a
+                # primary-key seek. First opener still wins via
+                # INSERT OR IGNORE, and racers still converge on the winner's
+                # token through the re-read.
                 row = self._conn.execute(
                     "SELECT value FROM state_meta WHERE key = ?", (_STATE_DB_GENERATION_KEY,),
                 ).fetchone()
+                if not (row and row[0]):
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO state_meta (key, value) VALUES (?, ?)",
+                        (_STATE_DB_GENERATION_KEY, token),
+                    )
+                    row = self._conn.execute(
+                        "SELECT value FROM state_meta WHERE key = ?",
+                        (_STATE_DB_GENERATION_KEY,),
+                    ).fetchone()
                 if row and row[0]:
                     token = str(row[0])
                 pragma_row = self._conn.execute("PRAGMA application_id").fetchone()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -916,19 +916,10 @@ class SessionDB(
         token = uuid.uuid4().hex
         try:
             with self._lock:
-                # Read before writing. The stamp is minted once per FILE, so
-                # every open after the first one used to issue an
-                # INSERT OR IGNORE that could not insert anything — and a
-                # write statement takes the database write lock even when it
-                # changes nothing. With a sibling process holding that lock
-                # the no-op INSERT blocks for the full busy timeout (~1s at
-                # the timeout=1.0 this connection is opened with) and the
-                # whole block is then abandoned by the handler below, so the
-                # stamp was LOST precisely when contention made it slowest.
-                # state_meta is keyed by TEXT PRIMARY KEY, so the probe is a
-                # primary-key seek. First opener still wins via
-                # INSERT OR IGNORE, and racers still converge on the winner's
-                # token through the re-read.
+                # Read first: the stamp is minted once per file, and a no-op INSERT OR IGNORE
+                # still takes the write lock — under a sibling's transaction it blocked for the
+                # busy timeout and the except below then dropped the token entirely. First
+                # opener still wins via INSERT OR IGNORE; racers converge on the re-read.
                 row = self._conn.execute(
                     "SELECT value FROM state_meta WHERE key = ?", (_STATE_DB_GENERATION_KEY,),
                 ).fetchone()

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -283,6 +283,41 @@ class SessionSchemaMixin:
         cursor.execute(_STATE_META_UPSERT_SQL, (FTS_TOOL_FULL_CONTENT_HIGH_WATER_KEY, str(high_water)))
 
     @staticmethod
+    def _execute_ddl_skipping_settled_triggers(cursor: sqlite3.Cursor, ddl: str) -> None:
+        """Run *ddl* statement by statement, skipping each ``DROP TRIGGER IF EXISTS x`` /
+        ``CREATE TRIGGER IF NOT EXISTS x …`` pair whose trigger already exists with the same body.
+
+        ``DROP TRIGGER IF EXISTS`` on an existing trigger takes SQLite's write lock (the
+        ``CREATE … IF NOT EXISTS`` forms do not), so the unconditional drop+recreate that lets a
+        changed trigger body roll out would otherwise block every open of a settled database
+        behind a sibling process's transaction. ``sqlite_master.sql`` stores the CREATE text
+        verbatim minus ``IF NOT EXISTS`` and the ``;``, so an exact comparison decides.
+        """
+        stored = dict(cursor.execute("SELECT name, sql FROM sqlite_master WHERE type = 'trigger'").fetchall())
+        pending_drop: Optional[str] = None
+        statement = ""
+        for line in ddl.splitlines():
+            statement += line + "\n"
+            if not sqlite3.complete_statement(statement):
+                continue
+            statement, current = "", statement.strip()
+            upper = current.upper()
+            if upper.startswith("DROP TRIGGER IF EXISTS "):
+                pending_drop = current
+                continue
+            if upper.startswith("CREATE TRIGGER IF NOT EXISTS "):
+                desired = current.replace("IF NOT EXISTS ", "", 1).rstrip(";")
+                if stored.get(desired.split(None, 3)[2]) == desired:
+                    pending_drop = None
+                    continue
+            if pending_drop is not None:
+                cursor.execute(pending_drop)
+                pending_drop = None
+            cursor.execute(current)
+        if statement.strip():
+            raise sqlite3.OperationalError("incomplete DDL statement")
+
+    @staticmethod
     def _execute_ddl_script_transactional(cursor: sqlite3.Cursor, ddl: str) -> None:
         """Execute a DDL script without ``executescript``'s implicit commit."""
         statement = ""
@@ -884,7 +919,7 @@ class SessionSchemaMixin:
             )
         except sqlite3.OperationalError as exc:
             logger.debug("idx_messages_platform_msg_id create skipped: %s", exc)
-        cursor.executescript(DEFERRED_INDEX_SQL)  # same ordering constraint (``active``)
+        self._execute_ddl_skipping_settled_triggers(cursor, DEFERRED_INDEX_SQL)  # same ordering constraint (``active``)
 
         # Heal NULL ``active`` rows on every startup: older reconciler builds added ``active``
         # without NOT NULL DEFAULT 1, so ``WHERE active = 1`` loaders hid whole histories. A

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -889,8 +889,13 @@ class SessionSchemaMixin:
         # Heal NULL ``active`` rows on every startup: older reconciler builds added ``active``
         # without NOT NULL DEFAULT 1, so ``WHERE active = 1`` loaders hid whole histories. A
         # ``current_version < 12`` gate never re-ran for already-v12+ databases.
+        # Read before writing: an UPDATE takes the write lock even when it matches no rows, so
+        # the unconditional form blocked every open behind a sibling's write transaction. The
+        # probe is short-circuited on the modern NOT NULL column and index-served on legacy
+        # ones. Deliberately not INDEXED BY (raises "no query solution" on NOT NULL columns).
         with contextlib.suppress(sqlite3.OperationalError):
-            cursor.execute("UPDATE messages SET active = 1 WHERE active IS NULL")
+            if cursor.execute("SELECT 1 FROM messages WHERE active IS NULL LIMIT 1").fetchone() is not None:
+                cursor.execute("UPDATE messages SET active = 1 WHERE active IS NULL")
 
         fts5_available = self._sqlite_supports_fts5(cursor)
         stale_row = cursor.execute("SELECT 1 FROM state_meta WHERE key = ? LIMIT 1", (FTS_STALE_KEY,)).fetchone()
@@ -1012,7 +1017,13 @@ class SessionSchemaMixin:
             and not self._has_fts_trash(cursor)
             and not self._fts_external_index_empty_with_messages(cursor)
         ):
-            self.set_meta("fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor)
+            # Stamp only when it would change something: on a settled DB every condition above
+            # already holds, and re-writing the same value takes the write lock on every open.
+            if cursor.execute(
+                "SELECT 1 FROM state_meta WHERE key = 'fts_storage_version' AND value = ? LIMIT 1",
+                (str(FTS_STORAGE_VERSION),),
+            ).fetchone() is None:
+                self.set_meta("fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor)
 
         # Advance schema_version — deliberately NOT gated on the FTS opt-in (that would block
         # every future migration for a user who never optimizes). FTS5 unavailable is the

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,7 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import contextlib
+import re
 import sqlite3
 import time
 import json
@@ -620,76 +622,55 @@ class TestMessageStorage:
 
 
 
-    def test_open_does_not_take_the_write_lock_when_nothing_needs_writing(self, tmp_path):
-        """A read-write open must not block on a sibling's write transaction.
+    def test_settled_open_issues_no_main_db_writes(self, tmp_path, monkeypatch):
+        """Opening a database that needs no repair must not execute any write statement.
 
-        Opening used to issue two unconditional writes — the generation
-        stamp's ``INSERT OR IGNORE`` and the NULL-``active`` repair ``UPDATE``
-        — and a write statement takes the database write lock even when it
-        changes nothing. With another process holding that lock, each one
-        blocked for a full busy timeout, so a plain open cost ~2s on a
-        database that needed no repair at all. Both are now gated on a read.
+        A write statement takes the write lock even when it changes nothing, so an
+        unconditional INSERT OR IGNORE / UPDATE / marker stamp blocks every open behind
+        a sibling process's transaction. The FTS5 capability probe on ``temp`` is exempt.
         """
         db_path = tmp_path / "state.db"
-        # Open until the file has settled: the first opens legitimately mint
-        # the generation stamp and the FTS layout marker. From then on a
-        # healthy DB needs no writes at all to be opened.
+        SessionDB(db_path=db_path).close()  # mints stamp + FTS layout marker
+        SessionDB(db_path=db_path).close()
+
+        writes = []
+        real_connect = sqlite3.connect
+
+        def tracing_connect(*args, **kwargs):
+            conn = real_connect(*args, **kwargs)
+            conn.set_trace_callback(
+                lambda stmt: writes.append(stmt)
+                if re.match(r"\s*(INSERT|UPDATE|DELETE|REPLACE)\b", stmt, re.I) and "temp." not in stmt
+                else None
+            )
+            return conn
+
+        monkeypatch.setattr(sqlite3, "connect", tracing_connect)
+        SessionDB(db_path=db_path).close()
+        assert writes == []
+
+    def test_open_completes_while_sibling_holds_write_lock(self, tmp_path):
+        """A settled read-write open must not wait on another connection's write transaction."""
+        db_path = tmp_path / "state.db"
         SessionDB(db_path=db_path).close()
         SessionDB(db_path=db_path).close()
 
         holder = sqlite3.connect(db_path, timeout=60)
-        holder.execute("PRAGMA busy_timeout=60000")
         holder.execute("BEGIN IMMEDIATE")
         holder.execute("UPDATE state_meta SET value = value WHERE key = 'nonexistent'")
+        release = threading.Timer(4.0, holder.rollback)
+        release.start()
         try:
             started = time.perf_counter()
-            session_db = SessionDB(db_path=db_path)
+            SessionDB(db_path=db_path).close()
             elapsed = time.perf_counter() - started
-            session_db.close()
         finally:
-            holder.rollback()
+            release.cancel()
+            with contextlib.suppress(sqlite3.Error):
+                holder.rollback()
             holder.close()
-
-        # One busy timeout is ~1s (the connection is opened with timeout=1.0);
-        # on the pre-fix code this took two of them. A generous bound keeps
-        # this from flaking on a loaded CI box while still failing loudly if a
-        # write creeps back onto the open path.
-        assert elapsed < 0.5, f"open blocked on the write lock for {elapsed:.3f}s"
-
-    def test_generation_stamp_survives_write_lock_contention(self, tmp_path):
-        """The stamp must be readable even when the write lock is held.
-
-        The stamp is minted once per file, so every later open only needs to
-        READ it. While the whole block was write-first, a held write lock made
-        it raise, the handler swallowed it, and the process ended up with no
-        generation token at all — losing the deleted-WAL/replaced-file guard
-        exactly when contention made it most likely to matter.
-        """
-        db_path = tmp_path / "state.db"
-        SessionDB(db_path=db_path).close()  # settle the FTS layout marker too
-        first = SessionDB(db_path=db_path)
-        try:
-            on_disk = first._conn.execute(
-                "SELECT value FROM state_meta WHERE key = ?",
-                (hermes_state._STATE_DB_GENERATION_KEY,),
-            ).fetchone()[0]
-        finally:
-            first.close()
-        assert on_disk
-
-        holder = sqlite3.connect(db_path, timeout=60)
-        holder.execute("PRAGMA busy_timeout=60000")
-        holder.execute("BEGIN IMMEDIATE")
-        holder.execute("UPDATE state_meta SET value = value WHERE key = 'nonexistent'")
-        try:
-            session_db = SessionDB(db_path=db_path)
-            try:
-                assert session_db._db_file_generation_token == on_disk
-            finally:
-                session_db.close()
-        finally:
-            holder.rollback()
-            holder.close()
+        # Pre-fix this waited for the whole 4 s hold (retry loop around the busy timeout).
+        assert elapsed < 2.0, f"open blocked on the write lock for {elapsed:.3f}s"
 
     def test_startup_heals_null_active_rows(self, tmp_path):
         """Rows written as active=NULL before the fix are un-hidden on startup.

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -640,7 +640,7 @@ class TestMessageStorage:
             conn = real_connect(*args, **kwargs)
             conn.set_trace_callback(
                 lambda stmt: writes.append(stmt)
-                if re.match(r"\s*(INSERT|UPDATE|DELETE|REPLACE)\b", stmt, re.I) and "temp." not in stmt
+                if re.match(r"\s*(INSERT|UPDATE|DELETE|REPLACE|ALTER|DROP\s+TRIGGER)\b", stmt, re.I) and "temp." not in stmt
                 else None
             )
             return conn

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -620,6 +620,77 @@ class TestMessageStorage:
 
 
 
+    def test_open_does_not_take_the_write_lock_when_nothing_needs_writing(self, tmp_path):
+        """A read-write open must not block on a sibling's write transaction.
+
+        Opening used to issue two unconditional writes — the generation
+        stamp's ``INSERT OR IGNORE`` and the NULL-``active`` repair ``UPDATE``
+        — and a write statement takes the database write lock even when it
+        changes nothing. With another process holding that lock, each one
+        blocked for a full busy timeout, so a plain open cost ~2s on a
+        database that needed no repair at all. Both are now gated on a read.
+        """
+        db_path = tmp_path / "state.db"
+        # Open until the file has settled: the first opens legitimately mint
+        # the generation stamp and the FTS layout marker. From then on a
+        # healthy DB needs no writes at all to be opened.
+        SessionDB(db_path=db_path).close()
+        SessionDB(db_path=db_path).close()
+
+        holder = sqlite3.connect(db_path, timeout=60)
+        holder.execute("PRAGMA busy_timeout=60000")
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("UPDATE state_meta SET value = value WHERE key = 'nonexistent'")
+        try:
+            started = time.perf_counter()
+            session_db = SessionDB(db_path=db_path)
+            elapsed = time.perf_counter() - started
+            session_db.close()
+        finally:
+            holder.rollback()
+            holder.close()
+
+        # One busy timeout is ~1s (the connection is opened with timeout=1.0);
+        # on the pre-fix code this took two of them. A generous bound keeps
+        # this from flaking on a loaded CI box while still failing loudly if a
+        # write creeps back onto the open path.
+        assert elapsed < 0.5, f"open blocked on the write lock for {elapsed:.3f}s"
+
+    def test_generation_stamp_survives_write_lock_contention(self, tmp_path):
+        """The stamp must be readable even when the write lock is held.
+
+        The stamp is minted once per file, so every later open only needs to
+        READ it. While the whole block was write-first, a held write lock made
+        it raise, the handler swallowed it, and the process ended up with no
+        generation token at all — losing the deleted-WAL/replaced-file guard
+        exactly when contention made it most likely to matter.
+        """
+        db_path = tmp_path / "state.db"
+        SessionDB(db_path=db_path).close()  # settle the FTS layout marker too
+        first = SessionDB(db_path=db_path)
+        try:
+            on_disk = first._conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (hermes_state._STATE_DB_GENERATION_KEY,),
+            ).fetchone()[0]
+        finally:
+            first.close()
+        assert on_disk
+
+        holder = sqlite3.connect(db_path, timeout=60)
+        holder.execute("PRAGMA busy_timeout=60000")
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("UPDATE state_meta SET value = value WHERE key = 'nonexistent'")
+        try:
+            session_db = SessionDB(db_path=db_path)
+            try:
+                assert session_db._db_file_generation_token == on_disk
+            finally:
+                session_db.close()
+        finally:
+            holder.rollback()
+            holder.close()
+
     def test_startup_heals_null_active_rows(self, tmp_path):
         """Rows written as active=NULL before the fix are un-hidden on startup.
 


### PR DESCRIPTION
Opening `state.db` no longer takes SQLite's write lock when the file needs no writes, so a fresh `hermes` process is not stalled behind a sibling process holding a transaction.

Based on #101881 by @jonpol01 (cherry-picked, authorship preserved).

## Root cause

Every read-write open ran three unconditional write statements plus an unconditional drop+recreate of four triggers — the `db_file_generation` stamp (`INSERT OR IGNORE`), the `active IS NULL` heal (`UPDATE … WHERE active IS NULL`) and the `fts_storage_version` marker upsert. SQLite takes the RESERVED lock for a write statement even when it matches zero rows, so on a settled database each open blocked for the full busy timeout whenever another process held `BEGIN IMMEDIATE`.

## Changes

- `hermes_state.py::_ensure_db_file_generation` — read the stamp first; insert only when absent (first opener still wins, re-read after insert).
- `hermes_state_schema.py` — the `active` heal runs only when a NULL row exists; the FTS layout marker is written only when its value differs.
- `hermes_state_schema.py` — the four display triggers in `DEFERRED_INDEX_SQL` were dropped and re-created on every open (`DROP TRIGGER IF EXISTS` on an existing trigger takes the write lock; the `CREATE … IF NOT EXISTS` forms do not); each pair now runs only when the stored trigger body differs from the desired one, so a changed trigger still rolls out. Found by review: without this the open still blocked and the lock test could not pass.
- `tests/test_hermes_state.py` — trimmed from the PR's 71 lines to two invariants: a settled open issues no `INSERT/UPDATE/DELETE` against the main tables; an open completes while a sibling process holds the write lock. Both proven RED with the gates reverted (statement gates AND the trigger gate), GREEN restored.

Comment on the stamp path tightened to the why.

## Measured impact

Temp `HERMES_HOME`, database settled by two prior opens, sibling subprocess holding `BEGIN IMMEDIATE` for 3 s, 5 runs each:

| | main | this PR |
|---|---|---|
| `SessionDB(path)` open under a sibling write lock (median) | 2845 ms | 16 ms |
| write-lock statements per settled open (`INSERT/UPDATE/DELETE/DROP TRIGGER`) | 8 | 0 (only the `temp.` FTS5 capability probe remains) |

`CREATE TABLE IF NOT EXISTS` statements are unchanged (SQLite resolves them against the schema before taking the lock). Read-only opens and the `_fts_stale` path are untouched.

Pre-existing on this host (fails identically on a clean `origin/main`, environmental): `TestPerformancePragmasEndToEnd::test_configured_pragmas_reach_all_connection_types` — linked SQLite 3.46 falls back to `journal_mode=DELETE` under the WAL-reset-bug guard.
