### PR TITLE
fix(agent): ignore Ollama num_ctx override on remote endpoints

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1987,11 +1987,28 @@ def _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length):
     # model.ollama_num_ctx overrides; model.context_length caps the detected value (VRAM).
     agent._ollama_num_ctx: int | None = None
     _override = _model_cfg.get("ollama_num_ctx") if isinstance(_model_cfg, dict) else None
+    _provider_name = str(getattr(agent, "provider", "") or "").strip().lower().replace("_", "-")
+    # An explicit endpoint is authoritative: an Ollama-named provider can
+    # still be pointed at a remote-compatible service. Only fall back to the
+    # provider name when no endpoint was resolved (the local provider defaults
+    # supply their own local route later).
+    _is_local_ollama_route = (
+        bool(agent.base_url) and is_local_endpoint(agent.base_url)
+    ) or (
+        not agent.base_url and _provider_name in {"ollama", "lmstudio", "lm-studio"}
+    )
     if _override is not None:
-        try:
-            agent._ollama_num_ctx = int(_override)
-        except (TypeError, ValueError):
-            _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _override)
+        if _is_local_ollama_route:
+            try:
+                agent._ollama_num_ctx = int(_override)
+            except (TypeError, ValueError):
+                _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _override)
+        else:
+            _ra().logger.info(
+                "Ignoring model.ollama_num_ctx=%r for non-local endpoint %s",
+                _override,
+                agent.base_url or f"provider={getattr(agent, 'provider', '')}",
+            )
     if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url):
         try:
             # api_key may be a callable (Entra token provider); detection needs a string.
@@ -2027,7 +2044,13 @@ def _configure_ollama_num_ctx(agent, _model_cfg, _config_context_length):
     # window to the effective num_ctx so threshold math operates on the context the server actually serves.
     # (Overlaps #60103's silent-clamp dead zone; this is the init-order half.)
     _cc_window = getattr(agent.context_compressor, "context_length", 0) or 0
-    if agent._ollama_num_ctx and agent._ollama_num_ctx > 0 and _cc_window and agent._ollama_num_ctx < _cc_window:
+    if (
+        _is_local_ollama_route
+        and agent._ollama_num_ctx
+        and agent._ollama_num_ctx > 0
+        and _cc_window
+        and agent._ollama_num_ctx < _cc_window
+    ):
         _ra().logger.info(
             "Compressor window clamped to Ollama num_ctx: %d -> %d",
             _cc_window, agent._ollama_num_ctx,

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -143,7 +143,7 @@ class TestCompressorClampsToNumCtx:
     must not leave the compressor targeting the probed model window while
     requests run at the smaller served num_ctx."""
 
-    def _build_agent(self, cfg, probed_ctx):
+    def _build_agent(self, cfg, probed_ctx, *, base_url="http://localhost:11434/v1", provider=None):
         import agent.context_compressor as cc_mod
         with (
             patch("model_tools.get_tool_definitions", return_value=[]),
@@ -160,14 +160,17 @@ class TestCompressorClampsToNumCtx:
             ),
         ):
             from run_agent import AIAgent
-            return AIAgent(
-                model="gemma3:27b",
-                api_key="ollama",
-                base_url="http://localhost:11434/v1",
-                quiet_mode=True,
-                skip_context_files=True,
-                skip_memory=True,
-            )
+            kwargs = {
+                "model": "gemma3:27b",
+                "api_key": "ollama",
+                "base_url": base_url,
+                "quiet_mode": True,
+                "skip_context_files": True,
+                "skip_memory": True,
+            }
+            if provider is not None:
+                kwargs["provider"] = provider
+            return AIAgent(**kwargs)
 
     def test_num_ctx_only_config_clamps_compressor_window(self):
         agent = self._build_agent(
@@ -179,6 +182,33 @@ class TestCompressorClampsToNumCtx:
         # compaction never fires (#57275 claim 3).
         assert agent.context_compressor.context_length == 65536
         assert agent.context_compressor.threshold_tokens < 65536
+
+    def test_num_ctx_only_config_is_ignored_for_remote_endpoint(self):
+        with patch("run_agent.logger") as mock_logger:
+            agent = self._build_agent(
+                {"agent": {}, "model": {"ollama_num_ctx": 65536}},
+                probed_ctx=1_000_000,
+                base_url="https://api.anthropic.com/v1",
+                provider="anthropic",
+            )
+
+        # Ollama's num_ctx is not meaningful for remote providers. In
+        # particular, it must not shrink the compressor's remote context.
+        assert agent._ollama_num_ctx is None
+        assert agent.context_compressor.context_length == 1_000_000
+        ignored_calls = [
+            call
+            for call in mock_logger.info.call_args_list
+            if call.args
+            and call.args[0]
+            == "Ignoring model.ollama_num_ctx=%r for non-local endpoint %s"
+        ]
+        assert len(ignored_calls) == 1
+        mock_logger.info.assert_any_call(
+            "Ignoring model.ollama_num_ctx=%r for non-local endpoint %s",
+            65536,
+            "https://api.anthropic.com/v1",
+        )
 
     def test_larger_num_ctx_does_not_inflate_compressor_window(self):
         agent = self._build_agent(


### PR DESCRIPTION
## Summary

`model.ollama_num_ctx` is an Ollama-only setting, but the init-order compressor recalibration previously applied it to every endpoint. A remote profile could therefore shrink a provider-resolved 1,000,000-token compressor to 65,536 tokens.

This canonical survivor:

- accepts the explicit override only for a local route (with the provider fallback used only when no endpoint is resolved);
- logs one INFO diagnostic when the setting is ignored for a non-local endpoint; and
- independently gates compressor recalibration to local routes.

## Regression coverage

- Remote Anthropic endpoint with `ollama_num_ctx: 65536` keeps `_ollama_num_ctx` unset and compressor context at 1,000,000.
- Local Ollama endpoint retains the 65,536 clamp.
- Focused suite: 15 tests passed on the prior isolated baseline; the refreshed head is based on current upstream `main` and will receive a fresh full CI run.
- `py_compile`, Ruff, and `git diff --check` passed on the refreshed touched files.
- Mutation proof: removing the local-route gates makes the remote regression fail.

## Upstream coordination

This PR is the canonical survivor for the remote-endpoint behavior requested in the affected-profile reproducer. Related PR #99953 covers the core clamp gate but not the explicit-ignore + INFO diagnostic; it is cross-linked as duplicate scope. Prior draft PR #101525 was closed during source-branch refresh because GitHub refused reopening a force-pushed source; this replacement carries the same verified patch at the current-main parent.

Refreshed against current upstream `main` at `113304199e96ed9ac9eea60020a0612218020796`; refreshed head is `c25cd36dfcba19b17f742f9826383a30c3af761c`.

No live-install, profile config, gateway, credential, deploy, merge, or trading changes were made. The next official Hermes refresh should wait for this upstream fix to land.
