### PR TITLE
fix(bluebubbles): drop repeat new-message/updated-message deliveries

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from collections import OrderedDict
 from contextlib import suppress
@@ -63,6 +64,13 @@ _PAGINATION_SUFFIX_RE = re.compile(r"\s*\(\d+/\d+\)$")
 _ADDRESS_RE = re.compile(r"^\+\d+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+
+# BlueBubbles emits both ``new-message`` and ``updated-message`` webhooks for the same
+# iMessage; the two payload shapes often resolve to different session chat IDs (chat GUID
+# vs bare handle), which used to spawn two sessions and double every reply. Drop repeat
+# deliveries of one message GUID inside this window.
+_INBOUND_DEDUP_WINDOW_S = 300.0
+_INBOUND_DEDUP_MAX = 500
 _LOCAL_HOSTS = {"0.0.0.0", "127.0.0.1", "localhost", "::"}
 
 
@@ -134,6 +142,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._inbound_message_ids: OrderedDict[str, float] = OrderedDict()
 
     # --- API helpers ---
 
@@ -557,6 +566,21 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             chat_identifier = sender
         return chat_guid, chat_identifier, sender
 
+    def _drop_duplicate_inbound(self, message_id: Optional[str]) -> bool:
+        """True when this message GUID was already accepted inside the dedup window."""
+        if not message_id:
+            return False
+        now = time.monotonic()
+        seen = self._inbound_message_ids
+        while seen and next(iter(seen.values())) < now - _INBOUND_DEDUP_WINDOW_S:
+            seen.popitem(last=False)
+        if message_id in seen:
+            return True
+        seen[message_id] = now
+        while len(seen) > _INBOUND_DEDUP_MAX:
+            seen.popitem(last=False)
+        return False
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -583,6 +607,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         chat_guid, chat_identifier, sender = self._resolve_chat_and_sender(payload, record)
         if not sender or not (chat_guid or chat_identifier) or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
+        message_id = self._value(record.get("guid"), record.get("messageGuid"), record.get("id"))
+        if self._drop_duplicate_inbound(message_id):
+            logger.debug("[bluebubbles] ignoring repeat delivery of message %s", message_id)
+            return _ok()
         session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -567,3 +567,76 @@ class TestBlueBubblesTimeoutErrorNormalization:
         assert "500 Internal Server Error" in (result.error or "")
 
 
+class TestBlueBubblesRepeatDeliveryDedup:
+    @pytest.mark.asyncio
+    async def test_updated_message_with_same_guid_is_acknowledged_and_skipped(
+        self, monkeypatch,
+    ):
+        """BlueBubbles fires new-message + updated-message for one iMessage; the
+        second payload shape often resolves to a different session chat ID, which
+        used to spawn a twin session and double every reply."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "MSG-DUP-1",
+                "text": "hello",
+                "handle": {"address": "+15550001111"},
+                "isFromMe": False,
+                "chats": [{"guid": "iMessage;-;+15550001111"}],
+            },
+        }))
+        await asyncio.sleep(0)
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-DUP-1",
+                "text": "hello",
+                "handle": {"address": "+15550001111"},
+                "isFromMe": False,
+                "chatIdentifier": "+15550001111",
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert len(handled) == 1
+
+    @pytest.mark.asyncio
+    async def test_distinct_messages_with_same_text_both_handled(
+        self, monkeypatch,
+    ):
+        """Dedup keys on the message GUID, so a user repeating the same text
+        still gets both messages processed."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        for guid in ("MSG-A", "MSG-B"):
+            await adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "new-message",
+                "data": {
+                    "guid": guid,
+                    "text": "same text twice",
+                    "handle": {"address": "+15550001111"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "iMessage;-;+15550001111"}],
+                },
+            }))
+        await asyncio.sleep(0)
+
+        assert len(handled) == 2
+
+


### PR DESCRIPTION
## Summary
BlueBubbles emits both `new-message` and `updated-message` webhooks for the same iMessage. The two payload shapes can resolve to different session chat IDs (chat GUID vs bare handle), spawning a twin session that doubles every reply. This tracks recent inbound message GUIDs and acks-but-skips repeats inside a 5-minute window. Dedup keys on the message GUID, so a user intentionally repeating the same text is unaffected.

Closes #30708 (also covers reported dupes #68718, #34372)

## Test plan
- New TestBlueBubblesRepeatDeliveryDedup: repeat GUID across both event shapes handled once; distinct GUIDs with identical text both handled
- Verified end-to-end against the production interpreter (gateway venv, has aiohttp): repeat dropped with 200, distinct kept
- Note: tests/gateway/test_bluebubbles.py has 2 pre-existing failures in this checkout's test venv (missing aiohttp; fails identically on clean tree), unrelated to this change