### PR TITLE
fix(agent): auto-focus deriver now sees a /steer row's text, not just skips it

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3686,10 +3686,22 @@ Write only the summary body. Do not include any preamble or prefix."""
         """Infer a compact focus hint from the most recent real user turns."""
         candidates: list[str] = []
         for msg in reversed(messages):
-            # display_kind notices are operational traffic, not user intent.
-            if msg.get("role") != "user" or cls._is_synthetic_compression_user_turn(msg) or msg.get("display_kind"):
+            if msg.get("role") != "user" or cls._is_synthetic_compression_user_turn(msg):
                 continue
-            text = _redact_compaction_text(_content_text_for_contains(msg.get("content")).strip())
+            display_kind = msg.get("display_kind")
+            # display_kind notices are operational traffic, not user intent — except a /steer row,
+            # which carries full user authority (mirrors _is_actionable_user_turn).
+            if display_kind and display_kind != STEER_DISPLAY_KIND:
+                continue
+            if display_kind == STEER_DISPLAY_KIND:
+                # A steer row's raw content is wrapped in an out-of-band marker meant for the
+                # model, not a human-readable focus hint — unwrap it the way the TUI history
+                # projection does.
+                from agent.conversation_compression import _extract_steer_text_from_message
+                raw_text = _extract_steer_text_from_message(msg) or ""
+            else:
+                raw_text = _content_text_for_contains(msg.get("content")).strip()
+            text = _redact_compaction_text(raw_text)
             if not text:
                 continue
             text = " ".join(text.split())

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -284,6 +284,30 @@ def test_background_process_notifications_do_not_become_compaction_anchors(
     assert compressor._find_last_user_message_idx(messages, head_end=0) == 0
 
 
+def test_steer_row_is_visible_to_auto_focus(compressor):
+    """A /steer row carries full user authority (see TestSteerRowIsHumanInput in
+    tests/run_agent/test_steer.py) but _derive_auto_focus_topic kept its own bare
+    ``msg.get("display_kind")`` skip that 26f4a674e0 never reached, despite that commit's own
+    message listing "auto-focus" among the fixed surfaces. A steer row must show up in the focus
+    hint, and with its unwrapped text — not the raw out-of-band marker boilerplate."""
+    from agent.prompt_builder import steer_user_row
+
+    human = {"role": "user", "content": "Add retries to the uploader."}
+    steer = steer_user_row("Actually, focus on the error handling in the retry loop.")
+    messages = [
+        human,
+        {"role": "assistant", "content": "Working on it.", "tool_calls": [{"id": "1"}]},
+        {"role": "tool", "tool_call_id": "1", "content": "some tool result"},
+        steer,
+    ]
+
+    assert compressor._derive_auto_focus_topic(messages) == (
+        "Recent user focus:\n"
+        "- Add retries to the uploader.\n"
+        "- Actually, focus on the error handling in the retry loop."
+    )
+
+
 @pytest.mark.parametrize(
     "content",
     [


### PR DESCRIPTION
## Summary

`26f4a674e0` ("a /steer row is human input for every user-turn predicate") whitelisted `STEER_DISPLAY_KIND` in `_is_actionable_user_turn` and `split_user_originated_turn`, and its own commit message explicitly lists the surfaces it restored: *"tail anchoring, auto-focus, dispatcher views, resume counts."*

But the function that actually **produces** the auto-focus hint, `_derive_auto_focus_topic`, carries its own independent, bare `msg.get("display_kind")` skip:

```python
if msg.get("role") != "user" or cls._is_synthetic_compression_user_turn(msg) or msg.get("display_kind"):
    continue
```

That commit never touched this line — its diff only changed `_is_actionable_user_turn` and `split_user_originated_turn`. So a `/steer` row was, and until this fix still is, dropped from every auto-compaction summary's focus hint — exactly the "most recent, most corrective mid-turn steering" a user would expect to survive compaction.

## Fix

Whitelist `STEER_DISPLAY_KIND` the same way `_is_actionable_user_turn` does. A steer row's raw `content` is wrapped in an out-of-band marker meant for the model (not human-readable), so extract the inner text via the established `_extract_steer_text_from_message` helper — the same one `tui_gateway/session_history.py`'s own history projection already uses for exactly this purpose — instead of feeding the raw marker boilerplate into the focus hint.

## Test plan

- [x] New test `test_steer_row_is_visible_to_auto_focus` in `tests/agent/test_context_compressor_zero_user_provenance.py`, using the established `steer_user_row()` helper (same one `tests/run_agent/test_steer.py::TestSteerRowIsHumanInput` uses) to build a realistic steer row, asserting it appears in the derived focus hint with its unwrapped text.
- [x] Mutation-verify: reverted just the production fix and confirmed the new test fails (steer row missing from the focus hint entirely); restored the fix and confirmed it passes again.
- [x] Full `tests/agent/test_context_compressor_zero_user_provenance.py` — 16 passed.
- [x] Broader regression sweep — `test_compaction_redaction_boundaries.py`, `test_compaction_ops_notification_anchor.py`, `tests/run_agent/test_steer.py`, and the full `tests/agent/test_context_compressor.py` — 214 passed.
- [x] Import sanity check (`agent.context_compressor` imports cleanly — no circular-import risk from the new local import, which mirrors the existing local-import pattern `tui_gateway/session_history.py` already uses for the same helper).
- [x] `ruff check` clean on both changed files.

## Note

`#92721` (open, unrelated) touches the same two files at a textually adjacent spot (a different constant/check in `_is_synthetic_compression_user_turn`, and a new test inserted right after the same anchor test) — no semantic overlap with `_derive_auto_focus_topic`, just a trivial rebase if both land.
