### PR TITLE
fix(tools): recognize the managed Nous selection in browser_exec backend resolution

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -434,6 +434,43 @@ class TestBackendCdpResolution:
         assert bu_cli._resolve_backend_cdp(env, "t1") is None
         assert env["BU_CDP_WS"] == "wss://browser.example/cdp/abc"
 
+    def test_managed_nous_selection_exports_gateway_cdp(self, monkeypatch):
+        """Regression for #93865. The picker writes ``browser.cloud_provider: nous`` and STRIPS the
+        legacy ``use_gateway`` flag, so a managed pick must be recognised by the selection alone: the
+        gateway provisions the browser server-side and its CDP URL has to reach the harness. Reading
+        only ``use_gateway`` made this fall through to the direct-Browser-Use branch, which exports
+        nothing and leaves the harness to reach BU cloud with a credential it does not have."""
+        class _BrowserUseProvider:
+            name = "browser-use"
+
+        monkeypatch.setattr("tools.browser_tool_cdp._get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: _BrowserUseProvider())
+        monkeypatch.setattr("hermes_cli.config.read_raw_config",
+                            lambda: {"browser": {"cloud_provider": "nous"}})
+        monkeypatch.setattr(bt_session, "_get_session_info",
+                            lambda task_id: {"cdp_url": "wss://gateway.example/cdp/xyz"})
+        env = self._env()
+        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        assert env["BU_CDP_WS"] == "wss://gateway.example/cdp/xyz"
+
+    def test_direct_browser_use_selection_still_autospawns(self, monkeypatch):
+        """The other side of the #93865 branch must not regress: a DIRECT Browser Use pick
+        (own API key, no managed selection) reaches BU cloud natively, so Hermes must NOT
+        provision a second, redundant session for it."""
+        class _BrowserUseProvider:
+            name = "browser-use"
+
+        monkeypatch.setattr("tools.browser_tool_cdp._get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt_cloud, "_get_cloud_provider", lambda: _BrowserUseProvider())
+        monkeypatch.setattr("hermes_cli.config.read_raw_config",
+                            lambda: {"browser": {"cloud_provider": "browser-use"}})
+        monkeypatch.setattr(bt_session, "_get_session_info",
+                            lambda task_id: pytest.fail("direct BU config must not create a session"))
+        env = self._env()
+        assert bu_cli._resolve_backend_cdp(env, "t1") is None
+        assert "BU_CDP_WS" not in env and "BU_CDP_URL" not in env
+        assert env[bu_cli._PRIVATE_BROWSER_SENTINEL] == "1"
+
     def test_no_provider_drives_packaged_chromium_not_user_chrome(self, monkeypatch, _fake_managed_chromium):
         """Local mode must hand the harness the agent-browser-launched Chromium (same browser the built-in
         tools use) — never leave BU_CDP_* unset, which makes the harness hunt for the user's installed

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -178,7 +178,21 @@ def _read_browser_cfg() -> dict:
 
 
 def _use_gateway(browser_cfg: dict) -> bool:
-    return is_truthy_value(browser_cfg.get("use_gateway"), default=False)
+    """True when the browser category runs through the Nous-managed gateway.
+
+    Two config shapes mean the same thing: the picker's ``browser.cloud_provider: nous`` and the
+    legacy ``browser.use_gateway: true``. Reading only the legacy flag stranded every managed user,
+    because (re)selecting the Browser Automation row strips ``use_gateway``
+    (``_write_provider_config``): :func:`_resolve_backend_cdp` then read a managed pick as a DIRECT
+    Browser Use config, exported no CDP, and the harness tried to reach Browser Use cloud natively
+    with no credential of its own -- "daemon default didn't come up" on every call. See #93865.
+    """
+    if is_truthy_value(browser_cfg.get("use_gateway"), default=False):
+        return True
+    # Lazy: tool_backend_helpers pulls the Nous stack that direct-key users never need.
+    from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER, normalize_browser_cloud_provider
+
+    return normalize_browser_cloud_provider(browser_cfg.get("cloud_provider")) == NOUS_MANAGED_PROVIDER
 
 
 def get_browser_backend() -> str:


### PR DESCRIPTION
## What does this PR do?

`_resolve_backend_cdp()` decided "managed Nous gateway" vs "direct Browser Use" by reading the
legacy `browser.use_gateway` flag alone. The tools picker writes `browser.cloud_provider: nous`
and `_write_provider_config()` strips `use_gateway` whenever the Browser Automation row is
(re)selected, so on any current install the managed pick was read as a DIRECT Browser Use config:
`browser_exec` exported no CDP endpoint and left the harness to reach Browser Use cloud natively
with a credential it does not have. Every call failed with:

```
browser-harness: daemon default didn't come up
```

`_use_gateway()` now recognises both shapes of the same selection — the picker's
`cloud_provider: nous` and the legacy `use_gateway: true` — so the gateway-provisioned CDP URL
reaches the harness again. The direct-Browser-Use branch is unchanged: a BYOK pick still
autospawns natively instead of having Hermes provision a second, redundant session.

## Related Issue

Fixes #93865

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_use_cli.py`: `_use_gateway()` returns True for the managed selection
  (`browser.cloud_provider: nous`, via `normalize_browser_cloud_provider` /
  `NOUS_MANAGED_PROVIDER`) as well as the legacy flag. The other call site,
  `is_legacy_browser_use_cloud_config()`, is unaffected: a `nous` provider already
  short-circuits that check before `_use_gateway` is consulted.
- `tests/tools/test_browser_use_cli.py`: the end-to-end `cloud_provider: nous` case through
  `_resolve_backend_cdp()` that the issue notes was missing, plus its counterpart asserting a
  direct Browser Use pick still autospawns and provisions no session.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_browser_use_cli.py -q` — 118 passed.
   The new `test_managed_nous_selection_exports_gateway_cdp` fails on unpatched main
   (`KeyError: 'BU_CDP_WS'` — the exact shape of the bug).
2. `scripts/run_tests.sh tests/tools/test_browser_cloud_fallback.py tests/tools/test_browser_cloud_provider_cache.py tests/tools/test_browser_cdp_override.py tests/tools/test_strict_provider_selection.py -q` — 66 passed.
3. Live, on a Nous Portal subscription with `browser.cloud_provider: nous` and no `use_gateway`
   key: `browser_exec` went from `{"success": false, "stderr": "browser-harness: daemon default
   didn't come up"}` to `{"success": true, "exit_code": 0, "output": "{'url':
   'https://example.com/', 'title': 'Example Domain', ...}"}`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open PR references #93865)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the affected suites instead (118 + 66 passed,
      commands above). The full tree needs optional extras this environment lacks: the only failures I saw
      are two pre-existing `TestParallelClientConfig` errors from a missing `parallel-web`, identical on an
      unpatched checkout.
- [x] I've tested on my platform: macOS 26.6.2 (arm64), Python 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — the `_use_gateway` docstring now records
      why the selection has two shapes
- [x] `cli-config.yaml.example` — N/A (no new config keys; this restores support for an existing one)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — config-shape only, no platform-specific paths
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Same machine, same profile, `browser.cloud_provider: nous` with no `use_gateway` key.

Before:

```json
{"success": false, "exit_code": 1, "output": "",
 "stderr": "browser-harness: daemon default didn't come up -- check .../bu-default.log"}
```

After:

```json
{"success": true, "exit_code": 0,
 "output": "{'url': 'https://example.com/', 'title': 'Example Domain', 'w': 1536, 'h': 643}"}
```
