### PR TITLE
ci: add infographic-check to the all-checks-pass gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,6 +251,7 @@ jobs:
       - supply-chain
       - review-labels
       - osv-scanner
+      - infographic-check
       # The image build runs in its own workflow (docker.yml) and reports
       # its own check. It was never required here, because it is too slow
       # to block a merge. A separate run also stops it from holding this

--- a/tests/ci/test_infographic_check_gate.py
+++ b/tests/ci/test_infographic_check_gate.py
@@ -1,0 +1,35 @@
+"""Guard: every always-on sub-workflow of ci.yaml must be a gate dependency.
+
+The ``all-checks-pass`` job is the only check branch protection requires.
+A sub-workflow job that runs unconditionally (no ``if:``) but is missing
+from its ``needs`` list is advisory-only -- its failure can never block a
+merge, even when the workflow's own docstring says it must enforce a
+policy (regression: ``infographic-check`` was silently advisory).
+"""
+from pathlib import Path
+
+import yaml
+
+CI = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yaml"
+
+
+def _ci():
+    return yaml.safe_load(CI.read_text(encoding="utf-8"))
+
+
+def test_unconditional_sub_workflows_are_gate_dependencies():
+    ci = _ci()
+    jobs = ci["jobs"]
+    gate_needs = set(jobs["all-checks-pass"]["needs"])
+    unconditional = [
+        name
+        for name, job in jobs.items()
+        if name not in {"detect", "all-checks-pass", "ci-timings"}
+        and "uses" in job  # sub-workflow calls only
+        and "if" not in job
+    ]
+    assert unconditional, "expected at least one unconditional sub-workflow"
+    missing = sorted(set(unconditional) - gate_needs)
+    assert not missing, (
+        "unconditional sub-workflows missing from all-checks-pass needs: %s" % missing
+    )


### PR DESCRIPTION
## Problem

`infographic-check` runs unconditionally on every PR (no `if:`, no lane gating), and its workflow docstring states the check exists to *enforce a policy*: committed PR-infographic images had already leaked three times (~14MB) before it was added, and a passive `.gitignore` rule cannot stop `git add -f`.

But the job was missing from the `all-checks-pass` gate `needs` list — the only check branch protection requires — so its failure can never block a merge. The check is advisory-only despite its stated purpose.

## Fix

- Add `infographic-check` to the `all-checks-pass` `needs` list.
- Add a guard test (`tests/ci/test_infographic_check_gate.py`) that parses `ci.yaml` and fails when any unconditional sub-workflow job is not a gate dependency — so the next enforcement-style check cannot silently become advisory the same way.

## Test

- `pytest tests/ci/test_infographic_check_gate.py` → 1 passed with the fix; verified the guard test **fails on main without the ci.yaml change** (RED/GREEN checked).
- `ci.yaml` re-validated with yaml.safe_load.