### PR TITLE
fix(mcp): preserve application results after transport recovery

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -137,8 +137,9 @@ def _install_stub_server(name: str = "wpcom"):
     ],
     ids=["stdio", "http"],
 )
+@pytest.mark.parametrize("application_error", [False, True], ids=["success", "application-error"])
 def test_call_tool_handler_rebuilds_configured_server_transport(
-    monkeypatch, tmp_path, transport_config, expected_route
+    monkeypatch, tmp_path, transport_config, expected_route, application_error
 ):
     """The real server run loop selects and rebuilds its configured transport."""
     from anyio import ClosedResourceError
@@ -160,7 +161,7 @@ def test_call_tool_handler_rebuilds_configured_server_transport(
             if call_count["n"] == 1:
                 raise ClosedResourceError
             result = MagicMock()
-            result.is_error = False
+            result.is_error = application_error
             result.content = [MagicMock(type="text", text="reconnected")]
             result.structured_content = None
             return result
@@ -196,7 +197,8 @@ def test_call_tool_handler_rebuilds_configured_server_transport(
         handler = _make_tool_handler("resumed", "health", 10.0)
         parsed = json.loads(handler({}))
 
-        assert parsed == {"result": "reconnected"}
+        assert parsed == {"error" if application_error else "result": "reconnected"}
+        assert mcp_tool._server_error_counts.get("resumed", 0) == 0
         assert call_count["n"] == 2
         assert routes == [expected_route, expected_route]
         assert configs == [transport_config, transport_config]

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -125,14 +125,13 @@ def _lookup_reconnectable_server(server_name: str, require_loop: bool = False):
 
 def _retry_once(server_name: str, retry_call, op_description: str, what: str):
     """Re-run ``retry_call`` after a recovery step. Returns the result (closing the breaker)
-    when it is not an error payload; None when the retry raised or errored (caller falls through)."""
+    when the RPC completed; None when the retry raised (caller falls through)."""
     try:
         result = retry_call()
     except Exception as retry_exc:
         logger.warning("MCP %s/%s retry after %s failed: %s", server_name, op_description, what, retry_exc)
         return None
-    if _result_is_error(result):
-        return None
+    # An application error still proves the recovered transport completed a round-trip.
     _core._reset_server_error(server_name)
     return result
 


### PR DESCRIPTION
## What does this PR do?

After MCP transport recovery, a completed tool call can return an application error. `_retry_once` currently discards that result and leaves the transport error counter untouched. Return the original result and reset the counter whenever the retry RPC completes; an exception still follows the existing failure path.

## Related Issue

Related to #98992 and #105116. Those proposals address the primary call path; this change covers the separate retry-after-recovery path and its transport lifecycle regression. It deliberately leaves the primary-path fix to those proposals.

## Type of Change

- [x] Bug fix

## Changes Made

- `tools/mcp_tool_handlers.py`: preserve completed application-error results after recovery and reset the transport breaker.
- `tests/tools/test_mcp_tool_session_expired.py`: exercise successful and application-error retry results for both stdio and HTTP recovery, asserting the original result and a cleared error counter.

## How to Test

Run `scripts/run_tests.sh tests/tools/test_mcp_tool_session_expired.py tests/tools/test_mcp_tool_401_handling.py tests/tools/test_mcp_circuit_breaker.py -j 3` with the project Python environment.

The new application-error cases fail against the original implementation. With the fix, all 25 tests across these three files pass, including after rebasing onto `a785db3`. Tested on macOS. The tests exercise the transport lifecycle with synthetic results; no live MCP server was used. The full repository suite was not run.

## Checklist

- [x] Read the contributing guide and searched existing PRs.
- [x] Conventional commit; only this recovery fix and its regression tests.
- [x] Added regression tests and ran the affected suites.
- [ ] Ran the full repository test suite.
- [x] Updated the affected helper docstring.
- [x] No configuration, platform-specific I/O, or tool schema changes.

Authored with OpenAI Codex.
