### PR TITLE
fix(desktop): prevent large legacy transcripts from exhausting gateway

### DIFF
--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -755,36 +755,39 @@ class SessionMessagesMixin:
         """Project a legacy read-only display page without retaining transcript payloads."""
         representatives: Dict[bytes, Tuple[int, int]] = {}
         with self._read_ctx() as conn:
-            rows = conn.execute(
-                "SELECT id, role, content, timestamp, tool_call_id, tool_calls, tool_name, active, "
-                "display_kind, display_metadata FROM messages INDEXED BY idx_messages_session_id "
-                "WHERE session_id = ? AND (active = 1 OR compacted = 1) ORDER BY id ASC",
-                (session_id,))
-            for row in rows:
-                identity = self._display_identity(self._display_dedupe_key(row))
-                current = representatives.get(identity)
-                candidate = (row["active"], row["id"])
-                if current is None or candidate > current:
-                    representatives[identity] = candidate
-            rows.close()
+            conn.execute("BEGIN")
+            try:
+                rows = conn.execute(
+                    "SELECT id, role, content, timestamp, tool_call_id, tool_calls, tool_name, active, "
+                    "display_kind, display_metadata FROM messages INDEXED BY idx_messages_session_id "
+                    "WHERE session_id = ? AND (active = 1 OR compacted = 1) ORDER BY id ASC",
+                    (session_id,))
+                for row in rows:
+                    identity = self._display_identity(self._display_dedupe_key(row))
+                    current = representatives.get(identity)
+                    candidate = (row["active"], row["id"])
+                    if current is None or candidate > current:
+                        representatives[identity] = candidate
+                rows.close()
 
-        identities = list(representatives)
-        if latest:
-            end = max(0, len(identities) - offset)
-            start = 0 if limit is None else max(0, end - limit)
-            identities = identities[start:end]
-        else:
-            identities = identities[offset:] if limit is None else identities[offset:offset + limit]
-        selected_ids = [representatives[identity][1] for identity in identities]
-        if not selected_ids:
-            return []
-
-        selected = {}
-        for start in range(0, len(selected_ids), 900):
-            chunk = selected_ids[start:start + 900]
-            selected.update({row["id"]: row for row in self._read_all(
-                f"SELECT * FROM messages WHERE id IN ({_placeholders(chunk)})", chunk)})
-        return [selected[row_id] for row_id in selected_ids]
+                identities = list(representatives)
+                if latest:
+                    end = max(0, len(identities) - offset)
+                    start = 0 if limit is None else max(0, end - limit)
+                    identities = identities[start:end]
+                else:
+                    identities = identities[offset:] if limit is None else identities[offset:offset + limit]
+                selected_ids = [representatives[identity][1] for identity in identities]
+                selected = {}
+                for start in range(0, len(selected_ids), 900):
+                    chunk = selected_ids[start:start + 900]
+                    selected.update({row["id"]: row for row in conn.execute(
+                        f"SELECT * FROM messages WHERE session_id = ? "
+                        f"AND (active = 1 OR compacted = 1) AND id IN ({_placeholders(chunk)})",
+                        (session_id, *chunk))})
+                return [selected[row_id] for row_id in selected_ids if row_id in selected]
+            finally:
+                conn.execute("ROLLBACK")
 
     def _row_to_message_dict(self, row, *, warn_context: str, summary_flag: bool) -> Dict[str, Any]:
         """``dict(row)`` with content/tool_calls/display_metadata decoded; *summary_flag* keeps

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -727,18 +727,25 @@ class SessionMessagesMixin:
             missing = conn.execute(missing_sql, (session_id,)).fetchone()
             if missing is None:
                 return True
-            rows = conn.execute(
-                "SELECT * FROM messages WHERE session_id = ? AND (active = 1 OR compacted = 1) ORDER BY id",
-                (session_id,)).fetchall()
-            first_id: Dict[Tuple[Any, ...], int] = {}
-            keyed_rows = []
-            for row in rows:
-                key = self._display_dedupe_key(row)
-                first_id[key] = min(first_id.get(key, row["id"]), row["id"])
-                keyed_rows.append((row["id"], key))
-            conn.executemany(
-                "UPDATE messages SET display_order = ?, display_identity = ? WHERE id = ?",
-                [(first_id[key], self._display_identity(key), row_id) for row_id, key in keyed_rows])
+            first_id: Dict[bytes, int] = {}
+            last_id = 0
+            while True:
+                rows = conn.execute(
+                    "SELECT id, role, content, timestamp, tool_call_id, tool_calls, tool_name, "
+                    "display_kind, display_metadata FROM messages INDEXED BY idx_messages_session_id "
+                    "WHERE session_id = ? AND id > ? AND (active = 1 OR compacted = 1) "
+                    "ORDER BY id LIMIT 1000",
+                    (session_id, last_id))
+                updates = []
+                for row in rows:
+                    last_id = row["id"]
+                    identity = self._display_identity(self._display_dedupe_key(row))
+                    updates.append((first_id.setdefault(identity, last_id), identity, last_id))
+                rows.close()
+                if not updates:
+                    break
+                conn.executemany(
+                    "UPDATE messages SET display_order = ?, display_identity = ? WHERE id = ?", updates)
             return True
 
         return bool(self._execute_write(_do))

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -750,6 +750,42 @@ class SessionMessagesMixin:
 
         return bool(self._execute_write(_do))
 
+    def _legacy_display_page(self, session_id: str, *, limit: Optional[int], offset: int,
+                             latest: bool) -> List[Any]:
+        """Project a legacy read-only display page without retaining transcript payloads."""
+        representatives: Dict[bytes, Tuple[int, int]] = {}
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT id, role, content, timestamp, tool_call_id, tool_calls, tool_name, active, "
+                "display_kind, display_metadata FROM messages INDEXED BY idx_messages_session_id "
+                "WHERE session_id = ? AND (active = 1 OR compacted = 1) ORDER BY id ASC",
+                (session_id,))
+            for row in rows:
+                identity = self._display_identity(self._display_dedupe_key(row))
+                current = representatives.get(identity)
+                candidate = (row["active"], row["id"])
+                if current is None or candidate > current:
+                    representatives[identity] = candidate
+            rows.close()
+
+        identities = list(representatives)
+        if latest:
+            end = max(0, len(identities) - offset)
+            start = 0 if limit is None else max(0, end - limit)
+            identities = identities[start:end]
+        else:
+            identities = identities[offset:] if limit is None else identities[offset:offset + limit]
+        selected_ids = [representatives[identity][1] for identity in identities]
+        if not selected_ids:
+            return []
+
+        selected = {}
+        for start in range(0, len(selected_ids), 900):
+            chunk = selected_ids[start:start + 900]
+            selected.update({row["id"]: row for row in self._read_all(
+                f"SELECT * FROM messages WHERE id IN ({_placeholders(chunk)})", chunk)})
+        return [selected[row_id] for row_id in selected_ids]
+
     def _row_to_message_dict(self, row, *, warn_context: str, summary_flag: bool) -> Dict[str, Any]:
         """``dict(row)`` with content/tool_calls/display_metadata decoded; *summary_flag* keeps
         ``_compressed_summary`` only as ``True``."""
@@ -801,10 +837,10 @@ class SessionMessagesMixin:
                 ORDER BY page.display_order ASC"""
             rows = self._read_all(sql, [session_id, -1 if limit is None else limit, offset, session_id])
         elif include_compacted:
-            # Read-only legacy stores cannot persist display identities; retain the exact old projection.
-            rows = self._dedupe_display_generations(self._read_all(
-                "SELECT * FROM messages WHERE session_id = ?" + active_clause + " ORDER BY id ASC", [session_id]))
-            rows = rows[::-1][offset:][:limit][::-1] if latest else rows[offset:][:limit]
+            # Read-only legacy stores cannot persist display identities. Retain the exact old projection,
+            # but keep only fixed-width identities and representative row ids while scanning; Desktop's
+            # bounded latest page must not materialize a multi-gigabyte transcript before it can paint.
+            rows = self._legacy_display_page(session_id, limit=limit, offset=offset, latest=latest)
         else:
             sql = (f"SELECT * FROM messages WHERE session_id = ?{active_clause}"
                 f"{' AND id > ?' if after_id is not None else ''} ORDER BY id {'DESC' if latest else 'ASC'}")

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -757,9 +757,14 @@ class SessionMessagesMixin:
         with self._read_ctx() as conn:
             conn.execute("BEGIN")
             try:
+                has_session_index = conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+                    ("idx_messages_session_id",),
+                ).fetchone() is not None
+                index_hint = "INDEXED BY idx_messages_session_id" if has_session_index else "NOT INDEXED"
                 rows = conn.execute(
                     "SELECT id, role, content, timestamp, tool_call_id, tool_calls, tool_name, active, "
-                    "display_kind, display_metadata FROM messages INDEXED BY idx_messages_session_id "
+                    f"display_kind, display_metadata FROM messages {index_hint} "
                     "WHERE session_id = ? AND (active = 1 OR compacted = 1) ORDER BY id ASC",
                     (session_id,))
                 for row in rows:

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -787,7 +787,8 @@ class SessionMessagesMixin:
                         (session_id, *chunk))})
                 return [selected[row_id] for row_id in selected_ids if row_id in selected]
             finally:
-                conn.execute("ROLLBACK")
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
 
     def _row_to_message_dict(self, row, *, warn_context: str, summary_flag: bool) -> Dict[str, Any]:
         """``dict(row)`` with content/tool_calls/display_metadata decoded; *summary_flag* keeps

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -416,6 +416,7 @@ class TestDisplayDedupe:
         conn.execute("DROP INDEX IF EXISTS idx_messages_display_page")
         conn.execute("DROP INDEX IF EXISTS idx_messages_display_backfill")
         conn.execute("DROP INDEX IF EXISTS idx_messages_display_identity")
+        conn.execute("DROP INDEX IF EXISTS idx_messages_session_id")
         columns = {row[1] for row in conn.execute("PRAGMA table_info(messages)")}
         for column in ("display_order", "display_identity"):
             if column in columns:

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -14,6 +14,7 @@ job of ``include_inactive`` (audit / debug reads).
 
 import json
 import sqlite3
+import threading
 import tracemalloc
 
 import pytest
@@ -224,6 +225,49 @@ class TestDisplayDedupe:
 
         assert page[0]["content"] == "L" * payload_size
         assert peak < payload_size * 5
+
+    def test_read_only_legacy_page_uses_one_snapshot(self, tmp_path):
+        path = tmp_path / "read-only-legacy-snapshot.db"
+        writer = SessionDB(path)
+        sid = "read-only-legacy-snapshot"
+        writer.create_session(sid, source="desktop")
+        writer.append_message(sid, "assistant", "visible-at-scan")
+        writer._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET display_order = NULL, display_identity = NULL WHERE session_id = ?",
+            (sid,),
+        ))
+        reader = SessionDB(path, read_only=True)
+        scanned = threading.Event()
+        written = threading.Event()
+        display_identity = reader._display_identity
+
+        def pause_after_scan(key):
+            identity = display_identity(key)
+            scanned.set()
+            assert written.wait(5)
+            return identity
+
+        reader._display_identity = pause_after_scan
+
+        def rewind_selected_row():
+            assert scanned.wait(5)
+            writer._execute_write(lambda conn: conn.execute(
+                "UPDATE messages SET content = ?, active = 0, compacted = 0 WHERE session_id = ?",
+                ("hidden-after-scan", sid),
+            ))
+            written.set()
+
+        mutation = threading.Thread(target=rewind_selected_row)
+        mutation.start()
+        try:
+            page = reader.get_messages(sid, include_compacted=True, latest=True, limit=1)
+        finally:
+            mutation.join(timeout=5)
+            reader.close()
+            writer.close()
+
+        assert not mutation.is_alive()
+        assert [(row["active"], row["content"]) for row in page] == [(1, "visible-at-scan")]
 
     def test_display_paging_and_append_work_is_bounded(self, db):
         """Page and identity-lookup work scale with the page, not the transcript: 10x rows

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -269,6 +269,33 @@ class TestDisplayDedupe:
         assert not mutation.is_alive()
         assert [(row["active"], row["content"]) for row in page] == [(1, "visible-at-scan")]
 
+    def test_read_only_legacy_page_preserves_transaction_failure(self, tmp_path):
+        path = tmp_path / "read-only-legacy-error.db"
+        writer = SessionDB(path)
+        sid = "read-only-legacy-error"
+        writer.create_session(sid, source="desktop")
+        writer.append_message(sid, "assistant", "message")
+        writer._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET display_order = NULL, display_identity = NULL WHERE session_id = ?",
+            (sid,),
+        ))
+        writer.close()
+        reader = SessionDB(path, read_only=True)
+        connection = reader._conn
+        assert connection is not None
+
+        def fail_after_sqlite_aborts_transaction(key) -> bytes:
+            del key
+            connection.execute("ROLLBACK")
+            raise sqlite3.OperationalError("disk I/O error")
+
+        reader._display_identity = fail_after_sqlite_aborts_transaction
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+                reader.get_messages(sid, include_compacted=True, latest=True, limit=1)
+        finally:
+            reader.close()
+
     def test_display_paging_and_append_work_is_bounded(self, db):
         """Page and identity-lookup work scale with the page, not the transcript: 10x rows
         must not cost 10x SQLite VM steps (the pre-index read deduped the whole session)."""

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -14,6 +14,7 @@ job of ``include_inactive`` (audit / debug reads).
 
 import json
 import sqlite3
+import tracemalloc
 
 import pytest
 
@@ -149,6 +150,51 @@ class TestDisplayDedupe:
             )
 
         db._execute_write(_do)
+
+    def test_legacy_backfill_streams_large_payloads_across_batches(self, db):
+        """Legacy backfill must finish every keyset batch without retaining the archived payload."""
+        sid = "large-legacy"
+        payload_size = 2_000_000
+        db.create_session(sid, source="desktop")
+        db.append_messages_batch(
+            sid,
+            [{"role": "assistant", "content": f"small-{index}"} for index in range(1_001)],
+            chunk_rows=500,
+        )
+        first_row_id = db._read_one(
+            "SELECT id FROM messages WHERE session_id = ? ORDER BY id LIMIT 1", (sid,))[0]
+        self._copy_tail_as_new_generation(db, sid, [first_row_id])
+        db.append_messages_batch(
+            sid,
+            [
+                {"role": "assistant", "content": chr(65 + index) * payload_size}
+                for index in range(12)
+            ],
+        )
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET display_order = NULL, display_identity = NULL WHERE session_id = ?",
+            (sid,),
+        ))
+
+        tracemalloc.start()
+        try:
+            page = db.get_messages(sid, include_compacted=True, latest=True, limit=1)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        assert page[0]["content"] == "L" * payload_size
+        assert peak < payload_size * 5
+        assert db._read_one(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ? "
+            "AND (display_order IS NULL OR display_identity IS NULL)",
+            (sid,),
+        )[0] == 0
+        duplicate_orders = db._read_all(
+            "SELECT display_order FROM messages WHERE session_id = ? AND content = ? ORDER BY id",
+            (sid, "small-0"),
+        )
+        assert [row[0] for row in duplicate_orders] == [first_row_id, first_row_id]
 
     def test_display_paging_and_append_work_is_bounded(self, db):
         """Page and identity-lookup work scale with the page, not the transcript: 10x rows

--- a/tests/hermes_state/test_get_messages_include_compacted.py
+++ b/tests/hermes_state/test_get_messages_include_compacted.py
@@ -196,6 +196,35 @@ class TestDisplayDedupe:
         )
         assert [row[0] for row in duplicate_orders] == [first_row_id, first_row_id]
 
+    def test_read_only_legacy_latest_page_does_not_retain_transcript_payloads(self, tmp_path):
+        path = tmp_path / "read-only-legacy.db"
+        writer = SessionDB(path)
+        sid = "read-only-legacy"
+        payload_size = 2_000_000
+        writer.create_session(sid, source="desktop")
+        writer.append_messages_batch(
+            sid,
+            [{"role": "assistant", "content": chr(65 + index) * payload_size}
+             for index in range(12)],
+        )
+        writer._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET display_order = NULL, display_identity = NULL WHERE session_id = ?",
+            (sid,),
+        ))
+        writer.close()
+
+        reader = SessionDB(path, read_only=True)
+        tracemalloc.start()
+        try:
+            page = reader.get_messages(sid, include_compacted=True, latest=True, limit=1)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+            reader.close()
+
+        assert page[0]["content"] == "L" * payload_size
+        assert peak < payload_size * 5
+
     def test_display_paging_and_append_work_is_bounded(self, db):
         """Page and identity-lookup work scale with the page, not the transcript: 10x rows
         must not cost 10x SQLite VM steps (the pre-index read deduped the whole session)."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3616,6 +3616,59 @@ def test_session_resume_deferred_history_acknowledges_and_reuses(monkeypatch):
                 server._sessions.pop(sid, None)
 
 
+def test_desktop_deferred_resume_hydrates_model_tip_without_display_lineage(monkeypatch):
+    hydrated = threading.Event()
+    reads = []
+    tip = {"role": "user", "content": "current model context"}
+
+    class FakeDB:
+        def get_session(self, target):
+            return {"id": target, "message_count": 1_200}
+
+        def resolve_resume_session_id(self, target):
+            return target
+
+        def reopen_session(self, target):
+            assert target == "large-desktop-session"
+
+        def get_messages_as_conversation(self, target, **kwargs):
+            reads.append((target, kwargs))
+            hydrated.set()
+            return [tip]
+
+        def get_resume_conversations(self, _target):
+            raise AssertionError("Desktop must not materialize the REST-owned display lineage")
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *_args: None)
+
+    try:
+        response = server._methods["session.resume"](
+            "desktop-resume",
+            {"session_id": "large-desktop-session", "source": "desktop",
+             "defer_history": True, "omit_messages": True},
+        )
+        assert "error" not in response, response
+        sid = response["result"]["session_id"]
+        assert hydrated.wait(timeout=1.0)
+        assert server._sessions[sid]["resume_history_ready"].wait(timeout=1.0)
+        assert reads == [("large-desktop-session", {
+            "repair_alternation": True, "include_row_ids": True})]
+        assert server._sessions[sid]["history"] == [tip]
+        assert server._sessions[sid]["display_history_prefix"] == []
+        assert server._sessions[sid]["resume_message_count"] == 1_200
+    finally:
+        for sid, session in list(server._sessions.items()):
+            if session.get("session_key") == "large-desktop-session":
+                lease = session.get("active_session_lease")
+                if lease is not None:
+                    lease.release()
+                server._sessions.pop(sid, None)
+
+
 def test_session_resume_deferred_history_failure_can_retry(monkeypatch):
     first_released = threading.Event()
     build_started = threading.Event()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -705,7 +705,12 @@ def _resume_deferred(ctx: _Resume) -> dict:
                   resume_message_count=int(ctx.found.get("message_count") or 0))
     if (reused := ctx.claim(sid, record)) is not None:
         return reused
-    _schedule_resume_hydration(sid, ctx.target, ctx.db, close_db=ctx.owns_db)
+    # Desktop already owns the visible transcript through bounded REST pages. Loading the full
+    # compression lineage again here only feeds an unused display prefix and can exhaust the backend.
+    model_history_only = source == "desktop" and ctx.omit_messages
+    _schedule_resume_hydration(
+        sid, ctx.target, ctx.db, close_db=ctx.owns_db,
+        model_history_only=model_history_only)
     ctx.owns_db = False  # the hydration worker now owns (and closes) the profile-scoped handle
     _schedule_session_cap_enforcement()
     return _resume_response(ctx, sid, record, info=ctx.info(cwd, overrides), messages=[],

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2501,10 +2501,14 @@ def _schedule_agent_build(sid: str, delay: float = 0.05) -> None:
     timer.start()
 
 
-def _load_resume_transcript(db, stored_id: str) -> tuple[list, list, list]:
+def _load_resume_transcript(db, stored_id: str, *, model_history_only: bool = False) -> tuple[list, list, list]:
     """(raw_history, display_history, ancestor_prefix) for a cold resume. The full lineage is materialized
     only while it fits sessions.max_resume_messages (the transcript is REST-paginated), else the tip alone."""
     from hermes_state import SessionResumeTooLargeError
+    if model_history_only:
+        raw_history = db.get_messages_as_conversation(
+            stored_id, repair_alternation=True, include_row_ids=True)
+        return raw_history, [], []
     prefix_fits = True
     guard = getattr(db, "assert_resume_safe", None)
     if callable(guard):
@@ -2523,7 +2527,8 @@ def _load_resume_transcript(db, stored_id: str) -> tuple[list, list, list]:
     return raw_history, raw_history, []
 
 
-def _schedule_resume_hydration(sid: str, stored_id: str, db, *, close_db: bool = False) -> None:
+def _schedule_resume_hydration(sid: str, stored_id: str, db, *, close_db: bool = False,
+                               model_history_only: bool = False) -> None:
     """Load a cold resume's transcript off the JSON-RPC response path."""
 
     def _run() -> None:
@@ -2533,7 +2538,8 @@ def _schedule_resume_hydration(sid: str, stored_id: str, db, *, close_db: bool =
                 return
             _emit("session.resume_progress", sid, {"phase": "history", "status": "loading"})
             db.reopen_session(stored_id)
-            raw_history, display_history, prefix = _load_resume_transcript(db, stored_id)
+            raw_history, display_history, prefix = _load_resume_transcript(
+                db, stored_id, model_history_only=model_history_only)
             # Display keeps the full transcript; the model-fed history drops a dangling/interrupted
             # tool-call tail so a session killed mid-loop does not replay the unanswered call forever
             # (#29086).
@@ -2541,15 +2547,16 @@ def _schedule_resume_hydration(sid: str, stored_id: str, db, *, close_db: bool =
             if _sessions.get(sid) is not session:
                 return
             with session["history_lock"]:
-                session.update(history=history, display_history_prefix=prefix, resume_hydrating=False,
-                               resume_message_count=len(display_history))
+                session.update(history=history, display_history_prefix=prefix, resume_hydrating=False)
+                if not model_history_only:
+                    session["resume_message_count"] = len(display_history)
             # Deferred resumes answered before the transcript existed; cache the derived todo snapshot now.
             todo_state = _todo_state_from_history(history)
             if todo_state is not None and session.get("todo_state") is None:
                 session["todo_state"] = todo_state
             session["resume_history_ready"].set()
             _emit("session.resume_progress", sid,
-                  {"message_count": len(display_history), "phase": "history", "status": "complete"})
+                  {"message_count": session["resume_message_count"], "phase": "history", "status": "complete"})
             _maybe_schedule_auto_continue(sid, session, stored_id)
             _start_agent_build(sid, session)
         except Exception as exc:


### PR DESCRIPTION
## P0 impact

Opening or switching to a large compacted conversation can make `hermes serve` allocate multiple gigabytes and stop answering Desktop RPCs for 30+ seconds. The Desktop reports errors such as `Session controls unavailable: request timed out after 30s: session.control.read`; repeated stalls make the gateway appear to crash-loop.

## Root cause

Two resume paths independently materialized the same large legacy transcript:

1. The read-only REST transcript path fell back to `SELECT * ... fetchall()` when display metadata had not yet been backfilled, retaining every payload and dedupe key before slicing the requested latest page.
2. Desktop deferred `session.resume` loaded the full compression/display lineage even with `omit_messages: true`, although Desktop renders its transcript from bounded REST pages and only needs the active model tip from JSON-RPC.

On the reported 16.47 GB state database, individual histories contain hundreds of thousands of physical rows and hundreds of MB of content. This drove multi-gigabyte RSS, CPU saturation, long switches, RPC timeouts, and backend restarts.

## Fix

- Backfill writable legacy display metadata in exhausted 1,000-row keyset pages through `idx_messages_session_id`, with no native SQLite temp sorter and no live read cursor during updates.
- In read-only legacy stores, stream only display-identity fields, retain fixed-width identities plus representative row IDs, and fetch payloads only for the requested page.
- Keep the legacy identity scan and payload fetch in one explicit read snapshot, preserving a coherent result during concurrent rewinds/deletes and preserving primary SQLite failures if SQLite auto-aborts the transaction.
- Preserve existing display dedupe/order semantics, including active representatives and cross-page duplicates.
- For Desktop deferred resumes with omitted messages, hydrate only the active model conversation; leave visible transcript ownership with bounded REST paging.
- Preserve the stored total message count for Desktop progress/UI state.

## Verification

- Exact old/new display projection comparison on a real large legacy session returned identical latest-page row IDs.
- Real legacy latest-120 projection completed in 1.786s at ~65 MB max RSS instead of multi-GB growth.
- Real model-tip hydration completed in 0.177s at ~83 MB max RSS.
- `EXPLAIN QUERY PLAN` uses `idx_messages_session_id` with no `USE TEMP B-TREE`.
- Deterministic WAL concurrency regression proves scan and payload fetch observe one snapshot.
- Auto-abort regression proves the original SQLite error is not masked by cleanup.
- `scripts/run_tests.sh tests/hermes_state/test_get_messages_include_compacted.py`: **19 passed**.
- Targeted Desktop deferred-resume tests: **3 passed**.
- `scripts/run_tests.sh tests/tui_gateway/test_protocol.py tests/tui_gateway/test_session_resume_db_ownership.py`: **80 passed**.
- Full `tests/test_tui_gateway_server.py`: **639 passed, 1 unrelated pre-existing failure** (`test_model_options_preserves_canonical_custom_row_after_agent_init`, reproducible alone).
- `git diff --check` and Python compilation: pass.

## Scope

No schema, display semantics, protocol shape, or public API changes. The change bounds legacy transcript projection and removes a redundant Desktop-only lineage load.
