### PR TITLE
fix(telegram): normalize unicode dashes in bot menu descriptions

### DIFF
--- a/hermes_cli/commands_platforms.py
+++ b/hermes_cli/commands_platforms.py
@@ -38,6 +38,15 @@ def _sanitize_telegram_name(raw: str) -> str:
     return _TG_MULTI_UNDERSCORE.sub("_", name).strip("_")
 
 
+_TG_DASHES = re.compile("[\u2012\u2013\u2014\u2015\u2212]")
+
+
+def _normalize_telegram_desc(desc: str) -> str:
+    """Fold Unicode dashes (em/en/figure/horizontal-bar/minus) to ASCII ``-``.
+    BotFather rejects setMyCommands descriptions containing them (#2925)."""
+    return _TG_DASHES.sub("-", desc)
+
+
 def _truncate_desc(desc: str, limit: int) -> str:
     """Clamp a menu description to *limit* chars with a ``...`` tail."""
     return desc if len(desc) <= limit else desc[:limit - 3] + "..."
@@ -80,7 +89,7 @@ def telegram_bot_commands(*, include_plugins: bool = True) -> list[tuple[str, st
     if include_plugins:
         pairs += [(n, d) for n, d, hint in _iter_plugin_command_entries()
                   if not _requires_argument(hint)]
-    return [(tg, desc) for name, desc in pairs if (tg := _sanitize_telegram_name(name))]
+    return [(tg, _normalize_telegram_desc(desc)) for name, desc in pairs if (tg := _sanitize_telegram_name(name))]
 
 
 # Telegram allows 100 BotCommands; the 60-slot default keeps every built-in plus common skill
@@ -279,7 +288,7 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
                    for name, desc, cmd_key, raw in entries]
     candidates = _prioritize_telegram_menu_candidates(candidates)
     overflow_count = max(0, len(candidates) - max_commands)
-    menu = [(name, desc) for name, desc, _source, _raw_name in candidates[:max_commands]]
+    menu = [(name, _normalize_telegram_desc(desc)) for name, desc, _source, _raw_name in candidates[:max_commands]]
     return menu, hidden_count + overflow_count
 
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -172,6 +172,23 @@ class TestTelegramBotCommands:
         for name, _ in telegram_bot_commands():
             assert "-" not in name, f"Telegram command '{name}' contains a hyphen"
 
+    def test_no_unicode_dashes_in_descriptions(self):
+        """BotFather rejects setMyCommands descriptions with em/en dashes (#2925)."""
+        for name, desc in telegram_bot_commands():
+            assert not any(c in desc for c in "\u2012\u2013\u2014\u2015\u2212"), (
+                f"Telegram command '{name}' description has a Unicode dash: {desc!r}")
+
+    def test_unicode_dashes_folded_to_hyphen(self, monkeypatch):
+        """Stubbed registry entry with em/en dashes comes back hyphenated."""
+        fake = CommandDef(name="dashy", description="does a \u2014 b \u2013 c",
+                          category="Session")
+        monkeypatch.setattr("hermes_cli.commands_platforms._gateway_available_commands",
+                            lambda: [fake])
+        monkeypatch.setattr("hermes_cli.commands_platforms._iter_plugin_command_entries",
+                            lambda: iter([]))
+        assert ("dashy", "does a - b - c") in telegram_bot_commands(
+            include_plugins=False)
+
 
     def test_includes_builtin_commands_with_required_args(self):
         """Built-in arg-taking commands (e.g. /queue, /steer, /bg, /btw)


### PR DESCRIPTION
## What does this PR do?

BotFather rejects `setMyCommands` descriptions containing Unicode em/en dashes. `telegram_bot_commands` sanitized command *names* but passed *descriptions* through untouched, so any core/plugin/skill description with an em dash broke menu registration. Fold U+2012-U+2015/U+2212 to ASCII hyphen at the two Telegram sinks (`telegram_bot_commands`, `telegram_menu_commands`).

## Related Issue

Fixes #2925

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/commands_platforms.py`: new `_normalize_telegram_desc` helper + applied at both Telegram sinks
- `tests/hermes_cli/test_commands.py`: live-output property test (no Unicode dashes in any description) + stubbed-registry fold test

## How to Test

1. `pytest tests/hermes_cli/test_commands.py -q -k Telegram` → 21 passed
2. Stub a command with an em-dash description; `telegram_bot_commands()` returns it hyphenated

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#2927 closed unmerged; this is a fresh fix, not a duplicate)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
- [x] `ruff check` on both changed files passes

### Documentation & Housekeeping

- [x] N/A (no docs/config/schema changes); cross-platform: pure-Python string fold, platform-independent