### PR TITLE
fix(docs): redirect /plugins to /plugins/ for desktop embed picker

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -59,6 +59,13 @@ const config: Config = {
             to: '/developer-guide/plugins',
           },
           {
+            // Desktop plugins iframe uses `/docs/plugins?embed=picker` without
+            // trailing slash; GitHub Pages 404s on that path. Redirect to `/plugins/`
+            // which resolves correctly on both edges (GH Pages and Vercel).
+            from: '/plugins',
+            to: '/plugins/',
+          },
+          {
             // Users guess these short paths from abbreviated links and hit
             // raw 404s (consumer-onboarding audit finding #1, Aug 2026).
             from: '/quickstart',


### PR DESCRIPTION
**Root cause:** Desktop Plugins iframe requests `/docs/plugins?embed=picker` (no trailing slash); GitHub Pages origin 404s on that path.

**Fix:** Add explicit redirect `/plugins` → `/plugins/` in Docusaurus config so both edges (GH Pages and Vercel) resolve the query-string variant correctly.

**Verified:** Live repro confirmed via Chrome and r.jina.ai; `/docs/skills?embed=picker` works, `/docs/plugins?embed=picker` 404s. With this redirect, the latter will resolve.

Fixes #106797.