### PR TITLE
fix(update): avoid polkit prompts for dashboard restarts

### DIFF
--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -120,11 +120,13 @@ def _restart_managed_dashboard_service(reason: str, unit: str = _DASHBOARD_SYSTE
     print(f"\n⟲ Restarting managed dashboard service ({reason})")
 
     scope_label = "systemctl --user" if scope else "sudo systemctl"
-    commands = [("systemctl", *scope, "restart", unit)]
+    commands = [("systemctl", *scope, "--no-ask-password", "restart", unit)]
     if not scope:
         # System units may require privilege escalation; user units must use
         # the user manager directly and never prompt for sudo.
-        commands.append(("sudo", "-n", "systemctl", "restart", unit))
+        commands.append(
+            ("sudo", "-n", "systemctl", "--no-ask-password", "restart", unit)
+        )
 
     errors: list[str] = []
     for command in commands:
@@ -195,13 +197,19 @@ def _get_pid_cgroup_path(pid: int) -> str | None:
 def _try_restart_systemd_service(svc_name: str, cgroup_path: str | None = None) -> bool:
     """Restart *svc_name* via systemctl (``--user`` for user-scope units). True on success.
 
-    Unknown scope tries system first, then user.
+    System units use non-interactive sudo for non-root callers, and every command
+    disables polkit prompts. Unknown scope tries system first, then user.
     """
+    from hermes_cli.update_cmd_fleet import _needs_sudo
+
     scope = _extract_scope_from_cgroup(cgroup_path) if cgroup_path else None
-    system_cmd = ["systemctl", "restart", svc_name]
-    user_cmd = ["systemctl", "--user", "restart", svc_name]
+    system_cmd = ("system", ["systemctl"])
+    user_cmd = ("user", ["systemctl", "--user"])
     candidates = {"user": [user_cmd], "system": [system_cmd]}.get(scope, [system_cmd, user_cmd])
-    for cmd in candidates:
+    for candidate_scope, prefix in candidates:
+        cmd = [*prefix, "--no-ask-password", "restart", svc_name]
+        if _needs_sudo(candidate_scope):
+            cmd = ["sudo", "-n", *cmd]
         try:
             if _run_probe(cmd, timeout=15).returncode == 0:
                 return True

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -239,7 +239,7 @@ class TestKillStaleDashboardPosix:
                 return MagicMock(returncode=0, stdout="active\n", stderr="")
             if args == ["systemctl", "--user", "is-enabled", "hermes-dashboard.service"]:
                 return MagicMock(returncode=0, stdout="enabled\n", stderr="")
-            if args == ["systemctl", "--user", "restart", "hermes-dashboard.service"]:
+            if args == ["systemctl", "--user", "--no-ask-password", "restart", "hermes-dashboard.service"]:
                 return MagicMock(returncode=0, stdout="", stderr="")
             raise AssertionError(f"unexpected subprocess.run call: {args}")
 
@@ -252,7 +252,7 @@ class TestKillStaleDashboardPosix:
             ["systemctl", "--user", "list-unit-files", "hermes-dashboard.service", "--no-legend", "--no-pager"],
             ["systemctl", "--user", "is-active", "hermes-dashboard.service"],
             ["systemctl", "--user", "is-enabled", "hermes-dashboard.service"],
-            ["systemctl", "--user", "restart", "hermes-dashboard.service"],
+            ["systemctl", "--user", "--no-ask-password", "restart", "hermes-dashboard.service"],
         ]
         assert all(call[:1] != ["sudo"] and call[:2] != ["systemctl"] for call in calls)
         # The pass keeps scanning for serve backends the dashboard unit does
@@ -381,6 +381,78 @@ class TestSupervisedBackendRestart:
 
     def _live(self):
         return main_dashboard
+
+    def test_managed_system_restart_disables_polkit_prompts(self):
+        """The standard system service restart must also remain non-interactive."""
+        restart_calls = []
+
+        def run_probe(command, *, timeout):
+            if "list-unit-files" in command:
+                return subprocess.CompletedProcess(
+                    command,
+                    1 if "--user" in command else 0,
+                    stdout="hermes-dashboard.service enabled\n",
+                )
+            if "is-active" in command:
+                return subprocess.CompletedProcess(command, 0, stdout="active\n")
+            if "is-enabled" in command:
+                return subprocess.CompletedProcess(command, 0, stdout="enabled\n")
+            if "restart" in command:
+                restart_calls.append(command)
+                return subprocess.CompletedProcess(command, 0)
+            raise AssertionError(command)
+
+        with patch.object(main_dashboard, "_run_probe", side_effect=run_probe):
+            restarted = main_dashboard._restart_managed_dashboard_service("update")
+
+        assert restarted is True
+        assert restart_calls == [[
+            "systemctl", "--no-ask-password", "restart", "hermes-dashboard.service",
+        ]]
+
+    def test_system_scope_restart_uses_noninteractive_sudo(self):
+        """A system unit must never send the updater through a polkit prompt."""
+        calls = []
+
+        def run_probe(command, *, timeout):
+            calls.append((command, timeout))
+            return subprocess.CompletedProcess(command, 0)
+
+        with patch("hermes_cli.update_cmd_fleet._needs_sudo", return_value=True), \
+             patch.object(main_dashboard, "_run_probe", side_effect=run_probe):
+            restarted = main_dashboard._try_restart_systemd_service(
+                "hermes-conduit.service", "/system.slice/hermes-conduit.service"
+            )
+
+        assert restarted is True
+        assert calls == [
+            ([
+                "sudo", "-n", "systemctl", "--no-ask-password", "restart",
+                "hermes-conduit.service",
+            ], 15)
+        ]
+
+    def test_refused_system_scope_restart_never_retries_interactively(self):
+        """A refused sudo restart returns promptly instead of trying plain systemctl."""
+        calls = []
+
+        def run_probe(command, *, timeout):
+            calls.append((command, timeout))
+            return subprocess.CompletedProcess(command, 1)
+
+        with patch("hermes_cli.update_cmd_fleet._needs_sudo", return_value=True), \
+             patch.object(main_dashboard, "_run_probe", side_effect=run_probe):
+            restarted = main_dashboard._try_restart_systemd_service(
+                "hermes-conduit.service", "/system.slice/hermes-conduit.service"
+            )
+
+        assert restarted is False
+        assert calls == [
+            ([
+                "sudo", "-n", "systemctl", "--no-ask-password", "restart",
+                "hermes-conduit.service",
+            ], 15)
+        ]
 
     def test_supervised_pid_restarts_owning_unit(self, capsys):
         """A killed PID whose cgroup names a custom unit → systemctl restart."""


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes update` from opening an interactive polkit password prompt while restarting dashboard backends. A prompt cannot be answered through the updater's captured subprocess, so the restart times out and leaves the service stopped.

System-scope custom units now use passwordless `sudo` when needed, and all dashboard restart commands pass `systemctl --no-ask-password`. User-scope units continue to use `systemctl --user` directly.

## Related issue

No exact open issue or PR found. The supervised-backend restart path was added in #72192.

## Type of change

- [x] Bug fix

## Changes made

- Make standard and cgroup-discovered dashboard service restarts non-interactive.
- Return promptly when passwordless privilege escalation is unavailable.
- Add regression coverage for standard system units, custom system units, and refused sudo.
- Focused updater suite: 104 passed, 3 platform-specific skips.
- Ruff and the Windows footgun scan pass.

## Checklist

- [x] Read the contributing guide.
- [x] Searched existing issues and pull requests.
- [x] Used a Conventional Commit.
- [x] Kept the change scoped to updater restart behavior.
- [x] Added regression tests and considered cross-platform impact.
- [x] Documentation and config changes are not applicable.
