### PR TITLE
fix: canonicalize BlueBubbles DM session id to the bare address

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -63,6 +63,19 @@ _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 _PAGINATION_SUFFIX_RE = re.compile(r"\s*\(\d+/\d+\)$")
 _ADDRESS_RE = re.compile(r"^\+\d+")
 
+
+def _canonical_dm_chat_id(chat_guid: Optional[str], chat_identifier: Optional[str]) -> Optional[str]:
+    """Bare address for a 1:1 DM so every BlueBubbles payload shape for the same chat
+    resolves to one session. ``chatGuid`` varies per event (full ``service;-;address``
+    guid vs absent); ``chatIdentifier`` is the stable bare address. Without this the
+    same DM fans out to two sessions (#106824). Group GUIDs are never passed here —
+    collapsing them would merge distinct group chats."""
+    if chat_identifier:
+        return chat_identifier
+    if chat_guid and ";-;" in chat_guid:
+        return chat_guid.split(";-;")[-1] or chat_guid
+    return chat_guid or chat_identifier
+
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
 
 # BlueBubbles emits both ``new-message`` and ``updated-message`` webhooks for the same
@@ -613,6 +626,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return _ok()
         session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        if not is_group:  # one DM, one session regardless of payload shape (#106824)
+            if canonical := _canonical_dm_chat_id(chat_guid, chat_identifier):
+                session_chat_id = canonical
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):
                 logger.debug("[bluebubbles] ignoring group message (require_mention=true, no mention pattern matched)")

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from collections import OrderedDict
 from contextlib import suppress
@@ -63,6 +64,13 @@ _PAGINATION_SUFFIX_RE = re.compile(r"\s*\(\d+/\d+\)$")
 _ADDRESS_RE = re.compile(r"^\+\d+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+
+# BlueBubbles emits both ``new-message`` and ``updated-message`` webhooks for the same
+# iMessage; the two payload shapes often resolve to different session chat IDs (chat GUID
+# vs bare handle), which used to spawn two sessions and double every reply. Drop repeat
+# deliveries of one message GUID inside this window.
+_INBOUND_DEDUP_WINDOW_S = 300.0
+_INBOUND_DEDUP_MAX = 500
 _LOCAL_HOSTS = {"0.0.0.0", "127.0.0.1", "localhost", "::"}
 
 
@@ -134,6 +142,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._inbound_message_ids: OrderedDict[str, float] = OrderedDict()
 
     # --- API helpers ---
 
@@ -557,6 +566,21 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             chat_identifier = sender
         return chat_guid, chat_identifier, sender
 
+    def _drop_duplicate_inbound(self, message_id: Optional[str]) -> bool:
+        """True when this message GUID was already accepted inside the dedup window."""
+        if not message_id:
+            return False
+        now = time.monotonic()
+        seen = self._inbound_message_ids
+        while seen and next(iter(seen.values())) < now - _INBOUND_DEDUP_WINDOW_S:
+            seen.popitem(last=False)
+        if message_id in seen:
+            return True
+        seen[message_id] = now
+        while len(seen) > _INBOUND_DEDUP_MAX:
+            seen.popitem(last=False)
+        return False
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -583,6 +607,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         chat_guid, chat_identifier, sender = self._resolve_chat_and_sender(payload, record)
         if not sender or not (chat_guid or chat_identifier) or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
+        message_id = self._value(record.get("guid"), record.get("messageGuid"), record.get("id"))
+        if self._drop_duplicate_inbound(message_id):
+            logger.debug("[bluebubbles] ignoring repeat delivery of message %s", message_id)
+            return _ok()
         session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -640,3 +640,61 @@ class TestBlueBubblesRepeatDeliveryDedup:
         assert len(handled) == 2
 
 
+class TestBlueBubblesDmSessionCanonicalization:
+    """One DM, one session regardless of webhook payload shape (#106824).
+
+    BlueBubbles emits varying shapes per event for the same DM (full
+    ``service;-;address`` guid vs bare identifier fallback). Without
+    canonicalization each shape opens its own session and both reply in
+    the same chat.
+    """
+
+    async def _chat_id_for(self, monkeypatch, adapter, payload):
+        seen = []
+
+        async def fake_handle_message(event):
+            seen.append(event.source.chat_id)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest(payload))
+        assert response.status == 200
+        await asyncio.sleep(0)
+        assert len(seen) == 1
+        return seen[0]
+
+    @pytest.mark.asyncio
+    async def test_dm_shapes_share_one_session_id(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        base = {
+            "text": "hello",
+            "handle": {"address": "+155****0100"},
+            "isFromMe": False,
+        }
+        shapes = [
+            {"type": "new-message",
+             "data": {**base, "guid": "msg-shape-guid", "chatGuid": "iMessage;-;+155****0100",
+                      "chatIdentifier": "+155****0100"}},
+            {"type": "new-message",
+             "data": {**base, "guid": "msg-shape-ident", "chatIdentifier": "+155****0100"}},
+            {"type": "new-message",
+             "data": {**base, "guid": "msg-shape-bare", "chatGuid": "iMessage;-;+155****0100"}},
+        ]
+        assert {await self._chat_id_for(monkeypatch, adapter, p) for p in shapes} == {"+155****0100"}
+
+    @pytest.mark.asyncio
+    async def test_group_guid_is_preserved_whole(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        chat_id = await self._chat_id_for(monkeypatch, adapter, {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-2",
+                "text": "hello all",
+                "handle": {"address": "+155****0100"},
+                "isFromMe": False,
+                "isGroup": True,
+                "chats": [{"guid": "iMessage;+;group-chat"}],
+            },
+        })
+        assert chat_id == "iMessage;+;group-chat"
+
+

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -567,3 +567,76 @@ class TestBlueBubblesTimeoutErrorNormalization:
         assert "500 Internal Server Error" in (result.error or "")
 
 
+class TestBlueBubblesRepeatDeliveryDedup:
+    @pytest.mark.asyncio
+    async def test_updated_message_with_same_guid_is_acknowledged_and_skipped(
+        self, monkeypatch,
+    ):
+        """BlueBubbles fires new-message + updated-message for one iMessage; the
+        second payload shape often resolves to a different session chat ID, which
+        used to spawn a twin session and double every reply."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "MSG-DUP-1",
+                "text": "hello",
+                "handle": {"address": "+15550001111"},
+                "isFromMe": False,
+                "chats": [{"guid": "iMessage;-;+15550001111"}],
+            },
+        }))
+        await asyncio.sleep(0)
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "MSG-DUP-1",
+                "text": "hello",
+                "handle": {"address": "+15550001111"},
+                "isFromMe": False,
+                "chatIdentifier": "+15550001111",
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert first.status == 200
+        assert second.status == 200
+        assert len(handled) == 1
+
+    @pytest.mark.asyncio
+    async def test_distinct_messages_with_same_text_both_handled(
+        self, monkeypatch,
+    ):
+        """Dedup keys on the message GUID, so a user repeating the same text
+        still gets both messages processed."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        for guid in ("MSG-A", "MSG-B"):
+            await adapter._handle_webhook(_FakeBlueBubblesRequest({
+                "type": "new-message",
+                "data": {
+                    "guid": guid,
+                    "text": "same text twice",
+                    "handle": {"address": "+15550001111"},
+                    "isFromMe": False,
+                    "chats": [{"guid": "iMessage;-;+15550001111"}],
+                },
+            }))
+        await asyncio.sleep(0)
+
+        assert len(handled) == 2
+
+

--- a/tests/tools/test_mcp_method_headers.py
+++ b/tests/tools/test_mcp_method_headers.py
@@ -1,0 +1,136 @@
+"""Tests for the SEP-2243 routing-header hook in ``tools/mcp_tool_transport.py``.
+
+The SDK stamps ``Mcp-Method``/``Mcp-Name`` only in modern (stateless) mode; the hook
+covers the default legacy sessions at the transport layer. Tests drive the hook with
+real httpx requests — no network.
+"""
+
+import builtins
+import json
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+from tools.mcp_tool_transport import _make_method_header_hook
+
+
+def _request(body, headers=None):
+    content = body if isinstance(body, bytes) else json.dumps(body).encode()
+    return httpx.Request("POST", "https://mcp.example/mcp", content=content,
+                         headers=headers or {})
+
+
+def _run_hook(body, headers=None):
+    hook = _make_method_header_hook()
+    assert hook is not None  # pinned SDK ships the header table
+    request = _request(body, headers)
+    hook(request)
+    return request
+
+
+class TestMethodHeaderHook:
+    def test_tools_call_stamps_method_and_name(self):
+        request = _run_hook({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                             "params": {"name": "search", "arguments": {"q": "x"}}})
+        assert request.headers["mcp-method"] == "tools/call"
+        assert request.headers["mcp-name"] == "search"
+
+    def test_resources_read_uses_uri_param(self):
+        request = _run_hook({"jsonrpc": "2.0", "id": 2, "method": "resources/read",
+                             "params": {"uri": "file:///tmp/a.txt"}})
+        assert request.headers["mcp-method"] == "resources/read"
+        assert request.headers["mcp-name"] == "file:///tmp/a.txt"
+
+    def test_plain_method_has_no_name(self):
+        request = _run_hook({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
+        assert request.headers["mcp-method"] == "tools/list"
+        assert "mcp-name" not in request.headers
+
+    def test_notification_without_id_still_routed(self):
+        request = _run_hook({"jsonrpc": "2.0", "method": "notifications/cancelled",
+                             "params": {"requestId": 1}})
+        assert request.headers["mcp-method"] == "notifications/cancelled"
+
+    def test_existing_headers_win(self):
+        request = _run_hook(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "a"}},
+            headers={"mcp-method": "tools/call", "mcp-name": "sdk-value"})
+        assert request.headers["mcp-name"] == "sdk-value"
+
+    def test_non_json_body_untouched(self):
+        hook = _make_method_header_hook()
+        assert hook is not None
+        request = _request(b"not json{{{")
+        hook(request)
+        assert "mcp-method" not in request.headers
+
+    def test_batch_body_untouched(self):
+        hook = _make_method_header_hook()
+        assert hook is not None
+        request = _request([{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}])
+        hook(request)
+        assert "mcp-method" not in request.headers
+
+    def test_non_ascii_name_encoded(self):
+        request = _run_hook({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                             "params": {"name": "recherche été"}})
+        assert request.headers["mcp-name"].startswith("=?base64?")
+
+    def test_missing_sdk_table_means_no_hook(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def _raise_for_inbound(name, *args, **kwargs):
+            if name == "mcp.shared.inbound":
+                raise ImportError("no table")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _raise_for_inbound)
+        assert _make_method_header_hook() is None
+
+
+class TestTransportWiring:
+    def test_streamable_http_installs_request_hook(self):
+        import asyncio
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        from tools import mcp_tool
+        from tools.mcp_tool import MCPServerTask, sdk_httpx
+        from tools.mcp_tool_common import _core
+
+        _core._ensure_mcp_sdk()  # production order: _run_http ensures before transport
+        captured: dict = {}
+
+        class _DummyAsyncClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+        @asynccontextmanager
+        async def _dummy_streams(url, http_client=None):
+            yield (object(), object())
+
+        server = MCPServerTask("hook-wiring")
+
+        async def _enter_transport():
+            with patch.object(sdk_httpx(), "AsyncClient", _DummyAsyncClient), \
+                    patch.object(mcp_tool, "streamable_http_client", _dummy_streams):
+                async with server._streamable_http_transport(
+                        "https://mcp.example/mcp", {}, 5.0, True, None, None, False, set()):
+                    pass
+
+        asyncio.run(_enter_transport())
+        hooks = captured.get("event_hooks", {})
+        assert "response" in hooks and len(hooks.get("request", [])) == 1
+        request = _request({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                            "params": {"name": "search"}})
+        for hook in hooks["request"]:
+            hook(request)
+        assert request.headers["mcp-method"] == "tools/call"
+        assert request.headers["mcp-name"] == "search"

--- a/tests/tools/test_mcp_method_headers.py
+++ b/tests/tools/test_mcp_method_headers.py
@@ -1,12 +1,19 @@
-"""Tests for the SEP-2243 routing-header hook in ``tools/mcp_tool_transport.py``.
+"""SEP-2243 routing headers on streamable HTTP, verified on the wire.
 
-The SDK stamps ``Mcp-Method``/``Mcp-Name`` only in modern (stateless) mode; the hook
-covers the default legacy sessions at the transport layer. Tests drive the hook with
-real httpx requests — no network.
+The SDK stamps ``Mcp-Method``/``Mcp-Name`` only in modern (stateless) mode; Hermes'
+default legacy sessions rely on the transport hook in ``tools/mcp_tool_transport.py``.
+These tests run a real client session against a stub MCP server over real HTTP and
+assert the headers arrive — no mocked transport.
 """
 
+from __future__ import annotations
+
+import asyncio
 import builtins
 import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import cast
 
 import pytest
 
@@ -15,67 +22,144 @@ httpx = pytest.importorskip("httpx")
 from tools.mcp_tool_transport import _make_method_header_hook
 
 
-def _request(body, headers=None):
-    content = body if isinstance(body, bytes) else json.dumps(body).encode()
-    return httpx.Request("POST", "https://mcp.example/mcp", content=content,
-                         headers=headers or {})
+class _StubServer(ThreadingHTTPServer):
+    def __init__(self, *args, **kwargs):
+        self.session_id = "stub-session"
+        self.captured: list = []
+        self.stop_event = threading.Event()
+        super().__init__(*args, **kwargs)
 
 
-def _run_hook(body, headers=None):
-    hook = _make_method_header_hook()
-    assert hook is not None  # pinned SDK ships the header table
-    request = _request(body, headers)
-    hook(request)
-    return request
+class _StubHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    @property
+    def _stub(self) -> _StubServer:
+        return cast("_StubServer", self.server)
+
+    def log_message(self, format, *args):  # noqa: A002 - stdlib signature
+        pass
+
+    def _send_json(self, payload, status=200):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Mcp-Session-Id", self._stub.session_id)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        self._stub.captured.append(
+            (dict(self.headers), body))
+        method = body.get("method", "")
+        if method == "initialize":
+            self._send_json({"jsonrpc": "2.0", "id": body.get("id"),
+                             "result": {
+                                 "protocolVersion": body["params"]["protocolVersion"],
+                                 "capabilities": {},
+                                 "serverInfo": {"name": "stub", "version": "0.1"}}})
+        elif "id" not in body:
+            self.send_response(202)
+            self.send_header("Content-Length", "0")
+            self.send_header("Mcp-Session-Id", self._stub.session_id)
+            self.end_headers()
+        elif method == "tools/call":
+            self._send_json({"jsonrpc": "2.0", "id": body.get("id"),
+                             "result": {"content": [{"type": "text", "text": "ok"}]}})
+        elif method == "tools/list":
+            self._send_json({"jsonrpc": "2.0", "id": body.get("id"),
+                             "result": {"tools": [
+                                 {"name": "search", "description": "stub",
+                                  "inputSchema": {"type": "object"}}]}})
+        else:
+            self._send_json({"jsonrpc": "2.0", "id": body.get("id"),
+                             "error": {"code": -32601, "message": "Method not found"}})
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Mcp-Session-Id", self._stub.session_id)
+        self.end_headers()
+        try:
+            self.wfile.flush()
+            self._stub.stop_event.wait(25)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def do_DELETE(self):
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.send_header("Mcp-Session-Id", self._stub.session_id)
+        self.end_headers()
 
 
-class TestMethodHeaderHook:
-    def test_tools_call_stamps_method_and_name(self):
-        request = _run_hook({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-                             "params": {"name": "search", "arguments": {"q": "x"}}})
-        assert request.headers["mcp-method"] == "tools/call"
-        assert request.headers["mcp-name"] == "search"
+def _posts_to(server, method):
+    return [(dict((k.lower(), v) for k, v in headers.items()), body)
+            for headers, body in server.captured
+            if body.get("method") == method]
 
-    def test_resources_read_uses_uri_param(self):
-        request = _run_hook({"jsonrpc": "2.0", "id": 2, "method": "resources/read",
-                             "params": {"uri": "file:///tmp/a.txt"}})
-        assert request.headers["mcp-method"] == "resources/read"
-        assert request.headers["mcp-name"] == "file:///tmp/a.txt"
 
-    def test_plain_method_has_no_name(self):
-        request = _run_hook({"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
-        assert request.headers["mcp-method"] == "tools/list"
-        assert "mcp-name" not in request.headers
+async def _run_session(url):
+    from mcp.client.session import ClientSession
 
-    def test_notification_without_id_still_routed(self):
-        request = _run_hook({"jsonrpc": "2.0", "method": "notifications/cancelled",
-                             "params": {"requestId": 1}})
-        assert request.headers["mcp-method"] == "notifications/cancelled"
+    from tools.mcp_tool import MCPServerTask
+    from tools.mcp_tool_common import _core
 
+    _core._ensure_mcp_sdk()  # production order: _run_http ensures before transport
+    server = MCPServerTask("wire-test")
+    async with server._streamable_http_transport(
+            url, {}, 5.0, True, None, None, False, set()) as streams:
+        read, write = streams
+        async with ClientSession(read, write, read_timeout_seconds=10) as session:
+            await session.initialize()
+            result = await session.call_tool("search", {"q": "x"})
+    return result
+
+
+@pytest.fixture
+def stub_server():
+    server = _StubServer(("127.0.0.1", 0), _StubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server
+    server.stop_event.set()
+    server.shutdown()
+    thread.join(timeout=5)
+
+
+class TestMethodHeadersOnTheWire:
+    def test_initialize_posts_method_without_name(self, stub_server):
+        asyncio.run(asyncio.wait_for(
+            _run_session(f"http://127.0.0.1:{stub_server.server_port}/mcp"), 25))
+        posts = _posts_to(stub_server, "initialize")
+        assert len(posts) == 1
+        assert posts[0][0]["mcp-method"] == "initialize"
+        assert "mcp-name" not in posts[0][0]
+
+    def test_tools_call_posts_method_and_name(self, stub_server):
+        asyncio.run(asyncio.wait_for(
+            _run_session(f"http://127.0.0.1:{stub_server.server_port}/mcp"), 25))
+        posts = _posts_to(stub_server, "tools/call")
+        assert len(posts) == 1
+        assert posts[0][0]["mcp-method"] == "tools/call"
+        assert posts[0][0]["mcp-name"] == "search"
+
+
+class TestMethodHeaderHookGuards:
     def test_existing_headers_win(self):
-        request = _run_hook(
-            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "a"}},
+        hook = _make_method_header_hook()
+        assert hook is not None
+        request = httpx.Request(
+            "POST", "https://mcp.example/mcp",
+            content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                                "params": {"name": "a"}}).encode(),
             headers={"mcp-method": "tools/call", "mcp-name": "sdk-value"})
+        asyncio.run(hook(request))  # hooks are async: httpx2 awaits them
         assert request.headers["mcp-name"] == "sdk-value"
-
-    def test_non_json_body_untouched(self):
-        hook = _make_method_header_hook()
-        assert hook is not None
-        request = _request(b"not json{{{")
-        hook(request)
-        assert "mcp-method" not in request.headers
-
-    def test_batch_body_untouched(self):
-        hook = _make_method_header_hook()
-        assert hook is not None
-        request = _request([{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}])
-        hook(request)
-        assert "mcp-method" not in request.headers
-
-    def test_non_ascii_name_encoded(self):
-        request = _run_hook({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-                             "params": {"name": "recherche été"}})
-        assert request.headers["mcp-name"].startswith("=?base64?")
 
     def test_missing_sdk_table_means_no_hook(self, monkeypatch):
         real_import = builtins.__import__
@@ -87,50 +171,3 @@ class TestMethodHeaderHook:
 
         monkeypatch.setattr(builtins, "__import__", _raise_for_inbound)
         assert _make_method_header_hook() is None
-
-
-class TestTransportWiring:
-    def test_streamable_http_installs_request_hook(self):
-        import asyncio
-        from contextlib import asynccontextmanager
-        from unittest.mock import patch
-
-        from tools import mcp_tool
-        from tools.mcp_tool import MCPServerTask, sdk_httpx
-        from tools.mcp_tool_common import _core
-
-        _core._ensure_mcp_sdk()  # production order: _run_http ensures before transport
-        captured: dict = {}
-
-        class _DummyAsyncClient:
-            def __init__(self, **kwargs):
-                captured.update(kwargs)
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                return False
-
-        @asynccontextmanager
-        async def _dummy_streams(url, http_client=None):
-            yield (object(), object())
-
-        server = MCPServerTask("hook-wiring")
-
-        async def _enter_transport():
-            with patch.object(sdk_httpx(), "AsyncClient", _DummyAsyncClient), \
-                    patch.object(mcp_tool, "streamable_http_client", _dummy_streams):
-                async with server._streamable_http_transport(
-                        "https://mcp.example/mcp", {}, 5.0, True, None, None, False, set()):
-                    pass
-
-        asyncio.run(_enter_transport())
-        hooks = captured.get("event_hooks", {})
-        assert "response" in hooks and len(hooks.get("request", [])) == 1
-        request = _request({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-                            "params": {"name": "search"}})
-        for hook in hooks["request"]:
-            hook(request)
-        assert request.headers["mcp-method"] == "tools/call"
-        assert request.headers["mcp-name"] == "search"

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -52,7 +52,7 @@ def _make_method_header_hook():
     except ImportError:
         return None
 
-    def _stamp_method_headers(request) -> None:
+    async def _stamp_method_headers(request) -> None:
         if "mcp-method" in request.headers:
             return
         try:

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -4,6 +4,7 @@ protocol negotiation and initial tool discovery. Split from tools/mcp_tool.py.""
 
 import logging
 import asyncio
+import json
 import os
 from contextlib import asynccontextmanager
 from typing import Dict, Optional, Set
@@ -33,6 +34,46 @@ def _is_2xx(resp) -> bool:
 def _present(**kwargs) -> dict:
     """*kwargs* minus the ``None`` values (optional httpx client arguments)."""
     return {k: v for k, v in kwargs.items() if v is not None}
+
+
+def _make_method_header_hook():
+    """httpx request hook stamping SEP-2243 routing headers from the JSON-RPC body.
+
+    The SDK stamps ``Mcp-Method``/``Mcp-Name`` only in modern (stateless) mode; the legacy
+    handshake stamp sends just the protocol version, so Hermes' default legacy sessions hide
+    the method from header-routing gateways. This hook closes the gap at the transport layer
+    for both eras: it derives the headers from the outgoing body and never overrides headers
+    already present (the modern stamp wins). The method → name-param mapping and value
+    encoding come from the SDK's own table so both ends agree by construction; without that
+    table (older SDK) there is no hook to install.
+    """
+    try:
+        from mcp.shared.inbound import NAME_BEARING_METHODS, encode_header_value
+    except ImportError:
+        return None
+
+    def _stamp_method_headers(request) -> None:
+        if "mcp-method" in request.headers:
+            return
+        try:
+            body = json.loads(request.content or b"")
+        except (ValueError, TypeError, UnicodeDecodeError):
+            return
+        if not isinstance(body, dict):
+            return  # batches carry several methods; no single header value exists
+        method = body.get("method")
+        if not isinstance(method, str) or not method:
+            return
+        request.headers["mcp-method"] = method
+        name_key = NAME_BEARING_METHODS.get(method)
+        if name_key is None:
+            return
+        params = body.get("params")
+        name = params.get(name_key) if isinstance(params, dict) else None
+        if isinstance(name, str) and name:
+            request.headers["mcp-name"] = encode_header_value(name)
+
+    return _stamp_method_headers
 
 
 def _pgroup_alive(pgid: Optional[int]) -> bool:
@@ -379,8 +420,12 @@ class MCPServerTransportMixin:
             httpx.URL(url), strict=strict_cfg_headers, configured_header_names=configured_header_names)
         client_kwargs: dict = {"follow_redirects": True, "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                                "verify": ssl_verify, **({"headers": headers} if headers else {}),
-                               "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
                                **_present(auth=oauth_auth, cert=client_cert)}
+        event_hooks: dict = {"response": [_strip_auth_on_cross_origin_redirect]}
+        _method_hook = _make_method_header_hook()
+        if _method_hook is not None:
+            event_hooks["request"] = [_method_hook]
+        client_kwargs["event_hooks"] = event_hooks
 
         @asynccontextmanager
         async def _owned_client_streams():  # the SDK skips cleanup when http_client is provided


### PR DESCRIPTION
Closes #106824.

Webhook payload shapes vary per event for the same DM: sometimes chatGuid is the full service;-;address guid, sometimes it is absent and the session falls back to the bare address. session_chat_id took whichever arrived, so one DM fanned out to two sessions that both replied in the same chat (verified live: two routing keys, two active turns, one DM).

DMs now resolve to the stable bare address; group GUIDs stay whole. Send path is unaffected (bare addresses already resolve via chat query).

Verified: 2 new webhook-level tests (three DM shapes share one id, group guid preserved); full bluebubbles suite 27/27 green; ruff clean; ty zero new.