### PR TITLE
fix(ci): main red since today's merges — messages schema history + gateway guard vs docker exec

### DIFF
--- a/hermes_cli/session_schema_history.py
+++ b/hermes_cli/session_schema_history.py
@@ -232,6 +232,10 @@ SCHEMA_HISTORY: dict[str, _TableHistory] = {
             ('+', 'display_metadata', 'display_kind'),
         )),
         ('14 2026-08-25T10:55Z 1104ffe0b9', (('+', '_compressed_summary', 'observed'),)),
+        ('15 2026-09-09T17:05Z 1c6683e8e0', (
+            ('+', 'display_identity', 'display_metadata'),
+            ('+', 'display_order', 'display_identity'),
+        )),
         ),
     ),
     "session_model_usage": _TableHistory(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1428,6 +1428,14 @@ def _live_system_guard(request, monkeypatch):
         "daemon-reload", "try-restart", "reload-or-restart",
     )
     _PROCESS_KILLERS = ("pkill", "killall", "taskkill", "skill", "fuser")
+    _CONTAINER_RUNTIMES = ("docker", "podman", "nerdctl")
+
+    def _first_token_basename(cmd_str: str) -> str:
+        try:
+            tokens = _shlex.split(cmd_str)
+        except ValueError:
+            tokens = cmd_str.split()
+        return tokens[0].rsplit("/", 1)[-1].lower() if tokens else ""
     # Shell/launcher executables whose arguments are themselves commands —
     # argv[0]-only scanning must not exempt what they wrap.
     _WRAPPER_COMMANDS = (
@@ -1563,7 +1571,14 @@ def _live_system_guard(request, monkeypatch):
         # sibling refactor moved the spawn seam and left tests patching the
         # facade. The canonical matcher, never an argv substring.
         from gateway.status import _gateway_command_subcommand
-        if not lookalike_ok and _gateway_command_subcommand(cmd_str) in ("run", "start", "restart"):
+        # A gateway launched INSIDE a container (`docker exec … hermes gateway start`) cannot
+        # reach the host's systemd unit or webhook port; tests/docker/ exists to exercise it.
+        in_container = _first_token_basename(cmd_str) in _CONTAINER_RUNTIMES
+        if (
+            not lookalike_ok
+            and not in_container
+            and _gateway_command_subcommand(cmd_str) in ("run", "start", "restart")
+        ):
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
                 f"subprocess.{name}({cmd!r}) — this would spawn a REAL "

--- a/tests/test_live_system_guard.py
+++ b/tests/test_live_system_guard.py
@@ -37,3 +37,29 @@ def test_wrapped_killer_command_is_still_blocked():
 def test_env_wrapped_killer_command_is_still_blocked():
     with pytest.raises(RuntimeError, match="live-system guard"):
         subprocess.run(["env", "GUARD_TEST=1", "pkill", "-f", "hermes-guard-regression-nomatch"])
+
+
+def test_gateway_start_inside_a_container_exec_is_not_blocked():
+    """``docker exec <ctr> hermes gateway start`` launches the gateway INSIDE the container,
+    where it cannot reach the host's systemd unit or webhook port; tests/docker/ depends on it.
+    The binary is a stub so the argv stays exact without needing a Docker daemon."""
+    import os
+    import stat
+
+    stub_dir = os.path.join(os.environ["HERMES_HOME"], "stub-bin")
+    os.makedirs(stub_dir, exist_ok=True)
+    stub = os.path.join(stub_dir, "docker")
+    with open(stub, "w") as fh:
+        fh.write("#!/bin/sh\nexit 0\n")
+    os.chmod(stub, os.stat(stub).st_mode | stat.S_IXUSR)
+    result = subprocess.run(
+        [stub, "exec", "-u", "hermes", "ctr", "sh", "-c", "hermes -p prof gateway start"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_gateway_start_on_the_host_is_still_blocked():
+    with pytest.raises(RuntimeError, match="REAL.*gateway runtime"):
+        subprocess.run(["python", "-m", "hermes_cli.main", "gateway", "start"])


### PR DESCRIPTION
Two independent main-red regressions from today's merges, fixed together because each PR alone stays red on the other's bug. Both are test/declaration-only; no runtime behaviour changes.

## 1. `messages` schema history (`hermes_cli/session_schema_history.py`, +4)

`test_session_schema_history.py::test_replayed_history_ends_at_current_schema[messages]` is red on `origin/main` since #106582 (`1c6683e8e0b`) added `display_identity`/`display_order` to `SCHEMA_SQL` without the matching `SCHEMA_HISTORY["messages"]` events. Appends event `15` with both columns.

## 2. Live-system gateway guard vs. Docker integration tests (`tests/conftest.py`, +17/−1)

Since #106623 (`ca16cafee40`) every Docker build job fails at "Run docker integration tests":
`RuntimeError: live-system guard: blocked subprocess.run(['docker', 'exec', '-u', 'hermes', …, 'sh', '-c', 'hermes -p test-harness-profile gateway start…'])`.
The guard uses `gateway.status._gateway_command_subcommand`, which strips `-p <profile>` and reads through `sh -c`, so a gateway started *inside a container* looks like a host spawn. A container process can reach neither the developer's systemd unit nor the webhook port, so the guard now skips commands whose `argv[0]` is a container runtime (`docker`, `podman`, `nerdctl`). Host spawns and every other guard rule (systemctl, killers, `hermes update`) are unchanged.

| Test | base | this PR |
|---|---|---|
| `test_replayed_history_ends_at_current_schema[messages]` | **RED** | green |
| `test_live_system_guard.py::test_gateway_start_inside_a_container_exec_is_not_blocked` (stub `docker`, exact failing argv) | **RED** | green |
| `test_gateway_start_on_the_host_is_still_blocked` | green | green |

Live evidence: on main-based runs today (#106733 run 34387507619, #106785 run 34393559670, #106820 run 34396264922) the Python-tests job fails only on (1) and the Docker jobs fail only on (2); each fix's solo PR went green on its own bug and red on the other's.
