### PR TITLE
fix(update): record a macOS launchd fleet-restart failure instead of swallowing it

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -1219,8 +1219,15 @@ def _restart_gateway_fleet_after_update(_pre_update_plan, gateway_mode: bool):
 
         # macOS: EVERY ai.hermes.gateway* LaunchAgent (systemd parity).
         if is_macos():
-            with suppress(FileNotFoundError, ImportError):
+            try:
                 _restart_macos_launchd_gateways(out.restarted_services, out.failed_or_stale_units, _drain_budget)
+            except (FileNotFoundError, ImportError) as exc:
+                # Same exception types the old bare suppress() dropped (e.g. hermes_cli.gateway
+                # no longer importing under a checkout replaced mid-restart, per
+                # _surviving_gateway_pids_after_failed_restart's own docstring below) — but
+                # recorded as a failure instead of silently reporting a clean fleet restart.
+                logger.debug("Fleet restart: launchd failed: %s", exc)
+                out.failed_or_stale_units.append("launchd")
 
         _restart_manual_gateways(out, _drain_budget)
 

--- a/tests/hermes_cli/test_update_fleet_macos_launchd_failure.py
+++ b/tests/hermes_cli/test_update_fleet_macos_launchd_failure.py
@@ -1,0 +1,85 @@
+"""A macOS launchd restart failure (e.g. hermes_cli.gateway no longer importing under a checkout
+replaced mid-restart, per _surviving_gateway_pids_after_failed_restart's own docstring) must be
+recorded as an incomplete fleet restart — not silently swallowed into a clean success receipt.
+
+_restart_gateway_fleet_after_update used to wrap the call to _restart_macos_launchd_gateways in a
+bare suppress(FileNotFoundError, ImportError): on those two exception types, out.failed_or_stale_units
+never got a "launchd" entry, so out.incomplete stayed False and the update reported success even
+though the whole launchd fleet was left on pre-update code. Its own catch-up sibling,
+_run_pending_fleet_restart, already recorded exactly this failure correctly.
+"""
+
+from __future__ import annotations
+
+import hermes_cli.update_cmd_fleet as update_cmd_fleet
+from hermes_cli.update_inventory import UpdatePlan
+
+
+def _stub_gateway_helpers(monkeypatch, *, is_macos: bool):
+    import hermes_cli.gateway as hermes_gateway
+
+    monkeypatch.setattr(hermes_gateway, "is_macos", lambda: is_macos)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **k: [])
+    monkeypatch.setattr(hermes_gateway, "find_profile_gateway_processes", lambda *a, **k: [])
+    monkeypatch.setattr(hermes_gateway, "_prepare_profile_gateway_update_restart", lambda *a, **k: None)
+    monkeypatch.setattr(hermes_gateway, "_get_service_pids", lambda *a, **k: [])
+    monkeypatch.setattr(hermes_gateway, "_wait_for_gateway_exit", lambda *a, **k: None)
+    monkeypatch.setattr(hermes_gateway, "_get_restart_exit_wait_budget", lambda: 45.0)
+
+
+def _stub_restart_phases(monkeypatch):
+    import hermes_cli.main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+    monkeypatch.setattr(update_cmd_fleet, "_restart_systemd_gateway_units", lambda *a, **k: None)
+    monkeypatch.setattr(update_cmd_fleet, "_restart_manual_gateways", lambda *a, **k: None)
+    monkeypatch.setattr(update_cmd_fleet, "_force_kill_stuck_gateways", lambda *a, **k: None)
+
+
+def test_launchd_import_error_marks_fleet_restart_incomplete(monkeypatch):
+    _stub_gateway_helpers(monkeypatch, is_macos=True)
+    _stub_restart_phases(monkeypatch)
+
+    def _raise_import_error(*a, **k):
+        raise ImportError("hermes_cli.gateway")
+
+    monkeypatch.setattr(update_cmd_fleet, "_restart_macos_launchd_gateways", _raise_import_error)
+
+    out = update_cmd_fleet._restart_gateway_fleet_after_update(UpdatePlan(), gateway_mode=False)
+
+    assert out.failed_or_stale_units == ["launchd"]
+    assert out.incomplete is True
+
+
+def test_launchd_file_not_found_marks_fleet_restart_incomplete(monkeypatch):
+    """launchctl missing from PATH mid-restart is the other exception type the old bare
+    suppress() dropped silently."""
+    _stub_gateway_helpers(monkeypatch, is_macos=True)
+    _stub_restart_phases(monkeypatch)
+
+    def _raise_file_not_found(*a, **k):
+        raise FileNotFoundError("launchctl")
+
+    monkeypatch.setattr(update_cmd_fleet, "_restart_macos_launchd_gateways", _raise_file_not_found)
+
+    out = update_cmd_fleet._restart_gateway_fleet_after_update(UpdatePlan(), gateway_mode=False)
+
+    assert out.failed_or_stale_units == ["launchd"]
+    assert out.incomplete is True
+
+
+def test_launchd_success_leaves_fleet_restart_complete(monkeypatch):
+    """Control: a launchd phase that actually restarts everything must NOT be marked incomplete —
+    guards against a fix that always appends "launchd" regardless of outcome."""
+    _stub_gateway_helpers(monkeypatch, is_macos=True)
+    _stub_restart_phases(monkeypatch)
+
+    def _succeed(restarted_services, failed_or_stale_units, drain_budget):
+        restarted_services.append("ai.hermes.gateway")
+
+    monkeypatch.setattr(update_cmd_fleet, "_restart_macos_launchd_gateways", _succeed)
+
+    out = update_cmd_fleet._restart_gateway_fleet_after_update(UpdatePlan(), gateway_mode=False)
+
+    assert out.failed_or_stale_units == []
+    assert out.incomplete is False


### PR DESCRIPTION
## Summary

`_restart_gateway_fleet_after_update` (`hermes_cli/update_cmd_fleet.py`) wraps the call to `_restart_macos_launchd_gateways` in a bare `suppress(FileNotFoundError, ImportError)`:

```python
if is_macos():
    with suppress(FileNotFoundError, ImportError):
        _restart_macos_launchd_gateways(out.restarted_services, out.failed_or_stale_units, _drain_budget)
```

`_restart_macos_launchd_gateways`'s own first statement is `from hermes_cli.gateway import (...)`, and this repo's own `_surviving_gateway_pids_after_failed_restart` docstring documents exactly this scenario: `None` when undeterminable, "notably `hermes_cli.gateway` no longer importing under the replaced checkout" — i.e. an update that has already replaced the on-disk checkout while this restart phase is still running against the pre-update interpreter.

When that import raises (or `launchctl` is missing from `PATH`, the other suppressed type), `out.failed_or_stale_units` never gets a `"launchd"` entry, so `out.incomplete` stays `False` and `out.record_receipt()` records a clean fleet restart — even though every `launchd`-managed gateway on the machine was left on pre-update code.

Two things in the same file point at this being an oversight rather than intent:
- Its systemd sibling three lines above, `_restart_systemd_gateway_units`, is called bare — no suppress.
- Its own catch-up caller of the *same* function, `_run_pending_fleet_restart`, already handles this correctly: `except Exception as exc: ... failed.append("launchd")`.

## Fix

Catch the same two exception types the old `suppress()` covered (not broader — anything else still escalates to the existing `_recover_after_restart_phase_abort` phase-abort recovery, unchanged), and record the failure the way the systemd path and the catch-up sibling already do.

## Test plan

- [x] New test file `tests/hermes_cli/test_update_fleet_macos_launchd_failure.py`: `_restart_macos_launchd_gateways` raising `ImportError` or `FileNotFoundError` must leave `out.failed_or_stale_units == ["launchd"]` and `out.incomplete is True`; a control test asserts a *successful* launchd restart leaves `out.incomplete is False` (guards against a fix that always marks incomplete regardless of outcome).
- [x] Mutation-verify: reverted just the production fix and confirmed both failure-path tests fail (`out.failed_or_stale_units == []` instead of `["launchd"]`) while the success-path control still passes; restored the fix and confirmed all three pass.
- [x] Full update-fleet test suite (`test_update_fleet_check_fail_closed.py`, `test_update_fleet_probe_resume_token.py`, `test_update_fleet_restart_timeout.py`, `test_update_fleet_restart_pending.py`, plus the new file) — 52 passed.
- [x] `ruff check` clean on both changed files.
