### PR TITLE
perf(agent): chat.completions requests skip the SDK's client-side transform of the conversation body (salvage #102036, extends #93650)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1454,9 +1454,10 @@ class _CodexCompletionsAdapter:
         guard = _CodexStreamGuard(self._client, total_timeout)
         try:
             guard.start()
-            from agent.codex_runtime import _bypass_sdk_request_transform, _consume_codex_event_stream
+            from agent.codex_runtime import _consume_codex_event_stream
+            from agent.sdk_transform_bypass import bypass_sdk_request_transform
             # Keep bulk wire payload out of the SDK's GIL-holding request transform.
-            stream_kwargs = _bypass_sdk_request_transform({**resp_kwargs, "stream": True})
+            stream_kwargs = bypass_sdk_request_transform({**resp_kwargs, "stream": True})
             event_stream = self._client.responses.create(**stream_kwargs)
             guard.adopt_stream(event_stream)
             # The timer may fire while responses.create() is blocked; if the cancelled attempt

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, Optional
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import (FailoverReason, PROVIDER_STREAM_NON_JSON_ERROR_CODE)
+from agent.sdk_transform_bypass import bypass_chat_sdk_request_transform
 from agent.errors import EmptyStreamError
 from agent.chat_completion_stream_monitor import StreamingWaitMonitor
 from agent.fast_mode import effective_request_overrides
@@ -703,7 +704,12 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         if not callable(getattr(_completions, "prepare", None)):
             api_kwargs.pop("_moa_prepared_request", None)
         return agent.client.chat.completions.create(**api_kwargs)
-    return make_client("chat_completion_request").chat.completions.create(**api_kwargs)
+    request_client = make_client("chat_completion_request")
+    # #93650: keep the bulk wire-format payload out of the SDK's GIL-holding
+    # request transform. No-op unless this really is the OpenAI SDK, so the
+    # MoA facade above and the suite's stand-in clients are unaffected.
+    api_kwargs = bypass_chat_sdk_request_transform(api_kwargs, request_client)
+    return request_client.chat.completions.create(**api_kwargs)
 
 
 def should_use_direct_api_call(agent) -> bool:
@@ -2694,6 +2700,9 @@ class _StreamingCall(StreamingWaitMonitor):
             self.agent._create_request_openai_client(reason="chat_completion_stream_request", api_kwargs=stream_kwargs))
         self.last_chunk_time["t"] = time.time()
         self.agent._touch_activity("waiting for provider response (streaming)")
+        # #93650: as above — the streaming path carries the same bulk
+        # messages/tools payload and pays the same client-side walk.
+        stream_kwargs = bypass_chat_sdk_request_transform(stream_kwargs, request_client)
         return request_client.chat.completions.create(**stream_kwargs)
 
     def _chat_stream_created(self, raw_stream: Any) -> None:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from agent.sdk_transform_bypass import bypass_sdk_request_transform
 from agent.usage_anchor import set_usage_anchor
 
 logger = logging.getLogger(__name__)
@@ -828,24 +829,6 @@ def _sanitize_consumer_codex_request(agent: Any, request: dict[str, Any]) -> dic
     return sanitized
 
 
-# The request-transform bypass (#93650) now lives in agent/sdk_transform_bypass
-# so the chat-completions path can share it. Re-exported here under the
-# original names: agent/auxiliary_client.py and
-# tests/run_agent/test_codex_sdk_transform_bypass.py import them from this
-# module, and those import paths stay valid.
-from agent.sdk_transform_bypass import (  # noqa: E402
-    RESPONSES_BYPASS_FIELDS as _SDK_TRANSFORM_BYPASS_FIELDS,
-    _is_plain_json_data,
-    bypass_sdk_request_transform as _bypass_sdk_request_transform,
-)
-
-__all__ = [
-    "_SDK_TRANSFORM_BYPASS_FIELDS",
-    "_is_plain_json_data",
-    "_bypass_sdk_request_transform",
-]
-
-
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
     """One streaming Responses API request over raw ``responses.create(stream=True)`` events."""
     import httpx as _httpx
@@ -902,7 +885,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     def _open_codex_stream(next_api_kwargs: dict[str, Any]):
         stream_kwargs = _sanitize_consumer_codex_request(agent, next_api_kwargs)
         stream_kwargs["stream"] = True
-        return active_client.responses.create(**_bypass_sdk_request_transform(stream_kwargs))
+        return active_client.responses.create(**bypass_sdk_request_transform(stream_kwargs))
 
     def _log_failure(exc: BaseException) -> None:
         request_body_bytes, exception_chain = _codex_request_failure_details(exc)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -828,40 +828,22 @@ def _sanitize_consumer_codex_request(agent: Any, request: dict[str, Any]) -> dic
     return sanitized
 
 
-# Bulk request fields carrying the conversation payload; the rest is scalar config the SDK transform handles fast.
-_SDK_TRANSFORM_BYPASS_FIELDS = ("input", "tools")
+# The request-transform bypass (#93650) now lives in agent/sdk_transform_bypass
+# so the chat-completions path can share it. Re-exported here under the
+# original names: agent/auxiliary_client.py and
+# tests/run_agent/test_codex_sdk_transform_bypass.py import them from this
+# module, and those import paths stay valid.
+from agent.sdk_transform_bypass import (  # noqa: E402
+    RESPONSES_BYPASS_FIELDS as _SDK_TRANSFORM_BYPASS_FIELDS,
+    _is_plain_json_data,
+    bypass_sdk_request_transform as _bypass_sdk_request_transform,
+)
 
-
-def _is_plain_json_data(value: Any) -> bool:
-    """True when ``value`` is purely JSON wire types; pydantic models / generators must keep the typed SDK path."""
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return True
-    if isinstance(value, dict):
-        return all(isinstance(key, str) and _is_plain_json_data(item) for key, item in value.items())
-    if isinstance(value, list):
-        return all(_is_plain_json_data(item) for item in value)
-    return False
-
-
-def _bypass_sdk_request_transform(stream_kwargs: dict) -> dict:
-    """Route bulk payload fields around the SDK's ``maybe_transform``.
-
-    ``responses.create`` re-walks the whole body against the ResponseCreateParams union with the GIL held —
-    multi-MB conversations can wedge for hours, pre-network, where no watchdog socket kill helps. The SDK
-    merges ``extra_body`` AFTER the transform, so moving wire-format bulk fields there yields a byte-identical
-    request without the walk. HERMES_CODEX_SDK_TRANSFORM=1 disables."""
-    if os.environ.get("HERMES_CODEX_SDK_TRANSFORM", "").strip().lower() in {"1", "true", "yes", "on"}:
-        return stream_kwargs
-    moved = {f: stream_kwargs[f] for f in _SDK_TRANSFORM_BYPASS_FIELDS
-             if isinstance(stream_kwargs.get(f), (dict, list)) and _is_plain_json_data(stream_kwargs[f])}
-    if not moved:
-        return stream_kwargs
-    bypassed = {key: value for key, value in stream_kwargs.items() if key not in moved}
-    extra_body = bypassed.get("extra_body")
-    merged = dict(extra_body) if isinstance(extra_body, dict) else {}
-    # An explicit caller-provided extra_body entry keeps precedence (SDK post-transform merge).
-    bypassed["extra_body"] = {**merged, **{f: v for f, v in moved.items() if f not in merged}}
-    return bypassed
+__all__ = [
+    "_SDK_TRANSFORM_BYPASS_FIELDS",
+    "_is_plain_json_data",
+    "_bypass_sdk_request_transform",
+]
 
 
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):

--- a/agent/sdk_transform_bypass.py
+++ b/agent/sdk_transform_bypass.py
@@ -1,0 +1,134 @@
+"""Route bulk request payloads around the OpenAI SDK's request transform (#93650).
+
+Both the Responses API (``responses.create``) and chat-completions
+(``chat.completions.create``) re-walk the entire request body against their
+TypedDict/union param graph client-side, before any byte leaves the process.
+That walk holds the GIL, and #93650 documents it wedging for 12+ hours on a
+~1.4 MB conversation — starving every other thread, including the TTFB and
+stale-call watchdogs whose whole job is to rescue this exact call. Because the
+hang is client-side and pre-network, no socket kill can unblock it.
+
+Hermes assembles these payloads from JSON round-trips, so they are already in
+wire format and the walk has nothing to convert. The SDK merges ``extra_body``
+into the JSON body *after* the transform
+(``_base_client._build_request``), so moving the already-wire-format bulk
+fields there skips the walk and produces a byte-identical request.
+
+This module is the shared home for the helpers; ``agent.codex_runtime``
+re-exports them so existing import paths keep working.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# Bulk request fields that carry the conversation payload, per API family.
+# Everything else in a request is scalar configuration the SDK transform
+# handles in microseconds.
+RESPONSES_BYPASS_FIELDS = ("input", "tools")
+CHAT_COMPLETIONS_BYPASS_FIELDS = ("messages", "tools")
+
+
+def _is_plain_json_data(value: Any) -> bool:
+    """True when ``value`` is composed purely of JSON wire types.
+
+    The SDK's request transform exists to convert typed params (TypedDict
+    key aliases, pydantic models, ``PropertyInfo`` formats) into wire
+    format.  Hermes assembles these payloads from JSON round-trips, so they
+    are already wire format — but that is only provable when every node is
+    a plain JSON type.  Anything else must keep the typed SDK path.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_plain_json_data(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return all(_is_plain_json_data(item) for item in value)
+    return False
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def bypass_sdk_request_transform(
+    request_kwargs: dict,
+    *,
+    fields: tuple = RESPONSES_BYPASS_FIELDS,
+    escape_hatch_env: str = "HERMES_CODEX_SDK_TRANSFORM",
+    required_empty: tuple = (),
+) -> dict:
+    """Move wire-format bulk ``fields`` into ``extra_body``.
+
+    Returns ``request_kwargs`` unchanged when there is nothing safe to move,
+    so a caller can always use the result unconditionally. Fields holding
+    anything that is not plain JSON data (pydantic models, generators) stay
+    on the typed path, which still needs the transform.
+
+    ``required_empty`` names fields the SDK declares ``@required_args`` and
+    would reject as missing: those are kept in the typed kwargs as an empty
+    list, and the ``extra_body`` copy overwrites them in the JSON body. Set
+    ``escape_hatch_env`` to restore the pre-fix behaviour.
+    """
+    if _env_flag(escape_hatch_env):
+        return request_kwargs
+
+    moved = {
+        field: request_kwargs[field]
+        for field in fields
+        if isinstance(request_kwargs.get(field), (dict, list))
+        and _is_plain_json_data(request_kwargs[field])
+    }
+    if not moved:
+        return request_kwargs
+
+    bypassed = {
+        key: value for key, value in request_kwargs.items() if key not in moved
+    }
+    for field in required_empty:
+        if field in moved:
+            # The SDK rejects the call outright if a @required_args parameter
+            # is absent; an empty list satisfies the signature and the
+            # extra_body entry replaces it in the body the server sees.
+            bypassed[field] = []
+    extra_body = bypassed.get("extra_body")
+    merged = dict(extra_body) if isinstance(extra_body, dict) else {}
+    for field, value in moved.items():
+        # An explicit caller-provided extra_body entry keeps precedence,
+        # matching what the SDK's post-transform merge would have done.
+        merged.setdefault(field, value)
+    bypassed["extra_body"] = merged
+    return bypassed
+
+
+def is_openai_sdk_completions(client: Any) -> bool:
+    """True when ``client.chat.completions`` is the real OpenAI SDK object.
+
+    Only the SDK performs the transform this bypass exists to skip, and only
+    the SDK merges ``extra_body`` into the body afterwards. Hermes also drives
+    chat-completions-shaped facades that are NOT the SDK — the in-process MoA
+    aggregator (``agent/moa_loop.py``) most importantly, plus the stand-ins
+    the test suite injects — and handing those an ``extra_body`` they never
+    merge would silently drop the conversation. Gate on the real thing.
+    """
+    completions = getattr(getattr(client, "chat", None), "completions", None)
+    if completions is None:
+        return False
+    return type(completions).__module__.startswith("openai.")
+
+
+def bypass_chat_sdk_request_transform(request_kwargs: dict, client: Any) -> dict:
+    """``bypass_sdk_request_transform`` for chat-completions, SDK-gated."""
+    if not is_openai_sdk_completions(client):
+        return request_kwargs
+    return bypass_sdk_request_transform(
+        request_kwargs,
+        fields=CHAT_COMPLETIONS_BYPASS_FIELDS,
+        escape_hatch_env="HERMES_CHAT_SDK_TRANSFORM",
+        # ``messages`` is @required_args on chat.completions.create.
+        required_empty=("messages",),
+    )

--- a/agent/sdk_transform_bypass.py
+++ b/agent/sdk_transform_bypass.py
@@ -1,21 +1,15 @@
 """Route bulk request payloads around the OpenAI SDK's request transform (#93650).
 
-Both the Responses API (``responses.create``) and chat-completions
-(``chat.completions.create``) re-walk the entire request body against their
-TypedDict/union param graph client-side, before any byte leaves the process.
-That walk holds the GIL, and #93650 documents it wedging for 12+ hours on a
-~1.4 MB conversation — starving every other thread, including the TTFB and
-stale-call watchdogs whose whole job is to rescue this exact call. Because the
-hang is client-side and pre-network, no socket kill can unblock it.
+``responses.create`` and ``chat.completions.create`` both re-walk the whole request
+body against their TypedDict/union param graph client-side, with the GIL held,
+before any byte leaves the process. #93650 documents that walk wedging for 12+
+hours on a ~1.4 MB conversation — starving the TTFB/stale watchdogs whose job is
+to rescue this exact call; the hang is pre-network, so no socket kill helps.
 
-Hermes assembles these payloads from JSON round-trips, so they are already in
-wire format and the walk has nothing to convert. The SDK merges ``extra_body``
-into the JSON body *after* the transform
-(``_base_client._build_request``), so moving the already-wire-format bulk
-fields there skips the walk and produces a byte-identical request.
-
-This module is the shared home for the helpers; ``agent.codex_runtime``
-re-exports them so existing import paths keep working.
+Hermes assembles these payloads from JSON round-trips, so they are already wire
+format and the walk has nothing to convert. The SDK merges ``extra_body`` into
+the JSON body *after* the transform (``_base_client._build_request``), so moving
+the bulk fields there skips the walk and yields the same request bytes.
 """
 
 from __future__ import annotations
@@ -23,112 +17,64 @@ from __future__ import annotations
 import os
 from typing import Any
 
-# Bulk request fields that carry the conversation payload, per API family.
-# Everything else in a request is scalar configuration the SDK transform
-# handles in microseconds.
+# Bulk request fields carrying the conversation payload, per API family. Everything
+# else is scalar configuration the SDK transform handles in microseconds.
 RESPONSES_BYPASS_FIELDS = ("input", "tools")
 CHAT_COMPLETIONS_BYPASS_FIELDS = ("messages", "tools")
 
+# One hatch for both API families (established by #93650); restores the typed SDK path.
+ESCAPE_HATCH_ENV = "HERMES_CODEX_SDK_TRANSFORM"
+
 
 def _is_plain_json_data(value: Any) -> bool:
-    """True when ``value`` is composed purely of JSON wire types.
-
-    The SDK's request transform exists to convert typed params (TypedDict
-    key aliases, pydantic models, ``PropertyInfo`` formats) into wire
-    format.  Hermes assembles these payloads from JSON round-trips, so they
-    are already wire format — but that is only provable when every node is
-    a plain JSON type.  Anything else must keep the typed SDK path.
-    """
+    """True when ``value`` is purely JSON wire types; pydantic models / generators must keep the typed SDK path."""
     if value is None or isinstance(value, (str, int, float, bool)):
         return True
     if isinstance(value, dict):
-        return all(
-            isinstance(key, str) and _is_plain_json_data(item)
-            for key, item in value.items()
-        )
+        return all(isinstance(key, str) and _is_plain_json_data(item) for key, item in value.items())
     if isinstance(value, list):
         return all(_is_plain_json_data(item) for item in value)
     return False
 
 
-def _env_flag(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
-
-
 def bypass_sdk_request_transform(
     request_kwargs: dict,
+    fields: tuple[str, ...] = RESPONSES_BYPASS_FIELDS,
     *,
-    fields: tuple = RESPONSES_BYPASS_FIELDS,
-    escape_hatch_env: str = "HERMES_CODEX_SDK_TRANSFORM",
-    required_empty: tuple = (),
+    keep_slots: bool = False,
 ) -> dict:
     """Move wire-format bulk ``fields`` into ``extra_body``.
 
-    Returns ``request_kwargs`` unchanged when there is nothing safe to move,
-    so a caller can always use the result unconditionally. Fields holding
-    anything that is not plain JSON data (pydantic models, generators) stay
-    on the typed path, which still needs the transform.
-
-    ``required_empty`` names fields the SDK declares ``@required_args`` and
-    would reject as missing: those are kept in the typed kwargs as an empty
-    list, and the ``extra_body`` copy overwrites them in the JSON body. Set
-    ``escape_hatch_env`` to restore the pre-fix behaviour.
+    Returns ``request_kwargs`` itself when nothing is safe to move, so callers use
+    the result unconditionally. ``keep_slots`` leaves an empty-list placeholder in
+    the typed kwargs for each moved field: it satisfies ``@required_args``
+    (``messages`` on chat.completions) and keeps the field's position in the JSON
+    body, so the bytes — and therefore any byte-keyed prompt cache — are unchanged.
     """
-    if _env_flag(escape_hatch_env):
+    if os.environ.get(ESCAPE_HATCH_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
         return request_kwargs
-
-    moved = {
-        field: request_kwargs[field]
-        for field in fields
-        if isinstance(request_kwargs.get(field), (dict, list))
-        and _is_plain_json_data(request_kwargs[field])
-    }
+    moved = {f: request_kwargs[f] for f in fields
+             if isinstance(request_kwargs.get(f), (dict, list)) and _is_plain_json_data(request_kwargs[f])}
     if not moved:
         return request_kwargs
-
-    bypassed = {
-        key: value for key, value in request_kwargs.items() if key not in moved
-    }
-    for field in required_empty:
-        if field in moved:
-            # The SDK rejects the call outright if a @required_args parameter
-            # is absent; an empty list satisfies the signature and the
-            # extra_body entry replaces it in the body the server sees.
-            bypassed[field] = []
+    bypassed = {key: ([] if keep_slots else value) if key in moved else value
+                for key, value in request_kwargs.items() if keep_slots or key not in moved}
     extra_body = bypassed.get("extra_body")
     merged = dict(extra_body) if isinstance(extra_body, dict) else {}
-    for field, value in moved.items():
-        # An explicit caller-provided extra_body entry keeps precedence,
-        # matching what the SDK's post-transform merge would have done.
-        merged.setdefault(field, value)
-    bypassed["extra_body"] = merged
+    # An explicit caller-provided extra_body entry keeps precedence (SDK post-transform merge).
+    bypassed["extra_body"] = {**merged, **{f: v for f, v in moved.items() if f not in merged}}
     return bypassed
 
 
-def is_openai_sdk_completions(client: Any) -> bool:
-    """True when ``client.chat.completions`` is the real OpenAI SDK object.
+def bypass_chat_sdk_request_transform(request_kwargs: dict, client: Any) -> dict:
+    """Chat-completions bypass, gated on the real OpenAI SDK.
 
-    Only the SDK performs the transform this bypass exists to skip, and only
-    the SDK merges ``extra_body`` into the body afterwards. Hermes also drives
-    chat-completions-shaped facades that are NOT the SDK — the in-process MoA
-    aggregator (``agent/moa_loop.py``) most importantly, plus the stand-ins
-    the test suite injects — and handing those an ``extra_body`` they never
-    merge would silently drop the conversation. Gate on the real thing.
+    Only the SDK performs the transform and only the SDK merges ``extra_body``
+    afterwards. Hermes also drives chat-shaped facades that are NOT the SDK (the
+    in-process MoA aggregator, test stand-ins); handing those an ``extra_body`` they
+    never merge would silently send an empty conversation.
     """
     completions = getattr(getattr(client, "chat", None), "completions", None)
-    if completions is None:
-        return False
-    return type(completions).__module__.startswith("openai.")
-
-
-def bypass_chat_sdk_request_transform(request_kwargs: dict, client: Any) -> dict:
-    """``bypass_sdk_request_transform`` for chat-completions, SDK-gated."""
-    if not is_openai_sdk_completions(client):
+    if completions is None or not type(completions).__module__.startswith("openai."):
         return request_kwargs
-    return bypass_sdk_request_transform(
-        request_kwargs,
-        fields=CHAT_COMPLETIONS_BYPASS_FIELDS,
-        escape_hatch_env="HERMES_CHAT_SDK_TRANSFORM",
-        # ``messages`` is @required_args on chat.completions.create.
-        required_empty=("messages",),
-    )
+    return bypass_sdk_request_transform(request_kwargs, CHAT_COMPLETIONS_BYPASS_FIELDS, keep_slots=True)

--- a/tests/run_agent/test_chat_sdk_transform_bypass.py
+++ b/tests/run_agent/test_chat_sdk_transform_bypass.py
@@ -1,0 +1,248 @@
+"""Chat-completions request-transform bypass (#93650).
+
+``chat.completions.create`` re-walks the whole request body against the
+``CompletionCreateParams`` union graph client-side, with the GIL held, before
+any byte leaves the process. #93650 documents that class of walk wedging for
+12+ hours on a ~1.4 MB conversation, where no in-process watchdog can fire and
+no socket kill helps because the hang is pre-network. #93773 fixed it for
+``responses.create`` only; these tests cover extending the same, already
+reviewed mechanism to the default chat path.
+
+The safety argument is that the request the server receives is unchanged, so
+the byte-identity test below is the important one.
+"""
+
+import json
+import sys
+import types
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import httpx
+import openai
+import pytest
+
+from agent.sdk_transform_bypass import (
+    bypass_chat_sdk_request_transform,
+    is_openai_sdk_completions,
+)
+
+_SSE = (
+    b'data: {"id":"1","object":"chat.completion.chunk","created":1,"model":"m",'
+    b'"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\n'
+    b"data: [DONE]\n\n"
+)
+
+
+def _wire_body(tools: bool = True) -> dict:
+    """A production-shaped chat body: list content parts, an image part, a
+    tool_calls turn, a tool result, and function tool schemas."""
+    body = {
+        "model": "hermes-4-70b",
+        "messages": [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://e.example/i.png", "detail": "low"},
+                    },
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"cmd":"ls"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "total 0"},
+        ],
+        "stream": True,
+        "temperature": 0.7,
+        "stream_options": {"include_usage": True},
+    }
+    if tools:
+        body["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": f"tool_{i}",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"p": {"type": "string"}},
+                        "required": ["p"],
+                    },
+                },
+            }
+            for i in range(30)
+        ]
+    return body
+
+
+class _Recorder:
+    """A real openai.OpenAI client whose transport records the request body."""
+
+    def __init__(self):
+        self.content: bytes | None = None
+        self.client = openai.OpenAI(
+            api_key="k",
+            base_url="https://chat.invalid/v1",
+            http_client=httpx.Client(transport=httpx.MockTransport(self._handle)),
+        )
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.content = request.content
+        return httpx.Response(
+            200, content=_SSE, headers={"content-type": "text/event-stream"}
+        )
+
+    def send(self, kwargs: dict) -> bytes:
+        stream = self.client.chat.completions.create(**kwargs)
+        for _ in stream:
+            pass
+        assert self.content is not None
+        return self.content
+
+
+class _FacadeCompletions:
+    """Stands in for the MoA aggregator: chat-completions shaped, not the SDK."""
+
+    def create(self, **kwargs):  # pragma: no cover - never called here
+        raise AssertionError("not exercised")
+
+
+class _FacadeClient:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(completions=_FacadeCompletions())
+
+
+class TestByteIdentity:
+    def test_request_body_is_byte_identical_with_and_without_the_bypass(self):
+        """The whole safety argument: the server sees the same request."""
+        recorder = _Recorder()
+        body = _wire_body()
+
+        plain = recorder.send(dict(body))
+        bypassed = recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client))
+
+        assert bypassed == plain
+        # And it really did take the bypass, rather than silently no-opping.
+        moved = bypass_chat_sdk_request_transform(dict(body), recorder.client)
+        assert moved["messages"] == []
+        assert moved["extra_body"]["messages"] == body["messages"]
+        assert moved["extra_body"]["tools"] == body["tools"]
+
+    def test_the_wire_payload_survives_a_json_round_trip_unchanged(self):
+        recorder = _Recorder()
+        body = _wire_body()
+        sent = json.loads(recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client)))
+
+        assert sent["messages"] == body["messages"]
+        assert sent["tools"] == body["tools"]
+        assert sent["temperature"] == 0.7
+        assert sent["stream_options"] == {"include_usage": True}
+
+
+class TestGuards:
+    def test_a_non_sdk_client_is_left_completely_alone(self):
+        """MoA's facade never merges extra_body, so moving the conversation
+        there would silently send an empty message list."""
+        kwargs = _wire_body()
+
+        result = bypass_chat_sdk_request_transform(kwargs, _FacadeClient())
+
+        assert result is kwargs
+        assert "extra_body" not in result
+        assert result["messages"][0]["role"] == "system"
+
+    def test_is_openai_sdk_completions_discriminates(self):
+        assert is_openai_sdk_completions(_Recorder().client)
+        assert not is_openai_sdk_completions(_FacadeClient())
+        assert not is_openai_sdk_completions(object())
+
+    def test_non_plain_json_messages_stay_on_the_typed_path(self):
+        """The transform exists to convert typed params; anything that is not
+        already wire data still needs it."""
+        recorder = _Recorder()
+        kwargs = _wire_body()
+        kwargs["messages"][1]["content"] = object()
+
+        result = bypass_chat_sdk_request_transform(kwargs, recorder.client)
+
+        assert result["messages"] is kwargs["messages"]
+        assert "extra_body" not in result or "messages" not in result["extra_body"]
+
+    def test_a_tool_free_request_does_not_gain_an_empty_tools_key(self):
+        recorder = _Recorder()
+        body = _wire_body(tools=False)
+
+        sent = json.loads(recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client)))
+
+        assert "tools" not in sent
+
+    def test_caller_supplied_extra_body_keeps_precedence(self):
+        """The chat path already populates extra_body from custom providers,
+        reasoning config and Nous Portal; those entries must win."""
+        recorder = _Recorder()
+        body = _wire_body()
+        body["extra_body"] = {"provider": {"order": ["nous"]}, "messages": ["caller wins"]}
+
+        result = bypass_chat_sdk_request_transform(dict(body), recorder.client)
+
+        assert result["extra_body"]["messages"] == ["caller wins"]
+        assert result["extra_body"]["provider"] == {"order": ["nous"]}
+
+    def test_env_escape_hatch_restores_the_pre_fix_kwargs(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CHAT_SDK_TRANSFORM", "1")
+        recorder = _Recorder()
+        kwargs = _wire_body()
+
+        assert bypass_chat_sdk_request_transform(kwargs, recorder.client) is kwargs
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_escape_hatch_stays_off_for_falsey_values(self, monkeypatch, value):
+        monkeypatch.setenv("HERMES_CHAT_SDK_TRANSFORM", value)
+        recorder = _Recorder()
+
+        result = bypass_chat_sdk_request_transform(_wire_body(), recorder.client)
+
+        assert result["messages"] == []
+
+
+class TestResponsesPathUnchanged:
+    def test_the_codex_import_path_and_behaviour_are_preserved(self):
+        """agent/auxiliary_client.py and the existing codex test import these
+        names from agent.codex_runtime; the move must not break them."""
+        from agent.codex_runtime import (
+            _SDK_TRANSFORM_BYPASS_FIELDS,
+            _bypass_sdk_request_transform,
+            _is_plain_json_data,
+        )
+
+        assert _SDK_TRANSFORM_BYPASS_FIELDS == ("input", "tools")
+        assert _is_plain_json_data([{"role": "user", "content": "hi"}])
+        assert not _is_plain_json_data([{"role": "user", "content": object()}])
+
+        kwargs = {
+            "model": "gpt-5.6-sol",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+            "tools": [{"type": "function", "name": "terminal", "parameters": {}}],
+            "stream": True,
+        }
+        bypassed = _bypass_sdk_request_transform(kwargs)
+
+        # Responses keeps its historical shape: the fields are REMOVED from the
+        # typed kwargs entirely (input is not @required_args there).
+        assert "input" not in bypassed
+        assert "tools" not in bypassed
+        assert bypassed["extra_body"]["input"] == kwargs["input"]

--- a/tests/run_agent/test_chat_sdk_transform_bypass.py
+++ b/tests/run_agent/test_chat_sdk_transform_bypass.py
@@ -1,18 +1,12 @@
-"""Chat-completions request-transform bypass (#93650).
+"""Chat-completions request-transform bypass (#93650 extended to chat.completions).
 
 ``chat.completions.create`` re-walks the whole request body against the
-``CompletionCreateParams`` union graph client-side, with the GIL held, before
-any byte leaves the process. #93650 documents that class of walk wedging for
-12+ hours on a ~1.4 MB conversation, where no in-process watchdog can fire and
-no socket kill helps because the hang is pre-network. #93773 fixed it for
-``responses.create`` only; these tests cover extending the same, already
-reviewed mechanism to the default chat path.
-
-The safety argument is that the request the server receives is unchanged, so
-the byte-identity test below is the important one.
+``CompletionCreateParams`` union client-side, GIL held, before any byte leaves
+the process. The bypass moves the already-wire-format bulk fields into
+``extra_body``; its whole safety argument is that the server receives the same
+bytes, so that is what these tests pin.
 """
 
-import json
 import sys
 import types
 
@@ -22,12 +16,8 @@ sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
 import httpx
 import openai
-import pytest
 
-from agent.sdk_transform_bypass import (
-    bypass_chat_sdk_request_transform,
-    is_openai_sdk_completions,
-)
+from agent.sdk_transform_bypass import ESCAPE_HATCH_ENV, bypass_chat_sdk_request_transform
 
 _SSE = (
     b'data: {"id":"1","object":"chat.completion.chunk","created":1,"model":"m",'
@@ -36,213 +26,73 @@ _SSE = (
 )
 
 
-def _wire_body(tools: bool = True) -> dict:
-    """A production-shaped chat body: list content parts, an image part, a
-    tool_calls turn, a tool result, and function tool schemas."""
-    body = {
+def _wire_body() -> dict:
+    """Production-shaped chat body: content parts incl. an image, a tool_calls turn, a tool
+    result, function tool schemas, and a caller-populated extra_body (reasoning/provider)."""
+    return {
         "model": "hermes-4-70b",
         "messages": [
             {"role": "system", "content": "You are Hermes."},
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": "look at this"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": "https://e.example/i.png", "detail": "low"},
-                    },
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [
-                    {
-                        "id": "c1",
-                        "type": "function",
-                        "function": {"name": "terminal", "arguments": '{"cmd":"ls"}'},
-                    }
-                ],
-            },
+            {"role": "user", "content": [
+                {"type": "text", "text": "look at this"},
+                {"type": "image_url", "image_url": {"url": "https://e.example/i.png", "detail": "low"}},
+            ]},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "terminal", "arguments": '{"cmd":"ls"}'}},
+            ]},
             {"role": "tool", "tool_call_id": "c1", "content": "total 0"},
         ],
+        "tools": [
+            {"type": "function", "function": {"name": f"tool_{i}", "description": "d",
+             "parameters": {"type": "object", "properties": {"p": {"type": "string"}}, "required": ["p"]}}}
+            for i in range(3)
+        ],
+        "tool_choice": "auto",
         "stream": True,
         "temperature": 0.7,
         "stream_options": {"include_usage": True},
+        "extra_body": {"reasoning": {"effort": "high"}, "provider": {"order": ["nous"]}},
     }
-    if tools:
-        body["tools"] = [
-            {
-                "type": "function",
-                "function": {
-                    "name": f"tool_{i}",
-                    "description": "d",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"p": {"type": "string"}},
-                        "required": ["p"],
-                    },
-                },
-            }
-            for i in range(30)
-        ]
-    return body
 
 
 class _Recorder:
-    """A real openai.OpenAI client whose transport records the request body."""
+    """A real openai.OpenAI client whose transport records the request bytes."""
 
     def __init__(self):
         self.content: bytes | None = None
         self.client = openai.OpenAI(
-            api_key="k",
-            base_url="https://chat.invalid/v1",
+            api_key="k", base_url="https://chat.invalid/v1",
             http_client=httpx.Client(transport=httpx.MockTransport(self._handle)),
         )
 
     def _handle(self, request: httpx.Request) -> httpx.Response:
         self.content = request.content
-        return httpx.Response(
-            200, content=_SSE, headers={"content-type": "text/event-stream"}
-        )
+        return httpx.Response(200, content=_SSE, headers={"content-type": "text/event-stream"})
 
     def send(self, kwargs: dict) -> bytes:
-        stream = self.client.chat.completions.create(**kwargs)
-        for _ in stream:
+        for _ in self.client.chat.completions.create(**kwargs):
             pass
         assert self.content is not None
         return self.content
 
 
-class _FacadeCompletions:
-    """Stands in for the MoA aggregator: chat-completions shaped, not the SDK."""
+def test_bulk_fields_ride_in_extra_body_and_the_wire_bytes_are_identical():
+    """Same bytes → same server behaviour and the same byte-keyed prompt-cache prefix."""
+    recorder = _Recorder()
+    body = _wire_body()
 
-    def create(self, **kwargs):  # pragma: no cover - never called here
-        raise AssertionError("not exercised")
+    moved = bypass_chat_sdk_request_transform(dict(body), recorder.client)
 
-
-class _FacadeClient:
-    def __init__(self):
-        self.chat = types.SimpleNamespace(completions=_FacadeCompletions())
-
-
-class TestByteIdentity:
-    def test_request_body_is_byte_identical_with_and_without_the_bypass(self):
-        """The whole safety argument: the server sees the same request."""
-        recorder = _Recorder()
-        body = _wire_body()
-
-        plain = recorder.send(dict(body))
-        bypassed = recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client))
-
-        assert bypassed == plain
-        # And it really did take the bypass, rather than silently no-opping.
-        moved = bypass_chat_sdk_request_transform(dict(body), recorder.client)
-        assert moved["messages"] == []
-        assert moved["extra_body"]["messages"] == body["messages"]
-        assert moved["extra_body"]["tools"] == body["tools"]
-
-    def test_the_wire_payload_survives_a_json_round_trip_unchanged(self):
-        recorder = _Recorder()
-        body = _wire_body()
-        sent = json.loads(recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client)))
-
-        assert sent["messages"] == body["messages"]
-        assert sent["tools"] == body["tools"]
-        assert sent["temperature"] == 0.7
-        assert sent["stream_options"] == {"include_usage": True}
+    assert moved["messages"] == [] and moved["tools"] == []
+    assert moved["extra_body"]["messages"] == body["messages"]
+    assert moved["extra_body"]["tools"] == body["tools"]
+    assert moved["extra_body"]["reasoning"] == body["extra_body"]["reasoning"]
+    assert recorder.send(moved) == recorder.send(dict(body))
 
 
-class TestGuards:
-    def test_a_non_sdk_client_is_left_completely_alone(self):
-        """MoA's facade never merges extra_body, so moving the conversation
-        there would silently send an empty message list."""
-        kwargs = _wire_body()
+def test_escape_hatch_restores_the_typed_sdk_path(monkeypatch):
+    monkeypatch.setenv(ESCAPE_HATCH_ENV, "1")
+    recorder = _Recorder()
+    kwargs = _wire_body()
 
-        result = bypass_chat_sdk_request_transform(kwargs, _FacadeClient())
-
-        assert result is kwargs
-        assert "extra_body" not in result
-        assert result["messages"][0]["role"] == "system"
-
-    def test_is_openai_sdk_completions_discriminates(self):
-        assert is_openai_sdk_completions(_Recorder().client)
-        assert not is_openai_sdk_completions(_FacadeClient())
-        assert not is_openai_sdk_completions(object())
-
-    def test_non_plain_json_messages_stay_on_the_typed_path(self):
-        """The transform exists to convert typed params; anything that is not
-        already wire data still needs it."""
-        recorder = _Recorder()
-        kwargs = _wire_body()
-        kwargs["messages"][1]["content"] = object()
-
-        result = bypass_chat_sdk_request_transform(kwargs, recorder.client)
-
-        assert result["messages"] is kwargs["messages"]
-        assert "extra_body" not in result or "messages" not in result["extra_body"]
-
-    def test_a_tool_free_request_does_not_gain_an_empty_tools_key(self):
-        recorder = _Recorder()
-        body = _wire_body(tools=False)
-
-        sent = json.loads(recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client)))
-
-        assert "tools" not in sent
-
-    def test_caller_supplied_extra_body_keeps_precedence(self):
-        """The chat path already populates extra_body from custom providers,
-        reasoning config and Nous Portal; those entries must win."""
-        recorder = _Recorder()
-        body = _wire_body()
-        body["extra_body"] = {"provider": {"order": ["nous"]}, "messages": ["caller wins"]}
-
-        result = bypass_chat_sdk_request_transform(dict(body), recorder.client)
-
-        assert result["extra_body"]["messages"] == ["caller wins"]
-        assert result["extra_body"]["provider"] == {"order": ["nous"]}
-
-    def test_env_escape_hatch_restores_the_pre_fix_kwargs(self, monkeypatch):
-        monkeypatch.setenv("HERMES_CHAT_SDK_TRANSFORM", "1")
-        recorder = _Recorder()
-        kwargs = _wire_body()
-
-        assert bypass_chat_sdk_request_transform(kwargs, recorder.client) is kwargs
-
-    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
-    def test_escape_hatch_stays_off_for_falsey_values(self, monkeypatch, value):
-        monkeypatch.setenv("HERMES_CHAT_SDK_TRANSFORM", value)
-        recorder = _Recorder()
-
-        result = bypass_chat_sdk_request_transform(_wire_body(), recorder.client)
-
-        assert result["messages"] == []
-
-
-class TestResponsesPathUnchanged:
-    def test_the_codex_import_path_and_behaviour_are_preserved(self):
-        """agent/auxiliary_client.py and the existing codex test import these
-        names from agent.codex_runtime; the move must not break them."""
-        from agent.codex_runtime import (
-            _SDK_TRANSFORM_BYPASS_FIELDS,
-            _bypass_sdk_request_transform,
-            _is_plain_json_data,
-        )
-
-        assert _SDK_TRANSFORM_BYPASS_FIELDS == ("input", "tools")
-        assert _is_plain_json_data([{"role": "user", "content": "hi"}])
-        assert not _is_plain_json_data([{"role": "user", "content": object()}])
-
-        kwargs = {
-            "model": "gpt-5.6-sol",
-            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
-            "tools": [{"type": "function", "name": "terminal", "parameters": {}}],
-            "stream": True,
-        }
-        bypassed = _bypass_sdk_request_transform(kwargs)
-
-        # Responses keeps its historical shape: the fields are REMOVED from the
-        # typed kwargs entirely (input is not @required_args there).
-        assert "input" not in bypassed
-        assert "tools" not in bypassed
-        assert bypassed["extra_body"]["input"] == kwargs["input"]
+    assert bypass_chat_sdk_request_transform(kwargs, recorder.client) is kwargs

--- a/tests/run_agent/test_codex_sdk_transform_bypass.py
+++ b/tests/run_agent/test_codex_sdk_transform_bypass.py
@@ -18,9 +18,9 @@ sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
 sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
 sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
-from agent.codex_runtime import (
-    _bypass_sdk_request_transform,
+from agent.sdk_transform_bypass import (
     _is_plain_json_data,
+    bypass_sdk_request_transform as _bypass_sdk_request_transform,
 )
 
 


### PR DESCRIPTION
The default chat.completions request path no longer hands the full conversation to the OpenAI SDK's client-side request transform, so a large context stops paying a GIL-holding walk of the whole body before any byte leaves the process — the same bypass #93650 landed for the Responses API.

Based on #102036 by @jonpol01 (cherry-picked, authorship preserved). Extends #93650 (Responses) to chat.completions.

## Root cause

`chat.completions.create` runs `maybe_transform` over the entire request against the `CompletionCreateParams` union before sending. Hermes builds `messages`/`tools` from JSON round-trips, so they are already wire format and the walk converts nothing; on a multi-MB conversation it is the dominant client-side cost and, per #93650, can wedge for hours where no watchdog can reach it (pre-network). The SDK merges `extra_body` into the JSON body *after* the transform, so moving the bulk fields there skips the walk.

## Changes

- `agent/sdk_transform_bypass.py` (new, moved out of `codex_runtime.py`) — `bypass_sdk_request_transform` shared by both API families; `bypass_chat_sdk_request_transform` applies it to `messages`/`tools` only when the client really is the OpenAI SDK (the in-process MoA facade and test stand-ins never merge `extra_body` and would otherwise send an empty conversation).
- `agent/chat_completion_helpers.py` — both the blocking and the streaming chat call go through it.
- `agent/codex_runtime.py`, `agent/auxiliary_client.py` — import from the defining module; no re-export shim.
- Folds on top of the contributor commit: moved fields leave an `[]` placeholder in their original slot (satisfies `@required_args` and keeps key order, so the request bytes are unchanged), and the PR's second env var was dropped — the existing `HERMES_CODEX_SDK_TRANSFORM=1` hatch from #93650 now restores the typed path for both families.
- Tests: two invariants (bulk fields ride in `extra_body` with byte-identical body; hatch restores the typed path), both RED with the bypass reverted.

## Wire-body proof

Real `openai.OpenAI` 2.24 + `httpx.MockTransport` capturing `request.content`; 403 messages (200 tool_calls/tool turns, one `image_url` part), 10 function tools, `temperature`, `max_tokens`, `tool_choice`, caller `extra_body={reasoning, provider}`.

| mode | dicts equal | bytes equal | caller extra_body precedence |
|---|---|---|---|
| stream=False | yes | yes | kept |
| stream=True (first request) | yes | yes | kept |

`maybe_transform` on these wire-format dicts is a no-op (verified); the only rewrite it performs anywhere in the request is `NotGiven` stripping on scalar fields, which stay on the typed path.

## Measured impact

Same harness, 2.85 MB messages JSON, 7 runs:

| path | `create()` median |
|---|---|
| main (typed kwargs) | 32.9 ms |
| this PR | 6.8 ms |
| `maybe_transform` alone | 52.8 ms |

Delta 79% of the client-side call cost at this size; the pathological case in #93650 scales with payload complexity, not just bytes.
