### PR TITLE
fix(cron): protect state DB during external worker restart

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -563,6 +563,18 @@ def get_running_job_ids() -> "frozenset[str]":
         return frozenset(_running_job_ids | _running_fire_owners.keys())
 
 
+def has_restart_safe_external_workers() -> bool:
+    """Whether a detached cron worker still owns a run outside this gateway.
+
+    The parent gateway waits synchronously on these workers, but the worker
+    itself lives in a separate restart-safe systemd scope. Shutdown cannot
+    quiesce its thread or process, so it must not checkpoint/close state.db
+    while the worker may be appending its final transcript.
+    """
+    with _running_lock:
+        return bool(_restart_safe_waiter_job_ids)
+
+
 def try_register_running_job(job_id: str) -> bool:
     """Atomically add ``job_id`` to the in-flight set; False (caller must skip) if already mid-run.
     Single dedupe owner for ticker + manual runs (the fire claim's 300s TTL is outlived by real

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1772,6 +1772,30 @@ class GatewayShutdownMixin:
                 "open for SQLite to recover on next open", _exec_live, _exec_quiesce_budget,
             )
             return
+        # A restart-safe cron worker is outside this gateway process and cannot
+        # be quiesced by the executor drain above. Its final transcript append
+        # still targets this profile's state.db, so an explicit close-time WAL
+        # checkpoint here would race the worker's live SQLite generation. The
+        # process is already shutting down; leave the handles alone and let
+        # process exit close them naturally. A replacement gateway can then
+        # open the same generation after this process is gone.
+        try:
+            from cron.scheduler import has_restart_safe_external_workers
+            if has_restart_safe_external_workers():
+                logger.warning(
+                    "Shutdown phase: restart-safe external cron worker(s) still active — "
+                    "skipping SessionDB close/checkpoint to protect the shared WAL generation"
+                )
+                return
+        except Exception as exc:
+            # Failing closed is safer than checkpointing an unknown live worker
+            # during a planned replacement.
+            logger.warning(
+                "Shutdown phase: could not inspect restart-safe cron workers (%s) — "
+                "skipping SessionDB close/checkpoint",
+                exc,
+            )
+            return
         logger.info("Shutdown phase: executor quiesced at +%.2fs", ctx.elapsed())
         _step = GatewayShutdownMixin._quiet_step
         # Close SQLite session DBs so --replace's new gateway does not hit 'database is locked'.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -415,7 +415,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
             {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
             {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
-            {"key": "observation_scopes", "description": "How observations are scoped during consolidation: 'combined' (default — one pass over all tags), 'per_tag' (one isolated observation per tag), 'all_combinations' (every tag subset — expensive), or a JSON list of tag-lists for explicit custom scopes. Empty uses Hindsight's 'combined' default.", "default": ""},
+            {"key": "observation_scopes", "description": "How observations are scoped during consolidation: 'combined' (default — one pass over all tags), 'shared' (global untagged belief pool), 'per_tag' (one isolated observation per tag), 'all_combinations' (every tag subset — expensive), or a JSON list of tag-lists for explicit custom scopes. Empty uses Hindsight's 'combined' default.", "default": ""},
             {"key": "retain_source", "description": "Metadata source value attached to retained memories (identifies the client that stored them)", "default": _DEFAULT_RETAIN_SOURCE},
             {"key": "retain_user_prefix", "description": "Label used before user turns in retained transcripts", "default": "User"},
             {"key": "retain_assistant_prefix", "description": "Label used before assistant turns in retained transcripts", "default": "Assistant"},

--- a/plugins/memory/hindsight/settings.py
+++ b/plugins/memory/hindsight/settings.py
@@ -41,7 +41,7 @@ _PROVIDER_DEFAULT_MODELS = {
 }
 # The embedded daemon speaks OpenAI wire format for these providers.
 _OPENAI_WIRE_PROVIDERS = {"openai_compatible", "openrouter"}
-_OBSERVATION_SCOPE_KEYWORDS = {"per_tag", "combined", "all_combinations"}
+_OBSERVATION_SCOPE_KEYWORDS = {"per_tag", "combined", "all_combinations", "shared"}
 
 
 def _parse_int_setting(value: Any, default: int) -> int:

--- a/tests/gateway/test_shutdown_executor_quiesce.py
+++ b/tests/gateway/test_shutdown_executor_quiesce.py
@@ -213,6 +213,29 @@ async def test_stuck_worker_skips_the_session_db_close():
     assert "worker_write" in events, "worker never finished"
 
 
+def test_restart_safe_external_worker_skips_session_db_close():
+    """Gateway restart must not checkpoint state.db while a detached cron worker owns a run.
+
+    The worker is outside this gateway process, so executor quiescing cannot
+    observe it. Closing the gateway's connection during the worker's final
+    transcript append races the shared WAL generation; the gateway must leave
+    that handle alone and let process exit close it naturally.
+    """
+    from cron import scheduler
+
+    events = []
+    gw = _FakeGateway(events)
+    scheduler._restart_safe_waiter_job_ids.add("external-cron-job")
+    try:
+        asyncio.run(gw_mod.GatewayRunner.stop(gw))
+    finally:
+        scheduler._restart_safe_waiter_job_ids.discard("external-cron-job")
+
+    assert "close:session_db" not in events, (
+        f"SessionDB was closed while a restart-safe external worker was active: {events}"
+    )
+
+
 def test_shutdown_executor_defaults_to_no_wait():
     """The no-argument call keeps the historical fire-and-forget contract."""
     gw = _FakeGateway([])

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -283,6 +283,8 @@ class TestConfig:
     def test_observation_scopes_keyword_config(self, provider_with_config):
         p = provider_with_config(observation_scopes="per_tag")
         assert p._observation_scopes == "per_tag"
+        p_shared = provider_with_config(observation_scopes="shared")
+        assert p_shared._observation_scopes == "shared"
 
 
     def test_custom_config_values(self, provider_with_config):


### PR DESCRIPTION
## Summary

- keep the gateway from checkpointing/closing the shared SessionDB while a restart-safe external cron worker is still appending its final transcript
- add a shutdown regression test for the external-worker lifecycle boundary
- include the small Hindsight `shared` observation-scope keyword support from the same local workstream

## Verification

- `git diff --check` passes
- targeted pytest verification is pending because the Hermes runtime venv has no pytest and the repository test runner requires a dedicated test environment
- no production service or state mutation was performed

Based on current `origin/main`.