### PR TITLE
fix(dashboard): block credential files from fs read

### DIFF
--- a/hermes_cli/web_routers/files.py
+++ b/hermes_cli/web_routers/files.py
@@ -613,6 +613,8 @@ async def fs_list(path: str):
             for entry in scan:
                 if entry.name in _FS_READDIR_HIDDEN:
                     continue
+                if _is_sensitive_path(target / entry.name):
+                    continue
                 entries.append({
                     "name": entry.name,
                     "path": str(target / entry.name),
@@ -630,6 +632,8 @@ async def fs_list(path: str):
 @router.get("/api/fs/read-text")
 async def fs_read_text(path: str):
     target, st = _fs_regular_file(_fs_path(path))
+    if _is_sensitive_path(target):
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
     if st.st_size > _FS_TEXT_SOURCE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     data = _fs_read_bytes(target, min(st.st_size, _FS_TEXT_PREVIEW_MAX_BYTES))

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -420,3 +420,55 @@ def test_credential_dir_trees_blocked_on_subdir_descent(forced_files_client):
     assert [e["name"] for e in mcp_listing.json()["entries"]] == []
 
 
+@pytest.fixture
+def fs_routes_client():
+    client, prev_auth_required, prev_bound_host = _client_with_app_state()
+    try:
+        yield client
+    finally:
+        _close_client(client)
+        _restore_app_state(prev_auth_required, prev_bound_host)
+
+
+def test_fs_read_text_refuses_credential_files(fs_routes_client, tmp_path):
+    """/api/fs/read-text must enforce the same sensitive-path guard as its
+    sibling read endpoints (/api/fs/read-data-url, /api/fs/download) and the
+    managed-files API — credential content must 403, ordinary files stay readable."""
+    client = fs_routes_client
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("SECRET_KEY=abc123")
+    assert client.get("/api/fs/read-text", params={"path": str(env_file)}).status_code == 403
+
+    mcp_dir = tmp_path / "mcp-tokens"
+    mcp_dir.mkdir()
+    token_file = mcp_dir / "github.json"
+    token_file.write_text('{"access_token": "SECRET"}\n')
+    assert client.get("/api/fs/read-text", params={"path": str(token_file)}).status_code == 403
+
+    ordinary = tmp_path / "notes.md"
+    ordinary.write_text("hello")
+    response = client.get("/api/fs/read-text", params={"path": str(ordinary)})
+    assert response.status_code == 200
+    assert response.json()["text"] == "hello"
+
+
+def test_fs_list_hides_credential_files(fs_routes_client, tmp_path):
+    """/api/fs/list must not expose credential filenames — mirrors the
+    managed-files listing filter."""
+    client = fs_routes_client
+
+    ordinary = tmp_path / "notes.md"
+    ordinary.write_text("hello")
+    (tmp_path / ".env").write_text("SECRET_KEY=abc123")
+    mcp_dir = tmp_path / "mcp-tokens"
+    mcp_dir.mkdir()
+    (mcp_dir / "github.json").write_text('{"access_token": "SECRET"}\n')
+
+    names = [e["name"] for e in client.get(
+        "/api/fs/list", params={"path": str(tmp_path)}).json()["entries"]]
+    assert "notes.md" in names
+    assert ".env" not in names
+    assert "mcp-tokens" not in names
+
+


### PR DESCRIPTION
## Summary

Completes sensitive-path protection for the remaining `/api/fs` file surfaces.

The existing `_is_sensitive_path()` guard already protects the managed `/api/files` endpoints and the `/api/fs/download` and `/api/fs/read-data-url` routes. However, `/api/fs/list` and `/api/fs/read-text` were still not applying the same guard.

As a result, sensitive credential files could still be enumerated through `/api/fs/list` and read through `/api/fs/read-text`.

This follows up on the existing dashboard credential-protection work in #57869 and the credential-read gap identified in #93167. On current main, `read-data-url` is already protected, while `list` and `read-text` remained unguarded.

## Changes

* Apply `_is_sensitive_path()` when listing `/api/fs` directory entries.
* Reject sensitive paths from `/api/fs/read-text` with HTTP 403.
* Reuse the existing sensitive-path policy rather than introducing another credential detection mechanism.
* Add regression coverage for:

  * `.env`
  * `mcp-tokens/<file>`
  * benign files as a positive control
  * sensitive entries being hidden from directory listings

## Validation

* `uv run pytest tests/hermes_cli/test_web_server_files.py tests/hermes_cli/test_web_server_fs.py -q` — **16 passed**
* `uv run ruff check hermes_cli/web_routers/files.py tests/hermes_cli/test_web_server_files.py` — **passed**
* `git diff --check` — **passed**

## Context

Related work:

* #57869 — prior dashboard `/api/fs` credential-read protection attempt.
* #93167 — identified the remaining `/api/fs` credential-read inconsistency.
* #58222 — established sensitive-path protection for the managed `/api/files` API.

This PR applies the existing sensitive-path policy consistently to the remaining `/api/fs` list/read surfaces on current main, with focused regression coverage.
