### PR TITLE
fix(spelling): OVERRIDEABLE_KEYS -> OVERRIDABLE_KEYS, interruptable comment

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -75,7 +75,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
 }
 
 # Canonical set of per-platform overrideable keys (for validation).
-OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
+OVERRIDABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 
 
 def resolve_display_setting(user_config: dict, platform_key: str, setting: str, fallback: Any = None) -> Any:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3298,7 +3298,7 @@ def _redirect_platform_display_key(key: str) -> tuple[str, Optional[str]]:
     """Canonicalize ``platforms.<name>.<display_setting>`` -> ``display.platforms.<name>.<setting>``.
     The gateway resolves per-platform display settings (streaming, show_reasoning, ...) from
     ``display.platforms``; the top-level ``platforms.<name>`` block holds only connection config.
-    Only known display settings (``OVERRIDEABLE_KEYS``) are redirected. Returns ``(key, note)``;
+    Only known display settings (``OVERRIDABLE_KEYS``) are redirected. Returns ``(key, note)``;
     the gateway import is guarded so the CLI works where the gateway package is unavailable.
 
     Before #71047 a write such as ``hermes config set platforms.telegram.streaming false`` landed on a key
@@ -3309,7 +3309,7 @@ def _redirect_platform_display_key(key: str) -> tuple[str, Optional[str]]:
     if len(segs) != 3 or segs[0] != "platforms":
         return key, None
     try:
-        from gateway.display_config import OVERRIDEABLE_KEYS as _display_keys
+        from gateway.display_config import OVERRIDABLE_KEYS as _display_keys
     except Exception:
         return key, None
     if segs[2] not in _display_keys:

--- a/tests/hermes_cli/test_config_set_platforms_redirect.py
+++ b/tests/hermes_cli/test_config_set_platforms_redirect.py
@@ -139,10 +139,10 @@ class TestRedirectSiblingSurfaces:
         assert "Set display.platforms.telegram.streaming = False" in out
 
     def test_redirect_helper_only_touches_known_display_keys(self):
-        from gateway.display_config import OVERRIDEABLE_KEYS
+        from gateway.display_config import OVERRIDABLE_KEYS
         from hermes_cli.config import _redirect_platform_display_key
 
-        for setting in OVERRIDEABLE_KEYS:
+        for setting in OVERRIDABLE_KEYS:
             canonical, note = _redirect_platform_display_key(f"platforms.discord.{setting}")
             assert canonical == f"display.platforms.discord.{setting}"
             assert note

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -926,7 +926,7 @@ def _split_wav_for_transcription(wav_path: str, *, max_file_size: int) -> List[s
     return chunk_paths
 
 
-# ── Audio playback (interruptable) ──
+# ── Audio playback (interruptible) ──
 _active_playback: Optional[subprocess.Popen] = None  # so stop_playback can interrupt it
 _playback_lock = threading.Lock()
 


### PR DESCRIPTION
## What does this PR do?

Finishes #9335: the codebase has converged on 'overridable' everywhere except the `OVERRIDEABLE_KEYS` constant (definition, one CLI import, one test) and a single 'interruptable' comment in voice_mode.py. Renames the constant at all sites; no behavior change.

## Related Issue

Fixes #9335
Supersedes #9336 (stale since July — same rename, re-applied to current main)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/display_config.py`, `hermes_cli/config.py` (import + docstring), `tests/hermes_cli/test_config_set_platforms_redirect.py`: constant rename
- `tools/voice_mode.py`: comment spelling
- Verified zero remaining `OVERRIDEABLE`/`interruptable` occurrences repo-wide

## How to Test

1. `pytest tests/hermes_cli/test_config_set_platforms_redirect.py -q` → 10 passed
2. `ruff check` on all four files passes

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#9336 stale/superseded, noted above)
- [x] My PR contains only changes related to this fix
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A (internal constant; grep confirms no docs/TS references)