### PR TITLE
feat(desktop): add project Markdown viewer

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -471,6 +471,19 @@ describe('renderMediaTags', () => {
     expect(renderMediaTags('MEDIA:/tmp/demo.mp4')).toBe('[Video: demo.mp4](#media:%2Ftmp%2Fdemo.mp4)')
   })
 
+  it('keeps spaces in an unquoted standalone MEDIA path', () => {
+    expect(renderMediaTags('MEDIA:/Users/example/Team Documents/reports/summary.md')).toBe(
+      '[File: summary.md](#media:%2FUsers%2Fexample%2FTeam%20Documents%2Freports%2Fsummary.md)'
+    )
+    expect(renderMediaTags('"MEDIA:/Users/example/Team Documents/reports/summary.md"')).toBe(
+      '[File: summary.md](#media:%2FUsers%2Fexample%2FTeam%20Documents%2Freports%2Fsummary.md)'
+    )
+  })
+
+  it('does not treat the next line as a MEDIA path', () => {
+    expect(renderMediaTags('MEDIA:\nHeading')).toBe('MEDIA:\nHeading')
+  })
+
   it('renders streamed assistant media once the tag is complete', () => {
     const parts = appendAssistantTextPart(appendAssistantTextPart([], 'ok\nMEDIA:'), '/tmp/voice.mp3')
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -10,9 +10,14 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+// A MEDIA tag that owns its line owns the rest of that line. Local paths
+// routinely contain spaces (`/Users/example/Team Documents/summary.md`); treating the
+// value as `\S+` truncates the target and leaves preview/download with a path
+// that does not exist. Inline MEDIA tags remain token-shaped below because
+// prose can legitimately follow them on the same line.
+const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:[\t ]*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^\n]+?)[`"']?[\t ]*(\n|$)/g
 
-const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+const MEDIA_TAG_RE = /[`"']?MEDIA:[\t ]*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
 
 function unquoteMediaPath(value: string): string {
   const trimmed = value.trim()

--- a/apps/desktop/src/plugins/markdown-viewer/plugin.js
+++ b/apps/desktop/src/plugins/markdown-viewer/plugin.js
@@ -1,0 +1,417 @@
+/* global Element, Node, document */
+
+import {
+  Badge,
+  Button,
+  Codicon,
+  EmptyState,
+  ErrorState,
+  Input,
+  KEYBINDS_AREA,
+  PALETTE_AREA,
+  Streamdown,
+  host,
+  useValue
+} from '@hermes/plugin-sdk'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { jsx, jsxs } from 'react/jsx-runtime'
+
+const ID = 'markdown-viewer'
+const WORKSPACE_ID = 'markdown-viewer.workspace'
+const MARKDOWN_PATH_RE = /\.(?:md|markdown|mdx)$/i
+
+function messageFrom(error) {
+  if (error && typeof error === 'object') {
+    if (typeof error.detail === 'string') return error.detail
+    if (typeof error.message === 'string') return error.message
+  }
+  return String(error || 'Unknown error')
+}
+
+function rootLabel(root) {
+  const parts = String(root || '')
+    .split(/[\\/]/)
+    .filter(Boolean)
+  return parts.at(-1) || root || 'No active Project'
+}
+
+function formatBytes(bytes) {
+  const value = Number(bytes || 0)
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(value >= 10 * 1024 ? 0 : 1)} KB`
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function decodedHrefPath(href) {
+  const raw = String(href || '').trim()
+  try {
+    if (raw.startsWith('#media:')) return decodeURIComponent(raw.slice('#media:'.length))
+    if (raw.startsWith('file://')) {
+      const path = decodeURIComponent(new URL(raw).pathname)
+      return /^\/[a-z]:\//i.test(path) ? path.slice(1) : path
+    }
+    if (/^[a-z]:[\\/]/i.test(raw) || raw.startsWith('\\\\')) return decodeURIComponent(raw)
+    if (!/^[a-z][a-z\d+.-]*:/i.test(raw)) return decodeURIComponent(raw)
+  } catch {
+    return ''
+  }
+  return ''
+}
+
+function markdownSuffixAfter(node) {
+  const nextSibling = node?.nextSibling
+  return nextSibling?.nodeType === Node.TEXT_NODE
+    ? String(nextSibling.textContent || '').match(/^([^\n]*?\.(?:md|markdown|mdx))(?=\s|$)/i)?.[1] || ''
+    : ''
+}
+
+function completeLegacyPath(path, node) {
+  if (MARKDOWN_PATH_RE.test(path)) return path
+  const suffix = markdownSuffixAfter(node)
+  return suffix ? path + suffix : path
+}
+
+export function markdownPathFromClickTarget(target) {
+  if (!(target instanceof Element)) return null
+
+  const button = target.closest('button')
+  if (button) {
+    const card = button.parentElement
+    const cardButtons = card ? Array.from(card.children).filter(child => child.tagName === 'BUTTON') : []
+    if (button !== cardButtons.at(-1)) return null
+
+    const titledPath = card?.querySelector('span[title]')?.getAttribute('title') || ''
+    const path = completeLegacyPath(titledPath, card)
+    return MARKDOWN_PATH_RE.test(path) ? path : null
+  }
+
+  const anchor = target.closest('a')
+  if (!anchor) return null
+
+  const path = completeLegacyPath(decodedHrefPath(anchor.getAttribute('href')), anchor)
+  return MARKDOWN_PATH_RE.test(path) ? path : null
+}
+
+function installTranscriptLinkBridge(ctx) {
+  const onClick = event => {
+    if (event.defaultPrevented || event.button !== 0) return
+    const path = markdownPathFromClickTarget(event.target)
+    if (!path) return
+    event.preventDefault()
+    event.stopImmediatePropagation()
+    openMarkdownWorkspace(ctx, path)
+  }
+
+  document.addEventListener('click', onClick, true)
+  ctx.onDispose(() => document.removeEventListener('click', onClick, true))
+}
+
+function MarkdownWorkspace({ ctx, initialPath }) {
+  const root = useValue(host.state.cwd)
+  const focusedStoredSessionId = useValue(host.state.focusedStoredSessionId)
+  const focusedSessionProfile = useValue(host.state.focusedSessionProfile)
+  const [files, setFiles] = useState([])
+  const [query, setQuery] = useState('')
+  const [manualPath, setManualPath] = useState('')
+  const [selected, setSelected] = useState(null)
+  const [document, setDocument] = useState(null)
+  const [listLoading, setListLoading] = useState(false)
+  const [docLoading, setDocLoading] = useState(false)
+  const [listError, setListError] = useState('')
+  const [docError, setDocError] = useState('')
+  const listGeneration = useRef(0)
+  const documentGeneration = useRef(0)
+
+  const loadList = useCallback(async () => {
+    if (!root) {
+      setFiles([])
+      setListError('Open a Project session to browse its Markdown files.')
+      return
+    }
+    const generation = ++listGeneration.current
+    setListLoading(true)
+    setListError('')
+    try {
+      const result = await ctx.rest(`/files?root=${encodeURIComponent(root)}&limit=2000`)
+      if (generation !== listGeneration.current) return
+      setFiles(Array.isArray(result?.files) ? result.files : [])
+      if (result?.truncated) {
+        setListError('Showing the first 2,000 Markdown files. Narrow the Project or type a relative path.')
+      }
+    } catch (error) {
+      if (generation !== listGeneration.current) return
+      setFiles([])
+      setListError(messageFrom(error))
+    } finally {
+      if (generation === listGeneration.current) setListLoading(false)
+    }
+  }, [ctx, root])
+
+  const loadFile = useCallback(
+    async (path, quiet = false) => {
+      const requested = String(path || '').trim()
+      if (!root || !requested) return
+      const generation = ++documentGeneration.current
+      if (!quiet) setDocLoading(true)
+      if (!quiet) setDocError('')
+      try {
+        const result = await ctx.rest(`/read?root=${encodeURIComponent(root)}&path=${encodeURIComponent(requested)}`)
+        if (generation !== documentGeneration.current) return
+        setSelected(result.relative)
+        setManualPath(result.relative)
+        setDocument(result)
+      } catch (error) {
+        if (generation !== documentGeneration.current) return
+        if (!quiet) {
+          setDocError(messageFrom(error))
+          setDocument(null)
+        }
+      } finally {
+        if (generation === documentGeneration.current && !quiet) setDocLoading(false)
+      }
+    },
+    [ctx, root]
+  )
+
+  useEffect(() => {
+    listGeneration.current += 1
+    documentGeneration.current += 1
+    setSelected(null)
+    setDocument(null)
+    setDocError('')
+    setManualPath('')
+    setQuery('')
+    void loadList()
+    if (initialPath) void loadFile(initialPath)
+  }, [root, focusedStoredSessionId, focusedSessionProfile, initialPath, loadFile, loadList])
+
+  useEffect(() => {
+    if (!selected) return undefined
+    const timer = setInterval(() => void loadFile(selected, true), 3000)
+    return () => clearInterval(timer)
+  }, [loadFile, selected])
+
+  const visibleFiles = useMemo(() => {
+    const needle = query.trim().toLocaleLowerCase()
+    if (!needle) return files
+    return files.filter(file =>
+      String(file.relative || '')
+        .toLocaleLowerCase()
+        .includes(needle)
+    )
+  }, [files, query])
+
+  const openManual = useCallback(() => void loadFile(manualPath), [loadFile, manualPath])
+
+  return jsxs('div', {
+    className: 'flex h-full min-h-0 flex-col text-sm',
+    'data-markdown-viewer': 'root',
+    children: [
+      jsxs('header', {
+        className: 'flex shrink-0 items-center gap-2 border-b border-border px-3 py-2',
+        children: [
+          jsx(Codicon, { name: 'markdown', size: '1rem' }),
+          jsxs('div', {
+            className: 'min-w-0 flex-1',
+            children: [
+              jsx('div', { className: 'truncate font-medium', children: rootLabel(root) }),
+              jsx('div', {
+                className: 'truncate text-[0.6875rem] text-(--ui-text-tertiary)',
+                title: root,
+                children: root || 'No working directory'
+              })
+            ]
+          }),
+          jsx(Badge, { variant: 'outline', children: focusedSessionProfile || 'default' }),
+          jsx(Button, {
+            'aria-label': 'Refresh Markdown files',
+            onClick: () => void loadList(),
+            size: 'icon-sm',
+            title: 'Refresh files',
+            variant: 'ghost',
+            children: jsx(Codicon, { name: 'refresh', size: '0.85rem' })
+          })
+        ]
+      }),
+      jsxs('div', {
+        className: 'flex min-h-0 flex-1',
+        children: [
+          jsxs('aside', {
+            className: 'flex w-72 shrink-0 flex-col border-r border-border',
+            children: [
+              jsxs('div', {
+                className: 'grid shrink-0 gap-2 border-b border-border p-2',
+                children: [
+                  jsx(Input, {
+                    'aria-label': 'Filter Markdown files',
+                    onChange: event => setQuery(event.target.value),
+                    placeholder: 'Filter Markdown files…',
+                    value: query
+                  }),
+                  jsxs('div', {
+                    className: 'flex gap-1.5',
+                    children: [
+                      jsx(Input, {
+                        'aria-label': 'Open relative Markdown path',
+                        className: 'min-w-0 flex-1 font-mono text-xs',
+                        onChange: event => setManualPath(event.target.value),
+                        onKeyDown: event => {
+                          if (event.key === 'Enter') openManual()
+                        },
+                        placeholder: 'path/to/file.md',
+                        value: manualPath
+                      }),
+                      jsx(Button, {
+                        disabled: !manualPath.trim(),
+                        onClick: openManual,
+                        size: 'sm',
+                        variant: 'outline',
+                        children: 'Open'
+                      })
+                    ]
+                  })
+                ]
+              }),
+              jsxs('div', {
+                className:
+                  'flex shrink-0 items-center justify-between px-2 py-1.5 text-[0.6875rem] text-(--ui-text-tertiary)',
+                children: [
+                  jsx('span', { children: `${visibleFiles.length} file${visibleFiles.length === 1 ? '' : 's'}` }),
+                  listLoading ? jsx('span', { children: 'Refreshing…' }) : null
+                ]
+              }),
+              listError
+                ? jsx('div', {
+                    className: 'border-y border-border px-2 py-1.5 text-xs text-(--ui-text-secondary)',
+                    children: listError
+                  })
+                : null,
+              jsx('div', {
+                className: 'min-h-0 flex-1 overflow-y-auto px-1 pb-2',
+                children:
+                  visibleFiles.length > 0
+                    ? visibleFiles.map(file =>
+                        jsxs(
+                          'button',
+                          {
+                            className:
+                              selected === file.relative
+                                ? 'flex w-full items-start gap-2 rounded-md bg-(--chrome-action-hover) px-2 py-1.5 text-left'
+                                : 'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left hover:bg-(--chrome-action-hover)',
+                            onClick: () => void loadFile(file.relative),
+                            title: file.relative,
+                            type: 'button',
+                            children: [
+                              jsx(Codicon, { className: 'mt-0.5 shrink-0', name: 'markdown', size: '0.8rem' }),
+                              jsxs('span', {
+                                className: 'min-w-0 flex-1',
+                                children: [
+                                  jsx('span', { className: 'block truncate text-xs', children: file.relative }),
+                                  jsx('span', {
+                                    className: 'block text-[0.625rem] text-(--ui-text-quaternary)',
+                                    children: formatBytes(file.size)
+                                  })
+                                ]
+                              })
+                            ]
+                          },
+                          file.path
+                        )
+                      )
+                    : !listLoading && !listError
+                      ? jsx(EmptyState, {
+                          description: query ? 'Try a different filter.' : 'No Markdown files were found.',
+                          title: query ? 'No matches' : 'No Markdown files'
+                        })
+                      : null
+              })
+            ]
+          }),
+          jsx('main', {
+            className: 'min-h-0 min-w-0 flex-1 overflow-y-auto',
+            children: docLoading
+              ? jsx('div', {
+                  className: 'grid h-full place-items-center text-(--ui-text-tertiary)',
+                  children: 'Opening Markdown…'
+                })
+              : docError
+                ? jsx(ErrorState, { description: docError, title: 'Could not open Markdown' })
+                : document
+                  ? jsxs('article', {
+                      className: 'mx-auto w-full max-w-4xl px-8 py-7',
+                      children: [
+                        jsxs('div', {
+                          className: 'mb-6 flex items-center justify-between gap-3 border-b border-border pb-3',
+                          children: [
+                            jsx('div', {
+                              className: 'min-w-0 truncate font-mono text-xs text-(--ui-text-secondary)',
+                              title: document.path,
+                              children: document.relative
+                            }),
+                            jsx('div', {
+                              className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)',
+                              children: formatBytes(document.size)
+                            })
+                          ]
+                        }),
+                        jsx('div', {
+                          className:
+                            'text-foreground [&_a]:underline [&_a]:underline-offset-2 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-3 [&_blockquote]:text-(--ui-text-secondary) [&_code]:font-mono [&_h1]:text-3xl [&_h1]:font-bold [&_h2]:mt-6 [&_h2]:text-2xl [&_h2]:font-semibold [&_h3]:mt-5 [&_h3]:text-xl [&_h3]:font-semibold [&_hr]:my-6 [&_hr]:border-border [&_li]:my-1 [&_ol]:list-decimal [&_ol]:pl-6 [&_p]:my-3 [&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:border [&_pre]:border-border [&_pre]:bg-card [&_pre]:p-3 [&_table]:my-4 [&_table]:w-full [&_table]:border-collapse [&_td]:border [&_td]:border-border [&_td]:p-2 [&_th]:border [&_th]:border-border [&_th]:p-2 [&_ul]:list-disc [&_ul]:pl-6',
+                          children: jsx(Streamdown, { mode: 'static', children: document.text })
+                        })
+                      ]
+                    })
+                  : jsx(EmptyState, {
+                      description: 'Choose a file from the active Project or enter a relative path.',
+                      title: 'Open a Markdown file'
+                    })
+          })
+        ]
+      })
+    ]
+  })
+}
+
+function openMarkdownWorkspace(ctx, initialPath = '') {
+  if (typeof host.openWorkspace !== 'function') {
+    host.notify({ kind: 'error', message: 'Update Hermes Desktop to use the Markdown Viewer workspace.' })
+    return
+  }
+  host.openWorkspace(WORKSPACE_ID, {
+    minWidth: 760,
+    render: () => jsx(MarkdownWorkspace, { ctx, initialPath }),
+    title: 'Markdown'
+  })
+}
+
+export default {
+  id: ID,
+  name: 'Markdown Viewer',
+  description: 'Browse and render Markdown files from the active Project.',
+  register(ctx) {
+    installTranscriptLinkBridge(ctx)
+    ctx.registerMany([
+      {
+        id: 'open-command',
+        area: PALETTE_AREA,
+        data: {
+          id: 'markdown-viewer.open',
+          keywords: ['markdown', 'md', 'preview', 'file', 'project'],
+          label: 'Markdown Viewer: Open Project File',
+          run: () => openMarkdownWorkspace(ctx)
+        }
+      },
+      {
+        id: 'open-keybind',
+        area: KEYBINDS_AREA,
+        data: {
+          category: 'view',
+          defaults: [],
+          id: 'markdown-viewer.open',
+          label: 'Markdown Viewer: Open Project File',
+          run: () => openMarkdownWorkspace(ctx)
+        }
+      }
+    ])
+  }
+}

--- a/apps/desktop/src/plugins/markdown-viewer/plugin.test.ts
+++ b/apps/desktop/src/plugins/markdown-viewer/plugin.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+async function loadPlugin() {
+  // The bundled source intentionally remains plain ESM so it can also be
+  // distributed through Hermes's uncompiled runtime-plugin door.
+  // @ts-expect-error -- TypeScript does not ingest the intentional .js source.
+  return import('./plugin.js')
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe('Markdown Viewer transcript targets', () => {
+  it('opens a complete Markdown media path', async () => {
+    const { markdownPathFromClickTarget } = await loadPlugin()
+    const anchor = document.createElement('a')
+    anchor.href = `#media:${encodeURIComponent('/Users/example/Team Documents/docs/guide.md')}`
+
+    expect(markdownPathFromClickTarget(anchor)).toBe('/Users/example/Team Documents/docs/guide.md')
+  })
+
+  it('recovers a Markdown path split by an older desktop renderer', async () => {
+    const { markdownPathFromClickTarget } = await loadPlugin()
+    const wrapper = document.createElement('div')
+    const anchor = document.createElement('a')
+    anchor.setAttribute('href', '#media:%2FUsers%2Fexample%2FTeam')
+    wrapper.append(anchor, ' Documents/docs/guide.md')
+
+    expect(markdownPathFromClickTarget(anchor)).toBe('/Users/example/Team Documents/docs/guide.md')
+  })
+
+  it('uses the attachment preview control without hijacking Download', async () => {
+    const { markdownPathFromClickTarget } = await loadPlugin()
+    const card = document.createElement('div')
+    const title = document.createElement('span')
+    const download = document.createElement('button')
+    const preview = document.createElement('button')
+    title.title = '/Users/example/Team Documents/docs/guide.md'
+    download.title = 'Download'
+    card.append(title, download, preview)
+
+    expect(markdownPathFromClickTarget(download)).toBeNull()
+    expect(markdownPathFromClickTarget(preview)).toBe('/Users/example/Team Documents/docs/guide.md')
+  })
+})

--- a/plugins/markdown-viewer/dashboard/manifest.json
+++ b/plugins/markdown-viewer/dashboard/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "markdown-viewer",
+  "label": "Markdown Viewer",
+  "description": "Project-aware Markdown file listing and preview backend for Hermes Desktop.",
+  "version": "1.0.0",
+  "tab": {
+    "hidden": true
+  },
+  "api": "plugin_api.py"
+}

--- a/plugins/markdown-viewer/dashboard/plugin_api.py
+++ b/plugins/markdown-viewer/dashboard/plugin_api.py
@@ -1,0 +1,194 @@
+"""Project-scoped Markdown file listing and preview routes.
+
+Mounted at ``/api/plugins/markdown-viewer/`` by the dashboard plugin system.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+
+router = APIRouter()
+
+MARKDOWN_SUFFIXES = {".md", ".markdown", ".mdx"}
+SKIP_DIRS = {
+    ".git",
+    ".hg",
+    ".svn",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    "dist",
+    "build",
+}
+MAX_FILE_BYTES = 2 * 1024 * 1024
+MAX_LIST_FILES = 2_000
+MANAGED_FILES_ROOT_ENV = "HERMES_DASHBOARD_FILES_ROOT"
+HOSTED_MANAGED_FILES_ROOT = Path("/opt/data")
+
+
+class MarkdownViewerError(ValueError):
+    """A safe, user-facing Markdown viewer error."""
+
+
+def _locked_files_root() -> Path | None:
+    raw = os.environ.get(MANAGED_FILES_ROOT_ENV, "").strip()
+    if raw:
+        try:
+            return Path(raw).expanduser().resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise MarkdownViewerError("The managed files root is unavailable.") from exc
+
+    raw_home = os.environ.get("HERMES_HOME", "").strip()
+    if raw_home:
+        try:
+            home = Path(raw_home).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError) as exc:
+            raise MarkdownViewerError("The Hermes home path is invalid.") from exc
+        if home == HOSTED_MANAGED_FILES_ROOT:
+            return HOSTED_MANAGED_FILES_ROOT
+    return None
+
+
+def _resolve_root(root: str) -> Path:
+    raw = str(root or "").strip()
+    if not raw or "\x00" in raw:
+        raise MarkdownViewerError("A valid Project root is required.")
+    try:
+        resolved = Path(raw).expanduser().resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise MarkdownViewerError(f"Project root is unavailable: {raw}") from exc
+    if not resolved.is_dir():
+        raise MarkdownViewerError(f"Project root is not a directory: {resolved}")
+    locked_root = _locked_files_root()
+    if locked_root is not None and resolved != locked_root and locked_root not in resolved.parents:
+        raise MarkdownViewerError("Project root is outside the managed files root.")
+    return resolved
+
+
+def _resolve_markdown(root: Path, requested: str) -> Path:
+    raw = str(requested or "").strip()
+    if not raw or "\x00" in raw:
+        raise MarkdownViewerError("Choose a Markdown file.")
+    unresolved = Path(raw).expanduser()
+    candidate = unresolved if unresolved.is_absolute() else root / unresolved
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise MarkdownViewerError(f"Markdown file is unavailable: {raw}") from exc
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise MarkdownViewerError("The requested file is outside the active Project.") from exc
+    if not resolved.is_file():
+        raise MarkdownViewerError(f"Markdown path is not a file: {raw}")
+    if resolved.suffix.lower() not in MARKDOWN_SUFFIXES:
+        raise MarkdownViewerError("Only Markdown files (.md, .markdown, or .mdx) can be opened.")
+    return resolved
+
+
+def list_markdown_files(root: str, query: str = "", limit: int = 500) -> dict[str, Any]:
+    project_root = _resolve_root(root)
+    needle = str(query or "").strip().casefold()
+    safe_limit = max(1, min(int(limit), MAX_LIST_FILES))
+    files: list[dict[str, Any]] = []
+    truncated = False
+
+    for current, dirs, names in os.walk(project_root, followlinks=False):
+        dirs[:] = sorted(
+            [name for name in dirs if name not in SKIP_DIRS and not name.startswith(".")],
+            key=str.casefold,
+        )
+        for name in sorted(names, key=str.casefold):
+            candidate = Path(current) / name
+            if candidate.suffix.lower() not in MARKDOWN_SUFFIXES:
+                continue
+            try:
+                resolved = candidate.resolve(strict=True)
+                relative = resolved.relative_to(project_root).as_posix()
+                stat = resolved.stat()
+            except (OSError, RuntimeError, ValueError):
+                continue
+            if needle and needle not in relative.casefold():
+                continue
+            files.append(
+                {
+                    "name": resolved.name,
+                    "relative": relative,
+                    "path": str(resolved),
+                    "size": stat.st_size,
+                    "modified_ns": stat.st_mtime_ns,
+                }
+            )
+            if len(files) >= safe_limit:
+                truncated = True
+                break
+        if truncated:
+            break
+
+    files.sort(key=lambda item: item["relative"].casefold())
+    return {
+        "root": str(project_root),
+        "files": files,
+        "count": len(files),
+        "truncated": truncated,
+    }
+
+
+def read_markdown_file(root: str, path: str) -> dict[str, Any]:
+    project_root = _resolve_root(root)
+    resolved = _resolve_markdown(project_root, path)
+    try:
+        with resolved.open("rb") as handle:
+            data = handle.read(MAX_FILE_BYTES + 1)
+    except OSError as exc:
+        raise MarkdownViewerError(f"Markdown file is unavailable: {path}") from exc
+    if len(data) > MAX_FILE_BYTES:
+        raise MarkdownViewerError(
+            f"Markdown file is too large to preview ({len(data)} bytes read; limit {MAX_FILE_BYTES})."
+        )
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise MarkdownViewerError("Markdown file is not valid UTF-8 text.") from exc
+    stat = resolved.stat()
+    return {
+        "root": str(project_root),
+        "path": str(resolved),
+        "relative": resolved.relative_to(project_root).as_posix(),
+        "name": resolved.name,
+        "text": text,
+        "size": len(data),
+        "modified_ns": stat.st_mtime_ns,
+    }
+
+
+def _http_error(exc: MarkdownViewerError) -> HTTPException:
+    return HTTPException(status_code=400, detail=str(exc))
+
+
+@router.get("/files")
+def files_endpoint(
+    root: str,
+    q: str = "",
+    limit: Annotated[int, Query(ge=1, le=MAX_LIST_FILES)] = 500,
+) -> dict[str, Any]:
+    try:
+        return list_markdown_files(root, query=q, limit=limit)
+    except MarkdownViewerError as exc:
+        raise _http_error(exc) from exc
+
+
+@router.get("/read")
+def read_endpoint(root: str, path: str) -> dict[str, Any]:
+    try:
+        return read_markdown_file(root, path)
+    except MarkdownViewerError as exc:
+        raise _http_error(exc) from exc

--- a/tests/plugins/test_markdown_viewer.py
+++ b/tests/plugins/test_markdown_viewer.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "markdown-viewer"
+    / "dashboard"
+    / "plugin_api.py"
+)
+
+
+def load_module():
+    assert MODULE_PATH.is_file(), f"plugin backend missing: {MODULE_PATH}"
+    spec = importlib.util.spec_from_file_location("hermes_markdown_viewer_plugin_api", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_lists_supported_markdown_files_in_stable_project_relative_order(tmp_path: Path):
+    api = load_module()
+    (tmp_path / "README.md").write_text("# Root", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "zeta.mdx").write_text("# Zeta", encoding="utf-8")
+    (tmp_path / "docs" / "alpha.markdown").write_text("# Alpha", encoding="utf-8")
+    (tmp_path / "docs" / "ignore.txt").write_text("ignore", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "hidden.md").write_text("hidden", encoding="utf-8")
+
+    result = api.list_markdown_files(str(tmp_path))
+
+    assert result["root"] == str(tmp_path.resolve())
+    assert [item["relative"] for item in result["files"]] == [
+        "docs/alpha.markdown",
+        "docs/zeta.mdx",
+        "README.md",
+    ]
+    assert result["count"] == 3
+    assert result["truncated"] is False
+
+
+def test_filters_file_list_case_insensitively(tmp_path: Path):
+    api = load_module()
+    (tmp_path / "Project Notes.md").write_text("notes", encoding="utf-8")
+    (tmp_path / "other.md").write_text("other", encoding="utf-8")
+
+    result = api.list_markdown_files(str(tmp_path), query="PROJECT")
+
+    assert [item["relative"] for item in result["files"]] == ["Project Notes.md"]
+
+
+def test_respects_managed_files_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    api = load_module()
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    (allowed / "README.md").write_text("# Allowed", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "private.md").write_text("# Private", encoding="utf-8")
+    monkeypatch.setenv(api.MANAGED_FILES_ROOT_ENV, str(allowed))
+
+    assert [item["relative"] for item in api.list_markdown_files(str(allowed))["files"]] == ["README.md"]
+    with pytest.raises(api.MarkdownViewerError, match="managed files root"):
+        api.list_markdown_files(str(outside))
+
+
+def test_reads_markdown_text_and_metadata(tmp_path: Path):
+    api = load_module()
+    path = tmp_path / "docs" / "guide.mdx"
+    path.parent.mkdir()
+    path.write_text("# Guide\n\nExample text.", encoding="utf-8")
+
+    result = api.read_markdown_file(str(tmp_path), "docs/guide.mdx")
+
+    assert result["relative"] == "docs/guide.mdx"
+    assert result["path"] == str(path.resolve())
+    assert result["text"] == "# Guide\n\nExample text."
+    assert result["size"] == path.stat().st_size
+    assert isinstance(result["modified_ns"], int)
+
+
+def test_rejects_unsupported_files_and_parent_traversal(tmp_path: Path):
+    api = load_module()
+    outside = tmp_path.parent / "outside.md"
+    outside.write_text("outside", encoding="utf-8")
+    (tmp_path / "data.txt").write_text("data", encoding="utf-8")
+
+    with pytest.raises(api.MarkdownViewerError, match="Markdown"):
+        api.read_markdown_file(str(tmp_path), "data.txt")
+    with pytest.raises(api.MarkdownViewerError, match="outside"):
+        api.read_markdown_file(str(tmp_path), "../outside.md")
+
+
+def test_rejects_symlink_escape(tmp_path: Path):
+    api = load_module()
+    outside = tmp_path.parent / "outside-link-target.md"
+    outside.write_text("outside", encoding="utf-8")
+    link = tmp_path / "linked.md"
+    link.symlink_to(outside)
+
+    with pytest.raises(api.MarkdownViewerError, match="outside"):
+        api.read_markdown_file(str(tmp_path), "linked.md")
+
+
+def test_rejects_oversized_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    api = load_module()
+    monkeypatch.setattr(api, "MAX_FILE_BYTES", 8)
+    (tmp_path / "large.md").write_text("123456789", encoding="utf-8")
+
+    with pytest.raises(api.MarkdownViewerError, match="too large"):
+        api.read_markdown_file(str(tmp_path), "large.md")
+
+
+def test_rejects_non_utf8_markdown(tmp_path: Path):
+    api = load_module()
+    (tmp_path / "encoded.md").write_bytes(b"\xff\xfe")
+
+    with pytest.raises(api.MarkdownViewerError, match="UTF-8"):
+        api.read_markdown_file(str(tmp_path), "encoded.md")
+
+
+def test_endpoints_preserve_spaces_and_return_project_relative_paths(tmp_path: Path):
+    api = load_module()
+    path = tmp_path / "Team Documents" / "overview.md"
+    path.parent.mkdir()
+    path.write_text("# Overview", encoding="utf-8")
+
+    listing = api.files_endpoint(root=str(tmp_path))
+    document = api.read_endpoint(
+        root=str(tmp_path),
+        path="Team Documents/overview.md",
+    )
+
+    assert [item["relative"] for item in listing["files"]] == [
+        "Team Documents/overview.md"
+    ]
+    assert document["relative"] == "Team Documents/overview.md"
+    assert document["text"] == "# Overview"


### PR DESCRIPTION
## Summary
- Add project-aware Markdown browsing and rendering in Hermes Desktop.
- Handle transcript MEDIA links, including paths containing spaces.
- Enforce security boundaries: project containment, symlink-escape rejection, managed root, UTF-8 validation, and a 2 MB cap.

## Verification
- 7,171 full desktop UI tests
- 78 post-fix focused UI tests
- 9 backend tests
- Typecheck, lint (0 errors), formatting, and diff checks


