### PR TITLE
fix(kanban): stand by on a contended dispatcher lock instead of exiting

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -49,6 +49,46 @@ class GatewayKanbanWatchersMixin:
         self._kanban_dispatcher_lock_handle = None
         _release_singleton_lock(handle)
 
+    def _may_dispatch_this_tick(self) -> bool:
+        """Return True when this gateway holds (or just took) the dispatcher lock.
+
+        A contended lock only says "somebody else is the dispatcher *right
+        now*" — it is not a verdict about the rest of this process's life.
+        Standby gateways therefore re-try the lock on every tick, and the
+        first one to tick after the holder goes away becomes the dispatcher.
+
+        Without the re-try the contended answer was permanent: every gateway
+        that lost the race at boot stopped asking, so when the holder later
+        exited (restart race, crash, `hermes gateway stop`) the lock was free
+        but nobody was left to take it, and the board stopped being dispatched
+        until a human restarted a gateway.
+        """
+        if self._owns_kanban_dispatcher_lock():
+            return True
+        lock_path = getattr(self, "_kanban_dispatcher_lock_path", None)
+        if lock_path is None:
+            # Advisory locking is unavailable on this filesystem; the
+            # `dispatch_in_gateway` config flag is the only control.
+            return True
+        handle, state = _acquire_singleton_lock(lock_path)
+        if state == "held":
+            self._kanban_dispatcher_lock_handle = handle  # hold for process lifetime
+            logger.info(
+                "kanban dispatcher: took over the singleton dispatcher lock (%s); "
+                "this gateway now dispatches", lock_path,
+            )
+            return True
+        if state == "unavailable":
+            # Locking stopped working mid-run — fall back to config-only
+            # control rather than freezing the board forever.
+            self._kanban_dispatcher_lock_path = None
+            logger.warning(
+                "kanban dispatcher: advisory lock unavailable at %s; proceeding "
+                "on config control alone.", lock_path,
+            )
+            return True
+        return False
+
     async def _sleep_between_ticks(self, interval: float) -> None:
         """Sleep *interval* (floored to 1s) in 1s slices so stop() never waits a full interval."""
         interval = max(interval, 1.0)
@@ -218,11 +258,14 @@ class GatewayKanbanWatchersMixin:
         self._kanban_dispatcher_lock_handle = None
         _lock_path = _kb.kanban_home() / "kanban" / ".dispatcher.lock"
         _lock_handle, _lock_state = _acquire_singleton_lock(_lock_path)
+        # `None` disables locking for the rest of this process (see
+        # `_may_dispatch_this_tick`); a path means "re-try it every tick".
+        self._kanban_dispatcher_lock_path = None if _lock_state == "unavailable" else _lock_path
         if _lock_state == "contended":
+            # Standby, not exit: the loop below re-tries the lock each tick.
             logger.info("kanban dispatcher: another gateway already holds the dispatcher "
-                        "lock (%s); this gateway will NOT dispatch.", _lock_path)
-            return None
-        if _lock_state == "held":
+                        "lock (%s); standing by and re-trying every tick.", _lock_path)
+        elif _lock_state == "held":
             self._kanban_dispatcher_lock_handle = _lock_handle  # hold for process lifetime
             logger.info("kanban dispatcher: holding singleton dispatcher lock (%s)", _lock_path)
         else:
@@ -258,6 +301,12 @@ class GatewayKanbanWatchersMixin:
 
         logger.info("kanban dispatcher: embedded in gateway (interval=%.1fs)", interval)
         while self._running:
+            # Standby tick: another gateway holds the lock. Ask again next
+            # tick instead of giving up for this process's lifetime.
+            if not self._may_dispatch_this_tick():
+                await self._sleep_between_ticks(interval)
+                continue
+
             try:
                 # Reap zombies before per-board work so a board DB failure
                 # cannot block cleanup of unrelated workers.

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -40,6 +40,10 @@ _HEALTH_WINDOW = 6
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
+    # Set once per process when the lock probe itself fails, so the warning is
+    # logged once instead of every tick.
+    _kanban_dispatcher_lock_probe_failed = False
+
     def _owns_kanban_dispatcher_lock(self) -> bool:
         return getattr(self, "_kanban_dispatcher_lock_handle", None) is not None
 
@@ -79,14 +83,23 @@ class GatewayKanbanWatchersMixin:
             )
             return True
         if state == "unavailable":
-            # Locking stopped working mid-run — fall back to config-only
-            # control rather than freezing the board forever.
-            self._kanban_dispatcher_lock_path = None
-            logger.warning(
-                "kanban dispatcher: advisory lock unavailable at %s; proceeding "
-                "on config control alone.", lock_path,
-            )
-            return True
+            # Locking stopped working mid-run. Do NOT read that as permission
+            # to dispatch: `_acquire_singleton_lock` answers "unavailable" for
+            # any OSError (fd exhaustion, ENOSPC, a transient EIO), not only
+            # for a filesystem without flock — and somebody demonstrably held
+            # this lock a moment ago. Dispatching anyway would put a second
+            # dispatcher on the board, which is what the lock exists to
+            # prevent. Boot-time "unavailable" is different (nobody was ever
+            # observed holding it) and still falls back to config-only control.
+            if not self._kanban_dispatcher_lock_probe_failed:
+                self._kanban_dispatcher_lock_probe_failed = True
+                logger.warning(
+                    "kanban dispatcher: cannot probe the singleton lock at %s; "
+                    "standing by rather than dispatching alongside the current "
+                    "holder.", lock_path,
+                )
+            return False
+        self._kanban_dispatcher_lock_probe_failed = False
         return False
 
     async def _sleep_between_ticks(self, interval: float) -> None:
@@ -261,6 +274,7 @@ class GatewayKanbanWatchersMixin:
         # `None` disables locking for the rest of this process (see
         # `_may_dispatch_this_tick`); a path means "re-try it every tick".
         self._kanban_dispatcher_lock_path = None if _lock_state == "unavailable" else _lock_path
+        self._kanban_dispatcher_lock_probe_failed = False
         if _lock_state == "contended":
             # Standby, not exit: the loop below re-tries the lock each tick.
             logger.info("kanban dispatcher: another gateway already holds the dispatcher "

--- a/tests/gateway/test_kanban_dispatcher_lock_standby.py
+++ b/tests/gateway/test_kanban_dispatcher_lock_standby.py
@@ -1,0 +1,156 @@
+"""A gateway that loses the dispatcher-lock race must stand by, not give up.
+
+Before this, losing the race at boot was a verdict for the whole process
+life: the watcher returned. When the holder later exited, the lock was free
+but every other gateway had already stopped asking, so the board was not
+dispatched by anyone until a human restarted a gateway.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway import kanban_watchers as kw
+from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.kanban_watchers_common import (
+    _acquire_singleton_lock,
+    _release_singleton_lock,
+)
+
+
+class _Runner(GatewayKanbanWatchersMixin):
+    def __init__(self):
+        self._running = True
+        self._kanban_dispatcher_lock_handle = None
+
+
+def _lock_path(tmp_path):
+    path = tmp_path / "kanban" / ".dispatcher.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def test_may_dispatch_is_false_while_contended_and_true_once_free(tmp_path):
+    """The per-tick question is re-asked, and its answer follows the lock."""
+    lock_path = _lock_path(tmp_path)
+    holder, state = _acquire_singleton_lock(lock_path)
+    assert state == "held"
+
+    runner = _Runner()
+    runner._kanban_dispatcher_lock_path = lock_path
+    try:
+        assert runner._may_dispatch_this_tick() is False
+        assert runner._owns_kanban_dispatcher_lock() is False
+        # Asking twice must not corrupt state or leak a handle.
+        assert runner._may_dispatch_this_tick() is False
+    finally:
+        _release_singleton_lock(holder)
+
+    assert runner._may_dispatch_this_tick() is True
+    assert runner._owns_kanban_dispatcher_lock() is True
+    # Already the owner: no second acquisition, still True.
+    assert runner._may_dispatch_this_tick() is True
+    runner._release_kanban_dispatcher_lock()
+
+
+def test_may_dispatch_is_true_when_locking_is_unavailable(tmp_path):
+    """No advisory locking -> config-only control, never a frozen board."""
+    runner = _Runner()
+    runner._kanban_dispatcher_lock_path = None
+    assert runner._may_dispatch_this_tick() is True
+    assert runner._owns_kanban_dispatcher_lock() is False
+
+
+class _FakeDispatcher:
+    def __init__(self, *_args, **_kwargs):
+        self.ticks = 0
+
+    def tick_once(self):
+        self.ticks += 1
+        return []
+
+    def ready_nonempty(self):
+        return False
+
+    def auto_decompose_tick(self, _per_tick):
+        return None
+
+
+def test_watcher_keeps_ticking_and_takes_over_when_the_holder_exits(
+    tmp_path, monkeypatch,
+):
+    """End to end: contended at boot, dispatching after the holder releases."""
+    lock_path = _lock_path(tmp_path)
+    holder, state = _acquire_singleton_lock(lock_path)
+    assert state == "held"
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "kanban_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **kw_: {"kanban": {"dispatch_in_gateway": True}},
+    )
+    monkeypatch.setattr(kw, "_kanban_dispatch_allowed", lambda: True)
+    monkeypatch.setattr(
+        kw, "_resolve_auto_decompose_settings", lambda _loader: (False, 0)
+    )
+    monkeypatch.setattr(
+        kw, "_resolve_dispatcher_settings",
+        lambda _cfg, _kb: SimpleNamespace(interval=1.0),
+    )
+    monkeypatch.setattr(kw, "_log_spawn_results", lambda _results: False)
+
+    dispatchers = []
+
+    def _make_dispatcher(*args, **kwargs):
+        made = _FakeDispatcher(*args, **kwargs)
+        dispatchers.append(made)
+        return made
+
+    monkeypatch.setattr(kw, "_KanbanDispatcher", _make_dispatcher)
+
+    runner = _Runner()
+    ticks_at_release = {}
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(_delay):
+        # Every await yields; the counter drives the scenario.
+        fake_sleep.calls += 1
+        if fake_sleep.calls == 5:
+            # Five standby sleeps happened with the lock held elsewhere:
+            # nothing may have been dispatched yet.
+            ticks_at_release["before"] = sum(d.ticks for d in dispatchers)
+            _release_singleton_lock(holder)
+        if fake_sleep.calls >= 12:
+            runner._running = False
+        await real_sleep(0)
+
+    fake_sleep.calls = 0
+    monkeypatch.setattr(kw.asyncio, "sleep", fake_sleep)
+
+    async def _drive():
+        await asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=10)
+
+    try:
+        asyncio.run(_drive())
+    finally:
+        runner._release_kanban_dispatcher_lock()
+
+    assert fake_sleep.calls >= 12, (
+        "the watcher exited instead of standing by while the lock was contended "
+        f"(only {fake_sleep.calls} sleeps happened)"
+    )
+    assert dispatchers, "the dispatcher loop exited before it ever built a dispatcher"
+    assert ticks_at_release.get("before") == 0, (
+        "the standby gateway dispatched while another one held the lock"
+    )
+    assert sum(d.ticks for d in dispatchers) > 0, (
+        "the gateway never took over the lock after the holder released it"
+    )
+    assert runner._owns_kanban_dispatcher_lock() is False  # released above
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/gateway/test_kanban_dispatcher_lock_standby.py
+++ b/tests/gateway/test_kanban_dispatcher_lock_standby.py
@@ -54,6 +54,26 @@ def test_may_dispatch_is_false_while_contended_and_true_once_free(tmp_path):
     runner._release_kanban_dispatcher_lock()
 
 
+def test_mid_run_probe_failure_does_not_dispatch(tmp_path, monkeypatch):
+    """A broken probe next to a live holder must NOT be read as permission.
+
+    `_acquire_singleton_lock` answers "unavailable" for any OSError — fd
+    exhaustion, ENOSPC, a transient EIO — not only for a filesystem without
+    flock. Treating that as "go ahead" would put a second dispatcher on the
+    board beside the real holder.
+    """
+    runner = _Runner()
+    runner._kanban_dispatcher_lock_path = _lock_path(tmp_path)
+    monkeypatch.setattr(kw, "_acquire_singleton_lock", lambda _p: (None, "unavailable"))
+
+    assert runner._may_dispatch_this_tick() is False
+    assert runner._may_dispatch_this_tick() is False
+    assert runner._owns_kanban_dispatcher_lock() is False
+    # The path must NOT be latched away: once the probe works again the
+    # gateway has to be able to take a freed lock.
+    assert runner._kanban_dispatcher_lock_path is not None
+
+
 def test_may_dispatch_is_true_when_locking_is_unavailable(tmp_path):
     """No advisory locking -> config-only control, never a frozen board."""
     runner = _Runner()


### PR DESCRIPTION
## Problem

The embedded kanban dispatcher takes a machine-global advisory lock so that only
one gateway dispatches. A gateway that loses that race at boot logs

    kanban dispatcher: another gateway already holds the dispatcher lock (...);
    this gateway will NOT dispatch.

and **returns** — the watcher coroutine ends. That turns a statement about the
current moment ("somebody else is the dispatcher right now") into a verdict for
the whole process life.

When the holder later goes away — a restart race, a crash, `hermes gateway
stop`, an OOM kill — the OS releases its flock, so the lock is free. But every
other gateway stopped asking hours ago, so nobody takes it. The board is not
dispatched by anyone until a human notices and restarts a gateway.

Observed on a six-gateway install: the holder exited at 15:23, five other
gateways were alive and healthy the whole time, and no card was dispatched for
8.5 hours. The existing "ready queue non-empty but 0 workers spawned" health
warning cannot fire, because it lives inside the loop that already returned.

## Fix

Stand by instead of exiting, and re-ask the question on every tick.

- `_kanban_dispatcher_boot()` no longer returns on `contended`; it records the
  lock path and lets the loop start.
- New `_may_dispatch_this_tick()` returns immediately when this gateway already
  owns the lock, otherwise re-tries the acquisition. On success it stores the
  handle and logs the takeover; while contended it returns False.
- The loop skips its body and sleeps one interval on a standby tick, so a
  standby gateway costs one non-blocking `flock` attempt per interval and never
  dispatches while somebody else holds the lock.
- If locking becomes `unavailable` mid-run, the gateway falls back to
  config-only control rather than freezing the board.

Handover latency is one dispatch interval (60s by default) instead of
"until a human restarts something".

## Related

Three open PRs touch the same lock from the **holder** side — recheck/steal a
stale lease (#100109), unlink a lock left by an unclean exit (#103537),
lock-owner diagnostics (#103108). This one fixes the **contender** side: none of
them helps if every other gateway has already stopped looking. It is small and
independent; happy to rebase on whichever lands first.

## Tests

`tests/gateway/test_kanban_dispatcher_lock_standby.py`

- `_may_dispatch_this_tick()` is False while contended, True (and owning) once
  the holder releases, idempotent when already owner.
- `unavailable` locking never blocks dispatch.
- End to end through `_kanban_dispatcher_watcher()`: contended at boot, no
  dispatch while the lock is held elsewhere, dispatch after the holder releases,
  loop still alive.

Verified red against three mutations (restore the early `return`, drop the
per-tick guard, forget to store the acquired handle). `tests/gateway -k kanban`:
61 passed, 2 skipped.
