### PR TITLE
fix(discord): require explicit bot handoffs and batch their continuations

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1346,6 +1346,7 @@ platform_toolsets:
 #
 # discord:
 #   require_mention: true            # Require @mention in server channels (default: true)
+#   bots_require_inline_mention: true  # Bot authors must type a literal @mention (default: true)
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed
 #   reactions: true                  # Show processing reactions (default: true)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1409,9 +1409,9 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",  # if set, ONLY respond in these channel IDs (whitelist)
         "auto_thread": True,  # auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # require @mention in threads too (multi-bot threads)
-        # Multi-bot rooms: another bot must type @thisbot (a reply/quote alone won't) to trigger a
-        # reply — stops two bots replying to each other forever. Humans unaffected.
-        "bots_require_inline_mention": False,
+        # Bot authors must type @thisbot to trigger a reply; Discord reply pings alone do not count.
+        # Set False only for trusted legacy relays. Humans are unaffected.
+        "bots_require_inline_mention": True,
         # Prepend recent channel scrollback when triggered (recovers messages gated out by
         # require_mention); limit = max messages scanned.
         "history_backfill": True,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4705,14 +4705,24 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
 
     def _discord_bots_require_inline_mention(self) -> bool:
-        """Whether a bot author must type a literal ``<@thisbot>`` to wake us (off by default).
-        A reply-ping adds us to ``message.mentions`` silently, letting two bots ping-pong forever.
-        Config: ``discord.bots_require_inline_mention`` / ``DISCORD_BOTS_REQUIRE_INLINE_MENTION``."""
-        configured = self.config.extra.get("bots_require_inline_mention")
-        if isinstance(configured, str):
-            return configured.lower() in {"true", "1", "yes", "on"}
+        """Whether another bot must type an inline @mention to trigger us.
+
+        On by default. A bot-authored message only wakes this bot if its
+        content contains a literal ``<@thisbot>`` token. A Discord reply/quote
+        to one of our messages is NOT enough on its own, because Discord's
+        reply-ping silently adds us to ``message.mentions`` even though the
+        author never typed our handle — which otherwise lets two bots ping-pong
+        replies at each other indefinitely. Humans are never affected by this
+        gate; it only applies to bot authors. Set the option to false only for
+        trusted relay integrations that intentionally depend on reply pings or
+        unmentioned bot messages.
+
+        Config: ``discord.bots_require_inline_mention`` (or env
+        ``DISCORD_BOTS_REQUIRE_INLINE_MENTION``).
+        """
         return self._extra_or_env_flag(
-            "bots_require_inline_mention", "DISCORD_BOTS_REQUIRE_INLINE_MENTION", "false", truthy=True)
+            "bots_require_inline_mention", "DISCORD_BOTS_REQUIRE_INLINE_MENTION", "true", truthy=True
+        )
 
     def _discord_channel_keys(self, message: Any, parent_channel_id: Optional[str] = None) -> set[str]:
         """Channel keys (ID, bare name, ``#name``, plus parent for threads) accepted by channel gates."""

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1028,6 +1028,10 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         self._text_batch_split_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0)
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        # A tagged bot may emit one logical response as several Discord
+        # messages. Keep its unmentioned continuation chunks eligible for the
+        # existing text batcher during this short, sender-scoped window.
+        self._bot_tag_debounce_until: Dict[str, float] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
         self._voice_sources: Dict[int, Dict[str, Any]] = {}  # guild_id -> linked text channel source metadata
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
@@ -1370,13 +1374,19 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         role_authorized = False
         if getattr(message.author, "bot", False):
             allow_bots = self._get_allow_bots()
+            bot_tag_continuation = self._is_bot_tag_debounce_continuation(message)
             if allow_bots == "none":
                 return False, False
-            if allow_bots == "mentions" and not self._self_is_explicitly_mentioned(message):
+            if (
+                allow_bots == "mentions"
+                and not self._self_is_explicitly_mentioned(message)
+                and not bot_tag_continuation
+            ):
                 return False, False
             if (
                 self._discord_bots_require_inline_mention()
                 and not self._self_is_raw_mentioned(message)
+                and not bot_tag_continuation
             ):
                 return False, False
         else:
@@ -1428,6 +1438,7 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         admitted, role_authorized = self._discord_message_admission(message, claim=True)
         if not admitted:
             return False
+        self._record_bot_tag_debounce(message)
         return await self._handle_message(message, role_authorized=role_authorized)
 
     # --- gateway_platform_event fire-sites ---
@@ -4670,6 +4681,46 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         """Per-profile DISCORD_ALLOW_BOTS mode (none|mentions|all)."""
         return self._gate_env("DISCORD_ALLOW_BOTS", "none").lower().strip() or "none"
 
+    @staticmethod
+    def _bot_tag_debounce_key(message: Any) -> str:
+        return (
+            f"{getattr(getattr(message, 'channel', None), 'id', '')}:"
+            f"{getattr(getattr(message, 'author', None), 'id', '')}"
+        )
+
+    def _record_bot_tag_debounce(self, message: Any) -> None:
+        """Open a short continuation window after a bot-authored tag."""
+        if (
+            self._text_batch_delay_seconds <= 0
+            or not getattr(getattr(message, "author", None), "bot", False)
+            or not self._self_is_explicitly_mentioned(message)
+        ):
+            return
+        window = max(
+            self._text_batch_delay_seconds,
+            self._text_batch_split_delay_seconds,
+        )
+        self._bot_tag_debounce_until[self._bot_tag_debounce_key(message)] = (
+            time.monotonic() + window
+        )
+
+    def _is_bot_tag_debounce_continuation(self, message: Any) -> bool:
+        """Return whether an unmentioned chunk belongs to a recent bot tag."""
+        if (
+            getattr(self, "_text_batch_delay_seconds", 0) <= 0
+            or not getattr(getattr(message, "author", None), "bot", False)
+        ):
+            return False
+        key = self._bot_tag_debounce_key(message)
+        debounce_until = getattr(self, "_bot_tag_debounce_until", None)
+        if not debounce_until:
+            return False
+        deadline = debounce_until.get(key, 0.0)
+        if deadline <= time.monotonic():
+            debounce_until.pop(key, None)
+            return False
+        return True
+
     def _discord_free_response_channels(self) -> set:
         """Channel IDs/names needing no mention; a lone "*" is preserved for wildcard short-circuit."""
         raw = self.config.extra.get("free_response_channels")
@@ -5704,7 +5755,11 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
             )
             in_bot_thread = self._in_bot_thread(message)
             if require_mention and not is_free_channel and not in_bot_thread:
-                if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
+                if (
+                    not self._self_is_explicitly_mentioned(message)
+                    and not mention_prefix
+                    and not self._is_bot_tag_debounce_continuation(message)
+                ):
                     return False
         # Auto-thread: isolate each @mention in a text channel into its own thread (Slack-style).
         auto_threaded_channel = None
@@ -5838,6 +5893,12 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
             timestamp=message.created_at, auto_skill=_skills, channel_prompt=_channel_prompt,
             channel_context=_channel_context,
         )
+        if (
+            getattr(getattr(message, "author", None), "bot", False)
+            and self._is_bot_tag_debounce_continuation(message)
+        ):
+            event._bot_tag_debounce = True  # type: ignore[attr-defined]
+
         # Track participation so follow-ups in this thread don't need @mention.
         if thread_id:
             self._threads.mark(thread_id)
@@ -5859,7 +5920,9 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         try:
             pending = self._pending_text_batches.get(key)
             last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
-            if last_len >= self._SPLIT_THRESHOLD:
+            if getattr(pending, "_bot_tag_debounce", False):
+                delay = self._text_batch_split_delay_seconds
+            elif last_len >= self._SPLIT_THRESHOLD:
                 delay = self._text_batch_split_delay_seconds
             else:
                 delay = self._text_batch_delay_seconds

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4771,6 +4771,9 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         Config: ``discord.bots_require_inline_mention`` (or env
         ``DISCORD_BOTS_REQUIRE_INLINE_MENTION``).
         """
+        configured = self.config.extra.get("bots_require_inline_mention")
+        if isinstance(configured, str):
+            return configured.lower() in {"true", "1", "yes", "on"}
         return self._extra_or_env_flag(
             "bots_require_inline_mention", "DISCORD_BOTS_REQUIRE_INLINE_MENTION", "true", truthy=True
         )

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -70,7 +70,7 @@ class TestDiscordBotFilter(unittest.TestCase):
         message,
         allow_bots="none",
         client_user=None,
-        bots_require_inline_mention=False,
+        bots_require_inline_mention=True,
     ):
         """Simulate the on_message filter logic and return whether message was accepted."""
         # Replicate the exact filter logic from discord.py on_message
@@ -117,7 +117,7 @@ class TestDiscordBotFilter(unittest.TestCase):
 
 
     def test_inline_mention_requirement_accepts_body_mention(self):
-        """Opt-in guard still admits intentional inline cross-bot mentions."""
+        """The default guard admits intentional inline cross-bot mentions."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(

--- a/tests/gateway/test_discord_bot_inline_mentions.py
+++ b/tests/gateway/test_discord_bot_inline_mentions.py
@@ -1,0 +1,102 @@
+"""Tests for hard-inline mention gating on bot-authored Discord messages."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import discord
+import pytest
+
+from gateway.platforms.helpers import MessageDeduplicator
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _adapter(*, allow_bots: str = "mentions", extra=None) -> DiscordAdapter:
+    adapter = object.__new__(DiscordAdapter)
+    setattr(adapter, "config", SimpleNamespace(extra=extra or {}))
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=99, bot=True))
+    adapter._dedup = MessageDeduplicator()
+    adapter._get_allow_bots = Mock(return_value=allow_bots)
+    adapter._is_allowed_user = Mock(return_value=True)
+    return adapter
+
+
+def _bot_message(adapter: DiscordAdapter, *, content: str, message_type):
+    return SimpleNamespace(
+        id=123,
+        author=SimpleNamespace(id=42, bot=True),
+        channel=SimpleNamespace(id=7),
+        content=content,
+        mentions=[getattr(adapter._client, "user")],
+        type=message_type,
+    )
+
+
+def test_bot_inline_mentions_are_required_by_default(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter()
+
+    assert adapter._discord_bots_require_inline_mention() is True
+    assert DEFAULT_CONFIG["discord"]["bots_require_inline_mention"] is True
+
+
+@pytest.mark.parametrize("allow_bots", ["mentions", "all"])
+def test_reply_ping_does_not_trigger_bot_by_default(monkeypatch, allow_bots):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter(allow_bots=allow_bots)
+    message = _bot_message(
+        adapter,
+        content="reply without a hard mention",
+        message_type=discord.MessageType.reply,
+    )
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+
+    assert admitted is False
+
+
+def test_hard_inline_mention_triggers_bot_by_default(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter(allow_bots="mentions")
+    message = _bot_message(
+        adapter,
+        content="<@99> intentional handoff",
+        message_type=discord.MessageType.default,
+    )
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+
+    assert admitted is True
+
+
+def test_human_messages_are_unaffected_by_inline_mention_gate(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter(allow_bots="none")
+    message = _bot_message(
+        adapter,
+        content="human reply without a hard mention",
+        message_type=discord.MessageType.reply,
+    )
+    message.author.bot = False
+    message.mentions = []
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+
+    assert admitted is True
+
+
+def test_explicit_false_restores_reply_ping_compatibility(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOTS_REQUIRE_INLINE_MENTION", raising=False)
+    adapter = _adapter(
+        allow_bots="mentions",
+        extra={"bots_require_inline_mention": False},
+    )
+    message = _bot_message(
+        adapter,
+        content="legacy reply handoff",
+        message_type=discord.MessageType.reply,
+    )
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+
+    assert admitted is True

--- a/tests/gateway/test_discord_bot_tag_debounce.py
+++ b/tests/gateway/test_discord_bot_tag_debounce.py
@@ -1,0 +1,99 @@
+"""Tests for coalescing rapid bot-authored Discord message chunks."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import discord
+import pytest
+
+from gateway.platforms.helpers import MessageDeduplicator
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _message(*, author_id: int, channel_id: int, mentions=()):
+    return SimpleNamespace(
+        id=author_id * 100 + channel_id,
+        author=SimpleNamespace(id=author_id, bot=True),
+        channel=SimpleNamespace(id=channel_id),
+        mentions=list(mentions),
+        content="chunk",
+        type=discord.MessageType.default,
+    )
+
+
+def _adapter():
+    adapter = object.__new__(DiscordAdapter)
+    adapter._bot_tag_debounce_until = {}
+    adapter._text_batch_delay_seconds = 0.6
+    adapter._text_batch_split_delay_seconds = 2.0
+    adapter._self_is_explicitly_mentioned = lambda message: bool(message.mentions)
+    return adapter
+
+
+def test_tag_opens_short_window_for_same_bot_and_channel_only():
+    adapter = _adapter()
+    tagged = _message(author_id=1, channel_id=10, mentions=[SimpleNamespace(id=99)])
+    continuation = _message(author_id=1, channel_id=10)
+
+    adapter._record_bot_tag_debounce(tagged)
+
+    assert adapter._is_bot_tag_debounce_continuation(continuation) is True
+    assert adapter._is_bot_tag_debounce_continuation(
+        _message(author_id=2, channel_id=10)
+    ) is False
+    assert adapter._is_bot_tag_debounce_continuation(
+        _message(author_id=1, channel_id=11)
+    ) is False
+
+
+def test_disabling_text_batching_disables_bot_tag_debounce():
+    adapter = _adapter()
+    adapter._text_batch_delay_seconds = 0
+    tagged = _message(author_id=1, channel_id=10, mentions=[SimpleNamespace(id=99)])
+
+    adapter._record_bot_tag_debounce(tagged)
+
+    assert adapter._is_bot_tag_debounce_continuation(
+        _message(author_id=1, channel_id=10)
+    ) is False
+
+
+def test_uninitialized_debounce_state_is_treated_as_disabled():
+    adapter = object.__new__(DiscordAdapter)
+
+    assert adapter._is_bot_tag_debounce_continuation(
+        _message(author_id=1, channel_id=10)
+    ) is False
+
+
+def test_mentions_mode_admits_unmentioned_chunk_during_debounce():
+    adapter = _adapter()
+    own_user = SimpleNamespace(id=99)
+    adapter._client = SimpleNamespace(user=own_user)
+    adapter._dedup = MessageDeduplicator()
+    adapter._get_allow_bots = Mock(return_value="mentions")
+    adapter._discord_bots_require_inline_mention = Mock(return_value=True)
+    adapter._self_is_raw_mentioned = Mock(return_value=False)
+    tagged = _message(author_id=1, channel_id=10, mentions=[own_user])
+    continuation = _message(author_id=1, channel_id=10)
+    adapter._record_bot_tag_debounce(tagged)
+
+    admitted, _ = adapter._discord_message_admission(continuation, claim=True)
+
+    assert admitted is True
+
+
+@pytest.mark.asyncio
+async def test_rejected_bot_tag_does_not_open_debounce_window():
+    adapter = _adapter()
+    adapter._ready_event = asyncio.Event()
+    adapter._ready_event.set()
+    adapter._record_bot_tag_debounce = Mock()
+    adapter._discord_message_admission = Mock(return_value=(False, False))
+    adapter._handle_message = AsyncMock()
+    message = _message(author_id=1, channel_id=10)
+
+    assert await adapter._dispatch_discord_message(message) is False
+    adapter._record_bot_tag_debounce.assert_not_called()
+    adapter._handle_message.assert_not_awaited()

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -1,5 +1,6 @@
 """Tests for Discord free-response defaults and mention gating."""
 
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -225,6 +226,62 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "hello with mention"
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_bot_chunks_join_recent_tag_batch(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._text_batch_delay_seconds = 0.01
+    adapter._text_batch_split_delay_seconds = 0.02
+    channel = FakeTextChannel(channel_id=321)
+    bot_user = adapter._client.user
+    tagged = make_message(
+        channel=channel,
+        content=f"<@{bot_user.id}> first chunk",
+        mentions=[bot_user],
+    )
+    tagged.author.bot = True
+    second = make_message(channel=channel, content="second chunk")
+    second.id = 124
+    second.author.bot = True
+    third = make_message(channel=channel, content="third chunk")
+    third.id = 125
+    third.author.bot = True
+    adapter._record_bot_tag_debounce(tagged)
+
+    assert await adapter._handle_message(tagged, role_authorized=True) is True
+    assert await adapter._handle_message(second, role_authorized=True) is True
+    assert await adapter._handle_message(third, role_authorized=True) is True
+    await asyncio.sleep(0.03)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "first chunk\nsecond chunk\nthird chunk"
+
+
+@pytest.mark.asyncio
+async def test_short_tagged_bot_chunk_waits_for_followup_window(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    adapter._text_batch_delay_seconds = 0.01
+    adapter._text_batch_split_delay_seconds = 0.08
+    channel = FakeTextChannel(channel_id=321)
+    bot_user = adapter._client.user
+    tagged = make_message(
+        channel=channel,
+        content=f"<@{bot_user.id}> short chunk",
+        mentions=[bot_user],
+    )
+    tagged.author.bot = True
+    adapter._record_bot_tag_debounce(tagged)
+
+    assert await adapter._handle_message(tagged, role_authorized=True) is True
+    await asyncio.sleep(0.03)
+    adapter.handle_message.assert_not_awaited()
+
+    await asyncio.sleep(0.07)
+    adapter.handle_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -232,10 +232,13 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
 async def test_unmentioned_bot_chunks_join_recent_tag_batch(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
-    adapter._text_batch_delay_seconds = 0.01
-    adapter._text_batch_split_delay_seconds = 0.02
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    adapter._ready_event.set()
+    adapter._text_batch_delay_seconds = 0.6
+    adapter._text_batch_split_delay_seconds = 2.0
     channel = FakeTextChannel(channel_id=321)
     bot_user = adapter._client.user
+    bot_user.bot = True
     tagged = make_message(
         channel=channel,
         content=f"<@{bot_user.id}> first chunk",
@@ -248,12 +251,12 @@ async def test_unmentioned_bot_chunks_join_recent_tag_batch(adapter, monkeypatch
     third = make_message(channel=channel, content="third chunk")
     third.id = 125
     third.author.bot = True
-    adapter._record_bot_tag_debounce(tagged)
-
-    assert await adapter._handle_message(tagged, role_authorized=True) is True
-    assert await adapter._handle_message(second, role_authorized=True) is True
-    assert await adapter._handle_message(third, role_authorized=True) is True
-    await asyncio.sleep(0.03)
+    assert await adapter._dispatch_discord_message(tagged) is True
+    assert await adapter._dispatch_discord_message(second) is True
+    assert await adapter._dispatch_discord_message(third) is True
+    await asyncio.wait_for(
+        asyncio.gather(*adapter._pending_text_batch_tasks.values()), timeout=5.0,
+    )
 
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
@@ -276,11 +279,12 @@ async def test_short_tagged_bot_chunk_waits_for_followup_window(adapter, monkeyp
     tagged.author.bot = True
     adapter._record_bot_tag_debounce(tagged)
 
-    assert await adapter._handle_message(tagged, role_authorized=True) is True
-    await asyncio.sleep(0.03)
-    adapter.handle_message.assert_not_awaited()
-
-    await asyncio.sleep(0.07)
+    # Assert the selected quiet period without a wall-clock race on busy CI.
+    with patch.object(discord_platform.asyncio, "sleep", new_callable=AsyncMock) as sleep:
+        assert await adapter._handle_message(tagged, role_authorized=True) is True
+        adapter.handle_message.assert_not_awaited()
+        await asyncio.gather(*adapter._pending_text_batch_tasks.values())
+        sleep.assert_awaited_once_with(adapter._text_batch_split_delay_seconds)
     adapter.handle_message.assert_awaited_once()
 
 

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -301,7 +301,8 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
-| `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
+| `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. By default, either enabled mode still requires a literal inline mention; see the next setting. |
+| `DISCORD_BOTS_REQUIRE_INLINE_MENTION` | No | `true` | Require bot-authored messages to contain a literal `<@BOT_ID>` / `<@!BOT_ID>` token. Discord reply pings only populate mention metadata and do not trigger Hermes. Set to `false` only for trusted relay integrations that depend on unmentioned bot messages or reply pings. Human-authored messages are unaffected. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
@@ -319,10 +320,10 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | No | `0.6` | Grace window the adapter waits before flushing a queued text chunk. Useful for smoothing streamed output. |
 | `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | No | `2.0` | Delay between split chunks when a single message exceeds Discord's length limit. |
 
-:::warning Bot-to-bot conversation is not supported
-`DISCORD_ALLOW_BOTS` exists to accept input from a specific trusted bot (e.g. a relay or webhook bot), not to let two Hermes profiles talk to each other. The default, `"none"`, ignores all other bots and is the safe setting.
+:::tip Bot-to-bot handoffs require hard mentions
+`DISCORD_ALLOW_BOTS` defaults to `"none"`. When you opt into `"mentions"` or `"all"`, bot-authored messages must contain a literal inline mention of Hermes by default. Discord's automatic replied-user ping does not count, so replying to another bot cannot silently invoke it again.
 
-Wiring multiple Hermes profiles to reply to one another in a shared channel — by setting `"mentions"` or `"all"` across several profiles — is an unsupported topology. Discord auto-`@mentions` the replied-to author on every reply, so under `"mentions"` two bots will satisfy each other's mention gate indefinitely and ack-loop. There is no circuit breaker for this because the supported configuration is simply to leave `DISCORD_ALLOW_BOTS` at `"none"`. If you must accept a particular bot, scope the acceptance narrowly and never to another auto-replying agent.
+This permits deliberate handoffs and multi-turn collaboration: each bot must explicitly type the next bot's mention on every turn it wants that bot to process. Set `discord.bots_require_inline_mention: false` only for a trusted relay integration that intentionally depends on unmentioned bot messages or reply pings; doing so restores the legacy reply-loop risk.
 :::
 
 ### Config File (`config.yaml`)
@@ -334,6 +335,7 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
+  bots_require_inline_mention: true  # Bot authors must type a literal @mention (default: true)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -318,7 +318,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | No | `false` | When `true`, the bot accepts attachments of any file type (not just the built-in PDF/text/zip/office allowlist). Unknown types are cached to disk and surfaced to the agent as a local path with `application/octet-stream` MIME so it can inspect them with `terminal` / `read_file` / `ffprobe` / etc. |
 | `DISCORD_MAX_ATTACHMENT_BYTES` | No | `33554432` | Maximum bytes per attachment the gateway will download and cache. Default 32 MiB. Set to `0` for no cap (attachments are held in memory while being written, so unlimited carries a real memory cost). |
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | No | `0.6` | Grace window the adapter waits before flushing a queued text chunk. Useful for smoothing streamed output. |
-| `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | No | `2.0` | Delay between split chunks when a single message exceeds Discord's length limit. |
+| `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | No | `2.0` | Longer quiet period for near-limit Discord splits and continuation chunks from a recently tagged bot in the same channel. |
 
 :::tip Bot-to-bot handoffs require hard mentions
 `DISCORD_ALLOW_BOTS` defaults to `"none"`. When you opt into `"mentions"` or `"all"`, bot-authored messages must contain a literal inline mention of Hermes by default. Discord's automatic replied-user ping does not count, so replying to another bot cannot silently invoke it again.

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -302,7 +302,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. By default, either enabled mode still requires a literal inline mention; see the next setting. |
-| `DISCORD_BOTS_REQUIRE_INLINE_MENTION` | No | `true` | Require bot-authored messages to contain a literal `<@BOT_ID>` / `<@!BOT_ID>` token. Discord reply pings only populate mention metadata and do not trigger Hermes. Set to `false` only for trusted relay integrations that depend on unmentioned bot messages or reply pings. Human-authored messages are unaffected. |
+| `DISCORD_BOTS_REQUIRE_INLINE_MENTION` | No | `true` | Require a literal `<@BOT_ID>` / `<@!BOT_ID>` token to start a bot handoff. Reply metadata alone does not start one. Brief same-sender/channel continuations are admitted as described below. Set to `false` only for trusted relays needing legacy admission. Human messages are unaffected. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
@@ -320,11 +320,30 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | No | `0.6` | Grace window the adapter waits before flushing a queued text chunk. Useful for smoothing streamed output. |
 | `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` | No | `2.0` | Longer quiet period for near-limit Discord splits and continuation chunks from a recently tagged bot in the same channel. |
 
-:::tip Bot-to-bot handoffs require hard mentions
-`DISCORD_ALLOW_BOTS` defaults to `"none"`. When you opt into `"mentions"` or `"all"`, bot-authored messages must contain a literal inline mention of Hermes by default. Discord's automatic replied-user ping does not count, so replying to another bot cannot silently invoke it again.
+### Bot-to-bot handoffs: tag once, collect the burst
 
-This permits deliberate handoffs and multi-turn collaboration: each bot must explicitly type the next bot's mention on every turn it wants that bot to process. Set `discord.bots_require_inline_mention: false` only for a trusted relay integration that intentionally depends on unmentioned bot messages or reply pings; doing so restores the legacy reply-loop risk.
-:::
+Bot input remains opt-in (`DISCORD_ALLOW_BOTS=none` by default). When enabled with `mentions` or `all`, **starting a bot handoff requires a literal `<@BOT_ID>` / `<@!BOT_ID>` in the message content by default**. Discord's automatic reply ping alone does not start a handoff. Human-authored messages retain their existing mention behavior.
+
+After an admitted bot mention, Hermes briefly accepts unmentioned follow-ups from **that same bot in that same channel or thread**. Text follow-ups enter the existing text batcher, so a rapidly split response can reach the agent together without repeating the tag on every part. No special sender protocol or part markers are required.
+
+For example, bot A sends `<@BOT_B_ID> Here is the review …`, followed immediately by two untagged text chunks in the same thread. Bot B admits those chunks during the continuation window and batches them with the tagged text. After the window expires, an untagged message or reply ping cannot start another handoff under the default policy. Explicit reciprocal tags remain supported; this prevents accidental reply-metadata loops, not intentionally continued conversations.
+
+#### Timing and limits
+
+The admission window lasts `max(HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS, HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS)` after the admitted mention (2 seconds with the defaults). An unmentioned continuation **does not extend that admission deadline**. Separately, each queued text chunk restarts the batch's quiet timer; a tagged bot batch uses the split quiet period even when its first chunk is short. These settings control receiver batching, not sender pacing. Disabling text batching (`HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS=0`) also disables continuation admission.
+
+This is a short-burst heuristic, not guaranteed multipart delivery. A delayed chunk outside the window needs its own mention under the default policy. Unrelated messages from the same bot and channel inside the window can also be admitted. The exception is not restricted to text: attachments and commands may pass admission, but only text enters this batcher; other message types follow their normal handling. Existing channel restrictions and `DISCORD_ALLOW_BOTS=none` still apply. History/backfill behavior is unchanged.
+
+#### Compatibility with trusted relays
+
+The inline-mention requirement now defaults to **true** (previously false), including when `DISCORD_ALLOW_BOTS=all`. If an existing relay intentionally relies on reply pings or unmentioned bot messages, retain the old admission behavior explicitly:
+
+```yaml
+discord:
+  bots_require_inline_mention: false
+```
+
+The existing `DISCORD_BOTS_REQUIRE_INLINE_MENTION=false` environment override is also supported when the YAML option is unset. With this opt-out, `mentions` accepts Discord's resolved mentions, including reply pings, and `all` removes the bot-specific mention requirement; other channel mention rules still apply. An admitted reply ping can also open the continuation window in this compatibility mode. Use it only for trusted relays because it restores the accidental reply-loop risk.
 
 ### Config File (`config.yaml`)
 


### PR DESCRIPTION
## Problem

When two Discord bots (e.g. two Hermes instances) talk to each other, two failure modes show up on current `main`:

**1. Accidental infinite loops.** Discord adds a "reply ping" to `message.mentions` whenever a message is a reply — no typed `@mention` needed. A mention-gated bot treats that metadata as a summons, so bot A replying to bot B re-triggers B, B replies and re-triggers A, forever. Nobody typed a mention after the first one.

**2. Lost message tails.** Discord caps messages at 2000 characters, so a long handoff goes out as several chunks. Only the first chunk contains the `<@target>` mention. A mention-gated receiver processes chunk 1 and silently ignores chunks 2..N — then acts on half the instructions.

## Fix

Two receiver-side changes that share one idea: **a summons is a deliberately typed mention, and one tag admits the short burst of chunks that follows it.**

**Strict summons (loop fix).** `discord.bots_require_inline_mention` (the guard added in #56605) now defaults to **on**: a bot-authored message triggers this bot only if its content contains a literal `<@BOT_ID>` / `<@!BOT_ID>` token. A reply ping alone no longer counts. Humans are unaffected; bots that intentionally tag each other can still do so.

**Continuation burst admission (lost-tail fix).** After a bot message with a valid tag is admitted, unmentioned *text* messages from the **same sender in the same channel/thread** are admitted for a short window (`max(batch_delay, split_delay)`, 2s by default) and coalesced into the same pending input by the existing text batcher — so a 3-chunk handoff becomes one complete agent turn instead of one truncated turn plus dropped chunks. Rejected messages never open a window; only text enters the batcher; disabling text batching disables the exception.

## Compatibility

- `DISCORD_ALLOW_BOTS` defaults (`none`) and semantics are unchanged; both changes only affect setups that already opted into bot input.
- Relay setups that relied on reply pings triggering the bot can restore the old behavior with `discord: { bots_require_inline_mention: false }` (or the existing env override). This restores the reply-loop risk that behavior carries.
- No settings renamed or reinterpreted; no send-path changes; history/backfill behavior unchanged.

## Known limits (deliberate)

The continuation window is a proximity heuristic (sender + channel + time), not message framing: an unrelated message from the same bot inside the window joins the batch, and a chunk delayed past the window needs its own tag. The window is anchored to the tagged message and not refreshed by continuations. We considered heavier alternatives (repeating the mention on every outgoing chunk — pings the recipient once per chunk; part-marker framing / utterance IDs — a wire protocol) and kept the simple version. This mechanism has run in a multi-bot production server for several weeks without an observed failure. Related: #27265 — this addresses the receiver side for short bursts, not guaranteed delivery of arbitrarily delayed multipart messages.

## Lineage

Supersedes #88723 and #88724 (combined, cherry-picked onto fresh `main`, original authorship preserved). Builds on the mechanism merged in #56605.

## Validation

```bash
scripts/run_tests.sh -j 2 --file-timeout 90 --file-retries 0 \
  tests/gateway/test_discord*.py tests/gateway/test_config.py -q
```

**370 passed, 0 failed across 51 files**; ruff and `git diff --check` clean.

Both fixes are proven red on unmodified upstream with this PR's tests applied:
- reply-ping-only bot message: admitted upstream, rejected here;
- unmentioned second chunk of a handoff: rejected upstream, admitted and batched here (the three-chunk test drives the real ingress/admission/batching path with fake transport objects and asserts one delivered event containing all three chunks).
