### PR TITLE
fix(tools): count final unterminated line in read_file total_lines

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -314,3 +314,74 @@ class TestSearchContextParsing:
         assert result.matches[0].path == "dir/file-12-name.py"
         assert result.matches[0].line_number == 8
         assert result.matches[0].content == "context here"
+
+
+# =========================================================================
+# total_lines for files without a trailing newline (#3907)
+# =========================================================================
+
+
+class TestNoTrailingNewlineTotalLines:
+    """``wc -l`` counts newlines, not lines: a final unterminated line must
+    still count. Covers the live read paths plus the assembler contract."""
+
+    @pytest.fixture()
+    def ops(self):
+        from tools.environments.local import LocalEnvironment
+
+        return ShellFileOperations(LocalEnvironment())
+
+    def test_total_lines_counts_final_unterminated_line(self, tmp_path, ops):
+        target = tmp_path / "no_trailing.txt"
+        target.write_bytes(b"line1\nline2\nline3")  # no trailing newline
+
+        result = ops.read_file(str(target))
+
+        assert result.error is None
+        assert result.total_lines == 3
+        assert result.content.split("\n") == ["1|line1", "2|line2", "3|line3"]
+
+    def test_pagination_admits_final_unterminated_line(self, tmp_path, ops):
+        target = tmp_path / "no_trailing.txt"
+        target.write_bytes(b"line1\nline2\nline3")
+
+        first = ops.read_file(str(target), offset=1, limit=2)
+        assert first.truncated is True
+        assert "of 3 lines" in (first.hint or "")
+
+        last = ops.read_file(str(target), offset=3)
+        assert last.error is None
+        assert last.content == "3|line3"
+        assert last.total_lines == 3
+
+    def test_terminated_and_empty_files_unchanged(self, tmp_path, ops):
+        terminated = tmp_path / "terminated.txt"
+        terminated.write_bytes(b"a\nb\nc\n")
+        assert ops.read_file(str(terminated)).total_lines == 3
+
+        empty = tmp_path / "empty.txt"
+        empty.write_bytes(b"")
+        result = ops.read_file(str(empty))
+        assert result.total_lines == 0
+
+    def test_native_path_counts_final_unterminated_line(self, tmp_path, ops):
+        target = tmp_path / "no_trailing.txt"
+        target.write_bytes(b"line1\nline2\nline3")
+
+        result = ops._read_file_native(str(target), 1, 2000)
+
+        assert result.error is None
+        assert result.total_lines == 3
+
+    def test_assembler_bumps_count_only_on_proven_missing_newline(self):
+        ops = ShellFileOperations.__new__(ShellFileOperations)
+
+        proved = ops._assemble_read_result(
+            "a\nb\nc\n", offset=1, end_line=2000, total_lines=2,
+            file_size=5, file_ends_with_newline=False)
+        assert proved.total_lines == 3
+
+        unknown = ops._assemble_read_result(
+            "a\nb\nc\n", offset=1, end_line=2000, total_lines=2,
+            file_size=5, file_ends_with_newline=None)
+        assert unknown.total_lines == 2

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -869,6 +869,12 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
         read path so the BOM strip, pagination hint, ``cut`` newline-artifact fix and
         the ambiguous-silence guards never drift apart. ``file_ends_with_newline`` is
         None when the caller could not tell (artifact left alone, as before)."""
+        # ``wc -l`` counts newlines, not lines: a nonempty file whose last byte
+        # is not a newline holds one more line than the count (#3907). Adjust
+        # here — the single choke point — so total_lines, truncation, and the
+        # past-EOF guard agree on every read path (compound, sequential, native).
+        if file_size > 0 and file_ends_with_newline is False:
+            total_lines += 1
         if offset == 1:  # only the first chunk can carry a BOM (byte 0)
             read_output, _ = _strip_bom(read_output)
         truncated = total_lines > end_line


### PR DESCRIPTION
## What does this PR do?

`read_file` reported `total_lines` straight from `wc -l`, which counts newlines rather than lines, so any file without a trailing newline undercounted by exactly one. The returned content already showed the real line count (via numbered lines), and worse, the wrong count fed pagination: a 3-line unterminated file read with `limit=2` reported `truncated: false`, and `offset=3` was rejected as beyond-EOF.

All three read paths (compound probe, sequential fallback, native) already determine whether the last byte is a newline (`file_ends_with_newline`) to strip `cut`'s phantom newline from content. This PR uses that same proven signal at the shared choke point, `_assemble_read_result`: when the file is nonempty and provably lacks a trailing newline, bump the count by one before truncation and the past-EOF guard are derived. Unknown signal (`None`, e.g. truncated sequential probe) leaves the count untouched, as before.

This covers the native and sequential paths too, which the earlier per-path attempt did not.

## Related Issue

Fixes #3907
Supersedes #3908 (stale since July; same issue, narrower approach — single choke-point adjustment instead of a new helper)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py`: +1 to `total_lines` in `_assemble_read_result` when `file_size > 0` and `file_ends_with_newline is False` (6 lines incl. comment)
- `tests/tools/test_file_operations_edge_cases.py`: new `TestNoTrailingNewlineTotalLines` class, 5 tests (live shell + native paths, pagination admission, terminated/empty unchanged, assembler contract)

## How to Test

1. `printf 'line1\nline2\nline3' > /tmp/no_trailing.txt` (no trailing newline)
2. `read_file(path='/tmp/no_trailing.txt')` → `total_lines` is 3 (was 2), content shows `1|..`..`3|..`
3. `read_file(path, offset=1, limit=2)` → `truncated: true` with `Use offset=3 ... (showing 1-2 of 3 lines)`; `offset=3` returns `3|line3`
4. `pytest tests/tools/test_file_operations_edge_cases.py -q` → 26 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#3908 is stale/superseded, noted above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the full `tests/tools/` file/read surface instead (see note below)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (shell path via Git Bash tooling)

Note on the suite: the targeted run (`-k 'file or read or utf16 or eof'`, ~1370 tests) passes with the fix; 118 failures in that surface are byte-identical before and after the change (verified via stash + rerun diff) and are Windows-environment issues in this checkout (symlink privilege WinError 1314, basetemp path assertions, missing optional deps like `snowballstemmer`/`fcntl`). `ruff check` on both changed files passes.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A: behavior now matches documented line semantics; no new config/keys)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (fix verified on Windows shell path; native path is pure-Python byte counting; compound probe uses POSIX `tail`, already required by the read path)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A: schema unchanged, `total_lines` now correct)