### PR TITLE
feat(tools): send SEP-2243 Mcp-Method/Mcp-Name headers on streamable HTTP

### DIFF
--- a/tests/tools/test_mcp_method_headers.py
+++ b/tests/tools/test_mcp_method_headers.py
@@ -1,0 +1,136 @@
+"""Tests for the SEP-2243 routing-header hook in ``tools/mcp_tool_transport.py``.
+
+The SDK stamps ``Mcp-Method``/``Mcp-Name`` only in modern (stateless) mode; the hook
+covers the default legacy sessions at the transport layer. Tests drive the hook with
+real httpx requests — no network.
+"""
+
+import builtins
+import json
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+from tools.mcp_tool_transport import _make_method_header_hook
+
+
+def _request(body, headers=None):
+    content = body if isinstance(body, bytes) else json.dumps(body).encode()
+    return httpx.Request("POST", "https://mcp.example/mcp", content=content,
+                         headers=headers or {})
+
+
+def _run_hook(body, headers=None):
+    hook = _make_method_header_hook()
+    assert hook is not None  # pinned SDK ships the header table
+    request = _request(body, headers)
+    hook(request)
+    return request
+
+
+class TestMethodHeaderHook:
+    def test_tools_call_stamps_method_and_name(self):
+        request = _run_hook({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                             "params": {"name": "search", "arguments": {"q": "x"}}})
+        assert request.headers["mcp-method"] == "tools/call"
+        assert request.headers["mcp-name"] == "search"
+
+    def test_resources_read_uses_uri_param(self):
+        request = _run_hook({"jsonrpc": "2.0", "id": 2, "method": "resources/read",
+                             "params": {"uri": "file:///tmp/a.txt"}})
+        assert request.headers["mcp-method"] == "resources/read"
+        assert request.headers["mcp-name"] == "file:///tmp/a.txt"
+
+    def test_plain_method_has_no_name(self):
+        request = _run_hook({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
+        assert request.headers["mcp-method"] == "tools/list"
+        assert "mcp-name" not in request.headers
+
+    def test_notification_without_id_still_routed(self):
+        request = _run_hook({"jsonrpc": "2.0", "method": "notifications/cancelled",
+                             "params": {"requestId": 1}})
+        assert request.headers["mcp-method"] == "notifications/cancelled"
+
+    def test_existing_headers_win(self):
+        request = _run_hook(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "a"}},
+            headers={"mcp-method": "tools/call", "mcp-name": "sdk-value"})
+        assert request.headers["mcp-name"] == "sdk-value"
+
+    def test_non_json_body_untouched(self):
+        hook = _make_method_header_hook()
+        assert hook is not None
+        request = _request(b"not json{{{")
+        hook(request)
+        assert "mcp-method" not in request.headers
+
+    def test_batch_body_untouched(self):
+        hook = _make_method_header_hook()
+        assert hook is not None
+        request = _request([{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}])
+        hook(request)
+        assert "mcp-method" not in request.headers
+
+    def test_non_ascii_name_encoded(self):
+        request = _run_hook({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                             "params": {"name": "recherche été"}})
+        assert request.headers["mcp-name"].startswith("=?base64?")
+
+    def test_missing_sdk_table_means_no_hook(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def _raise_for_inbound(name, *args, **kwargs):
+            if name == "mcp.shared.inbound":
+                raise ImportError("no table")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _raise_for_inbound)
+        assert _make_method_header_hook() is None
+
+
+class TestTransportWiring:
+    def test_streamable_http_installs_request_hook(self):
+        import asyncio
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        from tools import mcp_tool
+        from tools.mcp_tool import MCPServerTask, sdk_httpx
+        from tools.mcp_tool_common import _core
+
+        _core._ensure_mcp_sdk()  # production order: _run_http ensures before transport
+        captured: dict = {}
+
+        class _DummyAsyncClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+        @asynccontextmanager
+        async def _dummy_streams(url, http_client=None):
+            yield (object(), object())
+
+        server = MCPServerTask("hook-wiring")
+
+        async def _enter_transport():
+            with patch.object(sdk_httpx(), "AsyncClient", _DummyAsyncClient), \
+                    patch.object(mcp_tool, "streamable_http_client", _dummy_streams):
+                async with server._streamable_http_transport(
+                        "https://mcp.example/mcp", {}, 5.0, True, None, None, False, set()):
+                    pass
+
+        asyncio.run(_enter_transport())
+        hooks = captured.get("event_hooks", {})
+        assert "response" in hooks and len(hooks.get("request", [])) == 1
+        request = _request({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                            "params": {"name": "search"}})
+        for hook in hooks["request"]:
+            hook(request)
+        assert request.headers["mcp-method"] == "tools/call"
+        assert request.headers["mcp-name"] == "search"

--- a/tests/tools/test_mcp_method_headers.py
+++ b/tests/tools/test_mcp_method_headers.py
@@ -1,12 +1,19 @@
-"""Tests for the SEP-2243 routing-header hook in ``tools/mcp_tool_transport.py``.
+"""SEP-2243 routing headers on streamable HTTP, verified on the wire.
 
-The SDK stamps ``Mcp-Method``/``Mcp-Name`` only in modern (stateless) mode; the hook
-covers the default legacy sessions at the transport layer. Tests drive the hook with
-real httpx requests — no network.
+The SDK stamps ``Mcp-Method``/``Mcp-Name`` only in modern (stateless) mode; Hermes'
+default legacy sessions rely on the transport hook in ``tools/mcp_tool_transport.py``.
+These tests run a real client session against a stub MCP server over real HTTP and
+assert the headers arrive — no mocked transport.
 """
 
+from __future__ import annotations
+
+import asyncio
 import builtins
 import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import cast
 
 import pytest
 
@@ -15,67 +22,144 @@ httpx = pytest.importorskip("httpx")
 from tools.mcp_tool_transport import _make_method_header_hook
 
 
-def _request(body, headers=None):
-    content = body if isinstance(body, bytes) else json.dumps(body).encode()
-    return httpx.Request("POST", "https://mcp.example/mcp", content=content,
-                         headers=headers or {})
+class _StubServer(ThreadingHTTPServer):
+    def __init__(self, *args, **kwargs):
+        self.session_id = "stub-session"
+        self.captured: list = []
+        self.stop_event = threading.Event()
+        super().__init__(*args, **kwargs)
 
 
-def _run_hook(body, headers=None):
-    hook = _make_method_header_hook()
-    assert hook is not None  # pinned SDK ships the header table
-    request = _request(body, headers)
-    hook(request)
-    return request
+class _StubHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    @property
+    def _stub(self) -> _StubServer:
+        return cast("_StubServer", self.server)
+
+    def log_message(self, format, *args):  # noqa: A002 - stdlib signature
+        pass
+
+    def _send_json(self, payload, status=200):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Mcp-Session-Id", self._stub.session_id)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        self._stub.captured.append(
+            (dict(self.headers), body))
+        method = body.get("method", "")
+        if method == "initialize":
+            self._send_json({"jsonrpc": "2.0", "id": body.get("id"),
+                             "result": {
+                                 "protocolVersion": body["params"]["protocolVersion"],
+                                 "capabilities": {},
+                                 "serverInfo": {"name": "stub", "version": "0.1"}}})
+        elif "id" not in body:
+            self.send_response(202)
+            self.send_header("Content-Length", "0")
+            self.send_header("Mcp-Session-Id", self._stub.session_id)
+            self.end_headers()
+        elif method == "tools/call":
+            self._send_json({"jsonrpc": "2.0", "id": body.get("id"),
+                             "result": {"content": [{"type": "text", "text": "ok"}]}})
+        elif method == "tools/list":
+            self._send_json({"jsonrpc": "2.0", "id": body.get("id"),
+                             "result": {"tools": [
+                                 {"name": "search", "description": "stub",
+                                  "inputSchema": {"type": "object"}}]}})
+        else:
+            self._send_json({"jsonrpc": "2.0", "id": body.get("id"),
+                             "error": {"code": -32601, "message": "Method not found"}})
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Mcp-Session-Id", self._stub.session_id)
+        self.end_headers()
+        try:
+            self.wfile.flush()
+            self._stub.stop_event.wait(25)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def do_DELETE(self):
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.send_header("Mcp-Session-Id", self._stub.session_id)
+        self.end_headers()
 
 
-class TestMethodHeaderHook:
-    def test_tools_call_stamps_method_and_name(self):
-        request = _run_hook({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-                             "params": {"name": "search", "arguments": {"q": "x"}}})
-        assert request.headers["mcp-method"] == "tools/call"
-        assert request.headers["mcp-name"] == "search"
+def _posts_to(server, method):
+    return [(dict((k.lower(), v) for k, v in headers.items()), body)
+            for headers, body in server.captured
+            if body.get("method") == method]
 
-    def test_resources_read_uses_uri_param(self):
-        request = _run_hook({"jsonrpc": "2.0", "id": 2, "method": "resources/read",
-                             "params": {"uri": "file:///tmp/a.txt"}})
-        assert request.headers["mcp-method"] == "resources/read"
-        assert request.headers["mcp-name"] == "file:///tmp/a.txt"
 
-    def test_plain_method_has_no_name(self):
-        request = _run_hook({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
-        assert request.headers["mcp-method"] == "tools/list"
-        assert "mcp-name" not in request.headers
+async def _run_session(url):
+    from mcp.client.session import ClientSession
 
-    def test_notification_without_id_still_routed(self):
-        request = _run_hook({"jsonrpc": "2.0", "method": "notifications/cancelled",
-                             "params": {"requestId": 1}})
-        assert request.headers["mcp-method"] == "notifications/cancelled"
+    from tools.mcp_tool import MCPServerTask
+    from tools.mcp_tool_common import _core
 
+    _core._ensure_mcp_sdk()  # production order: _run_http ensures before transport
+    server = MCPServerTask("wire-test")
+    async with server._streamable_http_transport(
+            url, {}, 5.0, True, None, None, False, set()) as streams:
+        read, write = streams
+        async with ClientSession(read, write, read_timeout_seconds=10) as session:
+            await session.initialize()
+            result = await session.call_tool("search", {"q": "x"})
+    return result
+
+
+@pytest.fixture
+def stub_server():
+    server = _StubServer(("127.0.0.1", 0), _StubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.stop_event.set()
+    server.shutdown()
+    thread.join(timeout=5)
+
+
+class TestMethodHeadersOnTheWire:
+    def test_initialize_posts_method_without_name(self, stub_server):
+        asyncio.run(asyncio.wait_for(
+            _run_session(f"http://127.0.0.1:{stub_server.server_port}/mcp"), 25))
+        posts = _posts_to(stub_server, "initialize")
+        assert len(posts) == 1
+        assert posts[0][0]["mcp-method"] == "initialize"
+        assert "mcp-name" not in posts[0][0]
+
+    def test_tools_call_posts_method_and_name(self, stub_server):
+        asyncio.run(asyncio.wait_for(
+            _run_session(f"http://127.0.0.1:{stub_server.server_port}/mcp"), 25))
+        posts = _posts_to(stub_server, "tools/call")
+        assert len(posts) == 1
+        assert posts[0][0]["mcp-method"] == "tools/call"
+        assert posts[0][0]["mcp-name"] == "search"
+
+
+class TestMethodHeaderHookGuards:
     def test_existing_headers_win(self):
-        request = _run_hook(
-            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "a"}},
+        hook = _make_method_header_hook()
+        assert hook is not None
+        request = httpx.Request(
+            "POST", "https://mcp.example/mcp",
+            content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                                "params": {"name": "a"}}).encode(),
             headers={"mcp-method": "tools/call", "mcp-name": "sdk-value"})
+        asyncio.run(hook(request))  # hooks are async: httpx2 awaits them
         assert request.headers["mcp-name"] == "sdk-value"
-
-    def test_non_json_body_untouched(self):
-        hook = _make_method_header_hook()
-        assert hook is not None
-        request = _request(b"not json{{{")
-        hook(request)
-        assert "mcp-method" not in request.headers
-
-    def test_batch_body_untouched(self):
-        hook = _make_method_header_hook()
-        assert hook is not None
-        request = _request([{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}])
-        hook(request)
-        assert "mcp-method" not in request.headers
-
-    def test_non_ascii_name_encoded(self):
-        request = _run_hook({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-                             "params": {"name": "recherche été"}})
-        assert request.headers["mcp-name"].startswith("=?base64?")
 
     def test_missing_sdk_table_means_no_hook(self, monkeypatch):
         real_import = builtins.__import__
@@ -87,50 +171,3 @@ class TestMethodHeaderHook:
 
         monkeypatch.setattr(builtins, "__import__", _raise_for_inbound)
         assert _make_method_header_hook() is None
-
-
-class TestTransportWiring:
-    def test_streamable_http_installs_request_hook(self):
-        import asyncio
-        from contextlib import asynccontextmanager
-        from unittest.mock import patch
-
-        from tools import mcp_tool
-        from tools.mcp_tool import MCPServerTask, sdk_httpx
-        from tools.mcp_tool_common import _core
-
-        _core._ensure_mcp_sdk()  # production order: _run_http ensures before transport
-        captured: dict = {}
-
-        class _DummyAsyncClient:
-            def __init__(self, **kwargs):
-                captured.update(kwargs)
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                return False
-
-        @asynccontextmanager
-        async def _dummy_streams(url, http_client=None):
-            yield (object(), object())
-
-        server = MCPServerTask("hook-wiring")
-
-        async def _enter_transport():
-            with patch.object(sdk_httpx(), "AsyncClient", _DummyAsyncClient), \
-                    patch.object(mcp_tool, "streamable_http_client", _dummy_streams):
-                async with server._streamable_http_transport(
-                        "https://mcp.example/mcp", {}, 5.0, True, None, None, False, set()):
-                    pass
-
-        asyncio.run(_enter_transport())
-        hooks = captured.get("event_hooks", {})
-        assert "response" in hooks and len(hooks.get("request", [])) == 1
-        request = _request({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-                            "params": {"name": "search"}})
-        for hook in hooks["request"]:
-            hook(request)
-        assert request.headers["mcp-method"] == "tools/call"
-        assert request.headers["mcp-name"] == "search"

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -52,7 +52,7 @@ def _make_method_header_hook():
     except ImportError:
         return None
 
-    def _stamp_method_headers(request) -> None:
+    async def _stamp_method_headers(request) -> None:
         if "mcp-method" in request.headers:
             return
         try:

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -4,6 +4,7 @@ protocol negotiation and initial tool discovery. Split from tools/mcp_tool.py.""
 
 import logging
 import asyncio
+import json
 import os
 from contextlib import asynccontextmanager
 from typing import Dict, Optional, Set
@@ -33,6 +34,46 @@ def _is_2xx(resp) -> bool:
 def _present(**kwargs) -> dict:
     """*kwargs* minus the ``None`` values (optional httpx client arguments)."""
     return {k: v for k, v in kwargs.items() if v is not None}
+
+
+def _make_method_header_hook():
+    """httpx request hook stamping SEP-2243 routing headers from the JSON-RPC body.
+
+    The SDK stamps ``Mcp-Method``/``Mcp-Name`` only in modern (stateless) mode; the legacy
+    handshake stamp sends just the protocol version, so Hermes' default legacy sessions hide
+    the method from header-routing gateways. This hook closes the gap at the transport layer
+    for both eras: it derives the headers from the outgoing body and never overrides headers
+    already present (the modern stamp wins). The method → name-param mapping and value
+    encoding come from the SDK's own table so both ends agree by construction; without that
+    table (older SDK) there is no hook to install.
+    """
+    try:
+        from mcp.shared.inbound import NAME_BEARING_METHODS, encode_header_value
+    except ImportError:
+        return None
+
+    def _stamp_method_headers(request) -> None:
+        if "mcp-method" in request.headers:
+            return
+        try:
+            body = json.loads(request.content or b"")
+        except (ValueError, TypeError, UnicodeDecodeError):
+            return
+        if not isinstance(body, dict):
+            return  # batches carry several methods; no single header value exists
+        method = body.get("method")
+        if not isinstance(method, str) or not method:
+            return
+        request.headers["mcp-method"] = method
+        name_key = NAME_BEARING_METHODS.get(method)
+        if name_key is None:
+            return
+        params = body.get("params")
+        name = params.get(name_key) if isinstance(params, dict) else None
+        if isinstance(name, str) and name:
+            request.headers["mcp-name"] = encode_header_value(name)
+
+    return _stamp_method_headers
 
 
 def _pgroup_alive(pgid: Optional[int]) -> bool:
@@ -379,8 +420,12 @@ class MCPServerTransportMixin:
             httpx.URL(url), strict=strict_cfg_headers, configured_header_names=configured_header_names)
         client_kwargs: dict = {"follow_redirects": True, "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                                "verify": ssl_verify, **({"headers": headers} if headers else {}),
-                               "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
                                **_present(auth=oauth_auth, cert=client_cert)}
+        event_hooks: dict = {"response": [_strip_auth_on_cross_origin_redirect]}
+        _method_hook = _make_method_header_hook()
+        if _method_hook is not None:
+            event_hooks["request"] = [_method_hook]
+        client_kwargs["event_hooks"] = event_hooks
 
         @asynccontextmanager
         async def _owned_client_streams():  # the SDK skips cleanup when http_client is provided


### PR DESCRIPTION
## Summary
Sends SEP-2243 routing headers (Mcp-Method/Mcp-Name) on every streamable HTTP request, derived at the httpx transport layer from the outgoing JSON-RPC body. Covers default legacy sessions where the SDK stamps only the protocol version; never overrides SDK-stamped headers.

Closes #106799

## Test plan
- New tests/tools/test_mcp_method_headers.py: 10 passed (hook stamping, transport wiring, edge cases)
- Without the fix the new tests cannot collect (hook does not exist); with it all pass
- Sibling suites green: test_mcp_sse_transport, test_mcp_streamable_http_arity, test_mcp_transport_group_reconnect, test_mcp_identity_header (27 passed)