### PR TITLE
test(conftest): refuse test writes into the real ~/.hermes/profiles registry

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,9 @@ test runner at ``scripts/run_tests.sh``.
 
 import asyncio
 import atexit
+import builtins
 import importlib
+import io
 import os
 import shutil
 import sqlite3
@@ -739,6 +741,164 @@ def _kanban_write_guard(_hermetic_environment, monkeypatch):
         )
 
     monkeypatch.setattr(_kdbc, "connect", _guarded_connect)
+
+
+# ── Real profile-directory write guard ──────────────────────────────────────
+# Third sibling of the two guards around it (kanban DB, state DB), for the
+# operator's PROFILE REGISTRY: ``<real hermes root>/profiles/``.
+#
+# The incident: a full-suite run left eight fixture directories behind in a
+# live ``~/.hermes/profiles`` — ``builder-auth``, ``work`` (carrying a
+# ``config.yaml`` whose ``mcp_servers`` pointed at example.com), ``worker``,
+# ``coder``, ``demo``, ``ops``, ``secondary``, ``yangyang``. Nothing crashed;
+# the tests passed. But ``hermes profile list`` enumerates that directory, so
+# every one of them became a *profile of the fleet* — and the watchdogs that
+# fan out over profiles started reporting on agents that do not exist.
+#
+# A directory is all it takes: no config, no session, no registration. That is
+# why this guard sits on ``mkdir`` rather than on some Hermes-level "create
+# profile" entry point — the leak does not go through one.
+#
+# Deny-list, not allow-list, for the same reason as the kanban guard (#69385):
+# tests legitimately move HERMES_HOME to sibling tempdirs, so an allow-list
+# captured at setup time would reject hermetic tests. Only paths resolving
+# under the REAL profiles root — captured from the pre-sandbox environment at
+# import time — are refused. Reads are untouched.
+#
+# Installed at conftest IMPORT time, not as an autouse fixture: a leak can
+# happen while a test module is being imported (collection) or inside a
+# session-scoped fixture, and both of those run outside any autouse window.
+
+
+def _capture_real_profile_roots() -> tuple[Path, ...]:
+    """The profile registries a test must never write into.
+
+    Always the platform-default ``~/.hermes/profiles``: the leak vector is
+    code that reaches for ``Path.home() / ".hermes"`` instead of the canonical
+    ``get_hermes_home()``, and that code ignores HERMES_HOME by construction.
+
+    Plus, when the pre-sandbox environment named a genuinely CUSTOM root
+    (Docker/portable installs), that root's ``profiles/`` too — mirroring the
+    deny-list capture of the kanban guard above.
+    """
+    roots: list[Path] = []
+
+    def _add(profiles_dir: Path) -> None:
+        try:
+            resolved = profiles_dir.expanduser().resolve()
+        except (OSError, RuntimeError, ValueError):
+            return
+        if resolved not in roots:
+            roots.append(resolved)
+
+    _add(Path.home() / ".hermes" / "profiles")
+    if _PRE_SANDBOX_HERMES_HOME and not _hermes_home_points_at_production(
+        _PRE_SANDBOX_HERMES_HOME
+    ):
+        custom = Path(_PRE_SANDBOX_HERMES_HOME).expanduser()
+        # HERMES_HOME may itself BE a profile home: <root>/profiles/<name>.
+        if custom.parent.name == "profiles":
+            custom = custom.parent.parent
+        _add(custom / "profiles")
+    return tuple(roots)
+
+
+_REAL_PROFILE_ROOTS = _capture_real_profile_roots()
+# Cheap pre-filter so the common case costs one substring scan instead of a
+# ``resolve()`` syscall walk. Derived from the roots themselves — never a
+# hardcoded literal — so a relocated registry keeps its guard.
+_REAL_PROFILE_HINTS = tuple({root.name for root in _REAL_PROFILE_ROOTS})
+
+
+def _denied_real_profile_path(path) -> Path | None:
+    """Resolved path when *path* lands in a real profile registry, else None."""
+    if not _REAL_PROFILE_ROOTS:
+        return None
+    try:
+        raw = os.fspath(path)
+    except TypeError:
+        # An int fd (``open(fd)``) or something exotic — not a path we can
+        # place, and not a way to create a directory.
+        return None
+    if isinstance(raw, bytes):
+        try:
+            raw = os.fsdecode(raw)
+        except (UnicodeDecodeError, ValueError):
+            return None
+    if not any(hint in raw for hint in _REAL_PROFILE_HINTS):
+        return None
+    try:
+        resolved = Path(raw).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    for root in _REAL_PROFILE_ROOTS:
+        if resolved == root or root in resolved.parents:
+            return resolved
+    return None
+
+
+def _refuse_real_profile_write(resolved: Path, action: str) -> None:
+    # PYTEST_CURRENT_TEST is what turns "something leaked during the suite"
+    # into "THIS test leaked" — the whole reason the guard exists rather than
+    # a post-run `ls`.
+    where = os.environ.get("PYTEST_CURRENT_TEST") or (
+        "<no active test — collection, or a session/module-scoped fixture>"
+    )
+    raise RuntimeError(
+        f"real_profile_write_guard: {action} resolved to {resolved}, which is "
+        f"under the REAL profile registry "
+        f"({', '.join(str(r) for r in _REAL_PROFILE_ROOTS)}). A fixture "
+        f"profile created there is picked up by `hermes profile list` as a "
+        f"member of the operator's fleet. Point the write at HERMES_HOME "
+        f"(get_hermes_home()), not at Path.home() / '.hermes'. "
+        f"Offending test: {where}"
+    )
+
+
+_UNGUARDED_OS_MKDIR = os.mkdir
+_UNGUARDED_IO_OPEN = io.open
+
+
+def _install_real_profile_write_guard() -> None:
+    """Patch the two primitives that can plant a profile in the real registry.
+
+    ``os.mkdir`` covers ``os.makedirs`` and ``pathlib.Path.mkdir`` too — both
+    look the name up on the ``os`` module at call time.
+
+    ``io.open`` is patched as well as ``builtins.open`` because they are the
+    same object reached through two different module attributes:
+    ``Path.open`` / ``Path.write_text`` go through ``io.open``, so patching
+    only the builtin would leave the pathlib half unguarded.
+    """
+    if not _REAL_PROFILE_ROOTS:
+        return
+    if getattr(os.mkdir, "_hermes_real_profile_guard", False):
+        return  # already installed (conftest re-imported under another name)
+
+    def _guarded_mkdir(path, mode=0o777, *, dir_fd=None):
+        if dir_fd is None:
+            hit = _denied_real_profile_path(path)
+            if hit is not None:
+                _refuse_real_profile_write(hit, "mkdir()")
+        return _UNGUARDED_OS_MKDIR(path, mode, dir_fd=dir_fd)
+
+    _guarded_mkdir._hermes_real_profile_guard = True
+
+    def _guarded_open(file, mode="r", *args, **kwargs):
+        if any(flag in mode for flag in "wax+"):
+            hit = _denied_real_profile_path(file)
+            if hit is not None:
+                _refuse_real_profile_write(hit, f"open(mode={mode!r})")
+        return _UNGUARDED_IO_OPEN(file, mode, *args, **kwargs)
+
+    _guarded_open._hermes_real_profile_guard = True
+
+    os.mkdir = _guarded_mkdir
+    io.open = _guarded_open
+    builtins.open = _guarded_open
+
+
+_install_real_profile_write_guard()
 
 
 # ── Live state.db write guard ───────────────────────────────────────────────

--- a/tests/test_real_profile_write_guard.py
+++ b/tests/test_real_profile_write_guard.py
@@ -1,0 +1,182 @@
+"""Canary for the real profile-registry write guard in ``tests/conftest.py``.
+
+This file is the mutation probe: it performs, deliberately, exactly the leak
+the guard exists to stop — creating a profile directory under the operator's
+real ``~/.hermes/profiles`` — and asserts the guard refuses it. Weaken the
+guard and these tests stop raising, which is a failure here.
+
+Why the guard exists: a full-suite run once left eight fixture directories in a
+live ``~/.hermes/profiles`` (``builder-auth``, ``work``, ``worker``,
+``coder``, ``demo``, ``ops``, ``secondary``, ``yangyang``). Every test passed.
+But ``hermes profile list`` enumerates that directory, so the fixtures joined
+the operator's fleet as real profiles, and the per-profile watchdogs began
+reporting on agents that never existed.
+
+FAIL-CLOSED, like ``test_live_system_guard_self_test.py``: the primitives
+below are REAL ``mkdir``/``open`` calls aimed at the real home. In any
+collection context where this file is present but its home ``conftest.py`` is
+not (published sdists that ship ``tests/`` without ``conftest.py``, trees
+assembled by copying ``test*.py`` — that glob does not match ``conftest.py`` —
+``pytest --noconftest``, a foreign rootdir), the guard never loaded and the
+probe would BE the leak. So every test refuses to run unless the guard is
+provably installed.
+"""
+from __future__ import annotations
+
+import builtins
+import io
+import os
+import types
+from pathlib import Path
+
+import pytest
+
+#: Names used by the probes. Distinctive on purpose: if the guard ever fails
+#: open, `ls ~/.hermes/profiles` names the culprit file immediately.
+_PROBE_DIR = "zz-write-guard-probe-should-never-exist"
+_PROBE_FILE = "zz-write-guard-probe-should-never-exist.yaml"
+
+
+def _guard_is_active() -> bool:
+    """True iff conftest's guard has patched the write primitives.
+
+    Detected structurally, not by name: the guard replaces the C builtins with
+    plain Python functions carrying its marker attribute. An unpatched
+    ``os.mkdir`` is a ``types.BuiltinFunctionType``.
+    """
+    for primitive in (os.mkdir, io.open, builtins.open):
+        if isinstance(primitive, types.BuiltinFunctionType):
+            return False
+        if not getattr(primitive, "_hermes_real_profile_guard", False):
+            return False
+    return True
+
+
+@pytest.fixture(autouse=True)
+def _require_guard():
+    if not _guard_is_active():
+        pytest.fail(
+            "REFUSING TO RUN: the real-profile write guard from "
+            "tests/conftest.py is not installed, so the probes below would "
+            "actually create directories in the operator's ~/.hermes/profiles "
+            "— they ARE the leak they test for. Run this file from the repo "
+            "rootdir with its conftest.py, without --noconftest."
+        )
+
+
+@pytest.fixture
+def real_profiles_root() -> Path:
+    """The real registry the guard protects, read from the guard itself.
+
+    Taken from conftest rather than recomputed here: a probe that recomputed
+    the path would keep passing after the guard started watching a different
+    (or empty) set of roots.
+    """
+    from tests.conftest import _REAL_PROFILE_ROOTS
+
+    if not _REAL_PROFILE_ROOTS:
+        pytest.fail(
+            "the guard captured no profile roots — it is watching nothing"
+        )
+    return _REAL_PROFILE_ROOTS[0]
+
+
+def test_guard_watches_the_pre_sandbox_home_not_the_test_sandbox():
+    """The deny-list must point at the operator's home, not the tempdir.
+
+    This is the kanban guard's #69385 lesson restated: capture the real root
+    BEFORE the session sandbox rewires ``HERMES_HOME``, or the guard silently
+    protects a throwaway directory and stops protecting anything that matters.
+    """
+    from tests.conftest import _REAL_PROFILE_ROOTS
+
+    expected = (Path.home() / ".hermes" / "profiles").resolve()
+    assert expected in _REAL_PROFILE_ROOTS
+    # And the sandbox HERMES_HOME — the thing a naive capture would grab — is
+    # NOT what the guard is watching.
+    sandbox = Path(os.environ["HERMES_HOME"]).resolve() / "profiles"
+    assert sandbox not in _REAL_PROFILE_ROOTS
+
+
+def test_mkdir_of_a_fixture_profile_is_refused(real_profiles_root: Path):
+    """The leak itself: ``mkdir`` of a new profile under the real registry."""
+    victim = real_profiles_root / _PROBE_DIR
+    with pytest.raises(RuntimeError, match="real_profile_write_guard"):
+        victim.mkdir(parents=True, exist_ok=True)
+    assert not victim.exists(), f"guard failed open: {victim} was created"
+
+
+def test_makedirs_of_a_nested_fixture_path_is_refused(real_profiles_root: Path):
+    """``os.makedirs`` is the other spelling and must be covered too.
+
+    It is not a separate patch — ``os.makedirs`` resolves ``mkdir`` on the
+    ``os`` module at call time — but that is an implementation detail of
+    CPython, and this test is what notices if it ever stops being true.
+    """
+    victim = real_profiles_root / _PROBE_DIR / "skills" / "leak"
+    with pytest.raises(RuntimeError, match="real_profile_write_guard"):
+        os.makedirs(victim, exist_ok=True)
+    assert not (real_profiles_root / _PROBE_DIR).exists()
+
+
+def test_writing_a_config_into_the_real_registry_is_refused(
+    real_profiles_root: Path,
+):
+    """A file write is the same leak one level down.
+
+    The leaked directories were not all empty: ``work`` carried a
+    ``config.yaml`` with ``mcp_servers`` pointing at example.com. Writing into
+    an EXISTING real profile needs no ``mkdir`` at all.
+    """
+    victim = real_profiles_root / _PROBE_FILE
+    with pytest.raises(RuntimeError, match="real_profile_write_guard"):
+        with open(victim, "w", encoding="utf-8") as fh:
+            fh.write("mcp_servers: {}\n")
+    assert not victim.exists()
+
+    # pathlib reaches the same primitive through ``io.open``; patching only
+    # ``builtins.open`` would leave this half open.
+    with pytest.raises(RuntimeError, match="real_profile_write_guard"):
+        victim.write_text("mcp_servers: {}\n", encoding="utf-8")
+    assert not victim.exists()
+
+
+def test_the_refusal_names_the_offending_test(real_profiles_root: Path):
+    """A guard that fires anonymously turns a 2-second fix into a bisect."""
+    with pytest.raises(RuntimeError) as excinfo:
+        (real_profiles_root / _PROBE_DIR).mkdir()
+    message = str(excinfo.value)
+    assert "test_the_refusal_names_the_offending_test" in message
+    assert str(real_profiles_root) in message
+
+
+def test_reads_of_the_real_registry_still_work(real_profiles_root: Path):
+    """Deny-list, not a wall: the guard must not break reads.
+
+    Plenty of legitimate test code stats or lists paths under the real home;
+    only writes are the leak.
+    """
+    real_profiles_root.exists()
+    if real_profiles_root.is_dir():
+        list(real_profiles_root.iterdir())
+    with pytest.raises((FileNotFoundError, IsADirectoryError, PermissionError)):
+        # Opening a non-existent path for READING must fail the ordinary way,
+        # not with the guard's RuntimeError.
+        open(real_profiles_root / _PROBE_FILE, encoding="utf-8").close()
+
+
+def test_hermetic_writes_are_untouched(tmp_path: Path):
+    """The other half of "deny-list": ordinary tempdir work stays free.
+
+    Including a path that mentions ``profiles`` — the guard's cheap pre-filter
+    keys on that word, and a filter that turned into the verdict would reject
+    every hermetic profile fixture in the suite.
+    """
+    hermetic = tmp_path / "hermes_home" / "profiles" / "work"
+    hermetic.mkdir(parents=True)
+    (hermetic / "config.yaml").write_text("mcp_servers: {}\n", encoding="utf-8")
+    assert (hermetic / "config.yaml").read_text(encoding="utf-8")
+
+    nested = tmp_path / "deep"
+    os.makedirs(nested / "profiles" / "other")
+    assert (nested / "profiles" / "other").is_dir()


### PR DESCRIPTION
## The leak

A full-suite run left **eight fixture directories** behind in a live
`~/.hermes/profiles`: `builder-auth`, `work`, `worker`, `coder`, `demo`, `ops`,
`secondary`, `yangyang`. Every test passed. Nothing crashed.

But `hermes profile list` enumerates that directory, so each fixture joined the
operator's fleet **as a real profile**. Everything that fans out over profiles
started acting on agents that never existed — on the affected host a per-profile
watchdog spent two days posting "nowhere to subscribe" into chat every two
minutes, once per phantom.

`work` was not even empty: it carried a `config.yaml` whose `mcp_servers`
pointed at `example.com`. And `builder-auth` was a **complete profile
skeleton** — `config.yaml`, `.env`, `cron/`, `skills/` with the bundle,
`memories/`, `sessions/` — because the test called the real `create_profile`
path. So no downstream "is this a real profile?" heuristic can tell it apart:
the fixture is byte-for-byte what the product creates.

That is why this belongs here, at the write, rather than downstream at the read.

## The guard

Third sibling of the two guards already in `tests/conftest.py` — the kanban-DB
guard (#69283/#69385) and the state-DB guard — and built the same way:

- **Deny-list, not allow-list.** Only paths resolving under the REAL profiles
  registry are refused. Tests that legitimately move `HERMES_HOME` to sibling
  tempdirs are unaffected; reads are untouched.
- **Root captured pre-sandbox.** Same lesson as #69385: the real root is taken
  from the environment snapshot at the top of the file, before the session
  `HERMES_HOME` sandbox rewires anything. Capture it after and the guard
  faithfully protects a throwaway tempdir while the real home stays open.
- **Installed at conftest import, not as an autouse fixture.** A leak can happen
  while a test module is being imported (collection) or inside a session-scoped
  fixture; both run outside any autouse window.
- **`os.mkdir`** covers `os.makedirs` and `pathlib.Path.mkdir` — both resolve the
  name on the `os` module at call time. **`io.open`** is patched alongside
  `builtins.open` because they are the same object reached through two different
  module attributes, and `Path.open` / `Path.write_text` go through `io.open`.
- The refusal **names the offending test** (`PYTEST_CURRENT_TEST`). A guard that
  fires anonymously turns a two-second fix into a bisect.

## The probe

`tests/test_real_profile_write_guard.py` is the mutation probe: it performs the
leak deliberately — `mkdir`, `os.makedirs`, `open(..., "w")`, `Path.write_text`
aimed at the real registry — and asserts each one is refused and that nothing
was created. Weaken the guard and these tests stop raising, which is a failure.

It **fails closed**, like `test_live_system_guard_self_test.py`: the primitives
are real, so in any collection context where this file is present but its home
`conftest.py` is not (an sdist shipping `tests/` without `conftest.py`, a tree
assembled by copying `test*.py` — that glob does not match `conftest.py` —
`--noconftest`, a foreign rootdir) the probe would *be* the leak. Every test in
it refuses to run unless the guard is provably installed, detected structurally
(the guard replaces C builtins with plain Python functions carrying its marker).

Two more tests keep the guard honest in the other direction: reads of the real
registry still work, and ordinary hermetic `tmp_path` work — including paths
that contain the word `profiles`, which is the guard's cheap pre-filter — is
untouched.

## Verification

Run on a live host whose `~/.hermes/profiles` holds seven named profiles.

- `pytest tests/test_real_profile_write_guard.py` — **7 passed**, and
  `~/.hermes/profiles` unchanged afterwards.
- **Mutation:** with the guard's installation disabled, all 7 error out with the
  fail-closed refusal — and still create nothing, which is the point of the
  fail-closed design.
- **Full suite, single process** (`pytest tests`, 25m22s) and **full suite via
  `scripts/run_tests_parallel.py`** (per-file subprocesses, ~45k tests) with the
  guard armed. `hermes profile list` afterwards: unchanged, exactly the eight
  real profiles.
- **No collateral.** The 46 files that failed or errored in the parallel run
  were re-run twice each, guard on and guard off, on the same tree: **46/46
  identical outcomes, 0 differences.** Those failures are pre-existing in this
  checkout (a missing optional `acp` module, network/credential-dependent
  tests); none of them is the guard.

The guard did not fire in either run — the original leak does not reproduce on
today's `main`. That is a fine outcome for a fail-closed seat belt: it costs
nothing while the tree is clean, and the next time a test reaches for the real
registry it fails immediately and names itself, instead of being discovered
days later by a watchdog reporting on agents that do not exist.

## Known limit

The guard is in-process, like its two siblings: a test that shells out to a
subprocess which creates a profile is not covered. The state-DB guard solves
that half with a subprocess-surviving `HERMES_TEST_ISOLATION` marker checked
inside the product code; doing the same for profile creation would mean a check
in `hermes_cli/profiles.py`, which is a product change and deliberately out of
scope here.
