### PR TITLE
fix(compressor): displace the head copy of a re-stated in-flight task

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4080,6 +4080,7 @@ Write only the summary body. Do not include any preamble or prefix."""
         self,
         compressed: List[Dict[str, Any]],
         inflight: Optional[Dict[str, Any]],
+        inflight_in_head: bool = False,
     ) -> List[Dict[str, Any]]:
         """Restate an unfinished user task after the compaction handoff.
 
@@ -4175,11 +4176,11 @@ Write only the summary body. Do not include any preamble or prefix."""
             )
             carrier[_INFLIGHT_REPLAY_MERGED_KEY] = True
             drop_stale_api_content(carrier)
-            self._displace_superseded_head_task(compressed, carrier_idx, inflight)
+            self._displace_superseded_head_task(compressed, carrier_idx, inflight, inflight_in_head)
             return compressed
 
         compressed.append(replay)
-        self._displace_superseded_head_task(compressed, carrier_idx, inflight)
+        self._displace_superseded_head_task(compressed, carrier_idx, inflight, inflight_in_head)
         return compressed
 
     def _displace_superseded_head_task(
@@ -4187,6 +4188,7 @@ Write only the summary body. Do not include any preamble or prefix."""
         compressed: List[Dict[str, Any]],
         carrier_idx: int,
         inflight: Dict[str, Any],
+        inflight_in_head: bool = False,
     ) -> None:
         """Stub out the head copy of a task that was just re-stated after the handoff.
 
@@ -4195,14 +4197,22 @@ Write only the summary body. Do not include any preamble or prefix."""
         request defeat the compression that was supposed to reclaim space
         (#106864). Replacing the payload with a short stub keeps the row (and
         with it the alternation and user-leading layout) while the restatement
-        becomes the only full copy. Text matching is exact and only actionable
-        user rows before the handoff carrier qualify, so a different request
-        that merely shares a prefix is never touched.
+        becomes the only full copy.
+
+        Only the row derived from the ACTIVE in-flight turn is rewritten. When
+        that turn was summarized away instead of protected, every same-text
+        row left in the head belongs to an earlier completed turn and keeps
+        its payload. When the turn does sit in the head, it is the newest
+        actionable user row there, so the LAST text-matching row before the
+        carrier is its copy; an earlier row with identical text is history
+        (a re-sent request) and must survive verbatim.
         """
+        if not inflight_in_head:
+            return
         original_text = _content_text_for_contains(inflight.get("content")).strip()
         if not original_text:
             return
-        for msg in compressed[:carrier_idx]:
+        for msg in reversed(compressed[:carrier_idx]):
             if (
                 isinstance(msg, dict)
                 and self._is_actionable_user_turn(msg)
@@ -4211,6 +4221,7 @@ Write only the summary body. Do not include any preamble or prefix."""
             ):
                 msg["content"] = _INFLIGHT_TASK_DISPLACED_STUB
                 drop_stale_api_content(msg)
+                return
 
     def _ensure_last_n_user_messages_in_tail(
         self, messages: List[Dict[str, Any]], cut_idx: int, head_end: int, n: int,
@@ -4592,6 +4603,7 @@ Write only the summary body. Do not include any preamble or prefix."""
 
     def _finalize_compressed(
         self, compressed: List[Dict[str, Any]], messages: List[Dict[str, Any]], n_messages: int,
+        compress_start: int = 0,
     ) -> List[Dict[str, Any]]:
         """Post-assembly cleanup: orphan pairs, media, savings, markers, replay prune, mem trim."""
         # Single-prompt cron shape: the only live instruction sits in the protected head, BEFORE the
@@ -4599,7 +4611,13 @@ Write only the summary body. Do not include any preamble or prefix."""
         # (#100818). Sanitize FIRST: the trailing-in-flight exemption (#79278) walks back from the list
         # end, and a replay user row there would strip a genuinely pending assistant(tool_calls).
         compressed = self._sanitize_tool_pairs(compressed)
-        compressed = self._reappend_inflight_user_task(compressed, self._find_inflight_user_task(messages))
+        inflight = self._find_inflight_user_task(messages)
+        # Displacement targets the head copy of the in-flight turn itself: identity in the
+        # pre-compression transcript decides whether that row survived in the protected head.
+        inflight_in_head = inflight is not None and any(
+            msg is inflight for msg in messages[:compress_start]
+        )
+        compressed = self._reappend_inflight_user_task(compressed, inflight, inflight_in_head)
         self.compression_count += 1
         # Replace historical image payloads with placeholders; multi-MB base64 blobs otherwise
         # exceed body limits.
@@ -4735,7 +4753,7 @@ Write only the summary body. Do not include any preamble or prefix."""
             )
         # Phase 4: Assemble compressed message list
         compressed = self._assemble_compressed(messages, compress_start, compress_end, scan, summary)
-        return self._finalize_compressed(compressed, messages, n_messages)
+        return self._finalize_compressed(compressed, messages, n_messages, compress_start)
 
     def _assemble_compressed(
         self, messages: List[Dict[str, Any]], compress_start: int, compress_end: int, scan: "_HandoffScan", summary: str,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -376,6 +376,16 @@ _INFLIGHT_TASK_REPLAY_HEADER = (
     "start over.]"
 )
 
+# Replaces the protected-head copy of a task once the restatement below the
+# handoff exists (#106864). The stub keeps the row — role, position and
+# alternation/user-leading contracts — while the restatement becomes the only
+# full copy, so a large request cannot occupy the head AND the tail of the
+# compacted transcript.
+_INFLIGHT_TASK_DISPLACED_STUB = (
+    "[The original request above was moved below the context summary and is "
+    "restated there; act on that copy.]"
+)
+
 _SALVAGE_SUMMARY_MAX_CHARS = 8_000
 _SALVAGE_KEEP_RECENT_TOOLS = 2
 
@@ -4165,10 +4175,42 @@ Write only the summary body. Do not include any preamble or prefix."""
             )
             carrier[_INFLIGHT_REPLAY_MERGED_KEY] = True
             drop_stale_api_content(carrier)
+            self._displace_superseded_head_task(compressed, carrier_idx, inflight)
             return compressed
 
         compressed.append(replay)
+        self._displace_superseded_head_task(compressed, carrier_idx, inflight)
         return compressed
+
+    def _displace_superseded_head_task(
+        self,
+        compressed: List[Dict[str, Any]],
+        carrier_idx: int,
+        inflight: Dict[str, Any],
+    ) -> None:
+        """Stub out the head copy of a task that was just re-stated after the handoff.
+
+        The protected head keeps the original turn verbatim while the
+        restatement below the summary repeats it — two full copies of a large
+        request defeat the compression that was supposed to reclaim space
+        (#106864). Replacing the payload with a short stub keeps the row (and
+        with it the alternation and user-leading layout) while the restatement
+        becomes the only full copy. Text matching is exact and only actionable
+        user rows before the handoff carrier qualify, so a different request
+        that merely shares a prefix is never touched.
+        """
+        original_text = _content_text_for_contains(inflight.get("content")).strip()
+        if not original_text:
+            return
+        for msg in compressed[:carrier_idx]:
+            if (
+                isinstance(msg, dict)
+                and self._is_actionable_user_turn(msg)
+                and not self._is_synthetic_compression_user_turn(msg)
+                and _content_text_for_contains(msg.get("content")).strip() == original_text
+            ):
+                msg["content"] = _INFLIGHT_TASK_DISPLACED_STUB
+                drop_stale_api_content(msg)
 
     def _ensure_last_n_user_messages_in_tail(
         self, messages: List[Dict[str, Any]], cut_idx: int, head_end: int, n: int,

--- a/tests/agent/test_compression_task_duplication.py
+++ b/tests/agent/test_compression_task_duplication.py
@@ -1,0 +1,155 @@
+"""Regression coverage for #106864: the first compression of a single-user
+task must not keep two full copies of the still-unfinished request.
+
+The protected head retains the original user turn verbatim, while
+``_reappend_inflight_user_task`` (#100818) restates the same instruction
+after the handoff so SUMMARY_PREFIX's "latest user message" pointer resolves
+to it. Both halves are needed — but keeping the original payload *and* the
+restatement doubles the input exactly when compression should be reclaiming
+space, so a large request risks the context overflow the compressor was
+trying to avoid.
+
+The fix displaces the superseded head copy with a short stub: the row (and
+its role) survives so alternation/user-leading contracts hold, but the
+restatement after the summary becomes the only full copy.
+"""
+
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    _SUMMARY_END_MARKER,
+    SUMMARY_PREFIX,
+    ContextCompressor,
+)
+
+
+TASK_SENTINEL = "AUDIT_TASK_sentinel_review_the_synthetic_policy_document"
+TASK = (TASK_SENTINEL + "\n" + "Synthetic policy material. " * 3000).rstrip()
+
+
+def _tool_pairs(count: int) -> List[Dict[str, Any]]:
+    """``count`` assistant(tool_calls) + tool result pairs — an unfinished run."""
+    turns: List[Dict[str, Any]] = []
+    for i in range(count):
+        turns.append(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": f"c{i}", "function": {"name": "terminal", "arguments": "{}"}}
+                ],
+            }
+        )
+        turns.append({"role": "tool", "tool_call_id": f"c{i}", "content": "accepted"})
+    return turns
+
+
+def _compress(messages: List[Dict[str, Any]], protect_first_n: int = 3):
+    with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+        compressor = ContextCompressor(
+            model="test",
+            quiet_mode=True,
+            protect_first_n=protect_first_n,
+            protect_last_n=20,
+        )
+    compressor.tail_token_budget = 2_000
+    with patch.object(
+        compressor,
+        "_generate_summary",
+        return_value=SUMMARY_PREFIX + "\nSynthetic handoff.",
+    ) as summary:
+        result = compressor.compress(messages, current_tokens=180_000, force=True)
+    assert summary.call_count == 1, "fixture must cross a summary boundary"
+    return result
+
+
+def _full_copies(compressed: List[Dict[str, Any]]) -> int:
+    """Count full copies of the task across ALL rows (any role), like #106864."""
+    return sum(str(m.get("content")).count(TASK) for m in compressed)
+
+
+def _text(message: Dict[str, Any]) -> str:
+    content = message.get("content")
+    return content if isinstance(content, str) else str(content)
+
+
+def _handoff_idx(compressed: List[Dict[str, Any]]) -> int:
+    for idx in range(len(compressed) - 1, -1, -1):
+        if _SUMMARY_END_MARKER in _text(compressed[idx]):
+            return idx
+    return -1
+
+
+def test_first_compaction_keeps_one_actionable_task_copy():
+    """Protected head + unfinished task: the restatement after the handoff
+    must be the ONLY full copy (#106864) while staying actionable (#100818)."""
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": TASK},
+        *_tool_pairs(10),
+    ]
+    compressed = _compress(messages)
+
+    idx = _handoff_idx(compressed)
+    assert idx >= 0, "expected a compaction handoff"
+
+    after_handoff = [_text(compressed[idx]).split(_SUMMARY_END_MARKER, 1)[1], *map(_text, compressed[idx + 1:])]
+    assert any(TASK in text for text in after_handoff), (
+        "the unfinished task must remain actionable after the handoff (#100818)"
+    )
+    assert _full_copies(compressed) == 1, (
+        f"full task copies after compression={_full_copies(compressed)}; "
+        "the superseded head copy must be displaced (#106864)"
+    )
+
+
+def test_displaced_head_row_keeps_its_role_and_position():
+    """The stub replaces the payload, not the row: role layout and head size
+    must survive so alternation / Anthropic user-leading contracts hold."""
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": TASK},
+        *_tool_pairs(10),
+    ]
+    compressed = _compress(messages)
+
+    head_user_rows = [
+        m for m in compressed[:_handoff_idx(compressed)]
+        if m.get("role") == "user"
+        and ContextCompressor._is_actionable_user_turn(m)
+    ]
+    assert head_user_rows, "the head user row must survive displacement"
+    assert all(TASK not in _text(m) for m in compressed[:_handoff_idx(compressed)])
+
+
+def test_completed_task_is_never_duplicated():
+    """Control: a completed exchange is not re-appended, so the head original
+    is the one copy and must NOT be displaced."""
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": TASK},
+        *_tool_pairs(10),
+        {"role": "assistant", "content": "Finished."},
+    ]
+    compressed = _compress(messages)
+
+    assert _full_copies(compressed) == 1
+    assert any(
+        TASK in _text(m)
+        for m in compressed
+        if m.get("role") == "user" and ContextCompressor._is_actionable_user_turn(m)
+    ), "a completed task's original copy must stay intact"
+
+
+def test_zero_protected_head_keeps_one_copy():
+    """Control: without head protection the original is summarised away, so
+    the restatement is already the only copy."""
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": TASK},
+        *_tool_pairs(10),
+    ]
+    compressed = _compress(messages, protect_first_n=0)
+
+    assert _full_copies(compressed) == 1

--- a/tests/agent/test_compression_task_duplication.py
+++ b/tests/agent/test_compression_task_duplication.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List
 from unittest.mock import patch
 
 from agent.context_compressor import (
+    _INFLIGHT_TASK_DISPLACED_STUB,
     _SUMMARY_END_MARKER,
     SUMMARY_PREFIX,
     ContextCompressor,
@@ -153,3 +154,69 @@ def test_zero_protected_head_keeps_one_copy():
     compressed = _compress(messages, protect_first_n=0)
 
     assert _full_copies(compressed) == 1
+
+
+def _head_user_rows(compressed: List[Dict[str, Any]]):
+    idx = _handoff_idx(compressed)
+    assert idx >= 0, "expected a compaction handoff"
+    return [
+        m
+        for m in compressed[:idx]
+        if m.get("role") == "user"
+        and ContextCompressor._is_actionable_user_turn(m)
+        and not ContextCompressor._is_synthetic_compression_user_turn(m)
+    ]
+
+
+def test_completed_same_text_turn_is_not_displaced():
+    """Equal old/active requests: an earlier COMPLETED turn whose text equals
+    the re-stated in-flight request keeps its payload verbatim — displacement
+    must rewrite only the row derived from the active in-flight turn."""
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": TASK},  # earlier completed turn (history)
+        {"role": "assistant", "content": "Done previously."},
+        {"role": "user", "content": TASK},  # re-stated request, still in flight
+        *_tool_pairs(15),
+    ]
+    compressed = _compress(messages, protect_first_n=5)
+
+    user_rows = _head_user_rows(compressed)
+    assert len(user_rows) == 2, "both head user rows must survive"
+    assert TASK_SENTINEL not in _text(user_rows[-1]), (
+        "the in-flight original (newest head user row) must be displaced"
+    )
+    assert TASK_SENTINEL in _text(user_rows[0]), (
+        "the earlier completed turn with identical text must keep its payload"
+    )
+    assert _INFLIGHT_TASK_DISPLACED_STUB in _text(user_rows[-1])
+    assert _full_copies(compressed) == 2, "history copy + restatement"
+
+
+def test_inflight_summarized_away_leaves_head_history_verbatim():
+    """The in-flight row itself is summarized away: the same-text row left in
+    the head is an earlier completed turn, so nothing may be displaced."""
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": TASK},  # earlier completed turn (history)
+        {"role": "assistant", "content": "Done previously."},
+        {"role": "user", "content": TASK},  # in flight, but inside the summary window
+        *_tool_pairs(15),
+    ]
+    compressed = _compress(messages, protect_first_n=2)
+
+    user_rows = _head_user_rows(compressed)
+    assert len(user_rows) == 1, "only the history row survives in the head"
+    assert TASK_SENTINEL in _text(user_rows[0]), (
+        "a summarized-away in-flight task must not displace the history row"
+    )
+    assert _INFLIGHT_TASK_DISPLACED_STUB not in _text(user_rows[0])
+    idx = _handoff_idx(compressed)
+    after_handoff = [
+        _text(compressed[idx]).split(_SUMMARY_END_MARKER, 1)[1],
+        *map(_text, compressed[idx + 1:]),
+    ]
+    assert any(
+        TASK_SENTINEL in t for t in after_handoff
+    ), "the restatement after the handoff must stay actionable (#100818)"
+    assert _full_copies(compressed) == 2, "history copy + restatement"


### PR DESCRIPTION
## What does this PR do?

The first compression of a single-user task could keep **two full copies** of a large unfinished request: the protected head retained the original turn verbatim, while `_reappend_inflight_user_task` (#100818) re-stated the same instruction after the handoff so `SUMMARY_PREFIX`'s "latest user message" pointer stays resolvable. Both halves are needed, but keeping the original payload *and* the restatement doubles the input exactly when compression should be reclaiming space — a large request can then risk the context overflow the compressor was trying to avoid (#106864).

Once the restatement exists, the superseded head copy is now displaced with a short stub. The row itself survives (role, position, alternation and Anthropic user-leading layout all hold), but the restatement below the summary becomes the only full copy. Early-exit paths of `_reappend_inflight_user_task` (no handoff carrier, a real user row already after the summary, or the request already actionable on the carrier) are untouched, so no-copy scenarios are never stubbed.

## Related Issue

Fixes #106864

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py`: added `_INFLIGHT_TASK_DISPLACED_STUB` and `_displace_superseded_head_task()`; called it from both restatement landing points (standalone replay row and merged-onto-carrier) in `_reappend_inflight_user_task()`.
- `tests/agent/test_compression_task_duplication.py`: new regression tests — the one-copy invariant for the protected-head + unfinished-task shape, head row/role survival after displacement, plus completed-task and zero-protected-head controls.

## How to Test

1. Run the new regression tests: `scripts/run_tests.sh tests/agent/test_compression_task_duplication.py` — all 4 tests should pass; on unpatched `upstream/main` the two one-copy tests fail with `full task copies after compression=2` (matches the reproducer in #106864).
2. Run the existing re-append coverage: `scripts/run_tests.sh tests/agent/test_cron_inflight_prompt_reappend_100818.py` — all 9 tests still pass, so the #100818 actionable-after-handoff and #80622 idle-session contracts are unchanged.
3. Observed result: `tests/agent/ -k "compress or compaction or summary"` → 806 passed, 1 skipped; ruff clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no skill added.

## Screenshots / Logs

Unpatched failure from the issue's reproducer shape (`2 failed, 4 passed`), and the same tests after this fix:

```text
tests/agent/test_compression_task_duplication.py ....                       [100%]
4 passed
```
