### PR TITLE
fix(desktop): qualify group (you) by connection, not bare profile name

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/cross-connection-bots.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/cross-connection-bots.test.ts
@@ -175,4 +175,48 @@ describe('a group room seats members from several machines', () => {
       })
     ).toMatch(/@dixie \[on Mac Mini\]/)
   })
+
+  it('does not self-attribute a same-named default on another connection (#106851)', () => {
+    // Cross-connection same profile name must not self-attribute in model prompt lines.
+    const line = formatGroupChatLine(
+      { at: 1, from: { kind: 'member', name: 'default', source: 'Connection B' }, text: 'Remote reply' },
+      { name: 'default' }
+    )
+
+    expect(line).not.toContain('(you)')
+    expect(line).toMatch(/Remote reply/)
+
+    // CONTROL: same-connection self still gets (you)
+    expect(
+      formatGroupChatLine(
+        { at: 2, from: { kind: 'member', name: 'default' }, text: 'Mine' },
+        { name: 'default' }
+      )
+    ).toContain('(you)')
+
+    // CONTROL: remote viewer seeing own remote line still gets (you)
+    expect(
+      formatGroupChatLine(
+        { at: 3, from: { kind: 'member', name: 'default', source: 'Connection B' }, text: 'Mine remote' },
+        { name: 'default', remoteSource: true, connectionLabel: 'Connection B', connectionId: 'conn-b' }
+      )
+    ).toContain('(you)')
+
+    // String viewer API is local / unsourced — a sourced peer of the same
+    // name must not pick up (you) just because the names match.
+    expect(
+      formatGroupChatLine(
+        { at: 4, from: { kind: 'member', name: 'default', source: 'Connection B' }, text: 'Still remote' },
+        'default'
+      )
+    ).not.toContain('(you)')
+
+    // User lines stay on the (user) path even when the display name collides.
+    expect(
+      formatGroupChatLine({ at: 5, from: { kind: 'user', name: 'default' }, text: 'human' }, { name: 'default' })
+    ).toContain('(user)')
+    expect(
+      formatGroupChatLine({ at: 5, from: { kind: 'user', name: 'default' }, text: 'human' }, { name: 'default' })
+    ).not.toContain('(you)')
+  })
 })

--- a/apps/desktop/src/plugins/hermes-bots/group-round-members.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-round-members.ts
@@ -93,7 +93,7 @@ function prepareGroupRoundMember(context: GroupRoundMemberContext, member: Group
     groupName: context.group,
     members,
     viewer: member,
-    deltaLines: delta.slice(-GROUP_CHAT_HISTORY_LIMIT).map((e: GroupMessage) => formatGroupChatLine(e, member.name))
+    deltaLines: delta.slice(-GROUP_CHAT_HISTORY_LIMIT).map((e: GroupMessage) => formatGroupChatLine(e, member))
   })
 
   // Images riding this delta (user attachments — member entries don't
@@ -268,7 +268,7 @@ async function runGroupContinuationMember(
     // The continuation prompt centers on what the member missed:
     // everything since its watermark, which includes the reply
     // that cites it.
-    deltaLines: delta.slice(-GROUP_CHAT_HISTORY_LIMIT).map((e: GroupMessage) => formatGroupChatLine(e, member.name))
+    deltaLines: delta.slice(-GROUP_CHAT_HISTORY_LIMIT).map((e: GroupMessage) => formatGroupChatLine(e, member))
   })
 
   updateGroupChat(context.group, (r: GroupChatRoom) => {

--- a/apps/desktop/src/plugins/hermes-bots/group-round-prompt.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-round-prompt.ts
@@ -1,11 +1,17 @@
 import { botHandle } from './data'
 import { groupSpeakerLabel } from './group-chat'
 import { groupMemberKey } from './group-membership'
-import type { GroupMember, GroupMessage } from './types'
+import type { GroupMember, GroupMessage, GroupMessageAuthor } from './types'
+
+/** Viewer identity for a room-log line. A bare string is the local, unsourced
+ *  profile name (legacy call sites and single-connection jobs). */
+export type GroupChatLineViewer =
+  | string
+  | (Pick<GroupMember, 'name'> & Partial<Pick<GroupMember, 'connectionId' | 'connectionLabel' | 'remoteSource'>>)
 
 /** Room-log line as a member sees it: `Name (user): …` / `Name: …` /
  *  `Name (you): …`. */
-export function formatGroupChatLine(entry: GroupMessage, viewerName: string) {
+export function formatGroupChatLine(entry: GroupMessage, viewer: GroupChatLineViewer) {
   // Attachments are staged into each member's session as real payloads; the
   // transcript line names them so the delta text and the bytes line up.
   const attached =
@@ -23,12 +29,42 @@ export function formatGroupChatLine(entry: GroupMessage, viewerName: string) {
     return `${entry.from.name || 'User'} (user): ${entry.text}${attached}`
   }
 
-  const suffix = entry.from.name === viewerName ? ' (you)' : ''
+  const suffix = isGroupChatSelf(entry.from, viewer) ? ' (you)' : ''
   // Cross-connection speakers carry their device so same-named agents on
   // two machines stay tellable apart in every member's transcript.
   const source = entry.from.source ? ` [${entry.from.source}]` : ''
 
   return `${groupSpeakerLabel(entry.from.name)}${suffix}${source}: ${entry.text}${attached}`
+}
+
+function viewerNameOf(viewer: GroupChatLineViewer): string {
+  return typeof viewer === 'string' ? viewer : viewer?.name || ''
+}
+
+/** Remote members stamp `from.source` as `connectionLabel || connectionId`.
+ *  Only a remoteSource viewer exposes those tokens; a string or local member
+ *  is unsourced so same-name remote lines fail open (no `(you)`). */
+function viewerConnectionSources(viewer: GroupChatLineViewer): string[] {
+  if (typeof viewer === 'string' || !viewer?.remoteSource) {
+    return []
+  }
+
+  return [viewer.connectionLabel, viewer.connectionId].filter((token): token is string => Boolean(token))
+}
+
+function isGroupChatSelf(from: GroupMessageAuthor, viewer: GroupChatLineViewer): boolean {
+  if (!from.name || from.name !== viewerNameOf(viewer)) {
+    return false
+  }
+
+  const speakerSource = from.source || ''
+  const viewerSources = viewerConnectionSources(viewer)
+
+  if (!speakerSource && viewerSources.length === 0) {
+    return true
+  }
+
+  return Boolean(speakerSource) && viewerSources.includes(speakerSource)
 }
 
 interface GroupChatTurnPromptInput {


### PR DESCRIPTION
## What does this PR do?

In Desktop Bot Mode group chats that seat the same profile name from two connections (e.g. both `default`), room-delta prompts sent to one member incorrectly labeled the other member's lines as `(you)`.

Root cause: `formatGroupChatLine` decided self-attribution with `entry.from.name === viewerName` only. Remote replies already stamp `from.source` (`connectionLabel || connectionId`), but the formatter ignored it; call sites also passed only `member.name`.

This change compares speaker vs viewer with connection-qualified identity: same bare name plus matching source (or both unsourced for legacy local rooms) before appending `(you)`. Call sites pass the full member descriptor.

## Related Issue

Fixes #106851

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/group-round-prompt.ts`: connection-aware `isGroupChatSelf`; viewer arg accepts string (local) or member-like identity
- `apps/desktop/src/plugins/hermes-bots/group-round-members.ts`: pass full `member` into `formatGroupChatLine`
- `apps/desktop/src/plugins/hermes-bots/cross-connection-bots.test.ts`: regression for cross-connection same-name `(you)` plus CONTROLs

## How to Test

```bash
cd apps/desktop
npx vitest run src/plugins/hermes-bots/cross-connection-bots.test.ts \
  src/plugins/hermes-bots/group-chat.test.ts \
  src/plugins/hermes-bots/group-rounds.test.ts
# -> 91 passed
```

Proof receipt:
- BEFORE (pre-fix): focused `#106851` case RED — object/local viewer + remote same-name line still mis-attributed / CONTROL path failed under name-only compare
- AFTER: same suite GREEN (8/8 in cross-connection file; 91 across the three files)
- CONTROL: same-connection self still gets `(you)`; remote viewer seeing own sourced line still gets `(you)`; user lines stay on `(user)`

## Related work (not duplicates)

- #94869 — Activity duplicate-name display; this PR is model-input prompt attribution only
- #96432 — connection-scoped transcript metadata/avatar; not the `(you)` predicate

## Review follow-up

- String viewer API remains local/unsourced for back-compat; a sourced peer with the same profile name will not get `(you)`.
- Fail-open: if connection identity cannot be aligned, prefer omitting `(you)` over mis-attributing another connection's speaker.
- Self-review P0 = 0; independent review not triggered (1 module, ~90 LOC, no auth/crypto/state.db).

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] Searched existing PRs for duplicates
- [x] PR contains only this fix
- [x] Relevant tests run locally
- [x] Tests added for the change
- [x] Tested on: macOS (darwin)

### Documentation & Housekeeping
- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] Cross-platform impact considered (Desktop renderer logic only)
- [x] Tool schemas — N/A

Made with [Cursor](https://cursor.com)