### PR TITLE
fix(update): honor stash policy when already current

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1145,17 +1145,23 @@ def _finalize_receipt(status: str, debug_message: str) -> None:
 def _finish_already_up_to_date(
     git_cmd, branch: str, current_branch: str, _plan, *, assume_yes: bool, gateway_mode: bool,
     gw_input_fn, pre_update_snapshot_id, desktop_dir, had_desktop_app_before_update: bool,
-    active_lazy_features, active_tool_dependencies, _windows_gateway_resume) -> None:
-    """"Already up to date" path: restore stash/branch, repair the checkout, catch up the fleet.
+    active_lazy_features, active_tool_dependencies, discard_local_changes: bool,
+    keep_stash: bool, _windows_gateway_resume) -> None:
+    """"Already up to date" path: resolve stash/branch, repair the checkout, catch up the fleet.
     ``sys.exit(1)`` when the repair is incomplete (after gateway exit code + partial receipt)."""
     _invalidate_update_cache()
 
     # Restore stash and switch back if we moved. EXCEPTION: a parked branch verified clean +
     # fully merged stays on the target — re-parking on the stale branch recreates the incident.
     if _plan.auto_stash_ref is not None:
-        _m()._restore_stashed_changes(
-            git_cmd, _m().PROJECT_ROOT, _plan.auto_stash_ref, prompt_user=_plan.prompt_for_restore,
-            input_fn=gw_input_fn)
+        if discard_local_changes:
+            _m()._discard_stashed_changes(git_cmd, _m().PROJECT_ROOT, _plan.auto_stash_ref)
+        elif keep_stash:
+            _m()._park_stashed_changes(_plan.auto_stash_ref)
+        else:
+            _m()._restore_stashed_changes(
+                git_cmd, _m().PROJECT_ROOT, _plan.auto_stash_ref, prompt_user=_plan.prompt_for_restore,
+                input_fn=gw_input_fn)
     if _plan.parked_branch_switched:
         if _plan.switch_block_reason.startswith("unmerged:"):
             _count = _plan.switch_block_reason.split(":", 1)[1]
@@ -1339,6 +1345,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 had_desktop_app_before_update=had_desktop_app_before_update,
                 active_lazy_features=opts.active_lazy_features,
                 active_tool_dependencies=opts.active_tool_dependencies,
+                discard_local_changes=opts.discard_local_changes,
+                keep_stash=opts.keep_stash,
                 _windows_gateway_resume=_windows_gateway_resume)
             return
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -957,8 +957,8 @@ def _resolve_update_options(args, gateway_mode: bool) -> _UpdateOptions:
     gw_input_fn = (
         (lambda prompt, default="": _gateway_prompt(prompt, default)) if gateway_mode else None)
     assume_yes = bool(getattr(args, "yes", False))
-    # --keep-stash (desktop updater): never re-apply the autostash; only when an update
-    # landed — abort/no-op paths still restore since the tree is unchanged.
+    # --keep-stash (desktop updater): never re-apply the autostash after a successful
+    # update or no-op repair; failed updates leave it preserved without further action.
     keep_stash = bool(getattr(args, "keep_stash", False))
     # --switch-branch: prefer switching over an in-place merge so an update never writes the
     # branch's history; only meaningful with parked_branch_strategy "update_in_place".

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -602,6 +602,20 @@ def test_update_keep_stash_parks_instead_of_restoring(monkeypatch, tmp_path):
     assert discard_calls == []
 
 
+def test_update_keep_stash_parks_when_already_up_to_date(monkeypatch, tmp_path):
+    """A no-op Desktop update must not restore source edits over the current checkout."""
+    restore_calls, discard_calls, park_calls = _setup_keep_stash_test(monkeypatch, tmp_path)
+    side_effect, _ = _make_update_side_effect(commit_count="0")
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace(yes=True, keep_stash=True))
+
+    assert len(park_calls) == 1
+    assert park_calls[0][0] == "abc123deadbeef"
+    assert restore_calls == []
+    assert discard_calls == []
+
+
 def test_update_without_keep_stash_still_restores(monkeypatch, tmp_path):
     """Regression guard: default behavior (no --keep-stash) is unchanged —
     the autostash is auto-restored under --yes."""


### PR DESCRIPTION
## P0 impact

A Desktop update can report success while leaving the source checkout mixed and the supervised gateway running stale code. Subsequent restarts return to the stale runtime, producing an apparent gateway crash loop.

## Reproduced incident

A real `hermes update --yes --gateway --keep-stash --branch main` receipt recorded:

- checkout expected SHA: `554eb9c2`
- live gateway code SHA: `9e0dc431`
- outcome: `success`
- empty gateway restart/fleet results

The checkout `HEAD` was current, but 315 restored source files exactly matched the older commit. The no-update path had stashed those changes and then unconditionally restored them despite `--keep-stash`.

## Root cause

`_finish_already_up_to_date()` did not receive the resolved stash policy. It always called `_restore_stashed_changes()`, unlike the update-available path. Therefore the Desktop safety flag was silently ignored whenever Git reported zero new commits—the exact recovery path for an already-current but mixed checkout.

## Fix

Pass the resolved `discard_local_changes` and `keep_stash` policy into the no-update path and apply the same disposition order as a normal update:

1. discard when explicitly configured,
2. park when `--keep-stash` is set,
3. otherwise preserve existing restore behavior.

## Verification

- New no-update regression proven red on base and green after the fix.
- Focused canonical runner: **1 passed, 0 failed**.
- Existing default/update-available behavior is unchanged by control flow.
- `git diff --check`: pass.

Two older update-available tests in the same file currently admit the host's live `ai.hermes.gateway` launchd unit into fleet verification and fail independently of this no-update branch; their output was not claimed as passing evidence.