### PR TITLE
fix(update): drain embedded kanban workers before restart

### DIFF
--- a/agent/estop.py
+++ b/agent/estop.py
@@ -61,9 +61,13 @@ def is_engaged() -> bool:
     return saw_stat_error
 
 
-def engage(reason: Optional[str] = None) -> Path:
-    """Create the ESTOP sentinel. Idempotent; re-engaging updates the file."""
-    path = sentinel_path()
+def engage(reason: Optional[str] = None, *, global_scope: bool = False) -> Path:
+    """Create the ESTOP sentinel. Idempotent; re-engaging updates the file.
+
+    ``global_scope`` writes the fleet-root sentinel even when a profile gateway
+    invokes the operation, keeping an embedded dispatcher pause global.
+    """
+    path = (_canonical_root() if global_scope else _hermes_home()) / SENTINEL_NAME
     payload = {"engaged_at": datetime.now(timezone.utc).isoformat(), "reason": reason or None}
     try:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1985,6 +1985,10 @@ updates:
   #             installs where local source edits should not persist
   non_interactive_local_changes: "stash"
 
+  # Maximum seconds `hermes update` waits for running Kanban workers after
+  # pausing new dispatch. On timeout, update refuses and leaves ESTOP engaged.
+  drain_timeout_seconds: 1800
+
 
 # =============================================================================
 # Web Dashboard

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2102,6 +2102,7 @@ DEFAULT_CONFIG = {
         # stay in a git stash). discard = stash and drop after the pull (stash-and-drop, not reset
         # --hard + clean -fd, so ignored paths like node_modules/venv are never touched).
         "non_interactive_local_changes": "stash",
+        "drain_timeout_seconds": 1800,
         # If the checkout is parked on a feature branch and the tree is clean, switch to the update
         # target (commits stay on the branch; a loud notice names it) so non-interactive updates
         # keep working. A DIRTY tree blocks the switch and the code update is SKIPPED with a loud

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4136,13 +4136,21 @@ def _wait_for_launchd_service_pid(
         time.sleep(0.5)
 
 
-def launchd_restart():
+def launchd_restart(*, no_drain: bool = False):
     label = get_launchd_label()
     domain = _launchd_domain()
     target = f"{domain}/{label}"
     from gateway.status import get_running_pid
     try:
         pid = get_running_pid()
+        if no_drain:
+            print(
+                f"⚠ {label}: --no-drain requested — forcing immediate restart; "
+                "in-flight work may be lost"
+            )
+            subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+            _launchd_ok("✓ Service restarted")
+            return
         if pid is not None and _request_gateway_self_restart(pid):
             _launchd_ok("✓ Service restart requested")
             return

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2203,6 +2203,18 @@ def _finalize_update_receipt(code: int, reason: str) -> None:
         pass
 
 
+def _prepare_kanban_drain_for_update(*, no_drain: bool = False):
+    """Late-bound update drain hook kept on the main command surface."""
+    from hermes_cli import update_cmd
+    return update_cmd._prepare_kanban_drain_for_update(no_drain=no_drain)
+
+
+def _finish_kanban_drain_for_update(state) -> None:
+    """Late-bound cleanup hook for the update-owned ESTOP."""
+    from hermes_cli import update_cmd
+    update_cmd._finish_kanban_drain_for_update(state)
+
+
 def _update_preflight_handled(args) -> bool:
     """Managed-install refusal, --plan, admission gate, --check. True = nothing more to do."""
     from hermes_cli.config import is_managed, managed_error
@@ -2283,10 +2295,16 @@ def cmd_update(args):
     # Exit code for the Windows hand-off child's hard exit (see finally); None
     # = not SystemExit-shaped, so real exceptions keep their traceback.
     _update_handoff_exit_code: int | None = None
-    from hermes_cli.update_cmd import _cmd_update_impl
+    _update_kanban_drain_state = None
+    from hermes_cli import update_cmd as _update_module
 
     try:
-        _cmd_update_impl(args, gateway_mode=gateway_mode)
+        _update_kanban_drain_state = _prepare_kanban_drain_for_update(
+            no_drain=bool(getattr(args, "no_drain", False))
+        )
+        if _update_kanban_drain_state and not _update_kanban_drain_state["ready"]:
+            sys.exit(_update_kanban_drain_state["exit_code"])
+        _update_module._cmd_update_impl(args, gateway_mode=gateway_mode)
     except SystemExit as _update_exit:
         # Receipt boundary: the impl has many early sys.exit paths that never
         # reach an inner finalize. Persist any still-open receipt with the real
@@ -2306,6 +2324,7 @@ def cmd_update(args):
         _finalize_update_receipt(0, COMMAND_BOUNDARY_STOP_REASON)
         _update_handoff_exit_code = 0
     finally:
+        _finish_kanban_drain_for_update(_update_kanban_drain_state)
         _update_lock.release()
         _finalize_update_output(_update_io_state)
         # Windows hand-off child: a leftover non-daemon thread from the update

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -66,4 +66,14 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         "--force-venv", action="store_true", default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
+    update_parser.add_argument(
+        "--no-drain",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the graceful gateway drain and use the immediate restart path. "
+            "This may terminate in-flight agent or cron work; use only when "
+            "you explicitly accept that loss."
+        ),
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -125,6 +125,123 @@ def _updates_config() -> dict:
     return section if isinstance(section, dict) else {}
 
 
+_UPDATE_DRAIN_DEFAULT_TIMEOUT = 1800.0
+_UPDATE_DRAIN_TIMEOUT_EXIT = 76
+_UPDATE_DRAIN_FOREIGN_ESTOP_EXIT = 75
+
+
+def _update_embedded_kanban_dispatcher_enabled() -> bool:
+    """Return whether this install uses the gateway-hosted dispatcher."""
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly() or {}
+        section = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        return bool(section.get("dispatch_in_gateway", True)) if isinstance(section, dict) else True
+    except Exception as exc:
+        logger.warning("Could not read kanban dispatcher setting: %s", exc)
+        return True
+
+
+def _update_kanban_drain_timeout() -> float:
+    """Read the bounded update drain budget from the active config."""
+    try:
+        raw = _updates_config().get("drain_timeout_seconds", _UPDATE_DRAIN_DEFAULT_TIMEOUT)
+        value = float(raw)
+        if value != value or value < 0 or value == float("inf"):
+            raise ValueError("timeout must be finite and non-negative")
+        return value
+    except (TypeError, ValueError, OverflowError) as exc:
+        logger.warning("Invalid updates.drain_timeout_seconds; using %.0fs: %s", _UPDATE_DRAIN_DEFAULT_TIMEOUT, exc)
+    except Exception as exc:
+        logger.warning("Could not read updates.drain_timeout_seconds; using %.0fs: %s", _UPDATE_DRAIN_DEFAULT_TIMEOUT, exc)
+    return _UPDATE_DRAIN_DEFAULT_TIMEOUT
+
+
+def _count_running_kanban_tasks_for_update() -> int | None:
+    """Count running board tasks read-only; ``None`` means the safety query failed."""
+    import sqlite3
+    try:
+        root = Path(get_default_hermes_root()).expanduser()
+        paths = [root / "kanban.db"]
+        paths.extend((root / "kanban" / "boards").glob("*/kanban.db"))
+        override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+        if override:
+            paths.append(Path(override).expanduser())
+        unique = []
+        seen = set()
+        for path in paths:
+            resolved = str(path.resolve())
+            if resolved not in seen and path.is_file():
+                seen.add(resolved)
+                unique.append(path)
+        total = 0
+        for path in unique:
+            conn = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True, timeout=1.0)
+            try:
+                row = conn.execute("SELECT COUNT(*) FROM tasks WHERE status = 'running'").fetchone()
+                total += int(row[0])
+            finally:
+                conn.close()
+        return total
+    except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
+        logger.warning("Kanban drain query failed; refusing update: %s", exc)
+        return None
+
+
+def _prepare_kanban_drain_for_update(*, no_drain: bool = False) -> dict | None:
+    """Pause new board work and wait for running tasks; refuse fail-closed on uncertainty."""
+    if no_drain or not _update_embedded_kanban_dispatcher_enabled():
+        return None
+    from agent import estop
+    if estop.is_engaged():
+        print("✗ Update refused: Hermes is already paused by another operator or update; run `hermes resume` after that operation completes.")
+        return {"engaged": False, "ready": False, "keep_paused": False, "exit_code": _UPDATE_DRAIN_FOREIGN_ESTOP_EXIT}
+    estop.engage(reason="hermes update: drain embedded kanban workers", global_scope=True)
+    state = {"engaged": True, "ready": False, "keep_paused": True, "exit_code": _UPDATE_DRAIN_TIMEOUT_EXIT}
+    if not estop.is_engaged():
+        print("✗ Update refused: could not engage ESTOP; no update was attempted.")
+        return state
+    engagement = estop.get_state()
+    if not engagement or not engagement.get("engaged_at"):
+        print("✗ Update refused: could not verify ESTOP ownership; no update was attempted and ESTOP remains engaged.")
+        return state
+    state["engaged_at"] = engagement["engaged_at"]
+    timeout = _update_kanban_drain_timeout()
+    deadline = _time.monotonic() + timeout
+    print(f"→ Paused new work; draining kanban workers (up to {int(timeout)}s)...")
+    while True:
+        running = _count_running_kanban_tasks_for_update()
+        if running is None:
+            print("✗ Update refused: could not verify kanban running-task state; ESTOP remains engaged and no update was attempted.")
+            return state
+        if running == 0:
+            state.update(ready=True, keep_paused=False)
+            print("✓ Kanban drain complete (running=0); continuing with one update.")
+            return state
+        if _time.monotonic() >= deadline:
+            print(f"✗ Update refused: {running} kanban worker(s) still running after {int(timeout)}s; ESTOP remains engaged and no update was attempted.")
+            return state
+        print(f"  … waiting for {running} kanban worker(s) to finish")
+        _time.sleep(min(1.0, max(0.05, deadline - _time.monotonic())))
+
+
+def _finish_kanban_drain_for_update(state: dict | None) -> None:
+    """Lift only an ESTOP this update successfully acquired."""
+    if not state or not state.get("engaged") or state.get("keep_paused"):
+        return
+    try:
+        from agent import estop
+        current = estop.get_state()
+        expected = state.get("engaged_at")
+        if not expected or not current or current.get("engaged_at") != expected:
+            logger.warning("Hermes update left ESTOP engaged because ownership changed during the update")
+            return
+        estop.disengage()
+        print("▶️ Kanban dispatch resumed after Hermes update.")
+    except Exception as exc:
+        logger.error("Hermes update could not resume ESTOP: %s", exc)
+
+
 def _no_prompt_git_kwargs() -> dict:
     """``subprocess.run`` kwargs for network git: a 401 (GitHub outage) would block forever on
     ``Username for ...``; disable only the *prompt* (credential helpers still run) so it fails fast."""
@@ -939,6 +1056,7 @@ class _UpdateOptions:
     keep_stash: bool
     switch_branch: bool
     discard_local_changes: bool
+    no_drain: bool
 
 
 def _resolve_update_options(args, gateway_mode: bool) -> _UpdateOptions:
@@ -977,7 +1095,8 @@ def _resolve_update_options(args, gateway_mode: bool) -> _UpdateOptions:
         active_lazy_features=active_lazy_features,
         active_tool_dependencies=active_tool_dependencies, pre_update_version=pre_update_version,
         gw_input_fn=gw_input_fn, assume_yes=assume_yes, keep_stash=keep_stash,
-        switch_branch=switch_branch, discard_local_changes=discard_local_changes)
+        switch_branch=switch_branch, discard_local_changes=discard_local_changes,
+        no_drain=bool(getattr(args, "no_drain", False)))
 
 
 def _begin_update_receipt_and_plan(args):
@@ -1239,7 +1358,8 @@ def _apply_pulled_update(
     if gateway_mode:
         _write_gateway_update_exit_code(update_complete)
 
-    _restart = _restart_gateway_fleet_after_update(_pre_update_plan, gateway_mode)
+    _restart = _restart_gateway_fleet_after_update(
+        _pre_update_plan, gateway_mode, no_drain=opts.no_drain)
     _resume_windows_gateways_and_merge_outcome(_restart, _windows_gateway_resume, gateway_mode)
     _verify_fleet_after_update(
         _restart, _pre_update_plan=_pre_update_plan, _windows_gateway_resume=_windows_gateway_resume,

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -495,7 +495,7 @@ def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
         print("    launchctl kickstart -k gui/$UID/<label>   # macOS (or user/$UID)")
 
 
-def _restart_launchd_gateway_after_update(*, supervision_verify: bool = True) -> tuple[list, list]:
+def _restart_launchd_gateway_after_update(*, supervision_verify: bool = True, no_drain: bool = False) -> tuple[list, list]:
     """Restart the invoking profile's launchd gateway after an update.
 
     No ``launchctl list`` gating: a booted-out job (plist present, definition
@@ -520,7 +520,10 @@ def _restart_launchd_gateway_after_update(*, supervision_verify: bool = True) ->
         if not get_launchd_plist_path().exists():
             return [], []  # not a launchd install — nothing to do or warn
         try:
-            launchd_restart()
+            if no_drain:
+                launchd_restart(no_drain=True)
+            else:
+                launchd_restart()
         except subprocess.CalledProcessError as e:
             stderr = (getattr(e, "stderr", "") or "").strip()
             print(
@@ -560,6 +563,7 @@ def _restart_launchd_gateway_after_update(*, supervision_verify: bool = True) ->
 
 def _restart_macos_launchd_gateways(
     restarted_services: list, failed_or_stale_units: list, drain_budget: float, *, require_supervision: bool = False,
+    no_drain: bool = False,
 ) -> None:
     """Restart every launchd-managed gateway after an update (macOS).
 
@@ -583,7 +587,8 @@ def _restart_macos_launchd_gateways(
         if listing.returncode != 0:
             failed_or_stale_units.append("launchd (listing failed)")
             return
-    _restarted, _failed = _restart_launchd_gateway_after_update(supervision_verify=True)
+    _restarted, _failed = _restart_launchd_gateway_after_update(
+        supervision_verify=True, no_drain=no_drain)
     restarted_services.extend(_restarted)
     failed_or_stale_units.extend(_failed)
     current_label = get_launchd_label()
@@ -600,7 +605,7 @@ def _restart_macos_launchd_gateways(
                     failed_or_stale_units.append(label)
                 continue  # A profile without an installed job has no restart target.
             graceful_ok = False
-            if old_pid is not None and old_pid > 0:
+            if old_pid is not None and old_pid > 0 and not no_drain:
                 print(f"  → {label}: draining (up to {int(drain_budget)}s)...")
                 graceful_ok = _graceful_restart_via_sigusr1(old_pid, drain_timeout=drain_budget)
             if graceful_ok and _wait_for_launchd_service_pid(label, old_pid=old_pid, timeout=10.0, domain=domain):
@@ -722,7 +727,9 @@ def _warn_gateway_restart_phase_aborted(exc: BaseException, pids) -> None:
     print("    hermes gateway status")
 
 
-def _drain_or_signal_gateway_for_update(pid: int, drain_budget: float, label: str) -> bool:
+def _drain_or_signal_gateway_for_update(
+    pid: int, drain_budget: float, label: str, *, no_drain: bool = False
+) -> bool:
     """Three-way triage (shared by systemd and bare-process paths) for handing a
     running gateway over to new code. Returns True when signalled/stopped.
 
@@ -742,12 +749,18 @@ def _drain_or_signal_gateway_for_update(pid: int, drain_budget: float, label: st
         _is_pid_ancestor_of_current_process, _request_gateway_self_restart, probe_gateway_loop_liveness,
     )
     if _is_pid_ancestor_of_current_process(pid):
-        print(
-            f"  → {label}: update is running inside this gateway's "
-            "process tree — signalling restart and letting the gateway "
-            "drain itself (avoids the cron-update deadlock, #100179)"
-        )
+        if no_drain:
+            print(f"  ⚠ {label}: --no-drain is unavailable for an in-tree gateway; using the safe fire-and-forget restart request")
+        else:
+            print(
+                f"  → {label}: update is running inside this gateway's "
+                "process tree — signalling restart and letting the gateway "
+                "drain itself (avoids the cron-update deadlock, #100179)"
+            )
         return _request_gateway_self_restart(pid)
+    if no_drain:
+        print(f"  ⚠ {label}: --no-drain requested — skipping graceful drain; in-flight work may be lost")
+        return False
     if probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
         print(f"  ⚠ {label}: gateway event loop is unresponsive — skipping drain, forcing a bounded stop...")
         _escalate_wedged_gateway(pid)
@@ -787,7 +800,7 @@ def _resolve_manage_cmd(cache: dict, scope_: str, scope_cmd_: list, svc_name_: s
 
 def _restart_one_systemd_gateway_unit(
     svc_name: str, *, scope: str, scope_cmd: list, drain_budget: float, _manage_cmd_cache: dict,
-    restarted_services: list, failed_or_stale_units: list,
+    restarted_services: list, failed_or_stale_units: list, no_drain: bool = False,
 ) -> None:
     """Restart one active systemd gateway/serve unit: graceful SIGUSR1 drain, then forced restart.
 
@@ -812,7 +825,15 @@ def _restart_one_systemd_gateway_unit(
             _main_pid = 0
 
     # Three-way triage (ancestor / wedged / graceful drain).
-    _graceful_ok = _main_pid > 0 and _drain_or_signal_gateway_for_update(_main_pid, drain_budget, svc_name)
+    if _main_pid > 0:
+        if no_drain:
+            _graceful_ok = _drain_or_signal_gateway_for_update(
+                _main_pid, drain_budget, svc_name, no_drain=True)
+        else:
+            _graceful_ok = _drain_or_signal_gateway_for_update(
+                _main_pid, drain_budget, svc_name)
+    else:
+        _graceful_ok = False
 
     if _graceful_ok:
         # ``Restart=always`` respawns only after RestartSec (60s in our unit; dead time for a
@@ -888,7 +909,9 @@ def _restart_one_systemd_gateway_unit(
     )
 
 
-def _restart_systemd_gateway_units(restarted_services, failed_or_stale_units, restarted_scoped_units, drain_budget):
+def _restart_systemd_gateway_units(
+    restarted_services, failed_or_stale_units, restarted_scoped_units, drain_budget, *, no_drain: bool = False
+):
     """Restart every active hermes-gateway*/hermes-serve* systemd unit (user + system).
 
     Settled units → ``restarted_services`` (bare) and ``restarted_scoped_units``
@@ -935,6 +958,7 @@ def _restart_systemd_gateway_units(restarted_services, failed_or_stale_units, re
                     _manage_cmd_cache=_manage_cmd_cache,
                     restarted_services=restarted_services,
                     failed_or_stale_units=failed_or_stale_units,
+                    no_drain=no_drain,
                 ),
                 on_unit_timeout=_on_unit_timeout,
             )
@@ -980,7 +1004,7 @@ class _GatewayRestartOutcome:
             )
 
 
-def _restart_manual_gateways(out: _GatewayRestartOutcome, _drain_budget) -> None:
+def _restart_manual_gateways(out: _GatewayRestartOutcome, _drain_budget, *, no_drain: bool = False) -> None:
     """Drain/stop every manual (non-service) gateway and print the restart summary.
 
     Mutates ``out`` in place; raises so the caller's abort recovery fires.
@@ -1019,7 +1043,13 @@ def _restart_manual_gateways(out: _GatewayRestartOutcome, _drain_budget) -> None
         # SIGUSR1 drain first, SIGTERM fallback if unsupported/over budget — the watcher
         # relaunches either way. The helper announces its choice first because a silent
         # full-budget wait reads as a hung update.
-        if not _drain_or_signal_gateway_for_update(pid, _drain_budget, proc.profile):
+        if no_drain:
+            _drained = _drain_or_signal_gateway_for_update(
+                pid, _drain_budget, proc.profile, no_drain=True)
+        else:
+            _drained = _drain_or_signal_gateway_for_update(
+                pid, _drain_budget, proc.profile)
+        if not _drained:
             with suppress(ProcessLookupError, PermissionError):
                 os.kill(pid, _signal.SIGTERM)
         # Wait ≤5s for exit: Telegram keeps the old getUpdates session ~30s; a new gateway
@@ -1155,7 +1185,7 @@ def _recover_after_restart_phase_abort(
     out.record_receipt(phase_error=str(e), fresh_recovery=_recovery_result)
 
 
-def _restart_gateway_fleet_after_update(_pre_update_plan, gateway_mode: bool):
+def _restart_gateway_fleet_after_update(_pre_update_plan, gateway_mode: bool, *, no_drain: bool = False):
     """Restart every running gateway (systemd, launchd, manual) onto the pulled code.
 
     Never raises: a phase abort runs fresh-child recovery and fails closed unless
@@ -1214,15 +1244,16 @@ def _restart_gateway_fleet_after_update(_pre_update_plan, gateway_mode: bool):
             out.pre_restart_gateway_pids = None
 
         _restart_systemd_gateway_units(
-            out.restarted_services, out.failed_or_stale_units, restarted_scoped_units, _drain_budget
-        )
+            out.restarted_services, out.failed_or_stale_units, restarted_scoped_units, _drain_budget,
+            no_drain=no_drain)
 
         # macOS: EVERY ai.hermes.gateway* LaunchAgent (systemd parity).
         if is_macos():
             with suppress(FileNotFoundError, ImportError):
-                _restart_macos_launchd_gateways(out.restarted_services, out.failed_or_stale_units, _drain_budget)
+                _restart_macos_launchd_gateways(
+                    out.restarted_services, out.failed_or_stale_units, _drain_budget, no_drain=no_drain)
 
-        _restart_manual_gateways(out, _drain_budget)
+        _restart_manual_gateways(out, _drain_budget, no_drain=no_drain)
 
         if out.failed_or_stale_units:
             out.incomplete = True

--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -77,6 +77,10 @@ def isolated_update_runtime(monkeypatch, tmp_path, request):
     monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
     monkeypatch.setattr(main, "_pause_windows_gateways_for_update", lambda: None)
     monkeypatch.setattr(main, "_resume_windows_gateways_after_update", lambda *a, **k: None)
+    # Simulated update tests must not inspect or mutate the live Kanban board;
+    # the embedded-dispatcher drain contract has dedicated unit coverage.
+    monkeypatch.setattr(main, "_prepare_kanban_drain_for_update", lambda **_k: None)
+    monkeypatch.setattr(main, "_finish_kanban_drain_for_update", lambda _state: None)
     monkeypatch.setattr(main, "_detect_venv_python_processes", lambda: [])
     monkeypatch.setattr(main, "_restore_active_tool_dependencies", lambda *a, **k: None)
     monkeypatch.setattr(update_cmd, "_clear_windows_venv_holders_or_exit", lambda *a, **k: None)

--- a/tests/hermes_cli/test_update_cron_deadlock_guard.py
+++ b/tests/hermes_cli/test_update_cron_deadlock_guard.py
@@ -16,6 +16,7 @@ The fix: when the target gateway PID is an ancestor of this process,
 fire-and-forget (SIGUSR1 + return) instead of drain-waiting.
 """
 
+import argparse
 from unittest.mock import patch
 
 import pytest
@@ -165,3 +166,121 @@ class TestDrainOrSignalTriage:
         assert calls["drain"] == [(1234, 900.0)]
         assert calls["self_restart"] == []
         assert calls["escalate"] == []
+
+    def test_no_drain_skips_graceful_paths_out_of_tree(self, monkeypatch, capsys):
+        from hermes_cli.update_cmd import _drain_or_signal_gateway_for_update
+
+        calls = self._patched(monkeypatch, ancestor=False, wedged=True)
+        assert _drain_or_signal_gateway_for_update(1234, 900.0, "svc", no_drain=True) is False
+        assert calls == {"self_restart": [], "escalate": [], "drain": []}
+        assert "--no-drain" in capsys.readouterr().out
+
+    def test_no_drain_keeps_ancestor_safety_guard(self, monkeypatch, capsys):
+        from hermes_cli.update_cmd import _drain_or_signal_gateway_for_update
+
+        calls = self._patched(monkeypatch, ancestor=True, wedged=False)
+        assert _drain_or_signal_gateway_for_update(1234, 900.0, "svc", no_drain=True) is True
+        assert calls["self_restart"] == [1234]
+        assert calls["escalate"] == []
+        assert calls["drain"] == []
+        assert "unavailable" in capsys.readouterr().out
+
+
+def test_embedded_update_drain_waits_for_running_workers(monkeypatch, capsys):
+    from agent import estop
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(update_cmd, "_update_embedded_kanban_dispatcher_enabled", lambda: True)
+    monkeypatch.setattr(update_cmd, "_update_kanban_drain_timeout", lambda: 30.0)
+    monkeypatch.setattr(update_cmd, "_count_running_kanban_tasks_for_update", iter([1, 0]).__next__)
+    engaged = []
+    monkeypatch.setattr(estop, "is_engaged", iter([False, True]).__next__)
+    monkeypatch.setattr(estop, "engage", lambda **kwargs: engaged.append(kwargs))
+    monkeypatch.setattr(estop, "get_state", lambda: {"engaged_at": "owned-by-test", "reason": "drain"})
+
+    state = update_cmd._prepare_kanban_drain_for_update()
+
+    assert state == {
+        "engaged": True, "ready": True, "keep_paused": False,
+        "exit_code": update_cmd._UPDATE_DRAIN_TIMEOUT_EXIT, "engaged_at": "owned-by-test",
+    }
+    assert engaged == [{"reason": "hermes update: drain embedded kanban workers", "global_scope": True}]
+    output = capsys.readouterr().out
+    assert "waiting for 1 kanban worker" in output
+    assert "running=0" in output
+
+
+def test_embedded_update_drain_refuses_foreign_estop(monkeypatch, capsys):
+    from agent import estop
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(update_cmd, "_update_embedded_kanban_dispatcher_enabled", lambda: True)
+    monkeypatch.setattr(estop, "is_engaged", lambda: True)
+    monkeypatch.setattr(estop, "engage", lambda **kwargs: pytest.fail("foreign ESTOP was adopted"))
+
+    state = update_cmd._prepare_kanban_drain_for_update()
+    assert state["exit_code"] == update_cmd._UPDATE_DRAIN_FOREIGN_ESTOP_EXIT
+    assert state["engaged"] is False
+    assert "already paused" in capsys.readouterr().out
+
+
+def test_embedded_update_drain_refuses_after_timeout(monkeypatch, capsys):
+    from agent import estop
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(update_cmd, "_update_embedded_kanban_dispatcher_enabled", lambda: True)
+    monkeypatch.setattr(update_cmd, "_update_kanban_drain_timeout", lambda: 0.0)
+    monkeypatch.setattr(update_cmd, "_count_running_kanban_tasks_for_update", lambda: 1)
+    monkeypatch.setattr(update_cmd._time, "monotonic", iter([0.0, 1.0]).__next__)
+    monkeypatch.setattr(estop, "is_engaged", iter([False, True]).__next__)
+    monkeypatch.setattr(estop, "engage", lambda **_: None)
+    monkeypatch.setattr(estop, "get_state", lambda: {"engaged_at": "owned-by-test", "reason": "drain"})
+
+    state = update_cmd._prepare_kanban_drain_for_update()
+    assert state["ready"] is False
+    assert state["keep_paused"] is True
+    assert "no update was attempted" in capsys.readouterr().out
+
+
+def test_update_parser_defaults_and_accepts_no_drain():
+    from hermes_cli.subcommands.update import build_update_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_update_parser(subparsers, cmd_update=lambda _args: None)
+    assert parser.parse_args(["update"]).no_drain is False
+    assert parser.parse_args(["update", "--no-drain"]).no_drain is True
+
+
+def test_finish_does_not_clear_replaced_estop(monkeypatch, caplog):
+    from agent import estop
+    from hermes_cli import update_cmd
+
+    disengaged = []
+    monkeypatch.setattr(estop, "get_state", lambda: {"engaged_at": "operator-owned", "reason": "manual pause"})
+    monkeypatch.setattr(estop, "disengage", lambda: disengaged.append(True))
+    update_cmd._finish_kanban_drain_for_update({
+        "engaged": True, "ready": True, "keep_paused": False, "engaged_at": "update-owned",
+    })
+    assert disengaged == []
+    assert "ownership changed" in caplog.text
+
+
+def test_cmd_update_drain_boundary_refuses_before_impl(monkeypatch):
+    from hermes_cli import main
+    from hermes_cli import update_cmd
+
+    state = {"engaged": True, "ready": False, "keep_paused": True, "exit_code": 76}
+    finished = []
+    monkeypatch.setattr(main, "_prepare_kanban_drain_for_update", lambda **_: state)
+    monkeypatch.setattr(main, "_finish_kanban_drain_for_update", finished.append)
+    monkeypatch.setattr(main, "_install_hangup_protection", lambda **_: None)
+    monkeypatch.setattr(main, "_finalize_update_output", lambda _state: None)
+    monkeypatch.setattr(update_cmd, "_cmd_update_impl", lambda *_a, **_k: pytest.fail("update ran"))
+    monkeypatch.setattr(main, "_update_preflight_handled", lambda _args: False)
+
+    from types import SimpleNamespace
+    with pytest.raises(SystemExit) as exc_info:
+        main.cmd_update(SimpleNamespace(gateway=False, no_drain=False))
+    assert exc_info.value.code == 76
+    assert finished == [state]


### PR DESCRIPTION
## Summary

This is the replacement upstream draft for the update-drain safety rework from t_264e6fca. It is based directly on current upstream `main` at `fb85b57ee9aecb086f659bdd6b450519b89059ef` and supersedes the stale delivery of PR #101986 and the earlier replacement draft #106760.

The change adds a bounded embedded-Kanban ESTOP drain before update mutation, fail-closed refusal for foreign/unreadable/timed-out running state, ownership-safe resume, explicit out-of-tree `--no-drain` behavior, and preserves the in-tree ancestor/self-restart guard. It includes the existing update regression coverage and hermetic test seam.

## Verification

- Exact source head: `73a3c82ff82e7b90dcd752478473bcd0e1935dfb`
- Base: `fb85b57ee9aecb086f659bdd6b450519b89059ef`
- The source tree was materialized from the current upstream tarball, and the reviewed patch applied cleanly to all 10 changed paths.
- No merge, deploy, gateway restart, or live `hermes update` was performed.
- `LIVE-CRASH-FREE-NEXT-UPDATE` remains a separate Frank-authorized live-deployment gate.

## Scope

This PR is intentionally source-only and draft. The fleet wrapper remains an interim extension-surface control; wrapper adoption/hook/cadence remains on child card `t_1bc8ccec`.
