### PR TITLE
feat(standards): add clarify-choice rule to skill authoring HARDLINE standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1092,6 +1092,16 @@ violate them.
    `.env.example` versions are usually stale and edits outside the
    skill's own block must be dropped during salvage.
 
+9. **When the user must choose between concrete options, use the
+   `clarify` tool instead of listing choices in prose.** Skills that
+   surface a decision (pick a style, pick a mode, confirm a direction,
+   choose one of N named options) should never end with a prose list +
+   "which one?". Call `clarify` directly with a question and a choices
+   array, with the recommended option first. Only use free-text
+   `clarify` (or a plain message) when there are genuinely no candidate
+   options to offer — e.g. asking for an absolute path or a free-form
+   value.
+
 The full salvage / modernization checklist for external skill PRs
 lives in the `hermes-agent-dev` skill at
 `references/new-skill-pr-salvage.md` — load it before polishing

--- a/skills/software-development/hermes-agent-skill-authoring/SKILL.md
+++ b/skills/software-development/hermes-agent-skill-authoring/SKILL.md
@@ -144,6 +144,7 @@ A skill exists to make the agent's process more predictable — the agent reliab
 4. **Co-locate rules with the concept they govern.**
 5. **Use strong leading words** ("tight loop," "root cause," "regression test") over long repeated explanations.
 6. **Prune duplication and no-ops.** "Be careful" and "use best practices" don't change model behavior — replace with a checkable criterion or delete.
+7. **Surface choices with `clarify`, never a prose list.** When the skill needs the user to pick between concrete options (style, mode, format, one of N named candidates), call the `clarify` tool with the choices array and the recommended option first. A prose list ending in "which do you prefer?" is a review-blocking non-conformance — models narrate all options before asking, which wastes a turn. Use free-text `clarify` only when no candidate options exist (paths, raw values).
 
 ## Tests and Docs (required for repo skills)
 


### PR DESCRIPTION
## Summary

Adds a hardline authoring standard requiring skills to surface user choices with the `clarify` tool instead of listing options in prose.

## Changes

1. **AGENTS.md** — new point 9 under `Skill authoring standards (HARDLINE)`:
   > When the user must choose between concrete options, use the `clarify` tool instead of listing choices in prose. Skills that surface a decision (pick a style, pick a mode, confirm a direction, choose one of N named options) should never end with a prose list + "which one?". Call `clarify` directly with a question and a choices array, with the recommended option first. Only use free-text `clarify` (or a plain message) when there are genuinely no candidate options to offer — e.g. asking for an absolute path or a free-form value.

2. **skills/software-development/hermes-agent-skill-authoring/SKILL.md** — new point 7 under `Writing Quality Principles`:
   > Surface choices with `clarify`, never a prose list. When the skill needs the user to pick between concrete options (style, mode, format, one of N named candidates), call the `clarify` tool with the choices array and the recommended option first. A prose list ending in "which do you prefer?" is a review-blocking non-conformance — models narrate all options before asking, which wastes a turn. Use free-text `clarify` only when no candidate options exist (paths, raw values).

## Why

Skills routinely ask the user to pick between concrete options (style, mode, format, etc.). Listing choices in prose and ending with a question costs an extra turn: the model narrates every option, then waits. `clarify` renders actual selectable choices and, on platforms with timeouts, defaults gracefully. This standard is the authored equivalent of the `clarify` guidance already scattered across shipped skills (baoyu-*, pixel-art, openclaw-migration, etc.) — it makes the pattern a reviewable rule instead of coincidence.

## Validation

- `git diff` reviewed — 2 files changed, 11 insertions, no auto-generated docs touched (source of truth is SKILL.md; web docs are generated from it via `generate-skill-docs.py`).