### PR TITLE
fix(tests): Docker integration job no longer blocked by the gateway-spawn guard (regression from #106623)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1428,6 +1428,14 @@ def _live_system_guard(request, monkeypatch):
         "daemon-reload", "try-restart", "reload-or-restart",
     )
     _PROCESS_KILLERS = ("pkill", "killall", "taskkill", "skill", "fuser")
+    _CONTAINER_RUNTIMES = ("docker", "podman", "nerdctl")
+
+    def _first_token_basename(cmd_str: str) -> str:
+        try:
+            tokens = _shlex.split(cmd_str)
+        except ValueError:
+            tokens = cmd_str.split()
+        return tokens[0].rsplit("/", 1)[-1].lower() if tokens else ""
     # Shell/launcher executables whose arguments are themselves commands —
     # argv[0]-only scanning must not exempt what they wrap.
     _WRAPPER_COMMANDS = (
@@ -1563,7 +1571,14 @@ def _live_system_guard(request, monkeypatch):
         # sibling refactor moved the spawn seam and left tests patching the
         # facade. The canonical matcher, never an argv substring.
         from gateway.status import _gateway_command_subcommand
-        if not lookalike_ok and _gateway_command_subcommand(cmd_str) in ("run", "start", "restart"):
+        # A gateway launched INSIDE a container (`docker exec … hermes gateway start`) cannot
+        # reach the host's systemd unit or webhook port; tests/docker/ exists to exercise it.
+        in_container = _first_token_basename(cmd_str) in _CONTAINER_RUNTIMES
+        if (
+            not lookalike_ok
+            and not in_container
+            and _gateway_command_subcommand(cmd_str) in ("run", "start", "restart")
+        ):
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
                 f"subprocess.{name}({cmd!r}) — this would spawn a REAL "

--- a/tests/test_live_system_guard.py
+++ b/tests/test_live_system_guard.py
@@ -37,3 +37,29 @@ def test_wrapped_killer_command_is_still_blocked():
 def test_env_wrapped_killer_command_is_still_blocked():
     with pytest.raises(RuntimeError, match="live-system guard"):
         subprocess.run(["env", "GUARD_TEST=1", "pkill", "-f", "hermes-guard-regression-nomatch"])
+
+
+def test_gateway_start_inside_a_container_exec_is_not_blocked():
+    """``docker exec <ctr> hermes gateway start`` launches the gateway INSIDE the container,
+    where it cannot reach the host's systemd unit or webhook port; tests/docker/ depends on it.
+    The binary is a stub so the argv stays exact without needing a Docker daemon."""
+    import os
+    import stat
+
+    stub_dir = os.path.join(os.environ["HERMES_HOME"], "stub-bin")
+    os.makedirs(stub_dir, exist_ok=True)
+    stub = os.path.join(stub_dir, "docker")
+    with open(stub, "w") as fh:
+        fh.write("#!/bin/sh\nexit 0\n")
+    os.chmod(stub, os.stat(stub).st_mode | stat.S_IXUSR)
+    result = subprocess.run(
+        [stub, "exec", "-u", "hermes", "ctr", "sh", "-c", "hermes -p prof gateway start"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_gateway_start_on_the_host_is_still_blocked():
+    with pytest.raises(RuntimeError, match="REAL.*gateway runtime"):
+        subprocess.run(["python", "-m", "hermes_cli.main", "gateway", "start"])


### PR DESCRIPTION
`tests/docker/test_profile_gateway.py::test_profile_create_then_gateway_start` no longer trips the live-system guard: a `hermes gateway start` issued through `docker exec` runs inside the container and is allowed; the same command on the host stays blocked.

**Symptom.** Since #106623 (`ca16cafee40`) every Docker build job fails at "Run docker integration tests":
`RuntimeError: tests/conftest.py live-system guard: blocked subprocess.run(['docker', 'exec', '-u', 'hermes', 'hermes-test-…', 'sh', '-c', 'hermes -p test-harness-profile gateway start…'])`. Seen on #106785 (run 34393558153, both amd64 and arm64).

**Root cause.** The guard uses the canonical matcher `gateway.status._gateway_command_subcommand`, which strips `-p <profile>` and reads through `sh -c`, so a gateway launched *inside a container* is indistinguishable from one launched on the host. The guard exists for the host case only (a detached child that resolves the developer's systemd unit and squats the webhook port); a container process can reach neither.

**Change** (`tests/conftest.py`, +17/−1): skip the gateway-spawn check when `argv[0]` is a container runtime (`docker`, `podman`, `nerdctl`). Everything else in the guard (systemctl mutations, process killers, `hermes update`) is untouched and still applies to container commands.

| Test (`tests/test_live_system_guard.py`) | base | this PR |
|---|---|---|
| `test_gateway_start_inside_a_container_exec_is_not_blocked` (stub `docker` binary, exact failing argv) | **RED** | green |
| `test_gateway_start_on_the_host_is_still_blocked` | green | green |

Local: `scripts/run_tests.sh tests/test_live_system_guard.py tests/test_live_system_guard_self_test.py tests/hermes_cli/test_gateway_service.py tests/docker/` → 147 passed, 0 failed (docker tests skip without a daemon; CI's Docker job is the live check).
