### PR TITLE
fix(tools): origin-pin XAI_BASE_URL in the API-key fallback branch of resolve_xai_http_credentials

### DIFF
--- a/tests/tools/test_xai_http_credentials.py
+++ b/tests/tools/test_xai_http_credentials.py
@@ -184,3 +184,48 @@ def test_prefer_api_key_honors_profile_scope_only_key(tmp_path, monkeypatch):
         secret_scope.reset_secret_scope(token)
         secret_scope.set_multiplex_active(previous_multiplex)
         invalidate_env_cache()
+
+
+def test_api_key_fallback_branch_pins_base_url_origin(monkeypatch):
+    """The final API-key fallback branch (no OAuth pool) must origin-pin the
+    env override like the prefer_api_key and OAuth branches: a tampered
+    XAI_BASE_URL / HERMES_XAI_BASE_URL (foreign host or non-HTTPS) is rejected
+    in favor of the default so the credential is never sent elsewhere."""
+    from tools.xai_http import resolve_xai_http_credentials
+
+    monkeypatch.setattr(
+        "tools.xai_http.get_env_value",
+        lambda name, default=None: {
+            "XAI_API_KEY": "paid-key-x1",
+            "XAI_BASE_URL": "http://attacker.example/v1",
+        }.get(name, default),
+    )
+    # No usable OAuth pool: force the fallback branch.
+    import agent.credential_pool as credential_pool
+
+    class _DeadPool:
+        def select(self):
+            raise RuntimeError("no pool")
+
+        def try_refresh_matching(self, _hint):
+            raise RuntimeError("no pool")
+
+    monkeypatch.setattr(
+        credential_pool, "load_pool", lambda provider_id: _DeadPool()
+    )
+
+    creds = resolve_xai_http_credentials()
+    assert creds["provider"] == "xai"
+    assert creds["api_key"] == "paid-key-x1"
+    assert creds["base_url"] == "https://api.x.ai/v1"
+
+    # A legitimate *.x.ai HTTPS override is still honored.
+    monkeypatch.setattr(
+        "tools.xai_http.get_env_value",
+        lambda name, default=None: {
+            "XAI_API_KEY": "paid-key-x1",
+            "XAI_BASE_URL": "https://staging.x.ai/v1",
+        }.get(name, default),
+    )
+    creds = resolve_xai_http_credentials()
+    assert creds["base_url"] == "https://staging.x.ai/v1"

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -236,5 +236,9 @@ def resolve_xai_http_credentials(
         pass
 
     api_key = _resolve_explicit_xai_api_key()
-    base_url = str(get_env_value("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+    # Origin-pin the env override exactly like the prefer_api_key and OAuth branches:
+    # without this, a tampered XAI_BASE_URL env (non-*.x.ai or non-HTTPS) is returned
+    # verbatim and callers send the credential to that URL (bearer exfiltration).
+    base_url = auth_mod._xai_validate_inference_base_url(
+        _xai_base_url_override(), fallback=DEFAULT_XAI_BASE_URL)
     return {"provider": "xai", "api_key": api_key, "base_url": base_url}


### PR DESCRIPTION
## Problem

`resolve_xai_http_credentials` has three credential branches. Two of them — the `prefer_api_key` branch and the OAuth branch — route the `XAI_BASE_URL` / `HERMES_XAI_BASE_URL` override through `_xai_validate_inference_base_url` (pin to `*.x.ai`, HTTPS-only, warn-and-fallback) so the bearer/API key can never be sent to a foreign origin.

The final API-key fallback branch (no OAuth pool configured) returned the raw env value **unvalidated**. With `XAI_API_KEY` set and no OAuth pool, a tampered `XAI_BASE_URL=http://attacker.example/v1` is returned verbatim, and downstream callers POST the credential to it (`x_search_tool.py` /responses, `tts_tool_providers.py` /tts, `transcription_cloud.py`, image/video-gen plugins).

## Fix

The fallback branch now applies the same `_xai_base_url_override()` + `_xai_validate_inference_base_url()` origin pinning as the other two branches. A legitimate `*.x.ai` HTTPS override is still honored; anything else falls back to `DEFAULT_XAI_BASE_URL`.

Supersedes #106764 (that branch carried unrelated commits from a stale base and its diff no longer rendered; this branch is a single commit on top of current main).

## Test

New regression test `test_api_key_fallback_branch_pins_base_url_origin` in `tests/tools/test_xai_http_credentials.py`:
- tampered non-HTTPS foreign override → rejected, default returned
- legitimate `https://staging.x.ai/v1` override → honored

`pytest tests/tools/test_xai_http_credentials.py` → 7 passed. Adjacent xAI suites (`test_x_search_tool.py`, `test_tts_streaming.py`, `test_web_providers_xai.py`) → 34 passed, 1 skipped.