### PR TITLE
fix(tools): fail vision analysis closed on empty content after retry

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -707,6 +707,21 @@ class TestErrorClassification:
         assert "rejected the image" in result["analysis"].lower()
         assert "smaller" in result["analysis"].lower()
 
+    @pytest.mark.asyncio
+    async def test_empty_after_retry_returns_failure(self, tmp_path):
+        """Empty vision content after retry must fail closed, not success-open (#6031)."""
+        img = tmp_path / "test.png"
+        img.write_bytes(VALID_PNG + b"\x00" * 8)
+
+        with (
+            patch("tools.vision_tools.async_call_llm", new=AsyncMock(return_value=MagicMock())),
+            patch("tools.vision_tools.extract_content_or_reasoning", return_value=""),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe", "test/model"))
+
+        assert result["success"] is False
+        assert "empty content" in result["error"].lower()
+
 
 class TestVisionRegistration:
     def test_vision_analyze_registered_with_schema(self):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -728,9 +728,17 @@ async def _run_analysis(
         logger.info("Analyzing %s: %s", kind, source[:60])
         logger.info("User prompt: %s", user_prompt[:100])
         analysis, scale_note = await stage(user_prompt, debug_call_data, temp_paths)
-        analysis_length = len(analysis) if analysis else 0
+        if not analysis:
+            error_msg = f"{tool_name} returned empty content after retry"
+            logger.error("%s", error_msg)
+            debug_call_data.update(success=False, analysis_length=0, error=error_msg)
+            return finish({
+                "success": False,
+                "error": error_msg,
+                "analysis": f"There was a problem with the request and the {kind} could not be analyzed.",
+            })
+        analysis_length = len(analysis)
         logger.info("%s analysis completed (%s characters)", kind.capitalize(), analysis_length)
-        analysis = analysis or f"There was a problem with the request and the {kind} could not be analyzed."
         result = {"success": True, "analysis": f"[{scale_note}] {analysis}" if scale_note else analysis}
         if scale_note:
             result["scale_note"] = scale_note


### PR DESCRIPTION
## What does this PR do?

`_run_analysis` (the shared image/video skeleton) returned `success: true` with a generic fallback message when the vision model yielded empty content even after the retry — hiding the failure from callers. Return `success: false` with an explicit empty-content error instead, for both paths.

## Related Issue

Fixes #6031
Supersedes #6029 (stale since July; same symptom on the pre-refactor monolith — re-applied at the shared skeleton, with credit to Tranquil-Flow)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py`: fail-closed branch in `_run_analysis` (mirrors the existing exception-path result shape, keeps debug logging via `finish()`)
- `tests/tools/test_vision_tools.py`: `test_empty_after_retry_returns_failure` (adapted from #6029 with a structurally-valid PNG, since corrupt-image gates now reject magic-bytes-only fakes)

## How to Test

1. Mock `async_call_llm` + `extract_content_or_reasoning` empty → `vision_analyze_tool` returns `success: false`, error mentions empty content
2. `pytest tests/tools/test_vision_tools.py -q -k 'ErrorClassification or empty_after_retry'` → passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#6029 stale/superseded, noted above)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
- [x] `ruff check` on both changed files passes

### Documentation & Housekeeping

- [x] N/A (no docs/config/schema changes; result shape matches the existing failure shape, so schema/consumers unaffected)