### PR TITLE
fix(agent): keep credential pool rotating through z.ai quota-exhaustion cascades

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -655,7 +655,13 @@ _STATUS_TO_FAILOVER_REASON = {
     403: FailoverReason.auth,
 }
 _USAGE_LIMIT_REASON_TOKENS = ("usage_limit_reached", "gousagelimit")
-_USAGE_LIMIT_MESSAGE_TOKENS = ("usage limit reached", "usage limit has been reached")
+_USAGE_LIMIT_MESSAGE_TOKENS = (
+    "usage limit reached", "usage limit has been reached",
+    # z.ai coding-plan quota tiers ("Weekly/Monthly Limit Exhausted. Your limit will
+    # reset at ...", error code 1310) — semipermanent until the stated reset, so rotate
+    # immediately instead of burning a retry on the same depleted key.
+    "limit exhausted",
+)
 
 
 def _failed_credential_identity(agent, pool) -> Tuple[Optional[str], Optional[str]]:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6821,11 +6821,18 @@ def _ladder_credential_rungs(
                 return (yield _LadderStep(
                     "retry_same_provider", (resolved_provider, route.resolved_model))), None
             except Exception as retry2_err:
-                # Rotated key also hit a wall: mark it now so concurrent processes skip it,
-                # then fall through to the provider fallback.
+                # The post-rotation retry also hit a wall. Attribute the failure to the key
+                # we KNOW failed (_client_api_key): the retry runs through the route-label
+                # client cache (e.g. "auto"), which embeds the pre-rotation main-runtime key,
+                # so a fast retry2 failure is usually the SAME stale key again. Marking the
+                # pool's current() here benches the just-rotated-to healthy entry with the
+                # old key's error (observed: healthy second z.ai key benched 0.4s after
+                # rotation, taking the whole pool offline). If the rotated key genuinely
+                # failed, the next recovery cycle identifies and marks it via its own
+                # _client_api_key instead — one extra failure cycle at worst.
                 if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
                         or _is_rate_limit_error(retry2_err)):
-                    _recover_provider_pool(pool_provider, retry2_err)
+                    _recover_provider_pool(pool_provider, retry2_err, failed_api_key=_client_api_key)
                     first_err = retry2_err
                 else:
                     raise

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -718,7 +718,21 @@ def _api_key_provider_runtime(provider, pconfig, requested_provider, model_cfg, 
                                           target_model or model_cfg.get("default", ""), opencode_by_model=True)
     base_url = _finalize_base_url(provider, api_mode, base_url)
     api_key = _actual_local_key(provider, creds.get("api_key", ""), base_url)
-    return _runtime(provider, api_mode, base_url, api_key, source=creds.get("source", "env"), requested_provider=requested_provider)
+    # Mirror the explicit-runtime ladder fix: when the resolved env/config key is itself a
+    # member of this provider's pool, attach that pool so a 429/402 can rotate to the next
+    # key. Without this, a session that starts while every pool entry is in cooldown
+    # (``_resolve_from_pool`` -> ``pool.select()`` returned None) runs on a bare env key and
+    # can never rotate — it burns max_retries on the dead key and aborts the turn.
+    credential_pool = None
+    try:
+        _pool = load_pool(provider)
+    except Exception:
+        _pool = None
+    if _pool is not None and _pool.has_credentials():
+        if any(entry.runtime_api_key == api_key for entry in _pool.entries()):
+            credential_pool = _pool
+    return _runtime(provider, api_mode, base_url, api_key, source=creds.get("source", "env"),
+                    requested_provider=requested_provider, credential_pool=credential_pool)
 
 
 # ── the resolution ladder ──────────────────────────────────────────────────────────────────

--- a/tests/agent/test_zai_quota_rotation.py
+++ b/tests/agent/test_zai_quota_rotation.py
@@ -1,0 +1,70 @@
+"""z.ai coding-plan quota 429s (error code 1310) must rotate immediately.
+
+The message "Weekly/Monthly Limit Exhausted. Your limit will reset at <ts>" is a
+semipermanent account cap, not a transient throttle: retrying the same key once before
+rotating just burns a request. The ``limit exhausted`` usage-limit token makes the
+rate-limit recovery branch rotate on the FIRST 429.
+"""
+
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import recover_with_credential_pool
+from agent.credential_pool import CredentialPool, PooledCredential
+from agent.error_classifier import FailoverReason
+
+ZAI_1310_MESSAGE = (
+    "Error code: 429 - {'error': {'code': '1310', 'message': "
+    "'Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-09-10 22:41:42'}}"
+)
+
+
+def _pool_two_keys():
+    failed = PooledCredential(
+        id="failed", provider="zai", label="GLM_API_KEY", auth_type="api_key",
+        priority=0, source="env:GLM_API_KEY", access_token="key-failed",
+    )
+    healthy = PooledCredential(
+        id="healthy", provider="zai", label="ZAI_API_KEY", auth_type="api_key",
+        priority=1, source="env:ZAI_API_KEY", access_token="key-healthy",
+    )
+    return CredentialPool("zai", [failed, healthy]), failed, healthy
+
+
+def test_zai_limit_exhausted_rotates_on_first_429():
+    pool, failed, healthy = _pool_two_keys()
+    agent = SimpleNamespace(
+        provider="zai", api_key="key-failed", _credential_pool=pool,
+        _credential_pool_entry_id="failed",
+        _swap_credential=lambda entry: None,
+    )
+    recovered, has_retried = recover_with_credential_pool(
+        agent, status_code=429, has_retried_429=False,
+        classified_reason=FailoverReason.rate_limit,
+        error_context={"message": ZAI_1310_MESSAGE},
+    )
+    # Immediate rotation: no same-key retry burned on a weekly/monthly cap.
+    assert (recovered, has_retried) == (True, False)
+    stored = {entry.id: entry for entry in pool.entries()}
+    assert stored["failed"].last_status == "exhausted"
+    assert stored["failed"].last_error_code == 429
+    assert stored["healthy"].last_status is None
+
+
+def test_zai_limit_exhausted_marks_failed_key_not_healthy():
+    """The exhausted marking must land on the key that served the request, so the
+    surviving key stays available for the rotation."""
+    pool, failed, healthy = _pool_two_keys()
+    agent = SimpleNamespace(
+        provider="zai", api_key="key-failed", _credential_pool=pool,
+        _credential_pool_entry_id="failed",
+        _swap_credential=lambda entry: None,
+    )
+    recover_with_credential_pool(
+        agent, status_code=429, has_retried_429=False,
+        classified_reason=FailoverReason.rate_limit,
+        error_context={"message": ZAI_1310_MESSAGE},
+    )
+    stored = {entry.id: entry for entry in pool.entries()}
+    assert stored["failed"].last_status == "exhausted"
+    assert stored["healthy"].last_status is None
+    assert pool.has_available()

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1783,3 +1783,81 @@ def test_custom_provider_pool_target_model_wins(monkeypatch):
 
     assert resolved is not None
     assert resolved["model"] == "myproxy/gemini-flash"
+
+
+class TestApiKeyProviderPoolAttachment:
+    """Env/config api_key runtimes must carry the provider pool when the resolved key is a
+    pool member. Sessions that start while every pool entry is in exhaustion cooldown fall
+    through ``_resolve_from_pool`` (``pool.select()`` returns None) onto the bare env key;
+    without the pool attached, a 429 can never rotate and the turn dies after max_retries."""
+
+    @staticmethod
+    def _pool_with(entries):
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return None  # every entry in cooldown: forces the env fallback path
+
+            def entries(self):
+                return list(entries)
+
+        return _Pool()
+
+    def _resolve_zai(self, monkeypatch, pool):
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {"provider": "zai", "default": "glm-5.3"},
+        )
+        monkeypatch.setattr(rp, "load_pool", lambda _provider: pool)
+        monkeypatch.setattr(
+            rp,
+            "resolve_api_key_provider_credentials",
+            lambda _provider: {
+                "provider": "zai",
+                "api_key": "env-zai-key",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "source": "env",
+            },
+        )
+        return rp.resolve_runtime_provider(requested="zai")
+
+    def test_pool_attached_when_env_key_is_pool_member(self, monkeypatch):
+        pool = self._pool_with([SimpleNamespace(runtime_api_key="env-zai-key")])
+        resolved = self._resolve_zai(monkeypatch, pool)
+        assert resolved["provider"] == "zai"
+        assert resolved["api_key"] == "env-zai-key"
+        assert resolved["credential_pool"] is pool
+
+    def test_pool_not_attached_when_env_key_is_not_pool_member(self, monkeypatch):
+        pool = self._pool_with([SimpleNamespace(runtime_api_key="some-other-key")])
+        resolved = self._resolve_zai(monkeypatch, pool)
+        assert resolved["api_key"] == "env-zai-key"
+        assert resolved["credential_pool"] is None
+
+    def test_pool_attach_survives_load_pool_failure(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "_get_model_config",
+            lambda: {"provider": "zai", "default": "glm-5.3"},
+        )
+
+        def _boom(_provider):
+            raise RuntimeError("auth store unavailable")
+
+        monkeypatch.setattr(rp, "load_pool", _boom)
+        monkeypatch.setattr(
+            rp,
+            "resolve_api_key_provider_credentials",
+            lambda _provider: {
+                "provider": "zai",
+                "api_key": "env-zai-key",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "source": "env",
+            },
+        )
+        resolved = rp.resolve_runtime_provider(requested="zai")
+        assert resolved["api_key"] == "env-zai-key"
+        assert resolved["credential_pool"] is None


### PR DESCRIPTION
## Problem

With a z.ai (GLM coding plan) credential pool of 2+ API keys, one key hitting its
weekly/monthly quota (HTTP 429, error code 1310, `Weekly/Monthly Limit Exhausted. Your
limit will reset at ...`) could take the **whole pool offline** and make sessions abort
with `API call failed after 3 retries` instead of rotating to the healthy key. Three
compounding defects, all reproduced from production logs:

1. **Env api_key runtimes carry no pool, so they can never rotate.**
   When every pool entry is in exhaustion cooldown, `_resolve_from_pool()` gets
   `pool.select() -> None` and the ladder falls through to `_api_key_provider_runtime()`,
   which returns a runtime with `credential_pool=None`. A session starting in that window
   runs on a bare env key: every 429 hits `recover_with_credential_pool()` with no pool,
   burns `max_retries` on the dead key and aborts the turn. Whether a session could rotate
   depended purely on *when* it started — some sessions worked, others hard-failed.

2. **The z.ai quota message matched no usage-limit token.**
   `Weekly/Monthly Limit Exhausted` contains none of the `_USAGE_LIMIT_MESSAGE_TOKENS`,
   so the rate-limit recovery branch retried the same depleted key once before rotating —
   a guaranteed-wasted request on a cap that resets days later.

3. **The auxiliary ladder benched the healthy rotated-to key.**
   After a successful pool rotation, the aux ladder's `retry_same_provider` goes through
   the route-label client cache (e.g. `auto`), whose key embeds the pre-rotation
   main-runtime api_key digest — so a fast retry2 failure is usually the *same stale key*
   again. The retry2 recovery called `_recover_provider_pool(...)` **without**
   `failed_api_key`, so `mark_exhausted_and_rotate()` fell back to `pool.current()` and
   marked the just-rotated-to **healthy** entry exhausted with the old key's error.
   Observed in production: healthy second z.ai key benched 0.4s after rotation (with
   `request_count: 0` and the first key's error message) — after which *all* entries were
   in cooldown and defect 1 made every new session fail.

## Fix

- `_api_key_provider_runtime()` now attaches the provider's credential pool when the
  resolved env/config key is itself a pool member, mirroring the existing explicit-runtime
  ladder fix. Sessions that start on a bare env key can now rotate on 429/402 exactly like
  pool-resolved sessions.
- Added `limit exhausted` to `_USAGE_LIMIT_MESSAGE_TOKENS` so z.ai weekly/monthly caps
  rotate on the first 429 instead of burning a same-key retry.
- The aux ladder's post-rotation retry recovery now passes the known-failed
  `_client_api_key` as `failed_api_key`. If the rotated key genuinely failed, the next
  recovery cycle identifies and marks it via its own `_client_api_key` — one extra failure
  cycle at worst, versus benching a healthy key and taking the pool offline.

## Testing

- New `tests/agent/test_zai_quota_rotation.py`: z.ai 1310 message rotates on the first
  429, marks only the failed key, keeps the healthy key available.
- New `TestApiKeyProviderPoolAttachment` in
  `tests/hermes_cli/test_runtime_provider_resolution.py`: pool attached when the env key
  is a pool member, not attached for non-member keys, resolution survives `load_pool`
  failure.
- RED/GREEN proven: all 5 new tests fail on unpatched `main`, pass with the fix.
- `tests/agent/test_credential_pool*.py`, `test_api_key_providers.py`,
  `test_authenticated_providers_exhausted_pool.py`, `test_runtime_provider_resolution.py`:
  199 + 70 passed.

Related: #103038 (z.ai `will reset at` classification), #46930 (absolute reset timestamps
in `credential_pool`) — this PR is orthogonal: runtime pool attachment, recovery-layer
usage-limit token, and aux attribution.
