### PR TITLE
fix(gateway): api-server requests keep the tool-availability cache unless extension control is on (#79047, salvage #102368)

### DIFF
--- a/tests/tools/test_browser_extension_router.py
+++ b/tests/tools/test_browser_extension_router.py
@@ -425,10 +425,12 @@ def test_routeable_browser_tools_preserve_legacy_gate_without_bound_identity(mon
     assert browser_tool.check_browser_snapshot_requirements() is False
 
 
-def test_bound_browser_request_bypasses_availability_caches():
+def test_bound_browser_request_bypasses_availability_caches(monkeypatch):
+    from gateway import browser_control_broker
     from gateway.session_context import clear_session_vars, set_session_vars
     from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope
 
+    monkeypatch.setattr(browser_control_broker, "browser_control_enabled", lambda: True)
     tokens = set_session_vars(
         session_id="session-fixture",
         browser_control_principal="principal-fixture",
@@ -436,6 +438,25 @@ def test_bound_browser_request_bypasses_availability_caches():
     )
     try:
         assert check_fn_cache_scope() == CHECK_FN_CACHE_BYPASS
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_bound_identity_without_extension_control_keeps_cache_scope(monkeypatch):
+    """api_server binds a principal on every request; without the feature flag
+    that identity must not bypass the availability caches (#79047)."""
+    from gateway import browser_control_broker
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope
+
+    monkeypatch.setattr(browser_control_broker, "browser_control_enabled", lambda: False)
+    tokens = set_session_vars(
+        session_id="session-fixture",
+        browser_control_principal="principal-fixture",
+        browser_control_transport_family="local-api",
+    )
+    try:
+        assert check_fn_cache_scope() != CHECK_FN_CACHE_BYPASS
     finally:
         clear_session_vars(tokens)
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -251,7 +251,12 @@ def check_fn_cache_scope() -> Optional[str]:
     try:
         from gateway.session_context import get_session_env
         if all(str(get_session_env(k, "") or "").strip() for k in _BROWSER_IDENTITY_KEYS):
-            return CHECK_FN_CACHE_BYPASS
+            # api_server binds a server-derived principal + transport family on EVERY request, so
+            # identity-present != controller-attached; only bypass when the extension-control
+            # feature is actually on (#79047).
+            from gateway.browser_control_broker import browser_control_enabled
+            if browser_control_enabled():
+                return CHECK_FN_CACHE_BYPASS
     except Exception:
         pass
     try:


### PR DESCRIPTION
An API-server request no longer bypasses the tool-availability caches unless browser extension control is actually enabled, so every `/v1/*` request stops re-running all availability check_fns.

Based on #102368 by @Finn763 (cherry-picked, authorship preserved). Refs #79047.

## Root cause

`tools.registry.check_fn_cache_scope()` returns the cache-BYPASS sentinel whenever a browser-control identity (session id + principal + transport family) is bound, because a live browser controller changes availability per attach/detach. But `api_server`'s profile middleware binds a server-derived principal and transport family on EVERY request (`_make_profile_prefix_middleware`), so identity-present ≠ controller-attached: with extension control disabled (the default) each request still recomputed every check_fn.

## Changes

- `tools/registry.py::check_fn_cache_scope` — bypass only when `browser_control_enabled()` (the same opt-in predicate `tools/browser_extension_router.py` already gates on; read through the cached read-only config loader, ~0.7 µs per call).
- `tests/tools/test_browser_extension_router.py` — the existing bypass test now pins the flag on (feature preserved for real extension-control users); one new invariant: bound identity + flag off ⇒ cache scope unchanged. Proven RED on main, GREEN on the branch.

## Measured impact

Temp `HERMES_HOME` (flag absent), identity bound exactly as `_bind_api_server_session` does, `model_tools.get_tool_definitions(quiet_mode=True)` timed over 6 calls (19 tools):

| | main | this PR |
|---|---|---|
| scope with api_server identity bound | BYPASS | `None` (process cache) |
| `get_tool_definitions` per call, steady state (median) | 60.7 ms | 0.7 ms |
| `browser_control_enabled()` | — | 0.7 µs/call |

The 3.3 s figure in #79047 was not reproduced on this machine (no network-probing check_fn here); the per-request recomputation itself is what this removes.
