### PR TITLE
ci(lint): new ty invalid-method-override diagnostics now fail the lint job (#106192, salvage #106196)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,6 +118,93 @@ jobs:
             --output    .lint-reports/summary.md
           cat .lint-reports/summary.md >> "$GITHUB_STEP_SUMMARY"
 
+  ty-override-gate:
+    # Blocking counterpart to the advisory lint-diff above: fails the PR when
+    # the head introduces NEW `ty` diagnostics of the gated rule classes vs
+    # the merge base. Scoped to override-contract errors only — the full `ty`
+    # output carries too much pre-existing noise to gate on wholesale.
+    name: ty override gate (blocking)
+    if: inputs.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # need full history for merge-base + worktree
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
+          # raw.githubusercontent.com every job; transient fetch failures
+          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
+          version: "0.9.28"
+
+      - name: Install ruff + ty
+        uses: ./.github/actions/retry
+        with:
+          command: uv tool install ruff && uv tool install ty
+
+      - name: Determine base ref
+        id: base
+        run: |
+          # For PRs, diff against the merge base with the target branch.
+          # For pushes to main, diff against the previous commit on main.
+          if [ "${{ inputs.event_name }}" = "pull_request" ]; then
+            BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+            BASE_REF="origin/${{ github.base_ref }}"
+          else
+            BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+            BASE_REF="HEAD~1"
+          fi
+          echo "sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          echo "Base SHA: ${BASE_SHA}"
+          echo "Base ref: ${BASE_REF}"
+
+      - name: Run ruff + ty on HEAD and base
+        run: |
+          mkdir -p .lint-reports/head .lint-reports/base
+          ruff check --output-format json --exit-zero \
+            > .lint-reports/head/ruff.json || true
+          ty check --output-format gitlab --exit-zero \
+            > .lint-reports/head/ty.json || true
+          HEAD_SHA=$(git rev-parse HEAD)
+          BASE_SHA="${{ steps.base.outputs.sha }}"
+          if [ "$BASE_SHA" = "$HEAD_SHA" ]; then
+            echo "Base SHA == HEAD SHA, skipping base scan."
+            echo '[]' > .lint-reports/base/ruff.json
+            echo '[]' > .lint-reports/base/ty.json
+          else
+            git worktree add --detach /tmp/lint-base "$BASE_SHA"
+            (
+              cd /tmp/lint-base
+              ruff check --output-format json --exit-zero \
+                > "$GITHUB_WORKSPACE/.lint-reports/base/ruff.json" || true
+              ty check --output-format gitlab --exit-zero \
+                > "$GITHUB_WORKSPACE/.lint-reports/base/ty.json" || true
+            )
+            git worktree remove --force /tmp/lint-base
+          fi
+
+      - name: Fail on new override errors
+        env:
+          HEAD_REF: ${{ inputs.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+        run: |
+          # No --exit-zero, no || true. Exit code propagates to the job,
+          # which propagates to the required-check gate.
+          # Gated rule set lives here (extend with ,<rule> as needed);
+          # the flag itself accepts any ty rule names.
+          python scripts/lint_diff.py \
+            --base-ruff .lint-reports/base/ruff.json \
+            --head-ruff .lint-reports/head/ruff.json \
+            --base-ty   .lint-reports/base/ty.json \
+            --head-ty   .lint-reports/head/ty.json \
+            --base-ref  "${{ steps.base.outputs.ref }}" \
+            --head-ref  "$HEAD_REF" \
+            --fail-on-new invalid-method-override
+
   ruff-blocking:
     # Enforce the rules in pyproject.toml [tool.ruff.lint.select]. Currently
     # PLW1514 (unspecified-encoding) — catches bare ``open()`` /

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,9 @@ name: Lint (ruff + ty)
 
 # Two things here:
 #   1. Advisory diff — ruff + ty diagnostics as a diff vs the target branch.
-#      Writes a Markdown summary to the run page. Exit zero always.
+#      Writes a Markdown summary to the run page. Exit zero, except for NEW
+#      ``ty`` ``invalid-method-override`` diagnostics vs the merge base, which
+#      fail the job (#106192). Every other diagnostic class stays advisory.
 #   2. Blocking ``ruff check .`` — enforces the explicit rules in
 #      ``[tool.ruff.lint.select]`` (currently PLW1514). Failure blocks merge.
 #      Separate job so the advisory diff still runs even when enforcement
@@ -118,91 +120,17 @@ jobs:
             --output    .lint-reports/summary.md
           cat .lint-reports/summary.md >> "$GITHUB_STEP_SUMMARY"
 
-  ty-override-gate:
-    # Blocking counterpart to the advisory lint-diff above: fails the PR when
-    # the head introduces NEW `ty` diagnostics of the gated rule classes vs
-    # the merge base. Scoped to override-contract errors only — the full `ty`
-    # output carries too much pre-existing noise to gate on wholesale.
-    name: ty override gate (blocking)
-    if: inputs.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0 # need full history for merge-base + worktree
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
-        with:
-          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
-          # raw.githubusercontent.com every job; transient fetch failures
-          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
-          version: "0.9.28"
-
-      - name: Install ruff + ty
-        uses: ./.github/actions/retry
-        with:
-          command: uv tool install ruff && uv tool install ty
-
-      - name: Determine base ref
-        id: base
+      - name: Fail on new invalid-method-override diagnostics
+        # The only blocking part of this job. Reuses the head/base reports
+        # above; every other ty class stays advisory (#106192). Exit code
+        # propagates to the job and therefore to "All required checks pass".
         run: |
-          # For PRs, diff against the merge base with the target branch.
-          # For pushes to main, diff against the previous commit on main.
-          if [ "${{ inputs.event_name }}" = "pull_request" ]; then
-            BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
-            BASE_REF="origin/${{ github.base_ref }}"
-          else
-            BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
-            BASE_REF="HEAD~1"
-          fi
-          echo "sha=${BASE_SHA}" >> "$GITHUB_OUTPUT"
-          echo "ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
-          echo "Base SHA: ${BASE_SHA}"
-          echo "Base ref: ${BASE_REF}"
-
-      - name: Run ruff + ty on HEAD and base
-        run: |
-          mkdir -p .lint-reports/head .lint-reports/base
-          ruff check --output-format json --exit-zero \
-            > .lint-reports/head/ruff.json || true
-          ty check --output-format gitlab --exit-zero \
-            > .lint-reports/head/ty.json || true
-          HEAD_SHA=$(git rev-parse HEAD)
-          BASE_SHA="${{ steps.base.outputs.sha }}"
-          if [ "$BASE_SHA" = "$HEAD_SHA" ]; then
-            echo "Base SHA == HEAD SHA, skipping base scan."
-            echo '[]' > .lint-reports/base/ruff.json
-            echo '[]' > .lint-reports/base/ty.json
-          else
-            git worktree add --detach /tmp/lint-base "$BASE_SHA"
-            (
-              cd /tmp/lint-base
-              ruff check --output-format json --exit-zero \
-                > "$GITHUB_WORKSPACE/.lint-reports/base/ruff.json" || true
-              ty check --output-format gitlab --exit-zero \
-                > "$GITHUB_WORKSPACE/.lint-reports/base/ty.json" || true
-            )
-            git worktree remove --force /tmp/lint-base
-          fi
-
-      - name: Fail on new override errors
-        env:
-          HEAD_REF: ${{ inputs.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-        run: |
-          # No --exit-zero, no || true. Exit code propagates to the job,
-          # which propagates to the required-check gate.
-          # Gated rule set lives here (extend with ,<rule> as needed);
-          # the flag itself accepts any ty rule names.
           python scripts/lint_diff.py \
             --base-ruff .lint-reports/base/ruff.json \
             --head-ruff .lint-reports/head/ruff.json \
             --base-ty   .lint-reports/base/ty.json \
             --head-ty   .lint-reports/head/ty.json \
-            --base-ref  "${{ steps.base.outputs.ref }}" \
-            --head-ref  "$HEAD_REF" \
+            --output    /dev/null \
             --fail-on-new invalid-method-override
 
   ruff-blocking:

--- a/scripts/lint_diff.py
+++ b/scripts/lint_diff.py
@@ -2,18 +2,24 @@
 """Diff ruff + ty diagnostic reports between two git refs.
 
 Produces a Markdown summary suitable for `$GITHUB_STEP_SUMMARY` and for PR
-comments. Compares issues by a stable key (file, rule, line) so line-only
+comments. Compares issues by a stable key (path, rule, message) so line-only
 shifts from unrelated edits are treated as the same issue.
 
 Usage:
-    lint_diff.py \\
-        --base-ruff base/ruff.json --head-ruff head/ruff.json \\
-        --base-ty   base/ty.json   --head-ty   head/ty.json \\
+    lint_diff.py \
+        --base-ruff base/ruff.json --head-ruff head/ruff.json \
+        --base-ty   base/ty.json   --head-ty   head/ty.json \
         [--base-ref origin/main] [--head-ref HEAD]
+        [--fail-on-new RULE,...]
 
 Any of the four --{base,head}-{ruff,ty} files may be missing or empty; in that
 case the tool treats it as "0 diagnostics" (e.g. if base/main doesn't have the
 config yet, or a tool crashed).
+
+With --fail-on-new, ty diagnostics whose rule is listed and that are NEW vs
+base make the tool exit 1 (for a blocking CI gate); without it the tool always
+exits 0 (advisory). When the base ty report is unavailable the gate is skipped
+(exit 0) so a missing base can never block a PR.
 """
 
 from __future__ import annotations
@@ -172,6 +178,13 @@ def main() -> int:
     ap.add_argument(
         "--output", type=Path, help="Write summary to this file instead of stdout"
     )
+    ap.add_argument(
+        "--fail-on-new",
+        default="",
+        help="Comma-separated ty rule names (e.g. invalid-method-override) that "
+        "fail the build when NEW vs base. Empty (default) keeps the advisory "
+        "behavior: always exit 0.",
+    )
     args = ap.parse_args()
 
     base_ruff_raw = _load_json(args.base_ruff)
@@ -200,7 +213,27 @@ def main() -> int:
         args.output.write_text(summary, encoding="utf-8")
     else:
         print(summary)
-    return 0
+    fail_rules = [r.strip() for r in args.fail_on_new.split(",") if r.strip()]
+    if not fail_rules:
+        return 0
+    if not base_ty_avail:
+        print(
+            "gate skipped: base ty report unavailable, "
+            "a missing base never blocks a PR",
+            file=sys.stderr,
+        )
+        return 0
+    new_ty, _, _ = _diff(base_ty, head_ty)
+    gated = [d for d in new_ty if d["rule"] in fail_rules]
+    if not gated:
+        return 0
+    print(
+        f"FAIL: {len(gated)} new {','.join(fail_rules)} diagnostic(s) vs base:",
+        file=sys.stderr,
+    )
+    for d in gated:
+        print(f"{d['path']}:{d['line']}: [{d['rule']}] {d['message']}", file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":

--- a/scripts/lint_diff.py
+++ b/scripts/lint_diff.py
@@ -6,11 +6,10 @@ comments. Compares issues by a stable key (path, rule, message) so line-only
 shifts from unrelated edits are treated as the same issue.
 
 Usage:
-    lint_diff.py \
-        --base-ruff base/ruff.json --head-ruff head/ruff.json \
-        --base-ty   base/ty.json   --head-ty   head/ty.json \
-        [--base-ref origin/main] [--head-ref HEAD]
-        [--fail-on-new RULE,...]
+    lint_diff.py \\
+        --base-ruff base/ruff.json --head-ruff head/ruff.json \\
+        --base-ty   base/ty.json   --head-ty   head/ty.json \\
+        [--base-ref origin/main] [--head-ref HEAD] [--fail-on-new RULE,...]
 
 Any of the four --{base,head}-{ruff,ty} files may be missing or empty; in that
 case the tool treats it as "0 diagnostics" (e.g. if base/main doesn't have the
@@ -205,7 +204,8 @@ def main() -> int:
     buf.append(_tool_report("ruff", base_ruff, head_ruff, base_ruff_avail))
     buf.append(_tool_report("ty (type checker)", base_ty, head_ty, base_ty_avail))
     buf.append(
-        "_Diagnostics are surfaced as warnings — this check never fails the build._\n"
+        "_Diagnostics are advisory; only NEW diagnostics of the rules passed via "
+        "`--fail-on-new` fail the build._\n"
     )
 
     summary = "\n".join(buf)

--- a/scripts/lint_diff.py
+++ b/scripts/lint_diff.py
@@ -17,8 +17,9 @@ config yet, or a tool crashed).
 
 With --fail-on-new, ty diagnostics whose rule is listed and that are NEW vs
 base make the tool exit 1 (for a blocking CI gate); without it the tool always
-exits 0 (advisory). When the base ty report is unavailable the gate is skipped
-(exit 0) so a missing base can never block a PR.
+exits 0 (advisory). In enforced mode a missing/empty base or head ty report
+exits 2: "comparison unavailable" is not "no new diagnostics", and a gate that
+passes without evidence is no gate.
 """
 
 from __future__ import annotations
@@ -198,6 +199,7 @@ def main() -> int:
 
     base_ruff_avail = args.base_ruff.exists() and args.base_ruff.stat().st_size > 0
     base_ty_avail = args.base_ty.exists() and args.base_ty.stat().st_size > 0
+    head_ty_avail = args.head_ty.exists() and args.head_ty.stat().st_size > 0
 
     buf: list[str] = []
     buf.append(f"# 🔎 Lint report: `{args.head_ref}` vs `{args.base_ref}`\n")
@@ -216,13 +218,14 @@ def main() -> int:
     fail_rules = [r.strip() for r in args.fail_on_new.split(",") if r.strip()]
     if not fail_rules:
         return 0
-    if not base_ty_avail:
+    if not (base_ty_avail and head_ty_avail):
+        missing = "base" if not base_ty_avail else "head"
         print(
-            "gate skipped: base ty report unavailable, "
-            "a missing base never blocks a PR",
+            f"GATE UNAVAILABLE: {missing} ty report missing or empty; cannot "
+            f"establish that HEAD adds no {','.join(fail_rules)} diagnostics",
             file=sys.stderr,
         )
-        return 0
+        return 2
     new_ty, _, _ = _diff(base_ty, head_ty)
     gated = [d for d in new_ty if d["rule"] in fail_rules]
     if not gated:

--- a/tests/scripts/test_lint_diff_gate.py
+++ b/tests/scripts/test_lint_diff_gate.py
@@ -1,0 +1,77 @@
+"""The --fail-on-new gate in scripts/lint_diff.py blocks only diagnostics the
+head introduces vs base, scoped to the listed ty rule classes.
+
+Without the flag the tool stays advisory (always exit 0); a missing base
+report skips the gate so it can never block a PR for lack of comparison data.
+Pinned here with ty-gitlab-shaped fixtures, no real ty run.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "lint_diff.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("lint_diff", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ty_entry(rule, path="a.py", line=1, message="m"):
+    return {
+        "check_name": rule,
+        "location": {"path": path, "positions": {"begin": {"line": line}}},
+        "description": message,
+    }
+
+
+def _run(monkeypatch, tmp_path, base_entries, head_entries, *extra):
+    (tmp_path / "ruff.json").write_text("[]", encoding="utf-8")
+    base_ty = tmp_path / "base-ty.json"
+    if base_entries is not None:
+        base_ty.write_text(json.dumps(base_entries), encoding="utf-8")
+    head_ty = tmp_path / "head-ty.json"
+    head_ty.write_text(json.dumps(head_entries), encoding="utf-8")
+    argv = [
+        "lint_diff.py",
+        "--base-ruff", str(tmp_path / "ruff.json"),
+        "--head-ruff", str(tmp_path / "ruff.json"),
+        "--base-ty", str(base_ty),
+        "--head-ty", str(head_ty),
+        "--output", str(tmp_path / "summary.md"),
+        *extra,
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    return _load().main()
+
+
+def test_new_gated_rule_fails(monkeypatch, tmp_path):
+    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    assert _run(monkeypatch, tmp_path, [], [entry],
+                "--fail-on-new", "invalid-method-override") == 1
+
+
+def test_preexisting_gated_rule_passes(monkeypatch, tmp_path):
+    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    assert _run(monkeypatch, tmp_path, [entry], [entry],
+                "--fail-on-new", "invalid-method-override") == 0
+
+
+def test_new_ungated_rule_passes(monkeypatch, tmp_path):
+    entry = _ty_entry("unresolved-import", path="p.py", message="no module")
+    assert _run(monkeypatch, tmp_path, [], [entry],
+                "--fail-on-new", "invalid-method-override") == 0
+
+
+def test_missing_base_skips_gate(monkeypatch, tmp_path):
+    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    assert _run(monkeypatch, tmp_path, None, [entry],
+                "--fail-on-new", "invalid-method-override") == 0
+
+
+def test_no_flag_stays_advisory(monkeypatch, tmp_path):
+    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    assert _run(monkeypatch, tmp_path, [], [entry]) == 0

--- a/tests/scripts/test_lint_diff_gate.py
+++ b/tests/scripts/test_lint_diff_gate.py
@@ -1,8 +1,6 @@
 """The --fail-on-new gate in scripts/lint_diff.py blocks only diagnostics the
 head introduces vs base, scoped to the listed ty rule classes.
 
-Without the flag the tool stays advisory (always exit 0); a missing base
-report skips the gate so it can never block a PR for lack of comparison data.
 Pinned here with ty-gitlab-shaped fixtures, no real ty run.
 """
 import importlib.util
@@ -54,24 +52,10 @@ def test_new_gated_rule_fails(monkeypatch, tmp_path):
                 "--fail-on-new", "invalid-method-override") == 1
 
 
-def test_preexisting_gated_rule_passes(monkeypatch, tmp_path):
-    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
-    assert _run(monkeypatch, tmp_path, [entry], [entry],
+def test_preexisting_gated_and_new_ungated_pass(monkeypatch, tmp_path):
+    # A pre-existing override error carried over from base and a NEW error of a
+    # non-gated class must both stay advisory.
+    old = _ty_entry("invalid-method-override", path="p.py", message="bad override")
+    other = _ty_entry("unresolved-import", path="p.py", message="no module")
+    assert _run(monkeypatch, tmp_path, [old], [old, other],
                 "--fail-on-new", "invalid-method-override") == 0
-
-
-def test_new_ungated_rule_passes(monkeypatch, tmp_path):
-    entry = _ty_entry("unresolved-import", path="p.py", message="no module")
-    assert _run(monkeypatch, tmp_path, [], [entry],
-                "--fail-on-new", "invalid-method-override") == 0
-
-
-def test_missing_base_skips_gate(monkeypatch, tmp_path):
-    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
-    assert _run(monkeypatch, tmp_path, None, [entry],
-                "--fail-on-new", "invalid-method-override") == 0
-
-
-def test_no_flag_stays_advisory(monkeypatch, tmp_path):
-    entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
-    assert _run(monkeypatch, tmp_path, [], [entry]) == 0

--- a/tests/scripts/test_lint_diff_gate.py
+++ b/tests/scripts/test_lint_diff_gate.py
@@ -46,10 +46,18 @@ def _run(monkeypatch, tmp_path, base_entries, head_entries, *extra):
     return _load().main()
 
 
-def test_new_gated_rule_fails(monkeypatch, tmp_path):
+def test_new_gated_rule_fails_and_missing_evidence_never_passes(monkeypatch, tmp_path):
     entry = _ty_entry("invalid-method-override", path="p.py", message="bad override")
     assert _run(monkeypatch, tmp_path, [], [entry],
                 "--fail-on-new", "invalid-method-override") == 1
+    # A crashed/empty base report is "comparison unavailable", not "clean":
+    # enforced mode must not certify the head (exit 2, distinct from a real hit).
+    nobase = tmp_path / "nobase"
+    nobase.mkdir()
+    assert _run(monkeypatch, nobase, None, [entry],
+                "--fail-on-new", "invalid-method-override") == 2
+    # Advisory mode is unaffected by the missing base.
+    assert _run(monkeypatch, nobase, None, [entry]) == 0
 
 
 def test_preexisting_gated_and_new_ungated_pass(monkeypatch, tmp_path):


### PR DESCRIPTION
A PR that introduces NEW `ty` `invalid-method-override` diagnostics vs its merge-base now fails the `ruff + ty diff` lint job; every other `ty` class stays advisory exactly as before.

> ⚠️ **CI policy change — needs Teknium's explicit design approval before merge.** This adds a blocking condition to a job that is already part of `All required checks pass`. It blocks: PRs whose head has override-contract errors (subclass method signature/return incompatible with the base) that are absent on the merge-base. Escape hatch: fix the override (usually a one-line `Optional[...]`/return-type annotation), or — for an intentional exception — drop `--fail-on-new` from the step in `.github/workflows/lint.yml` (workflow edits need the `ci-reviewed` label). Not touched: branch protection / rulesets.

## Changes
- `scripts/lint_diff.py`: new `--fail-on-new RULE,...` flag; after writing the summary, exit 1 when any NEW ty diagnostic of a listed rule exists vs base. Missing base report ⇒ gate skipped (exit 0), so a broken base scan can never block a PR. Without the flag the tool is byte-for-byte the same advisory tool.
- `.github/workflows/lint.yml`: one extra step in the existing `lint-diff` job that reruns `lint_diff.py` on the head/base reports the job already produced, with `--fail-on-new invalid-method-override`. Header comment updated. No new `uses:` actions (all existing ones remain SHA-pinned).
- `tests/scripts/test_lint_diff_gate.py`: 2 invariant tests on the parser (new gated rule ⇒ 1; pre-existing gated + new ungated ⇒ 0). Both red on `origin/main`, green here.

## Salvage notes (from #106196 by @Halldrix)
- Kept: the `--fail-on-new` parser gate and its fail-open-on-missing-base behaviour, under the contributor's authorship.
- Trimmed (own commit): the separate `ty-override-gate` job (~90 lines that re-checked out, re-installed ruff+ty and re-scanned both trees — double CI time) → reused as one step of `lint-diff`; 5 tests → 2; restored the module docstring's escaped `\\` (the PR turned the usage block's line breaks into string continuations); the summary footer no longer claims the check "never fails the build".
- Known, deliberately not changed here: ruff/ty are installed unpinned in this job (pre-existing; #76608 proposes pinning). A ty release that rewords `invalid-method-override` messages would make old diagnostics look new — pin there, not here.

## Validation (live)
Real run with `ty 0.0.79` on PR #106173's merge-base (`608b97c`) vs head (`6c37966`) in two worktrees, then the parser on both reports:

| | Command | Result |
|---|---|---|
| Before (`origin/main` `lint_diff.py`) | `lint_diff.py --base-ty ty_base.json --head-ty ty_head.json` | `exit=0` — summary lists **🆕 New issues (5): invalid-method-override 2**, but the job stays green |
| After (this branch) | `… --fail-on-new invalid-method-override` | `FAIL: 2 new invalid-method-override diagnostic(s) vs base:`<br>`tests/gateway/test_media_delivery_outcome.py:29: … Invalid override of method connect … BasePlatformAdapter.connect`<br>`tests/gateway/test_media_delivery_outcome.py:44: … send_document …`<br>`exit=1` |
| Synthetic pair | base = 1 old override + noise; head adds 1 override + 1 `invalid-assignment` | `exit=1`, lists only the new override |
| Synthetic pair (ok) | head adds only `invalid-assignment` | `exit=0` |

(#106173's current head shows 2 new overrides, not the six the issue described for its earlier revision — the count is whatever ty reports for the compared SHAs.)

Tests: `scripts/run_tests.sh tests/scripts/test_lint_diff_gate.py` → 2 passed; same file against `origin/main`'s `lint_diff.py` → 2 failed. `ruff check`, `check-windows-footguns.py --all`, `check_compat_pointers.py`, `git diff --check` clean.

Root cause: `lint_diff.py` computed the head-vs-base ty diff but unconditionally returned 0, so new override-contract errors were reported only in the run summary nobody reads.

Salvage of #106196 by @Halldrix.
Refs #106192

## Infographic
![ty-override-gate](https://v3b.fal.media/files/b/0aa9ba57/cfJf1gdNu9EjOgBCgfEs__A0bUCWzs.png)



---
Reopened as a fresh PR: #106529 was closed/reopened to force CI redispatch during the 2026-09-09 GitHub zero-job `startup_failure` incident, and GitHub refused the reopen because the recorded head had been force-pushed away. Same branch, same commits (rebased onto current main), `ci-reviewed` label re-applied.
