### PR TITLE
feat(desktop): persist approval resolution cards

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval-resolution.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval-resolution.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ApprovalResolutionCard, approvalResolutionFromResult } from './approval-resolution'
+
+afterEach(cleanup)
+
+describe('approvalResolutionFromResult', () => {
+  it('accepts the durable live/history result shape', () => {
+    expect(
+      approvalResolutionFromResult(
+        JSON.stringify({
+          output: 'ok',
+          approval: {
+            status: 'approved',
+            choice: 'once',
+            actor: 'authenticated_user',
+            resolved_at: 123.5,
+            request_id: 'opaque-request'
+          },
+          execution: { status: 'succeeded' }
+        })
+      )
+    ).toEqual({
+      approval: {
+        status: 'approved',
+        choice: 'once',
+        actor: 'authenticated_user',
+        resolved_at: 123.5,
+        request_id: 'opaque-request'
+      },
+      execution: { status: 'succeeded' }
+    })
+  })
+
+  it('keeps rejection distinct from a technical approval failure', () => {
+    expect(approvalResolutionFromResult({ approval: { status: 'rejected' }, execution: { status: 'not_attempted' } })).toEqual({
+      approval: { status: 'rejected', choice: undefined, actor: undefined, resolved_at: undefined, request_id: undefined },
+      execution: { status: 'not_attempted' }
+    })
+    expect(approvalResolutionFromResult({ approval: { status: 'unavailable' }, execution: { status: 'not_attempted' } })).not.toEqual(
+      approvalResolutionFromResult({ approval: { status: 'rejected' }, execution: { status: 'not_attempted' } })
+    )
+  })
+
+  it('ignores untrusted or incomplete result metadata', () => {
+    expect(approvalResolutionFromResult({ approval: { status: 'unknown', actor: 'model' } })).toBeNull()
+  })
+
+  it('renders a resolved card without actionable controls', () => {
+    render(
+      <ApprovalResolutionCard
+        resolution={{
+          approval: { status: 'approved', choice: 'once', actor: 'authenticated_user' },
+          execution: { status: 'succeeded' }
+        }}
+      />
+    )
+
+    expect(screen.getByText('Approved once')).toBeTruthy()
+    expect(screen.getByText(/Execution succeeded/)).toBeTruthy()
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/tool/approval-resolution.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval-resolution.test.tsx
@@ -47,18 +47,34 @@ describe('approvalResolutionFromResult', () => {
     expect(approvalResolutionFromResult({ approval: { status: 'unknown', actor: 'model' } })).toBeNull()
   })
 
-  it('renders a resolved card without actionable controls', () => {
+  it.each([
+    ['once', 'Approved once'],
+    ['session', 'Approved for this session'],
+    ['always', 'Approved always']
+  ] as const)('renders the %s approval choice label without actionable controls', (choice, label) => {
     render(
       <ApprovalResolutionCard
         resolution={{
-          approval: { status: 'approved', choice: 'once', actor: 'authenticated_user' },
+          approval: { status: 'approved', choice, actor: 'authenticated_user' },
           execution: { status: 'succeeded' }
         }}
       />
     )
 
-    expect(screen.getByText('Approved once')).toBeTruthy()
+    expect(screen.getByText(label)).toBeTruthy()
+    if (choice === 'always') {
+      expect(screen.queryByText('Approved once')).toBeNull()
+    }
     expect(screen.getByText(/Execution succeeded/)).toBeTruthy()
     expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it.each([
+    ['rejected', 'Rejected'],
+    ['unavailable', 'Approval unavailable']
+  ] as const)('keeps the %s approval label unchanged', (status, label) => {
+    render(<ApprovalResolutionCard resolution={{ approval: { status } }} />)
+
+    expect(screen.getByText(label)).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool/approval-resolution.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval-resolution.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { type FC } from 'react'
+
+import { cn } from '@/lib/utils'
+
+export type ApprovalResolutionStatus = 'approved' | 'rejected' | 'unavailable'
+export type ApprovalExecutionStatus = 'succeeded' | 'failed' | 'not_attempted'
+
+export interface ApprovalResolution {
+  status: ApprovalResolutionStatus
+  choice?: 'once' | 'session' | 'always' | null
+  actor?: 'authenticated_user' | 'system'
+  resolved_at?: number
+  request_id?: string
+}
+
+export interface ApprovalExecution {
+  status: ApprovalExecutionStatus
+}
+
+export interface ApprovalResolutionRecord {
+  approval: ApprovalResolution
+  execution?: ApprovalExecution
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+function parse(value: unknown): Record<string, unknown> | null {
+  const direct = record(value)
+
+  if (direct) {
+    return direct
+  }
+
+  if (typeof value !== 'string' || !value.trim()) {
+    return null
+  }
+
+  try {
+    return record(JSON.parse(value))
+  } catch {
+    return null
+  }
+}
+
+export function approvalResolutionFromResult(value: unknown): ApprovalResolutionRecord | null {
+  const result = parse(value)
+  const approval = record(result?.approval)
+  const status = approval?.status
+
+  if (!approval || (status !== 'approved' && status !== 'rejected' && status !== 'unavailable')) {
+    return null
+  }
+
+  const execution = record(result?.execution)
+  const executionStatus = execution?.status
+
+  return {
+    approval: {
+      status,
+      choice:
+        approval.choice === 'once' || approval.choice === 'session' || approval.choice === 'always' || approval.choice === null
+          ? approval.choice
+          : undefined,
+      actor: approval.actor === 'authenticated_user' || approval.actor === 'system' ? approval.actor : undefined,
+      resolved_at: typeof approval.resolved_at === 'number' ? approval.resolved_at : undefined,
+      request_id: typeof approval.request_id === 'string' ? approval.request_id : undefined
+    },
+    ...(executionStatus === 'succeeded' || executionStatus === 'failed' || executionStatus === 'not_attempted'
+      ? { execution: { status: executionStatus } }
+      : {})
+  }
+}
+
+function resolutionLabel(resolution: ApprovalResolution): string {
+  if (resolution.status === 'approved') {
+    return resolution.choice === 'session' ? 'Approved for this session' : 'Approved once'
+  }
+
+  if (resolution.status === 'rejected') {
+    return 'Rejected'
+  }
+
+  return 'Approval unavailable'
+}
+
+function executionLabel(execution?: ApprovalExecution): string | null {
+  if (!execution || execution.status === 'not_attempted') {
+    return execution ? 'Not executed' : null
+  }
+
+  return execution.status === 'succeeded' ? 'Execution succeeded' : 'Execution failed'
+}
+
+export const ApprovalResolutionCard: FC<{ resolution: ApprovalResolutionRecord }> = ({ resolution }) => {
+  const execution = executionLabel(resolution.execution)
+  const isApproved = resolution.approval.status === 'approved'
+
+  return (
+    <div
+      className={cn(
+        'mt-1 flex items-center gap-2 rounded-md border px-2 py-1 text-xs',
+        isApproved
+          ? 'border-emerald-600/25 bg-emerald-600/5 text-emerald-700 dark:border-emerald-400/25 dark:bg-emerald-400/5 dark:text-emerald-300'
+          : resolution.approval.status === 'rejected'
+            ? 'border-amber-600/25 bg-amber-600/5 text-amber-700 dark:border-amber-400/25 dark:bg-amber-400/5 dark:text-amber-300'
+            : 'border-destructive/25 bg-destructive/5 text-destructive'
+      )}
+      data-approval-resolution={resolution.approval.status}
+    >
+      <span className="font-medium">{resolutionLabel(resolution.approval)}</span>
+      {resolution.approval.actor === 'authenticated_user' && <span className="opacity-75">by you</span>}
+      {execution && <span className="opacity-75">· {execution}</span>}
+    </div>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/tool/approval-resolution.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval-resolution.tsx
@@ -77,7 +77,11 @@ export function approvalResolutionFromResult(value: unknown): ApprovalResolution
 
 function resolutionLabel(resolution: ApprovalResolution): string {
   if (resolution.status === 'approved') {
-    return resolution.choice === 'session' ? 'Approved for this session' : 'Approved once'
+    if (resolution.choice === 'session') {
+      return 'Approved for this session'
+    }
+
+    return resolution.choice === 'always' ? 'Approved always' : 'Approved once'
   }
 
   if (resolution.status === 'rejected') {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback.tsx
@@ -53,6 +53,7 @@ import { $toolRowDismissed, dismissToolRow } from '@/store/tool-dismiss'
 import { $anyToolDisclosureOpen, $toolDisclosureOpen, $toolViewMode, setToolDisclosureOpen } from '@/store/tool-view'
 
 import { APPROVAL_TOOLS, PendingToolApproval } from './approval'
+import { ApprovalResolutionCard, approvalResolutionFromResult } from './approval-resolution'
 import {
   buildToolView,
   clampForDisplay,
@@ -373,6 +374,7 @@ function ToolEntry({ part }: ToolEntryProps) {
   // re-render every mounted tool row (the factory caches a per-id atom).
   const sideDiff = useStore($toolInlineDiff(toolCallId ?? ''))
   const inlineDiff = stripInlineDiffChrome(sideDiff) || inlineDiffFromResult(result)
+  const approvalResolution = useMemo(() => approvalResolutionFromResult(result), [result])
   const isFileEdit = isFileEditTool(toolName)
   const defaultOpen = Boolean(inlineDiff)
   const open = useDisclosureOpen(disclosureId, defaultOpen)
@@ -537,7 +539,7 @@ function ToolEntry({ part }: ToolEntryProps) {
   // persists its diff in the tool result, so creates rehydrate diff-less and
   // read like dead duplicates of the real diff row. Hide them — but keep
   // in-flight writes (activity) and failures (errors) visible.
-  if (isFileEdit && !isPending && view.status !== 'error' && !view.inlineDiff) {
+  if (isFileEdit && !isPending && view.status !== 'error' && !view.inlineDiff && !approvalResolution) {
     return null
   }
 
@@ -599,6 +601,7 @@ function ToolEntry({ part }: ToolEntryProps) {
         </DisclosureRow>
       </div>
       {isPending && <PendingToolApproval part={part} />}
+      {!isPending && approvalResolution && <ApprovalResolutionCard resolution={approvalResolution} />}
       {open && (
         <div className="relative grid w-full min-w-0 max-w-full gap-1.5 overflow-hidden p-1.5">
           {copyAction.text && (


### PR DESCRIPTION
## Summary

- render durable non-interactive approval cards after Approve once or Reject
- preserve authenticated human approval/rejection resolution in model-visible tool context
- keep approval outcome distinct from execution outcome

## Validation

- approval-resolution focused tests: 8/8 passed
- Desktop typecheck passed
- Desktop build passed