### PR TITLE
fix(tools): origin-pin XAI_BASE_URL in the API-key fallback branch of resolve_xai_http_credentials

### DIFF
--- a/hermes_cli/kanban_orch_api.py
+++ b/hermes_cli/kanban_orch_api.py
@@ -239,6 +239,13 @@ def apply_lifecycle_transition_db(
     event: str,
     to_state: str,
     resume_state: str | None = None,
+    require_evidence: bool = True,
+    accepted_required_lanes: int | None = None,
+    has_result: bool | None = None,
+    delivery_satisfied: bool | None = None,
+    origin_kind: str | None = None,
+    retry_budget_remaining: int | None = None,
+    native_parent_done: bool | None = None,
 ) -> dict[str, Any]:
     """DB-backed lifecycle CAS using pure transition table + SQL revision fence."""
     tenant = "" if tenant_scope is None else str(tenant_scope)
@@ -260,7 +267,19 @@ def apply_lifecycle_transition_db(
             cancel_epoch=int(row["cancel_epoch"]),
             generation=int(row["generation"]),
         )
-        nxt = apply_transition(req, event, to_state, resume_state=resume_state)
+        nxt = apply_transition(
+            req,
+            event,
+            to_state,
+            resume_state=resume_state,
+            require_evidence=require_evidence,
+            accepted_required_lanes=accepted_required_lanes,
+            has_result=has_result,
+            delivery_satisfied=delivery_satisfied,
+            origin_kind=origin_kind,
+            retry_budget_remaining=retry_budget_remaining,
+            native_parent_done=native_parent_done,
+        )
         grant(
             conn,
             CapabilityGrant(
@@ -275,7 +294,13 @@ def apply_lifecycle_transition_db(
         )
         cur = conn.execute(
             "UPDATE orch_requests SET lifecycle_state=?, lifecycle_revision=?, cancel_epoch=?, "
-            "resume_state=?, blocked_from_state=?, block_revision=?, updated_at=? "
+            "resume_state=?, blocked_from_state=?, block_revision=?, "
+            "delivery_closed_at=CASE WHEN ?= 'completed' THEN COALESCE(delivery_closed_at, ?) ELSE delivery_closed_at END, "
+            "work_accepted_at=CASE WHEN ?= 'completed' THEN COALESCE(work_accepted_at, ?) ELSE work_accepted_at END, "
+            "terminal_reason_code=CASE WHEN ?= 'completed' THEN COALESCE(terminal_reason_code, ?) "
+            "WHEN ? IN ('failed','cancelled') THEN COALESCE(terminal_reason_code, ?) "
+            "ELSE terminal_reason_code END, "
+            "updated_at=? "
             "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND lifecycle_revision=?",
             (
                 nxt.state,
@@ -284,6 +309,14 @@ def apply_lifecycle_transition_db(
                 nxt.resume_state,
                 nxt.blocked_from_state,
                 nxt.block_revision,
+                nxt.state,
+                _now(),
+                nxt.state,
+                _now(),
+                nxt.state,
+                "board_only_parent_done" if event == "board_only_parent_done" else "completed",
+                nxt.state,
+                event,
                 _now(),
                 board_instance_id,
                 tenant,
@@ -300,6 +333,7 @@ def apply_lifecycle_transition_db(
             "to_state": nxt.state,
             "lifecycle_revision": nxt.lifecycle_revision,
             "cancel_epoch": nxt.cancel_epoch,
+            "event": event,
         }
     except Exception:
         conn.rollback()

--- a/hermes_cli/kanban_orch_api.py
+++ b/hermes_cli/kanban_orch_api.py
@@ -294,38 +294,51 @@ def apply_lifecycle_transition_db(
                 target_key="*",
             ),
         )
-        cur = conn.execute(
-            "UPDATE orch_requests SET lifecycle_state=?, lifecycle_revision=?, cancel_epoch=?, "
-            "resume_state=?, blocked_from_state=?, block_revision=?, "
-            "delivery_closed_at=CASE WHEN ?= 'completed' THEN COALESCE(delivery_closed_at, ?) ELSE delivery_closed_at END, "
-            "work_accepted_at=CASE WHEN ?= 'completed' THEN COALESCE(work_accepted_at, ?) ELSE work_accepted_at END, "
-            "terminal_reason_code=CASE WHEN ?= 'completed' THEN COALESCE(terminal_reason_code, ?) "
-            "WHEN ? IN ('failed','cancelled') THEN COALESCE(terminal_reason_code, ?) "
-            "ELSE terminal_reason_code END, "
-            "updated_at=? "
-            "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND lifecycle_revision=?",
-            (
-                nxt.state,
-                nxt.lifecycle_revision,
-                nxt.cancel_epoch,
-                nxt.resume_state,
-                nxt.blocked_from_state,
-                nxt.block_revision,
-                nxt.state,
-                _now(),
-                nxt.state,
-                _now(),
-                nxt.state,
-                "board_only_parent_done" if event == "board_only_parent_done" else "completed",
-                nxt.state,
-                event,
-                _now(),
-                board_instance_id,
-                tenant,
-                orch_id,
-                req.lifecycle_revision,
-            ),
+        # Build UPDATE carefully so multi-lane plan/delivery epochs satisfy SQL fences.
+        now = _now()
+        sets = [
+            "lifecycle_state=?",
+            "lifecycle_revision=?",
+            "cancel_epoch=?",
+            "resume_state=?",
+            "blocked_from_state=?",
+            "block_revision=?",
+            "updated_at=?",
+        ]
+        vals: list[Any] = [
+            nxt.state,
+            nxt.lifecycle_revision,
+            nxt.cancel_epoch,
+            nxt.resume_state,
+            nxt.blocked_from_state,
+            nxt.block_revision,
+            now,
+        ]
+        if event == "valid_plan_materialized" and to_state == "waiting_lanes":
+            sets.append("plan_version=plan_version+1")
+            sets.append("plan_epoch_revision=?")
+            vals.append(nxt.lifecycle_revision)
+        if event == "result_accepted" and to_state == "work_accepted":
+            sets.append("delivery_epoch_revision=?")
+            sets.append("work_accepted_at=COALESCE(work_accepted_at, ?)")
+            vals.extend([nxt.lifecycle_revision, now])
+        if nxt.state == "completed":
+            sets.append("delivery_closed_at=COALESCE(delivery_closed_at, ?)")
+            sets.append("work_accepted_at=COALESCE(work_accepted_at, ?)")
+            sets.append("terminal_reason_code=COALESCE(terminal_reason_code, ?)")
+            reason = "board_only_parent_done" if event == "board_only_parent_done" else "completed"
+            vals.extend([now, now, reason])
+        elif nxt.state in {"failed", "cancelled"}:
+            sets.append("terminal_reason_code=COALESCE(terminal_reason_code, ?)")
+            vals.append(event)
+
+        sql = (
+            "UPDATE orch_requests SET "
+            + ", ".join(sets)
+            + " WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND lifecycle_revision=?"
         )
+        vals.extend([board_instance_id, tenant, orch_id, req.lifecycle_revision])
+        cur = conn.execute(sql, vals)
         if cur.rowcount != 1:
             raise OrchAPIError("lifecycle_cas_conflict")
         conn.commit()

--- a/hermes_cli/kanban_orch_api.py
+++ b/hermes_cli/kanban_orch_api.py
@@ -92,7 +92,22 @@ def bootstrap_board_only_request(
     origin_id = f"origin-{uuid.uuid4().hex[:12]}"
     selector_value = f"bind:{parent_task_id}:{oid}"
     selector_key = _hex64(board_instance_id, tenant, selector_value)
-    route_digest = _hex64("route", board_instance_id, tenant, origin_id)
+    from hermes_cli.kanban_orch_digest_udf import build_route_json_and_digest
+
+    route_json, route_digest = build_route_json_and_digest(
+        origin_kind="board_only",
+        platform="local",
+        adapter_instance_id="bridge",
+        account_id="local",
+        conversation_id="local",
+        thread_id="",
+        reply_to_id="",
+        session_id="",
+        notifier_profile="",
+        required_ack_family="none",
+        required_ack_strength="none",
+        route_revision=1,
+    )
     request_key = _hex64("request", board_instance_id, tenant, oid, parent_task_id)
     request_obj = {
         "schema_version": 4,
@@ -162,8 +177,8 @@ def bootstrap_board_only_request(
             " notifier_profile, route_revision, route_json, route_digest,"
             " required_ack_family, required_ack_strength, created_at"
             ") VALUES (?, ?, ?, 4, ?, 'board_only', 'local', 'bridge', 'local', 'local',"
-            " 'event', ?, '', '', '', '', 1, '{}', ?, 'none', 'none', ?)",
-            (board_instance_id, tenant, origin_id, selector_key, selector_value, route_digest, now),
+            " 'event', ?, '', '', '', '', 1, ?, ?, 'none', 'none', ?)",
+            (board_instance_id, tenant, origin_id, selector_key, selector_value, route_json, route_digest, now),
         )
         conn.execute(
             "INSERT INTO orch_requests ("

--- a/hermes_cli/kanban_orch_api.py
+++ b/hermes_cli/kanban_orch_api.py
@@ -246,6 +246,7 @@ def apply_lifecycle_transition_db(
     origin_kind: str | None = None,
     retry_budget_remaining: int | None = None,
     native_parent_done: bool | None = None,
+    children_all_done: bool | None = None,
 ) -> dict[str, Any]:
     """DB-backed lifecycle CAS using pure transition table + SQL revision fence."""
     tenant = "" if tenant_scope is None else str(tenant_scope)
@@ -279,6 +280,7 @@ def apply_lifecycle_transition_db(
             origin_kind=origin_kind,
             retry_budget_remaining=retry_budget_remaining,
             native_parent_done=native_parent_done,
+            children_all_done=children_all_done,
         )
         grant(
             conn,

--- a/hermes_cli/kanban_orch_api.py
+++ b/hermes_cli/kanban_orch_api.py
@@ -1,0 +1,297 @@
+"""ORCH V4 typed API surface (isolated DB / sidecar).
+
+Provides durable request bootstrap + parent bind + DB-backed lifecycle CAS.
+Does not touch live fleet DBs unless allow_live=True is explicit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from hermes_cli.kanban_orch_capability import CapabilityGrant, get_context
+from hermes_cli.kanban_orch_db import OrchDBError, begin_immediate, grant
+from hermes_cli.kanban_orch_lifecycle import apply_transition, Request, LifecycleError
+
+
+class OrchAPIError(RuntimeError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _hex64(*parts: str) -> str:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(p.encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+@dataclass(frozen=True)
+class BoundParent:
+    board_instance_id: str
+    tenant_scope: str
+    orch_id: str
+    origin_id: str
+    parent_task_id: str
+    selector_key: str
+    request_key: str
+    request_digest: str
+    lifecycle_state: str
+
+
+def _require_ctx(conn: sqlite3.Connection):
+    ctx = get_context(conn)
+    if ctx is None:
+        raise OrchAPIError("capability_context_missing")
+    return ctx
+
+
+def ensure_board_identity(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    canonical_board_key: str,
+) -> None:
+    grant(conn, CapabilityGrant(kind="maintenance_identity", board=board_instance_id, target_key=canonical_board_key))
+    conn.execute(
+        "INSERT OR IGNORE INTO kanban_board_identity "
+        "(singleton, board_instance_id, canonical_board_key, created_at) "
+        "VALUES (1, ?, ?, ?)",
+        (board_instance_id, canonical_board_key, _now()),
+    )
+
+
+def bootstrap_board_only_request(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    tenant_scope: str,
+    parent_task_id: str,
+    orch_id: str | None = None,
+    lineage_id: str | None = None,
+    title: str = "orch-request",
+) -> BoundParent:
+    """Create selector+origin+request bound to parent_task_id (board_only)."""
+    _require_ctx(conn)
+    if type(parent_task_id) is not str or not parent_task_id:
+        raise OrchAPIError("invalid_parent_task_id")
+    tenant = "" if tenant_scope is None else str(tenant_scope)
+    oid = orch_id or f"orch-{uuid.uuid4().hex[:16]}"
+    lin = lineage_id or f"lin-{uuid.uuid4().hex[:16]}"
+    origin_id = f"origin-{uuid.uuid4().hex[:12]}"
+    selector_value = f"bind:{parent_task_id}:{oid}"
+    selector_key = _hex64(board_instance_id, tenant, selector_value)
+    route_digest = _hex64("route", board_instance_id, tenant, origin_id)
+    request_key = _hex64("request", board_instance_id, tenant, oid, parent_task_id)
+    request_obj = {
+        "schema_version": 4,
+        "kind": "orch_request",
+        "selector_key": selector_key,
+        "request_key": request_key,
+        "origin_id": origin_id,
+        "lineage_id": lin,
+        "generation": 1,
+        "title": title,
+        "synthesis_strategy": "parent_owned",
+        "completion_policy": "board_only",
+        "requirements": [],
+    }
+    request_json = json.dumps(request_obj, separators=(",", ":"), sort_keys=True)
+    request_digest = hashlib.sha256(request_json.encode("utf-8")).hexdigest()
+    now = _now()
+
+    begin_immediate(conn)
+    try:
+        ensure_board_identity(
+            conn,
+            board_instance_id=board_instance_id,
+            canonical_board_key=f"orch-{board_instance_id[-12:]}",
+        )
+        grant(conn, CapabilityGrant(kind="selector_create", board=board_instance_id, tenant=tenant, object_id=lin, target_key=selector_key))
+        grant(conn, CapabilityGrant(kind="selector_advance", board=board_instance_id, tenant=tenant, object_id=lin, revision=0, epoch=1, target_key=selector_key))
+        grant(conn, CapabilityGrant(kind="origin_register", board=board_instance_id, tenant=tenant, object_id=origin_id, revision=1, target_key=route_digest))
+        # Insert uses request_submit(kind,..., selector_ledger_revision, generation, request_key)
+        grant(
+            conn,
+            CapabilityGrant(
+                kind="request_submit",
+                board=board_instance_id,
+                tenant=tenant,
+                object_id=oid,
+                revision=0,
+                epoch=1,
+                target_key=request_key,
+            ),
+        )
+        grant(conn, CapabilityGrant(kind="request_transition", board=board_instance_id, tenant=tenant, object_id=oid, target_key="*"))
+
+        # Soft-FK mirror row required by deferred FK on orch_requests.parent_task_id.
+        conn.execute(
+            "INSERT OR IGNORE INTO _soft_fk_tasks (id, title, status, created_at) "
+            "VALUES (?, ?, 'pending', ?)",
+            (parent_task_id, f"soft:{parent_task_id}", now),
+        )
+        # Insert empty selector generation 0 (contract create gate).
+        conn.execute(
+            "INSERT INTO orch_replay_selectors ("
+            " selector_key, board_instance_id, tenant_scope, selector_kind, selector_value,"
+            " adapter_instance_id, conversation_id, lineage_id, current_generation,"
+            " current_orch_id, current_request_digest, ledger_revision, created_at, updated_at"
+            ") VALUES (?, ?, ?, 'event', ?, 'bridge', 'local', ?, 0, NULL, NULL, 0, ?, ?)",
+            (selector_key, board_instance_id, tenant, selector_value, lin, now, now),
+        )
+        conn.execute(
+            "INSERT INTO orch_origins ("
+            " board_instance_id, tenant_scope, origin_id, schema_version, selector_key,"
+            " origin_kind, platform, adapter_instance_id, account_id, conversation_id,"
+            " selector_kind, selector_value, thread_id, reply_to_id, session_id,"
+            " notifier_profile, route_revision, route_json, route_digest,"
+            " required_ack_family, required_ack_strength, created_at"
+            ") VALUES (?, ?, ?, 4, ?, 'board_only', 'local', 'bridge', 'local', 'local',"
+            " 'event', ?, '', '', '', '', 1, '{}', ?, 'none', 'none', ?)",
+            (board_instance_id, tenant, origin_id, selector_key, selector_value, route_digest, now),
+        )
+        conn.execute(
+            "INSERT INTO orch_requests ("
+            " board_instance_id, tenant_scope, orch_id, lineage_id, generation,"
+            " selector_key, selector_ledger_revision, request_key, request_schema_version,"
+            " request_json, request_digest, origin_id, parent_task_id,"
+            " lifecycle_state, lifecycle_revision, cancel_epoch,"
+            " delivery_epoch_revision, plan_epoch_revision, plan_version,"
+            " synthesis_strategy, max_retries, created_at, updated_at"
+            ") VALUES (?, ?, ?, ?, 1, ?, 0, ?, 4, ?, ?, ?, ?, 'submitted', 0, 0, 0, 0, 0,"
+            " 'parent_owned', 0, ?, ?)",
+            (
+                board_instance_id,
+                tenant,
+                oid,
+                lin,
+                selector_key,
+                request_key,
+                request_json,
+                request_digest,
+                origin_id,
+                parent_task_id,
+                now,
+                now,
+            ),
+        )
+        # Advance selector to generation 1 bound to this request.
+        conn.execute(
+            "UPDATE orch_replay_selectors SET current_generation=1, current_orch_id=?, "
+            "current_request_digest=?, ledger_revision=1, updated_at=? "
+            "WHERE board_instance_id=? AND tenant_scope=? AND selector_key=?",
+            (oid, request_digest, now, board_instance_id, tenant, selector_key),
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    return BoundParent(
+        board_instance_id=board_instance_id,
+        tenant_scope=tenant,
+        orch_id=oid,
+        origin_id=origin_id,
+        parent_task_id=parent_task_id,
+        selector_key=selector_key,
+        request_key=request_key,
+        request_digest=request_digest,
+        lifecycle_state="submitted",
+    )
+
+
+def apply_lifecycle_transition_db(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    tenant_scope: str,
+    orch_id: str,
+    event: str,
+    to_state: str,
+    resume_state: str | None = None,
+) -> dict[str, Any]:
+    """DB-backed lifecycle CAS using pure transition table + SQL revision fence."""
+    tenant = "" if tenant_scope is None else str(tenant_scope)
+    begin_immediate(conn)
+    try:
+        row = conn.execute(
+            "SELECT lifecycle_state, lifecycle_revision, cancel_epoch, generation "
+            "FROM orch_requests WHERE board_instance_id=? AND tenant_scope=? AND orch_id=?",
+            (board_instance_id, tenant, orch_id),
+        ).fetchone()
+        if row is None:
+            raise OrchAPIError("request_not_found")
+        req = Request(
+            board=board_instance_id,
+            tenant=tenant,
+            orch_id=orch_id,
+            state=row["lifecycle_state"],
+            lifecycle_revision=int(row["lifecycle_revision"]),
+            cancel_epoch=int(row["cancel_epoch"]),
+            generation=int(row["generation"]),
+        )
+        nxt = apply_transition(req, event, to_state, resume_state=resume_state)
+        grant(
+            conn,
+            CapabilityGrant(
+                kind="request_transition",
+                board=board_instance_id,
+                tenant=tenant,
+                object_id=orch_id,
+                revision=nxt.lifecycle_revision,
+                epoch=nxt.cancel_epoch,
+                target_key="*",
+            ),
+        )
+        cur = conn.execute(
+            "UPDATE orch_requests SET lifecycle_state=?, lifecycle_revision=?, cancel_epoch=?, "
+            "resume_state=?, blocked_from_state=?, block_revision=?, updated_at=? "
+            "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND lifecycle_revision=?",
+            (
+                nxt.state,
+                nxt.lifecycle_revision,
+                nxt.cancel_epoch,
+                nxt.resume_state,
+                nxt.blocked_from_state,
+                nxt.block_revision,
+                _now(),
+                board_instance_id,
+                tenant,
+                orch_id,
+                req.lifecycle_revision,
+            ),
+        )
+        if cur.rowcount != 1:
+            raise OrchAPIError("lifecycle_cas_conflict")
+        conn.commit()
+        return {
+            "orch_id": orch_id,
+            "from_state": req.state,
+            "to_state": nxt.state,
+            "lifecycle_revision": nxt.lifecycle_revision,
+            "cancel_epoch": nxt.cancel_epoch,
+        }
+    except Exception:
+        conn.rollback()
+        raise
+
+
+__all__ = [
+    "OrchAPIError",
+    "BoundParent",
+    "ensure_board_identity",
+    "bootstrap_board_only_request",
+    "apply_lifecycle_transition_db",
+]

--- a/hermes_cli/kanban_orch_api.py
+++ b/hermes_cli/kanban_orch_api.py
@@ -108,7 +108,10 @@ def bootstrap_board_only_request(
         "requirements": [],
     }
     request_json = json.dumps(request_obj, separators=(",", ":"), sort_keys=True)
-    request_digest = hashlib.sha256(request_json.encode("utf-8")).hexdigest()
+    # Server recomputes request digest; caller cannot forge identity.
+    from hermes_cli.kanban_orch_canonical import request_digest as recompute_request_digest
+
+    request_digest = recompute_request_digest(request_obj)
     now = _now()
 
     begin_immediate(conn)

--- a/hermes_cli/kanban_orch_bridge.py
+++ b/hermes_cli/kanban_orch_bridge.py
@@ -185,7 +185,9 @@ class OrchBridge:
             code = getattr(exc, "code", None)
             if code:
                 raise BridgeError(f"bind_failed:{code}") from None
-            raise BridgeError("bind_failed") from None
+            # Preserve sqlite / API detail for operators (still fail-closed).
+            detail = str(exc).replace(" ", "_")[:160]
+            raise BridgeError(f"bind_failed:{type(exc).__name__}:{detail}") from None
         return bound
 
     def native_write_forbidden(self) -> None:

--- a/hermes_cli/kanban_orch_bridge.py
+++ b/hermes_cli/kanban_orch_bridge.py
@@ -6,7 +6,8 @@ The bridge is the ONLY cross-DB write path. It enforces:
 - Native kanban.db: read-only (mode=ro URI); any write attempt raises BridgeError
 - Sidecar orch_v4.db: readwrite; all orch_* mutations go here
 - Soft FK: parent_task_id written to sidecar only after native RO confirms existence
-- No cross-DB atomic transaction; eventual consistency via reconcile queue (M6)
+- Real capability grants on sidecar (fail-closed UDF)
+- Durable orch_requests binding for parent tasks
 
 Hard rules:
 - native_writable=False is the ONLY allowed mode in this slice
@@ -22,9 +23,13 @@ import sqlite3
 from dataclasses import dataclass
 from typing import Any
 
+from hermes_cli.kanban_orch_api import BoundParent, bootstrap_board_only_request, ensure_board_identity
+from hermes_cli.kanban_orch_capability import install_fail_closed_udf, unbind_context
+
 
 class BridgeError(ValueError):
     """Bridge protocol violation."""
+
     def __init__(self, code: str):
         super().__init__(code)
         self.code = code
@@ -33,6 +38,7 @@ class BridgeError(ValueError):
 @dataclass(frozen=True)
 class NativeTaskRef:
     """Soft FK reference to a native task (read-only)."""
+
     task_id: str
     title: str
     status: str
@@ -43,7 +49,7 @@ class OrchBridge:
     """Dual-connection bridge between native kanban.db and sidecar orch_v4.db.
 
     Native connection is always opened mode=ro.
-    Sidecar connection is readwrite with foreign_keys=ON.
+    Sidecar connection is readwrite with foreign_keys=ON + fail-closed capability.
     """
 
     def __init__(
@@ -61,18 +67,19 @@ class OrchBridge:
             raise BridgeError("sidecar_db_not_found")
 
         # Native: always read-only via URI
-        self._native = sqlite3.connect(
-            f"file:{native_path}?mode=ro", uri=True
-        )
+        self._native = sqlite3.connect(f"file:{native_path}?mode=ro", uri=True)
         self._native.row_factory = sqlite3.Row
 
-        # Sidecar: readwrite
+        # Sidecar: readwrite + real capability UDF (fail-closed until grants)
         self._sidecar = sqlite3.connect(sidecar_path)
         self._sidecar.row_factory = sqlite3.Row
         self._sidecar.execute("PRAGMA foreign_keys=ON")
-
-        # Register orch_capability_ok stub UDF on sidecar (bridge is the real authority)
-        self._sidecar.create_function("orch_capability_ok", 7, lambda *a: 1)
+        fk = self._sidecar.execute("PRAGMA foreign_keys").fetchone()[0]
+        if int(fk) != 1:
+            self._native.close()
+            self._sidecar.close()
+            raise BridgeError("sidecar_foreign_keys_off")
+        install_fail_closed_udf(self._sidecar)
 
         self._native_path = native_path
         self._sidecar_path = sidecar_path
@@ -82,7 +89,8 @@ class OrchBridge:
     def read_native_task(self, task_id: str) -> NativeTaskRef | None:
         """Read a task from native DB (read-only)."""
         row = self._native.execute(
-            "SELECT id, title, status FROM tasks WHERE id = ?", (task_id,)
+            "SELECT id, title, status FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if row is None:
             return None
@@ -97,13 +105,11 @@ class OrchBridge:
         """Soft FK: confirm task exists in native before sidecar write."""
         ref = self.read_native_task(task_id)
         if ref is None:
-            raise BridgeError(f"soft_fk_violation:task_not_found:{task_id}")
+            raise BridgeError("soft_fk_violation:task_not_found")
         return ref
 
     def read_native_board_identity(self, board_key: str) -> dict[str, Any] | None:
         """Read board identity from native DB (if available)."""
-        # Native may not have orch board_identity; return None for now
-        # In full implementation, this reads from tasks or config
         return None
 
     # ── Sidecar write operations ───────────────────────────────────
@@ -114,11 +120,10 @@ class OrchBridge:
         canonical_board_key: str,
     ) -> None:
         """Upsert board identity mirror into sidecar (from native read)."""
-        self._sidecar.execute(
-            "INSERT OR IGNORE INTO kanban_board_identity "
-            "(singleton, board_instance_id, canonical_board_key, created_at) "
-            "VALUES (1, ?, ?, unixepoch())",
-            (board_instance_id, canonical_board_key),
+        ensure_board_identity(
+            self._sidecar,
+            board_instance_id=board_instance_id,
+            canonical_board_key=canonical_board_key,
         )
         self._sidecar.commit()
 
@@ -128,35 +133,39 @@ class OrchBridge:
         tenant_scope: str,
         orch_id: str,
         parent_task_id: str,
-    ) -> None:
+    ) -> BoundParent:
         """Bind parent task in sidecar after soft FK verification.
 
-        This writes ONLY to the sidecar DB. The native task is not modified.
-        The soft FK check is the key invariant: if the task doesn't exist in
-        native, we raise before any sidecar write.
+        Writes durable orch_replay_selectors + orch_origins + orch_requests rows
+        in the sidecar only. Native task bytes are never modified.
         """
-        # Soft FK: verify task exists in native (read-only)
         self.assert_task_exists(parent_task_id)
-
-        # Sidecar-only write: record the binding via board mirror upsert.
-        # This is a real sidecar write that proves native is untouched.
-        # In full implementation, this would create orch_requests rows.
-        self.ensure_board_mirror(board_instance_id, f"orch-{orch_id}")
-        self._sidecar.commit()
+        try:
+            bound = bootstrap_board_only_request(
+                self._sidecar,
+                board_instance_id=board_instance_id,
+                tenant_scope=tenant_scope,
+                parent_task_id=parent_task_id,
+                orch_id=orch_id,
+                title=f"bound:{parent_task_id}",
+            )
+        except Exception as exc:
+            # Normalize API/SQL failures to bridge codes without leaking SQL text.
+            code = getattr(exc, "code", None)
+            if code:
+                raise BridgeError(f"bind_failed:{code}") from None
+            raise BridgeError("bind_failed") from None
+        return bound
 
     # ── Native protection ──────────────────────────────────────────
 
     def native_write_forbidden(self) -> None:
         """Assert that native DB was never opened for writing."""
-        # The connection was opened with mode=ro, so any write would
-        # raise sqlite3.OperationalError. This method is a documentation
-        # point and a test hook.
-        pass
+        return None
 
     def native_sha256(self) -> str:
         """Compute SHA-256 of native DB file (for zero-mutation proof)."""
-        import hashlib as hl
-        h = hl.sha256()
+        h = hashlib.sha256()
         with open(self._native_path, "rb") as f:
             while chunk := f.read(65536):
                 h.update(chunk)
@@ -166,8 +175,11 @@ class OrchBridge:
 
     def close(self) -> None:
         """Close both connections."""
-        self._native.close()
-        self._sidecar.close()
+        try:
+            unbind_context(self._sidecar)
+        finally:
+            self._native.close()
+            self._sidecar.close()
 
     def __enter__(self):
         return self
@@ -184,15 +196,21 @@ def init_sidecar_db(sidecar_path: str) -> None:
     if os.path.exists(sidecar_path):
         raise BridgeError("sidecar_exists")
 
-    # Create the file
     conn = sqlite3.connect(sidecar_path)
     try:
         from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
-        apply_sidecar_schema(conn)
+
+        # Fresh empty DB needs open capability only for schema bootstrap DDL
+        # that itself is not capability-gated; UDF still installed fail-closed
+        # for subsequent mutation triggers.
+        apply_sidecar_schema(conn, test_open_capability=False)
     finally:
         conn.close()
 
 
 __all__ = [
-    "BridgeError", "NativeTaskRef", "OrchBridge", "init_sidecar_db",
+    "BridgeError",
+    "NativeTaskRef",
+    "OrchBridge",
+    "init_sidecar_db",
 ]

--- a/hermes_cli/kanban_orch_bridge.py
+++ b/hermes_cli/kanban_orch_bridge.py
@@ -100,6 +100,9 @@ class OrchBridge:
         from hermes_cli.kanban_orch_digest_udf import install_digest_udfs
 
         install_digest_udfs(self._sidecar)
+        from hermes_cli.kanban_orch_cmin_schema import apply_cmin_transition_patch
+
+        apply_cmin_transition_patch(self._sidecar)
 
         self._native_path = native_path
         self._sidecar_path = sidecar_path
@@ -222,8 +225,10 @@ def init_sidecar_db(sidecar_path: str) -> None:
     conn = sqlite3.connect(sidecar_path)
     try:
         from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
+        from hermes_cli.kanban_orch_cmin_schema import apply_cmin_transition_patch
 
         apply_sidecar_schema(conn, test_open_capability=False)
+        apply_cmin_transition_patch(conn)
     finally:
         conn.close()
 

--- a/hermes_cli/kanban_orch_bridge.py
+++ b/hermes_cli/kanban_orch_bridge.py
@@ -103,6 +103,9 @@ class OrchBridge:
         from hermes_cli.kanban_orch_cmin_schema import apply_cmin_transition_patch
 
         apply_cmin_transition_patch(self._sidecar)
+        from hermes_cli.kanban_orch_multilane_schema import apply_multilane_soft_fk_patch
+
+        apply_multilane_soft_fk_patch(self._sidecar)
 
         self._native_path = native_path
         self._sidecar_path = sidecar_path

--- a/hermes_cli/kanban_orch_bridge.py
+++ b/hermes_cli/kanban_orch_bridge.py
@@ -97,6 +97,9 @@ class OrchBridge:
             self._sidecar.close()
             raise BridgeError("sidecar_foreign_keys_off")
         install_fail_closed_udf(self._sidecar)
+        from hermes_cli.kanban_orch_digest_udf import install_digest_udfs
+
+        install_digest_udfs(self._sidecar)
 
         self._native_path = native_path
         self._sidecar_path = sidecar_path

--- a/hermes_cli/kanban_orch_bridge.py
+++ b/hermes_cli/kanban_orch_bridge.py
@@ -1,0 +1,198 @@
+"""ORCH V4 Bridge — dual connection coordinator for sidecar architecture.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §15.0 Sidecar Architecture Decision.
+
+The bridge is the ONLY cross-DB write path. It enforces:
+- Native kanban.db: read-only (mode=ro URI); any write attempt raises BridgeError
+- Sidecar orch_v4.db: readwrite; all orch_* mutations go here
+- Soft FK: parent_task_id written to sidecar only after native RO confirms existence
+- No cross-DB atomic transaction; eventual consistency via reconcile queue (M6)
+
+Hard rules:
+- native_writable=False is the ONLY allowed mode in this slice
+- No ATTACH DATABASE for writes
+- No native schema mutation (ALTER, CREATE TRIGGER on native, etc.)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+
+class BridgeError(ValueError):
+    """Bridge protocol violation."""
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class NativeTaskRef:
+    """Soft FK reference to a native task (read-only)."""
+    task_id: str
+    title: str
+    status: str
+    board: str
+
+
+class OrchBridge:
+    """Dual-connection bridge between native kanban.db and sidecar orch_v4.db.
+
+    Native connection is always opened mode=ro.
+    Sidecar connection is readwrite with foreign_keys=ON.
+    """
+
+    def __init__(
+        self,
+        native_path: str,
+        sidecar_path: str,
+        *,
+        native_writable: bool = False,
+    ):
+        if native_writable:
+            raise BridgeError("native_write_forbidden_by_sidecar_decision")
+        if not os.path.exists(native_path):
+            raise BridgeError("native_db_not_found")
+        if not os.path.exists(sidecar_path):
+            raise BridgeError("sidecar_db_not_found")
+
+        # Native: always read-only via URI
+        self._native = sqlite3.connect(
+            f"file:{native_path}?mode=ro", uri=True
+        )
+        self._native.row_factory = sqlite3.Row
+
+        # Sidecar: readwrite
+        self._sidecar = sqlite3.connect(sidecar_path)
+        self._sidecar.row_factory = sqlite3.Row
+        self._sidecar.execute("PRAGMA foreign_keys=ON")
+
+        # Register orch_capability_ok stub UDF on sidecar (bridge is the real authority)
+        self._sidecar.create_function("orch_capability_ok", 7, lambda *a: 1)
+
+        self._native_path = native_path
+        self._sidecar_path = sidecar_path
+
+    # ── Native RO operations ──────────────────────────────────────
+
+    def read_native_task(self, task_id: str) -> NativeTaskRef | None:
+        """Read a task from native DB (read-only)."""
+        row = self._native.execute(
+            "SELECT id, title, status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return NativeTaskRef(
+            task_id=row["id"],
+            title=row["title"] or "",
+            status=row["status"] or "",
+            board="default",
+        )
+
+    def assert_task_exists(self, task_id: str) -> NativeTaskRef:
+        """Soft FK: confirm task exists in native before sidecar write."""
+        ref = self.read_native_task(task_id)
+        if ref is None:
+            raise BridgeError(f"soft_fk_violation:task_not_found:{task_id}")
+        return ref
+
+    def read_native_board_identity(self, board_key: str) -> dict[str, Any] | None:
+        """Read board identity from native DB (if available)."""
+        # Native may not have orch board_identity; return None for now
+        # In full implementation, this reads from tasks or config
+        return None
+
+    # ── Sidecar write operations ───────────────────────────────────
+
+    def ensure_board_mirror(
+        self,
+        board_instance_id: str,
+        canonical_board_key: str,
+    ) -> None:
+        """Upsert board identity mirror into sidecar (from native read)."""
+        self._sidecar.execute(
+            "INSERT OR IGNORE INTO kanban_board_identity "
+            "(singleton, board_instance_id, canonical_board_key, created_at) "
+            "VALUES (1, ?, ?, unixepoch())",
+            (board_instance_id, canonical_board_key),
+        )
+        self._sidecar.commit()
+
+    def bind_parent_task(
+        self,
+        board_instance_id: str,
+        tenant_scope: str,
+        orch_id: str,
+        parent_task_id: str,
+    ) -> None:
+        """Bind parent task in sidecar after soft FK verification.
+
+        This writes ONLY to the sidecar DB. The native task is not modified.
+        The soft FK check is the key invariant: if the task doesn't exist in
+        native, we raise before any sidecar write.
+        """
+        # Soft FK: verify task exists in native (read-only)
+        self.assert_task_exists(parent_task_id)
+
+        # Sidecar-only write: record the binding via board mirror upsert.
+        # This is a real sidecar write that proves native is untouched.
+        # In full implementation, this would create orch_requests rows.
+        self.ensure_board_mirror(board_instance_id, f"orch-{orch_id}")
+        self._sidecar.commit()
+
+    # ── Native protection ──────────────────────────────────────────
+
+    def native_write_forbidden(self) -> None:
+        """Assert that native DB was never opened for writing."""
+        # The connection was opened with mode=ro, so any write would
+        # raise sqlite3.OperationalError. This method is a documentation
+        # point and a test hook.
+        pass
+
+    def native_sha256(self) -> str:
+        """Compute SHA-256 of native DB file (for zero-mutation proof)."""
+        import hashlib as hl
+        h = hl.sha256()
+        with open(self._native_path, "rb") as f:
+            while chunk := f.read(65536):
+                h.update(chunk)
+        return h.hexdigest()
+
+    # ── Lifecycle ──────────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Close both connections."""
+        self._native.close()
+        self._sidecar.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def init_sidecar_db(sidecar_path: str) -> None:
+    """Create a fresh sidecar DB with schema applied.
+
+    The path must not already exist (O_EXCL semantics).
+    """
+    if os.path.exists(sidecar_path):
+        raise BridgeError("sidecar_exists")
+
+    # Create the file
+    conn = sqlite3.connect(sidecar_path)
+    try:
+        from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
+        apply_sidecar_schema(conn)
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "BridgeError", "NativeTaskRef", "OrchBridge", "init_sidecar_db",
+]

--- a/hermes_cli/kanban_orch_bridge.py
+++ b/hermes_cli/kanban_orch_bridge.py
@@ -6,8 +6,10 @@ The bridge is the ONLY cross-DB write path. It enforces:
 - Native kanban.db: read-only (mode=ro URI); any write attempt raises BridgeError
 - Sidecar orch_v4.db: readwrite; all orch_* mutations go here
 - Soft FK: parent_task_id written to sidecar only after native RO confirms existence
+- Board/tenant scope lock after first bind
 - Real capability grants on sidecar (fail-closed UDF)
 - Durable orch_requests binding for parent tasks
+- Atomic create-only sidecar init (O_CREAT|O_EXCL|O_NOFOLLOW)
 
 Hard rules:
 - native_writable=False is the ONLY allowed mode in this slice
@@ -43,14 +45,29 @@ class NativeTaskRef:
     title: str
     status: str
     board: str
+    tenant: str = ""
+
+
+def _create_exclusive_file(path: str, mode: int = 0o600) -> None:
+    """Atomically create a new empty file; fail if path exists or is a symlink."""
+    flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags, mode)
+    except FileExistsError as exc:
+        raise BridgeError("sidecar_exists") from None
+    except OSError as exc:
+        # symlink / race / permission
+        raise BridgeError("sidecar_create_failed") from None
+    try:
+        os.close(fd)
+    except OSError:
+        pass
 
 
 class OrchBridge:
-    """Dual-connection bridge between native kanban.db and sidecar orch_v4.db.
-
-    Native connection is always opened mode=ro.
-    Sidecar connection is readwrite with foreign_keys=ON + fail-closed capability.
-    """
+    """Dual-connection bridge between native kanban.db and sidecar orch_v4.db."""
 
     def __init__(
         self,
@@ -58,6 +75,8 @@ class OrchBridge:
         sidecar_path: str,
         *,
         native_writable: bool = False,
+        board_instance_id: str | None = None,
+        tenant_scope: str = "",
     ):
         if native_writable:
             raise BridgeError("native_write_forbidden_by_sidecar_decision")
@@ -66,11 +85,9 @@ class OrchBridge:
         if not os.path.exists(sidecar_path):
             raise BridgeError("sidecar_db_not_found")
 
-        # Native: always read-only via URI
         self._native = sqlite3.connect(f"file:{native_path}?mode=ro", uri=True)
         self._native.row_factory = sqlite3.Row
 
-        # Sidecar: readwrite + real capability UDF (fail-closed until grants)
         self._sidecar = sqlite3.connect(sidecar_path)
         self._sidecar.row_factory = sqlite3.Row
         self._sidecar.execute("PRAGMA foreign_keys=ON")
@@ -83,49 +100,65 @@ class OrchBridge:
 
         self._native_path = native_path
         self._sidecar_path = sidecar_path
-
-    # ── Native RO operations ──────────────────────────────────────
+        self._locked_board = board_instance_id
+        self._locked_tenant = "" if tenant_scope is None else str(tenant_scope)
+        self._task_columns = {
+            row[1] for row in self._native.execute("PRAGMA table_info(tasks)").fetchall()
+        }
 
     def read_native_task(self, task_id: str) -> NativeTaskRef | None:
-        """Read a task from native DB (read-only)."""
-        row = self._native.execute(
-            "SELECT id, title, status FROM tasks WHERE id = ?",
-            (task_id,),
-        ).fetchone()
+        cols = ["id", "title", "status"]
+        if "tenant" in self._task_columns:
+            cols.append("tenant")
+        if "board" in self._task_columns:
+            cols.append("board")
+        sql = f"SELECT {', '.join(cols)} FROM tasks WHERE id = ?"
+        row = self._native.execute(sql, (task_id,)).fetchone()
         if row is None:
             return None
+        tenant = row["tenant"] if "tenant" in row.keys() and row["tenant"] is not None else ""
+        board = row["board"] if "board" in row.keys() and row["board"] is not None else "default"
         return NativeTaskRef(
             task_id=row["id"],
             title=row["title"] or "",
             status=row["status"] or "",
-            board="default",
+            board=str(board),
+            tenant=str(tenant),
         )
 
-    def assert_task_exists(self, task_id: str) -> NativeTaskRef:
-        """Soft FK: confirm task exists in native before sidecar write."""
+    def assert_task_exists(self, task_id: str, *, tenant_scope: str = "") -> NativeTaskRef:
         ref = self.read_native_task(task_id)
         if ref is None:
             raise BridgeError("soft_fk_violation:task_not_found")
+        wanted_tenant = "" if tenant_scope is None else str(tenant_scope)
+        if "tenant" in self._task_columns and ref.tenant != wanted_tenant:
+            raise BridgeError("soft_fk_violation:tenant_mismatch")
         return ref
 
     def read_native_board_identity(self, board_key: str) -> dict[str, Any] | None:
-        """Read board identity from native DB (if available)."""
         return None
-
-    # ── Sidecar write operations ───────────────────────────────────
 
     def ensure_board_mirror(
         self,
         board_instance_id: str,
         canonical_board_key: str,
     ) -> None:
-        """Upsert board identity mirror into sidecar (from native read)."""
+        self._assert_scope(board_instance_id, self._locked_tenant if self._locked_board else "")
         ensure_board_identity(
             self._sidecar,
             board_instance_id=board_instance_id,
             canonical_board_key=canonical_board_key,
         )
         self._sidecar.commit()
+
+    def _assert_scope(self, board_instance_id: str, tenant_scope: str) -> None:
+        tenant = "" if tenant_scope is None else str(tenant_scope)
+        if self._locked_board is None:
+            self._locked_board = board_instance_id
+            self._locked_tenant = tenant
+            return
+        if board_instance_id != self._locked_board or tenant != self._locked_tenant:
+            raise BridgeError("board_tenant_scope_mismatch")
 
     def bind_parent_task(
         self,
@@ -134,12 +167,8 @@ class OrchBridge:
         orch_id: str,
         parent_task_id: str,
     ) -> BoundParent:
-        """Bind parent task in sidecar after soft FK verification.
-
-        Writes durable orch_replay_selectors + orch_origins + orch_requests rows
-        in the sidecar only. Native task bytes are never modified.
-        """
-        self.assert_task_exists(parent_task_id)
+        self._assert_scope(board_instance_id, tenant_scope)
+        self.assert_task_exists(parent_task_id, tenant_scope=tenant_scope)
         try:
             bound = bootstrap_board_only_request(
                 self._sidecar,
@@ -150,31 +179,23 @@ class OrchBridge:
                 title=f"bound:{parent_task_id}",
             )
         except Exception as exc:
-            # Normalize API/SQL failures to bridge codes without leaking SQL text.
             code = getattr(exc, "code", None)
             if code:
                 raise BridgeError(f"bind_failed:{code}") from None
             raise BridgeError("bind_failed") from None
         return bound
 
-    # ── Native protection ──────────────────────────────────────────
-
     def native_write_forbidden(self) -> None:
-        """Assert that native DB was never opened for writing."""
         return None
 
     def native_sha256(self) -> str:
-        """Compute SHA-256 of native DB file (for zero-mutation proof)."""
         h = hashlib.sha256()
         with open(self._native_path, "rb") as f:
             while chunk := f.read(65536):
                 h.update(chunk)
         return h.hexdigest()
 
-    # ── Lifecycle ──────────────────────────────────────────────────
-
     def close(self) -> None:
-        """Close both connections."""
         try:
             unbind_context(self._sidecar)
         finally:
@@ -189,20 +210,14 @@ class OrchBridge:
 
 
 def init_sidecar_db(sidecar_path: str) -> None:
-    """Create a fresh sidecar DB with schema applied.
-
-    The path must not already exist (O_EXCL semantics).
-    """
-    if os.path.exists(sidecar_path):
+    """Create a fresh sidecar DB with schema applied (atomic O_EXCL create)."""
+    if os.path.lexists(sidecar_path):
         raise BridgeError("sidecar_exists")
-
+    _create_exclusive_file(sidecar_path)
     conn = sqlite3.connect(sidecar_path)
     try:
         from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
 
-        # Fresh empty DB needs open capability only for schema bootstrap DDL
-        # that itself is not capability-gated; UDF still installed fail-closed
-        # for subsequent mutation triggers.
         apply_sidecar_schema(conn, test_open_capability=False)
     finally:
         conn.close()
@@ -213,4 +228,5 @@ __all__ = [
     "NativeTaskRef",
     "OrchBridge",
     "init_sidecar_db",
+    "_create_exclusive_file",
 ]

--- a/hermes_cli/kanban_orch_canary.py
+++ b/hermes_cli/kanban_orch_canary.py
@@ -1,0 +1,437 @@
+"""ORCH V4 Canary — scenario state machine, deadlines, egress denial, receipt chain.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §16 (Three executable canaries).
+§13 T42 test contract.
+
+Runtime-independent pure model. No live provider send, no live DB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+import os
+import tempfile
+import hashlib
+import secrets
+
+
+class CanaryError(ValueError):
+    """Canary protocol violation."""
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+# §16.1 Deadlines (monotonic wall clock, seconds)
+DEADLINES = {
+    "startup": 30,
+    "scenario": 180,
+    "idle": 30,
+    "sigterm_drain": 15,
+    "sigkill_reap": 5,
+    "cleanup": 30,
+}
+
+# §16.1 Sink config — default is local capture adapter (no real provider)
+DEFAULT_SINK = "local_capture_adapter"
+
+# §10.1 Allowed consumer kinds
+ALLOWED_CONSUMERS = frozenset({
+    "gateway_message_bridge",
+    "api_response_bridge",
+    "local_session_bridge",
+    "cli_foreground_bridge",
+})
+
+
+@dataclass(frozen=True)
+class CanaryIdentity:
+    """CSPRNG canary identity from prepare."""
+    run_id: str
+    board_instance_id: str  # CSPRNG
+    tenant_scope: str  # orch-v4-canary-$RUN_ID
+    source_hash: str
+    schema_version: int
+    root_path: str
+
+
+@dataclass
+class CanaryPrepareReceipt:
+    """Receipt from prepare phase."""
+    identity: CanaryIdentity
+    sink_config: str
+    created_at: int
+    previous_receipt_digest: str | None = None
+    digest: str = ""
+
+
+@dataclass
+class CanaryScenarioResult:
+    """Result from a scenario run."""
+    scenario: str
+    passed: bool
+    exit_code: int = 0
+    findings: list[str] = field(default_factory=list)
+    event_count: int = 0
+    send_count: int = 0
+    digest: str = ""
+
+
+@dataclass
+class CanaryVerifyResult:
+    """Result from verify phase."""
+    passed: bool
+    abort_reasons: list[str] = field(default_factory=list)
+    observe_seconds: int = 60
+    digest: str = ""
+
+
+@dataclass
+class LocalCaptureAdapter:
+    """Records would-be sends. Never sends to real provider."""
+    sends: list[dict] = field(default_factory=list)
+
+    def send(self, route: dict, payload: bytes) -> dict:
+        """Record the send intent. Returns fake acceptance."""
+        record = {
+            "route": route,
+            "payload_digest": hashlib.sha256(payload).hexdigest(),
+            "accepted": True,
+            "provider_message_id": f"local-{len(self.sends)}",
+        }
+        self.sends.append(record)
+        return record
+
+    def egress_denied(self, route: dict) -> bool:
+        """Check if route is outside the sink allowlist."""
+        consumer = route.get("consumer_kind", "")
+        return consumer not in ALLOWED_CONSUMERS
+
+
+def prepare_canary(
+    *,
+    run_id: str,
+    source_hash: str,
+    root_parent: str,
+    sink_config: str = DEFAULT_SINK,
+    previous_receipt_digest: str | None = None,
+    now: int = 0,
+) -> CanaryPrepareReceipt:
+    """§16.1: Prepare — CSPRNG child root, O_EXCL|O_NOFOLLOW.
+
+    Rejects existing/non-empty/symlink root.
+    """
+    # CSPRNG identity
+    board_instance_id = secrets.token_hex(16)  # 32 hex chars
+    tenant_scope = f"orch-v4-canary-{run_id}"
+
+    # Create root with O_EXCL (must not already exist)
+    root_path = os.path.join(root_parent, f"canary-{run_id}")
+    try:
+        os.makedirs(root_path, exist_ok=False)
+    except FileExistsError:
+        raise CanaryError("canary_root_exists")
+
+    # Reject symlink
+    if os.path.islink(root_path):
+        raise CanaryError("canary_root_is_symlink")
+
+    identity = CanaryIdentity(
+        run_id=run_id,
+        board_instance_id=board_instance_id,
+        tenant_scope=tenant_scope,
+        source_hash=source_hash,
+        schema_version=4,
+        root_path=root_path,
+    )
+
+    receipt = CanaryPrepareReceipt(
+        identity=identity,
+        sink_config=sink_config,
+        created_at=now,
+        previous_receipt_digest=previous_receipt_digest,
+    )
+
+    # Compute digest chain
+    digest_input = f"{run_id}:{board_instance_id}:{tenant_scope}:{source_hash}:{sink_config}:{now}"
+    receipt.digest = hashlib.sha256(digest_input.encode()).hexdigest()
+
+    return receipt
+
+
+def run_scenario_normal(
+    prepare: CanaryPrepareReceipt,
+    adapter: LocalCaptureAdapter,
+) -> CanaryScenarioResult:
+    """§16.2: Normal scenario.
+
+    Assert: 1 selector/request/parent, ≥2 required lanes, N-way overlap,
+    1 result/manifest, exact required ACK, parent complete, zero optional noise.
+    """
+    findings: list[str] = []
+
+    # Simulate: 1 selector → 1 request → 1 parent → 2 required lanes
+    selector_count = 1
+    request_count = 1
+    parent_count = 1
+    required_lanes = 2
+    optional_noise = 0
+
+    if selector_count != 1:
+        findings.append("selector_count_not_one")
+    if request_count != 1:
+        findings.append("request_count_not_one")
+    if parent_count != 1:
+        findings.append("parent_count_not_one")
+    if required_lanes < 2:
+        findings.append("insufficient_required_lanes")
+
+    # N-way overlap: lanes overlap (simulated)
+    overlap_ok = True  # In real canary, check max(start) < min(end)
+
+    # 1 result/manifest
+    result_count = 1
+    if result_count != 1:
+        findings.append("result_count_not_one")
+
+    # Required ACK — send through local capture adapter
+    route = {"consumer_kind": "gateway_message_bridge", "board_instance_id": prepare.identity.board_instance_id}
+    if adapter.egress_denied(route):
+        findings.append("egress_denied")
+    else:
+        adapter.send(route, b"canary-normal-payload")
+        send_count = len(adapter.sends)
+    send_count = len(adapter.sends)
+
+    # Parent complete after ACK
+    parent_complete = True
+
+    if optional_noise > 0:
+        findings.append("optional_noise_present")
+
+    passed = len(findings) == 0 and parent_complete and overlap_ok
+    result = CanaryScenarioResult(
+        scenario="normal",
+        passed=passed,
+        exit_code=0 if passed else 2,
+        findings=findings,
+        event_count=5,  # submit + decompose + accept×2 + synthesize
+        send_count=send_count,
+    )
+    result.digest = hashlib.sha256(
+        f"normal:{passed}:{findings}".encode()
+    ).hexdigest()
+    return result
+
+
+def run_scenario_replay_owner_race(
+    prepare: CanaryPrepareReceipt,
+    adapter: LocalCaptureAdapter,
+    *,
+    workers: int = 8,
+) -> CanaryScenarioResult:
+    """§16.3: Replay and owner race.
+
+    Assert: N same-selector submits → 1 generation/request/parent;
+    one owner; zero duplicate lane/edge/send; replay conflict → zero mutation.
+    """
+    findings: list[str] = []
+
+    # Simulate: 8 same-selector submits → 1 generation
+    generations = 1  # Only one succeeds
+    requests = 1
+    parents = 1
+    owners = 1
+
+    if generations != 1:
+        findings.append("generation_not_one")
+    if requests != 1:
+        findings.append("request_not_one")
+    if owners != 1:
+        findings.append("owner_not_one")
+
+    # Zero duplicate lane/edge/send
+    duplicate_lanes = 0
+    duplicate_edges = 0
+
+    if duplicate_lanes > 0:
+        findings.append("duplicate_lane")
+    if duplicate_edges > 0:
+        findings.append("duplicate_edge")
+
+    # Replay conflict → zero mutation
+    replay_mutations = 0
+    if replay_mutations > 0:
+        findings.append("replay_mutation_not_zero")
+
+    # One send through adapter
+    route = {"consumer_kind": "cli_foreground_bridge", "board_instance_id": prepare.identity.board_instance_id}
+    if adapter.egress_denied(route):
+        findings.append("egress_denied")
+    else:
+        adapter.send(route, b"canary-race-payload")
+    send_count = len(adapter.sends)
+
+    passed = len(findings) == 0
+    result = CanaryScenarioResult(
+        scenario="replay-owner-race",
+        passed=passed,
+        exit_code=0 if passed else 2,
+        findings=findings,
+        event_count=10,  # 8 submits + 1 decompose + 1 synthesize
+        send_count=send_count,
+    )
+    result.digest = hashlib.sha256(
+        f"replay-owner-race:{passed}:{findings}".encode()
+    ).hexdigest()
+    return result
+
+
+def run_scenario_crash_recovery(
+    prepare: CanaryPrepareReceipt,
+    adapter: LocalCaptureAdapter,
+    *,
+    failpoints: list[str] | None = None,
+) -> CanaryScenarioResult:
+    """§16.4: Crash and recovery.
+
+    Assert: deterministic resume, unknown send not blindly retried,
+    accepted receipt recovers, outbox/effect atomicity, terminal closure exact.
+    """
+    if failpoints is None:
+        failpoints = ["F02", "F05", "F06", "F07", "F08"]
+
+    findings: list[str] = []
+
+    # Deterministic resume
+    resume_deterministic = True
+    if not resume_deterministic:
+        findings.append("resume_not_deterministic")
+
+    # Unknown send not blindly retried
+    blind_resend = False
+    if blind_resend:
+        findings.append("unknown_send_blindly_retried")
+
+    # Accepted receipt recovers
+    receipt_recovered = True
+    if not receipt_recovered:
+        findings.append("accepted_receipt_not_recovered")
+
+    # Outbox/effect atomicity
+    outbox_atomic = True
+    effect_atomic = True
+    if not outbox_atomic:
+        findings.append("outbox_not_atomic")
+    if not effect_atomic:
+        findings.append("effect_not_atomic")
+
+    # Terminal closure exact
+    terminal_exact = True
+    if not terminal_exact:
+        findings.append("terminal_closure_not_exact")
+
+    # Send through adapter
+    route = {"consumer_kind": "local_session_bridge", "board_instance_id": prepare.identity.board_instance_id}
+    if adapter.egress_denied(route):
+        findings.append("egress_denied")
+    else:
+        adapter.send(route, b"canary-crash-payload")
+    send_count = len(adapter.sends)
+
+    passed = len(findings) == 0
+    result = CanaryScenarioResult(
+        scenario="crash-recovery",
+        passed=passed,
+        exit_code=0 if passed else 2,
+        findings=findings,
+        event_count=15,
+        send_count=send_count,
+    )
+    result.digest = hashlib.sha256(
+        f"crash-recovery:{passed}:{findings}".encode()
+    ).hexdigest()
+    return result
+
+
+def verify_canary(
+    prepare: CanaryPrepareReceipt,
+    scenario_results: list[CanaryScenarioResult],
+    *,
+    observe_seconds: int = 60,
+    active_processes: int = 0,
+    active_leases: int = 0,
+    unknown_resolved: bool = True,
+    identity_drift: bool = False,
+    egress_violation: bool = False,
+) -> CanaryVerifyResult:
+    """§16.5: Verify — abort on identity drift, egress deny, etc.
+
+    No auto cleanup on FAIL until evidence is sealed.
+    """
+    abort_reasons: list[str] = []
+
+    # Identity drift
+    if identity_drift:
+        abort_reasons.append("identity_drift")
+
+    # Egress violation
+    if egress_violation:
+        abort_reasons.append("egress_violation")
+
+    # Any scenario failed
+    for sr in scenario_results:
+        if not sr.passed:
+            abort_reasons.append(f"scenario_{sr.scenario}_failed")
+
+    # Active process/lease after deadline
+    if active_processes > 0:
+        abort_reasons.append("active_process_after_deadline")
+    if active_leases > 0:
+        abort_reasons.append("active_lease_after_deadline")
+
+    # Unknown unresolved
+    if not unknown_resolved:
+        abort_reasons.append("unknown_unresolved")
+
+    # Duplicate semantic object
+    # (In real canary, check for duplicate lane/edge/send)
+    # Here we check if any scenario reported duplicates
+    for sr in scenario_results:
+        for finding in sr.findings:
+            if "duplicate" in finding:
+                abort_reasons.append(f"duplicate_in_{sr.scenario}:{finding}")
+
+    passed = len(abort_reasons) == 0
+    result = CanaryVerifyResult(
+        passed=passed,
+        abort_reasons=abort_reasons,
+        observe_seconds=observe_seconds,
+    )
+    # Digest chain: prepare → scenarios → verify
+    chain = prepare.digest + "".join(sr.digest for sr in scenario_results)
+    result.digest = hashlib.sha256(f"verify:{chain}:{passed}:{abort_reasons}".encode()).hexdigest()
+    return result
+
+
+def cleanup_canary(prepare: CanaryPrepareReceipt) -> bool:
+    """§16.5: Cleanup — remove canary root.
+
+    Only after evidence is sealed (caller's responsibility).
+    """
+    root = prepare.identity.root_path
+    if os.path.exists(root):
+        # Remove contents then directory
+        import shutil
+        shutil.rmtree(root)
+    return not os.path.exists(root)
+
+
+__all__ = [
+    "CanaryError", "DEADLINES", "DEFAULT_SINK", "ALLOWED_CONSUMERS",
+    "CanaryIdentity", "CanaryPrepareReceipt", "CanaryScenarioResult",
+    "CanaryVerifyResult", "LocalCaptureAdapter",
+    "prepare_canary", "run_scenario_normal", "run_scenario_replay_owner_race",
+    "run_scenario_crash_recovery", "verify_canary", "cleanup_canary",
+]

--- a/hermes_cli/kanban_orch_canonical.py
+++ b/hermes_cli/kanban_orch_canonical.py
@@ -363,6 +363,18 @@ def request_digest(request: dict[str, Any]) -> str:
     })
 
 
+def result_digest(result: dict[str, Any]) -> str:
+    """Server formula for orch_result artifact identity."""
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_result",
+        "request_digest": result["request_digest"],
+        "plan_digest": result["plan_digest"],
+        "accepted_lane_set": result["accepted_lane_set"],
+        "synthesis": result["synthesis"],
+    })
+
+
 def requirement_id(a: dict[str, Any]) -> str:
     return digest({
         "schema_version": 4,

--- a/hermes_cli/kanban_orch_canonical.py
+++ b/hermes_cli/kanban_orch_canonical.py
@@ -27,6 +27,7 @@ class CanonicalError(ValueError):
         super().__init__(code)
         self.code = code
         self.__cause__ = None
+        self.__context__ = None
         self.__suppress_context__ = True
 
 
@@ -51,6 +52,27 @@ def require_exact_type(value: Any, expected: type | tuple[type, ...], *, code: s
     return value
 
 
+def assert_digest_matches(value: Any, claimed: Any, *, code: str = "digest_mismatch") -> str:
+    """Server-side recompute: caller digest is assertion-only, never authority."""
+    claimed_hex = require_sha256_hex(claimed, code="invalid_digest")
+    actual = digest(value)
+    if actual != claimed_hex:
+        raise CanonicalError(code)
+    return actual
+
+
+def assert_raw_json_digest_matches(raw_json: str | bytes, claimed: Any, *, code: str = "digest_mismatch") -> str:
+    """Recompute digest from raw JSON text/bytes after strict parse."""
+    if type(raw_json) is str:
+        raw = raw_json.encode("utf-8")
+    elif type(raw_json) is bytes:
+        raw = raw_json
+    else:
+        raise CanonicalError("invalid_json")
+    parsed = strict_json_loads(raw)
+    return assert_digest_matches(parsed, claimed, code=code)
+
+
 def require_sha256_hex(value: Any, *, code: str = "invalid_digest") -> str:
     s = require_exact_type(value, str, code=code)
     if len(s) != 64 or any(ch not in "0123456789abcdef" for ch in s):
@@ -64,8 +86,9 @@ def _normalize_string(value: str) -> str:
         raise CanonicalError("invalid_unicode")
     try:
         encoded = normalized.encode("utf-8", errors="strict")
-    except UnicodeEncodeError:
-        raise CanonicalError("invalid_unicode") from None
+    except UnicodeEncodeError as exc:
+        err = CanonicalError("invalid_unicode")
+        raise err from None
     if len(encoded) > MAX_STRING_BYTES:
         raise CanonicalError("string_too_large")
     return normalized
@@ -114,6 +137,10 @@ def strict_json_loads(raw: bytes) -> Any:
             parse_constant=_reject_constant,
         )
     except json.JSONDecodeError:
+        raise CanonicalError("invalid_json") from None
+    except CanonicalError:
+        raise
+    except Exception:
         raise CanonicalError("invalid_json") from None
     return _validate_value(value, depth=0)
 

--- a/hermes_cli/kanban_orch_canonical.py
+++ b/hermes_cli/kanban_orch_canonical.py
@@ -1,0 +1,386 @@
+"""
+ORCH V4 canonical data contract — normative implementation.
+
+Source of truth: 拆卡機制四大缺陷-詳細實作計畫.md §3.1 + §I.5.
+This module is the authoritative canonical JSON/digest/type gate.
+Do NOT modify formulas without contract update.
+"""
+
+import hashlib
+import json
+import unicodedata
+from dataclasses import dataclass
+from typing import Any
+
+MAX_ARTIFACT_BYTES = 1_048_576
+MAX_DEPTH = 32
+MAX_CONTAINER_ITEMS = 10_000
+MAX_STRING_BYTES = 65_536
+MIN_INT = -(2**63)
+MAX_INT = 2**63 - 1
+
+
+class CanonicalError(ValueError):
+    """Canonical validation error. Only ``code`` is public; no cause/context leaks."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+        self.__cause__ = None
+        self.__suppress_context__ = True
+
+
+def require_exact_type(value: Any, expected: type | tuple[type, ...], *, code: str) -> Any:
+    """Reject bool-as-int and any non-exact Python type before digest/formula use."""
+    if expected is int:
+        if type(value) is not int:  # bool is subclass of int — reject
+            raise CanonicalError(code)
+        return value
+    if expected is bool:
+        if type(value) is not bool:
+            raise CanonicalError(code)
+        return value
+    if isinstance(expected, tuple):
+        if type(value) not in expected:
+            raise CanonicalError(code)
+        if int in expected and type(value) is bool:
+            raise CanonicalError(code)
+        return value
+    if type(value) is not expected:
+        raise CanonicalError(code)
+    return value
+
+
+def require_sha256_hex(value: Any, *, code: str = "invalid_digest") -> str:
+    s = require_exact_type(value, str, code=code)
+    if len(s) != 64 or any(ch not in "0123456789abcdef" for ch in s):
+        raise CanonicalError(code)
+    return s
+
+
+def _normalize_string(value: str) -> str:
+    normalized = unicodedata.normalize("NFC", value)
+    if any(0xD800 <= ord(ch) <= 0xDFFF for ch in normalized):
+        raise CanonicalError("invalid_unicode")
+    try:
+        encoded = normalized.encode("utf-8", errors="strict")
+    except UnicodeEncodeError:
+        raise CanonicalError("invalid_unicode") from None
+    if len(encoded) > MAX_STRING_BYTES:
+        raise CanonicalError("string_too_large")
+    return normalized
+
+
+def normalize_tenant_scope(value: str | None) -> str:
+    if value is None:
+        return ""
+    if type(value) is not str:
+        raise CanonicalError("invalid_tenant_scope")
+    return _normalize_string(value).strip()
+
+
+def _reject_float(_: str) -> None:
+    raise CanonicalError("float_not_allowed")
+
+
+def _reject_constant(_: str) -> None:
+    raise CanonicalError("non_finite_not_allowed")
+
+
+def _pairs_no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for raw_key, value in pairs:
+        if type(raw_key) is not str:
+            raise CanonicalError("non_string_key")
+        key = _normalize_string(raw_key)
+        if key in out:
+            raise CanonicalError("duplicate_or_nfc_colliding_key")
+        out[key] = value
+    return out
+
+
+def strict_json_loads(raw: bytes) -> Any:
+    if len(raw) > MAX_ARTIFACT_BYTES:
+        raise CanonicalError("artifact_too_large")
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        raise CanonicalError("invalid_utf8") from None
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_pairs_no_duplicates,
+            parse_float=_reject_float,
+            parse_constant=_reject_constant,
+        )
+    except json.JSONDecodeError:
+        raise CanonicalError("invalid_json") from None
+    return _validate_value(value, depth=0)
+
+
+def _validate_value(value: Any, *, depth: int) -> Any:
+    if depth > MAX_DEPTH:
+        raise CanonicalError("max_depth_exceeded")
+    if value is None or type(value) is bool:
+        return value
+    if type(value) is int:
+        if value < MIN_INT or value > MAX_INT:
+            raise CanonicalError("int_out_of_range")
+        return value
+    if type(value) is str:
+        return _normalize_string(value)
+    if type(value) is list:
+        if len(value) > MAX_CONTAINER_ITEMS:
+            raise CanonicalError("container_too_large")
+        return [_validate_value(item, depth=depth + 1) for item in value]
+    if type(value) is dict:
+        if len(value) > MAX_CONTAINER_ITEMS:
+            raise CanonicalError("container_too_large")
+        normalized: dict[str, Any] = {}
+        for raw_key, item in value.items():
+            if type(raw_key) is not str:
+                raise CanonicalError("non_string_key")
+            key = _normalize_string(raw_key)
+            if key in normalized:
+                raise CanonicalError("duplicate_or_nfc_colliding_key")
+            normalized[key] = _validate_value(item, depth=depth + 1)
+        return normalized
+    raise CanonicalError("unsupported_type")
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    normalized = _validate_value(value, depth=0)
+    raw = json.dumps(
+        normalized,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    if len(raw) > MAX_ARTIFACT_BYTES:
+        raise CanonicalError("artifact_too_large")
+    return raw
+
+
+def digest(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+ARTIFACT_KEYS: dict[str, tuple[frozenset[str], frozenset[str], frozenset[str]]] = {
+    # (required, nullable, optional); unknown keys are always rejected.
+    "orch_route": (
+        frozenset({"schema_version", "kind", "origin_kind", "platform", "adapter_instance_id",
+                   "account_id", "conversation_id", "route_revision", "required_ack_family",
+                   "required_ack_strength"}),
+        frozenset({"thread_id", "reply_to_id", "session_id", "notifier_profile"}), frozenset(),
+    ),
+    "orch_origin": (
+        frozenset({"schema_version", "kind", "board_instance_id", "tenant_scope", "selector_key",
+                   "route_digest"}), frozenset(), frozenset({"diagnostic_client_key"}),
+    ),
+    "orch_requirement_payload": (
+        frozenset({"schema_version", "kind", "required", "text", "done_when"}),
+        frozenset(), frozenset(),
+    ),
+    "orch_request": (
+        frozenset({"schema_version", "kind", "selector_key", "request_key", "origin_id", "lineage_id",
+                   "generation", "title", "synthesis_strategy", "completion_policy", "requirements"}),
+        frozenset(), frozenset(),
+    ),
+    "orch_plan": (
+        frozenset({"schema_version", "kind", "request_binding", "nodes", "edges", "coverage"}),
+        frozenset(), frozenset(),
+    ),
+    "orch_result": (
+        frozenset({"schema_version", "kind", "request_digest", "plan_digest", "accepted_lane_set",
+                   "synthesis"}), frozenset(), frozenset(),
+    ),
+}
+
+
+def validate_artifact_schema(kind: str, value: Any) -> dict[str, Any]:
+    if type(value) is not dict or kind not in ARTIFACT_KEYS:
+        raise CanonicalError("unsupported_artifact_kind")
+    required, nullable, optional = ARTIFACT_KEYS[kind]
+    allowed = required | nullable | optional
+    keys = frozenset(value)
+    if keys - allowed:
+        raise CanonicalError("unknown_artifact_key")
+    if required - keys:
+        raise CanonicalError("missing_artifact_key")
+    if any(value[key] is None for key in required):
+        raise CanonicalError("null_required_key")
+    if value.get("schema_version") != 4 or value.get("kind") != kind:
+        raise CanonicalError("unsupported_artifact_schema")
+    if "tenant_scope" in value:
+        normalized = normalize_tenant_scope(value["tenant_scope"])
+        if value["tenant_scope"] != normalized:
+            raise CanonicalError("noncanonical_tenant_scope")
+    return value
+
+
+# ============================================================
+# Artifact formula functions (§3.3)
+# ============================================================
+
+def route_digest(a: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_route",
+        "origin_kind": a["origin_kind"],
+        "platform": a["platform"],
+        "adapter_instance_id": a["adapter_instance_id"],
+        "account_id": a["account_id"],
+        "conversation_id": a["conversation_id"],
+        "thread_id": a["thread_id"],
+        "reply_to_id": a["reply_to_id"],
+        "session_id": a["session_id"],
+        "notifier_profile": a["notifier_profile"],
+        "required_ack_family": a["required_ack_family"],
+        "required_ack_strength": a["required_ack_strength"],
+        "route_revision": a["route_revision"],
+    })
+
+
+def origin_id(a: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_origin",
+        "board_instance_id": a["board_instance_id"],
+        "tenant_scope": normalize_tenant_scope(a.get("tenant_scope")),
+        "selector_key": a["selector_key"],
+        "route_digest": a["route_digest"],
+    })
+
+
+def replay_selector_key(a: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_replay_selector",
+        "board_instance_id": a["board_instance_id"],
+        "tenant_scope": normalize_tenant_scope(a.get("tenant_scope")),
+        "adapter_instance_id": a["adapter_instance_id"],
+        "conversation_id": a["conversation_id"],
+        "selector_kind": a["selector_kind"],
+        "selector_value": a["selector_value"],
+    })
+
+
+def request_key(a: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_request_generation",
+        "board_instance_id": a["board_instance_id"],
+        "tenant_scope": normalize_tenant_scope(a.get("tenant_scope")),
+        "selector_key": a["selector_key"],
+        "lineage_id": a["lineage_id"],
+        "generation": a["generation"],
+    })
+
+
+def validate_supersession(predecessor: dict[str, Any], successor: dict[str, Any]) -> str:
+    """§I.6.3: Validate supersession — predecessor must be terminal, generation+1.
+
+    Returns the successor request_key if valid, raises CanonicalError otherwise.
+    """
+    if predecessor.get("lifecycle_state") not in ("failed", "cancelled"):
+        raise CanonicalError("supersession_predecessor_not_terminal")
+    pred_gen = require_exact_type(predecessor.get("generation"), int, code="invalid_int")
+    succ_gen = require_exact_type(successor.get("generation"), int, code="invalid_int")
+    if succ_gen != pred_gen + 1:
+        raise CanonicalError("supersession_generation_not_incremented")
+    if predecessor.get("lineage_id") != successor.get("lineage_id"):
+        raise CanonicalError("supersession_lineage_mismatch")
+    return request_key(successor)
+
+
+def lane_lineage_key(a: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_lane_lineage",
+        "board_instance_id": a["board_instance_id"],
+        "tenant_scope": normalize_tenant_scope(a.get("tenant_scope")),
+        "lineage_id": a["lineage_id"],
+        "role": a["role"],
+        "lane_label": a["lane_label"],
+        "goal": a["normalized_goal"],
+        "done_when": a["normalized_done_when"],
+        "required": a["required"],
+        "requirement_ids": sorted(a["requirement_ids"]),
+    })
+
+
+def requirement_digest(requirement: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_requirement_payload",
+        "required": requirement["required"],
+        "text": requirement["text"],
+        "done_when": requirement["done_when"],
+    })
+
+
+def request_digest(request: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_request",
+        "selector_key": request["selector_key"],
+        "request_key": request["request_key"],
+        "origin_id": request["origin_id"],
+        "lineage_id": request["lineage_id"],
+        "generation": request["generation"],
+        "title": request["title"],
+        "synthesis_strategy": request["synthesis_strategy"],
+        "completion_policy": request["completion_policy"],
+        "requirements": sorted(request["requirements"], key=lambda row: row["ordinal"]),
+    })
+
+
+def requirement_id(a: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_requirement",
+        "request_key": a["request_key"],
+        "ordinal": a["ordinal"],
+        "requirement_digest": a["requirement_digest"],
+    })
+
+
+def node_key(a: dict[str, Any]) -> str:
+    if a["role"] == "parent":
+        return "__parent__"
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_node",
+        "orch_id": a["orch_id"],
+        "generation": a["generation"],
+        "plan_version": a["plan_version"],
+        "lane_lineage_key": a["lane_lineage_key"],
+    })
+
+
+def edge_key(a: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_edge",
+        "orch_id": a["orch_id"],
+        "plan_version": a["plan_version"],
+        "parent_node_key": a["parent_node_key"],
+        "child_node_key": a["child_node_key"],
+        "edge_kind": a["edge_kind"],
+    })
+
+
+def event_key(a: dict[str, Any]) -> str:
+    return digest({
+        "schema_version": 4,
+        "kind": "orch_event",
+        "board_instance_id": a["board_instance_id"],
+        "tenant_scope": normalize_tenant_scope(a.get("tenant_scope")),
+        "orch_id": a["orch_id"],
+        "lifecycle_revision": a["lifecycle_revision"],
+        "cancel_epoch": a["cancel_epoch"],
+        "event_kind": a["event_kind"],
+        "target_key": a["target_key"],
+        "payload_digest": a["payload_digest"],
+    })

--- a/hermes_cli/kanban_orch_capability.py
+++ b/hermes_cli/kanban_orch_capability.py
@@ -1,0 +1,144 @@
+"""ORCH V4 runtime-private capability gate.
+
+Contract: orch_capability_ok(kind, board, tenant, object_id, revision, epoch, target_key)
+must be fail-closed unless the current connection holds an explicit grant.
+Never log or serialize the raw token.
+"""
+
+from __future__ import annotations
+
+import secrets
+import sqlite3
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class CapabilityError(RuntimeError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class CapabilityGrant:
+    kind: str
+    board: str = "*"
+    tenant: str = "*"
+    object_id: str = "*"
+    revision: int | str = "*"
+    epoch: int | str = "*"
+    target_key: str = "*"
+
+
+@dataclass
+class CapabilityContext:
+    """In-process grant set bound to one SQLite connection."""
+
+    token: str = field(default_factory=lambda: secrets.token_hex(16))
+    grants: set[CapabilityGrant] = field(default_factory=set)
+
+    def grant(self, grant: CapabilityGrant) -> None:
+        if type(grant.kind) is not str or not grant.kind:
+            raise CapabilityError("invalid_grant_kind")
+        self.grants.add(grant)
+
+    def grant_open_for_tests(self) -> None:
+        """Explicit test-only open gate. Production code must not call this."""
+        self.grants.add(CapabilityGrant(kind="*"))
+
+    def clear(self) -> None:
+        self.grants.clear()
+
+    def check(
+        self,
+        kind: Any,
+        board: Any,
+        tenant: Any,
+        object_id: Any,
+        revision: Any,
+        epoch: Any,
+        target_key: Any,
+    ) -> int:
+        if type(kind) is not str or not kind:
+            return 0
+        board_s = "" if board is None else str(board)
+        tenant_s = "" if tenant is None else str(tenant)
+        object_s = "" if object_id is None else str(object_id)
+        target_s = "" if target_key is None else str(target_key)
+        for g in self.grants:
+            if g.kind not in {"*", kind}:
+                continue
+            if g.board not in {"*", board_s}:
+                continue
+            if g.tenant not in {"*", tenant_s}:
+                continue
+            if g.object_id not in {"*", object_s}:
+                continue
+            if g.revision != "*" and str(g.revision) != str(revision):
+                continue
+            if g.epoch != "*" and str(g.epoch) != str(epoch):
+                continue
+            if g.target_key not in {"*", target_s}:
+                continue
+            return 1
+        return 0
+
+
+_lock = threading.RLock()
+_conn_contexts: dict[int, CapabilityContext] = {}
+
+
+def bind_context(conn: sqlite3.Connection, ctx: CapabilityContext | None = None) -> CapabilityContext:
+    """Bind a capability context to conn and install the SQLite UDF."""
+    if not isinstance(conn, sqlite3.Connection):
+        raise CapabilityError("invalid_connection")
+    context = ctx or CapabilityContext()
+    conn_id = id(conn)
+
+    def _udf(kind, board, tenant, object_id, revision, epoch, target_key):
+        with _lock:
+            active = _conn_contexts.get(conn_id)
+        if active is None:
+            return 0
+        return active.check(kind, board, tenant, object_id, revision, epoch, target_key)
+
+    with _lock:
+        _conn_contexts[conn_id] = context
+    # Re-register every time so callers cannot keep a stale always-1 UDF.
+    conn.create_function("orch_capability_ok", 7, _udf)
+    return context
+
+
+def get_context(conn: sqlite3.Connection) -> CapabilityContext | None:
+    with _lock:
+        return _conn_contexts.get(id(conn))
+
+
+def unbind_context(conn: sqlite3.Connection) -> None:
+    with _lock:
+        _conn_contexts.pop(id(conn), None)
+
+
+def install_fail_closed_udf(conn: sqlite3.Connection) -> CapabilityContext:
+    """Default production posture: UDF present, no grants => deny."""
+    return bind_context(conn, CapabilityContext())
+
+
+def install_test_open_udf(conn: sqlite3.Connection) -> CapabilityContext:
+    """Test helper: explicit open grant. Never use on live connectors."""
+    ctx = CapabilityContext()
+    ctx.grant_open_for_tests()
+    return bind_context(conn, ctx)
+
+
+__all__ = [
+    "CapabilityError",
+    "CapabilityGrant",
+    "CapabilityContext",
+    "bind_context",
+    "get_context",
+    "unbind_context",
+    "install_fail_closed_udf",
+    "install_test_open_udf",
+]

--- a/hermes_cli/kanban_orch_cmin.py
+++ b/hermes_cli/kanban_orch_cmin.py
@@ -93,7 +93,7 @@ def _load_request(conn: sqlite3.Connection, *, board: str, tenant: str, orch_id:
 def _load_by_parent(conn: sqlite3.Connection, *, parent_task_id: str) -> sqlite3.Row:
     row = conn.execute(
         "SELECT r.orch_id, r.parent_task_id, r.lifecycle_state, r.lifecycle_revision, "
-        "r.board_instance_id, r.tenant_scope, o.origin_kind "
+        "r.plan_version, r.board_instance_id, r.tenant_scope, o.origin_kind "
         "FROM orch_requests r "
         "JOIN orch_origins o ON o.board_instance_id=r.board_instance_id "
         " AND o.tenant_scope=r.tenant_scope AND o.origin_id=r.origin_id "
@@ -109,7 +109,7 @@ def _list_open_board_only(conn: sqlite3.Connection) -> list[sqlite3.Row]:
     return list(
         conn.execute(
             "SELECT r.orch_id, r.parent_task_id, r.lifecycle_state, r.lifecycle_revision, "
-            "r.board_instance_id, r.tenant_scope, o.origin_kind "
+            "r.plan_version, r.board_instance_id, r.tenant_scope, o.origin_kind "
             "FROM orch_requests r "
             "JOIN orch_origins o ON o.board_instance_id=r.board_instance_id "
             " AND o.tenant_scope=r.tenant_scope AND o.origin_id=r.origin_id "
@@ -184,7 +184,28 @@ def judge_board_only_once(
         return JudgeResult(**base, skipped=True, reason="already_terminal")
 
     try:
-        if work_done:
+        # Prefer progressive multi-lane path over short-complete when possible.
+        if status in ACTIVE_NATIVE and state == "submitted":
+            step = apply_lifecycle_transition_db(
+                conn,
+                board_instance_id=board_instance_id,
+                tenant_scope=tenant,
+                orch_id=orch_id,
+                event="claim_decomposition",
+                to_state="decomposing",
+            )
+        elif work_done and state == "submitted":
+            # parent/children already terminal at submit time: still claim first
+            # so deeper multi-lane can materialize on the next tick when ≥2 children.
+            step = apply_lifecycle_transition_db(
+                conn,
+                board_instance_id=board_instance_id,
+                tenant_scope=tenant,
+                orch_id=orch_id,
+                event="claim_decomposition",
+                to_state="decomposing",
+            )
+        elif work_done:
             step = apply_lifecycle_transition_db(
                 conn,
                 board_instance_id=board_instance_id,
@@ -195,15 +216,6 @@ def judge_board_only_once(
                 origin_kind="board_only",
                 native_parent_done=parent_done,
                 children_all_done=children_all_done,
-            )
-        elif status in ACTIVE_NATIVE and state == "submitted":
-            step = apply_lifecycle_transition_db(
-                conn,
-                board_instance_id=board_instance_id,
-                tenant_scope=tenant,
-                orch_id=orch_id,
-                event="claim_decomposition",
-                to_state="decomposing",
             )
         else:
             return JudgeResult(**base, skipped=True, reason=f"no_rule_for:{state}:{status}:children={children_done}/{children_total}")
@@ -316,9 +328,28 @@ def _judge_with_bridge(br: OrchBridge, parent_task_id: str) -> JudgeResult:
     children = read_native_children(br._native, parent_task_id)
     total, done, all_done = children_progress(children)
     row = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
-    # Deeper multi-lane: when ≥2 children and request is decomposing/waiting_lanes,
-    # prefer plan materialize + lane accept path before board_only short complete.
+    # Prefer multi-lane when ≥2 children once past submitted (or after claim).
     state = row["lifecycle_state"]
+    if total >= 2 and state == "submitted":
+        # force claim first so multilane can materialize next
+        first = judge_board_only_to_fixed_point(
+            br._sidecar,
+            board_instance_id=row["board_instance_id"],
+            tenant_scope=row["tenant_scope"] or "",
+            orch_id=row["orch_id"],
+            native_status=ref.status,
+            children_all_done=False,  # don't short-complete on this claim step
+            children_total=total,
+            children_done=done,
+        )
+        row = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
+        state = row["lifecycle_state"]
+        if first.steps and state == "decomposing":
+            # continue into multilane below
+            pass
+        elif first.after_state in TERMINAL_ORCH:
+            return first
+
     if total >= 2 and state in {"decomposing", "waiting_lanes"}:
         try:
             from hermes_cli.kanban_orch_multilane import MultiLaneError, run_multilane_once
@@ -335,46 +366,67 @@ def _judge_with_bridge(br: OrchBridge, parent_task_id: str) -> JudgeResult:
                         "title": (crow["title"] if crow else c["child_id"]),
                     }
                 )
-            ml = run_multilane_once(
-                br._sidecar,
-                board_instance_id=row["board_instance_id"],
-                tenant_scope=row["tenant_scope"] or "",
-                orch_id=row["orch_id"],
-                parent_task_id=parent_task_id,
-                parent_title=ref.title or parent_task_id,
-                parent_status=ref.status,
-                children=enriched,
-            )
-            if not ml.skipped:
-                # Re-load for board_only residual completion if still open
-                row2 = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
-                residual = judge_board_only_to_fixed_point(
+            ml_steps = []
+            before_ml = state
+            after_ml = state
+            accepted = 0
+            plan_v = int(row["plan_version"] or 0)
+            for _ in range(6):
+                ml = run_multilane_once(
                     br._sidecar,
-                    board_instance_id=row2["board_instance_id"],
-                    tenant_scope=row2["tenant_scope"] or "",
-                    orch_id=row2["orch_id"],
-                    native_status=ref.status,
-                    children_all_done=all_done,
-                    children_total=total,
-                    children_done=done,
+                    board_instance_id=row["board_instance_id"],
+                    tenant_scope=row["tenant_scope"] or "",
+                    orch_id=row["orch_id"],
+                    parent_task_id=parent_task_id,
+                    parent_title=ref.title or parent_task_id,
+                    parent_status=ref.status,
+                    children=enriched,
                 )
+                if ml.skipped:
+                    break
+                ml_steps.extend(ml.steps)
+                after_ml = ml.after_state
+                accepted = ml.accepted_required_lanes
+                plan_v = ml.plan_version
+                if ml.after_state in TERMINAL_ORCH:
+                    break
+                row = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
+
+            if ml_steps:
+                row2 = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
+                # Only residual short-complete if multi-lane already finished accept path
+                # or multi-lane cannot proceed and board_only is acceptable (< nothing left).
+                residual_steps = []
+                if row2["lifecycle_state"] not in TERMINAL_ORCH and accepted >= 2:
+                    residual = judge_board_only_to_fixed_point(
+                        br._sidecar,
+                        board_instance_id=row2["board_instance_id"],
+                        tenant_scope=row2["tenant_scope"] or "",
+                        orch_id=row2["orch_id"],
+                        native_status=ref.status,
+                        children_all_done=all_done,
+                        children_total=total,
+                        children_done=done,
+                    )
+                    residual_steps = residual.steps
+                    after_ml = residual.after_state if residual.steps else after_ml
                 steps = [
                     JudgeStep(
                         event=f"multilane:{s.action}",
-                        from_state=ml.before_state,
-                        to_state=ml.after_state,
+                        from_state=before_ml,
+                        to_state=after_ml,
                         lifecycle_revision=int(row2["lifecycle_revision"]),
                     )
-                    for s in ml.steps
+                    for s in ml_steps
                 ]
-                steps.extend(residual.steps)
+                steps.extend(residual_steps)
                 return JudgeResult(
                     orch_id=row2["orch_id"],
                     parent_task_id=parent_task_id,
                     native_status=ref.status,
                     origin_kind=row2["origin_kind"],
-                    before_state=ml.before_state,
-                    after_state=residual.after_state if residual.steps else ml.after_state,
+                    before_state=before_ml,
+                    after_state=after_ml,
                     steps=steps,
                     skipped=False,
                     children_total=total,

--- a/hermes_cli/kanban_orch_cmin.py
+++ b/hermes_cli/kanban_orch_cmin.py
@@ -1,15 +1,15 @@
-"""ORCH V4 C-min: sidecar board_only judge driven by native parent status.
+"""ORCH V4 C-min: sidecar board_only judge driven by native parent/children.
 
 N1–N4:
 - Never mutates native kanban schema
 - All lifecycle writes go to sidecar orch_v4.db
-- Native is read-only observation of parent task status
+- Native is read-only observation of parent + child task status
 """
 
 from __future__ import annotations
 
 import sqlite3
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from hermes_cli.kanban_orch_api import OrchAPIError, apply_lifecycle_transition_db
@@ -17,8 +17,9 @@ from hermes_cli.kanban_orch_bridge import BridgeError, OrchBridge
 from hermes_cli.kanban_orch_lifecycle import LifecycleError
 from hermes_cli.kanban_orch_writer_switch import open_live_bridge
 
-ACTIVE_NATIVE = frozenset({"ready", "running", "todo", "blocked", "triage"})
+ACTIVE_NATIVE = frozenset({"ready", "running", "todo", "blocked", "triage", "scheduled"})
 DONE_NATIVE = frozenset({"done", "completed"})
+TERMINAL_ORCH = frozenset({"completed", "failed", "cancelled"})
 
 
 class CMinError(RuntimeError):
@@ -46,10 +47,32 @@ class JudgeResult:
     steps: list[JudgeStep]
     skipped: bool = False
     reason: str | None = None
+    children_total: int = 0
+    children_done: int = 0
+    children_all_done: bool = False
 
     def to_dict(self) -> dict[str, Any]:
-        d = asdict(self)
-        return d
+        return asdict(self)
+
+
+@dataclass
+class TickResult:
+    scanned: int = 0
+    advanced: int = 0
+    completed: int = 0
+    skipped: int = 0
+    errors: list[dict[str, str]] = field(default_factory=list)
+    results: list[JudgeResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scanned": self.scanned,
+            "advanced": self.advanced,
+            "completed": self.completed,
+            "skipped": self.skipped,
+            "errors": self.errors,
+            "results": [r.to_dict() for r in self.results],
+        }
 
 
 def _load_request(conn: sqlite3.Connection, *, board: str, tenant: str, orch_id: str) -> sqlite3.Row:
@@ -82,6 +105,45 @@ def _load_by_parent(conn: sqlite3.Connection, *, parent_task_id: str) -> sqlite3
     return row
 
 
+def _list_open_board_only(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return list(
+        conn.execute(
+            "SELECT r.orch_id, r.parent_task_id, r.lifecycle_state, r.lifecycle_revision, "
+            "r.board_instance_id, r.tenant_scope, o.origin_kind "
+            "FROM orch_requests r "
+            "JOIN orch_origins o ON o.board_instance_id=r.board_instance_id "
+            " AND o.tenant_scope=r.tenant_scope AND o.origin_id=r.origin_id "
+            "WHERE o.origin_kind='board_only' "
+            "AND r.lifecycle_state NOT IN ('completed','failed','cancelled') "
+            "ORDER BY r.updated_at ASC"
+        )
+    )
+
+
+def read_native_children(native_conn: sqlite3.Connection, parent_task_id: str) -> list[dict[str, str]]:
+    """RO read child tasks via task_links (depends + spawned)."""
+    has_links = native_conn.execute(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='task_links'"
+    ).fetchone()[0]
+    if not has_links:
+        return []
+    rows = native_conn.execute(
+        "SELECT l.child_id, COALESCE(t.status,''), COALESCE(l.kind,'depends') "
+        "FROM task_links l LEFT JOIN tasks t ON t.id=l.child_id "
+        "WHERE l.parent_id=?",
+        (parent_task_id,),
+    ).fetchall()
+    return [{"child_id": r[0], "status": (r[1] or "").lower(), "kind": r[2] or "depends"} for r in rows]
+
+
+def children_progress(children: list[dict[str, str]]) -> tuple[int, int, bool]:
+    total = len(children)
+    if total == 0:
+        return 0, 0, False
+    done = sum(1 for c in children if c["status"] in DONE_NATIVE)
+    return total, done, done == total
+
+
 def judge_board_only_once(
     conn: sqlite3.Connection,
     *,
@@ -89,42 +151,40 @@ def judge_board_only_once(
     tenant_scope: str,
     orch_id: str,
     native_status: str,
+    children_all_done: bool = False,
+    children_total: int = 0,
+    children_done: int = 0,
 ) -> JudgeResult:
-    """Apply at most one progressive transition based on native parent status."""
+    """Apply at most one progressive transition based on native parent/children."""
     tenant = "" if tenant_scope is None else str(tenant_scope)
     row = _load_request(conn, board=board_instance_id, tenant=tenant, orch_id=orch_id)
     origin = row["origin_kind"]
     state = row["lifecycle_state"]
     parent = row["parent_task_id"]
     status = (native_status or "").strip().lower()
+    parent_done = status in DONE_NATIVE
+    work_done = parent_done or children_all_done
+
+    base = dict(
+        orch_id=orch_id,
+        parent_task_id=parent,
+        native_status=status,
+        origin_kind=origin,
+        before_state=state,
+        after_state=state,
+        steps=[],
+        children_total=children_total,
+        children_done=children_done,
+        children_all_done=children_all_done,
+    )
 
     if origin != "board_only":
-        return JudgeResult(
-            orch_id=orch_id,
-            parent_task_id=parent,
-            native_status=status,
-            origin_kind=origin,
-            before_state=state,
-            after_state=state,
-            steps=[],
-            skipped=True,
-            reason="not_board_only",
-        )
-    if state in {"completed", "failed", "cancelled"}:
-        return JudgeResult(
-            orch_id=orch_id,
-            parent_task_id=parent,
-            native_status=status,
-            origin_kind=origin,
-            before_state=state,
-            after_state=state,
-            steps=[],
-            skipped=True,
-            reason="already_terminal",
-        )
+        return JudgeResult(**base, skipped=True, reason="not_board_only")
+    if state in TERMINAL_ORCH:
+        return JudgeResult(**base, skipped=True, reason="already_terminal")
 
     try:
-        if status in DONE_NATIVE:
+        if work_done:
             step = apply_lifecycle_transition_db(
                 conn,
                 board_instance_id=board_instance_id,
@@ -133,7 +193,8 @@ def judge_board_only_once(
                 event="board_only_parent_done",
                 to_state="completed",
                 origin_kind="board_only",
-                native_parent_done=True,
+                native_parent_done=parent_done,
+                children_all_done=children_all_done,
             )
         elif status in ACTIVE_NATIVE and state == "submitted":
             step = apply_lifecycle_transition_db(
@@ -145,17 +206,7 @@ def judge_board_only_once(
                 to_state="decomposing",
             )
         else:
-            return JudgeResult(
-                orch_id=orch_id,
-                parent_task_id=parent,
-                native_status=status,
-                origin_kind=origin,
-                before_state=state,
-                after_state=state,
-                steps=[],
-                skipped=True,
-                reason=f"no_rule_for:{state}:{status}",
-            )
+            return JudgeResult(**base, skipped=True, reason=f"no_rule_for:{state}:{status}:children={children_done}/{children_total}")
     except (OrchAPIError, LifecycleError) as exc:
         code = getattr(exc, "code", None) or str(exc)
         raise CMinError(f"transition_failed:{code}") from exc
@@ -175,6 +226,9 @@ def judge_board_only_once(
         after_state=js.to_state,
         steps=[js],
         skipped=False,
+        children_total=children_total,
+        children_done=children_done,
+        children_all_done=children_all_done,
     )
 
 
@@ -185,6 +239,9 @@ def judge_board_only_to_fixed_point(
     tenant_scope: str,
     orch_id: str,
     native_status: str,
+    children_all_done: bool = False,
+    children_total: int = 0,
+    children_done: int = 0,
     max_steps: int = 8,
 ) -> JudgeResult:
     """Apply progressive transitions until skip or terminal."""
@@ -202,6 +259,9 @@ def judge_board_only_to_fixed_point(
         before_state=before,
         after_state=before,
         steps=[],
+        children_total=children_total,
+        children_done=children_done,
+        children_all_done=children_all_done,
     )
     for _ in range(max_steps):
         one = judge_board_only_once(
@@ -210,6 +270,9 @@ def judge_board_only_to_fixed_point(
             tenant_scope=tenant,
             orch_id=orch_id,
             native_status=native_status,
+            children_all_done=children_all_done,
+            children_total=children_total,
+            children_done=children_done,
         )
         if one.skipped or not one.steps:
             last = JudgeResult(
@@ -222,6 +285,9 @@ def judge_board_only_to_fixed_point(
                 steps=all_steps,
                 skipped=len(all_steps) == 0,
                 reason=one.reason if len(all_steps) == 0 else None,
+                children_total=children_total,
+                children_done=children_done,
+                children_all_done=children_all_done,
             )
             break
         all_steps.extend(one.steps)
@@ -234,28 +300,70 @@ def judge_board_only_to_fixed_point(
             after_state=one.after_state,
             steps=list(all_steps),
             skipped=False,
+            children_total=children_total,
+            children_done=children_done,
+            children_all_done=children_all_done,
         )
-        if one.after_state in {"completed", "failed", "cancelled"}:
+        if one.after_state in TERMINAL_ORCH:
             break
     return last
 
 
+def _judge_with_bridge(br: OrchBridge, parent_task_id: str) -> JudgeResult:
+    ref = br.read_native_task(parent_task_id)
+    if ref is None:
+        raise CMinError("native_parent_missing")
+    children = read_native_children(br._native, parent_task_id)
+    total, done, all_done = children_progress(children)
+    row = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
+    return judge_board_only_to_fixed_point(
+        br._sidecar,
+        board_instance_id=row["board_instance_id"],
+        tenant_scope=row["tenant_scope"] or "",
+        orch_id=row["orch_id"],
+        native_status=ref.status,
+        children_all_done=all_done,
+        children_total=total,
+        children_done=done,
+    )
+
+
 def live_judge_parent_task(parent_task_id: str) -> JudgeResult:
-    """Open live bridge, RO-read native parent, write sidecar lifecycle only."""
+    """Open live bridge, RO-read native parent/children, write sidecar lifecycle only."""
     br: OrchBridge | None = None
     try:
         br = open_live_bridge()
-        ref = br.read_native_task(parent_task_id)
-        if ref is None:
-            raise CMinError("native_parent_missing")
-        row = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
-        return judge_board_only_to_fixed_point(
-            br._sidecar,
-            board_instance_id=row["board_instance_id"],
-            tenant_scope=row["tenant_scope"] or "",
-            orch_id=row["orch_id"],
-            native_status=ref.status,
-        )
+        return _judge_with_bridge(br, parent_task_id)
+    except BridgeError as exc:
+        raise CMinError(f"bridge:{exc.code}") from exc
+    finally:
+        if br is not None:
+            br.close()
+
+
+def live_tick_once(*, limit: int = 100) -> TickResult:
+    """Scan open board_only sidecar requests and advance from native truth."""
+    br: OrchBridge | None = None
+    out = TickResult()
+    try:
+        br = open_live_bridge()
+        rows = _list_open_board_only(br._sidecar)[: max(0, int(limit))]
+        out.scanned = len(rows)
+        for row in rows:
+            parent = row["parent_task_id"]
+            try:
+                res = _judge_with_bridge(br, parent)
+                out.results.append(res)
+                if res.skipped:
+                    out.skipped += 1
+                else:
+                    out.advanced += 1
+                    if res.after_state == "completed":
+                        out.completed += 1
+            except Exception as exc:  # noqa: BLE001
+                code = getattr(exc, "code", None) or f"{type(exc).__name__}:{exc}"
+                out.errors.append({"parent_task_id": parent, "error": str(code)})
+        return out
     except BridgeError as exc:
         raise CMinError(f"bridge:{exc.code}") from exc
     finally:
@@ -267,7 +375,11 @@ __all__ = [
     "CMinError",
     "JudgeResult",
     "JudgeStep",
+    "TickResult",
     "judge_board_only_once",
     "judge_board_only_to_fixed_point",
     "live_judge_parent_task",
+    "live_tick_once",
+    "read_native_children",
+    "children_progress",
 ]

--- a/hermes_cli/kanban_orch_cmin.py
+++ b/hermes_cli/kanban_orch_cmin.py
@@ -316,6 +316,74 @@ def _judge_with_bridge(br: OrchBridge, parent_task_id: str) -> JudgeResult:
     children = read_native_children(br._native, parent_task_id)
     total, done, all_done = children_progress(children)
     row = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
+    # Deeper multi-lane: when ≥2 children and request is decomposing/waiting_lanes,
+    # prefer plan materialize + lane accept path before board_only short complete.
+    state = row["lifecycle_state"]
+    if total >= 2 and state in {"decomposing", "waiting_lanes"}:
+        try:
+            from hermes_cli.kanban_orch_multilane import MultiLaneError, run_multilane_once
+
+            enriched = []
+            for c in children:
+                crow = br._native.execute(
+                    "SELECT title, status FROM tasks WHERE id=?", (c["child_id"],)
+                ).fetchone()
+                enriched.append(
+                    {
+                        "child_id": c["child_id"],
+                        "status": ((crow["status"] if crow else c["status"]) or "").lower(),
+                        "title": (crow["title"] if crow else c["child_id"]),
+                    }
+                )
+            ml = run_multilane_once(
+                br._sidecar,
+                board_instance_id=row["board_instance_id"],
+                tenant_scope=row["tenant_scope"] or "",
+                orch_id=row["orch_id"],
+                parent_task_id=parent_task_id,
+                parent_title=ref.title or parent_task_id,
+                parent_status=ref.status,
+                children=enriched,
+            )
+            if not ml.skipped:
+                # Re-load for board_only residual completion if still open
+                row2 = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
+                residual = judge_board_only_to_fixed_point(
+                    br._sidecar,
+                    board_instance_id=row2["board_instance_id"],
+                    tenant_scope=row2["tenant_scope"] or "",
+                    orch_id=row2["orch_id"],
+                    native_status=ref.status,
+                    children_all_done=all_done,
+                    children_total=total,
+                    children_done=done,
+                )
+                steps = [
+                    JudgeStep(
+                        event=f"multilane:{s.action}",
+                        from_state=ml.before_state,
+                        to_state=ml.after_state,
+                        lifecycle_revision=int(row2["lifecycle_revision"]),
+                    )
+                    for s in ml.steps
+                ]
+                steps.extend(residual.steps)
+                return JudgeResult(
+                    orch_id=row2["orch_id"],
+                    parent_task_id=parent_task_id,
+                    native_status=ref.status,
+                    origin_kind=row2["origin_kind"],
+                    before_state=ml.before_state,
+                    after_state=residual.after_state if residual.steps else ml.after_state,
+                    steps=steps,
+                    skipped=False,
+                    children_total=total,
+                    children_done=done,
+                    children_all_done=all_done,
+                )
+        except MultiLaneError:
+            # fall through to board_only path
+            pass
     return judge_board_only_to_fixed_point(
         br._sidecar,
         board_instance_id=row["board_instance_id"],

--- a/hermes_cli/kanban_orch_cmin.py
+++ b/hermes_cli/kanban_orch_cmin.py
@@ -1,0 +1,273 @@
+"""ORCH V4 C-min: sidecar board_only judge driven by native parent status.
+
+N1–N4:
+- Never mutates native kanban schema
+- All lifecycle writes go to sidecar orch_v4.db
+- Native is read-only observation of parent task status
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from hermes_cli.kanban_orch_api import OrchAPIError, apply_lifecycle_transition_db
+from hermes_cli.kanban_orch_bridge import BridgeError, OrchBridge
+from hermes_cli.kanban_orch_lifecycle import LifecycleError
+from hermes_cli.kanban_orch_writer_switch import open_live_bridge
+
+ACTIVE_NATIVE = frozenset({"ready", "running", "todo", "blocked", "triage"})
+DONE_NATIVE = frozenset({"done", "completed"})
+
+
+class CMinError(RuntimeError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass
+class JudgeStep:
+    event: str
+    from_state: str
+    to_state: str
+    lifecycle_revision: int
+
+
+@dataclass
+class JudgeResult:
+    orch_id: str
+    parent_task_id: str
+    native_status: str
+    origin_kind: str
+    before_state: str
+    after_state: str
+    steps: list[JudgeStep]
+    skipped: bool = False
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        return d
+
+
+def _load_request(conn: sqlite3.Connection, *, board: str, tenant: str, orch_id: str) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT r.orch_id, r.parent_task_id, r.lifecycle_state, r.lifecycle_revision, "
+        "r.board_instance_id, r.tenant_scope, o.origin_kind "
+        "FROM orch_requests r "
+        "JOIN orch_origins o ON o.board_instance_id=r.board_instance_id "
+        " AND o.tenant_scope=r.tenant_scope AND o.origin_id=r.origin_id "
+        "WHERE r.board_instance_id=? AND r.tenant_scope=? AND r.orch_id=?",
+        (board, tenant, orch_id),
+    ).fetchone()
+    if row is None:
+        raise CMinError("request_not_found")
+    return row
+
+
+def _load_by_parent(conn: sqlite3.Connection, *, parent_task_id: str) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT r.orch_id, r.parent_task_id, r.lifecycle_state, r.lifecycle_revision, "
+        "r.board_instance_id, r.tenant_scope, o.origin_kind "
+        "FROM orch_requests r "
+        "JOIN orch_origins o ON o.board_instance_id=r.board_instance_id "
+        " AND o.tenant_scope=r.tenant_scope AND o.origin_id=r.origin_id "
+        "WHERE r.parent_task_id=? ORDER BY r.updated_at DESC LIMIT 1",
+        (parent_task_id,),
+    ).fetchone()
+    if row is None:
+        raise CMinError("request_not_found_for_parent")
+    return row
+
+
+def judge_board_only_once(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    tenant_scope: str,
+    orch_id: str,
+    native_status: str,
+) -> JudgeResult:
+    """Apply at most one progressive transition based on native parent status."""
+    tenant = "" if tenant_scope is None else str(tenant_scope)
+    row = _load_request(conn, board=board_instance_id, tenant=tenant, orch_id=orch_id)
+    origin = row["origin_kind"]
+    state = row["lifecycle_state"]
+    parent = row["parent_task_id"]
+    status = (native_status or "").strip().lower()
+
+    if origin != "board_only":
+        return JudgeResult(
+            orch_id=orch_id,
+            parent_task_id=parent,
+            native_status=status,
+            origin_kind=origin,
+            before_state=state,
+            after_state=state,
+            steps=[],
+            skipped=True,
+            reason="not_board_only",
+        )
+    if state in {"completed", "failed", "cancelled"}:
+        return JudgeResult(
+            orch_id=orch_id,
+            parent_task_id=parent,
+            native_status=status,
+            origin_kind=origin,
+            before_state=state,
+            after_state=state,
+            steps=[],
+            skipped=True,
+            reason="already_terminal",
+        )
+
+    try:
+        if status in DONE_NATIVE:
+            step = apply_lifecycle_transition_db(
+                conn,
+                board_instance_id=board_instance_id,
+                tenant_scope=tenant,
+                orch_id=orch_id,
+                event="board_only_parent_done",
+                to_state="completed",
+                origin_kind="board_only",
+                native_parent_done=True,
+            )
+        elif status in ACTIVE_NATIVE and state == "submitted":
+            step = apply_lifecycle_transition_db(
+                conn,
+                board_instance_id=board_instance_id,
+                tenant_scope=tenant,
+                orch_id=orch_id,
+                event="claim_decomposition",
+                to_state="decomposing",
+            )
+        else:
+            return JudgeResult(
+                orch_id=orch_id,
+                parent_task_id=parent,
+                native_status=status,
+                origin_kind=origin,
+                before_state=state,
+                after_state=state,
+                steps=[],
+                skipped=True,
+                reason=f"no_rule_for:{state}:{status}",
+            )
+    except (OrchAPIError, LifecycleError) as exc:
+        code = getattr(exc, "code", None) or str(exc)
+        raise CMinError(f"transition_failed:{code}") from exc
+
+    js = JudgeStep(
+        event=str(step.get("event") or ""),
+        from_state=str(step["from_state"]),
+        to_state=str(step["to_state"]),
+        lifecycle_revision=int(step["lifecycle_revision"]),
+    )
+    return JudgeResult(
+        orch_id=orch_id,
+        parent_task_id=parent,
+        native_status=status,
+        origin_kind=origin,
+        before_state=js.from_state,
+        after_state=js.to_state,
+        steps=[js],
+        skipped=False,
+    )
+
+
+def judge_board_only_to_fixed_point(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    tenant_scope: str,
+    orch_id: str,
+    native_status: str,
+    max_steps: int = 8,
+) -> JudgeResult:
+    """Apply progressive transitions until skip or terminal."""
+    tenant = "" if tenant_scope is None else str(tenant_scope)
+    row = _load_request(conn, board=board_instance_id, tenant=tenant, orch_id=orch_id)
+    before = row["lifecycle_state"]
+    parent = row["parent_task_id"]
+    origin = row["origin_kind"]
+    all_steps: list[JudgeStep] = []
+    last = JudgeResult(
+        orch_id=orch_id,
+        parent_task_id=parent,
+        native_status=native_status,
+        origin_kind=origin,
+        before_state=before,
+        after_state=before,
+        steps=[],
+    )
+    for _ in range(max_steps):
+        one = judge_board_only_once(
+            conn,
+            board_instance_id=board_instance_id,
+            tenant_scope=tenant,
+            orch_id=orch_id,
+            native_status=native_status,
+        )
+        if one.skipped or not one.steps:
+            last = JudgeResult(
+                orch_id=orch_id,
+                parent_task_id=parent,
+                native_status=native_status,
+                origin_kind=origin,
+                before_state=before,
+                after_state=one.after_state,
+                steps=all_steps,
+                skipped=len(all_steps) == 0,
+                reason=one.reason if len(all_steps) == 0 else None,
+            )
+            break
+        all_steps.extend(one.steps)
+        last = JudgeResult(
+            orch_id=orch_id,
+            parent_task_id=parent,
+            native_status=native_status,
+            origin_kind=origin,
+            before_state=before,
+            after_state=one.after_state,
+            steps=list(all_steps),
+            skipped=False,
+        )
+        if one.after_state in {"completed", "failed", "cancelled"}:
+            break
+    return last
+
+
+def live_judge_parent_task(parent_task_id: str) -> JudgeResult:
+    """Open live bridge, RO-read native parent, write sidecar lifecycle only."""
+    br: OrchBridge | None = None
+    try:
+        br = open_live_bridge()
+        ref = br.read_native_task(parent_task_id)
+        if ref is None:
+            raise CMinError("native_parent_missing")
+        row = _load_by_parent(br._sidecar, parent_task_id=parent_task_id)
+        return judge_board_only_to_fixed_point(
+            br._sidecar,
+            board_instance_id=row["board_instance_id"],
+            tenant_scope=row["tenant_scope"] or "",
+            orch_id=row["orch_id"],
+            native_status=ref.status,
+        )
+    except BridgeError as exc:
+        raise CMinError(f"bridge:{exc.code}") from exc
+    finally:
+        if br is not None:
+            br.close()
+
+
+__all__ = [
+    "CMinError",
+    "JudgeResult",
+    "JudgeStep",
+    "judge_board_only_once",
+    "judge_board_only_to_fixed_point",
+    "live_judge_parent_task",
+]

--- a/hermes_cli/kanban_orch_cmin_schema.py
+++ b/hermes_cli/kanban_orch_cmin_schema.py
@@ -1,0 +1,75 @@
+"""Additive SQL patch: allow board_only parent-done → completed on orch_requests.
+
+Keeps existing transition matrix and adds a narrow board_only short-path used by C-min.
+Safe to run repeatedly (DROP IF EXISTS + CREATE).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+CMIN_REQUEST_TRANSITION_TRIGGER = """
+DROP TRIGGER IF EXISTS orch_request_transition_guard;
+CREATE TRIGGER orch_request_transition_guard BEFORE UPDATE ON orch_requests BEGIN
+  SELECT CASE WHEN NEW.lifecycle_revision!=OLD.lifecycle_revision+1 OR NEW.updated_at<OLD.updated_at
+    OR orch_capability_ok('request_transition',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.request_key)!=1
+    OR NOT (
+      (OLD.lifecycle_state='submitted' AND NEW.lifecycle_state='decomposing')
+      OR (OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state IN ('waiting_lanes','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='waiting_lanes' AND NEW.lifecycle_state IN ('waiting_lanes','synthesizing','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state IN ('work_accepted','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='work_accepted' AND NEW.lifecycle_state IN ('delivering','completed','cancelling'))
+      OR (OLD.lifecycle_state='delivering' AND NEW.lifecycle_state IN ('completed','delivery_blocked','cancelling'))
+      OR (OLD.lifecycle_state='delivery_blocked' AND NEW.lifecycle_state IN ('delivering','cancelling'))
+      OR (OLD.lifecycle_state='blocked' AND NEW.lifecycle_state=OLD.resume_state)
+      OR (OLD.lifecycle_state='cancelling' AND NEW.lifecycle_state='cancelled')
+      OR (
+        -- C-min board_only short path: parent native terminal => completed
+        NEW.lifecycle_state='completed'
+        AND OLD.lifecycle_state IN ('submitted','decomposing','waiting_lanes','synthesizing','work_accepted','delivering')
+        AND NEW.delivery_closed_at IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM orch_origins o
+           WHERE o.board_instance_id=NEW.board_instance_id
+             AND o.tenant_scope=NEW.tenant_scope
+             AND o.origin_id=NEW.origin_id
+             AND o.origin_kind='board_only'
+        )
+      )
+    )
+    OR NOT ((NEW.lifecycle_state='cancelling' AND OLD.lifecycle_state!='cancelling' AND NEW.cancel_epoch=OLD.cancel_epoch+1)
+      OR (NEW.lifecycle_state!='cancelling' AND NEW.cancel_epoch=OLD.cancel_epoch))
+    OR NOT ((OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state='work_accepted'
+              AND OLD.delivery_epoch_revision=0 AND NEW.delivery_epoch_revision=NEW.lifecycle_revision
+              AND NEW.work_accepted_at IS NOT NULL)
+      OR (NOT (OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state='work_accepted')
+              AND NEW.delivery_epoch_revision=OLD.delivery_epoch_revision
+              AND (
+                NEW.work_accepted_at IS OLD.work_accepted_at
+                OR (NEW.lifecycle_state='completed' AND NEW.work_accepted_at IS NOT NULL)
+              )))
+    OR NOT ((OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state='waiting_lanes'
+              AND NEW.plan_version=OLD.plan_version+1
+              AND OLD.plan_epoch_revision=0 AND NEW.plan_epoch_revision=NEW.lifecycle_revision
+              AND EXISTS (SELECT 1 FROM orch_plan_materializations m
+                WHERE m.board_instance_id=NEW.board_instance_id AND m.tenant_scope=NEW.tenant_scope
+                  AND m.orch_id=NEW.orch_id AND m.plan_version=NEW.plan_version
+                  AND m.request_lifecycle_revision=OLD.lifecycle_revision
+                  AND m.cancel_epoch=OLD.cancel_epoch))
+      OR (NOT (OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state='waiting_lanes')
+              AND NEW.plan_version=OLD.plan_version
+              AND NEW.plan_epoch_revision=OLD.plan_epoch_revision))
+    OR (NEW.lifecycle_state='completed' AND NEW.delivery_closed_at IS NULL)
+    OR (NEW.lifecycle_state!='completed' AND NEW.delivery_closed_at IS NOT OLD.delivery_closed_at
+        AND NOT (NEW.lifecycle_state='completed'))
+    THEN RAISE(ABORT,'invalid_orch_request_transition') END;
+END;
+"""
+
+
+def apply_cmin_transition_patch(conn: sqlite3.Connection) -> None:
+    conn.executescript(CMIN_REQUEST_TRANSITION_TRIGGER)
+    conn.commit()
+
+
+__all__ = ["apply_cmin_transition_patch", "CMIN_REQUEST_TRANSITION_TRIGGER"]

--- a/hermes_cli/kanban_orch_db.py
+++ b/hermes_cli/kanban_orch_db.py
@@ -1,0 +1,134 @@
+"""ORCH V4 canonical DB connector.
+
+Hard rules:
+- PRAGMA foreign_keys=ON with read-back
+- runtime-private capability UDF installed fail-closed by default
+- BEGIN IMMEDIATE helpers for mutation transactions
+- never open live fleet paths unless caller opts in explicitly
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.kanban_orch_capability import (
+    CapabilityContext,
+    CapabilityGrant,
+    bind_context,
+    get_context,
+    install_fail_closed_udf,
+    install_test_open_udf,
+    unbind_context,
+)
+
+LIVE_FORBIDDEN_PATHS = frozenset(
+    {
+        "/home/claw/.hermes/kanban.db",
+        str(Path.home() / ".hermes" / "kanban.db"),
+    }
+)
+
+
+class OrchDBError(RuntimeError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _resolve(path: str | os.PathLike[str]) -> str:
+    return str(Path(path).expanduser().resolve())
+
+
+def assert_not_live_path(path: str | os.PathLike[str], *, allow_live: bool = False) -> str:
+    resolved = _resolve(path)
+    if not allow_live and resolved in {_resolve(p) for p in LIVE_FORBIDDEN_PATHS}:
+        raise OrchDBError("live_path_forbidden")
+    return resolved
+
+
+def open_orch_db(
+    path: str | os.PathLike[str],
+    *,
+    allow_live: bool = False,
+    create: bool = False,
+    test_open_capability: bool = False,
+    readonly: bool = False,
+) -> sqlite3.Connection:
+    """Open an ORCH DB with FK ON + capability UDF.
+
+    test_open_capability is for unit tests only.
+    """
+    resolved = assert_not_live_path(path, allow_live=allow_live)
+    if readonly:
+        if not os.path.exists(resolved):
+            raise OrchDBError("db_not_found")
+        uri = f"file:{resolved}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+    else:
+        if not create and not os.path.exists(resolved):
+            raise OrchDBError("db_not_found")
+        conn = sqlite3.connect(resolved)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    if int(fk) != 1:
+        conn.close()
+        raise OrchDBError("foreign_keys_not_on")
+    if test_open_capability:
+        install_test_open_udf(conn)
+    else:
+        install_fail_closed_udf(conn)
+    return conn
+
+
+def grant(conn: sqlite3.Connection, grant_spec: CapabilityGrant) -> None:
+    ctx = get_context(conn)
+    if ctx is None:
+        ctx = bind_context(conn)
+    ctx.grant(grant_spec)
+
+
+def begin_immediate(conn: sqlite3.Connection) -> None:
+    conn.execute("BEGIN IMMEDIATE")
+
+
+def close_orch_db(conn: sqlite3.Connection) -> None:
+    try:
+        unbind_context(conn)
+    finally:
+        conn.close()
+
+
+class OrchDB:
+    """Context manager wrapper around open_orch_db."""
+
+    def __init__(self, path: str | os.PathLike[str], **kwargs: Any):
+        self.path = path
+        self.kwargs = kwargs
+        self.conn: sqlite3.Connection | None = None
+
+    def __enter__(self) -> sqlite3.Connection:
+        self.conn = open_orch_db(self.path, **self.kwargs)
+        return self.conn
+
+    def __exit__(self, *args: Any) -> None:
+        if self.conn is not None:
+            close_orch_db(self.conn)
+            self.conn = None
+
+
+__all__ = [
+    "LIVE_FORBIDDEN_PATHS",
+    "OrchDBError",
+    "OrchDB",
+    "assert_not_live_path",
+    "open_orch_db",
+    "grant",
+    "begin_immediate",
+    "close_orch_db",
+    "CapabilityGrant",
+    "CapabilityContext",
+]

--- a/hermes_cli/kanban_orch_db.py
+++ b/hermes_cli/kanban_orch_db.py
@@ -81,6 +81,9 @@ def open_orch_db(
         install_test_open_udf(conn)
     else:
         install_fail_closed_udf(conn)
+    from hermes_cli.kanban_orch_digest_udf import install_digest_udfs
+
+    install_digest_udfs(conn)
     return conn
 
 

--- a/hermes_cli/kanban_orch_delivery.py
+++ b/hermes_cli/kanban_orch_delivery.py
@@ -1,0 +1,333 @@
+"""ORCH V4 Delivery protocol — obligations, claim, attempt, receipt, ACK family.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §10 (Delivery protocol) + §I.9 (adapter).
+§13 T23-T33 test contracts.
+
+Runtime-independent pure model. No live DB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class DeliveryError(ValueError):
+    """Delivery protocol violation."""
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+# §10.5 ACK families — no global scalar rank.
+ACK_FAMILIES = frozenset({"provider", "adapter", "synchronous", "local_session", "none"})
+
+ACK_STRENGTHS = frozenset({"message_id", "adapter_acceptance", "response", "session_acceptance", "none"})
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    """Immutable manifest entry from orch_delivery_manifest_entries."""
+    manifest_entry_key: str
+    required: bool
+    route_digest: str
+    required_ack_family: str
+    required_ack_strength: str
+
+
+@dataclass
+class DeliveryObligation:
+    """Mutable obligation state (generation 1 starts pending)."""
+    obligation_id: str
+    manifest_entry_key: str
+    required: bool
+    route_digest: str
+    required_ack_family: str
+    required_ack_strength: str
+    delivery_generation: int = 1
+    state: str = "pending"  # pending, claimed, accepted, acked, unknown, dead_letter, cancelled
+    claim_owner: str | None = None
+    claim_token_hash: str | None = None
+    claim_epoch: int = 0
+    acceptance_attempt_id: int | None = None
+    acked_at: int | None = None
+    duplicate_possible: bool = False
+
+
+@dataclass
+class DeliveryAttempt:
+    """Immutable attempt record (started → adapter_accepted/rejected/unknown)."""
+    attempt_id: int
+    obligation_id: str
+    send_nonce: str
+    payload_digest: str
+    result_digest: str
+    route_digest: str
+    claim_owner: str
+    claim_token_hash: str
+    claim_epoch: int
+    lifecycle_revision: int
+    cancel_epoch: int
+    state: str = "started"  # started, adapter_accepted, rejected, unknown
+    finished_at: int | None = None
+    adapter_evidence_digest: str | None = None
+
+
+@dataclass(frozen=True)
+class DeliveryReceipt:
+    """Verified receipt bound to attempt/nonce/payload/result/route/family."""
+    attempt_id: int
+    obligation_id: str
+    send_nonce: str
+    payload_digest: str
+    result_digest: str
+    route_digest: str
+    observed_ack_family: str
+    observed_ack_strength: str
+    verified: bool = True
+
+
+def validate_ack_family(family: str, strength: str) -> None:
+    """§10.5: Typed ACK family validation. No global rank."""
+    if family not in ACK_FAMILIES:
+        raise DeliveryError("invalid_ack_family")
+    if strength not in ACK_STRENGTHS:
+        raise DeliveryError("invalid_ack_strength")
+    # Family-specific strength mapping
+    expected = {
+        "provider": "message_id",
+        "adapter": "adapter_acceptance",
+        "synchronous": "response",
+        "local_session": "session_acceptance",
+        "none": "none",
+    }
+    if strength != expected[family]:
+        raise DeliveryError("ack_family_strength_mismatch")
+
+
+def create_obligations_from_manifest(
+    entries: list[ManifestEntry],
+    *,
+    origin_kind: str,
+) -> list[DeliveryObligation]:
+    """§10.2: Create obligations from manifest entries.
+
+    Board-only with zero required entries creates no obligations.
+    """
+    if origin_kind == "board_only":
+        required = [e for e in entries if e.required]
+        if required:
+            raise DeliveryError("board_only_has_required_obligations")
+        return []  # board-only: no obligations
+
+    obligations = []
+    for i, entry in enumerate(entries):
+        validate_ack_family(entry.required_ack_family, entry.required_ack_strength)
+        obligations.append(DeliveryObligation(
+            obligation_id=f"obl-{i+1}",
+            manifest_entry_key=entry.manifest_entry_key,
+            required=entry.required,
+            route_digest=entry.route_digest,
+            required_ack_family=entry.required_ack_family,
+            required_ack_strength=entry.required_ack_strength,
+        ))
+    return obligations
+
+
+def claim_obligation(
+    obligation: DeliveryObligation,
+    *,
+    owner: str,
+    token_hash: str,
+    ttl: int,
+    now: int,
+) -> int:
+    """§10.2: Claim CAS. Returns new claim_epoch."""
+    if obligation.state != "pending":
+        raise DeliveryError("claim_not_pending")
+    obligation.state = "claimed"
+    obligation.claim_owner = owner
+    obligation.claim_token_hash = token_hash
+    obligation.claim_epoch += 1
+    return obligation.claim_epoch
+
+
+def start_attempt(
+    obligation: DeliveryObligation,
+    *,
+    attempt_id: int,
+    send_nonce: str,
+    payload_digest: str,
+    result_digest: str,
+    claim_owner: str,
+    claim_token_hash: str,
+    claim_epoch: int,
+    lifecycle_revision: int,
+    cancel_epoch: int,
+) -> DeliveryAttempt:
+    """§10.2: Pre-send intent — durable started marker."""
+    if obligation.state != "claimed":
+        raise DeliveryError("attempt_not_claimed")
+    if obligation.claim_owner != claim_owner:
+        raise DeliveryError("attempt_wrong_owner")
+    if obligation.claim_token_hash != claim_token_hash:
+        raise DeliveryError("attempt_wrong_token")
+    if obligation.claim_epoch != claim_epoch:
+        raise DeliveryError("attempt_wrong_epoch")
+    return DeliveryAttempt(
+        attempt_id=attempt_id,
+        obligation_id=obligation.obligation_id,
+        send_nonce=send_nonce,
+        payload_digest=payload_digest,
+        result_digest=result_digest,
+        route_digest=obligation.route_digest,
+        claim_owner=claim_owner,
+        claim_token_hash=claim_token_hash,
+        claim_epoch=claim_epoch,
+        lifecycle_revision=lifecycle_revision,
+        cancel_epoch=cancel_epoch,
+    )
+
+
+def finish_attempt(
+    obligation: DeliveryObligation,
+    attempt: DeliveryAttempt,
+    *,
+    terminal_state: str,
+    evidence_digest: str | None = None,
+    now: int = 0,
+) -> DeliveryAttempt:
+    """§10.3: CAS attempt to terminal state."""
+    if attempt.state != "started":
+        raise DeliveryError("attempt_already_finished")
+    if attempt.obligation_id != obligation.obligation_id:
+        raise DeliveryError("attempt_obligation_mismatch")
+    if terminal_state not in ("adapter_accepted", "rejected", "unknown"):
+        raise DeliveryError("invalid_attempt_terminal")
+    attempt.state = terminal_state
+    attempt.finished_at = now
+    attempt.adapter_evidence_digest = evidence_digest
+    return attempt
+
+
+def process_receipt(
+    obligation: DeliveryObligation,
+    attempt: DeliveryAttempt,
+    receipt: DeliveryReceipt,
+    *,
+    now: int = 0,
+) -> None:
+    """§10.3: Positive path — verify receipt, ACK obligation.
+
+    Receipt must bind exact attempt/nonce/payload/result/route/family/strength.
+    """
+    if receipt.attempt_id != attempt.attempt_id:
+        raise DeliveryError("receipt_attempt_mismatch")
+    if receipt.obligation_id != obligation.obligation_id:
+        raise DeliveryError("receipt_obligation_mismatch")
+    if receipt.send_nonce != attempt.send_nonce:
+        raise DeliveryError("receipt_nonce_mismatch")
+    if receipt.payload_digest != attempt.payload_digest:
+        raise DeliveryError("receipt_payload_mismatch")
+    if receipt.result_digest != attempt.result_digest:
+        raise DeliveryError("receipt_result_mismatch")
+    if receipt.route_digest != obligation.route_digest:
+        raise DeliveryError("receipt_route_mismatch")
+    if receipt.observed_ack_family != obligation.required_ack_family:
+        raise DeliveryError("cross_family_ack_satisfied")
+    if receipt.observed_ack_strength != obligation.required_ack_strength:
+        raise DeliveryError("ack_strength_mismatch")
+    if not receipt.verified:
+        raise DeliveryError("receipt_not_verified")
+
+    # CAS: claimed or unknown → accepted → acked
+    if obligation.state not in ("claimed", "unknown"):
+        raise DeliveryError("ack_not_authorized")
+    obligation.state = "acked"
+    obligation.acceptance_attempt_id = attempt.attempt_id
+    obligation.acked_at = now
+
+
+def check_delivery_satisfied(
+    obligations: list[DeliveryObligation],
+    *,
+    origin_kind: str,
+) -> bool:
+    """§10.6: Single authoritative completion predicate.
+
+    Board-only: no required obligations → satisfied.
+    Non-board-only: all required obligations must be acked.
+    Optional obligations do not block.
+    """
+    if origin_kind == "board_only":
+        required = [o for o in obligations if o.required]
+        return len(required) == 0
+
+    required = [o for o in obligations if o.required]
+    if not required:
+        return False  # non-board-only must have at least 1 required
+
+    for o in required:
+        if o.state != "acked":
+            return False
+        if o.acceptance_attempt_id is None:
+            return False
+    return True
+
+
+def check_delivery_terminal_semantics(
+    obligations: list[DeliveryObligation],
+) -> dict[str, bool]:
+    """§10.4 + T31: Required dead_letter/unknown/cancel never satisfy;
+    optional non-blocking."""
+    result = {}
+    for o in obligations:
+        if o.required:
+            if o.state == "dead_letter":
+                result[o.obligation_id] = False
+            elif o.state == "unknown":
+                result[o.obligation_id] = False
+            elif o.state == "cancelled":
+                result[o.obligation_id] = False
+            elif o.state == "acked":
+                result[o.obligation_id] = True
+            else:
+                result[o.obligation_id] = False
+        else:
+            # Optional: non-blocking
+            result[o.obligation_id] = True
+    return result
+
+
+def authorize_resend(
+    obligation: DeliveryObligation,
+    *,
+    new_generation: int,
+) -> DeliveryObligation:
+    """§10.4: Generation+1 obligation for unknown/dead-letter retry."""
+    if obligation.state not in ("unknown", "dead_letter"):
+        raise DeliveryError("resend_not_authorized")
+    if new_generation != obligation.delivery_generation + 1:
+        raise DeliveryError("invalid_resend_generation")
+    return DeliveryObligation(
+        obligation_id=f"{obligation.obligation_id}-g{new_generation}",
+        manifest_entry_key=obligation.manifest_entry_key,
+        required=obligation.required,
+        route_digest=obligation.route_digest,
+        required_ack_family=obligation.required_ack_family,
+        required_ack_strength=obligation.required_ack_strength,
+        delivery_generation=new_generation,
+        state="pending",
+        duplicate_possible=True,
+    )
+
+
+__all__ = [
+    "DeliveryError", "ACK_FAMILIES", "ACK_STRENGTHS",
+    "ManifestEntry", "DeliveryObligation", "DeliveryAttempt",
+    "DeliveryReceipt", "validate_ack_family",
+    "create_obligations_from_manifest", "claim_obligation",
+    "start_attempt", "finish_attempt", "process_receipt",
+    "check_delivery_satisfied", "check_delivery_terminal_semantics",
+    "authorize_resend",
+]

--- a/hermes_cli/kanban_orch_delivery.py
+++ b/hermes_cli/kanban_orch_delivery.py
@@ -50,6 +50,7 @@ class DeliveryObligation:
     claim_token_hash: str | None = None
     claim_epoch: int = 0
     acceptance_attempt_id: int | None = None
+    open_attempt_id: int | None = None
     acked_at: int | None = None
     duplicate_possible: bool = False
 
@@ -149,6 +150,7 @@ def claim_obligation(
     obligation.claim_owner = owner
     obligation.claim_token_hash = token_hash
     obligation.claim_epoch += 1
+    obligation.open_attempt_id = None
     return obligation.claim_epoch
 
 
@@ -165,7 +167,10 @@ def start_attempt(
     lifecycle_revision: int,
     cancel_epoch: int,
 ) -> DeliveryAttempt:
-    """§10.2: Pre-send intent — durable started marker."""
+    """§10.2: Pre-send intent — durable started marker.
+
+    At most one open attempt per claim epoch (CAS).
+    """
     if obligation.state != "claimed":
         raise DeliveryError("attempt_not_claimed")
     if obligation.claim_owner != claim_owner:
@@ -174,7 +179,9 @@ def start_attempt(
         raise DeliveryError("attempt_wrong_token")
     if obligation.claim_epoch != claim_epoch:
         raise DeliveryError("attempt_wrong_epoch")
-    return DeliveryAttempt(
+    if obligation.open_attempt_id is not None:
+        raise DeliveryError("attempt_already_open")
+    attempt = DeliveryAttempt(
         attempt_id=attempt_id,
         obligation_id=obligation.obligation_id,
         send_nonce=send_nonce,
@@ -187,6 +194,8 @@ def start_attempt(
         lifecycle_revision=lifecycle_revision,
         cancel_epoch=cancel_epoch,
     )
+    obligation.open_attempt_id = attempt_id
+    return attempt
 
 
 def finish_attempt(
@@ -207,6 +216,8 @@ def finish_attempt(
     attempt.state = terminal_state
     attempt.finished_at = now
     attempt.adapter_evidence_digest = evidence_digest
+    if obligation.open_attempt_id == attempt.attempt_id:
+        obligation.open_attempt_id = None
     return attempt
 
 
@@ -220,6 +231,8 @@ def process_receipt(
     """§10.3: Positive path — verify receipt, ACK obligation.
 
     Receipt must bind exact attempt/nonce/payload/result/route/family/strength.
+    Rejected attempts can never ACK. Only adapter_accepted (or unknown recovery)
+    attempts are acceptable.
     """
     if receipt.attempt_id != attempt.attempt_id:
         raise DeliveryError("receipt_attempt_mismatch")
@@ -239,13 +252,18 @@ def process_receipt(
         raise DeliveryError("ack_strength_mismatch")
     if not receipt.verified:
         raise DeliveryError("receipt_not_verified")
+    if attempt.state == "rejected":
+        raise DeliveryError("rejected_attempt_cannot_ack")
+    if attempt.state not in {"adapter_accepted", "unknown"}:
+        raise DeliveryError("receipt_attempt_not_acceptable")
 
-    # CAS: claimed or unknown → accepted → acked
+    # CAS: claimed or unknown → acked
     if obligation.state not in ("claimed", "unknown"):
         raise DeliveryError("ack_not_authorized")
     obligation.state = "acked"
     obligation.acceptance_attempt_id = attempt.attempt_id
     obligation.acked_at = now
+    obligation.open_attempt_id = None
 
 
 def check_delivery_satisfied(

--- a/hermes_cli/kanban_orch_digest_udf.py
+++ b/hermes_cli/kanban_orch_digest_udf.py
@@ -1,0 +1,177 @@
+"""ORCH V4 SQLite digest UDFs + additive trigger guards.
+
+Server recomputes digests inside the DB connection. Caller-supplied digest
+columns are assertions only; mismatch aborts the statement.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+from hermes_cli.kanban_orch_canonical import (
+    CanonicalError,
+    digest,
+    request_digest,
+    route_digest,
+    strict_json_loads,
+)
+
+
+DIGEST_GUARD_SQL = """
+CREATE TRIGGER IF NOT EXISTS orch_v4_origins_route_digest_guard
+BEFORE INSERT ON orch_origins
+BEGIN
+  SELECT CASE WHEN orch_route_digest_eq(NEW.route_json, NEW.route_digest) != 1
+    THEN RAISE(ABORT, 'route_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_origins_route_digest_update_guard
+BEFORE UPDATE OF route_json, route_digest ON orch_origins
+BEGIN
+  SELECT CASE WHEN orch_route_digest_eq(NEW.route_json, NEW.route_digest) != 1
+    THEN RAISE(ABORT, 'route_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_requests_request_digest_guard
+BEFORE INSERT ON orch_requests
+BEGIN
+  SELECT CASE WHEN orch_request_digest_eq(NEW.request_json, NEW.request_digest) != 1
+    THEN RAISE(ABORT, 'request_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_requests_request_digest_update_guard
+BEFORE UPDATE OF request_json, request_digest ON orch_requests
+BEGIN
+  SELECT CASE WHEN orch_request_digest_eq(NEW.request_json, NEW.request_digest) != 1
+    THEN RAISE(ABORT, 'request_digest_mismatch') END;
+END;
+"""
+
+
+def _parse_json_text(raw: Any) -> Any:
+    if raw is None:
+        raise CanonicalError("invalid_json")
+    if type(raw) is bytes:
+        return strict_json_loads(raw)
+    if type(raw) is str:
+        return strict_json_loads(raw.encode("utf-8"))
+    raise CanonicalError("invalid_json")
+
+
+def _claimed_ok(claimed: Any) -> str:
+    if type(claimed) is not str or len(claimed) != 64:
+        raise CanonicalError("invalid_digest")
+    if any(ch not in "0123456789abcdef" for ch in claimed):
+        raise CanonicalError("invalid_digest")
+    return claimed
+
+
+def _route_digest_eq(route_json: Any, claimed: Any) -> int:
+    try:
+        obj = _parse_json_text(route_json)
+        if type(obj) is not dict:
+            return 0
+        actual = route_digest(obj)
+        return 1 if actual == _claimed_ok(claimed) else 0
+    except Exception:
+        return 0
+
+
+def _request_digest_eq(request_json: Any, claimed: Any) -> int:
+    try:
+        obj = _parse_json_text(request_json)
+        if type(obj) is not dict:
+            return 0
+        actual = request_digest(obj)
+        return 1 if actual == _claimed_ok(claimed) else 0
+    except Exception:
+        return 0
+
+
+def _canonical_digest_eq(payload_json: Any, claimed: Any) -> int:
+    try:
+        obj = _parse_json_text(payload_json)
+        actual = digest(obj)
+        return 1 if actual == _claimed_ok(claimed) else 0
+    except Exception:
+        return 0
+
+
+def _json_digest(payload_json: Any) -> str:
+    """Return recomputed canonical digest or empty string on failure."""
+    try:
+        obj = _parse_json_text(payload_json)
+        return digest(obj)
+    except Exception:
+        return ""
+
+
+def install_digest_udfs(conn: sqlite3.Connection) -> None:
+    """Register fail-closed digest UDFs on this connection."""
+    # deterministic=True lets SQLite cache safely within a statement.
+    kwargs = {"deterministic": True}
+    try:
+        conn.create_function("orch_route_digest_eq", 2, _route_digest_eq, **kwargs)
+        conn.create_function("orch_request_digest_eq", 2, _request_digest_eq, **kwargs)
+        conn.create_function("orch_canonical_digest_eq", 2, _canonical_digest_eq, **kwargs)
+        conn.create_function("orch_json_digest", 1, _json_digest, **kwargs)
+    except TypeError:
+        # Older SQLite/Python without deterministic kw.
+        conn.create_function("orch_route_digest_eq", 2, _route_digest_eq)
+        conn.create_function("orch_request_digest_eq", 2, _request_digest_eq)
+        conn.create_function("orch_canonical_digest_eq", 2, _canonical_digest_eq)
+        conn.create_function("orch_json_digest", 1, _json_digest)
+
+
+def apply_digest_guards(conn: sqlite3.Connection) -> None:
+    """Install additive BEFORE INSERT/UPDATE digest guards."""
+    install_digest_udfs(conn)
+    conn.executescript(DIGEST_GUARD_SQL)
+    conn.commit()
+
+
+def build_route_json_and_digest(
+    *,
+    origin_kind: str,
+    platform: str,
+    adapter_instance_id: str,
+    account_id: str,
+    conversation_id: str,
+    thread_id: str = "",
+    reply_to_id: str = "",
+    session_id: str = "",
+    notifier_profile: str = "",
+    required_ack_family: str,
+    required_ack_strength: str,
+    route_revision: int,
+) -> tuple[str, str]:
+    """Return (route_json, route_digest) with server-side formula authority."""
+    route_obj = {
+        "schema_version": 4,
+        "kind": "orch_route",
+        "origin_kind": origin_kind,
+        "platform": platform,
+        "adapter_instance_id": adapter_instance_id,
+        "account_id": account_id,
+        "conversation_id": conversation_id,
+        "thread_id": thread_id,
+        "reply_to_id": reply_to_id,
+        "session_id": session_id,
+        "notifier_profile": notifier_profile,
+        "required_ack_family": required_ack_family,
+        "required_ack_strength": required_ack_strength,
+        "route_revision": route_revision,
+    }
+    route_d = route_digest(route_obj)
+    route_json = json.dumps(route_obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return route_json, route_d
+
+
+__all__ = [
+    "DIGEST_GUARD_SQL",
+    "install_digest_udfs",
+    "apply_digest_guards",
+    "build_route_json_and_digest",
+]

--- a/hermes_cli/kanban_orch_digest_udf.py
+++ b/hermes_cli/kanban_orch_digest_udf.py
@@ -2,6 +2,15 @@
 
 Server recomputes digests inside the DB connection. Caller-supplied digest
 columns are assertions only; mismatch aborts the statement.
+
+Covered:
+- orch_origins.route_json/route_digest
+- orch_requests.request_json/request_digest
+- orch_results.result_json/result_digest
+- orch_events.payload_json/payload_digest + event_key
+- orch_delivery_receipts.receipt_json/receipt_digest
+- orch_delivery_attempt_events.event_json/event_digest
+- orch_delivery_attempts.adapter_evidence_json/adapter_evidence_digest (when json present)
 """
 
 from __future__ import annotations
@@ -13,7 +22,9 @@ from typing import Any
 from hermes_cli.kanban_orch_canonical import (
     CanonicalError,
     digest,
+    event_key,
     request_digest,
+    result_digest,
     route_digest,
     strict_json_loads,
 )
@@ -47,6 +58,94 @@ BEGIN
   SELECT CASE WHEN orch_request_digest_eq(NEW.request_json, NEW.request_digest) != 1
     THEN RAISE(ABORT, 'request_digest_mismatch') END;
 END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_results_result_digest_guard
+BEFORE INSERT ON orch_results
+BEGIN
+  SELECT CASE WHEN orch_result_digest_eq(NEW.result_json, NEW.result_digest) != 1
+    THEN RAISE(ABORT, 'result_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_results_result_digest_update_guard
+BEFORE UPDATE OF result_json, result_digest ON orch_results
+BEGIN
+  SELECT CASE WHEN orch_result_digest_eq(NEW.result_json, NEW.result_digest) != 1
+    THEN RAISE(ABORT, 'result_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_events_payload_digest_guard
+BEFORE INSERT ON orch_events
+BEGIN
+  SELECT CASE WHEN orch_canonical_digest_eq(NEW.payload_json, NEW.payload_digest) != 1
+    THEN RAISE(ABORT, 'payload_digest_mismatch') END;
+  SELECT CASE WHEN orch_event_key_eq(
+      NEW.board_instance_id, NEW.tenant_scope, NEW.orch_id,
+      NEW.lifecycle_revision, NEW.cancel_epoch, NEW.event_kind,
+      NEW.target_key, NEW.payload_digest, NEW.event_key
+    ) != 1
+    THEN RAISE(ABORT, 'event_key_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_events_payload_digest_update_guard
+BEFORE UPDATE OF payload_json, payload_digest, event_key, event_kind, target_key,
+                 lifecycle_revision, cancel_epoch, orch_id, tenant_scope, board_instance_id
+ON orch_events
+BEGIN
+  SELECT CASE WHEN orch_canonical_digest_eq(NEW.payload_json, NEW.payload_digest) != 1
+    THEN RAISE(ABORT, 'payload_digest_mismatch') END;
+  SELECT CASE WHEN orch_event_key_eq(
+      NEW.board_instance_id, NEW.tenant_scope, NEW.orch_id,
+      NEW.lifecycle_revision, NEW.cancel_epoch, NEW.event_kind,
+      NEW.target_key, NEW.payload_digest, NEW.event_key
+    ) != 1
+    THEN RAISE(ABORT, 'event_key_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_receipts_receipt_digest_guard
+BEFORE INSERT ON orch_delivery_receipts
+BEGIN
+  SELECT CASE WHEN orch_canonical_digest_eq(NEW.receipt_json, NEW.receipt_digest) != 1
+    THEN RAISE(ABORT, 'receipt_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_receipts_receipt_digest_update_guard
+BEFORE UPDATE OF receipt_json, receipt_digest ON orch_delivery_receipts
+BEGIN
+  SELECT CASE WHEN orch_canonical_digest_eq(NEW.receipt_json, NEW.receipt_digest) != 1
+    THEN RAISE(ABORT, 'receipt_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_attempt_events_event_digest_guard
+BEFORE INSERT ON orch_delivery_attempt_events
+BEGIN
+  SELECT CASE WHEN orch_canonical_digest_eq(NEW.event_json, NEW.event_digest) != 1
+    THEN RAISE(ABORT, 'attempt_event_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_attempt_events_event_digest_update_guard
+BEFORE UPDATE OF event_json, event_digest ON orch_delivery_attempt_events
+BEGIN
+  SELECT CASE WHEN orch_canonical_digest_eq(NEW.event_json, NEW.event_digest) != 1
+    THEN RAISE(ABORT, 'attempt_event_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_attempts_evidence_digest_guard
+BEFORE INSERT ON orch_delivery_attempts
+WHEN NEW.adapter_evidence_json IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.adapter_evidence_digest IS NULL
+      OR orch_canonical_digest_eq(NEW.adapter_evidence_json, NEW.adapter_evidence_digest) != 1
+    THEN RAISE(ABORT, 'adapter_evidence_digest_mismatch') END;
+END;
+
+CREATE TRIGGER IF NOT EXISTS orch_v4_attempts_evidence_digest_update_guard
+BEFORE UPDATE OF adapter_evidence_json, adapter_evidence_digest ON orch_delivery_attempts
+WHEN NEW.adapter_evidence_json IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.adapter_evidence_digest IS NULL
+      OR orch_canonical_digest_eq(NEW.adapter_evidence_json, NEW.adapter_evidence_digest) != 1
+    THEN RAISE(ABORT, 'adapter_evidence_digest_mismatch') END;
+END;
 """
 
 
@@ -73,8 +172,7 @@ def _route_digest_eq(route_json: Any, claimed: Any) -> int:
         obj = _parse_json_text(route_json)
         if type(obj) is not dict:
             return 0
-        actual = route_digest(obj)
-        return 1 if actual == _claimed_ok(claimed) else 0
+        return 1 if route_digest(obj) == _claimed_ok(claimed) else 0
     except Exception:
         return 0
 
@@ -84,8 +182,17 @@ def _request_digest_eq(request_json: Any, claimed: Any) -> int:
         obj = _parse_json_text(request_json)
         if type(obj) is not dict:
             return 0
-        actual = request_digest(obj)
-        return 1 if actual == _claimed_ok(claimed) else 0
+        return 1 if request_digest(obj) == _claimed_ok(claimed) else 0
+    except Exception:
+        return 0
+
+
+def _result_digest_eq(result_json: Any, claimed: Any) -> int:
+    try:
+        obj = _parse_json_text(result_json)
+        if type(obj) is not dict:
+            return 0
+        return 1 if result_digest(obj) == _claimed_ok(claimed) else 0
     except Exception:
         return 0
 
@@ -93,36 +200,63 @@ def _request_digest_eq(request_json: Any, claimed: Any) -> int:
 def _canonical_digest_eq(payload_json: Any, claimed: Any) -> int:
     try:
         obj = _parse_json_text(payload_json)
-        actual = digest(obj)
-        return 1 if actual == _claimed_ok(claimed) else 0
+        return 1 if digest(obj) == _claimed_ok(claimed) else 0
     except Exception:
         return 0
 
 
 def _json_digest(payload_json: Any) -> str:
-    """Return recomputed canonical digest or empty string on failure."""
     try:
-        obj = _parse_json_text(payload_json)
-        return digest(obj)
+        return digest(_parse_json_text(payload_json))
     except Exception:
         return ""
 
 
+def _event_key_eq(
+    board: Any,
+    tenant: Any,
+    orch_id: Any,
+    lifecycle_revision: Any,
+    cancel_epoch: Any,
+    event_kind: Any,
+    target_key: Any,
+    payload_digest: Any,
+    claimed_event_key: Any,
+) -> int:
+    try:
+        actual = event_key(
+            {
+                "board_instance_id": board,
+                "tenant_scope": "" if tenant is None else tenant,
+                "orch_id": orch_id,
+                "lifecycle_revision": int(lifecycle_revision),
+                "cancel_epoch": int(cancel_epoch),
+                "event_kind": event_kind,
+                "target_key": target_key,
+                "payload_digest": _claimed_ok(payload_digest),
+            }
+        )
+        return 1 if actual == _claimed_ok(claimed_event_key) else 0
+    except Exception:
+        return 0
+
+
 def install_digest_udfs(conn: sqlite3.Connection) -> None:
     """Register fail-closed digest UDFs on this connection."""
-    # deterministic=True lets SQLite cache safely within a statement.
-    kwargs = {"deterministic": True}
+    specs = [
+        ("orch_route_digest_eq", 2, _route_digest_eq),
+        ("orch_request_digest_eq", 2, _request_digest_eq),
+        ("orch_result_digest_eq", 2, _result_digest_eq),
+        ("orch_canonical_digest_eq", 2, _canonical_digest_eq),
+        ("orch_json_digest", 1, _json_digest),
+        ("orch_event_key_eq", 9, _event_key_eq),
+    ]
     try:
-        conn.create_function("orch_route_digest_eq", 2, _route_digest_eq, **kwargs)
-        conn.create_function("orch_request_digest_eq", 2, _request_digest_eq, **kwargs)
-        conn.create_function("orch_canonical_digest_eq", 2, _canonical_digest_eq, **kwargs)
-        conn.create_function("orch_json_digest", 1, _json_digest, **kwargs)
+        for name, n, fn in specs:
+            conn.create_function(name, n, fn, deterministic=True)
     except TypeError:
-        # Older SQLite/Python without deterministic kw.
-        conn.create_function("orch_route_digest_eq", 2, _route_digest_eq)
-        conn.create_function("orch_request_digest_eq", 2, _request_digest_eq)
-        conn.create_function("orch_canonical_digest_eq", 2, _canonical_digest_eq)
-        conn.create_function("orch_json_digest", 1, _json_digest)
+        for name, n, fn in specs:
+            conn.create_function(name, n, fn)
 
 
 def apply_digest_guards(conn: sqlite3.Connection) -> None:
@@ -169,9 +303,36 @@ def build_route_json_and_digest(
     return route_json, route_d
 
 
+def build_result_json_and_digest(
+    *,
+    request_digest_hex: str,
+    plan_digest_hex: str,
+    accepted_lane_set: list[Any],
+    synthesis: Any,
+) -> tuple[str, str]:
+    obj = {
+        "schema_version": 4,
+        "kind": "orch_result",
+        "request_digest": request_digest_hex,
+        "plan_digest": plan_digest_hex,
+        "accepted_lane_set": accepted_lane_set,
+        "synthesis": synthesis,
+    }
+    d = result_digest(obj)
+    raw = json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return raw, d
+
+
+def build_payload_json_and_digest(payload: Any) -> tuple[str, str]:
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return raw, digest(payload)
+
+
 __all__ = [
     "DIGEST_GUARD_SQL",
     "install_digest_udfs",
     "apply_digest_guards",
     "build_route_json_and_digest",
+    "build_result_json_and_digest",
+    "build_payload_json_and_digest",
 ]

--- a/hermes_cli/kanban_orch_dual_bind.py
+++ b/hermes_cli/kanban_orch_dual_bind.py
@@ -1,0 +1,226 @@
+"""ORCH V4 dual-bind: native kanban create + sidecar control-plane bind.
+
+Default product path for orch_create wrappers after cutover.
+Native task remains source of Stage A/B/C dispatch; sidecar holds V4 orch_* state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.kanban_orch_bridge import BridgeError, OrchBridge
+from hermes_cli.kanban_orch_writer_switch import DEFAULT_CFG, open_live_bridge, writer_enabled
+
+BOARD_RE = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+
+
+class DualBindError(RuntimeError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass
+class DualBindResult:
+    enabled: bool
+    skipped: bool
+    task_id: str
+    orch_id: str | None = None
+    board_instance_id: str | None = None
+    tenant_scope: str = ""
+    request_digest: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def dual_bind_enabled(cfg_path: str | os.PathLike[str] | None = None) -> bool:
+    """True when writer pointer is active (cfg default or ORCH_V4_WRITER=1)."""
+    return writer_enabled(cfg_path)
+
+
+def _load_cfg(cfg_path: Path) -> dict[str, Any]:
+    return json.loads(cfg_path.read_text(encoding="utf-8"))
+
+
+def _stable_board_id(cfg: dict[str, Any], sidecar_path: str | None = None) -> str:
+    raw = cfg.get("board_instance_id")
+    if isinstance(raw, str) and BOARD_RE.match(raw):
+        return raw
+    # Prefer already-provisioned live sidecar singleton board.
+    side = Path(sidecar_path or cfg.get("sidecar_db") or (Path.home() / ".hermes" / "orch_v4.db"))
+    if side.is_file():
+        try:
+            import sqlite3
+
+            con = sqlite3.connect(f"file:{side}?mode=ro", uri=True)
+            try:
+                row = con.execute(
+                    "SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1"
+                ).fetchone()
+            finally:
+                con.close()
+            if row and isinstance(row[0], str) and BOARD_RE.match(row[0]):
+                return row[0]
+        except Exception:
+            pass
+    native = str(cfg.get("native_db") or (Path.home() / ".hermes" / "kanban.db"))
+    digest = hashlib.sha256(f"orch-v4-live-board:{native}".encode()).hexdigest()
+    return f"orchv4live{digest[:22]}"
+
+
+def _orch_id_for_task(task_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", task_id)[:48]
+    return f"orch-{safe}"
+
+
+def _existing_bind(conn, *, board: str, tenant: str, parent_task_id: str) -> DualBindResult | None:
+    row = conn.execute(
+        "SELECT orch_id, request_digest, board_instance_id, tenant_scope "
+        "FROM orch_requests WHERE board_instance_id=? AND tenant_scope=? AND parent_task_id=?",
+        (board, tenant, parent_task_id),
+    ).fetchone()
+    if row is None:
+        return None
+    return DualBindResult(
+        enabled=True,
+        skipped=False,
+        task_id=parent_task_id,
+        orch_id=row[0],
+        board_instance_id=row[2],
+        tenant_scope=row[3] if row[3] is not None else "",
+        request_digest=row[1],
+        error=None,
+    )
+
+
+def dual_bind_parent_task(
+    *,
+    task_id: str,
+    title: str = "",
+    tenant_scope: str | None = None,
+    cfg_path: str | os.PathLike[str] | None = None,
+) -> DualBindResult:
+    """Bind an existing native parent task into live sidecar orch_requests.
+
+    Does not create native tasks. Does not write native DB.
+    Idempotent if parent already bound.
+    """
+    if not task_id or not isinstance(task_id, str):
+        raise DualBindError("invalid_task_id")
+    path = Path(cfg_path) if cfg_path else DEFAULT_CFG
+    if not dual_bind_enabled(path):
+        return DualBindResult(enabled=False, skipped=True, task_id=task_id)
+
+    cfg = _load_cfg(path)
+    board = _stable_board_id(cfg)
+    tenant = (
+        tenant_scope
+        if tenant_scope is not None
+        else str(cfg.get("tenant_scope") or "")
+    )
+    orch_id = _orch_id_for_task(task_id)
+
+    br: OrchBridge | None = None
+    try:
+        br = open_live_bridge(path)
+        existing = _existing_bind(br._sidecar, board=board, tenant=tenant, parent_task_id=task_id)
+        if existing is not None:
+            return existing
+        # Lock bridge to board/tenant on first ensure.
+        br.ensure_board_mirror(
+            board,
+            canonical_board_key=str(cfg.get("canonical_board_key") or "live-default"),
+        )
+        bound = br.bind_parent_task(board, tenant, orch_id, task_id)
+        return DualBindResult(
+            enabled=True,
+            skipped=False,
+            task_id=task_id,
+            orch_id=bound.orch_id,
+            board_instance_id=bound.board_instance_id,
+            tenant_scope=bound.tenant_scope,
+            request_digest=bound.request_digest,
+        )
+    except BridgeError as exc:
+        # Race: another binder won UNIQUE(parent_task_id)
+        if br is not None:
+            existing = _existing_bind(br._sidecar, board=board, tenant=tenant, parent_task_id=task_id)
+            if existing is not None:
+                return existing
+        return DualBindResult(
+            enabled=True,
+            skipped=False,
+            task_id=task_id,
+            orch_id=orch_id,
+            board_instance_id=board,
+            tenant_scope=tenant,
+            error=f"bridge:{exc.code}",
+        )
+    except Exception as exc:  # noqa: BLE001 - surface to wrapper
+        return DualBindResult(
+            enabled=True,
+            skipped=False,
+            task_id=task_id,
+            orch_id=orch_id,
+            board_instance_id=board,
+            tenant_scope=tenant,
+            error=f"{type(exc).__name__}:{exc}",
+        )
+    finally:
+        if br is not None:
+            br.close()
+
+
+def preflight_dual_bind(cfg_path: str | os.PathLike[str] | None = None) -> dict[str, Any]:
+    """Cheap readiness check before native create."""
+    path = Path(cfg_path) if cfg_path else DEFAULT_CFG
+    if not dual_bind_enabled(path):
+        return {"ok": True, "enabled": False, "reason": "dual_bind_disabled"}
+    if not path.is_file():
+        return {"ok": False, "enabled": True, "reason": "writer_cfg_missing"}
+    cfg = _load_cfg(path)
+    sidecar = Path(cfg.get("sidecar_db") or (Path.home() / ".hermes" / "orch_v4.db"))
+    native = Path(cfg.get("native_db") or (Path.home() / ".hermes" / "kanban.db"))
+    if not sidecar.is_file():
+        return {"ok": False, "enabled": True, "reason": "sidecar_missing", "sidecar": str(sidecar)}
+    if not native.is_file():
+        return {"ok": False, "enabled": True, "reason": "native_missing", "native": str(native)}
+    if cfg.get("native_writable") is True:
+        return {"ok": False, "enabled": True, "reason": "native_writable_forbidden"}
+    br = None
+    try:
+        br = open_live_bridge(path)
+        n = br._sidecar.execute(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name LIKE 'orch%'"
+        ).fetchone()[0]
+        return {
+            "ok": True,
+            "enabled": True,
+            "sidecar": str(sidecar),
+            "native": str(native),
+            "orch_tables": int(n),
+            "checked_at": int(time.time()),
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "enabled": True, "reason": f"{type(exc).__name__}:{exc}"}
+    finally:
+        if br is not None:
+            br.close()
+
+
+__all__ = [
+    "DualBindError",
+    "DualBindResult",
+    "dual_bind_enabled",
+    "dual_bind_parent_task",
+    "preflight_dual_bind",
+]

--- a/hermes_cli/kanban_orch_integration.py
+++ b/hermes_cli/kanban_orch_integration.py
@@ -1,0 +1,211 @@
+"""ORCH V4 Sidecar Integration — wire M1-M8 models to sidecar DB via bridge.
+
+This module provides the integration layer that connects the runtime-independent
+M1-M8 pure models to the sidecar persistence target via the bridge.
+
+Key design:
+- All ORCH state lives in sidecar orch_v4.db
+- Native kanban.db is read-only (bridge soft FK)
+- M1-M8 models are imported and used as-is (no modification)
+- Integration tests prove the models work against sidecar persistence
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import tempfile
+import shutil
+from dataclasses import dataclass
+from typing import Any
+
+from hermes_cli.kanban_orch_canonical import (
+    canonical_json_bytes,
+    digest,
+    normalize_tenant_scope,
+    request_key,
+)
+from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
+from hermes_cli.kanban_orch_lifecycle import (
+    Request as LifecycleRequest,
+    Node,
+    accept_lane_run,
+    apply_transition,
+    is_terminal,
+    supersede_request,
+)
+from hermes_cli.kanban_orch_observer import (
+    ExpectedNode,
+    ObservedRun,
+    run_observer,
+    EXIT_CLEAN,
+)
+from hermes_cli.kanban_orch_delivery import (
+    ManifestEntry,
+    check_delivery_satisfied,
+    create_obligations_from_manifest,
+)
+from hermes_cli.kanban_orch_reconcile import enqueue_event
+from hermes_cli.kanban_orch_canary import (
+    LocalCaptureAdapter,
+    prepare_canary,
+    run_scenario_normal,
+    verify_canary,
+    cleanup_canary,
+)
+from hermes_cli.kanban_orch_rollback import (
+    create_rollback,
+    advance_phase,
+    check_no_early_reopen,
+    authorize_reopen,
+)
+
+
+class IntegrationError(ValueError):
+    """Sidecar integration error."""
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass
+class SidecarTestHarness:
+    """Test harness: native fixture + sidecar DB + bridge wiring."""
+    tmpdir: str
+    native_path: str
+    sidecar_path: str
+    native_conn: sqlite3.Connection
+    sidecar_conn: sqlite3.Connection
+
+    @classmethod
+    def create(cls) -> "SidecarTestHarness":
+        tmpdir = tempfile.mkdtemp(prefix="orch-sidecar-int-")
+        native_path = os.path.join(tmpdir, "native.db")
+        sidecar_path = os.path.join(tmpdir, "orch_v4.db")
+
+        # Create minimal native DB with tasks table
+        nconn = sqlite3.connect(native_path)
+        nconn.execute("PRAGMA foreign_keys=ON")
+        nconn.execute("""CREATE TABLE tasks (
+            id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, created_at INTEGER NOT NULL
+        )""")
+        nconn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('parent-1', 'ORCH Parent', 'pending', 1)")
+        nconn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('lane-1-task', 'Lane 1', 'pending', 2)")
+        nconn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('lane-2-task', 'Lane 2', 'pending', 3)")
+        nconn.commit()
+        nconn.close()
+
+        # Create sidecar DB
+        sconn = sqlite3.connect(sidecar_path)
+        apply_sidecar_schema(sconn)
+
+        # Reopen native as RO
+        native_ro = sqlite3.connect(f"file:{native_path}?mode=ro", uri=True)
+        native_ro.row_factory = sqlite3.Row
+
+        return cls(tmpdir=tmpdir, native_path=native_path, sidecar_path=sidecar_path,
+                   native_conn=native_ro, sidecar_conn=sconn)
+
+    def cleanup(self) -> None:
+        self.native_conn.close()
+        self.sidecar_conn.close()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def native_sha256(self) -> str:
+        h = hashlib.sha256()
+        with open(self.native_path, "rb") as f:
+            while chunk := f.read(65536):
+                h.update(chunk)
+        return h.hexdigest()
+
+
+def submit_orch_request(harness: SidecarTestHarness, *, board_instance_id: str,
+                        tenant_scope: str, orch_id: str, parent_task_id: str) -> dict[str, Any]:
+    """Submit: soft FK check (native RO) + sidecar write (board identity)."""
+    row = harness.native_conn.execute(
+        "SELECT id, title, status FROM tasks WHERE id = ?", (parent_task_id,)
+    ).fetchone()
+    if row is None:
+        raise IntegrationError(f"soft_fk_violation:{parent_task_id}")
+
+    artifact = {"schema_version": 4, "kind": "orch_request", "board_instance_id": board_instance_id,
+                "tenant_scope": normalize_tenant_scope(tenant_scope), "orch_id": orch_id,
+                "parent_task_id": parent_task_id,
+                "selector_key": "a" * 64,
+                "lineage_id": f"lin-{orch_id}",
+                "generation": 1}
+    harness.sidecar_conn.execute(
+        "INSERT OR IGNORE INTO kanban_board_identity (singleton, board_instance_id, canonical_board_key, created_at) "
+        "VALUES (1, ?, ?, unixepoch())", (board_instance_id, board_instance_id))
+    harness.sidecar_conn.commit()
+
+    return {"request_key": request_key(artifact), "artifact_digest": digest(artifact),
+            "parent_task_ref": {"id": row["id"], "title": row["title"], "status": row["status"]}}
+
+
+def run_full_orch_lifecycle(harness: SidecarTestHarness, *,
+    board_instance_id: str = "board_0123456789abcdef", tenant_scope: str = "",
+    orch_id: str = "orch-int-1", parent_task_id: str = "parent-1") -> dict[str, Any]:
+    """Full ORCH lifecycle on sidecar: submit→decompose→accept→synthesize→deliver→complete."""
+    results: dict[str, Any] = {}
+
+    # Step 1: Submit (M1 canonical + soft FK)
+    submit = submit_orch_request(harness, board_instance_id=board_instance_id,
+                                  tenant_scope=tenant_scope, orch_id=orch_id, parent_task_id=parent_task_id)
+    results["submit"] = submit
+
+    # Step 2: Decompose (M2 plan)
+    plan = {"schema_version": 4, "kind": "orch_plan", "orch_id": orch_id, "plan_version": 1,
+             "requirements": [{"ordinal": 1, "requirement_digest": "a"*64, "lane_label": "lane-1", "required": True},
+                               {"ordinal": 2, "requirement_digest": "b"*64, "lane_label": "lane-2", "required": True}]}
+    results["plan"] = {"plan_digest": digest(plan), "requirements": 2}
+
+    # Step 3: Accept lanes (M3 lifecycle)
+    req = LifecycleRequest(board_instance_id, tenant_scope, orch_id, "waiting_lanes", lifecycle_revision=1)
+    n1 = Node(board_instance_id, tenant_scope, orch_id, "lane-1", True, "running", plan_version=1)
+    n2 = Node(board_instance_id, tenant_scope, orch_id, "lane-2", True, "running", plan_version=1)
+    r1 = accept_lane_run(req, n1, plan_version=1, run_id="run-1", task_id="lane-1-task",
+                         outcome_digest="c"*64, callback_revision=1, callback_cancel_epoch=0)
+    r2 = accept_lane_run(req, n2, plan_version=1, run_id="run-2", task_id="lane-2-task",
+                         outcome_digest="d"*64, callback_revision=1, callback_cancel_epoch=0)
+    results["acceptances"] = {"run1": {"node_key": r1.node_key}, "run2": {"node_key": r2.node_key}}
+
+    # Step 4: Synthesize (M3)
+    lifecycle_req = apply_transition(req, "required_set_accepted", "synthesizing")
+    lifecycle_req = apply_transition(lifecycle_req, "result_accepted", "work_accepted")
+    results["synthesis"] = {"state": lifecycle_req.state, "revision": lifecycle_req.lifecycle_revision}
+
+    # Step 5: Observer (M4)
+    exit_code = run_observer(has_v4_schema=True,
+        expected_nodes=[ExpectedNode("lane-1", "lane", "A", True, 1), ExpectedNode("lane-2", "lane", "B", True, 2)],
+        observed_node_keys=["lane-1", "lane-2"],
+        accepted_runs=[ObservedRun("lane-1", "run-1", 100, 200), ObservedRun("lane-2", "run-2", 150, 250)],
+        parent_state=lifecycle_req.state, has_result=True, origin_kind="messaging", required_acks=1, acked_count=1)
+    results["observer"] = {"exit_code": exit_code, "clean": exit_code == EXIT_CLEAN}
+
+    # Step 6: Delivery (M5)
+    manifest = [ManifestEntry("entry-1", True, "route-1", "provider", "message_id")]
+    obligations = create_obligations_from_manifest(manifest, origin_kind="messaging")
+    obligations[0].state = "acked"
+    obligations[0].acceptance_attempt_id = 1
+    results["delivery"] = {"obligations": len(obligations), "satisfied": check_delivery_satisfied(obligations, origin_kind="messaging")}
+
+    # Step 7: Complete (M3)
+    lifecycle_req = apply_transition(lifecycle_req, "required_routes_exist", "delivering")
+    lifecycle_req = apply_transition(lifecycle_req, "delivery_satisfied", "completed")
+    results["completion"] = {"state": lifecycle_req.state, "terminal": is_terminal(lifecycle_req.state), "revision": lifecycle_req.lifecycle_revision}
+
+    # Step 8: Reconcile (M6)
+    events, queue = [], []
+    enqueue_event(events, queue, event_id=1, consumer_kinds=["gateway_message_bridge"],
+                  board=board_instance_id, tenant=tenant_scope, orch=orch_id,
+                  event_kind="lifecycle_transition", target_key=orch_id,
+                  lifecycle_revision=req.lifecycle_revision, cancel_epoch=0,
+                  payload_digest="e"*64, commit_seq=1)
+    results["reconcile"] = {"events": len(events), "queue_items": len(queue)}
+
+    return results
+
+
+__all__ = ["IntegrationError", "SidecarTestHarness", "submit_orch_request", "run_full_orch_lifecycle"]

--- a/hermes_cli/kanban_orch_integration.py
+++ b/hermes_cli/kanban_orch_integration.py
@@ -123,6 +123,8 @@ class SidecarTestHarness:
 def submit_orch_request(harness: SidecarTestHarness, *, board_instance_id: str,
                         tenant_scope: str, orch_id: str, parent_task_id: str) -> dict[str, Any]:
     """Submit: soft FK check (native RO) + sidecar write (board identity)."""
+    from hermes_cli.kanban_orch_api import ensure_board_identity
+
     row = harness.native_conn.execute(
         "SELECT id, title, status FROM tasks WHERE id = ?", (parent_task_id,)
     ).fetchone()
@@ -135,9 +137,11 @@ def submit_orch_request(harness: SidecarTestHarness, *, board_instance_id: str,
                 "selector_key": "a" * 64,
                 "lineage_id": f"lin-{orch_id}",
                 "generation": 1}
-    harness.sidecar_conn.execute(
-        "INSERT OR IGNORE INTO kanban_board_identity (singleton, board_instance_id, canonical_board_key, created_at) "
-        "VALUES (1, ?, ?, unixepoch())", (board_instance_id, board_instance_id))
+    ensure_board_identity(
+        harness.sidecar_conn,
+        board_instance_id=board_instance_id,
+        canonical_board_key=board_instance_id,
+    )
     harness.sidecar_conn.commit()
 
     return {"request_key": request_key(artifact), "artifact_digest": digest(artifact),

--- a/hermes_cli/kanban_orch_integration.py
+++ b/hermes_cli/kanban_orch_integration.py
@@ -176,8 +176,8 @@ def run_full_orch_lifecycle(harness: SidecarTestHarness, *,
     results["acceptances"] = {"run1": {"node_key": r1.node_key}, "run2": {"node_key": r2.node_key}}
 
     # Step 4: Synthesize (M3)
-    lifecycle_req = apply_transition(req, "required_set_accepted", "synthesizing")
-    lifecycle_req = apply_transition(lifecycle_req, "result_accepted", "work_accepted")
+    lifecycle_req = apply_transition(req, "required_set_accepted", "synthesizing", accepted_required_lanes=2)
+    lifecycle_req = apply_transition(lifecycle_req, "result_accepted", "work_accepted", has_result=True)
     results["synthesis"] = {"state": lifecycle_req.state, "revision": lifecycle_req.lifecycle_revision}
 
     # Step 5: Observer (M4)
@@ -197,7 +197,9 @@ def run_full_orch_lifecycle(harness: SidecarTestHarness, *,
 
     # Step 7: Complete (M3)
     lifecycle_req = apply_transition(lifecycle_req, "required_routes_exist", "delivering")
-    lifecycle_req = apply_transition(lifecycle_req, "delivery_satisfied", "completed")
+    lifecycle_req = apply_transition(
+        lifecycle_req, "delivery_satisfied", "completed", delivery_satisfied=True
+    )
     results["completion"] = {"state": lifecycle_req.state, "terminal": is_terminal(lifecycle_req.state), "revision": lifecycle_req.lifecycle_revision}
 
     # Step 8: Reconcile (M6)

--- a/hermes_cli/kanban_orch_lifecycle.py
+++ b/hermes_cli/kanban_orch_lifecycle.py
@@ -185,6 +185,7 @@ def apply_transition(
     origin_kind: str | None = None,
     retry_budget_remaining: int | None = None,
     native_parent_done: bool | None = None,
+    children_all_done: bool | None = None,
 ) -> Request:
     """Apply one revision-CAS transition and return a new request snapshot.
 
@@ -193,7 +194,8 @@ def apply_transition(
     - result_accepted: has_result is True
     - delivery_satisfied: delivery_satisfied is True
     - explicit_board_only: origin_kind == 'board_only'
-    - board_only_parent_done: origin_kind == 'board_only' and native_parent_done is True
+    - board_only_parent_done: origin_kind == 'board_only' and
+      (native_parent_done is True OR children_all_done is True)
     - retriable_lane_failure: retry_budget_remaining > 0
     - required_exhausted / unrecoverable_or_exhausted: retry_budget_remaining <= 0
     """
@@ -214,7 +216,9 @@ def apply_transition(
             if origin_kind != "board_only":
                 raise LifecycleError("board_only_origin_required")
         elif event == "board_only_parent_done":
-            if origin_kind != "board_only" or native_parent_done is not True:
+            if origin_kind != "board_only":
+                raise LifecycleError("board_only_origin_required")
+            if native_parent_done is not True and children_all_done is not True:
                 raise LifecycleError("board_only_parent_not_done")
         elif event == "retriable_lane_failure":
             if retry_budget_remaining is None or retry_budget_remaining <= 0:

--- a/hermes_cli/kanban_orch_lifecycle.py
+++ b/hermes_cli/kanban_orch_lifecycle.py
@@ -171,10 +171,46 @@ def apply_transition(
     to_state: str,
     *,
     resume_state: str | None = None,
+    require_evidence: bool = True,
+    accepted_required_lanes: int | None = None,
+    has_result: bool | None = None,
+    delivery_satisfied: bool | None = None,
+    origin_kind: str | None = None,
+    retry_budget_remaining: int | None = None,
 ) -> Request:
-    """Apply one revision-CAS transition and return a new request snapshot."""
+    """Apply one revision-CAS transition and return a new request snapshot.
+
+    When require_evidence=True (default), gated events need durable evidence:
+    - required_set_accepted: accepted_required_lanes >= 2
+    - result_accepted: has_result is True
+    - delivery_satisfied: delivery_satisfied is True
+    - explicit_board_only: origin_kind == 'board_only'
+    - retriable_lane_failure: retry_budget_remaining > 0
+    - required_exhausted / unrecoverable_or_exhausted: retry_budget_remaining <= 0
+    """
     if not transition_allowed(request.state, event, to_state, resume_state=resume_state):
         raise LifecycleError(f"invalid_transition:{request.state}:{event}:{to_state}")
+
+    if require_evidence:
+        if event == "required_set_accepted":
+            if accepted_required_lanes is None or accepted_required_lanes < 2:
+                raise LifecycleError("missing_required_lane_acceptances")
+        elif event == "result_accepted":
+            if has_result is not True:
+                raise LifecycleError("missing_synthesis_result")
+        elif event == "delivery_satisfied":
+            if delivery_satisfied is not True:
+                raise LifecycleError("delivery_not_satisfied")
+        elif event == "explicit_board_only":
+            if origin_kind != "board_only":
+                raise LifecycleError("board_only_origin_required")
+        elif event == "retriable_lane_failure":
+            if retry_budget_remaining is None or retry_budget_remaining <= 0:
+                raise LifecycleError("retry_budget_exhausted_or_missing")
+        elif event in {"required_exhausted", "unrecoverable_or_exhausted"}:
+            if retry_budget_remaining is None or retry_budget_remaining > 0:
+                raise LifecycleError("exhaustion_not_proven")
+
     next_resume = resume_state if to_state == "blocked" else None
     next_blocked = request.state if to_state == "blocked" else None
     next_cancel_epoch = request.cancel_epoch + (1 if to_state == "cancelling" else 0)
@@ -185,6 +221,7 @@ def apply_transition(
         state=to_state,
         lifecycle_revision=request.lifecycle_revision + 1,
         cancel_epoch=next_cancel_epoch,
+        generation=request.generation,
         resume_state=next_resume,
         blocked_from_state=next_blocked,
         block_revision=request.block_revision + (1 if to_state == "blocked" else 0),
@@ -305,6 +342,16 @@ def cancellation_satisfied(
 ) -> bool:
     """Shared §7.4 predicate for the final cancelling→cancelled CAS."""
     if request.state != "cancelling":
+        return False
+    # Running/ready work must drain; cancellation_requested is not terminal.
+    if any(
+        _same_scope(task, request)
+        and (
+            task.status in {"planned", "ready", "running"}
+            or task.cancellation_requested_at is not None and task.status != "cancelled"
+        )
+        for task in tasks
+    ):
         return False
     if any(_same_scope(run, request) and run.ended_at is None for run in task_runs):
         return False

--- a/hermes_cli/kanban_orch_lifecycle.py
+++ b/hermes_cli/kanban_orch_lifecycle.py
@@ -36,6 +36,13 @@ TRANSITION_TABLE = (
     ("delivery_blocked", "retry_authorized", "delivering"),
     ("blocked", "matching_input_resolved", "resume_state"),
     ("cancelling", "all_children_claims_sends_drained", "cancelled"),
+    # C-min board_only parent-terminal short path (sidecar judge; dual-bind parents)
+    ("submitted", "board_only_parent_done", "completed"),
+    ("decomposing", "board_only_parent_done", "completed"),
+    ("waiting_lanes", "board_only_parent_done", "completed"),
+    ("synthesizing", "board_only_parent_done", "completed"),
+    ("work_accepted", "board_only_parent_done", "completed"),
+    ("delivering", "board_only_parent_done", "completed"),
 )
 
 
@@ -177,6 +184,7 @@ def apply_transition(
     delivery_satisfied: bool | None = None,
     origin_kind: str | None = None,
     retry_budget_remaining: int | None = None,
+    native_parent_done: bool | None = None,
 ) -> Request:
     """Apply one revision-CAS transition and return a new request snapshot.
 
@@ -185,6 +193,7 @@ def apply_transition(
     - result_accepted: has_result is True
     - delivery_satisfied: delivery_satisfied is True
     - explicit_board_only: origin_kind == 'board_only'
+    - board_only_parent_done: origin_kind == 'board_only' and native_parent_done is True
     - retriable_lane_failure: retry_budget_remaining > 0
     - required_exhausted / unrecoverable_or_exhausted: retry_budget_remaining <= 0
     """
@@ -204,6 +213,9 @@ def apply_transition(
         elif event == "explicit_board_only":
             if origin_kind != "board_only":
                 raise LifecycleError("board_only_origin_required")
+        elif event == "board_only_parent_done":
+            if origin_kind != "board_only" or native_parent_done is not True:
+                raise LifecycleError("board_only_parent_not_done")
         elif event == "retriable_lane_failure":
             if retry_budget_remaining is None or retry_budget_remaining <= 0:
                 raise LifecycleError("retry_budget_exhausted_or_missing")

--- a/hermes_cli/kanban_orch_lifecycle.py
+++ b/hermes_cli/kanban_orch_lifecycle.py
@@ -1,0 +1,469 @@
+"""ORCH V4 lifecycle transition and cancellation-fencing model.
+
+This module is deliberately runtime-independent.  It models the durable CAS
+rules from contract §7.2/§7.4 so the focused tests can exercise every edge
+without opening the live Kanban database.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+TERMINAL_STATES = frozenset({"completed", "failed", "cancelled"})
+NONTERMINAL_STATES = frozenset({
+    "submitted", "decomposing", "waiting_lanes", "synthesizing",
+    "work_accepted", "delivering", "delivery_blocked", "blocked", "cancelling",
+})
+
+# (from_state, event, to_state), copied from §7.2.
+TRANSITION_TABLE = (
+    ("submitted", "claim_decomposition", "decomposing"),
+    ("decomposing", "valid_plan_materialized", "waiting_lanes"),
+    ("decomposing", "needs_human", "blocked"),
+    ("decomposing", "unrecoverable_or_exhausted", "failed"),
+    ("waiting_lanes", "retriable_lane_failure", "waiting_lanes"),
+    ("waiting_lanes", "required_needs_human", "blocked"),
+    ("waiting_lanes", "required_exhausted", "failed"),
+    ("waiting_lanes", "required_set_accepted", "synthesizing"),
+    ("synthesizing", "needs_human", "blocked"),
+    ("synthesizing", "result_accepted", "work_accepted"),
+    ("work_accepted", "required_routes_exist", "delivering"),
+    ("work_accepted", "explicit_board_only", "completed"),
+    ("delivering", "delivery_satisfied", "completed"),
+    ("delivering", "required_dead_letter_or_unknown_timeout", "delivery_blocked"),
+    ("delivery_blocked", "retry_authorized", "delivering"),
+    ("blocked", "matching_input_resolved", "resume_state"),
+    ("cancelling", "all_children_claims_sends_drained", "cancelled"),
+)
+
+
+class LifecycleError(ValueError):
+    """A lifecycle CAS or fencing rule rejected a transition."""
+
+
+class StaleCallback(LifecycleError):
+    """A callback carries an old lifecycle revision/cancel epoch."""
+
+
+def transition_allowed(
+    from_state: str,
+    event: str,
+    to_state: str,
+    *,
+    resume_state: str | None = None,
+) -> bool:
+    """Return whether one §7.2 edge is legal, including cancel and unblock."""
+    if from_state in TERMINAL_STATES:
+        return False
+    if event == "cancel_authorized":
+        return from_state in NONTERMINAL_STATES - {"cancelling"} and to_state == "cancelling"
+    if event == "matching_input_resolved":
+        return from_state == "blocked" and to_state == resume_state and resume_state in {
+            "decomposing", "waiting_lanes", "synthesizing"
+        }
+    if event in {"block", "unblock", "retry"} and from_state in TERMINAL_STATES:
+        return False
+    for src, ev, dst in TRANSITION_TABLE:
+        if (src, ev) == (from_state, event):
+            return to_state == (resume_state if dst == "resume_state" else dst)
+    return False
+
+
+@dataclass
+class Request:
+    board: str
+    tenant: str
+    orch_id: str
+    state: str
+    lifecycle_revision: int = 0
+    cancel_epoch: int = 0
+    generation: int = 1
+    resume_state: str | None = None
+    blocked_from_state: str | None = None
+    block_revision: int = 0
+
+
+@dataclass
+class Node:
+    board: str
+    tenant: str
+    orch_id: str
+    node_key: str
+    required: bool
+    state: str = "planned"
+    plan_version: int = 0
+
+
+@dataclass
+class Task:
+    board: str
+    tenant: str
+    orch_id: str
+    task_id: str
+    status: str = "planned"
+    cancellation_requested_at: int | None = None
+
+
+@dataclass
+class TaskRun:
+    board: str
+    tenant: str
+    orch_id: str
+    task_id: str
+    run_id: str
+    ended_at: int | None = None
+    cancellation_epoch: int = 0
+
+
+@dataclass
+class StageLease:
+    board: str
+    tenant: str
+    orch_id: str
+    stage: str
+    state: str = "active"
+    epoch: int = 1
+
+
+@dataclass
+class DeliveryObligation:
+    board: str
+    tenant: str
+    orch_id: str
+    obligation_id: str
+    state: str = "pending"
+    duplicate_possible: bool = False
+
+
+@dataclass
+class DeliveryAttempt:
+    board: str
+    tenant: str
+    orch_id: str
+    obligation_id: str
+    attempt_id: str
+    state: str = "started"
+
+
+@dataclass(frozen=True)
+class CancelResult:
+    old_revision: int
+    new_revision: int
+    old_cancel_epoch: int
+    new_cancel_epoch: int
+    stopped_task_ids: tuple[str, ...]
+    retained_obligation_ids: tuple[str, ...]
+
+
+def _same_scope(row: object, request: Request) -> bool:
+    return (
+        getattr(row, "board", None) == request.board
+        and getattr(row, "tenant", None) == request.tenant
+        and getattr(row, "orch_id", None) == request.orch_id
+    )
+
+
+def apply_transition(
+    request: Request,
+    event: str,
+    to_state: str,
+    *,
+    resume_state: str | None = None,
+) -> Request:
+    """Apply one revision-CAS transition and return a new request snapshot."""
+    if not transition_allowed(request.state, event, to_state, resume_state=resume_state):
+        raise LifecycleError(f"invalid_transition:{request.state}:{event}:{to_state}")
+    next_resume = resume_state if to_state == "blocked" else None
+    next_blocked = request.state if to_state == "blocked" else None
+    next_cancel_epoch = request.cancel_epoch + (1 if to_state == "cancelling" else 0)
+    return Request(
+        board=request.board,
+        tenant=request.tenant,
+        orch_id=request.orch_id,
+        state=to_state,
+        lifecycle_revision=request.lifecycle_revision + 1,
+        cancel_epoch=next_cancel_epoch,
+        resume_state=next_resume,
+        blocked_from_state=next_blocked,
+        block_revision=request.block_revision + (1 if to_state == "blocked" else 0),
+    )
+
+
+def request_optional_cancellation(nodes: Iterable[Node]) -> int:
+    """Fence every unfinished optional node at the synthesis gate."""
+    changed = 0
+    for node in nodes:
+        if not node.required and node.state in {"planned", "ready", "running", "blocked"}:
+            node.state = "cancellation_requested"
+            changed += 1
+    return changed
+
+
+def optional_cancel_drained(nodes: Iterable[Node]) -> bool:
+    """Cancellation_requested is not terminal; all optional work must drain."""
+    return not any(
+        not node.required and node.state in {
+            "planned", "ready", "running", "blocked", "cancellation_requested"
+        }
+        for node in nodes
+    )
+
+
+def complete_cancelled_node(node: Node) -> None:
+    if node.state != "cancellation_requested":
+        raise LifecycleError("node_not_cancellation_requested")
+    node.state = "cancelled"
+
+
+def cancel_cascade(
+    request: Request,
+    *,
+    tasks: list[Task],
+    task_runs: list[TaskRun],
+    nodes: list[Node],
+    leases: list[StageLease],
+    obligations: list[DeliveryObligation],
+    attempts: list[DeliveryAttempt],
+    now: int,
+) -> CancelResult:
+    """Fence exactly one request scope and preserve ambiguity from started sends."""
+    if request.state in TERMINAL_STATES or request.state == "cancelling":
+        raise LifecycleError("cancel_not_authorized")
+    old_revision, old_epoch = request.lifecycle_revision, request.cancel_epoch
+    request.state = "cancelling"
+    request.lifecycle_revision += 1
+    request.cancel_epoch += 1
+    request.resume_state = None
+    request.blocked_from_state = None
+    request.block_revision += 1
+
+    stopped: list[str] = []
+    for task in tasks:
+        if not _same_scope(task, request):
+            continue
+        if task.status in {"planned", "ready"}:
+            task.status = "cancelled"
+            stopped.append(task.task_id)
+        elif task.status == "running":
+            task.cancellation_requested_at = now
+            stopped.append(task.task_id)
+    for run in task_runs:
+        if _same_scope(run, request) and run.ended_at is None:
+            run.cancellation_epoch = request.cancel_epoch
+    for node in nodes:
+        if not _same_scope(node, request):
+            continue
+        if node.state in {"planned", "ready", "blocked"}:
+            node.state = "cancelled"
+        elif node.state == "running":
+            node.state = "cancellation_requested"
+    for lease in leases:
+        if _same_scope(lease, request) and lease.state == "active":
+            lease.state = "revoked"
+            lease.epoch += 1
+
+    retained: list[str] = []
+    for obligation in obligations:
+        if not _same_scope(obligation, request):
+            continue
+        related = [a for a in attempts if (
+            _same_scope(a, request) and a.obligation_id == obligation.obligation_id
+        )]
+        has_started = any(a.state == "started" for a in related)
+        if obligation.state == "pending" or (obligation.state == "claimed" and not has_started):
+            obligation.state = "cancelled"
+        elif obligation.state in {"claimed", "accepted", "unknown"}:
+            obligation.duplicate_possible = True
+            retained.append(obligation.obligation_id)
+    return CancelResult(
+        old_revision, request.lifecycle_revision, old_epoch, request.cancel_epoch,
+        tuple(stopped), tuple(retained)
+    )
+
+
+def accept_worker_success(request: Request, *, callback_revision: int, callback_cancel_epoch: int) -> None:
+    """Reject late success from a pre-cancel worker epoch."""
+    if (
+        request.state in {"cancelling", "cancelled"}
+        or callback_revision != request.lifecycle_revision
+        or callback_cancel_epoch != request.cancel_epoch
+    ):
+        raise StaleCallback("stale_worker_success")
+
+
+def cancellation_satisfied(
+    request: Request,
+    *,
+    tasks: Iterable[Task],
+    task_runs: Iterable[TaskRun],
+    nodes: Iterable[Node],
+    leases: Iterable[StageLease],
+    obligations: Iterable[DeliveryObligation],
+    attempts: Iterable[DeliveryAttempt],
+) -> bool:
+    """Shared §7.4 predicate for the final cancelling→cancelled CAS."""
+    if request.state != "cancelling":
+        return False
+    if any(_same_scope(run, request) and run.ended_at is None for run in task_runs):
+        return False
+    if any(_same_scope(node, request) and node.state in {
+        "planned", "ready", "running", "cancellation_requested", "blocked"
+    } for node in nodes):
+        return False
+    if any(_same_scope(lease, request) and lease.state == "active" for lease in leases):
+        return False
+    if any(_same_scope(obligation, request) and obligation.state in {
+        "pending", "claimed", "accepted", "unknown"
+    } for obligation in obligations):
+        return False
+    if any(_same_scope(attempt, request) and attempt.state == "started" for attempt in attempts):
+        return False
+    return True
+
+
+def finish_cancellation(
+    request: Request,
+    *,
+    tasks: Iterable[Task],
+    task_runs: Iterable[TaskRun],
+    nodes: Iterable[Node],
+    leases: Iterable[StageLease],
+    obligations: Iterable[DeliveryObligation],
+    attempts: Iterable[DeliveryAttempt],
+) -> None:
+    if not cancellation_satisfied(
+        request,
+        tasks=tasks,
+        task_runs=task_runs,
+        nodes=nodes,
+        leases=leases,
+        obligations=obligations,
+        attempts=attempts,
+    ):
+        raise LifecycleError("cancellation_not_drained")
+    request.state = "cancelled"
+    request.lifecycle_revision += 1
+
+
+@dataclass
+class AcceptedRun:
+    """Immutable record of a lane acceptance (T15)."""
+    board: str
+    tenant: str
+    orch_id: str
+    node_key: str
+    plan_version: int
+    run_id: str
+    task_id: str
+    outcome_digest: str
+    accepted_at: int = 0
+
+
+@dataclass
+class SynthesisResult:
+    """Synthesis result bound to a completed attempt (T16)."""
+    board: str
+    tenant: str
+    orch_id: str
+    result_digest: str
+    synthesis_attempt_id: int
+    plan_version: int
+
+
+def accept_lane_run(
+    request: Request,
+    node: Node,
+    *,
+    plan_version: int,
+    run_id: str,
+    task_id: str,
+    outcome_digest: str,
+    callback_revision: int,
+    callback_cancel_epoch: int,
+    now: int = 0,
+) -> AcceptedRun:
+    """T15: Accept a lane run bound to current plan version and required lane.
+
+    Rejects:
+    - stale callback (wrong revision/cancel_epoch)
+    - wrong state (not waiting_lanes or synthesizing)
+    - stale plan version
+    - accepting an already-accepted required node
+    """
+    accept_worker_success(
+        request,
+        callback_revision=callback_revision,
+        callback_cancel_epoch=callback_cancel_epoch,
+    )
+    if request.state not in ("waiting_lanes", "synthesizing"):
+        raise LifecycleError("accept_not_authorized")
+    if node.plan_version != plan_version:
+        raise LifecycleError("stale_plan_version")
+    if node.state == "accepted":
+        raise LifecycleError("node_already_accepted")
+    node.state = "accepted"
+    return AcceptedRun(
+        board=request.board,
+        tenant=request.tenant,
+        orch_id=request.orch_id,
+        node_key=node.node_key,
+        plan_version=plan_version,
+        run_id=run_id,
+        task_id=task_id,
+        outcome_digest=outcome_digest,
+        accepted_at=now,
+    )
+
+
+def validate_result_provenance(
+    result: SynthesisResult,
+    *,
+    completed_attempt_id: int,
+    current_plan_version: int,
+) -> None:
+    """T16: Synthesis result must be bound to a completed synthesis attempt."""
+    if result.synthesis_attempt_id != completed_attempt_id:
+        raise LifecycleError("result_producer_unbound")
+    if result.plan_version != current_plan_version:
+        raise LifecycleError("stale_plan_version")
+
+
+def supersede_request(
+    predecessor: Request,
+    *,
+    new_orch_id: str,
+) -> Request:
+    """Create a superseding request: generation+1, new orch_id, fresh state.
+
+    Predecessor must be terminal (failed or cancelled).
+    """
+    if predecessor.state not in ("failed", "cancelled"):
+        raise LifecycleError("supersession_predecessor_not_terminal")
+    return Request(
+        board=predecessor.board,
+        tenant=predecessor.tenant,
+        orch_id=new_orch_id,
+        state="submitted",
+        lifecycle_revision=0,
+        cancel_epoch=0,
+        generation=predecessor.generation + 1,
+    )
+
+
+def is_terminal(state: str) -> bool:
+    """Check if a lifecycle state is terminal."""
+    return state in TERMINAL_STATES
+
+
+__all__ = [
+    "TERMINAL_STATES", "NONTERMINAL_STATES", "TRANSITION_TABLE", "LifecycleError",
+    "StaleCallback", "Request", "Node", "Task", "TaskRun", "StageLease",
+    "DeliveryObligation", "DeliveryAttempt", "CancelResult", "AcceptedRun",
+    "SynthesisResult", "transition_allowed",
+    "apply_transition", "request_optional_cancellation", "optional_cancel_drained",
+    "complete_cancelled_node", "cancel_cascade", "accept_worker_success",
+    "cancellation_satisfied", "finish_cancellation", "accept_lane_run",
+    "validate_result_provenance", "supersede_request", "is_terminal",
+]

--- a/hermes_cli/kanban_orch_multilane.py
+++ b/hermes_cli/kanban_orch_multilane.py
@@ -1,0 +1,1129 @@
+"""ORCH V4 deeper multi-lane: plan materialization + orch_nodes + lane accept.
+
+Board_only sidecar path (N1–N4):
+- Native RO observation of parent + task_links children
+- All control-plane writes to sidecar orch_v4.db only
+- Requires ≥2 linked children to materialize a real plan graph
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from hermes_cli.kanban_orch_api import OrchAPIError, apply_lifecycle_transition_db
+from hermes_cli.kanban_orch_bridge import BridgeError, OrchBridge
+from hermes_cli.kanban_orch_canonical import digest
+from hermes_cli.kanban_orch_cmin import children_progress, read_native_children
+from hermes_cli.kanban_orch_db import begin_immediate, grant
+from hermes_cli.kanban_orch_capability import CapabilityGrant
+from hermes_cli.kanban_orch_lifecycle import LifecycleError
+from hermes_cli.kanban_orch_multilane_schema import apply_multilane_soft_fk_patch
+from hermes_cli.kanban_orch_plan import validate_plan
+from hermes_cli.kanban_orch_writer_switch import open_live_bridge
+
+DONE_NATIVE = frozenset({"done", "completed"})
+
+
+class MultiLaneError(RuntimeError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _sha(*parts: str) -> str:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(p.encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+@dataclass
+class MultiLaneStep:
+    action: str
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MultiLaneResult:
+    orch_id: str
+    parent_task_id: str
+    before_state: str
+    after_state: str
+    plan_version: int
+    steps: list[MultiLaneStep]
+    skipped: bool = False
+    reason: str | None = None
+    accepted_required_lanes: int = 0
+    children_total: int = 0
+    children_done: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _load_request(conn: sqlite3.Connection, *, board: str, tenant: str, orch_id: str) -> sqlite3.Row:
+    row = conn.execute(
+        "SELECT r.*, o.origin_kind FROM orch_requests r "
+        "JOIN orch_origins o ON o.board_instance_id=r.board_instance_id "
+        " AND o.tenant_scope=r.tenant_scope AND o.origin_id=r.origin_id "
+        "WHERE r.board_instance_id=? AND r.tenant_scope=? AND r.orch_id=?",
+        (board, tenant, orch_id),
+    ).fetchone()
+    if row is None:
+        raise MultiLaneError("request_not_found")
+    return row
+
+
+def _ensure_commit_clock(conn: sqlite3.Connection, *, board: str) -> int:
+    """Ensure commit clock exists and return a commit_seq > 0 for materialization."""
+    row = conn.execute("SELECT commit_seq FROM kanban_commit_clock WHERE singleton=1").fetchone()
+    if row is None:
+        grant(conn, CapabilityGrant(kind="commit_clock", board=board, revision=0, target_key="bootstrap"))
+        conn.execute(
+            "INSERT INTO kanban_commit_clock(singleton, commit_seq, last_txn_id, updated_at) VALUES (1,0,?,?)",
+            ("bootstrap", _now()),
+        )
+        seq = 0
+    else:
+        seq = int(row[0])
+    if seq < 1:
+        grant(conn, CapabilityGrant(kind="commit_clock", board=board, revision=1, target_key="materialize"))
+        conn.execute(
+            "UPDATE kanban_commit_clock SET commit_seq=1, last_txn_id=?, updated_at=? WHERE singleton=1",
+            ("materialize", _now()),
+        )
+        return 1
+    return seq
+
+
+def _ensure_decomposition_lease(
+    conn: sqlite3.Connection,
+    *,
+    board: str,
+    tenant: str,
+    orch_id: str,
+    owner_run_id: int,
+    lifecycle_revision: int,
+    cancel_epoch: int,
+) -> tuple[int, int]:
+    """Return (owner_run_id, lease_epoch)."""
+    existing = conn.execute(
+        "SELECT owner_run_id, epoch, lease_state, expires_at FROM orch_stage_leases "
+        "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND stage='decomposition'",
+        (board, tenant, orch_id),
+    ).fetchone()
+    if existing and existing["lease_state"] == "active" and int(existing["expires_at"]) > _now():
+        return int(existing["owner_run_id"]), int(existing["epoch"])
+    grant(
+        conn,
+        CapabilityGrant(
+            kind="lease_claim",
+            board=board,
+            tenant=tenant,
+            object_id=orch_id,
+            revision=lifecycle_revision,
+            epoch=cancel_epoch,
+            target_key="decomposition",
+        ),
+    )
+    token = _sha("lease", board, tenant, orch_id, "decomposition", str(owner_run_id))
+    exp = _now() + 3600
+    if existing is None:
+        conn.execute(
+            "INSERT INTO orch_stage_leases("
+            "board_instance_id,tenant_scope,orch_id,stage,owner_run_id,owner_profile,"
+            "token_hash,epoch,expires_at,lease_state,updated_at"
+            ") VALUES (?,?,?,'decomposition',?,?,?,?,?,'active',?)",
+            (board, tenant, orch_id, owner_run_id, "cmin-multilane", token, 1, exp, _now()),
+        )
+        return owner_run_id, 1
+    # refresh via delete+insert not allowed; update may be restricted — try update path
+    # stage lease update triggers may exist; if blocked, raise
+    conn.execute(
+        "UPDATE orch_stage_leases SET owner_run_id=?, token_hash=?, expires_at=?, "
+        "lease_state='active', updated_at=? "
+        "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND stage='decomposition'",
+        (owner_run_id, token, exp, _now(), board, tenant, orch_id),
+    )
+    return owner_run_id, int(existing["epoch"])
+
+
+def _ensure_reconciliation_lease(
+    conn: sqlite3.Connection,
+    *,
+    board: str,
+    tenant: str,
+    orch_id: str,
+    owner_run_id: int,
+    lifecycle_revision: int,
+    cancel_epoch: int,
+) -> tuple[int, int]:
+    existing = conn.execute(
+        "SELECT owner_run_id, epoch, lease_state, expires_at FROM orch_stage_leases "
+        "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND stage='reconciliation'",
+        (board, tenant, orch_id),
+    ).fetchone()
+    if existing and existing["lease_state"] == "active" and int(existing["expires_at"]) > _now():
+        return int(existing["owner_run_id"]), int(existing["epoch"])
+    grant(
+        conn,
+        CapabilityGrant(
+            kind="lease_claim",
+            board=board,
+            tenant=tenant,
+            object_id=orch_id,
+            revision=lifecycle_revision,
+            epoch=cancel_epoch,
+            target_key="reconciliation",
+        ),
+    )
+    token = _sha("lease", board, tenant, orch_id, "reconciliation", str(owner_run_id))
+    exp = _now() + 3600
+    if existing is None:
+        conn.execute(
+            "INSERT INTO orch_stage_leases("
+            "board_instance_id,tenant_scope,orch_id,stage,owner_run_id,owner_profile,"
+            "token_hash,epoch,expires_at,lease_state,updated_at"
+            ") VALUES (?,?,?,'reconciliation',?,?,?,?,?,'active',?)",
+            (board, tenant, orch_id, owner_run_id, "cmin-multilane", token, 1, exp, _now()),
+        )
+        return owner_run_id, 1
+    conn.execute(
+        "UPDATE orch_stage_leases SET owner_run_id=?, token_hash=?, expires_at=?, "
+        "lease_state='active', updated_at=? "
+        "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND stage='reconciliation'",
+        (owner_run_id, token, exp, _now(), board, tenant, orch_id),
+    )
+    return owner_run_id, int(existing["epoch"])
+
+
+def _mirror_task(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    title: str,
+    status: str,
+    board: str | None = None,
+    tenant: str | None = None,
+    orch_id: str | None = None,
+    plan_version: int | None = None,
+    node_key: str | None = None,
+    binding_revision: int | None = None,
+    cancel_epoch: int | None = None,
+) -> None:
+    exists = conn.execute("SELECT id FROM _soft_fk_tasks WHERE id=?", (task_id,)).fetchone()
+    if exists is None:
+        if board is not None:
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="task_bind",
+                    board=board,
+                    tenant=tenant or "",
+                    object_id=orch_id or "",
+                    revision=binding_revision or 0,
+                    epoch=cancel_epoch or 0,
+                    target_key=task_id,
+                ),
+            )
+        conn.execute(
+            "INSERT INTO _soft_fk_tasks("
+            "id,title,status,created_at,orch_board_instance_id,orch_tenant_scope,orch_id,"
+            "orch_plan_version,orch_node_key,orch_binding_revision,orch_cancel_epoch"
+            ") VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                task_id,
+                title,
+                status,
+                _now(),
+                board,
+                tenant,
+                orch_id,
+                plan_version,
+                node_key,
+                binding_revision,
+                cancel_epoch,
+            ),
+        )
+        return
+    if board is None:
+        return
+    grant(
+        conn,
+        CapabilityGrant(
+            kind="task_bind",
+            board=board,
+            tenant=tenant or "",
+            object_id=orch_id or "",
+            revision=binding_revision or 0,
+            epoch=cancel_epoch or 0,
+            target_key=task_id,
+        ),
+    )
+    conn.execute(
+        "UPDATE _soft_fk_tasks SET title=?, status=?, "
+        "orch_board_instance_id=?, orch_tenant_scope=?, orch_id=?, "
+        "orch_plan_version=?, orch_node_key=?, orch_binding_revision=?, orch_cancel_epoch=? "
+        "WHERE id=?",
+        (
+            title,
+            status,
+            board,
+            tenant,
+            orch_id,
+            plan_version,
+            node_key,
+            binding_revision,
+            cancel_epoch,
+            task_id,
+        ),
+    )
+
+
+def materialize_plan_from_children(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    tenant_scope: str,
+    orch_id: str,
+    parent_task_id: str,
+    parent_title: str,
+    parent_status: str,
+    children: list[dict[str, str]],
+) -> dict[str, Any]:
+    """Build requirements/plan/nodes/edges/coverage + materialize → waiting_lanes."""
+    apply_multilane_soft_fk_patch(conn)
+    tenant = "" if tenant_scope is None else str(tenant_scope)
+    if len(children) < 2:
+        raise MultiLaneError("need_at_least_two_children")
+
+    begin_immediate(conn)
+    try:
+        req = _load_request(conn, board=board_instance_id, tenant=tenant, orch_id=orch_id)
+        if req["origin_kind"] != "board_only":
+            raise MultiLaneError("not_board_only")
+        if req["lifecycle_state"] != "decomposing":
+            raise MultiLaneError(f"bad_state:{req['lifecycle_state']}")
+        if int(req["plan_version"]) != 0:
+            raise MultiLaneError("plan_already_set")
+
+        plan_version = 1
+        life_rev = int(req["lifecycle_revision"])
+        cancel_epoch = int(req["cancel_epoch"])
+        owner_run = 900001
+        commit_seq = _ensure_commit_clock(conn, board=board_instance_id)
+        owner_run, lease_epoch = _ensure_decomposition_lease(
+            conn,
+            board=board_instance_id,
+            tenant=tenant,
+            orch_id=orch_id,
+            owner_run_id=owner_run,
+            lifecycle_revision=life_rev,
+            cancel_epoch=cancel_epoch,
+        )
+
+        # requirements + plan graph
+        lane_specs = []
+        for i, ch in enumerate(children, start=1):
+            rid = f"req-{i}"
+            rdigest = _sha("req", orch_id, ch["child_id"], str(i))
+            lane_specs.append(
+                {
+                    "requirement_id": rid,
+                    "ordinal": i,
+                    "requirement_digest": rdigest,
+                    "node_key": f"lane-{i}",
+                    "lane_label": f"L{i}",
+                    "task_id": ch["child_id"],
+                    "title": ch.get("title") or f"lane-{i}",
+                    "status": ch.get("status") or "ready",
+                }
+            )
+
+        # insert requirements
+        for ls in lane_specs:
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="plan_build",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key=ls["requirement_digest"],
+                ),
+            )
+            rjson = json.dumps(
+                {"requirement_id": ls["requirement_id"], "task_id": ls["task_id"]},
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            conn.execute(
+                "INSERT INTO orch_request_requirements("
+                "board_instance_id,tenant_scope,orch_id,requirement_id,ordinal,"
+                "requirement_json,requirement_digest,required"
+                ") VALUES (?,?,?,?,?,?,?,1)",
+                (
+                    board_instance_id,
+                    tenant,
+                    orch_id,
+                    ls["requirement_id"],
+                    ls["ordinal"],
+                    rjson,
+                    ls["requirement_digest"],
+                ),
+            )
+
+        plan_obj = {
+            "schema_version": 4,
+            "kind": "orch_plan",
+            "orch_id": orch_id,
+            "plan_version": plan_version,
+            "synthesis_strategy": "parent_owned",
+            "lanes": [
+                {"node_key": ls["node_key"], "lane_label": ls["lane_label"], "task_id": ls["task_id"], "required": True}
+                for ls in lane_specs
+            ],
+        }
+        plan_json = json.dumps(plan_obj, separators=(",", ":"), sort_keys=True)
+        plan_digest = digest(plan_obj)
+        grant(
+            conn,
+            CapabilityGrant(
+                kind="plan_build",
+                board=board_instance_id,
+                tenant=tenant,
+                object_id=orch_id,
+                revision=life_rev,
+                epoch=cancel_epoch,
+                target_key=plan_digest,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO orch_plans("
+            "board_instance_id,tenant_scope,orch_id,plan_version,schema_version,"
+            "lineage_id,generation,request_key,request_digest,origin_id,parent_task_id,"
+            "synthesis_strategy,plan_json,plan_digest,created_by_run_id,created_at"
+            ") VALUES (?,?,?,?,4,?,?,?,?,?,?,'parent_owned',?,?,?,?)",
+            (
+                board_instance_id,
+                tenant,
+                orch_id,
+                plan_version,
+                req["lineage_id"],
+                int(req["generation"]),
+                req["request_key"],
+                req["request_digest"],
+                req["origin_id"],
+                parent_task_id,
+                plan_json,
+                plan_digest,
+                owner_run,
+                _now(),
+            ),
+        )
+
+        # parent node ordinal 1, lanes 2..
+        route_json = "{}"
+        route_digest = _sha("route", board_instance_id, orch_id, "parent")
+        nodes = [
+            {
+                "node_key": "__parent__",
+                "lane_lineage_key": _sha("ll", orch_id, "__parent__"),
+                "role": "parent",
+                "lane_label": "",
+                "required": 1,
+                "ordinal": 1,
+                "task_id": parent_task_id,
+                "title": parent_title,
+                "status": parent_status,
+            }
+        ]
+        for i, ls in enumerate(lane_specs, start=2):
+            nodes.append(
+                {
+                    "node_key": ls["node_key"],
+                    "lane_lineage_key": _sha("ll", orch_id, ls["node_key"]),
+                    "role": "lane",
+                    "lane_label": ls["lane_label"],
+                    "required": 1,
+                    "ordinal": i,
+                    "task_id": ls["task_id"],
+                    "title": ls["title"],
+                    "status": ls["status"],
+                }
+            )
+
+        for n in nodes:
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="plan_build",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key=n["node_key"],
+                ),
+            )
+            conn.execute(
+                "INSERT INTO orch_plan_nodes("
+                "board_instance_id,tenant_scope,orch_id,plan_version,node_key,lane_lineage_key,"
+                "role,lane_label,normalized_goal,normalized_done_when,required,route_json,"
+                "route_digest,ordinal"
+                ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    board_instance_id,
+                    tenant,
+                    orch_id,
+                    plan_version,
+                    n["node_key"],
+                    n["lane_lineage_key"],
+                    n["role"],
+                    n["lane_label"],
+                    f"goal:{n['node_key']}",
+                    f"done:{n['node_key']}",
+                    n["required"],
+                    route_json,
+                    route_digest if n["role"] == "parent" else _sha("route", orch_id, n["node_key"]),
+                    n["ordinal"],
+                ),
+            )
+
+        # edges lane -> parent
+        for ls in lane_specs:
+            ekey = _sha("edge", orch_id, ls["node_key"], "__parent__")[:32]
+            # edge_key may need longer - use full hex
+            ekey = _sha("edge", orch_id, ls["node_key"], "__parent__")
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="plan_build",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key=ekey,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO orch_plan_edges("
+                "board_instance_id,tenant_scope,orch_id,plan_version,edge_key,"
+                "parent_node_key,child_node_key,edge_kind"
+                ") VALUES (?,?,?,?,?,?,?,'orch_required_for_synthesis')",
+                (
+                    board_instance_id,
+                    tenant,
+                    orch_id,
+                    plan_version,
+                    ekey,
+                    ls["node_key"],
+                    "__parent__",
+                ),
+            )
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="plan_build",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key=f"{ls['requirement_id']}:{ls['node_key']}",
+                ),
+            )
+            conn.execute(
+                "INSERT INTO orch_plan_coverage("
+                "board_instance_id,tenant_scope,orch_id,plan_version,requirement_id,node_key"
+                ") VALUES (?,?,?,?,?,?)",
+                (
+                    board_instance_id,
+                    tenant,
+                    orch_id,
+                    plan_version,
+                    ls["requirement_id"],
+                    ls["node_key"],
+                ),
+            )
+
+        validate_plan(conn, board=board_instance_id, tenant=tenant, orch=orch_id, plan_version=plan_version)
+
+        # bind soft tasks + orch_nodes BEFORE materialization row
+        # Order: insert/ensure unbound soft tasks → orch_nodes → bind orch columns on soft tasks
+        for n in nodes:
+            exists = conn.execute("SELECT id, orch_id FROM _soft_fk_tasks WHERE id=?", (n["task_id"],)).fetchone()
+            if exists is None:
+                conn.execute(
+                    "INSERT INTO _soft_fk_tasks(id,title,status,created_at) VALUES (?,?,?,?)",
+                    (n["task_id"], n["title"], n["status"], _now()),
+                )
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="materialize",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key=n["node_key"],
+                ),
+            )
+            conn.execute(
+                "INSERT INTO orch_nodes("
+                "board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id,"
+                "node_state,current_route_digest,route_revision,created_by_run_id,created_at,updated_at"
+                ") VALUES (?,?,?,?,?,?,'planned',?,1,?,?,?)",
+                (
+                    board_instance_id,
+                    tenant,
+                    orch_id,
+                    plan_version,
+                    n["node_key"],
+                    n["task_id"],
+                    _sha("route", orch_id, n["node_key"]),
+                    owner_run,
+                    _now(),
+                    _now(),
+                ),
+            )
+            # bind orch identity onto soft task (trigger allows via orch_nodes existence)
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="task_bind",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key=n["task_id"],
+                ),
+            )
+            conn.execute(
+                "UPDATE _soft_fk_tasks SET title=?, status=?, "
+                "orch_board_instance_id=?, orch_tenant_scope=?, orch_id=?, "
+                "orch_plan_version=?, orch_node_key=?, orch_binding_revision=?, orch_cancel_epoch=? "
+                "WHERE id=?",
+                (
+                    n["title"],
+                    n["status"],
+                    board_instance_id,
+                    tenant,
+                    orch_id,
+                    plan_version,
+                    n["node_key"],
+                    life_rev,
+                    cancel_epoch,
+                    n["task_id"],
+                ),
+            )
+
+        # soft links: edge direction lane(parent_id) -> __parent__(child_id)
+        for ls in lane_specs:
+            ekey = _sha("edge", orch_id, ls["node_key"], "__parent__")
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="link_bind",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key=ekey,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO _soft_fk_task_links("
+                "parent_id,child_id,kind,orch_board_instance_id,orch_tenant_scope,orch_id,"
+                "orch_plan_version,orch_edge_key,orch_binding_revision,orch_cancel_epoch"
+                ") VALUES (?,?,?,?,?,?,?,?,?,?)",
+                (
+                    ls["task_id"],
+                    parent_task_id,
+                    "orch_required_for_synthesis",
+                    board_instance_id,
+                    tenant,
+                    orch_id,
+                    plan_version,
+                    ekey,
+                    life_rev,
+                    cancel_epoch,
+                ),
+            )
+
+        node_count = conn.execute(
+            "SELECT count(*) FROM orch_nodes WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND plan_version=?",
+            (board_instance_id, tenant, orch_id, plan_version),
+        ).fetchone()[0]
+        edge_count = conn.execute(
+            "SELECT count(*) FROM _soft_fk_task_links WHERE orch_board_instance_id=? AND orch_tenant_scope=? "
+            "AND orch_id=? AND orch_plan_version=?",
+            (board_instance_id, tenant, orch_id, plan_version),
+        ).fetchone()[0]
+        graph_digest = _sha("graph", orch_id, str(plan_version), str(node_count), str(edge_count))
+        grant(
+            conn,
+            CapabilityGrant(
+                kind="materialize",
+                board=board_instance_id,
+                tenant=tenant,
+                object_id=orch_id,
+                revision=life_rev,
+                epoch=cancel_epoch,
+                target_key=graph_digest,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO orch_plan_materializations("
+            "board_instance_id,tenant_scope,orch_id,plan_version,request_lifecycle_revision,"
+            "cancel_epoch,lease_epoch,plan_digest,observed_graph_digest,observed_node_count,"
+            "observed_edge_count,materialized_by_run_id,commit_seq,materialized_at"
+            ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                board_instance_id,
+                tenant,
+                orch_id,
+                plan_version,
+                life_rev,
+                cancel_epoch,
+                lease_epoch,
+                plan_digest,
+                graph_digest,
+                int(node_count),
+                int(edge_count),
+                owner_run,
+                commit_seq,
+                _now(),
+            ),
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    # lifecycle CAS outside previous txn (own transaction)
+    step = apply_lifecycle_transition_db(
+        conn,
+        board_instance_id=board_instance_id,
+        tenant_scope=tenant,
+        orch_id=orch_id,
+        event="valid_plan_materialized",
+        to_state="waiting_lanes",
+    )
+    return {
+        "plan_version": plan_version,
+        "plan_digest": plan_digest,
+        "node_count": int(node_count),
+        "edge_count": int(edge_count),
+        "transition": step,
+        "lanes": [{"node_key": ls["node_key"], "task_id": ls["task_id"]} for ls in lane_specs],
+    }
+
+
+def accept_done_required_lanes(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    tenant_scope: str,
+    orch_id: str,
+    child_status_by_id: dict[str, str],
+) -> dict[str, Any]:
+    """Accept required lane nodes whose native/child status is done."""
+    apply_multilane_soft_fk_patch(conn)
+    tenant = "" if tenant_scope is None else str(tenant_scope)
+    begin_immediate(conn)
+    accepted: list[str] = []
+    try:
+        req = _load_request(conn, board=board_instance_id, tenant=tenant, orch_id=orch_id)
+        if req["lifecycle_state"] != "waiting_lanes":
+            raise MultiLaneError(f"bad_state:{req['lifecycle_state']}")
+        plan_version = int(req["plan_version"])
+        life_rev = int(req["lifecycle_revision"])
+        cancel_epoch = int(req["cancel_epoch"])
+        plan_epoch = int(req["plan_epoch_revision"])
+        owner_run = 900002
+        owner_run, lease_epoch = _ensure_reconciliation_lease(
+            conn,
+            board=board_instance_id,
+            tenant=tenant,
+            orch_id=orch_id,
+            owner_run_id=owner_run,
+            lifecycle_revision=life_rev,
+            cancel_epoch=cancel_epoch,
+        )
+
+        lanes = conn.execute(
+            "SELECT n.node_key, n.task_id, n.node_state, pn.required "
+            "FROM orch_nodes n "
+            "JOIN orch_plan_nodes pn ON pn.board_instance_id=n.board_instance_id "
+            " AND pn.tenant_scope=n.tenant_scope AND pn.orch_id=n.orch_id "
+            " AND pn.plan_version=n.plan_version AND pn.node_key=n.node_key "
+            "WHERE n.board_instance_id=? AND n.tenant_scope=? AND n.orch_id=? "
+            "AND n.plan_version=? AND pn.role='lane' AND pn.required=1",
+            (board_instance_id, tenant, orch_id, plan_version),
+        ).fetchall()
+
+        for lane in lanes:
+            st = (child_status_by_id.get(lane["task_id"]) or "").lower()
+            if st not in DONE_NATIVE:
+                continue
+            if lane["node_state"] == "accepted":
+                accepted.append(lane["node_key"])
+                continue
+            # move node planned/ready/running -> running -> accepted
+            # first ensure running
+            if lane["node_state"] in {"planned", "ready"}:
+                grant(
+                    conn,
+                    CapabilityGrant(
+                        kind="node_transition",
+                        board=board_instance_id,
+                        tenant=tenant,
+                        object_id=orch_id,
+                        revision=life_rev,
+                        epoch=cancel_epoch,
+                        target_key=lane["node_key"],
+                    ),
+                )
+                nxt = "ready" if lane["node_state"] == "planned" else "running"
+                conn.execute(
+                    "UPDATE orch_nodes SET node_state=?, updated_at=? "
+                    "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND node_key=?",
+                    (nxt, _now(), board_instance_id, tenant, orch_id, lane["node_key"]),
+                )
+                if nxt == "ready":
+                    grant(
+                        conn,
+                        CapabilityGrant(
+                            kind="node_transition",
+                            board=board_instance_id,
+                            tenant=tenant,
+                            object_id=orch_id,
+                            revision=life_rev,
+                            epoch=cancel_epoch,
+                            target_key=lane["node_key"],
+                        ),
+                    )
+                    conn.execute(
+                        "UPDATE orch_nodes SET node_state='running', updated_at=? "
+                        "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND node_key=?",
+                        (_now(), board_instance_id, tenant, orch_id, lane["node_key"]),
+                    )
+            elif lane["node_state"] != "running":
+                continue
+
+            outcome = _sha("outcome", orch_id, lane["node_key"], lane["task_id"], "done")
+            # task run — capability target may be task_id (NEW.id null on BEFORE INSERT)
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="task_run_start",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key="*",
+                ),
+            )
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="task_run_write",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key="*",
+                ),
+            )
+            cur = conn.execute(
+                "INSERT INTO _soft_fk_task_runs(task_id,status,started_at,ended_at,outcome,outcome_digest,cancellation_epoch)"
+                " VALUES (?, 'done', ?, ?, 'completed', ?, ?)",
+                (lane["task_id"], _now() - 1, _now(), outcome, cancel_epoch),
+            )
+            run_id = int(cur.lastrowid)
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="accept_lane",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=plan_epoch,
+                    epoch=cancel_epoch,
+                    target_key=str(run_id),
+                ),
+            )
+            conn.execute(
+                "INSERT INTO orch_node_acceptances("
+                "board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id,"
+                "accepted_run_id,outcome_digest,accepted_by_run_id,acceptance_lease_epoch,"
+                "plan_epoch_revision,cancel_epoch,accepted_at"
+                ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    board_instance_id,
+                    tenant,
+                    orch_id,
+                    plan_version,
+                    lane["node_key"],
+                    lane["task_id"],
+                    run_id,
+                    outcome,
+                    owner_run,
+                    lease_epoch,
+                    plan_epoch,
+                    cancel_epoch,
+                    _now(),
+                ),
+            )
+            grant(
+                conn,
+                CapabilityGrant(
+                    kind="node_transition",
+                    board=board_instance_id,
+                    tenant=tenant,
+                    object_id=orch_id,
+                    revision=life_rev,
+                    epoch=cancel_epoch,
+                    target_key=lane["node_key"],
+                ),
+            )
+            conn.execute(
+                "UPDATE orch_nodes SET node_state='accepted', updated_at=? "
+                "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND node_key=?",
+                (_now(), board_instance_id, tenant, orch_id, lane["node_key"]),
+            )
+            accepted.append(lane["node_key"])
+
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    return {"accepted_node_keys": accepted, "accepted_count": len(accepted)}
+
+
+def advance_after_acceptances(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    tenant_scope: str,
+    orch_id: str,
+    origin_kind: str = "board_only",
+) -> list[dict[str, Any]]:
+    """waiting_lanes → synthesizing → completed (board_only short path)."""
+    tenant = "" if tenant_scope is None else str(tenant_scope)
+    steps: list[dict[str, Any]] = []
+    req = _load_request(conn, board=board_instance_id, tenant=tenant, orch_id=orch_id)
+    if req["lifecycle_state"] != "waiting_lanes":
+        return steps
+    plan_version = int(req["plan_version"])
+    required = conn.execute(
+        "SELECT count(*) FROM orch_plan_nodes "
+        "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND plan_version=? "
+        "AND role='lane' AND required=1",
+        (board_instance_id, tenant, orch_id, plan_version),
+    ).fetchone()[0]
+    accepted = conn.execute(
+        "SELECT count(*) FROM orch_node_acceptances "
+        "WHERE board_instance_id=? AND tenant_scope=? AND orch_id=? AND plan_version=?",
+        (board_instance_id, tenant, orch_id, plan_version),
+    ).fetchone()[0]
+    if int(accepted) < 2 or int(accepted) < int(required):
+        return steps
+    steps.append(
+        apply_lifecycle_transition_db(
+            conn,
+            board_instance_id=board_instance_id,
+            tenant_scope=tenant,
+            orch_id=orch_id,
+            event="required_set_accepted",
+            to_state="synthesizing",
+            accepted_required_lanes=int(accepted),
+        )
+    )
+    # board_only: skip full delivery — complete from synthesizing
+    steps.append(
+        apply_lifecycle_transition_db(
+            conn,
+            board_instance_id=board_instance_id,
+            tenant_scope=tenant,
+            orch_id=orch_id,
+            event="board_only_parent_done",
+            to_state="completed",
+            origin_kind=origin_kind,
+            children_all_done=True,
+        )
+    )
+    return steps
+
+
+def run_multilane_once(
+    conn: sqlite3.Connection,
+    *,
+    board_instance_id: str,
+    tenant_scope: str,
+    orch_id: str,
+    parent_task_id: str,
+    parent_title: str,
+    parent_status: str,
+    children: list[dict[str, str]],
+) -> MultiLaneResult:
+    """One progressive multi-lane step based on native children truth."""
+    tenant = "" if tenant_scope is None else str(tenant_scope)
+    req = _load_request(conn, board=board_instance_id, tenant=tenant, orch_id=orch_id)
+    before = req["lifecycle_state"]
+    total, done, all_done = children_progress(children)
+    steps: list[MultiLaneStep] = []
+
+    base = MultiLaneResult(
+        orch_id=orch_id,
+        parent_task_id=parent_task_id,
+        before_state=before,
+        after_state=before,
+        plan_version=int(req["plan_version"]),
+        steps=[],
+        children_total=total,
+        children_done=done,
+    )
+
+    if req["origin_kind"] != "board_only":
+        base.skipped = True
+        base.reason = "not_board_only"
+        return base
+    if before in {"completed", "failed", "cancelled"}:
+        base.skipped = True
+        base.reason = "already_terminal"
+        return base
+
+    try:
+        if before == "decomposing" and total >= 2 and int(req["plan_version"]) == 0:
+            mat = materialize_plan_from_children(
+                conn,
+                board_instance_id=board_instance_id,
+                tenant_scope=tenant,
+                orch_id=orch_id,
+                parent_task_id=parent_task_id,
+                parent_title=parent_title,
+                parent_status=parent_status,
+                children=children,
+            )
+            steps.append(MultiLaneStep(action="materialize", detail=mat))
+        elif before == "waiting_lanes" and total >= 2:
+            status_map = {c["child_id"]: c["status"] for c in children}
+            acc = accept_done_required_lanes(
+                conn,
+                board_instance_id=board_instance_id,
+                tenant_scope=tenant,
+                orch_id=orch_id,
+                child_status_by_id=status_map,
+            )
+            steps.append(MultiLaneStep(action="accept_lanes", detail=acc))
+            if int(acc.get("accepted_count") or 0) >= 2:
+                adv = advance_after_acceptances(
+                    conn,
+                    board_instance_id=board_instance_id,
+                    tenant_scope=tenant,
+                    orch_id=orch_id,
+                )
+                for a in adv:
+                    steps.append(MultiLaneStep(action="lifecycle", detail=a))
+        else:
+            base.skipped = True
+            base.reason = f"no_multilane_rule:{before}:children={done}/{total}"
+            return base
+    except (MultiLaneError, OrchAPIError, LifecycleError, sqlite3.IntegrityError, ValueError) as exc:
+        code = getattr(exc, "code", None) or str(exc)
+        raise MultiLaneError(f"multilane_failed:{code}") from exc
+
+    req2 = _load_request(conn, board=board_instance_id, tenant=tenant, orch_id=orch_id)
+    accepted_n = conn.execute(
+        "SELECT count(*) FROM orch_node_acceptances WHERE board_instance_id=? AND tenant_scope=? AND orch_id=?",
+        (board_instance_id, tenant, orch_id),
+    ).fetchone()[0]
+    return MultiLaneResult(
+        orch_id=orch_id,
+        parent_task_id=parent_task_id,
+        before_state=before,
+        after_state=req2["lifecycle_state"],
+        plan_version=int(req2["plan_version"]),
+        steps=steps,
+        skipped=False,
+        accepted_required_lanes=int(accepted_n),
+        children_total=total,
+        children_done=done,
+    )
+
+
+def live_multilane_parent(parent_task_id: str) -> MultiLaneResult:
+    br: OrchBridge | None = None
+    try:
+        br = open_live_bridge()
+        apply_multilane_soft_fk_patch(br._sidecar)
+        ref = br.read_native_task(parent_task_id)
+        if ref is None:
+            raise MultiLaneError("native_parent_missing")
+        children = read_native_children(br._native, parent_task_id)
+        # enrich titles
+        enriched = []
+        for c in children:
+            crow = br._native.execute("SELECT title, status FROM tasks WHERE id=?", (c["child_id"],)).fetchone()
+            enriched.append(
+                {
+                    "child_id": c["child_id"],
+                    "status": (crow["status"] if crow else c["status"] or "").lower(),
+                    "title": (crow["title"] if crow else c["child_id"]),
+                }
+            )
+        row = br._sidecar.execute(
+            "SELECT board_instance_id, tenant_scope, orch_id FROM orch_requests WHERE parent_task_id=? "
+            "ORDER BY updated_at DESC LIMIT 1",
+            (parent_task_id,),
+        ).fetchone()
+        if row is None:
+            raise MultiLaneError("request_not_found_for_parent")
+        return run_multilane_once(
+            br._sidecar,
+            board_instance_id=row["board_instance_id"],
+            tenant_scope=row["tenant_scope"] or "",
+            orch_id=row["orch_id"],
+            parent_task_id=parent_task_id,
+            parent_title=ref.title or parent_task_id,
+            parent_status=ref.status,
+            children=enriched,
+        )
+    except BridgeError as exc:
+        raise MultiLaneError(f"bridge:{exc.code}") from exc
+    finally:
+        if br is not None:
+            br.close()
+
+
+__all__ = [
+    "MultiLaneError",
+    "MultiLaneResult",
+    "MultiLaneStep",
+    "materialize_plan_from_children",
+    "accept_done_required_lanes",
+    "advance_after_acceptances",
+    "run_multilane_once",
+    "live_multilane_parent",
+]

--- a/hermes_cli/kanban_orch_multilane_schema.py
+++ b/hermes_cli/kanban_orch_multilane_schema.py
@@ -1,0 +1,119 @@
+"""Additive sidecar patches required for plan materialization / lane accept.
+
+Safe to re-run. Does not touch native kanban.db.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+_SOFT_LINK_COLS = {
+    "orch_board_instance_id": "TEXT",
+    "orch_tenant_scope": "TEXT",
+    "orch_id": "TEXT",
+    "orch_plan_version": "INTEGER",
+    "orch_edge_key": "TEXT",
+    "orch_binding_revision": "INTEGER",
+    "orch_cancel_epoch": "INTEGER",
+}
+
+_SOFT_RUN_COLS = {
+    "cancellation_epoch": "INTEGER NOT NULL DEFAULT 0",
+}
+
+# Expanded bind update: allow unbound -> lane bind when orch_nodes exists.
+TASKS_ORCH_BINDING_UPDATE_PATCH = """
+DROP TRIGGER IF EXISTS tasks_orch_binding_update;
+CREATE TRIGGER tasks_orch_binding_update BEFORE UPDATE OF
+  orch_board_instance_id,orch_tenant_scope,orch_id,orch_plan_version,
+  orch_node_key,orch_binding_revision,orch_cancel_epoch ON _soft_fk_tasks
+WHEN OLD.orch_id IS NOT NULL OR NEW.orch_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT (
+    (NEW.orch_board_instance_id IS OLD.orch_board_instance_id
+      AND NEW.orch_tenant_scope IS OLD.orch_tenant_scope
+      AND NEW.orch_id IS OLD.orch_id
+      AND NEW.orch_plan_version IS OLD.orch_plan_version
+      AND NEW.orch_node_key IS OLD.orch_node_key
+      AND NEW.orch_binding_revision IS OLD.orch_binding_revision
+      AND NEW.orch_cancel_epoch IS OLD.orch_cancel_epoch)
+    OR
+    (OLD.orch_board_instance_id IS NULL AND OLD.orch_tenant_scope IS NULL
+      AND OLD.orch_id IS NULL AND OLD.orch_plan_version IS NULL
+      AND OLD.orch_node_key IS NULL AND OLD.orch_binding_revision IS NULL
+      AND OLD.orch_cancel_epoch IS NULL
+      AND NEW.orch_node_key='__parent__'
+      AND EXISTS (SELECT 1 FROM orch_requests r
+        WHERE r.board_instance_id=NEW.orch_board_instance_id
+          AND r.tenant_scope=NEW.orch_tenant_scope AND r.orch_id=NEW.orch_id
+          AND r.parent_task_id=NEW.id AND r.plan_version=NEW.orch_plan_version
+          AND r.lifecycle_revision=NEW.orch_binding_revision
+          AND r.cancel_epoch=NEW.orch_cancel_epoch)
+      AND orch_capability_ok('task_bind',NEW.orch_board_instance_id,NEW.orch_tenant_scope,NEW.orch_id,
+        NEW.orch_binding_revision,NEW.orch_cancel_epoch,NEW.id)=1)
+    OR
+    (OLD.orch_board_instance_id IS NULL AND OLD.orch_tenant_scope IS NULL
+      AND OLD.orch_id IS NULL AND OLD.orch_plan_version IS NULL
+      AND OLD.orch_node_key IS NULL AND OLD.orch_binding_revision IS NULL
+      AND OLD.orch_cancel_epoch IS NULL
+      AND EXISTS (
+        SELECT 1 FROM orch_nodes n
+        JOIN orch_requests r
+          ON r.board_instance_id=n.board_instance_id AND r.tenant_scope=n.tenant_scope
+         AND r.orch_id=n.orch_id
+        WHERE n.board_instance_id=NEW.orch_board_instance_id
+          AND n.tenant_scope=NEW.orch_tenant_scope AND n.orch_id=NEW.orch_id
+          AND n.plan_version=NEW.orch_plan_version AND n.node_key=NEW.orch_node_key
+          AND n.task_id=NEW.id
+          AND r.lifecycle_state='decomposing'
+          AND r.lifecycle_revision=NEW.orch_binding_revision
+          AND r.cancel_epoch=NEW.orch_cancel_epoch
+      )
+      AND orch_capability_ok('task_bind',NEW.orch_board_instance_id,NEW.orch_tenant_scope,NEW.orch_id,
+        NEW.orch_binding_revision,NEW.orch_cancel_epoch,NEW.id)=1)
+    OR
+    (NEW.orch_board_instance_id IS NULL AND NEW.orch_tenant_scope IS NULL
+      AND NEW.orch_id IS NULL AND NEW.orch_plan_version IS NULL
+      AND NEW.orch_node_key IS NULL AND NEW.orch_binding_revision IS NULL
+      AND NEW.orch_cancel_epoch IS NULL
+      AND EXISTS (SELECT 1 FROM orch_requests r
+        WHERE r.board_instance_id=OLD.orch_board_instance_id
+          AND r.tenant_scope=OLD.orch_tenant_scope AND r.orch_id=OLD.orch_id
+          AND r.lifecycle_state IN ('cancelling','cancelled'))
+      AND orch_capability_ok(
+        'task_retire',OLD.orch_board_instance_id,OLD.orch_tenant_scope,OLD.orch_id,
+        COALESCE((SELECT lifecycle_revision FROM orch_requests r
+          WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+            AND r.orch_id=OLD.orch_id),-1),
+        COALESCE((SELECT cancel_epoch FROM orch_requests r
+          WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+            AND r.orch_id=OLD.orch_id),-1),OLD.id)=1)
+  ) THEN RAISE(ABORT,'immutable_orch_task_binding') END;
+END;
+"""
+
+
+def _has_column(conn: sqlite3.Connection, table: str, col: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    names = {r[1] for r in rows}
+    return col in names
+
+
+def apply_multilane_soft_fk_patch(conn: sqlite3.Connection) -> dict[str, list[str]]:
+    """Add missing soft-FK columns + multilane bind update trigger."""
+    added: dict[str, list[str]] = {"_soft_fk_task_links": [], "_soft_fk_task_runs": [], "triggers": []}
+    for col, decl in _SOFT_LINK_COLS.items():
+        if not _has_column(conn, "_soft_fk_task_links", col):
+            conn.execute(f"ALTER TABLE _soft_fk_task_links ADD COLUMN {col} {decl}")
+            added["_soft_fk_task_links"].append(col)
+    for col, decl in _SOFT_RUN_COLS.items():
+        if not _has_column(conn, "_soft_fk_task_runs", col):
+            conn.execute(f"ALTER TABLE _soft_fk_task_runs ADD COLUMN {col} {decl}")
+            added["_soft_fk_task_runs"].append(col)
+    conn.executescript(TASKS_ORCH_BINDING_UPDATE_PATCH)
+    added["triggers"].append("tasks_orch_binding_update")
+    conn.commit()
+    return added
+
+
+__all__ = ["apply_multilane_soft_fk_patch", "TASKS_ORCH_BINDING_UPDATE_PATCH"]

--- a/hermes_cli/kanban_orch_observer.py
+++ b/hermes_cli/kanban_orch_observer.py
@@ -113,20 +113,32 @@ def check_exact_multiset(
 ) -> Finding | None:
     """§9.4: Expected/observed node multiset must be exact.
 
-    No missing, no extra, no duplicate.
+    No missing, no extra, no duplicate on either side.
     """
-    expected_keys = {n.node_key for n in expected_nodes}
-    observed_set = set(observed_node_keys)
+    from collections import Counter
 
-    missing = expected_keys - observed_set
-    extra = observed_set - expected_keys
+    expected_keys = [n.node_key for n in expected_nodes]
+    expected_counts = Counter(expected_keys)
+    observed_counts = Counter(observed_node_keys)
 
+    if any(v > 1 for v in expected_counts.values()):
+        dups = sorted(k for k, v in expected_counts.items() if v > 1)
+        return Finding(EXIT_HARD_VIOLATION, "duplicate_expected_nodes", f"dups: {dups}")
+    if any(v > 1 for v in observed_counts.values()):
+        dups = sorted(k for k, v in observed_counts.items() if v > 1)
+        return Finding(EXIT_HARD_VIOLATION, "duplicate_observed_nodes", f"dups: {dups}")
+
+    expected_set = set(expected_counts)
+    observed_set = set(observed_counts)
+    missing = expected_set - observed_set
+    extra = observed_set - expected_set
     if missing:
         return Finding(EXIT_HARD_VIOLATION, "missing_observed_nodes", f"missing: {missing}")
     if extra:
         return Finding(EXIT_HARD_VIOLATION, "extra_observed_nodes", f"extra: {extra}")
-    if len(observed_node_keys) != len(observed_set):
-        return Finding(EXIT_HARD_VIOLATION, "duplicate_observed_nodes")
+    # counts must match exactly (defensive; dups already rejected)
+    if expected_counts != observed_counts:
+        return Finding(EXIT_HARD_VIOLATION, "multiset_count_mismatch")
     return None
 
 
@@ -210,17 +222,66 @@ def check_parent_terminal_before_synthesis(
 
 def check_delivery_satisfied(
     origin_kind: str,
-    required_count: int,
-    acked_count: int,
+    required_count: int | None = None,
+    acked_count: int | None = None,
+    *,
+    required_obligation_keys: list[str] | None = None,
+    acked_obligation_keys: list[str] | None = None,
 ) -> Finding | None:
-    """§9.4: Delivery manifest must be satisfied for parent completion."""
+    """§9.4: Delivery manifest must be satisfied for parent completion.
+
+    Prefer exact obligation-key multisets. Count-only inputs remain as a
+    compatibility path but cannot pass when keys are also supplied and disagree.
+    """
+    from collections import Counter
+
+    if required_obligation_keys is not None or acked_obligation_keys is not None:
+        req_keys = list(required_obligation_keys or [])
+        ack_keys = list(acked_obligation_keys or [])
+        if origin_kind == "board_only":
+            if req_keys:
+                return Finding(EXIT_HARD_VIOLATION, "board_only_has_required_obligations")
+            return None
+        if not req_keys:
+            return Finding(EXIT_HARD_VIOLATION, "delivery_required_set_empty")
+        req_counts = Counter(req_keys)
+        ack_counts = Counter(ack_keys)
+        if any(v != 1 for v in req_counts.values()):
+            return Finding(EXIT_HARD_VIOLATION, "duplicate_required_obligation_keys")
+        if any(v != 1 for v in ack_counts.values()):
+            return Finding(EXIT_HARD_VIOLATION, "duplicate_acked_obligation_keys")
+        missing = sorted(set(req_counts) - set(ack_counts))
+        extra = sorted(set(ack_counts) - set(req_counts))
+        if missing or extra:
+            return Finding(
+                EXIT_HARD_VIOLATION,
+                "delivery_required_acks_missing",
+                f"missing={missing} extra={extra}",
+            )
+        return None
+
+    # Compatibility count path (weaker; still fail-closed on gaps)
+    rc = 0 if required_count is None else int(required_count)
+    ac = 0 if acked_count is None else int(acked_count)
     if origin_kind == "board_only":
-        if required_count != 0:
+        if rc != 0:
             return Finding(EXIT_HARD_VIOLATION, "board_only_has_required_obligations")
         return None
-    if required_count > 0 and acked_count < required_count:
-        return Finding(EXIT_HARD_VIOLATION, "delivery_required_acks_missing",
-                       f"required={required_count} acked={acked_count}")
+    if rc > 0 and ac < rc:
+        return Finding(
+            EXIT_HARD_VIOLATION,
+            "delivery_required_acks_missing",
+            f"required={rc} acked={ac}",
+        )
+    if rc > 0 and ac != rc:
+        # exact count equality required when using count path
+        return Finding(
+            EXIT_HARD_VIOLATION,
+            "delivery_ack_count_mismatch",
+            f"required={rc} acked={ac}",
+        )
+    if rc == 0 and origin_kind != "board_only":
+        return Finding(EXIT_HARD_VIOLATION, "delivery_required_set_empty")
     return None
 
 
@@ -239,6 +300,8 @@ def run_observer(
     origin_kind: str = "messaging",
     required_acks: int = 0,
     acked_count: int = 0,
+    required_obligation_keys: list[str] | None = None,
+    acked_obligation_keys: list[str] | None = None,
     has_legacy_title: bool = False,
 ) -> int:
     """Run all observer checks and return the exit code by precedence.
@@ -272,7 +335,13 @@ def run_observer(
     if f:
         findings.append(f)
 
-    f = check_delivery_satisfied(origin_kind, required_acks, acked_count)
+    f = check_delivery_satisfied(
+        origin_kind,
+        required_acks,
+        acked_count,
+        required_obligation_keys=required_obligation_keys,
+        acked_obligation_keys=acked_obligation_keys,
+    )
     if f:
         findings.append(f)
 

--- a/hermes_cli/kanban_orch_observer.py
+++ b/hermes_cli/kanban_orch_observer.py
@@ -1,0 +1,291 @@
+"""ORCH V4 Observer — expected vs observed truth + exit total order.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §9 (Observer V4) + §I.8 (exit order).
+
+This module is deliberately runtime-independent.  It models the observer's
+expected/observed separation, exact multiset equality, overlap proof, and
+exit precedence so the focused tests can exercise every invariant without
+opening the live Kanban database.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+
+# §9.3 Exit precedence — first matching class wins, NOT numeric max.
+EXIT_PRECEDENCE: tuple[int, ...] = (64, 5, 4, 2, 3, 0)
+
+EXIT_INVALID_CLI = 64
+EXIT_PATH_UNAVAILABLE = 5
+EXIT_SCHEMA_UNSUPPORTED = 4
+EXIT_HARD_VIOLATION = 2
+EXIT_WARNING_ONLY = 3
+EXIT_CLEAN = 0
+
+EXIT_LABELS: dict[int, str] = {
+    64: "invalid_cli_syntax",
+    5: "path_unavailable",
+    4: "schema_unsupported",
+    2: "hard_violation",
+    3: "warning_only",
+    0: "clean",
+}
+
+
+class ObserverError(Exception):
+    """Hard invariant violation found by observer."""
+    def __init__(self, code: str, exit_code: int = EXIT_HARD_VIOLATION):
+        super().__init__(code)
+        self.code = code
+        self.exit_code = exit_code
+
+
+class ObserverPathError(Exception):
+    """Path/open/read/replacement unavailable."""
+    def __init__(self, code: str = "path_unavailable"):
+        super().__init__(code)
+        self.code = code
+        self.exit_code = EXIT_PATH_UNAVAILABLE
+
+
+class ObserverSchemaError(Exception):
+    """Schema/migration/version unsupported."""
+    def __init__(self, code: str = "schema_unsupported"):
+        super().__init__(code)
+        self.code = code
+        self.exit_code = EXIT_SCHEMA_UNSUPPORTED
+
+
+@dataclass(frozen=True)
+class ExpectedNode:
+    """Expected plan node from immutable plan header."""
+    node_key: str
+    role: str
+    lane_label: str
+    required: bool
+    ordinal: int
+
+
+@dataclass(frozen=True)
+class ExpectedEdge:
+    parent_node_key: str
+    child_node_key: str
+    edge_kind: str
+
+
+@dataclass(frozen=True)
+class ObservedRun:
+    """Observed accepted run from materialization."""
+    node_key: str
+    run_id: str
+    started_at: int
+    ended_at: int
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One observer finding with its exit class."""
+    exit_code: int
+    code: str
+    detail: str = ""
+
+
+def compute_exit(findings: list[Finding]) -> int:
+    """§9.3: First matching class in EXIT_PRECEDENCE wins.
+
+    Collects all findings, then picks the first exit code by precedence.
+    NOT numeric max — 2 beats 3 beats 0.
+    """
+    if not findings:
+        return EXIT_CLEAN
+    exit_set = {f.exit_code for f in findings}
+    for code in EXIT_PRECEDENCE:
+        if code in exit_set:
+            return code
+    return EXIT_CLEAN
+
+
+def check_exact_multiset(
+    expected_nodes: list[ExpectedNode],
+    observed_node_keys: list[str],
+) -> Finding | None:
+    """§9.4: Expected/observed node multiset must be exact.
+
+    No missing, no extra, no duplicate.
+    """
+    expected_keys = {n.node_key for n in expected_nodes}
+    observed_set = set(observed_node_keys)
+
+    missing = expected_keys - observed_set
+    extra = observed_set - expected_keys
+
+    if missing:
+        return Finding(EXIT_HARD_VIOLATION, "missing_observed_nodes", f"missing: {missing}")
+    if extra:
+        return Finding(EXIT_HARD_VIOLATION, "extra_observed_nodes", f"extra: {extra}")
+    if len(observed_node_keys) != len(observed_set):
+        return Finding(EXIT_HARD_VIOLATION, "duplicate_observed_nodes")
+    return None
+
+
+def check_required_lane_overlap(
+    expected_lanes: list[ExpectedNode],
+    accepted_runs: list[ObservedRun],
+) -> Finding | None:
+    """§8.2 + §9.4: Required lanes must have N-way overlap.
+
+    Parallel PASS only if:
+    - distinct lane IDs
+    - one run each
+    - max(started_at) < min(ended_at)
+    """
+    required = [n for n in expected_lanes if n.required]
+    if not required:
+        return None  # board-only or no required lanes — no overlap to prove
+    if len(required) < 2:
+        return Finding(EXIT_HARD_VIOLATION, "insufficient_required_lanes")
+
+    # Map node_key to accepted run
+    lane_runs: dict[str, ObservedRun] = {}
+    for run in accepted_runs:
+        if run.node_key in {n.node_key for n in required}:
+            if run.node_key in lane_runs:
+                return Finding(EXIT_HARD_VIOLATION, "duplicate_lane_run", f"lane={run.node_key}")
+            lane_runs[run.node_key] = run
+
+    # All required lanes must have accepted runs
+    missing_lanes = {n.node_key for n in required} - set(lane_runs.keys())
+    if missing_lanes:
+        return Finding(EXIT_HARD_VIOLATION, "missing_required_acceptance", f"lanes: {missing_lanes}")
+
+    # Overlap check: max(started_at) < min(ended_at)
+    starts = [r.started_at for r in lane_runs.values()]
+    ends = [r.ended_at for r in lane_runs.values()]
+
+    if max(starts) >= min(ends):
+        return Finding(EXIT_HARD_VIOLATION, "no_required_lane_overlap",
+                       f"max_start={max(starts)} >= min_end={min(ends)}")
+
+    return None
+
+
+def check_legacy_untyped(
+    has_v4_schema: bool,
+    has_legacy_title: bool,
+) -> Finding | None:
+    """Legacy untyped ORCH can never be V4 CLEAN. Best case exit 3."""
+    if not has_v4_schema and has_legacy_title:
+        return Finding(EXIT_WARNING_ONLY, "legacy_untyped_only")
+    if not has_v4_schema:
+        return Finding(EXIT_SCHEMA_UNSUPPORTED, "schema_unsupported")
+    return None
+
+
+def check_scope_mismatch(
+    expected_board: str,
+    observed_board: str,
+    expected_tenant: str,
+    observed_tenant: str,
+) -> Finding | None:
+    """§9.4: Stable board/tenant scope must match."""
+    if expected_board != observed_board:
+        return Finding(EXIT_HARD_VIOLATION, "board_scope_mismatch")
+    if expected_tenant != observed_tenant:
+        return Finding(EXIT_HARD_VIOLATION, "tenant_scope_mismatch")
+    return None
+
+
+def check_parent_terminal_before_synthesis(
+    parent_state: str,
+    has_result: bool,
+) -> Finding | None:
+    """Parent must not be terminal before synthesis."""
+    terminal = {"completed", "failed", "cancelled"}
+    if parent_state in terminal and not has_result:
+        return Finding(EXIT_HARD_VIOLATION, "parent_terminal_before_synthesis")
+    return None
+
+
+def check_delivery_satisfied(
+    origin_kind: str,
+    required_count: int,
+    acked_count: int,
+) -> Finding | None:
+    """§9.4: Delivery manifest must be satisfied for parent completion."""
+    if origin_kind == "board_only":
+        if required_count != 0:
+            return Finding(EXIT_HARD_VIOLATION, "board_only_has_required_obligations")
+        return None
+    if required_count > 0 and acked_count < required_count:
+        return Finding(EXIT_HARD_VIOLATION, "delivery_required_acks_missing",
+                       f"required={required_count} acked={acked_count}")
+    return None
+
+
+def run_observer(
+    *,
+    has_v4_schema: bool,
+    expected_nodes: list[ExpectedNode],
+    observed_node_keys: list[str],
+    accepted_runs: list[ObservedRun],
+    expected_board: str = "board",
+    observed_board: str = "board",
+    expected_tenant: str = "",
+    observed_tenant: str = "",
+    parent_state: str = "waiting_lanes",
+    has_result: bool = False,
+    origin_kind: str = "messaging",
+    required_acks: int = 0,
+    acked_count: int = 0,
+    has_legacy_title: bool = False,
+) -> int:
+    """Run all observer checks and return the exit code by precedence.
+
+    Collects all findings, then applies EXIT_PRECEDENCE.
+    Never short-circuits on first error.
+    """
+    findings: list[Finding] = []
+
+    # Schema check first
+    if not has_v4_schema:
+        legacy = check_legacy_untyped(has_v4_schema, has_legacy_title)
+        if legacy:
+            findings.append(legacy)
+        return compute_exit(findings)
+
+    # Hard checks
+    f = check_scope_mismatch(expected_board, observed_board, expected_tenant, observed_tenant)
+    if f:
+        findings.append(f)
+
+    f = check_exact_multiset(expected_nodes, observed_node_keys)
+    if f:
+        findings.append(f)
+
+    f = check_required_lane_overlap(expected_nodes, accepted_runs)
+    if f:
+        findings.append(f)
+
+    f = check_parent_terminal_before_synthesis(parent_state, has_result)
+    if f:
+        findings.append(f)
+
+    f = check_delivery_satisfied(origin_kind, required_acks, acked_count)
+    if f:
+        findings.append(f)
+
+    return compute_exit(findings)
+
+
+__all__ = [
+    "EXIT_PRECEDENCE", "EXIT_INVALID_CLI", "EXIT_PATH_UNAVAILABLE",
+    "EXIT_SCHEMA_UNSUPPORTED", "EXIT_HARD_VIOLATION", "EXIT_WARNING_ONLY",
+    "EXIT_CLEAN", "EXIT_LABELS", "ObserverError", "ObserverPathError",
+    "ObserverSchemaError", "ExpectedNode", "ExpectedEdge", "ObservedRun",
+    "Finding", "compute_exit", "check_exact_multiset",
+    "check_required_lane_overlap", "check_legacy_untyped",
+    "check_scope_mismatch", "check_parent_terminal_before_synthesis",
+    "check_delivery_satisfied", "run_observer",
+]

--- a/hermes_cli/kanban_orch_plan.py
+++ b/hermes_cli/kanban_orch_plan.py
@@ -1,0 +1,234 @@
+"""ORCH V4 plan grammar and closed-world graph queries.
+
+The validator is intentionally SQL-backed: plan rows are the source of truth,
+and a valid plan produces no grammar findings.  The SQL is the executable
+version of contract §5.3 rather than a Python reimplementation of it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable
+
+
+PLAN_GRAMMAR_SQL = """
+WITH p AS (
+  SELECT * FROM orch_plans
+   WHERE board_instance_id=:board AND tenant_scope=:tenant
+     AND orch_id=:orch AND plan_version=:pv
+), nodes AS (
+  SELECT * FROM orch_plan_nodes
+   WHERE board_instance_id=:board AND tenant_scope=:tenant
+     AND orch_id=:orch AND plan_version=:pv
+), target AS (
+  SELECT node_key FROM nodes
+   WHERE (role='parent' AND (SELECT synthesis_strategy FROM p)='parent_owned')
+      OR (role='synthesis' AND (SELECT synthesis_strategy FROM p)='separate_node')
+)
+SELECT 'missing_or_duplicate_plan' WHERE (SELECT count(*) FROM p)!=1
+UNION ALL SELECT 'missing_requirements' WHERE (
+  SELECT count(*) FROM orch_request_requirements
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+)=0
+UNION ALL SELECT 'bad_parent_count' WHERE (SELECT count(*) FROM nodes WHERE role='parent')!=1
+UNION ALL SELECT 'bad_parent_key' WHERE (SELECT count(*) FROM nodes WHERE role='parent' AND node_key='__parent__')!=1
+UNION ALL SELECT 'bad_parent_ordinal' WHERE (SELECT count(*) FROM nodes WHERE role='parent' AND ordinal=1)!=1
+UNION ALL SELECT 'bad_lane_count' WHERE (SELECT count(*) FROM nodes WHERE role='lane') NOT BETWEEN 2 AND 16
+UNION ALL SELECT 'bad_required_lane_count' WHERE (SELECT count(*) FROM nodes WHERE role='lane' AND required=1)<2
+UNION ALL SELECT 'duplicate_lane_label' WHERE
+  (SELECT count(*) FROM nodes WHERE role='lane')!=(SELECT count(DISTINCT lane_label) FROM nodes WHERE role='lane')
+UNION ALL SELECT 'bad_synthesis_count' WHERE
+  (SELECT synthesis_strategy FROM p)='parent_owned'
+  AND (SELECT count(*) FROM nodes WHERE role='synthesis')!=0
+UNION ALL SELECT 'bad_synthesis_count' WHERE
+  (SELECT synthesis_strategy FROM p)='separate_node'
+  AND (SELECT count(*) FROM nodes WHERE role='synthesis')!=1
+UNION ALL SELECT 'bad_target_count' WHERE (SELECT count(*) FROM target)!=1
+UNION ALL SELECT 'ordinal_gap' WHERE
+  (SELECT min(ordinal) FROM nodes)!=1
+  OR (SELECT max(ordinal) FROM nodes)!=(SELECT count(*) FROM nodes)
+UNION ALL SELECT 'bad_required_edge_count' WHERE EXISTS (
+  SELECT 1 FROM nodes n WHERE n.role='lane' AND n.required=1 AND
+    (SELECT count(*) FROM orch_plan_edges e
+      WHERE e.board_instance_id=:board AND e.tenant_scope=:tenant
+        AND e.orch_id=:orch AND e.plan_version=:pv
+        AND e.parent_node_key=n.node_key
+        AND e.child_node_key=(SELECT node_key FROM target)
+        AND e.edge_kind='orch_required_for_synthesis')!=1
+)
+UNION ALL SELECT 'bad_optional_edge' WHERE EXISTS (
+  SELECT 1 FROM nodes n WHERE n.role='lane' AND n.required=0 AND
+    ((SELECT count(*) FROM orch_plan_edges e
+       WHERE e.board_instance_id=:board AND e.tenant_scope=:tenant
+         AND e.orch_id=:orch AND e.plan_version=:pv
+         AND e.parent_node_key=n.node_key)>1
+     OR EXISTS (
+       SELECT 1 FROM orch_plan_edges e
+        WHERE e.board_instance_id=:board AND e.tenant_scope=:tenant
+          AND e.orch_id=:orch AND e.plan_version=:pv
+          AND e.parent_node_key=n.node_key
+          AND (e.child_node_key!=(SELECT node_key FROM target)
+               OR e.edge_kind!='orch_optional_context')
+     ))
+)
+UNION ALL SELECT 'illegal_edge_shape' WHERE EXISTS (
+  SELECT 1 FROM orch_plan_edges e JOIN nodes n ON n.node_key=e.parent_node_key
+   WHERE e.board_instance_id=:board AND e.tenant_scope=:tenant
+     AND e.orch_id=:orch AND e.plan_version=:pv
+     AND (n.role!='lane' OR e.child_node_key!=(SELECT node_key FROM target)
+       OR (n.required=1 AND e.edge_kind!='orch_required_for_synthesis')
+       OR (n.required=0 AND e.edge_kind!='orch_optional_context'))
+)
+UNION ALL SELECT 'uncovered_requirement' WHERE EXISTS (
+  SELECT 1 FROM orch_request_requirements r
+   WHERE r.board_instance_id=:board AND r.tenant_scope=:tenant
+     AND r.orch_id=:orch AND r.required=1 AND NOT EXISTS (
+       SELECT 1 FROM orch_plan_coverage c JOIN nodes n ON n.node_key=c.node_key
+        WHERE c.board_instance_id=:board AND c.tenant_scope=:tenant
+          AND c.orch_id=:orch AND c.requirement_id=r.requirement_id
+          AND c.plan_version=:pv AND n.role='lane'
+     )
+)
+UNION ALL SELECT 'coverage_to_non_lane' WHERE EXISTS (
+  SELECT 1 FROM orch_plan_coverage c JOIN nodes n ON n.node_key=c.node_key
+   WHERE c.board_instance_id=:board AND c.tenant_scope=:tenant
+     AND c.orch_id=:orch AND c.plan_version=:pv AND n.role!='lane'
+)
+"""
+
+MATERIALIZATION_PROVENANCE_SQL = """
+WITH p AS (
+  SELECT * FROM orch_plans
+   WHERE board_instance_id=:board AND tenant_scope=:tenant
+     AND orch_id=:orch AND plan_version=:pv
+), r AS (
+  SELECT * FROM orch_requests
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+), m AS (
+  SELECT * FROM orch_plan_materializations
+   WHERE board_instance_id=:board AND tenant_scope=:tenant
+     AND orch_id=:orch AND plan_version=:pv
+)
+SELECT 'missing_plan' WHERE (SELECT count(*) FROM p)!=1
+UNION ALL SELECT 'materialization_without_plan' WHERE
+  (SELECT count(*) FROM m)>0 AND (SELECT count(*) FROM p)=0
+UNION ALL SELECT 'plan_request_header_mismatch' WHERE EXISTS (
+  SELECT 1 FROM p CROSS JOIN r
+   WHERE p.request_key!=r.request_key
+      OR p.request_digest!=r.request_digest
+      OR p.origin_id!=r.origin_id
+      OR p.parent_task_id!=r.parent_task_id
+      OR p.synthesis_strategy!=r.synthesis_strategy
+      OR p.lineage_id!=r.lineage_id
+      OR p.generation!=r.generation
+)
+UNION ALL SELECT 'materialization_plan_digest_mismatch' WHERE EXISTS (
+  SELECT 1 FROM m LEFT JOIN p
+    ON p.board_instance_id=m.board_instance_id
+   AND p.tenant_scope=m.tenant_scope AND p.orch_id=m.orch_id
+   AND p.plan_version=m.plan_version AND p.plan_digest=m.plan_digest
+   WHERE p.orch_id IS NULL
+)
+UNION ALL SELECT 'materialization_request_revision_mismatch' WHERE EXISTS (
+  SELECT 1 FROM m CROSS JOIN r
+   WHERE m.request_lifecycle_revision!=r.lifecycle_revision
+      OR m.cancel_epoch!=r.cancel_epoch
+)
+"""
+
+CLOSED_WORLD_SQL = """
+WITH RECURSIVE
+seed(task_id) AS (
+  SELECT parent_task_id FROM orch_requests
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT task_id FROM orch_nodes
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT id FROM tasks
+   WHERE orch_board_instance_id=:board AND orch_tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT parent_task_id FROM orch_external_edges
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT child_task_id FROM orch_external_edges
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+),
+closure(task_id) AS (
+  SELECT task_id FROM seed
+  UNION
+  SELECT l.child_id FROM task_links l JOIN closure c ON l.parent_id=c.task_id
+  UNION
+  SELECT l.parent_id FROM task_links l JOIN closure c ON l.child_id=c.task_id
+)
+SELECT task_id FROM closure ORDER BY task_id
+"""
+
+
+def _params(board: str, tenant: str, orch: str, plan_version: int) -> dict[str, object]:
+    return {"board": board, "tenant": tenant, "orch": orch, "pv": plan_version}
+
+
+def grammar_findings(
+    conn: sqlite3.Connection, *, board: str, tenant: str, orch: str, plan_version: int
+) -> list[str]:
+    """Return contract §5.3 grammar findings; an accepted plan returns ``[]``."""
+    rows = conn.execute(PLAN_GRAMMAR_SQL, _params(board, tenant, orch, plan_version)).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def validate_plan(
+    conn: sqlite3.Connection, *, board: str, tenant: str, orch: str, plan_version: int
+) -> None:
+    """Raise ``ValueError`` if the plan grammar is not non-vacuously valid."""
+    findings = grammar_findings(conn, board=board, tenant=tenant, orch=orch, plan_version=plan_version)
+    if findings:
+        raise ValueError("invalid_orch_plan:" + ",".join(findings))
+
+
+def materialization_findings(
+    conn: sqlite3.Connection, *, board: str, tenant: str, orch: str, plan_version: int
+) -> list[str]:
+    """Return plan-header/materialization provenance findings."""
+    rows = conn.execute(
+        MATERIALIZATION_PROVENANCE_SQL,
+        _params(board, tenant, orch, plan_version),
+    ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def validate_materialization_provenance(
+    conn: sqlite3.Connection, *, board: str, tenant: str, orch: str, plan_version: int
+) -> None:
+    findings = materialization_findings(
+        conn, board=board, tenant=tenant, orch=orch, plan_version=plan_version
+    )
+    if findings:
+        raise ValueError("invalid_materialization_provenance:" + ",".join(findings))
+
+
+def closed_world_closure(
+    conn: sqlite3.Connection, *, board: str, tenant: str, orch: str
+) -> list[str]:
+    """Compute the recursive bidirectional task closure from contract §4.5."""
+    return [str(row[0]) for row in conn.execute(
+        CLOSED_WORLD_SQL, {"board": board, "tenant": tenant, "orch": orch}
+    ).fetchall()]
+
+
+# Short aliases useful to callers that treat the validator as a query object.
+validate_grammar = grammar_findings
+recursive_closed_world = closed_world_closure
+
+__all__ = [
+    "PLAN_GRAMMAR_SQL",
+    "MATERIALIZATION_PROVENANCE_SQL",
+    "CLOSED_WORLD_SQL",
+    "grammar_findings",
+    "validate_grammar",
+    "validate_plan",
+    "materialization_findings",
+    "validate_materialization_provenance",
+    "closed_world_closure",
+    "recursive_closed_world",
+]

--- a/hermes_cli/kanban_orch_reconcile.py
+++ b/hermes_cli/kanban_orch_reconcile.py
@@ -1,0 +1,282 @@
+"""ORCH V4 Reconciliation — outbox, effect ledger, queue recovery.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §11 (Event-driven reconciliation).
+§13 T35-T37 test contracts.
+
+Runtime-independent pure model. No live DB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ReconcileError(ValueError):
+    """Reconciliation protocol violation."""
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass
+class OrchEvent:
+    """Immutable event from a state transition."""
+    event_id: int
+    board_instance_id: str
+    tenant_scope: str
+    orch_id: str
+    event_kind: str
+    target_key: str
+    lifecycle_revision: int
+    cancel_epoch: int
+    payload_digest: str
+    event_key: str
+    commit_seq: int
+
+
+@dataclass
+class QueueItem:
+    """Reconcile queue item."""
+    event_id: int
+    consumer_kind: str
+    board_instance_id: str
+    tenant_scope: str
+    state: str = "pending"  # pending, claimed, done, dead_letter
+    claim_owner: str | None = None
+    claim_token_hash: str | None = None
+    claim_epoch: int = 0
+    claim_expires_at: int | None = None
+    attempts: int = 0
+    max_attempts: int = 5
+    available_at: int = 0
+    last_error_code: str | None = None
+    done_effect_digest: str | None = None
+
+
+@dataclass(frozen=True)
+class EffectLedgerEntry:
+    """Immutable effect ledger — exactly-once within SQLite."""
+    board_instance_id: str
+    tenant_scope: str
+    event_id: int
+    consumer_kind: str
+    effect_digest: str
+
+
+def enqueue_event(
+    events: list[OrchEvent],
+    queue: list[QueueItem],
+    *,
+    event_id: int,
+    consumer_kinds: list[str],
+    board: str,
+    tenant: str,
+    orch: str,
+    event_kind: str,
+    target_key: str,
+    lifecycle_revision: int,
+    cancel_epoch: int,
+    payload_digest: str,
+    commit_seq: int,
+) -> tuple[OrchEvent, list[QueueItem]]:
+    """§11: Transition/event/fanout same commit, no event-loss window.
+
+    Creates one event + one queue item per consumer_kind atomically.
+    """
+    event_key = f"{board}:{tenant}:{orch}:{event_kind}:{target_key}:{lifecycle_revision}:{cancel_epoch}:{payload_digest}"
+
+    # Check for duplicate event_key
+    for e in events:
+        if e.event_key == event_key:
+            raise ReconcileError("duplicate_event_key")
+
+    event = OrchEvent(
+        event_id=event_id,
+        board_instance_id=board,
+        tenant_scope=tenant,
+        orch_id=orch,
+        event_kind=event_kind,
+        target_key=target_key,
+        lifecycle_revision=lifecycle_revision,
+        cancel_epoch=cancel_epoch,
+        payload_digest=payload_digest,
+        event_key=event_key,
+        commit_seq=commit_seq,
+    )
+    events.append(event)
+
+    new_items = []
+    for ck in consumer_kinds:
+        # Check for duplicate (event_id, consumer_kind)
+        for q in queue:
+            if q.event_id == event_id and q.consumer_kind == ck:
+                raise ReconcileError("duplicate_queue_item")
+        item = QueueItem(
+            event_id=event_id,
+            consumer_kind=ck,
+            board_instance_id=board,
+            tenant_scope=tenant,
+        )
+        queue.append(item)
+        new_items.append(item)
+
+    return event, new_items
+
+
+def claim_queue_item(
+    item: QueueItem,
+    *,
+    owner: str,
+    token_hash: str,
+    ttl: int,
+    now: int,
+) -> int:
+    """§11: Claim CAS with epoch fencing."""
+    if item.state != "pending":
+        raise ReconcileError("claim_not_pending")
+    if item.available_at > now:
+        raise ReconcileError("claim_not_available")
+    if item.attempts >= item.max_attempts:
+        raise ReconcileError("claim_max_attempts")
+    item.state = "claimed"
+    item.claim_owner = owner
+    item.claim_token_hash = token_hash
+    item.claim_epoch += 1
+    item.claim_expires_at = now + ttl
+    item.attempts += 1
+    return item.claim_epoch
+
+
+def apply_effect(
+    item: QueueItem,
+    effects: list[EffectLedgerEntry],
+    *,
+    board: str,
+    tenant: str,
+    effect_digest: str,
+    owner: str,
+    token_hash: str,
+    epoch: int,
+) -> None:
+    """§11: Effect ledger + queue done one commit, replay idempotent.
+
+    If effect already exists with same digest → replay (no-op, just finish queue).
+    Different digest → corruption/conflict.
+    """
+    if item.state != "claimed":
+        raise ReconcileError("effect_not_claimed")
+    if item.claim_owner != owner:
+        raise ReconcileError("effect_wrong_owner")
+    if item.claim_token_hash != token_hash:
+        raise ReconcileError("effect_wrong_token")
+    if item.claim_epoch != epoch:
+        raise ReconcileError("effect_wrong_epoch")
+
+    # Check for existing effect with same (event_id, consumer_kind)
+    for e in effects:
+        if (e.event_id == item.event_id and e.consumer_kind == item.consumer_kind):
+            if e.effect_digest == effect_digest:
+                # Replay — idempotent, just finish queue
+                item.state = "done"
+                item.done_effect_digest = effect_digest
+                item.claim_owner = None
+                item.claim_token_hash = None
+                item.claim_expires_at = None
+                return
+            else:
+                raise ReconcileError("effect_digest_conflict")
+
+    # New effect
+    effects.append(EffectLedgerEntry(
+        board_instance_id=board,
+        tenant_scope=tenant,
+        event_id=item.event_id,
+        consumer_kind=item.consumer_kind,
+        effect_digest=effect_digest,
+    ))
+    item.state = "done"
+    item.done_effect_digest = effect_digest
+    item.claim_owner = None
+    item.claim_token_hash = None
+    item.claim_expires_at = None
+
+
+def recover_expired_claim(
+    item: QueueItem,
+    *,
+    now: int,
+    effects: list[EffectLedgerEntry],
+) -> str:
+    """§11: Expired claim recovery — return to pending or dead_letter.
+
+    Active nonexpired claim can never be swept to dead-letter.
+    """
+    if item.state != "claimed":
+        return item.state
+    if item.claim_expires_at is not None and item.claim_expires_at > now:
+        return item.state  # still active
+
+    # Expired — check if effect exists
+    has_effect = any(
+        e.event_id == item.event_id and e.consumer_kind == item.consumer_kind
+        for e in effects
+    )
+
+    if has_effect:
+        item.state = "done"
+    elif item.attempts < item.max_attempts:
+        item.state = "pending"
+        item.claim_owner = None
+        item.claim_token_hash = None
+        item.claim_expires_at = None
+        item.available_at = now  # immediate retry
+    else:
+        item.state = "dead_letter"
+        item.claim_owner = None
+        item.claim_token_hash = None
+        item.claim_expires_at = None
+        if not item.last_error_code:
+            item.last_error_code = "reconcile_attempts_exhausted"
+
+    return item.state
+
+
+def sweep_dead_letters(queue: list[QueueItem], effects: list[EffectLedgerEntry], *, now: int = 0) -> int:
+    """§11: Sweep items at max_attempts with no effect to dead_letter.
+
+    Active nonexpired claim can never be swept to dead-letter.
+    """
+    count = 0
+    for item in queue:
+        if item.attempts >= item.max_attempts:
+            has_effect = any(
+                e.event_id == item.event_id and e.consumer_kind == item.consumer_kind
+                for e in effects
+            )
+            if not has_effect and item.state == "pending":
+                item.state = "dead_letter"
+                item.claim_owner = None
+                item.claim_token_hash = None
+                item.claim_expires_at = None
+                if not item.last_error_code:
+                    item.last_error_code = "reconcile_attempts_exhausted"
+                count += 1
+            elif not has_effect and item.state == "claimed":
+                # Only sweep if claim has expired
+                if item.claim_expires_at is not None and item.claim_expires_at <= now:
+                    item.state = "dead_letter"
+                    item.claim_owner = None
+                    item.claim_token_hash = None
+                    item.claim_expires_at = None
+                    if not item.last_error_code:
+                        item.last_error_code = "reconcile_attempts_exhausted"
+                    count += 1
+    return count
+
+
+__all__ = [
+    "ReconcileError", "OrchEvent", "QueueItem", "EffectLedgerEntry",
+    "enqueue_event", "claim_queue_item", "apply_effect",
+    "recover_expired_claim", "sweep_dead_letters",
+]

--- a/hermes_cli/kanban_orch_rollback.py
+++ b/hermes_cli/kanban_orch_rollback.py
@@ -1,0 +1,239 @@
+"""ORCH V4 Rollback — forward phase state machine with CAS.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §17 (Durable rollback contract).
+§13 T43 test contract.
+
+Runtime-independent pure model. No live writer switch, no live DB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class RollbackError(ValueError):
+    """Rollback protocol violation."""
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+# §17 Rollback phases — forward transition, never DB-file replacement
+ROLLBACK_PHASES = (
+    "gate_submits",
+    "fence_draining",
+    "workers_stopped",
+    "leases_revoked",
+    "snapshot_sealed",
+    "code_switched",
+    "old_writer_receipts_verified",
+    "verified",
+    "reopened",
+)
+
+# Fence stays closed from fence_draining through verified
+FENCE_CLOSED_PHASES = frozenset({
+    "fence_draining", "workers_stopped", "leases_revoked",
+    "snapshot_sealed", "code_switched", "old_writer_receipts_verified", "verified",
+})
+
+
+@dataclass
+class RollbackOperation:
+    """Durable rollback operation state."""
+    operation_id: str
+    owner_token_hash: str
+    source_live_hash: str
+    source_code_hash: str
+    target_live_hash: str
+    target_code_hash: str
+    fence_generation: int = 0
+    phase_revision: int = 0
+    current_phase: str = "gate_submits"
+    completed_phases: list[str] = field(default_factory=list)
+    is_active: bool = False  # reopened = True
+
+    # Phase conditions (tracked for CAS)
+    phase_conditions: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+def create_rollback(
+    *,
+    operation_id: str,
+    owner_token_hash: str,
+    source_live_hash: str,
+    source_code_hash: str,
+    target_live_hash: str,
+    target_code_hash: str,
+) -> RollbackOperation:
+    """Create a new rollback operation at gate_submits."""
+    # §17.2: Compatible preimage must be M0 fence-aware
+    # Pre-M0 code can never be a rollback target
+    if not source_code_hash:
+        raise RollbackError("preimage_missing")
+    if not target_code_hash:
+        raise RollbackError("target_missing")
+
+    return RollbackOperation(
+        operation_id=operation_id,
+        owner_token_hash=owner_token_hash,
+        source_live_hash=source_live_hash,
+        source_code_hash=source_code_hash,
+        target_live_hash=target_live_hash,
+        target_code_hash=target_code_hash,
+        fence_generation=1,  # starts at 1 (fence closed)
+        current_phase="gate_submits",
+    )
+
+
+def advance_phase(
+    op: RollbackOperation,
+    *,
+    target_phase: str,
+    owner_token_hash: str,
+    expected_revision: int,
+) -> str:
+    """Advance rollback to target_phase with owner + revision CAS.
+
+    Rules:
+    - Cannot skip phases (must be next in sequence)
+    - Owner token must match
+    - Phase revision must match
+    - Fence stays closed from fence_draining through verified
+    - reopened requires additional David-level token (is_active=True)
+    """
+    if owner_token_hash != op.owner_token_hash:
+        raise RollbackError("owner_token_mismatch")
+
+    if expected_revision != op.phase_revision:
+        raise RollbackError("phase_revision_mismatch")
+
+    # Find current and target phase indices
+    try:
+        current_idx = ROLLBACK_PHASES.index(op.current_phase)
+        target_idx = ROLLBACK_PHASES.index(target_phase)
+    except ValueError:
+        raise RollbackError("invalid_phase")
+
+    # Cannot skip: must advance by exactly 1
+    if target_idx != current_idx + 1:
+        if target_idx <= current_idx:
+            raise RollbackError("phase_rollback_not_allowed")
+        raise RollbackError("phase_skip_not_allowed")
+
+    # Fence must stay closed from fence_draining through verified
+    if target_phase in FENCE_CLOSED_PHASES and op.fence_generation < 1:
+        raise RollbackError("fence_not_closed")
+
+    # reopened requires additional David-level token
+    if target_phase == "reopened":
+        if op.current_phase != "verified":
+            raise RollbackError("reopen_before_verified")
+        # In pure model, caller must set is_active=True before calling
+        # This is the "additional David-level token" gate
+        if not op.is_active:
+            raise RollbackError("reopen_requires_additional_token")
+
+    # Phase-specific conditions (§17)
+    if target_phase == "fence_draining":
+        # Write fence must be closed; dirty requests listed
+        if op.fence_generation < 1:
+            raise RollbackError("fence_not_closed_for_draining")
+    elif target_phase == "workers_stopped":
+        # Tracked processes stopped; no new claims
+        pass  # Model: caller ensures
+    elif target_phase == "leases_revoked":
+        # All leases list empty across all boards
+        pass  # Model: caller ensures
+    elif target_phase == "snapshot_sealed":
+        # Sealed board range; board identity verified
+        pass  # Model: caller ensures
+    elif target_phase == "code_switched":
+        # New code is reading old code bytes
+        pass  # Model: caller ensures
+    elif target_phase == "old_writer_receipts_verified":
+        # Verification receipts from all previous writer roles
+        pass  # Model: caller ensures
+    elif target_phase == "verified":
+        # All submitted gates closed and zero unexpected writers
+        # Late ACK/event after cutoff is appended, never discarded
+        pass  # Model: caller ensures
+
+    # Advance
+    op.completed_phases.append(op.current_phase)
+    op.current_phase = target_phase
+    op.phase_revision += 1
+
+    # reopened releases the fence
+    if target_phase == "reopened":
+        op.fence_generation = 0  # fence released
+        op.is_active = True
+
+    return op.current_phase
+
+
+def resume_rollback(
+    op: RollbackOperation,
+    *,
+    owner_token_hash: str,
+) -> str:
+    """§17.1: Crash resumes from durable phase/revision.
+
+    Returns current phase without advancing.
+    """
+    if owner_token_hash != op.owner_token_hash:
+        raise RollbackError("resume_owner_mismatch")
+    return op.current_phase
+
+
+def authorize_reopen(op: RollbackOperation, *, david_token: str) -> None:
+    """§17.6: Reopen requires additional David-level token.
+
+    Observer, manifest, transition-write and unknown-delivery invariants
+    must pass before reopen is authorized.
+    """
+    if op.current_phase != "verified":
+        raise RollbackError("reopen_before_verified")
+    if not david_token:
+        raise RollbackError("david_token_missing")
+    op.is_active = True  # Mark as authorized
+
+
+def check_no_early_reopen(op: RollbackOperation) -> bool:
+    """§17.1: Fence stays closed from fence_draining through verified.
+
+    Returns True if fence is properly closed (no early reopen).
+    """
+    if op.current_phase in FENCE_CLOSED_PHASES:
+        return op.fence_generation >= 1  # fence must be closed
+    if op.current_phase == "gate_submits":
+        return True  # not yet started
+    if op.current_phase == "reopened":
+        return op.fence_generation == 0  # properly released
+    return False
+
+
+def check_preimage_compatible(
+    source_code_hash: str,
+    target_code_hash: str,
+    *,
+    is_m0_aware: bool = True,
+) -> bool:
+    """§17.2: Compatible preimage means M0 fence-aware source hash.
+
+    Pre-M0 code can never be a rollback target.
+    """
+    if not is_m0_aware:
+        return False
+    if not source_code_hash or not target_code_hash:
+        return False
+    return source_code_hash != target_code_hash  # must be different (rollback)
+
+
+__all__ = [
+    "RollbackError", "ROLLBACK_PHASES", "FENCE_CLOSED_PHASES",
+    "RollbackOperation", "create_rollback", "advance_phase",
+    "resume_rollback", "authorize_reopen", "check_no_early_reopen",
+    "check_preimage_compatible",
+]

--- a/hermes_cli/kanban_orch_schema_sidecar.py
+++ b/hermes_cli/kanban_orch_schema_sidecar.py
@@ -1,0 +1,100 @@
+"""ORCH V4 Sidecar Schema — DDL loader for sidecar orch_v4.db.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §15.0 Sidecar Architecture Decision.
+
+This module applies the sidecar schema to a fresh SQLite connection.
+Unlike the in-place schema (kanban_orch_schema_v4.py), this does NOT create
+stub native tables (tasks, task_links, etc.) — those live in the native
+kanban.db and are accessed read-only via the bridge.
+
+Hard rules:
+- No REFERENCES to native tables (tasks.id, etc.) — soft FK handled by bridge
+- No stub table creation — sidecar is pure orch_* tables
+- foreign_keys=ON enforced
+- orch_capability_ok UDF registered as allow-all (bridge enforces real capability)
+"""
+
+import sqlite3
+import os
+
+_SCHEMA_DIR = os.path.dirname(os.path.abspath(__file__))
+
+EXPECTED_SIDECAR_TABLES: frozenset[str] = frozenset({
+    "kanban_board_identity", "kanban_schema_migrations", "kanban_write_fence",
+    "kanban_commit_clock", "kanban_migration_operations", "orch_rollback_operations",
+    "orch_replay_selectors", "orch_origins", "orch_requests", "orch_request_requirements",
+    "orch_plans", "orch_plan_nodes", "orch_plan_edges", "orch_plan_coverage",
+    "orch_plan_materializations", "orch_nodes", "orch_external_edges",
+    "orch_node_acceptances", "orch_stage_leases", "orch_stage_attempts",
+    "orch_results", "orch_delivery_manifests", "orch_delivery_obligations",
+    "orch_delivery_manifest_entries", "orch_delivery_attempts",
+    "orch_delivery_attempt_events", "orch_delivery_receipts",
+    "orch_events", "orch_reconcile_queue", "orch_effect_ledger",
+    "orch_delivery_resend_authorizations", "orch_mutation_log",
+})
+
+# Tables that exist in native kanban.db (NOT created in sidecar)
+NATIVE_TABLES = frozenset({
+    "tasks", "task_links", "task_comments", "task_events", "task_intakes",
+    "task_input_requests", "task_review_requirements", "kanban_notify_subs",
+    "kanban_delivery_outbox", "lost_and_found", "independent_reviews",
+    "independent_review_evidence", "independent_review_cancellations",
+    "kanban_chief_escalations", "task_attachments", "task_runs",
+})
+
+
+def apply_sidecar_schema(conn: sqlite3.Connection) -> None:
+    """Apply sidecar V4 schema DDL to a fresh SQLite connection.
+
+    This does NOT create native table stubs. The sidecar DB contains only
+    orch_* tables + board identity + write fence + commit clock + migration ops.
+    Cross-DB FKs to native tables (tasks.id) are removed; the bridge enforces
+    soft FK at the application layer.
+    """
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    sql_path = os.path.join(_SCHEMA_DIR, "orch_v4_schema_sidecar.sql")
+    with open(sql_path, "r", encoding="utf-8") as f:
+        ddl = f.read()
+    conn.executescript(ddl)
+    conn.commit()
+
+    # Register orch_capability_ok stub UDF (sidecar-local).
+    # In production, the bridge provides a real capability check.
+    # For isolated testing, always allow (1).
+    conn.create_function("orch_capability_ok", 7, lambda *a: 1)
+
+
+def get_sidecar_table_names(conn: sqlite3.Connection) -> list[str]:
+    """Return sorted list of table names in the sidecar DB."""
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def get_sidecar_trigger_names(conn: sqlite3.Connection) -> list[str]:
+    """Return sorted list of trigger names in the sidecar DB."""
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' ORDER BY name"
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def verify_no_native_tables(conn: sqlite3.Connection) -> bool:
+    """Verify that no native Kanban tables exist in the sidecar DB.
+
+    Returns True if clean (no native tables found).
+    """
+    tables = set(get_sidecar_table_names(conn))
+    leaked = tables & NATIVE_TABLES
+    if leaked:
+        raise RuntimeError(f"Native tables leaked into sidecar: {leaked}")
+    return True
+
+
+__all__ = [
+    "EXPECTED_SIDECAR_TABLES", "NATIVE_TABLES",
+    "apply_sidecar_schema", "get_sidecar_table_names",
+    "get_sidecar_trigger_names", "verify_no_native_tables",
+]

--- a/hermes_cli/kanban_orch_schema_sidecar.py
+++ b/hermes_cli/kanban_orch_schema_sidecar.py
@@ -68,6 +68,10 @@ def apply_sidecar_schema(conn: sqlite3.Connection, *, test_open_capability: bool
     else:
         install_fail_closed_udf(conn)
 
+    from hermes_cli.kanban_orch_digest_udf import apply_digest_guards
+
+    apply_digest_guards(conn)
+
 
 def get_sidecar_table_names(conn: sqlite3.Connection) -> list[str]:
     """Return sorted list of table names in the sidecar DB."""

--- a/hermes_cli/kanban_orch_schema_sidecar.py
+++ b/hermes_cli/kanban_orch_schema_sidecar.py
@@ -43,14 +43,18 @@ NATIVE_TABLES = frozenset({
 })
 
 
-def apply_sidecar_schema(conn: sqlite3.Connection) -> None:
+def apply_sidecar_schema(conn: sqlite3.Connection, *, test_open_capability: bool = False) -> None:
     """Apply sidecar V4 schema DDL to a fresh SQLite connection.
 
     This does NOT create native table stubs. The sidecar DB contains only
     orch_* tables + board identity + write fence + commit clock + migration ops.
     Cross-DB FKs to native tables (tasks.id) are removed; the bridge enforces
     soft FK at the application layer.
+
+    Capability UDF is fail-closed by default.
     """
+    from hermes_cli.kanban_orch_capability import install_fail_closed_udf, install_test_open_udf
+
     conn.execute("PRAGMA foreign_keys=ON")
 
     sql_path = os.path.join(_SCHEMA_DIR, "orch_v4_schema_sidecar.sql")
@@ -59,10 +63,10 @@ def apply_sidecar_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(ddl)
     conn.commit()
 
-    # Register orch_capability_ok stub UDF (sidecar-local).
-    # In production, the bridge provides a real capability check.
-    # For isolated testing, always allow (1).
-    conn.create_function("orch_capability_ok", 7, lambda *a: 1)
+    if test_open_capability:
+        install_test_open_udf(conn)
+    else:
+        install_fail_closed_udf(conn)
 
 
 def get_sidecar_table_names(conn: sqlite3.Connection) -> list[str]:

--- a/hermes_cli/kanban_orch_schema_v4.py
+++ b/hermes_cli/kanban_orch_schema_v4.py
@@ -1,0 +1,266 @@
+"""
+ORCH V4 Schema — DDL + triggers from §4 of the implementation contract.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §4.3 (normative schema) + §4.4 (triggers).
+Provides apply_schema(conn) which executes all DDL via executescript().
+"""
+
+import sqlite3
+import os
+
+_SCHEMA_DIR = os.path.dirname(os.path.abspath(__file__))
+
+EXPECTED_TABLES: frozenset[str] = frozenset({
+    "kanban_board_identity", "kanban_schema_migrations", "kanban_write_fence",
+    "kanban_commit_clock", "kanban_migration_operations", "orch_rollback_operations",
+    "orch_replay_selectors", "orch_origins", "orch_requests", "orch_request_requirements",
+    "orch_plans", "orch_plan_nodes", "orch_plan_edges", "orch_plan_coverage",
+    "orch_plan_materializations", "orch_nodes", "orch_external_edges",
+    "orch_node_acceptances", "orch_stage_leases", "orch_stage_attempts",
+    "orch_results", "orch_delivery_manifests", "orch_delivery_obligations",
+    "orch_delivery_manifest_entries", "orch_delivery_attempts",
+    "orch_delivery_attempt_events", "orch_delivery_receipts",
+    "orch_events", "orch_reconcile_queue", "orch_effect_ledger",
+    "orch_delivery_resend_authorizations", "orch_mutation_log",
+})
+
+# Minimal stubs for existing Kanban tables that V4 triggers reference.
+# These match the live DB shape (from recon) but are minimal for temp DB testing.
+_STUB_DDL = """
+CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    body TEXT,
+    assignee TEXT,
+    status TEXT NOT NULL,
+    priority INTEGER DEFAULT 0,
+    created_by TEXT,
+    created_at INTEGER NOT NULL,
+    started_at INTEGER,
+    completed_at INTEGER,
+    workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+    workspace_path TEXT,
+    claim_lock TEXT,
+    claim_expires INTEGER,
+    tenant TEXT,
+    result TEXT,
+    idempotency_key TEXT,
+    spawn_failures INTEGER NOT NULL DEFAULT 0,
+    worker_pid INTEGER,
+    last_spawn_error TEXT,
+    max_runtime_seconds INTEGER,
+    last_heartbeat_at INTEGER,
+    current_run_id INTEGER,
+    workflow_template_id TEXT,
+    current_step_key TEXT,
+    skills TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    last_failure_error TEXT,
+    max_retries INTEGER,
+    branch_name TEXT,
+    model_override TEXT,
+    session_id TEXT,
+    goal_mode INTEGER NOT NULL DEFAULT 0,
+    goal_max_turns INTEGER,
+    project_id TEXT,
+    block_kind TEXT,
+    block_recurrences INTEGER NOT NULL DEFAULT 0,
+    source_chat TEXT,
+    source_fingerprint TEXT,
+    done_when TEXT,
+    evidence TEXT,
+    human_needed INTEGER NOT NULL DEFAULT 0,
+    next_action TEXT,
+    block_revision INTEGER NOT NULL DEFAULT 0,
+    provider_override TEXT,
+    reasoning_effort TEXT,
+    orch_board_instance_id TEXT,
+    orch_tenant_scope TEXT,
+    orch_id TEXT,
+    orch_plan_version INTEGER,
+    orch_node_key TEXT,
+    orch_binding_revision INTEGER,
+    orch_cancel_epoch INTEGER,
+    created_by_run_id INTEGER,
+    cancellation_requested_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS task_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at INTEGER,
+    ended_at INTEGER,
+    outcome TEXT,
+    outcome_digest TEXT,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS task_links (
+    parent_id TEXT NOT NULL,
+    child_id TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'depends',
+    PRIMARY KEY (parent_id, child_id)
+);
+
+CREATE TABLE IF NOT EXISTS task_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    author TEXT,
+    body TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS task_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS task_intakes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    intake_data TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS task_input_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    request_kind TEXT,
+    status TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS task_review_requirements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    requirement TEXT,
+    met INTEGER DEFAULT 0,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS kanban_notify_subs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    platform TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS kanban_delivery_outbox (
+    input_request_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    block_revision INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'sending',
+    created_at INTEGER NOT NULL,
+    UNIQUE(task_id, block_revision),
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS lost_and_found (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    found_key TEXT,
+    found_data TEXT,
+    found_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS independent_reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    reviewer TEXT,
+    status TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS independent_review_evidence (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    review_id INTEGER NOT NULL,
+    evidence TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (review_id) REFERENCES independent_reviews(id)
+);
+
+CREATE TABLE IF NOT EXISTS independent_review_cancellations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    review_id INTEGER NOT NULL,
+    reason TEXT,
+    cancelled_at INTEGER NOT NULL,
+    FOREIGN KEY (review_id) REFERENCES independent_reviews(id)
+);
+
+CREATE TABLE IF NOT EXISTS kanban_chief_escalations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    escalated_by TEXT,
+    reason TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS task_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    file_path TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+"""
+
+
+def create_existing_table_stubs(conn: sqlite3.Connection) -> None:
+    """Create the legacy Kanban tables referenced by V4 foreign keys/triggers.
+
+    V4 is compiled in isolation in tests and migrations, while the live
+    Kanban database owns these tables.  Keep these definitions deliberately
+    compatible with the live columns used by the V4 binding guards; they are
+    not a second source of truth for the legacy schema.
+    """
+    conn.executescript(_STUB_DDL)
+
+
+def apply_schema(conn: sqlite3.Connection) -> None:
+    """Apply all V4 schema DDL + triggers to a fresh SQLite connection.
+
+    The caller normally enables foreign keys, but enabling it here as well
+    makes the isolated compiler fail closed instead of silently accepting an
+    invalid test connection.  Legacy table stubs must exist before SQLite
+    compiles V4 foreign keys and triggers that reference them.
+    """
+    conn.execute("PRAGMA foreign_keys=ON")
+    create_existing_table_stubs(conn)
+
+    sql_path = os.path.join(_SCHEMA_DIR, "orch_v4_schema.sql")
+    with open(sql_path, "r", encoding="utf-8") as f:
+        ddl = f.read()
+    conn.executescript(ddl)
+    conn.commit()
+
+    # Register orch_capability_ok stub UDF (temp DB only).
+    # In production, this is a runtime-private SQLite authorizer.
+    # For tests, it always returns 1 (allow) so triggers pass.
+    conn.create_function("orch_capability_ok", 7, lambda *a: 1)
+
+
+def get_table_names(conn: sqlite3.Connection) -> list[str]:
+    """Return sorted list of table names in the database."""
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def get_trigger_names(conn: sqlite3.Connection) -> list[str]:
+    """Return sorted list of trigger names."""
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='trigger' ORDER BY name"
+    ).fetchall()
+    return [r[0] for r in rows]

--- a/hermes_cli/kanban_orch_schema_v4.py
+++ b/hermes_cli/kanban_orch_schema_v4.py
@@ -227,14 +227,19 @@ def create_existing_table_stubs(conn: sqlite3.Connection) -> None:
     conn.executescript(_STUB_DDL)
 
 
-def apply_schema(conn: sqlite3.Connection) -> None:
+def apply_schema(conn: sqlite3.Connection, *, test_open_capability: bool = False) -> None:
     """Apply all V4 schema DDL + triggers to a fresh SQLite connection.
 
     The caller normally enables foreign keys, but enabling it here as well
     makes the isolated compiler fail closed instead of silently accepting an
     invalid test connection.  Legacy table stubs must exist before SQLite
     compiles V4 foreign keys and triggers that reference them.
+
+    Capability UDF is fail-closed by default. Tests that need writes must
+    either pass test_open_capability=True or install explicit grants.
     """
+    from hermes_cli.kanban_orch_capability import install_fail_closed_udf, install_test_open_udf
+
     conn.execute("PRAGMA foreign_keys=ON")
     create_existing_table_stubs(conn)
 
@@ -244,10 +249,10 @@ def apply_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(ddl)
     conn.commit()
 
-    # Register orch_capability_ok stub UDF (temp DB only).
-    # In production, this is a runtime-private SQLite authorizer.
-    # For tests, it always returns 1 (allow) so triggers pass.
-    conn.create_function("orch_capability_ok", 7, lambda *a: 1)
+    if test_open_capability:
+        install_test_open_udf(conn)
+    else:
+        install_fail_closed_udf(conn)
 
 
 def get_table_names(conn: sqlite3.Connection) -> list[str]:

--- a/hermes_cli/kanban_orch_schema_v4.py
+++ b/hermes_cli/kanban_orch_schema_v4.py
@@ -254,6 +254,10 @@ def apply_schema(conn: sqlite3.Connection, *, test_open_capability: bool = False
     else:
         install_fail_closed_udf(conn)
 
+    from hermes_cli.kanban_orch_digest_udf import apply_digest_guards
+
+    apply_digest_guards(conn)
+
 
 def get_table_names(conn: sqlite3.Connection) -> list[str]:
     """Return sorted list of table names in the database."""

--- a/hermes_cli/kanban_orch_writer_switch.py
+++ b/hermes_cli/kanban_orch_writer_switch.py
@@ -1,7 +1,9 @@
-"""Opt-in ORCH V4 live sidecar writer pointer.
+"""Opt-in / default ORCH V4 live sidecar writer pointer.
 
-Default is OFF. Enable only when:
-  os.environ.get("ORCH_V4_WRITER") == "1"
+Enabled when either:
+  - os.environ.get("ORCH_V4_WRITER") == "1", or
+  - writer json has enabled_default=true
+
 and /home/claw/.hermes/orch_v4_writer.json exists.
 """
 from __future__ import annotations
@@ -10,16 +12,29 @@ import json
 import os
 from pathlib import Path
 
-from hermes_cli.kanban_orch_bridge import OrchBridge, BridgeError
+from hermes_cli.kanban_orch_bridge import BridgeError, OrchBridge
 
 DEFAULT_CFG = Path.home() / ".hermes" / "orch_v4_writer.json"
 
 
+def _cfg_default_enabled(path: Path) -> bool:
+    try:
+        cfg = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    return bool(cfg.get("enabled_default") is True)
+
+
 def writer_enabled(cfg_path: str | os.PathLike[str] | None = None) -> bool:
     path = Path(cfg_path) if cfg_path else DEFAULT_CFG
-    if os.environ.get("ORCH_V4_WRITER") != "1":
+    if not path.is_file():
         return False
-    return path.is_file()
+    if os.environ.get("ORCH_V4_WRITER") == "0":
+        # explicit kill switch
+        return False
+    if os.environ.get("ORCH_V4_WRITER") == "1":
+        return True
+    return _cfg_default_enabled(path)
 
 
 def open_live_bridge(cfg_path: str | os.PathLike[str] | None = None) -> OrchBridge:

--- a/hermes_cli/kanban_orch_writer_switch.py
+++ b/hermes_cli/kanban_orch_writer_switch.py
@@ -1,0 +1,41 @@
+"""Opt-in ORCH V4 live sidecar writer pointer.
+
+Default is OFF. Enable only when:
+  os.environ.get("ORCH_V4_WRITER") == "1"
+and /home/claw/.hermes/orch_v4_writer.json exists.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from hermes_cli.kanban_orch_bridge import OrchBridge, BridgeError
+
+DEFAULT_CFG = Path.home() / ".hermes" / "orch_v4_writer.json"
+
+
+def writer_enabled(cfg_path: str | os.PathLike[str] | None = None) -> bool:
+    path = Path(cfg_path) if cfg_path else DEFAULT_CFG
+    if os.environ.get("ORCH_V4_WRITER") != "1":
+        return False
+    return path.is_file()
+
+
+def open_live_bridge(cfg_path: str | os.PathLike[str] | None = None) -> OrchBridge:
+    if not writer_enabled(cfg_path):
+        raise BridgeError("writer_switch_disabled")
+    path = Path(cfg_path) if cfg_path else DEFAULT_CFG
+    cfg = json.loads(path.read_text(encoding="utf-8"))
+    if cfg.get("native_writable") is True:
+        raise BridgeError("native_write_forbidden_by_sidecar_decision")
+    return OrchBridge(
+        cfg["native_db"],
+        cfg["sidecar_db"],
+        native_writable=False,
+        board_instance_id=cfg.get("board_instance_id"),
+        tenant_scope=cfg.get("tenant_scope", ""),
+    )
+
+
+__all__ = ["writer_enabled", "open_live_bridge", "DEFAULT_CFG"]

--- a/hermes_cli/orch_v4_schema.sql
+++ b/hermes_cli/orch_v4_schema.sql
@@ -1,0 +1,1790 @@
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE kanban_board_identity (
+  singleton INTEGER PRIMARY KEY CHECK (singleton=1),
+  board_instance_id TEXT NOT NULL UNIQUE CHECK (length(board_instance_id) BETWEEN 16 AND 128),
+  canonical_board_key TEXT NOT NULL CHECK (length(canonical_board_key) BETWEEN 1 AND 256),
+  created_at INTEGER NOT NULL CHECK (created_at>0)
+);
+
+CREATE TABLE kanban_schema_migrations (
+  migration_id TEXT PRIMARY KEY,
+  target_schema_version INTEGER NOT NULL UNIQUE CHECK (target_schema_version>0),
+  state TEXT NOT NULL CHECK (state IN ('prepared','applied','verified','failed')),
+  board_instance_id TEXT NOT NULL,
+  source_digest TEXT NOT NULL CHECK (length(source_digest)=64),
+  backup_digest TEXT NOT NULL CHECK (length(backup_digest)=64),
+  receipt_digest TEXT,
+  fence_generation INTEGER NOT NULL CHECK (fence_generation>=0),
+  prepared_at INTEGER NOT NULL,
+  applied_at INTEGER,
+  verified_at INTEGER,
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id),
+  CHECK ((state='verified' AND receipt_digest IS NOT NULL AND length(receipt_digest)=64 AND verified_at IS NOT NULL)
+      OR (state!='verified'))
+);
+
+CREATE TABLE kanban_write_fence (
+  singleton INTEGER PRIMARY KEY CHECK (singleton=1),
+  mode TEXT NOT NULL CHECK (mode IN ('open','draining','fenced')),
+  generation INTEGER NOT NULL CHECK (generation>=0),
+  owner_token_hash TEXT,
+  reason TEXT,
+  updated_at INTEGER NOT NULL,
+  CHECK ((mode='open' AND owner_token_hash IS NULL) OR (mode!='open' AND owner_token_hash IS NOT NULL))
+);
+
+CREATE TABLE kanban_commit_clock (
+  singleton INTEGER PRIMARY KEY CHECK (singleton=1),
+  commit_seq INTEGER NOT NULL CHECK (commit_seq>=0),
+  last_txn_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE kanban_migration_operations (
+  migration_id TEXT PRIMARY KEY,
+  board_instance_id TEXT NOT NULL,
+  owner_token_hash TEXT NOT NULL CHECK (length(owner_token_hash)=64),
+  source_digest TEXT NOT NULL CHECK (length(source_digest)=64),
+  plan_digest TEXT NOT NULL CHECK (length(plan_digest)=64),
+  schema_digest TEXT NOT NULL CHECK (length(schema_digest)=64),
+  backup_digest TEXT,
+  fence_generation INTEGER NOT NULL CHECK (fence_generation>=0),
+  phase TEXT NOT NULL CHECK (phase IN (
+    'prepared','barrier_held','backup_sealed','committed',
+    'receipt_completed','verified','unfenced','failed'
+  )),
+  phase_revision INTEGER NOT NULL CHECK (phase_revision>=0),
+  receipt_digest TEXT,
+  started_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id)
+);
+
+CREATE TABLE orch_rollback_operations (
+  rollback_id TEXT PRIMARY KEY,
+  migration_id TEXT NOT NULL,
+  board_instance_id TEXT NOT NULL,
+  owner_token_hash TEXT NOT NULL CHECK (length(owner_token_hash)=64),
+  source_manifest_digest TEXT NOT NULL CHECK (length(source_manifest_digest)=64),
+  target_manifest_digest TEXT NOT NULL CHECK (length(target_manifest_digest)=64),
+  fence_generation INTEGER NOT NULL CHECK (fence_generation>=0),
+  phase TEXT NOT NULL CHECK (phase IN (
+    'gate_submits','fence_draining','workers_stopped','leases_revoked',
+    'snapshot_sealed','code_switched','old_writer_receipts_verified','verified','reopened','failed'
+  )),
+  phase_revision INTEGER NOT NULL CHECK (phase_revision>=0),
+  snapshot_digest TEXT,
+  started_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (migration_id) REFERENCES kanban_migration_operations(migration_id),
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id)
+);
+
+CREATE TABLE orch_replay_selectors (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  selector_key TEXT NOT NULL CHECK (length(selector_key)=64),
+  selector_kind TEXT NOT NULL CHECK (selector_kind IN ('event','client')),
+  selector_value TEXT NOT NULL CHECK (length(selector_value)>0),
+  adapter_instance_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  lineage_id TEXT NOT NULL,
+  current_generation INTEGER NOT NULL CHECK (current_generation>=0),
+  current_orch_id TEXT,
+  current_request_digest TEXT,
+  ledger_revision INTEGER NOT NULL CHECK (ledger_revision>=0),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,selector_key),
+  UNIQUE (board_instance_id,tenant_scope,adapter_instance_id,conversation_id,selector_kind,selector_value),
+  UNIQUE (board_instance_id,tenant_scope,lineage_id),
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id),
+  CHECK ((current_generation=0 AND current_orch_id IS NULL AND current_request_digest IS NULL)
+      OR (current_generation>0 AND current_orch_id IS NOT NULL AND length(current_request_digest)=64))
+);
+
+CREATE TABLE orch_origins (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  origin_id TEXT NOT NULL,
+  schema_version INTEGER NOT NULL CHECK (schema_version=4),
+  selector_key TEXT NOT NULL CHECK (length(selector_key)=64),
+  origin_kind TEXT NOT NULL CHECK (origin_kind IN ('messaging','api','local_session','board_only')),
+  platform TEXT NOT NULL,
+  adapter_instance_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  selector_kind TEXT NOT NULL CHECK (selector_kind IN ('event','client')),
+  selector_value TEXT NOT NULL CHECK (length(selector_value)>0),
+  client_idempotency_key TEXT,
+  thread_id TEXT NOT NULL,
+  reply_to_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  notifier_profile TEXT NOT NULL,
+  route_revision INTEGER NOT NULL CHECK (route_revision>0),
+  route_json TEXT NOT NULL,
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  required_ack_family TEXT NOT NULL CHECK (required_ack_family IN (
+    'provider','adapter','synchronous','local_session','none'
+  )),
+  required_ack_strength TEXT NOT NULL CHECK (required_ack_strength IN (
+    'provider_message_id','adapter_acceptance','synchronous_response',
+    'local_session_acceptance','none'
+  )),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,origin_id),
+  UNIQUE (board_instance_id,tenant_scope,origin_id,route_revision,route_digest),
+  UNIQUE (board_instance_id,tenant_scope,selector_key,route_revision),
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,selector_key)
+    REFERENCES orch_replay_selectors(board_instance_id,tenant_scope,selector_key),
+  CHECK ((selector_kind='client' AND client_idempotency_key=selector_value)
+      OR selector_kind='event'),
+  CHECK ((origin_kind='board_only' AND required_ack_strength='none') OR
+         (origin_kind!='board_only' AND required_ack_strength!='none')),
+  CHECK ((required_ack_family='provider' AND required_ack_strength='provider_message_id')
+      OR (required_ack_family='adapter' AND required_ack_strength='adapter_acceptance')
+      OR (required_ack_family='synchronous' AND required_ack_strength='synchronous_response')
+      OR (required_ack_family='local_session' AND required_ack_strength='local_session_acceptance')
+      OR (required_ack_family='none' AND required_ack_strength='none'))
+);
+
+CREATE TABLE orch_requests (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  lineage_id TEXT NOT NULL,
+  generation INTEGER NOT NULL CHECK (generation>0),
+  selector_key TEXT NOT NULL CHECK (length(selector_key)=64),
+  selector_ledger_revision INTEGER NOT NULL CHECK (selector_ledger_revision>=0),
+  request_key TEXT NOT NULL CHECK (length(request_key)=64),
+  request_schema_version INTEGER NOT NULL CHECK (request_schema_version=4),
+  request_json TEXT NOT NULL,
+  request_digest TEXT NOT NULL CHECK (length(request_digest)=64),
+  origin_id TEXT NOT NULL,
+  parent_task_id TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN (
+    'submitted','decomposing','waiting_lanes','synthesizing','work_accepted',
+    'delivering','delivery_blocked','blocked','cancelling','completed','failed','cancelled'
+  )),
+  lifecycle_revision INTEGER NOT NULL DEFAULT 0 CHECK (lifecycle_revision>=0),
+  cancel_epoch INTEGER NOT NULL DEFAULT 0 CHECK (cancel_epoch>=0),
+  delivery_epoch_revision INTEGER NOT NULL DEFAULT 0 CHECK (
+    delivery_epoch_revision>=0 AND delivery_epoch_revision<=lifecycle_revision
+  ),
+  plan_epoch_revision INTEGER NOT NULL DEFAULT 0 CHECK (
+    plan_epoch_revision>=0 AND plan_epoch_revision<=lifecycle_revision
+  ),
+  plan_version INTEGER NOT NULL DEFAULT 0 CHECK (plan_version>=0),
+  synthesis_strategy TEXT NOT NULL CHECK (synthesis_strategy IN ('parent_owned','separate_node')),
+  blocked_from_state TEXT,
+  resume_state TEXT,
+  block_kind TEXT,
+  block_revision INTEGER NOT NULL DEFAULT 0 CHECK (block_revision>=0),
+  input_request_id INTEGER,
+  retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count>=0),
+  max_retries INTEGER NOT NULL CHECK (max_retries BETWEEN 0 AND 100),
+  deadline_at INTEGER,
+  work_accepted_at INTEGER,
+  delivery_closed_at INTEGER,
+  terminal_reason_code TEXT,
+  supersedes_orch_id TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id),
+  UNIQUE (board_instance_id,tenant_scope,lineage_id,generation),
+  UNIQUE (board_instance_id,tenant_scope,request_key),
+  UNIQUE (board_instance_id,tenant_scope,parent_task_id),
+  UNIQUE (board_instance_id,tenant_scope,supersedes_orch_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,request_key,request_digest,origin_id,parent_task_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,lineage_id,generation,request_key,
+          request_digest,origin_id,parent_task_id,synthesis_strategy),
+  FOREIGN KEY (board_instance_id,tenant_scope,selector_key)
+    REFERENCES orch_replay_selectors(board_instance_id,tenant_scope,selector_key),
+  FOREIGN KEY (board_instance_id,tenant_scope,origin_id)
+    REFERENCES orch_origins(board_instance_id,tenant_scope,origin_id),
+  FOREIGN KEY (parent_task_id) REFERENCES tasks(id) DEFERRABLE INITIALLY DEFERRED,
+  FOREIGN KEY (board_instance_id,tenant_scope,supersedes_orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id),
+  CHECK (
+    (lifecycle_state='blocked' AND blocked_from_state IN ('decomposing','waiting_lanes','synthesizing')
+       AND resume_state=blocked_from_state AND block_kind IN ('needs_input','capability','policy','external'))
+    OR
+    (lifecycle_state!='blocked' AND blocked_from_state IS NULL AND resume_state IS NULL AND block_kind IS NULL)
+  ),
+  CHECK ((lifecycle_state IN ('completed','failed','cancelled') AND terminal_reason_code IS NOT NULL)
+      OR (lifecycle_state NOT IN ('completed','failed','cancelled'))),
+  CHECK ((lifecycle_state='completed' AND work_accepted_at IS NOT NULL AND delivery_closed_at IS NOT NULL)
+      OR lifecycle_state!='completed')
+);
+
+CREATE TABLE orch_request_requirements (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  requirement_id TEXT NOT NULL,
+  ordinal INTEGER NOT NULL CHECK (ordinal>0),
+  requirement_json TEXT NOT NULL,
+  requirement_digest TEXT NOT NULL CHECK (length(requirement_digest)=64),
+  required INTEGER NOT NULL CHECK (required IN (0,1)),
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,requirement_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,ordinal),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id)
+);
+
+CREATE TABLE orch_plans (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL CHECK (plan_version>0),
+  schema_version INTEGER NOT NULL CHECK (schema_version=4),
+  lineage_id TEXT NOT NULL,
+  generation INTEGER NOT NULL,
+  request_key TEXT NOT NULL,
+  request_digest TEXT NOT NULL,
+  origin_id TEXT NOT NULL,
+  parent_task_id TEXT NOT NULL,
+  synthesis_strategy TEXT NOT NULL CHECK (synthesis_strategy IN ('parent_owned','separate_node')),
+  plan_json TEXT NOT NULL,
+  plan_digest TEXT NOT NULL CHECK (length(plan_digest)=64),
+  created_by_run_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_digest),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,plan_digest),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,request_digest,plan_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,lineage_id,generation,request_key,
+               request_digest,origin_id,parent_task_id,synthesis_strategy)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id,lineage_id,generation,request_key,
+                             request_digest,origin_id,parent_task_id,synthesis_strategy),
+  CHECK (generation>0)
+);
+
+CREATE TABLE orch_plan_nodes (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  node_key TEXT NOT NULL,
+  lane_lineage_key TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('parent','lane','synthesis')),
+  lane_label TEXT NOT NULL,
+  normalized_goal TEXT NOT NULL,
+  normalized_done_when TEXT NOT NULL,
+  required INTEGER NOT NULL CHECK (required IN (0,1)),
+  route_json TEXT NOT NULL,
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  ordinal INTEGER NOT NULL CHECK (ordinal>0),
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version,node_key),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,ordinal),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,lane_lineage_key),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version)
+    REFERENCES orch_plans(board_instance_id,tenant_scope,orch_id,plan_version),
+  CHECK ((role='lane' AND lane_label!='') OR (role!='lane' AND lane_label='')),
+  CHECK ((role='lane') OR required=1)
+);
+
+CREATE TABLE orch_plan_edges (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  edge_key TEXT NOT NULL,
+  parent_node_key TEXT NOT NULL,
+  child_node_key TEXT NOT NULL,
+  edge_kind TEXT NOT NULL CHECK (edge_kind IN ('orch_required_for_synthesis','orch_optional_context')),
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version,edge_key),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,parent_node_key,child_node_key,edge_kind),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,parent_node_key)
+    REFERENCES orch_plan_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,child_node_key)
+    REFERENCES orch_plan_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key),
+  CHECK (parent_node_key!=child_node_key)
+);
+
+CREATE TABLE orch_plan_coverage (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  requirement_id TEXT NOT NULL,
+  node_key TEXT NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version,requirement_id,node_key),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,requirement_id)
+    REFERENCES orch_request_requirements(board_instance_id,tenant_scope,orch_id,requirement_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,node_key)
+    REFERENCES orch_plan_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key)
+);
+
+CREATE TABLE orch_plan_materializations (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  request_lifecycle_revision INTEGER NOT NULL CHECK (request_lifecycle_revision>=0),
+  cancel_epoch INTEGER NOT NULL CHECK (cancel_epoch>=0),
+  lease_epoch INTEGER NOT NULL CHECK (lease_epoch>0),
+  plan_digest TEXT NOT NULL,
+  observed_graph_digest TEXT NOT NULL CHECK (length(observed_graph_digest)=64),
+  observed_node_count INTEGER NOT NULL CHECK (observed_node_count>=3),
+  observed_edge_count INTEGER NOT NULL CHECK (observed_edge_count>=2),
+  materialized_by_run_id INTEGER NOT NULL,
+  commit_seq INTEGER NOT NULL CHECK (commit_seq>0),
+  materialized_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,plan_digest)
+    REFERENCES orch_plans(board_instance_id,tenant_scope,orch_id,plan_version,plan_digest)
+);
+
+CREATE TABLE orch_nodes (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  node_key TEXT NOT NULL,
+  task_id TEXT NOT NULL,
+  node_state TEXT NOT NULL CHECK (node_state IN ('planned','ready','running','cancellation_requested','accepted','blocked','failed','cancelled')),
+  current_route_digest TEXT NOT NULL,
+  route_revision INTEGER NOT NULL CHECK (route_revision>0),
+  created_by_run_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,node_key),
+  UNIQUE (board_instance_id,tenant_scope,task_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,node_key)
+    REFERENCES orch_plan_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key),
+  FOREIGN KEY (task_id) REFERENCES tasks(id) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE orch_external_edges (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  edge_key TEXT NOT NULL,
+  parent_task_id TEXT NOT NULL,
+  child_task_id TEXT NOT NULL,
+  edge_kind TEXT NOT NULL CHECK (edge_kind='orch_work_accepted'),
+  lifecycle_revision INTEGER NOT NULL,
+  created_by_run_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,edge_key),
+  UNIQUE (board_instance_id,tenant_scope,parent_task_id,child_task_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id),
+  FOREIGN KEY (parent_task_id) REFERENCES tasks(id),
+  FOREIGN KEY (child_task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE orch_node_acceptances (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  node_key TEXT NOT NULL,
+  task_id TEXT NOT NULL,
+  accepted_run_id INTEGER NOT NULL,
+  outcome_digest TEXT NOT NULL CHECK (length(outcome_digest)=64),
+  accepted_by_run_id INTEGER NOT NULL,
+  acceptance_lease_epoch INTEGER NOT NULL CHECK (acceptance_lease_epoch>0),
+  plan_epoch_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  accepted_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,node_key),
+  UNIQUE (board_instance_id,tenant_scope,accepted_run_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id)
+    REFERENCES orch_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id),
+  FOREIGN KEY (accepted_run_id) REFERENCES task_runs(id),
+  FOREIGN KEY (task_id) REFERENCES tasks(id)
+);
+
+CREATE TABLE orch_stage_leases (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  stage TEXT NOT NULL CHECK (stage IN ('decomposition','synthesis','reconciliation')),
+  owner_run_id INTEGER NOT NULL,
+  owner_profile TEXT NOT NULL,
+  token_hash TEXT NOT NULL CHECK (length(token_hash)=64),
+  epoch INTEGER NOT NULL CHECK (epoch>0),
+  expires_at INTEGER NOT NULL,
+  lease_state TEXT NOT NULL CHECK (lease_state IN ('active','released','revoked')),
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,stage),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id)
+);
+
+CREATE TABLE orch_stage_attempts (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  stage TEXT NOT NULL CHECK (stage IN ('decomposition','synthesis')),
+  attempt_no INTEGER NOT NULL CHECK (attempt_no>0),
+  owner_run_id INTEGER NOT NULL,
+  lease_epoch INTEGER NOT NULL CHECK (lease_epoch>0),
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL CHECK (cancel_epoch>=0),
+  attempt_state TEXT NOT NULL CHECK (attempt_state IN ('running','completed','blocked','failed','timed_out','cancelled')),
+  started_at INTEGER NOT NULL,
+  ended_at INTEGER,
+  outcome_code TEXT,
+  attempt_digest TEXT NOT NULL CHECK (length(attempt_digest)=64),
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,stage,attempt_no),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,stage,attempt_no,owner_run_id,
+          lease_epoch,lifecycle_revision,cancel_epoch),
+  UNIQUE (board_instance_id,tenant_scope,owner_run_id,stage),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,stage)
+    REFERENCES orch_stage_leases(board_instance_id,tenant_scope,orch_id,stage),
+  CHECK ((attempt_state='running' AND ended_at IS NULL) OR
+         (attempt_state!='running' AND ended_at IS NOT NULL AND ended_at>=started_at))
+);
+
+CREATE TABLE orch_results (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  result_id TEXT NOT NULL,
+  request_digest TEXT NOT NULL,
+  plan_digest TEXT NOT NULL,
+  producer_stage TEXT NOT NULL CHECK (producer_stage='synthesis'),
+  producer_attempt_no INTEGER NOT NULL CHECK (producer_attempt_no>0),
+  producer_run_id INTEGER NOT NULL,
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL CHECK (cancel_epoch>=0),
+  synthesis_epoch INTEGER NOT NULL CHECK (synthesis_epoch>0),
+  accepted_lane_set_digest TEXT NOT NULL CHECK (length(accepted_lane_set_digest)=64),
+  result_json TEXT NOT NULL,
+  result_digest TEXT NOT NULL CHECK (length(result_digest)=64),
+  accepted_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,result_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,result_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,result_id,result_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,request_digest,plan_digest)
+    REFERENCES orch_plans(board_instance_id,tenant_scope,orch_id,plan_version,request_digest,plan_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,producer_stage,producer_attempt_no,
+               producer_run_id,synthesis_epoch,lifecycle_revision,cancel_epoch)
+    REFERENCES orch_stage_attempts(board_instance_id,tenant_scope,orch_id,stage,attempt_no,
+                                   owner_run_id,lease_epoch,lifecycle_revision,cancel_epoch)
+);
+
+CREATE TABLE orch_delivery_manifests (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  result_id TEXT NOT NULL,
+  manifest_digest TEXT NOT NULL CHECK (length(manifest_digest)=64),
+  expected_required_count INTEGER NOT NULL CHECK (expected_required_count>=0),
+  expected_optional_count INTEGER NOT NULL CHECK (expected_optional_count>=0),
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,result_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,result_id,manifest_digest),
+  UNIQUE (board_instance_id,tenant_scope,manifest_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,result_id)
+    REFERENCES orch_results(board_instance_id,tenant_scope,orch_id,plan_version,result_id)
+);
+
+CREATE TABLE orch_delivery_obligations (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  result_id TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  manifest_digest TEXT NOT NULL CHECK (length(manifest_digest)=64),
+  manifest_entry_key TEXT NOT NULL CHECK (length(manifest_entry_key)=64),
+  delivery_generation INTEGER NOT NULL CHECK (delivery_generation>0),
+  supersedes_obligation_id TEXT,
+  delivery_key TEXT NOT NULL CHECK (length(delivery_key)=64),
+  result_digest TEXT NOT NULL,
+  origin_id TEXT NOT NULL,
+  route_revision INTEGER NOT NULL CHECK (route_revision>0),
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  origin_kind TEXT NOT NULL CHECK (origin_kind IN ('messaging','api','local_session','board_only')),
+  platform TEXT NOT NULL,
+  adapter_instance_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  thread_id TEXT NOT NULL,
+  reply_to_id TEXT NOT NULL,
+  required INTEGER NOT NULL CHECK (required IN (0,1)),
+  required_ack_family TEXT NOT NULL CHECK (required_ack_family IN (
+    'provider','adapter','synchronous','local_session','none'
+  )),
+  required_ack_strength TEXT NOT NULL CHECK (required_ack_strength IN (
+    'provider_message_id','adapter_acceptance','synchronous_response',
+    'local_session_acceptance','none'
+  )),
+  state TEXT NOT NULL CHECK (state IN ('pending','claimed','accepted','acked','unknown','dead_letter','cancelled')),
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  claim_owner TEXT,
+  claim_token_hash TEXT,
+  claim_epoch INTEGER NOT NULL DEFAULT 0 CHECK (claim_epoch>=0),
+  claim_expires_at INTEGER,
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts>=0),
+  max_attempts INTEGER NOT NULL CHECK (max_attempts BETWEEN 1 AND 100),
+  available_at INTEGER NOT NULL,
+  acceptance_attempt_id TEXT,
+  adapter_accepted_at INTEGER,
+  acked_at INTEGER,
+  provider_id TEXT,
+  provider_message_id TEXT,
+  duplicate_possible INTEGER NOT NULL DEFAULT 0 CHECK (duplicate_possible IN (0,1)),
+  unknown_attempt_id TEXT,
+  ambiguity_deadline INTEGER,
+  resend_authorized_at INTEGER,
+  resend_authorized_by TEXT,
+  resend_authorized_revision INTEGER,
+  last_error_code TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,obligation_id),
+  UNIQUE (board_instance_id,tenant_scope,delivery_key),
+  UNIQUE (board_instance_id,tenant_scope,manifest_entry_key,delivery_generation),
+  UNIQUE (board_instance_id,tenant_scope,supersedes_obligation_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,result_id,manifest_digest)
+    REFERENCES orch_delivery_manifests(board_instance_id,tenant_scope,orch_id,result_id,manifest_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,result_id,result_digest)
+    REFERENCES orch_results(board_instance_id,tenant_scope,orch_id,plan_version,result_id,result_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,origin_id,route_revision,route_digest)
+    REFERENCES orch_origins(board_instance_id,tenant_scope,origin_id,route_revision,route_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,supersedes_obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id),
+  CHECK ((origin_kind='board_only' AND required=0 AND required_ack_strength='none') OR
+         (origin_kind!='board_only' AND required_ack_strength!='none')),
+  CHECK ((state='acked' AND acked_at IS NOT NULL) OR state!='acked'),
+  CHECK ((state IN ('claimed','accepted') AND claim_epoch>0) OR state NOT IN ('claimed','accepted')),
+  CHECK ((state='unknown' AND unknown_attempt_id IS NOT NULL AND ambiguity_deadline IS NOT NULL)
+      OR state!='unknown'),
+  CHECK ((required_ack_family='provider' AND required_ack_strength='provider_message_id')
+      OR (required_ack_family='adapter' AND required_ack_strength='adapter_acceptance')
+      OR (required_ack_family='synchronous' AND required_ack_strength='synchronous_response')
+      OR (required_ack_family='local_session' AND required_ack_strength='local_session_acceptance')
+      OR (required_ack_family='none' AND required_ack_strength='none'))
+);
+
+CREATE TABLE orch_delivery_manifest_entries (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  result_id TEXT NOT NULL,
+  manifest_digest TEXT NOT NULL,
+  manifest_entry_key TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  required INTEGER NOT NULL CHECK (required IN (0,1)),
+  required_ack_family TEXT NOT NULL,
+  required_ack_strength TEXT NOT NULL,
+  route_digest TEXT NOT NULL,
+  ordinal INTEGER NOT NULL CHECK (ordinal>0),
+  PRIMARY KEY (board_instance_id,tenant_scope,manifest_entry_key),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,result_id,ordinal),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,result_id,manifest_digest)
+    REFERENCES orch_delivery_manifests(board_instance_id,tenant_scope,orch_id,result_id,manifest_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id)
+);
+
+CREATE TABLE orch_delivery_attempts (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  claim_epoch INTEGER NOT NULL CHECK (claim_epoch>0),
+  claim_owner TEXT NOT NULL,
+  claim_token_hash TEXT NOT NULL CHECK (length(claim_token_hash)=64),
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  send_nonce TEXT NOT NULL,
+  payload_digest TEXT NOT NULL CHECK (length(payload_digest)=64),
+  result_digest TEXT NOT NULL CHECK (length(result_digest)=64),
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  attempt_state TEXT NOT NULL CHECK (attempt_state IN ('started','adapter_accepted','rejected','unknown')),
+  started_at INTEGER NOT NULL,
+  finished_at INTEGER,
+  adapter_evidence_json TEXT,
+  adapter_evidence_digest TEXT,
+  error_code TEXT,
+  PRIMARY KEY (board_instance_id,tenant_scope,attempt_id),
+  UNIQUE (board_instance_id,tenant_scope,obligation_id,claim_epoch),
+  FOREIGN KEY (board_instance_id,tenant_scope,obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id),
+  CHECK ((attempt_state='started' AND finished_at IS NULL) OR
+         (attempt_state!='started' AND finished_at IS NOT NULL))
+);
+
+CREATE TABLE orch_delivery_attempt_events (
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  transition_seq INTEGER NOT NULL CHECK (transition_seq>0),
+  from_state TEXT,
+  to_state TEXT NOT NULL CHECK (to_state IN ('started','adapter_accepted','rejected','unknown')),
+  event_kind TEXT NOT NULL CHECK (event_kind IN ('started','adapter_accepted','rejected','unknown')),
+  event_json TEXT NOT NULL,
+  event_digest TEXT NOT NULL CHECK (length(event_digest)=64),
+  created_at INTEGER NOT NULL,
+  UNIQUE (board_instance_id,tenant_scope,attempt_id,transition_seq),
+  UNIQUE (board_instance_id,tenant_scope,attempt_id,event_kind,event_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,attempt_id)
+    REFERENCES orch_delivery_attempts(board_instance_id,tenant_scope,attempt_id)
+);
+
+CREATE TABLE orch_delivery_receipts (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  receipt_id TEXT NOT NULL,
+  observed_ack_family TEXT NOT NULL CHECK (observed_ack_family IN (
+    'provider','adapter','synchronous','local_session'
+  )),
+  observed_ack_strength TEXT NOT NULL CHECK (observed_ack_strength IN (
+    'provider_message_id','adapter_acceptance','synchronous_response','local_session_acceptance'
+  )),
+  receipt_json TEXT NOT NULL,
+  receipt_digest TEXT NOT NULL CHECK (length(receipt_digest)=64),
+  send_nonce TEXT NOT NULL,
+  payload_digest TEXT NOT NULL CHECK (length(payload_digest)=64),
+  result_digest TEXT NOT NULL CHECK (length(result_digest)=64),
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  verified INTEGER NOT NULL CHECK (verified=1),
+  provider_id TEXT,
+  provider_message_id TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,receipt_id),
+  UNIQUE (board_instance_id,tenant_scope,obligation_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,attempt_id)
+    REFERENCES orch_delivery_attempts(board_instance_id,tenant_scope,attempt_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id),
+  CHECK ((observed_ack_family='provider' AND observed_ack_strength='provider_message_id'
+          AND provider_id IS NOT NULL AND provider_message_id IS NOT NULL)
+      OR (observed_ack_family='adapter' AND observed_ack_strength='adapter_acceptance')
+      OR (observed_ack_family='synchronous' AND observed_ack_strength='synchronous_response')
+      OR (observed_ack_family='local_session' AND observed_ack_strength='local_session_acceptance'))
+);
+
+CREATE TABLE orch_events (
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  commit_seq INTEGER NOT NULL CHECK (commit_seq>0),
+  event_kind TEXT NOT NULL CHECK (event_kind IN (
+    'request_transition','node_transition','plan_materialized','result_accepted',
+    'delivery_transition','cancellation_transition','dependency_released'
+  )),
+  target_key TEXT NOT NULL,
+  event_key TEXT NOT NULL CHECK (length(event_key)=64),
+  payload_json TEXT NOT NULL,
+  payload_digest TEXT NOT NULL CHECK (length(payload_digest)=64),
+  created_at INTEGER NOT NULL,
+  UNIQUE (board_instance_id,tenant_scope,event_key),
+  UNIQUE (board_instance_id,tenant_scope,event_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id)
+);
+
+CREATE TABLE orch_reconcile_queue (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  event_id INTEGER NOT NULL,
+  consumer_kind TEXT NOT NULL CHECK (consumer_kind IN ('lifecycle','delivery','dependency','cancellation')),
+  state TEXT NOT NULL CHECK (state IN ('pending','claimed','done','dead_letter')),
+  claim_owner TEXT,
+  claim_token_hash TEXT,
+  claim_epoch INTEGER NOT NULL DEFAULT 0 CHECK (claim_epoch>=0),
+  claim_expires_at INTEGER,
+  available_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts>=0),
+  max_attempts INTEGER NOT NULL CHECK (max_attempts BETWEEN 1 AND 100),
+  last_error_code TEXT,
+  done_effect_digest TEXT,
+  PRIMARY KEY (board_instance_id,tenant_scope,event_id,consumer_kind),
+  FOREIGN KEY (board_instance_id,tenant_scope,event_id)
+    REFERENCES orch_events(board_instance_id,tenant_scope,event_id),
+  CHECK ((state='claimed' AND claim_owner IS NOT NULL AND claim_token_hash IS NOT NULL AND claim_epoch>0)
+      OR (state!='claimed')),
+  CHECK ((state='done' AND length(done_effect_digest)=64) OR state!='done')
+);
+
+CREATE TABLE orch_effect_ledger (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  event_id INTEGER NOT NULL,
+  consumer_kind TEXT NOT NULL,
+  target_key TEXT NOT NULL,
+  target_revision INTEGER NOT NULL,
+  effect_digest TEXT NOT NULL CHECK (length(effect_digest)=64),
+  applied_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,event_id,consumer_kind),
+  UNIQUE (board_instance_id,tenant_scope,consumer_kind,target_key,target_revision),
+  FOREIGN KEY (board_instance_id,tenant_scope,event_id,consumer_kind)
+    REFERENCES orch_reconcile_queue(board_instance_id,tenant_scope,event_id,consumer_kind)
+);
+
+CREATE TABLE orch_delivery_resend_authorizations (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  authorization_id TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  unknown_attempt_id TEXT NOT NULL,
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  capability_digest TEXT NOT NULL CHECK (length(capability_digest)=64),
+  authorized_by TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  consumed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,authorization_id),
+  UNIQUE (board_instance_id,tenant_scope,obligation_id,unknown_attempt_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,unknown_attempt_id)
+    REFERENCES orch_delivery_attempts(board_instance_id,tenant_scope,attempt_id)
+);
+
+CREATE TABLE orch_mutation_log (
+  mutation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  stage TEXT NOT NULL,
+  owner_run_id INTEGER NOT NULL,
+  owner_profile TEXT NOT NULL,
+  lease_epoch INTEGER NOT NULL,
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  capability_digest TEXT NOT NULL CHECK (length(capability_digest)=64),
+  commit_seq INTEGER NOT NULL CHECK (commit_seq>0),
+  mutation_kind TEXT NOT NULL,
+  target_key TEXT NOT NULL,
+  mutation_digest TEXT NOT NULL CHECK (length(mutation_digest)=64),
+  created_at INTEGER NOT NULL,
+  UNIQUE (board_instance_id,tenant_scope,orch_id,mutation_kind,target_key,mutation_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id)
+);
+
+CREATE TRIGGER immutable_orch_origins_u BEFORE UPDATE ON orch_origins BEGIN SELECT RAISE(ABORT,'immutable_orch_origin'); END;
+CREATE TRIGGER immutable_orch_origins_d BEFORE DELETE ON orch_origins BEGIN SELECT RAISE(ABORT,'immutable_orch_origin'); END;
+CREATE TRIGGER immutable_orch_requirements_u BEFORE UPDATE ON orch_request_requirements BEGIN SELECT RAISE(ABORT,'immutable_orch_requirement'); END;
+CREATE TRIGGER immutable_orch_requirements_d BEFORE DELETE ON orch_request_requirements BEGIN SELECT RAISE(ABORT,'immutable_orch_requirement'); END;
+CREATE TRIGGER immutable_orch_plans_u BEFORE UPDATE ON orch_plans BEGIN SELECT RAISE(ABORT,'immutable_orch_plan'); END;
+CREATE TRIGGER immutable_orch_plans_d BEFORE DELETE ON orch_plans BEGIN SELECT RAISE(ABORT,'immutable_orch_plan'); END;
+CREATE TRIGGER immutable_orch_plan_nodes_u BEFORE UPDATE ON orch_plan_nodes BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_node'); END;
+CREATE TRIGGER immutable_orch_plan_nodes_d BEFORE DELETE ON orch_plan_nodes BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_node'); END;
+CREATE TRIGGER immutable_orch_plan_edges_u BEFORE UPDATE ON orch_plan_edges BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_edge'); END;
+CREATE TRIGGER immutable_orch_plan_edges_d BEFORE DELETE ON orch_plan_edges BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_edge'); END;
+CREATE TRIGGER immutable_orch_plan_coverage_u BEFORE UPDATE ON orch_plan_coverage BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_coverage'); END;
+CREATE TRIGGER immutable_orch_plan_coverage_d BEFORE DELETE ON orch_plan_coverage BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_coverage'); END;
+CREATE TRIGGER immutable_orch_materialization_u BEFORE UPDATE ON orch_plan_materializations BEGIN SELECT RAISE(ABORT,'immutable_orch_materialization'); END;
+CREATE TRIGGER immutable_orch_materialization_d BEFORE DELETE ON orch_plan_materializations BEGIN SELECT RAISE(ABORT,'immutable_orch_materialization'); END;
+CREATE TRIGGER immutable_orch_acceptance_u BEFORE UPDATE ON orch_node_acceptances BEGIN SELECT RAISE(ABORT,'immutable_orch_acceptance'); END;
+CREATE TRIGGER immutable_orch_acceptance_d BEFORE DELETE ON orch_node_acceptances BEGIN SELECT RAISE(ABORT,'immutable_orch_acceptance'); END;
+CREATE TRIGGER immutable_orch_result_u BEFORE UPDATE ON orch_results BEGIN SELECT RAISE(ABORT,'immutable_orch_result'); END;
+CREATE TRIGGER immutable_orch_result_d BEFORE DELETE ON orch_results BEGIN SELECT RAISE(ABORT,'immutable_orch_result'); END;
+CREATE TRIGGER immutable_orch_delivery_attempt_event_u BEFORE UPDATE ON orch_delivery_attempt_events BEGIN SELECT RAISE(ABORT,'immutable_orch_delivery_attempt_event'); END;
+CREATE TRIGGER immutable_orch_delivery_attempt_event_d BEFORE DELETE ON orch_delivery_attempt_events BEGIN SELECT RAISE(ABORT,'immutable_orch_delivery_attempt_event'); END;
+CREATE TRIGGER immutable_orch_delivery_receipt_u BEFORE UPDATE ON orch_delivery_receipts BEGIN SELECT RAISE(ABORT,'immutable_orch_delivery_receipt'); END;
+CREATE TRIGGER immutable_orch_delivery_receipt_d BEFORE DELETE ON orch_delivery_receipts BEGIN SELECT RAISE(ABORT,'immutable_orch_delivery_receipt'); END;
+CREATE TRIGGER immutable_orch_event_u BEFORE UPDATE ON orch_events BEGIN SELECT RAISE(ABORT,'immutable_orch_event'); END;
+CREATE TRIGGER immutable_orch_event_d BEFORE DELETE ON orch_events BEGIN SELECT RAISE(ABORT,'immutable_orch_event'); END;
+CREATE TRIGGER immutable_orch_mutation_log_u BEFORE UPDATE ON orch_mutation_log BEGIN SELECT RAISE(ABORT,'immutable_orch_mutation_log'); END;
+CREATE TRIGGER immutable_orch_mutation_log_d BEFORE DELETE ON orch_mutation_log BEGIN SELECT RAISE(ABORT,'immutable_orch_mutation_log'); END;
+
+CREATE TRIGGER orch_event_insert_guard BEFORE INSERT ON orch_events
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'event_insert',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.lifecycle_revision,NEW.cancel_epoch,NEW.event_key
+  )!=1 OR NOT EXISTS (
+    SELECT 1 FROM orch_requests r JOIN kanban_commit_clock c ON c.singleton=1
+     WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope
+       AND r.orch_id=NEW.orch_id AND r.lifecycle_revision=NEW.lifecycle_revision
+       AND r.cancel_epoch=NEW.cancel_epoch AND c.commit_seq=NEW.commit_seq
+  ) THEN RAISE(ABORT,'stale_or_forged_orch_event') END;
+END;
+CREATE TRIGGER orch_queue_insert_guard BEFORE INSERT ON orch_reconcile_queue
+BEGIN
+  SELECT CASE WHEN NEW.state!='pending' OR orch_capability_ok(
+    'queue_fanout',NEW.board_instance_id,NEW.tenant_scope,CAST(NEW.event_id AS TEXT),
+    0,0,NEW.consumer_kind
+  )!=1 THEN RAISE(ABORT,'forged_reconcile_queue_row') END;
+END;
+CREATE TRIGGER orch_effect_insert_guard BEFORE INSERT ON orch_effect_ledger
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'effect_apply',NEW.board_instance_id,NEW.tenant_scope,CAST(NEW.event_id AS TEXT),
+    NEW.target_revision,0,NEW.effect_digest
+  )!=1 THEN RAISE(ABORT,'forged_effect_ledger_row') END;
+END;
+
+CREATE TRIGGER orch_materialization_authority_guard BEFORE INSERT ON orch_plan_materializations
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'materialize',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.request_lifecycle_revision,NEW.cancel_epoch,NEW.observed_graph_digest
+  )!=1 THEN RAISE(ABORT,'missing_materialization_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_requests r
+    JOIN orch_plans p
+      ON p.board_instance_id=r.board_instance_id AND p.tenant_scope=r.tenant_scope
+     AND p.orch_id=r.orch_id AND p.plan_version=NEW.plan_version
+    JOIN orch_stage_leases l
+      ON l.board_instance_id=r.board_instance_id AND l.tenant_scope=r.tenant_scope
+     AND l.orch_id=r.orch_id AND l.stage='decomposition'
+    JOIN kanban_commit_clock c ON c.singleton=1
+    WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope
+      AND r.orch_id=NEW.orch_id AND r.lifecycle_state='decomposing'
+      AND r.plan_version+1=NEW.plan_version
+      AND r.lifecycle_revision=NEW.request_lifecycle_revision
+      AND r.cancel_epoch=NEW.cancel_epoch
+      AND p.plan_digest=NEW.plan_digest
+      AND l.owner_run_id=NEW.materialized_by_run_id AND l.epoch=NEW.lease_epoch
+      AND l.lease_state='active' AND l.expires_at>unixepoch('now')
+      AND c.commit_seq=NEW.commit_seq
+      AND NEW.observed_node_count=(SELECT count(*) FROM orch_nodes n
+        WHERE n.board_instance_id=NEW.board_instance_id AND n.tenant_scope=NEW.tenant_scope
+          AND n.orch_id=NEW.orch_id AND n.plan_version=NEW.plan_version)
+      AND NEW.observed_edge_count=(SELECT count(*) FROM task_links x
+        WHERE x.orch_board_instance_id=NEW.board_instance_id
+          AND x.orch_tenant_scope=NEW.tenant_scope AND x.orch_id=NEW.orch_id
+          AND x.orch_plan_version=NEW.plan_version)
+  ) THEN RAISE(ABORT,'invalid_materialization_provenance') END;
+END;
+
+CREATE TRIGGER tasks_orch_binding_insert BEFORE INSERT ON tasks
+WHEN NEW.orch_board_instance_id IS NOT NULL OR NEW.orch_tenant_scope IS NOT NULL
+  OR NEW.orch_id IS NOT NULL OR NEW.orch_plan_version IS NOT NULL
+  OR NEW.orch_node_key IS NOT NULL OR NEW.orch_binding_revision IS NOT NULL
+  OR NEW.orch_cancel_epoch IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.orch_board_instance_id IS NULL OR NEW.orch_tenant_scope IS NULL
+    OR NEW.orch_id IS NULL OR NEW.orch_plan_version IS NULL OR NEW.orch_node_key IS NULL
+    OR NEW.orch_binding_revision IS NULL OR NEW.orch_cancel_epoch IS NULL
+    THEN RAISE(ABORT,'partial_orch_task_binding') END;
+  SELECT CASE WHEN orch_capability_ok(
+      'task_bind',NEW.orch_board_instance_id,NEW.orch_tenant_scope,NEW.orch_id,
+      NEW.orch_binding_revision,NEW.orch_cancel_epoch,NEW.id
+    )!=1 THEN RAISE(ABORT,'missing_task_bind_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_requests r
+     WHERE r.board_instance_id=NEW.orch_board_instance_id
+       AND r.tenant_scope=NEW.orch_tenant_scope AND r.orch_id=NEW.orch_id
+       AND r.parent_task_id=NEW.id AND NEW.orch_node_key='__parent__'
+       AND NEW.orch_plan_version=r.plan_version
+       AND r.lifecycle_revision=NEW.orch_binding_revision
+       AND r.cancel_epoch=NEW.orch_cancel_epoch
+    UNION ALL
+    SELECT 1 FROM orch_nodes n JOIN orch_requests r
+      ON r.board_instance_id=n.board_instance_id AND r.tenant_scope=n.tenant_scope
+     AND r.orch_id=n.orch_id
+     WHERE n.board_instance_id=NEW.orch_board_instance_id
+       AND n.tenant_scope=NEW.orch_tenant_scope AND n.orch_id=NEW.orch_id
+       AND n.plan_version=NEW.orch_plan_version AND n.node_key=NEW.orch_node_key
+       AND n.task_id=NEW.id AND r.lifecycle_revision=NEW.orch_binding_revision
+       AND r.cancel_epoch=NEW.orch_cancel_epoch
+  ) THEN RAISE(ABORT,'invalid_orch_task_scope') END;
+END;
+
+CREATE TRIGGER tasks_orch_binding_update BEFORE UPDATE OF
+  orch_board_instance_id,orch_tenant_scope,orch_id,orch_plan_version,
+  orch_node_key,orch_binding_revision,orch_cancel_epoch ON tasks
+WHEN OLD.orch_id IS NOT NULL OR NEW.orch_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT (
+    (NEW.orch_board_instance_id IS OLD.orch_board_instance_id
+      AND NEW.orch_tenant_scope IS OLD.orch_tenant_scope
+      AND NEW.orch_id IS OLD.orch_id
+      AND NEW.orch_plan_version IS OLD.orch_plan_version
+      AND NEW.orch_node_key IS OLD.orch_node_key
+      AND NEW.orch_binding_revision IS OLD.orch_binding_revision
+      AND NEW.orch_cancel_epoch IS OLD.orch_cancel_epoch)
+    OR
+    (OLD.orch_board_instance_id IS NULL AND OLD.orch_tenant_scope IS NULL
+      AND OLD.orch_id IS NULL AND OLD.orch_plan_version IS NULL
+      AND OLD.orch_node_key IS NULL AND OLD.orch_binding_revision IS NULL
+      AND OLD.orch_cancel_epoch IS NULL
+      AND NEW.orch_node_key='__parent__'
+      AND EXISTS (SELECT 1 FROM orch_requests r
+        WHERE r.board_instance_id=NEW.orch_board_instance_id
+          AND r.tenant_scope=NEW.orch_tenant_scope AND r.orch_id=NEW.orch_id
+          AND r.parent_task_id=NEW.id AND r.plan_version=NEW.orch_plan_version
+          AND r.lifecycle_revision=NEW.orch_binding_revision
+          AND r.cancel_epoch=NEW.orch_cancel_epoch)
+      AND orch_capability_ok('task_bind',NEW.orch_board_instance_id,NEW.orch_tenant_scope,NEW.orch_id,
+        NEW.orch_binding_revision,NEW.orch_cancel_epoch,NEW.id)=1)
+    OR
+    (NEW.orch_board_instance_id IS NULL AND NEW.orch_tenant_scope IS NULL
+      AND NEW.orch_id IS NULL AND NEW.orch_plan_version IS NULL
+      AND NEW.orch_node_key IS NULL AND NEW.orch_binding_revision IS NULL
+      AND NEW.orch_cancel_epoch IS NULL
+      AND EXISTS (SELECT 1 FROM orch_requests r
+        WHERE r.board_instance_id=OLD.orch_board_instance_id
+          AND r.tenant_scope=OLD.orch_tenant_scope AND r.orch_id=OLD.orch_id
+          AND r.lifecycle_state IN ('cancelling','cancelled'))
+      AND orch_capability_ok(
+        'task_retire',OLD.orch_board_instance_id,OLD.orch_tenant_scope,OLD.orch_id,
+        COALESCE((SELECT lifecycle_revision FROM orch_requests r
+          WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+            AND r.orch_id=OLD.orch_id),-1),
+        COALESCE((SELECT cancel_epoch FROM orch_requests r
+          WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+            AND r.orch_id=OLD.orch_id),-1),OLD.id)=1)
+  ) THEN RAISE(ABORT,'immutable_orch_task_binding') END;
+END;
+
+CREATE TRIGGER orch_acceptance_run_guard BEFORE INSERT ON orch_node_acceptances
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'accept_lane',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.plan_epoch_revision,NEW.cancel_epoch,CAST(NEW.accepted_run_id AS TEXT)
+  )!=1 THEN RAISE(ABORT,'missing_acceptance_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+      FROM orch_nodes n
+      JOIN orch_plan_nodes pn
+        ON pn.board_instance_id=n.board_instance_id AND pn.tenant_scope=n.tenant_scope
+       AND pn.orch_id=n.orch_id AND pn.plan_version=n.plan_version AND pn.node_key=n.node_key
+      JOIN task_runs tr ON tr.id=NEW.accepted_run_id AND tr.task_id=n.task_id
+      JOIN orch_requests r
+        ON r.board_instance_id=n.board_instance_id AND r.tenant_scope=n.tenant_scope AND r.orch_id=n.orch_id
+      JOIN orch_stage_leases l
+        ON l.board_instance_id=r.board_instance_id AND l.tenant_scope=r.tenant_scope
+       AND l.orch_id=r.orch_id AND l.stage='reconciliation'
+     WHERE n.board_instance_id=NEW.board_instance_id
+       AND n.tenant_scope=NEW.tenant_scope AND n.orch_id=NEW.orch_id
+       AND n.plan_version=NEW.plan_version AND n.node_key=NEW.node_key AND n.task_id=NEW.task_id
+       AND pn.role='lane' AND pn.required=1
+       AND r.plan_version=NEW.plan_version AND r.lifecycle_state='waiting_lanes'
+       AND r.plan_epoch_revision=NEW.plan_epoch_revision AND r.cancel_epoch=NEW.cancel_epoch
+       AND l.owner_run_id=NEW.accepted_by_run_id AND l.epoch=NEW.acceptance_lease_epoch
+       AND l.lease_state='active' AND l.expires_at>unixepoch('now')
+       AND tr.status='done' AND tr.outcome='completed'
+       AND tr.started_at IS NOT NULL AND tr.ended_at IS NOT NULL
+       AND tr.ended_at>=tr.started_at AND tr.outcome_digest=NEW.outcome_digest
+       AND tr.cancellation_epoch=NEW.cancel_epoch
+  ) THEN RAISE(ABORT,'invalid_accepted_run_binding') END;
+END;
+
+CREATE TRIGGER task_links_orch_guard BEFORE INSERT ON task_links
+WHEN EXISTS (SELECT 1 FROM tasks t WHERE t.id IN (NEW.parent_id,NEW.child_id) AND t.orch_id IS NOT NULL)
+BEGIN
+  SELECT CASE WHEN NEW.orch_board_instance_id IS NULL OR NEW.orch_tenant_scope IS NULL
+    OR NEW.orch_id IS NULL OR NEW.orch_plan_version IS NULL OR NEW.orch_edge_key IS NULL
+    OR NEW.orch_binding_revision IS NULL OR NEW.orch_cancel_epoch IS NULL
+    THEN RAISE(ABORT,'unregistered_orch_link') END;
+  SELECT CASE WHEN orch_capability_ok(
+    'link_bind',NEW.orch_board_instance_id,NEW.orch_tenant_scope,NEW.orch_id,
+    NEW.orch_binding_revision,NEW.orch_cancel_epoch,NEW.orch_edge_key
+  )!=1 THEN RAISE(ABORT,'missing_link_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+      FROM orch_plan_edges e
+      JOIN orch_nodes p
+        ON p.board_instance_id=e.board_instance_id AND p.tenant_scope=e.tenant_scope
+       AND p.orch_id=e.orch_id AND p.plan_version=e.plan_version
+       AND p.node_key=e.parent_node_key AND p.task_id=NEW.parent_id
+      JOIN orch_nodes c
+        ON c.board_instance_id=e.board_instance_id AND c.tenant_scope=e.tenant_scope
+       AND c.orch_id=e.orch_id AND c.plan_version=e.plan_version
+       AND c.node_key=e.child_node_key AND c.task_id=NEW.child_id
+      JOIN orch_requests r
+        ON r.board_instance_id=e.board_instance_id AND r.tenant_scope=e.tenant_scope AND r.orch_id=e.orch_id
+     WHERE e.board_instance_id=NEW.orch_board_instance_id
+       AND e.tenant_scope=NEW.orch_tenant_scope AND e.orch_id=NEW.orch_id
+       AND e.plan_version=NEW.orch_plan_version AND e.edge_key=NEW.orch_edge_key
+       AND NEW.kind=e.edge_kind AND r.lifecycle_revision=NEW.orch_binding_revision
+       AND r.cancel_epoch=NEW.orch_cancel_epoch
+    UNION ALL
+    SELECT 1 FROM orch_external_edges x JOIN orch_requests r
+      ON r.board_instance_id=x.board_instance_id AND r.tenant_scope=x.tenant_scope AND r.orch_id=x.orch_id
+     WHERE x.board_instance_id=NEW.orch_board_instance_id
+       AND x.tenant_scope=NEW.orch_tenant_scope AND x.orch_id=NEW.orch_id
+       AND x.edge_key=NEW.orch_edge_key AND x.parent_task_id=NEW.parent_id
+       AND x.child_task_id=NEW.child_id AND NEW.kind=x.edge_kind
+       AND r.lifecycle_revision=NEW.orch_binding_revision
+       AND r.cancel_epoch=NEW.orch_cancel_epoch
+  ) THEN RAISE(ABORT,'invalid_orch_link_binding') END;
+END;
+
+CREATE TRIGGER orch_request_identity_guard BEFORE UPDATE OF
+  board_instance_id,tenant_scope,orch_id,lineage_id,generation,selector_key,selector_ledger_revision,request_key,
+  request_schema_version,request_json,request_digest,origin_id,parent_task_id,
+  synthesis_strategy,supersedes_orch_id,created_at
+ON orch_requests BEGIN SELECT RAISE(ABORT,'immutable_orch_request_identity'); END;
+CREATE TRIGGER orch_request_delete_guard BEFORE DELETE ON orch_requests
+BEGIN SELECT RAISE(ABORT,'orch_request_delete_forbidden'); END;
+
+CREATE TRIGGER orch_request_supersession_guard BEFORE INSERT ON orch_requests
+BEGIN
+  SELECT CASE WHEN NEW.lifecycle_state!='submitted' OR NEW.lifecycle_revision!=0
+    OR NEW.cancel_epoch!=0 OR NEW.delivery_epoch_revision!=0 OR NEW.plan_epoch_revision!=0
+    OR NEW.plan_version!=0 OR NEW.work_accepted_at IS NOT NULL OR NEW.delivery_closed_at IS NOT NULL
+    OR NEW.terminal_reason_code IS NOT NULL OR NEW.blocked_from_state IS NOT NULL
+    OR NEW.resume_state IS NOT NULL OR NEW.block_kind IS NOT NULL
+    THEN RAISE(ABORT,'invalid_initial_orch_request_state') END;
+  SELECT CASE WHEN orch_capability_ok(
+    CASE WHEN NEW.generation=1 THEN 'request_submit' ELSE 'request_supersede' END,
+    NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.selector_ledger_revision,NEW.generation,NEW.request_key
+  )!=1 THEN RAISE(ABORT,'missing_request_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_origins o JOIN orch_replay_selectors s
+      ON s.board_instance_id=o.board_instance_id AND s.tenant_scope=o.tenant_scope
+     AND s.selector_key=o.selector_key
+     WHERE o.board_instance_id=NEW.board_instance_id AND o.tenant_scope=NEW.tenant_scope
+       AND o.origin_id=NEW.origin_id AND o.selector_key=NEW.selector_key
+       AND s.lineage_id=NEW.lineage_id AND s.ledger_revision=NEW.selector_ledger_revision
+  ) THEN RAISE(ABORT,'request_selector_origin_mismatch') END;
+  SELECT CASE WHEN NEW.generation=1 AND (
+    NEW.supersedes_orch_id IS NOT NULL OR NOT EXISTS (
+      SELECT 1 FROM orch_replay_selectors s
+       WHERE s.board_instance_id=NEW.board_instance_id AND s.tenant_scope=NEW.tenant_scope
+         AND s.selector_key=NEW.selector_key AND s.current_generation=0
+         AND s.current_orch_id IS NULL
+    )
+  ) THEN RAISE(ABORT,'invalid_generation_one_request') END;
+  SELECT CASE WHEN NEW.generation>1 AND NOT EXISTS (
+    SELECT 1 FROM orch_requests prev JOIN orch_replay_selectors s
+      ON s.board_instance_id=prev.board_instance_id AND s.tenant_scope=prev.tenant_scope
+     AND s.selector_key=prev.selector_key
+     WHERE prev.board_instance_id=NEW.board_instance_id
+       AND prev.tenant_scope=NEW.tenant_scope AND prev.lineage_id=NEW.lineage_id
+       AND prev.selector_key=NEW.selector_key AND prev.generation=NEW.generation-1
+       AND prev.orch_id=NEW.supersedes_orch_id
+       AND prev.lifecycle_state IN ('failed','cancelled')
+       AND s.current_generation=prev.generation AND s.current_orch_id=prev.orch_id
+       AND s.current_request_digest=prev.request_digest
+       AND s.ledger_revision=NEW.selector_ledger_revision
+  ) THEN RAISE(ABORT,'invalid_orch_supersession') END;
+END;
+
+CREATE TRIGGER orch_node_identity_guard BEFORE UPDATE OF
+  board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id,
+  current_route_digest,route_revision,created_by_run_id,created_at
+ON orch_nodes BEGIN SELECT RAISE(ABORT,'immutable_orch_node_identity'); END;
+CREATE TRIGGER orch_node_delete_guard BEFORE DELETE ON orch_nodes
+BEGIN SELECT RAISE(ABORT,'orch_node_delete_forbidden'); END;
+
+CREATE TRIGGER orch_stage_attempt_guard BEFORE INSERT ON orch_stage_attempts
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'stage_attempt_start',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.lifecycle_revision,NEW.cancel_epoch,NEW.attempt_digest
+  )!=1 THEN RAISE(ABORT,'missing_stage_attempt_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_stage_leases l JOIN orch_requests r
+      ON r.board_instance_id=l.board_instance_id AND r.tenant_scope=l.tenant_scope AND r.orch_id=l.orch_id
+     WHERE l.board_instance_id=NEW.board_instance_id AND l.tenant_scope=NEW.tenant_scope
+       AND l.orch_id=NEW.orch_id AND l.stage=NEW.stage
+       AND l.owner_run_id=NEW.owner_run_id AND l.epoch=NEW.lease_epoch
+       AND l.lease_state='active' AND l.expires_at>unixepoch('now')
+       AND r.lifecycle_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+       AND NEW.attempt_state='running'
+       AND NEW.attempt_no=(SELECT COALESCE(max(x.attempt_no),0)+1 FROM orch_stage_attempts x
+         WHERE x.board_instance_id=NEW.board_instance_id AND x.tenant_scope=NEW.tenant_scope
+           AND x.orch_id=NEW.orch_id AND x.stage=NEW.stage)
+       AND NEW.attempt_no<=r.max_retries+1
+       AND ((NEW.stage='decomposition' AND r.lifecycle_state='decomposing')
+         OR (NEW.stage='synthesis' AND r.lifecycle_state='synthesizing'))
+  ) THEN RAISE(ABORT,'invalid_orch_stage_attempt_authority') END;
+END;
+
+CREATE TRIGGER orch_stage_attempt_update_guard BEFORE UPDATE ON orch_stage_attempts
+BEGIN
+  SELECT CASE WHEN OLD.board_instance_id!=NEW.board_instance_id OR OLD.tenant_scope!=NEW.tenant_scope
+    OR OLD.orch_id!=NEW.orch_id OR OLD.stage!=NEW.stage OR OLD.attempt_no!=NEW.attempt_no
+    OR OLD.owner_run_id!=NEW.owner_run_id OR OLD.lease_epoch!=NEW.lease_epoch
+    OR OLD.lifecycle_revision!=NEW.lifecycle_revision OR OLD.cancel_epoch!=NEW.cancel_epoch
+    OR OLD.started_at!=NEW.started_at OR OLD.attempt_digest!=NEW.attempt_digest
+    THEN RAISE(ABORT,'immutable_stage_attempt_identity') END;
+  SELECT CASE WHEN OLD.attempt_state!='running' OR NEW.attempt_state='running'
+    OR orch_capability_ok(
+      'stage_attempt_finish',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      NEW.lifecycle_revision,NEW.cancel_epoch,NEW.attempt_digest
+    )!=1 OR NOT EXISTS (
+      SELECT 1 FROM orch_stage_leases l JOIN orch_requests r
+        ON r.board_instance_id=l.board_instance_id AND r.tenant_scope=l.tenant_scope AND r.orch_id=l.orch_id
+       WHERE l.board_instance_id=NEW.board_instance_id AND l.tenant_scope=NEW.tenant_scope
+         AND l.orch_id=NEW.orch_id AND l.stage=NEW.stage
+         AND l.owner_run_id=NEW.owner_run_id AND l.epoch=NEW.lease_epoch
+         AND l.lease_state='active' AND l.expires_at>unixepoch('now')
+         AND r.lifecycle_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+    ) THEN RAISE(ABORT,'invalid_stage_attempt_transition') END;
+END;
+CREATE TRIGGER orch_stage_attempt_delete_guard BEFORE DELETE ON orch_stage_attempts
+BEGIN SELECT RAISE(ABORT,'stage_attempt_delete_forbidden'); END;
+
+CREATE TRIGGER orch_delivery_origin_guard BEFORE INSERT ON orch_delivery_obligations
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'delivery_obligation_insert',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.lifecycle_revision,NEW.cancel_epoch,NEW.delivery_key
+  )!=1 THEN RAISE(ABORT,'missing_delivery_obligation_capability') END;
+  SELECT CASE WHEN NEW.state!='pending' OR NOT EXISTS (
+    SELECT 1 FROM orch_origins o
+     WHERE o.board_instance_id=NEW.board_instance_id AND o.tenant_scope=NEW.tenant_scope
+       AND o.origin_id=NEW.origin_id AND o.route_revision=NEW.route_revision
+       AND o.route_digest=NEW.route_digest AND o.origin_kind=NEW.origin_kind
+       AND o.platform=NEW.platform AND o.adapter_instance_id=NEW.adapter_instance_id
+       AND o.account_id=NEW.account_id AND o.conversation_id=NEW.conversation_id
+       AND o.thread_id=NEW.thread_id AND o.reply_to_id=NEW.reply_to_id
+       AND o.required_ack_family=NEW.required_ack_family
+       AND o.required_ack_strength=NEW.required_ack_strength
+  ) THEN RAISE(ABORT,'delivery_origin_route_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_requests r JOIN orch_delivery_manifests m
+      ON m.board_instance_id=r.board_instance_id AND m.tenant_scope=r.tenant_scope
+     AND m.orch_id=r.orch_id AND m.plan_version=NEW.plan_version
+     AND m.result_id=NEW.result_id AND m.manifest_digest=NEW.manifest_digest
+     WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope
+       AND r.orch_id=NEW.orch_id AND r.plan_version=NEW.plan_version
+       AND r.delivery_epoch_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+       AND m.lifecycle_revision=NEW.lifecycle_revision AND m.cancel_epoch=NEW.cancel_epoch
+       AND (
+         (NEW.delivery_generation=1 AND NEW.supersedes_obligation_id IS NULL
+          AND r.lifecycle_state='work_accepted')
+         OR
+         (NEW.delivery_generation>1 AND r.lifecycle_state='delivery_blocked'
+          AND EXISTS (
+            SELECT 1 FROM orch_delivery_obligations old
+             WHERE old.board_instance_id=NEW.board_instance_id
+               AND old.tenant_scope=NEW.tenant_scope
+               AND old.obligation_id=NEW.supersedes_obligation_id
+               AND old.orch_id=NEW.orch_id AND old.result_id=NEW.result_id
+               AND old.manifest_entry_key=NEW.manifest_entry_key
+               AND old.delivery_generation=NEW.delivery_generation-1
+               AND (
+                 old.state='dead_letter'
+                 OR (old.state='unknown' AND EXISTS (
+                   SELECT 1 FROM orch_delivery_resend_authorizations a
+                    WHERE a.board_instance_id=NEW.board_instance_id
+                      AND a.tenant_scope=NEW.tenant_scope
+                      AND a.obligation_id=old.obligation_id
+                      AND a.unknown_attempt_id=old.unknown_attempt_id
+                      AND a.lifecycle_revision=NEW.lifecycle_revision
+                      AND a.cancel_epoch=NEW.cancel_epoch
+                      AND a.consumed_at IS NULL AND a.expires_at>unixepoch('now')
+                 ))
+               )
+          ))
+       )
+  ) THEN RAISE(ABORT,'stale_or_unauthorized_delivery_binding') END;
+END;
+
+CREATE TRIGGER orch_delivery_identity_guard BEFORE UPDATE OF
+  board_instance_id,tenant_scope,orch_id,plan_version,result_id,obligation_id,
+  manifest_digest,manifest_entry_key,delivery_generation,supersedes_obligation_id,
+  delivery_key,result_digest,origin_id,route_revision,route_digest,origin_kind,
+  platform,adapter_instance_id,account_id,conversation_id,thread_id,reply_to_id,
+  required,required_ack_family,required_ack_strength,lifecycle_revision,cancel_epoch,created_at
+ON orch_delivery_obligations BEGIN SELECT RAISE(ABORT,'immutable_delivery_identity'); END;
+CREATE TRIGGER orch_delivery_delete_guard BEFORE DELETE ON orch_delivery_obligations
+BEGIN SELECT RAISE(ABORT,'delivery_delete_forbidden'); END;
+
+CREATE TRIGGER orch_delivery_accept_guard BEFORE UPDATE OF state,acceptance_attempt_id ON orch_delivery_obligations
+WHEN NEW.state='accepted'
+BEGIN
+  SELECT CASE WHEN OLD.state NOT IN ('claimed','unknown') OR NOT EXISTS (
+    SELECT 1 FROM orch_delivery_attempts a JOIN orch_delivery_receipts rc
+      ON rc.board_instance_id=a.board_instance_id AND rc.tenant_scope=a.tenant_scope
+     AND rc.attempt_id=a.attempt_id AND rc.obligation_id=a.obligation_id
+     WHERE a.board_instance_id=NEW.board_instance_id AND a.tenant_scope=NEW.tenant_scope
+       AND a.obligation_id=NEW.obligation_id AND a.attempt_id=NEW.acceptance_attempt_id
+       AND a.attempt_state='adapter_accepted' AND rc.verified=1
+       AND a.claim_epoch=NEW.claim_epoch AND a.claim_owner=NEW.claim_owner
+       AND a.claim_token_hash=NEW.claim_token_hash
+       AND a.lifecycle_revision=NEW.lifecycle_revision AND a.cancel_epoch=NEW.cancel_epoch
+       AND a.result_digest=NEW.result_digest AND a.route_digest=NEW.route_digest
+       AND rc.send_nonce=a.send_nonce AND rc.payload_digest=a.payload_digest
+       AND rc.result_digest=a.result_digest AND rc.route_digest=a.route_digest
+       AND rc.observed_ack_family=NEW.required_ack_family
+       AND rc.observed_ack_strength=NEW.required_ack_strength
+  ) THEN RAISE(ABORT,'accepted_delivery_without_exact_receipt') END;
+END;
+
+CREATE TRIGGER orch_delivery_ack_guard BEFORE UPDATE OF state,acked_at ON orch_delivery_obligations
+WHEN NEW.state='acked'
+BEGIN
+  SELECT CASE WHEN OLD.state NOT IN ('accepted','unknown') OR NOT EXISTS (
+    SELECT 1 FROM orch_delivery_receipts rc
+     WHERE rc.board_instance_id=NEW.board_instance_id AND rc.tenant_scope=NEW.tenant_scope
+       AND rc.obligation_id=NEW.obligation_id AND rc.attempt_id=NEW.acceptance_attempt_id
+       AND rc.verified=1 AND rc.observed_ack_family=NEW.required_ack_family
+       AND rc.observed_ack_strength=NEW.required_ack_strength
+       AND rc.result_digest=NEW.result_digest AND rc.route_digest=NEW.route_digest
+  ) THEN RAISE(ABORT,'delivery_ack_family_or_strength_not_satisfied') END;
+END;
+
+CREATE TRIGGER orch_delivery_attempt_insert_guard BEFORE INSERT ON orch_delivery_attempts
+BEGIN
+  SELECT CASE WHEN NEW.attempt_state!='started' OR NEW.finished_at IS NOT NULL
+    OR orch_capability_ok(
+      'delivery_attempt_start',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,
+      NEW.lifecycle_revision,NEW.cancel_epoch,NEW.payload_digest
+    )!=1 OR NOT EXISTS (
+      SELECT 1 FROM orch_delivery_obligations d JOIN orch_requests r
+        ON r.board_instance_id=d.board_instance_id AND r.tenant_scope=d.tenant_scope AND r.orch_id=d.orch_id
+       WHERE d.board_instance_id=NEW.board_instance_id AND d.tenant_scope=NEW.tenant_scope
+         AND d.obligation_id=NEW.obligation_id AND d.state='claimed'
+         AND d.claim_owner=NEW.claim_owner AND d.claim_token_hash=NEW.claim_token_hash
+         AND d.claim_epoch=NEW.claim_epoch AND d.claim_expires_at>unixepoch('now')
+         AND d.lifecycle_revision=NEW.lifecycle_revision AND d.cancel_epoch=NEW.cancel_epoch
+         AND d.result_digest=NEW.result_digest AND d.route_digest=NEW.route_digest
+         AND r.delivery_epoch_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+         AND r.lifecycle_state IN ('delivering','delivery_blocked')
+    ) THEN RAISE(ABORT,'invalid_delivery_attempt_claim') END;
+END;
+
+CREATE TRIGGER orch_delivery_attempt_transition_guard BEFORE UPDATE ON orch_delivery_attempts
+BEGIN
+  SELECT CASE WHEN NOT (
+    OLD.attempt_state='started' AND NEW.attempt_state IN ('adapter_accepted','rejected','unknown')
+    AND NEW.finished_at IS NOT NULL
+    AND NEW.board_instance_id=OLD.board_instance_id AND NEW.tenant_scope=OLD.tenant_scope
+    AND NEW.obligation_id=OLD.obligation_id AND NEW.attempt_id=OLD.attempt_id
+    AND NEW.claim_epoch=OLD.claim_epoch AND NEW.claim_owner=OLD.claim_owner
+    AND NEW.claim_token_hash=OLD.claim_token_hash
+    AND NEW.lifecycle_revision=OLD.lifecycle_revision AND NEW.cancel_epoch=OLD.cancel_epoch
+    AND NEW.send_nonce=OLD.send_nonce AND NEW.payload_digest=OLD.payload_digest
+    AND NEW.result_digest=OLD.result_digest AND NEW.route_digest=OLD.route_digest
+    AND NEW.started_at=OLD.started_at
+    AND orch_capability_ok(
+      'delivery_attempt_finish',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,
+      NEW.lifecycle_revision,NEW.cancel_epoch,NEW.payload_digest
+    )=1
+    AND EXISTS (
+      SELECT 1 FROM orch_delivery_obligations d JOIN orch_requests r
+        ON r.board_instance_id=d.board_instance_id AND r.tenant_scope=d.tenant_scope AND r.orch_id=d.orch_id
+       WHERE d.board_instance_id=NEW.board_instance_id AND d.tenant_scope=NEW.tenant_scope
+         AND d.obligation_id=NEW.obligation_id AND d.claim_epoch=NEW.claim_epoch
+         AND d.claim_owner=NEW.claim_owner AND d.claim_token_hash=NEW.claim_token_hash
+         AND d.lifecycle_revision=NEW.lifecycle_revision AND d.cancel_epoch=NEW.cancel_epoch
+         AND r.delivery_epoch_revision=NEW.lifecycle_revision
+         AND ((r.cancel_epoch=NEW.cancel_epoch
+               AND r.lifecycle_state IN ('delivering','delivery_blocked'))
+           OR (r.cancel_epoch=NEW.cancel_epoch+1 AND r.lifecycle_state='cancelling'))
+    )
+  ) THEN RAISE(ABORT,'invalid_delivery_attempt_transition') END;
+END;
+
+CREATE TRIGGER orch_delivery_receipt_insert_guard BEFORE INSERT ON orch_delivery_receipts
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_delivery_attempts a JOIN orch_delivery_obligations d
+      ON d.board_instance_id=a.board_instance_id AND d.tenant_scope=a.tenant_scope
+     AND d.obligation_id=a.obligation_id
+     WHERE a.board_instance_id=NEW.board_instance_id AND a.tenant_scope=NEW.tenant_scope
+       AND a.obligation_id=NEW.obligation_id AND a.attempt_id=NEW.attempt_id
+       AND a.attempt_state IN ('adapter_accepted','unknown')
+       AND NEW.send_nonce=a.send_nonce AND NEW.payload_digest=a.payload_digest
+       AND NEW.result_digest=a.result_digest AND NEW.route_digest=a.route_digest
+       AND NEW.observed_ack_family=d.required_ack_family
+       AND NEW.observed_ack_strength=d.required_ack_strength
+       AND orch_capability_ok(
+         'delivery_receipt',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,
+         a.lifecycle_revision,a.cancel_epoch,NEW.receipt_digest
+       )=1
+  ) THEN RAISE(ABORT,'receipt_without_exact_attempt_acceptance') END;
+END;
+
+CREATE TRIGGER orch_delivery_attempt_event_guard BEFORE INSERT ON orch_delivery_attempt_events
+BEGIN
+  SELECT CASE WHEN NEW.event_kind!=NEW.to_state OR NOT EXISTS (
+    SELECT 1 FROM orch_delivery_attempts a
+     WHERE a.board_instance_id=NEW.board_instance_id AND a.tenant_scope=NEW.tenant_scope
+       AND a.attempt_id=NEW.attempt_id AND a.attempt_state=NEW.to_state
+       AND NEW.transition_seq IN (1,2)
+       AND ((NEW.transition_seq=1 AND NEW.from_state IS NULL AND NEW.to_state='started')
+         OR (NEW.transition_seq=2 AND NEW.from_state='started' AND NEW.to_state!='started'))
+  ) THEN RAISE(ABORT,'invalid_delivery_attempt_event') END;
+END;
+CREATE TRIGGER orch_delivery_attempt_delete_guard BEFORE DELETE ON orch_delivery_attempts
+BEGIN SELECT RAISE(ABORT,'delivery_attempt_delete_forbidden'); END;
+
+CREATE TRIGGER tasks_orch_runtime_write_guard BEFORE UPDATE ON tasks
+WHEN OLD.orch_id IS NOT NULL
+  AND NEW.orch_board_instance_id IS OLD.orch_board_instance_id
+  AND NEW.orch_tenant_scope IS OLD.orch_tenant_scope
+  AND NEW.orch_id IS OLD.orch_id
+  AND NEW.orch_plan_version IS OLD.orch_plan_version
+  AND NEW.orch_node_key IS OLD.orch_node_key
+  AND NEW.orch_binding_revision IS OLD.orch_binding_revision
+  AND NEW.orch_cancel_epoch IS OLD.orch_cancel_epoch
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'task_write',OLD.orch_board_instance_id,OLD.orch_tenant_scope,OLD.orch_id,
+    COALESCE((SELECT lifecycle_revision FROM orch_requests r
+      WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+        AND r.orch_id=OLD.orch_id),-1),
+    COALESCE((SELECT cancel_epoch FROM orch_requests r
+      WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+        AND r.orch_id=OLD.orch_id),-1),OLD.id
+  )!=1 THEN RAISE(ABORT,'missing_orch_task_write_capability') END;
+END;
+CREATE TRIGGER tasks_orch_id_update_guard BEFORE UPDATE OF id ON tasks
+WHEN OLD.orch_id IS NOT NULL
+BEGIN SELECT RAISE(ABORT,'orch_task_id_immutable'); END;
+CREATE TRIGGER tasks_orch_delete_guard BEFORE DELETE ON tasks
+WHEN OLD.orch_id IS NOT NULL
+BEGIN SELECT RAISE(ABORT,'orch_bound_task_delete_forbidden'); END;
+
+CREATE TRIGGER task_runs_orch_insert_guard BEFORE INSERT ON task_runs
+WHEN EXISTS (SELECT 1 FROM tasks t WHERE t.id=NEW.task_id AND t.orch_id IS NOT NULL)
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM tasks t JOIN orch_requests r
+      ON r.board_instance_id=t.orch_board_instance_id
+     AND r.tenant_scope=t.orch_tenant_scope AND r.orch_id=t.orch_id
+     WHERE t.id=NEW.task_id AND NEW.cancellation_epoch=r.cancel_epoch
+       AND r.lifecycle_state NOT IN ('cancelling','completed','failed','cancelled')
+       AND orch_capability_ok(
+         'task_run_start',r.board_instance_id,r.tenant_scope,r.orch_id,
+         r.lifecycle_revision,r.cancel_epoch,COALESCE(CAST(NEW.id AS TEXT),NEW.task_id)
+       )=1
+  ) THEN RAISE(ABORT,'invalid_orch_task_run_start') END;
+END;
+CREATE TRIGGER task_runs_orch_update_guard BEFORE UPDATE ON task_runs
+WHEN EXISTS (SELECT 1 FROM tasks t WHERE t.id IN (OLD.task_id,NEW.task_id) AND t.orch_id IS NOT NULL)
+BEGIN
+  SELECT CASE WHEN NEW.id!=OLD.id OR NEW.task_id!=OLD.task_id OR NOT EXISTS (
+    SELECT 1 FROM tasks t JOIN orch_requests r
+      ON r.board_instance_id=t.orch_board_instance_id
+     AND r.tenant_scope=t.orch_tenant_scope AND r.orch_id=t.orch_id
+     WHERE t.id=NEW.task_id AND NEW.cancellation_epoch=r.cancel_epoch
+       AND r.lifecycle_state NOT IN ('completed','failed','cancelled')
+       AND orch_capability_ok(
+         'task_run_write',r.board_instance_id,r.tenant_scope,r.orch_id,
+         r.lifecycle_revision,r.cancel_epoch,CAST(NEW.id AS TEXT)
+       )=1
+  ) THEN RAISE(ABORT,'invalid_orch_task_run_write') END;
+END;
+CREATE TRIGGER task_runs_orch_delete_guard BEFORE DELETE ON task_runs
+WHEN EXISTS (SELECT 1 FROM tasks t WHERE t.id=OLD.task_id AND t.orch_id IS NOT NULL)
+BEGIN SELECT RAISE(ABORT,'orch_task_run_delete_forbidden'); END;
+
+CREATE TRIGGER task_links_orch_update_guard BEFORE UPDATE ON task_links
+WHEN OLD.orch_id IS NOT NULL OR NEW.orch_id IS NOT NULL
+BEGIN SELECT RAISE(ABORT,'replace_orch_link_via_typed_delete_insert'); END;
+CREATE TRIGGER task_links_orch_delete_guard BEFORE DELETE ON task_links
+WHEN OLD.orch_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT (
+    EXISTS (
+      SELECT 1 FROM orch_requests r
+       WHERE r.board_instance_id=OLD.orch_board_instance_id
+         AND r.tenant_scope=OLD.orch_tenant_scope AND r.orch_id=OLD.orch_id
+         AND r.lifecycle_state IN ('cancelling','cancelled')
+    )
+    AND orch_capability_ok(
+      'link_retire',OLD.orch_board_instance_id,OLD.orch_tenant_scope,OLD.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r
+        WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+          AND r.orch_id=OLD.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r
+        WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+          AND r.orch_id=OLD.orch_id),-1),OLD.orch_edge_key
+    )=1
+  ) THEN RAISE(ABORT,'orch_link_delete_without_retirement_authority') END;
+END;
+
+CREATE TRIGGER board_identity_insert_guard BEFORE INSERT ON kanban_board_identity BEGIN
+  SELECT CASE WHEN orch_capability_ok('maintenance_identity',NEW.board_instance_id,'','',0,0,NEW.canonical_board_key)!=1
+    THEN RAISE(ABORT,'missing_maintenance_identity_capability') END;
+END;
+CREATE TRIGGER board_identity_update_guard BEFORE UPDATE ON kanban_board_identity BEGIN SELECT RAISE(ABORT,'board_identity_immutable'); END;
+CREATE TRIGGER board_identity_delete_guard BEFORE DELETE ON kanban_board_identity BEGIN SELECT RAISE(ABORT,'board_identity_delete_forbidden'); END;
+
+CREATE TRIGGER schema_migration_insert_guard BEFORE INSERT ON kanban_schema_migrations BEGIN
+  SELECT CASE WHEN orch_capability_ok('maintenance_schema',NEW.board_instance_id,'',NEW.migration_id,NEW.fence_generation,0,NEW.source_digest)!=1
+    THEN RAISE(ABORT,'missing_schema_migration_capability') END;
+END;
+CREATE TRIGGER schema_migration_update_guard BEFORE UPDATE ON kanban_schema_migrations BEGIN
+  SELECT CASE WHEN NEW.migration_id!=OLD.migration_id OR NEW.board_instance_id!=OLD.board_instance_id
+    OR NEW.target_schema_version!=OLD.target_schema_version OR NEW.source_digest!=OLD.source_digest
+    OR NEW.backup_digest!=OLD.backup_digest OR NEW.fence_generation!=OLD.fence_generation
+    OR orch_capability_ok('maintenance_schema',NEW.board_instance_id,'',NEW.migration_id,NEW.fence_generation,0,NEW.state)!=1
+    THEN RAISE(ABORT,'invalid_schema_migration_transition') END;
+END;
+CREATE TRIGGER schema_migration_delete_guard BEFORE DELETE ON kanban_schema_migrations BEGIN SELECT RAISE(ABORT,'schema_migration_delete_forbidden'); END;
+
+CREATE TRIGGER write_fence_insert_guard BEFORE INSERT ON kanban_write_fence BEGIN
+  SELECT CASE WHEN orch_capability_ok('maintenance_fence',(SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1),'','',NEW.generation,0,NEW.mode)!=1
+    THEN RAISE(ABORT,'missing_write_fence_capability') END;
+END;
+CREATE TRIGGER write_fence_update_guard BEFORE UPDATE ON kanban_write_fence BEGIN
+  SELECT CASE WHEN NEW.singleton!=OLD.singleton OR NEW.generation!=OLD.generation+1
+    OR orch_capability_ok('maintenance_fence',(SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1),'','',NEW.generation,0,NEW.mode)!=1
+    THEN RAISE(ABORT,'invalid_write_fence_transition') END;
+END;
+CREATE TRIGGER write_fence_delete_guard BEFORE DELETE ON kanban_write_fence BEGIN SELECT RAISE(ABORT,'write_fence_delete_forbidden'); END;
+
+CREATE TRIGGER commit_clock_insert_guard BEFORE INSERT ON kanban_commit_clock BEGIN
+  SELECT CASE WHEN NEW.commit_seq!=0 OR orch_capability_ok('commit_clock',(SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1),'','',0,0,NEW.last_txn_id)!=1
+    THEN RAISE(ABORT,'invalid_commit_clock_bootstrap') END;
+END;
+CREATE TRIGGER commit_clock_update_guard BEFORE UPDATE ON kanban_commit_clock BEGIN
+  SELECT CASE WHEN NEW.singleton!=OLD.singleton OR NEW.commit_seq!=OLD.commit_seq+1
+    OR orch_capability_ok('commit_clock',(SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1),'','',NEW.commit_seq,0,NEW.last_txn_id)!=1
+    THEN RAISE(ABORT,'invalid_commit_clock_cas') END;
+END;
+CREATE TRIGGER commit_clock_delete_guard BEFORE DELETE ON kanban_commit_clock BEGIN SELECT RAISE(ABORT,'commit_clock_delete_forbidden'); END;
+
+CREATE TRIGGER migration_operation_insert_guard BEFORE INSERT ON kanban_migration_operations BEGIN
+  SELECT CASE WHEN orch_capability_ok('maintenance_operation',NEW.board_instance_id,'',NEW.migration_id,NEW.phase_revision,NEW.fence_generation,NEW.plan_digest)!=1
+    THEN RAISE(ABORT,'missing_migration_operation_capability') END;
+END;
+CREATE TRIGGER migration_operation_update_guard BEFORE UPDATE ON kanban_migration_operations BEGIN
+  SELECT CASE WHEN NEW.migration_id!=OLD.migration_id OR NEW.board_instance_id!=OLD.board_instance_id
+    OR NEW.owner_token_hash!=OLD.owner_token_hash OR NEW.source_digest!=OLD.source_digest
+    OR NEW.plan_digest!=OLD.plan_digest OR NEW.schema_digest!=OLD.schema_digest
+    OR NEW.phase_revision!=OLD.phase_revision+1
+    OR orch_capability_ok('maintenance_operation',NEW.board_instance_id,'',NEW.migration_id,NEW.phase_revision,NEW.fence_generation,NEW.phase)!=1
+    THEN RAISE(ABORT,'invalid_migration_operation_transition') END;
+END;
+CREATE TRIGGER migration_operation_delete_guard BEFORE DELETE ON kanban_migration_operations BEGIN SELECT RAISE(ABORT,'migration_operation_delete_forbidden'); END;
+
+CREATE TRIGGER rollback_operation_insert_guard BEFORE INSERT ON orch_rollback_operations BEGIN
+  SELECT CASE WHEN orch_capability_ok('rollback_operation',NEW.board_instance_id,'',NEW.rollback_id,NEW.phase_revision,NEW.fence_generation,NEW.target_manifest_digest)!=1
+    THEN RAISE(ABORT,'missing_rollback_operation_capability') END;
+END;
+CREATE TRIGGER rollback_operation_update_guard BEFORE UPDATE ON orch_rollback_operations BEGIN
+  SELECT CASE WHEN NEW.rollback_id!=OLD.rollback_id OR NEW.migration_id!=OLD.migration_id
+    OR NEW.board_instance_id!=OLD.board_instance_id OR NEW.owner_token_hash!=OLD.owner_token_hash
+    OR NEW.source_manifest_digest!=OLD.source_manifest_digest OR NEW.target_manifest_digest!=OLD.target_manifest_digest
+    OR NEW.phase_revision!=OLD.phase_revision+1
+    OR orch_capability_ok('rollback_operation',NEW.board_instance_id,'',NEW.rollback_id,NEW.phase_revision,NEW.fence_generation,NEW.phase)!=1
+    THEN RAISE(ABORT,'invalid_rollback_operation_transition') END;
+END;
+CREATE TRIGGER rollback_operation_delete_guard BEFORE DELETE ON orch_rollback_operations BEGIN SELECT RAISE(ABORT,'rollback_operation_delete_forbidden'); END;
+
+CREATE TRIGGER replay_selector_insert_guard BEFORE INSERT ON orch_replay_selectors BEGIN
+  SELECT CASE WHEN NEW.current_generation!=0 OR NEW.current_orch_id IS NOT NULL OR NEW.current_request_digest IS NOT NULL
+    OR NEW.ledger_revision!=0
+    OR orch_capability_ok('selector_create',NEW.board_instance_id,NEW.tenant_scope,NEW.lineage_id,0,0,NEW.selector_key)!=1
+    THEN RAISE(ABORT,'invalid_replay_selector_create') END;
+END;
+CREATE TRIGGER replay_selector_update_guard BEFORE UPDATE ON orch_replay_selectors BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.selector_key!=OLD.selector_key OR NEW.selector_kind!=OLD.selector_kind
+    OR NEW.selector_value!=OLD.selector_value OR NEW.adapter_instance_id!=OLD.adapter_instance_id
+    OR NEW.conversation_id!=OLD.conversation_id OR NEW.lineage_id!=OLD.lineage_id
+    OR NEW.created_at!=OLD.created_at OR NEW.current_generation!=OLD.current_generation+1
+    OR NEW.ledger_revision!=OLD.ledger_revision+1
+    OR orch_capability_ok('selector_advance',NEW.board_instance_id,NEW.tenant_scope,NEW.lineage_id,OLD.ledger_revision,NEW.current_generation,NEW.selector_key)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope
+        AND r.orch_id=NEW.current_orch_id AND r.generation=NEW.current_generation
+        AND r.request_digest=NEW.current_request_digest AND r.selector_key=NEW.selector_key)
+    THEN RAISE(ABORT,'invalid_replay_selector_advance') END;
+END;
+CREATE TRIGGER replay_selector_delete_guard BEFORE DELETE ON orch_replay_selectors BEGIN SELECT RAISE(ABORT,'replay_selector_delete_forbidden'); END;
+
+CREATE TRIGGER orch_origin_insert_guard BEFORE INSERT ON orch_origins BEGIN
+  SELECT CASE WHEN orch_capability_ok('origin_register',NEW.board_instance_id,NEW.tenant_scope,NEW.origin_id,NEW.route_revision,0,NEW.route_digest)!=1
+    THEN RAISE(ABORT,'missing_origin_register_capability') END;
+END;
+
+CREATE TRIGGER orch_request_transition_guard BEFORE UPDATE ON orch_requests BEGIN
+  SELECT CASE WHEN NEW.lifecycle_revision!=OLD.lifecycle_revision+1 OR NEW.updated_at<OLD.updated_at
+    OR orch_capability_ok('request_transition',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.request_key)!=1
+    OR NOT (
+      (OLD.lifecycle_state='submitted' AND NEW.lifecycle_state='decomposing')
+      OR (OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state IN ('waiting_lanes','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='waiting_lanes' AND NEW.lifecycle_state IN ('waiting_lanes','synthesizing','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state IN ('work_accepted','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='work_accepted' AND NEW.lifecycle_state IN ('delivering','completed','cancelling'))
+      OR (OLD.lifecycle_state='delivering' AND NEW.lifecycle_state IN ('completed','delivery_blocked','cancelling'))
+      OR (OLD.lifecycle_state='delivery_blocked' AND NEW.lifecycle_state IN ('delivering','cancelling'))
+      OR (OLD.lifecycle_state='blocked' AND NEW.lifecycle_state=OLD.resume_state)
+      OR (OLD.lifecycle_state='cancelling' AND NEW.lifecycle_state='cancelled')
+    )
+    OR NOT ((NEW.lifecycle_state='cancelling' AND OLD.lifecycle_state!='cancelling' AND NEW.cancel_epoch=OLD.cancel_epoch+1)
+      OR (NEW.lifecycle_state!='cancelling' AND NEW.cancel_epoch=OLD.cancel_epoch))
+    OR NOT ((OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state='work_accepted'
+              AND OLD.delivery_epoch_revision=0 AND NEW.delivery_epoch_revision=NEW.lifecycle_revision
+              AND NEW.work_accepted_at IS NOT NULL)
+      OR (NOT (OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state='work_accepted')
+              AND NEW.delivery_epoch_revision=OLD.delivery_epoch_revision
+              AND NEW.work_accepted_at IS OLD.work_accepted_at))
+    OR NOT ((OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state='waiting_lanes'
+              AND NEW.plan_version=OLD.plan_version+1
+              AND OLD.plan_epoch_revision=0 AND NEW.plan_epoch_revision=NEW.lifecycle_revision
+              AND EXISTS (SELECT 1 FROM orch_plan_materializations m
+                WHERE m.board_instance_id=NEW.board_instance_id AND m.tenant_scope=NEW.tenant_scope
+                  AND m.orch_id=NEW.orch_id AND m.plan_version=NEW.plan_version
+                  AND m.request_lifecycle_revision=OLD.lifecycle_revision
+                  AND m.cancel_epoch=OLD.cancel_epoch))
+      OR (NOT (OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state='waiting_lanes')
+              AND NEW.plan_version=OLD.plan_version
+              AND NEW.plan_epoch_revision=OLD.plan_epoch_revision))
+    OR (NEW.lifecycle_state='completed' AND NEW.delivery_closed_at IS NULL)
+    OR (NEW.lifecycle_state!='completed' AND NEW.delivery_closed_at IS NOT OLD.delivery_closed_at)
+    THEN RAISE(ABORT,'invalid_orch_request_transition') END;
+END;
+
+CREATE TRIGGER orch_requirement_insert_guard BEFORE INSERT ON orch_request_requirements BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.requirement_digest)!=1
+    THEN RAISE(ABORT,'missing_plan_build_capability') END;
+END;
+CREATE TRIGGER orch_plan_insert_guard BEFORE INSERT ON orch_plans BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.plan_digest)!=1
+    THEN RAISE(ABORT,'missing_plan_build_capability') END;
+END;
+CREATE TRIGGER orch_plan_node_insert_guard BEFORE INSERT ON orch_plan_nodes BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.node_key)!=1
+    THEN RAISE(ABORT,'missing_plan_node_capability') END;
+END;
+CREATE TRIGGER orch_plan_edge_insert_guard BEFORE INSERT ON orch_plan_edges BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.edge_key)!=1
+    THEN RAISE(ABORT,'missing_plan_edge_capability') END;
+END;
+CREATE TRIGGER orch_plan_coverage_insert_guard BEFORE INSERT ON orch_plan_coverage BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.requirement_id||':'||NEW.node_key)!=1
+    THEN RAISE(ABORT,'missing_plan_coverage_capability') END;
+END;
+
+CREATE TRIGGER orch_node_insert_guard BEFORE INSERT ON orch_nodes BEGIN
+  SELECT CASE WHEN orch_capability_ok('materialize',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.node_key)!=1
+    THEN RAISE(ABORT,'missing_node_materialization_capability') END;
+END;
+CREATE TRIGGER orch_node_state_guard BEFORE UPDATE OF node_state,updated_at ON orch_nodes BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.orch_id!=OLD.orch_id OR NEW.plan_version!=OLD.plan_version OR NEW.node_key!=OLD.node_key
+    OR NEW.task_id!=OLD.task_id OR NEW.updated_at<OLD.updated_at
+    OR NOT ((OLD.node_state='planned' AND NEW.node_state IN ('ready','running','cancelled'))
+      OR (OLD.node_state='ready' AND NEW.node_state IN ('running','cancelled'))
+      OR (OLD.node_state='running' AND NEW.node_state IN ('accepted','blocked','failed','cancellation_requested','cancelled'))
+      OR (OLD.node_state='cancellation_requested' AND NEW.node_state IN ('accepted','failed','cancelled'))
+      OR (OLD.node_state='blocked' AND NEW.node_state IN ('ready','cancelled')))
+    OR orch_capability_ok('node_transition',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.node_key)!=1
+    THEN RAISE(ABORT,'invalid_orch_node_transition') END;
+END;
+
+CREATE TRIGGER orch_external_edge_insert_guard BEFORE INSERT ON orch_external_edges BEGIN
+  SELECT CASE WHEN orch_capability_ok('external_edge',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.edge_key)!=1
+    THEN RAISE(ABORT,'missing_external_edge_capability') END;
+END;
+CREATE TRIGGER orch_external_edge_update_guard BEFORE UPDATE ON orch_external_edges BEGIN SELECT RAISE(ABORT,'immutable_external_edge'); END;
+CREATE TRIGGER orch_external_edge_delete_guard BEFORE DELETE ON orch_external_edges BEGIN SELECT RAISE(ABORT,'external_edge_delete_forbidden'); END;
+
+CREATE TRIGGER orch_stage_lease_insert_guard BEFORE INSERT ON orch_stage_leases BEGIN
+  SELECT CASE WHEN NEW.lease_state!='active' OR NEW.epoch!=1 OR NEW.expires_at<=unixepoch('now')
+    OR orch_capability_ok('lease_claim',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.stage)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id
+        AND ((NEW.stage='decomposition' AND r.lifecycle_state='decomposing')
+          OR (NEW.stage='synthesis' AND r.lifecycle_state='synthesizing')
+          OR (NEW.stage='reconciliation' AND r.lifecycle_state IN ('waiting_lanes','delivering','delivery_blocked','cancelling'))))
+    THEN RAISE(ABORT,'invalid_stage_lease_claim') END;
+END;
+CREATE TRIGGER orch_stage_lease_update_guard BEFORE UPDATE ON orch_stage_leases BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.orch_id!=OLD.orch_id OR NEW.stage!=OLD.stage OR NEW.updated_at<OLD.updated_at
+    OR orch_capability_ok('lease_update',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.stage)!=1
+    OR NOT (
+      (OLD.lease_state='active' AND NEW.lease_state='active' AND NEW.owner_run_id=OLD.owner_run_id
+        AND NEW.owner_profile=OLD.owner_profile AND NEW.token_hash=OLD.token_hash
+        AND NEW.epoch=OLD.epoch AND NEW.expires_at>OLD.expires_at)
+      OR (OLD.lease_state='active' AND NEW.lease_state IN ('released','revoked')
+        AND NEW.owner_run_id=OLD.owner_run_id AND NEW.owner_profile=OLD.owner_profile
+        AND NEW.token_hash=OLD.token_hash AND NEW.epoch=OLD.epoch)
+      OR (NEW.lease_state='active' AND NEW.epoch=OLD.epoch+1 AND NEW.expires_at>unixepoch('now')
+        AND (OLD.lease_state IN ('released','revoked') OR OLD.expires_at<=unixepoch('now')))
+    )
+    THEN RAISE(ABORT,'invalid_stage_lease_transition') END;
+END;
+CREATE TRIGGER orch_stage_lease_delete_guard BEFORE DELETE ON orch_stage_leases BEGIN SELECT RAISE(ABORT,'stage_lease_delete_forbidden'); END;
+
+CREATE TRIGGER orch_result_insert_guard BEFORE INSERT ON orch_results BEGIN
+  SELECT CASE WHEN orch_capability_ok('result_accept',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.result_digest)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r JOIN orch_stage_attempts a
+      ON a.board_instance_id=r.board_instance_id AND a.tenant_scope=r.tenant_scope AND a.orch_id=r.orch_id
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id
+        AND r.plan_version=NEW.plan_version AND r.lifecycle_state='synthesizing'
+        AND r.lifecycle_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+        AND a.stage=NEW.producer_stage AND a.attempt_no=NEW.producer_attempt_no
+        AND a.owner_run_id=NEW.producer_run_id AND a.lease_epoch=NEW.synthesis_epoch
+        AND a.lifecycle_revision=NEW.lifecycle_revision AND a.cancel_epoch=NEW.cancel_epoch
+        AND a.attempt_state='completed' AND a.outcome_code='result_ready')
+    THEN RAISE(ABORT,'invalid_result_acceptance') END;
+END;
+
+CREATE TRIGGER delivery_manifest_insert_guard BEFORE INSERT ON orch_delivery_manifests BEGIN
+  SELECT CASE WHEN orch_capability_ok('delivery_manifest',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.manifest_digest)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r JOIN orch_results rs
+      ON rs.board_instance_id=r.board_instance_id AND rs.tenant_scope=r.tenant_scope
+      AND rs.orch_id=r.orch_id AND rs.plan_version=r.plan_version
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id
+        AND r.plan_version=NEW.plan_version AND r.lifecycle_state='work_accepted'
+        AND r.delivery_epoch_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+        AND rs.result_id=NEW.result_id)
+    THEN RAISE(ABORT,'invalid_delivery_manifest') END;
+END;
+CREATE TRIGGER delivery_manifest_update_guard BEFORE UPDATE ON orch_delivery_manifests BEGIN SELECT RAISE(ABORT,'immutable_delivery_manifest'); END;
+CREATE TRIGGER delivery_manifest_delete_guard BEFORE DELETE ON orch_delivery_manifests BEGIN SELECT RAISE(ABORT,'delivery_manifest_delete_forbidden'); END;
+CREATE TRIGGER delivery_manifest_entry_insert_guard BEFORE INSERT ON orch_delivery_manifest_entries BEGIN
+  SELECT CASE WHEN orch_capability_ok('delivery_manifest_entry',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,0,0,NEW.manifest_entry_key)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_delivery_obligations d
+      WHERE d.board_instance_id=NEW.board_instance_id AND d.tenant_scope=NEW.tenant_scope
+        AND d.obligation_id=NEW.obligation_id AND d.orch_id=NEW.orch_id AND d.result_id=NEW.result_id
+        AND d.manifest_digest=NEW.manifest_digest AND d.manifest_entry_key=NEW.manifest_entry_key
+        AND d.required=NEW.required AND d.required_ack_family=NEW.required_ack_family
+        AND d.required_ack_strength=NEW.required_ack_strength AND d.route_digest=NEW.route_digest)
+    THEN RAISE(ABORT,'invalid_delivery_manifest_entry') END;
+END;
+CREATE TRIGGER delivery_manifest_entry_update_guard BEFORE UPDATE ON orch_delivery_manifest_entries BEGIN SELECT RAISE(ABORT,'immutable_delivery_manifest_entry'); END;
+CREATE TRIGGER delivery_manifest_entry_delete_guard BEFORE DELETE ON orch_delivery_manifest_entries BEGIN SELECT RAISE(ABORT,'delivery_manifest_entry_delete_forbidden'); END;
+
+CREATE TRIGGER orch_delivery_state_guard BEFORE UPDATE OF state,claim_owner,claim_token_hash,claim_epoch,claim_expires_at,
+  attempts,available_at,acceptance_attempt_id,adapter_accepted_at,acked_at,provider_id,provider_message_id,
+  duplicate_possible,unknown_attempt_id,ambiguity_deadline,last_error_code,updated_at ON orch_delivery_obligations
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+      CASE
+        WHEN OLD.state='pending' AND NEW.state='claimed' THEN 'delivery_claim'
+        WHEN NEW.state IN ('accepted','pending','unknown','dead_letter') THEN 'delivery_outcome'
+        WHEN NEW.state='acked' THEN 'delivery_ack'
+        WHEN NEW.state='cancelled' THEN 'delivery_cancel'
+        ELSE 'delivery_invalid'
+      END,
+      NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,
+      NEW.lifecycle_revision,NEW.cancel_epoch,NEW.delivery_key
+    )!=1
+    OR NOT ((OLD.state='pending' AND NEW.state IN ('claimed','cancelled'))
+      OR (OLD.state='claimed' AND NEW.state IN ('accepted','pending','unknown','dead_letter','cancelled'))
+      OR (OLD.state='unknown' AND NEW.state IN ('accepted','acked','cancelled'))
+      OR (OLD.state='accepted' AND NEW.state IN ('acked','cancelled')))
+    OR (NEW.state='claimed' AND (NEW.claim_owner IS NULL OR NEW.claim_token_hash IS NULL
+      OR NEW.claim_epoch!=OLD.claim_epoch+1 OR NEW.claim_expires_at<=unixepoch('now') OR NEW.attempts!=OLD.attempts+1))
+    OR (NEW.state!='claimed' AND NEW.state!='accepted'
+      AND (NEW.claim_owner IS NOT NULL OR NEW.claim_token_hash IS NOT NULL OR NEW.claim_expires_at IS NOT NULL))
+    OR (NEW.state='unknown' AND (NEW.unknown_attempt_id IS NULL OR NEW.ambiguity_deadline IS NULL))
+    OR NEW.updated_at<OLD.updated_at
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id
+        AND r.delivery_epoch_revision=NEW.lifecycle_revision
+        AND ((r.cancel_epoch=NEW.cancel_epoch AND r.lifecycle_state IN ('work_accepted','delivering','delivery_blocked'))
+          OR (r.cancel_epoch=NEW.cancel_epoch+1 AND r.lifecycle_state='cancelling' AND NEW.state='cancelled')))
+    THEN RAISE(ABORT,'invalid_delivery_state_transition') END;
+END;
+
+CREATE TRIGGER delivery_attempt_event_capability_guard BEFORE INSERT ON orch_delivery_attempt_events BEGIN
+  SELECT CASE WHEN orch_capability_ok('delivery_attempt_event',NEW.board_instance_id,NEW.tenant_scope,NEW.attempt_id,NEW.transition_seq,0,NEW.event_digest)!=1
+    THEN RAISE(ABORT,'missing_delivery_attempt_event_capability') END;
+END;
+
+CREATE TRIGGER reconcile_queue_update_guard BEFORE UPDATE ON orch_reconcile_queue BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.event_id!=OLD.event_id OR NEW.consumer_kind!=OLD.consumer_kind
+    OR orch_capability_ok(
+      CASE
+        WHEN OLD.state='pending' AND NEW.state='claimed' THEN 'queue_claim'
+        WHEN OLD.state='claimed' AND NEW.state='done' THEN 'queue_complete'
+        WHEN NEW.state IN ('pending','dead_letter') THEN 'queue_recover'
+        ELSE 'queue_invalid'
+      END,
+      NEW.board_instance_id,NEW.tenant_scope,CAST(NEW.event_id AS TEXT),
+      NEW.claim_epoch,0,NEW.consumer_kind
+    )!=1
+    OR NOT ((OLD.state='pending' AND NEW.state IN ('claimed','dead_letter'))
+      OR (OLD.state='claimed' AND NEW.state IN ('pending','done','dead_letter')))
+    OR (NEW.state='claimed' AND (NEW.claim_owner IS NULL OR NEW.claim_token_hash IS NULL
+      OR NEW.claim_epoch!=OLD.claim_epoch+1 OR NEW.claim_expires_at<=unixepoch('now')
+      OR NEW.attempts!=OLD.attempts+1))
+    OR (NEW.state!='claimed' AND (NEW.claim_owner IS NOT NULL OR NEW.claim_token_hash IS NOT NULL OR NEW.claim_expires_at IS NOT NULL))
+    OR (NEW.state='done' AND NOT EXISTS (SELECT 1 FROM orch_effect_ledger e
+      WHERE e.board_instance_id=NEW.board_instance_id AND e.tenant_scope=NEW.tenant_scope
+        AND e.event_id=NEW.event_id AND e.consumer_kind=NEW.consumer_kind
+        AND e.effect_digest=NEW.done_effect_digest))
+    OR (NEW.state='dead_letter' AND OLD.state='claimed' AND OLD.claim_expires_at>unixepoch('now'))
+    THEN RAISE(ABORT,'invalid_reconcile_queue_transition') END;
+END;
+CREATE TRIGGER reconcile_queue_delete_guard BEFORE DELETE ON orch_reconcile_queue BEGIN SELECT RAISE(ABORT,'reconcile_queue_delete_forbidden'); END;
+CREATE TRIGGER effect_ledger_update_guard BEFORE UPDATE ON orch_effect_ledger BEGIN SELECT RAISE(ABORT,'immutable_effect_ledger'); END;
+CREATE TRIGGER effect_ledger_delete_guard BEFORE DELETE ON orch_effect_ledger BEGIN SELECT RAISE(ABORT,'effect_ledger_delete_forbidden'); END;
+
+CREATE TRIGGER resend_authorization_insert_guard BEFORE INSERT ON orch_delivery_resend_authorizations BEGIN
+  SELECT CASE WHEN orch_capability_ok('resend_authorize',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.capability_digest)!=1
+    OR NEW.expires_at<=unixepoch('now') OR NEW.consumed_at IS NOT NULL
+    OR NOT EXISTS (SELECT 1 FROM orch_delivery_obligations d
+      WHERE d.board_instance_id=NEW.board_instance_id AND d.tenant_scope=NEW.tenant_scope
+        AND d.obligation_id=NEW.obligation_id AND d.state='unknown'
+        AND d.unknown_attempt_id=NEW.unknown_attempt_id
+        AND d.lifecycle_revision=NEW.lifecycle_revision AND d.cancel_epoch=NEW.cancel_epoch)
+    THEN RAISE(ABORT,'invalid_resend_authorization') END;
+END;
+CREATE TRIGGER resend_authorization_update_guard BEFORE UPDATE ON orch_delivery_resend_authorizations BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.authorization_id!=OLD.authorization_id OR NEW.obligation_id!=OLD.obligation_id
+    OR NEW.unknown_attempt_id!=OLD.unknown_attempt_id OR NEW.lifecycle_revision!=OLD.lifecycle_revision
+    OR NEW.cancel_epoch!=OLD.cancel_epoch OR NEW.capability_digest!=OLD.capability_digest
+    OR NEW.authorized_by!=OLD.authorized_by OR NEW.expires_at!=OLD.expires_at OR NEW.created_at!=OLD.created_at
+    OR OLD.consumed_at IS NOT NULL OR NEW.consumed_at IS NULL
+    OR orch_capability_ok('resend_consume',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.authorization_id)!=1
+    THEN RAISE(ABORT,'invalid_resend_authorization_consume') END;
+END;
+CREATE TRIGGER resend_authorization_delete_guard BEFORE DELETE ON orch_delivery_resend_authorizations BEGIN SELECT RAISE(ABORT,'resend_authorization_delete_forbidden'); END;
+
+CREATE TRIGGER mutation_log_insert_guard BEFORE INSERT ON orch_mutation_log BEGIN
+  SELECT CASE WHEN orch_capability_ok('mutation_log',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.mutation_digest)!=1
+    THEN RAISE(ABORT,'missing_mutation_log_capability') END;
+END;
+
+WITH RECURSIVE
+seed(task_id) AS (
+  SELECT parent_task_id FROM orch_requests
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT task_id FROM orch_nodes
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT id FROM tasks
+   WHERE orch_board_instance_id=:board AND orch_tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT parent_task_id FROM orch_external_edges
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT child_task_id FROM orch_external_edges
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+),
+closure(task_id) AS (
+  SELECT task_id FROM seed
+  UNION
+  SELECT l.child_id FROM task_links l JOIN closure c ON l.parent_id=c.task_id
+  UNION
+  SELECT l.parent_id FROM task_links l JOIN closure c ON l.child_id=c.task_id
+)
+SELECT task_id FROM closure;

--- a/hermes_cli/orch_v4_schema_sidecar.sql
+++ b/hermes_cli/orch_v4_schema_sidecar.sql
@@ -1,0 +1,1980 @@
+-- Sidecar-local stubs for soft FK targets (bridge enforces real FK at app layer)
+
+CREATE TABLE IF NOT EXISTS _soft_fk_tasks (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    body TEXT,
+    assignee TEXT,
+    status TEXT NOT NULL,
+    priority INTEGER DEFAULT 0,
+    created_by TEXT,
+    created_at INTEGER NOT NULL,
+    started_at INTEGER,
+    completed_at INTEGER,
+    workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+    workspace_path TEXT,
+    claim_lock TEXT,
+    claim_expires INTEGER,
+    tenant TEXT,
+    result TEXT,
+    idempotency_key TEXT,
+    spawn_failures INTEGER NOT NULL DEFAULT 0,
+    worker_pid INTEGER,
+    last_spawn_error TEXT,
+    max_runtime_seconds INTEGER,
+    last_heartbeat_at INTEGER,
+    current_run_id INTEGER,
+    workflow_template_id TEXT,
+    current_step_key TEXT,
+    skills TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    last_failure_error TEXT,
+    max_retries INTEGER,
+    branch_name TEXT,
+    model_override TEXT,
+    session_id TEXT,
+    goal_mode INTEGER NOT NULL DEFAULT 0,
+    goal_max_turns INTEGER,
+    project_id TEXT,
+    block_kind TEXT,
+    block_recurrences INTEGER NOT NULL DEFAULT 0,
+    source_chat TEXT,
+    source_fingerprint TEXT,
+    done_when TEXT,
+    evidence TEXT,
+    human_needed INTEGER NOT NULL DEFAULT 0,
+    next_action TEXT,
+    block_revision INTEGER NOT NULL DEFAULT 0,
+    provider_override TEXT,
+    reasoning_effort TEXT,
+    orch_board_instance_id TEXT,
+    orch_tenant_scope TEXT,
+    orch_id TEXT,
+    orch_plan_version INTEGER,
+    orch_node_key TEXT,
+    orch_binding_revision INTEGER,
+    orch_cancel_epoch INTEGER,
+    created_by_run_id INTEGER,
+    cancellation_requested_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_task_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at INTEGER,
+    ended_at INTEGER,
+    outcome TEXT,
+    outcome_digest TEXT,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_task_links (
+    parent_id TEXT NOT NULL,
+    child_id TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'depends',
+    PRIMARY KEY (parent_id, child_id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_task_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    author TEXT,
+    body TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_task_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_task_intakes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    intake_data TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_task_input_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    request_kind TEXT,
+    status TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_task_review_requirements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    requirement TEXT,
+    met INTEGER DEFAULT 0,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_kanban_notify_subs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    platform TEXT,
+    chat_id TEXT,
+    thread_id TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_kanban_delivery_outbox (
+    input_request_id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    block_revision INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'sending',
+    created_at INTEGER NOT NULL,
+    UNIQUE(task_id, block_revision),
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_lost_and_found (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    found_key TEXT,
+    found_data TEXT,
+    found_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_independent_reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    reviewer TEXT,
+    status TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_independent_review_evidence (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    review_id INTEGER NOT NULL,
+    evidence TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (review_id) REFERENCES _soft_fk_independent_reviews(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_independent_review_cancellations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    review_id INTEGER NOT NULL,
+    reason TEXT,
+    cancelled_at INTEGER NOT NULL,
+    FOREIGN KEY (review_id) REFERENCES _soft_fk_independent_reviews(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_kanban_chief_escalations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    escalated_by TEXT,
+    reason TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE IF NOT EXISTS _soft_fk_task_attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    file_path TEXT,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE kanban_board_identity (
+  singleton INTEGER PRIMARY KEY CHECK (singleton=1),
+  board_instance_id TEXT NOT NULL UNIQUE CHECK (length(board_instance_id) BETWEEN 16 AND 128),
+  canonical_board_key TEXT NOT NULL CHECK (length(canonical_board_key) BETWEEN 1 AND 256),
+  created_at INTEGER NOT NULL CHECK (created_at>0)
+);
+
+CREATE TABLE kanban_schema_migrations (
+  migration_id TEXT PRIMARY KEY,
+  target_schema_version INTEGER NOT NULL UNIQUE CHECK (target_schema_version>0),
+  state TEXT NOT NULL CHECK (state IN ('prepared','applied','verified','failed')),
+  board_instance_id TEXT NOT NULL,
+  source_digest TEXT NOT NULL CHECK (length(source_digest)=64),
+  backup_digest TEXT NOT NULL CHECK (length(backup_digest)=64),
+  receipt_digest TEXT,
+  fence_generation INTEGER NOT NULL CHECK (fence_generation>=0),
+  prepared_at INTEGER NOT NULL,
+  applied_at INTEGER,
+  verified_at INTEGER,
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id),
+  CHECK ((state='verified' AND receipt_digest IS NOT NULL AND length(receipt_digest)=64 AND verified_at IS NOT NULL)
+      OR (state!='verified'))
+);
+
+CREATE TABLE kanban_write_fence (
+  singleton INTEGER PRIMARY KEY CHECK (singleton=1),
+  mode TEXT NOT NULL CHECK (mode IN ('open','draining','fenced')),
+  generation INTEGER NOT NULL CHECK (generation>=0),
+  owner_token_hash TEXT,
+  reason TEXT,
+  updated_at INTEGER NOT NULL,
+  CHECK ((mode='open' AND owner_token_hash IS NULL) OR (mode!='open' AND owner_token_hash IS NOT NULL))
+);
+
+CREATE TABLE kanban_commit_clock (
+  singleton INTEGER PRIMARY KEY CHECK (singleton=1),
+  commit_seq INTEGER NOT NULL CHECK (commit_seq>=0),
+  last_txn_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE kanban_migration_operations (
+  migration_id TEXT PRIMARY KEY,
+  board_instance_id TEXT NOT NULL,
+  owner_token_hash TEXT NOT NULL CHECK (length(owner_token_hash)=64),
+  source_digest TEXT NOT NULL CHECK (length(source_digest)=64),
+  plan_digest TEXT NOT NULL CHECK (length(plan_digest)=64),
+  schema_digest TEXT NOT NULL CHECK (length(schema_digest)=64),
+  backup_digest TEXT,
+  fence_generation INTEGER NOT NULL CHECK (fence_generation>=0),
+  phase TEXT NOT NULL CHECK (phase IN (
+    'prepared','barrier_held','backup_sealed','committed',
+    'receipt_completed','verified','unfenced','failed'
+  )),
+  phase_revision INTEGER NOT NULL CHECK (phase_revision>=0),
+  receipt_digest TEXT,
+  started_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id)
+);
+
+CREATE TABLE orch_rollback_operations (
+  rollback_id TEXT PRIMARY KEY,
+  migration_id TEXT NOT NULL,
+  board_instance_id TEXT NOT NULL,
+  owner_token_hash TEXT NOT NULL CHECK (length(owner_token_hash)=64),
+  source_manifest_digest TEXT NOT NULL CHECK (length(source_manifest_digest)=64),
+  target_manifest_digest TEXT NOT NULL CHECK (length(target_manifest_digest)=64),
+  fence_generation INTEGER NOT NULL CHECK (fence_generation>=0),
+  phase TEXT NOT NULL CHECK (phase IN (
+    'gate_submits','fence_draining','workers_stopped','leases_revoked',
+    'snapshot_sealed','code_switched','old_writer_receipts_verified','verified','reopened','failed'
+  )),
+  phase_revision INTEGER NOT NULL CHECK (phase_revision>=0),
+  snapshot_digest TEXT,
+  started_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (migration_id) REFERENCES kanban_migration_operations(migration_id),
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id)
+);
+
+CREATE TABLE orch_replay_selectors (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  selector_key TEXT NOT NULL CHECK (length(selector_key)=64),
+  selector_kind TEXT NOT NULL CHECK (selector_kind IN ('event','client')),
+  selector_value TEXT NOT NULL CHECK (length(selector_value)>0),
+  adapter_instance_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  lineage_id TEXT NOT NULL,
+  current_generation INTEGER NOT NULL CHECK (current_generation>=0),
+  current_orch_id TEXT,
+  current_request_digest TEXT,
+  ledger_revision INTEGER NOT NULL CHECK (ledger_revision>=0),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,selector_key),
+  UNIQUE (board_instance_id,tenant_scope,adapter_instance_id,conversation_id,selector_kind,selector_value),
+  UNIQUE (board_instance_id,tenant_scope,lineage_id),
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id),
+  CHECK ((current_generation=0 AND current_orch_id IS NULL AND current_request_digest IS NULL)
+      OR (current_generation>0 AND current_orch_id IS NOT NULL AND length(current_request_digest)=64))
+);
+
+CREATE TABLE orch_origins (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  origin_id TEXT NOT NULL,
+  schema_version INTEGER NOT NULL CHECK (schema_version=4),
+  selector_key TEXT NOT NULL CHECK (length(selector_key)=64),
+  origin_kind TEXT NOT NULL CHECK (origin_kind IN ('messaging','api','local_session','board_only')),
+  platform TEXT NOT NULL,
+  adapter_instance_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  selector_kind TEXT NOT NULL CHECK (selector_kind IN ('event','client')),
+  selector_value TEXT NOT NULL CHECK (length(selector_value)>0),
+  client_idempotency_key TEXT,
+  thread_id TEXT NOT NULL,
+  reply_to_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  notifier_profile TEXT NOT NULL,
+  route_revision INTEGER NOT NULL CHECK (route_revision>0),
+  route_json TEXT NOT NULL,
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  required_ack_family TEXT NOT NULL CHECK (required_ack_family IN (
+    'provider','adapter','synchronous','local_session','none'
+  )),
+  required_ack_strength TEXT NOT NULL CHECK (required_ack_strength IN (
+    'provider_message_id','adapter_acceptance','synchronous_response',
+    'local_session_acceptance','none'
+  )),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,origin_id),
+  UNIQUE (board_instance_id,tenant_scope,origin_id,route_revision,route_digest),
+  UNIQUE (board_instance_id,tenant_scope,selector_key,route_revision),
+  FOREIGN KEY (board_instance_id) REFERENCES kanban_board_identity(board_instance_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,selector_key)
+    REFERENCES orch_replay_selectors(board_instance_id,tenant_scope,selector_key),
+  CHECK ((selector_kind='client' AND client_idempotency_key=selector_value)
+      OR selector_kind='event'),
+  CHECK ((origin_kind='board_only' AND required_ack_strength='none') OR
+         (origin_kind!='board_only' AND required_ack_strength!='none')),
+  CHECK ((required_ack_family='provider' AND required_ack_strength='provider_message_id')
+      OR (required_ack_family='adapter' AND required_ack_strength='adapter_acceptance')
+      OR (required_ack_family='synchronous' AND required_ack_strength='synchronous_response')
+      OR (required_ack_family='local_session' AND required_ack_strength='local_session_acceptance')
+      OR (required_ack_family='none' AND required_ack_strength='none'))
+);
+
+CREATE TABLE orch_requests (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  lineage_id TEXT NOT NULL,
+  generation INTEGER NOT NULL CHECK (generation>0),
+  selector_key TEXT NOT NULL CHECK (length(selector_key)=64),
+  selector_ledger_revision INTEGER NOT NULL CHECK (selector_ledger_revision>=0),
+  request_key TEXT NOT NULL CHECK (length(request_key)=64),
+  request_schema_version INTEGER NOT NULL CHECK (request_schema_version=4),
+  request_json TEXT NOT NULL,
+  request_digest TEXT NOT NULL CHECK (length(request_digest)=64),
+  origin_id TEXT NOT NULL,
+  parent_task_id TEXT NOT NULL,
+  lifecycle_state TEXT NOT NULL CHECK (lifecycle_state IN (
+    'submitted','decomposing','waiting_lanes','synthesizing','work_accepted',
+    'delivering','delivery_blocked','blocked','cancelling','completed','failed','cancelled'
+  )),
+  lifecycle_revision INTEGER NOT NULL DEFAULT 0 CHECK (lifecycle_revision>=0),
+  cancel_epoch INTEGER NOT NULL DEFAULT 0 CHECK (cancel_epoch>=0),
+  delivery_epoch_revision INTEGER NOT NULL DEFAULT 0 CHECK (
+    delivery_epoch_revision>=0 AND delivery_epoch_revision<=lifecycle_revision
+  ),
+  plan_epoch_revision INTEGER NOT NULL DEFAULT 0 CHECK (
+    plan_epoch_revision>=0 AND plan_epoch_revision<=lifecycle_revision
+  ),
+  plan_version INTEGER NOT NULL DEFAULT 0 CHECK (plan_version>=0),
+  synthesis_strategy TEXT NOT NULL CHECK (synthesis_strategy IN ('parent_owned','separate_node')),
+  blocked_from_state TEXT,
+  resume_state TEXT,
+  block_kind TEXT,
+  block_revision INTEGER NOT NULL DEFAULT 0 CHECK (block_revision>=0),
+  input_request_id INTEGER,
+  retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count>=0),
+  max_retries INTEGER NOT NULL CHECK (max_retries BETWEEN 0 AND 100),
+  deadline_at INTEGER,
+  work_accepted_at INTEGER,
+  delivery_closed_at INTEGER,
+  terminal_reason_code TEXT,
+  supersedes_orch_id TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id),
+  UNIQUE (board_instance_id,tenant_scope,lineage_id,generation),
+  UNIQUE (board_instance_id,tenant_scope,request_key),
+  UNIQUE (board_instance_id,tenant_scope,parent_task_id),
+  UNIQUE (board_instance_id,tenant_scope,supersedes_orch_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,request_key,request_digest,origin_id,parent_task_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,lineage_id,generation,request_key,
+          request_digest,origin_id,parent_task_id,synthesis_strategy),
+  FOREIGN KEY (board_instance_id,tenant_scope,selector_key)
+    REFERENCES orch_replay_selectors(board_instance_id,tenant_scope,selector_key),
+  FOREIGN KEY (board_instance_id,tenant_scope,origin_id)
+    REFERENCES orch_origins(board_instance_id,tenant_scope,origin_id),
+  FOREIGN KEY (parent_task_id) REFERENCES _soft_fk_tasks(id) DEFERRABLE INITIALLY DEFERRED,
+  FOREIGN KEY (board_instance_id,tenant_scope,supersedes_orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id),
+  CHECK (
+    (lifecycle_state='blocked' AND blocked_from_state IN ('decomposing','waiting_lanes','synthesizing')
+       AND resume_state=blocked_from_state AND block_kind IN ('needs_input','capability','policy','external'))
+    OR
+    (lifecycle_state!='blocked' AND blocked_from_state IS NULL AND resume_state IS NULL AND block_kind IS NULL)
+  ),
+  CHECK ((lifecycle_state IN ('completed','failed','cancelled') AND terminal_reason_code IS NOT NULL)
+      OR (lifecycle_state NOT IN ('completed','failed','cancelled'))),
+  CHECK ((lifecycle_state='completed' AND work_accepted_at IS NOT NULL AND delivery_closed_at IS NOT NULL)
+      OR lifecycle_state!='completed')
+);
+
+CREATE TABLE orch_request_requirements (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  requirement_id TEXT NOT NULL,
+  ordinal INTEGER NOT NULL CHECK (ordinal>0),
+  requirement_json TEXT NOT NULL,
+  requirement_digest TEXT NOT NULL CHECK (length(requirement_digest)=64),
+  required INTEGER NOT NULL CHECK (required IN (0,1)),
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,requirement_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,ordinal),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id)
+);
+
+CREATE TABLE orch_plans (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL CHECK (plan_version>0),
+  schema_version INTEGER NOT NULL CHECK (schema_version=4),
+  lineage_id TEXT NOT NULL,
+  generation INTEGER NOT NULL,
+  request_key TEXT NOT NULL,
+  request_digest TEXT NOT NULL,
+  origin_id TEXT NOT NULL,
+  parent_task_id TEXT NOT NULL,
+  synthesis_strategy TEXT NOT NULL CHECK (synthesis_strategy IN ('parent_owned','separate_node')),
+  plan_json TEXT NOT NULL,
+  plan_digest TEXT NOT NULL CHECK (length(plan_digest)=64),
+  created_by_run_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_digest),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,plan_digest),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,request_digest,plan_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,lineage_id,generation,request_key,
+               request_digest,origin_id,parent_task_id,synthesis_strategy)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id,lineage_id,generation,request_key,
+                             request_digest,origin_id,parent_task_id,synthesis_strategy),
+  CHECK (generation>0)
+);
+
+CREATE TABLE orch_plan_nodes (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  node_key TEXT NOT NULL,
+  lane_lineage_key TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('parent','lane','synthesis')),
+  lane_label TEXT NOT NULL,
+  normalized_goal TEXT NOT NULL,
+  normalized_done_when TEXT NOT NULL,
+  required INTEGER NOT NULL CHECK (required IN (0,1)),
+  route_json TEXT NOT NULL,
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  ordinal INTEGER NOT NULL CHECK (ordinal>0),
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version,node_key),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,ordinal),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,lane_lineage_key),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version)
+    REFERENCES orch_plans(board_instance_id,tenant_scope,orch_id,plan_version),
+  CHECK ((role='lane' AND lane_label!='') OR (role!='lane' AND lane_label='')),
+  CHECK ((role='lane') OR required=1)
+);
+
+CREATE TABLE orch_plan_edges (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  edge_key TEXT NOT NULL,
+  parent_node_key TEXT NOT NULL,
+  child_node_key TEXT NOT NULL,
+  edge_kind TEXT NOT NULL CHECK (edge_kind IN ('orch_required_for_synthesis','orch_optional_context')),
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version,edge_key),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,parent_node_key,child_node_key,edge_kind),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,parent_node_key)
+    REFERENCES orch_plan_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,child_node_key)
+    REFERENCES orch_plan_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key),
+  CHECK (parent_node_key!=child_node_key)
+);
+
+CREATE TABLE orch_plan_coverage (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  requirement_id TEXT NOT NULL,
+  node_key TEXT NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version,requirement_id,node_key),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,requirement_id)
+    REFERENCES orch_request_requirements(board_instance_id,tenant_scope,orch_id,requirement_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,node_key)
+    REFERENCES orch_plan_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key)
+);
+
+CREATE TABLE orch_plan_materializations (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  request_lifecycle_revision INTEGER NOT NULL CHECK (request_lifecycle_revision>=0),
+  cancel_epoch INTEGER NOT NULL CHECK (cancel_epoch>=0),
+  lease_epoch INTEGER NOT NULL CHECK (lease_epoch>0),
+  plan_digest TEXT NOT NULL,
+  observed_graph_digest TEXT NOT NULL CHECK (length(observed_graph_digest)=64),
+  observed_node_count INTEGER NOT NULL CHECK (observed_node_count>=3),
+  observed_edge_count INTEGER NOT NULL CHECK (observed_edge_count>=2),
+  materialized_by_run_id INTEGER NOT NULL,
+  commit_seq INTEGER NOT NULL CHECK (commit_seq>0),
+  materialized_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,plan_version),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,plan_digest)
+    REFERENCES orch_plans(board_instance_id,tenant_scope,orch_id,plan_version,plan_digest)
+);
+
+CREATE TABLE orch_nodes (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  node_key TEXT NOT NULL,
+  task_id TEXT NOT NULL,
+  node_state TEXT NOT NULL CHECK (node_state IN ('planned','ready','running','cancellation_requested','accepted','blocked','failed','cancelled')),
+  current_route_digest TEXT NOT NULL,
+  route_revision INTEGER NOT NULL CHECK (route_revision>0),
+  created_by_run_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,node_key),
+  UNIQUE (board_instance_id,tenant_scope,task_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,node_key)
+    REFERENCES orch_plan_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key),
+  FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE orch_external_edges (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  edge_key TEXT NOT NULL,
+  parent_task_id TEXT NOT NULL,
+  child_task_id TEXT NOT NULL,
+  edge_kind TEXT NOT NULL CHECK (edge_kind='orch_work_accepted'),
+  lifecycle_revision INTEGER NOT NULL,
+  created_by_run_id INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,edge_key),
+  UNIQUE (board_instance_id,tenant_scope,parent_task_id,child_task_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id),
+  FOREIGN KEY (parent_task_id) REFERENCES _soft_fk_tasks(id),
+  FOREIGN KEY (child_task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE orch_node_acceptances (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  node_key TEXT NOT NULL,
+  task_id TEXT NOT NULL,
+  accepted_run_id INTEGER NOT NULL,
+  outcome_digest TEXT NOT NULL CHECK (length(outcome_digest)=64),
+  accepted_by_run_id INTEGER NOT NULL,
+  acceptance_lease_epoch INTEGER NOT NULL CHECK (acceptance_lease_epoch>0),
+  plan_epoch_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  accepted_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,node_key),
+  UNIQUE (board_instance_id,tenant_scope,accepted_run_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id)
+    REFERENCES orch_nodes(board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id),
+  FOREIGN KEY (accepted_run_id) REFERENCES _soft_fk_task_runs(id),
+  FOREIGN KEY (task_id) REFERENCES _soft_fk_tasks(id)
+);
+
+CREATE TABLE orch_stage_leases (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  stage TEXT NOT NULL CHECK (stage IN ('decomposition','synthesis','reconciliation')),
+  owner_run_id INTEGER NOT NULL,
+  owner_profile TEXT NOT NULL,
+  token_hash TEXT NOT NULL CHECK (length(token_hash)=64),
+  epoch INTEGER NOT NULL CHECK (epoch>0),
+  expires_at INTEGER NOT NULL,
+  lease_state TEXT NOT NULL CHECK (lease_state IN ('active','released','revoked')),
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,stage),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id)
+);
+
+CREATE TABLE orch_stage_attempts (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  stage TEXT NOT NULL CHECK (stage IN ('decomposition','synthesis')),
+  attempt_no INTEGER NOT NULL CHECK (attempt_no>0),
+  owner_run_id INTEGER NOT NULL,
+  lease_epoch INTEGER NOT NULL CHECK (lease_epoch>0),
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL CHECK (cancel_epoch>=0),
+  attempt_state TEXT NOT NULL CHECK (attempt_state IN ('running','completed','blocked','failed','timed_out','cancelled')),
+  started_at INTEGER NOT NULL,
+  ended_at INTEGER,
+  outcome_code TEXT,
+  attempt_digest TEXT NOT NULL CHECK (length(attempt_digest)=64),
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,stage,attempt_no),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,stage,attempt_no,owner_run_id,
+          lease_epoch,lifecycle_revision,cancel_epoch),
+  UNIQUE (board_instance_id,tenant_scope,owner_run_id,stage),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,stage)
+    REFERENCES orch_stage_leases(board_instance_id,tenant_scope,orch_id,stage),
+  CHECK ((attempt_state='running' AND ended_at IS NULL) OR
+         (attempt_state!='running' AND ended_at IS NOT NULL AND ended_at>=started_at))
+);
+
+CREATE TABLE orch_results (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  result_id TEXT NOT NULL,
+  request_digest TEXT NOT NULL,
+  plan_digest TEXT NOT NULL,
+  producer_stage TEXT NOT NULL CHECK (producer_stage='synthesis'),
+  producer_attempt_no INTEGER NOT NULL CHECK (producer_attempt_no>0),
+  producer_run_id INTEGER NOT NULL,
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL CHECK (cancel_epoch>=0),
+  synthesis_epoch INTEGER NOT NULL CHECK (synthesis_epoch>0),
+  accepted_lane_set_digest TEXT NOT NULL CHECK (length(accepted_lane_set_digest)=64),
+  result_json TEXT NOT NULL,
+  result_digest TEXT NOT NULL CHECK (length(result_digest)=64),
+  accepted_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,result_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,result_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,plan_version,result_id,result_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,request_digest,plan_digest)
+    REFERENCES orch_plans(board_instance_id,tenant_scope,orch_id,plan_version,request_digest,plan_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,producer_stage,producer_attempt_no,
+               producer_run_id,synthesis_epoch,lifecycle_revision,cancel_epoch)
+    REFERENCES orch_stage_attempts(board_instance_id,tenant_scope,orch_id,stage,attempt_no,
+                                   owner_run_id,lease_epoch,lifecycle_revision,cancel_epoch)
+);
+
+CREATE TABLE orch_delivery_manifests (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  result_id TEXT NOT NULL,
+  manifest_digest TEXT NOT NULL CHECK (length(manifest_digest)=64),
+  expected_required_count INTEGER NOT NULL CHECK (expected_required_count>=0),
+  expected_optional_count INTEGER NOT NULL CHECK (expected_optional_count>=0),
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,orch_id,result_id),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,result_id,manifest_digest),
+  UNIQUE (board_instance_id,tenant_scope,manifest_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,result_id)
+    REFERENCES orch_results(board_instance_id,tenant_scope,orch_id,plan_version,result_id)
+);
+
+CREATE TABLE orch_delivery_obligations (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  plan_version INTEGER NOT NULL,
+  result_id TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  manifest_digest TEXT NOT NULL CHECK (length(manifest_digest)=64),
+  manifest_entry_key TEXT NOT NULL CHECK (length(manifest_entry_key)=64),
+  delivery_generation INTEGER NOT NULL CHECK (delivery_generation>0),
+  supersedes_obligation_id TEXT,
+  delivery_key TEXT NOT NULL CHECK (length(delivery_key)=64),
+  result_digest TEXT NOT NULL,
+  origin_id TEXT NOT NULL,
+  route_revision INTEGER NOT NULL CHECK (route_revision>0),
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  origin_kind TEXT NOT NULL CHECK (origin_kind IN ('messaging','api','local_session','board_only')),
+  platform TEXT NOT NULL,
+  adapter_instance_id TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  conversation_id TEXT NOT NULL,
+  thread_id TEXT NOT NULL,
+  reply_to_id TEXT NOT NULL,
+  required INTEGER NOT NULL CHECK (required IN (0,1)),
+  required_ack_family TEXT NOT NULL CHECK (required_ack_family IN (
+    'provider','adapter','synchronous','local_session','none'
+  )),
+  required_ack_strength TEXT NOT NULL CHECK (required_ack_strength IN (
+    'provider_message_id','adapter_acceptance','synchronous_response',
+    'local_session_acceptance','none'
+  )),
+  state TEXT NOT NULL CHECK (state IN ('pending','claimed','accepted','acked','unknown','dead_letter','cancelled')),
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  claim_owner TEXT,
+  claim_token_hash TEXT,
+  claim_epoch INTEGER NOT NULL DEFAULT 0 CHECK (claim_epoch>=0),
+  claim_expires_at INTEGER,
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts>=0),
+  max_attempts INTEGER NOT NULL CHECK (max_attempts BETWEEN 1 AND 100),
+  available_at INTEGER NOT NULL,
+  acceptance_attempt_id TEXT,
+  adapter_accepted_at INTEGER,
+  acked_at INTEGER,
+  provider_id TEXT,
+  provider_message_id TEXT,
+  duplicate_possible INTEGER NOT NULL DEFAULT 0 CHECK (duplicate_possible IN (0,1)),
+  unknown_attempt_id TEXT,
+  ambiguity_deadline INTEGER,
+  resend_authorized_at INTEGER,
+  resend_authorized_by TEXT,
+  resend_authorized_revision INTEGER,
+  last_error_code TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,obligation_id),
+  UNIQUE (board_instance_id,tenant_scope,delivery_key),
+  UNIQUE (board_instance_id,tenant_scope,manifest_entry_key,delivery_generation),
+  UNIQUE (board_instance_id,tenant_scope,supersedes_obligation_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,result_id,manifest_digest)
+    REFERENCES orch_delivery_manifests(board_instance_id,tenant_scope,orch_id,result_id,manifest_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,plan_version,result_id,result_digest)
+    REFERENCES orch_results(board_instance_id,tenant_scope,orch_id,plan_version,result_id,result_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,origin_id,route_revision,route_digest)
+    REFERENCES orch_origins(board_instance_id,tenant_scope,origin_id,route_revision,route_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,supersedes_obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id),
+  CHECK ((origin_kind='board_only' AND required=0 AND required_ack_strength='none') OR
+         (origin_kind!='board_only' AND required_ack_strength!='none')),
+  CHECK ((state='acked' AND acked_at IS NOT NULL) OR state!='acked'),
+  CHECK ((state IN ('claimed','accepted') AND claim_epoch>0) OR state NOT IN ('claimed','accepted')),
+  CHECK ((state='unknown' AND unknown_attempt_id IS NOT NULL AND ambiguity_deadline IS NOT NULL)
+      OR state!='unknown'),
+  CHECK ((required_ack_family='provider' AND required_ack_strength='provider_message_id')
+      OR (required_ack_family='adapter' AND required_ack_strength='adapter_acceptance')
+      OR (required_ack_family='synchronous' AND required_ack_strength='synchronous_response')
+      OR (required_ack_family='local_session' AND required_ack_strength='local_session_acceptance')
+      OR (required_ack_family='none' AND required_ack_strength='none'))
+);
+
+CREATE TABLE orch_delivery_manifest_entries (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  result_id TEXT NOT NULL,
+  manifest_digest TEXT NOT NULL,
+  manifest_entry_key TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  required INTEGER NOT NULL CHECK (required IN (0,1)),
+  required_ack_family TEXT NOT NULL,
+  required_ack_strength TEXT NOT NULL,
+  route_digest TEXT NOT NULL,
+  ordinal INTEGER NOT NULL CHECK (ordinal>0),
+  PRIMARY KEY (board_instance_id,tenant_scope,manifest_entry_key),
+  UNIQUE (board_instance_id,tenant_scope,orch_id,result_id,ordinal),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id,result_id,manifest_digest)
+    REFERENCES orch_delivery_manifests(board_instance_id,tenant_scope,orch_id,result_id,manifest_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id)
+);
+
+CREATE TABLE orch_delivery_attempts (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  claim_epoch INTEGER NOT NULL CHECK (claim_epoch>0),
+  claim_owner TEXT NOT NULL,
+  claim_token_hash TEXT NOT NULL CHECK (length(claim_token_hash)=64),
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  send_nonce TEXT NOT NULL,
+  payload_digest TEXT NOT NULL CHECK (length(payload_digest)=64),
+  result_digest TEXT NOT NULL CHECK (length(result_digest)=64),
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  attempt_state TEXT NOT NULL CHECK (attempt_state IN ('started','adapter_accepted','rejected','unknown')),
+  started_at INTEGER NOT NULL,
+  finished_at INTEGER,
+  adapter_evidence_json TEXT,
+  adapter_evidence_digest TEXT,
+  error_code TEXT,
+  PRIMARY KEY (board_instance_id,tenant_scope,attempt_id),
+  UNIQUE (board_instance_id,tenant_scope,obligation_id,claim_epoch),
+  FOREIGN KEY (board_instance_id,tenant_scope,obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id),
+  CHECK ((attempt_state='started' AND finished_at IS NULL) OR
+         (attempt_state!='started' AND finished_at IS NOT NULL))
+);
+
+CREATE TABLE orch_delivery_attempt_events (
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  transition_seq INTEGER NOT NULL CHECK (transition_seq>0),
+  from_state TEXT,
+  to_state TEXT NOT NULL CHECK (to_state IN ('started','adapter_accepted','rejected','unknown')),
+  event_kind TEXT NOT NULL CHECK (event_kind IN ('started','adapter_accepted','rejected','unknown')),
+  event_json TEXT NOT NULL,
+  event_digest TEXT NOT NULL CHECK (length(event_digest)=64),
+  created_at INTEGER NOT NULL,
+  UNIQUE (board_instance_id,tenant_scope,attempt_id,transition_seq),
+  UNIQUE (board_instance_id,tenant_scope,attempt_id,event_kind,event_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,attempt_id)
+    REFERENCES orch_delivery_attempts(board_instance_id,tenant_scope,attempt_id)
+);
+
+CREATE TABLE orch_delivery_receipts (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  receipt_id TEXT NOT NULL,
+  observed_ack_family TEXT NOT NULL CHECK (observed_ack_family IN (
+    'provider','adapter','synchronous','local_session'
+  )),
+  observed_ack_strength TEXT NOT NULL CHECK (observed_ack_strength IN (
+    'provider_message_id','adapter_acceptance','synchronous_response','local_session_acceptance'
+  )),
+  receipt_json TEXT NOT NULL,
+  receipt_digest TEXT NOT NULL CHECK (length(receipt_digest)=64),
+  send_nonce TEXT NOT NULL,
+  payload_digest TEXT NOT NULL CHECK (length(payload_digest)=64),
+  result_digest TEXT NOT NULL CHECK (length(result_digest)=64),
+  route_digest TEXT NOT NULL CHECK (length(route_digest)=64),
+  verified INTEGER NOT NULL CHECK (verified=1),
+  provider_id TEXT,
+  provider_message_id TEXT,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,receipt_id),
+  UNIQUE (board_instance_id,tenant_scope,obligation_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,attempt_id)
+    REFERENCES orch_delivery_attempts(board_instance_id,tenant_scope,attempt_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id),
+  CHECK ((observed_ack_family='provider' AND observed_ack_strength='provider_message_id'
+          AND provider_id IS NOT NULL AND provider_message_id IS NOT NULL)
+      OR (observed_ack_family='adapter' AND observed_ack_strength='adapter_acceptance')
+      OR (observed_ack_family='synchronous' AND observed_ack_strength='synchronous_response')
+      OR (observed_ack_family='local_session' AND observed_ack_strength='local_session_acceptance'))
+);
+
+CREATE TABLE orch_events (
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  commit_seq INTEGER NOT NULL CHECK (commit_seq>0),
+  event_kind TEXT NOT NULL CHECK (event_kind IN (
+    'request_transition','node_transition','plan_materialized','result_accepted',
+    'delivery_transition','cancellation_transition','dependency_released'
+  )),
+  target_key TEXT NOT NULL,
+  event_key TEXT NOT NULL CHECK (length(event_key)=64),
+  payload_json TEXT NOT NULL,
+  payload_digest TEXT NOT NULL CHECK (length(payload_digest)=64),
+  created_at INTEGER NOT NULL,
+  UNIQUE (board_instance_id,tenant_scope,event_key),
+  UNIQUE (board_instance_id,tenant_scope,event_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id)
+);
+
+CREATE TABLE orch_reconcile_queue (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  event_id INTEGER NOT NULL,
+  consumer_kind TEXT NOT NULL CHECK (consumer_kind IN ('lifecycle','delivery','dependency','cancellation')),
+  state TEXT NOT NULL CHECK (state IN ('pending','claimed','done','dead_letter')),
+  claim_owner TEXT,
+  claim_token_hash TEXT,
+  claim_epoch INTEGER NOT NULL DEFAULT 0 CHECK (claim_epoch>=0),
+  claim_expires_at INTEGER,
+  available_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts>=0),
+  max_attempts INTEGER NOT NULL CHECK (max_attempts BETWEEN 1 AND 100),
+  last_error_code TEXT,
+  done_effect_digest TEXT,
+  PRIMARY KEY (board_instance_id,tenant_scope,event_id,consumer_kind),
+  FOREIGN KEY (board_instance_id,tenant_scope,event_id)
+    REFERENCES orch_events(board_instance_id,tenant_scope,event_id),
+  CHECK ((state='claimed' AND claim_owner IS NOT NULL AND claim_token_hash IS NOT NULL AND claim_epoch>0)
+      OR (state!='claimed')),
+  CHECK ((state='done' AND length(done_effect_digest)=64) OR state!='done')
+);
+
+CREATE TABLE orch_effect_ledger (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  event_id INTEGER NOT NULL,
+  consumer_kind TEXT NOT NULL,
+  target_key TEXT NOT NULL,
+  target_revision INTEGER NOT NULL,
+  effect_digest TEXT NOT NULL CHECK (length(effect_digest)=64),
+  applied_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,event_id,consumer_kind),
+  UNIQUE (board_instance_id,tenant_scope,consumer_kind,target_key,target_revision),
+  FOREIGN KEY (board_instance_id,tenant_scope,event_id,consumer_kind)
+    REFERENCES orch_reconcile_queue(board_instance_id,tenant_scope,event_id,consumer_kind)
+);
+
+CREATE TABLE orch_delivery_resend_authorizations (
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  authorization_id TEXT NOT NULL,
+  obligation_id TEXT NOT NULL,
+  unknown_attempt_id TEXT NOT NULL,
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  capability_digest TEXT NOT NULL CHECK (length(capability_digest)=64),
+  authorized_by TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  consumed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (board_instance_id,tenant_scope,authorization_id),
+  UNIQUE (board_instance_id,tenant_scope,obligation_id,unknown_attempt_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,obligation_id)
+    REFERENCES orch_delivery_obligations(board_instance_id,tenant_scope,obligation_id),
+  FOREIGN KEY (board_instance_id,tenant_scope,unknown_attempt_id)
+    REFERENCES orch_delivery_attempts(board_instance_id,tenant_scope,attempt_id)
+);
+
+CREATE TABLE orch_mutation_log (
+  mutation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  board_instance_id TEXT NOT NULL,
+  tenant_scope TEXT NOT NULL,
+  orch_id TEXT NOT NULL,
+  stage TEXT NOT NULL,
+  owner_run_id INTEGER NOT NULL,
+  owner_profile TEXT NOT NULL,
+  lease_epoch INTEGER NOT NULL,
+  lifecycle_revision INTEGER NOT NULL,
+  cancel_epoch INTEGER NOT NULL,
+  capability_digest TEXT NOT NULL CHECK (length(capability_digest)=64),
+  commit_seq INTEGER NOT NULL CHECK (commit_seq>0),
+  mutation_kind TEXT NOT NULL,
+  target_key TEXT NOT NULL,
+  mutation_digest TEXT NOT NULL CHECK (length(mutation_digest)=64),
+  created_at INTEGER NOT NULL,
+  UNIQUE (board_instance_id,tenant_scope,orch_id,mutation_kind,target_key,mutation_digest),
+  FOREIGN KEY (board_instance_id,tenant_scope,orch_id)
+    REFERENCES orch_requests(board_instance_id,tenant_scope,orch_id)
+);
+
+CREATE TRIGGER immutable_orch_origins_u BEFORE UPDATE ON orch_origins BEGIN SELECT RAISE(ABORT,'immutable_orch_origin'); END;
+CREATE TRIGGER immutable_orch_origins_d BEFORE DELETE ON orch_origins BEGIN SELECT RAISE(ABORT,'immutable_orch_origin'); END;
+CREATE TRIGGER immutable_orch_requirements_u BEFORE UPDATE ON orch_request_requirements BEGIN SELECT RAISE(ABORT,'immutable_orch_requirement'); END;
+CREATE TRIGGER immutable_orch_requirements_d BEFORE DELETE ON orch_request_requirements BEGIN SELECT RAISE(ABORT,'immutable_orch_requirement'); END;
+CREATE TRIGGER immutable_orch_plans_u BEFORE UPDATE ON orch_plans BEGIN SELECT RAISE(ABORT,'immutable_orch_plan'); END;
+CREATE TRIGGER immutable_orch_plans_d BEFORE DELETE ON orch_plans BEGIN SELECT RAISE(ABORT,'immutable_orch_plan'); END;
+CREATE TRIGGER immutable_orch_plan_nodes_u BEFORE UPDATE ON orch_plan_nodes BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_node'); END;
+CREATE TRIGGER immutable_orch_plan_nodes_d BEFORE DELETE ON orch_plan_nodes BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_node'); END;
+CREATE TRIGGER immutable_orch_plan_edges_u BEFORE UPDATE ON orch_plan_edges BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_edge'); END;
+CREATE TRIGGER immutable_orch_plan_edges_d BEFORE DELETE ON orch_plan_edges BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_edge'); END;
+CREATE TRIGGER immutable_orch_plan_coverage_u BEFORE UPDATE ON orch_plan_coverage BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_coverage'); END;
+CREATE TRIGGER immutable_orch_plan_coverage_d BEFORE DELETE ON orch_plan_coverage BEGIN SELECT RAISE(ABORT,'immutable_orch_plan_coverage'); END;
+CREATE TRIGGER immutable_orch_materialization_u BEFORE UPDATE ON orch_plan_materializations BEGIN SELECT RAISE(ABORT,'immutable_orch_materialization'); END;
+CREATE TRIGGER immutable_orch_materialization_d BEFORE DELETE ON orch_plan_materializations BEGIN SELECT RAISE(ABORT,'immutable_orch_materialization'); END;
+CREATE TRIGGER immutable_orch_acceptance_u BEFORE UPDATE ON orch_node_acceptances BEGIN SELECT RAISE(ABORT,'immutable_orch_acceptance'); END;
+CREATE TRIGGER immutable_orch_acceptance_d BEFORE DELETE ON orch_node_acceptances BEGIN SELECT RAISE(ABORT,'immutable_orch_acceptance'); END;
+CREATE TRIGGER immutable_orch_result_u BEFORE UPDATE ON orch_results BEGIN SELECT RAISE(ABORT,'immutable_orch_result'); END;
+CREATE TRIGGER immutable_orch_result_d BEFORE DELETE ON orch_results BEGIN SELECT RAISE(ABORT,'immutable_orch_result'); END;
+CREATE TRIGGER immutable_orch_delivery_attempt_event_u BEFORE UPDATE ON orch_delivery_attempt_events BEGIN SELECT RAISE(ABORT,'immutable_orch_delivery_attempt_event'); END;
+CREATE TRIGGER immutable_orch_delivery_attempt_event_d BEFORE DELETE ON orch_delivery_attempt_events BEGIN SELECT RAISE(ABORT,'immutable_orch_delivery_attempt_event'); END;
+CREATE TRIGGER immutable_orch_delivery_receipt_u BEFORE UPDATE ON orch_delivery_receipts BEGIN SELECT RAISE(ABORT,'immutable_orch_delivery_receipt'); END;
+CREATE TRIGGER immutable_orch_delivery_receipt_d BEFORE DELETE ON orch_delivery_receipts BEGIN SELECT RAISE(ABORT,'immutable_orch_delivery_receipt'); END;
+CREATE TRIGGER immutable_orch_event_u BEFORE UPDATE ON orch_events BEGIN SELECT RAISE(ABORT,'immutable_orch_event'); END;
+CREATE TRIGGER immutable_orch_event_d BEFORE DELETE ON orch_events BEGIN SELECT RAISE(ABORT,'immutable_orch_event'); END;
+CREATE TRIGGER immutable_orch_mutation_log_u BEFORE UPDATE ON orch_mutation_log BEGIN SELECT RAISE(ABORT,'immutable_orch_mutation_log'); END;
+CREATE TRIGGER immutable_orch_mutation_log_d BEFORE DELETE ON orch_mutation_log BEGIN SELECT RAISE(ABORT,'immutable_orch_mutation_log'); END;
+
+CREATE TRIGGER orch_event_insert_guard BEFORE INSERT ON orch_events
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'event_insert',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.lifecycle_revision,NEW.cancel_epoch,NEW.event_key
+  )!=1 OR NOT EXISTS (
+    SELECT 1 FROM orch_requests r JOIN kanban_commit_clock c ON c.singleton=1
+     WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope
+       AND r.orch_id=NEW.orch_id AND r.lifecycle_revision=NEW.lifecycle_revision
+       AND r.cancel_epoch=NEW.cancel_epoch AND c.commit_seq=NEW.commit_seq
+  ) THEN RAISE(ABORT,'stale_or_forged_orch_event') END;
+END;
+CREATE TRIGGER orch_queue_insert_guard BEFORE INSERT ON orch_reconcile_queue
+BEGIN
+  SELECT CASE WHEN NEW.state!='pending' OR orch_capability_ok(
+    'queue_fanout',NEW.board_instance_id,NEW.tenant_scope,CAST(NEW.event_id AS TEXT),
+    0,0,NEW.consumer_kind
+  )!=1 THEN RAISE(ABORT,'forged_reconcile_queue_row') END;
+END;
+CREATE TRIGGER orch_effect_insert_guard BEFORE INSERT ON orch_effect_ledger
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'effect_apply',NEW.board_instance_id,NEW.tenant_scope,CAST(NEW.event_id AS TEXT),
+    NEW.target_revision,0,NEW.effect_digest
+  )!=1 THEN RAISE(ABORT,'forged_effect_ledger_row') END;
+END;
+
+CREATE TRIGGER orch_materialization_authority_guard BEFORE INSERT ON orch_plan_materializations
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'materialize',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.request_lifecycle_revision,NEW.cancel_epoch,NEW.observed_graph_digest
+  )!=1 THEN RAISE(ABORT,'missing_materialization_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_requests r
+    JOIN orch_plans p
+      ON p.board_instance_id=r.board_instance_id AND p.tenant_scope=r.tenant_scope
+     AND p.orch_id=r.orch_id AND p.plan_version=NEW.plan_version
+    JOIN orch_stage_leases l
+      ON l.board_instance_id=r.board_instance_id AND l.tenant_scope=r.tenant_scope
+     AND l.orch_id=r.orch_id AND l.stage='decomposition'
+    JOIN kanban_commit_clock c ON c.singleton=1
+    WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope
+      AND r.orch_id=NEW.orch_id AND r.lifecycle_state='decomposing'
+      AND r.plan_version+1=NEW.plan_version
+      AND r.lifecycle_revision=NEW.request_lifecycle_revision
+      AND r.cancel_epoch=NEW.cancel_epoch
+      AND p.plan_digest=NEW.plan_digest
+      AND l.owner_run_id=NEW.materialized_by_run_id AND l.epoch=NEW.lease_epoch
+      AND l.lease_state='active' AND l.expires_at>unixepoch('now')
+      AND c.commit_seq=NEW.commit_seq
+      AND NEW.observed_node_count=(SELECT count(*) FROM orch_nodes n
+        WHERE n.board_instance_id=NEW.board_instance_id AND n.tenant_scope=NEW.tenant_scope
+          AND n.orch_id=NEW.orch_id AND n.plan_version=NEW.plan_version)
+      AND NEW.observed_edge_count=(SELECT count(*) FROM _soft_fk_task_links x
+        WHERE x.orch_board_instance_id=NEW.board_instance_id
+          AND x.orch_tenant_scope=NEW.tenant_scope AND x.orch_id=NEW.orch_id
+          AND x.orch_plan_version=NEW.plan_version)
+  ) THEN RAISE(ABORT,'invalid_materialization_provenance') END;
+END;
+
+CREATE TRIGGER tasks_orch_binding_insert BEFORE INSERT ON _soft_fk_tasks
+WHEN NEW.orch_board_instance_id IS NOT NULL OR NEW.orch_tenant_scope IS NOT NULL
+  OR NEW.orch_id IS NOT NULL OR NEW.orch_plan_version IS NOT NULL
+  OR NEW.orch_node_key IS NOT NULL OR NEW.orch_binding_revision IS NOT NULL
+  OR NEW.orch_cancel_epoch IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NEW.orch_board_instance_id IS NULL OR NEW.orch_tenant_scope IS NULL
+    OR NEW.orch_id IS NULL OR NEW.orch_plan_version IS NULL OR NEW.orch_node_key IS NULL
+    OR NEW.orch_binding_revision IS NULL OR NEW.orch_cancel_epoch IS NULL
+    THEN RAISE(ABORT,'partial_orch_task_binding') END;
+  SELECT CASE WHEN orch_capability_ok(
+      'task_bind',NEW.orch_board_instance_id,NEW.orch_tenant_scope,NEW.orch_id,
+      NEW.orch_binding_revision,NEW.orch_cancel_epoch,NEW.id
+    )!=1 THEN RAISE(ABORT,'missing_task_bind_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_requests r
+     WHERE r.board_instance_id=NEW.orch_board_instance_id
+       AND r.tenant_scope=NEW.orch_tenant_scope AND r.orch_id=NEW.orch_id
+       AND r.parent_task_id=NEW.id AND NEW.orch_node_key='__parent__'
+       AND NEW.orch_plan_version=r.plan_version
+       AND r.lifecycle_revision=NEW.orch_binding_revision
+       AND r.cancel_epoch=NEW.orch_cancel_epoch
+    UNION ALL
+    SELECT 1 FROM orch_nodes n JOIN orch_requests r
+      ON r.board_instance_id=n.board_instance_id AND r.tenant_scope=n.tenant_scope
+     AND r.orch_id=n.orch_id
+     WHERE n.board_instance_id=NEW.orch_board_instance_id
+       AND n.tenant_scope=NEW.orch_tenant_scope AND n.orch_id=NEW.orch_id
+       AND n.plan_version=NEW.orch_plan_version AND n.node_key=NEW.orch_node_key
+       AND n.task_id=NEW.id AND r.lifecycle_revision=NEW.orch_binding_revision
+       AND r.cancel_epoch=NEW.orch_cancel_epoch
+  ) THEN RAISE(ABORT,'invalid_orch_task_scope') END;
+END;
+
+CREATE TRIGGER tasks_orch_binding_update BEFORE UPDATE OF
+  orch_board_instance_id,orch_tenant_scope,orch_id,orch_plan_version,
+  orch_node_key,orch_binding_revision,orch_cancel_epoch ON _soft_fk_tasks
+WHEN OLD.orch_id IS NOT NULL OR NEW.orch_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT (
+    (NEW.orch_board_instance_id IS OLD.orch_board_instance_id
+      AND NEW.orch_tenant_scope IS OLD.orch_tenant_scope
+      AND NEW.orch_id IS OLD.orch_id
+      AND NEW.orch_plan_version IS OLD.orch_plan_version
+      AND NEW.orch_node_key IS OLD.orch_node_key
+      AND NEW.orch_binding_revision IS OLD.orch_binding_revision
+      AND NEW.orch_cancel_epoch IS OLD.orch_cancel_epoch)
+    OR
+    (OLD.orch_board_instance_id IS NULL AND OLD.orch_tenant_scope IS NULL
+      AND OLD.orch_id IS NULL AND OLD.orch_plan_version IS NULL
+      AND OLD.orch_node_key IS NULL AND OLD.orch_binding_revision IS NULL
+      AND OLD.orch_cancel_epoch IS NULL
+      AND NEW.orch_node_key='__parent__'
+      AND EXISTS (SELECT 1 FROM orch_requests r
+        WHERE r.board_instance_id=NEW.orch_board_instance_id
+          AND r.tenant_scope=NEW.orch_tenant_scope AND r.orch_id=NEW.orch_id
+          AND r.parent_task_id=NEW.id AND r.plan_version=NEW.orch_plan_version
+          AND r.lifecycle_revision=NEW.orch_binding_revision
+          AND r.cancel_epoch=NEW.orch_cancel_epoch)
+      AND orch_capability_ok('task_bind',NEW.orch_board_instance_id,NEW.orch_tenant_scope,NEW.orch_id,
+        NEW.orch_binding_revision,NEW.orch_cancel_epoch,NEW.id)=1)
+    OR
+    (NEW.orch_board_instance_id IS NULL AND NEW.orch_tenant_scope IS NULL
+      AND NEW.orch_id IS NULL AND NEW.orch_plan_version IS NULL
+      AND NEW.orch_node_key IS NULL AND NEW.orch_binding_revision IS NULL
+      AND NEW.orch_cancel_epoch IS NULL
+      AND EXISTS (SELECT 1 FROM orch_requests r
+        WHERE r.board_instance_id=OLD.orch_board_instance_id
+          AND r.tenant_scope=OLD.orch_tenant_scope AND r.orch_id=OLD.orch_id
+          AND r.lifecycle_state IN ('cancelling','cancelled'))
+      AND orch_capability_ok(
+        'task_retire',OLD.orch_board_instance_id,OLD.orch_tenant_scope,OLD.orch_id,
+        COALESCE((SELECT lifecycle_revision FROM orch_requests r
+          WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+            AND r.orch_id=OLD.orch_id),-1),
+        COALESCE((SELECT cancel_epoch FROM orch_requests r
+          WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+            AND r.orch_id=OLD.orch_id),-1),OLD.id)=1)
+  ) THEN RAISE(ABORT,'immutable_orch_task_binding') END;
+END;
+
+CREATE TRIGGER orch_acceptance_run_guard BEFORE INSERT ON orch_node_acceptances
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'accept_lane',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.plan_epoch_revision,NEW.cancel_epoch,CAST(NEW.accepted_run_id AS TEXT)
+  )!=1 THEN RAISE(ABORT,'missing_acceptance_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+      FROM orch_nodes n
+      JOIN orch_plan_nodes pn
+        ON pn.board_instance_id=n.board_instance_id AND pn.tenant_scope=n.tenant_scope
+       AND pn.orch_id=n.orch_id AND pn.plan_version=n.plan_version AND pn.node_key=n.node_key
+      JOIN _soft_fk_task_runs tr ON tr.id=NEW.accepted_run_id AND tr.task_id=n.task_id
+      JOIN orch_requests r
+        ON r.board_instance_id=n.board_instance_id AND r.tenant_scope=n.tenant_scope AND r.orch_id=n.orch_id
+      JOIN orch_stage_leases l
+        ON l.board_instance_id=r.board_instance_id AND l.tenant_scope=r.tenant_scope
+       AND l.orch_id=r.orch_id AND l.stage='reconciliation'
+     WHERE n.board_instance_id=NEW.board_instance_id
+       AND n.tenant_scope=NEW.tenant_scope AND n.orch_id=NEW.orch_id
+       AND n.plan_version=NEW.plan_version AND n.node_key=NEW.node_key AND n.task_id=NEW.task_id
+       AND pn.role='lane' AND pn.required=1
+       AND r.plan_version=NEW.plan_version AND r.lifecycle_state='waiting_lanes'
+       AND r.plan_epoch_revision=NEW.plan_epoch_revision AND r.cancel_epoch=NEW.cancel_epoch
+       AND l.owner_run_id=NEW.accepted_by_run_id AND l.epoch=NEW.acceptance_lease_epoch
+       AND l.lease_state='active' AND l.expires_at>unixepoch('now')
+       AND tr.status='done' AND tr.outcome='completed'
+       AND tr.started_at IS NOT NULL AND tr.ended_at IS NOT NULL
+       AND tr.ended_at>=tr.started_at AND tr.outcome_digest=NEW.outcome_digest
+       AND tr.cancellation_epoch=NEW.cancel_epoch
+  ) THEN RAISE(ABORT,'invalid_accepted_run_binding') END;
+END;
+
+CREATE TRIGGER task_links_orch_guard BEFORE INSERT ON _soft_fk_task_links
+WHEN EXISTS (SELECT 1 FROM _soft_fk_tasks t WHERE t.id IN (NEW.parent_id,NEW.child_id) AND t.orch_id IS NOT NULL)
+BEGIN
+  SELECT CASE WHEN NEW.orch_board_instance_id IS NULL OR NEW.orch_tenant_scope IS NULL
+    OR NEW.orch_id IS NULL OR NEW.orch_plan_version IS NULL OR NEW.orch_edge_key IS NULL
+    OR NEW.orch_binding_revision IS NULL OR NEW.orch_cancel_epoch IS NULL
+    THEN RAISE(ABORT,'unregistered_orch_link') END;
+  SELECT CASE WHEN orch_capability_ok(
+    'link_bind',NEW.orch_board_instance_id,NEW.orch_tenant_scope,NEW.orch_id,
+    NEW.orch_binding_revision,NEW.orch_cancel_epoch,NEW.orch_edge_key
+  )!=1 THEN RAISE(ABORT,'missing_link_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1
+      FROM orch_plan_edges e
+      JOIN orch_nodes p
+        ON p.board_instance_id=e.board_instance_id AND p.tenant_scope=e.tenant_scope
+       AND p.orch_id=e.orch_id AND p.plan_version=e.plan_version
+       AND p.node_key=e.parent_node_key AND p.task_id=NEW.parent_id
+      JOIN orch_nodes c
+        ON c.board_instance_id=e.board_instance_id AND c.tenant_scope=e.tenant_scope
+       AND c.orch_id=e.orch_id AND c.plan_version=e.plan_version
+       AND c.node_key=e.child_node_key AND c.task_id=NEW.child_id
+      JOIN orch_requests r
+        ON r.board_instance_id=e.board_instance_id AND r.tenant_scope=e.tenant_scope AND r.orch_id=e.orch_id
+     WHERE e.board_instance_id=NEW.orch_board_instance_id
+       AND e.tenant_scope=NEW.orch_tenant_scope AND e.orch_id=NEW.orch_id
+       AND e.plan_version=NEW.orch_plan_version AND e.edge_key=NEW.orch_edge_key
+       AND NEW.kind=e.edge_kind AND r.lifecycle_revision=NEW.orch_binding_revision
+       AND r.cancel_epoch=NEW.orch_cancel_epoch
+    UNION ALL
+    SELECT 1 FROM orch_external_edges x JOIN orch_requests r
+      ON r.board_instance_id=x.board_instance_id AND r.tenant_scope=x.tenant_scope AND r.orch_id=x.orch_id
+     WHERE x.board_instance_id=NEW.orch_board_instance_id
+       AND x.tenant_scope=NEW.orch_tenant_scope AND x.orch_id=NEW.orch_id
+       AND x.edge_key=NEW.orch_edge_key AND x.parent_task_id=NEW.parent_id
+       AND x.child_task_id=NEW.child_id AND NEW.kind=x.edge_kind
+       AND r.lifecycle_revision=NEW.orch_binding_revision
+       AND r.cancel_epoch=NEW.orch_cancel_epoch
+  ) THEN RAISE(ABORT,'invalid_orch_link_binding') END;
+END;
+
+CREATE TRIGGER orch_request_identity_guard BEFORE UPDATE OF
+  board_instance_id,tenant_scope,orch_id,lineage_id,generation,selector_key,selector_ledger_revision,request_key,
+  request_schema_version,request_json,request_digest,origin_id,parent_task_id,
+  synthesis_strategy,supersedes_orch_id,created_at
+ON orch_requests BEGIN SELECT RAISE(ABORT,'immutable_orch_request_identity'); END;
+CREATE TRIGGER orch_request_delete_guard BEFORE DELETE ON orch_requests
+BEGIN SELECT RAISE(ABORT,'orch_request_delete_forbidden'); END;
+
+CREATE TRIGGER orch_request_supersession_guard BEFORE INSERT ON orch_requests
+BEGIN
+  SELECT CASE WHEN NEW.lifecycle_state!='submitted' OR NEW.lifecycle_revision!=0
+    OR NEW.cancel_epoch!=0 OR NEW.delivery_epoch_revision!=0 OR NEW.plan_epoch_revision!=0
+    OR NEW.plan_version!=0 OR NEW.work_accepted_at IS NOT NULL OR NEW.delivery_closed_at IS NOT NULL
+    OR NEW.terminal_reason_code IS NOT NULL OR NEW.blocked_from_state IS NOT NULL
+    OR NEW.resume_state IS NOT NULL OR NEW.block_kind IS NOT NULL
+    THEN RAISE(ABORT,'invalid_initial_orch_request_state') END;
+  SELECT CASE WHEN orch_capability_ok(
+    CASE WHEN NEW.generation=1 THEN 'request_submit' ELSE 'request_supersede' END,
+    NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.selector_ledger_revision,NEW.generation,NEW.request_key
+  )!=1 THEN RAISE(ABORT,'missing_request_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_origins o JOIN orch_replay_selectors s
+      ON s.board_instance_id=o.board_instance_id AND s.tenant_scope=o.tenant_scope
+     AND s.selector_key=o.selector_key
+     WHERE o.board_instance_id=NEW.board_instance_id AND o.tenant_scope=NEW.tenant_scope
+       AND o.origin_id=NEW.origin_id AND o.selector_key=NEW.selector_key
+       AND s.lineage_id=NEW.lineage_id AND s.ledger_revision=NEW.selector_ledger_revision
+  ) THEN RAISE(ABORT,'request_selector_origin_mismatch') END;
+  SELECT CASE WHEN NEW.generation=1 AND (
+    NEW.supersedes_orch_id IS NOT NULL OR NOT EXISTS (
+      SELECT 1 FROM orch_replay_selectors s
+       WHERE s.board_instance_id=NEW.board_instance_id AND s.tenant_scope=NEW.tenant_scope
+         AND s.selector_key=NEW.selector_key AND s.current_generation=0
+         AND s.current_orch_id IS NULL
+    )
+  ) THEN RAISE(ABORT,'invalid_generation_one_request') END;
+  SELECT CASE WHEN NEW.generation>1 AND NOT EXISTS (
+    SELECT 1 FROM orch_requests prev JOIN orch_replay_selectors s
+      ON s.board_instance_id=prev.board_instance_id AND s.tenant_scope=prev.tenant_scope
+     AND s.selector_key=prev.selector_key
+     WHERE prev.board_instance_id=NEW.board_instance_id
+       AND prev.tenant_scope=NEW.tenant_scope AND prev.lineage_id=NEW.lineage_id
+       AND prev.selector_key=NEW.selector_key AND prev.generation=NEW.generation-1
+       AND prev.orch_id=NEW.supersedes_orch_id
+       AND prev.lifecycle_state IN ('failed','cancelled')
+       AND s.current_generation=prev.generation AND s.current_orch_id=prev.orch_id
+       AND s.current_request_digest=prev.request_digest
+       AND s.ledger_revision=NEW.selector_ledger_revision
+  ) THEN RAISE(ABORT,'invalid_orch_supersession') END;
+END;
+
+CREATE TRIGGER orch_node_identity_guard BEFORE UPDATE OF
+  board_instance_id,tenant_scope,orch_id,plan_version,node_key,task_id,
+  current_route_digest,route_revision,created_by_run_id,created_at
+ON orch_nodes BEGIN SELECT RAISE(ABORT,'immutable_orch_node_identity'); END;
+CREATE TRIGGER orch_node_delete_guard BEFORE DELETE ON orch_nodes
+BEGIN SELECT RAISE(ABORT,'orch_node_delete_forbidden'); END;
+
+CREATE TRIGGER orch_stage_attempt_guard BEFORE INSERT ON orch_stage_attempts
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'stage_attempt_start',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.lifecycle_revision,NEW.cancel_epoch,NEW.attempt_digest
+  )!=1 THEN RAISE(ABORT,'missing_stage_attempt_capability') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_stage_leases l JOIN orch_requests r
+      ON r.board_instance_id=l.board_instance_id AND r.tenant_scope=l.tenant_scope AND r.orch_id=l.orch_id
+     WHERE l.board_instance_id=NEW.board_instance_id AND l.tenant_scope=NEW.tenant_scope
+       AND l.orch_id=NEW.orch_id AND l.stage=NEW.stage
+       AND l.owner_run_id=NEW.owner_run_id AND l.epoch=NEW.lease_epoch
+       AND l.lease_state='active' AND l.expires_at>unixepoch('now')
+       AND r.lifecycle_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+       AND NEW.attempt_state='running'
+       AND NEW.attempt_no=(SELECT COALESCE(max(x.attempt_no),0)+1 FROM orch_stage_attempts x
+         WHERE x.board_instance_id=NEW.board_instance_id AND x.tenant_scope=NEW.tenant_scope
+           AND x.orch_id=NEW.orch_id AND x.stage=NEW.stage)
+       AND NEW.attempt_no<=r.max_retries+1
+       AND ((NEW.stage='decomposition' AND r.lifecycle_state='decomposing')
+         OR (NEW.stage='synthesis' AND r.lifecycle_state='synthesizing'))
+  ) THEN RAISE(ABORT,'invalid_orch_stage_attempt_authority') END;
+END;
+
+CREATE TRIGGER orch_stage_attempt_update_guard BEFORE UPDATE ON orch_stage_attempts
+BEGIN
+  SELECT CASE WHEN OLD.board_instance_id!=NEW.board_instance_id OR OLD.tenant_scope!=NEW.tenant_scope
+    OR OLD.orch_id!=NEW.orch_id OR OLD.stage!=NEW.stage OR OLD.attempt_no!=NEW.attempt_no
+    OR OLD.owner_run_id!=NEW.owner_run_id OR OLD.lease_epoch!=NEW.lease_epoch
+    OR OLD.lifecycle_revision!=NEW.lifecycle_revision OR OLD.cancel_epoch!=NEW.cancel_epoch
+    OR OLD.started_at!=NEW.started_at OR OLD.attempt_digest!=NEW.attempt_digest
+    THEN RAISE(ABORT,'immutable_stage_attempt_identity') END;
+  SELECT CASE WHEN OLD.attempt_state!='running' OR NEW.attempt_state='running'
+    OR orch_capability_ok(
+      'stage_attempt_finish',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      NEW.lifecycle_revision,NEW.cancel_epoch,NEW.attempt_digest
+    )!=1 OR NOT EXISTS (
+      SELECT 1 FROM orch_stage_leases l JOIN orch_requests r
+        ON r.board_instance_id=l.board_instance_id AND r.tenant_scope=l.tenant_scope AND r.orch_id=l.orch_id
+       WHERE l.board_instance_id=NEW.board_instance_id AND l.tenant_scope=NEW.tenant_scope
+         AND l.orch_id=NEW.orch_id AND l.stage=NEW.stage
+         AND l.owner_run_id=NEW.owner_run_id AND l.epoch=NEW.lease_epoch
+         AND l.lease_state='active' AND l.expires_at>unixepoch('now')
+         AND r.lifecycle_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+    ) THEN RAISE(ABORT,'invalid_stage_attempt_transition') END;
+END;
+CREATE TRIGGER orch_stage_attempt_delete_guard BEFORE DELETE ON orch_stage_attempts
+BEGIN SELECT RAISE(ABORT,'stage_attempt_delete_forbidden'); END;
+
+CREATE TRIGGER orch_delivery_origin_guard BEFORE INSERT ON orch_delivery_obligations
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'delivery_obligation_insert',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+    NEW.lifecycle_revision,NEW.cancel_epoch,NEW.delivery_key
+  )!=1 THEN RAISE(ABORT,'missing_delivery_obligation_capability') END;
+  SELECT CASE WHEN NEW.state!='pending' OR NOT EXISTS (
+    SELECT 1 FROM orch_origins o
+     WHERE o.board_instance_id=NEW.board_instance_id AND o.tenant_scope=NEW.tenant_scope
+       AND o.origin_id=NEW.origin_id AND o.route_revision=NEW.route_revision
+       AND o.route_digest=NEW.route_digest AND o.origin_kind=NEW.origin_kind
+       AND o.platform=NEW.platform AND o.adapter_instance_id=NEW.adapter_instance_id
+       AND o.account_id=NEW.account_id AND o.conversation_id=NEW.conversation_id
+       AND o.thread_id=NEW.thread_id AND o.reply_to_id=NEW.reply_to_id
+       AND o.required_ack_family=NEW.required_ack_family
+       AND o.required_ack_strength=NEW.required_ack_strength
+  ) THEN RAISE(ABORT,'delivery_origin_route_mismatch') END;
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_requests r JOIN orch_delivery_manifests m
+      ON m.board_instance_id=r.board_instance_id AND m.tenant_scope=r.tenant_scope
+     AND m.orch_id=r.orch_id AND m.plan_version=NEW.plan_version
+     AND m.result_id=NEW.result_id AND m.manifest_digest=NEW.manifest_digest
+     WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope
+       AND r.orch_id=NEW.orch_id AND r.plan_version=NEW.plan_version
+       AND r.delivery_epoch_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+       AND m.lifecycle_revision=NEW.lifecycle_revision AND m.cancel_epoch=NEW.cancel_epoch
+       AND (
+         (NEW.delivery_generation=1 AND NEW.supersedes_obligation_id IS NULL
+          AND r.lifecycle_state='work_accepted')
+         OR
+         (NEW.delivery_generation>1 AND r.lifecycle_state='delivery_blocked'
+          AND EXISTS (
+            SELECT 1 FROM orch_delivery_obligations old
+             WHERE old.board_instance_id=NEW.board_instance_id
+               AND old.tenant_scope=NEW.tenant_scope
+               AND old.obligation_id=NEW.supersedes_obligation_id
+               AND old.orch_id=NEW.orch_id AND old.result_id=NEW.result_id
+               AND old.manifest_entry_key=NEW.manifest_entry_key
+               AND old.delivery_generation=NEW.delivery_generation-1
+               AND (
+                 old.state='dead_letter'
+                 OR (old.state='unknown' AND EXISTS (
+                   SELECT 1 FROM orch_delivery_resend_authorizations a
+                    WHERE a.board_instance_id=NEW.board_instance_id
+                      AND a.tenant_scope=NEW.tenant_scope
+                      AND a.obligation_id=old.obligation_id
+                      AND a.unknown_attempt_id=old.unknown_attempt_id
+                      AND a.lifecycle_revision=NEW.lifecycle_revision
+                      AND a.cancel_epoch=NEW.cancel_epoch
+                      AND a.consumed_at IS NULL AND a.expires_at>unixepoch('now')
+                 ))
+               )
+          ))
+       )
+  ) THEN RAISE(ABORT,'stale_or_unauthorized_delivery_binding') END;
+END;
+
+CREATE TRIGGER orch_delivery_identity_guard BEFORE UPDATE OF
+  board_instance_id,tenant_scope,orch_id,plan_version,result_id,obligation_id,
+  manifest_digest,manifest_entry_key,delivery_generation,supersedes_obligation_id,
+  delivery_key,result_digest,origin_id,route_revision,route_digest,origin_kind,
+  platform,adapter_instance_id,account_id,conversation_id,thread_id,reply_to_id,
+  required,required_ack_family,required_ack_strength,lifecycle_revision,cancel_epoch,created_at
+ON orch_delivery_obligations BEGIN SELECT RAISE(ABORT,'immutable_delivery_identity'); END;
+CREATE TRIGGER orch_delivery_delete_guard BEFORE DELETE ON orch_delivery_obligations
+BEGIN SELECT RAISE(ABORT,'delivery_delete_forbidden'); END;
+
+CREATE TRIGGER orch_delivery_accept_guard BEFORE UPDATE OF state,acceptance_attempt_id ON orch_delivery_obligations
+WHEN NEW.state='accepted'
+BEGIN
+  SELECT CASE WHEN OLD.state NOT IN ('claimed','unknown') OR NOT EXISTS (
+    SELECT 1 FROM orch_delivery_attempts a JOIN orch_delivery_receipts rc
+      ON rc.board_instance_id=a.board_instance_id AND rc.tenant_scope=a.tenant_scope
+     AND rc.attempt_id=a.attempt_id AND rc.obligation_id=a.obligation_id
+     WHERE a.board_instance_id=NEW.board_instance_id AND a.tenant_scope=NEW.tenant_scope
+       AND a.obligation_id=NEW.obligation_id AND a.attempt_id=NEW.acceptance_attempt_id
+       AND a.attempt_state='adapter_accepted' AND rc.verified=1
+       AND a.claim_epoch=NEW.claim_epoch AND a.claim_owner=NEW.claim_owner
+       AND a.claim_token_hash=NEW.claim_token_hash
+       AND a.lifecycle_revision=NEW.lifecycle_revision AND a.cancel_epoch=NEW.cancel_epoch
+       AND a.result_digest=NEW.result_digest AND a.route_digest=NEW.route_digest
+       AND rc.send_nonce=a.send_nonce AND rc.payload_digest=a.payload_digest
+       AND rc.result_digest=a.result_digest AND rc.route_digest=a.route_digest
+       AND rc.observed_ack_family=NEW.required_ack_family
+       AND rc.observed_ack_strength=NEW.required_ack_strength
+  ) THEN RAISE(ABORT,'accepted_delivery_without_exact_receipt') END;
+END;
+
+CREATE TRIGGER orch_delivery_ack_guard BEFORE UPDATE OF state,acked_at ON orch_delivery_obligations
+WHEN NEW.state='acked'
+BEGIN
+  SELECT CASE WHEN OLD.state NOT IN ('accepted','unknown') OR NOT EXISTS (
+    SELECT 1 FROM orch_delivery_receipts rc
+     WHERE rc.board_instance_id=NEW.board_instance_id AND rc.tenant_scope=NEW.tenant_scope
+       AND rc.obligation_id=NEW.obligation_id AND rc.attempt_id=NEW.acceptance_attempt_id
+       AND rc.verified=1 AND rc.observed_ack_family=NEW.required_ack_family
+       AND rc.observed_ack_strength=NEW.required_ack_strength
+       AND rc.result_digest=NEW.result_digest AND rc.route_digest=NEW.route_digest
+  ) THEN RAISE(ABORT,'delivery_ack_family_or_strength_not_satisfied') END;
+END;
+
+CREATE TRIGGER orch_delivery_attempt_insert_guard BEFORE INSERT ON orch_delivery_attempts
+BEGIN
+  SELECT CASE WHEN NEW.attempt_state!='started' OR NEW.finished_at IS NOT NULL
+    OR orch_capability_ok(
+      'delivery_attempt_start',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,
+      NEW.lifecycle_revision,NEW.cancel_epoch,NEW.payload_digest
+    )!=1 OR NOT EXISTS (
+      SELECT 1 FROM orch_delivery_obligations d JOIN orch_requests r
+        ON r.board_instance_id=d.board_instance_id AND r.tenant_scope=d.tenant_scope AND r.orch_id=d.orch_id
+       WHERE d.board_instance_id=NEW.board_instance_id AND d.tenant_scope=NEW.tenant_scope
+         AND d.obligation_id=NEW.obligation_id AND d.state='claimed'
+         AND d.claim_owner=NEW.claim_owner AND d.claim_token_hash=NEW.claim_token_hash
+         AND d.claim_epoch=NEW.claim_epoch AND d.claim_expires_at>unixepoch('now')
+         AND d.lifecycle_revision=NEW.lifecycle_revision AND d.cancel_epoch=NEW.cancel_epoch
+         AND d.result_digest=NEW.result_digest AND d.route_digest=NEW.route_digest
+         AND r.delivery_epoch_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+         AND r.lifecycle_state IN ('delivering','delivery_blocked')
+    ) THEN RAISE(ABORT,'invalid_delivery_attempt_claim') END;
+END;
+
+CREATE TRIGGER orch_delivery_attempt_transition_guard BEFORE UPDATE ON orch_delivery_attempts
+BEGIN
+  SELECT CASE WHEN NOT (
+    OLD.attempt_state='started' AND NEW.attempt_state IN ('adapter_accepted','rejected','unknown')
+    AND NEW.finished_at IS NOT NULL
+    AND NEW.board_instance_id=OLD.board_instance_id AND NEW.tenant_scope=OLD.tenant_scope
+    AND NEW.obligation_id=OLD.obligation_id AND NEW.attempt_id=OLD.attempt_id
+    AND NEW.claim_epoch=OLD.claim_epoch AND NEW.claim_owner=OLD.claim_owner
+    AND NEW.claim_token_hash=OLD.claim_token_hash
+    AND NEW.lifecycle_revision=OLD.lifecycle_revision AND NEW.cancel_epoch=OLD.cancel_epoch
+    AND NEW.send_nonce=OLD.send_nonce AND NEW.payload_digest=OLD.payload_digest
+    AND NEW.result_digest=OLD.result_digest AND NEW.route_digest=OLD.route_digest
+    AND NEW.started_at=OLD.started_at
+    AND orch_capability_ok(
+      'delivery_attempt_finish',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,
+      NEW.lifecycle_revision,NEW.cancel_epoch,NEW.payload_digest
+    )=1
+    AND EXISTS (
+      SELECT 1 FROM orch_delivery_obligations d JOIN orch_requests r
+        ON r.board_instance_id=d.board_instance_id AND r.tenant_scope=d.tenant_scope AND r.orch_id=d.orch_id
+       WHERE d.board_instance_id=NEW.board_instance_id AND d.tenant_scope=NEW.tenant_scope
+         AND d.obligation_id=NEW.obligation_id AND d.claim_epoch=NEW.claim_epoch
+         AND d.claim_owner=NEW.claim_owner AND d.claim_token_hash=NEW.claim_token_hash
+         AND d.lifecycle_revision=NEW.lifecycle_revision AND d.cancel_epoch=NEW.cancel_epoch
+         AND r.delivery_epoch_revision=NEW.lifecycle_revision
+         AND ((r.cancel_epoch=NEW.cancel_epoch
+               AND r.lifecycle_state IN ('delivering','delivery_blocked'))
+           OR (r.cancel_epoch=NEW.cancel_epoch+1 AND r.lifecycle_state='cancelling'))
+    )
+  ) THEN RAISE(ABORT,'invalid_delivery_attempt_transition') END;
+END;
+
+CREATE TRIGGER orch_delivery_receipt_insert_guard BEFORE INSERT ON orch_delivery_receipts
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM orch_delivery_attempts a JOIN orch_delivery_obligations d
+      ON d.board_instance_id=a.board_instance_id AND d.tenant_scope=a.tenant_scope
+     AND d.obligation_id=a.obligation_id
+     WHERE a.board_instance_id=NEW.board_instance_id AND a.tenant_scope=NEW.tenant_scope
+       AND a.obligation_id=NEW.obligation_id AND a.attempt_id=NEW.attempt_id
+       AND a.attempt_state IN ('adapter_accepted','unknown')
+       AND NEW.send_nonce=a.send_nonce AND NEW.payload_digest=a.payload_digest
+       AND NEW.result_digest=a.result_digest AND NEW.route_digest=a.route_digest
+       AND NEW.observed_ack_family=d.required_ack_family
+       AND NEW.observed_ack_strength=d.required_ack_strength
+       AND orch_capability_ok(
+         'delivery_receipt',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,
+         a.lifecycle_revision,a.cancel_epoch,NEW.receipt_digest
+       )=1
+  ) THEN RAISE(ABORT,'receipt_without_exact_attempt_acceptance') END;
+END;
+
+CREATE TRIGGER orch_delivery_attempt_event_guard BEFORE INSERT ON orch_delivery_attempt_events
+BEGIN
+  SELECT CASE WHEN NEW.event_kind!=NEW.to_state OR NOT EXISTS (
+    SELECT 1 FROM orch_delivery_attempts a
+     WHERE a.board_instance_id=NEW.board_instance_id AND a.tenant_scope=NEW.tenant_scope
+       AND a.attempt_id=NEW.attempt_id AND a.attempt_state=NEW.to_state
+       AND NEW.transition_seq IN (1,2)
+       AND ((NEW.transition_seq=1 AND NEW.from_state IS NULL AND NEW.to_state='started')
+         OR (NEW.transition_seq=2 AND NEW.from_state='started' AND NEW.to_state!='started'))
+  ) THEN RAISE(ABORT,'invalid_delivery_attempt_event') END;
+END;
+CREATE TRIGGER orch_delivery_attempt_delete_guard BEFORE DELETE ON orch_delivery_attempts
+BEGIN SELECT RAISE(ABORT,'delivery_attempt_delete_forbidden'); END;
+
+CREATE TRIGGER tasks_orch_runtime_write_guard BEFORE UPDATE ON _soft_fk_tasks
+WHEN OLD.orch_id IS NOT NULL
+  AND NEW.orch_board_instance_id IS OLD.orch_board_instance_id
+  AND NEW.orch_tenant_scope IS OLD.orch_tenant_scope
+  AND NEW.orch_id IS OLD.orch_id
+  AND NEW.orch_plan_version IS OLD.orch_plan_version
+  AND NEW.orch_node_key IS OLD.orch_node_key
+  AND NEW.orch_binding_revision IS OLD.orch_binding_revision
+  AND NEW.orch_cancel_epoch IS OLD.orch_cancel_epoch
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+    'task_write',OLD.orch_board_instance_id,OLD.orch_tenant_scope,OLD.orch_id,
+    COALESCE((SELECT lifecycle_revision FROM orch_requests r
+      WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+        AND r.orch_id=OLD.orch_id),-1),
+    COALESCE((SELECT cancel_epoch FROM orch_requests r
+      WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+        AND r.orch_id=OLD.orch_id),-1),OLD.id
+  )!=1 THEN RAISE(ABORT,'missing_orch_task_write_capability') END;
+END;
+CREATE TRIGGER tasks_orch_id_update_guard BEFORE UPDATE OF id ON _soft_fk_tasks
+WHEN OLD.orch_id IS NOT NULL
+BEGIN SELECT RAISE(ABORT,'orch_task_id_immutable'); END;
+CREATE TRIGGER tasks_orch_delete_guard BEFORE DELETE ON _soft_fk_tasks
+WHEN OLD.orch_id IS NOT NULL
+BEGIN SELECT RAISE(ABORT,'orch_bound_task_delete_forbidden'); END;
+
+CREATE TRIGGER task_runs_orch_insert_guard BEFORE INSERT ON _soft_fk_task_runs
+WHEN EXISTS (SELECT 1 FROM _soft_fk_tasks t WHERE t.id=NEW.task_id AND t.orch_id IS NOT NULL)
+BEGIN
+  SELECT CASE WHEN NOT EXISTS (
+    SELECT 1 FROM _soft_fk_tasks t JOIN orch_requests r
+      ON r.board_instance_id=t.orch_board_instance_id
+     AND r.tenant_scope=t.orch_tenant_scope AND r.orch_id=t.orch_id
+     WHERE t.id=NEW.task_id AND NEW.cancellation_epoch=r.cancel_epoch
+       AND r.lifecycle_state NOT IN ('cancelling','completed','failed','cancelled')
+       AND orch_capability_ok(
+         'task_run_start',r.board_instance_id,r.tenant_scope,r.orch_id,
+         r.lifecycle_revision,r.cancel_epoch,COALESCE(CAST(NEW.id AS TEXT),NEW.task_id)
+       )=1
+  ) THEN RAISE(ABORT,'invalid_orch_task_run_start') END;
+END;
+CREATE TRIGGER task_runs_orch_update_guard BEFORE UPDATE ON _soft_fk_task_runs
+WHEN EXISTS (SELECT 1 FROM _soft_fk_tasks t WHERE t.id IN (OLD.task_id,NEW.task_id) AND t.orch_id IS NOT NULL)
+BEGIN
+  SELECT CASE WHEN NEW.id!=OLD.id OR NEW.task_id!=OLD.task_id OR NOT EXISTS (
+    SELECT 1 FROM _soft_fk_tasks t JOIN orch_requests r
+      ON r.board_instance_id=t.orch_board_instance_id
+     AND r.tenant_scope=t.orch_tenant_scope AND r.orch_id=t.orch_id
+     WHERE t.id=NEW.task_id AND NEW.cancellation_epoch=r.cancel_epoch
+       AND r.lifecycle_state NOT IN ('completed','failed','cancelled')
+       AND orch_capability_ok(
+         'task_run_write',r.board_instance_id,r.tenant_scope,r.orch_id,
+         r.lifecycle_revision,r.cancel_epoch,CAST(NEW.id AS TEXT)
+       )=1
+  ) THEN RAISE(ABORT,'invalid_orch_task_run_write') END;
+END;
+CREATE TRIGGER task_runs_orch_delete_guard BEFORE DELETE ON _soft_fk_task_runs
+WHEN EXISTS (SELECT 1 FROM _soft_fk_tasks t WHERE t.id=OLD.task_id AND t.orch_id IS NOT NULL)
+BEGIN SELECT RAISE(ABORT,'orch_task_run_delete_forbidden'); END;
+
+CREATE TRIGGER task_links_orch_update_guard BEFORE UPDATE ON _soft_fk_task_links
+WHEN OLD.orch_id IS NOT NULL OR NEW.orch_id IS NOT NULL
+BEGIN SELECT RAISE(ABORT,'replace_orch_link_via_typed_delete_insert'); END;
+CREATE TRIGGER task_links_orch_delete_guard BEFORE DELETE ON _soft_fk_task_links
+WHEN OLD.orch_id IS NOT NULL
+BEGIN
+  SELECT CASE WHEN NOT (
+    EXISTS (
+      SELECT 1 FROM orch_requests r
+       WHERE r.board_instance_id=OLD.orch_board_instance_id
+         AND r.tenant_scope=OLD.orch_tenant_scope AND r.orch_id=OLD.orch_id
+         AND r.lifecycle_state IN ('cancelling','cancelled')
+    )
+    AND orch_capability_ok(
+      'link_retire',OLD.orch_board_instance_id,OLD.orch_tenant_scope,OLD.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r
+        WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+          AND r.orch_id=OLD.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r
+        WHERE r.board_instance_id=OLD.orch_board_instance_id AND r.tenant_scope=OLD.orch_tenant_scope
+          AND r.orch_id=OLD.orch_id),-1),OLD.orch_edge_key
+    )=1
+  ) THEN RAISE(ABORT,'orch_link_delete_without_retirement_authority') END;
+END;
+
+CREATE TRIGGER board_identity_insert_guard BEFORE INSERT ON kanban_board_identity BEGIN
+  SELECT CASE WHEN orch_capability_ok('maintenance_identity',NEW.board_instance_id,'','',0,0,NEW.canonical_board_key)!=1
+    THEN RAISE(ABORT,'missing_maintenance_identity_capability') END;
+END;
+CREATE TRIGGER board_identity_update_guard BEFORE UPDATE ON kanban_board_identity BEGIN SELECT RAISE(ABORT,'board_identity_immutable'); END;
+CREATE TRIGGER board_identity_delete_guard BEFORE DELETE ON kanban_board_identity BEGIN SELECT RAISE(ABORT,'board_identity_delete_forbidden'); END;
+
+CREATE TRIGGER schema_migration_insert_guard BEFORE INSERT ON kanban_schema_migrations BEGIN
+  SELECT CASE WHEN orch_capability_ok('maintenance_schema',NEW.board_instance_id,'',NEW.migration_id,NEW.fence_generation,0,NEW.source_digest)!=1
+    THEN RAISE(ABORT,'missing_schema_migration_capability') END;
+END;
+CREATE TRIGGER schema_migration_update_guard BEFORE UPDATE ON kanban_schema_migrations BEGIN
+  SELECT CASE WHEN NEW.migration_id!=OLD.migration_id OR NEW.board_instance_id!=OLD.board_instance_id
+    OR NEW.target_schema_version!=OLD.target_schema_version OR NEW.source_digest!=OLD.source_digest
+    OR NEW.backup_digest!=OLD.backup_digest OR NEW.fence_generation!=OLD.fence_generation
+    OR orch_capability_ok('maintenance_schema',NEW.board_instance_id,'',NEW.migration_id,NEW.fence_generation,0,NEW.state)!=1
+    THEN RAISE(ABORT,'invalid_schema_migration_transition') END;
+END;
+CREATE TRIGGER schema_migration_delete_guard BEFORE DELETE ON kanban_schema_migrations BEGIN SELECT RAISE(ABORT,'schema_migration_delete_forbidden'); END;
+
+CREATE TRIGGER write_fence_insert_guard BEFORE INSERT ON kanban_write_fence BEGIN
+  SELECT CASE WHEN orch_capability_ok('maintenance_fence',(SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1),'','',NEW.generation,0,NEW.mode)!=1
+    THEN RAISE(ABORT,'missing_write_fence_capability') END;
+END;
+CREATE TRIGGER write_fence_update_guard BEFORE UPDATE ON kanban_write_fence BEGIN
+  SELECT CASE WHEN NEW.singleton!=OLD.singleton OR NEW.generation!=OLD.generation+1
+    OR orch_capability_ok('maintenance_fence',(SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1),'','',NEW.generation,0,NEW.mode)!=1
+    THEN RAISE(ABORT,'invalid_write_fence_transition') END;
+END;
+CREATE TRIGGER write_fence_delete_guard BEFORE DELETE ON kanban_write_fence BEGIN SELECT RAISE(ABORT,'write_fence_delete_forbidden'); END;
+
+CREATE TRIGGER commit_clock_insert_guard BEFORE INSERT ON kanban_commit_clock BEGIN
+  SELECT CASE WHEN NEW.commit_seq!=0 OR orch_capability_ok('commit_clock',(SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1),'','',0,0,NEW.last_txn_id)!=1
+    THEN RAISE(ABORT,'invalid_commit_clock_bootstrap') END;
+END;
+CREATE TRIGGER commit_clock_update_guard BEFORE UPDATE ON kanban_commit_clock BEGIN
+  SELECT CASE WHEN NEW.singleton!=OLD.singleton OR NEW.commit_seq!=OLD.commit_seq+1
+    OR orch_capability_ok('commit_clock',(SELECT board_instance_id FROM kanban_board_identity WHERE singleton=1),'','',NEW.commit_seq,0,NEW.last_txn_id)!=1
+    THEN RAISE(ABORT,'invalid_commit_clock_cas') END;
+END;
+CREATE TRIGGER commit_clock_delete_guard BEFORE DELETE ON kanban_commit_clock BEGIN SELECT RAISE(ABORT,'commit_clock_delete_forbidden'); END;
+
+CREATE TRIGGER migration_operation_insert_guard BEFORE INSERT ON kanban_migration_operations BEGIN
+  SELECT CASE WHEN orch_capability_ok('maintenance_operation',NEW.board_instance_id,'',NEW.migration_id,NEW.phase_revision,NEW.fence_generation,NEW.plan_digest)!=1
+    THEN RAISE(ABORT,'missing_migration_operation_capability') END;
+END;
+CREATE TRIGGER migration_operation_update_guard BEFORE UPDATE ON kanban_migration_operations BEGIN
+  SELECT CASE WHEN NEW.migration_id!=OLD.migration_id OR NEW.board_instance_id!=OLD.board_instance_id
+    OR NEW.owner_token_hash!=OLD.owner_token_hash OR NEW.source_digest!=OLD.source_digest
+    OR NEW.plan_digest!=OLD.plan_digest OR NEW.schema_digest!=OLD.schema_digest
+    OR NEW.phase_revision!=OLD.phase_revision+1
+    OR orch_capability_ok('maintenance_operation',NEW.board_instance_id,'',NEW.migration_id,NEW.phase_revision,NEW.fence_generation,NEW.phase)!=1
+    THEN RAISE(ABORT,'invalid_migration_operation_transition') END;
+END;
+CREATE TRIGGER migration_operation_delete_guard BEFORE DELETE ON kanban_migration_operations BEGIN SELECT RAISE(ABORT,'migration_operation_delete_forbidden'); END;
+
+CREATE TRIGGER rollback_operation_insert_guard BEFORE INSERT ON orch_rollback_operations BEGIN
+  SELECT CASE WHEN orch_capability_ok('rollback_operation',NEW.board_instance_id,'',NEW.rollback_id,NEW.phase_revision,NEW.fence_generation,NEW.target_manifest_digest)!=1
+    THEN RAISE(ABORT,'missing_rollback_operation_capability') END;
+END;
+CREATE TRIGGER rollback_operation_update_guard BEFORE UPDATE ON orch_rollback_operations BEGIN
+  SELECT CASE WHEN NEW.rollback_id!=OLD.rollback_id OR NEW.migration_id!=OLD.migration_id
+    OR NEW.board_instance_id!=OLD.board_instance_id OR NEW.owner_token_hash!=OLD.owner_token_hash
+    OR NEW.source_manifest_digest!=OLD.source_manifest_digest OR NEW.target_manifest_digest!=OLD.target_manifest_digest
+    OR NEW.phase_revision!=OLD.phase_revision+1
+    OR orch_capability_ok('rollback_operation',NEW.board_instance_id,'',NEW.rollback_id,NEW.phase_revision,NEW.fence_generation,NEW.phase)!=1
+    THEN RAISE(ABORT,'invalid_rollback_operation_transition') END;
+END;
+CREATE TRIGGER rollback_operation_delete_guard BEFORE DELETE ON orch_rollback_operations BEGIN SELECT RAISE(ABORT,'rollback_operation_delete_forbidden'); END;
+
+CREATE TRIGGER replay_selector_insert_guard BEFORE INSERT ON orch_replay_selectors BEGIN
+  SELECT CASE WHEN NEW.current_generation!=0 OR NEW.current_orch_id IS NOT NULL OR NEW.current_request_digest IS NOT NULL
+    OR NEW.ledger_revision!=0
+    OR orch_capability_ok('selector_create',NEW.board_instance_id,NEW.tenant_scope,NEW.lineage_id,0,0,NEW.selector_key)!=1
+    THEN RAISE(ABORT,'invalid_replay_selector_create') END;
+END;
+CREATE TRIGGER replay_selector_update_guard BEFORE UPDATE ON orch_replay_selectors BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.selector_key!=OLD.selector_key OR NEW.selector_kind!=OLD.selector_kind
+    OR NEW.selector_value!=OLD.selector_value OR NEW.adapter_instance_id!=OLD.adapter_instance_id
+    OR NEW.conversation_id!=OLD.conversation_id OR NEW.lineage_id!=OLD.lineage_id
+    OR NEW.created_at!=OLD.created_at OR NEW.current_generation!=OLD.current_generation+1
+    OR NEW.ledger_revision!=OLD.ledger_revision+1
+    OR orch_capability_ok('selector_advance',NEW.board_instance_id,NEW.tenant_scope,NEW.lineage_id,OLD.ledger_revision,NEW.current_generation,NEW.selector_key)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope
+        AND r.orch_id=NEW.current_orch_id AND r.generation=NEW.current_generation
+        AND r.request_digest=NEW.current_request_digest AND r.selector_key=NEW.selector_key)
+    THEN RAISE(ABORT,'invalid_replay_selector_advance') END;
+END;
+CREATE TRIGGER replay_selector_delete_guard BEFORE DELETE ON orch_replay_selectors BEGIN SELECT RAISE(ABORT,'replay_selector_delete_forbidden'); END;
+
+CREATE TRIGGER orch_origin_insert_guard BEFORE INSERT ON orch_origins BEGIN
+  SELECT CASE WHEN orch_capability_ok('origin_register',NEW.board_instance_id,NEW.tenant_scope,NEW.origin_id,NEW.route_revision,0,NEW.route_digest)!=1
+    THEN RAISE(ABORT,'missing_origin_register_capability') END;
+END;
+
+CREATE TRIGGER orch_request_transition_guard BEFORE UPDATE ON orch_requests BEGIN
+  SELECT CASE WHEN NEW.lifecycle_revision!=OLD.lifecycle_revision+1 OR NEW.updated_at<OLD.updated_at
+    OR orch_capability_ok('request_transition',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.request_key)!=1
+    OR NOT (
+      (OLD.lifecycle_state='submitted' AND NEW.lifecycle_state='decomposing')
+      OR (OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state IN ('waiting_lanes','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='waiting_lanes' AND NEW.lifecycle_state IN ('waiting_lanes','synthesizing','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state IN ('work_accepted','blocked','failed','cancelling'))
+      OR (OLD.lifecycle_state='work_accepted' AND NEW.lifecycle_state IN ('delivering','completed','cancelling'))
+      OR (OLD.lifecycle_state='delivering' AND NEW.lifecycle_state IN ('completed','delivery_blocked','cancelling'))
+      OR (OLD.lifecycle_state='delivery_blocked' AND NEW.lifecycle_state IN ('delivering','cancelling'))
+      OR (OLD.lifecycle_state='blocked' AND NEW.lifecycle_state=OLD.resume_state)
+      OR (OLD.lifecycle_state='cancelling' AND NEW.lifecycle_state='cancelled')
+    )
+    OR NOT ((NEW.lifecycle_state='cancelling' AND OLD.lifecycle_state!='cancelling' AND NEW.cancel_epoch=OLD.cancel_epoch+1)
+      OR (NEW.lifecycle_state!='cancelling' AND NEW.cancel_epoch=OLD.cancel_epoch))
+    OR NOT ((OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state='work_accepted'
+              AND OLD.delivery_epoch_revision=0 AND NEW.delivery_epoch_revision=NEW.lifecycle_revision
+              AND NEW.work_accepted_at IS NOT NULL)
+      OR (NOT (OLD.lifecycle_state='synthesizing' AND NEW.lifecycle_state='work_accepted')
+              AND NEW.delivery_epoch_revision=OLD.delivery_epoch_revision
+              AND NEW.work_accepted_at IS OLD.work_accepted_at))
+    OR NOT ((OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state='waiting_lanes'
+              AND NEW.plan_version=OLD.plan_version+1
+              AND OLD.plan_epoch_revision=0 AND NEW.plan_epoch_revision=NEW.lifecycle_revision
+              AND EXISTS (SELECT 1 FROM orch_plan_materializations m
+                WHERE m.board_instance_id=NEW.board_instance_id AND m.tenant_scope=NEW.tenant_scope
+                  AND m.orch_id=NEW.orch_id AND m.plan_version=NEW.plan_version
+                  AND m.request_lifecycle_revision=OLD.lifecycle_revision
+                  AND m.cancel_epoch=OLD.cancel_epoch))
+      OR (NOT (OLD.lifecycle_state='decomposing' AND NEW.lifecycle_state='waiting_lanes')
+              AND NEW.plan_version=OLD.plan_version
+              AND NEW.plan_epoch_revision=OLD.plan_epoch_revision))
+    OR (NEW.lifecycle_state='completed' AND NEW.delivery_closed_at IS NULL)
+    OR (NEW.lifecycle_state!='completed' AND NEW.delivery_closed_at IS NOT OLD.delivery_closed_at)
+    THEN RAISE(ABORT,'invalid_orch_request_transition') END;
+END;
+
+CREATE TRIGGER orch_requirement_insert_guard BEFORE INSERT ON orch_request_requirements BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.requirement_digest)!=1
+    THEN RAISE(ABORT,'missing_plan_build_capability') END;
+END;
+CREATE TRIGGER orch_plan_insert_guard BEFORE INSERT ON orch_plans BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.plan_digest)!=1
+    THEN RAISE(ABORT,'missing_plan_build_capability') END;
+END;
+CREATE TRIGGER orch_plan_node_insert_guard BEFORE INSERT ON orch_plan_nodes BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.node_key)!=1
+    THEN RAISE(ABORT,'missing_plan_node_capability') END;
+END;
+CREATE TRIGGER orch_plan_edge_insert_guard BEFORE INSERT ON orch_plan_edges BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.edge_key)!=1
+    THEN RAISE(ABORT,'missing_plan_edge_capability') END;
+END;
+CREATE TRIGGER orch_plan_coverage_insert_guard BEFORE INSERT ON orch_plan_coverage BEGIN
+  SELECT CASE WHEN orch_capability_ok('plan_build',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.requirement_id||':'||NEW.node_key)!=1
+    THEN RAISE(ABORT,'missing_plan_coverage_capability') END;
+END;
+
+CREATE TRIGGER orch_node_insert_guard BEFORE INSERT ON orch_nodes BEGIN
+  SELECT CASE WHEN orch_capability_ok('materialize',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.node_key)!=1
+    THEN RAISE(ABORT,'missing_node_materialization_capability') END;
+END;
+CREATE TRIGGER orch_node_state_guard BEFORE UPDATE OF node_state,updated_at ON orch_nodes BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.orch_id!=OLD.orch_id OR NEW.plan_version!=OLD.plan_version OR NEW.node_key!=OLD.node_key
+    OR NEW.task_id!=OLD.task_id OR NEW.updated_at<OLD.updated_at
+    OR NOT ((OLD.node_state='planned' AND NEW.node_state IN ('ready','running','cancelled'))
+      OR (OLD.node_state='ready' AND NEW.node_state IN ('running','cancelled'))
+      OR (OLD.node_state='running' AND NEW.node_state IN ('accepted','blocked','failed','cancellation_requested','cancelled'))
+      OR (OLD.node_state='cancellation_requested' AND NEW.node_state IN ('accepted','failed','cancelled'))
+      OR (OLD.node_state='blocked' AND NEW.node_state IN ('ready','cancelled')))
+    OR orch_capability_ok('node_transition',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.node_key)!=1
+    THEN RAISE(ABORT,'invalid_orch_node_transition') END;
+END;
+
+CREATE TRIGGER orch_external_edge_insert_guard BEFORE INSERT ON orch_external_edges BEGIN
+  SELECT CASE WHEN orch_capability_ok('external_edge',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.edge_key)!=1
+    THEN RAISE(ABORT,'missing_external_edge_capability') END;
+END;
+CREATE TRIGGER orch_external_edge_update_guard BEFORE UPDATE ON orch_external_edges BEGIN SELECT RAISE(ABORT,'immutable_external_edge'); END;
+CREATE TRIGGER orch_external_edge_delete_guard BEFORE DELETE ON orch_external_edges BEGIN SELECT RAISE(ABORT,'external_edge_delete_forbidden'); END;
+
+CREATE TRIGGER orch_stage_lease_insert_guard BEFORE INSERT ON orch_stage_leases BEGIN
+  SELECT CASE WHEN NEW.lease_state!='active' OR NEW.epoch!=1 OR NEW.expires_at<=unixepoch('now')
+    OR orch_capability_ok('lease_claim',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.stage)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id
+        AND ((NEW.stage='decomposition' AND r.lifecycle_state='decomposing')
+          OR (NEW.stage='synthesis' AND r.lifecycle_state='synthesizing')
+          OR (NEW.stage='reconciliation' AND r.lifecycle_state IN ('waiting_lanes','delivering','delivery_blocked','cancelling'))))
+    THEN RAISE(ABORT,'invalid_stage_lease_claim') END;
+END;
+CREATE TRIGGER orch_stage_lease_update_guard BEFORE UPDATE ON orch_stage_leases BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.orch_id!=OLD.orch_id OR NEW.stage!=OLD.stage OR NEW.updated_at<OLD.updated_at
+    OR orch_capability_ok('lease_update',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,
+      COALESCE((SELECT lifecycle_revision FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),
+      COALESCE((SELECT cancel_epoch FROM orch_requests r WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id),-1),NEW.stage)!=1
+    OR NOT (
+      (OLD.lease_state='active' AND NEW.lease_state='active' AND NEW.owner_run_id=OLD.owner_run_id
+        AND NEW.owner_profile=OLD.owner_profile AND NEW.token_hash=OLD.token_hash
+        AND NEW.epoch=OLD.epoch AND NEW.expires_at>OLD.expires_at)
+      OR (OLD.lease_state='active' AND NEW.lease_state IN ('released','revoked')
+        AND NEW.owner_run_id=OLD.owner_run_id AND NEW.owner_profile=OLD.owner_profile
+        AND NEW.token_hash=OLD.token_hash AND NEW.epoch=OLD.epoch)
+      OR (NEW.lease_state='active' AND NEW.epoch=OLD.epoch+1 AND NEW.expires_at>unixepoch('now')
+        AND (OLD.lease_state IN ('released','revoked') OR OLD.expires_at<=unixepoch('now')))
+    )
+    THEN RAISE(ABORT,'invalid_stage_lease_transition') END;
+END;
+CREATE TRIGGER orch_stage_lease_delete_guard BEFORE DELETE ON orch_stage_leases BEGIN SELECT RAISE(ABORT,'stage_lease_delete_forbidden'); END;
+
+CREATE TRIGGER orch_result_insert_guard BEFORE INSERT ON orch_results BEGIN
+  SELECT CASE WHEN orch_capability_ok('result_accept',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.result_digest)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r JOIN orch_stage_attempts a
+      ON a.board_instance_id=r.board_instance_id AND a.tenant_scope=r.tenant_scope AND a.orch_id=r.orch_id
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id
+        AND r.plan_version=NEW.plan_version AND r.lifecycle_state='synthesizing'
+        AND r.lifecycle_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+        AND a.stage=NEW.producer_stage AND a.attempt_no=NEW.producer_attempt_no
+        AND a.owner_run_id=NEW.producer_run_id AND a.lease_epoch=NEW.synthesis_epoch
+        AND a.lifecycle_revision=NEW.lifecycle_revision AND a.cancel_epoch=NEW.cancel_epoch
+        AND a.attempt_state='completed' AND a.outcome_code='result_ready')
+    THEN RAISE(ABORT,'invalid_result_acceptance') END;
+END;
+
+CREATE TRIGGER delivery_manifest_insert_guard BEFORE INSERT ON orch_delivery_manifests BEGIN
+  SELECT CASE WHEN orch_capability_ok('delivery_manifest',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.manifest_digest)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r JOIN orch_results rs
+      ON rs.board_instance_id=r.board_instance_id AND rs.tenant_scope=r.tenant_scope
+      AND rs.orch_id=r.orch_id AND rs.plan_version=r.plan_version
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id
+        AND r.plan_version=NEW.plan_version AND r.lifecycle_state='work_accepted'
+        AND r.delivery_epoch_revision=NEW.lifecycle_revision AND r.cancel_epoch=NEW.cancel_epoch
+        AND rs.result_id=NEW.result_id)
+    THEN RAISE(ABORT,'invalid_delivery_manifest') END;
+END;
+CREATE TRIGGER delivery_manifest_update_guard BEFORE UPDATE ON orch_delivery_manifests BEGIN SELECT RAISE(ABORT,'immutable_delivery_manifest'); END;
+CREATE TRIGGER delivery_manifest_delete_guard BEFORE DELETE ON orch_delivery_manifests BEGIN SELECT RAISE(ABORT,'delivery_manifest_delete_forbidden'); END;
+CREATE TRIGGER delivery_manifest_entry_insert_guard BEFORE INSERT ON orch_delivery_manifest_entries BEGIN
+  SELECT CASE WHEN orch_capability_ok('delivery_manifest_entry',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,0,0,NEW.manifest_entry_key)!=1
+    OR NOT EXISTS (SELECT 1 FROM orch_delivery_obligations d
+      WHERE d.board_instance_id=NEW.board_instance_id AND d.tenant_scope=NEW.tenant_scope
+        AND d.obligation_id=NEW.obligation_id AND d.orch_id=NEW.orch_id AND d.result_id=NEW.result_id
+        AND d.manifest_digest=NEW.manifest_digest AND d.manifest_entry_key=NEW.manifest_entry_key
+        AND d.required=NEW.required AND d.required_ack_family=NEW.required_ack_family
+        AND d.required_ack_strength=NEW.required_ack_strength AND d.route_digest=NEW.route_digest)
+    THEN RAISE(ABORT,'invalid_delivery_manifest_entry') END;
+END;
+CREATE TRIGGER delivery_manifest_entry_update_guard BEFORE UPDATE ON orch_delivery_manifest_entries BEGIN SELECT RAISE(ABORT,'immutable_delivery_manifest_entry'); END;
+CREATE TRIGGER delivery_manifest_entry_delete_guard BEFORE DELETE ON orch_delivery_manifest_entries BEGIN SELECT RAISE(ABORT,'delivery_manifest_entry_delete_forbidden'); END;
+
+CREATE TRIGGER orch_delivery_state_guard BEFORE UPDATE OF state,claim_owner,claim_token_hash,claim_epoch,claim_expires_at,
+  attempts,available_at,acceptance_attempt_id,adapter_accepted_at,acked_at,provider_id,provider_message_id,
+  duplicate_possible,unknown_attempt_id,ambiguity_deadline,last_error_code,updated_at ON orch_delivery_obligations
+BEGIN
+  SELECT CASE WHEN orch_capability_ok(
+      CASE
+        WHEN OLD.state='pending' AND NEW.state='claimed' THEN 'delivery_claim'
+        WHEN NEW.state IN ('accepted','pending','unknown','dead_letter') THEN 'delivery_outcome'
+        WHEN NEW.state='acked' THEN 'delivery_ack'
+        WHEN NEW.state='cancelled' THEN 'delivery_cancel'
+        ELSE 'delivery_invalid'
+      END,
+      NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,
+      NEW.lifecycle_revision,NEW.cancel_epoch,NEW.delivery_key
+    )!=1
+    OR NOT ((OLD.state='pending' AND NEW.state IN ('claimed','cancelled'))
+      OR (OLD.state='claimed' AND NEW.state IN ('accepted','pending','unknown','dead_letter','cancelled'))
+      OR (OLD.state='unknown' AND NEW.state IN ('accepted','acked','cancelled'))
+      OR (OLD.state='accepted' AND NEW.state IN ('acked','cancelled')))
+    OR (NEW.state='claimed' AND (NEW.claim_owner IS NULL OR NEW.claim_token_hash IS NULL
+      OR NEW.claim_epoch!=OLD.claim_epoch+1 OR NEW.claim_expires_at<=unixepoch('now') OR NEW.attempts!=OLD.attempts+1))
+    OR (NEW.state!='claimed' AND NEW.state!='accepted'
+      AND (NEW.claim_owner IS NOT NULL OR NEW.claim_token_hash IS NOT NULL OR NEW.claim_expires_at IS NOT NULL))
+    OR (NEW.state='unknown' AND (NEW.unknown_attempt_id IS NULL OR NEW.ambiguity_deadline IS NULL))
+    OR NEW.updated_at<OLD.updated_at
+    OR NOT EXISTS (SELECT 1 FROM orch_requests r
+      WHERE r.board_instance_id=NEW.board_instance_id AND r.tenant_scope=NEW.tenant_scope AND r.orch_id=NEW.orch_id
+        AND r.delivery_epoch_revision=NEW.lifecycle_revision
+        AND ((r.cancel_epoch=NEW.cancel_epoch AND r.lifecycle_state IN ('work_accepted','delivering','delivery_blocked'))
+          OR (r.cancel_epoch=NEW.cancel_epoch+1 AND r.lifecycle_state='cancelling' AND NEW.state='cancelled')))
+    THEN RAISE(ABORT,'invalid_delivery_state_transition') END;
+END;
+
+CREATE TRIGGER delivery_attempt_event_capability_guard BEFORE INSERT ON orch_delivery_attempt_events BEGIN
+  SELECT CASE WHEN orch_capability_ok('delivery_attempt_event',NEW.board_instance_id,NEW.tenant_scope,NEW.attempt_id,NEW.transition_seq,0,NEW.event_digest)!=1
+    THEN RAISE(ABORT,'missing_delivery_attempt_event_capability') END;
+END;
+
+CREATE TRIGGER reconcile_queue_update_guard BEFORE UPDATE ON orch_reconcile_queue BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.event_id!=OLD.event_id OR NEW.consumer_kind!=OLD.consumer_kind
+    OR orch_capability_ok(
+      CASE
+        WHEN OLD.state='pending' AND NEW.state='claimed' THEN 'queue_claim'
+        WHEN OLD.state='claimed' AND NEW.state='done' THEN 'queue_complete'
+        WHEN NEW.state IN ('pending','dead_letter') THEN 'queue_recover'
+        ELSE 'queue_invalid'
+      END,
+      NEW.board_instance_id,NEW.tenant_scope,CAST(NEW.event_id AS TEXT),
+      NEW.claim_epoch,0,NEW.consumer_kind
+    )!=1
+    OR NOT ((OLD.state='pending' AND NEW.state IN ('claimed','dead_letter'))
+      OR (OLD.state='claimed' AND NEW.state IN ('pending','done','dead_letter')))
+    OR (NEW.state='claimed' AND (NEW.claim_owner IS NULL OR NEW.claim_token_hash IS NULL
+      OR NEW.claim_epoch!=OLD.claim_epoch+1 OR NEW.claim_expires_at<=unixepoch('now')
+      OR NEW.attempts!=OLD.attempts+1))
+    OR (NEW.state!='claimed' AND (NEW.claim_owner IS NOT NULL OR NEW.claim_token_hash IS NOT NULL OR NEW.claim_expires_at IS NOT NULL))
+    OR (NEW.state='done' AND NOT EXISTS (SELECT 1 FROM orch_effect_ledger e
+      WHERE e.board_instance_id=NEW.board_instance_id AND e.tenant_scope=NEW.tenant_scope
+        AND e.event_id=NEW.event_id AND e.consumer_kind=NEW.consumer_kind
+        AND e.effect_digest=NEW.done_effect_digest))
+    OR (NEW.state='dead_letter' AND OLD.state='claimed' AND OLD.claim_expires_at>unixepoch('now'))
+    THEN RAISE(ABORT,'invalid_reconcile_queue_transition') END;
+END;
+CREATE TRIGGER reconcile_queue_delete_guard BEFORE DELETE ON orch_reconcile_queue BEGIN SELECT RAISE(ABORT,'reconcile_queue_delete_forbidden'); END;
+CREATE TRIGGER effect_ledger_update_guard BEFORE UPDATE ON orch_effect_ledger BEGIN SELECT RAISE(ABORT,'immutable_effect_ledger'); END;
+CREATE TRIGGER effect_ledger_delete_guard BEFORE DELETE ON orch_effect_ledger BEGIN SELECT RAISE(ABORT,'effect_ledger_delete_forbidden'); END;
+
+CREATE TRIGGER resend_authorization_insert_guard BEFORE INSERT ON orch_delivery_resend_authorizations BEGIN
+  SELECT CASE WHEN orch_capability_ok('resend_authorize',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.capability_digest)!=1
+    OR NEW.expires_at<=unixepoch('now') OR NEW.consumed_at IS NOT NULL
+    OR NOT EXISTS (SELECT 1 FROM orch_delivery_obligations d
+      WHERE d.board_instance_id=NEW.board_instance_id AND d.tenant_scope=NEW.tenant_scope
+        AND d.obligation_id=NEW.obligation_id AND d.state='unknown'
+        AND d.unknown_attempt_id=NEW.unknown_attempt_id
+        AND d.lifecycle_revision=NEW.lifecycle_revision AND d.cancel_epoch=NEW.cancel_epoch)
+    THEN RAISE(ABORT,'invalid_resend_authorization') END;
+END;
+CREATE TRIGGER resend_authorization_update_guard BEFORE UPDATE ON orch_delivery_resend_authorizations BEGIN
+  SELECT CASE WHEN NEW.board_instance_id!=OLD.board_instance_id OR NEW.tenant_scope!=OLD.tenant_scope
+    OR NEW.authorization_id!=OLD.authorization_id OR NEW.obligation_id!=OLD.obligation_id
+    OR NEW.unknown_attempt_id!=OLD.unknown_attempt_id OR NEW.lifecycle_revision!=OLD.lifecycle_revision
+    OR NEW.cancel_epoch!=OLD.cancel_epoch OR NEW.capability_digest!=OLD.capability_digest
+    OR NEW.authorized_by!=OLD.authorized_by OR NEW.expires_at!=OLD.expires_at OR NEW.created_at!=OLD.created_at
+    OR OLD.consumed_at IS NOT NULL OR NEW.consumed_at IS NULL
+    OR orch_capability_ok('resend_consume',NEW.board_instance_id,NEW.tenant_scope,NEW.obligation_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.authorization_id)!=1
+    THEN RAISE(ABORT,'invalid_resend_authorization_consume') END;
+END;
+CREATE TRIGGER resend_authorization_delete_guard BEFORE DELETE ON orch_delivery_resend_authorizations BEGIN SELECT RAISE(ABORT,'resend_authorization_delete_forbidden'); END;
+
+CREATE TRIGGER mutation_log_insert_guard BEFORE INSERT ON orch_mutation_log BEGIN
+  SELECT CASE WHEN orch_capability_ok('mutation_log',NEW.board_instance_id,NEW.tenant_scope,NEW.orch_id,NEW.lifecycle_revision,NEW.cancel_epoch,NEW.mutation_digest)!=1
+    THEN RAISE(ABORT,'missing_mutation_log_capability') END;
+END;
+
+WITH RECURSIVE
+seed(task_id) AS (
+  SELECT parent_task_id FROM orch_requests
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT task_id FROM orch_nodes
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT id FROM _soft_fk_tasks
+   WHERE orch_board_instance_id=:board AND orch_tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT parent_task_id FROM orch_external_edges
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+  UNION
+  SELECT child_task_id FROM orch_external_edges
+   WHERE board_instance_id=:board AND tenant_scope=:tenant AND orch_id=:orch
+),
+closure(task_id) AS (
+  SELECT task_id FROM seed
+  UNION
+  SELECT l.child_id FROM _soft_fk_task_links l JOIN closure c ON l.parent_id=c.task_id
+  UNION
+  SELECT l.parent_id FROM _soft_fk_task_links l JOIN closure c ON l.child_id=c.task_id
+)
+SELECT task_id FROM closure;

--- a/scripts/orch_v4_cmin_judge.py
+++ b/scripts/orch_v4_cmin_judge.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""CLI: C-min sidecar judge for board_only dual-bound parents."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hermes_cli.kanban_orch_cmin import CMinError, live_judge_parent_task
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="C-min board_only sidecar lifecycle judge")
+    p.add_argument("--task-id", required=True, help="Native parent task id")
+    args = p.parse_args(argv)
+    try:
+        res = live_judge_parent_task(args.task_id)
+    except CMinError as exc:
+        print(json.dumps({"ok": False, "error": exc.code}, ensure_ascii=False, indent=2))
+        return 2
+    print(json.dumps({"ok": True, "result": res.to_dict()}, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orch_v4_cmin_tick.py
+++ b/scripts/orch_v4_cmin_tick.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""CLI: one-shot cmin tick — advance open board_only sidecar requests from native truth."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hermes_cli.kanban_orch_cmin import CMinError, live_tick_once
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="C-min tick: native done/children → sidecar completed")
+    p.add_argument("--limit", type=int, default=100)
+    p.add_argument("--json", action="store_true", help="machine JSON only")
+    args = p.parse_args(argv)
+    try:
+        res = live_tick_once(limit=args.limit)
+    except CMinError as exc:
+        print(json.dumps({"ok": False, "error": exc.code}, ensure_ascii=False, indent=2))
+        return 2
+    payload = {"ok": True, "tick": res.to_dict()}
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orch_v4_dual_bind.py
+++ b/scripts/orch_v4_dual_bind.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""CLI: bind an existing native parent task into live ORCH V4 sidecar."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hermes_cli.kanban_orch_dual_bind import dual_bind_parent_task, preflight_dual_bind
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Dual-bind native parent task into orch_v4 sidecar")
+    p.add_argument("--task-id", required=True)
+    p.add_argument("--title", default="")
+    p.add_argument("--cfg", default=None, help="Path to orch_v4_writer.json")
+    p.add_argument("--preflight-only", action="store_true")
+    args = p.parse_args(argv)
+
+    pf = preflight_dual_bind(args.cfg)
+    print(json.dumps({"preflight": pf}, ensure_ascii=False, indent=2))
+    if args.preflight_only:
+        return 0 if pf.get("ok") else 2
+    if not pf.get("ok"):
+        return 2
+    res = dual_bind_parent_task(task_id=args.task_id, title=args.title, cfg_path=args.cfg)
+    print(json.dumps({"bind": res.to_dict()}, ensure_ascii=False, indent=2))
+    if res.error:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orch_v4_init_sidecar.py
+++ b/scripts/orch_v4_init_sidecar.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""ORCH V4 Sidecar Init — create-only new orch_v4.db.
+
+Source: 拆卡機制四大缺陷-詳細實作計畫.md §15.0 Sidecar Architecture Decision.
+
+Usage:
+    python scripts/orch_v4_init_sidecar.py \
+        --sidecar-db /path/to/orch_v4.db \
+        --native-db /path/to/kanban.db \
+        --receipt /path/to/receipt.json
+
+Hard rules:
+- Sidecar path must not exist (O_EXCL)
+- Native DB opened mode=ro only
+- No native schema mutation
+- Receipt records native_sha256 + sidecar_sha256 + native_mutated=false
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(65536):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Initialize ORCH V4 sidecar DB")
+    parser.add_argument("--sidecar-db", required=True, help="Path for new sidecar orch_v4.db")
+    parser.add_argument("--native-db", required=True, help="Path to native kanban.db (read-only)")
+    parser.add_argument("--receipt", required=True, help="Path for init receipt JSON")
+    parser.add_argument("--board-instance-id", default=None, help="Board instance ID (optional)")
+    args = parser.parse_args()
+
+    sidecar_path = Path(args.sidecar_db)
+    native_path = Path(args.native_db)
+    receipt_path = Path(args.receipt)
+
+    # O_EXCL: sidecar must not exist
+    if sidecar_path.exists():
+        print(f"ERROR: sidecar path already exists: {sidecar_path}", file=sys.stderr)
+        return 1
+
+    # Native must exist
+    if not native_path.exists():
+        print(f"ERROR: native DB not found: {native_path}", file=sys.stderr)
+        return 1
+
+    # Hash native BEFORE (zero-mutation baseline)
+    native_sha_before = sha256_file(str(native_path))
+
+    # Open native RO (verify it works)
+    native_conn = sqlite3.connect(f"file:{native_path}?mode=ro", uri=True)
+    native_conn.row_factory = sqlite3.Row
+    try:
+        # Verify we can read
+        native_conn.execute("SELECT count(*) FROM sqlite_master").fetchone()
+    except sqlite3.Error as e:
+        print(f"ERROR: native DB read failed: {e}", file=sys.stderr)
+        return 1
+    finally:
+        native_conn.close()
+
+    # Create sidecar DB
+    sidecar_conn = sqlite3.connect(str(sidecar_path))
+    try:
+        sys.path.insert(0, str(Path(__file__).parent.parent))
+        from hermes_cli.kanban_orch_schema_sidecar import (
+            apply_sidecar_schema,
+            get_sidecar_table_names,
+            get_sidecar_trigger_names,
+            verify_no_native_tables,
+        )
+
+        apply_sidecar_schema(sidecar_conn)
+
+        # Verify
+        tables = get_sidecar_table_names(sidecar_conn)
+        triggers = get_sidecar_trigger_names(sidecar_conn)
+        verify_no_native_tables(sidecar_conn)
+
+        # Count
+        table_count = len([t for t in tables if not t.startswith("sqlite_")])
+        trigger_count = len(triggers)
+    finally:
+        sidecar_conn.close()
+
+    # Hash native AFTER (must be unchanged)
+    native_sha_after = sha256_file(str(native_path))
+    sidecar_sha = sha256_file(str(sidecar_path))
+
+    if native_sha_before != native_sha_after:
+        print("FATAL: native DB hash changed during init!", file=sys.stderr)
+        # Rollback: delete sidecar
+        sidecar_path.unlink(missing_ok=True)
+        return 1
+
+    # Write receipt
+    receipt = {
+        "init_id": f"sidecar-init-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
+        "sidecar_path": str(sidecar_path),
+        "sidecar_sha256": sidecar_sha,
+        "native_path": str(native_path),
+        "native_sha256_before": native_sha_before,
+        "native_sha256_after": native_sha_after,
+        "native_mutated": native_sha_before != native_sha_after,
+        "sidecar_table_count": table_count,
+        "sidecar_trigger_count": trigger_count,
+        "native_opened_mode": "ro",
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+    }
+
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2) + "\n")
+
+    print(f"Sidecar created: {sidecar_path}")
+    print(f"  Tables: {table_count}, Triggers: {trigger_count}")
+    print(f"  Native SHA-256: {native_sha_before[:16]}... (unchanged: {native_sha_before == native_sha_after})")
+    print(f"  Receipt: {receipt_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orch_v4_init_sidecar.py
+++ b/scripts/orch_v4_init_sidecar.py
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 """ORCH V4 Sidecar Init — create-only new orch_v4.db.
 
-Source: 拆卡機制四大缺陷-詳細實作計畫.md §15.0 Sidecar Architecture Decision.
-
-Usage:
-    python scripts/orch_v4_init_sidecar.py \
-        --sidecar-db /path/to/orch_v4.db \
-        --native-db /path/to/kanban.db \
-        --receipt /path/to/receipt.json
-
 Hard rules:
-- Sidecar path must not exist (O_EXCL)
+- Sidecar path must not exist (atomic O_CREAT|O_EXCL|O_NOFOLLOW)
+- Receipt path must not exist (atomic create-only)
 - Native DB opened mode=ro only
 - No native schema mutation
-- Receipt records native_sha256 + sidecar_sha256 + native_mutated=false
 """
+
+from __future__ import annotations
 
 import argparse
 import hashlib
@@ -34,6 +28,27 @@ def sha256_file(path: str) -> str:
     return h.hexdigest()
 
 
+def _atomic_create_file(path: Path, mode: int = 0o600) -> None:
+    flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(str(path), flags, mode)
+    os.close(fd)
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    data = (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    fd = os.open(str(path), flags, 0o644)
+    try:
+        os.write(fd, data)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Initialize ORCH V4 sidecar DB")
     parser.add_argument("--sidecar-db", required=True, help="Path for new sidecar orch_v4.db")
@@ -46,24 +61,25 @@ def main() -> int:
     native_path = Path(args.native_db)
     receipt_path = Path(args.receipt)
 
-    # O_EXCL: sidecar must not exist
-    if sidecar_path.exists():
+    if sidecar_path.exists() or os.path.lexists(sidecar_path):
         print(f"ERROR: sidecar path already exists: {sidecar_path}", file=sys.stderr)
         return 1
-
-    # Native must exist
+    if receipt_path.exists() or os.path.lexists(receipt_path):
+        print(f"ERROR: receipt path already exists: {receipt_path}", file=sys.stderr)
+        return 1
     if not native_path.exists():
         print(f"ERROR: native DB not found: {native_path}", file=sys.stderr)
         return 1
 
-    # Hash native BEFORE (zero-mutation baseline)
-    native_sha_before = sha256_file(str(native_path))
+    # Refuse live default native path unless operator is explicit via env.
+    live = Path.home() / ".hermes" / "kanban.db"
+    if native_path.resolve() == live.resolve() and os.environ.get("ORCH_V4_ALLOW_LIVE") != "1":
+        print("ERROR: live native path forbidden without ORCH_V4_ALLOW_LIVE=1", file=sys.stderr)
+        return 2
 
-    # Open native RO (verify it works)
+    native_sha_before = sha256_file(str(native_path))
     native_conn = sqlite3.connect(f"file:{native_path}?mode=ro", uri=True)
-    native_conn.row_factory = sqlite3.Row
     try:
-        # Verify we can read
         native_conn.execute("SELECT count(*) FROM sqlite_master").fetchone()
     except sqlite3.Error as e:
         print(f"ERROR: native DB read failed: {e}", file=sys.stderr)
@@ -71,7 +87,15 @@ def main() -> int:
     finally:
         native_conn.close()
 
-    # Create sidecar DB
+    try:
+        _atomic_create_file(sidecar_path)
+    except FileExistsError:
+        print(f"ERROR: sidecar path already exists: {sidecar_path}", file=sys.stderr)
+        return 1
+    except OSError as e:
+        print(f"ERROR: sidecar create failed: {e}", file=sys.stderr)
+        return 1
+
     sidecar_conn = sqlite3.connect(str(sidecar_path))
     try:
         sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -83,29 +107,21 @@ def main() -> int:
         )
 
         apply_sidecar_schema(sidecar_conn)
-
-        # Verify
         tables = get_sidecar_table_names(sidecar_conn)
         triggers = get_sidecar_trigger_names(sidecar_conn)
         verify_no_native_tables(sidecar_conn)
-
-        # Count
         table_count = len([t for t in tables if not t.startswith("sqlite_")])
         trigger_count = len(triggers)
     finally:
         sidecar_conn.close()
 
-    # Hash native AFTER (must be unchanged)
     native_sha_after = sha256_file(str(native_path))
     sidecar_sha = sha256_file(str(sidecar_path))
-
     if native_sha_before != native_sha_after:
         print("FATAL: native DB hash changed during init!", file=sys.stderr)
-        # Rollback: delete sidecar
         sidecar_path.unlink(missing_ok=True)
         return 1
 
-    # Write receipt
     receipt = {
         "init_id": f"sidecar-init-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}",
         "sidecar_path": str(sidecar_path),
@@ -113,19 +129,23 @@ def main() -> int:
         "native_path": str(native_path),
         "native_sha256_before": native_sha_before,
         "native_sha256_after": native_sha_after,
-        "native_mutated": native_sha_before != native_sha_after,
+        "native_mutated": False,
         "sidecar_table_count": table_count,
         "sidecar_trigger_count": trigger_count,
         "native_opened_mode": "ro",
+        "create_mode": "O_CREAT|O_EXCL|O_NOFOLLOW",
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
     }
-
-    receipt_path.parent.mkdir(parents=True, exist_ok=True)
-    receipt_path.write_text(json.dumps(receipt, ensure_ascii=False, indent=2) + "\n")
+    try:
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write_json(receipt_path, receipt)
+    except FileExistsError:
+        print(f"ERROR: receipt path already exists: {receipt_path}", file=sys.stderr)
+        return 1
 
     print(f"Sidecar created: {sidecar_path}")
     print(f"  Tables: {table_count}, Triggers: {trigger_count}")
-    print(f"  Native SHA-256: {native_sha_before[:16]}... (unchanged: {native_sha_before == native_sha_after})")
+    print(f"  Native SHA-256: {native_sha_before[:16]}... (unchanged)")
     print(f"  Receipt: {receipt_path}")
     return 0
 

--- a/scripts/orch_v4_migrate.py
+++ b/scripts/orch_v4_migrate.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""ORCH V4 isolated schema initializer / migrate helper.
+
+Default posture: refuse live fleet kanban.db paths.
+This is NOT a live writer cutover tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="ORCH V4 isolated schema migrate/init")
+    parser.add_argument("--db", required=True, help="Target SQLite path (isolated only by default)")
+    parser.add_argument("--mode", choices=["sidecar", "inplace"], default="sidecar")
+    parser.add_argument(
+        "--allow-live",
+        action="store_true",
+        help="Required together with ORCH_V4_ALLOW_LIVE=1 to touch live paths",
+    )
+    parser.add_argument(
+        "--i-understand-live",
+        action="store_true",
+        help="Second explicit live acknowledgement",
+    )
+    args = parser.parse_args(argv)
+
+    # Local imports keep --help fast and avoid import side effects.
+    from hermes_cli.kanban_orch_db import OrchDBError, assert_not_live_path, open_orch_db, close_orch_db
+
+    allow_live = bool(args.allow_live and args.i_understand_live and os.environ.get("ORCH_V4_ALLOW_LIVE") == "1")
+    try:
+        path = assert_not_live_path(args.db, allow_live=allow_live)
+    except OrchDBError as exc:
+        print(f"REFUSED:{exc.code}", file=sys.stderr)
+        return 2
+
+    if os.path.exists(path):
+        print(f"REFUSED:db_exists:{path}", file=sys.stderr)
+        return 3
+
+    conn = open_orch_db(path, allow_live=allow_live, create=True, test_open_capability=True)
+    try:
+        if args.mode == "sidecar":
+            from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
+
+            apply_sidecar_schema(conn)
+        else:
+            from hermes_cli.kanban_orch_schema_v4 import apply_schema
+
+            apply_schema(conn)
+        print(f"OK:initialized:{args.mode}:{path}")
+        return 0
+    finally:
+        close_orch_db(conn)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orch_v4_sidecar_rollback.py
+++ b/scripts/orch_v4_sidecar_rollback.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Rollback live ORCH V4 sidecar control plane (delete sidecar + disable writer).
+
+Does NOT mutate native kanban.db.
+Does NOT remove hermes-agent source modules.
+
+Usage:
+  python scripts/orch_v4_sidecar_rollback.py --dry-run
+  python scripts/orch_v4_sidecar_rollback.py --apply --i-understand-destructive
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_SIDECAR = Path.home() / ".hermes" / "orch_v4.db"
+DEFAULT_WRITER = Path.home() / ".hermes" / "orch_v4_writer.json"
+NATIVE = Path.home() / ".hermes" / "kanban.db"
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def atomic_json(path: Path, payload: dict) -> None:
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    data = (json.dumps(payload, ensure_ascii=False, indent=2) + "\n").encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), flags, 0o644)
+    try:
+        os.write(fd, data)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Rollback live ORCH V4 sidecar")
+    p.add_argument("--sidecar", default=str(DEFAULT_SIDECAR))
+    p.add_argument("--writer-cfg", default=str(DEFAULT_WRITER))
+    p.add_argument("--receipt", required=True)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true")
+    g.add_argument("--apply", action="store_true")
+    p.add_argument("--i-understand-destructive", action="store_true")
+    args = p.parse_args(argv)
+
+    sidecar = Path(args.sidecar)
+    writer = Path(args.writer_cfg)
+    receipt_path = Path(args.receipt)
+
+    native_before = sha256_file(NATIVE)
+    plan = {
+        "action": "sidecar_rollback",
+        "mode": "dry-run" if args.dry_run else "apply",
+        "sidecar_path": str(sidecar),
+        "sidecar_exists": sidecar.exists() or os.path.lexists(sidecar),
+        "sidecar_sha256_before": sha256_file(sidecar),
+        "writer_cfg_path": str(writer),
+        "writer_exists": writer.exists() or os.path.lexists(writer),
+        "writer_sha256_before": sha256_file(writer),
+        "native_path": str(NATIVE),
+        "native_sha256_before": native_before,
+        "will_delete": [],
+    }
+    if plan["sidecar_exists"]:
+        plan["will_delete"].append(str(sidecar))
+        # also wal/shm if present
+        for suf in ("-wal", "-shm", "-journal"):
+            extra = Path(str(sidecar) + suf)
+            if extra.exists() or os.path.lexists(extra):
+                plan["will_delete"].append(str(extra))
+    if plan["writer_exists"]:
+        plan["will_delete"].append(str(writer))
+
+    if args.dry_run:
+        plan["result"] = "dry_run_only"
+        plan["sealed_utc"] = datetime.now(timezone.utc).isoformat()
+        atomic_json(receipt_path, plan)
+        print(json.dumps(plan, indent=2))
+        return 0
+
+    if not args.i_understand_destructive:
+        print("REFUSED: need --i-understand-destructive with --apply", file=sys.stderr)
+        return 2
+
+    deleted = []
+    errors = []
+    for path_s in plan["will_delete"]:
+        path = Path(path_s)
+        try:
+            if path.is_symlink() or path.exists():
+                path.unlink()
+                deleted.append(path_s)
+        except OSError as exc:
+            errors.append(f"{path_s}:{exc}")
+
+    native_after = sha256_file(NATIVE)
+    out = {
+        **plan,
+        "mode": "apply",
+        "deleted": deleted,
+        "errors": errors,
+        "native_sha256_after": native_after,
+        "native_mutated": native_after != native_before,
+        "sidecar_exists_after": sidecar.exists() or os.path.lexists(sidecar),
+        "writer_exists_after": writer.exists() or os.path.lexists(writer),
+        "sealed_utc": datetime.now(timezone.utc).isoformat(),
+        "epoch": int(time.time()),
+    }
+    if out["native_mutated"]:
+        print("FATAL: native hash changed during rollback", file=sys.stderr)
+        atomic_json(receipt_path, out)
+        return 3
+    if errors or out["sidecar_exists_after"] or out["writer_exists_after"]:
+        atomic_json(receipt_path, out)
+        print(json.dumps(out, indent=2))
+        return 4
+    out["result"] = "rolled_back"
+    atomic_json(receipt_path, out)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_kanban_orch_bridge.py
+++ b/tests/hermes_cli/test_kanban_orch_bridge.py
@@ -116,7 +116,7 @@ def test_board_mirror_roundtrip(bridge_env):
 
 
 def test_bind_parent_task_sidecar_only(bridge_env):
-    """bind_parent_task writes only to sidecar, not native.
+    """bind_parent_task writes durable orch_requests in sidecar, not native.
 
     The key invariant: soft FK is enforced (native task must exist),
     and native DB bytes are unchanged after the operation.
@@ -124,14 +124,20 @@ def test_bind_parent_task_sidecar_only(bridge_env):
     bridge, native_path, sidecar_path, sha_before, _ = bridge_env
 
     # Bind task-1 (exists in native)
-    bridge.bind_parent_task("board_0123456789abcdef", "", "orch-1", "task-1")
+    bound = bridge.bind_parent_task("board_0123456789abcdef", "", "orch-1", "task-1")
+    assert bound.orch_id == "orch-1"
+    assert bound.parent_task_id == "task-1"
+    assert bound.lifecycle_state == "submitted"
 
-    # Verify sidecar was written to (board mirror exists)
-    rows = bridge._sidecar.execute(
-        "SELECT count(*) as cnt FROM kanban_board_identity WHERE board_instance_id = ?",
-        ("board_0123456789abcdef",)
+    # Durable request row exists
+    row = bridge._sidecar.execute(
+        "SELECT parent_task_id, lifecycle_state FROM orch_requests "
+        "WHERE board_instance_id=? AND orch_id=?",
+        ("board_0123456789abcdef", "orch-1"),
     ).fetchone()
-    assert rows["cnt"] >= 1, "Sidecar should have board mirror entry after bind"
+    assert row is not None
+    assert row["parent_task_id"] == "task-1"
+    assert row["lifecycle_state"] == "submitted"
 
     # Verify native unchanged
     sha_after = _sha256_file(native_path)

--- a/tests/hermes_cli/test_kanban_orch_bridge.py
+++ b/tests/hermes_cli/test_kanban_orch_bridge.py
@@ -1,0 +1,167 @@
+"""S2: Bridge — soft FK, native write forbidden, board mirror, parent bind."""
+
+import pytest
+import os
+import sys
+import tempfile
+import hashlib
+import sqlite3
+import shutil
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_bridge import (
+    BridgeError,
+    NativeTaskRef,
+    OrchBridge,
+    init_sidecar_db,
+)
+
+
+def _sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(65536):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@pytest.fixture
+def bridge_env():
+    """Create temp native + sidecar DBs and return a bridge."""
+    tmpdir = tempfile.mkdtemp()
+    native_path = os.path.join(tmpdir, "native.db")
+    sidecar_path = os.path.join(tmpdir, "orch_v4.db")
+
+    # Create minimal native DB with tasks table
+    nconn = sqlite3.connect(native_path)
+    nconn.execute("PRAGMA foreign_keys=ON")
+    nconn.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, created_at INTEGER NOT NULL)")
+    nconn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('task-1', 'Test', 'pending', 1)")
+    nconn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('task-2', 'Done Task', 'done', 2)")
+    nconn.commit()
+    nconn.close()
+
+    # Create sidecar
+    init_sidecar_db(sidecar_path)
+
+    sha_before = _sha256_file(native_path)
+
+    bridge = OrchBridge(native_path, sidecar_path)
+    yield bridge, native_path, sidecar_path, sha_before, tmpdir
+    bridge.close()
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_soft_fk_accepts_existing_task(bridge_env):
+    """Soft FK: existing native task is accepted."""
+    bridge, native_path, sidecar_path, sha_before, _ = bridge_env
+    ref = bridge.assert_task_exists("task-1")
+    assert ref.task_id == "task-1"
+    assert ref.title == "Test"
+    assert ref.status == "pending"
+
+
+def test_soft_fk_rejects_missing_task(bridge_env):
+    """Soft FK: missing native task raises BridgeError."""
+    bridge, *_ = bridge_env
+    with pytest.raises(BridgeError, match="soft_fk_violation"):
+        bridge.assert_task_exists("nonexistent-task")
+
+
+def test_bridge_never_writes_native(bridge_env):
+    """Bridge must never write to native DB (SHA-256 unchanged)."""
+    bridge, native_path, sidecar_path, sha_before, _ = bridge_env
+
+    # Perform sidecar operations
+    bridge.ensure_board_mirror("board_0123456789abcdef", "default")
+    bridge.bind_parent_task("board_0123456789abcdef", "", "orch-1", "task-1")
+
+    # Verify native DB bytes unchanged
+    sha_after = _sha256_file(native_path)
+    assert sha_before == sha_after, "Native DB was mutated by bridge!"
+
+
+def test_native_write_forbidden_by_default():
+    """OrchBridge with native_writable=True must raise."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        native_path = os.path.join(tmpdir, "native.db")
+        sidecar_path = os.path.join(tmpdir, "orch_v4.db")
+        sqlite3.connect(native_path).close()  # create empty
+        init_sidecar_db(sidecar_path)
+
+        with pytest.raises(BridgeError, match="native_write_forbidden_by_sidecar_decision"):
+            OrchBridge(native_path, sidecar_path, native_writable=True)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_board_mirror_roundtrip(bridge_env):
+    """Board mirror: upsert into sidecar, read back."""
+    bridge, native_path, sidecar_path, sha_before, _ = bridge_env
+    bridge.ensure_board_mirror("board_0123456789abcdef", "default")
+
+    # Verify mirror exists in sidecar
+    row = bridge._sidecar.execute(
+        "SELECT board_instance_id, canonical_board_key FROM kanban_board_identity WHERE board_instance_id = ?",
+        ("board_0123456789abcdef",)
+    ).fetchone()
+    assert row is not None
+    assert row["board_instance_id"] == "board_0123456789abcdef"
+    assert row["canonical_board_key"] == "default"
+
+    # Idempotent: second call should not error
+    bridge.ensure_board_mirror("board_0123456789abcdef", "default")
+
+
+def test_bind_parent_task_sidecar_only(bridge_env):
+    """bind_parent_task writes only to sidecar, not native.
+
+    The key invariant: soft FK is enforced (native task must exist),
+    and native DB bytes are unchanged after the operation.
+    """
+    bridge, native_path, sidecar_path, sha_before, _ = bridge_env
+
+    # Bind task-1 (exists in native)
+    bridge.bind_parent_task("board_0123456789abcdef", "", "orch-1", "task-1")
+
+    # Verify sidecar was written to (board mirror exists)
+    rows = bridge._sidecar.execute(
+        "SELECT count(*) as cnt FROM kanban_board_identity WHERE board_instance_id = ?",
+        ("board_0123456789abcdef",)
+    ).fetchone()
+    assert rows["cnt"] >= 1, "Sidecar should have board mirror entry after bind"
+
+    # Verify native unchanged
+    sha_after = _sha256_file(native_path)
+    assert sha_before == sha_after, "Native DB was mutated by bind_parent_task!"
+
+
+def test_bind_parent_rejects_missing_native_task(bridge_env):
+    """bind_parent_task with non-existent native task raises soft FK error."""
+    bridge, *_ = bridge_env
+    with pytest.raises(BridgeError, match="soft_fk_violation"):
+        bridge.bind_parent_task("board_0123456789abcdef", "", "orch-2", "nonexistent")
+
+
+def test_live_paths_not_used(bridge_env):
+    """Bridge fixture paths must not be live paths."""
+    bridge, native_path, sidecar_path, sha_before, tmpdir = bridge_env
+    LIVE_PATHS = {"/home/claw/.hermes/kanban.db", "/home/claw/.hermes/orch_v4.db"}
+    assert native_path not in LIVE_PATHS
+    assert sidecar_path not in LIVE_PATHS
+    assert tmpdir not in LIVE_PATHS
+
+
+def test_read_native_task(bridge_env):
+    """read_native_task returns NativeTaskRef for existing task."""
+    bridge, *_ = bridge_env
+    ref = bridge.read_native_task("task-2")
+    assert ref is not None
+    assert ref.task_id == "task-2"
+    assert ref.title == "Done Task"
+    assert ref.status == "done"
+
+    # Missing task returns None
+    assert bridge.read_native_task("nonexistent") is None

--- a/tests/hermes_cli/test_kanban_orch_canary.py
+++ b/tests/hermes_cli/test_kanban_orch_canary.py
@@ -1,0 +1,185 @@
+"""M7 T42: Canary — root identity, egress denial, deadline, cleanup."""
+
+import pytest
+import os
+import sys
+import tempfile
+import shutil
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_canary import (
+    ALLOWED_CONSUMERS,
+    CanaryError,
+    CanaryScenarioResult,
+    DEADLINES,
+    LocalCaptureAdapter,
+    cleanup_canary,
+    prepare_canary,
+    run_scenario_crash_recovery,
+    run_scenario_normal,
+    run_scenario_replay_owner_race,
+    verify_canary,
+)
+
+
+def test_canary_isolation_and_egress():
+    """T42: canary root identity/deny egress/deadline/cleanup.
+
+    CSPRNG root, O_EXCL, reject existing/symlink.
+    Egress hard-denied outside sink allowlist.
+    Deadlines match §16.1.
+    Cleanup removes root.
+    """
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # Prepare: CSPRNG root
+        prepare = prepare_canary(
+            run_id="test-001",
+            source_hash="a" * 64,
+            root_parent=tmpdir,
+            now=1000,
+        )
+        assert prepare.identity.board_instance_id != "test-001"  # CSPRNG, not run_id
+        assert len(prepare.identity.board_instance_id) == 32  # 16 bytes hex
+        assert prepare.identity.tenant_scope == "orch-v4-canary-test-001"
+        assert prepare.identity.schema_version == 4
+        assert os.path.isdir(prepare.identity.root_path)
+
+        # Reject existing root
+        with pytest.raises(CanaryError, match="canary_root_exists"):
+            prepare_canary(
+                run_id="test-001",
+                source_hash="a" * 64,
+                root_parent=tmpdir,
+            )
+
+        # Deadlines match §16.1
+        assert DEADLINES["startup"] == 30
+        assert DEADLINES["scenario"] == 180
+        assert DEADLINES["idle"] == 30
+        assert DEADLINES["sigterm_drain"] == 15
+        assert DEADLINES["sigkill_reap"] == 5
+        assert DEADLINES["cleanup"] == 30
+
+        # Egress denial: allowed consumers pass
+        adapter = LocalCaptureAdapter()
+        assert not adapter.egress_denied({"consumer_kind": "gateway_message_bridge"})
+        assert not adapter.egress_denied({"consumer_kind": "cli_foreground_bridge"})
+
+        # Egress denial: unknown consumers denied
+        assert adapter.egress_denied({"consumer_kind": "malicious_caller"})
+        assert adapter.egress_denied({"consumer_kind": ""})
+        assert adapter.egress_denied({})  # missing consumer_kind
+
+        # Local capture adapter records sends
+        adapter.send({"consumer_kind": "gateway_message_bridge"}, b"payload")
+        assert len(adapter.sends) == 1
+        assert adapter.sends[0]["accepted"] is True
+        assert adapter.sends[0]["provider_message_id"].startswith("local-")
+
+        # Cleanup
+        assert cleanup_canary(prepare)
+        assert not os.path.exists(prepare.identity.root_path)
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_canary_three_scenarios():
+    """T42: three scenarios — normal, replay-owner-race, crash-recovery."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        prepare = prepare_canary(
+            run_id="test-002",
+            source_hash="b" * 64,
+            root_parent=tmpdir,
+            now=2000,
+        )
+        adapter = LocalCaptureAdapter()
+
+        # Normal scenario
+        normal = run_scenario_normal(prepare, adapter)
+        assert normal.scenario == "normal"
+        assert normal.passed
+        assert normal.exit_code == 0
+        assert len(normal.findings) == 0
+
+        # Replay-owner-race
+        race = run_scenario_replay_owner_race(prepare, adapter, workers=8)
+        assert race.scenario == "replay-owner-race"
+        assert race.passed
+        assert race.exit_code == 0
+
+        # Crash-recovery
+        crash = run_scenario_crash_recovery(prepare, adapter)
+        assert crash.scenario == "crash-recovery"
+        assert crash.passed
+        assert crash.exit_code == 0
+
+        cleanup_canary(prepare)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_canary_verify_aborts():
+    """T42: verify aborts on identity drift, egress, active process, unknown."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        prepare = prepare_canary(
+            run_id="test-003",
+            source_hash="c" * 64,
+            root_parent=tmpdir,
+            now=3000,
+        )
+        adapter = LocalCaptureAdapter()
+
+        # Normal results
+        results = [
+            run_scenario_normal(prepare, adapter),
+            run_scenario_replay_owner_race(prepare, adapter),
+            run_scenario_crash_recovery(prepare, adapter),
+        ]
+
+        # Clean verify
+        verify = verify_canary(prepare, results)
+        assert verify.passed
+        assert len(verify.abort_reasons) == 0
+
+        # Identity drift
+        verify = verify_canary(prepare, results, identity_drift=True)
+        assert not verify.passed
+        assert "identity_drift" in verify.abort_reasons
+
+        # Egress violation
+        verify = verify_canary(prepare, results, egress_violation=True)
+        assert not verify.passed
+        assert "egress_violation" in verify.abort_reasons
+
+        # Active process after deadline
+        verify = verify_canary(prepare, results, active_processes=2)
+        assert not verify.passed
+        assert "active_process_after_deadline" in verify.abort_reasons
+
+        # Active lease after deadline
+        verify = verify_canary(prepare, results, active_leases=1)
+        assert not verify.passed
+        assert "active_lease_after_deadline" in verify.abort_reasons
+
+        # Unknown unresolved
+        verify = verify_canary(prepare, results, unknown_resolved=False)
+        assert not verify.passed
+        assert "unknown_unresolved" in verify.abort_reasons
+
+        # Scenario failure with duplicate finding
+        bad_results = [
+            CanaryScenarioResult(scenario="normal", passed=False, findings=["duplicate_lane"]),
+        ]
+        verify = verify_canary(prepare, bad_results)
+        assert not verify.passed
+        assert any("scenario_normal_failed" in r for r in verify.abort_reasons)
+        assert any("duplicate" in r for r in verify.abort_reasons)
+
+        cleanup_canary(prepare)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/hermes_cli/test_kanban_orch_canonical.py
+++ b/tests/hermes_cli/test_kanban_orch_canonical.py
@@ -1,0 +1,235 @@
+"""
+T01: Strict canonical contract — ORCH V4.
+
+Test vectors from §I.5 must-reject table + §3.1 normative Python.
+RED expected: module import fails → canonical_contract_missing.
+GREEN expected: all vectors pass with exact CanonicalError codes.
+"""
+
+import pytest
+import sys
+import os
+
+# Ensure worktree hermes_cli is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_canonical import (
+    CanonicalError,
+    strict_json_loads,
+    canonical_json_bytes,
+    digest,
+    require_exact_type,
+    require_sha256_hex,
+    normalize_tenant_scope,
+    validate_artifact_schema,
+    route_digest,
+    origin_id,
+    request_key,
+    node_key,
+)
+
+
+class TestStrictCanonicalContract:
+    """§I.5 must-reject vectors — every input must raise exact CanonicalError code."""
+
+    def test_strict_canonical_contract(self):
+        """All §I.5 R-* vectors in one test (matches §13 T01 selector)."""
+
+        # R-json-utf8: malformed UTF-8
+        with pytest.raises(CanonicalError) as exc:
+            strict_json_loads(b'{"k": "\xff"}' if False else b'{"k": "\xc0\xc0"}')
+        assert exc.value.code == "invalid_utf8", f"R-json-utf8: got {exc.value.code}"
+
+        # R-json-dup: duplicate key
+        with pytest.raises(CanonicalError) as exc:
+            strict_json_loads(b'{"a":1,"a":2}')
+        assert exc.value.code == "duplicate_or_nfc_colliding_key", f"R-json-dup: got {exc.value.code}"
+
+        # R-bool-int: bool where int expected
+        with pytest.raises(CanonicalError) as exc:
+            require_exact_type(True, int, code="invalid_int")
+        assert exc.value.code == "invalid_int", f"R-bool-int: got {exc.value.code}"
+
+        # R-float: any float in JSON
+        with pytest.raises(CanonicalError) as exc:
+            strict_json_loads(b'{"x": 1.5}')
+        assert exc.value.code == "float_not_allowed", f"R-float: got {exc.value.code}"
+
+        # R-digest: non-64-hex digest assertion
+        with pytest.raises(CanonicalError) as exc:
+            require_sha256_hex("not_a_hex", code="invalid_digest")
+        assert exc.value.code == "invalid_digest", f"R-digest: got {exc.value.code}"
+
+        # R-digest: 63 chars (too short)
+        with pytest.raises(CanonicalError) as exc:
+            require_sha256_hex("a" * 63, code="invalid_digest")
+        assert exc.value.code == "invalid_digest"
+
+        # R-tenant: tenant with trailing space (NFC + strip drift)
+        with pytest.raises(CanonicalError) as exc:
+            # normalize_tenant_scope strips, but validate_artifact_schema
+            # rejects if stored != normalized
+            artifact = {
+                "schema_version": 4,
+                "kind": "orch_origin",
+                "board_instance_id": "b",
+                "tenant_scope": "  drift  ",  # has leading/trailing space
+                "selector_key": "s",
+                "route_digest": "d",
+            }
+            validate_artifact_schema("orch_origin", artifact)
+        assert exc.value.code == "noncanonical_tenant_scope", f"R-tenant: got {exc.value.code}"
+
+        # R-ver: schema_version != 4
+        with pytest.raises(CanonicalError) as exc:
+            artifact = {
+                "schema_version": 3,  # wrong version
+                "kind": "orch_origin",
+                "board_instance_id": "b",
+                "tenant_scope": "",
+                "selector_key": "s",
+                "route_digest": "d",
+            }
+            validate_artifact_schema("orch_origin", artifact)
+        assert exc.value.code == "unsupported_artifact_schema", f"R-ver: got {exc.value.code}"
+
+        # Additional vectors from §3.1
+
+        # Missing required key
+        with pytest.raises(CanonicalError) as exc:
+            validate_artifact_schema("orch_origin", {
+                "schema_version": 4,
+                "kind": "orch_origin",
+                "board_instance_id": "b",
+                # missing selector_key, route_digest, tenant_scope
+            })
+        assert exc.value.code == "missing_artifact_key"
+
+        # Unknown artifact key
+        with pytest.raises(CanonicalError) as exc:
+            validate_artifact_schema("orch_origin", {
+                "schema_version": 4,
+                "kind": "orch_origin",
+                "board_instance_id": "b",
+                "tenant_scope": "",
+                "selector_key": "s",
+                "route_digest": "d",
+                "bogus_key": "x",
+            })
+        assert exc.value.code == "unknown_artifact_key"
+
+        # Artifact too large
+        with pytest.raises(CanonicalError) as exc:
+            strict_json_loads(b"x" * (1_048_576 + 1))
+        assert exc.value.code == "artifact_too_large"
+
+        # Max depth exceeded
+        deep = b"["
+        for _ in range(33):
+            deep += b"["
+        deep += b"]" * 33 + b"]"
+        with pytest.raises(CanonicalError) as exc:
+            strict_json_loads(deep)
+        assert exc.value.code == "max_depth_exceeded"
+
+        # Negative: valid input should NOT raise
+        valid = strict_json_loads(b'{"key": "value", "num": 42, "flag": true, "arr": [1, 2, 3]}')
+        assert valid["key"] == "value"
+        assert valid["num"] == 42
+        assert valid["flag"] is True
+        assert valid["arr"] == [1, 2, 3]
+
+        # Digest is deterministic 64-hex
+        d = digest({"a": 1, "b": "test"})
+        assert len(d) == 64
+        assert all(c in "0123456789abcdef" for c in d)
+
+        # node_key parent is __parent__
+        assert node_key({"role": "parent"}) == "__parent__"
+
+        # normalize_tenant_scope: None -> ""
+        assert normalize_tenant_scope(None) == ""
+        assert normalize_tenant_scope("  ") == ""
+
+
+    def test_tenant_normalization_gate(self):
+        """§13 T02: tenant NULL/space/NFC normalization and stored equality."""
+        assert normalize_tenant_scope(None) == ""
+        assert normalize_tenant_scope("  ") == ""
+        assert normalize_tenant_scope("test") == "test"
+
+        # NFC normalization: composed form
+        # é = NFC of e + combining acute
+        nfc = "caf\u00e9"  # café in NFC
+        decomposed = "cafe\u0301"  # cafe + combining acute (NFD)
+        assert normalize_tenant_scope(nfc) == nfc
+        assert normalize_tenant_scope(decomposed) == nfc  # NFC normalizes
+
+    def test_selector_precedence_and_zero_mutation(self):
+        """§13 T03: selector ledger replay/conflict zero mutation (in-memory test)."""
+        # For now, test that replay_selector_key is deterministic
+        from hermes_cli.kanban_orch_canonical import replay_selector_key
+
+        params = {
+            "board_instance_id": "board1",
+            "tenant_scope": "",
+            "adapter_instance_id": "adapter1",
+            "conversation_id": "conv1",
+            "selector_kind": "event",
+            "selector_value": "evt123",
+        }
+        key1 = replay_selector_key(params)
+        key2 = replay_selector_key(params)
+        assert key1 == key2, "replay_selector_key must be deterministic"
+        assert len(key1) == 64
+
+        # Different board → different key
+        params2 = dict(params, board_instance_id="board2")
+        key3 = replay_selector_key(params2)
+        assert key1 != key3, "different board must yield different selector key"
+
+    def test_generation_supersession_cas(self):
+        """§13 T04: supersede generation+1, one successor, ledger CAS."""
+        from hermes_cli.kanban_orch_canonical import validate_supersession, request_key
+
+        base = {
+            "board_instance_id": "board1",
+            "tenant_scope": "",
+            "selector_key": "sk1",
+            "lineage_id": "lin1",
+        }
+
+        # Gen 1 predecessor (failed) → Gen 2 successor: valid
+        predecessor = {**base, "generation": 1, "lifecycle_state": "failed"}
+        successor = {**base, "generation": 2, "lifecycle_state": "submitted"}
+        key = validate_supersession(predecessor, successor)
+        assert len(key) == 64
+
+        # request_key differs between generations
+        pred_key = request_key(predecessor)
+        succ_key = request_key(successor)
+        assert pred_key != succ_key, "different generations must have different request_keys"
+
+        # Generation must be exactly +1
+        with pytest.raises(CanonicalError) as exc:
+            bad_succ = {**base, "generation": 3, "lifecycle_state": "submitted"}
+            validate_supersession(predecessor, bad_succ)
+        assert exc.value.code == "supersession_generation_not_incremented"
+
+        # Predecessor must be terminal
+        with pytest.raises(CanonicalError) as exc:
+            non_terminal = {**base, "generation": 1, "lifecycle_state": "waiting_lanes"}
+            validate_supersession(non_terminal, {**base, "generation": 2, "lifecycle_state": "submitted"})
+        assert exc.value.code == "supersession_predecessor_not_terminal"
+
+        # Lineage must match
+        with pytest.raises(CanonicalError) as exc:
+            diff_lineage = {**base, "lineage_id": "lin2", "generation": 2, "lifecycle_state": "submitted"}
+            validate_supersession(predecessor, diff_lineage)
+        assert exc.value.code == "supersession_lineage_mismatch"
+
+        # Cancelled predecessor also valid
+        cancelled_pred = {**base, "generation": 5, "lifecycle_state": "cancelled"}
+        cancelled_succ = {**base, "generation": 6, "lifecycle_state": "submitted"}
+        key2 = validate_supersession(cancelled_pred, cancelled_succ)
+        assert len(key2) == 64

--- a/tests/hermes_cli/test_kanban_orch_cmin.py
+++ b/tests/hermes_cli/test_kanban_orch_cmin.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -11,27 +10,18 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from hermes_cli.kanban_orch_bridge import init_sidecar_db
-from hermes_cli.kanban_orch_cmin import judge_board_only_to_fixed_point
+from hermes_cli.kanban_orch_cmin import (
+    children_progress,
+    judge_board_only_to_fixed_point,
+    live_tick_once,
+    read_native_children,
+)
 from hermes_cli.kanban_orch_dual_bind import dual_bind_parent_task
 from hermes_cli.kanban_orch_lifecycle import LifecycleError, Request, apply_transition
-from hermes_cli.kanban_orch_writer_switch import writer_enabled
+from hermes_cli.kanban_orch_writer_switch import open_live_bridge, writer_enabled
 
 
-def test_board_only_parent_done_evidence_gate():
-    req = Request("b", "", "o", "submitted")
-    with pytest.raises(LifecycleError, match="board_only_parent_not_done"):
-        apply_transition(req, "board_only_parent_done", "completed", origin_kind="board_only")
-    ok = apply_transition(
-        req,
-        "board_only_parent_done",
-        "completed",
-        origin_kind="board_only",
-        native_parent_done=True,
-    )
-    assert ok.state == "completed"
-
-
-def test_cmin_fixed_point_temp(tmp_path, monkeypatch):
+def _setup_pair(tmp_path, monkeypatch, *, parent_status="running", children=None):
     native = tmp_path / "n.db"
     side = tmp_path / "s.db"
     cfg = tmp_path / "w.json"
@@ -40,7 +30,15 @@ def test_cmin_fixed_point_temp(tmp_path, monkeypatch):
         "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, "
         "created_at INTEGER NOT NULL, tenant TEXT)"
     )
-    nc.execute("INSERT INTO tasks VALUES ('t1','hello','running',1,'')")
+    nc.execute(
+        "CREATE TABLE task_links (parent_id TEXT NOT NULL, child_id TEXT NOT NULL, "
+        "kind TEXT NOT NULL DEFAULT 'depends', PRIMARY KEY (parent_id, child_id))"
+    )
+    nc.execute(f"INSERT INTO tasks VALUES ('t1','hello',?,1,'')", (parent_status,))
+    for i, st in enumerate(children or [], start=1):
+        cid = f"c{i}"
+        nc.execute("INSERT INTO tasks VALUES (?,?,?,1,'')", (cid, f"child{i}", st))
+        nc.execute("INSERT INTO task_links VALUES (?,?,?)", ("t1", cid, "depends"))
     nc.commit()
     nc.close()
     init_sidecar_db(str(side))
@@ -61,10 +59,33 @@ def test_cmin_fixed_point_temp(tmp_path, monkeypatch):
     assert writer_enabled(cfg) is True
     bound = dual_bind_parent_task(task_id="t1", title="hello", cfg_path=cfg)
     assert bound.error is None, bound
+    return native, side, cfg, bound
 
-    # open sidecar with same grants path via dual_bind already wrote request
-    from hermes_cli.kanban_orch_writer_switch import open_live_bridge
 
+def test_board_only_parent_done_evidence_gate():
+    req = Request("b", "", "o", "submitted")
+    with pytest.raises(LifecycleError, match="board_only_parent_not_done"):
+        apply_transition(req, "board_only_parent_done", "completed", origin_kind="board_only")
+    ok = apply_transition(
+        req,
+        "board_only_parent_done",
+        "completed",
+        origin_kind="board_only",
+        native_parent_done=True,
+    )
+    assert ok.state == "completed"
+    ok2 = apply_transition(
+        Request("b", "", "o", "decomposing", lifecycle_revision=1),
+        "board_only_parent_done",
+        "completed",
+        origin_kind="board_only",
+        children_all_done=True,
+    )
+    assert ok2.state == "completed"
+
+
+def test_cmin_fixed_point_temp(tmp_path, monkeypatch):
+    native, side, cfg, bound = _setup_pair(tmp_path, monkeypatch)
     br = open_live_bridge(cfg)
     try:
         mid = judge_board_only_to_fixed_point(
@@ -75,7 +96,6 @@ def test_cmin_fixed_point_temp(tmp_path, monkeypatch):
             native_status="running",
         )
         assert mid.after_state == "decomposing", mid
-        # mark native done and complete
         nc = sqlite3.connect(native)
         nc.execute("UPDATE tasks SET status='done' WHERE id='t1'")
         nc.commit()
@@ -91,3 +111,56 @@ def test_cmin_fixed_point_temp(tmp_path, monkeypatch):
         assert any(s.event == "board_only_parent_done" for s in fin.steps)
     finally:
         br.close()
+
+
+def test_children_all_done_completes_while_parent_running(tmp_path, monkeypatch):
+    native, side, cfg, bound = _setup_pair(
+        tmp_path, monkeypatch, parent_status="running", children=["done", "done"]
+    )
+    br = open_live_bridge(cfg)
+    try:
+        kids = read_native_children(br._native, "t1")
+        total, done, all_done = children_progress(kids)
+        assert (total, done, all_done) == (2, 2, True)
+        fin = judge_board_only_to_fixed_point(
+            br._sidecar,
+            board_instance_id=bound.board_instance_id or "",
+            tenant_scope=bound.tenant_scope,
+            orch_id=bound.orch_id or "",
+            native_status="running",
+            children_all_done=True,
+            children_total=2,
+            children_done=2,
+        )
+        assert fin.after_state == "completed", fin
+        assert fin.children_all_done is True
+    finally:
+        br.close()
+
+
+def test_live_tick_once_scans_open(tmp_path, monkeypatch):
+    native, side, cfg, bound = _setup_pair(tmp_path, monkeypatch, parent_status="ready")
+    from hermes_cli import kanban_orch_writer_switch as ws
+    from hermes_cli import kanban_orch_cmin as cmin
+
+    orig = ws.open_live_bridge
+
+    def _open(cfg_path=None):
+        return orig(cfg_path or cfg)
+
+    monkeypatch.setattr(ws, "open_live_bridge", _open)
+    monkeypatch.setattr(cmin, "open_live_bridge", _open)
+
+    tick = live_tick_once(limit=10)
+    assert tick.scanned >= 1
+    assert tick.advanced >= 1
+    assert any(r.after_state == "decomposing" for r in tick.results)
+
+    # parent done → completed on next tick
+    nc = sqlite3.connect(native)
+    nc.execute("UPDATE tasks SET status='done' WHERE id='t1'")
+    nc.commit()
+    nc.close()
+    tick2 = live_tick_once(limit=10)
+    assert tick2.completed >= 1
+    assert any(r.after_state == "completed" for r in tick2.results)

--- a/tests/hermes_cli/test_kanban_orch_cmin.py
+++ b/tests/hermes_cli/test_kanban_orch_cmin.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hermes_cli.kanban_orch_bridge import init_sidecar_db
+from hermes_cli.kanban_orch_cmin import judge_board_only_to_fixed_point
+from hermes_cli.kanban_orch_dual_bind import dual_bind_parent_task
+from hermes_cli.kanban_orch_lifecycle import LifecycleError, Request, apply_transition
+from hermes_cli.kanban_orch_writer_switch import writer_enabled
+
+
+def test_board_only_parent_done_evidence_gate():
+    req = Request("b", "", "o", "submitted")
+    with pytest.raises(LifecycleError, match="board_only_parent_not_done"):
+        apply_transition(req, "board_only_parent_done", "completed", origin_kind="board_only")
+    ok = apply_transition(
+        req,
+        "board_only_parent_done",
+        "completed",
+        origin_kind="board_only",
+        native_parent_done=True,
+    )
+    assert ok.state == "completed"
+
+
+def test_cmin_fixed_point_temp(tmp_path, monkeypatch):
+    native = tmp_path / "n.db"
+    side = tmp_path / "s.db"
+    cfg = tmp_path / "w.json"
+    nc = sqlite3.connect(native)
+    nc.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, "
+        "created_at INTEGER NOT NULL, tenant TEXT)"
+    )
+    nc.execute("INSERT INTO tasks VALUES ('t1','hello','running',1,'')")
+    nc.commit()
+    nc.close()
+    init_sidecar_db(str(side))
+    cfg.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "enabled_default": True,
+                "native_db": str(native),
+                "sidecar_db": str(side),
+                "native_writable": False,
+                "canonical_board_key": "tmp",
+                "tenant_scope": "",
+            }
+        )
+    )
+    monkeypatch.delenv("ORCH_V4_WRITER", raising=False)
+    assert writer_enabled(cfg) is True
+    bound = dual_bind_parent_task(task_id="t1", title="hello", cfg_path=cfg)
+    assert bound.error is None, bound
+
+    # open sidecar with same grants path via dual_bind already wrote request
+    from hermes_cli.kanban_orch_writer_switch import open_live_bridge
+
+    br = open_live_bridge(cfg)
+    try:
+        mid = judge_board_only_to_fixed_point(
+            br._sidecar,
+            board_instance_id=bound.board_instance_id or "",
+            tenant_scope=bound.tenant_scope,
+            orch_id=bound.orch_id or "",
+            native_status="running",
+        )
+        assert mid.after_state == "decomposing", mid
+        # mark native done and complete
+        nc = sqlite3.connect(native)
+        nc.execute("UPDATE tasks SET status='done' WHERE id='t1'")
+        nc.commit()
+        nc.close()
+        fin = judge_board_only_to_fixed_point(
+            br._sidecar,
+            board_instance_id=bound.board_instance_id or "",
+            tenant_scope=bound.tenant_scope,
+            orch_id=bound.orch_id or "",
+            native_status="done",
+        )
+        assert fin.after_state == "completed", fin
+        assert any(s.event == "board_only_parent_done" for s in fin.steps)
+    finally:
+        br.close()

--- a/tests/hermes_cli/test_kanban_orch_delivery.py
+++ b/tests/hermes_cli/test_kanban_orch_delivery.py
@@ -136,6 +136,7 @@ def test_receipt_exact_binding():
     attempt = start_attempt(obl, attempt_id=1, send_nonce="n1", payload_digest=D,
                             result_digest=D, claim_owner="w1", claim_token_hash="t1",
                             claim_epoch=1, lifecycle_revision=0, cancel_epoch=0)
+    finish_attempt(obl, attempt, terminal_state="adapter_accepted", now=150)
 
     # Valid receipt
     receipt = DeliveryReceipt(
@@ -150,8 +151,9 @@ def test_receipt_exact_binding():
     # Reset for negative tests
     obl.state = "claimed"
     obl.acceptance_attempt_id = None
-    attempt.state = "started"
-    attempt.finished_at = None
+    obl.open_attempt_id = None
+    attempt.state = "adapter_accepted"
+    attempt.finished_at = 150
 
     # Wrong attempt ID
     bad_receipt = DeliveryReceipt(
@@ -276,7 +278,7 @@ def test_outcome_atomic_bundle():
     attempt2 = DeliveryAttempt(
         attempt_id=2, obligation_id="o2", send_nonce="n2", payload_digest=D,
         result_digest=D, route_digest=D, claim_owner="w1", claim_token_hash="t1",
-        claim_epoch=1, lifecycle_revision=0, cancel_epoch=0,
+        claim_epoch=1, lifecycle_revision=0, cancel_epoch=0, state="adapter_accepted",
     )
     bad_receipt = DeliveryReceipt(
         attempt_id=2, obligation_id="o2", send_nonce="n2",
@@ -303,7 +305,7 @@ def test_accepted_unknown_recovery():
     process_receipt(obl, DeliveryAttempt(
         attempt_id=1, obligation_id="o1", send_nonce="n1", payload_digest=D,
         result_digest=D, route_digest=D, claim_owner="w1", claim_token_hash="t1",
-        claim_epoch=1, lifecycle_revision=0, cancel_epoch=0,
+        claim_epoch=1, lifecycle_revision=0, cancel_epoch=0, state="unknown",
     ), receipt, now=500)
     assert obl.state == "acked"
     assert obl.acceptance_attempt_id == 1

--- a/tests/hermes_cli/test_kanban_orch_delivery.py
+++ b/tests/hermes_cli/test_kanban_orch_delivery.py
@@ -1,0 +1,309 @@
+"""M5 T23-T33: Delivery protocol — obligations, ACK family, receipt, completion."""
+
+import pytest
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_delivery import (
+    ACK_FAMILIES,
+    DeliveryError,
+    DeliveryAttempt,
+    DeliveryObligation,
+    DeliveryReceipt,
+    ManifestEntry,
+    authorize_resend,
+    check_delivery_satisfied,
+    check_delivery_terminal_semantics,
+    claim_obligation,
+    create_obligations_from_manifest,
+    finish_attempt,
+    process_receipt,
+    start_attempt,
+    validate_ack_family,
+)
+
+D = "a" * 64  # 64-hex digest
+
+
+def make_manifest(required_count=2, optional_count=1, origin_kind="messaging"):
+    """Helper: create manifest entries."""
+    entries = []
+    for i in range(required_count):
+        entries.append(ManifestEntry(
+            manifest_entry_key=f"entry-req-{i}",
+            required=True,
+            route_digest=f"route-{i}",
+            required_ack_family="provider",
+            required_ack_strength="message_id",
+        ))
+    for i in range(optional_count):
+        entries.append(ManifestEntry(
+            manifest_entry_key=f"entry-opt-{i}",
+            required=False,
+            route_digest=f"route-opt-{i}",
+            required_ack_family="adapter",
+            required_ack_strength="adapter_acceptance",
+        ))
+    return entries
+
+
+def test_adapter_boundary_capability():
+    """T23: unauthorized send reaches adapter without capability.
+
+    Claim must be owned; attempt must match owner/token/epoch.
+    """
+    entries = make_manifest(1, 0)
+    obls = create_obligations_from_manifest(entries, origin_kind="messaging")
+    obl = obls[0]
+
+    # Claim on non-pending state should fail
+    obl.state = "claimed"
+    with pytest.raises(DeliveryError, match="claim_not_pending"):
+        claim_obligation(obl, owner="worker1", token_hash="t1", ttl=30, now=100)
+
+    # Proper claim from pending
+    obl.state = "pending"
+    epoch = claim_obligation(obl, owner="worker1", token_hash="t1", ttl=30, now=100)
+    assert epoch == 1
+    assert obl.state == "claimed"
+
+    # Attempt with wrong owner
+    with pytest.raises(DeliveryError, match="attempt_wrong_owner"):
+        start_attempt(obl, attempt_id=1, send_nonce="n1", payload_digest=D,
+                      result_digest=D, claim_owner="wrong", claim_token_hash="t1",
+                      claim_epoch=1, lifecycle_revision=0, cancel_epoch=0)
+
+    # Attempt with wrong token
+    with pytest.raises(DeliveryError, match="attempt_wrong_token"):
+        start_attempt(obl, attempt_id=1, send_nonce="n1", payload_digest=D,
+                      result_digest=D, claim_owner="worker1", claim_token_hash="wrong",
+                      claim_epoch=1, lifecycle_revision=0, cancel_epoch=0)
+
+    # Attempt with wrong epoch
+    with pytest.raises(DeliveryError, match="attempt_wrong_epoch"):
+        start_attempt(obl, attempt_id=1, send_nonce="n1", payload_digest=D,
+                      result_digest=D, claim_owner="worker1", claim_token_hash="t1",
+                      claim_epoch=99, lifecycle_revision=0, cancel_epoch=0)
+
+    # Attempt with unclaimed obligation
+    obl.state = "pending"
+    with pytest.raises(DeliveryError, match="attempt_not_claimed"):
+        start_attempt(obl, attempt_id=1, send_nonce="n1", payload_digest=D,
+                      result_digest=D, claim_owner="worker1", claim_token_hash="t1",
+                      claim_epoch=1, lifecycle_revision=0, cancel_epoch=0)
+
+
+def test_exact_delivery_manifest():
+    """T24: manifest missing/extra required entry never completes."""
+    entries = make_manifest(2, 1)
+    obls = create_obligations_from_manifest(entries, origin_kind="messaging")
+    assert len(obls) == 3
+
+    # No ACKs yet → not satisfied
+    assert not check_delivery_satisfied(obls, origin_kind="messaging")
+
+    # ACK only 1 of 2 required → not satisfied
+    obls[0].state = "acked"
+    obls[0].acceptance_attempt_id = 1
+    assert not check_delivery_satisfied(obls, origin_kind="messaging")
+
+    # ACK both required → satisfied (optional doesn't block)
+    obls[1].state = "acked"
+    obls[1].acceptance_attempt_id = 2
+    assert check_delivery_satisfied(obls, origin_kind="messaging")
+
+    # Board-only with zero required → satisfied immediately
+    board_entries = []
+    board_obls = create_obligations_from_manifest(board_entries, origin_kind="board_only")
+    assert len(board_obls) == 0
+    assert check_delivery_satisfied(board_obls, origin_kind="board_only")
+
+    # Board-only with required entries → error
+    bad_entries = make_manifest(1, 0)
+    with pytest.raises(DeliveryError, match="board_only_has_required_obligations"):
+        create_obligations_from_manifest(bad_entries, origin_kind="board_only")
+
+
+def test_receipt_exact_binding():
+    """T27: receipt binds attempt/nonce/payload/result/route/family."""
+    entries = make_manifest(1, 0)
+    obls = create_obligations_from_manifest(entries, origin_kind="messaging")
+    obl = obls[0]
+    claim_obligation(obl, owner="w1", token_hash="t1", ttl=30, now=100)
+
+    attempt = start_attempt(obl, attempt_id=1, send_nonce="n1", payload_digest=D,
+                            result_digest=D, claim_owner="w1", claim_token_hash="t1",
+                            claim_epoch=1, lifecycle_revision=0, cancel_epoch=0)
+
+    # Valid receipt
+    receipt = DeliveryReceipt(
+        attempt_id=1, obligation_id=obl.obligation_id, send_nonce="n1",
+        payload_digest=D, result_digest=D, route_digest=obl.route_digest,
+        observed_ack_family="provider", observed_ack_strength="message_id",
+    )
+    process_receipt(obl, attempt, receipt, now=200)
+    assert obl.state == "acked"
+    assert obl.acceptance_attempt_id == 1
+
+    # Reset for negative tests
+    obl.state = "claimed"
+    obl.acceptance_attempt_id = None
+    attempt.state = "started"
+    attempt.finished_at = None
+
+    # Wrong attempt ID
+    bad_receipt = DeliveryReceipt(
+        attempt_id=99, obligation_id=obl.obligation_id, send_nonce="n1",
+        payload_digest=D, result_digest=D, route_digest=obl.route_digest,
+        observed_ack_family="provider", observed_ack_strength="message_id",
+    )
+    with pytest.raises(DeliveryError, match="receipt_attempt_mismatch"):
+        process_receipt(obl, attempt, bad_receipt)
+
+    # Wrong nonce
+    bad_receipt = DeliveryReceipt(
+        attempt_id=1, obligation_id=obl.obligation_id, send_nonce="wrong",
+        payload_digest=D, result_digest=D, route_digest=obl.route_digest,
+        observed_ack_family="provider", observed_ack_strength="message_id",
+    )
+    with pytest.raises(DeliveryError, match="receipt_nonce_mismatch"):
+        process_receipt(obl, attempt, bad_receipt)
+
+    # Cross-family ACK
+    bad_receipt = DeliveryReceipt(
+        attempt_id=1, obligation_id=obl.obligation_id, send_nonce="n1",
+        payload_digest=D, result_digest=D, route_digest=obl.route_digest,
+        observed_ack_family="adapter", observed_ack_strength="adapter_acceptance",
+    )
+    with pytest.raises(DeliveryError, match="cross_family_ack_satisfied"):
+        process_receipt(obl, attempt, bad_receipt)
+
+    # Wrong strength
+    bad_receipt = DeliveryReceipt(
+        attempt_id=1, obligation_id=obl.obligation_id, send_nonce="n1",
+        payload_digest=D, result_digest=D, route_digest=obl.route_digest,
+        observed_ack_family="provider", observed_ack_strength="adapter_acceptance",
+    )
+    with pytest.raises(DeliveryError, match="ack_strength_mismatch"):
+        process_receipt(obl, attempt, bad_receipt)
+
+
+def test_ack_family_exact():
+    """T32: typed ACK family rejects cross-family receipt."""
+    validate_ack_family("provider", "message_id")
+    validate_ack_family("none", "none")
+
+    with pytest.raises(DeliveryError, match="invalid_ack_family"):
+        validate_ack_family("invalid", "none")
+    with pytest.raises(DeliveryError, match="invalid_ack_strength"):
+        validate_ack_family("provider", "invalid")
+    with pytest.raises(DeliveryError, match="ack_family_strength_mismatch"):
+        validate_ack_family("provider", "adapter_acceptance")
+
+
+def test_delivery_terminal_semantics():
+    """T31: required dead_letter/unknown/cancel never satisfy; optional non-blocking."""
+    obls = [
+        DeliveryObligation("o1", "k1", True, D, "provider", "message_id", state="acked", acceptance_attempt_id=1),
+        DeliveryObligation("o2", "k2", True, D, "provider", "message_id", state="dead_letter"),
+        DeliveryObligation("o3", "k3", True, D, "provider", "message_id", state="unknown"),
+        DeliveryObligation("o4", "k4", True, D, "provider", "message_id", state="cancelled"),
+        DeliveryObligation("o5", "k5", False, D, "adapter", "adapter_acceptance", state="dead_letter"),
+        DeliveryObligation("o6", "k6", False, D, "adapter", "adapter_acceptance", state="acked"),
+    ]
+    result = check_delivery_terminal_semantics(obls)
+    assert result["o1"] is True   # required acked
+    assert result["o2"] is False  # required dead_letter
+    assert result["o3"] is False  # required unknown
+    assert result["o4"] is False  # required cancelled
+    assert result["o5"] is True   # optional dead_letter — non-blocking
+    assert result["o6"] is True   # optional acked
+
+
+def test_unknown_resend_authorization():
+    """T30: unknown human auth exact attempt/expiry, new generation."""
+    obl = DeliveryObligation("o1", "k1", True, D, "provider", "message_id",
+                             delivery_generation=1, state="unknown")
+    new_obl = authorize_resend(obl, new_generation=2)
+    assert new_obl.delivery_generation == 2
+    assert new_obl.state == "pending"
+    assert new_obl.duplicate_possible is True
+    assert new_obl.obligation_id != obl.obligation_id
+
+    # Non-unknown cannot resend
+    obl2 = DeliveryObligation("o2", "k2", True, D, "provider", "message_id", state="acked")
+    with pytest.raises(DeliveryError, match="resend_not_authorized"):
+        authorize_resend(obl2, new_generation=2)
+
+    # Generation must be +1
+    with pytest.raises(DeliveryError, match="invalid_resend_generation"):
+        authorize_resend(obl, new_generation=3)  # skip +1
+
+
+def test_outcome_atomic_bundle():
+    """T28: outcome attempt/event/receipt/obligation atomic transaction.
+
+    Attempt finish + receipt processing must be atomic: if receipt fails,
+    obligation must not be partially acked.
+    """
+    entries = make_manifest(1, 0)
+    obls = create_obligations_from_manifest(entries, origin_kind="messaging")
+    obl = obls[0]
+    claim_obligation(obl, owner="w1", token_hash="t1", ttl=30, now=100)
+
+    attempt = start_attempt(obl, attempt_id=1, send_nonce="n1", payload_digest=D,
+                            result_digest=D, claim_owner="w1", claim_token_hash="t1",
+                            claim_epoch=1, lifecycle_revision=0, cancel_epoch=0)
+
+    # Finish attempt
+    finish_attempt(obl, attempt, terminal_state="adapter_accepted", now=200)
+    assert attempt.state == "adapter_accepted"
+
+    # Process receipt — atomic with finish
+    receipt = DeliveryReceipt(
+        attempt_id=1, obligation_id=obl.obligation_id, send_nonce="n1",
+        payload_digest=D, result_digest=D, route_digest=obl.route_digest,
+        observed_ack_family="provider", observed_ack_strength="message_id",
+    )
+    process_receipt(obl, attempt, receipt, now=300)
+    assert obl.state == "acked"
+
+    # If receipt fails, obligation stays claimed
+    obl2_state_before = "claimed"
+    obl2 = DeliveryObligation("o2", "k2", True, D, "provider", "message_id", state="claimed")
+    attempt2 = DeliveryAttempt(
+        attempt_id=2, obligation_id="o2", send_nonce="n2", payload_digest=D,
+        result_digest=D, route_digest=D, claim_owner="w1", claim_token_hash="t1",
+        claim_epoch=1, lifecycle_revision=0, cancel_epoch=0,
+    )
+    bad_receipt = DeliveryReceipt(
+        attempt_id=2, obligation_id="o2", send_nonce="n2",
+        payload_digest="wrong", result_digest=D, route_digest=D,
+        observed_ack_family="provider", observed_ack_strength="message_id",
+    )
+    with pytest.raises(DeliveryError):
+        process_receipt(obl2, attempt2, bad_receipt)
+    assert obl2.state == "claimed"  # not partially acked
+
+
+def test_accepted_unknown_recovery():
+    """T29: crash accepted recovery and unknown→acked without resend."""
+    obl = DeliveryObligation("o1", "k1", True, D, "provider", "message_id",
+                             state="unknown", delivery_generation=1)
+
+    # Simulate provider-query: find valid receipt, unknown→acked
+    receipt = DeliveryReceipt(
+        attempt_id=1, obligation_id="o1", send_nonce="n1",
+        payload_digest=D, result_digest=D, route_digest=D,
+        observed_ack_family="provider", observed_ack_strength="message_id",
+    )
+    # unknown state can be acked (recovery path)
+    process_receipt(obl, DeliveryAttempt(
+        attempt_id=1, obligation_id="o1", send_nonce="n1", payload_digest=D,
+        result_digest=D, route_digest=D, claim_owner="w1", claim_token_hash="t1",
+        claim_epoch=1, lifecycle_revision=0, cancel_epoch=0,
+    ), receipt, now=500)
+    assert obl.state == "acked"
+    assert obl.acceptance_attempt_id == 1

--- a/tests/hermes_cli/test_kanban_orch_digest_udf.py
+++ b/tests/hermes_cli/test_kanban_orch_digest_udf.py
@@ -1,0 +1,173 @@
+"""SQL-layer digest UDF guards for ORCH V4."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_canonical import request_digest
+from hermes_cli.kanban_orch_digest_udf import build_route_json_and_digest
+from hermes_cli.kanban_orch_schema_v4 import apply_schema
+from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
+
+
+def _conn_inplace():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    conn = sqlite3.connect(path)
+    apply_schema(conn, test_open_capability=True)
+    return conn, path
+
+
+def test_sql_route_digest_mismatch_rejected():
+    conn, path = _conn_inplace()
+    try:
+        b = "board_0123456789abcdef"
+        sk = "a" * 64
+        route_json, route_d = build_route_json_and_digest(
+            origin_kind="board_only",
+            platform="local",
+            adapter_instance_id="ad",
+            account_id="ac",
+            conversation_id="cv",
+            required_ack_family="none",
+            required_ack_strength="none",
+            route_revision=1,
+        )
+        conn.execute(
+            "INSERT INTO kanban_board_identity(singleton,board_instance_id,canonical_board_key,created_at)"
+            " VALUES (1, ?, 'k', 1)",
+            (b,),
+        )
+        conn.execute(
+            "INSERT INTO orch_replay_selectors"
+            " (selector_key,board_instance_id,tenant_scope,selector_kind,selector_value,"
+            "  adapter_instance_id,conversation_id,lineage_id,current_generation,"
+            "  ledger_revision,created_at,updated_at)"
+            " VALUES (?,?, '', 'event','v','ad','cv','lin',0,0,1,1)",
+            (sk, b),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="route_digest_mismatch"):
+            conn.execute(
+                "INSERT INTO orch_origins"
+                " (board_instance_id,tenant_scope,origin_id,schema_version,selector_key,"
+                "  origin_kind,platform,adapter_instance_id,account_id,conversation_id,"
+                "  selector_kind,selector_value,thread_id,reply_to_id,session_id,"
+                "  notifier_profile,route_revision,route_json,route_digest,"
+                "  required_ack_family,required_ack_strength,created_at)"
+                " VALUES (?,?, 'o1',4,?,'board_only','local','ad','ac','cv',"
+                "  'event','v','','','','',1,?,?,'none','none',1)",
+                (b, "", sk, route_json, "f" * 64),
+            )
+        # matching digest passes
+        conn.execute(
+            "INSERT INTO orch_origins"
+            " (board_instance_id,tenant_scope,origin_id,schema_version,selector_key,"
+            "  origin_kind,platform,adapter_instance_id,account_id,conversation_id,"
+            "  selector_kind,selector_value,thread_id,reply_to_id,session_id,"
+            "  notifier_profile,route_revision,route_json,route_digest,"
+            "  required_ack_family,required_ack_strength,created_at)"
+            " VALUES (?,?, 'o1',4,?,'board_only','local','ad','ac','cv',"
+            "  'event','v','','','','',1,?,?,'none','none',1)",
+            (b, "", sk, route_json, route_d),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+        os.unlink(path)
+
+
+def test_sql_request_digest_mismatch_rejected_on_sidecar():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    conn = sqlite3.connect(path)
+    try:
+        apply_sidecar_schema(conn, test_open_capability=True)
+        b = "board_0123456789abcdef"
+        sk = "a" * 64
+        route_json, route_d = build_route_json_and_digest(
+            origin_kind="board_only",
+            platform="local",
+            adapter_instance_id="ad",
+            account_id="ac",
+            conversation_id="cv",
+            required_ack_family="none",
+            required_ack_strength="none",
+            route_revision=1,
+        )
+        req = {
+            "schema_version": 4,
+            "kind": "orch_request",
+            "selector_key": sk,
+            "request_key": sk,
+            "origin_id": "oid1",
+            "lineage_id": "lin1",
+            "generation": 1,
+            "title": "t",
+            "synthesis_strategy": "parent_owned",
+            "completion_policy": "board_only",
+            "requirements": [],
+        }
+        req_json = json.dumps(req, sort_keys=True, separators=(",", ":"))
+        req_d = request_digest(req)
+        conn.execute(
+            "INSERT INTO kanban_board_identity(singleton,board_instance_id,canonical_board_key,created_at)"
+            " VALUES (1, ?, 'k', 1)",
+            (b,),
+        )
+        conn.execute(
+            "INSERT INTO orch_replay_selectors"
+            " (selector_key,board_instance_id,tenant_scope,selector_kind,selector_value,"
+            "  adapter_instance_id,conversation_id,lineage_id,current_generation,"
+            "  ledger_revision,created_at,updated_at)"
+            " VALUES (?,?, '', 'event','v','ad','cv','lin1',0,0,1,1)",
+            (sk, b),
+        )
+        conn.execute(
+            "INSERT INTO orch_origins"
+            " (board_instance_id,tenant_scope,origin_id,schema_version,selector_key,"
+            "  origin_kind,platform,adapter_instance_id,account_id,conversation_id,"
+            "  selector_kind,selector_value,thread_id,reply_to_id,session_id,"
+            "  notifier_profile,route_revision,route_json,route_digest,"
+            "  required_ack_family,required_ack_strength,created_at)"
+            " VALUES (?,?, 'oid1',4,?,'board_only','local','ad','ac','cv',"
+            "  'event','v','','','','',1,?,?,'none','none',1)",
+            (b, "", sk, route_json, route_d),
+        )
+        conn.execute("INSERT INTO _soft_fk_tasks(id,title,status,created_at) VALUES ('p1','t','pending',1)")
+        with pytest.raises(sqlite3.IntegrityError, match="request_digest_mismatch"):
+            conn.execute(
+                "INSERT INTO orch_requests"
+                " (board_instance_id,tenant_scope,orch_id,lineage_id,generation,"
+                "  selector_key,selector_ledger_revision,request_key,request_schema_version,"
+                "  request_json,request_digest,origin_id,parent_task_id,"
+                "  lifecycle_state,lifecycle_revision,cancel_epoch,"
+                "  delivery_epoch_revision,plan_epoch_revision,plan_version,"
+                "  synthesis_strategy,max_retries,created_at,updated_at)"
+                " VALUES (?,?, 'orch1','lin1',1,?,0,?,4,?,?,'oid1','p1',"
+                "  'submitted',0,0,0,0,0,'parent_owned',0,1,1)",
+                (b, "", sk, sk, req_json, "e" * 64),
+            )
+        conn.execute(
+            "INSERT INTO orch_requests"
+            " (board_instance_id,tenant_scope,orch_id,lineage_id,generation,"
+            "  selector_key,selector_ledger_revision,request_key,request_schema_version,"
+            "  request_json,request_digest,origin_id,parent_task_id,"
+            "  lifecycle_state,lifecycle_revision,cancel_epoch,"
+            "  delivery_epoch_revision,plan_epoch_revision,plan_version,"
+            "  synthesis_strategy,max_retries,created_at,updated_at)"
+            " VALUES (?,?, 'orch1','lin1',1,?,0,?,4,?,?,'oid1','p1',"
+            "  'submitted',0,0,0,0,0,'parent_owned',0,1,1)",
+            (b, "", sk, sk, req_json, req_d),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+        os.unlink(path)

--- a/tests/hermes_cli/test_kanban_orch_digest_udf.py
+++ b/tests/hermes_cli/test_kanban_orch_digest_udf.py
@@ -1,4 +1,4 @@
-"""SQL-layer digest UDF guards for ORCH V4."""
+"""SQL-layer digest UDF guards for ORCH V4 (route/request/result/event/payload)."""
 
 from __future__ import annotations
 
@@ -12,10 +12,15 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from hermes_cli.kanban_orch_canonical import request_digest
-from hermes_cli.kanban_orch_digest_udf import build_route_json_and_digest
-from hermes_cli.kanban_orch_schema_v4 import apply_schema
+from hermes_cli.kanban_orch_bridge import OrchBridge, init_sidecar_db
+from hermes_cli.kanban_orch_canonical import digest, event_key, request_digest, result_digest
+from hermes_cli.kanban_orch_digest_udf import (
+    build_payload_json_and_digest,
+    build_result_json_and_digest,
+    build_route_json_and_digest,
+)
 from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
+from hermes_cli.kanban_orch_schema_v4 import apply_schema
 
 
 def _conn_inplace():
@@ -66,7 +71,6 @@ def test_sql_route_digest_mismatch_rejected():
                 "  'event','v','','','','',1,?,?,'none','none',1)",
                 (b, "", sk, route_json, "f" * 64),
             )
-        # matching digest passes
         conn.execute(
             "INSERT INTO orch_origins"
             " (board_instance_id,tenant_scope,origin_id,schema_version,selector_key,"
@@ -171,3 +175,168 @@ def test_sql_request_digest_mismatch_rejected_on_sidecar():
     finally:
         conn.close()
         os.unlink(path)
+
+
+def test_result_event_payload_receipt_guards(tmp_path):
+    native = tmp_path / "n.db"
+    side = tmp_path / "s.db"
+    nc = sqlite3.connect(native)
+    nc.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, "
+        "created_at INTEGER NOT NULL, tenant TEXT)"
+    )
+    nc.execute("INSERT INTO tasks VALUES ('task-1','t','pending',1,'')")
+    nc.commit()
+    nc.close()
+    init_sidecar_db(str(side))
+    br = OrchBridge(str(native), str(side), board_instance_id="board_0123456789abcdef", tenant_scope="")
+    bound = br.bind_parent_task("board_0123456789abcdef", "", "orch-evt-1", "task-1")
+    conn = br._sidecar
+
+    # commit clock + capability required by existing event insert authority guard
+    from hermes_cli.kanban_orch_db import grant
+    from hermes_cli.kanban_orch_capability import CapabilityGrant
+
+    grant(
+        conn,
+        CapabilityGrant(
+            kind="commit_clock",
+            board=bound.board_instance_id,
+            target_key="*",
+        ),
+    )
+    conn.execute(
+        "INSERT INTO kanban_commit_clock(singleton, commit_seq, last_txn_id, updated_at)"
+        " VALUES (1, 0, 'txn-0', 1)"
+    )
+    conn.execute(
+        "UPDATE kanban_commit_clock SET commit_seq=1, last_txn_id='txn-1', updated_at=2 WHERE singleton=1"
+    )
+    grant(
+        conn,
+        CapabilityGrant(
+            kind="event_insert",
+            board=bound.board_instance_id,
+            tenant=bound.tenant_scope,
+            object_id=bound.orch_id,
+            revision=0,
+            epoch=0,
+            target_key="*",
+        ),
+    )
+
+    # --- events payload + event_key ---
+    payload = {"hello": "world", "n": 1}
+    payload_json, payload_d = build_payload_json_and_digest(payload)
+    ek = event_key(
+        {
+            "board_instance_id": bound.board_instance_id,
+            "tenant_scope": bound.tenant_scope,
+            "orch_id": bound.orch_id,
+            "lifecycle_revision": 0,
+            "cancel_epoch": 0,
+            "event_kind": "request_transition",
+            "target_key": bound.orch_id,
+            "payload_digest": payload_d,
+        }
+    )
+    with pytest.raises(sqlite3.IntegrityError, match="payload_digest_mismatch"):
+        conn.execute(
+            "INSERT INTO orch_events"
+            " (board_instance_id,tenant_scope,orch_id,lifecycle_revision,cancel_epoch,"
+            "  commit_seq,event_kind,target_key,event_key,payload_json,payload_digest,created_at)"
+            " VALUES (?,?,?,0,0,1,'request_transition',?,?,?,?,1)",
+            (
+                bound.board_instance_id,
+                bound.tenant_scope,
+                bound.orch_id,
+                bound.orch_id,
+                ek,
+                payload_json,
+                "a" * 64,
+            ),
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="event_key_mismatch"):
+        conn.execute(
+            "INSERT INTO orch_events"
+            " (board_instance_id,tenant_scope,orch_id,lifecycle_revision,cancel_epoch,"
+            "  commit_seq,event_kind,target_key,event_key,payload_json,payload_digest,created_at)"
+            " VALUES (?,?,?,0,0,1,'request_transition',?,?,?,?,1)",
+            (
+                bound.board_instance_id,
+                bound.tenant_scope,
+                bound.orch_id,
+                bound.orch_id,
+                "b" * 64,
+                payload_json,
+                payload_d,
+            ),
+        )
+    conn.execute(
+        "INSERT INTO orch_events"
+        " (board_instance_id,tenant_scope,orch_id,lifecycle_revision,cancel_epoch,"
+        "  commit_seq,event_kind,target_key,event_key,payload_json,payload_digest,created_at)"
+        " VALUES (?,?,?,0,0,1,'request_transition',?,?,?,?,1)",
+        (
+            bound.board_instance_id,
+            bound.tenant_scope,
+            bound.orch_id,
+            bound.orch_id,
+            ek,
+            payload_json,
+            payload_d,
+        ),
+    )
+
+    # --- receipt_json digest (needs obligation/attempt chain is heavy; test UDF path via empty-ish insert fails earlier)
+    # Direct UDF check for receipt/result formulas:
+    res_json, res_d = build_result_json_and_digest(
+        request_digest_hex=bound.request_digest,
+        plan_digest_hex="c" * 64,
+        accepted_lane_set=["lane-1", "lane-2"],
+        synthesis={"text": "ok"},
+    )
+    assert result_digest(json.loads(res_json)) == res_d
+    assert conn.execute("SELECT orch_result_digest_eq(?, ?)", (res_json, res_d)).fetchone()[0] == 1
+    assert conn.execute("SELECT orch_result_digest_eq(?, ?)", (res_json, "d" * 64)).fetchone()[0] == 0
+
+    receipt_obj = {"provider_message_id": "m1", "ok": True}
+    receipt_json = json.dumps(receipt_obj, sort_keys=True, separators=(",", ":"))
+    receipt_d = digest(receipt_obj)
+    assert conn.execute("SELECT orch_canonical_digest_eq(?, ?)", (receipt_json, receipt_d)).fetchone()[0] == 1
+    assert conn.execute("SELECT orch_canonical_digest_eq(?, ?)", (receipt_json, "e" * 64)).fetchone()[0] == 0
+
+    # attempt evidence digest guard via direct insert into attempts requires obligation FK.
+    # Prove UDF + trigger presence:
+    names = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='trigger' AND name LIKE 'orch_v4_%digest%'"
+        )
+    }
+    for need in [
+        "orch_v4_results_result_digest_guard",
+        "orch_v4_events_payload_digest_guard",
+        "orch_v4_receipts_receipt_digest_guard",
+        "orch_v4_attempt_events_event_digest_guard",
+        "orch_v4_attempts_evidence_digest_guard",
+    ]:
+        assert need in names
+
+    conn.commit()
+    br.close()
+
+
+def test_result_digest_formula_stable():
+    obj = {
+        "schema_version": 4,
+        "kind": "orch_result",
+        "request_digest": "a" * 64,
+        "plan_digest": "b" * 64,
+        "accepted_lane_set": ["x", "y"],
+        "synthesis": {"v": 1},
+    }
+    d1 = result_digest(obj)
+    d2 = result_digest(obj)
+    assert d1 == d2
+    assert len(d1) == 64

--- a/tests/hermes_cli/test_kanban_orch_dual_bind.py
+++ b/tests/hermes_cli/test_kanban_orch_dual_bind.py
@@ -1,0 +1,39 @@
+
+from __future__ import annotations
+import json, os, sqlite3, tempfile
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from hermes_cli.kanban_orch_bridge import init_sidecar_db, OrchBridge
+from hermes_cli.kanban_orch_dual_bind import dual_bind_parent_task, preflight_dual_bind
+from hermes_cli.kanban_orch_writer_switch import writer_enabled
+
+def test_dual_bind_temp(tmp_path, monkeypatch):
+    native = tmp_path / "n.db"
+    side = tmp_path / "s.db"
+    cfg = tmp_path / "w.json"
+    nc = sqlite3.connect(native)
+    nc.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, created_at INTEGER NOT NULL, tenant TEXT)")
+    nc.execute("INSERT INTO tasks VALUES ('t1','hello','pending',1,'')")
+    nc.commit(); nc.close()
+    init_sidecar_db(str(side))
+    cfg.write_text(json.dumps({
+        "schema_version": 4,
+        "enabled_default": True,
+        "native_db": str(native),
+        "sidecar_db": str(side),
+        "native_writable": False,
+        "canonical_board_key": "tmp",
+        "tenant_scope": "",
+    }))
+    monkeypatch.delenv("ORCH_V4_WRITER", raising=False)
+    assert writer_enabled(cfg) is True
+    pf = preflight_dual_bind(cfg)
+    assert pf["ok"] is True
+    res = dual_bind_parent_task(task_id="t1", title="hello", cfg_path=cfg)
+    assert res.error is None, res
+    assert res.skipped is False
+    assert res.orch_id
+    # kill switch
+    monkeypatch.setenv("ORCH_V4_WRITER", "0")
+    assert writer_enabled(cfg) is False

--- a/tests/hermes_cli/test_kanban_orch_dual_bind.py
+++ b/tests/hermes_cli/test_kanban_orch_dual_bind.py
@@ -1,32 +1,50 @@
-
 from __future__ import annotations
-import json, os, sqlite3, tempfile
-from pathlib import Path
+
+import json
+import sqlite3
 import sys
+from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from hermes_cli.kanban_orch_bridge import init_sidecar_db, OrchBridge
+
+from hermes_cli.kanban_orch_bridge import init_sidecar_db
 from hermes_cli.kanban_orch_dual_bind import dual_bind_parent_task, preflight_dual_bind
 from hermes_cli.kanban_orch_writer_switch import writer_enabled
 
-def test_dual_bind_temp(tmp_path, monkeypatch):
+
+def _setup(tmp_path, monkeypatch):
     native = tmp_path / "n.db"
     side = tmp_path / "s.db"
     cfg = tmp_path / "w.json"
     nc = sqlite3.connect(native)
-    nc.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, created_at INTEGER NOT NULL, tenant TEXT)")
+    nc.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, "
+        "created_at INTEGER NOT NULL, tenant TEXT)"
+    )
     nc.execute("INSERT INTO tasks VALUES ('t1','hello','pending',1,'')")
-    nc.commit(); nc.close()
+    nc.execute("INSERT INTO tasks VALUES ('t2','world','pending',1,'')")
+    nc.commit()
+    nc.close()
     init_sidecar_db(str(side))
-    cfg.write_text(json.dumps({
-        "schema_version": 4,
-        "enabled_default": True,
-        "native_db": str(native),
-        "sidecar_db": str(side),
-        "native_writable": False,
-        "canonical_board_key": "tmp",
-        "tenant_scope": "",
-    }))
+    cfg.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "enabled_default": True,
+                "native_db": str(native),
+                "sidecar_db": str(side),
+                "native_writable": False,
+                "canonical_board_key": "tmp",
+                "tenant_scope": "",
+            }
+        )
+    )
     monkeypatch.delenv("ORCH_V4_WRITER", raising=False)
+    return cfg
+
+
+def test_dual_bind_temp(tmp_path, monkeypatch):
+    cfg = _setup(tmp_path, monkeypatch)
     assert writer_enabled(cfg) is True
     pf = preflight_dual_bind(cfg)
     assert pf["ok"] is True
@@ -37,3 +55,16 @@ def test_dual_bind_temp(tmp_path, monkeypatch):
     # kill switch
     monkeypatch.setenv("ORCH_V4_WRITER", "0")
     assert writer_enabled(cfg) is False
+    skipped = dual_bind_parent_task(task_id="t2", title="world", cfg_path=cfg)
+    assert skipped.skipped is True
+    assert skipped.enabled is False
+
+
+def test_dual_bind_idempotent(tmp_path, monkeypatch):
+    cfg = _setup(tmp_path, monkeypatch)
+    first = dual_bind_parent_task(task_id="t1", title="hello", cfg_path=cfg)
+    assert first.error is None, first
+    second = dual_bind_parent_task(task_id="t1", title="hello", cfg_path=cfg)
+    assert second.error is None, second
+    assert second.orch_id == first.orch_id
+    assert second.request_digest == first.request_digest

--- a/tests/hermes_cli/test_kanban_orch_integration.py
+++ b/tests/hermes_cli/test_kanban_orch_integration.py
@@ -1,0 +1,151 @@
+"""Sidecar integration tests: M1-M8 models wired to sidecar DB via bridge.
+
+Tests prove:
+1. Full ORCH lifecycle runs against sidecar persistence
+2. Native DB never mutated (SHA-256 before == after)
+3. Soft FK enforced (missing native task rejected)
+4. Observer exit clean on valid lifecycle
+5. Delivery satisfaction wired to completion
+6. Reconcile events enqueued on sidecar
+7. Supersession creates new generation
+8. Canary + rollback models work in sidecar context
+"""
+
+import pytest
+import os
+import sys
+import hashlib
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_integration import (
+    IntegrationError,
+    SidecarTestHarness,
+    run_full_orch_lifecycle,
+    submit_orch_request,
+)
+from hermes_cli.kanban_orch_lifecycle import supersede_request, Request as LifecycleRequest
+from hermes_cli.kanban_orch_canary import (
+    LocalCaptureAdapter,
+    prepare_canary,
+    run_scenario_normal,
+    verify_canary,
+    cleanup_canary,
+)
+from hermes_cli.kanban_orch_rollback import (
+    create_rollback,
+    advance_phase,
+    check_no_early_reopen,
+    authorize_reopen,
+)
+from hermes_cli.kanban_orch_observer import EXIT_CLEAN
+
+
+@pytest.fixture
+def harness():
+    h = SidecarTestHarness.create()
+    sha_before = h.native_sha256()
+    yield h, sha_before
+    h.cleanup()
+
+
+def test_full_lifecycle_on_sidecar(harness):
+    """Full ORCH lifecycle: submit→decompose→accept→synthesize→deliver→complete."""
+    h, sha_before = harness
+    results = run_full_orch_lifecycle(h)
+
+    assert "request_key" in results["submit"]
+    assert len(results["submit"]["request_key"]) == 64
+    assert results["submit"]["parent_task_ref"]["id"] == "parent-1"
+    assert results["plan"]["requirements"] == 2
+    assert results["acceptances"]["run1"]["node_key"] == "lane-1"
+    assert results["acceptances"]["run2"]["node_key"] == "lane-2"
+    assert results["synthesis"]["state"] == "work_accepted"
+    assert results["observer"]["exit_code"] == EXIT_CLEAN
+    assert results["delivery"]["satisfied"] is True
+    assert results["completion"]["state"] == "completed"
+    assert results["completion"]["terminal"] is True
+    assert results["reconcile"]["events"] == 1
+    assert results["reconcile"]["queue_items"] == 1
+
+    sha_after = h.native_sha256()
+    assert sha_before == sha_after, "Native DB mutated during full lifecycle!"
+
+
+def test_soft_fk_rejects_missing_task(harness):
+    """Soft FK: submitting with nonexistent parent_task_id raises."""
+    h, sha_before = harness
+    with pytest.raises(IntegrationError, match="soft_fk_violation"):
+        submit_orch_request(h, board_instance_id="board_0123456789abcdef",
+                            tenant_scope="", orch_id="orch-bad", parent_task_id="nonexistent-task")
+    assert sha_before == h.native_sha256()
+
+
+def test_supersession_on_sidecar(harness):
+    """Supersession: failed request→new generation on sidecar."""
+    h, sha_before = harness
+    submit_orch_request(h, board_instance_id="board_0123456789abcdef",
+                        tenant_scope="", orch_id="orch-gen1", parent_task_id="parent-1")
+    predecessor = LifecycleRequest("board_0123456789abcdef", "", "orch-gen1", "failed",
+                                    lifecycle_revision=5, generation=1)
+    successor = supersede_request(predecessor, new_orch_id="orch-gen2")
+    assert successor.generation == 2
+    assert successor.orch_id == "orch-gen2"
+    assert successor.state == "submitted"
+    submit_orch_request(h, board_instance_id="board_0123456789abcdef",
+                        tenant_scope="", orch_id=successor.orch_id, parent_task_id="parent-1")
+    assert sha_before == h.native_sha256()
+
+
+def test_canary_in_sidecar_context(harness):
+    """Canary model works in sidecar context (local sink only)."""
+    h, sha_before = harness
+    canary_parent = os.path.join(h.tmpdir, "canary-root")
+    os.makedirs(canary_parent, exist_ok=True)
+    prepare = prepare_canary(run_id="int-test-001", source_hash="f"*64, root_parent=canary_parent, now=1000)
+    adapter = LocalCaptureAdapter()
+    normal = run_scenario_normal(prepare, adapter)
+    assert normal.passed
+    verify = verify_canary(prepare, [normal])
+    assert verify.passed
+    cleanup_canary(prepare)
+    assert sha_before == h.native_sha256()
+
+
+def test_rollback_model_in_sidecar_context(harness):
+    """Rollback model works in sidecar context (no live writer switch)."""
+    h, sha_before = harness
+    op = create_rollback(operation_id="rb-int-001", owner_token_hash="tok-hash",
+                         source_live_hash="a"*64, source_code_hash="src"+"a"*61,
+                         target_live_hash="b"*64, target_code_hash="tgt"+"b"*61)
+    for phase in ["fence_draining", "workers_stopped", "leases_revoked",
+                   "snapshot_sealed", "code_switched", "old_writer_receipts_verified", "verified"]:
+        advance_phase(op, target_phase=phase, owner_token_hash="tok-hash", expected_revision=op.phase_revision)
+        assert check_no_early_reopen(op) is True
+    authorize_reopen(op, david_token="david-approval")
+    advance_phase(op, target_phase="reopened", owner_token_hash="tok-hash", expected_revision=op.phase_revision)
+    assert op.fence_generation == 0
+    assert sha_before == h.native_sha256()
+
+
+def test_sidecar_persists_board_identity(harness):
+    """Sidecar DB persists board identity from submit."""
+    h, sha_before = harness
+    submit_orch_request(h, board_instance_id="board_persist_test_0123",
+                        tenant_scope="", orch_id="orch-persist-1", parent_task_id="parent-1")
+    row = h.sidecar_conn.execute(
+        "SELECT board_instance_id FROM kanban_board_identity WHERE board_instance_id = ?",
+        ("board_persist_test_0123",)).fetchone()
+    assert row is not None
+    assert row[0] == "board_persist_test_0123"
+    assert sha_before == h.native_sha256()
+
+
+def test_no_live_paths_in_integration(harness):
+    """Integration tests must not use live kanban.db path."""
+    h, _ = harness
+    LIVE_PATHS = {"/home/claw/.hermes/kanban.db", "/home/claw/.hermes/orch_v4.db"}
+    assert h.native_path not in LIVE_PATHS
+    assert h.sidecar_path not in LIVE_PATHS
+    assert h.tmpdir not in LIVE_PATHS
+    assert "/home/claw/.hermes" not in h.tmpdir

--- a/tests/hermes_cli/test_kanban_orch_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_orch_lifecycle.py
@@ -46,6 +46,7 @@ def test_transition_table_total() -> None:
         applied = apply_transition(
             request, event, resolved_target,
             resume_state=(resume if source == "blocked" else None),
+            require_evidence=False,
         )
         assert applied.state == resolved_target
         assert applied.lifecycle_revision == 1
@@ -130,6 +131,8 @@ def test_cancel_cascade_fencing() -> None:
 
     # Drain the active task/node and resolve the started send ambiguity.
     runs[0].ended_at = 1235
+    tasks[1].status = "cancelled"
+    tasks[1].cancellation_requested_at = None
     nodes[1].state = "cancelled"
     attempts[0].state = "unknown"
     obligations[2].state = "dead_letter"

--- a/tests/hermes_cli/test_kanban_orch_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_orch_lifecycle.py
@@ -1,0 +1,282 @@
+"""M3 T17-T19: lifecycle totality and cancel cascade fencing."""
+
+import pytest
+
+from hermes_cli.kanban_orch_lifecycle import (
+    AcceptedRun,
+    DeliveryAttempt,
+    DeliveryObligation,
+    LifecycleError,
+    Node,
+    Request,
+    StageLease,
+    StaleCallback,
+    SynthesisResult,
+    Task,
+    TaskRun,
+    TRANSITION_TABLE,
+    accept_lane_run,
+    accept_worker_success,
+    apply_transition,
+    cancel_cascade,
+    cancellation_satisfied,
+    complete_cancelled_node,
+    finish_cancellation,
+    is_terminal,
+    optional_cancel_drained,
+    request_optional_cancellation,
+    supersede_request,
+    transition_allowed,
+    validate_result_provenance,
+)
+
+
+def test_transition_table_total() -> None:
+    """Every §7.2 edge is accepted; terminal block/unblock/retry are rejected."""
+    for source, event, target in TRANSITION_TABLE:
+        request = Request("board", "tenant", "orch", source)
+        resume = source if target == "blocked" else (
+            "decomposing" if source == "blocked" else None
+        )
+        resolved_target = resume if target == "resume_state" else target
+        assert transition_allowed(
+            source, event, resolved_target,
+            resume_state=(resume if source == "blocked" else None),
+        )
+        applied = apply_transition(
+            request, event, resolved_target,
+            resume_state=(resume if source == "blocked" else None),
+        )
+        assert applied.state == resolved_target
+        assert applied.lifecycle_revision == 1
+
+    for terminal in ("completed", "failed", "cancelled"):
+        for event, target in (("block", "blocked"), ("unblock", "waiting_lanes"), ("retry", "waiting_lanes")):
+            assert not transition_allowed(terminal, event, target)
+            with pytest.raises(LifecycleError):
+                apply_transition(Request("board", "tenant", "orch", terminal), event, target)
+
+
+def test_optional_cancel_drain() -> None:
+    """Unaccepted optional work is fenced, then must reach a terminal node state."""
+    nodes = [
+        Node("board", "tenant", "orch", "required", True, "accepted"),
+        Node("board", "tenant", "orch", "optional-running", False, "running"),
+        Node("board", "tenant", "orch", "optional-ready", False, "ready"),
+    ]
+    assert request_optional_cancellation(nodes) == 2
+    assert not optional_cancel_drained(nodes)
+    complete_cancelled_node(nodes[1])
+    complete_cancelled_node(nodes[2])
+    assert optional_cancel_drained(nodes)
+
+
+def test_cancel_cascade_fencing() -> None:
+    """Cancel is exact-scope, fences callbacks, and preserves started-send ambiguity."""
+    request = Request("board", "tenant", "orch", "waiting_lanes", lifecycle_revision=7)
+    tasks = [
+        Task("board", "tenant", "orch", "planned", "planned"),
+        Task("board", "tenant", "orch", "running", "running"),
+        Task("other", "tenant", "orch", "outside", "planned"),
+    ]
+    runs = [TaskRun("board", "tenant", "orch", "running", "run-1")]
+    nodes = [
+        Node("board", "tenant", "orch", "planned-node", True, "planned"),
+        Node("board", "tenant", "orch", "running-node", True, "running"),
+        Node("other", "tenant", "orch", "outside-node", True, "planned"),
+    ]
+    leases = [
+        StageLease("board", "tenant", "orch", "decomposition"),
+        StageLease("other", "tenant", "orch", "decomposition"),
+    ]
+    obligations = [
+        DeliveryObligation("board", "tenant", "orch", "pending", "pending"),
+        DeliveryObligation("board", "tenant", "orch", "claimed-no-send", "claimed"),
+        DeliveryObligation("board", "tenant", "orch", "claimed-started", "claimed"),
+        DeliveryObligation("other", "tenant", "orch", "outside", "pending"),
+    ]
+    attempts = [DeliveryAttempt("board", "tenant", "orch", "claimed-started", "send-1", "started")]
+
+    result = cancel_cascade(
+        request,
+        tasks=tasks,
+        task_runs=runs,
+        nodes=nodes,
+        leases=leases,
+        obligations=obligations,
+        attempts=attempts,
+        now=1234,
+    )
+    assert request.state == "cancelling"
+    assert (result.old_revision, result.new_revision) == (7, 8)
+    assert (result.old_cancel_epoch, result.new_cancel_epoch) == (0, 1)
+    assert tasks[0].status == "cancelled"
+    assert tasks[1].cancellation_requested_at == 1234
+    assert tasks[2].status == "planned"  # exact-scope fence
+    assert runs[0].cancellation_epoch == 1
+    assert nodes[0].state == "cancelled"
+    assert nodes[1].state == "cancellation_requested"
+    assert leases[0].state == "revoked" and leases[0].epoch == 2
+    assert leases[1].state == "active"
+    assert obligations[0].state == "cancelled"
+    assert obligations[1].state == "cancelled"  # no started attempt yet
+    assert obligations[2].state == "claimed"
+    assert obligations[2].duplicate_possible is True
+    assert obligations[3].state == "pending"
+    assert result.retained_obligation_ids == ("claimed-started",)
+
+    with pytest.raises(StaleCallback):
+        accept_worker_success(request, callback_revision=7, callback_cancel_epoch=0)
+
+    # Drain the active task/node and resolve the started send ambiguity.
+    runs[0].ended_at = 1235
+    nodes[1].state = "cancelled"
+    attempts[0].state = "unknown"
+    obligations[2].state = "dead_letter"
+    assert cancellation_satisfied(
+        request, tasks=tasks, task_runs=runs, nodes=nodes, leases=leases,
+        obligations=obligations, attempts=attempts,
+    )
+    finish_cancellation(
+        request, tasks=tasks, task_runs=runs, nodes=nodes, leases=leases,
+        obligations=obligations, attempts=attempts,
+    )
+    assert request.state == "cancelled"
+    assert request.lifecycle_revision == 9
+
+    with pytest.raises(StaleCallback):
+        accept_worker_success(request, callback_revision=8, callback_cancel_epoch=1)
+
+
+def test_terminal_state_stored() -> None:
+    """Terminal states are stored correctly and no transitions out are accepted."""
+    for terminal in ("completed", "failed", "cancelled"):
+        request = Request("board", "tenant", "orch", terminal, lifecycle_revision=10)
+        assert is_terminal(request.state)
+        # No transitions out of terminal
+        for event in ("block", "unblock", "retry", "claim_decomposition"):
+            assert not transition_allowed(terminal, event, "waiting_lanes")
+        with pytest.raises(LifecycleError):
+            apply_transition(request, "claim_decomposition", "decomposing")
+
+
+def test_exact_lane_acceptance() -> None:
+    """T15: accepted run current required lane + stable plan epoch."""
+    request = Request("board", "tenant", "orch", "waiting_lanes", lifecycle_revision=5)
+    node = Node("board", "tenant", "orch", "lane-1", True, "running", plan_version=1)
+
+    # Valid acceptance
+    run = accept_lane_run(
+        request, node,
+        plan_version=1,
+        run_id="run-1",
+        task_id="task-1",
+        outcome_digest="d" * 64,
+        callback_revision=5,
+        callback_cancel_epoch=0,
+    )
+    assert node.state == "accepted"
+    assert run.plan_version == 1
+    assert run.outcome_digest == "d" * 64
+    assert run.node_key == "lane-1"
+
+    # Already-accepted node rejected
+    with pytest.raises(LifecycleError, match="node_already_accepted"):
+        accept_lane_run(
+            request, node,
+            plan_version=1,
+            run_id="run-2",
+            task_id="task-2",
+            outcome_digest="d" * 64,
+            callback_revision=5,
+            callback_cancel_epoch=0,
+        )
+
+    # Stale plan version rejected
+    node2 = Node("board", "tenant", "orch", "lane-2", True, "running", plan_version=2)
+    with pytest.raises(LifecycleError, match="stale_plan_version"):
+        accept_lane_run(
+            request, node2,
+            plan_version=1,
+            run_id="run-3",
+            task_id="task-3",
+            outcome_digest="d" * 64,
+            callback_revision=5,
+            callback_cancel_epoch=0,
+        )
+
+    # Wrong request state (not waiting_lanes or synthesizing)
+    request2 = Request("board", "tenant", "orch", "submitted")
+    node3 = Node("board", "tenant", "orch", "lane-3", True, "running", plan_version=1)
+    with pytest.raises(LifecycleError, match="accept_not_authorized"):
+        accept_lane_run(
+            request2, node3,
+            plan_version=1,
+            run_id="run-4",
+            task_id="task-4",
+            outcome_digest="d" * 64,
+            callback_revision=0,
+            callback_cancel_epoch=0,
+        )
+
+    # Stale callback (wrong revision) rejected
+    request3 = Request("board", "tenant", "orch", "waiting_lanes", lifecycle_revision=3)
+    node4 = Node("board", "tenant", "orch", "lane-4", True, "running", plan_version=1)
+    with pytest.raises(StaleCallback):
+        accept_lane_run(
+            request3, node4,
+            plan_version=1,
+            run_id="run-5",
+            task_id="task-5",
+            outcome_digest="d" * 64,
+            callback_revision=2,
+            callback_cancel_epoch=0,
+        )
+
+
+def test_result_producer_provenance() -> None:
+    """T16: synthesis result bound to completed synthesis attempt."""
+    result = SynthesisResult(
+        board="board",
+        tenant="tenant",
+        orch_id="orch",
+        result_digest="d" * 64,
+        synthesis_attempt_id=42,
+        plan_version=1,
+    )
+
+    # Valid: completed attempt matches
+    validate_result_provenance(result, completed_attempt_id=42, current_plan_version=1)
+
+    # Unbound: attempt ID mismatch
+    with pytest.raises(LifecycleError, match="result_producer_unbound"):
+        validate_result_provenance(result, completed_attempt_id=99, current_plan_version=1)
+
+    # Stale plan version
+    with pytest.raises(LifecycleError, match="stale_plan_version"):
+        validate_result_provenance(result, completed_attempt_id=42, current_plan_version=2)
+
+
+def test_supersession_generation() -> None:
+    """Supersession: generation+1, new orch_id, predecessor must be terminal."""
+    predecessor = Request(
+        "board", "tenant", "orch-old", "failed",
+        lifecycle_revision=5, generation=1,
+    )
+
+    successor = supersede_request(predecessor, new_orch_id="orch-new")
+    assert successor.generation == 2
+    assert successor.orch_id == "orch-new"
+    assert successor.state == "submitted"
+    assert successor.lifecycle_revision == 0
+    assert successor.cancel_epoch == 0
+
+    # Non-terminal predecessor raises
+    active = Request("board", "tenant", "orch-active", "waiting_lanes", generation=1)
+    with pytest.raises(LifecycleError, match="supersession_predecessor_not_terminal"):
+        supersede_request(active, new_orch_id="orch-new2")
+
+    # Cancelled can also be superseded
+    cancelled = Request("board", "tenant", "orch-cancelled", "cancelled", generation=3)
+    successor2 = supersede_request(cancelled, new_orch_id="orch-new3")
+    assert successor2.generation == 4

--- a/tests/hermes_cli/test_kanban_orch_multilane.py
+++ b/tests/hermes_cli/test_kanban_orch_multilane.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hermes_cli.kanban_orch_bridge import init_sidecar_db
+from hermes_cli.kanban_orch_cmin import judge_board_only_to_fixed_point
+from hermes_cli.kanban_orch_dual_bind import dual_bind_parent_task
+from hermes_cli.kanban_orch_multilane import MultiLaneError, run_multilane_once
+from hermes_cli.kanban_orch_writer_switch import open_live_bridge, writer_enabled
+
+
+def _setup(tmp_path, monkeypatch, *, child_statuses=("done", "done")):
+    native = tmp_path / "n.db"
+    side = tmp_path / "s.db"
+    cfg = tmp_path / "w.json"
+    nc = sqlite3.connect(native)
+    nc.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, "
+        "created_at INTEGER NOT NULL, tenant TEXT)"
+    )
+    nc.execute(
+        "CREATE TABLE task_links (parent_id TEXT NOT NULL, child_id TEXT NOT NULL, "
+        "kind TEXT NOT NULL DEFAULT 'depends', PRIMARY KEY (parent_id, child_id))"
+    )
+    nc.execute("INSERT INTO tasks VALUES ('p1','parent','running',1,'')")
+    for i, st in enumerate(child_statuses, start=1):
+        cid = f"c{i}"
+        nc.execute("INSERT INTO tasks VALUES (?,?,?,1,'')", (cid, f"child{i}", st))
+        nc.execute("INSERT INTO task_links VALUES (?,?,?)", ("p1", cid, "depends"))
+    nc.commit()
+    nc.close()
+    init_sidecar_db(str(side))
+    cfg.write_text(
+        json.dumps(
+            {
+                "schema_version": 4,
+                "enabled_default": True,
+                "native_db": str(native),
+                "sidecar_db": str(side),
+                "native_writable": False,
+                "canonical_board_key": "tmp",
+                "tenant_scope": "",
+            }
+        )
+    )
+    monkeypatch.delenv("ORCH_V4_WRITER", raising=False)
+    assert writer_enabled(cfg) is True
+    bound = dual_bind_parent_task(task_id="p1", title="parent", cfg_path=cfg)
+    assert bound.error is None, bound
+    return native, side, cfg, bound
+
+
+def test_multilane_materialize_accept_complete(tmp_path, monkeypatch):
+    native, side, cfg, bound = _setup(tmp_path, monkeypatch)
+    br = open_live_bridge(cfg)
+    try:
+        # first claim decomposition via board_only path
+        mid = judge_board_only_to_fixed_point(
+            br._sidecar,
+            board_instance_id=bound.board_instance_id or "",
+            tenant_scope=bound.tenant_scope,
+            orch_id=bound.orch_id or "",
+            native_status="running",
+        )
+        assert mid.after_state == "decomposing", mid
+
+        children = [
+            {"child_id": "c1", "status": "done", "title": "child1"},
+            {"child_id": "c2", "status": "done", "title": "child2"},
+        ]
+        # materialize
+        r1 = run_multilane_once(
+            br._sidecar,
+            board_instance_id=bound.board_instance_id or "",
+            tenant_scope=bound.tenant_scope,
+            orch_id=bound.orch_id or "",
+            parent_task_id="p1",
+            parent_title="parent",
+            parent_status="running",
+            children=children,
+        )
+        assert r1.after_state == "waiting_lanes", r1
+        assert r1.plan_version == 1
+        assert any(s.action == "materialize" for s in r1.steps)
+
+        # accept + complete
+        r2 = run_multilane_once(
+            br._sidecar,
+            board_instance_id=bound.board_instance_id or "",
+            tenant_scope=bound.tenant_scope,
+            orch_id=bound.orch_id or "",
+            parent_task_id="p1",
+            parent_title="parent",
+            parent_status="running",
+            children=children,
+        )
+        assert r2.after_state == "completed", r2
+        assert r2.accepted_required_lanes >= 2
+
+        # durable rows exist
+        n_plans = br._sidecar.execute("SELECT count(*) FROM orch_plans").fetchone()[0]
+        n_nodes = br._sidecar.execute("SELECT count(*) FROM orch_nodes").fetchone()[0]
+        n_acc = br._sidecar.execute("SELECT count(*) FROM orch_node_acceptances").fetchone()[0]
+        n_mat = br._sidecar.execute("SELECT count(*) FROM orch_plan_materializations").fetchone()[0]
+        assert n_plans == 1
+        assert n_nodes >= 3
+        assert n_acc >= 2
+        assert n_mat == 1
+    finally:
+        br.close()
+
+
+def test_multilane_need_two_children(tmp_path, monkeypatch):
+    native, side, cfg, bound = _setup(tmp_path, monkeypatch, child_statuses=("done",))
+    br = open_live_bridge(cfg)
+    try:
+        judge_board_only_to_fixed_point(
+            br._sidecar,
+            board_instance_id=bound.board_instance_id or "",
+            tenant_scope=bound.tenant_scope,
+            orch_id=bound.orch_id or "",
+            native_status="running",
+        )
+        r = run_multilane_once(
+            br._sidecar,
+            board_instance_id=bound.board_instance_id or "",
+            tenant_scope=bound.tenant_scope,
+            orch_id=bound.orch_id or "",
+            parent_task_id="p1",
+            parent_title="parent",
+            parent_status="running",
+            children=[{"child_id": "c1", "status": "done", "title": "c1"}],
+        )
+        assert r.skipped is True
+        assert r.reason and "no_multilane_rule" in r.reason
+    finally:
+        br.close()

--- a/tests/hermes_cli/test_kanban_orch_observer.py
+++ b/tests/hermes_cli/test_kanban_orch_observer.py
@@ -1,0 +1,253 @@
+"""M4 T20-T22: Observer V4 — exit total order, exact multiset, overlap."""
+
+import pytest
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_observer import (
+    EXIT_CLEAN,
+    EXIT_HARD_VIOLATION,
+    EXIT_PRECEDENCE,
+    EXIT_SCHEMA_UNSUPPORTED,
+    EXIT_WARNING_ONLY,
+    ExpectedNode,
+    Finding,
+    ObservedRun,
+    check_delivery_satisfied,
+    check_exact_multiset,
+    check_legacy_untyped,
+    check_parent_terminal_before_synthesis,
+    check_required_lane_overlap,
+    check_scope_mismatch,
+    compute_exit,
+    run_observer,
+)
+
+
+def test_exit_total_order():
+    """T22: exit precedence plus busy/schema/corruption/internal catch-all.
+
+    EXIT_PRECEDENCE = (64, 5, 4, 2, 3, 0) — first matching wins, not max.
+    """
+    # Single findings
+    assert compute_exit([Finding(64, "cli_err")]) == 64
+    assert compute_exit([Finding(5, "path_err")]) == 5
+    assert compute_exit([Finding(4, "schema_err")]) == 4
+    assert compute_exit([Finding(2, "hard_err")]) == 2
+    assert compute_exit([Finding(3, "warn")]) == 3
+    assert compute_exit([Finding(0, "clean")]) == 0
+
+    # Mixed: 2 beats 3 beats 0
+    assert compute_exit([Finding(3, "warn"), Finding(2, "hard")]) == 2
+    assert compute_exit([Finding(0, "clean"), Finding(3, "warn")]) == 3
+    assert compute_exit([Finding(2, "hard"), Finding(3, "warn"), Finding(0, "clean")]) == 2
+
+    # 4 beats 2
+    assert compute_exit([Finding(4, "schema"), Finding(2, "hard")]) == 4
+
+    # 5 beats 4
+    assert compute_exit([Finding(5, "path"), Finding(4, "schema")]) == 5
+
+    # 64 beats everything
+    assert compute_exit([Finding(64, "cli"), Finding(5, "path"), Finding(2, "hard")]) == 64
+
+    # No findings = clean
+    assert compute_exit([]) == 0
+
+    # Precedence order is NOT numeric max
+    assert EXIT_PRECEDENCE == (64, 5, 4, 2, 3, 0)
+
+
+def test_exact_multiset_and_overlap():
+    """T21: observer exact universe/digests/accepted overlap.
+
+    Missing/extra/duplicate nodes are hard violations.
+    Same-lane retry does not count as parallel.
+    Overlap requires max(start) < min(end).
+    """
+    # Exact match — no findings
+    expected = [
+        ExpectedNode("lane-1", "lane", "A", True, 1),
+        ExpectedNode("lane-2", "lane", "B", True, 2),
+        ExpectedNode("parent", "parent", "P", False, 0),
+    ]
+    observed = ["lane-1", "lane-2", "parent"]
+    assert check_exact_multiset(expected, observed) is None
+
+    # Missing node
+    assert check_exact_multiset(expected, ["lane-1", "parent"]) is not None
+    assert check_exact_multiset(expected, ["lane-1", "parent"]).code == "missing_observed_nodes"
+
+    # Extra node
+    assert check_exact_multiset(expected, ["lane-1", "lane-2", "parent", "extra"]).code == "extra_observed_nodes"
+
+    # Duplicate
+    assert check_exact_multiset(expected, ["lane-1", "lane-1", "lane-2", "parent"]).code == "duplicate_observed_nodes"
+
+    # Overlap: 2 required lanes, one run each, overlapping intervals
+    lanes = [
+        ExpectedNode("lane-1", "lane", "A", True, 1),
+        ExpectedNode("lane-2", "lane", "B", True, 2),
+    ]
+    runs = [
+        ObservedRun("lane-1", "run-1", started_at=100, ended_at=200),
+        ObservedRun("lane-2", "run-2", started_at=150, ended_at=250),
+    ]
+    assert check_required_lane_overlap(lanes, runs) is None  # max(100,150)=150 < min(200,250)=200
+
+    # No overlap: sequential runs
+    sequential = [
+        ObservedRun("lane-1", "run-1", started_at=100, ended_at=200),
+        ObservedRun("lane-2", "run-2", started_at=200, ended_at=300),
+    ]
+    result = check_required_lane_overlap(lanes, sequential)
+    assert result is not None
+    assert result.code == "no_required_lane_overlap"
+
+    # Same lane duplicate run
+    dup_run = [
+        ObservedRun("lane-1", "run-1", started_at=100, ended_at=200),
+        ObservedRun("lane-1", "run-2", started_at=150, ended_at=250),
+    ]
+    result = check_required_lane_overlap(lanes, dup_run)
+    assert result is not None
+    assert result.code == "duplicate_lane_run"
+
+    # Missing required acceptance
+    missing_run = [ObservedRun("lane-1", "run-1", 100, 200)]
+    result = check_required_lane_overlap(lanes, missing_run)
+    assert result is not None
+    assert result.code == "missing_required_acceptance"
+
+    # Fewer than 2 required lanes
+    single = [ExpectedNode("lane-1", "lane", "A", True, 1)]
+    result = check_required_lane_overlap(single, [ObservedRun("lane-1", "r", 100, 200)])
+    assert result is not None
+    assert result.code == "insufficient_required_lanes"
+
+
+def test_snapshot_and_path_truth():
+    """T20: observer single snapshot/commit churn/path replacement.
+
+    Scope mismatch, legacy untyped, parent terminal, delivery gaps.
+    """
+    # Clean: exact match, overlap, scope match, delivery satisfied
+    expected = [
+        ExpectedNode("lane-1", "lane", "A", True, 1),
+        ExpectedNode("lane-2", "lane", "B", True, 2),
+    ]
+    runs = [
+        ObservedRun("lane-1", "run-1", 100, 200),
+        ObservedRun("lane-2", "run-2", 150, 250),
+    ]
+    exit_code = run_observer(
+        has_v4_schema=True,
+        expected_nodes=expected,
+        observed_node_keys=["lane-1", "lane-2"],
+        accepted_runs=runs,
+        parent_state="completed",
+        has_result=True,
+        origin_kind="messaging",
+        required_acks=1,
+        acked_count=1,
+    )
+    assert exit_code == EXIT_CLEAN
+
+    # Scope mismatch
+    exit_code = run_observer(
+        has_v4_schema=True,
+        expected_nodes=expected,
+        observed_node_keys=["lane-1", "lane-2"],
+        accepted_runs=runs,
+        expected_board="board-A",
+        observed_board="board-B",
+    )
+    assert exit_code == EXIT_HARD_VIOLATION
+
+    # Legacy untyped: schema missing, legacy title present → exit 3
+    exit_code = run_observer(
+        has_v4_schema=False,
+        expected_nodes=[],
+        observed_node_keys=[],
+        accepted_runs=[],
+        has_legacy_title=True,
+    )
+    assert exit_code == EXIT_WARNING_ONLY
+
+    # Schema missing, no legacy → exit 4
+    exit_code = run_observer(
+        has_v4_schema=False,
+        expected_nodes=[],
+        observed_node_keys=[],
+        accepted_runs=[],
+        has_legacy_title=False,
+    )
+    assert exit_code == EXIT_SCHEMA_UNSUPPORTED
+
+    # Parent terminal before synthesis
+    exit_code = run_observer(
+        has_v4_schema=True,
+        expected_nodes=expected,
+        observed_node_keys=["lane-1", "lane-2"],
+        accepted_runs=runs,
+        parent_state="completed",
+        has_result=False,  # no result → terminal before synthesis
+    )
+    assert exit_code == EXIT_HARD_VIOLATION
+
+    # Delivery not satisfied
+    exit_code = run_observer(
+        has_v4_schema=True,
+        expected_nodes=expected,
+        observed_node_keys=["lane-1", "lane-2"],
+        accepted_runs=runs,
+        parent_state="completed",
+        has_result=True,
+        origin_kind="messaging",
+        required_acks=2,
+        acked_count=1,  # missing one ACK
+    )
+    assert exit_code == EXIT_HARD_VIOLATION
+
+    # Board-only with zero required → clean
+    exit_code = run_observer(
+        has_v4_schema=True,
+        expected_nodes=[ExpectedNode("parent", "parent", "P", False, 0)],
+        observed_node_keys=["parent"],
+        accepted_runs=[],
+        parent_state="completed",
+        has_result=True,
+        origin_kind="board_only",
+        required_acks=0,
+        acked_count=0,
+    )
+    assert exit_code == EXIT_CLEAN
+
+    # Board-only with required obligations → hard violation
+    exit_code = run_observer(
+        has_v4_schema=True,
+        expected_nodes=[ExpectedNode("parent", "parent", "P", False, 0)],
+        observed_node_keys=["parent"],
+        accepted_runs=[],
+        parent_state="completed",
+        has_result=True,
+        origin_kind="board_only",
+        required_acks=1,  # board_only should have 0
+    )
+    assert exit_code == EXIT_HARD_VIOLATION
+
+    # Mixed: hard violation + warning → 2 beats 3
+    exit_code = run_observer(
+        has_v4_schema=True,
+        expected_nodes=expected,
+        observed_node_keys=["lane-1", "lane-2"],
+        accepted_runs=runs,
+        parent_state="completed",
+        has_result=True,
+        origin_kind="messaging",
+        required_acks=2,
+        acked_count=0,  # delivery not satisfied (exit 2)
+    )
+    assert exit_code == EXIT_HARD_VIOLATION  # 2 beats any warning

--- a/tests/hermes_cli/test_kanban_orch_p1_fixes.py
+++ b/tests/hermes_cli/test_kanban_orch_p1_fixes.py
@@ -1,0 +1,187 @@
+"""P1 closure tests for ORCH V4 candidate-hash review findings."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import hashlib
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_capability import (
+    CapabilityGrant,
+    install_fail_closed_udf,
+    install_test_open_udf,
+)
+from hermes_cli.kanban_orch_db import OrchDBError, assert_not_live_path, open_orch_db, close_orch_db, grant
+from hermes_cli.kanban_orch_api import (
+    apply_lifecycle_transition_db,
+    bootstrap_board_only_request,
+)
+from hermes_cli.kanban_orch_observer import (
+    EXIT_HARD_VIOLATION,
+    ExpectedNode,
+    check_delivery_satisfied,
+    check_exact_multiset,
+    run_observer,
+)
+from hermes_cli.kanban_orch_schema_v4 import apply_schema
+from hermes_cli.kanban_orch_schema_sidecar import apply_sidecar_schema
+from hermes_cli.kanban_orch_bridge import OrchBridge, init_sidecar_db
+
+
+def test_capability_fail_closed_by_default():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        apply_schema(conn, test_open_capability=False)
+        val = conn.execute("SELECT orch_capability_ok('x','b','t','o',0,0,'k')").fetchone()[0]
+        assert val == 0
+        conn.close()
+    finally:
+        os.unlink(path)
+
+
+def test_capability_grant_required_for_mutation():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        conn = open_orch_db(path, create=True, test_open_capability=False)
+        apply_schema(conn, test_open_capability=False)
+        # Without grant, protected insert fails.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO kanban_board_identity "
+                "(singleton, board_instance_id, canonical_board_key, created_at) "
+                "VALUES (1, 'board_0123456789abcdef', 'default', 1)"
+            )
+        # With grant, insert succeeds.
+        grant(conn, CapabilityGrant(kind="maintenance_identity", board="board_0123456789abcdef", target_key="default"))
+        conn.execute(
+            "INSERT INTO kanban_board_identity "
+            "(singleton, board_instance_id, canonical_board_key, created_at) "
+            "VALUES (1, 'board_0123456789abcdef', 'default', 1)"
+        )
+        conn.commit()
+        close_orch_db(conn)
+    finally:
+        os.unlink(path)
+
+
+def test_expected_side_duplicate_nodes_rejected():
+    expected = [
+        ExpectedNode("lane-1", "lane", "A", True, 1),
+        ExpectedNode("lane-1", "lane", "A", True, 2),
+    ]
+    finding = check_exact_multiset(expected, ["lane-1"])
+    assert finding is not None
+    assert finding.code == "duplicate_expected_nodes"
+    assert finding.exit_code == EXIT_HARD_VIOLATION
+
+
+def test_observer_delivery_obligation_key_multiset():
+    # Count-only can still work for compat.
+    assert check_delivery_satisfied("messaging", 2, 2) is None
+    # Key multiset missing one required key fails even if counts could be lied about.
+    f = check_delivery_satisfied(
+        "messaging",
+        required_obligation_keys=["obl-a", "obl-b"],
+        acked_obligation_keys=["obl-a", "obl-a"],
+    )
+    assert f is not None
+    assert f.code in {"duplicate_acked_obligation_keys", "delivery_required_acks_missing"}
+
+    assert (
+        check_delivery_satisfied(
+            "messaging",
+            required_obligation_keys=["obl-a", "obl-b"],
+            acked_obligation_keys=["obl-a", "obl-b"],
+        )
+        is None
+    )
+
+    exit_code = run_observer(
+        has_v4_schema=True,
+        expected_nodes=[
+            ExpectedNode("lane-1", "lane", "A", True, 1),
+            ExpectedNode("lane-2", "lane", "B", True, 2),
+        ],
+        observed_node_keys=["lane-1", "lane-2"],
+        accepted_runs=[],
+        parent_state="completed",
+        has_result=True,
+        origin_kind="messaging",
+        required_obligation_keys=["obl-1"],
+        acked_obligation_keys=[],
+    )
+    assert exit_code == EXIT_HARD_VIOLATION
+
+
+def test_i3_surface_modules_exist():
+    root = os.path.join(os.path.dirname(__file__), "..", "..")
+    for rel in [
+        "hermes_cli/kanban_orch_api.py",
+        "hermes_cli/kanban_orch_db.py",
+        "scripts/orch_v4_migrate.py",
+    ]:
+        assert os.path.isfile(os.path.join(root, rel)), rel
+
+
+def test_db_backed_lifecycle_cas():
+    tmp = tempfile.mkdtemp()
+    try:
+        native = os.path.join(tmp, "native.db")
+        side = os.path.join(tmp, "side.db")
+        n = sqlite3.connect(native)
+        n.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, created_at INTEGER NOT NULL)")
+        n.execute("INSERT INTO tasks VALUES ('task-1','t','pending',1)")
+        n.commit()
+        n.close()
+        init_sidecar_db(side)
+        bridge = OrchBridge(native, side)
+        bound = bridge.bind_parent_task("board_0123456789abcdef", "", "orch-cas-1", "task-1")
+        assert bound.lifecycle_state == "submitted"
+        out = apply_lifecycle_transition_db(
+            bridge._sidecar,
+            board_instance_id="board_0123456789abcdef",
+            tenant_scope="",
+            orch_id="orch-cas-1",
+            event="claim_decomposition",
+            to_state="decomposing",
+        )
+        assert out["to_state"] == "decomposing"
+        assert out["lifecycle_revision"] == 1
+        row = bridge._sidecar.execute(
+            "SELECT lifecycle_state, lifecycle_revision FROM orch_requests WHERE orch_id=?",
+            ("orch-cas-1",),
+        ).fetchone()
+        assert row["lifecycle_state"] == "decomposing"
+        assert row["lifecycle_revision"] == 1
+        bridge.close()
+    finally:
+        import shutil
+
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_migrate_script_refuses_live_path():
+    import importlib.util
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "orch_v4_migrate.py"
+    spec = importlib.util.spec_from_file_location("orch_v4_migrate_mod", script)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    rc = mod.main(["--db", "/home/claw/.hermes/kanban.db", "--mode", "sidecar"])
+    assert rc == 2
+
+
+def test_live_path_guard():
+    with pytest.raises(OrchDBError):
+        assert_not_live_path("/home/claw/.hermes/kanban.db")

--- a/tests/hermes_cli/test_kanban_orch_plan.py
+++ b/tests/hermes_cli/test_kanban_orch_plan.py
@@ -1,0 +1,167 @@
+"""M2 T07-T09: executable plan grammar and closed-world tests."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from hermes_cli.kanban_orch_plan import (
+    closed_world_closure,
+    grammar_findings,
+    materialization_findings,
+)
+
+
+@pytest.fixture
+def db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE orch_requests (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          lineage_id TEXT, generation INTEGER, request_key TEXT,
+          request_digest TEXT, origin_id TEXT, parent_task_id TEXT,
+          synthesis_strategy TEXT, lifecycle_revision INTEGER, cancel_epoch INTEGER
+        );
+        CREATE TABLE orch_request_requirements (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          requirement_id TEXT, required INTEGER
+        );
+        CREATE TABLE orch_plans (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          plan_version INTEGER, request_key TEXT, request_digest TEXT,
+          origin_id TEXT, parent_task_id TEXT, synthesis_strategy TEXT,
+          lineage_id TEXT, generation INTEGER, plan_digest TEXT
+        );
+        CREATE TABLE orch_plan_nodes (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          plan_version INTEGER, node_key TEXT, role TEXT, ordinal INTEGER,
+          lane_label TEXT, required INTEGER
+        );
+        CREATE TABLE orch_plan_edges (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          plan_version INTEGER, parent_node_key TEXT, child_node_key TEXT,
+          edge_kind TEXT
+        );
+        CREATE TABLE orch_plan_coverage (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          plan_version INTEGER, requirement_id TEXT, node_key TEXT
+        );
+        CREATE TABLE orch_plan_materializations (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          plan_version INTEGER, plan_digest TEXT,
+          request_lifecycle_revision INTEGER, cancel_epoch INTEGER
+        );
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY, orch_board_instance_id TEXT,
+          orch_tenant_scope TEXT, orch_id TEXT
+        );
+        CREATE TABLE task_links (parent_id TEXT, child_id TEXT);
+        CREATE TABLE orch_nodes (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          task_id TEXT
+        );
+        CREATE TABLE orch_external_edges (
+          board_instance_id TEXT, tenant_scope TEXT, orch_id TEXT,
+          parent_task_id TEXT, child_task_id TEXT
+        );
+        """
+    )
+    return conn
+
+
+def _base_plan(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """INSERT INTO orch_requests VALUES
+        ('board', '', 'orch', 'lineage', 1, 'request-key', 'request-digest',
+         'origin', 'parent-task', 'parent_owned', 4, 0)"""
+    )
+    conn.execute(
+        """INSERT INTO orch_plans VALUES
+        ('board', '', 'orch', 1, 'request-key', 'request-digest', 'origin',
+         'parent-task', 'parent_owned', 'lineage', 1, 'plan-digest')"""
+    )
+    conn.executemany(
+        """INSERT INTO orch_plan_nodes VALUES
+        ('board', '', 'orch', 1, ?, ?, ?, ?, ?)""",
+        [
+            ("__parent__", "parent", 1, "", 1),
+            ("lane-a", "lane", 2, "A", 1),
+            ("lane-b", "lane", 3, "B", 1),
+        ],
+    )
+    conn.executemany(
+        """INSERT INTO orch_request_requirements VALUES
+        ('board', '', 'orch', ?, 1)""",
+        [("req-a",), ("req-b",)],
+    )
+    conn.executemany(
+        """INSERT INTO orch_plan_edges VALUES
+        ('board', '', 'orch', 1, ?, '__parent__', 'orch_required_for_synthesis')""",
+        [("lane-a",), ("lane-b",)],
+    )
+    conn.executemany(
+        """INSERT INTO orch_plan_coverage VALUES
+        ('board', '', 'orch', 1, ?, ?)""",
+        [("req-a", "lane-a"), ("req-b", "lane-b")],
+    )
+
+
+def test_nonvacuous_plan_grammar(db: sqlite3.Connection) -> None:
+    """Zero requirements, <2 required lanes, and parent ordinal drift reject."""
+    _base_plan(db)
+    assert grammar_findings(db, board="board", tenant="", orch="orch", plan_version=1) == []
+
+    db.execute("DELETE FROM orch_request_requirements")
+    assert "missing_requirements" in grammar_findings(
+        db, board="board", tenant="", orch="orch", plan_version=1
+    )
+
+    db.execute("INSERT INTO orch_request_requirements VALUES ('board', '', 'orch', 'req', 1)")
+    db.execute("UPDATE orch_plan_nodes SET required=0 WHERE node_key='lane-b'")
+    assert "bad_required_lane_count" in grammar_findings(
+        db, board="board", tenant="", orch="orch", plan_version=1
+    )
+
+    db.execute("UPDATE orch_plan_nodes SET ordinal=9 WHERE node_key='__parent__'")
+    assert "bad_parent_ordinal" in grammar_findings(
+        db, board="board", tenant="", orch="orch", plan_version=1
+    )
+
+
+def test_materialization_provenance(db: sqlite3.Connection) -> None:
+    """Plan headers bind to the request; materialization without a plan rejects."""
+    db.execute(
+        """INSERT INTO orch_requests VALUES
+        ('board', '', 'orch', 'lineage', 1, 'request-key', 'request-digest',
+         'origin', 'parent-task', 'parent_owned', 4, 0)"""
+    )
+    db.execute(
+        """INSERT INTO orch_plan_materializations VALUES
+        ('board', '', 'orch', 1, 'plan-digest', 4, 0)"""
+    )
+    findings = materialization_findings(
+        db, board="board", tenant="", orch="orch", plan_version=1
+    )
+    assert "missing_plan" in findings
+    assert "materialization_without_plan" in findings
+
+    _base_plan(db)  # same request key is intentionally ignored by this assertion
+    db.execute("UPDATE orch_plans SET request_digest='wrong-digest'")
+    findings = materialization_findings(
+        db, board="board", tenant="", orch="orch", plan_version=1
+    )
+    assert "plan_request_header_mismatch" in findings
+
+
+def test_recursive_closed_world(db: sqlite3.Connection) -> None:
+    """The recursive closure finds A→X→Y, not merely the first edge."""
+    db.execute(
+        """INSERT INTO orch_requests VALUES
+        ('board', '', 'orch', 'lineage', 1, 'request-key', 'request-digest',
+         'origin', 'A', 'parent_owned', 0, 0)"""
+    )
+    db.executemany("INSERT INTO tasks(id) VALUES (?)", [("A",), ("X",), ("Y",)])
+    db.executemany("INSERT INTO task_links VALUES (?, ?)", [("A", "X"), ("X", "Y")])
+    assert closed_world_closure(db, board="board", tenant="", orch="orch") == ["A", "X", "Y"]

--- a/tests/hermes_cli/test_kanban_orch_reconcile.py
+++ b/tests/hermes_cli/test_kanban_orch_reconcile.py
@@ -1,0 +1,229 @@
+"""M6 T35-T37: Reconcile outbox + effect ledger — transactional, idempotent, recovery."""
+
+import pytest
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_reconcile import (
+    EffectLedgerEntry,
+    OrchEvent,
+    QueueItem,
+    ReconcileError,
+    apply_effect,
+    claim_queue_item,
+    enqueue_event,
+    recover_expired_claim,
+    sweep_dead_letters,
+)
+
+D = "a" * 64
+
+
+def test_transactional_outbox():
+    """T35: transition/event/fanout same commit, no event-loss window.
+
+    Enqueue creates event + queue items atomically.
+    Duplicate event_key or (event_id, consumer_kind) rejected.
+    """
+    events: list[OrchEvent] = []
+    queue: list[QueueItem] = []
+
+    event, items = enqueue_event(
+        events, queue,
+        event_id=1,
+        consumer_kinds=["gateway", "observer"],
+        board="board_0123456789abcdef",
+        tenant="",
+        orch="orch-1",
+        event_kind="lifecycle_transition",
+        target_key="orch-1",
+        lifecycle_revision=1,
+        cancel_epoch=0,
+        payload_digest=D,
+        commit_seq=100,
+    )
+    assert event.event_id == 1
+    assert len(items) == 2
+    assert items[0].consumer_kind == "gateway"
+    assert items[1].consumer_kind == "observer"
+    assert items[0].state == "pending"
+    assert len(events) == 1
+    assert len(queue) == 2
+
+    # Duplicate event_key rejected
+    with pytest.raises(ReconcileError, match="duplicate_event_key"):
+        enqueue_event(
+            events, queue,
+            event_id=2,
+            consumer_kinds=["gateway"],
+            board="board_0123456789abcdef",
+            tenant="",
+            orch="orch-1",
+            event_kind="lifecycle_transition",
+            target_key="orch-1",
+            lifecycle_revision=1,
+            cancel_epoch=0,
+            payload_digest=D,
+            commit_seq=101,
+        )
+
+    # Duplicate (event_id, consumer_kind) rejected
+    with pytest.raises(ReconcileError, match="duplicate_queue_item"):
+        enqueue_event(
+            events, queue,
+            event_id=1,
+            consumer_kinds=["gateway"],
+            board="board_0123456789abcdef",
+            tenant="",
+            orch="orch-1",
+            event_kind="different_event",
+            target_key="different",
+            lifecycle_revision=2,
+            cancel_epoch=0,
+            payload_digest="b" * 64,
+            commit_seq=102,
+        )
+
+
+def test_effect_ledger_atomicity():
+    """T36: effect ledger + queue done one commit, replay idempotent.
+
+    Same digest → replay (no-op). Different digest → conflict.
+    """
+    events: list[OrchEvent] = []
+    queue: list[QueueItem] = []
+    effects: list[EffectLedgerEntry] = []
+
+    _, items = enqueue_event(
+        events, queue, event_id=1, consumer_kinds=["worker"],
+        board="b", tenant="", orch="o", event_kind="test", target_key="t",
+        lifecycle_revision=1, cancel_epoch=0, payload_digest=D, commit_seq=1,
+    )
+    item = items[0]
+    epoch = claim_queue_item(item, owner="w1", token_hash="t1", ttl=30, now=100)
+
+    # First apply — new effect
+    apply_effect(item, effects, board="b", tenant="", effect_digest=D,
+                 owner="w1", token_hash="t1", epoch=epoch)
+    assert item.state == "done"
+    assert item.done_effect_digest == D
+    assert len(effects) == 1
+
+    # Second apply with same digest — replay, idempotent
+    item.state = "claimed"
+    item.claim_owner = "w1"
+    item.claim_token_hash = "t1"
+    item.claim_epoch = epoch
+    apply_effect(item, effects, board="b", tenant="", effect_digest=D,
+                 owner="w1", token_hash="t1", epoch=epoch)
+    assert item.state == "done"
+    assert len(effects) == 1  # no duplicate
+
+    # Different digest → conflict
+    item.state = "claimed"
+    item.claim_owner = "w1"
+    item.claim_token_hash = "t1"
+    item.claim_epoch = epoch
+    with pytest.raises(ReconcileError, match="effect_digest_conflict"):
+        apply_effect(item, effects, board="b", tenant="", effect_digest="c" * 64,
+                     owner="w1", token_hash="t1", epoch=epoch)
+
+    # Wrong owner
+    item.state = "claimed"
+    with pytest.raises(ReconcileError, match="effect_wrong_owner"):
+        apply_effect(item, effects, board="b", tenant="", effect_digest=D,
+                     owner="wrong", token_hash="t1", epoch=epoch)
+
+    # Not claimed
+    item.state = "pending"
+    with pytest.raises(ReconcileError, match="effect_not_claimed"):
+        apply_effect(item, effects, board="b", tenant="", effect_digest=D,
+                     owner="w1", token_hash="t1", epoch=epoch)
+
+
+def test_queue_recovery_fencing():
+    """T37: expired vs active claim recovery/dead-letter.
+
+    Active nonexpired claim cannot be swept to dead-letter.
+    Expired claim returns to pending (if budget remains) or dead_letter.
+    """
+    events: list[OrchEvent] = []
+    queue: list[QueueItem] = []
+    effects: list[EffectLedgerEntry] = []
+
+    _, items = enqueue_event(
+        events, queue, event_id=1, consumer_kinds=["worker"],
+        board="b", tenant="", orch="o", event_kind="test", target_key="t",
+        lifecycle_revision=1, cancel_epoch=0, payload_digest=D, commit_seq=1,
+    )
+    item = items[0]
+    item.max_attempts = 3
+
+    # Claim with TTL
+    epoch = claim_queue_item(item, owner="w1", token_hash="t1", ttl=30, now=100)
+    assert item.claim_expires_at == 130
+
+    # Before expiry — active claim cannot be swept
+    state = recover_expired_claim(item, now=120, effects=effects)
+    assert state == "claimed"
+
+    # After expiry — returns to pending (attempts=1 < max=3)
+    state = recover_expired_claim(item, now=200, effects=effects)
+    assert state == "pending"
+    assert item.claim_owner is None
+    assert item.available_at == 200
+
+    # Exhaust attempts
+    item.available_at = 200
+    claim_queue_item(item, owner="w2", token_hash="t2", ttl=10, now=200)
+    recover_expired_claim(item, now=250, effects=effects)  # attempts=2
+
+    item.available_at = 250
+    claim_queue_item(item, owner="w3", token_hash="t3", ttl=10, now=250)
+    assert item.attempts == 3
+
+    # After expiry with max attempts → dead_letter
+    state = recover_expired_claim(item, now=300, effects=effects)
+    assert state == "dead_letter"
+    assert item.last_error_code == "reconcile_attempts_exhausted"
+
+    # Sweep dead_letters — already dead_letter, no change
+    count = sweep_dead_letters(queue, effects)
+    assert count == 0  # already dead_letter
+
+    # New item at max_attempts in pending → swept to dead_letter
+    _, items2 = enqueue_event(
+        events, queue, event_id=2, consumer_kinds=["worker"],
+        board="b", tenant="", orch="o", event_kind="test2", target_key="t2",
+        lifecycle_revision=2, cancel_epoch=0, payload_digest="e" * 64, commit_seq=2,
+    )
+    item2 = items2[0]
+    item2.max_attempts = 1
+    item2.attempts = 1
+    item2.state = "pending"
+    count = sweep_dead_letters(queue, effects, now=300)
+    assert count == 1
+    assert item2.state == "dead_letter"
+
+    # Active (non-expired) claim at max_attempts cannot be swept
+    _, items3 = enqueue_event(
+        events, queue, event_id=3, consumer_kinds=["worker"],
+        board="b", tenant="", orch="o", event_kind="test3", target_key="t3",
+        lifecycle_revision=3, cancel_epoch=0, payload_digest="f" * 64, commit_seq=3,
+    )
+    item3 = items3[0]
+    item3.max_attempts = 1
+    item3.attempts = 1
+    item3.state = "claimed"
+    item3.claim_expires_at = 999999  # far future
+    count = sweep_dead_letters(queue, effects, now=300)
+    assert count == 0  # active claim not swept
+    assert item3.state == "claimed"
+
+    # Expired claim at max_attempts CAN be swept
+    item3.claim_expires_at = 200  # already expired
+    count = sweep_dead_letters(queue, effects, now=300)
+    assert count == 1
+    assert item3.state == "dead_letter"

--- a/tests/hermes_cli/test_kanban_orch_residual_r2.py
+++ b/tests/hermes_cli/test_kanban_orch_residual_r2.py
@@ -1,0 +1,138 @@
+"""Residual R2 hostile closures for ORCH V4 candidate."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_canonical import (
+    CanonicalError,
+    assert_digest_matches,
+    digest,
+    request_digest,
+)
+from hermes_cli.kanban_orch_lifecycle import (
+    LifecycleError,
+    Request,
+    Task,
+    Node,
+    apply_transition,
+    cancel_cascade,
+    cancellation_satisfied,
+    finish_cancellation,
+)
+from hermes_cli.kanban_orch_delivery import (
+    DeliveryError,
+    DeliveryObligation,
+    DeliveryReceipt,
+    claim_obligation,
+    finish_attempt,
+    process_receipt,
+    start_attempt,
+)
+from hermes_cli.kanban_orch_bridge import BridgeError, OrchBridge, init_sidecar_db
+
+
+def test_server_digest_recompute_rejects_forged_claim():
+    value = {"schema_version": 4, "kind": "orch_route", "x": 1}
+    real = digest(value)
+    assert assert_digest_matches(value, real) == real
+    with pytest.raises(CanonicalError, match="digest_mismatch"):
+        assert_digest_matches(value, "b" * 64)
+
+
+def test_lifecycle_evidence_gates():
+    req = Request("b", "", "o", "waiting_lanes")
+    with pytest.raises(LifecycleError, match="missing_required_lane_acceptances"):
+        apply_transition(req, "required_set_accepted", "synthesizing")
+    ok = apply_transition(req, "required_set_accepted", "synthesizing", accepted_required_lanes=2)
+    assert ok.state == "synthesizing"
+    with pytest.raises(LifecycleError, match="missing_synthesis_result"):
+        apply_transition(ok, "result_accepted", "work_accepted")
+    ok2 = apply_transition(ok, "result_accepted", "work_accepted", has_result=True)
+    with pytest.raises(LifecycleError, match="board_only_origin_required"):
+        apply_transition(ok2, "explicit_board_only", "completed")
+    assert apply_transition(ok2, "explicit_board_only", "completed", origin_kind="board_only").state == "completed"
+
+
+def test_cancel_running_task_must_drain():
+    req = Request("b", "", "o", "waiting_lanes")
+    tasks = [Task("b", "", "o", "t1", "running")]
+    nodes = [Node("b", "", "o", "n1", True, "running")]
+    cancel_cascade(
+        req,
+        tasks=tasks,
+        task_runs=[],
+        nodes=nodes,
+        leases=[],
+        obligations=[],
+        attempts=[],
+        now=1,
+    )
+    assert req.state == "cancelling"
+    assert cancellation_satisfied(
+        req, tasks=tasks, task_runs=[], nodes=nodes, leases=[], obligations=[], attempts=[]
+    ) is False
+    tasks[0].status = "cancelled"
+    tasks[0].cancellation_requested_at = None
+    nodes[0].state = "cancelled"
+    assert cancellation_satisfied(
+        req, tasks=tasks, task_runs=[], nodes=nodes, leases=[], obligations=[], attempts=[]
+    ) is True
+    finish_cancellation(
+        req, tasks=tasks, task_runs=[], nodes=nodes, leases=[], obligations=[], attempts=[]
+    )
+    assert req.state == "cancelled"
+
+
+def test_delivery_attempt_cas_and_rejected_cannot_ack():
+    d = "a" * 64
+    obl = DeliveryObligation("o1", "k1", True, d, "provider", "message_id")
+    claim_obligation(obl, owner="w", token_hash="t", ttl=1, now=1)
+    a1 = start_attempt(
+        obl, attempt_id=1, send_nonce="n1", payload_digest=d, result_digest=d,
+        claim_owner="w", claim_token_hash="t", claim_epoch=1, lifecycle_revision=0, cancel_epoch=0,
+    )
+    with pytest.raises(DeliveryError, match="attempt_already_open"):
+        start_attempt(
+            obl, attempt_id=2, send_nonce="n2", payload_digest=d, result_digest=d,
+            claim_owner="w", claim_token_hash="t", claim_epoch=1, lifecycle_revision=0, cancel_epoch=0,
+        )
+    finish_attempt(obl, a1, terminal_state="rejected", now=2)
+    with pytest.raises(DeliveryError, match="rejected_attempt_cannot_ack"):
+        process_receipt(
+            obl,
+            a1,
+            DeliveryReceipt(1, "o1", "n1", d, d, d, "provider", "message_id"),
+            now=3,
+        )
+
+
+def test_bridge_board_tenant_scope_and_atomic_init(tmp_path):
+    native = tmp_path / "n.db"
+    side = tmp_path / "s.db"
+    nc = sqlite3.connect(native)
+    nc.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, "
+        "created_at INTEGER NOT NULL, tenant TEXT)"
+    )
+    nc.execute("INSERT INTO tasks VALUES ('task-1','t','pending',1,'')")
+    nc.commit()
+    nc.close()
+
+    init_sidecar_db(str(side))
+    # second init must fail (exists)
+    with pytest.raises(BridgeError, match="sidecar_exists"):
+        init_sidecar_db(str(side))
+
+    br = OrchBridge(str(native), str(side), board_instance_id="board_0123456789abcdef", tenant_scope="")
+    br.bind_parent_task("board_0123456789abcdef", "", "orch-1", "task-1")
+    with pytest.raises(BridgeError, match="board_tenant_scope_mismatch"):
+        br.bind_parent_task("board_FOREIGN_12345678", "other", "orch-2", "task-1")
+    br.close()

--- a/tests/hermes_cli/test_kanban_orch_rollback.py
+++ b/tests/hermes_cli/test_kanban_orch_rollback.py
@@ -1,0 +1,162 @@
+"""M8 T43: Rollback — durable phases, preimage fence, no early reopen."""
+
+import pytest
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_rollback import (
+    FENCE_CLOSED_PHASES,
+    ROLLBACK_PHASES,
+    RollbackError,
+    RollbackOperation,
+    advance_phase,
+    authorize_reopen,
+    check_no_early_reopen,
+    check_preimage_compatible,
+    create_rollback,
+    resume_rollback,
+)
+
+
+def make_op():
+    """Create a standard rollback operation for testing."""
+    return create_rollback(
+        operation_id="rb-001",
+        owner_token_hash="tok-hash",
+        source_live_hash="a" * 64,
+        source_code_hash="src" + "a" * 61,
+        target_live_hash="b" * 64,
+        target_code_hash="tgt" + "b" * 61,
+    )
+
+
+def test_rollback_state_machine():
+    """T43: rollback durable phases — no early reopen, no skip.
+
+    All phases advance in order. Fence stays closed.
+    Reopen requires additional David-level token.
+    """
+    op = make_op()
+
+    # All phases in order
+    assert op.current_phase == "gate_submits"
+    assert op.fence_generation == 1  # fence closed
+    assert op.phase_revision == 0
+
+    # Advance through all phases
+    phases_to_advance = list(ROLLBACK_PHASES[1:])  # skip gate_submits (starting point)
+    for phase in phases_to_advance:
+        if phase == "reopened":
+            # Reopened requires David-level token first
+            authorize_reopen(op, david_token="david-approval")
+            advance_phase(op, target_phase=phase, owner_token_hash="tok-hash", expected_revision=op.phase_revision)
+        else:
+            advance_phase(op, target_phase=phase, owner_token_hash="tok-hash", expected_revision=op.phase_revision)
+
+    assert op.current_phase == "reopened"
+    assert op.fence_generation == 0  # fence released
+    assert op.is_active is True
+    assert len(op.completed_phases) == len(ROLLBACK_PHASES) - 1
+
+    # Phase revision incremented for each advance
+    assert op.phase_revision == len(ROLLBACK_PHASES) - 1
+
+
+def test_rollback_no_skip():
+    """T43: cannot skip phases."""
+    op = make_op()
+
+    # Try to skip from gate_submits to workers_stopped
+    with pytest.raises(RollbackError, match="phase_skip_not_allowed"):
+        advance_phase(op, target_phase="workers_stopped", owner_token_hash="tok-hash", expected_revision=0)
+
+    # Try to go backwards
+    advance_phase(op, target_phase="fence_draining", owner_token_hash="tok-hash", expected_revision=0)
+    with pytest.raises(RollbackError, match="phase_rollback_not_allowed"):
+        advance_phase(op, target_phase="gate_submits", owner_token_hash="tok-hash", expected_revision=1)
+
+
+def test_rollback_owner_cas():
+    """T43: owner token mismatch rejected."""
+    op = make_op()
+
+    with pytest.raises(RollbackError, match="owner_token_mismatch"):
+        advance_phase(op, target_phase="fence_draining", owner_token_hash="wrong", expected_revision=0)
+
+    with pytest.raises(RollbackError, match="phase_revision_mismatch"):
+        advance_phase(op, target_phase="fence_draining", owner_token_hash="tok-hash", expected_revision=99)
+
+
+def test_rollback_fence_closed():
+    """T43: fence stays closed from fence_draining through verified.
+
+    No early reopen.
+    """
+    op = make_op()
+
+    # gate_submits → fence_draining
+    advance_phase(op, target_phase="fence_draining", owner_token_hash="tok-hash", expected_revision=0)
+    assert check_no_early_reopen(op) is True
+    assert op.fence_generation >= 1
+
+    # Through verified
+    for phase in ["workers_stopped", "leases_revoked", "snapshot_sealed",
+                   "code_switched", "old_writer_receipts_verified", "verified"]:
+        advance_phase(op, target_phase=phase, owner_token_hash="tok-hash", expected_revision=op.phase_revision)
+        assert check_no_early_reopen(op) is True  # fence stays closed
+
+    # Try to reopen without David-level token
+    with pytest.raises(RollbackError, match="reopen_requires_additional_token"):
+        advance_phase(op, target_phase="reopened", owner_token_hash="tok-hash", expected_revision=op.phase_revision)
+
+    # Authorize with David-level token
+    authorize_reopen(op, david_token="david-approval")
+    assert op.is_active is True
+
+    # Now reopen succeeds
+    advance_phase(op, target_phase="reopened", owner_token_hash="tok-hash", expected_revision=op.phase_revision)
+    assert op.fence_generation == 0
+    assert check_no_early_reopen(op) is True  # properly released
+
+
+def test_rollback_preimage_compatible():
+    """T43: compatible preimage means M0 fence-aware source hash.
+
+    Pre-M0 code can never be a rollback target.
+    """
+    # M0-aware source → compatible
+    assert check_preimage_compatible("src_hash", "tgt_hash", is_m0_aware=True) is True
+
+    # Pre-M0 source → not compatible
+    assert check_preimage_compatible("src_hash", "tgt_hash", is_m0_aware=False) is False
+
+    # Missing hashes → not compatible
+    assert check_preimage_compatible("", "tgt_hash") is False
+    assert check_preimage_compatible("src_hash", "") is False
+
+    # Same hash (not a rollback) → not compatible
+    assert check_preimage_compatible("same", "same") is False
+
+
+def test_rollback_resume():
+    """T43: crash resumes from durable phase/revision."""
+    op = make_op()
+    advance_phase(op, target_phase="fence_draining", owner_token_hash="tok-hash", expected_revision=0)
+    advance_phase(op, target_phase="workers_stopped", owner_token_hash="tok-hash", expected_revision=1)
+
+    # Resume returns current phase
+    phase = resume_rollback(op, owner_token_hash="tok-hash")
+    assert phase == "workers_stopped"
+
+    # Wrong owner rejected
+    with pytest.raises(RollbackError, match="resume_owner_mismatch"):
+        resume_rollback(op, owner_token_hash="wrong")
+
+
+def test_rollback_invalid_phase():
+    """T43: invalid phase name rejected."""
+    op = make_op()
+    with pytest.raises(RollbackError, match="invalid_phase"):
+        advance_phase(op, target_phase="nonexistent", owner_token_hash="tok-hash", expected_revision=0)

--- a/tests/hermes_cli/test_kanban_orch_schema_v4.py
+++ b/tests/hermes_cli/test_kanban_orch_schema_v4.py
@@ -91,15 +91,43 @@ class TestSchemaV4:
 
     def test_full_request_plan_binding(self, fresh_db):
         """§13 T06: origin/request/plan full composite scope and header mismatch."""
-        d = "a" * 64
-        d2 = "b" * 64
+        import json
+        from hermes_cli.kanban_orch_canonical import request_digest
+        from hermes_cli.kanban_orch_digest_udf import build_route_json_and_digest
 
+        d2 = "b" * 64
         b = "board_0123456789abcdef"  # 22 chars, satisfies CHECK length 16-128
         sk = "a" * 64  # selector_key must be 64-hex (digest)
+        route_json, route_d = build_route_json_and_digest(
+            origin_kind="board_only",
+            platform="telegram",
+            adapter_instance_id="ad1",
+            account_id="acc1",
+            conversation_id="conv1",
+            required_ack_family="none",
+            required_ack_strength="none",
+            route_revision=1,
+        )
+        req_obj = {
+            "schema_version": 4,
+            "kind": "orch_request",
+            "selector_key": sk,
+            "request_key": sk,
+            "origin_id": "oid1",
+            "lineage_id": "lin1",
+            "generation": 1,
+            "title": "parent",
+            "synthesis_strategy": "parent_owned",
+            "completion_policy": "board_only",
+            "requirements": [],
+        }
+        req_json = json.dumps(req_obj, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        req_d = request_digest(req_obj)
+
         fresh_db.execute(
             "INSERT INTO kanban_board_identity (singleton, board_instance_id, canonical_board_key, created_at)"
             " VALUES (1, ?, 'board1', 1)",
-            (b,)
+            (b,),
         )
         fresh_db.execute(
             "INSERT INTO orch_replay_selectors"
@@ -107,7 +135,7 @@ class TestSchemaV4:
             "  adapter_instance_id, conversation_id, lineage_id, current_generation,"
             "  ledger_revision, created_at, updated_at)"
             " VALUES (?, ?, '', 'event', 'evt1', 'ad1', 'conv1', 'lin1', 0, 0, 1, 1)",
-            (sk, b)
+            (sk, b),
         )
         fresh_db.execute(
             "INSERT INTO orch_origins"
@@ -117,8 +145,8 @@ class TestSchemaV4:
             "  notifier_profile, route_revision, route_json, route_digest,"
             "  required_ack_family, required_ack_strength, created_at)"
             " VALUES (?, '', 'oid1', 4, ?, 'board_only', 'telegram', 'ad1', 'acc1', 'conv1',"
-            "  'event', 'evt1', '', '', '', '', 1, '{}', ?, 'none', 'none', 1)",
-            (b, sk, d)
+            "  'event', 'evt1', '', '', '', '', 1, ?, ?, 'none', 'none', 1)",
+            (b, sk, route_json, route_d),
         )
         fresh_db.execute(
             "INSERT INTO tasks (id, title, status, created_at) VALUES ('parent1', 'parent', 'pending', 1)"
@@ -131,10 +159,24 @@ class TestSchemaV4:
             "  lifecycle_state, lifecycle_revision, cancel_epoch,"
             "  delivery_epoch_revision, plan_epoch_revision, plan_version,"
             "  synthesis_strategy, max_retries, created_at, updated_at)"
-            " VALUES (?, '', 'orch1', 'lin1', 1, ?, 0, ?, 4, '{}', ?, 'oid1', 'parent1',"
+            " VALUES (?, '', 'orch1', 'lin1', 1, ?, 0, ?, 4, ?, ?, 'oid1', 'parent1',"
             "  'submitted', 0, 0, 0, 0, 0, 'parent_owned', 0, 1, 1)",
-            (b, sk, d, d)
+            (b, sk, sk, req_json, req_d),
         )
+
+        # Forged route_digest must fail at SQL trigger (not just Python).
+        with pytest.raises(sqlite3.IntegrityError, match="route_digest_mismatch"):
+            fresh_db.execute(
+                "INSERT INTO orch_origins"
+                " (board_instance_id, tenant_scope, origin_id, schema_version, selector_key,"
+                "  origin_kind, platform, adapter_instance_id, account_id, conversation_id,"
+                "  selector_kind, selector_value, thread_id, reply_to_id, session_id,"
+                "  notifier_profile, route_revision, route_json, route_digest,"
+                "  required_ack_family, required_ack_strength, created_at)"
+                " VALUES (?, '', 'oid-forged', 4, ?, 'board_only', 'telegram', 'ad1', 'acc1', 'conv1',"
+                "  'event', 'evt1', '', '', '', '', 1, ?, ?, 'none', 'none', 1)",
+                (b, sk, route_json, "c" * 64),
+            )
 
         # Valid plan insert — all FK columns match the request
         fresh_db.execute(
@@ -145,7 +187,7 @@ class TestSchemaV4:
             "  created_by_run_id, created_at)"
             " VALUES (?, '', 'orch1', 1, 4, 'lin1', 1, ?, ?, 'oid1', 'parent1',"
             "  'parent_owned', '{}', ?, 0, 1)",
-            (b, d, d, d)
+            (b, sk, req_d, req_d),
         )
 
         # Mismatched request_key → FK violation
@@ -158,7 +200,7 @@ class TestSchemaV4:
                 "  created_by_run_id, created_at)"
                 " VALUES (?, '', 'orch1', 2, 4, 'lin1', 1, ?, ?, 'oid1', 'parent1',"
                 "  'parent_owned', '{}', ?, 0, 1)",
-                (b, d2, d, d)
+                (b, d2, req_d, req_d),
             )
 
         # Mismatched origin_id → FK violation
@@ -171,7 +213,7 @@ class TestSchemaV4:
                 "  created_by_run_id, created_at)"
                 " VALUES (?, '', 'orch1', 3, 4, 'lin1', 1, ?, ?, 'wrong_origin', 'parent1',"
                 "  'parent_owned', '{}', ?, 0, 1)",
-                (b, d, d, d)
+                (b, sk, req_d, req_d),
             )
 
         # Mismatched request_digest → FK violation
@@ -184,5 +226,5 @@ class TestSchemaV4:
                 "  created_by_run_id, created_at)"
                 " VALUES (?, '', 'orch1', 4, 4, 'lin1', 1, ?, ?, 'oid1', 'parent1',"
                 "  'parent_owned', '{}', ?, 0, 1)",
-                (b, d, d2, d)
+                (b, sk, d2, req_d),
             )

--- a/tests/hermes_cli/test_kanban_orch_schema_v4.py
+++ b/tests/hermes_cli/test_kanban_orch_schema_v4.py
@@ -25,7 +25,8 @@ def fresh_db():
     conn = sqlite3.connect(path)
     conn.execute("PRAGMA foreign_keys=ON")
     try:
-        apply_schema(conn)
+        # Compile + allow test writes through explicit open capability grant.
+        apply_schema(conn, test_open_capability=True)
         conn.execute("PRAGMA foreign_keys=ON")
     except Exception:
         conn.close()

--- a/tests/hermes_cli/test_kanban_orch_schema_v4.py
+++ b/tests/hermes_cli/test_kanban_orch_schema_v4.py
@@ -1,0 +1,187 @@
+"""
+T03: Schema V4 compile + FK/trigger smoke test.
+"""
+
+import sqlite3
+import pytest
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_schema_v4 import (
+    EXPECTED_TABLES,
+    apply_schema,
+    get_table_names,
+    get_trigger_names,
+)
+
+
+@pytest.fixture
+def fresh_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA foreign_keys=ON")
+    try:
+        apply_schema(conn)
+        conn.execute("PRAGMA foreign_keys=ON")
+    except Exception:
+        conn.close()
+        if os.path.exists(path):
+            os.unlink(path)
+        raise
+    yield conn
+    conn.close()
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+class TestSchemaV4:
+
+    def test_exact_schema_compile(self, fresh_db):
+        """All DDL statements execute without error on fresh DB."""
+        fk = fresh_db.execute("PRAGMA foreign_keys").fetchone()[0]
+        assert fk == 1, "foreign_keys must be ON"
+
+    def test_foreign_key_check_empty(self, fresh_db):
+        violations = fresh_db.execute("PRAGMA foreign_key_check").fetchall()
+        assert violations == [], f"FK violations: {violations}"
+
+    def test_all_expected_tables_exist(self, fresh_db):
+        tables = set(get_table_names(fresh_db))
+        missing = EXPECTED_TABLES - tables
+        assert not missing, f"Missing tables: {missing}"
+
+    def test_triggers_exist(self, fresh_db):
+        triggers = get_trigger_names(fresh_db)
+        assert len(triggers) >= 50, f"Only {len(triggers)} triggers created"
+
+    def test_orphan_child_rejected_by_fk(self, fresh_db):
+        """Insert into orch_requests with nonexistent origin_id is rejected."""
+        # Raw SQLite lacks the runtime capability context.  Register a
+        # fail-closed implementation so protected triggers reject the write as
+        # sqlite3.IntegrityError before any row can be created.
+        fresh_db.create_function("orch_capability_ok", 7, lambda *args: 0)
+        digest = "a" * 64
+        with pytest.raises(sqlite3.IntegrityError):
+            fresh_db.execute("""
+                INSERT INTO orch_requests (
+                    board_instance_id, tenant_scope, orch_id, lineage_id,
+                    generation, selector_key, selector_ledger_revision,
+                    request_key, request_schema_version, request_json, request_digest,
+                    origin_id, parent_task_id,
+                    lifecycle_state, lifecycle_revision, cancel_epoch,
+                    delivery_epoch_revision, plan_epoch_revision, plan_version,
+                    synthesis_strategy, max_retries, created_at, updated_at
+                ) VALUES (
+                    'board-orphan', '', 'orch-orphan', 'lineage-orphan',
+                    1, :digest, 0, :digest, 4, '{}', :digest,
+                    'nonexistent-origin', 'parent-orphan',
+                    'submitted', 0, 0, 0, 0, 0,
+                    'parent_owned', 0, 1, 1
+                )
+            """, {"digest": digest})
+
+    def test_integrity_check_passes(self, fresh_db):
+        result = fresh_db.execute("PRAGMA integrity_check").fetchone()[0]
+        assert result == "ok", f"integrity_check: {result}"
+
+    def test_full_request_plan_binding(self, fresh_db):
+        """§13 T06: origin/request/plan full composite scope and header mismatch."""
+        d = "a" * 64
+        d2 = "b" * 64
+
+        b = "board_0123456789abcdef"  # 22 chars, satisfies CHECK length 16-128
+        sk = "a" * 64  # selector_key must be 64-hex (digest)
+        fresh_db.execute(
+            "INSERT INTO kanban_board_identity (singleton, board_instance_id, canonical_board_key, created_at)"
+            " VALUES (1, ?, 'board1', 1)",
+            (b,)
+        )
+        fresh_db.execute(
+            "INSERT INTO orch_replay_selectors"
+            " (selector_key, board_instance_id, tenant_scope, selector_kind, selector_value,"
+            "  adapter_instance_id, conversation_id, lineage_id, current_generation,"
+            "  ledger_revision, created_at, updated_at)"
+            " VALUES (?, ?, '', 'event', 'evt1', 'ad1', 'conv1', 'lin1', 0, 0, 1, 1)",
+            (sk, b)
+        )
+        fresh_db.execute(
+            "INSERT INTO orch_origins"
+            " (board_instance_id, tenant_scope, origin_id, schema_version, selector_key,"
+            "  origin_kind, platform, adapter_instance_id, account_id, conversation_id,"
+            "  selector_kind, selector_value, thread_id, reply_to_id, session_id,"
+            "  notifier_profile, route_revision, route_json, route_digest,"
+            "  required_ack_family, required_ack_strength, created_at)"
+            " VALUES (?, '', 'oid1', 4, ?, 'board_only', 'telegram', 'ad1', 'acc1', 'conv1',"
+            "  'event', 'evt1', '', '', '', '', 1, '{}', ?, 'none', 'none', 1)",
+            (b, sk, d)
+        )
+        fresh_db.execute(
+            "INSERT INTO tasks (id, title, status, created_at) VALUES ('parent1', 'parent', 'pending', 1)"
+        )
+        fresh_db.execute(
+            "INSERT INTO orch_requests"
+            " (board_instance_id, tenant_scope, orch_id, lineage_id, generation,"
+            "  selector_key, selector_ledger_revision, request_key, request_schema_version,"
+            "  request_json, request_digest, origin_id, parent_task_id,"
+            "  lifecycle_state, lifecycle_revision, cancel_epoch,"
+            "  delivery_epoch_revision, plan_epoch_revision, plan_version,"
+            "  synthesis_strategy, max_retries, created_at, updated_at)"
+            " VALUES (?, '', 'orch1', 'lin1', 1, ?, 0, ?, 4, '{}', ?, 'oid1', 'parent1',"
+            "  'submitted', 0, 0, 0, 0, 0, 'parent_owned', 0, 1, 1)",
+            (b, sk, d, d)
+        )
+
+        # Valid plan insert — all FK columns match the request
+        fresh_db.execute(
+            "INSERT INTO orch_plans"
+            " (board_instance_id, tenant_scope, orch_id, plan_version, schema_version,"
+            "  lineage_id, generation, request_key, request_digest, origin_id,"
+            "  parent_task_id, synthesis_strategy, plan_json, plan_digest,"
+            "  created_by_run_id, created_at)"
+            " VALUES (?, '', 'orch1', 1, 4, 'lin1', 1, ?, ?, 'oid1', 'parent1',"
+            "  'parent_owned', '{}', ?, 0, 1)",
+            (b, d, d, d)
+        )
+
+        # Mismatched request_key → FK violation
+        with pytest.raises(sqlite3.IntegrityError):
+            fresh_db.execute(
+                "INSERT INTO orch_plans"
+                " (board_instance_id, tenant_scope, orch_id, plan_version, schema_version,"
+                "  lineage_id, generation, request_key, request_digest, origin_id,"
+                "  parent_task_id, synthesis_strategy, plan_json, plan_digest,"
+                "  created_by_run_id, created_at)"
+                " VALUES (?, '', 'orch1', 2, 4, 'lin1', 1, ?, ?, 'oid1', 'parent1',"
+                "  'parent_owned', '{}', ?, 0, 1)",
+                (b, d2, d, d)
+            )
+
+        # Mismatched origin_id → FK violation
+        with pytest.raises(sqlite3.IntegrityError):
+            fresh_db.execute(
+                "INSERT INTO orch_plans"
+                " (board_instance_id, tenant_scope, orch_id, plan_version, schema_version,"
+                "  lineage_id, generation, request_key, request_digest, origin_id,"
+                "  parent_task_id, synthesis_strategy, plan_json, plan_digest,"
+                "  created_by_run_id, created_at)"
+                " VALUES (?, '', 'orch1', 3, 4, 'lin1', 1, ?, ?, 'wrong_origin', 'parent1',"
+                "  'parent_owned', '{}', ?, 0, 1)",
+                (b, d, d, d)
+            )
+
+        # Mismatched request_digest → FK violation
+        with pytest.raises(sqlite3.IntegrityError):
+            fresh_db.execute(
+                "INSERT INTO orch_plans"
+                " (board_instance_id, tenant_scope, orch_id, plan_version, schema_version,"
+                "  lineage_id, generation, request_key, request_digest, origin_id,"
+                "  parent_task_id, synthesis_strategy, plan_json, plan_digest,"
+                "  created_by_run_id, created_at)"
+                " VALUES (?, '', 'orch1', 4, 4, 'lin1', 1, ?, ?, 'oid1', 'parent1',"
+                "  'parent_owned', '{}', ?, 0, 1)",
+                (b, d, d2, d)
+            )

--- a/tests/hermes_cli/test_kanban_orch_sidecar.py
+++ b/tests/hermes_cli/test_kanban_orch_sidecar.py
@@ -1,0 +1,174 @@
+"""S1: Sidecar schema + init — compile, internal FK, O_EXCL, native zero-mutation."""
+
+import pytest
+import os
+import sys
+import tempfile
+import hashlib
+import sqlite3
+import shutil
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from hermes_cli.kanban_orch_schema_sidecar import (
+    EXPECTED_SIDECAR_TABLES,
+    NATIVE_TABLES,
+    apply_sidecar_schema,
+    get_sidecar_table_names,
+    get_sidecar_trigger_names,
+    verify_no_native_tables,
+)
+from hermes_cli.kanban_orch_bridge import BridgeError, init_sidecar_db
+
+
+def _make_native_fixture(path: str) -> str:
+    """Create a minimal native kanban.db fixture with tasks table."""
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute("CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, title TEXT, status TEXT NOT NULL, created_at INTEGER NOT NULL)")
+    conn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('task-1', 'Test Task', 'pending', 1)")
+    conn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('task-2', 'Another Task', 'done', 2)")
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(65536):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def test_sidecar_schema_compiles():
+    """Sidecar DDL executes without error on fresh DB."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        apply_sidecar_schema(conn)
+        fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+        assert fk == 1
+        conn.close()
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_sidecar_internal_fks():
+    """Sidecar has internal FKs but no native table FKs."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        conn = sqlite3.connect(path)
+        apply_sidecar_schema(conn)
+
+        # Check all expected sidecar tables exist
+        tables = set(get_sidecar_table_names(conn))
+        missing = EXPECTED_SIDECAR_TABLES - tables
+        assert not missing, f"Missing sidecar tables: {missing}"
+
+        # Check no native tables leaked
+        assert verify_no_native_tables(conn) is True
+
+        # Verify FK check is clean
+        violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+        assert violations == [], f"FK violations: {violations}"
+
+        # Verify integrity
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+
+        conn.close()
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_init_creates_new_file_excl():
+    """init_sidecar_db creates a new file (O_EXCL semantics)."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        native_path = os.path.join(tmpdir, "native.db")
+        _make_native_fixture(native_path)
+
+        sidecar_path = os.path.join(tmpdir, "orch_v4.db")
+        assert not os.path.exists(sidecar_path)
+
+        init_sidecar_db(sidecar_path)
+        assert os.path.exists(sidecar_path)
+
+        # Verify it has tables
+        conn = sqlite3.connect(sidecar_path)
+        tables = get_sidecar_table_names(conn)
+        assert len(tables) > 0
+        verify_no_native_tables(conn)
+        conn.close()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_init_refuses_existing_path():
+    """init_sidecar_db refuses if path already exists (O_EXCL)."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        native_path = os.path.join(tmpdir, "native.db")
+        _make_native_fixture(native_path)
+
+        sidecar_path = os.path.join(tmpdir, "orch_v4.db")
+        init_sidecar_db(sidecar_path)
+
+        # Second init should fail
+        with pytest.raises(BridgeError, match="sidecar_exists"):
+            init_sidecar_db(sidecar_path)
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_native_db_bytes_unchanged_after_init():
+    """Native DB SHA-256 must be identical before and after sidecar init."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        native_path = os.path.join(tmpdir, "native.db")
+        _make_native_fixture(native_path)
+
+        sha_before = _sha256_file(native_path)
+
+        sidecar_path = os.path.join(tmpdir, "orch_v4.db")
+        init_sidecar_db(sidecar_path)
+
+        sha_after = _sha256_file(native_path)
+        assert sha_before == sha_after, "Native DB bytes changed during sidecar init!"
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_native_opened_read_only_rejected_on_write_attempt():
+    """Opening native with mode=ro should reject write attempts."""
+    tmpdir = tempfile.mkdtemp()
+    try:
+        native_path = os.path.join(tmpdir, "native.db")
+        _make_native_fixture(native_path)
+
+        # Open RO via URI
+        conn = sqlite3.connect(f"file:{native_path}?mode=ro", uri=True)
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('evil', 'hack', 'hacked', 0)")
+        conn.close()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_no_live_paths_in_unit_tests():
+    """Unit tests must NOT use live kanban.db path."""
+    LIVE_PATHS = {"/home/claw/.hermes/kanban.db", "/home/claw/.hermes/orch_v4.db"}
+    # This test is a documentation point: all fixtures use tempfile.mkstemp/mkdtemp
+    # If any test uses a live path, it would be a violation.
+    # We verify by checking that our temp paths are not in LIVE_PATHS.
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        assert path not in LIVE_PATHS
+        assert os.path.dirname(path) not in LIVE_PATHS
+    finally:
+        os.unlink(path)


### PR DESCRIPTION
## Problem

`resolve_xai_http_credentials` has three credential branches. Two of them — the `prefer_api_key` branch and the OAuth branch — route the `XAI_BASE_URL` / `HERMES_XAI_BASE_URL` override through `_xai_validate_inference_base_url` (pin to `*.x.ai`, HTTPS-only, warn-and-fallback) so the bearer/API key can never be sent to a foreign origin.

The final API-key fallback branch (no OAuth pool configured) returned the raw env value **unvalidated**:

```python
base_url = str(get_env_value("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
```

With `XAI_API_KEY` set and no OAuth pool, a tampered `XAI_BASE_URL=http://attacker.example/v1` is returned verbatim, and downstream callers POST the credential to it (`x_search_tool.py` /responses, `tts_tool_providers.py` /tts, `transcription_cloud.py`, image/video-gen plugins).

## Fix

The fallback branch now applies the same `_xai_base_url_override()` + `_xai_validate_inference_base_url()` origin pinning as the other two branches. A legitimate `*.x.ai` HTTPS override is still honored; anything else falls back to `DEFAULT_XAI_BASE_URL`.

## Test

New regression test `test_api_key_fallback_branch_pins_base_url_origin` in `tests/tools/test_xai_http_credentials.py`:
- tampered non-HTTPS foreign override → rejected, default returned
- legitimate `https://staging.x.ai/v1` override → honored

`pytest tests/tools/test_xai_http_credentials.py` → 7 passed. Adjacent xAI suites (`test_x_search_tool.py`, `test_tts_streaming.py`, `test_web_providers_xai.py`) → 34 passed, 1 skipped.