### PR TITLE
fix(cli): preserve venv for env-python session relaunches

### DIFF
--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -2,6 +2,8 @@
 across process replacement so ``hermes sessions browse`` / post-setup relaunch keep the user's mode."""
 
 import os
+import re
+import shlex
 import shutil
 import sys
 from typing import Optional, Sequence
@@ -80,12 +82,37 @@ def resolve_hermes_bin() -> Optional[str]:
     return shutil.which("hermes") or None
 
 
+def _env_python_args(bin_path: str) -> Optional[list[str]]:
+    """Interpreter flags for an env-resolved Python script; None for other launchers."""
+    try:
+        with open(bin_path, "rb") as launcher:
+            shebang = launcher.readline(256)
+        if not shebang.startswith(b"#!"):
+            return None
+        words = shlex.split(shebang[2:].decode("utf-8"))
+    except (OSError, UnicodeError, ValueError):
+        return None
+    if not words or os.path.basename(words.pop(0)) != "env":
+        return None
+    if words[:1] == ["-S"]:
+        words.pop(0)
+    if words and re.fullmatch(r"python(?:\d+(?:\.\d+)*)?", words[0]):
+        return words[1:]
+    return None
+
+
 def build_relaunch_argv(
     extra_args: Sequence[str], *, preserve_inherited: bool = True, original_argv: Optional[Sequence[str]] = None
 ) -> list[str]:
     """Construct an argv list for replacing the current process with hermes."""
     bin_path = resolve_hermes_bin()
     argv = [bin_path] if bin_path else [sys.executable, "-m", "hermes_cli.main"]
+    if bin_path:
+        python_args = _env_python_args(bin_path)
+        if python_args is not None:
+            # Installer shims enter the venv without activating it on PATH.
+            # Re-executing an env-python shebang would leave that environment.
+            argv = [sys.executable, *python_args, bin_path]
     src = list(original_argv) if original_argv is not None else list(sys.argv[1:])
     if preserve_inherited:
         argv.extend(_extract_inherited_flags(src))

--- a/tests/hermes_cli/test_relaunch.py
+++ b/tests/hermes_cli/test_relaunch.py
@@ -1,6 +1,12 @@
 """Tests for hermes_cli.relaunch — unified self-relaunch utility."""
 
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
 import sys
+import venv
 
 import pytest
 
@@ -68,10 +74,16 @@ class TestInheritedFlagTable:
 
 
 class TestBuildRelaunchArgv:
-    def test_uses_bin_when_available(self, monkeypatch):
-        monkeypatch.setattr(relaunch_mod, "resolve_hermes_bin", lambda: "/usr/bin/hermes")
-        argv = relaunch_mod.build_relaunch_argv(["--resume", "abc"])
-        assert argv[0] == "/usr/bin/hermes"
+    @pytest.mark.parametrize("header", [
+        b"#!/bin/sh\n", b"#!/usr/bin/env bash\n",
+        b"#!/opt/hermes/venv/bin/python3\n", b"\x7fELF\x00\xff",
+    ])
+    def test_uses_bin_when_available(self, monkeypatch, tmp_path, header):
+        launcher = tmp_path / "hermes"
+        launcher.write_bytes(header)
+        monkeypatch.setattr(relaunch_mod, "resolve_hermes_bin", lambda: str(launcher))
+        argv = relaunch_mod.build_relaunch_argv(["--resume", "abc"], original_argv=[])
+        assert argv == [str(launcher), "--resume", "abc"]
 
 
     def test_preserves_inherited_flags(self, monkeypatch):
@@ -99,6 +111,53 @@ class TestBuildRelaunchArgv:
 
 
 class TestRelaunch:
+    @pytest.mark.linux_only
+    @pytest.mark.parametrize("env_command", ["python3", "-S python3 -u"])
+    def test_env_python_relaunch_keeps_venv_dependencies(self, tmp_path, env_command):
+        """The installer wrapper must survive a real exec with a non-venv PATH."""
+        root = Path(__file__).resolve().parents[2]
+        env_dir = tmp_path / "venv"
+        venv.EnvBuilder(with_pip=False).create(env_dir)
+        python = env_dir / "bin" / "python"
+        purelib = subprocess.check_output(
+            [str(python), "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
+            text=True,
+        ).strip()
+        (Path(purelib) / "relaunch_venv_dependency.py").write_text("VALUE = 'venv-only'\n")
+        path_bin = tmp_path / "path-bin"
+        path_bin.mkdir()
+        (path_bin / "python3").symlink_to(Path(sys.executable).resolve())
+        launcher = tmp_path / "hermes"
+        launcher.write_text(
+            f"#!/usr/bin/env {env_command}\n"
+            "import json, sys\n"
+            "from hermes_cli.relaunch import relaunch\n"
+            "if '--resume' not in sys.argv:\n"
+            "    relaunch(['--resume', 'test-session'])\n"
+            "else:\n"
+            "    import relaunch_venv_dependency as dependency\n"
+            "    print(json.dumps([sys.executable, dependency.VALUE, sys.argv[1:],\n"
+            "                      sys.stdout.write_through]))\n"
+        )
+        launcher.chmod(0o755)
+        wrapper = tmp_path / "wrapper"
+        wrapper.write_text(
+            f"#!/bin/sh\nexec {shlex.quote(str(python))} {shlex.quote(str(launcher))} \"$@\"\n"
+        )
+        wrapper.chmod(0o755)
+        env = dict(os.environ, PATH=str(path_bin), PYTHONPATH=str(root))
+        env.pop("PYTHONHOME", None)
+        env.pop("PYTHONUNBUFFERED", None)
+        result = subprocess.run(
+            [str(wrapper), "--tui", "sessions", "browse"],
+            env=env, capture_output=True, text=True, timeout=20,
+        )
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout) == [
+            str(python), "venv-only", ["--tui", "--resume", "test-session"],
+            "-u" in shlex.split(env_command),
+        ]
+
     def test_calls_execvp(self, monkeypatch):
         calls = []
 


### PR DESCRIPTION
## What does this PR do?

Fixes `hermes sessions browse` crashing after selection on the official POSIX git-install layout when the login-shell PATH resolves `python3` outside Hermes's venv.

The installer wrapper invokes `<venv>/bin/python <checkout>/hermes` without activating the venv on PATH. After selection, `relaunch()` currently executes `<checkout>/hermes` directly. Its `#!/usr/bin/env python3` shebang selects a different interpreter, causing `ModuleNotFoundError` (observed for `dotenv`) despite the dependency being correctly installed in Hermes's venv.

## Related work / draft status

This is a draft for comparison/consolidation with existing fixes, not a claim of a newly discovered issue. Related open PRs: #76520 (original diagnosis by @Frozen), #80580 (@procesd), and #86551 (@hamid-mouti). Credit to those contributors for documenting the same failure mode.

This version leaves launcher resolution unchanged and fixes only construction of the final exec argv. It also supplies a real isolated-venv regression test instead of relying only on mocked exec arguments.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/relaunch.py`: recognize env-resolved Python shebangs and invoke the selected script with `sys.executable`, retaining Python interpreter arguments (including `env -S python3 -u`). Preserve inherited Hermes flags and the source script path.
- Leave explicitly pinned Python interpreters, shell wrappers, native executables, and the existing module fallback unchanged.
- `tests/hermes_cli/test_relaunch.py`: run a real shell wrapper and `relaunch()`/`execvp` under a disposable venv. A module installed only in that venv must remain importable after relaunch even though PATH points at a different Python. Assert interpreter identity, inherited/resume arguments, and unbuffered mode. Strengthen existing launcher-preservation coverage with real file fixtures.

## How to Test / Results

Reproduction: use the official venv launcher from a shell without the venv activated, run `hermes sessions browse`, select a session.

Automated command:

```bash
scripts/run_tests.sh tests/hermes_cli/test_relaunch.py tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_session_handoff.py tests/hermes_cli/test_coalesce_session_args.py --file-retries 0
```

- Before implementation: both real-exec regression cases failed with `ModuleNotFoundError: No module named 'relaunch_venv_dependency'` after process replacement.
- After implementation: **34 passed, 4 Windows-only tests skipped** on WSL/Linux.
- Ruff on both changed files and `git diff --check`: passed.
- Actual source CLI smoke probe using the generated relaunch argv plus `--resume test-session --help`: exit 0, help rendered. Disposable `HERMES_HOME`; no real user session opened or changed.
- Independent review: no blocking security or logic findings. Its suggestion to assert interpreter-option preservation was incorporated.
- Full suite: attempted through `scripts/run_tests.sh -j 8 --file-retries 0`, then stopped after the selected test environment showed missing async-test support (`pytest-asyncio`). **Full-suite success is not claimed.** This draft still needs full CI and host-native Windows/macOS validation.

## Checklist

- [x] Read the contributing guidance and scoped AGENTS.md instructions.
- [x] Conventional commit; only the relaunch fix and tests are included.
- [x] Searched related PRs; overlaps are explicitly acknowledged above.
- [x] Added a regression test and observed it fail before implementation.
- [x] Tested on WSL/Linux.
- [ ] Full test suite green.
- [ ] Windows/macOS host-native validation.
- [x] No configuration, schema, tool-surface, or dependency changes.
