### PR TITLE
fix(session_search): stop cross-profile reads on a bare session id miss

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1812,6 +1812,14 @@ DEFAULT_CONFIG = {
             # Range 200..60000.
             "listing_max_tokens": 4000,
         },
+        "session_search": {
+            # Scan every profile's state.db when a bare session id misses the current
+            # profile. Off by default: profile isolation must fail closed — a session id
+            # alone (seen in logs and tool output) must not grant cross-profile reads.
+            # `@session:<profile>/<id>` links and an explicit `profile` still cross
+            # profiles; this flag only governs the bare-id fallback scan.
+            "cross_profile_scan": False,
+        },
     },
     "logging": {  # File logging to ~/.hermes/logs/: agent.log captures INFO+, errors.log WARNING+.
         "level": "INFO",       # minimum level for agent.log: DEBUG, INFO, WARNING

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,15 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_session_search_cross_profile_scan_is_recognized(
+        self, _isolated_hermes_home, capsys
+    ):
+        """The session_search isolation opt-in is runtime config."""
+        set_config_value("tools.session_search.cross_profile_scan", "true")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "cross_profile_scan: true" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -523,9 +523,9 @@ class TestCrossProfileRead:
         monkeypatch.setattr(profiles_mod, "profile_exists", lambda n: exists)
         monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: home)
 
-    def test_bare_id_locates_across_profiles(self, db, tmp_path, monkeypatch):
-        # The real-world failure: model dropped the owning profile and passed a
-        # bare id. The tool must scan profiles and find it anyway.
+    def test_bare_id_miss_stays_in_current_profile_by_default(self, db, tmp_path, monkeypatch):
+        # Profile isolation fails closed: a bare id that misses the current profile
+        # must not be hunted through other profiles' state.db (#106761).
         other_home = tmp_path / "asdf_home"
         other_home.mkdir()
         other = SessionDB(other_home / "state.db")
@@ -538,12 +538,59 @@ class TestCrossProfileRead:
         Info = namedtuple("Info", "name path")
         monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: tmp_path / "default_home")
         monkeypatch.setattr(profiles_mod, "list_profiles", lambda: [Info("asdf", other_home)])
+        monkeypatch.setattr("tools.session_search_tool._cross_profile_scan_enabled", lambda: False)
+
+        result = json.loads(session_search(session_id="s_far", db=db))
+        assert result["success"] is False
+        assert "not found" in result["error"]
+        assert "profile" not in result
+
+    def test_bare_id_locates_across_profiles_when_enabled(self, db, tmp_path, monkeypatch):
+        # Operator opt-in restores the legacy safety net for linked-session reads
+        # where the model dropped the owning profile from the link.
+        other_home = tmp_path / "asdf_home"
+        other_home.mkdir()
+        other = SessionDB(other_home / "state.db")
+        other.create_session("s_far", source="cli")
+        other.append_message("s_far", role="user", content="hi")
+        other._conn.commit()
+
+        from collections import namedtuple
+        from hermes_cli import profiles as profiles_mod
+        Info = namedtuple("Info", "name path")
+        monkeypatch.setattr(profiles_mod, "get_profile_dir", lambda n: tmp_path / "default_home")
+        monkeypatch.setattr(profiles_mod, "list_profiles", lambda: [Info("asdf", other_home)])
+        monkeypatch.setattr("tools.session_search_tool._cross_profile_scan_enabled", lambda: True)
 
         # `db` (current profile) lacks s_far; no profile passed → scan finds it.
         result = json.loads(session_search(session_id="s_far", db=db))
         assert result["success"] is True
         assert result["mode"] == "read"
         assert result["profile"] == "asdf"
+
+    def test_explicit_profile_miss_does_not_scan_other_profiles(self, db, tmp_path, monkeypatch):
+        # A read that names one profile and misses must stay a miss: falling back to a
+        # full-profile scan would leak the session through a different profile.
+        named_home = tmp_path / "named_home"       # the profile the caller named
+        secret_home = tmp_path / "secret_home"     # where the session actually lives
+        for home in (named_home, secret_home):
+            home.mkdir()
+        secret = SessionDB(secret_home / "state.db")
+        secret.create_session("s_secret", source="cli")
+        secret.append_message("s_secret", role="user", content="hi")
+        secret._conn.commit()
+
+        from collections import namedtuple
+        from hermes_cli import profiles as profiles_mod
+        Info = namedtuple("Info", "name path")
+        self._patch_profiles(monkeypatch, named_home)
+        monkeypatch.setattr(profiles_mod, "get_profile_dir",
+                            lambda n: named_home if n == "asdf" else tmp_path / "default_home")
+        monkeypatch.setattr(profiles_mod, "list_profiles", lambda: [Info("elsewhere", secret_home)])
+        monkeypatch.setattr("tools.session_search_tool._cross_profile_scan_enabled", lambda: True)
+
+        result = json.loads(session_search(session_id="s_secret", profile="asdf", db=db))
+        assert result["success"] is False
 
 
     def test_combined_value_autosplits(self, db, tmp_path, monkeypatch):

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -383,11 +383,27 @@ def _read_session(db, session_id: str, head: int = 20, tail: int = 10, link_prof
                                "Pass around_message_id (any id above) to scroll the middle.")} if truncated else {}))
 
 
+def _cross_profile_scan_enabled() -> bool:
+    """Operator opt-in for scanning other profiles on a bare-id miss; isolation by default."""
+    try:
+        from hermes_cli.config import load_config
+        tools_cfg = (load_config() or {}).get("tools") or {}
+        return bool(
+            tools_cfg.get("session_search", {}).get("cross_profile_scan", False)
+        )
+    except Exception:
+        return False
+
+
 def _read_with_profile_fallback(db, sid: str, profile: Optional[str]) -> str:
     """Read shape; on a miss scan every profile (the model may have dropped the owning
-    profile from the link) and tag the result with where it was found."""
+    profile from the link) and tag the result with where it was found. The scan is an
+    operator opt-in: without it a bare id that misses the current profile stays a plain
+    miss, so profile isolation fails closed."""
     result = _read_session(db, sid, link_profile=profile)
-    located, owner = (None, None) if json.loads(result).get("success") else _locate_session_db(sid)
+    if json.loads(result).get("success") or not _cross_profile_scan_enabled():
+        return result
+    located, owner = _locate_session_db(sid)
     if located is None:
         return result
     try:


### PR DESCRIPTION
## Summary

`session_search` with a bare `session_id` that misses the caller's own `state.db` fell through to `_locate_session_db`, which scans **every profile's** database and returns the first hit — a cross-profile read with no opt-in and no authorization check (session ids appear in logs, tool output and the databases themselves). Text search never had this hole; only the by-ID read path did.

Fix, following the direction proposed in #106761:

- **Fail closed by default**: a bare-id miss now stays a plain miss (`session_id not found: <id>`). The cross-profile scan only runs behind the operator opt-in `tools.session_search.cross_profile_scan: true` (new key in `DEFAULT_CONFIG`, recognized by `hermes config set`).
- The documented use case is untouched: `@session:<profile>/<id>` links and an explicit `profile=` already carry the profile and keep resolving through `_resolve_profile_db`.
- The opt-in also covers an explicit-profile miss: naming profile B and missing no longer falls back to scanning every other profile either (that fallback was the same unconditional `_locate_session_db` call).

## Testing

- `env -u HERMES_YOLO_MODE .venv/bin/python -m pytest tests/tools/test_session_search.py tests/hermes_cli/test_set_config_value.py -q` → **143 passed** (55 + 88).
- `tests/hermes_cli/test_config.py` → 121 passed, 4 skipped (golden config unaffected by the new default key).
- Mutation RED: removing the `_cross_profile_scan_enabled()` guard makes `test_bare_id_miss_stays_in_current_profile_by_default` fail; restored → green.
- Live end-to-end on the patched tree, two profiles in one `HERMES_HOME`: default → bare id of the other profile refused (`success: false, session_id not found`); with `cross_profile_scan: true` → found and tagged `profile: victim`; `@session:victim/<id>` and explicit `profile="victim"` both still resolve; own sessions unaffected.
- `ruff check` clean on all four files; `ruff format --diff` raises no complaints on the touched lines.

Fixes #106761

Related (not duplicated): #61947 (per-profile `protected` opt-out, open since July), #87779 (broader chat-ownership scoping), #98159 (cross-profile discover). This PR implements the fail-closed default those discuss; the per-profile opt-out can layer on top.
