### PR TITLE
fix(memory): track holographic retrieval usage

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -12,7 +12,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List
 
-from agent.memory_provider import MemoryProvider
+from agent.memory_provider import MemoryProvider, RecallStatus
 from tools.registry import tool_error
 from utils import is_truthy_value
 from .store import MemoryStore
@@ -103,6 +103,7 @@ class HolographicMemoryProvider(MemoryProvider):
         self._config = config or _load_plugin_config()
         self._store = self._retriever = None
         self._min_trust = float(self._config.get("min_trust_threshold", 0.3))
+        self._last_recall_count = 0
 
     @property
     def name(self) -> str:
@@ -160,15 +161,23 @@ class HolographicMemoryProvider(MemoryProvider):
         return "# Holographic Memory\n" + body + "Use fact_feedback to rate facts after using them (trains trust scores)."
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
+        self._last_recall_count = 0
         if not self._retriever or not query:
             return ""
         try:
             results = self._retriever.search(query, min_trust=self._min_trust, limit=5)
+            self._record_retrievals(results)
+            self._last_recall_count = len(results)
             lines = [f"- [{r.get('trust_score', r.get('trust', 0)):.1f}] {r.get('content', '')}" for r in results]
             return "## Holographic Memory\n" + "\n".join(lines) if results else ""
         except Exception as e:
             logger.debug("Holographic prefetch failed: %s", e)
             return ""
+
+    def recall_status(self) -> RecallStatus | None:
+        if not self._last_recall_count:
+            return None
+        return RecallStatus(provider_label="Holographic", count=self._last_recall_count)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [FACT_STORE_SCHEMA, FACT_FEEDBACK_SCHEMA]
@@ -210,17 +219,32 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def _entity_query(self, method: str, a: dict) -> str:
         """'probe' / 'related': single-entity retriever queries."""
-        return _results(getattr(self._retriever, method)(a["entity"], category=a.get("category"), limit=_limit(a)))
+        return _results(self._record_retrievals(
+            getattr(self._retriever, method)(a["entity"], category=a.get("category"), limit=_limit(a))
+        ))
+
+    def _record_retrievals(self, results: list[dict]) -> list[dict]:
+        """Persist usage telemetry without letting an advisory counter break recall."""
+        if self._store:
+            try:
+                self._store.record_retrievals([
+                    fact_id for result in results if isinstance((fact_id := result.get("fact_id")), int)
+                ])
+            except Exception as exc:
+                logger.debug("Holographic retrieval tracking failed: %s", exc)
+        return results
 
     _TOOL_HANDLERS = {
         "fact_store": _tool_handler({
             "add": lambda self, a: json.dumps({"fact_id": self._store.add_fact(
                 a["content"], category=a.get("category", "general"), tags=a.get("tags", "")), "status": "added"}),
-            "search": lambda self, a: _results(self._retriever.search(
-                a["query"], category=a.get("category"), min_trust=float(a.get("min_trust", self._min_trust)), limit=_limit(a))),
+            "search": lambda self, a: _results(self._record_retrievals(self._retriever.search(
+                a["query"], category=a.get("category"), min_trust=float(a.get("min_trust", self._min_trust)), limit=_limit(a)
+            ))),
             "probe": lambda self, a: self._entity_query("probe", a),
             "related": lambda self, a: self._entity_query("related", a),
-            "reason": lambda self, a: _results(self._retriever.reason(a["entities"], category=a.get("category"), limit=_limit(a)))
+            "reason": lambda self, a: _results(self._record_retrievals(self._retriever.reason(
+                a["entities"], category=a.get("category"), limit=_limit(a))))
             if a.get("entities") else tool_error("reason requires 'entities' list"),
             "contradict": lambda self, a: _results(self._retriever.contradict(category=a.get("category"), limit=_limit(a))),
             "update": lambda self, a: json.dumps({"updated": self._store.update_fact(

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -198,6 +198,18 @@ class MemoryStore:
                    "ORDER BY trust_score DESC LIMIT ?")
             return [dict(r) for r in self._conn.execute(sql, params).fetchall()]
 
+    def record_retrievals(self, fact_ids: list[int]) -> None:
+        """Increment usage once for every distinct fact returned to a caller."""
+        ids = list(dict.fromkeys(fact_ids))
+        if not ids:
+            return
+        with self._lock:
+            placeholders = ", ".join("?" for _ in ids)
+            self._write(
+                f"UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id IN ({placeholders})",
+                ids,
+            )
+
     def record_feedback(self, fact_id: int, helpful: bool) -> dict:
         """Adjust trust asymmetrically: helpful -> +0.05 and helpful_count += 1; unhelpful -> -0.10.
         Returns {fact_id, old_trust, new_trust, helpful_count}. Raises KeyError if fact_id is unknown."""

--- a/tests/plugins/memory/test_holographic_retrieval_telemetry.py
+++ b/tests/plugins/memory/test_holographic_retrieval_telemetry.py
@@ -1,0 +1,75 @@
+"""Regression tests for holographic retrieval usage telemetry."""
+
+from __future__ import annotations
+
+from plugins.memory.holographic import HolographicMemoryProvider
+from plugins.memory.holographic.store import MemoryStore
+
+
+def _provider(tmp_path) -> HolographicMemoryProvider:
+    provider = HolographicMemoryProvider(
+        config={"db_path": str(tmp_path / "memory_store.db"), "hrr_dim": 64}
+    )
+    provider.initialize(session_id="telemetry-test")
+    return provider
+
+
+def _store(provider: HolographicMemoryProvider) -> MemoryStore:
+    assert provider._store is not None
+    return provider._store
+
+
+def _retrieval_count(provider: HolographicMemoryProvider, fact_id: int) -> int:
+    row = _store(provider)._conn.execute(
+        "SELECT retrieval_count FROM facts WHERE fact_id = ?", (fact_id,)
+    ).fetchone()
+    return row["retrieval_count"]
+
+
+def test_prefetch_counts_injected_facts_and_reports_recall_status(tmp_path):
+    provider = _provider(tmp_path)
+    try:
+        first = _store(provider).add_fact("H59 requires a live check before advising action.")
+        second = _store(provider).add_fact("H59 alerts after a sustained 12-hour elevation.")
+
+        block = provider.prefetch("What is the H59 alert workflow?")
+
+        assert block
+        assert _retrieval_count(provider, first) == 1
+        assert _retrieval_count(provider, second) == 1
+        status = provider.recall_status()
+        assert status is not None
+        assert status.provider_label == "Holographic"
+        assert status.count == 2
+    finally:
+        provider.shutdown()
+
+
+def test_manual_search_counts_returned_facts_once_per_retrieval(tmp_path):
+    provider = _provider(tmp_path)
+    try:
+        matched = _store(provider).add_fact("Use an H59 live check first.")
+        unmatched = _store(provider).add_fact("The garden watering schedule is weekly.")
+
+        response = provider.handle_tool_call(
+            "fact_store", {"action": "search", "query": "H59 live check"}
+        )
+
+        assert '"count": 1' in response
+        assert _retrieval_count(provider, matched) == 1
+        assert _retrieval_count(provider, unmatched) == 0
+    finally:
+        provider.shutdown()
+
+
+def test_empty_prefetch_clears_prior_recall_status(tmp_path):
+    provider = _provider(tmp_path)
+    try:
+        _store(provider).add_fact("H59 requires a live check before advising action.")
+        assert provider.prefetch("H59 live check")
+        assert provider.recall_status() is not None
+
+        assert provider.prefetch("unrelated xylophone taxonomy") == ""
+        assert provider.recall_status() is None
+    finally:
+        provider.shutdown()


### PR DESCRIPTION
## Summary

The holographic memory schema has a `retrieval_count` column, but the active retrieval paths never updated it. Facts injected by automatic prefetch or returned by the `fact_store` tool therefore remained indistinguishable from facts that had never been used. The provider also did not implement the shared `recall_status()` contract, so Hermes could not show its deterministic recall indicator after holographic memory was injected.

This PR fixes both gaps.

## Implementation

- Adds `MemoryStore.record_retrievals()`: a parameterized, shared-lock SQLite update that increments usage once per distinct returned fact.
- Records usage only after facts are selected for automatic `prefetch()` and agent-facing `fact_store` retrieval actions: `search`, `probe`, `related`, and `reason`.
- Implements `HolographicMemoryProvider.recall_status()` from the most recent successful prefetch count. This activates the existing status path, which renders `🧠 Holographic — recalled N memories`.
- Resets the prior recall count before every prefetch, preventing empty results or failures from showing stale recall status.
- Deliberately leaves `list` and `contradict` uncounted: they are CRUD browsing and diagnostic-pair output, rather than recalled facts delivered to the agent.

## Safety

The counter write is advisory and uses the store's existing shared SQLite lock. IDs are deduplicated before the batch update, and a telemetry-write failure is logged without changing the facts returned to the agent. This does not alter tool schemas or prompt construction.

## Tests

New regression coverage verifies that:

1. Automatic prefetch increments every injected fact and reports the correct recall count.
2. Manual `fact_store(action='search')` increments returned facts but not unrelated facts.
3. An empty prefetch clears a prior recall status.

Validated with:

```text
scripts/run_tests.sh tests/plugins/memory/test_holographic_store.py tests/plugins/memory/test_holographic_retrieval.py tests/plugins/memory/test_holographic_shutdown_closes_db.py tests/plugins/memory/test_holographic_auto_extract.py tests/plugins/memory/test_holographic_retrieval_telemetry.py tests/plugins/test_holographic_vector_storage.py
# 56 passed
```

Fixes #17899
