### PR TITLE
fix(telegram): preserve nested and multiline legacy emphasis

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4956,10 +4956,17 @@ class TelegramAdapter(BasePlatformAdapter):
             return _ph(f'*{_escape_mdv2(inner)}*')
 
         text = re.sub(r'^#{1,6}\s+(.+)$', _convert_header, text, flags=re.MULTILINE)
-        # 5) Bold **text** → *text*; 6) Italic *text* → _text_ ([^*\n]+ keeps matches on one line, or *
-        # bullet lists corrupt); 7) Strikethrough ~~text~~ → ~text~; 8) Spoiler ||text|| kept as-is.
-        text = re.sub(r'\*\*(.+?)\*\*', _ph_wrap('*', '*'), text)
-        text = re.sub(r'\*([^*\n]+)\*', _ph_wrap('_', '_'), text)
+        # Resolve nested/multiline asterisk emphasis before the final escaping pass.
+        from plugins.platforms.telegram.emphasis import protect_asterisk_emphasis
+
+        # Header/fence placeholders must still interrupt paragraphs during emphasis
+        # parsing. Their replacements have the same line count as their keys.
+        block_source = text
+        for key, value in placeholders.items():
+            if value.startswith(('```', '*')):
+                block_source = block_source.replace(key, '# protected block')
+        text = protect_asterisk_emphasis(text, _ph, _escape_mdv2, block_source=block_source)
+        # 7) Strikethrough ~~text~~ → ~text~; 8) Spoiler ||text|| kept as-is.
         text = re.sub(r'~~(.+?)~~', _ph_wrap('~', '~'), text)
         text = re.sub(r'\|\|(.+?)\|\|', _ph_wrap('||', '||'), text)
         # 9) Blockquotes: protect leading > from escaping; expandable quotes (**> starts, trailing || ends).

--- a/plugins/platforms/telegram/emphasis.py
+++ b/plugins/platforms/telegram/emphasis.py
@@ -1,0 +1,75 @@
+"""Asterisk emphasis for the legacy Telegram MarkdownV2 converter."""
+
+import re
+from collections.abc import Callable
+
+from markdown_it import MarkdownIt
+from markdown_it.rules_inline.emphasis import tokenize
+from markdown_it.rules_inline.escape import escape as tokenize_escape
+
+
+def _asterisks_only(state, silent):
+    return state.src[state.pos] == "*" and tokenize(state, silent)
+
+
+def _emphasis_escape(state, silent):
+    return state.src[state.pos:state.pos + 2] in (r"\*", r"\\") and tokenize_escape(state, silent)
+
+
+def protect_asterisk_emphasis(
+    text: str, protect: Callable[[str], str], escape: Callable[[str], str],
+    *, block_source: str,
+) -> str:
+    """Resolve emphasis within blocks, protecting complete spans from later passes."""
+    parser = MarkdownIt("commonmark")
+    parser.inline.ruler.enableOnly(["text", "escape", "emphasis"])
+    parser.inline.ruler.at("emphasis", _asterisks_only)
+    parser.inline.ruler.at("escape", _emphasis_escape)
+    # Use block source maps only: do not normalize or render the block structure,
+    # which would change whitespace, bullets, and the caller's NUL placeholders.
+    blocks = []
+    parser.block.parse(block_source, parser, {}, blocks)
+    lines = text.splitlines(keepends=True)
+    boundaries = {0, len(lines)}
+    for block in blocks:
+        if block.type == "inline" and block.map:
+            boundaries.update(block.map)
+    boundaries = sorted(boundaries)
+    parts = []
+    for start, end in zip(boundaries, boundaries[1:]):
+        tokens = []
+        parser.inline.parse("".join(lines[start:end]), parser, {}, tokens)
+        depth = {"*": 0, "**": 0}
+        span = []
+        line_start = True
+        for token in tokens:
+            if token.nesting:
+                line_start = False
+                marker = "*" if token.markup == "**" else "_"
+                if token.nesting == 1:
+                    if depth[token.markup] == 0:
+                        span.append(marker)
+                    depth[token.markup] += 1
+                else:
+                    depth[token.markup] -= 1
+                    if depth[token.markup] == 0:
+                        span.append(marker)
+                    if not any(depth.values()):
+                        parts.append(protect("".join(span)))
+                        span = []
+            else:
+                content = token.content
+                if any(depth.values()):
+                    # Quote continuation prefixes are structural, even inside a span.
+                    # A prefix at a token boundary is structural only at line start.
+                    prefix = "" if line_start else "x"
+                    quoted = re.sub(r"(?m)^(>{1,3}) ",
+                                    lambda m: protect(m.group(1)) + " ", prefix + content)
+                    span.append(escape(quoted[len(prefix):]))
+                elif token.type == "text_special":
+                    parts.append(protect(escape(content)))
+                else:
+                    parts.append(content)
+                if content:
+                    line_start = content.endswith("\n")
+    return "".join(parts)

--- a/tests/gateway/test_telegram_emphasis.py
+++ b/tests/gateway/test_telegram_emphasis.py
@@ -1,0 +1,61 @@
+"""Legacy Telegram emphasis preserves structure without consuming literal stars."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+@pytest.mark.parametrize(("source", "expected"), [
+    ("***both***", "_*both*_"),
+    ("**bold *italic* text**", "*bold _italic_ text*"),
+    ("*italic **bold** text*", "_italic *bold* text_"),
+    ("**bold\ntext**", "*bold\ntext*"),
+    ("**outer **inner** end**", "*outer inner end*"),
+    ("*outer *inner* end*", "_outer inner end_"),
+])
+@pytest.mark.asyncio
+async def test_legacy_send_preserves_emphasis(source, expected):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._rich_messages_enabled = False
+    adapter._bot = SimpleNamespace(send_message=AsyncMock(return_value=SimpleNamespace(message_id=1)))
+    result = await adapter.send("12345", source)
+    assert result.success
+    adapter._bot.send_message.assert_awaited_once()
+    sent = adapter._bot.send_message.call_args.kwargs
+    assert sent["text"] == expected
+    assert sent["parse_mode"] == "MarkdownV2"
+
+
+@pytest.mark.parametrize(("source", "expected"), [
+    ("**unclosed", r"\*\*unclosed"),
+    ("**a *b*> c**", r"*a _b_\> c*"),
+    ("line\\\n  next", "line\\\\\n  next"),
+    ("> *first\n> second*", "> _first\n> second_"),
+    ("Files: *.py\n# Heading\nFootnote*", "Files: \\*\\.py\n*Heading*\nFootnote\\*"),
+    ("Files: *.py\n```\ncode\n```\nFootnote*", "Files: \\*\\.py\n```\ncode\n```\nFootnote\\*"),
+    ("**bold ~~strike** tail~~", r"*bold \~\~strike* tail\~\~"),
+    ("**bold ||secret** tail||", r"*bold \|\|secret* tail\|\|"),
+    ("Files: *.py\n- Footnote*", "Files: \\*\\.py\n\\- Footnote\\*"),
+    ("_**(bold)**_", r"\_*\(bold\)*\_"),
+    ("Files: *.py\n\nFootnote*", "Files: \\*\\.py\n\nFootnote\\*"),
+    (r"\_prefix **value\_ suffix**", r"\\\_prefix *value\\\_ suffix*"),
+    ("trailing **", r"trailing \*\*"),
+    (r"\*literal\*", r"\*literal\*"),
+    ("2 * 3 * 4", r"2 \* 3 \* 4"),
+    ("*.py and *.md", r"\*\.py and \*\.md"),
+    ("* first\n* second", "\\* first\n\\* second"),
+    ("`***code***`", "`***code***`"),
+    ("```\n***code***\n```", "```\n***code***\n```"),
+    ("[link](https://example.com)", "[link](https://example.com)"),
+    ("~~strike~~ ||spoiler||", "~strike~ ||spoiler||"),
+    ("> quote", "> quote"),
+    ("**> quote||", "**> quote||"),
+    ("snake_case and _literal_", r"snake\_case and \_literal\_"),
+])
+def test_legacy_emphasis_preserves_other_content(source, expected):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    assert adapter.format_message(source) == expected


### PR DESCRIPTION
## What does this PR do?

Fixes valid nested/combined bold and italic and multiline bold in the legacy Telegram MarkdownV2 converter. The two sequential regular expressions consume each other's delimiters and escape inner formatting. Resolve asterisk emphasis together using the existing markdown-it dependency, without replacing the renderer.

Fixes #106891.

## Changes made

- Add a small `plugins/platforms/telegram/emphasis.py` helper using markdown-it's delimiter resolver; flatten redundant same-style nesting for Telegram.
- Keep code/link/header protections and the remaining legacy pipeline. Keep raw punctuation for asterisk-only delimiter resolution, protect complete formatted spans against crossing strike/spoiler matches, and use block source maps to prevent unrelated literal markers from pairing across blocks.
- Add two parametrized behavioral invariants: exact legacy `send()` payloads with rich messages disabled, and literal/protected syntax preservation (30 cases total).

No new dependency, configuration, rich-message change, malformed-output repair, or marker-stripping fallback. Related #55887 overlaps multiline bold but removes leftover markers rather than preserving this nested-emphasis/literal contract; #11287 proposes a substantially broader entities rewrite.

## Testing

On macOS, using `scripts/run_tests.sh`:

- Baseline `2db0c7a2d8f29debe7d1cbfb4a72f4f98dc00808`: ten failing cases (nested/multiline/send, quote continuation, escaped asterisks, multiplication and globs), twenty passing preservation cases.
- Final focused formatter suite: **72 passed**.
- Final Telegram/table-helper subsystem: **695 passed, two failed, two skipped**. Both failures are in `test_telegram_media_read_timeout.py`; both also fail on the unmodified baseline (`MagicMock` awaited in the existing media-send mock path).
- Ruff on all changed Python files: passed.

```bash
scripts/run_tests.sh -j 8 tests/gateway/test_telegram_emphasis.py tests/gateway/test_telegram_format.py
scripts/run_tests.sh -j 8 tests/gateway/test_telegram*.py tests/gateway/test_table_helpers.py
ruff check plugins/platforms/telegram/adapter.py plugins/platforms/telegram/emphasis.py tests/gateway/test_telegram_emphasis.py
```

The new tests inspect the actual outgoing MarkdownV2 payload; no live Telegram server/rendering or full-repository green result is claimed. AI-assisted implementation and automated review; every reported test result was actually run.

## Checklist

- [x] Read contribution guidance and searched existing open/closed issues and PRs.
- [x] Focused bug fix, conventional commit, behavioral regression tests.
- [x] No public API, config, schema or platform-specific filesystem/process changes.
- [ ] Full repository suite passes (not claimed; affected-surface results above).
