### PR TITLE
fix(dashboard): scope auto-archive policy to the requested profile, not the dashboard's own config

### DIFF
--- a/hermes_cli/web_server_sessions.py
+++ b/hermes_cli/web_server_sessions.py
@@ -216,7 +216,9 @@ def _maybe_auto_archive_for_profile(profile: Optional[str]) -> None:
         _last_auto_archive_check[key] = now
 
         from hermes_cli.config import load_config as _load_full_config
-        cfg = (_load_full_config().get("sessions") or {})
+        from hermes_cli.web_server_profiles import _config_profile_scope
+        with _config_profile_scope(profile):
+            cfg = (_load_full_config().get("sessions") or {})
         if not cfg.get("auto_archive", False):
             return
         db = _open_session_db_for_profile(profile, read_only=False)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -428,6 +428,51 @@ class TestWebServerEndpoints:
         finally:
             verify.close()
 
+    def test_get_sessions_auto_archive_reads_the_requested_profiles_own_config(self):
+        """``?profile=<name>`` auto-archive must gate on THAT profile's sessions.auto_archive,
+        not the dashboard process's own config.yaml.
+
+        _maybe_auto_archive_for_profile already opens the target profile's state.db and
+        throttles per-profile, but read its policy via a bare load_config() — the dashboard
+        process's own home. A profile that explicitly disabled auto_archive still had its
+        stale sessions swept whenever anyone hit the dashboard's own auto_archive=True.
+        """
+        from hermes_cli import profiles as profiles_mod
+        from hermes_cli.config import load_config, save_config
+        from hermes_state import SessionDB
+
+        # Dashboard process's own config: aggressive auto-archive.
+        config = load_config()
+        config.setdefault("sessions", {}).update(
+            {"auto_archive": True, "auto_archive_days": 1, "min_interval_hours": 0})
+        save_config(config)
+
+        # A secondary profile that explicitly opted OUT of auto-archive.
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+        (worker_home / "config.yaml").write_text(
+            yaml.safe_dump({"sessions": {"auto_archive": False}}), encoding="utf-8")
+
+        seed = SessionDB(db_path=worker_home / "state.db")
+        try:
+            seed.create_session("worker-stale", source="cli")
+            seed._conn.execute(
+                "UPDATE sessions SET started_at = ? WHERE id = ?",
+                (time.time() - 30 * 86400, "worker-stale"))
+        finally:
+            seed.close()
+
+        _web_server_sessions._last_auto_archive_check.clear()
+        response = self.client.get("/api/sessions?profile=worker&limit=50&offset=0")
+
+        assert response.status_code == 200
+        verify = SessionDB(db_path=worker_home / "state.db", read_only=True)
+        try:
+            assert verify.get_session("worker-stale")["archived"] == 0
+            assert verify.get_meta("last_auto_archive") is None
+        finally:
+            verify.close()
+
     def test_get_sessions_fresh_store_returns_empty_list(self):
         response = self.client.get("/api/sessions?limit=50&offset=0")
 


### PR DESCRIPTION
## Summary

`_maybe_auto_archive_for_profile(profile)` (`hermes_cli/web_server_sessions.py`, triggered from `GET /api/sessions?profile=<name>` in `hermes_cli/web_routers/sessions.py`) already gets two things right for a non-default profile:

- the throttle key (`_last_auto_archive_check[profile or ""]`)
- the target `state.db` (`_open_session_db_for_profile(profile, ...)`)

but reads the `sessions.auto_archive` / `auto_archive_days` / `min_interval_hours` policy via a bare `load_config()` — the **dashboard process's own** `config.yaml`, not the profile named in `?profile=`.

Effect: hitting the dashboard's session list for a *different* profile applies the dashboard's own auto-archive policy to that profile's sessions, regardless of what the profile itself configured — a profile that explicitly set `auto_archive: false` still gets its stale sessions swept if the dashboard's own config has it enabled, and a profile that enabled it is never swept if the dashboard's own config doesn't.

Every sibling router in this family (`config_env.py`, `audio.py`, `messaging.py`, `status.py`, `mcp.py`) already wraps its profile-scoped config read in `_config_profile_scope(profile)` (a task-local `HERMES_HOME` context manager — no-op for the current/default profile, otherwise scopes `load_config()` to that profile's home for the block). This call site just never got wired into it.

## Fix

Wrap the `load_config()` call in `_config_profile_scope(profile)`, mirroring the established pattern used everywhere else in `web_routers/`.

## Test plan

- [x] New regression test `test_get_sessions_auto_archive_reads_the_requested_profiles_own_config` in `tests/hermes_cli/test_web_server.py`: dashboard's own config enables aggressive auto-archive, a secondary "worker" profile explicitly disables it and has a 30-day-stale session; `GET /api/sessions?profile=worker` must leave that session unarchived.
- [x] Mutation-verify: reverted just the production fix and confirmed the new test fails (`archived == 1` instead of `0`, log shows "auto-archive: archived 1 session(s)"); restored the fix and confirmed it passes again.
- [x] Full `tests/hermes_cli/test_web_server.py` — 188 passed, 1 pre-existing skip.
- [x] `ruff check` clean on both changed files.
