### PR TITLE
fix(bluebubbles): canonicalize DM session ids across webhook payload shapes

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -583,8 +583,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         chat_guid, chat_identifier, sender = self._resolve_chat_and_sender(payload, record)
         if not sender or not (chat_guid or chat_identifier) or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
-        session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
+        if is_group:
+            # Group guids keep their full shape so distinct chats stay distinct.
+            session_chat_id = chat_guid or chat_identifier
+        else:
+            # Canonicalize DM routing to the bare address: payloads vary in
+            # shape for the same DM (full ``service;-;address`` guid vs. bare
+            # identifier only), which would otherwise fork one DM into two
+            # sessions with separate routing keys. Outbound calls already
+            # re-resolve bare addresses via _resolve_chat_guid (#24157).
+            session_chat_id = chat_identifier or chat_guid.split(";-;", 1)[-1]
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):
                 logger.debug("[bluebubbles] ignoring group message (require_mention=true, no mention pattern matched)")

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -175,6 +175,92 @@ class TestBlueBubblesWebhookParsing:
         assert record == payload["data"][0]
 
 
+class TestBlueBubblesDmSessionNormalization:
+    """Regression for #106824: varying webhook payload shapes for the same DM
+    must resolve to a single session id, while group guids keep their full shape.
+    """
+
+    @staticmethod
+    def _capture_adapter(monkeypatch):
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        return adapter, handled
+
+    @pytest.mark.asyncio
+    async def test_dm_payload_shapes_converge_on_one_session_id(self, monkeypatch):
+        adapter, handled = self._capture_adapter(monkeypatch)
+        guid_shape = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-1",
+                "text": "hello",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;+15555550100",
+                "chatIdentifier": "+15555550100",
+            },
+        }
+        bare_shape = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-2",
+                "text": "hello again",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "chatIdentifier": "+15555550100",
+            },
+        }
+        first = await adapter._handle_webhook(_FakeBlueBubblesRequest(guid_shape))
+        second = await adapter._handle_webhook(_FakeBlueBubblesRequest(bare_shape))
+        await asyncio.sleep(0)
+
+        assert first.status == 200 and second.status == 200
+        assert len(handled) == 2
+        assert {event.source.chat_id for event in handled} == {"+15555550100"}
+
+    @pytest.mark.asyncio
+    async def test_dm_with_guid_only_strips_service_prefix(self, monkeypatch):
+        adapter, handled = self._capture_adapter(monkeypatch)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-3",
+                "text": "hello",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;+15555550100",
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled[0].source.chat_id == "+15555550100"
+
+    @pytest.mark.asyncio
+    async def test_group_guid_keeps_full_shape(self, monkeypatch):
+        adapter, handled = self._capture_adapter(monkeypatch)
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-4",
+                "text": "hello team",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;+;chat0000000000-family",
+                "chatIdentifier": "chat0000000000",
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert handled[0].source.chat_id == "iMessage;+;chat0000000000-family"
+
+
 class TestBlueBubblesGuidResolution:
 
 


### PR DESCRIPTION
## What does this PR do?

BlueBubbles emits varying payload shapes for the same 1:1 DM: sometimes `chatGuid` carries the full `service;-;address` guid, sometimes it is absent and `_handle_webhook` falls back to the bare `chatIdentifier`. The unnormalized `session_chat_id = chat_guid or chat_identifier` therefore resolved one DM to two session ids, fanning messages out to two sessions that both reply in the same chat and share a working directory (verified live by the reporter).

This canonicalizes 1:1 DM routing to the bare address: prefer `chatIdentifier`, and strip the `service;-;` prefix when only the guid is available. Group guids keep their full shape so distinct group chats never collapse. Outbound calls (read receipts via `mark_read`, typing indicators) already re-resolve bare addresses through `_resolve_chat_guid` (#24157), so they are unaffected.

## Related Issue

Fixes #106824

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py`: compute `is_group` first; DMs route on `chatIdentifier` (or the guid with the `service;-;` prefix stripped), groups keep the full guid.
- `tests/gateway/test_bluebubbles.py`: regression tests — both payload shapes for one DM converge on a single `source.chat_id`, guid-only DMs resolve to the bare address, and group guids keep their full shape.

## How to Test

1. Run `pytest tests/gateway/test_bluebubbles.py -q` — Observed result: 26 passed (23 pre-existing + 3 new).
2. Run `pytest tests/gateway/test_bluebubbles.py tests/gateway/test_aiohttp_body_caps.py tests/gateway/test_adapter_startup_secret_scope.py -q` — Observed result: 102 passed.
3. New test `test_dm_payload_shapes_converge_on_one_session_id` feeds the same DM as two payload shapes (full guid vs. bare identifier) and asserts a single session id — should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A