### PR TITLE
fix(compression): warn at init and add remediation when checkpoint_required cannot pass

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1877,6 +1877,8 @@ def _build_context_engine(agent, _agent_cfg, cs, _custom_providers, _effective_c
         if hasattr(_cc, _attr):
             setattr(_cc, _attr, _value)
     agent.compression_checkpoint_required = cs.checkpoint_required
+    from agent.conversation_compression import warn_checkpoint_provider_mismatch
+    warn_checkpoint_provider_mismatch(agent)
     agent.codex_app_server_auto_compaction = cs.codex_app_server_auto
     agent.codex_responses_native_compaction = cs.codex_responses_native
     agent.codex_responses_compact_threshold = cs.codex_responses_compact_threshold

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1143,6 +1143,51 @@ def _checkpoint_blocked(reason: str) -> CompressionCheckpointUnavailable:
     )
 
 
+def checkpoint_capability_remediation() -> str:
+    """Remediation hint appended to checkpoint-gate refusals the operator can fix in config."""
+    return (
+        "compression.checkpoint_required is enabled: disable it to restore "
+        "compression, or use a memory provider that advertises checkpoint API "
+        f"v{PRE_COMPRESS_CHECKPOINT_API_VERSION}"
+    )
+
+
+def warn_checkpoint_provider_mismatch(agent: Any) -> None:
+    """Warn at init when the checkpoint gate is armed but cannot ever pass.
+
+    The gate refuses lossy rewrites unless an active memory provider advertises
+    checkpoint API v2. When the flag is set and no such provider is active, every
+    compression attempt fails closed — better to say so once at startup than
+    discover it from an opaque slash-command error mid-session.
+    """
+    if getattr(agent, "compression_checkpoint_required", False) is not True:
+        return
+    memory_manager = getattr(agent, "_memory_manager", None)
+    supports_checkpoint = getattr(
+        memory_manager, "supports_pre_compress_checkpoint", None
+    )
+    if callable(supports_checkpoint):
+        try:
+            if bool(supports_checkpoint(PRE_COMPRESS_CHECKPOINT_API_VERSION)):
+                return
+        except Exception:
+            pass  # probe failure here is re-reported per attempt at compress time
+    provider_name = "none"
+    for provider in getattr(memory_manager, "providers", None) or []:
+        name = getattr(provider, "name", None)
+        if isinstance(name, str) and name.strip():
+            provider_name = name
+            break
+    logger.warning(
+        "compression.checkpoint_required is enabled but memory provider '%s' does not "
+        "advertise checkpoint API v%s: every compression attempt will be blocked. "
+        "Disable compression.checkpoint_required or switch to a checkpoint-capable "
+        "memory provider.",
+        provider_name,
+        PRE_COMPRESS_CHECKPOINT_API_VERSION,
+    )
+
+
 def _lock_api_is_absent_on_session_db(lock_db: Any) -> bool:
     """Whether the live in-memory SessionDB class structurally predates locks.
     Only the exact old ``hermes_state.SessionDB`` class (hot-reload skew) may fail open; proxies, lookalikes,
@@ -2604,6 +2649,7 @@ def _pre_compress_memory_context(agent: Any, messages: list, checkpoint_required
         if memory_manager is None or not callable(supports_checkpoint):
             raise _checkpoint_blocked(
                 f"no active provider implements checkpoint API v{PRE_COMPRESS_CHECKPOINT_API_VERSION}"
+                f" ({checkpoint_capability_remediation()})"
             )
         try:
             compatible = bool(supports_checkpoint(PRE_COMPRESS_CHECKPOINT_API_VERSION))
@@ -2612,6 +2658,7 @@ def _pre_compress_memory_context(agent: Any, messages: list, checkpoint_required
         if not compatible:
             raise _checkpoint_blocked(
                 f"active provider does not implement checkpoint API v{PRE_COMPRESS_CHECKPOINT_API_VERSION}"
+                f" ({checkpoint_capability_remediation()})"
             )
         try:
             _maybe_ctx = memory_manager.on_pre_compress(

--- a/tests/agent/test_pre_compress_checkpoint_contract.py
+++ b/tests/agent/test_pre_compress_checkpoint_contract.py
@@ -556,3 +556,85 @@ def test_agent_init_suppresses_micro_compaction_under_checkpoint_gate():
     )
     assert assign_idx != -1
     assert suppress_idx < assign_idx
+
+
+class TestCheckpointCapabilityMismatchDiagnostics:
+    """Startup warning and actionable refusal text for a mis-armed gate."""
+
+    def _agent(self, *, checkpoint_required, manager=None):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            compression_checkpoint_required=checkpoint_required,
+            _memory_manager=manager,
+        )
+
+    def test_init_warns_when_gate_armed_without_capable_provider(self, caplog):
+        from agent.conversation_compression import warn_checkpoint_provider_mismatch
+
+        manager = MemoryManager()
+        manager.add_provider(_BaseStubProvider("holographic"))
+
+        with caplog.at_level("WARNING"):
+            warn_checkpoint_provider_mismatch(
+                self._agent(checkpoint_required=True, manager=manager)
+            )
+
+        assert "compression.checkpoint_required" in caplog.text
+        assert "holographic" in caplog.text
+        assert "blocked" in caplog.text
+
+    def test_init_warns_without_any_active_provider(self, caplog):
+        from agent.conversation_compression import warn_checkpoint_provider_mismatch
+
+        with caplog.at_level("WARNING"):
+            warn_checkpoint_provider_mismatch(
+                self._agent(checkpoint_required=True, manager=None)
+            )
+
+        assert "compression.checkpoint_required" in caplog.text
+        assert "'none'" in caplog.text
+
+    def test_init_is_silent_when_gate_off_or_provider_capable(self, caplog):
+        from agent.conversation_compression import warn_checkpoint_provider_mismatch
+
+        capable_manager = MemoryManager()
+        capable_manager.add_provider(_CheckpointProvider("durable"))
+
+        with caplog.at_level("WARNING"):
+            warn_checkpoint_provider_mismatch(
+                self._agent(checkpoint_required=False, manager=capable_manager)
+            )
+            warn_checkpoint_provider_mismatch(
+                self._agent(checkpoint_required=True, manager=capable_manager)
+            )
+
+        assert "compression.checkpoint_required" not in caplog.text
+
+    def test_capability_refusal_names_the_config_key_to_change(self):
+        from agent.conversation_compression import _pre_compress_memory_context
+
+        manager = MemoryManager()
+        manager.add_provider(_BaseStubProvider("holographic"))
+        agent = self._agent(checkpoint_required=True, manager=manager)
+
+        with pytest.raises(CompressionCheckpointUnavailable) as excinfo:
+            _pre_compress_memory_context(agent, [], checkpoint_required=True)
+
+        message = str(excinfo.value)
+        assert message.startswith("BLOCKED_MISSING_PREREQUISITE:")
+        assert "does not implement checkpoint API v" in message
+        assert "compression.checkpoint_required" in message
+        assert "disable it to restore compression" in message
+
+    def test_missing_manager_refusal_also_names_the_config_key(self):
+        from agent.conversation_compression import _pre_compress_memory_context
+
+        agent = self._agent(checkpoint_required=True, manager=None)
+
+        with pytest.raises(CompressionCheckpointUnavailable) as excinfo:
+            _pre_compress_memory_context(agent, [], checkpoint_required=True)
+
+        message = str(excinfo.value)
+        assert "no active provider implements checkpoint API v" in message
+        assert "compression.checkpoint_required" in message

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -178,6 +178,12 @@ uncompressed transcript is preserved, the compaction attempt errors with
 `BLOCKED_MISSING_PREREQUISITE`, and it can be retried once your store
 recovers. With the gate off (default), nothing changes for existing providers.
 
+None of the providers bundled with Hermes advertise checkpoint API v2 — the
+contract is opt-in and exists for third-party archiving providers. Enabling
+`checkpoint_required` without one therefore blocks every compression attempt
+(manual and automatic): agent init logs a warning naming the active provider,
+and each refusal names `compression.checkpoint_required` as the key to disable.
+
 The gate binds to every compaction authority, not just the Hermes
 summarizer: server-side native compaction (`compression.codex_responses_native`)
 is suppressed while the gate is armed, post-turn micro-compaction


### PR DESCRIPTION
Reproduced and confirmed on main — the fail-closed gate itself is sound; this PR closes the discoverability gap (points 1, 2 and the docs part of 3 from the report). No behavior changes.

**1. Startup warning** — `agent_init` knows the mismatch is unfixable at runtime: memory providers are loaded before compression settings are applied, and `MemoryManager.supports_pre_compress_checkpoint()` already exists. When `compression.checkpoint_required` is truthy and no active provider advertises checkpoint API v2, `init_agent` now logs a warning naming the provider and both remediations (`warn_checkpoint_provider_mismatch`, placed after `agent.compression_checkpoint_required` is set so it runs for both built-in and external context engines).

**2. Actionable slash error** — the two capability-refusal branches in `_pre_compress_memory_context` (`agent/conversation_compression.py`) now append which config key armed the gate and the two ways out:

```
/compress · error: BLOCKED_MISSING_PREREQUISITE: required pre-compress checkpoint unavailable: active provider does not implement checkpoint API v2 (compression.checkpoint_required is enabled: disable it to restore compression, or use a memory provider that advertises checkpoint API v2)
```

**3. Docs** — `website/docs/developer-guide/memory-provider-plugin.md` now states that no bundled provider advertises checkpoint API v2 (the contract is opt-in for third-party archiving providers), so the flag can be set knowingly.

Tests: 5 new cases in `tests/agent/test_pre_compress_checkpoint_contract.py` (warning on mismatch with provider name / without any provider / silence when gate off or provider capable; both refusal texts name `compression.checkpoint_required`). Mutation-verified: never-warn, dropped-remediation and inverted-probe each fail exactly one test. All 28 contract tests + adjacent specs (`test_pre_compress_memory_context.py`, `test_manual_compression_refusal_feedback.py`, `test_meta_agent_init.py`) green locally.

Closes #106870