### PR TITLE
fix(desktop): open explicit chat links in a new Browser tab

### DIFF
--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -108,6 +108,66 @@ describe('preview store', () => {
     expect(new Set(urlTabs.map(tab => tab.id)).size).toBe(2)
   })
 
+  // A chat click is an explicit ask for that page. It must not replace the
+  // Browser you already have — an unfinished form on that tab would vanish.
+  it('opens an explicit chat URL in its own Browser tab without replacing the vessel', () => {
+    const urlA = 'https://forms.example/dashboard'
+    const urlB = 'https://docs.example/chat-link'
+    const urlC = 'https://agent.example/tool-page'
+
+    openPreview(urlTarget(urlA), 'tool-result')
+    const formTabId = $previewTabs.get()[0].id
+
+    openPreview(urlTarget(urlB), 'explicit-link')
+
+    let urlTabs = $previewTabs.get().filter(tab => tab.target.kind === 'url')
+
+    expect(urlTabs).toHaveLength(2)
+    expect($previewTabs.get().find(tab => tab.id === formTabId)?.target.url).toBe(urlA)
+    expect($previewTarget.get()?.url).toBe(urlB)
+    expect($rightRailActiveTabId.get()).not.toBe(formTabId)
+
+    const clickedTabId = $rightRailActiveTabId.get()
+
+    openPreview(urlTarget(urlB), 'explicit-link')
+
+    urlTabs = $previewTabs.get().filter(tab => tab.target.kind === 'url')
+
+    expect(urlTabs).toHaveLength(2)
+    expect($rightRailActiveTabId.get()).toBe(clickedTabId)
+    expect($previewTabs.get().find(tab => tab.id === formTabId)?.target.url).toBe(urlA)
+
+    openPreview(urlTarget(urlC), 'tool-result')
+
+    urlTabs = $previewTabs.get().filter(tab => tab.target.kind === 'url')
+
+    expect(urlTabs).toHaveLength(2)
+    expect($previewTabs.get().find(tab => tab.id === formTabId)?.target.url).toBe(urlA)
+    expect($previewTarget.get()?.url).toBe(urlC)
+    expect($rightRailActiveTabId.get()).toBe(clickedTabId)
+  })
+
+  it('re-fronts the matching Browser when the same chat URL is clicked again', () => {
+    const urlA = 'https://chat.example/one'
+    const urlB = 'https://chat.example/two'
+
+    openPreview(urlTarget(urlA), 'explicit-link')
+    const first = $rightRailActiveTabId.get()
+
+    openPreview(urlTarget(urlB), 'explicit-link')
+    const second = $rightRailActiveTabId.get()
+
+    expect($previewTabs.get().filter(tab => tab.target.kind === 'url')).toHaveLength(2)
+    expect(second).not.toBe(first)
+
+    openPreview(urlTarget(urlA), 'explicit-link')
+
+    expect($previewTabs.get().filter(tab => tab.target.kind === 'url')).toHaveLength(2)
+    expect($rightRailActiveTabId.get()).toBe(first)
+    expect($previewTabs.get().find(tab => tab.id === first)?.target.url).toBe(urlA)
+    expect($previewTabs.get().find(tab => tab.id === second)?.target.url).toBe(urlB)
+  })
+
   // Which Browser a link lands in: the one on screen. Selecting the older tab
   // must send the next page there, not to whichever was opened most recently.
   it('navigates the Browser you are looking at', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -352,9 +352,8 @@ function mintBrowserTabId(): RightRailTabId {
 }
 
 /** The Browser a URL should open in: the one you're looking at, else the one
- *  you used last. A link from chat navigates the browser you already have
- *  rather than stacking another identical tab — new tabs are something you
- *  ask for (the strip's "+"), the way they are in a real browser. */
+ *  you used last. Tool/manual navigation uses this vessel rather than stacking
+ *  another tab — explicit chat clicks mint or re-front in `openPreview`. */
 function browserTabId(tabs: PreviewTab[]): RightRailTabId {
   const active = tabs.find(tab => tab.id === $rightRailActiveTabId.get())
 
@@ -363,6 +362,24 @@ function browserTabId(tabs: PreviewTab[]): RightRailTabId {
   }
 
   return tabs.findLast(isBrowserTab)?.id ?? mintBrowserTabId()
+}
+
+/** Compare Browser URLs after a light canonicalize so `https://a.com` and
+ *  `https://a.com/` are the same tab, while still failing open on junk. */
+function canonicalBrowserUrl(url: string): string {
+  const trimmed = url.trim()
+
+  try {
+    return new URL(trimmed).href
+  } catch {
+    return trimmed
+  }
+}
+
+function matchingBrowserTabId(tabs: PreviewTab[], url: string): RightRailTabId | undefined {
+  const canonical = canonicalBrowserUrl(url)
+
+  return tabs.findLast(tab => isBrowserTab(tab) && canonicalBrowserUrl(tab.target.url) === canonical)?.id
 }
 
 // Browsing files is "peek at the source"; a tool or an explicit link handing
@@ -381,11 +398,20 @@ function previewTargetForSource(target: PreviewTarget, source: PreviewRecordSour
 
 /** Open (or re-front) the tab for `target`. Re-opening an existing tab refreshes
  *  its target so a stale label/path can't outlive the thing it points at. The
- *  only way anything reaches a preview. */
+ *  only way anything reaches a preview.
+ *
+ *  An explicit chat URL (`source === 'explicit-link'`) is a user ask for that
+ *  page: re-front a tab already showing it, otherwise mint a new Browser.
+ *  Tool/manual/file-browser URLs still navigate the current vessel. */
 export function openPreview(target: PreviewTarget, source: PreviewRecordSource = 'manual') {
   const resolved = previewTargetForSource(target, source)
   const current = $previewTabs.get()
-  const id = resolved.kind === 'url' ? browserTabId(current) : previewTabId(resolved)
+  const id =
+    resolved.kind === 'url'
+      ? source === 'explicit-link'
+        ? (matchingBrowserTabId(current, resolved.url) ?? mintBrowserTabId())
+        : browserTabId(current)
+      : previewTabId(resolved)
   const index = current.findIndex(tab => tab.id === id)
   const tab: PreviewTab = { id, target: resolved }
 


### PR DESCRIPTION
## Summary
- Explicit chat URL clicks (`source === 'explicit-link'`) now mint a new Browser tab or re-front a matching URL tab, instead of replacing the active vessel page.
- Tool/manual/file-browser URL opens keep the existing vessel navigation so agent tool results do not flood tabs.
- Addresses unfinished-form loss when clicking a different HTTPS link from chat while a dashboard is open in the Desktop browser pane.

Fixes #106825

## Proof
- **BEFORE (RED)**: `apps/desktop` vitest `src/store/preview.test.ts` — new cases failed with tab length 1 (explicit-link still replaced vessel).
- **AFTER (GREEN)**: same focused suite — 22 passed.
- **CONTROL**: existing tool-result vessel navigation / multi-Browser-on-request tests still pass.

Command:
```bash
cd apps/desktop && NODE_OPTIONS='--localstorage-file=/tmp/hermes-vitest-localstorage' \
  npx vitest run src/store/preview.test.ts
```

## Risks
- URL matching uses light `new URL(...).href` canonicalize; junk URLs fail open to trimmed-string compare.
- No user preference UI; default behavior change is limited to explicit-link URL opens.

## Test plan
- [ ] Click two different HTTPS links from chat while a browser form/dashboard tab is open — form tab retained, second link opens/focuses another tab
- [ ] Click the same chat URL twice — re-fronts matching tab, no duplicate
- [ ] Agent/tool URL open still navigates the active Browser vessel (no extra tabs)

Made with [Cursor](https://cursor.com)