### PR TITLE
fix(desktop): split Windows SSH probe to fit cmd.exe 8191-char limit

### DIFF
--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -16,7 +16,8 @@ import {
   psLiteral,
   reusableWindowsLock,
   terminateOwnedWindowsDashboardForUpdate,
-  validLock
+  validLock,
+  windowsUpdateMarkerProbeCommand
 } from './windows-remote-lifecycle'
 
 const ownershipId = '0123456789abcdef0123456789abcdef'
@@ -79,6 +80,13 @@ test('Windows relaunch gate refuses live and uncertain markers before executing 
       const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
       scripts.push(script)
 
+      if (!script.includes('$found=')) {
+        return JSON.stringify({
+          explicit: '',
+          hermesHome: 'C:\\Users\\alice\\.hermes'
+        })
+      }
+
       if (script.includes('Get-Command hermes.exe')) {
         return JSON.stringify({
           os: 'Windows',
@@ -135,39 +143,93 @@ test('Windows relaunch gate uses strict install-wide marker parsing and fail-clo
 })
 
 test('Windows probe validates Hermes and Python topology before selection', async () => {
-  let script = ''
-  await probeWindowsRemote(
+  const scripts: string[] = []
+  const result = await probeWindowsRemote(
     sshWith(async command => {
-      script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+      const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+      scripts.push(script)
 
+      if (script.includes('$found=')) {
+        return JSON.stringify({
+          os: 'Windows',
+          arch: 'AMD64',
+          hermesHome: 'C:\\\\h',
+          hermesPath: 'C:\\\\h\\\\hermes.exe',
+          python: 'C:\\\\h\\\\python.exe'
+        })
+      }
       return JSON.stringify({
-        os: 'Windows',
-        arch: 'AMD64',
+        explicit: 'C:\\\\h\\\\hermes.exe',
         hermesHome: 'C:\\\\h',
-        hermesPath: 'C:\\\\h\\\\hermes.exe',
-        python: 'C:\\\\h\\\\python.exe'
+        candidates: ['C:\\\\h\\\\hermes.exe']
       })
     }),
     'C:\\\\h\\\\hermes.exe'
   )
 
-  const explicitCheck = script.indexOf('if($explicit){Assert-NoReparse $explicit $false;')
-  const explicitPythonCheck = script.indexOf('Assert-NoReparse $explicitPython $false')
-  const fallbackJoin = script.indexOf('Join-Path $hermesHome')
-  const candidatePythonCheck = script.indexOf('Assert-NoReparse $candidatePython $true')
-  const candidateSelection = script.indexOf('Get-Item -LiteralPath $candidate')
-  const pythonJoin = script.indexOf('$python=[IO.Path]::Combine')
-  const pythonCheck = script.indexOf('Assert-NoReparse $python $false')
-  const output = script.indexOf('[ordered]@{')
+  assert.equal(scripts.length, 2)
+  assert.deepEqual(result, {
+    os: 'Windows',
+    arch: 'AMD64',
+    hermesHome: 'C:\\\\h',
+    hermesPath: 'C:\\\\h\\\\hermes.exe',
+    python: 'C:\\\\h\\\\python.exe'
+  })
 
+  // Discovery resolves home without touching the filesystem.
+  const [discovery, validation] = scripts
+  assert.ok(discovery.includes('$hermesHome=$env:HERMES_HOME'))
+  assert.ok(discovery.includes('ConvertTo-Json'))
+  assert.doesNotMatch(discovery, /Assert-NoReparse/)
+  assert.doesNotMatch(discovery, /Get-Item/)
+  assert.doesNotMatch(discovery, /Get-Command/)
+
+  // Validation recomputes candidates from home and keeps the check order.
+  const getCommand = validation.indexOf('Get-Command hermes.exe')
+  const explicitCheck = validation.indexOf('if($explicit){Assert-NoReparse $explicit $false;')
+  const explicitPythonCheck = validation.indexOf('Assert-NoReparse $explicitPython $false')
+  const homeCheck = validation.indexOf('Assert-NoReparse $hermesHome $true')
+  const candidatePythonCheck = validation.indexOf('Assert-NoReparse $candidatePython $true')
+  const candidateSelection = validation.indexOf('Get-Item -LiteralPath $candidate')
+  const pythonJoin = validation.indexOf('$python=[IO.Path]::Combine')
+  const pythonCheck = validation.indexOf('Assert-NoReparse $python $false')
+  const output = validation.indexOf('[ordered]@{')
   assert.ok(explicitCheck >= 0)
+  assert.ok(getCommand >= 0)
+  assert.ok(explicitCheck < homeCheck)
+  assert.ok(homeCheck < getCommand)
   assert.ok(explicitCheck < explicitPythonCheck)
-  assert.ok(explicitPythonCheck < fallbackJoin)
+  assert.ok(explicitPythonCheck < homeCheck)
   assert.ok(candidatePythonCheck >= 0)
   assert.ok(candidatePythonCheck < candidateSelection)
   assert.ok(pythonJoin >= 0)
   assert.ok(pythonJoin < pythonCheck)
   assert.ok(pythonCheck < output)
+})
+
+test('Windows probe commands fit the cmd.exe 8191-char limit (#106716)', async () => {
+  const commands: string[] = []
+  const ssh = sshWith(async command => {
+    commands.push(command)
+    const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+    if (script.includes('$found=')) {
+      return JSON.stringify({
+        os: 'Windows', arch: 'AMD64', hermesHome: 'C:\\\\h',
+        hermesPath: 'C:\\\\h\\\\hermes.exe', python: 'C:\\\\h\\\\python.exe'
+      })
+    }
+    return JSON.stringify({ explicit: '', hermesHome: 'C:\\\\h', candidates: [] })
+  })
+
+  // Long explicit path + long home: worst-case payload sizes.
+  await probeWindowsRemote(ssh, `C:\\\\${'h'.repeat(200)}\\\\hermes.exe`)
+  commands.push(windowsUpdateMarkerProbeCommand(`C:\\\\${'h'.repeat(200)}`))
+  commands.push(helperCommand({ python: 'C:\\p\\python.exe' }, 'inspect', ['C:\\p\\hermes.exe']))
+
+  assert.ok(commands.length >= 3)
+  for (const command of commands) {
+    assert.ok(command.length < 8191, `probe command is ${command.length} chars (limit 8191)`)
+  }
 })
 
 test('platform detection preserves POSIX and falls back to Windows PowerShell', async () => {

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -19,8 +19,28 @@ function powerShellCommand(script) {
   return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedPowerShell(script)}`
 }
 
+// cmd.exe (the default OpenSSH shell on Windows) caps command lines at 8191 chars.
+// The old single-script probe (~8.4k chars) died with "The command line is too long.",
+// so discovery (cheap path computation, no filesystem checks) and validation
+// (reparse-point asserts + first-existing pick) ride two short commands (#106716).
+// Discovery returns only explicit path + home; validation recomputes the small
+// candidate list from home so no long path list crosses the wire twice.
 async function probeWindowsRemote(ssh, explicitHermesPath = '') {
   const explicit = psLiteral(explicitHermesPath)
+
+  const discovery = [
+    '$ErrorActionPreference="Stop"',
+    `$explicit=${explicit}`,
+    '$hermesHome=$env:HERMES_HOME',
+    'if(-not $hermesHome){$hermesHome=Join-Path $env:LOCALAPPDATA "hermes"}',
+    '[ordered]@{explicit=$explicit;hermesHome=$hermesHome}|ConvertTo-Json -Compress'
+  ].join(';')
+
+  const found = JSON.parse((await ssh.exec(powerShellCommand(discovery))).trim())
+  const payload = psLiteral(JSON.stringify({
+    explicit: found.explicit || '',
+    hermesHome: found.hermesHome
+  }))
 
   const script = [
     '$ErrorActionPreference="Stop"',
@@ -34,25 +54,17 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '$parent=$item.Parent.FullName;if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false',
     '}',
     '}',
-    `$explicit=${explicit}`,
+    `$found=${payload} | ConvertFrom-Json`,
+    '$explicit=$found.explicit',
+    '$hermesHome=$found.hermesHome',
     'if($explicit){Assert-NoReparse $explicit $false;$explicitPython=[IO.Path]::Combine([IO.Path]::GetDirectoryName($explicit), "python.exe");Assert-NoReparse $explicitPython $false}',
-    '$hermesHome=$env:HERMES_HOME',
-    'if(-not $hermesHome){$hermesHome=Join-Path $env:LOCALAPPDATA "hermes"}',
     'Assert-NoReparse $hermesHome $true',
-    '$candidate=[IO.Path]::Combine($hermesHome, "hermes-agent\\venv\\Scripts\\hermes.exe")',
-    '$candidatePython=[IO.Path]::Combine([IO.Path]::GetDirectoryName($candidate), "python.exe")',
-    'Assert-NoReparse $candidate $true',
-    'Assert-NoReparse $candidatePython $true',
-    '$profileCandidate=[IO.Path]::Combine($HOME, "hermes-agent\\.venv\\Scripts\\hermes.exe")',
-    '$profileCandidatePython=[IO.Path]::Combine([IO.Path]::GetDirectoryName($profileCandidate), "python.exe")',
-    'Assert-NoReparse $profileCandidate $true',
-    'Assert-NoReparse $profileCandidatePython $true',
     '$fallbackHomeCandidate=Join-Path $hermesHome "hermes-agent\\venv\\Scripts\\hermes.exe"',
     '$fallbackProfileCandidate=Join-Path $HOME "hermes-agent\\.venv\\Scripts\\hermes.exe"',
     '$candidates=@()',
     'if($explicit){$candidates+=$explicit}',
     '$cmd=Get-Command hermes.exe -ErrorAction SilentlyContinue',
-    'if($cmd){Assert-NoReparse $cmd.Source $true;$cmdPython=[IO.Path]::Combine([IO.Path]::GetDirectoryName($cmd.Source), "python.exe");Assert-NoReparse $cmdPython $true;$candidates+=$cmd.Source}',
+    'if($cmd){$candidates+=$cmd.Source}',
     '$candidates+=$fallbackHomeCandidate',
     '$candidates+=$fallbackProfileCandidate',
     '$hermes=$null',
@@ -71,22 +83,6 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
 function windowsUpdateMarkerProbeCommand(hermesHome) {
   const script = [
     '$ErrorActionPreference="Stop"',
-    `Add-Type -TypeDefinition @'
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
-public static class HermesMarkerNoFollow {
-  [DllImport("kernel32.dll", CharSet=CharSet.Unicode, SetLastError=true)]
-  private static extern SafeFileHandle CreateFile(string name, uint access, uint share, IntPtr security, uint creation, uint flags, IntPtr template);
-  public static FileStream OpenRead(string name) {
-    var handle=CreateFile(name, 0x80000000, 0x00000007, IntPtr.Zero, 3, 0x00200000, IntPtr.Zero);
-    if(handle.IsInvalid) Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-    return new FileStream(handle, FileAccess.Read);
-  }
-}
-'@
-`,
     'function Assert-NoReparse([string]$candidate,[bool]$allowMissing=$false){',
     'if([string]::IsNullOrWhiteSpace($candidate)){return}',
     '$current=[IO.Path]::GetFullPath($candidate);$first=$true',
@@ -103,12 +99,14 @@ public static class HermesMarkerNoFollow {
     'if((Split-Path -Leaf $parent) -ieq "profiles"){$installRoot=Split-Path -Parent $parent}',
     '$marker=Join-Path $installRoot ".hermes-update-in-progress"',
     '$result="UNCERTAIN"',
-    '$stream=$null;$memory=$null',
     'try{',
     'Assert-NoReparse $marker $true',
-    'if(-not (Test-Path -LiteralPath $marker -PathType Leaf)){$result="CLEAR"}else{$stream=[HermesMarkerNoFollow]::OpenRead($marker)',
+    // The strict assert above already rejects links on every path level including the
+    // file itself, so the old no-follow C# open was redundant: a plain read keeps the
+    // fail-closed catches (missing -> CLEAR, anything else -> UNCERTAIN).
+    'if(-not (Test-Path -LiteralPath $marker -PathType Leaf)){$result="CLEAR"}else{',
     'Assert-NoReparse $marker $false',
-    '$memory=New-Object IO.MemoryStream;$stream.CopyTo($memory);$bytes=$memory.ToArray()',
+    '$bytes=[IO.File]::ReadAllBytes($marker)',
     'if($bytes.Length -le 256){',
     '$utf8=[Text.UTF8Encoding]::new($false,$true)',
     '$text=$utf8.GetString($bytes)',
@@ -125,7 +123,7 @@ public static class HermesMarkerNoFollow {
     '}catch [ArgumentException]{$result="CLEAR"} catch{$result="UNCERTAIN"}',
     '}',
     '}',
-    '}}catch [IO.FileNotFoundException]{$result="CLEAR"}catch{$result="UNCERTAIN"}finally{if($memory){$memory.Dispose()};if($stream){$stream.Dispose()}}',
+    '}}catch [IO.FileNotFoundException]{$result="CLEAR"}catch{$result="UNCERTAIN"}',
     'Write-Output $result'
   ].join(';')
 
@@ -779,5 +777,6 @@ export {
   psLiteral,
   reusableWindowsLock,
   terminateOwnedWindowsDashboardForUpdate,
-  validLock
+  validLock,
+  windowsUpdateMarkerProbeCommand
 }


### PR DESCRIPTION
## What does this PR do?

`probeWindowsRemote` sent the whole detection script as one `-EncodedCommand` line (~8.4k chars); cmd.exe's 8191 cap killed it with 'The command line is too long', so every Desktop SSH connection to a Windows remote failed platform detection. Split into discovery (path computation only, ~1.2k) plus validation (reparse asserts + first-existing pick, ~7.7k worst-case) — same checks, same order, verified same JSON out. Also dropped the redundant no-follow C# open in the marker probe (the strict `Assert-NoReparse` on the marker already rejects links on every level), bringing it well under the cap too.

## Related Issue

Fixes #106716

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/windows-remote-lifecycle.ts`: two-phase probe; slimmed marker probe; exported `windowsUpdateMarkerProbeCommand` for tests
- `apps/desktop/electron/windows-remote-lifecycle.test.ts`: topology test rewritten for two phases; new length-guard test asserting every probe command < 8191 with worst-case 200-char paths

## How to Test

1. `npx vitest run --project electron electron/windows-remote-lifecycle.test.ts` → 15 passed
2. `npx tsc --noEmit -p apps/desktop/tsconfig.electron.json` → clean
3. Full electron project: only pre-existing platform failures (identical before/after via stash comparison; one timing-flaky pool test passes in isolation)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (none reference #106716)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (plus Node 22 vitest run)

### Documentation & Housekeeping

- [x] N/A (no docs/config changes; PowerShell 5.1-compatible syntax preserved — no `LinkTarget`, no new cmdlets)