### PR TITLE
fix(state): quarantine a corrupt/replaced handle out of rebuild_fts() too

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1208,7 +1208,8 @@ class SessionSearchMixin:
 
         Uses the FTS5 ``'rebuild'`` command, which rewrites the internal b-tree segments from the content
         rows. Unlike ``optimize_fts`` (which merges existing segments), ``rebuild`` discards and recreates
-        the index data entirely. See #50502.
+        the index data entirely — the more destructive of the two, so it is quarantined the same way. See
+        #50502.
         A full structural rebuild must never run concurrently in two processes sharing one state.db — that
         interleaving has structurally corrupted the database in production (PR #93200) — so this admits
         through the cross-process ``fts_rebuild_admission`` authority and FAILS CLOSED: if another process
@@ -1217,6 +1218,8 @@ class SessionSearchMixin:
         path, which retries in-process from the gateway housekeeping tick (``retry_deferred_fts_recovery``)
         and at next startup.
         """
+        self._raise_if_db_corrupt()
+        self._raise_if_db_replaced()
         rebuilt = 0
         with fts_rebuild_admission(self.db_path) as admitted:
             if not admitted:

--- a/tests/hermes_state/test_state_db_corrupt_quarantine.py
+++ b/tests/hermes_state/test_state_db_corrupt_quarantine.py
@@ -307,3 +307,26 @@ class TestVacuumAndMaintenanceRespectQuarantine:
             _clear_flag(db, flag_name)
             db._conn = real_conn
             db.close()
+
+    @pytest.mark.parametrize("flag_name,expected_exc", _QUARANTINE_FLAGS)
+    def test_rebuild_fts_refuses_when_quarantined(self, tmp_path, flag_name, expected_exc):
+        """rebuild_fts() is reachable outside _execute_write's own quarantine check — the gateway's
+        FTS-corruption transcript-retry path (gateway/session_transcript.py::_rebuild_fts_once)
+        calls it directly. Unlike optimize_fts ("merges existing segments"), rebuild_fts "discards
+        and recreates the index data entirely" — strictly more destructive — so it must refuse at
+        least as eagerly."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        real_conn = db._conn
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            db.append_message("s1", role="user", content="hello world")
+            recorder = _RecordingConn(real_conn)
+            db._conn = recorder
+            _force_flag(db, flag_name)
+            with pytest.raises(expected_exc):
+                db.rebuild_fts()
+            assert recorder.recorded == []
+        finally:
+            _clear_flag(db, flag_name)
+            db._conn = real_conn
+            db.close()


### PR DESCRIPTION
## Summary

`optimize_fts()` and `vacuum()` already refuse to run against a quarantined handle — `self._raise_if_db_corrupt()` / `self._raise_if_db_replaced()` before touching the connection — because either would rewrite index/file pages in place over damaged or foreign pages and commit the result back, turning contained, diagnosable corruption into an amplified one.

`rebuild_fts()` never got the same guard, despite being the *more* destructive of the two: its own docstring says it "discards and recreates the index data entirely", versus `optimize_fts`'s segment merge.

It's also independently reachable *outside* `_execute_write`'s own quarantine check (which protects every write that goes through the normal write path): `gateway/session_transcript.py`'s `_rebuild_fts_once()` calls `db.rebuild_fts()` directly from the FTS-corruption transcript-retry path, guarded only by a WAL split-brain / foreign-process-holder check — a different concern that says nothing about this process's own quarantine flags. A quarantined handle hitting that retry path would run a full FTS rebuild, and commit it, over a corrupt, replaced, or split-WAL-generation file.

## Fix

Add the same `self._raise_if_db_corrupt()` / `self._raise_if_db_replaced()` pair `optimize_fts()` already has, at the top of `rebuild_fts()`, before it enters the cross-process rebuild admission.

## Test plan

- [x] New parametrized test `test_rebuild_fts_refuses_when_quarantined` in `tests/hermes_state/test_state_db_corrupt_quarantine.py`, mirroring the existing `test_optimize_fts_refuses_when_quarantined`/`test_vacuum_refuses_when_quarantined` coverage across all three quarantine flags (`_db_corrupt`, `_db_replaced`, `_db_wal_generation_lost`), asserting the connection is never touched (`recorder.recorded == []`).
- [x] Mutation-verify: reverted just the production fix and confirmed all three parametrized cases fail (`DID NOT RAISE`); restored the fix and confirmed they pass again.
- [x] Full `tests/hermes_state/test_state_db_corrupt_quarantine.py` — 17 passed, 1 pre-existing skip.
- [x] Broader regression sweep — `tests/state/test_fts_runtime_rebuild.py`, `tests/state/test_fts_rebuild_admission.py`, `tests/test_hermes_state.py`, `tests/gateway/test_session.py` — 400 passed, 6 pre-existing skips.
- [x] `ruff check` clean on both changed files.

## Scope note

`_merge_fts_incrementally()` (and its only caller, `_try_incremental_merge_fts()`) runs the FTS5 `'merge'` command and carries a similar theoretical risk, but its only production call site is inside `_execute_write`'s own success path — `_execute_write` already calls `_raise_if_db_corrupt()`/`_raise_if_db_replaced()` at the top of its retry loop before that path can be reached, and there is no independent, quarantine-check-free call site for it the way `gateway/session_transcript.py` gives `rebuild_fts()`. Left out of this PR as lower-value, harder-to-justify scope.
