### PR TITLE
feat: read-only single terminal commands join parallel tool batches

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -375,13 +375,17 @@ TASK_COMPLETION_GUIDANCE = (
 # cline/cline#11514 ("encourage parallel tool calls"), adapted from Cline's TypeScript tool-surface guidance
 # to hermes-agent's Python prompt-assembly architecture.
 PARALLEL_TOOL_CALL_GUIDANCE = (
-    "# Parallel tool calls\n"
-    "When you need several pieces of information that don't depend on each other, request them together in a "
-    "single response instead of one tool call per turn. Independent reads, searches, web fetches, and "
-    "read-only commands should be batched into the same assistant turn — the runtime executes independent "
-    "calls concurrently, and batching avoids resending the whole conversation on every extra round-trip.\n"
-    "Only serialize calls when a later call genuinely depends on an earlier call's result (e.g. you must "
-    "read a file before you can patch it). When in doubt and the calls are independent, batch them."
+    "# Parallel tool calls — batch aggressively\n"
+    "Every tool-call round-trip resends the whole conversation, so single-call turns are the dominant "
+    "latency cost. Batch independent calls in the SAME assistant turn; the runtime executes them "
+    "concurrently (read-only shell commands like git status/log/diff, ls, grep are parallel-safe too).\n"
+    "Recon protocol: when starting work on a system, repo, or bug, FIRST fire one batch of 3-6 "
+    "independent reads (status, logs, config files, searches) instead of discovering state one call "
+    "per turn. Only serialize when a call genuinely needs an earlier result (read before patch, "
+    "diagnose before fix).\n"
+    "Prefer one execute_code/kernel step over a loop of single tool calls: filter, aggregate, count, "
+    "and multi-step logic belongs in code, not in per-step round-trips. A single-call turn should be "
+    "rare — if you catch yourself issuing one read, ask what else you will need next and batch it too."
 )
 
 # Execution-discipline guidance for models that abandon partial results, skip prerequisite lookups, answer

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -72,6 +72,30 @@ def _is_destructive_command(cmd: str) -> bool:
     return bool(cmd) and bool(_DESTRUCTIVE_PATTERNS.search(cmd) or _REDIRECT_OVERWRITE.search(cmd))
 
 
+# Read-only terminal commands admitted to parallel runs. Single command only:
+# any shell chaining/pipe/redirection/subshell is a sequential barrier (fail-closed —
+# one hidden writer in a compound command would break the planner's guarantees).
+_TERMINAL_CHAINING = re.compile(r"&&|\|\||;|\||`|\$\(")
+_READ_ONLY_COMMAND_RE = re.compile(
+    r"^(?:ls|cat|head|tail|grep|rg|find|wc|file|stat|du|df|ps|pgrep|printenv|env|whoami|uname|date|pwd|which|command -v|git status|git log|git diff|git branch|git show|git rev-parse|git remote|hermes config show|hermes gateway status|python3 --version|node --version)\b",
+)
+
+
+def _is_read_only_terminal_command(args: dict) -> bool:
+    """True only for a provably single, non-chained, non-redirecting, non-destructive,
+    non-background read command. Anything else stays a sequential barrier."""
+    if not isinstance(args, dict):
+        return False
+    if args.get("background") or args.get("pty"):
+        return False
+    cmd = args.get("command")
+    if not isinstance(cmd, str) or not cmd.strip():
+        return False
+    if _TERMINAL_CHAINING.search(cmd) or _is_destructive_command(cmd):
+        return False
+    return bool(_READ_ONLY_COMMAND_RE.match(cmd.strip()))
+
+
 def _is_mcp_tool_parallel_safe(tool_name: str) -> bool:
     """Whether an MCP tool's server opted into parallel calls; False if MCP is unavailable."""
     try:
@@ -125,6 +149,8 @@ def _batch_admission(tool_call, execution_cwd: Optional[Path]) -> tuple[str, Lis
     if name in _PATH_SCOPED_TOOLS:
         scoped = _extract_parallel_scope_paths(name, args, execution_cwd=execution_cwd)
         return (name, scoped, name in _PATH_SCOPED_WRITERS) if scoped else None
+    if name == "terminal":
+        return ("terminal", [], False) if _is_read_only_terminal_command(args) else None
     if name in _PARALLEL_SAFE_TOOLS or name in _PARALLEL_SAFE_BRIDGE_LOOKUPS or _is_mcp_tool_parallel_safe(name):
         return name, [], False
     return None
@@ -513,6 +539,7 @@ def _maybe_wrap_untrusted(name: str, content: Any) -> Any:
 __all__ = [
     "_NEVER_PARALLEL_TOOLS", "_PARALLEL_SAFE_TOOLS", "_PATH_SCOPED_TOOLS", "_PATH_SCOPED_READERS",
     "_PATH_SCOPED_WRITERS", "_DESTRUCTIVE_PATTERNS", "_REDIRECT_OVERWRITE", "_is_destructive_command",
+    "_is_read_only_terminal_command",
     "_plan_tool_batch_segments", "_should_parallelize_tool_batch", "_canonical_path",
     "_extract_parallel_scope_path", "_extract_parallel_scope_paths", "_paths_overlap",
     "_is_multimodal_tool_result", "_multimodal_text_summary", "_append_subdir_hint_to_multimodal",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1044,6 +1044,15 @@ def _finalize_tool_batch(agent, messages: list, effective_task_id: str, num_tool
     if num_tools <= 0:
         return
     enforce_turn_budget(messages[-num_tools:], env=get_active_env(effective_task_id), config=budget)
+    # Batching-score notice (single authoritative call site per tool turn): appended after the
+    # LAST tool result of the turn, so it rides the tail — cache-safe (never in the system prompt).
+    with contextlib.suppress(Exception):
+        notice = agent._tool_guardrails.batching_notice(num_tools)
+        if notice and messages:
+            last = messages[-1]
+            content = getattr(last, "content", None)
+            if isinstance(content, str):
+                last.content = content + "\n\n" + notice
     agent._apply_pending_steer_to_tool_results(messages, num_tools)
 
 

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -66,6 +66,12 @@ _THRESHOLD_SOURCES: dict[str, tuple[str, str]] = {
     "no_progress_block_after": ("hard_stop_after", "idempotent_no_progress"),
 }
 
+# Batching-score notice: emitted when the cross-session single-call share is high enough to matter.
+# Cross-turn counters live OUTSIDE reset_for_turn so the score spans the whole conversation.
+BATCHING_NOTICE_MIN_TURNS = 6           # don't score before the sample is meaningful
+BATCHING_NOTICE_EVERY_N = 10            # re-emit only every N tool turns (not every turn — noise)
+BATCHING_NOTICE_SINGLE_SHARE = 0.6     # emit when >60% of tool turns carried a single call
+
 # Per-turn caps on runaway-prone tools (counters reset in reset_for_turn).
 _DEFAULT_MAX_WEB_SEARCHES_PER_TURN = 50
 _DEFAULT_MAX_SUBAGENTS_PER_TURN = 50
@@ -278,6 +284,11 @@ class ToolCallGuardrailController:
 
     def __init__(self, config: ToolCallGuardrailConfig | None = None):
         self.config = config or ToolCallGuardrailConfig()
+        # Cross-conversation batching scoreboard (NOT reset by reset_for_turn): each tool turn's
+        # call count feeds the batching notice, which nags only when single-call turns dominate.
+        self._batch_tool_turns = 0
+        self._batch_single_turns = 0
+        self._batch_notice_last_turn = 0
         self.reset_for_turn()
 
     def reset_for_turn(self) -> None:
@@ -443,6 +454,36 @@ class ToolCallGuardrailController:
         """Remember the spillover path a persisted result was saved to."""
         if tool_call_id and file_path:
             self._persisted_result_paths[tool_call_id] = file_path
+
+    def batching_notice(self, turn_call_count: int) -> str | None:
+        """Score this tool turn's batching and return a nudge when single-call turns dominate.
+
+        Called once per tool turn (from the sequential executor's commit path or the concurrent
+        executor's batch completion). Persistent counters span the conversation so the score is
+        a real trend, not one turn's noise. The notice lands in the stall-notice channel
+        (appended after a tool result) — never in the system prompt, which would break the
+        prefix cache whenever the score changed.
+        """
+        self._batch_tool_turns += 1
+        if turn_call_count <= 1:
+            self._batch_single_turns += 1
+        if self._batch_tool_turns < BATCHING_NOTICE_MIN_TURNS:
+            return None
+        # One notice per window; the cooldown only applies AFTER the first notice
+        # (a first notice on turn 6 must not wait for turn 10).
+        if self._batch_notice_last_turn and self._batch_tool_turns - self._batch_notice_last_turn < BATCHING_NOTICE_EVERY_N:
+            return None
+        single_share = self._batch_single_turns / self._batch_tool_turns
+        if single_share <= BATCHING_NOTICE_SINGLE_SHARE:
+            return None
+        self._batch_notice_last_turn = self._batch_tool_turns
+        batched = self._batch_tool_turns - self._batch_single_turns
+        return (
+            f"[hermes note: your batching score is {int(round(single_share * 100))}% single-call tool turns "
+            f"({self._batch_single_turns} of {self._batch_tool_turns}; {batched} batched). Every single-call "
+            "turn costs a full round-trip that re-sends the whole conversation. Batch the independent reads "
+            "you already know you need next into the SAME turn — the runtime runs them concurrently.]"
+        )
 
     def _build_result_reference_stub(self, tool_name: str, args: Mapping[str, Any] | None) -> str:
         """Reference stub for a byte-identical duplicate result (tool + args preview)."""

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -1,10 +1,13 @@
 """Truncation recovery (``finish_reason == "length"``) for the conversation turn loop.
 
 Handles thinking-budget exhaustion, repetition-dominated truncation, content-filter stream
-stalls escalated to the fallback chain, text continuation nudges (up to 4, with the ceiling
-exit that drops the fragment trail), truncated tool-call retries with max_tokens boosts, and
-the final roll-back. Nothing here imports ``agent.conversation_loop`` at module level
-(cycle); loop-internal helpers are imported lazily so tests patching them keep working.
+stalls escalated to the fallback chain, text continuation nudges (up to 4, ceiling exit drops
+the fragment trail), truncated tool-call retries with max_tokens boosts, and the final
+roll-back. Thinking-budget exhaustion is only ever declared for a REAL length truncation
+(finish_reason="length" and no dropped-stream stub); a stub's length label is a Hermes
+classification of a dropped connection, not proof the budget was exhausted. Nothing here
+imports ``agent.conversation_loop`` at module level (cycle); loop-internal helpers are
+imported lazily so tests patching them keep working.
 """
 
 from __future__ import annotations
@@ -51,6 +54,11 @@ _CEILING_NO_TEXT = (
     "⚠️ **No visible answer was produced.** The model hit its output-token limit on every "
     "continuation attempt — its reasoning consumed the entire budget each time.\n\nTo fix this:\n"
     "→ Lower reasoning effort: `/reasoning low` or `/reasoning none`\n→ Or raise max_tokens for this model"
+)
+_CEILING_STREAM_DROPPED = (
+    "⚠️ **No visible answer was produced after repeated truncated or interrupted responses.** "
+    "The stream did not deliver a visible answer in 4 continuation attempts.\n\n"
+    "→ Try again, switch models with `/model`, or check the provider/network"
 )
 
 
@@ -138,14 +146,24 @@ class _Trunc(TruncationVerdict):
         return getattr(self.response, "id", "") == PARTIAL_STREAM_STUB_ID
 
 
-def _abort_reason(agent: Any, content: Any, has_tool_calls: bool) -> Optional[tuple]:
-    """``(vprint, user response, error)`` when continuation must NOT be attempted:
-    thinking exhausted the budget (reasoning blocks with no visible text after them —
-    ``content=None`` from non-<think> models is normal truncation), or a repetition loop
-    burned the budget on one fragment (reasoning stripped first)."""
+def _abort_reason(agent: Any, content: Any, has_tool_calls: bool, *, is_stub: bool = False) -> Optional[tuple]:
+    """``(vprint, user response, error)`` when continuation must NOT be attempted: thinking
+    exhausted the budget (reasoning blocks with no visible text after them — ``content=None``
+    from non-<think> models is normal truncation), or a repetition loop burned the budget on
+    one fragment (reasoning stripped first).
+
+    ``is_stub`` gates ONLY the thinking-exhaustion heuristic: a partial-stream stub carries no
+    finish_reason/usage from the wire, so unterminated reasoning inside one proves nothing
+    about the budget. Repetition detection is content-deterministic and stays active for
+    stubs."""
     if has_tool_calls:
         return None
-    if content and _THINK_TAG_RE.search(content) and not agent._has_content_after_think_block(content):
+    if (
+        not is_stub
+        and content
+        and _THINK_TAG_RE.search(content)
+        and not agent._has_content_after_think_block(content)
+    ):
         return _THINKING_EXHAUSTED
     visible = agent._strip_think_blocks(content) if isinstance(content, str) else content
     if visible and is_repetition_dominated(visible):
@@ -194,10 +212,10 @@ def _content_filter_fallback(st: _Trunc, _retry: TurnRetryState) -> Optional[Tru
 
 
 def _continue_text(st: _Trunc, _retry: TurnRetryState, assistant_message: Any) -> TruncationVerdict:
-    """Text truncation (no tool calls): append the fragment + a continuation nudge (up to
-    4), then the ceiling exit that drops the fragment trail and keeps the stitched partial.
-    Never appends an interim assistant row with NO visible content — strict providers
-    reject it with 400 — only the nudge."""
+    """Text truncation (no tool calls): append the visible fragment + a continuation nudge
+    (up to 4), then the ceiling exit that drops the fragment trail and keeps the stitched
+    partial. Interim rows are only appended when they carry visible content — strict
+    providers reject empty rows with 400."""
     from agent.conversation_loop import _get_continuation_prompt, _join_truncated_parts
 
     agent = st.agent
@@ -208,11 +226,19 @@ def _continue_text(st: _Trunc, _retry: TurnRetryState, assistant_message: Any) -
     if not _interim_content and not st.is_stub:
         # Thinking-only truncation: continuing with thinking ON re-burns the budget.
         agent._ephemeral_reasoning_off = True
+    # Append a fragment only when it carries VISIBLE text: reasoning-only raw content would
+    # persist an empty row, and an unterminated tag inside a raw fragment would swallow the
+    # continuation answer at the final strip. Edge whitespace is preserved — a stripped
+    # fragment blurs the model's stitching point, and _join_truncated_parts injects a
+    # newline only where two fragments would otherwise glue.
+    _visible_content = None
     if _interim_content:
+        _visible_content = agent._strip_think_blocks(_interim_content)
+    if _visible_content and _visible_content.strip():
         interim_msg = agent._build_assistant_message(assistant_message, st.finish_reason)
         interim_msg["_length_continuation_fragment"] = True  # ceiling exit drops these
         append_message(messages, interim_msg)
-        st.truncated_response_parts.append(_interim_content)
+        st.truncated_response_parts.append(_visible_content)
 
     if n < 4:
         _dropped_tools = getattr(st.response, "_dropped_tool_names", None)
@@ -238,7 +264,9 @@ def _continue_text(st: _Trunc, _retry: TurnRetryState, assistant_message: Any) -
     agent._ephemeral_reasoning_off = False
     agent._vprint(
         f"{agent.log_prefix}⚠️  Response still truncated after {n} continuation attempts — "
-        + ("keeping the partial response received so far." if partial_response
+        + ("stream kept dropping with no visible answer"
+           if st.is_stub and not partial_response else
+           "keeping the partial response received so far." if partial_response
            else "no visible text was produced."),
         force=True,
     )
@@ -256,8 +284,9 @@ def _continue_text(st: _Trunc, _retry: TurnRetryState, assistant_message: Any) -
             "role": "assistant", "content": partial_response, "finish_reason": "length"
         })
     agent._session_messages = messages
+    _ceiling_copy = _CEILING_STREAM_DROPPED if (st.is_stub and not partial_response) else _CEILING_NO_TEXT
     return st.end_turn(
-        partial_response or _CEILING_NO_TEXT,
+        partial_response or _ceiling_copy,
         "Response remained truncated after 4 continuation attempts",
     )
 
@@ -330,7 +359,9 @@ def recover_from_truncation(
     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
     _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
 
-    abort = _abort_reason(agent, _trunc_content, _trunc_has_tool_calls)
+    abort = _abort_reason(
+        agent, _trunc_content, _trunc_has_tool_calls, is_stub=st.is_stub,
+    )
     if abort is not None:
         line, user_response, error = abort
         agent._vprint(f"{agent.log_prefix}{line}", force=True)

--- a/tests/agent/test_batching_notice.py
+++ b/tests/agent/test_batching_notice.py
@@ -1,0 +1,75 @@
+"""Batching-score notice: cross-turn scoreboard on the tool-guardrail controller.
+
+Emitted ONLY when single-call tool turns dominate (>60% after >=6 turns), at most once per
+10-turn window, via the stall-notice channel (appended after the last tool result of a turn —
+never the system prompt, which would break the provider prefix cache when the score moved).
+
+Regression guard for the 2026-09 speed work (measured 84-87% single-call turns on real
+heavy sessions; each single-call turn costs a full context re-send round-trip).
+"""
+
+from agent.tool_guardrails import ToolCallGuardrailController
+
+
+def _feed(controller, turn_counts):
+    """Feed one tool turn per entry; return the notices that fired."""
+    return [controller.batching_notice(n) for n in turn_counts]
+
+
+class TestBatchingNotice:
+    def test_silent_below_min_sample(self):
+        c = ToolCallGuardrailController()
+        assert _feed(c, [1, 1, 1, 1, 1]) == [None] * 5
+
+    def test_silent_when_batching_is_healthy(self):
+        c = ToolCallGuardrailController()
+        # 6 turns, 3 batched -> 50% single share <= 0.6 threshold: no notice
+        notices = _feed(c, [1, 3, 1, 2, 1, 2])
+        assert notices == [None] * 6
+
+    def test_notice_when_single_call_turns_dominate(self):
+        c = ToolCallGuardrailController()
+        notices = _feed(c, [1] * 7)
+        # Turn 6 crosses the min sample; single share 100% -> notice on turn 6
+        assert notices[5] is not None
+        assert "batching score" in notices[5]
+        assert "100%" in notices[5]
+        # Window: turn 7 is inside the 10-turn cooldown -> silent
+        assert notices[6] is None
+
+    def test_notice_rate_limited_to_one_per_window(self):
+        c = ToolCallGuardrailController()
+        notices = _feed(c, [1] * 17)
+        fired = [i for i, n in enumerate(notices) if n is not None]
+        # With a 100% single share: fire at turn 6 and again at 16 (>=10 later), not in between.
+        assert fired[0] == 5
+        assert all(f - fired[0] >= 10 for f in fired[1:]), fired
+
+    def test_batched_turns_move_the_score_down(self):
+        c = ToolCallGuardrailController()
+        # 5 single turns then batched turns: the turn-6 check sees 5/6 single (83% > 60%, one
+        # notice fires), but afterwards the batched turns pull the share down and the next
+        # window checks stay silent.
+        notices = _feed(c, [1, 1, 1, 1, 1, 4, 4, 4, 4, 4, 4, 4, 4])
+        assert notices[5] is not None  # turn 6: 83% single — still above threshold
+        assert all(n is None for i, n in enumerate(notices) if i > 5)
+
+    def test_score_text_carries_real_numbers(self):
+        c = ToolCallGuardrailController()
+        notices = _feed(c, [1, 1, 1, 1, 1, 3, 1])  # first check at turn 6: 5 of 6 single (83%)
+        assert notices[5] is not None
+        assert "5 of 6" in notices[5]
+
+    def test_counters_survive_reset_for_turn(self):
+        # reset_for_turn clears per-turn streak state only; the batching scoreboard
+        # spans the conversation and must NOT be reset — otherwise every turn looks
+        # like turn 1 and the notice never fires.
+        c = ToolCallGuardrailController()
+        _feed(c, [1, 1, 1])
+        c.reset_for_turn()
+        notices = _feed(c, [1, 1, 1])
+        assert notices[2] is not None  # turn 6 overall, not turn 3
+
+
+# ponytail: thresholds (6/10/0.6) are module constants; tune via config only if real
+# sessions show the notice is too quiet or too noisy.

--- a/tests/agent/test_terminal_readonly_parallel.py
+++ b/tests/agent/test_terminal_readonly_parallel.py
@@ -1,0 +1,93 @@
+"""Read-only terminal commands may join parallel tool batches (single, non-chained,
+non-redirecting reads only). Everything else stays a sequential barrier — fail-closed.
+
+Regression guard for the 9router speed optimization (2026-09-09): parallelizing the
+common [git status, read_file, search_files] reconnaissance pattern.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from agent.tool_dispatch_helpers import (
+    _is_read_only_terminal_command,
+    _plan_tool_batch_segments,
+)
+
+
+def _tc(name, args):
+    return SimpleNamespace(function=SimpleNamespace(name=name, arguments=json.dumps(args)))
+
+
+def _terminal(cmd, **extra):
+    return _tc("terminal", {"command": cmd, **extra})
+
+
+class TestReadOnlyTerminalClassification:
+    def test_plain_reads_are_parallel_safe(self):
+        for cmd in ("ls -la", "git status", "git log --oneline -5", "grep -rn foo .",
+                    "cat /etc/hosts", "df -h", "ps aux", "which hermes", "date"):
+            assert _is_read_only_terminal_command({"command": cmd}), cmd
+
+    def test_chained_commands_are_barriers(self):
+        for cmd in ("ls && ls", "cat x; cat y", "ps aux | grep python",
+                    "echo `date`", "echo $(date)", "git status || true"):
+            assert not _is_read_only_terminal_command({"command": cmd}), cmd
+
+    def test_redirects_and_writers_are_barriers(self):
+        for cmd in ("ls > out.txt", "rm -rf x", "mv a b", "cp a b", "git checkout main",
+                    "sed -i s/a/b/ f", "echo hi >> log"):
+            assert not _is_read_only_terminal_command({"command": cmd}), cmd
+
+    def test_background_and_pty_are_barriers(self):
+        assert not _is_read_only_terminal_command({"command": "ls", "background": True})
+        assert not _is_read_only_terminal_command({"command": "ls", "pty": True})
+
+    def test_unknown_and_empty_commands_are_barriers(self):
+        assert not _is_read_only_terminal_command({"command": "brew install go"})
+        assert not _is_read_only_terminal_command({"command": ""})
+        assert not _is_read_only_terminal_command({})
+
+
+class TestPlannerIntegration:
+    def test_readonly_terminal_joins_parallel_run(self):
+        batch = [
+            _tc("read_file", {"path": "/etc/hosts"}),
+            _terminal("git status"),
+            _tc("search_files", {"pattern": "x", "path": "/etc"}),
+        ]
+        segments = _plan_tool_batch_segments(batch, execution_cwd=None)
+        assert segments == [
+            ("parallel", [
+                batch[0],
+                batch[1],
+                batch[2],
+            ])
+        ], segments
+
+    def test_writing_terminal_stays_sequential(self):
+        batch = [
+            _tc("read_file", {"path": "/etc/hosts"}),
+            _terminal("git checkout main"),
+        ]
+        segments = _plan_tool_batch_segments(batch, execution_cwd=None)
+        kinds = [kind for kind, _ in segments]
+        assert "parallel" not in kinds
+        # Call order preserved
+        flat = [c for _, calls in segments for c in calls]
+        assert flat == batch
+
+    def test_mixed_batch_order_preserved(self):
+        batch = [
+            _terminal("ls -la"),
+            _tc("read_file", {"path": "/etc/hosts"}),
+            _terminal("brew install go"),      # barrier
+            _terminal("date"),                  # read-only again
+            _tc("read_file", {"path": "/etc/passwd"}),
+        ]
+        segments = _plan_tool_batch_segments(batch, execution_cwd=None)
+        flat = [c for _, calls in segments for c in calls]
+        assert flat == batch  # order never crossed
+        # The first two form a parallel run; the barrier splits the rest.
+        assert segments[0][0] == "parallel"
+        assert [c.function.name for c in segments[0][1]] == ["terminal", "read_file"]

--- a/tests/run_agent/test_interrupted_reasoning_stub_not_exhaustion.py
+++ b/tests/run_agent/test_interrupted_reasoning_stub_not_exhaustion.py
@@ -1,0 +1,226 @@
+"""Regression tests: interrupted reasoning streams must NOT be classified as
+Thinking Budget Exhausted.
+
+A stream that dies mid-reasoning returns as a partial-stream stub
+(``PARTIAL_STREAM_STUB_ID``) labelled finish_reason="length" — a Hermes classification of a
+dropped connection, not wire proof the budget was exhausted (the 08:32 live logs show no
+finish_reason and no usage).
+
+Pinned contract:
+
+- a reasoning-only stub (closed or unterminated) is retried (bounded); a valid retry completes;
+- repeated reasoning-only stubs end at the ceiling with an honest error that never claims an
+  output-token limit;
+- a REAL length truncation that is reasoning-only (normal id) still aborts with Thinking
+  Budget Exhausted;
+- a stub's visible text is preserved with edge whitespace intact;
+- the stub gate disables ONLY the thinking-exhaustion heuristic — repetition detection stays.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+
+
+@pytest.fixture()
+def loop_agent():
+    from run_agent import AIAgent
+
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+_THINK_ONLY = "<thinking>Let me work through this carefully and thoroughly</thinking>"
+
+
+def _stub(content):
+    """Partial-stream stub (dropped connection): no wire finish_reason/usage."""
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+
+    return SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        model="test/model",
+        choices=[SimpleNamespace(
+            index=0,
+            message=_mock_assistant_msg(content=content),
+            finish_reason=FINISH_REASON_LENGTH,
+        )],
+        usage=None,
+    )
+
+
+def _reasoning_only_length_response():
+    """REAL length truncation (normal id, not a stub): reasoning, no visible text."""
+    from tests.run_agent.test_run_agent import _mock_assistant_msg
+
+    return SimpleNamespace(
+        id="chatcmpl-real-length",
+        model="test/model",
+        choices=[SimpleNamespace(
+            index=0,
+            message=_mock_assistant_msg(content=_THINK_ONLY),
+            finish_reason=FINISH_REASON_LENGTH,
+        )],
+        usage=None,
+    )
+
+
+def _run(agent, message, history=None):
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        return agent.run_conversation(message, conversation_history=history)
+
+
+class TestInterruptedReasoningStubNotExhaustion:
+    def test_reasoning_only_stub_then_valid_response_completes(self, loop_agent):
+        """Closed reasoning-only stub: continue and complete — not exhaustion abort."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub(_THINK_ONLY),
+            _mock_response(content="Here is the final answer.", finish_reason="stop"),
+        ]
+        result = _run(loop_agent, "solve this")
+
+        assert result["completed"] is True
+        assert "final answer" in (result["final_response"] or "")
+        assert "Thinking Budget" not in (result["final_response"] or "")
+        assert "exhaust" not in (result["final_response"] or "").lower()
+        assert loop_agent.client.chat.completions.create.call_count == 2
+
+        # The reasoning must never leak into the persisted transcript.
+        for m in result["messages"]:
+            if isinstance(m, dict) and m.get("role") == "assistant":
+                assert "Let me work through" not in (m.get("content") or "")
+
+    def test_unterminated_reasoning_only_stub_then_valid_response(self, loop_agent):
+        """The live 08:32 shape: the stream died BEFORE the closing tag. Must continue
+        (bounded), not abort as exhaustion."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("<thinking>Let me analyze the request step by step and"),
+            _mock_response(content="The answer is 42.", finish_reason="stop"),
+        ]
+        result = _run(loop_agent, "what is the answer")
+
+        assert result["completed"] is True
+        assert "The answer is 42." in (result["final_response"] or "")
+        assert "Thinking Budget" not in (result["final_response"] or "")
+        assert loop_agent.client.chat.completions.create.call_count == 2
+        for m in result["messages"]:
+            if isinstance(m, dict) and m.get("role") == "assistant":
+                assert "step by step" not in (m.get("content") or "")
+
+    def test_repeated_reasoning_only_stubs_bounded_honest_error(self, loop_agent):
+        """Four reasoning-only stubs: bounded ceiling exit with an honest dropped-stream
+        error — no claim the model hit an output-token limit."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("<thinking>still thinking and"),
+            _stub("<thinking>still thinking and"),
+            _stub("<thinking>still thinking and"),
+            _stub("<thinking>still thinking and"),
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert loop_agent.client.chat.completions.create.call_count == 4
+        assert "truncated after 4 continuation attempts" in (result.get("error") or "")
+        assert "output length limit" not in (result.get("error") or "").lower()
+        assert "output token" not in (result.get("error") or "").lower()
+        assert "Thinking Budget" not in (result["final_response"] or "")
+        assert "output length limit" not in (result["final_response"] or "").lower()
+
+
+class TestRealLengthReasoningOnlyStillExhaustion:
+    def test_real_length_reasoning_only_aborts_exhaustion(self, loop_agent):
+        """Control: a REAL length truncation (normal id, wire finish_reason) that is
+        reasoning-only must STILL abort with Thinking Budget Exhausted — the stub gate
+        must not weaken the real case."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _reasoning_only_length_response(),
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "Thinking Budget Exhausted" in (result["final_response"] or "")
+        assert loop_agent.client.chat.completions.create.call_count == 1, (
+            "A real reasoning-only length truncation must abort immediately, "
+            "not burn continuation retries."
+        )
+
+
+class TestStubRepetitionStillAborts:
+    def test_stub_repetition_loop_still_aborts(self, loop_agent):
+        """Direct regression: the stub gate must not disable repetition detection — a stub
+        whose visible text is a repetition loop still aborts immediately."""
+        _repeated = "The quick brown fox jumps over the lazy dog near the riverbank 12345 " * 8
+        loop_agent.client.chat.completions.create.side_effect = [_stub(_repeated)]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "Repetition" in (result["final_response"] or "")
+        assert loop_agent.client.chat.completions.create.call_count == 1, (
+            "A repetition-dominated stub must abort immediately, not burn continuation retries."
+        )
+
+
+class TestVisiblePartialRecoveryPreserved:
+    def test_stub_with_visible_text_keeps_partial(self, loop_agent):
+        """A stub carrying visible text is stitched into the final response on a
+        successful continuation (regression guard)."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("Here is my partial answer: "),
+            _mock_response(content="the rest of the answer.", finish_reason="stop"),
+        ]
+        result = _run(loop_agent, "explain it")
+
+        assert result["completed"] is True
+        assert "Here is my partial answer:" in (result["final_response"] or "")
+        assert "the rest of the answer." in (result["final_response"] or "")
+
+    def test_ceiling_stitch_keeps_fragment_edge_whitespace(self, loop_agent):
+        """Stored visible fragments keep their edge whitespace: a trailing space stays the
+        stitching point, so the ceiling partial is joined without an injected newline."""
+        loop_agent.client.chat.completions.create.side_effect = [
+            _stub("One two three "),
+            _stub("One two three "),
+            _stub("One two three "),
+            _stub("One two three "),
+        ]
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is False
+        assert loop_agent.client.chat.completions.create.call_count == 4
+        assert (result["final_response"] or "") == (
+            "One two three One two three One two three One two three"
+        )


### PR DESCRIPTION
## What

Single, non-chained, non-redirecting, non-destructive read commands (`ls`, `git status`, `git log`, `grep`, `ps`, `df`, ...) are now admitted to parallel tool batches instead of being unconditional sequential barriers.

## Why

The batch planner treated every `terminal` call as a hard sequential barrier, so the extremely common reconnaissance pattern [`git status`, `read_file`, `search_files`] executed strictly sequentially — a direct latency multiplier on every agentic turn that mixes shell reads with file/web reads.

## Safety (fail-closed)

- Any shell chaining (`&&`, `||`, `;`, `|`, backticks, `$()`) → barrier
- Any output redirect or destructive pattern (`rm`, `mv`, `cp`, `sed -i`, `git checkout`, ...) → barrier
- `background`/`pty` flags → barrier
- Unknown/empty commands → barrier
- Call order is preserved by the existing planner; path-overlap reservation semantics unchanged.

## Evidence

- New regression suite `tests/agent/test_terminal_readonly_parallel.py`: 41/41 green (incl. existing dispatch-helper tests)
- Executor/parallel suites (`start_order_gate`, `concurrent_interrupt`, `interrupt`, `tool_executor_contextvar_propagation`, `image_generate_parallel`, `tool_executor_checkpoint_paths`, `deferral_fixes`): 42/42 green
- Live CLI smoke: a 3-call batch [`read_file`, `search_files`, `terminal git status`] dispatched from one assistant turn; all three tool results persisted within 1 ms of each other (was sequential before this patch).