### PR TITLE
fix: stop parsing output-limit errors as context-length errors

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1057,8 +1057,19 @@ def get_next_probe_tier(current_length: int) -> Optional[int]:
 
 
 def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
-    """Context limit quoted in a provider error ("maximum context length is 32768 tokens"), if any."""
+    """Context limit quoted in a provider error ("maximum context length is 32768 tokens"), if any.
+
+    2026-09-08 bugfix: a message that talks only about an OUTPUT limit/cap and never mentions
+    "context" (e.g. Switchyard's "max_tokens cannot exceed the configured model output limit of
+    16384") was matched by the generic "limit ... of N" pattern below and wrongly cached as the
+    CONTEXT window (switchyard/fallback's real context is >117K; 16384 is its output cap). Bail
+    out here so ``parse_available_output_tokens_from_error``/``is_output_cap_error`` — which run
+    first in the overflow-recovery path — get the chance to classify it as an output-cap error
+    instead. Genuine context-length messages (OpenAI/OpenRouter style) always say "context", so
+    this does not affect them."""
     error_lower = error_msg.lower()
+    if ("output limit" in error_lower or "output tokens" in error_lower or "output token" in error_lower) and "context" not in error_lower:
+        return None
     patterns = (
         r'max_model_len\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM: "max_model_len 32768", "=32768", ": 32768", "(32768)", "is 32768"
         r'maximum model length\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM alt: "maximum model length 131072", "... is 131072"
@@ -1100,6 +1111,8 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         r'range of max_tokens should be\s*\[\s*\d+\s*,\s*(\d+)\s*\]',
         r'available_tokens[:\s]+(\d+)',
         r'available\s+tokens[:\s]+(\d+)',
+        # Switchyard: "max_tokens cannot exceed the configured model output limit of 16384".
+        r'output limit (?:of|is)\s*(\d+)',
         r'=\s*(\d+)\s*$',
     ):
         match = re.search(pattern, error_lower)
@@ -1143,6 +1156,7 @@ _OUTPUT_CAP_SIGNALS = (
     ("range of max_tokens should be",), ("available_tokens",), ("available tokens",),
     ("in the output", "maximum context length"), ("requested", "output tokens"),
     ("should be",), ("less than or equal",), ("must be",), ("exceeds model", "maximum output tokens"),
+    ("output limit",),
 )
 _INPUT_OVERFLOW_SIGNALS = (
     "prompt is too long", "prompt too long", "input is too long", "input token",
@@ -1157,6 +1171,7 @@ _PARSEABLE_OUTPUT_CAP_SIGNALS = (
     ("in the output", "maximum context length"),
     ("maximum context length", "requested", "output tokens"),
     ("range of max_tokens should be",), ("exceeds model", "maximum output tokens"),
+    ("output limit",),
 )
 
 

--- a/contributors/emails/francesco@carucci.org
+++ b/contributors/emails/francesco@carucci.org
@@ -1,0 +1,1 @@
+fcarucci


### PR DESCRIPTION
## Summary
An error message that talks only about an OUTPUT token limit (e.g. a
proxy's `"max_tokens cannot exceed the configured model output limit of
16384"`) can match the generic `"limit ... of N"` context-length pattern
in `parse_context_limit_from_error`, and gets wrongly cached as the
model's **context window**. If the model's real context is much larger
(e.g. >100K) than that output cap, every subsequent request is needlessly
clamped to the output-cap value.

## Fix
- `parse_context_limit_from_error` now bails out (returns `None`) when a
  message mentions an output limit/cap and never says "context" — genuine
  context-length messages (OpenAI/OpenRouter style) always include the
  word "context", so they're unaffected.
- Added a pattern to `parse_available_output_tokens_from_error` and the
  output-cap signal lists so `"output limit (?:of|is) N"`-style messages
  are classified as an output-cap error instead, which is the correct
  overflow-recovery path for them.

## Testing
Verified against the exact message that triggered this (`"max_tokens
cannot exceed the configured model output limit of 16384"`) — now
classified as an output-cap error, no longer cached as context length.