### PR TITLE
fix(send): report partial Telegram media delivery as failure

### DIFF
--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -77,6 +77,21 @@ def fake_tool(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_partial_media_failure_exits_one(fake_tool, capsys):
+    fake_tool.payload = {
+        "error": "Failed to deliver 1 of 1 Telegram media attachments",
+        "partial_success": True,
+        "message_id": "m123",
+    }
+
+    args = _parse(["--to", "telegram:12345", "Daily report"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+
+    assert exc.value.code == 1
+    assert "Failed to deliver" in capsys.readouterr().err
+
+
 
 
 def test_file_decode_error_suggests_media_directive(fake_tool, capsys, monkeypatch, tmp_path):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -466,6 +466,36 @@ class TestSendTelegramMediaDelivery:
         assert "No deliverable text or media remained" in result["error"]
         bot.send_message.assert_not_awaited()
 
+    def test_media_failure_after_text_delivery_returns_partial_error(self, tmp_path, monkeypatch):
+        report_path = tmp_path / "report.html"
+        report_path.write_text("<html><body>report</body></html>")
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock(side_effect=RuntimeError("upload timed out"))
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "token",
+                "12345",
+                "Daily report",
+                media_files=[(str(report_path), False)],
+            )
+        )
+
+        assert "error" in result
+        assert result["partial_success"] is True
+        assert result["message_id"] == "1"
+        assert "1 of 1 Telegram media attachments" in result["error"]
+        assert "upload timed out" in result["warnings"][0]
+        bot.send_message.assert_awaited_once()
+        bot.send_document.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # Regression: long messages are chunked before platform dispatch

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -250,7 +250,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         thread_kwargs = _telegram_thread_kwargs(thread_id)
         # disable_web_page_preview is only valid for send_message, not media sends.
         text_kwargs = {**thread_kwargs, **({"disable_web_page_preview": True} if disable_link_previews else {})}
-        last_msg, warnings, _tg_caption = None, [], None
+        last_msg, warnings, media_failures, _tg_caption = None, [], [], None
         # MEDIA caption rides on the bubble as its *formatted* caption; formatting can inflate a
         # raw <1024 string past Telegram's cap, so re-check in UTF-16 units.
         _cap, _ = _media_caption_split(message, media_files, max_caption_len=_TELEGRAM_CAPTION_LIMIT)
@@ -261,8 +261,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             last_msg = await _telegram_send_text_chunk(bot, int_chat_id, chunk, send_parse_mode, _has_html, text_kwargs)
         for media_path, is_voice in media_files:
             if not os.path.exists(media_path):
-                warnings.append(f"Media file not found, skipping: {media_path}")
-                logger.warning(warnings[-1])
+                failure = f"Media file not found, skipping: {media_path}"
+                warnings.append(failure)
+                media_failures.append(failure)
+                logger.warning(failure)
                 # Caption mode suppressed the text send; the file is gone, so deliver the words alone.
                 if _tg_caption is not None and last_msg is None:
                     try:
@@ -278,10 +280,23 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                     bot, int_chat_id, media_path, is_voice, caption=_tg_caption, parse_mode=send_parse_mode,
                     has_html=_has_html, thread_kwargs=thread_kwargs, force_document=force_document)
             except Exception as e:
-                warnings.append(_sanitize_error_text(f"Failed to send media {media_path}: {e}"))
-                logger.error(warnings[-1])
+                failure = _sanitize_error_text(f"Failed to send media {media_path}: {e}")
+                warnings.append(failure)
+                media_failures.append(failure)
+                logger.error(failure)
         if last_msg is None:
             return {"error": _NO_DELIVERABLE, **({"warnings": warnings} if warnings else {})}
+        if media_failures:
+            result = {
+                "error": (
+                    f"Failed to deliver {len(media_failures)} of "
+                    f"{len(media_files)} Telegram media attachments"
+                ),
+                "warnings": warnings,
+                "partial_success": True,
+                "message_id": str(last_msg.message_id),
+            }
+            return result
         return _success("telegram", chat_id, warnings, message_id=str(last_msg.message_id))
     except ImportError:
         return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}


### PR DESCRIPTION
## What does this PR do?

Telegram sends currently return `success: true` when a text message was
delivered but a requested media attachment failed. Because `hermes send`
maps that result to exit code 0, scripts and cron jobs can report successful
delivery even though the attachment is missing.

This change tracks requested media failures separately and returns an error
with `partial_success: true` and the delivered message ID when earlier content
was already sent. Telegram timeouts are not retried because the platform may
have accepted the upload before the client timed out.

## Related Issue

N/A — no matching open issue or pull request was found.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- Treat missing or failed Telegram media attachments as delivery failures.
- Preserve partial-delivery information when text or an earlier attachment succeeded.
- Make `hermes send` exit with code 1 for partial media delivery.
- Add regression tests for the sender result and CLI exit code.

## How to Test

1. `pytest tests/tools/test_send_message_tool.py tests/hermes_cli/test_send_cmd.py -q`
2. `ruff check tools/send_message_senders.py tests/tools/test_send_message_tool.py tests/hermes_cli/test_send_cmd.py`

Result: 60 passed; Ruff checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and pull requests for duplicates.
- [x] This PR contains only changes related to this fix.
- [ ] I've run the complete `pytest tests/ -q` suite locally; focused coverage passed and the draft PR is ready for CI.
- [x] I've added regression tests for the bug.
- [x] I've tested the focused behavior on macOS.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or command syntax changes.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A.
- [x] Cross-platform impact considered; the result-shape change is platform-independent Python.
- [x] Tool description/schema update: N/A; the existing error contract is reused.
