### PR TITLE
fix(dashboard): bootstrap active profile before chat

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1373,6 +1373,7 @@ def start_server(
     """
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
+    app.state.initial_profile = initial_profile
 
     # Dashboard-mode starts don't route through main.py's `serve` path, which
     # applies the same RLIMIT_NOFILE floor (policy in resource_limits, #81547).

--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -153,9 +153,11 @@ def mount_spa(application: FastAPI):
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
         token_js = "" if gated else f'window.__HERMES_SESSION_TOKEN__="{_server()._SESSION_TOKEN}";'
+        initial_profile_js = json.dumps(getattr(application.state, "initial_profile", "")).replace("<", "\\u003c")
         bootstrap_script = (
             f"<script>{token_js}"
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
+            f"window.__HERMES_INITIAL_PROFILE__={initial_profile_js};"
             f'window.__HERMES_BASE_PATH__="{prefix}";'
             f"window.__HERMES_AUTH_REQUIRED__={'true' if gated else 'false'};"
             f"</script>"

--- a/web/src/contexts/ProfileProvider.test.tsx
+++ b/web/src/contexts/ProfileProvider.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { act, useContext } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, useLocation } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getActiveProfile: vi.fn(),
+  getProfiles: vi.fn(),
+}));
+const setManagementProfile = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({ api: apiMocks, setManagementProfile }));
+
+import { ProfileContext } from "@/contexts/profile-context";
+import { ProfileProvider } from "@/contexts/ProfileProvider";
+
+let container: HTMLDivElement;
+let root: Root;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Probe() {
+  const { profile, setProfile } = useContext(ProfileContext);
+  const { search } = useLocation();
+  return <button onClick={() => setProfile("later")}>{profile}|{search}</button>;
+}
+
+async function render(entry: string) {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root.render(
+    <MemoryRouter initialEntries={[entry]}>
+      <ProfileProvider><Probe /></ProfileProvider>
+    </MemoryRouter>,
+  ));
+}
+
+beforeEach(() => {
+  apiMocks.getProfiles.mockResolvedValue({ profiles: [] });
+  apiMocks.getActiveProfile.mockResolvedValue({ current: "default", active: "default" });
+  setManagementProfile.mockClear();
+  Object.defineProperty(window, "__HERMES_INITIAL_PROFILE__", {
+    configurable: true,
+    value: "",
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+});
+
+describe("ProfileProvider launch bootstrap", () => {
+  it("uses the server profile on the first bare-chat render", async () => {
+    Object.defineProperty(window, "__HERMES_INITIAL_PROFILE__", {
+      configurable: true,
+      value: "worker_x",
+    });
+
+    await render("/chat");
+
+    expect(container.textContent).toBe("worker_x|?profile=worker_x");
+    expect(setManagementProfile).toHaveBeenCalledWith("worker_x");
+  });
+
+  it("lets an explicit URL profile override the launch bootstrap", async () => {
+    Object.defineProperty(window, "__HERMES_INITIAL_PROFILE__", {
+      configurable: true,
+      value: "worker_x",
+    });
+
+    await render("/chat?profile=other");
+
+    expect(container.textContent).toBe("other|?profile=other");
+    expect(setManagementProfile).toHaveBeenCalledWith("other");
+  });
+
+  it("keeps the unscoped default and allows later profile changes", async () => {
+    await render("/chat");
+
+    expect(container.textContent).toBe("|");
+    await act(async () => container.querySelector("button")?.click());
+    expect(container.textContent).toBe("later|?profile=later");
+  });
+});

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -42,7 +42,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   // Initial value comes from the URL (deep link / refresh / unified-launch
   // preselect); afterwards state leads and the URL follows.
   const [profile, setProfileState] = useState(
-    () => searchParams.get("profile") ?? "",
+    () => searchParams.get("profile") ?? window.__HERMES_INITIAL_PROFILE__ ?? "",
   );
 
   // Mirror into the api module synchronously on every render where it

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -31,6 +31,8 @@ declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
     __HERMES_BASE_PATH__?: string;
+    /** Server-injected profile for a named-profile dashboard launch. */
+    __HERMES_INITIAL_PROFILE__?: string;
     /** Server-injected flag: ``true`` when the dashboard's OAuth gate is
      * engaged (public bind, no ``--insecure``). Toggles the SPA's
      * WS-upgrade path from legacy ``?token=`` to single-use ``?ticket=``


### PR DESCRIPTION
## Summary
- inject the named dashboard launch profile into the SPA bootstrap
- initialize profile scope synchronously before the first chat PTY opens
- preserve explicit URL precedence and later profile switching
- escape inline JSON against script termination

## Verification
- profile and chat frontend tests: 9 passed
- TypeScript and ESLint: passed
- backend bootstrap/security check: passed
- Python compile and diff check: passed