### PR TITLE
fix(docker): don't resurrect a deleted/emptied .env from a stale pre-migrate backup

### DIFF
--- a/scripts/docker_config_migrate.py
+++ b/scripts/docker_config_migrate.py
@@ -2,6 +2,7 @@
 """Run Docker boot-time config migrations safely."""
 from __future__ import annotations
 
+import filecmp
 import shutil
 import sys
 from pathlib import Path
@@ -22,11 +23,28 @@ from utils import env_var_enabled
 
 
 def _backup_existing(paths: Iterable[Path]) -> dict[Path, Path]:
-    """Snapshot each file into backups/config/; an identical existing snapshot is reused."""
+    """Snapshot each file into backups/config/; an identical existing snapshot is reused.
+
+    A file that does not currently exist gets no entry (nothing to roll back to). When
+    ``backup_config`` skips a live file — same bytes as the newest ``pre-docker-migrate``
+    snapshot, but also an empty file, a same-second name collision, or a write error — only
+    fall back to that newest snapshot when its bytes still match the file on disk right now;
+    otherwise a failed migration's rollback would restore stale content (e.g. resurrecting a
+    deleted .env with a since-revoked API key) instead of leaving the file alone.
+    """
     backups: dict[Path, Path] = {}
     for path in paths:
-        dest = backup_config(path, "pre-docker-migrate") or next(
-            iter(list_config_backups(path, "pre-docker-migrate")), None)
+        if not path.is_file():
+            continue
+        dest = backup_config(path, "pre-docker-migrate")
+        if dest is None:
+            existing = next(iter(list_config_backups(path, "pre-docker-migrate")), None)
+            if existing is not None:
+                try:
+                    if filecmp.cmp(path, existing, shallow=False):
+                        dest = existing
+                except OSError:
+                    pass
         if dest is not None:
             backups[path] = dest
     return backups

--- a/tests/tools/test_docker_config_migrate.py
+++ b/tests/tools/test_docker_config_migrate.py
@@ -174,6 +174,83 @@ def test_docker_config_migrate_restores_backups_after_failed_migration(
     assert list((tmp_path / "backups" / "config").glob(".env.pre-docker-migrate.*"))
 
 
+def test_docker_config_migrate_does_not_resurrect_a_deleted_env_on_rollback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale pre-docker-migrate backup of .env from an earlier boot must not be used to
+    recreate .env on a failed-migration rollback once the user has since deleted it (e.g.
+    moved secrets to container env vars). Regression for the dropped is_file() guard in
+    _backup_existing: `backup_config(...) or next(iter(list_config_backups(...)), None)`
+    silently reused whatever snapshot existed, even for a file that no longer exists."""
+    module = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    original_config = yaml.safe_dump({"_config_version": 12, "gateway": {"provider": "telegram"}})
+    config_path.write_text(original_config, encoding="utf-8")
+    env_path.write_text("TELEGRAM_BOT_TOKEN=old-revoked-token\n", encoding="utf-8")
+
+    # Seed a stale backup, as if an earlier boot already ran the pre-migration snapshot step.
+    from hermes_cli.config_backups import backup_config
+
+    backup_config(env_path, "pre-docker-migrate")
+
+    # The user has since deleted .env.
+    env_path.unlink()
+
+    monkeypatch.setattr(module, "check_config_version", lambda: (12, DEFAULT_CONFIG["_config_version"]))
+    monkeypatch.setattr(module, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(module, "get_env_path", lambda: env_path)
+
+    def _failing_migrate(*, interactive: bool, quiet: bool):
+        config_path.write_text("gateway: {}\n", encoding="utf-8")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(module, "migrate_config", _failing_migrate)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        module.main()
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert not env_path.exists(), ".env must stay deleted, not be resurrected from a stale backup"
+
+
+def test_docker_config_migrate_does_not_reuse_stale_backup_for_emptied_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """backup_config() also skips (returns None) for a zero-byte file. The rollback fallback
+    must not then reuse an older, non-empty snapshot — that would silently refill an
+    intentionally emptied .env with old credentials."""
+    module = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+    original_config = yaml.safe_dump({"_config_version": 12, "gateway": {"provider": "telegram"}})
+    config_path.write_text(original_config, encoding="utf-8")
+    env_path.write_text("TELEGRAM_BOT_TOKEN=old-revoked-token\n", encoding="utf-8")
+
+    from hermes_cli.config_backups import backup_config
+
+    backup_config(env_path, "pre-docker-migrate")
+
+    # .env is emptied (still exists, zero bytes) rather than deleted.
+    env_path.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(module, "check_config_version", lambda: (12, DEFAULT_CONFIG["_config_version"]))
+    monkeypatch.setattr(module, "get_config_path", lambda: config_path)
+    monkeypatch.setattr(module, "get_env_path", lambda: env_path)
+
+    def _failing_migrate(*, interactive: bool, quiet: bool):
+        config_path.write_text("gateway: {}\n", encoding="utf-8")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(module, "migrate_config", _failing_migrate)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        module.main()
+
+    assert config_path.read_text(encoding="utf-8") == original_config
+    assert env_path.read_text(encoding="utf-8") == "", ".env must stay empty, not be refilled from a stale backup"
+
+
 def test_docker_config_migrate_restores_backups_when_version_does_not_advance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

`bf53ff00a7` ("one bounded backups/config/ dir replaces four config.yaml.bak schemes") replaced the old guard-and-copy loop in `_backup_existing` (`scripts/docker_config_migrate.py`) with:

```python
dest = backup_config(path, "pre-docker-migrate") or next(
    iter(list_config_backups(path, "pre-docker-migrate")), None)
```

`backup_config()` returns `None` for several distinct reasons — the file is missing, the file is empty, a same-second name collision, an `OSError` from the copy, or (the one case this fallback is actually meant for) the file's bytes are identical to the newest existing snapshot for that reason. The fallback can't tell these apart, so it silently reuses whichever snapshot happens to already exist on disk regardless of why `backup_config` returned `None`.

Concretely: a user deletes `.env` after moving secrets to container env vars, or empties it intentionally. A later boot's migration then fails and rolls back via `_restore_backups`, which copies the *stale* snapshot from an earlier run back over the now-deleted/emptied file — resurrecting old, possibly revoked, credentials.

The old code guarded against the missing-file case explicitly (`if not path.is_file(): continue`); that guard was dropped in the rewrite, and the zero-byte/collision/`OSError` cases were never guarded at all.

## Fix

Restore the `is_file()` guard so a currently-missing file gets no backup entry (nothing to roll back to, matching the old behavior exactly). For the fallback path, only reuse an existing snapshot when its bytes still match the file on disk right now (`filecmp.cmp`) — this covers the identical-content case the fallback was designed for, while correctly rejecting the empty-file and `OSError`/collision cases without reintroducing a file-existence assumption.

## Test plan

- [x] Two new regression tests in `tests/tools/test_docker_config_migrate.py`, exercising the real `main()` end to end (seed a stale `pre-docker-migrate` backup, delete/empty `.env`, force `migrate_config` to fail, assert `.env` stays deleted/empty after rollback instead of being resurrected).
- [x] Mutation-verify: reverted just the production fix and confirmed both new tests fail (`.env` gets refilled with the old token); restored the fix and confirmed they pass again.
- [x] Full `tests/tools/test_docker_config_migrate.py` — 10 passed (including the existing byte-for-byte second-boot regression test, unaffected).
- [x] `ruff check` clean on both changed files.
