### PR TITLE
fix(desktop): prevent sidebar focus from dimming the active chat

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -314,6 +314,9 @@ long transcript or a busy terminal.
 
 - Keyboard ownership follows focus. The focused surface wins its keys; shell
   shortcuts must not steal a terminal's or editor's bindings.
+- Focusing the Sessions sidebar preserves the last active chat's visual emphasis.
+  Dimming still distinguishes session panes; sidebar navigation must not desaturate
+  the chat or transfer its active highlight to a hidden primary tab.
 - Register global shortcuts through the shared layer, not ad-hoc listeners.
 - One cancel gesture does one thing: cancel the active interaction, or close the
   topmost dismissable surface — never both, never the control underneath.

--- a/apps/desktop/src/store/session-focus.ts
+++ b/apps/desktop/src/store/session-focus.ts
@@ -1,0 +1,46 @@
+import { atom, computed } from 'nanostores'
+
+import { findGroup, findGroupOfPane } from '@/components/pane-shell/tree/model'
+import { $activeTreeGroup, $layoutTree } from '@/components/pane-shell/tree/store'
+import { $workspaceMode } from '@/components/pane-shell/workspace-scope'
+
+// The sidebar still owns keyboard focus, but navigating its chrome must not
+// replace the chat being worked in with the route's (possibly hidden) primary.
+const $lastContentGroup = atom<null | string>(null)
+
+$activeTreeGroup.subscribe(groupId => {
+  const tree = $layoutTree.get()
+  const active = groupId && tree ? findGroup(tree, groupId)?.active : undefined
+
+  if (active !== 'sessions') {
+    $lastContentGroup.set(groupId)
+  }
+})
+
+export const $focusedTreePaneId = computed(
+  [$activeTreeGroup, $layoutTree, $workspaceMode, $lastContentGroup],
+  (groupId, tree, workspaceMode, lastContentGroup) => {
+    let active = groupId && tree ? findGroup(tree, groupId)?.active : undefined
+
+    if (active === 'sessions' && tree) {
+      const content = lastContentGroup ? findGroup(tree, lastContentGroup) : null
+      active = (content ?? findGroupOfPane(tree, 'workspace'))?.active
+    }
+
+    if (active?.startsWith('session-tile:')) {
+      return active
+    }
+
+    // Bot chats are tiles, never the primary selection. Sidebar roster focus
+    // must not publish a null session and let the Bots home reclaim the chat.
+    if (workspaceMode === 'bots' && tree) {
+      const mainActive = findGroupOfPane(tree, 'workspace')?.active
+
+      if (mainActive?.startsWith('session-tile:')) {
+        return mainActive
+      }
+    }
+
+    return active
+  }
+)

--- a/apps/desktop/src/store/session-sidebar-focus.test.ts
+++ b/apps/desktop/src/store/session-sidebar-focus.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { group, split } from '@/components/pane-shell/tree/model'
+import {
+  $activeTreeGroup,
+  $layoutTree,
+  noteActiveTreeGroup,
+  trackActiveTreeGroup
+} from '@/components/pane-shell/tree/store'
+import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
+import { $selectedStoredSessionId } from '@/store/session'
+import { $focusedStoredSessionId } from '@/store/session-states'
+
+const pane = (id: string) => `session-tile:${id}`
+
+function target(groupId: string) {
+  const button = document.createElement('button')
+  button.dataset.treeGroup = groupId
+  document.body.append(button)
+
+  return button
+}
+
+describe('session focus while interacting with the sidebar', () => {
+  let stopTracking: () => void
+
+  beforeEach(() => {
+    setWorkspaceScope('sessions')
+    $selectedStoredSessionId.set('primary')
+    noteActiveTreeGroup(null)
+    $layoutTree.set(
+      split('row', [
+        group(['sessions'], { active: 'sessions', id: 'sidebar' }),
+        group(['workspace', pane('main')], { active: pane('main'), id: 'main' }),
+        group([pane('split')], { active: pane('split'), id: 'split' })
+      ])
+    )
+    stopTracking = trackActiveTreeGroup()
+  })
+
+  afterEach(() => {
+    stopTracking()
+    document.body.replaceChildren()
+    $layoutTree.set(null)
+    noteActiveTreeGroup(null)
+    $selectedStoredSessionId.set(null)
+  })
+
+  it('retains the active chat through sidebar clicks and keyboard focus while still switching between chats', () => {
+    const sidebar = target('sidebar')
+    const main = target('main')
+    const split = target('split')
+
+    main.focus()
+    expect($focusedStoredSessionId.get()).toBe('main')
+    sidebar.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    expect($activeTreeGroup.get()).toBe('sidebar')
+    expect($focusedStoredSessionId.get()).toBe('main')
+
+    split.focus()
+    expect($focusedStoredSessionId.get()).toBe('split')
+    sidebar.focus()
+    expect($activeTreeGroup.get()).toBe('sidebar')
+    expect($focusedStoredSessionId.get()).toBe('split')
+
+    main.focus()
+    expect($focusedStoredSessionId.get()).toBe('main')
+  })
+
+  it('uses the visible main tab on restore and after the remembered split closes', () => {
+    const sidebar = target('sidebar')
+    sidebar.focus()
+    expect($focusedStoredSessionId.get()).toBe('main')
+
+    target('split').focus()
+    sidebar.focus()
+    $layoutTree.set(
+      split('row', [
+        group(['sessions'], { active: 'sessions', id: 'sidebar' }),
+        group(['workspace', pane('main')], { active: pane('main'), id: 'main' })
+      ])
+    )
+    expect($focusedStoredSessionId.get()).toBe('main')
+
+    $selectedStoredSessionId.set('new-primary')
+    expect($focusedStoredSessionId.get()).toBe('new-primary')
+  })
+})

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -1038,7 +1038,7 @@ describe('$focusedStoredSessionId in Bot Mode (#96062)', () => {
     expect($focusedStoredSessionId.get()).toBeNull()
   })
 
-  it('sessions mode keeps collapsing to the primary selection (derivation gated to Bot Mode)', () => {
+  it('sessions-sidebar focus follows the visible main tab instead of a hidden primary selection', () => {
     $selectedStoredSessionId.set('primary-1')
     $layoutTree.set(
       split('row', [
@@ -1048,10 +1048,8 @@ describe('$focusedStoredSessionId in Bot Mode (#96062)', () => {
     )
     noteActiveTreeGroup('grp-sessions')
 
-    // The main-zone tile must NOT answer here: in sessions mode the sidebar
-    // highlight follows the primary selection exactly as it always has.
     expect($workspaceMode.get()).toBe('sessions')
-    expect($focusedStoredSessionId.get()).toBe('primary-1')
+    expect($focusedStoredSessionId.get()).toBe('stacked')
   })
 })
 

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -20,9 +20,8 @@ import { type GatewayEvent, LOCAL_CONNECTION_ID, registryBackendScopeKey } from 
 import { atom, computed } from 'nanostores'
 
 import type { ClientSessionState } from '@/app/types'
-import { findGroup, findGroupOfPane, type LayoutNode } from '@/components/pane-shell/tree/model'
+import { findGroupOfPane, type LayoutNode } from '@/components/pane-shell/tree/model'
 import {
-  $activeTreeGroup,
   $layoutTree,
   focusedSessionTabAnchor,
   isPaneVisible,
@@ -30,7 +29,7 @@ import {
   noteActiveTreeGroup,
   revealTreePane
 } from '@/components/pane-shell/tree/store'
-import { $workspaceMode, resolveRememberedActivePane, workspaceScopeKey } from '@/components/pane-shell/workspace-scope'
+import { resolveRememberedActivePane, workspaceScopeKey } from '@/components/pane-shell/workspace-scope'
 import type { WorkspaceMode } from '@/contrib/types'
 import { stableArray } from '@/lib/stable-array'
 import { readJson, writeJson } from '@/lib/storage'
@@ -57,6 +56,7 @@ import {
   setSessions
 } from './session'
 import { secondaryProfileOwnerForEvent } from './session-event-provenance'
+import { $focusedTreePaneId } from './session-focus'
 import { assertSessionOwnerResolved } from './session-owner-resolution'
 import {
   requestForSessionProfile,
@@ -1916,45 +1916,13 @@ export function reopenLastClosedTile(): void {
 
 // ---------------------------------------------------------------------------
 // The FOCUSED session — one derivation, not another hand-maintained
-// "$activeSession" sibling. The layout's interaction tracker ($activeTreeGroup:
-// last click/focus, the same source ⌘W uses) resolves to a zone; its active
+// "$activeSession" sibling. session-focus resolves the interacted content zone,
+// retaining it while the Sessions sidebar owns keyboard focus. Its active
 // pane names the session: a `session-tile:<storedId>` pane IS that session,
 // anything else falls back to the route-driven primary. Chrome that should
 // follow the user between tiles (titlebar session title, statusbar context /
 // timer / model) reads these instead of the primary-only atoms.
 // ---------------------------------------------------------------------------
-
-/** Focused pane identity, retaining Bot Mode's main-zone fallback. */
-const $focusedTreePaneId = computed([$activeTreeGroup, $layoutTree, $workspaceMode], (groupId, tree, workspaceMode) => {
-  const active = groupId && tree ? findGroup(tree, groupId)?.active : undefined
-
-  if (active?.startsWith(TILE_PANE_PREFIX)) {
-    return active
-  }
-
-  // The interaction tracker can point at sidebar CHROME while a chat still
-  // holds the main zone's active tab — clicking a Bots-pane roster row moves
-  // it to the sidebar group, whose active pane ('hermes-bots:pane') is not a
-  // session tile. In sessions mode the primary selection answers, exactly as
-  // always. In Bot Mode that fallback alone publishes a NULL "focused"
-  // edge: bot chats open as TILES and never set $selectedStoredSessionId,
-  // so the selection is null while the chat is plainly on screen. The Bots
-  // plugin reads that null edge as "the chat lost the center", releases its
-  // open claim, and re-asserts the Bots home over the still-visible chat —
-  // the reported "clicking a bot chat jumps to the list" (#96062). Bot
-  // Mode's on-screen truth is the main zone's active TILE; only when the
-  // main zone holds no tile (chat closed) does the selection answer, so a
-  // genuine close still lets the home return.
-  if (workspaceMode === 'bots' && tree) {
-    const mainActive = findGroupOfPane(tree, 'workspace')?.active
-
-    if (mainActive?.startsWith(TILE_PANE_PREFIX)) {
-      return mainActive
-    }
-  }
-
-  return active
-})
 
 export const $focusedSessionIsTile = computed($focusedTreePaneId, active =>
   Boolean(active?.startsWith(TILE_PANE_PREFIX))


### PR DESCRIPTION
## Summary
Clicking or keyboard-focusing the Sessions sidebar could dim and desaturate the visible chat by falling back to a hidden primary session. Keep the last content group active for session presentation while the sidebar retains keyboard focus. Switching between chat panes still dims the inactive pane.

The focus resolver now lives in `session-focus.ts`. It falls back to the visible main tab on restore or after the remembered group closes, preserves Bot Mode's existing fallback, and continues to follow explicit session navigation.

## Test plan
- [x] Reproduced the sidebar focus regression with two failing tests before the fix.
- [x] 83 targeted tests pass across session focus, session state, rendered sidebar activity, and saved pane restoration.
- [x] ESLint passes for all four changed TypeScript files.
- [x] Playwright component preview using the real `ChatView`, `ChatSidebar`, and layout focus tracker: sidebar clicks and keyboard focus leave chat opacity and filter unchanged in light and dark themes; switching chat panes still transfers dimming. No page errors.

Verification used isolated fixture state, without changing the running app or real sessions. Full build and full test suites were not run.
