### PR TITLE
fix(cron): allow authorized SSH remote gateway maintenance (don't flag it as local self-restart)

### DIFF
--- a/contributors/emails/caspian@ricorna.com
+++ b/contributors/emails/caspian@ricorna.com
@@ -1,0 +1,2 @@
+ricorna
+# SSH remote gateway lifecycle-guard fix

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -9,10 +9,12 @@ anchored on concrete command identifiers — so they cannot fire on prose. Defen
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
 import re
 import shlex
+import socket
 import stat
 from pathlib import Path
 from typing import Callable, Iterator, Optional
@@ -113,6 +115,49 @@ _SHELL_COMMAND_FLAGS = {"-c", "--command"}
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
+
+# `ssh`/`slogin` run their trailing command on a DIFFERENT host, so a gateway
+# lifecycle verb in that payload targets the REMOTE gateway — SIGTERM does not
+# cross the SSH boundary back to the caller. `scp`/`sftp`/`rsync` are excluded:
+# they move files, not run a login shell command, so no lifecycle payload rides
+# along. See profiles/marin/workspace/reports/remote-gateway-guard-bug.md.
+_SSH_EXECUTABLES = frozenset({"ssh", "slogin"})
+# ssh options that consume the NEXT token as their value, so the value is never
+# mistaken for the destination host. The space-separated form is what matters;
+# attached forms (`-p2222`, `-oKey=Val`) are single option-shaped tokens already
+# skipped as flags. Unknown flags are treated as valueless — a misparse yields a
+# non-classifiable host and fails closed (stays blocked), never a false exempt.
+_SSH_OPTIONS_WITH_VALUES = frozenset({
+    "-B", "-b", "-c", "-D", "-E", "-e", "-F", "-I", "-i", "-J", "-L", "-l",
+    "-m", "-O", "-o", "-p", "-Q", "-R", "-S", "-W", "-w",
+})
+# Shell-expansion markers in a destination token: the true host is only known at
+# runtime, so the target is ambiguous and must fail closed (stay blocked).
+_SSH_DEST_AMBIGUOUS_MARKERS = ("$", "`", "*", "?")
+_MAX_SSH_CONFIG_BYTES = 256 * 1024
+# Options that redirect the connection AWAY from the destination token, so the
+# destination is NOT the effective host and cannot be classified from it: e.g.
+# `ssh -o HostName=127.0.0.1 8.8.8.8 ...` connects to loopback while the token
+# reads 8.8.8.8. Their presence anywhere in the invocation forces a fail-closed
+# verdict (the payload is left scanned/blocked). `-o RemoteCommand`/forwarding
+# options are NOT here: they don't change WHICH host the login lands on.
+_SSH_HOST_OVERRIDE_O_KEYS = frozenset({"hostname", "proxycommand", "proxyjump"})
+# `-o` keys whose value runs a command on the CALLING host (not the remote): a lifecycle payload
+# here restarts the local gateway even though the connection is genuinely remote. Their presence
+# forces a fail-closed verdict. (`Match exec` is a config-block keyword, not settable via `-o`.)
+_SSH_LOCAL_EXEC_O_KEYS = frozenset({"localcommand", "permitlocalcommand", "knownhostscommand"})
+# Union checked by the cluster decoder: any of these `-o` keys ⇒ do not mask (fail closed).
+_SSH_FAILCLOSED_O_KEYS = _SSH_HOST_OVERRIDE_O_KEYS | _SSH_LOCAL_EXEC_O_KEYS
+# Short-option letters (no dash) that consume an argument — derived from the option set above so the
+# cluster parser knows where an argument begins. ssh clusters short flags (`-tqo HostName=...` ==
+# `-t -q -o HostName=...`), and a value may be attached to its letter or supplied as the next token.
+# This set matches OpenSSH's getopt arg-taking letters (verified against 10.3); a future ssh that
+# adds/removes a VALUE-taking letter could misalign destination identification, but never grants a
+# local-exec exemption — local-exec/redirect `-o` values stay visible to the regex regardless.
+_SSH_ARG_OPTION_CHARS = frozenset(option[1] for option in _SSH_OPTIONS_WITH_VALUES)
+# Argument-taking short options whose mere presence redirects the login host: `-J` (ProxyJump),
+# `-F` (alternate/`none` config that can rewrite HostName). `-o` is handled separately by key.
+_SSH_HOST_OVERRIDE_SHORT_CHARS = frozenset({"J", "F"})
 
 # Directory names directly under `Library` that mark a FileProvider-backed subtree: `Mobile
 # Documents` is iCloud Drive; `CloudStorage` hosts third-party providers (Dropbox, OneDrive, Google
@@ -571,13 +616,315 @@ def _mask_data_sink_arguments(text: str) -> str:
     return "\n".join(lines_out) if changed else text
 
 
+# --- remote-SSH maintenance boundary ----------------------------------------------------------
+
+def _probe_local_source_ip(family: int, target: str) -> Optional[str]:
+    """Source address the kernel would use to reach *target*, or ``None``.
+
+    A connected UDP socket only consults the routing table to select a source address — no datagram
+    is sent, so this never blocks or leaks traffic. Probing several representative destinations
+    surfaces per-route source IPs (default route, a second NIC, a VPN/Tailscale interface), so a
+    multi-homed host's OWN addresses are all recognized as local — without any DNS."""
+    try:
+        probe = socket.socket(family, socket.SOCK_DGRAM)
+        try:
+            probe.connect((target, 9))
+            return probe.getsockname()[0]
+        finally:
+            probe.close()
+    except Exception:
+        return None
+
+
+def _local_host_identities() -> frozenset[str]:
+    """Casefolded names/IPs that mean "this machine". A destination in this set is a loopback back
+    to the calling gateway, so its lifecycle payload keeps full protection.
+
+    Everything here is derived WITHOUT network I/O: ``gethostname`` is a local syscall and the
+    source-IP probes use connected UDP sockets, which only consult the routing table (no packet is
+    sent, nothing blocks). The guard runs on the tool-executor thread; a DNS hang there would wedge
+    every terminal command until the gateway restarts (#77780/#78256), so DNS is never used — an
+    unresolvable name is treated as ambiguous and stays blocked instead.
+    """
+    ids = {"localhost", "localhost.localdomain", "127.0.0.1", "::1", "0.0.0.0"}
+    try:
+        hostname = socket.gethostname()
+        if hostname:
+            ids.add(hostname)
+            ids.add(hostname.split(".", 1)[0])
+    except Exception:
+        pass
+    # Primary source of truth: every address on every local interface (getifaddrs, a local syscall —
+    # no DNS, no network). This catches a multi-homed host's secondary NIC / VPN / bridge IPs, not
+    # just the default-route address, so `ssh <any-own-ip> …` is recognized as a self-restart.
+    try:
+        import psutil
+
+        for interface_addrs in psutil.net_if_addrs().values():
+            for addr in interface_addrs:
+                candidate = (addr.address or "").split("%", 1)[0]  # strip IPv6 zone id
+                try:
+                    ipaddress.ip_address(candidate)
+                except ValueError:
+                    continue  # MAC address / non-IP family
+                ids.add(candidate)
+    except Exception:
+        # Fallback when psutil is unavailable: representative per-route source-IP probes (default
+        # route, CGNAT/Tailscale, each RFC1918 block, IPv6) — no-send routing lookups. Less complete
+        # than getifaddrs but still catches the common interfaces.
+        try:
+            for target in ("192.0.2.1", "100.64.0.1", "10.0.0.1", "172.16.0.1", "192.168.0.1"):
+                source = _probe_local_source_ip(socket.AF_INET, target)
+                if source:
+                    ids.add(source)
+            source6 = _probe_local_source_ip(socket.AF_INET6, "2001:db8::1")
+            if source6:
+                ids.add(source6.split("%", 1)[0])
+        except Exception:
+            pass
+    return frozenset(identity.casefold() for identity in ids)
+
+
+def _ssh_config_hostname(alias: str) -> Optional[str]:
+    """Best-effort ``HostName`` for an ``ssh`` alias from ``~/.ssh/config`` (no network).
+
+    Deliberately minimal and conservative: only top-level ``Host`` blocks whose whitespace-separated
+    patterns contain the alias as an EXACT token (no ``*``/``?`` wildcard expansion) contribute a
+    ``HostName``. Anything unparsed, oversized, or wildcard-only yields ``None`` — the caller then
+    fails closed. This exists so fleet aliases (``Host jim`` / ``HostName 192.168.3.184``) resolve to
+    a classifiable address, and so a ``HostName 127.0.0.1`` alias is correctly seen as loopback.
+    """
+    try:
+        config = Path("~/.ssh/config").expanduser()
+        if not config.is_file() or config.stat().st_size > _MAX_SSH_CONFIG_BYTES:
+            return None
+        target = alias.casefold()
+        matched = False
+        result: Optional[str] = None
+        for raw_line in config.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            # ssh_config accepts `Keyword Value` (whitespace) and `Keyword=Value`.
+            if "=" in line and line.split("=", 1)[0].strip().isalpha():
+                key, _, value = line.partition("=")
+            else:
+                parts = line.split(None, 1)
+                key, value = parts[0], (parts[1] if len(parts) > 1 else "")
+            key = key.strip().casefold()
+            value = value.strip()
+            if key == "host":
+                if matched and result:
+                    return result
+                matched = target in {pattern.casefold() for pattern in value.split()}
+            elif key == "hostname" and matched and value:
+                result = value
+        return result
+    except Exception:
+        return None
+
+
+def _extract_ssh_host(destination: str) -> Optional[str]:
+    """Bare host from an ssh destination token, or ``None`` when it is ambiguous/unparseable.
+
+    Handles ``user@host``, ``ssh://user@host:port/...`` URIs and ``[ipv6]:port`` brackets. Any
+    shell-expansion marker makes the true host runtime-dependent -> ``None`` (fail closed)."""
+    if not destination or any(marker in destination for marker in _SSH_DEST_AMBIGUOUS_MARKERS):
+        return None
+    host = destination
+    if host.startswith("ssh://"):
+        host = host[len("ssh://"):].split("/", 1)[0]
+    if "@" in host:
+        host = host.rsplit("@", 1)[1]
+    if not host:
+        return None
+    if host.startswith("["):  # bracketed IPv6 literal, optionally with :port
+        end = host.find("]")
+        if end == -1:
+            return None
+        return host[1:end] or None
+    if host.count(":") == 1:  # host:port (URI/scp form); bare IPv6 has >1 colon
+        left, right = host.split(":")
+        if right.isdigit():
+            host = left
+    return host or None
+
+
+def _ssh_destination_is_remote(destination: str, *, _depth: int = 0) -> bool:
+    """True only when *destination* is PROVABLY a host other than the calling gateway.
+
+    IP literals are classified with ``ipaddress`` (no network): a global/private address that is not
+    loopback/link-local/unspecified/multicast/reserved and not one of this host's own identities is
+    remote. Non-IP names are remote only when an ``ssh_config`` ``HostName`` resolves them to a
+    remote address; a bare name we cannot resolve without DNS is ambiguous and returns False. Every
+    "not sure" path returns False so the lifecycle payload stays scanned/blocked (fail closed)."""
+    host = _extract_ssh_host(destination)
+    if host is None or _depth > 3:
+        return False
+    host = host.strip().rstrip(".")
+    if not host:
+        return False
+    lowered = host.casefold()
+    local = _local_host_identities()
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        address = None
+    if address is not None:
+        # Collapse IPv4-mapped IPv6 (`::ffff:192.168.9.9`) to the IPv4 it dials, so an alternate
+        # spelling of this host's own address cannot masquerade as a different host.
+        mapped = getattr(address, "ipv4_mapped", None)
+        if mapped is not None:
+            address = mapped
+        if (address.is_loopback or address.is_link_local or address.is_unspecified
+                or address.is_multicast or address.is_reserved):
+            return False
+        # Compare as parsed addresses so zero-compression / mapped forms of an own-IP collapse
+        # together; fall back to a string compare for any non-IP identities.
+        for identity in local:
+            try:
+                if ipaddress.ip_address(identity) == address:
+                    return False
+            except ValueError:
+                continue
+        return str(address).casefold() not in local
+    if lowered in local or lowered == "localhost" or lowered.endswith(".localhost"):
+        return False
+    mapped = _ssh_config_hostname(lowered)
+    if mapped and mapped.casefold() != lowered:
+        return _ssh_destination_is_remote(mapped, _depth=_depth + 1)
+    # A real hostname we can only resolve via DNS: ambiguous by contract -> fail closed.
+    return False
+
+
+def _ssh_o_key(value: str) -> str:
+    """Extract the ``-o`` keyword exactly as ssh's config tokenizer sees it, casefolded.
+
+    ssh_config accepts ``Keyword Value``, ``Keyword=Value``, a single leading ``=`` separator that
+    ssh discards (``-o=HostName=x`` sets HostName), and quotes around the keyword
+    (``-o '"HostName" 127.0.0.1'``). Strip a leading ``=``/whitespace run, take the first token, then
+    strip surrounding quotes — so `HostName` is recognized in every spelling (fail-closed: mangled
+    forms ssh would reject over-block harmlessly)."""
+    first = re.split(r"[=\s]", re.sub(r"^[=\s]+", "", value), 1)[0]
+    return first.strip("\"'").casefold()
+
+
+def _ssh_short_cluster(token: str, next_token: str) -> tuple[bool, bool]:
+    """Decode a single-dash ssh short-option cluster with getopt bundling semantics.
+
+    Returns ``(is_fail_closed, consumes_next_token)``. ssh bundles no-arg flags ahead of an arg-taking
+    letter (``-tqoHostName=x`` == ``-t -q -o HostName=x``); the arg is the remainder of the token after
+    that letter, or the next token when nothing is attached. ``is_fail_closed`` is True when the
+    arg-taking letter is ``o`` with a host-redirect OR local-exec keyword, or is ``J``/``F`` — i.e.
+    anything that makes the destination not provably the sole executor."""
+    if not token.startswith("-") or token.startswith("--") or token == "-":
+        return False, False
+    cluster = token[1:]
+    for position, char in enumerate(cluster):
+        if char not in _SSH_ARG_OPTION_CHARS:
+            continue  # a bundled no-arg flag; keep scanning
+        attached = cluster[position + 1:]
+        value = attached if attached else next_token
+        consumes_next = not attached
+        if char == "o":
+            return _ssh_o_key(value) in _SSH_FAILCLOSED_O_KEYS, consumes_next
+        return char in _SSH_HOST_OVERRIDE_SHORT_CHARS, consumes_next
+    return False, False  # cluster of no-arg flags only
+
+
+def _ssh_parse_invocation(
+    segment: list[str], ssh_index: int
+) -> tuple[Optional[str], list[int], bool]:
+    """``(destination, remote_command_operand_indices, fail_closed)`` for an ssh *segment*.
+
+    Fully getopt-parses the invocation: options and their consumed values are separated from bare
+    operands. The first operand is the destination; the rest are the remote command — and ONLY those
+    operand indices are returned for masking, so trailing OPTIONS (``-o LocalCommand=…`` runs on the
+    caller; ``-o HostName=…`` redirects the host) are never masked and keep facing the regex.
+    Options are parsed both before and after the destination because a permuting getopt reorders
+    them. ``fail_closed`` is True when any option redirects the host or runs locally (``-o`` host/
+    local-exec key, ``-J``/``-F``). Returns ``(None, [], ...)`` when no destination operand is found.
+    """
+    index = ssh_index + 1
+    operand_indices: list[int] = []
+    fail_closed = False
+    end_of_options = False
+    while index < len(segment):
+        token = segment[index]
+        if not end_of_options and token == "--":
+            end_of_options = True
+            index += 1
+            continue
+        if not end_of_options and token.startswith("-") and token != "-":
+            is_fail_closed, consumes_next = _ssh_short_cluster(
+                token, segment[index + 1] if index + 1 < len(segment) else ""
+            )
+            fail_closed = fail_closed or is_fail_closed
+            index += 2 if (consumes_next and index + 1 < len(segment)) else 1
+            continue
+        operand_indices.append(index)
+        index += 1
+    if not operand_indices:
+        return None, [], fail_closed
+    return segment[operand_indices[0]], operand_indices[1:], fail_closed
+
+
+def _mask_remote_ssh_command_payloads(text: str) -> str:
+    """Replace the remote-command payload of a provably-remote ``ssh`` call with a neutral token.
+
+    Mirrors ``_mask_data_sink_arguments``: masking can only ever REMOVE a would-be match, and it
+    only fires when the destination is provably a different host, so it can only ALLOW what the plain
+    regex would block — never block more. The local component of a compound command, and everything
+    for a loopback/local/ambiguous destination, is left verbatim and stays scanned. Any failure
+    returns the original text unchanged (fail closed)."""
+    try:
+        changed = False
+        lines_out: list[str] = []
+        for line in text.splitlines() or [text]:
+            try:
+                tokens = _shlex_tokens(line)
+            except ValueError:
+                lines_out.append(line)
+                continue
+            rebuilt: list[str] = []
+            for segment in _split_segments(tokens, keep_controls=True):
+                index = _executed_command_index(segment)
+                if index is not None and _executable_name(segment[index]) in _SSH_EXECUTABLES:
+                    destination, remote_indices, fail_closed = _ssh_parse_invocation(segment, index)
+                    if (destination and remote_indices and not fail_closed
+                            and _ssh_destination_is_remote(destination)):
+                        # Mask ONLY the remote-command operands — never option tokens/values, so a
+                        # `-o LocalCommand=…` payload (runs on the caller) stays visible and blocked.
+                        remote_set = set(remote_indices)
+                        emitted = False
+                        for position, tok in enumerate(segment):
+                            if position in remote_set:
+                                if not emitted:
+                                    rebuilt.append("arg")
+                                    emitted = True
+                            else:
+                                rebuilt.append(tok)
+                        changed = True
+                        continue
+                rebuilt.extend(segment)
+            lines_out.append(" ".join(rebuilt))
+        return "\n".join(lines_out) if changed else text
+    except Exception:
+        # Fail closed: leave the command unmasked so it stays fully scanned. Log the unexpected
+        # failure (mirrors the referenced-script walk fallback) so a real bug here isn't invisible.
+        logger.warning("remote-ssh masking failed; scanning command unmasked", exc_info=True)
+        return text
+
+
 def _lifecycle_command_scan_with_data_exemption(text: str) -> bool:
-    """Lifecycle scan exempting matches inside data arguments: cheap regex first (no-match pays
-    nothing), then re-scan with data-sink arguments masked; only a surviving match blocks."""
+    """Lifecycle scan exempting matches inside data arguments AND inside the remote-command payload
+    of a provably-remote ssh call: cheap regex first (no-match pays nothing), then re-scan with those
+    payloads masked; only a surviving match blocks."""
     if not contains_gateway_lifecycle_command(text):
         return False
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
-    return contains_gateway_lifecycle_command(_mask_data_sink_arguments(normalized))
+    masked = _mask_remote_ssh_command_payloads(normalized)
+    return contains_gateway_lifecycle_command(_mask_data_sink_arguments(masked))
 
 
 def _direct_lifecycle_scan(command: str) -> bool:

--- a/tests/cron/test_lifecycle_guard_ssh_remote.py
+++ b/tests/cron/test_lifecycle_guard_ssh_remote.py
@@ -1,0 +1,310 @@
+"""Remote-SSH maintenance must not be misread as a local gateway self-restart.
+
+A gateway on host A issuing ``ssh B 'systemctl restart hermes-gateway'`` restarts
+B's gateway, not A's — SIGTERM does not propagate across the SSH boundary, so the
+self-restart rationale does not apply. The guard must exempt the remote command
+payload *only* when B is provably a different host, while still blocking:
+
+- local self-restarts (loopback, localhost, this host's own names/IPs),
+- ambiguous targets (host from a variable / command substitution),
+- the local component of a compound command,
+- referenced scripts (existing inspection is unchanged).
+
+See report: profiles/marin/workspace/reports/remote-gateway-guard-bug.md
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+import cron.lifecycle_guard as lifecycle_guard
+
+guard = lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script
+
+# Captured before the autouse fixture pins it, so the getifaddrs test can exercise the real impl.
+_REAL_LOCAL_IDENTITIES = lifecycle_guard._local_host_identities
+
+# A fixed local identity set keeps the loopback/self tests deterministic across
+# machines: 192.168.9.9 stands in for "this host's own LAN IP".
+_FIXED_LOCAL = frozenset(
+    {"localhost", "localhost.localdomain", "127.0.0.1", "::1", "0.0.0.0",
+     "thishost", "thishost.local", "192.168.9.9"}
+)
+
+
+@pytest.fixture(autouse=True)
+def _pin_local_identities(monkeypatch):
+    monkeypatch.setattr(lifecycle_guard, "_local_host_identities", lambda: _FIXED_LOCAL)
+
+
+# --- authorized remote maintenance is allowed ---------------------------------
+
+@pytest.mark.parametrize("command", [
+    "ssh jim@192.168.3.184 'systemctl --user restart hermes-gateway'",
+    "ssh 192.168.3.184 systemctl restart hermes-gateway",
+    "ssh -p 2222 -i ~/.ssh/id_ed25519 jim@192.168.3.184 'systemctl --user restart hermes-gateway'",
+    "ssh -o StrictHostKeyChecking=no jim@192.168.3.184 'hermes gateway restart'",
+    "sudo ssh jim@192.168.3.184 'systemctl restart hermes-gateway'",
+    "ssh root@10.4.5.6 'launchctl kickstart -k gui/501/ai.hermes.gateway'",
+])
+def test_remote_host_maintenance_allowed(command):
+    assert not guard(command), f"remote maintenance should be allowed: {command!r}"
+
+
+def test_ssh_config_alias_to_remote_ip_allowed(monkeypatch, tmp_path):
+    home = tmp_path
+    ssh_dir = home / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "config").write_text(
+        textwrap.dedent(
+            """\
+            Host jimbox
+                HostName 192.168.3.184
+                User jim
+            """
+        )
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Path.expanduser() keys off this on Windows
+    assert not guard("ssh jimbox 'systemctl --user restart hermes-gateway'")
+
+
+# --- the calling gateway stays protected --------------------------------------
+
+@pytest.mark.parametrize("command", [
+    # Direct local self-restart forms are untouched by the SSH path.
+    "hermes gateway restart",
+    "systemctl --user restart hermes-gateway",
+    "launchctl kickstart -k gui/501/ai.hermes.gateway",
+    # SSH back to the local host in its many spellings.
+    "ssh localhost 'systemctl restart hermes-gateway'",
+    "ssh root@127.0.0.1 'hermes gateway restart'",
+    "ssh [::1] 'systemctl restart hermes-gateway'",
+    "ssh 0.0.0.0 'systemctl restart hermes-gateway'",
+    "ssh thishost 'systemctl restart hermes-gateway'",
+    "ssh 192.168.9.9 'systemctl restart hermes-gateway'",  # this host's own LAN IP
+    # Ambiguous target: cannot prove it is remote -> fail closed.
+    "ssh $TARGET 'systemctl restart hermes-gateway'",
+    "ssh \"$(cat host)\" 'systemctl restart hermes-gateway'",
+    # Bare hostname with no ssh-config entry and no DNS resolution -> ambiguous.
+    "ssh buildbox 'systemctl restart hermes-gateway'",
+])
+def test_local_self_restart_still_blocked(command):
+    assert guard(command), f"self-restart must stay blocked: {command!r}"
+
+
+def test_ssh_config_alias_to_loopback_still_blocked(monkeypatch, tmp_path):
+    home = tmp_path
+    ssh_dir = home / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "config").write_text("Host localbox\n    HostName 127.0.0.1\n")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Path.expanduser() keys off this on Windows
+    assert guard("ssh localbox 'systemctl restart hermes-gateway'")
+
+
+# --- adversarial: option overrides that redirect the connection (review Finding 1/4) ----------
+# A global-looking destination token combined with an option that makes ssh actually dial the
+# local host must NOT exempt the payload. These all restart the CALLING gateway if allowed.
+
+@pytest.mark.parametrize("command", [
+    "ssh -o HostName=127.0.0.1 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -oHostName=127.0.0.1 8.8.8.8 'systemctl restart hermes-gateway'",       # attached
+    "ssh -o Hostname=localhost 8.8.8.8 'hermes gateway restart'",                # case-insensitive key
+    "ssh 8.8.8.8 -o HostName=127.0.0.1 'hermes gateway restart'",                # override AFTER dest
+    "ssh -o HostName=192.168.9.9 8.8.8.8 'systemctl restart hermes-gateway'",    # own LAN IP via override
+    "ssh -o ProxyJump=localhost 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -o ProxyCommand=nc 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -J localhost 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -Jlocalhost 8.8.8.8 'hermes gateway restart'",                          # attached -J
+    "ssh -F /tmp/eviltunnel.cfg 8.8.8.8 'systemctl restart hermes-gateway'",     # alternate config
+    "ssh -F none jimbox 'systemctl restart hermes-gateway'",                     # config bypass
+    # Space-separated -o key/value (ssh_config accepts whitespace, not just '=').
+    "ssh -o 'HostName 127.0.0.1' 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -o 'hostname 127.0.0.1' 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh 8.8.8.8 -o 'HostName 127.0.0.1' 'hermes gateway restart'",
+    "ssh -o 'ProxyJump localhost' 8.8.8.8 'systemctl restart hermes-gateway'",
+    # Bundled short-flag clusters ahead of an arg-taking -o / -J / -F (getopt bundling).
+    "ssh -tqoHostName=127.0.0.1 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -4oHostName=127.0.0.1 8.8.8.8 'hermes gateway restart'",
+    "ssh -qoHostName=127.0.0.1 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -CqoHostName=localhost 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -qo 'HostName 127.0.0.1' 8.8.8.8 'systemctl restart hermes-gateway'",   # bundled + spaced value
+    "ssh -qJlocalhost 8.8.8.8 'systemctl restart hermes-gateway'",               # bundled ProxyJump
+    "ssh -CqFnone jimbox 'systemctl restart hermes-gateway'",                     # bundled -F none
+    "slogin -tqoHostName=127.0.0.1 8.8.8.8 'hermes gateway restart'",
+    # Leading '=' separator: ssh discards one leading '=' (`-o=HostName=x` sets HostName).
+    "ssh -o=HostName=127.0.0.1 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -o =HostName=127.0.0.1 8.8.8.8 'hermes gateway restart'",
+    "ssh -qo=HostName=127.0.0.1 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -o=ProxyJump=localhost 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -o '=HostName 127.0.0.1' 8.8.8.8 'systemctl restart hermes-gateway'",
+    # Quoted keyword — ssh strips quotes around the keyword (review Finding 8).
+    "ssh -o '\"HostName\" 127.0.0.1' 8.8.8.8 'systemctl restart hermes-gateway'",
+    "ssh -o 'HostName\"\" 127.0.0.1' 8.8.8.8 'systemctl restart hermes-gateway'",
+    # LocalCommand runs on the CALLING host — payload must stay scanned (review Finding 7).
+    "ssh jim@192.168.3.184 -o PermitLocalCommand=yes -o LocalCommand='systemctl restart hermes-gateway' uptime",
+    "ssh -tq jim@192.168.3.184 -oPermitLocalCommand=yes -oLocalCommand='hermes gateway restart' echo done",
+    "ssh jim@192.168.3.184 uptime -o PermitLocalCommand=yes -o LocalCommand='systemctl restart hermes-gateway'",
+    "ssh jim@192.168.3.184 -o LocalCommand='hermes gateway restart'",            # login-only + LocalCommand
+    "ssh -o KnownHostsCommand='systemctl restart hermes-gateway' jim@192.168.3.184 uptime",
+])
+def test_host_override_options_fail_closed(command):
+    assert guard(command), f"host-override must fail closed (stay blocked): {command!r}"
+
+
+def test_remote_operand_masked_but_trailing_option_value_scanned():
+    # The genuinely-remote operand ('uptime') is exempt, but a LocalCommand option value carrying a
+    # lifecycle command on the SAME line is still blocked — proving only operands are masked.
+    assert not guard("ssh jim@192.168.3.184 uptime")
+    assert guard(
+        "ssh jim@192.168.3.184 -o LocalCommand='hermes gateway restart' uptime"
+    )
+
+
+# --- adversarial: alternate spellings of this host's own IP (review Finding 2) -----------------
+
+@pytest.mark.parametrize("command", [
+    "ssh ::ffff:192.168.9.9 'systemctl restart hermes-gateway'",       # IPv4-mapped own LAN IP
+    "ssh [::ffff:192.168.9.9] 'systemctl restart hermes-gateway'",     # bracketed
+    "ssh ::ffff:127.0.0.1 'systemctl restart hermes-gateway'",         # IPv4-mapped loopback
+    "ssh [::1] 'hermes gateway restart'",
+    "ssh 0:0:0:0:0:0:0:1 'systemctl restart hermes-gateway'",          # expanded ::1
+])
+def test_alternate_ip_spellings_of_local_blocked(command):
+    assert guard(command), f"own/loopback IP spelling must stay blocked: {command!r}"
+
+
+@pytest.mark.parametrize("dest", [
+    "::ffff:192.168.9.9",   # own LAN IP, IPv4-mapped
+    "::ffff:127.0.0.1",     # loopback, IPv4-mapped
+    "0:0:0:0:0:0:0:1",      # expanded loopback
+    "192.168.9.9.",         # trailing dot on own IP
+])
+def test_ssh_destination_alternate_local_spellings_are_not_remote(monkeypatch, dest):
+    monkeypatch.setattr(lifecycle_guard, "_local_host_identities", lambda: _FIXED_LOCAL)
+    assert lifecycle_guard._ssh_destination_is_remote(dest) is False
+
+
+def test_slogin_remote_allowed_but_override_blocked():
+    assert not guard("slogin jim@192.168.3.184 'systemctl --user restart hermes-gateway'")
+    assert guard("slogin -o HostName=127.0.0.1 8.8.8.8 'systemctl restart hermes-gateway'")
+
+
+def test_all_local_interface_ips_recognized_via_getifaddrs(monkeypatch):
+    # A multi-homed host: the default route yields one IP but a second NIC has another. Full
+    # interface enumeration (psutil.net_if_addrs) must recognize BOTH as local so `ssh <second-nic>
+    # 'systemctl restart hermes-gateway'` is a self-restart and stays blocked.
+    import socket
+
+    import psutil
+
+    import cron.lifecycle_guard as lg
+
+    class _Addr:
+        def __init__(self, address):
+            self.address = address
+
+    fake = {
+        "lo0": [_Addr("127.0.0.1"), _Addr("::1")],
+        "en0": [_Addr("192.168.3.152"), _Addr("aa:bb:cc:dd:ee:ff")],   # + a MAC, must be ignored
+        "en1": [_Addr("192.168.3.214")],
+        "utun3": [_Addr("100.90.1.2%utun3")],                          # VPN w/ IPv6-style zone id
+    }
+    # Restore the real implementation (the autouse fixture pinned a fixed set) so we exercise the
+    # actual getifaddrs enumeration, with psutil/gethostname patched for determinism.
+    monkeypatch.setattr(lg, "_local_host_identities", _REAL_LOCAL_IDENTITIES)
+    monkeypatch.setattr(psutil, "net_if_addrs", lambda: fake)
+    monkeypatch.setattr(socket, "gethostname", lambda: "")
+    identities = lg._local_host_identities()
+    assert "192.168.3.152" in identities
+    assert "192.168.3.214" in identities
+    assert "100.90.1.2" in identities            # zone id stripped
+    assert "aa:bb:cc:dd:ee:ff" not in identities  # MAC ignored
+    assert lg._ssh_destination_is_remote("192.168.3.214") is False
+    assert lg._ssh_destination_is_remote("100.90.1.2") is False
+    assert lg._ssh_destination_is_remote("192.168.3.184") is True  # a genuine peer stays remote
+
+
+# --- compound commands keep protection for the local component ----------------
+
+@pytest.mark.parametrize("command", [
+    "ssh jim@192.168.3.184 'uptime'; hermes gateway restart",
+    "hermes gateway restart && ssh jim@192.168.3.184 'uptime'",
+    "ssh jim@192.168.3.184 'echo ok' | systemctl restart hermes-gateway",
+    "ssh jim@192.168.3.184 'systemctl restart hermes-gateway' ; systemctl restart hermes-gateway",
+])
+def test_compound_local_component_blocked(command):
+    assert guard(command), f"local component must stay blocked: {command!r}"
+
+
+# --- referenced scripts keep their existing inspection ------------------------
+
+def test_referenced_local_script_still_scanned(tmp_path):
+    script = tmp_path / "restart.sh"
+    script.write_text("#!/bin/sh\nhermes gateway restart\n")
+    assert guard(f"bash {script}")
+
+
+def test_remote_payload_does_not_expand_local_script_reference(tmp_path):
+    # The remote command references a path that also exists locally; it must NOT
+    # be read as a local script (it runs on the remote host). The command is a
+    # benign remote copy, so nothing should block.
+    local_twin = tmp_path / "deploy.sh"
+    local_twin.write_text("#!/bin/sh\necho harmless\n")
+    assert not guard(f"ssh jim@192.168.3.184 'bash {local_twin}'")
+
+
+# --- direct unit coverage of the classifier -----------------------------------
+
+@pytest.mark.parametrize("dest,expected", [
+    ("192.168.3.184", True),
+    ("jim@192.168.3.184", True),
+    ("10.0.0.5", True),
+    ("8.8.8.8", True),
+    ("127.0.0.1", False),
+    ("::1", False),
+    ("0.0.0.0", False),
+    ("localhost", False),
+    ("thishost", False),
+    ("192.168.9.9", False),          # pinned local identity
+    ("$HOST", False),                 # variable -> ambiguous
+    ("`hostname`", False),            # command substitution -> ambiguous
+    ("buildbox", False),              # unresolvable bare name -> ambiguous
+    ("", False),
+])
+def test_ssh_destination_is_remote(monkeypatch, dest, expected):
+    monkeypatch.setattr(lifecycle_guard, "_local_host_identities", lambda: _FIXED_LOCAL)
+    assert lifecycle_guard._ssh_destination_is_remote(dest) is expected
+
+
+# --- only ssh/slogin get the remote exemption ---------------------------------
+
+@pytest.mark.parametrize("command", [
+    # scp/rsync/telnet and look-alike names are NOT remote-shell executors here, so their
+    # arguments are never masked — a lifecycle command in that text stays fully scanned.
+    "scp jim@192.168.3.184 'systemctl restart hermes-gateway'",
+    "rsync jim@192.168.3.184 'hermes gateway restart'",
+    "sshpass jim@192.168.3.184 'systemctl restart hermes-gateway'",
+    "notssh jim@192.168.3.184 'systemctl restart hermes-gateway'",
+])
+def test_only_ssh_and_slogin_are_masked(command):
+    assert guard(command), f"non-ssh executable must not gain the exemption: {command!r}"
+
+
+# --- getifaddrs failure degrades to the probe fallback without crashing -------
+
+def test_local_identities_fall_back_when_getifaddrs_fails(monkeypatch):
+    import psutil
+
+    def _boom():
+        raise RuntimeError("simulated getifaddrs failure")
+
+    monkeypatch.setattr(lifecycle_guard, "_local_host_identities", _REAL_LOCAL_IDENTITIES)
+    monkeypatch.setattr(psutil, "net_if_addrs", _boom)
+    identities = lifecycle_guard._local_host_identities()  # must not raise
+    assert "127.0.0.1" in identities and "::1" in identities  # loopback still recognized
+    # And a loopback self-restart stays blocked even with enumeration degraded.
+    assert lifecycle_guard._ssh_destination_is_remote("127.0.0.1") is False


### PR DESCRIPTION
## What does this PR do?

A supervised gateway must never be tricked into restarting/stopping **itself** — `contains_gateway_lifecycle_command_or_referenced_script` blocks `hermes gateway restart`, `systemctl … hermes-gateway`, matching `launchctl`, and `pkill` of the gateway when issued from inside the gateway process, because SIGTERM would kill the in-flight command before it completes.

But the scan has **no SSH awareness**: it scans the entire command string — including the command passed to `ssh` — as if it ran locally. So anyone running a **fleet of hermes agents that administer each other over SSH** cannot perform authorized remote maintenance. This:

```
ssh jim@10.0.0.5 'systemctl --user restart hermes-gateway'
```

is rejected with *"command or referenced script cannot restart, stop, or uninstall the gateway from inside the gateway process"* — even though the payload runs on a **different host** and cannot SIGTERM the caller.

The fix, at the direct-scan choke point (`_lifecycle_command_scan_with_data_exemption`), masks **only the getopt-classified remote-command operands** of an `ssh`/`slogin` invocation whose destination is **provably a different host**; every option token *and its value* stays visible to the scan. Masking can only ever *remove* a match and is gated on provable-remoteness, so it can only **ALLOW** what the plain regex would block — never block more (same contract as the existing data-sink masker). All prior self-restart protection is preserved.

**Stays blocked (fails closed):**
- loopback / localhost / this host's own names & IPs — every local interface via `getifaddrs` (`psutil.net_if_addrs`), so a multi-homed host's secondary NIC / VPN IP is covered; **no DNS**, so the guard never hangs on the tool-executor thread;
- ambiguous destinations — `$VAR`, command substitution, bare names not resolvable without DNS;
- host-redirect options that make the destination not the effective host: `-o HostName=`/`ProxyJump`/`ProxyCommand` (spaced, attached, bundled short-flag clusters, leading `=`, quoted keyword), `-J`, `-F`;
- local-exec options whose payload runs on the *caller*: `-o LocalCommand`/`PermitLocalCommand`/`KnownHostsCommand`;
- the local component of compound commands — `ssh host '…' ; hermes gateway restart`;
- referenced scripts — existing inspection/recursion is unchanged.

No blanket SSH exemption, no globally-disabled guards/approvals, no signal- or rename-based evasion.

## Related Issue

Fixes #107481

Filed alongside this PR. I searched open **and** merged issues/PRs first (`gh search issues/prs --repo NousResearch/hermes-agent`); no existing report covered the SSH-to-remote-host case — the nearest are unrelated: #74808 goes the opposite direction (hardening *aliased self-restarts*), and #105301 / #83436 concern local *cross-profile* restarts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

> Touches a security-sensitive guard: it *loosens* a false positive while preserving the self-restart invariant. The masking contract and the fail-closed cases above were the review focus.

## Changes Made

- `cron/lifecycle_guard.py` — add SSH remote-maintenance awareness:
  - `_ssh_parse_invocation` / `_ssh_short_cluster` — getopt-accurate short-option cluster decoder (bundling, attached/spaced values, `--`); separates options+values from bare operands.
  - `_ssh_destination_is_remote` / `_extract_ssh_host` / `_ssh_config_hostname` — classify the effective host with `ipaddress` (IPv4-mapped collapsed), `~/.ssh/config` `HostName` resolution (no DNS), fail-closed on ambiguity.
  - `_local_host_identities` / `_probe_local_source_ip` — this host's names + all interface IPs via `getifaddrs`, with a no-send UDP-route-probe fallback.
  - `_mask_remote_ssh_command_payloads` — mask only remote-command operands; leave every option/value scanned. Wired into `_lifecycle_command_scan_with_data_exemption`.
  - `_ssh_o_key` normalizes the `-o` keyword exactly as ssh's config tokenizer does (leading `=`, quotes) with `encoding="utf-8"` on the config read (PLW1514).
- `tests/cron/test_lifecycle_guard_ssh_remote.py` — 92 tests covering allowed remote maintenance, every self-restart/loopback/own-IP/ambiguous form, option-smuggling bypasses, compound commands, referenced scripts, and the getifaddrs path.
- `contributors/emails/caspian@ricorna.com` — attribution mapping (contributor-check).

## How to Test

Reproduce the false positive on `main` (before this PR): from inside a supervised gateway, `ssh <remote> 'systemctl --user restart hermes-gateway'` is blocked.

With this PR:

```bash
scripts/run_tests.sh tests/cron/test_lifecycle_guard_ssh_remote.py    # 92 passed
# behavioral spot-check:
python - <<'PY'
from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script as g
assert not g("ssh jim@10.0.0.5 'systemctl --user restart hermes-gateway'")  # remote: allowed
assert g("ssh localhost 'systemctl restart hermes-gateway'")                # loopback: blocked
assert g("ssh -o HostName=127.0.0.1 8.8.8.8 'systemctl restart hermes-gateway'")  # override: blocked
assert g("hermes gateway restart")                                          # local self: blocked
print("ok")
PY
```

Option/host classification was cross-checked against real OpenSSH `ssh -G` (effective-config resolution) so the guard's parse matches ssh's.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cron):`, `chore(contributors):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (guard + tests + attribution mapping)
- [x] I've run `pytest tests/ -q` and all tests pass (guard + regression suites; `ruff check` clean on the PLW1514/ASYNC gate)
- [x] I've added tests for my changes (92 new tests)
- [x] I've tested on my platform: macOS (Darwin 25.6). The guard runs on the calling gateway; the code paths are cross-platform (`psutil`, `socket`, `ipaddress`, `pathlib`), no Unix-only assumptions, no DNS.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — thorough docstrings on every new function; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — text file read uses explicit `encoding="utf-8"`; interface enumeration and host classification are cross-platform; no DNS (avoids the async/getaddrinfo freeze class)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (guard-internal; no tool schema change)

## Screenshots / Logs

Original rejection this fixes:

> Blocked: command or referenced script cannot restart, stop, or uninstall the gateway from inside the gateway process. The gateway would kill this command before it could complete (SIGTERM propagates to child processes). Run `hermes gateway restart` from a separate shell outside the running gateway.
