### PR TITLE
fix: compressor failure message reports the route that actually ran

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3247,7 +3247,13 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             raise AuxiliaryExplicitCancellation()
         # Reasoning-field fallback (DeepSeek/Qwen/Kimi put the summary in reasoning_content); capped.
         content = extract_content_or_reasoning(response, max_reasoning_chars=8000)
-        where = f"(provider={self.provider or 'auto'} model={self.summary_model or self.model})"
+        # 2026-09-08 bugfix: this used to read `self.summary_model or self.model`, which falls through to
+        # the MAIN conversation model (e.g. switchyard/fallback after a failover) whenever self.summary_model
+        # is unset and routing resolved the real summarizer via `task="compression"` instead — so a truncated
+        # switchyard/compress summary was misreported to the user as a switchyard/fallback failure. Reuse the
+        # same actually-resolved-route precedence as the telemetry above (`_aux_route` is populated by
+        # call_llm with the route it really selected).
+        where = f"(provider={_aux_route.get('provider') or self.provider or 'auto'} model={_aux_model})"
         # Some OpenAI-compatible proxies (e.g. cmkey.cn, one-api channels) return a well-formed HTTP 200
         # with an empty or whitespace-only ``content`` instead of an error or empty ``choices``. That
         # payload passes ``_validate_llm_response`` (a ``message`` exists), so it reaches here and would

--- a/contributors/emails/francesco@carucci.org
+++ b/contributors/emails/francesco@carucci.org
@@ -1,0 +1,1 @@
+fcarucci


### PR DESCRIPTION
## Summary
When the compression summary call fails, the logged \"where\" string used
\`self.summary_model or self.model\`, which falls through to the **main
conversation model** whenever \`summary_model\` is unset and routing
actually resolved the summarizer via \`task="compression"\`. A failure in
the real summarizer route was therefore misreported as a failure in the
main chat model/route, sending debugging effort at the wrong component.

## Fix
Reuse \`_aux_route\`, which \`call_llm\` already populates with the route
it actually selected (same precedence the telemetry a few lines above
already uses), instead of falling back to the configured-but-unused
\`self.model\`.

## Testing
Reproduced with a provider configured for \`task="compression"\` distinct
from the main chat provider; the failure message now names the
compression route instead of the chat route.