### PR TITLE
fix(approvals): detect destructive commands behind global flag runs

### DIFF
--- a/tests/tools/test_global_flag_subcommand_bypass.py
+++ b/tests/tools/test_global_flag_subcommand_bypass.py
@@ -1,0 +1,218 @@
+"""Tests for the global-flag bypass of ``<binary> <subcommand>``-anchored DANGEROUS_PATTERNS.
+
+Several rules were anchored so the subcommand had to follow the command word immediately
+(``\\bgit\\s+push\\b``), or admitted a run of dash-tokens only (``(-[^\\s]+\\s+)*``). Both spellings
+are defeated by a global option that takes a SEPARATE value word, because the value is a bare
+word the anchor cannot cross:
+
+  git -C /tmp push --force      →  allowed, no prompt
+  git -c k=v reset --hard       →  allowed, no prompt
+  git --work-tree /tmp clean -fd → allowed, no prompt
+  systemctl -M host stop nginx  →  allowed, no prompt
+  killall -u root -9 foo        →  allowed, no prompt
+  pkill -u root -9 foo          →  allowed, no prompt
+  hermes -p ade update          →  allowed, no prompt
+  docker --log-level x context use prod → allowed, no prompt
+
+The fix threads ``_GLOBAL_FLAG_RUN`` between the command word and the anchored token. The run
+consumes option TOKENS only (``-x``/``--xy``, optionally plus a glued ``=value`` or ONE following
+value word), never a bare word on its own, so a compound command such as
+``git status && echo push --force`` cannot be pulled into a match. Its separators are horizontal
+whitespace, which keeps the run inside a single command segment.
+"""
+
+import pytest
+
+from tools.approval import detect_dangerous_command
+
+
+GIT_GLOBAL_FLAG_BYPASSES = [
+    # (command, substring expected in the rule description)
+    ("git -C /tmp push --force origin main", "force"),
+    ("git -C /tmp push -f origin main", "force"),
+    ("git -c user.name=x push --force origin main", "force"),
+    ("git --git-dir=/opt/x push --force origin main", "force"),
+    ("git --exec-path=/opt/x push --force origin main", "force"),
+    ("git --namespace ns push --force origin main", "force"),
+    ("git -C /tmp clean -fd", "clean"),
+    ("git --work-tree /tmp -C /tmp clean -fd", "clean"),
+    ("git -C /tmp reset --hard HEAD", "reset"),
+    ("git -c core.pager=less reset --hard HEAD", "reset"),
+    ("git -C /tmp branch -D feat", "branch"),
+    ("git -C /tmp branch -d -f feat", "branch"),
+    ("git -C /tmp branch --force --delete feat", "branch"),
+]
+
+
+class TestGitGlobalFlagBypass:
+    """A git global option must not defeat the destructive-git rules.
+
+    ``git`` accepts ``-C <path>``, ``-c <k>=<v>``, ``--git-dir``, ``--work-tree``,
+    ``--exec-path`` and ``--namespace`` before the subcommand. Every one of them separates
+    ``git`` from ``push``/``clean``/``reset``/``branch`` and so slipped every anchored rule.
+    """
+
+    @pytest.mark.parametrize("cmd,expected_word", GIT_GLOBAL_FLAG_BYPASSES)
+    def test_git_global_flag_forms_detected(self, cmd, expected_word):
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True, f"global-flag form not detected: {cmd!r}"
+        assert key is not None
+        assert expected_word in desc.lower()
+
+
+class TestGitPlainFormRegressions:
+    """The flag-free spellings the rules already caught must keep firing."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push --force origin main",
+            "git push -f origin main",
+            "git push --forc origin main",
+            "git clean -fd",
+            "git reset --hard HEAD",
+            "git reset --h HEAD",
+            "git branch -D feat",
+            "git branch -d -f feat",
+        ],
+    )
+    def test_plain_form_still_detected(self, cmd):
+        dangerous, key, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, f"plain form regressed: {cmd!r}"
+        assert key is not None
+
+
+class TestGitNoFalsePositives:
+    """The flag run must not turn benign git usage into a prompt.
+
+    The run cannot consume a bare word, so it can never bridge from a harmless subcommand to a
+    dangerous keyword appearing later in a compound command or inside a commit message.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # The dangerous keyword belongs to a LATER command, not to git.
+            "git status && echo push --force",
+            "git log --oneline && echo clean -fd",
+            "git diff && echo branch -D",
+            "git -C /tmp status && echo push --force",
+            # Dangerous keyword as prose inside a commit message.
+            "git commit -m 'do not push --force here'",
+            "git -c user.name=x commit -m 'push --force in the message'",
+            # Benign git, with and without global flags.
+            "git push --set-upstream origin feature",
+            "git status",
+            "git -C /tmp status",
+            "git -C /tmp log --oneline",
+            "git -C /tmp branch --list",
+            # A path segment that merely spells a subcommand.
+            "git -C /tmp/push status",
+        ],
+    )
+    def test_benign_git_not_flagged(self, cmd):
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is False, f"false positive on: {cmd!r} -> {desc}"
+
+
+class TestNonGitGlobalFlagBypass:
+    """The same defect in the systemctl / killall / pkill / hermes / docker rules.
+
+    ``systemctl`` and ``killall`` admitted ``(-[^\\s]+\\s+)*``, which accepts dash-tokens but not
+    the value word that ``-M <host>`` / ``-u <user>`` supplies. ``pkill``, ``hermes update`` and
+    ``docker context use`` admitted no flag run at all, even though sibling rules for the same
+    binaries already did.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd,expected_word",
+        [
+            ("systemctl -M remote stop nginx", "service"),
+            ("systemctl --host remote restart nginx", "service"),
+            ("killall -u root -9 foo", "kill"),
+            ("killall -u root -s KILL foo", "kill"),
+            ("killall -u root -r 'fire.*'", "kill"),
+            ("pkill -u root -9 foo", "kill"),
+            ("hermes -p ade update", "update"),
+            ("docker --log-level debug context use prod", "context"),
+        ],
+    )
+    def test_global_flag_forms_detected(self, cmd, expected_word):
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True, f"global-flag form not detected: {cmd!r}"
+        assert key is not None
+        assert expected_word in desc.lower()
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "systemctl stop nginx",
+            "systemctl restart nginx",
+            "killall -9 foo",
+            "killall -s KILL foo",
+            "killall -r 'fire.*'",
+            "pkill -9 foo",
+            "hermes update",
+            "hermes gateway stop",
+            "docker context use prod",
+        ],
+    )
+    def test_plain_form_still_detected(self, cmd):
+        dangerous, key, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, f"plain form regressed: {cmd!r}"
+        assert key is not None
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "systemctl status nginx",
+            "systemctl --type service list-units",
+            "docker ps",
+            "docker --log-level debug ps",
+            "killall foo",
+            "pkill foo",
+            "hermes --version",
+            "hermes -p ade run hello",
+            # Horizontal-only separators keep the run inside one command segment: the `update`
+            # here belongs to `npm`, not to `hermes`.
+            "hermes --version\nnpm update",
+        ],
+    )
+    def test_benign_not_flagged(self, cmd):
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is False, f"false positive on: {cmd!r} -> {desc}"
+
+
+class TestLegacyApprovalKeysPreserved:
+    """Widening a regex renames its derived approval key; the alias table must keep the old one.
+
+    ``_PATTERN_KEY_ALIASES`` derives a legacy key from the regex TEXT, so an allowlist or session
+    entry stored against the pre-fix spelling would silently stop matching without these aliases.
+    """
+
+    @pytest.mark.parametrize(
+        "description,legacy_key",
+        [
+            ("git force push (rewrites remote history)", r"git\s+push"),
+            ("git force push short flag (rewrites remote history)", r"git\s+push"),
+            ("git clean with force (deletes untracked files)", r"git\s+clean\s+-[^\s]*f"),
+            ("git branch force delete", r"git\s+branch\s+-D"),
+            ("git branch force delete (long flags)", r"git\s+branch"),
+            ("git reset --hard (destroys uncommitted changes)",
+             r"git\s+reset\s+--h(?:a(?:r(?:d)?)?)?"),
+            ("stop/restart system service",
+             r"systemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)"),
+            ("force kill processes", r"pkill\s+-9"),
+            ("force kill processes (killall -KILL)",
+             r"killall\s+(-[^\s]*\s+)*-(9|KILL|SIGKILL)"),
+            ("kill processes by regex (killall -r)", r"killall\s+(-[^\s]*\s+)*-r"),
+            ("hermes update (restarts gateway, kills running agents)", r"hermes\s+update"),
+            ("docker context use (switches default daemon for future commands)",
+             r"docker\s+context\s+use"),
+        ],
+    )
+    def test_legacy_key_still_aliases(self, description, legacy_key):
+        from tools.approval_detection import _approval_key_aliases
+
+        assert legacy_key in _approval_key_aliases(description)
+        assert description in _approval_key_aliases(legacy_key)

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -194,6 +194,66 @@ def detect_hardline_command(command: str) -> tuple:
     return (False, None)
 
 
+# ---- Global-flag runs between a command word and its subcommand ---------------------------
+# `git`, `systemctl`, `killall`, `pkill`, `hermes` and `docker` all accept OPTIONS before the
+# token the rules below anchor on, and several of those options take a SEPARATE value word
+# (`git -C <path>`, `git --git-dir <p>`, `systemctl -M <host>`, `killall -u <user>`,
+# `hermes -p <name>`, `docker --log-level <lvl>`). A rule written `\bgit\s+push\b` therefore never
+# matched `git -C /tmp push --force` and auto-approved it with no prompt at all; the older
+# `(-[^\s]+\s+)*` spelling is broken by the same value word, since it only accepts dash-tokens.
+#
+# `_global_flag_run` builds the run per program from the options that program actually takes a
+# separate value for. Two alternatives, and NEITHER can match the same span as the other:
+#
+#   * a named value-taking option followed by whitespace and its value word. The option must be
+#     followed by whitespace, so a glued `--git-dir=/p` never reaches this branch.
+#   * any other single option token, which covers boolean flags and every glued `=value` form.
+#
+# Naming the value-taking options is what makes the run both safe and cheap:
+#
+#   * It cannot swallow a real subcommand. A boolean flag consumes only itself, so
+#     `systemctl --user status restart-nginx.service` and `git --no-pager log push --force` are
+#     NOT matched — with a blanket "any option may take a value" run they were, because the run
+#     paired `--user` with `status` and `--no-pager` with `log`.
+#   * It is unambiguous, so the match is linear. A blanket run tiles a sequence of dash-tokens as
+#     either one- or two-token pieces (Fibonacci-many tilings, doubled again by `-{1,2}` on every
+#     `--` token) and explores all of them before failing. Measured on the blanket spelling:
+#     `git ` + `--ab ` * 16 + `x` took 10.6s inside `detect_dangerous_command`, and a benign
+#     `rsync -av --exclude .git ...` line reached it through the `.git` in the excluded path,
+#     because `\bgit` matches there. With the run below every token has exactly one parse.
+#
+# Separators are HORIZONTAL whitespace on purpose, so the run stays inside one command segment.
+# A punctuation separator (`;`, `&&`, `|`) already stops it — that token starts with neither `-`
+# nor the anchor, so it cannot be consumed — but a NEWLINE-separated command is not stopped by a
+# plain `\s+`, which would let the value word straddle the line break and reach an unrelated later
+# token. Measured on the sibling docker lifecycle rule, whose `\s+` spelling this deliberately
+# does not copy: `docker --tls ps\nkill 123` matches it as a container kill, and
+# `hermes --version\nnpm update` would match a `\s+` version of the `hermes update` rule here.
+def _global_flag_run(value_taking: str) -> str:
+    """A run of global options before the token a rule anchors on.
+
+    *value_taking* is an alternation of the options of this program that take a SEPARATE value
+    word. Everything else is consumed one token at a time.
+    """
+    return (rf'(?:(?:{value_taking})[^\S\n]+\S+[^\S\n]+'
+            rf'|(?!(?:{value_taking})[^\S\n])-{{1,2}}[^\s-]\S*[^\S\n]+)*')
+
+
+# Value-taking GLOBAL options, i.e. those legal before the subcommand. Boolean globals
+# (`git --no-pager`, `systemctl --user`, `docker --debug`) are deliberately absent: listing one
+# would let the run pair it with the following word and swallow a real subcommand.
+_GIT_GLOBAL_FLAG_RUN = _global_flag_run(
+    r'-c|-C|--git-dir|--work-tree|--namespace|--exec-path|--config-env|--super-prefix')
+_SYSTEMCTL_GLOBAL_FLAG_RUN = _global_flag_run(
+    r'-M|--machine|-H|--host|-t|--type|-p|--property|--state|--root|--signal')
+# killall(1)/pkill(1): `-s`/`--signal` is deliberately absent — the SIGKILL rules anchor ON it.
+_SIGNAL_GLOBAL_FLAG_RUN = _global_flag_run(
+    r'-u|--user|-t|--tty|-n|--ns|-G|--group|-P|--parent|-Z|--context|--older-than|--younger-than')
+_HERMES_GLOBAL_FLAG_RUN = _global_flag_run(r'-p|--profile|--config')
+_DOCKER_GLOBAL_FLAG_RUN = _global_flag_run(
+    r'-l|--log-level|--config|-D|--tlscacert|--tlscert|--tlskey')
+
+
 # ---- Dangerous command patterns -----------------------------------------------------------
 DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
@@ -269,14 +329,17 @@ DANGEROUS_PATTERNS = [
     (r'\bDELETE\s+FROM\b(?![^\n]*\bWHERE\b)', "SQL DELETE without WHERE"),
     (r'\bTRUNCATE\s+(TABLE)?\s*\w', "SQL TRUNCATE"),
     (rf'>\s*{_SYSTEM_CONFIG_PATH}', "overwrite system config"),
-    (r'\bsystemctl\s+(-[^\s]+\s+)*(stop|restart|disable|mask)\b', "stop/restart system service"),
+    # `(-[^\s]+\s+)*` accepted dash-tokens only, so a value-taking global option defeated it:
+    # `systemctl -M <host> stop nginx` / `systemctl --host <host> restart nginx` auto-approved.
+    (rf'\bsystemctl\s+{_SYSTEMCTL_GLOBAL_FLAG_RUN}(stop|restart|disable|mask)\b', "stop/restart system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
-    (r'\bpkill\s+-9\b', "force kill processes"),
+    # `pkill -u <user> -9 <name>` put a value word before `-9` and slipped the anchor.
+    (rf'\bpkill\s+{_SIGNAL_GLOBAL_FLAG_RUN}-9\b', "force kill processes"),
     # killall with SIGKILL (-9 / -KILL / -s KILL / -SIGKILL) and `killall -r <regex>` broad sweeps
     # that can wipe unrelated processes.
-    (r'\bkillall\s+(-[^\s]*\s+)*-(9|KILL|SIGKILL)\b', "force kill processes (killall -KILL)"),
-    (r'\bkillall\s+(-[^\s]*\s+)*-s\s+(KILL|SIGKILL|9)\b', "force kill processes (killall -s KILL)"),
-    (r'\bkillall\s+(-[^\s]*\s+)*-r\b', "kill processes by regex (killall -r)"),
+    (rf'\bkillall\s+{_SIGNAL_GLOBAL_FLAG_RUN}-(9|KILL|SIGKILL)\b', "force kill processes (killall -KILL)"),
+    (rf'\bkillall\s+{_SIGNAL_GLOBAL_FLAG_RUN}-s\s+(KILL|SIGKILL|9)\b', "force kill processes (killall -s KILL)"),
+    (rf'\bkillall\s+{_SIGNAL_GLOBAL_FLAG_RUN}-r\b', "kill processes by regex (killall -r)"),
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Shell -c is parsed structurally by _execution_flag_findings(); a regex searching a dash-token
     # for "c" also matched --norc/--rcfile/--restricted.
@@ -304,7 +367,9 @@ DANGEROUS_PATTERNS = [
     # Gateway lifecycle: stopping/restarting the gateway kills all running agents. Global flags
     # between `hermes` and `gateway` (`hermes -p ade gateway restart`) are allowed so a profile flag can't slip past.
     (r'\bhermes\s+(?:-{1,2}\S+(?:\s+\S+)?\s+)*gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
-    (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
+    # The gateway rule above already tolerated global flags; `hermes update` did not, so
+    # `hermes -p <profile> update` restarted the gateway with no prompt.
+    (rf'\bhermes\s+{_HERMES_GLOBAL_FLAG_RUN}update\b', "hermes update (restarts gateway, kills running agents)"),
     # Docker/Podman daemon redirect — global flags or env that point the CLI at a DIFFERENT (often remote) daemon:
     # `docker -H ssh://prod stop app` looks local but operates on remote infra, so any redirect requires approval
     # regardless of subcommand. The flag must be in global position (before the subcommand) and -H/--host/--context
@@ -312,7 +377,9 @@ DANGEROUS_PATTERNS = [
     # a redirected lifecycle command surfaces the more specific reason.
     (r'\bdocker\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(?:-h|--host)[=\s]+\S+', "docker with remote daemon redirect (-H/--host)"),
     (r'\bdocker\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(?:-c|--context)[=\s]+\S+', "docker with daemon redirect (--context: alternate daemon)"),
-    (r'\bdocker\s+context\s+use\b', "docker context use (switches default daemon for future commands)"),
+    # Sibling docker rules already admit a global-flag run; this one did not, so
+    # `docker --log-level debug context use prod` switched the default daemon with no prompt.
+    (rf'\bdocker\s+{_DOCKER_GLOBAL_FLAG_RUN}context\s+use\b', "docker context use (switches default daemon for future commands)"),
     (r'\bpodman\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(?:--url|--connection|--identity)[=\s]+\S+', "podman with remote daemon redirect (--url/--connection/--identity)"),
     (r'\bpodman\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(?:-r\b|--remote\b)', "podman remote mode (-r/--remote: remote daemon)"),
     (r'\b(?:docker_host|docker_context|container_host|container_connection)=\S+', "docker/podman daemon redirect via environment (DOCKER_HOST/CONTAINER_HOST)"),
@@ -373,15 +440,19 @@ DANGEROUS_PATTERNS = [
     # Git destructive operations. `git reset --hard` accepts any unambiguous long-flag prefix (--h,
     # --ha, --har): --hard is the only reset mode starting with "h", and `--help` is special-cased
     # by git before mode resolution.
-    (r'\bgit\s+reset\s+--h(?:a(?:r(?:d)?)?)?\b', "git reset --hard (destroys uncommitted changes)"),
-    (r'\bgit\s+push\b.*--forc[a-z]*\b', "git force push (rewrites remote history)"),
-    (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
-    (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
-    (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
+    # Every git rule admits a run of GLOBAL options between `git` and the subcommand
+    # (_GLOBAL_FLAG_RUN): `git -C <path> push --force`, `git -c k=v reset --hard`,
+    # `git --git-dir=<p> clean -fd` and `git --work-tree <p> branch -D` all reached the shell with
+    # no approval prompt while the rules were anchored `\bgit\s+<subcommand>`.
+    (rf'\bgit\s+{_GIT_GLOBAL_FLAG_RUN}reset\s+--h(?:a(?:r(?:d)?)?)?\b', "git reset --hard (destroys uncommitted changes)"),
+    (rf'\bgit\s+{_GIT_GLOBAL_FLAG_RUN}push\b[^;|&\n]*--forc[a-z]*\b', "git force push (rewrites remote history)"),
+    (rf'\bgit\s+{_GIT_GLOBAL_FLAG_RUN}push\b[^;|&\n]*-f\b', "git force push short flag (rewrites remote history)"),
+    (rf'\bgit\s+{_GIT_GLOBAL_FLAG_RUN}clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
+    (rf'\bgit\s+{_GIT_GLOBAL_FLAG_RUN}branch\s+-D\b', "git branch force delete"),
     # `-D` = `-d --force`; the long spellings are different tokens, so match delete+force in either order, bounded to
     # one command segment (no `;`/`|`/`&`/newline) so an unrelated later command isn't contaminated.
-    (r'\bgit\s+branch\b[^;|&\n]*?(?:-d\b|--delete\b)[^;|&\n]*?(?:-f\b|--force\b)', "git branch force delete (long flags)"),
-    (r'\bgit\s+branch\b[^;|&\n]*?(?:-f\b|--force\b)[^;|&\n]*?(?:-d\b|--delete\b)', "git branch force delete (long flags, force-first)"),
+    (rf'\bgit\s+{_GIT_GLOBAL_FLAG_RUN}branch\b[^;|&\n]*?(?:-d\b|--delete\b)[^;|&\n]*?(?:-f\b|--force\b)', "git branch force delete (long flags)"),
+    (rf'\bgit\s+{_GIT_GLOBAL_FLAG_RUN}branch\b[^;|&\n]*?(?:-f\b|--force\b)[^;|&\n]*?(?:-d\b|--delete\b)', "git branch force delete (long flags, force-first)"),
     # chmod +x then immediate run: the script content may hold dangerous commands individual patterns miss.
     (r'\bchmod\s+\+x\b.*[;&|]+\s*\./', "chmod +x followed by immediate execution"),
     # Sudo stdin/askpass/shell/list-privs flags. The agent has no TTY, so sudo invocations that succeed
@@ -399,9 +470,26 @@ DANGEROUS_PATTERNS = [
 DANGEROUS_PATTERNS_COMPILED = [(re.compile(p, _RE_FLAGS), d) for p, d in DANGEROUS_PATTERNS]
 
 # Preserve approvals stored under the removed interpreter regex rules.
+# Also preserves the keys of every rule whose regex gained a _GLOBAL_FLAG_RUN: the legacy key is
+# derived from the regex text (`p.split(r'\b')[1]` below), so widening the pattern silently
+# renames it and an allowlist/session entry stored under the old spelling would stop matching.
 _REMOVED_PATTERN_KEY_ALIASES = {
     "script execution via -e/-c flag": "(python[23]?|perl|ruby|node)\\s+-[ec]\\s+",
     "script execution via heredoc": "(python[23]?|perl|ruby|node)\\s+<<",
+    "git reset --hard (destroys uncommitted changes)": "git\\s+reset\\s+--h(?:a(?:r(?:d)?)?)?",
+    "git force push (rewrites remote history)": "git\\s+push",
+    "git force push short flag (rewrites remote history)": "git\\s+push",
+    "git clean with force (deletes untracked files)": "git\\s+clean\\s+-[^\\s]*f",
+    "git branch force delete": "git\\s+branch\\s+-D",
+    "git branch force delete (long flags)": "git\\s+branch",
+    "git branch force delete (long flags, force-first)": "git\\s+branch",
+    "stop/restart system service": "systemctl\\s+(-[^\\s]+\\s+)*(stop|restart|disable|mask)",
+    "force kill processes": "pkill\\s+-9",
+    "force kill processes (killall -KILL)": "killall\\s+(-[^\\s]*\\s+)*-(9|KILL|SIGKILL)",
+    "force kill processes (killall -s KILL)": "killall\\s+(-[^\\s]*\\s+)*-s\\s+(KILL|SIGKILL|9)",
+    "kill processes by regex (killall -r)": "killall\\s+(-[^\\s]*\\s+)*-r",
+    "hermes update (restarts gateway, kills running agents)": "hermes\\s+update",
+    "docker context use (switches default daemon for future commands)": "docker\\s+context\\s+use",
 }
 # description <-> legacy regex-derived key (the old approval key, kept for backwards compatibility
 # with stored allowlist/session entries), both ways.


### PR DESCRIPTION
## What does this PR do?

Fourteen rules in `DANGEROUS_PATTERNS` anchor a subcommand directly to the program name. Any global option that takes a **separate value word** pushes the subcommand out of that anchor, the rule stops matching, no other rule covers the command, and the approval gate auto-approves it with no prompt at all.

```python
detect_dangerous_command("git push --force origin main")
# (True, 'git force push (rewrites remote history)', ...)   prompts

detect_dangerous_command("git -C /tmp push --force origin main")
# (False, None, None)                                       no rule
```

This is the same defect #55515 fixed for `hermes gateway stop|restart` in June, after the profile-flag self-kill loop. That fix was scoped to one rule; the rest still carry it.

`\bgit\s+push\b` requires `push` to follow `git` immediately, so `-C <path>`, `-c <k>=<v>`, `--git-dir <p>`, `--work-tree <p>`, `--exec-path <p>` and `--namespace <n>` each break the match. The older `(-[^\s]+\s+)*` spelling used by the systemctl and killall rules does not help either, since it accepts dash-tokens only and the value these options take is a bare word.

**Why this approach.** The run is built **per program**, from the options that program actually takes a separate value for, and offers two alternatives that cannot match the same span: a named value-taking option plus its value word, or any other single option token. A blanket "any option may take a value" run is simpler and wrong twice over:

- It swallows real subcommands. `systemctl --user status restart-nginx.service` and `git --no-pager log push --force` both match under a blanket run, because it pairs `--user` with `status` and `--no-pager` with `log`.
- It makes matching non-linear. A blanket run tiles a sequence of dash-tokens as one- or two-token pieces, Fibonacci-many ways, doubled again by `-{1,2}` on every `--` token. Measured: `"git " + "--ab " * 16 + "x"` took **10.6 s** inside `detect_dangerous_command`, and a benign `rsync -av --exclude .git src/ dst/` reached that path because `\bgit` matches inside `.git`. With the per-program run every token has exactly one parse and the same input returns in under a millisecond.

## Related Issue

No open issue. Prior art is #55515, which fixed this class for a single rule.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Deliberately not filed as a security fix: `SECURITY.md` §3.2 puts approval-gate pattern bypasses out of scope as vulnerabilities, since the gate is a heuristic rather than a boundary, and §2.4 says so directly. This is hardening of an acknowledged heuristic, offered through the channel §3.2 asks for.

## Changes Made

- `tools/approval_detection.py` — `_global_flag_run()` builds a per-program run; `_GIT_`, `_SYSTEMCTL_`, `_SIGNAL_`, `_HERMES_` and `_DOCKER_GLOBAL_FLAG_RUN` are threaded into the fourteen affected rules. The two git force-push rules also move from `.*` to `[^;|&\n]*` between `push` and the force flag, so a match stays inside one command segment, matching the bounded spelling the branch-delete rules beside them already use. Each widened rule's pre-fix approval key is recorded in `_REMOVED_PATTERN_KEY_ALIASES`, so stored allowlist and session entries keep matching.
- `tests/tools/test_global_flag_subcommand_bypass.py` — 71 cases, in the style of `test_gnu_long_option_abbreviation_bypass.py`.

## How to Test

1. On `main`, every one of these returns `(False, None, None)`:

```
git -C /tmp push --force origin main      git --work-tree /p branch -D main
git -C /tmp clean -fd                     systemctl -M host stop nginx
git -c user.name=x reset --hard           killall -u bob -9 python
git --git-dir=/p clean -fd                pkill -u bob -9 python
hermes -p prof update                     docker --log-level debug context use prod
```

2. With this branch, all ten are flagged, and the plain forms (`git push --force origin main`, `git clean -fd`, `git reset --hard`) still are.
3. These must stay unflagged, and do: `git status && echo push --force`, `systemctl --user status restart-nginx.service`, `git --no-pager log push --force`, `rsync -av --exclude .git src/ dst/`, `git push origin main`.
4. `pytest tests/tools/test_global_flag_subcommand_bypass.py -q` — 71 pass here, 21 fail on `main`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [ ] `pytest tests/ -q` — **not claimed in full.** `tests/acp` and `tests/acp_adapter` fail collection in my environment for missing optional extras, and the whole tree does not finish in the time I had. What I did run: **all twenty test files that reach the changed module** (every file referencing `approval_detection`, `detect_dangerous_command`, `DANGEROUS_PATTERNS` or `_REMOVED_PATTERN_KEY_ALIASES`) — **828 passed, 4 failed**. All four fail identically on unmodified `main`: three are `test_execution_flag_detection.py::test_real_binaries_execute_leading_dash_program_payload` with the real `sort` and `man` binaries on macOS, and one is `test_approval.py::TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`. Happy to have CI confirm the rest.
- [x] I've tested on my platform: macOS 15 (Darwin 24), Python 3.13.4

### Documentation & Housekeeping

- [x] Documentation — N/A, no user-facing surface changes
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact considered: the change is regex-only, with no path, shell or platform assumptions; separators are `[^\S\n]` rather than `\s`, which behaves identically on all platforms
- [x] Tool descriptions/schemas — N/A
