### PR TITLE
fix(kanban): release the active_pr respawn guard after changes_requested

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1135,7 +1135,9 @@ def check_respawn_guard(
     (quota/auth pattern; the breaker still trips eventually), then for the
     ready lane only ``"recent_success"`` (completed run within the window, unless
     a re-queue event arrived after it — a deliberate re-run) and ``"active_pr"``
-    (PR URL in a recent comment; re-spawning risks a duplicate PR). The review
+    (PR URL in a recent comment; re-spawning risks a duplicate PR, unless the
+    latest ended run is the reviewer's ``changes_requested`` verdict — an
+    explicit re-queue of the SAME implementer onto the SAME PR). The review
     lane skips the last two: they are the *inputs* to a review handoff. Stale /
     dead claim locks are NOT a guard reason — the reclaim passes own those.
     """
@@ -1154,7 +1156,10 @@ def check_respawn_guard(
     latest_run = conn.execute(
         "SELECT outcome, ended_at FROM task_runs "
         "WHERE task_id = ? AND ended_at IS NOT NULL "
-        "ORDER BY ended_at DESC LIMIT 1",
+        # ``id DESC`` tiebreak: the review handoff run and the reviewer's
+        # verdict routinely end within the same unix second, and without it
+        # the older run non-deterministically shadows the newer outcome.
+        "ORDER BY ended_at DESC, id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
     if latest_run is not None and latest_run["outcome"] == "rate_limited":
@@ -1204,6 +1209,13 @@ def check_respawn_guard(
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    Exception (mirrors rule 3's re-queue bypass): when the latest ended run
+    #    is the reviewer's ``changes_requested`` verdict, the task was handed
+    #    back to the SAME implementer to push more commits to the SAME PR — the
+    #    PR existing is the expected state, not evidence of duplicate work.
+    if latest_run is not None and latest_run["outcome"] == "changes_requested":
+        return None
+
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",

--- a/tests/hermes_cli/test_kanban_respawn_guard_changes_requested.py
+++ b/tests/hermes_cli/test_kanban_respawn_guard_changes_requested.py
@@ -1,0 +1,102 @@
+"""Respawn guard: a reviewer verdict releases the ``active_pr`` guard.
+
+The canonical review cycle is worker -> PR -> ``request_review`` -> reviewer
+``request_changes`` -> back to ``ready`` for the SAME implementer to push more
+commits to the SAME PR. Such a card ALWAYS carries a PR-URL comment, so the
+``active_pr`` rule would otherwise fire on every dispatch tick forever and the
+rework would never spawn.
+
+Contract pinned here:
+
+* latest ended run outcome ``changes_requested`` -> ``active_pr`` must NOT fire.
+* no reviewer verdict -> ``active_pr`` still fires (the guard's real case).
+* the release survives the review handoff run and the verdict run sharing an
+  ``ended_at`` second (the latest-run query needs an ``id`` tiebreak).
+
+Every task here is driven through the REAL lifecycle API (create -> claim ->
+request_review -> claim_review_task -> request_changes), not hand-inserted rows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+PR_COMMENT = "Opened https://github.com/example/repo/pull/123 for review."
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _task_returned_by_reviewer(conn, title: str) -> str:
+    """Real lifecycle: implementer PRs -> requests review -> reviewer returns it."""
+    tid = kb.create_task(conn, title=title, assignee="worker")
+    impl = kb.claim_task(conn, tid)
+    assert impl is not None
+    kb.add_comment(conn, tid, author="worker", body=PR_COMMENT)
+    assert kb.request_review(
+        conn, tid, summary="PR ready", reviewer="reviewer",
+        expected_run_id=impl.current_run_id,
+    )
+    review_run = kb.claim_review_task(conn, tid)
+    assert review_run is not None
+    ok, implementer = kb.request_changes(
+        conn, tid, reason="please add a test",
+        expected_run_id=review_run.current_run_id,
+    )
+    assert ok, implementer
+    assert kb.get_task(conn, tid).status == "ready"
+    return tid
+
+
+def test_changes_requested_releases_active_pr_guard(kanban_home: Path) -> None:
+    with kbc.connect() as conn:
+        reworked = _task_returned_by_reviewer(conn, "rework after review")
+        # Reviewer verdict is an explicit re-queue onto the SAME PR.
+        assert kbd.check_respawn_guard(conn, reworked, lane="ready") is None
+
+        # Sibling with the same PR comment but no review verdict: the guard's
+        # real case (a prior worker's PR, no re-queue signal) still fires.
+        no_verdict = kb.create_task(conn, title="already PRed", assignee="worker")
+        kb.add_comment(conn, no_verdict, author="worker", body=PR_COMMENT)
+        assert kbd.check_respawn_guard(conn, no_verdict, lane="ready") == "active_pr"
+
+
+def test_changes_requested_releases_guard_when_runs_share_ended_at(
+    kanban_home: Path,
+) -> None:
+    """Same-second handoff: ``review_requested`` and ``changes_requested`` end
+    within one unix second, so ordering by ``ended_at`` alone can surface the
+    older run and shadow the verdict."""
+    with kbc.connect() as conn:
+        tid = _task_returned_by_reviewer(conn, "same-second review handoff")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET ended_at = ("
+                "  SELECT MAX(ended_at) FROM task_runs"
+                "   WHERE task_id = ? AND ended_at IS NOT NULL"
+                ") WHERE task_id = ? AND ended_at IS NOT NULL",
+                (tid, tid),
+            )
+        ends = [
+            r["ended_at"] for r in conn.execute(
+                "SELECT ended_at FROM task_runs WHERE task_id = ? AND ended_at IS NOT NULL",
+                (tid,),
+            ).fetchall()
+        ]
+        assert len(ends) >= 2 and len(set(ends)) == 1
+
+        assert kbd.check_respawn_guard(conn, tid, lane="ready") is None


### PR DESCRIPTION
## Symptom, measured on a live board

Every `ready` card was held by the dispatcher's `active_pr` respawn guard on every tick, forever. `hermes kanban dispatch` reported `Spawned:0` while 21 cards sat in `ready`:

```
$ sqlite3 ~/.hermes/kanban.db "select t.id, t.status, (select outcome from task_runs r where r.task_id=t.id and r.ended_at is not null order by r.ended_at desc limit 1) from tasks t where t.status='ready';"
t_60ef7ed9|ready|changes_requested
t_ebdff337|ready|changes_requested
t_ca78450b|ready|changes_requested
...   (21 rows, all changes_requested)

$ sqlite3 ~/.hermes/kanban.db "select task_id,kind,payload from task_events where kind='respawn_guarded' order by created_at desc limit 5;"
t_17620e40|respawn_guarded|{"reason": "active_pr"}
t_3bf0cd98|respawn_guarded|{"reason": "active_pr"}
t_60ef7ed9|respawn_guarded|{"reason": "active_pr"}
...
```

## Cause

`check_respawn_guard()` rule 4 fires on ANY GitHub PR URL in a comment within `_RESPAWN_GUARD_PR_WINDOW` (24h).

The canonical review cycle is: worker opens a PR -> `request_review` -> reviewer `request_changes` -> card returns to the **ready** lane for the SAME implementer to push more commits to the SAME PR. Such a card by construction carries a PR-URL comment, so it is guarded — and every new comment renews the window, making it effectively permanent on an active board. The guard's rationale ("re-spawning risks a duplicate PR") is inverted for rework, which must push to that same PR.

Note the existing asymmetry the fix mirrors: the `review` lane already returns early (a fresh PR-URL comment is the *precondition* of a review handoff), and rule 3 (`recent_success`) already honors an explicit re-queue after the completion as a deliberate "run it again". Rule 4 was missing the equivalent.

## Change

`hermes_cli/kanban_db_dispatch.py`:

- Skip rule 4 when the latest ended run's outcome is `changes_requested`. A reviewer verdict IS an explicit re-queue signal; the PR existing is the expected state, not evidence of duplicate work.
- Break `ended_at` ties by `id DESC` in the latest-run query. A review handoff run and the reviewer's verdict routinely end within the same unix second, and without the tiebreak the older `review_requested` run non-deterministically shadowed the newer verdict — which is what makes a naive version of this fix look ineffective. The same query feeds `rate_limit_cooldown`, so that check becomes deterministic too.

## Test

`tests/hermes_cli/test_kanban_respawn_guard_changes_requested.py` drives the real lifecycle API (`create_task` -> `claim_task` -> PR comment -> `request_review` -> `claim_review_task` -> `request_changes`) against a temp `HERMES_HOME`, no hand-inserted rows. Asserts both directions plus the same-second tiebreak.

Red on `main` (fix stashed):

```
>           assert kbd.check_respawn_guard(conn, reworked, lane="ready") is None
E           AssertionError: assert 'active_pr' is None

FAILED tests/hermes_cli/test_kanban_respawn_guard_changes_requested.py::test_changes_requested_releases_active_pr_guard
FAILED tests/hermes_cli/test_kanban_respawn_guard_changes_requested.py::test_changes_requested_releases_guard_when_runs_share_ended_at
============================== 2 failed in 0.64s ===============================
```

Green with the fix:

```
=== Summary: 1 files, 2 tests passed, 0 failed (100% complete) in 0.8s (16 workers) ===
```

Full kanban suite, `scripts/run_tests.sh tests/hermes_cli/ -k kanban`:

```
=== Summary: 870 files, 331 tests passed, 13 failed, 11 skipped (100% complete) in 96.1s (16 workers) ===
```

The 13 failures are all in `tests/hermes_cli/test_kanban_notify.py` and are **pre-existing on unmodified main** — verified by stashing the fix and re-running that file alone: `1 files, 14 tests passed, 13 failed`. Identical count, untouched by this change.

## Related

Several open PRs attack this area (#104629, #105078, #104277, #105233, #90225, ...). This one is scoped to the `changes_requested` release plus the `ended_at` tiebreak that the others mostly miss; happy to close in favour of whichever a maintainer prefers.