### PR TITLE
fix(release): correctly strip scoped conventional prefixes in clean_subject

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2288,8 +2288,8 @@ def categorize_commit(subject: str) -> str:
 
 def clean_subject(subject: str) -> str:
     """Clean up a commit subject for display."""
-    # Remove conventional commit prefix
-    cleaned = re.sub(r"^(feat|fix|docs|chore|refactor|test|perf|ci|build|improve|add|update|cleanup|hotfix|breaking|enhance|optimize|bugfix|bug|feature|tests|deps|bump)[\s:(!]+\s*", "", subject, flags=re.IGNORECASE)
+    # Remove conventional commit prefix (handles scoped prefixes like feat(scope):, feat!:, feat(scope)!:)
+    cleaned = re.sub(r"^(feat|fix|docs?|chore|refactor|test|tests|perf|ci|build|improve|add|update|clean|cleanup|hotfix|breaking|enhance|optimize|bugfix|bug|feature|deps|bump)(\([^)]*\))?!?[:\s]+", "", subject, flags=re.IGNORECASE)
     # Remove trailing issue refs that are redundant with PR links
     cleaned = cleaned.strip()
     # Capitalize first letter


### PR DESCRIPTION
### Problem
`clean_subject` in `scripts/release.py:2292` used `[\\s:(!]+\\s*` to strip conventional-commit prefixes. For scoped commits like `feat(gateway): add something` or `fix(agent): ...` the `)` was not in the class, so only `feat(` was removed, leaving `gateway): add something` in the generated changelog/release notes.

The prefix list also missed `doc` (only `docs`) and `clean` (only `cleanup`), unlike `categorize_commit`.

### Fix
- Replace with scoped-aware regex: `^(<types>)(\([^)]*\))?!?[:\\s]+`
- Covers `feat(scope):`, `feat!:`, `feat(scope)!:` and plain `feat:`/`feat `
- Align types to `categorize_commit`: add `doc`/`docs?`, `clean`, `tests`.

### Verification
- Manual `clean_subject` tests for 11 cases (scoped, breaking, singular forms) — all OK
- `py_compile` on `scripts/release.py` — ok
- No existing unit tests for this function; import check suffices.

Grepped candidate `scripts/release.py:2292` from auto-fix scan.