### PR TITLE
fix(gateway): tolerate unresolvable UIDs in launchd plist path lookup (#57292)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2556,8 +2556,16 @@ def get_launchd_plist_path() -> Path:
     import pwd
     suffix = _profile_suffix()
     name = f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
-    # Real account home: profile mode may point HOME at a profile dir.
-    home = Path(pwd.getpwuid(os.getuid()).pw_dir)  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    # Real account home: profile mode may point HOME at a profile dir. Sandboxed/app-hosted
+    # shells can expose a UID that pwd cannot resolve (#57292); fall back to the shared
+    # real-home resolver (HERMES_REAL_HOME → HOME → pwd → ~, profile home skipped) instead
+    # of crashing launchd commands.
+    try:
+        home = Path(pwd.getpwuid(os.getuid()).pw_dir)  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    except (KeyError, ImportError, OSError):
+        from hermes_constants import get_real_home
+
+        home = Path(get_real_home())
     return home / "Library" / "LaunchAgents" / f"{name}.plist"
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1786,6 +1786,90 @@ class TestProfileArg:
 
         assert plist_path == machine_home / "Library" / "LaunchAgents" / "ai.hermes.gateway-orcha.plist"
 
+    def test_launchd_plist_path_falls_back_to_home_when_uid_lookup_fails(self, tmp_path, monkeypatch):
+        """Sandboxed macOS shells can expose a UID that pwd cannot resolve (#57292)."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        machine_home = tmp_path / "Users" / "example"
+        machine_home.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(machine_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+
+        def raise_key_error(uid):
+            raise KeyError(f"getpwuid(): uid not found: {uid}")
+
+        monkeypatch.setattr(pwd, "getpwuid", raise_key_error)
+
+        plist_path = gateway_cli.get_launchd_plist_path()
+
+        assert plist_path == machine_home / "Library" / "LaunchAgents" / "ai.hermes.gateway-mybot.plist"
+
+    def test_launchd_plist_path_prefers_hermes_real_home_when_uid_lookup_fails(self, tmp_path, monkeypatch):
+        """HERMES_REAL_HOME is the explicit operator override for unresolvable UIDs (#57292)."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        real_home = tmp_path / "real-home"
+        other_home = tmp_path / "other-home"
+        real_home.mkdir(parents=True)
+        other_home.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.setenv("HOME", str(other_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+
+        def raise_key_error(uid):
+            raise KeyError(f"getpwuid(): uid not found: {uid}")
+
+        monkeypatch.setattr(pwd, "getpwuid", raise_key_error)
+
+        plist_path = gateway_cli.get_launchd_plist_path()
+
+        assert plist_path == real_home / "Library" / "LaunchAgents" / "ai.hermes.gateway-mybot.plist"
+
+    def test_launchd_plist_path_fallback_never_returns_profile_home(self, tmp_path, monkeypatch):
+        """When pwd fails and HOME IS the profile home, the fallback must skip it (#57292)."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "mybot"
+        profile_dir.mkdir(parents=True)
+        profile_home = profile_dir / "home"
+        profile_home.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+
+        def raise_key_error(uid):
+            raise KeyError(f"getpwuid(): uid not found: {uid}")
+
+        monkeypatch.setattr(pwd, "getpwuid", raise_key_error)
+
+        plist_path = gateway_cli.get_launchd_plist_path()
+
+        assert profile_home not in plist_path.parents
+        assert profile_dir not in plist_path.parents
+
+    def test_installed_service_kind_returns_none_when_uid_unresolvable(self, tmp_path, monkeypatch):
+        """`gateway restart`/`status` degrade to "not installed" instead of crashing (#57292)."""
+        machine_home = tmp_path / "Users" / "example"
+        machine_home.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.delenv("HERMES_REAL_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(machine_home))
+
+        def raise_key_error(uid):
+            raise KeyError(f"getpwuid(): uid not found: {uid}")
+
+        monkeypatch.setattr(pwd, "getpwuid", raise_key_error)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_systemd_unit_installed", lambda: False)
+
+        assert gateway_cli._installed_service_kind_for(lambda: False) is None
+
 
 class TestRemapPathForUser:
     """Unit tests for _remap_path_for_user()."""


### PR DESCRIPTION
## What

`hermes gateway status` / `install` / `restart` crash with `KeyError: getpwuid(): uid not found` in sandboxed or app-hosted macOS shells where the real UID has no resolvable passwd entry. The crash is a single raw `pwd.getpwuid(os.getuid())` call in `get_launchd_plist_path()` — the only unguarded production `getpwuid` site in the repo (every sibling site is already guarded).

## Fix

Wrap the existing pwd lookup in `try/except (KeyError, ImportError, OSError)` and, on failure, fall back to the shared real-home resolver `get_real_home()` from `hermes_constants` (`HERMES_REAL_HOME` → `HOME` → pwd → `~`, profile home skipped, `/tmp` last resort):

- **pwd stays authoritative when it resolves** — the existing contract (`test_launchd_plist_path_uses_real_user_home_not_profile_home`) is preserved; this is fallback-only-on-failure.
- **No new env var** — reuses the established `HERMES_REAL_HOME` operator override instead of introducing a launchd-specific one.
- **Graceful degradation at the end of the ladder** — when nothing is resolvable the resolver ends at `/tmp`, so the plist lookup returns a nonexistent path and `_installed_service_kind_for()` yields `None` ("not installed") instead of crashing — which is what the issue asks for; a raised `RuntimeError` would keep `gateway status` crashing with a nicer message.

Fixes both reported crash sites (`gateway install` → `get_launchd_plist_path()`, `gateway restart` → `_installed_service_kind_for()` → same call) plus all 12 in-file callers and the external ones (`profiles.py`, `uninstall.py`, `update_cmd_fleet.py`).

## Verification

- **RED**: 4 new regression tests fail on upstream/main base with the issue's exact traceback at both crash sites (gateway.py:2560 and gateway.py:5858).
- **GREEN**: `TestProfileArg` 7/7; full `tests/hermes_cli/test_gateway_service.py` 114 passed, 1 skipped; external-caller suites 31 passed, 11 skipped (independently re-run by reviewer).
- 3 failures in `tests/hermes_cli/test_update_launchd_fleet_restart.py` are pre-existing on clean upstream/main (verified via `git stash` re-run) — macOS systemctl environment artifacts, unrelated to this change.
- `git rev-list --left-right --count upstream/main...HEAD` → `0 1` (single focused commit).

## Relation to prior PRs

Credit to @tianma-if (#57456) and @thomkozik (#57485) — both diagnosed the same underlying issue and their fallback ordering informed this fix. Both patch the pre-refactor `_launchd_user_home()` helper which the service-kind refactor has since deleted, so they cannot merge as-is. This PR:

- keeps pwd authoritative on success where #57456 replaces it entirely (which breaks the existing pwd-wins contract test), and degrades gracefully where #57456 raises `RuntimeError`;
- reuses `HERMES_REAL_HOME` where #57485 introduces a new `HERMES_LAUNCHD_HOME` env var;
- adds service-kind degradation coverage neither has.

Closes #57292

Auto-published by Moonsong via Path B automated pipeline.