### PR TITLE
fix(desktop): contain unsafe macOS updates

### DIFF
--- a/apps/desktop/electron/macos-update-containment.test.ts
+++ b/apps/desktop/electron/macos-update-containment.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  createDesktopUpdateIpcHandlers,
+  MACOS_SAFE_PUBLISHER_CAPABILITY,
+  parseMacosSafePublisherCapability,
+  registerDesktopUpdateIpc,
+  SAFE_PUBLISHER_UNAVAILABLE_MESSAGE
+} from './macos-update-containment'
+
+test('macOS apply IPC rechecks the safe publisher while check-only stays available', async () => {
+  let capabilityVersion: number | null = null
+  let applies = 0
+  let checks = 0
+
+  const handlers = createDesktopUpdateIpcHandlers({
+    applyUpdates: async () => {
+      applies += 1
+
+      return { ok: true }
+    },
+    checkUpdates: async () => {
+      checks += 1
+
+      return { supported: true }
+    },
+    isMac: true,
+    publisherCapability: () =>
+      capabilityVersion === null
+        ? null
+        : { capability: MACOS_SAFE_PUBLISHER_CAPABILITY, version: capabilityVersion }
+  })
+
+  assert.deepEqual(await handlers.check(), { supported: true })
+  assert.equal(checks, 1, 'check-only must not depend on mutation capability')
+
+  assert.deepEqual(await handlers.apply({ stopSafeBlockers: true }), {
+    error: 'safe-publisher-unavailable',
+    message: SAFE_PUBLISHER_UNAVAILABLE_MESSAGE,
+    ok: false
+  })
+  assert.equal(applies, 0, 'direct IPC must not reach mutation without the capability')
+
+  capabilityVersion = 1
+  assert.deepEqual(await handlers.apply({ stopSafeBlockers: true }), { ok: true })
+  assert.equal(applies, 1)
+
+  capabilityVersion = null
+  assert.equal((await handlers.apply({ staleRendererRequest: true } as any)).ok, false)
+  assert.equal(applies, 1, 'a stale renderer cannot reuse an earlier positive capability result')
+})
+
+test('registers the authoritative check and apply handlers at the Electron main boundary', async () => {
+  const registered = new Map<string, (...args: any[]) => Promise<any>>()
+  registerDesktopUpdateIpc(
+    {
+      handle: (channel: string, handler: (...args: any[]) => Promise<any>) => {
+        registered.set(channel, handler)
+      }
+    },
+    createDesktopUpdateIpcHandlers({
+      applyUpdates: async () => ({ ok: true }),
+      checkUpdates: async () => ({ supported: true }),
+      isMac: true,
+      publisherCapability: () => null
+    })
+  )
+
+  const check = registered.get('hermes:updates:check')
+  const apply = registered.get('hermes:updates:apply')
+
+  if (!check || !apply) {
+    throw new Error('update IPC handlers were not registered')
+  }
+
+  assert.deepEqual(await check({}), { supported: true })
+  assert.equal((await apply({}, {})).ok, false)
+})
+
+test('macOS publisher capability parsing fails closed and requires a compatible version', () => {
+  assert.deepEqual(
+    parseMacosSafePublisherCapability(
+      JSON.stringify({ capability: MACOS_SAFE_PUBLISHER_CAPABILITY, version: 1, additiveField: 'ignored' })
+    ),
+    { capability: MACOS_SAFE_PUBLISHER_CAPABILITY, version: 1 }
+  )
+  assert.equal(
+    parseMacosSafePublisherCapability(JSON.stringify({ capability: MACOS_SAFE_PUBLISHER_CAPABILITY, version: 0 })),
+    null
+  )
+  assert.equal(parseMacosSafePublisherCapability(JSON.stringify({ capability: 'legacy-posix-swap', version: 99 })), null)
+  assert.equal(parseMacosSafePublisherCapability('not-json'), null)
+})
+
+test('Linux and Windows update apply behavior does not probe the macOS publisher', async () => {
+  for (const isMac of [false]) {
+    let probes = 0
+
+    const handlers = createDesktopUpdateIpcHandlers({
+      applyUpdates: async payload => ({ ok: true, payload }),
+      checkUpdates: async () => ({ supported: true }),
+      isMac,
+      publisherCapability: () => {
+        probes += 1
+
+        return null
+      }
+    })
+
+    assert.equal((await handlers.apply({ platform: 'preserved' })).ok, true)
+    assert.equal(probes, 0)
+  }
+})

--- a/apps/desktop/electron/macos-update-containment.ts
+++ b/apps/desktop/electron/macos-update-containment.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from 'node:child_process'
+
+import type { UpdateScriptHandoff } from './updater-process'
+
+export const MACOS_SAFE_PUBLISHER_CAPABILITY = 'hermes-desktop-macos-publisher'
+export const MACOS_SAFE_PUBLISHER_MIN_VERSION = 1
+export const SAFE_PUBLISHER_UNAVAILABLE_MESSAGE =
+  'In-app updates are temporarily disabled on macOS because this build does not include the safe Desktop publisher. Run `hermes update` in a terminal, then install Hermes through the trusted replacement package.'
+
+export interface MacosSafePublisherCapability {
+  capability: typeof MACOS_SAFE_PUBLISHER_CAPABILITY
+  version: number
+}
+
+export function parseMacosSafePublisherCapability(raw: string): MacosSafePublisherCapability | null {
+  try {
+    const parsed = JSON.parse(raw)
+
+    if (
+      parsed?.capability !== MACOS_SAFE_PUBLISHER_CAPABILITY ||
+      !Number.isInteger(parsed?.version) ||
+      parsed.version < MACOS_SAFE_PUBLISHER_MIN_VERSION
+    ) {
+      return null
+    }
+
+    return { capability: MACOS_SAFE_PUBLISHER_CAPABILITY, version: parsed.version }
+  } catch {
+    return null
+  }
+}
+
+/** Ask the repo-owned coordinator whether it delegates macOS publication to a
+ * compatible safe publisher. Unsupported, stale, malformed, or failed probes
+ * all fail closed; executing the probe must not mutate the checkout or app. */
+export function probeMacosSafePublisherCapability(
+  handoff: UpdateScriptHandoff,
+  run: typeof execFileSync = execFileSync
+): MacosSafePublisherCapability | null {
+  try {
+    const raw = run(handoff.command, [...handoff.args, '--publisher-capability'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000
+    })
+
+    return parseMacosSafePublisherCapability(String(raw).trim())
+  } catch {
+    return null
+  }
+}
+
+interface UpdateIpcHandlersDeps {
+  applyUpdates: (payload: any) => Promise<any>
+  checkUpdates: () => Promise<any>
+  isMac: boolean
+  publisherCapability: () => MacosSafePublisherCapability | null
+  checkErrorBranch?: () => string
+  now?: () => number
+}
+
+export interface DesktopUpdateIpcHandlers {
+  check: () => Promise<any>
+  apply: (payload?: any) => Promise<any>
+}
+
+/** Authoritative Electron-main boundary for desktop update IPC. The publisher
+ * capability is probed for every macOS mutation request, so direct IPC and a
+ * renderer that was loaded before containment cannot reuse stale permission. */
+export function createDesktopUpdateIpcHandlers(deps: UpdateIpcHandlersDeps): DesktopUpdateIpcHandlers {
+  return {
+    check: async () =>
+      deps.checkUpdates().catch(error => ({
+        branch: deps.checkErrorBranch?.() ?? 'main',
+        error: 'check-failed',
+        fetchedAt: (deps.now ?? Date.now)(),
+        message: error?.message || String(error),
+        supported: true
+      })),
+    apply: async (payload?: any) => {
+      if (deps.isMac && !deps.publisherCapability()) {
+        return {
+          error: 'safe-publisher-unavailable',
+          message: SAFE_PUBLISHER_UNAVAILABLE_MESSAGE,
+          ok: false
+        }
+      }
+
+      return deps.applyUpdates(payload || {}).catch(error => ({
+        error: 'apply-failed',
+        message: error?.message || String(error),
+        ok: false
+      }))
+    }
+  }
+}
+
+interface IpcMainHandleBoundary {
+  handle: (channel: string, handler: (...args: any[]) => Promise<any>) => unknown
+}
+
+/** Register both updater channels from one shared main-process owner. */
+export function registerDesktopUpdateIpc(ipcMain: IpcMainHandleBoundary, handlers: DesktopUpdateIpcHandlers): void {
+  ipcMain.handle('hermes:updates:check', async () => handlers.check())
+  ipcMain.handle('hermes:updates:apply', async (_event, payload) => handlers.apply(payload))
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -232,6 +232,11 @@ import { createHudSnapShortcut } from './hud-snap-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
+import {
+  createDesktopUpdateIpcHandlers,
+  probeMacosSafePublisherCapability,
+  registerDesktopUpdateIpc
+} from './macos-update-containment'
 import { ensureMainWindow } from './main-window-lifecycle'
 import {
   assertManagedUpdatePreflightClear,
@@ -4299,6 +4304,18 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     updateInFlight = false
   }
 }
+
+const desktopUpdateIpcHandlers = createDesktopUpdateIpcHandlers({
+  applyUpdates,
+  checkUpdates,
+  isMac: IS_MAC,
+  checkErrorBranch: () => readDesktopUpdateConfig().branch,
+  publisherCapability: () => {
+    const handoff = resolvePosixScriptHandoff(resolveUpdateRoot())
+
+    return handoff ? probeMacosSafePublisherCapability(handoff) : null
+  }
+})
 
 async function handOffWindowsBootstrapRecovery(reason) {
   if (!IS_WINDOWS || !IS_PACKAGED) {
@@ -15924,7 +15941,7 @@ ipcMain.handle('hermes:connections:update-all', async (_event, payload) => {
           if (connection.kind === 'local') {
             // The app-managed runtime updates through the same pipeline as the
             // Settings → Updates button (marker + venv gate + relaunch flow).
-            const result: any = await applyUpdates({})
+            const result: any = await desktopUpdateIpcHandlers.apply({})
 
             return { ...base, ok: result?.ok !== false, detail: result?.message || 'update started' }
           }
@@ -17597,23 +17614,7 @@ const terminalIpc = registerTerminalIpc({
 
 const disposeTerminalSession = terminalIpc.disposeTerminalSession
 
-ipcMain.handle('hermes:updates:check', async () =>
-  checkUpdates().catch(error => ({
-    supported: true,
-    branch: readDesktopUpdateConfig().branch,
-    error: 'check-failed',
-    message: error?.message || String(error),
-    fetchedAt: Date.now()
-  }))
-)
-
-ipcMain.handle('hermes:updates:apply', async (_event, payload) =>
-  applyUpdates(payload || {}).catch(error => ({
-    ok: false,
-    error: 'apply-failed',
-    message: error?.message || String(error)
-  }))
-)
+registerDesktopUpdateIpc(ipcMain, desktopUpdateIpcHandlers)
 
 ipcMain.handle('hermes:updates:branch:get', async () => readDesktopUpdateConfig())
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -759,6 +759,7 @@ from hermes_cli.main_desktop import (  # frozen updater surface: update_cmd*.py 
     _desktop_dist_exists,
     _desktop_macos_relaunchable_fixup,
     _desktop_packaged_executable,
+    _write_desktop_producer_receipt,
 )
 from hermes_cli.main_web_build import (
     _sweep_stale_bytecode_if_checkout_changed,

--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -4,10 +4,13 @@ Split out of ``hermes_cli/main.py``. Names that still live in main (``PROJECT_RO
 are imported lazily inside the functions that use them (avoids an import cycle).
 """
 
-import logging
-import contextlib
 import argparse
+import contextlib
+import hashlib
+import json
+import logging
 import os
+import plistlib
 import re
 import shlex
 import shutil
@@ -16,9 +19,10 @@ import subprocess
 import sys
 import tempfile
 import time as _time_mod
+from datetime import datetime, timezone
 
 from pathlib import Path
-from typing import Optional
+from typing import NoReturn, Optional
 from hermes_cli.main_tui_launch import _npm_lifecycle_env
 from hermes_cli.main_web_build import (
     _hash_source_tree, _nixos_build_env, _stamp_is_current, _write_build_stamp)
@@ -191,6 +195,168 @@ def _desktop_unpacked_root(exe: Path, release_dir: Path) -> Path:
     return unpacked
 
 
+_DESKTOP_PRODUCER_RECEIPT = ".hermes-desktop-producer-receipt.json"
+_DESKTOP_UPDATE_TRANSACTION_ENV = "HERMES_DESKTOP_UPDATE_TRANSACTION_ID"
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
+
+def _desktop_macos_reader_state(app: Optional[Path]) -> str:
+    """Return ``none|present|unknown`` for open files under the exact app bundle.
+
+    ``lsof +D`` is deliberately fail-closed: only its documented no-match exit
+    can prove ``none``; missing tooling, timeout, malformed output, or any other
+    failure is ``unknown``.
+    """
+    if app is None or not app.exists():
+        return "none"
+    lsof = shutil.which("lsof")
+    if not lsof and Path("/usr/sbin/lsof").is_file():
+        lsof = "/usr/sbin/lsof"
+    if not lsof:
+        return "unknown"
+    try:
+        result = subprocess.run(
+            [lsof, "-F", "p", "+D", str(app.resolve())],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+    pids = [line[1:] for line in (result.stdout or "").splitlines()
+            if line.startswith("p") and line[1:].isdigit()]
+    if result.returncode == 0 and pids:
+        return "present"
+    if (
+        result.returncode == 1
+        and not (result.stdout or "").strip()
+        and not (result.stderr or "").strip()
+    ):
+        return "none"
+    return "unknown"
+
+
+def _desktop_macos_strict_signature_valid(app: Path) -> bool:
+    """Independently require ``codesign --verify --deep --strict``."""
+    codesign = shutil.which("codesign")
+    if not codesign:
+        return False
+    try:
+        return _codesign_verify(codesign, app, check=False, text=True).returncode == 0
+    except OSError:
+        return False
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _run_candidate_fact(command: list[str], *, cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False, timeout=10)
+    if result.returncode != 0:
+        raise RuntimeError(f"candidate fact probe failed: {command[0]} exited {result.returncode}")
+    return result
+
+
+def _atomic_write_json_fsynced(path: Path, payload: dict) -> None:
+    """Replace *path* atomically and fsync both file and containing directory."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.tmp-", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, sort_keys=True, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temp_path, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            temp_path.unlink()
+
+
+def _write_desktop_producer_receipt(
+    artifact_executable: Path, exact_candidate_executable: Path, *, rebuilt: bool
+) -> Optional[Path]:
+    """Write the txid-bound macOS candidate receipt next to the signed app."""
+    transaction_id = os.environ.get(_DESKTOP_UPDATE_TRANSACTION_ENV)
+    if transaction_id is None:
+        return None
+    if not _UUID_RE.fullmatch(transaction_id):
+        raise RuntimeError("invalid desktop update transaction ID")
+
+    from hermes_cli.main import PROJECT_ROOT
+
+    artifact_app = artifact_executable.parents[2]
+    candidate_app = exact_candidate_executable.parents[2].resolve()
+    resources = artifact_app / "Contents" / "Resources"
+    app_asar = resources / "app.asar"
+    with (artifact_app / "Contents" / "Info.plist").open("rb") as stream:
+        info = plistlib.load(stream)
+
+    source_sha = _run_candidate_fact(["git", "rev-parse", "HEAD"], cwd=PROJECT_ROOT).stdout.strip()
+    if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+        raise RuntimeError("post-update source SHA is unavailable")
+    source_status = _run_candidate_fact(
+        ["git", "status", "--porcelain", "--untracked-files=no"], cwd=PROJECT_ROOT
+    ).stdout
+    architectures = _run_candidate_fact(["/usr/bin/lipo", "-archs", str(artifact_executable)]).stdout.split()
+    if not architectures:
+        raise RuntimeError("candidate architecture is unavailable")
+    signature = _run_candidate_fact(
+        ["/usr/bin/codesign", "-dv", "--verbose=4", str(artifact_app)]
+    )
+    signing_text = "\n".join((signature.stdout or "", signature.stderr or ""))
+    authorities = re.findall(r"^Authority=(.+)$", signing_text, re.MULTILINE)
+    if "Signature=adhoc" in signing_text:
+        signing_policy, signing_identity = "adhoc", "-"
+    elif authorities:
+        signing_policy, signing_identity = "identity", authorities[0].strip()
+    else:
+        raise RuntimeError("candidate signing identity is unavailable")
+
+    required = {
+        "bundle_id": info.get("CFBundleIdentifier"),
+        "version": info.get("CFBundleShortVersionString"),
+        "build_version": info.get("CFBundleVersion"),
+    }
+    if not all(isinstance(value, str) and value for value in required.values()):
+        raise RuntimeError("candidate bundle metadata is incomplete")
+
+    receipt_path = artifact_app.parent / _DESKTOP_PRODUCER_RECEIPT
+    payload = {
+        "schema_version": 1,
+        "transaction_id": transaction_id,
+        "candidate_path": str(candidate_app),
+        "post_update_source_sha": source_sha,
+        "rebuilt": bool(rebuilt),
+        "build_timestamp": datetime.fromtimestamp(
+            artifact_executable.stat().st_mtime, timezone.utc
+        ).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source_state": "clean" if not source_status.strip() else "dirty",
+        "architecture": sorted(set(architectures)),
+        **required,
+        "signing_policy": signing_policy,
+        "signing_identity": signing_identity,
+        "executable_sha256": _sha256_file(artifact_executable),
+        "app_asar_sha256": _sha256_file(app_asar),
+    }
+    _atomic_write_json_fsynced(receipt_path, payload)
+    return receipt_path
+
+
+def _macos_live_app(desktop_dir: Path) -> Optional[Path]:
+    executable = _desktop_packaged_executable(desktop_dir)
+    return executable.parents[2] if executable is not None else None
+
+
 def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[Path]:
     """Promote a VERIFIED staged pack over ``release/`` by two renames (live → ``.previous``, staged →
     live); a failure between them rolls back. Returns the live exe or None (live app kept). Never raises."""
@@ -204,6 +370,10 @@ def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[P
         live_root = release_dir / staged_root.name
         previous = release_dir / (staged_root.name + _DESKTOP_PREVIOUS_SUFFIX)
         release_dir.mkdir(parents=True, exist_ok=True)
+        if sys.platform == "darwin":
+            reader_state = _desktop_macos_reader_state(_macos_live_app(desktop_dir))
+            if reader_state != "none":
+                raise RuntimeError(f"macOS release reader state is {reader_state} immediately before promotion")
         shutil.rmtree(previous, ignore_errors=True)
         moved_aside = live_root.exists()
         if moved_aside:
@@ -220,7 +390,7 @@ def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[P
             raise
         if moved_aside:
             shutil.rmtree(previous, ignore_errors=True)
-    except (OSError, ValueError) as exc:
+    except (OSError, RuntimeError, ValueError) as exc:
         logger.warning("desktop stage-and-swap failed, live app kept: %s", exc)
         return None
     finally:
@@ -1325,28 +1495,45 @@ def _run_desktop_pack_with_recovery(
 
 
 def _promote_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Path:
-    """Sign + integrity-gate the STAGED pack, then swap it over the live app. Exits (live app kept) on failure."""
+    """Validate a staged pack completely, then swap it over the repo release."""
     staged_executable = _desktop_packaged_executable_in(staging_dir)
-    # Locally-built apps are ad-hoc signed; make them relaunchable after an
-    # in-place self-update. Signs the STAGED bundle so the live app is never
-    # half-signed. No-op on non-macOS and on real-identity builds.
-    _desktop_macos_relaunchable_fixup(desktop_dir, release_dir=staging_dir)
+
+    def refuse(message: str) -> NoReturn:
+        _discard_desktop_staging(staging_dir)
+        print(f"✗ {message}")
+        print(_PREVIOUS_APP_KEPT)
+        raise SystemExit(1)
+
+    if staged_executable is None:
+        refuse(f"Desktop build produced no launchable app in {staging_dir}")
+
+    if sys.platform == "darwin":
+        reader_state = _desktop_macos_reader_state(_macos_live_app(desktop_dir))
+        if reader_state != "none":
+            refuse(f"Desktop candidate promotion refused: macOS release reader state is {reader_state}")
+        if not _desktop_macos_relaunchable_fixup(desktop_dir, release_dir=staging_dir):
+            refuse("Desktop candidate signing failed")
+        staged_app = staged_executable.parents[2]
+        if not _desktop_macos_strict_signature_valid(staged_app):
+            refuse("Desktop candidate failed strict macOS signature verification")
+        try:
+            staged_root = _desktop_unpacked_root(staged_executable, staging_dir)
+            final_executable = (
+                desktop_dir / "release" / staged_root.name / staged_executable.relative_to(staged_root)
+            )
+            _write_desktop_producer_receipt(staged_executable, final_executable, rebuilt=True)
+        except (OSError, RuntimeError, ValueError) as exc:
+            refuse(f"Desktop candidate receipt failed: {exc}")
 
     # Windows integrity gate: never declare the rebuild a success on a
     # Hermes.exe Windows cannot load. Verified on the STAGED exe, so a failure
     # simply discards staging and fails loudly for the updater's retry-once.
     verified_executable, rolled_back = _ensure_desktop_exe_launchable(desktop_dir, staged_executable)
-    if staged_executable is None or rolled_back or verified_executable is None:
-        _discard_desktop_staging(staging_dir)
-        if staged_executable is None:
-            print(f"✗ Desktop build produced no launchable app in {staging_dir}")
-        print(_PREVIOUS_APP_KEPT)
-        sys.exit(1)
+    if rolled_back or verified_executable is None:
+        refuse("Desktop build produced no launchable app")
     packaged_executable = _swap_staged_desktop_app(desktop_dir, staging_dir)
     if packaged_executable is None:
-        print(f"✗ Could not install the rebuilt desktop app into {desktop_dir / 'release'}")
-        print(_PREVIOUS_APP_KEPT)
-        sys.exit(1)
+        refuse(f"Could not install the rebuilt desktop app into {desktop_dir / 'release'}")
     return packaged_executable
 
 

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -835,6 +835,14 @@ def _rebuild_desktop_after_update(
     except Exception:
         skip_desktop_build = False
     if skip_desktop_build:
+        if sys.platform == "darwin":
+            executable = _m()._desktop_packaged_executable(desktop_dir)
+            if executable is not None:
+                try:
+                    _m()._write_desktop_producer_receipt(executable, executable, rebuilt=False)
+                except (OSError, RuntimeError, ValueError) as exc:
+                    print(f"  ⚠ Desktop candidate receipt failed: {exc}")
+                    return False
         print("  ✓ Desktop app up to date")
         return True
 

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -39,7 +39,7 @@ ORIGINAL_ARGS=("$@")
 INSTALL_ROOT="" BRANCH="main" DESKTOP_PID=0 RELAUNCH_TARGET=""
 RELAUNCH_CWD="" SANDBOX_FALLBACK=0 RELAUNCH_ARGS=()
 NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0
-SELF_TEST_TCC_HEAL=0
+SELF_TEST_TCC_HEAL=0 SELF_TEST_TRANSACTION=0
 HANDOFF_DAEMONIZED=0
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -54,6 +54,7 @@ while [ $# -gt 0 ]; do
     --self-test-ui) SELF_TEST_UI=1; shift ;;
     --self-test-gate) SELF_TEST_GATE=1; shift ;;
     --self-test-tcc-heal) SELF_TEST_TCC_HEAL=1; shift ;;
+    --self-test-transaction) SELF_TEST_TRANSACTION=1; shift ;;
     --daemonized) HANDOFF_DAEMONIZED=1; shift ;;
     --self-test-marker) SELF_TEST_MARKER=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
     --) shift; RELAUNCH_ARGS=("$@"); shift $# ;;
@@ -616,7 +617,24 @@ tcc_pick_update_invoke() { # sets UPDATE_INVOKE; safety net past a failed heal
   fi
 }
 
+create_desktop_transaction() {
+  [ "$(uname)" = "Darwin" ] || return 0
+  HERMES_DESKTOP_UPDATE_TRANSACTION_ID="$(/usr/bin/python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null)" || return 1
+  case "$HERMES_DESKTOP_UPDATE_TRANSACTION_ID" in
+    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-4[0-9a-f][0-9a-f][0-9a-f]-[89ab][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+    *) return 1 ;;
+  esac
+  export HERMES_DESKTOP_UPDATE_TRANSACTION_ID
+}
+
 # ── self-tests: no update, touch nothing ────────────────────────────────────
+if [ "$SELF_TEST_TRANSACTION" -eq 1 ]; then
+  trap - EXIT
+  create_desktop_transaction || { echo "transaction generation failed" >&2; exit 1; }
+  /usr/bin/python3 -c 'import json, os; value = os.environ.get("HERMES_DESKTOP_UPDATE_TRANSACTION_ID", ""); print(json.dumps({"transaction_id": value, "exported_transaction_id": value}))'
+  exit 0
+fi
+
 if [ "$SELF_TEST_TCC_HEAL" -eq 1 ]; then
   # Runs the REAL heal + invoke selection against --install-root and reports;
   # tests/test_desktop_update_tcc_heal.py drives the state matrix through it.
@@ -674,6 +692,14 @@ os.execve("/bin/bash", ["/bin/bash", sys.argv[1], *sys.argv[2:]], env)
   exit 0
 fi
 
+if [ "$(uname)" = "Darwin" ]; then
+  create_desktop_transaction || {
+    FINAL_CODE=9
+    FINAL_MSG="Update aborted: a secure Desktop update transaction ID could not be created. Nothing was changed."
+    exit "$FINAL_CODE"
+  }
+fi
+
 # Electron terminates the entire detached updater process group during quit,
 # including the loopback status server.  Arm TERM immunity before `start_ui`
 # so the shim server and the later `hermes update` subprocess both inherit
@@ -697,7 +723,12 @@ if [ "${#STARTED_AT}" -ne "${#NOW}" ] \
     || [[ "$STARTED_AT" > "$NOW" || "$STARTED_AT" < "$MIN_STARTED_AT" ]]; then
   STARTED_AT="$NOW"
 fi
-printf '%s\n%s\n' "$$" "$STARTED_AT" > "$MARKER" 2>/dev/null || log "WARNING: could not write update marker"
+if [ -n "${HERMES_DESKTOP_UPDATE_TRANSACTION_ID:-}" ]; then
+  printf '%s\n%s\n%s\n' "$$" "$STARTED_AT" "$HERMES_DESKTOP_UPDATE_TRANSACTION_ID" > "$MARKER" 2>/dev/null \
+    || log "WARNING: could not write update marker"
+else
+  printf '%s\n%s\n' "$$" "$STARTED_AT" > "$MARKER" 2>/dev/null || log "WARNING: could not write update marker"
+fi
 
 if [ "$SELF_TEST_MARKER" -eq 1 ]; then
   trap - EXIT

--- a/tests/hermes_cli/test_desktop_candidate_safety.py
+++ b/tests/hermes_cli/test_desktop_candidate_safety.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import plistlib
+import re
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import main_desktop, update_cmd, update_cmd_deps
+
+
+TXID = "12345678-1234-4abc-8def-1234567890ab"
+
+
+def test_update_facade_exports_candidate_receipt_writer():
+    """The post-update path resolves desktop helpers through ``update_cmd._m()``."""
+    assert update_cmd._m()._write_desktop_producer_receipt is main_desktop._write_desktop_producer_receipt
+
+
+def _make_mac_release(root: Path, label: str) -> tuple[Path, Path]:
+    app = root / "mac-arm64" / "Hermes.app"
+    exe = app / "Contents" / "MacOS" / "Hermes"
+    resources = app / "Contents" / "Resources"
+    exe.parent.mkdir(parents=True)
+    resources.mkdir(parents=True)
+    exe.write_bytes(f"{label}-executable".encode())
+    (resources / "app.asar").write_bytes(f"{label}-asar".encode())
+    with (app / "Contents" / "Info.plist").open("wb") as stream:
+        plistlib.dump(
+            {
+                "CFBundleIdentifier": "com.nousresearch.hermes",
+                "CFBundleShortVersionString": "1.2.3",
+                "CFBundleVersion": "456",
+            },
+            stream,
+        )
+    return app, exe
+
+
+def _assert_promotion_refused_unchanged(
+    desktop_dir: Path,
+    staging_dir: Path,
+    live_exe: Path,
+    live_before: bytes,
+) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main_desktop._promote_staged_desktop_app(desktop_dir, staging_dir)
+    assert exc.value.code == 1
+    assert live_exe.read_bytes() == live_before
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("returncode,stdout,stderr", [(1, "", "permission denied"), (0, "", "")])
+def test_macos_reader_scan_treats_ambiguous_lsof_results_as_unknown(
+    tmp_path, monkeypatch, returncode, stdout, stderr
+):
+    app, _ = _make_mac_release(tmp_path / "release", "live")
+    monkeypatch.setattr(main_desktop.shutil, "which", lambda _name: "/usr/sbin/lsof")
+    monkeypatch.setattr(
+        main_desktop.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], returncode, stdout, stderr),
+    )
+
+    assert main_desktop._desktop_macos_reader_state(app) == "unknown"
+
+
+@pytest.mark.macos_only
+def test_macos_promotion_refuses_false_signing_fixup_without_touching_release(tmp_path, monkeypatch):
+    desktop = tmp_path / "desktop"
+    _, live_exe = _make_mac_release(desktop / "release", "live")
+    _, _ = _make_mac_release(desktop / ".staging", "staged")
+    live_before = live_exe.read_bytes()
+    monkeypatch.setattr(main_desktop, "_desktop_macos_reader_state", lambda _app: "none")
+    monkeypatch.setattr(main_desktop, "_desktop_macos_relaunchable_fixup", lambda *a, **kw: False)
+
+    _assert_promotion_refused_unchanged(desktop, desktop / ".staging", live_exe, live_before)
+
+
+@pytest.mark.macos_only
+def test_macos_promotion_refuses_failed_independent_strict_signature_check(tmp_path, monkeypatch):
+    desktop = tmp_path / "desktop"
+    _, live_exe = _make_mac_release(desktop / "release", "live")
+    _, _ = _make_mac_release(desktop / ".staging", "staged")
+    live_before = live_exe.read_bytes()
+    monkeypatch.setattr(main_desktop, "_desktop_macos_reader_state", lambda _app: "none")
+    monkeypatch.setattr(main_desktop, "_desktop_macos_relaunchable_fixup", lambda *a, **kw: True)
+    monkeypatch.setattr(main_desktop, "_desktop_macos_strict_signature_valid", lambda _app: False)
+
+    _assert_promotion_refused_unchanged(desktop, desktop / ".staging", live_exe, live_before)
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("reader_state", ["present", "unknown"])
+def test_macos_promotion_refuses_live_or_unknown_release_readers(tmp_path, monkeypatch, reader_state):
+    desktop = tmp_path / "desktop"
+    _, live_exe = _make_mac_release(desktop / "release", "live")
+    _, _ = _make_mac_release(desktop / ".staging", "staged")
+    live_before = live_exe.read_bytes()
+    monkeypatch.setattr(main_desktop, "_desktop_macos_reader_state", lambda _app: reader_state)
+
+    with patch.object(main_desktop, "_desktop_macos_relaunchable_fixup") as fixup:
+        _assert_promotion_refused_unchanged(desktop, desktop / ".staging", live_exe, live_before)
+    fixup.assert_not_called()
+
+
+@pytest.mark.macos_only
+def test_macos_promotion_refuses_reader_that_appears_immediately_before_swap(tmp_path, monkeypatch):
+    desktop = tmp_path / "desktop"
+    _, live_exe = _make_mac_release(desktop / "release", "live")
+    _, _ = _make_mac_release(desktop / ".staging", "staged")
+    live_before = live_exe.read_bytes()
+    states = iter(["none", "present"])
+    monkeypatch.setattr(main_desktop, "_desktop_macos_reader_state", lambda _app: next(states))
+    monkeypatch.setattr(main_desktop, "_desktop_macos_relaunchable_fixup", lambda *a, **kw: True)
+    monkeypatch.setattr(main_desktop, "_desktop_macos_strict_signature_valid", lambda _app: True)
+
+    _assert_promotion_refused_unchanged(desktop, desktop / ".staging", live_exe, live_before)
+
+
+@pytest.mark.macos_only
+def test_macos_producer_receipt_binds_candidate_and_artifact_facts(tmp_path, monkeypatch):
+    project = tmp_path / "repo"
+    desktop = project / "apps" / "desktop"
+    app, exe = _make_mac_release(desktop / "release", "candidate")
+    asar = app / "Contents" / "Resources" / "app.asar"
+    os.utime(exe, (1_700_000_000, 1_700_000_000))
+    monkeypatch.setattr("hermes_cli.main.PROJECT_ROOT", project)
+    monkeypatch.setenv("HERMES_DESKTOP_UPDATE_TRANSACTION_ID", TXID)
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            return subprocess.CompletedProcess(command, 0, "a" * 40 + "\n", "")
+        if command[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(command, 0, "", "")
+        if command[:2] == ["/usr/bin/lipo", "-archs"]:
+            return subprocess.CompletedProcess(command, 0, "arm64\n", "")
+        if command[:2] == ["/usr/bin/codesign", "-dv"]:
+            return subprocess.CompletedProcess(command, 0, "", "Signature=adhoc\nIdentifier=com.nousresearch.hermes\n")
+        raise AssertionError(command)
+
+    monkeypatch.setattr(main_desktop.subprocess, "run", fake_run)
+    receipt = main_desktop._write_desktop_producer_receipt(exe, exe, rebuilt=True)
+
+    assert receipt == desktop / "release" / "mac-arm64" / ".hermes-desktop-producer-receipt.json"
+    payload = json.loads(receipt.read_text())
+    assert payload == {
+        "schema_version": 1,
+        "transaction_id": TXID,
+        "candidate_path": str(app.resolve()),
+        "post_update_source_sha": "a" * 40,
+        "rebuilt": True,
+        "build_timestamp": "2023-11-14T22:13:20Z",
+        "source_state": "clean",
+        "architecture": ["arm64"],
+        "bundle_id": "com.nousresearch.hermes",
+        "version": "1.2.3",
+        "build_version": "456",
+        "signing_policy": "adhoc",
+        "signing_identity": "-",
+        "executable_sha256": hashlib.sha256(exe.read_bytes()).hexdigest(),
+        "app_asar_sha256": hashlib.sha256(asar.read_bytes()).hexdigest(),
+    }
+
+
+@pytest.mark.macos_only
+def test_reused_macos_candidate_gets_a_transaction_bound_receipt(tmp_path, monkeypatch):
+    desktop = tmp_path / "apps" / "desktop"
+    desktop.mkdir(parents=True)
+    (desktop / "package.json").write_text("{}", encoding="utf-8")
+    _, executable = _make_mac_release(desktop / "release", "reused")
+    facade = MagicMock()
+    facade.PROJECT_ROOT = tmp_path
+    facade._desktop_packaged_executable.return_value = executable
+    facade._desktop_dist_exists.return_value = False
+    facade._resolve_node_runtime_npm.return_value = "/usr/bin/npm"
+    facade._desktop_build_needed.return_value = False
+    monkeypatch.setattr(update_cmd, "_m", lambda: facade)
+
+    assert update_cmd_deps._rebuild_desktop_after_update(
+        desktop, had_desktop_app_before_update=True
+    ) is True
+    facade._write_desktop_producer_receipt.assert_called_once_with(
+        executable, executable, rebuilt=False
+    )
+
+
+@pytest.mark.macos_only
+def test_posix_orchestrator_creates_and_exports_a_v4_transaction_id(tmp_path):
+    script = Path(__file__).parents[2] / "scripts" / "desktop-update" / "posix.sh"
+    install_root = tmp_path / "hermes-agent"
+    install_root.mkdir()
+    result = subprocess.run(
+        ["/bin/bash", str(script), "--install-root", str(install_root), "--self-test-transaction"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["transaction_id"] == payload["exported_transaction_id"]
+    assert re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+        payload["transaction_id"],
+    )

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -152,6 +152,8 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
          patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main_desktop._register_linux_desktop_entry"), \
          patch("hermes_cli.main.subprocess.run", side_effect=_pack_into_staging(root)) as mock_run, \
@@ -217,6 +219,8 @@ def test_gui_install_env_prepends_managed_node_on_bare_path(tmp_path, monkeypatc
          patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.main.subprocess.run", return_value=launch_ok), \
          pytest.raises(SystemExit):
@@ -315,6 +319,8 @@ def test_gui_does_not_retry_after_packaged_executable_exists(tmp_path, monkeypat
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main_web_build._run_npm_install_deterministic", return_value=install_ok), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main_desktop._purge_electron_build_cache", return_value=[Path("/c/electron.zip")]) as mock_purge, \
          patch("hermes_cli.main_desktop._redownload_electron_dist", return_value=True) as mock_dl, \
          patch("hermes_cli.main.subprocess.run", side_effect=pack_fail) as mock_run, \
@@ -1046,6 +1052,8 @@ def test_gui_skips_desktop_entry_off_linux(tmp_path, monkeypatch):
     with patch("hermes_cli.main_desktop._desktop_build_needed", return_value=False), \
          patch("hermes_cli.main_install_repair._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main.subprocess.run", return_value=launch_ok), \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
@@ -1108,6 +1116,8 @@ def test_gui_bridges_ozone_hint_to_launch_env(tmp_path, monkeypatch):
          patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1124,6 +1134,8 @@ def test_gui_bridges_ozone_hint_to_launch_env(tmp_path, monkeypatch):
          patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1205,6 +1217,8 @@ def test_gui_linux_packaged_launch_bridges_detected_password_store(tmp_path, mon
          patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value={}), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1256,6 +1270,8 @@ def test_gui_config_password_store_skips_detection(tmp_path, monkeypatch):
          patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1285,6 +1301,8 @@ def test_gui_explicit_password_store_env_wins_over_config_and_detection(tmp_path
          patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.main_desktop._desktop_linux_sandbox_fixup", return_value=True), \
          patch("hermes_cli.config.load_config", return_value=cfg), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
@@ -1312,6 +1330,8 @@ def test_gui_password_store_bridge_is_linux_only(tmp_path, monkeypatch):
          patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True), \
          patch("hermes_cli.main_desktop._write_desktop_build_stamp"), \
          patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"), \
+         patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"), \
+         patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True), \
          patch("hermes_cli.config.load_config", return_value={}), \
          patch("hermes_cli.linux_desktop_entry.install_desktop_entry", return_value=None), \
          patch("hermes_cli.main_desktop._detect_linux_password_store") as mock_detect, \
@@ -1340,6 +1360,8 @@ def _gui_build_patches(root: Path, run_side_effect):
         patch("hermes_cli.main_desktop._desktop_build_needed", return_value=True),
         patch("hermes_cli.main_desktop._write_desktop_build_stamp"),
         patch("hermes_cli.main_desktop._desktop_macos_relaunchable_fixup"),
+        patch("hermes_cli.main_desktop._desktop_macos_reader_state", return_value="none"),
+        patch("hermes_cli.main_desktop._desktop_macos_strict_signature_valid", return_value=True),
         patch("hermes_cli.main_desktop._register_linux_desktop_entry"),
         patch("hermes_cli.main_desktop._stop_desktop_processes_locking_build", return_value=[]),
         patch("hermes_cli.main_desktop._purge_electron_build_cache", return_value=[]),

--- a/tests/hermes_cli/test_update_desktop_stale_warning.py
+++ b/tests/hermes_cli/test_update_desktop_stale_warning.py
@@ -48,6 +48,10 @@ def desktop_env(tmp_path, monkeypatch):
             return calls["build_needed"]
 
         @staticmethod
+        def _desktop_packaged_executable(_desktop_dir):
+            return None
+
+        @staticmethod
         def _run_logged_subprocess(cmd, cwd=None, env=None):
             calls["builds"] += 1
             return _Result(1, stdout="Error: [stage-native-deps] boom")


### PR DESCRIPTION
## Summary
- fail closed on every macOS Desktop update IPC path until a compatible safe publisher is available
- gate staged macOS candidate promotion on reader state, signing success, and strict signature verification
- create transaction-bound producer receipts with candidate identity and hashes
- preserve legacy marker parsing while adding the transaction ID for the later publisher

## Review fixes
- routes `hermes:connections:update-all` local updates through the same authoritative containment handler
- updates cleanly from current `origin/main`
- exports the receipt writer through the frozen updater facade
- treats ambiguous `lsof` stderr as unknown rather than no readers

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_desktop_candidate_safety.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_update_handoff_desktop_rebuild.py tests/hermes_cli/test_update_desktop_stale_warning.py tests/hermes_cli/test_desktop_update_verify.py tests/test_desktop_update_tcc_heal.py tests/test_desktop_update_shim_profile_cleanup.py tests/test_desktop_update_shim_progress.py` — 92 passed, 11 platform skips
- focused Electron updater tests — 64 passed, 1 skipped
- `npm run typecheck` — passed
- `npm run lint` — passed with 144 pre-existing warnings, 0 errors
- `uvx --from ruff==0.15.10 ruff check ...` — passed
- `bash -n scripts/desktop-update/posix.sh` and transaction self-test — passed

Full Desktop Vitest run: 9,547 passed, 6 skipped, 3 failed outside changed scope (`managed-ssh-update.test.ts` launcher environment; two `voice-prefs.test.ts` localStorage isolation failures). No files in those failing surfaces are changed by this PR.

## Scope
PR 1 only: containment and candidate-producer safety. No installed publisher, activation, or merge is included.
