### PR TITLE
fix(image_gen): bump Codex host chat model + make it overridable

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -22,8 +22,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from agent.image_gen_provider import DEFAULT_ASPECT_RATIO, resolve_aspect_ratio, save_b64_image, success_response
 from plugins.image_gen._common import (
     GPT_IMAGE_2_API_MODEL as API_MODEL, GPT_IMAGE_2_DEFAULT as DEFAULT_MODEL, GPT_IMAGE_2_TIERS,
-    StaticImageGenProvider, collect_source_images, error_factory, prompt_required_error,
-    resolve_static_model, size_for)
+    StaticImageGenProvider, collect_source_images, error_factory, load_image_gen_config,
+    prompt_required_error, resolve_static_model, size_for)
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,12 @@ logger = logging.getLogger(__name__)
 _MAX_ERROR_BODY_CHARS = 500
 
 # Hosts the ``image_generation`` tool call; ``API_MODEL`` does the image work.
-_CODEX_CHAT_MODEL = "gpt-5.5"
+# ``gpt-5.5`` was retired by the ChatGPT/Codex backend around 2026-09-08 (404 model_not_found on
+# every Codex-signed box). ``gpt-5.6-luna`` is a currently-served Codex Responses model (it has
+# pricing in ``agent/usage_pricing`` and a context window in ``agent/model_metadata``). Override
+# via ``OPENAI_CODEX_CHAT_MODEL`` / ``image_gen.openai-codex.chat_model`` / ``image_gen.chat_model``
+# so the next retirement doesn't hard-break the tool — see ``_resolve_chat_model`` and issue #106683.
+_CODEX_CHAT_MODEL = "gpt-5.6-luna"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation and image editing "
@@ -77,6 +82,32 @@ def _summarize_error_body(body: str) -> str:
 def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return resolve_static_model(
         GPT_IMAGE_2_TIERS, DEFAULT_MODEL, env_var="OPENAI_IMAGE_MODEL", config_key="openai-codex")
+
+
+def _resolve_chat_model(
+    explicit: Optional[str] = None, config: Optional[Dict[str, Any]] = None
+) -> str:
+    """Host chat model that carries the Codex ``image_generation`` tool call.
+
+    Mirrors ``_resolve_model``'s precedence but without a fixed catalog (the host model is a
+    single OpenAI Responses model id, not one of the image tiers), so any non-empty string
+    wins. Precedence: *explicit* → ``OPENAI_CODEX_CHAT_MODEL`` →
+    ``image_gen.openai-codex.chat_model`` → ``image_gen.chat_model`` → ``_CODEX_CHAT_MODEL``.
+    The override exists so a fleet can pin a served model when OpenAI retires the default
+    (#106683: ``gpt-5.5`` 404'd and the constant was the only source — the next ``hermes
+    update`` reverted any source edit)."""
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip()
+    env_override = os.environ.get("OPENAI_CODEX_CHAT_MODEL")
+    if isinstance(env_override, str) and env_override.strip():
+        return env_override.strip()
+    cfg = load_image_gen_config() if config is None else config
+    scoped = cfg.get("openai-codex")
+    scoped_chat = scoped.get("chat_model") if isinstance(scoped, dict) else None
+    for candidate in (scoped_chat, cfg.get("chat_model")):
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    return _CODEX_CHAT_MODEL
 
 
 def _read_codex_access_token() -> Optional[str]:
@@ -181,7 +212,7 @@ def _build_responses_payload(
     nudged by ``instructions``."""
     content: List[Dict[str, Any]] = [{"type": "input_text", "text": prompt}, *(input_images or [])]
     return {
-        "model": _CODEX_CHAT_MODEL,
+        "model": _resolve_chat_model(),
         "store": False,
         "instructions": _CODEX_INSTRUCTIONS,
         "input": [{"type": "message", "role": "user", "content": content}],

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -141,7 +141,7 @@ class TestGenerate:
         result = provider.generate("a cat", aspect_ratio="portrait")
         assert result["success"] is True
 
-        assert captured["model"] == "gpt-5.5"
+        assert captured["model"] == "gpt-5.6-luna"
         assert captured["store"] is False
         assert captured["input"][0]["type"] == "message"
         assert captured["input"][0]["role"] == "user"
@@ -465,3 +465,55 @@ class TestRegistration:
         codex_plugin.register(_Ctx())
         assert len(registered) == 1
         assert registered[0].name == "openai-codex"
+
+
+class TestCodexChatModel:
+    """Resolution precedence for the host chat model (#106683: ``gpt-5.5`` retired → 404).
+
+    The default is bumped to ``gpt-5.6-luna`` (a served Codex Responses model), and an
+    override chain (explicit → ``OPENAI_CODEX_CHAT_MODEL`` → scoped config → top-level
+    config → default) lets a fleet pin a model when OpenAI retires the default."""
+
+    def test_default_is_served_luna_model(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_CODEX_CHAT_MODEL", raising=False)
+        assert codex_plugin._resolve_chat_model(config={}) == "gpt-5.6-luna"
+
+    def test_explicit_wins_over_env_and_config(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_CODEX_CHAT_MODEL", "gpt-5.6-sol")
+        assert codex_plugin._resolve_chat_model(
+            "gpt-5.6-terra", config={"openai-codex": {"chat_model": "gpt-5.6-terra"}}) == "gpt-5.6-terra"
+
+    def test_env_var_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_CODEX_CHAT_MODEL", "gpt-5.6-sol")
+        assert codex_plugin._resolve_chat_model(
+            config={"openai-codex": {"chat_model": "gpt-5.6-terra"}}) == "gpt-5.6-sol"
+
+    def test_scoped_config_overrides_top_level(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_CODEX_CHAT_MODEL", raising=False)
+        cfg = {"openai-codex": {"chat_model": "gpt-5.6-sol"}, "chat_model": "gpt-5.6-terra"}
+        assert codex_plugin._resolve_chat_model(config=cfg) == "gpt-5.6-sol"
+
+    def test_top_level_config_used_when_scoped_absent(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_CODEX_CHAT_MODEL", raising=False)
+        assert codex_plugin._resolve_chat_model(config={"chat_model": "gpt-5.6-terra"}) == "gpt-5.6-terra"
+
+    def test_blank_values_fall_through(self, monkeypatch):
+        # Empty strings / whitespace must not short-circuit the chain.
+        monkeypatch.setenv("OPENAI_CODEX_CHAT_MODEL", "  ")
+        assert codex_plugin._resolve_chat_model(
+            "   ", config={"openai-codex": {"chat_model": ""}, "chat_model": "  "}) == "gpt-5.6-luna"
+
+    def test_payload_uses_env_override(self, provider, monkeypatch):
+        # Integration: the env override reaches the wire payload, not just the resolver.
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setenv("OPENAI_CODEX_CHAT_MODEL", "gpt-5.6-sol")
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality, input_images=None):
+            captured.update(codex_plugin._build_responses_payload(
+                prompt=prompt, size=size, quality=quality, input_images=input_images))
+            return {"b64": _b64_png(), "source": "final"}
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+        provider.generate("a cat", aspect_ratio="portrait")
+        assert captured["model"] == "gpt-5.6-sol"


### PR DESCRIPTION
## Summary

Fixes #106683.

The `openai-codex` image_gen plugin hard-coded `_CODEX_CHAT_MODEL = "gpt-5.5"` as the host Responses model that carries the `image_generation` tool call. OpenAI retired that model around 2026-09-08 — every Codex-signed install now gets a non-retryable `404 model_not_found` and the image tool is broken fleet-wide. The image_gen config keys (`image_gen.openai-codex.model`, `image_gen.model`, `OPENAI_IMAGE_MODEL`) only select the **image tier** (`gpt-image-2-*`); the host chat model had **no config or env override**, so the constant was the only source and the only workaround was editing installed plugin source (reverted by the next `hermes update`).

## Changes

`plugins/image_gen/openai-codex/__init__.py`
- Bump `_CODEX_CHAT_MODEL` default `gpt-5.5` → `gpt-5.6-luna` (a currently-served Codex Responses model — it already has pricing in `agent/usage_pricing` and a context window in `agent/model_metadata` / `_CODEX_900K_SNAPSHOT_BASES`).
- Add `_resolve_chat_model()` with an override chain mirroring the image-tier `_resolve_model()`: **explicit → `OPENAI_CODEX_CHAT_MODEL` → `image_gen.openai-codex.chat_model` → `image_gen.chat_model` → default**. Unlike the image tier there is no fixed catalog (a single host model id), so any non-empty string wins — a fleet can pin a served model when OpenAI next retires the default.
- Wire `_build_responses_payload` to use `_resolve_chat_model()` instead of the bare constant.

`tests/plugins/image_gen/test_openai_codex_provider.py`
- 7 new tests under `TestCodexChatModel`: default value, explicit > env > config precedence, scoped config beats top-level, top-level used when scoped absent, blank/whitespace values fall through (don't short-circuit), and an integration test that the env override reaches the wire payload.
- Updated the existing `test_codex_stream_request_shape` assertion (`gpt-5.5` → `gpt-5.6-luna`).

## Verification

- `ruff check` clean on both files.
- All 35 tests in `test_openai_codex_provider.py` pass (28 existing + 7 new).
- **Mutation-verified**: reverting the default to `gpt-5.5` fails 3 tests (`test_codex_stream_request_shape`, `test_default_is_served_luna_model`, `test_blank_values_fall_through`); reverting the payload to use the bare constant fails `test_payload_uses_env_override`. Restoring the fix passes all 35.

The default bump makes it work out-of-the-box again; the override chain means the next retirement is a one-line config/env change rather than a source edit + `hermes update` revert cycle.

Happy to adjust the default or the config/env key names if there's a preferred convention. The reporter (@the reporter of #106683) offered to test a patch on real fleet boxes.
