### PR TITLE
fix(auth): retain Codex login identity for account labels

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -291,12 +291,16 @@ class PooledCredential:
         return self.base_url
 
 
-def label_from_token(token: str, fallback: str) -> str:
-    claims = _decode_jwt_claims(token)
-    for key in ("email", "preferred_username", "upn"):
-        value = claims.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
+def label_from_token(token: str, fallback: str, *, id_token: str = "") -> str:
+    """Read display metadata only; these decoded claims never authorize an account."""
+    for candidate in (id_token, token):
+        claims = _decode_jwt_claims(candidate)
+        profile = claims.get("https://api.openai.com/profile")
+        for identity in (claims, profile if isinstance(profile, dict) else {}):
+            for key in ("email", "preferred_username", "upn"):
+                value = identity.get(key)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
     return fallback
 
 
@@ -2496,7 +2500,8 @@ def _seed_tokens_singleton(seed: _Seeder, auth_store: Dict[str, Any]) -> None:
         "refresh_token": tokens.get("refresh_token"),
         "base_url": base_url,
         "last_refresh": state.get("last_refresh"),
-        "label": custom_label or label_from_token(tokens.get("access_token", ""), "device_code"),
+        "label": custom_label or label_from_token(
+            tokens.get("access_token", ""), "device_code", id_token=tokens.get("id_token", "")),
     })
 
 

--- a/hermes_cli/auth_codex.py
+++ b/hermes_cli/auth_codex.py
@@ -833,6 +833,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
     return {
         "tokens": {
             "access_token": tokens.get("access_token", ""),
-            "refresh_token": tokens.get("refresh_token", "")},
+            "refresh_token": tokens.get("refresh_token", ""),
+            "id_token": tokens.get("id_token", "")},
         "base_url": _codex_base_url(), "last_refresh": _utc_now_z(), "auth_mode": "chatgpt",
         "source": "device-code"}

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -371,7 +371,8 @@ def _add_credential(args, provider: str, pool, requested_type: str) -> PooledCre
     creds = spec.login(args)
     token = spec.token(creds)
     label = (getattr(args, "label", None) or "").strip() or label_from_token(
-        token, f"{provider}-oauth-{len(pool.entries()) + 1}")
+        token, f"{provider}-oauth-{len(pool.entries()) + 1}",
+        id_token=creds.get("tokens", {}).get("id_token", "") if provider == "openai-codex" else "")
     # Every account gets a distinct, self-contained pool entry instead of routing through a
     # singleton save path (which collapsed every added account into the latest login).
     # ``manual:*`` entries refresh from their own token pair, so they need no singleton shadow.

--- a/hermes_cli/web_routers/oauth.py
+++ b/hermes_cli/web_routers/oauth.py
@@ -196,7 +196,9 @@ def _codex_exchange_tokens(httpx, code_resp: Dict[str, Any]) -> Dict[str, str]:
     tokens = token_resp.json()
     if not tokens.get("access_token"):
         raise RuntimeError("token exchange did not return access_token")
-    return {"access_token": tokens.get("access_token", ""), "refresh_token": tokens.get("refresh_token", "")}
+    return {"access_token": tokens.get("access_token", ""),
+            "refresh_token": tokens.get("refresh_token", ""),
+            **({"id_token": tokens["id_token"]} if tokens.get("id_token") else {})}
 
 
 def _codex_full_login_worker(session_id: str) -> None:

--- a/tests/hermes_cli/test_codex_identity_labels.py
+++ b/tests/hermes_cli/test_codex_identity_labels.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import httpx
 
 from agent.credential_pool import label_from_token, load_pool
-from hermes_cli import auth_commands
+from hermes_cli import auth_codex, auth_commands
 from hermes_cli.web_routers import oauth
 
 
@@ -23,7 +23,10 @@ def test_codex_identity_survives_exchange_and_pool_reload(tmp_path, monkeypatch)
     monkeypatch.setattr(httpx, "Client", lambda **kw: real_client(
         transport=httpx.MockTransport(lambda request: httpx.Response(200, json=tokens)), **kw))
     exchanged = oauth._codex_exchange_tokens(httpx, {"authorization_code": "code", "code_verifier": "verifier"})
-    monkeypatch.setattr(auth_commands.auth_mod, "_codex_device_code_login", lambda: {"tokens": exchanged})
+    monkeypatch.setattr(auth_codex, "_codex_request_device_code", lambda *args: {
+        "user_code": "CODE", "device_auth_id": "device", "interval": 1})
+    monkeypatch.setattr(auth_codex, "_codex_poll_authorization_code", lambda *args, **kw: {})
+    monkeypatch.setattr(auth_codex, "_codex_exchange_authorization_code", lambda *args: exchanged)
     pool = load_pool("openai-codex")
     first = auth_commands._add_credential(SimpleNamespace(label=None), "openai-codex", pool, "oauth")
     assert first.label == "first@example.test"

--- a/tests/hermes_cli/test_codex_identity_labels.py
+++ b/tests/hermes_cli/test_codex_identity_labels.py
@@ -1,4 +1,5 @@
 """Provider identity is display metadata; pool IDs and explicit labels remain authoritative."""
+import asyncio
 import base64
 import json
 from types import SimpleNamespace
@@ -7,7 +8,7 @@ import httpx
 
 from agent.credential_pool import label_from_token, load_pool
 from hermes_cli import auth_codex, auth_commands
-from hermes_cli.web_routers import oauth
+from hermes_cli.web_routers import oauth, ops
 
 
 def jwt(claims):
@@ -15,7 +16,7 @@ def jwt(claims):
     return f"header.{payload}.signature"
 
 
-def test_codex_identity_survives_exchange_and_pool_reload(tmp_path, monkeypatch):
+def test_codex_identity_survives_exchange_and_pool_reload(tmp_path, monkeypatch, caplog, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     tokens = {"access_token": jwt({"sub": "account-a"}), "refresh_token": "refresh-a",
               "id_token": jwt({"email": "first@example.test"})}
@@ -40,6 +41,38 @@ def test_codex_identity_survives_exchange_and_pool_reload(tmp_path, monkeypatch)
     assert reloaded[second.id].label == "Work account"
     assert reloaded[first.id].access_token == first.access_token
     assert reloaded[second.id].access_token == tokens["access_token"]
+
+    # Refresh rotates secrets, not identity or the native account selector.
+    def refresh(access_token, refresh_token, **kwargs):
+        assert access_token == first.access_token
+        assert refresh_token == first.refresh_token
+        return {"access_token": "rotated-access-secret", "refresh_token": "rotated-refresh-secret"}
+
+    monkeypatch.setattr(auth_commands.auth_mod, "refresh_codex_oauth_pure", refresh)
+    monkeypatch.setattr(auth_codex, "refresh_codex_oauth_pure", refresh)
+    refreshed = pool._refresh_entry(first, force=True)
+    assert refreshed is not None
+    assert (refreshed.id, refreshed.label) == (first.id, first.label)
+    assert refreshed.access_token == "rotated-access-secret"
+    assert load_pool("openai-codex").entries()[0].label == first.label
+
+    # Disconnect/reconnect one login leaves the other account and its custom name intact.
+    assert pool.remove_index(1).id == first.id
+    exchanged.update(access_token=jwt({"sub": "account-a-reconnected"}),
+                     refresh_token="reconnected-refresh-secret",
+                     id_token=jwt({"email": first.label}))
+    reconnected = auth_commands._add_credential(SimpleNamespace(label=None), "openai-codex", pool, "oauth")
+    assert reconnected.id != first.id and reconnected.label == first.label
+    listed = asyncio.run(ops.list_credential_pool())
+    rows = next(provider["entries"] for provider in listed["providers"] if provider["provider"] == "openai-codex")
+    assert {row["id"]: row["label"] for row in rows} == {
+        second.id: "Work account", reconnected.id: first.label}
+    visible = json.dumps(listed) + caplog.text + capsys.readouterr().out
+    for secret in (first.access_token, first.refresh_token, second.access_token,
+                   second.refresh_token, refreshed.access_token, refreshed.refresh_token,
+                   reconnected.access_token, reconnected.refresh_token, exchanged["id_token"]):
+        assert secret not in visible
+    assert all("id_token" not in row and "access_token" not in row and "refresh_token" not in row for row in rows)
 
 
 def test_identity_claims_are_optional_and_never_used_as_account_ids():

--- a/tests/hermes_cli/test_codex_identity_labels.py
+++ b/tests/hermes_cli/test_codex_identity_labels.py
@@ -1,0 +1,48 @@
+"""Provider identity is display metadata; pool IDs and explicit labels remain authoritative."""
+import base64
+import json
+from types import SimpleNamespace
+
+import httpx
+
+from agent.credential_pool import label_from_token, load_pool
+from hermes_cli import auth_commands
+from hermes_cli.web_routers import oauth
+
+
+def jwt(claims):
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+def test_codex_identity_survives_exchange_and_pool_reload(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    tokens = {"access_token": jwt({"sub": "account-a"}), "refresh_token": "refresh-a",
+              "id_token": jwt({"email": "first@example.test"})}
+    real_client = httpx.Client
+    monkeypatch.setattr(httpx, "Client", lambda **kw: real_client(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=tokens)), **kw))
+    exchanged = oauth._codex_exchange_tokens(httpx, {"authorization_code": "code", "code_verifier": "verifier"})
+    monkeypatch.setattr(auth_commands.auth_mod, "_codex_device_code_login", lambda: {"tokens": exchanged})
+    pool = load_pool("openai-codex")
+    first = auth_commands._add_credential(SimpleNamespace(label=None), "openai-codex", pool, "oauth")
+    assert first.label == "first@example.test"
+    tokens.update(access_token=jwt({"https://api.openai.com/profile": {"email": "second@example.test"}}),
+                  refresh_token="refresh-b", id_token="")
+    exchanged.update(tokens)
+    second = auth_commands._add_credential(SimpleNamespace(label="Work account"), "openai-codex", pool, "oauth")
+    reloaded = {entry.id: entry for entry in load_pool("openai-codex").entries()}
+    assert first.id != second.id
+    assert reloaded[first.id].label == first.label
+    assert reloaded[second.id].label == "Work account"
+    assert reloaded[first.id].access_token == first.access_token
+    assert reloaded[second.id].access_token == tokens["access_token"]
+
+
+def test_identity_claims_are_optional_and_never_used_as_account_ids():
+    assert label_from_token(jwt({"https://api.openai.com/profile": {"email": " a@example.test "}}), "fallback") == "a@example.test"
+    for claims in ({}, [], {"email": 123}, {"https://api.openai.com/profile": "invalid"}, {"email": "  "}):
+        assert label_from_token(jwt(claims), "fallback", id_token="malformed") == "fallback"
+    assert label_from_token("opaque", "fallback") == "fallback"
+    assert label_from_token(jwt({"email": "access@example.test"}), "fallback",
+                            id_token=jwt({"email": "identity@example.test"})) == "identity@example.test"


### PR DESCRIPTION
Codex logins can appear as `openai-codex-oauth-1` or `device_code` even when the OAuth response contains an email. Both browser and CLI device login discard `id_token`, and the label helper only reads top-level access-token claims.

Retain the optional ID token through login and reuse the existing native label helper to read identity-token claims, with access-token and namespaced OpenAI profile fallbacks. Explicit labels retain precedence, and pool IDs and credentials remain independent of display names. Missing or malformed identity claims keep the existing fallback behavior. Decoded claims are display metadata, not an authorization mechanism.

Validation:
- Reproduced both new invariant-test failures on upstream main `267a6b79c8e0d8e0456d27948a80b79fea8f63d2`.
- `scripts/run_tests.sh tests/hermes_cli/test_codex_identity_labels.py tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_web_oauth_dispatch.py tests/agent/test_credential_pool_oauth_writethrough.py`: 53 passed.
- Tests exercise the browser token exchange with a provider HTTP fixture and real native pool persistence/reload, including distinct credentials, custom-label preservation, native token refresh, disconnect/reconnect isolation, and absence of full access/refresh/ID tokens in account API output or captured logs. No real provider login was performed for these tests.
