### PR TITLE
Main goes green: Docker lane lets docker-exec gateway starts through; messages schema history records the display columns

### DIFF
--- a/hermes_cli/session_schema_history.py
+++ b/hermes_cli/session_schema_history.py
@@ -232,6 +232,10 @@ SCHEMA_HISTORY: dict[str, _TableHistory] = {
             ('+', 'display_metadata', 'display_kind'),
         )),
         ('14 2026-08-25T10:55Z 1104ffe0b9', (('+', '_compressed_summary', 'observed'),)),
+        ('15 2026-09-09T17:05Z 1c6683e8e0', (
+            ('+', 'display_identity', 'display_metadata'),
+            ('+', 'display_order', 'display_identity'),
+        )),
         ),
     ),
     "session_model_usage": _TableHistory(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1561,9 +1561,14 @@ def _live_system_guard(request, monkeypatch):
         # suffix), restarts the live gateway, and the survivors squat the
         # webhook port. 2026-09-03: 39 such orphans lived 6 days after a
         # sibling refactor moved the spawn seam and left tests patching the
-        # facade. The canonical matcher, never an argv substring.
+        # facade. The canonical matcher, never an argv substring. Commands addressed to a
+        # container (``docker exec … <cmd>``) run inside that container: a gateway
+        # started there cannot reach the host's unit, home or ports, and the Docker
+        # harness reaps the container. Only host-side spawns are the hazard.
         from gateway.status import _gateway_command_subcommand
-        if not lookalike_ok and _gateway_command_subcommand(cmd_str) in ("run", "start", "restart"):
+        argv = cmd if isinstance(cmd, (list, tuple)) else _shlex.split(cmd_str)
+        in_container = len(argv) > 1 and str(argv[0]).rsplit("/", 1)[-1] == "docker" and argv[1] == "exec"
+        if not lookalike_ok and not in_container and _gateway_command_subcommand(cmd_str) in ("run", "start", "restart"):
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
                 f"subprocess.{name}({cmd!r}) — this would spawn a REAL "

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -165,6 +165,17 @@ def test_subprocess_run_setsid_systemctl_blocked():
         subprocess.run(["setsid", "systemctl", "kill", "hermes-gateway"])
 
 
+def test_host_gateway_start_blocked_but_container_exec_allowed():
+    """A host-side ``hermes gateway start`` spawns a real runtime; the same words addressed to
+    a container via ``docker exec`` stay inside it and are the Docker harness's business."""
+    with pytest.raises(RuntimeError, match="REAL hermes gateway runtime"):
+        subprocess.run(["hermes", "-p", "p", "gateway", "start"])
+    argv = ["docker", "exec", "-u", "hermes", "hermes-test-x", "sh", "-c", "hermes -p p gateway start"]
+    # Past the guard the call reaches the real subprocess.run; a missing binary is fine here.
+    with pytest.raises(FileNotFoundError):
+        subprocess.run(argv, env={"PATH": "/nonexistent"})
+
+
 def test_subprocess_run_string_shell_true_blocked():
     with pytest.raises(RuntimeError, match="live-system guard"):
         subprocess.run(


### PR DESCRIPTION
`main` goes green: the Docker lane's live-system guard no longer blocks `hermes gateway start` addressed to a throwaway container via `docker exec`, and the messages schema history records the two display columns that `test_session_schema_history` has been red on since 1c6683e8e0b.

## Changes
- `tests/conftest.py`: the gateway-spawn branch of the live-system guard (added in ca16cafee40) exempts argv whose first two tokens are `docker exec`. A gateway started inside a container cannot adopt the developer's systemd unit, home or webhook port, and the Docker harness reaps the container; only host-side spawns are the hazard the guard exists for. Host-side `hermes gateway run|start|restart` stays blocked.
- `tests/test_live_system_guard_self_test.py`: one invariant covering both halves (host blocked, `docker exec` passes through to the real `subprocess.run`).

## Changes (2)
- `hermes_cli/session_schema_history.py`: event 15 replays `display_identity` / `display_order` (added to `messages` in 1c6683e8e0b without a history event).

## Root cause
ca16cafee40 matched the canonical gateway subcommand anywhere in the command line; `tests/docker/test_profile_gateway.py::test_profile_create_then_gateway_start` runs `docker exec … sh -c 'hermes -p <profile> gateway start'` and has failed on every `main` push since (e.g. run 34398578553).

## Validation
| Check | Before | After |
|---|---|---|
| `tests/test_live_system_guard_self_test.py::test_host_gateway_start_blocked_but_container_exec_allowed` | red (guard raises on the `docker exec` argv) | green |
| `tests/test_live_system_guard*.py` | — | 36 passed |
| Docker lane (`Docker Build, Test, and Publish`) | 1 failed on every main push | green on this PR (run 34401400857) |
| `tests/hermes_cli/test_session_schema_history.py` | red on main (`display_identity`, `display_order` missing) | 3 passed |


## Infographic

![live-system guard: host vs container](https://v3b.fal.media/files/b/0aa9c68a/jRYcoJEU1IV_iOZdNlrfW_LEiHXLM8.png)
