### PR TITLE
feat(telegram): open a forum topic when the bot is @mentioned in General

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1487,6 +1487,11 @@ DEFAULT_CONFIG = {
         "channel_prompts": {},
         "allowed_chats": "",  # if set, ONLY respond in these group/supergroup chat IDs
         "extra": {
+            # Opt-in Discord-style auto-thread for Telegram forum groups: @mention in General
+            # opens a named topic and copies the source message into it. Off by default because
+            # the bot must be a forum admin with Manage Topics.
+            "auto_topic_on_mention": False,
+            "auto_topic_copy_source": True,
             # Bot API 10.1 native rich messages (tables/task lists/math). Off = legacy MarkdownV2,
             # since rich messages are hard to copy as plain text.
             "rich_messages": False,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5162,6 +5162,104 @@ class TelegramAdapter(BasePlatformAdapter):
             return None
         return cls._GENERAL_TOPIC_THREAD_ID if is_forum_group else None
 
+    def _telegram_auto_topic_on_mention(self) -> bool:
+        """Opt-in: open a forum topic when the bot is @mentioned in General (Discord auto_thread parity)."""
+        return self._extra_bool("auto_topic_on_mention", "TELEGRAM_AUTO_TOPIC_ON_MENTION", "false")
+
+    def _telegram_auto_topic_copy_source(self) -> bool:
+        """Copy the triggering General message into the new topic (default on)."""
+        return self._extra_bool("auto_topic_copy_source", "TELEGRAM_AUTO_TOPIC_COPY_SOURCE", "true")
+
+    def _telegram_auto_topic_source_ids(self) -> set[str]:
+        """Thread ids treated as the forum lobby. Default: General (``1``)."""
+        raw = self.config.extra.get("auto_topic_source_threads")
+        if raw is None:
+            raw = os.getenv("TELEGRAM_AUTO_TOPIC_SOURCE_THREADS", "1")
+        if isinstance(raw, list):
+            parts = [str(part).strip() for part in raw if str(part).strip()]
+        else:
+            parts = [part.strip() for part in str(raw).split(",") if part.strip()]
+        return set(parts) or {self._GENERAL_TOPIC_THREAD_ID}
+
+    def _derive_auto_topic_name(self, content: str, bot_username: str = "") -> str:
+        """Placeholder topic name from the user request; mentions stripped (Discord auto-thread parity)."""
+        text = (content or "").strip()
+        if bot_username:
+            text = re.sub("@" + re.escape(bot_username) + r"\b", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"@\w+", "", text)
+        text = re.sub(r"\s+", " ", text).strip()
+        if text.startswith("/"):
+            return "Hermes"
+        if not text:
+            return "Hermes"
+        if len(text) > 80:
+            return text[:77].rstrip() + "..."
+        return text
+
+    def _should_open_forum_auto_topic(self, message: Message) -> bool:
+        """True only for an addressed mention in a forum General topic when the feature is on."""
+        if not self._telegram_auto_topic_on_mention():
+            return False
+        chat = getattr(message, "chat", None)
+        if not chat or getattr(chat, "is_forum", False) is not True:
+            return False
+        if self._chat_type_str(chat) not in {"group", "supergroup"}:
+            return False
+        thread_id = self._topic_id_or_general(self._effective_message_thread_id(message))
+        if thread_id not in self._telegram_auto_topic_source_ids():
+            return False
+        text = (getattr(message, "text", None) or getattr(message, "caption", None) or "").strip()
+        if text.startswith("/"):
+            return False
+        return self._message_mentions_bot(message) or self._message_matches_mention_patterns(message)
+
+    async def _maybe_open_forum_auto_topic(self, message: Message, event: MessageEvent) -> MessageEvent:
+        """Create a named forum topic for a General @mention; fail closed and keep General on error.
+
+        Discord already auto-threads @mentions. Telegram forum groups had no equivalent: General
+        stayed a dump of every job. Opt-in because the bot must be allowed to manage topics.
+        """
+        if not self._should_open_forum_auto_topic(message) or not self._bot:
+            return event
+        chat_id = getattr(getattr(message, "chat", None), "id", None)
+        message_id = getattr(message, "message_id", None)
+        if chat_id is None:
+            return event
+        bot_username = str(getattr(self._bot, "username", "") or "")
+        topic_name = self._derive_auto_topic_name(
+            getattr(message, "text", None) or getattr(message, "caption", None) or "",
+            bot_username,
+        )
+        try:
+            topic = await self._bot.create_forum_topic(chat_id=chat_id, name=topic_name)
+            thread_id = getattr(topic, "message_thread_id", None)
+        except Exception as exc:
+            logger.warning(
+                "[%s] Could not create auto-topic in chat %s: %s",
+                self.name, chat_id, _redact_telegram_error_text(exc),
+            )
+            return event
+        if not thread_id:
+            return event
+        thread_id_str = str(thread_id)
+        if self._telegram_auto_topic_copy_source() and message_id is not None:
+            try:
+                await self._bot.copy_message(
+                    chat_id=chat_id, from_chat_id=chat_id, message_id=int(message_id),
+                    message_thread_id=int(thread_id),
+                )
+            except Exception as exc:
+                logger.debug(
+                    "[%s] Auto-topic source copy failed in chat %s thread %s: %s",
+                    self.name, chat_id, thread_id_str, _redact_telegram_error_text(exc),
+                )
+        source = event.source
+        source.thread_id = thread_id_str
+        source.auto_thread_created = True
+        source.auto_thread_initial_name = topic_name
+        source.prospective_thread_id = thread_id_str
+        return event
+
     # Decides only whether a FOREIGN @handle is bot-shaped; our own handle is matched by identity, never
     # shape (collectible/Fragment bot usernames need not end in "bot").
     _FOREIGN_BOT_HANDLE_RE = re.compile(r"[a-z0-9_]{2,29}bot", re.IGNORECASE)
@@ -5727,7 +5825,9 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._gate_or_observe(msg, update, MessageType.TEXT):
             return
         await self._ensure_forum_commands(update.message)
-        self._enqueue_text_event(await self._build_triggered_event(msg, update, MessageType.TEXT))
+        event = await self._build_triggered_event(msg, update, MessageType.TEXT)
+        event = await self._maybe_open_forum_auto_topic(msg, event)
+        self._enqueue_text_event(event)
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
@@ -6038,6 +6138,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if msg.caption:
             from plugins.platforms.telegram.telegram_context import group_trigger_text
             event.text = group_trigger_text(self, msg, msg.caption)
+        event = await self._maybe_open_forum_auto_topic(msg, event)
         # Stickers: _handle_sticker overwrites event.text with its vision description, so observe attribution must run after it.
         if msg.sticker:
             await self._handle_sticker(msg, event)
@@ -6502,6 +6603,9 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
 
     if "disable_topic_auto_rename" in telegram_cfg:
         extras.setdefault("disable_topic_auto_rename", telegram_cfg["disable_topic_auto_rename"])
+    for _auto_key in ("auto_topic_on_mention", "auto_topic_copy_source", "auto_topic_source_threads"):
+        if _auto_key in telegram_cfg:
+            extras.setdefault(_auto_key, telegram_cfg[_auto_key])
     _effective_rm = telegram_cfg.get("require_mention", yaml_cfg.get("require_mention"))
     if _effective_rm is not None:
         _set_env("TELEGRAM_REQUIRE_MENTION", str(_effective_rm).lower())

--- a/tests/gateway/test_telegram_forum_auto_topic.py
+++ b/tests/gateway/test_telegram_forum_auto_topic.py
@@ -1,0 +1,135 @@
+"""Forum auto-topic on @mention in General (Discord auto_thread parity)."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.event import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _adapter(*, auto_topic=True, copy_source=True, bot_username="hermes_bot"):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    extra = {
+        "auto_topic_on_mention": auto_topic,
+        "auto_topic_copy_source": copy_source,
+        "allowed_chats": [],
+        "allowed_topics": [],
+        "group_allowed_chats": [],
+    }
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.name = "telegram"
+    adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
+    adapter._bot = SimpleNamespace(
+        id=999,
+        username=bot_username,
+        create_forum_topic=AsyncMock(return_value=SimpleNamespace(message_thread_id=77)),
+        copy_message=AsyncMock(),
+    )
+    adapter._mention_patterns = []
+    adapter._bot_username_observed = bot_username.lower()
+    return adapter
+
+
+def _forum_general(*, text="@hermes_bot deploy staging", thread_id=None, is_forum=True, chat_type="supergroup"):
+    return SimpleNamespace(
+        message_id=42,
+        text=text,
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=thread_id,
+        is_topic_message=thread_id is not None,
+        chat=SimpleNamespace(id=-1001, type=chat_type, title="Team", is_forum=is_forum),
+        from_user=SimpleNamespace(id=111, full_name="Ada", first_name="Ada", username="ada"),
+        reply_to_message=None,
+    )
+
+
+def _event_for(message):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=str(message.chat.id),
+        chat_type="group",
+        user_id="111",
+        thread_id="1" if message.message_thread_id is None else str(message.message_thread_id),
+        message_id=str(message.message_id),
+    )
+    return MessageEvent(text=message.text or "", message_type=MessageType.TEXT, source=source, raw_message=message)
+
+
+def test_topic_name_strips_bot_mention():
+    adapter = _adapter()
+    assert adapter._derive_auto_topic_name("@hermes_bot deploy staging", "hermes_bot") == "deploy staging"
+
+
+def test_topic_name_falls_back_when_only_mention():
+    adapter = _adapter()
+    assert adapter._derive_auto_topic_name("@hermes_bot", "hermes_bot") == "Hermes"
+
+
+def test_off_by_default():
+    adapter = _adapter(auto_topic=False)
+    assert adapter._should_open_forum_auto_topic(_forum_general()) is False
+
+
+def test_skips_existing_topics():
+    adapter = _adapter()
+    msg = _forum_general(thread_id=12)
+    assert adapter._should_open_forum_auto_topic(msg) is False
+
+
+def test_skips_non_forum_groups():
+    adapter = _adapter()
+    msg = _forum_general(is_forum=False, chat_type="group")
+    assert adapter._should_open_forum_auto_topic(msg) is False
+
+
+def test_skips_slash_commands():
+    adapter = _adapter()
+    msg = _forum_general(text="@hermes_bot /status")
+    # leading slash after strip still starts with @ so this is not a command;
+    # a bare /status in General must not open a topic.
+    cmd = _forum_general(text="/status")
+    assert adapter._should_open_forum_auto_topic(cmd) is False
+    assert adapter._should_open_forum_auto_topic(msg) is True
+
+
+def test_opens_topic_copies_source_and_reroutes_session():
+    adapter = _adapter()
+    msg = _forum_general()
+    event = _event_for(msg)
+
+    async def _run():
+        return await adapter._maybe_open_forum_auto_topic(msg, event)
+
+    out = asyncio.run(_run())
+    adapter._bot.create_forum_topic.assert_awaited_once()
+    kwargs = adapter._bot.create_forum_topic.await_args.kwargs
+    assert kwargs["name"] == "deploy staging"
+    adapter._bot.copy_message.assert_awaited_once()
+    copy_kwargs = adapter._bot.copy_message.await_args.kwargs
+    assert copy_kwargs["message_thread_id"] == 77
+    assert copy_kwargs["message_id"] == 42
+    assert out.source.thread_id == "77"
+    assert out.source.auto_thread_created is True
+    assert out.source.auto_thread_initial_name == "deploy staging"
+    assert out.source.prospective_thread_id == "77"
+
+
+def test_create_failure_stays_in_general():
+    adapter = _adapter()
+    adapter._bot.create_forum_topic = AsyncMock(side_effect=RuntimeError("not enough rights"))
+    msg = _forum_general()
+    event = _event_for(msg)
+
+    async def _run():
+        return await adapter._maybe_open_forum_auto_topic(msg, event)
+
+    out = asyncio.run(_run())
+    assert out.source.thread_id == "1"
+    assert out.source.auto_thread_created is False
+    adapter._bot.copy_message.assert_not_called()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -333,6 +333,8 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `TELEGRAM_BOTS_REQUIRE_MENTION` | When enabled, a message sent by another bot must explicitly `@thisbot` to trigger a response — a quote-reply alone is ignored, which stops two bots from replying to each other forever. Human replies are unaffected. Default: `false`. Equivalent to `telegram.bots_require_mention`. |
 | `TELEGRAM_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all`. Matches the Discord pattern. |
 | `TELEGRAM_IGNORED_THREADS` | Comma-separated Telegram forum topic/thread IDs where the bot never responds |
+| `TELEGRAM_AUTO_TOPIC_ON_MENTION` | Opt-in: when `true`, an `@mention` in a forum **General** topic opens a named forum topic and routes the reply there (Discord `auto_thread` parity). Default `false`. Equivalent to `telegram.extra.auto_topic_on_mention`. |
+| `TELEGRAM_AUTO_TOPIC_COPY_SOURCE` | Copy the triggering General message into the new auto-topic. Default `true`. Equivalent to `telegram.extra.auto_topic_copy_source`. |
 | `TELEGRAM_PROXY` | Proxy URL for Telegram connections — overrides `HTTPS_PROXY`. Supports `http://`, `https://`, `socks5://` |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to use the bot |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -883,42 +883,21 @@ sqlite3 ~/.hermes/state.db \
 
 If you downgrade to a Hermes version that predates `/topic`, the feature simply stops working — the `telegram_dm_topic_mode` and `telegram_dm_topic_bindings` tables remain in `state.db` but are ignored by older code. DMs revert to the native per-thread isolation (each `message_thread_id` still gets its own session via `build_session_key`), so your existing Telegram topics keep working as parallel sessions. The root DM is no longer a lobby — messages there go into the agent like they used to. Re-upgrading reactivates multi-session mode exactly where it was.
 
-## Auto-topics in group forums (opt-in)
+## Open a topic on @mention (opt-in)
 
-### The Discord gap
+On Discord, mentioning the bot opens a **thread**. On Telegram, the same mention in a group with Topics still replies in **General**, so every job lands in one place.
 
-On **Discord**, `discord.auto_thread` is **on by default**. Someone `@mention`s Hermes in a channel, and Hermes opens a thread. The channel stays a lobby. Each job has a name.
+Set `telegram.extra.auto_topic_on_mention: true` to match Discord for **forum groups**:
 
-On **Matrix**, `MATRIX_AUTO_THREAD` does the same, also **on by default**.
+1. Someone mentions the bot in General
+2. Hermes creates a topic named from their message (`deploy staging`)
+3. Copies that message into the topic and replies there
 
-**Telegram does not.** Hermes can already *talk inside* a forum topic, and it can auto-create topics in a **1:1 DM** (`/topic`). It does **not** auto-create a topic when the bot is mentioned in a **team group**. So every request lands in **General**, the session mixes with the last job, and the group looks messy.
+Follow-ups stay in the topic. Mentions already inside a topic do not open another one. Slash commands in General (`/status`, `/model`) do not create a topic.
 
-This flag is that missing Discord/Matrix behaviour — for Telegram **forum groups only**.
+**Off by default.** The bot must be a forum admin with **Manage Topics**. If create fails, Hermes stays in General.
 
-### Where it works, and where it cannot
-
-Telegram is not one kind of chat:
-
-| Surface | Can Hermes auto-open a thread? |
-|---|---|
-| **Forum supergroup** (Topics mode on) | **Yes** — this feature. `@mention` in General → new named topic. |
-| **Normal group** (no Topics) | **No.** Telegram has no thread object there. Turn on Topics in group settings first. |
-| **Broadcast channel** | **No.** Channels are one-way posts, not Discord-style threads. |
-| **DM with the bot** | Already covered by [`/topic`](#multi-session-dm-mode-topic). Do not use this flag. |
-
-If the group is not a forum, this setting does nothing. That is Telegram, not a Hermes bug.
-
-### What people see
-
-Someone `@mention`s the bot in **General**:
-
-1. Hermes opens a topic named from the request (`deploy staging`, not `Chat 14:32`)
-2. It copies their message to the top of that topic (so the topic is readable without scrolling General)
-3. It answers **inside the new topic**
-
-Follow-ups in that topic stay there. A mention that was already inside a topic is unchanged. Slash commands in General (`/status`, `/model`) do **not** open a topic.
-
-**Off by default.** Discord can default this on because any member can start a thread. Telegram topics need the bot to be a forum admin with **Manage Topics**. If create fails, Hermes stays in General and logs `Could not create auto-topic`.
+This only works in a group that already has Topics enabled. It does nothing in a normal group, a broadcast channel, or a DM (`/topic` already covers DMs).
 
 ```yaml
 telegram:
@@ -928,8 +907,6 @@ telegram:
 ```
 
 Equivalent env: `TELEGRAM_AUTO_TOPIC_ON_MENTION=true`.
-
-This is the Telegram equivalent of `discord.auto_thread` and Matrix `MATRIX_AUTO_THREAD`, with a safer default.
 
 ## Group Forum Topic Skill Binding
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -883,6 +883,54 @@ sqlite3 ~/.hermes/state.db \
 
 If you downgrade to a Hermes version that predates `/topic`, the feature simply stops working — the `telegram_dm_topic_mode` and `telegram_dm_topic_bindings` tables remain in `state.db` but are ignored by older code. DMs revert to the native per-thread isolation (each `message_thread_id` still gets its own session via `build_session_key`), so your existing Telegram topics keep working as parallel sessions. The root DM is no longer a lobby — messages there go into the agent like they used to. Re-upgrading reactivates multi-session mode exactly where it was.
 
+## Auto-topics in group forums (opt-in)
+
+### The Discord gap
+
+On **Discord**, `discord.auto_thread` is **on by default**. Someone `@mention`s Hermes in a channel, and Hermes opens a thread. The channel stays a lobby. Each job has a name.
+
+On **Matrix**, `MATRIX_AUTO_THREAD` does the same, also **on by default**.
+
+**Telegram does not.** Hermes can already *talk inside* a forum topic, and it can auto-create topics in a **1:1 DM** (`/topic`). It does **not** auto-create a topic when the bot is mentioned in a **team group**. So every request lands in **General**, the session mixes with the last job, and the group looks messy.
+
+This flag is that missing Discord/Matrix behaviour — for Telegram **forum groups only**.
+
+### Where it works, and where it cannot
+
+Telegram is not one kind of chat:
+
+| Surface | Can Hermes auto-open a thread? |
+|---|---|
+| **Forum supergroup** (Topics mode on) | **Yes** — this feature. `@mention` in General → new named topic. |
+| **Normal group** (no Topics) | **No.** Telegram has no thread object there. Turn on Topics in group settings first. |
+| **Broadcast channel** | **No.** Channels are one-way posts, not Discord-style threads. |
+| **DM with the bot** | Already covered by [`/topic`](#multi-session-dm-mode-topic). Do not use this flag. |
+
+If the group is not a forum, this setting does nothing. That is Telegram, not a Hermes bug.
+
+### What people see
+
+Someone `@mention`s the bot in **General**:
+
+1. Hermes opens a topic named from the request (`deploy staging`, not `Chat 14:32`)
+2. It copies their message to the top of that topic (so the topic is readable without scrolling General)
+3. It answers **inside the new topic**
+
+Follow-ups in that topic stay there. A mention that was already inside a topic is unchanged. Slash commands in General (`/status`, `/model`) do **not** open a topic.
+
+**Off by default.** Discord can default this on because any member can start a thread. Telegram topics need the bot to be a forum admin with **Manage Topics**. If create fails, Hermes stays in General and logs `Could not create auto-topic`.
+
+```yaml
+telegram:
+  extra:
+    auto_topic_on_mention: true   # default false
+    auto_topic_copy_source: true  # copy the General message into the new topic
+```
+
+Equivalent env: `TELEGRAM_AUTO_TOPIC_ON_MENTION=true`.
+
+This is the Telegram equivalent of `discord.auto_thread` and Matrix `MATRIX_AUTO_THREAD`, with a safer default.
+
 ## Group Forum Topic Skill Binding
 
 Supergroups with **Topics mode** enabled (also called "forum topics") already get session isolation per topic — each `thread_id` maps to its own conversation. But you may want to **auto-load a skill** when messages arrive in a specific group topic, just like DM topic skill binding works.


### PR DESCRIPTION
## Problem

On Discord, `@mention`ing the bot opens a **thread**. The channel stays a lobby.

On Telegram, `@mention`ing the bot in a **group with Topics** still replies in **General**. Every job lands in the same place, and the next request mixes with the last one.

## Change

New setting: `telegram.extra.auto_topic_on_mention` (default **off**).

When someone mentions the bot in **General**:

1. Hermes creates a topic named from their message (`deploy staging`, not a timestamp)
2. Copies that message into the new topic
3. Replies in the topic

Follow-ups in that topic stay there. A mention that is already inside a topic does not open another one. `/status` and other slash commands in General do not create a topic.

If Telegram cannot create the topic (bot is not an admin, or missing **Manage Topics**), Hermes keeps answering in General.

## How to turn it on

The group must have **Topics** enabled, and the bot must be allowed to manage topics.

```yaml
telegram:
  extra:
    auto_topic_on_mention: true
    auto_topic_copy_source: true
```

## What this does not cover

Telegram only has topics in **forum groups**. This flag does nothing in a normal group, a broadcast channel, or a DM. DMs already have `/topic`.

## Tests

```
scripts/run_tests.sh tests/gateway/test_telegram_forum_auto_topic.py
```

Related: #28263