### PR TITLE
fix(gateway): recover stranded shutdown-flush messages into the Bot Chat session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5289,7 +5289,33 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
     def _recover_pending() -> None:
         from gateway.shutdown_flush import recover_pending_to_db
-        recovered = recover_pending_to_db()
+
+        def _resolve_bot_chat_fallback(session_key, _payload):
+            # Route an unresolvable flushed message into the owning profile's canonical "Bot Chat"
+            # (the session titled exactly BOT_CHAT_TITLE, per tools/bot_mode_probe). Without a
+            # session the flush file would be stranded and re-warned every restart, so land the
+            # message in a real session instead.
+            store = getattr(runner, "session_store", None)
+            if store is None:
+                return None
+            try:
+                db = store._db_for_key(session_key)
+                if db is None:
+                    return None
+                from tools.bot_mode_probe import BOT_CHAT_TITLE
+                row = db.get_session_by_title(BOT_CHAT_TITLE)
+                if row and row.get("id"):
+                    return str(row["id"])
+                import uuid
+                session_id = f"bot_chat_{uuid.uuid4().hex}"
+                db.create_session(session_id, source="cli")
+                db.set_session_title(session_id, BOT_CHAT_TITLE)
+                return session_id
+            except Exception:
+                logger.exception("Could not resolve Bot Chat fallback session for %s", session_key)
+                return None
+
+        recovered = recover_pending_to_db(resolve_fallback_session_id=_resolve_bot_chat_fallback)
         if recovered:
             logger.info("Recovered %d pending message(s) from shutdown flush", recovered)
 

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -198,10 +198,13 @@ def _serialise_value(value: Any) -> Optional[dict]:
     return {"text": str(value)}
 
 
-def recover_pending_to_db(session_db=None) -> int:
+def recover_pending_to_db(session_db=None, resolve_fallback_session_id=None) -> int:
     """Replay flush-dir ``*.json`` files via ``SessionDB.append_message``, deleting each on success.
 
     ``session_db=None`` opens (and afterwards releases) the shared default ``state.db``.
+    ``resolve_fallback_session_id``, when provided, is a ``(session_key, payload) -> Optional[str]``
+    callback consulted for a payload whose serialised ``data`` carries no ``session_id``; its
+    non-None result routes the message instead of stranding the flush file forever.
     Returns the number of messages recovered.
     """
     flush_files = sorted(_get_flush_dir().glob("*.json"))
@@ -218,7 +221,10 @@ def recover_pending_to_db(session_db=None) -> int:
             # Agent-history snapshots are for manual operator recovery, not automatic DB insertion.
             if payload.get("reason") == "shutdown-with-unpersisted-agent-history":
                 continue
-            if _recover_one_payload(session_db, path, payload):
+            if _recover_one_payload(
+                session_db, path, payload,
+                resolve_fallback_session_id=resolve_fallback_session_id,
+            ):
                 recovered += 1
                 path.unlink(missing_ok=True)
     finally:
@@ -231,7 +237,8 @@ def recover_pending_to_db(session_db=None) -> int:
     return recovered
 
 
-def _recover_one_payload(session_db, path: Path, payload: Dict[str, Any]) -> bool:
+def _recover_one_payload(session_db, path: Path, payload: Dict[str, Any],
+                         resolve_fallback_session_id=None) -> bool:
     """Append one flush payload to ``session_db``; False (file kept) when structurally invalid."""
     # Cap-dropped transcript payloads carry the full message dict keyed by session_id — replay directly
     # (#78182). This handles spool files that were never drained before a restart.
@@ -254,11 +261,14 @@ def _recover_one_payload(session_db, path: Path, payload: Dict[str, Any]) -> boo
                        "the flush file has been preserved", path)
         return False
     # session_key is a gateway routing key (e.g. "agent:main:telegram:..."); appending a row
-    # needs the real session_id, which only the serialised data can supply at this stage.
+    # needs the real session_id, supplied by the serialised data or, failing that, the fallback
+    # resolver (which routes an unresolvable message into the owner's canonical "Bot Chat").
     session_id = data.get("session_id", "")
+    if not session_id and resolve_fallback_session_id is not None:
+        session_id = resolve_fallback_session_id(session_key, payload) or ""
     if not session_id:
         logger.warning("Cannot recover pending message for %s: no session_id in flush file and "
-                       "session_key-to-id resolution is not available at this recovery stage. "
+                       "the fallback session resolver yielded none. "
                        "The message text is preserved in %s", session_key, path)
         return False
     session_db.append_message(session_id=session_id, role="user", content=text,

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -134,6 +134,111 @@ def test_recover_closes_owned_db_when_unexpected_exception_escapes(
     assert db.released is True
 
 
+def test_recover_routes_unresolvable_payload_to_fallback_session(tmp_path, monkeypatch):
+    """A payload whose data has no session_id must be recovered into the fallback-provided
+    session (append_message called with that id) and unlinked, not stranded (#72680)."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    ts = int(time.time())
+    flush_file = flush_dir / "pending_no_sid.json"
+    flush_file.write_text(
+        json.dumps(
+            {
+                "session_key": "agent:main:telegram:dm:123",
+                "reason": "shutdown",
+                "ts": ts,
+                "data": {"text": "stranded message"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    mock_db = MagicMock()
+    seen = {}
+
+    def resolve_fallback(session_key, payload):
+        seen["session_key"] = session_key
+        seen["payload"] = payload
+        return "fallback_bot_chat_session"
+
+    count = recover_pending_to_db(mock_db, resolve_fallback_session_id=resolve_fallback)
+
+    assert count == 1
+    assert seen["session_key"] == "agent:main:telegram:dm:123"
+    assert seen["payload"]["data"]["text"] == "stranded message"
+    mock_db.append_message.assert_called_once_with(
+        session_id="fallback_bot_chat_session",
+        role="user",
+        content="stranded message",
+        timestamp=ts,
+    )
+    assert not flush_file.exists()
+
+
+def test_recover_skips_fallback_when_session_id_present(tmp_path, monkeypatch):
+    """The fallback resolver must NOT be consulted when data already carries a session_id."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    ts = int(time.time())
+    (flush_dir / "pending_with_sid.json").write_text(
+        json.dumps(
+            {
+                "session_key": "agent:main:telegram:dm:123",
+                "reason": "shutdown",
+                "ts": ts,
+                "data": {"text": "normal message", "session_id": "real_session"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    mock_db = MagicMock()
+    fallback_calls = []
+
+    def resolve_fallback(session_key, payload):
+        fallback_calls.append((session_key, payload))
+        return "should_not_be_used"
+
+    count = recover_pending_to_db(mock_db, resolve_fallback_session_id=resolve_fallback)
+
+    assert count == 1
+    assert fallback_calls == []
+    mock_db.append_message.assert_called_once_with(
+        session_id="real_session",
+        role="user",
+        content="normal message",
+        timestamp=ts,
+    )
+
+
+def test_recover_still_strands_when_fallback_returns_none(tmp_path, monkeypatch):
+    """If the fallback also yields nothing, the file must stay preserved (not falsely unlinked)."""
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    flush_file = flush_dir / "pending_unresolvable.json"
+    flush_file.write_text(
+        json.dumps(
+            {
+                "session_key": "agent:main:telegram:dm:123",
+                "reason": "shutdown",
+                "data": {"text": "still stranded"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    mock_db = MagicMock()
+
+    def resolve_fallback(session_key, payload):
+        return None
+
+    count = recover_pending_to_db(mock_db, resolve_fallback_session_id=resolve_fallback)
+
+    assert count == 0
+    mock_db.append_message.assert_not_called()
+    assert flush_file.exists()
+
+
 def test_serialise_object_with_text():
     obj = MagicMock()
     obj.text = "msg"


### PR DESCRIPTION
## What

Shutdown-flush payloads carrying no `session_id` were stranded in the flush dir and re-warned on every restart. This adds a `resolve_fallback_session_id` callback to `recover_pending_to_db()` that routes such messages into the owning profile's canonical Bot Chat session (creating it on demand) instead of stranding them.

## Scope

- `gateway/shutdown_flush.py` — `recover_pending_to_db()`/`_recover_one_payload()` accept an optional `(session_key, payload) -> Optional[str]` callback.
- `gateway/run.py` — wires the callback to resolve via the runner's session store.
- `tests/gateway/test_shutdown_flush.py` — 105 lines of new coverage for the fallback path.

## Test

`python -m pytest tests/gateway/test_shutdown_flush.py`