### PR TITLE
fix(agent): route partial 413s through byte recovery

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2178,7 +2178,7 @@ def cleanup_task_resources(agent, task_id: str) -> None:
 
 
 def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, usage_obj, *,
-    dropped_tool_names=None, overflow_terminal=False):
+    dropped_tool_names=None, overflow_terminal=False, payload_too_large_error=None):
     """Stub for an SSE stream that ended without ``finish_reason`` after
     delivering content. Tagged ``PARTIAL_STREAM_STUB_ID`` + ``FINISH_REASON_LENGTH``
     so the loop enters its continuation/retry path instead of accepting
@@ -2188,6 +2188,11 @@ def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, u
     context-overflow error. Seeding the recovered text as a continuation stub
     would grow every later request into the same overflow (#106260); the loop
     treats the marker as terminal and ends the turn via the recovery contract.
+
+    ``payload_too_large_error``: the stream delivered content before an in-band
+    413 error. The response check re-raises this original error so the outer
+    retry loop reaches the byte-scored 413 recovery owner instead of treating
+    the fragment as a length continuation.
     """
     return SimpleNamespace(
         id=PARTIAL_STREAM_STUB_ID,
@@ -2201,6 +2206,7 @@ def _build_partial_stream_stub(role, full_content, full_reasoning, model_name, u
         usage=usage_obj,
         _dropped_tool_names=dropped_tool_names or None,
         _overflow_terminal=overflow_terminal,
+        _payload_too_large_error=payload_too_large_error,
     )
 
 
@@ -3278,6 +3284,7 @@ class _StreamingCall(StreamingWaitMonitor):
             from agent.error_classifier import classify_api_error
             _cls = classify_api_error(
                 error, provider=str(getattr(self.agent, "provider", "") or ""), model=str(getattr(self.agent, "model", "") or ""))
+        _is_payload_overflow = _cls is not None and _cls.reason == FailoverReason.payload_too_large
         _reset_stale_streak(self.agent)  # deltas fired => provider responsive: clear the breaker
         # #106260: continuing after a context-overflow error re-sends a larger request into the
         # same overflow. Return an EMPTY stub marked terminal so the loop ends the turn instead.
@@ -3294,12 +3301,21 @@ class _StreamingCall(StreamingWaitMonitor):
                 dropped_tool_names=_partial_names, overflow_terminal=True,
             )
         if not _partial_names:
-            logger.warning(
-                "Partial stream delivered before error; returning length-truncated stub with %s chars of "
-                "recovered content so the loop can continue from where the stream died: %s",
-                len(_partial_text or ""), error)
-        _stub = _build_partial_stream_stub("assistant", _partial_text, None,
-            getattr(self.agent, "model", "unknown"), None, dropped_tool_names=_partial_names)
+            if _is_payload_overflow:
+                logger.warning(
+                    "Partial stream delivered before a payload-too-large error; returning a marker for "
+                    "byte-scored recovery with %s chars of recovered content: %s",
+                    len(_partial_text or ""), error)
+            else:
+                logger.warning(
+                    "Partial stream delivered before error; returning length-truncated stub with %s chars of "
+                    "recovered content so the loop can continue from where the stream died: %s",
+                    len(_partial_text or ""), error)
+        _stub = _build_partial_stream_stub(
+            "assistant", _partial_text, None, getattr(self.agent, "model", "unknown"), None,
+            dropped_tool_names=_partial_names,
+            payload_too_large_error=(error if _is_payload_overflow else None),
+        )
         if _cls is not None and _cls.reason == FailoverReason.content_policy_blocked:
             _stub._content_filter_terminated = True
         return _stub

--- a/agent/turn_response_check.py
+++ b/agent/turn_response_check.py
@@ -161,6 +161,13 @@ def check_api_response(
         return _verdict("break")
 
     if finish_reason == "length":
+        # A 413 may arrive as an in-band error after a stream already delivered
+        # deltas. Re-raise it before truncation recovery so the outer loop reaches
+        # turn_overflow._recover_payload_too_large; appending the partial fragment
+        # here would bypass byte-scored image recovery and grow the transcript.
+        _partial_payload_error = getattr(response, "_payload_too_large_error", None)
+        if _partial_payload_error is not None:
+            raise _partial_payload_error
         _tv = recover_from_truncation(
             agent, response, finish_reason, _retry, messages=messages,
             conversation_history=conversation_history, api_kwargs=api_kwargs,

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -153,6 +153,45 @@ def test_current_user_turn_is_persisted_before_provider_call(agent):
 class TestHTTP413Compression:
     """413 errors should trigger compression, not abort as generic 4xx."""
 
+    def test_in_stream_413_reenters_byte_scored_recovery(self, agent):
+        """A 413 arriving after a stream delta must use the normal 413 owner.
+
+        The partial response is deliberately not appended to the transcript:
+        the outer API-error handler must receive the original error and run the
+        byte-scored recovery path before the next request is built.
+        """
+        from agent.chat_completion_helpers import _build_partial_stream_stub
+
+        err_413 = _make_413_error()
+        partial = _build_partial_stream_stub(
+            "assistant", "partial stream text", None, "test/model", None,
+            payload_too_large_error=err_413,
+        )
+        ok_resp = _mock_response(content="Recovered after streamed 413", finish_reason="stop")
+        agent._has_stream_consumers = lambda: True
+        agent._interruptible_streaming_api_call = MagicMock(side_effect=[partial, ok_resp])
+
+        with (
+            patch.object(agent, "_compress_context", return_value=(
+                [{"role": "user", "content": "compressed"}],
+                "compressed prompt",
+            )) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "continue",
+                conversation_history=[{"role": "user", "content": "old context"}],
+            )
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after streamed 413"
+        assert agent._interruptible_streaming_api_call.call_count == 2
+        mock_compress.assert_called_once()
+        assert all(message.get("content") != "partial stream text" for message in result["messages"])
+        assert not any(message.get("_length_continuation_nudge") for message in result["messages"])
+
     def test_413_triggers_compression(self, agent):
         """A 413 error should call _compress_context and retry, not abort."""
         # First call raises 413; second call succeeds after compression.

--- a/tests/run_agent/test_overflow_partial_terminal_106260.py
+++ b/tests/run_agent/test_overflow_partial_terminal_106260.py
@@ -78,7 +78,7 @@ class TestOverflowTerminalStub:
     ):
         """Review P1 (andrexibiza): payload_too_large (413) has its own byte-scored
         recovery owner and must NOT be collapsed into the context-overflow terminal
-        contract — the partial keeps its normal continuation stub."""
+        contract — the partial keeps its content for that owner."""
         def _overflowing_stream():
             yield _make_stream_chunk(content="some media-heavy partial output ...")
             raise RuntimeError(
@@ -97,8 +97,73 @@ class TestOverflowTerminalStub:
 
         assert response.id == PARTIAL_STREAM_STUB_ID
         assert getattr(response, "_overflow_terminal", False) is False
-        # The recovered text is preserved for the normal continuation path.
+        assert getattr(response, "_payload_too_large_error", None) is not None
+        # The recovered text is preserved for the byte-scored overflow owner.
         assert response.choices[0].message.content == "some media-heavy partial output ..."
+
+
+    def test_payload_too_large_partial_returns_to_overflow_owner_before_continuation(self):
+        """An in-stream 413 must be re-raised to the outer API-error handler.
+
+        The outer handler owns ``turn_overflow._recover_payload_too_large``;
+        letting this response enter ``recover_from_truncation`` would append the
+        partial fragment and continuation nudge to the transcript first.
+        """
+        from agent.turn_response_check import check_api_response
+
+        error = RuntimeError("Request entity too large")
+        response = SimpleNamespace(
+            id=PARTIAL_STREAM_STUB_ID,
+            _payload_too_large_error=error,
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="partial", tool_calls=None),
+                finish_reason=FINISH_REASON_LENGTH,
+            )],
+            usage=None,
+        )
+        agent = MagicMock()
+        agent.api_mode = "chat_completions"
+        agent.quiet_mode = True
+        agent.verbose_logging = False
+        agent.thinking_callback = None
+        agent._get_transport.return_value.validate_response.return_value = True
+        agent._get_transport.return_value.normalize_response.return_value = SimpleNamespace(
+            finish_reason=FINISH_REASON_LENGTH,
+        )
+        agent._should_treat_stop_as_truncated.return_value = False
+        messages = [{"role": "user", "content": "unchanged"}]
+
+        with pytest.raises(RuntimeError, match="Request entity too large") as raised:
+            check_api_response(
+                agent,
+                response=response,
+                _retry=MagicMock(),
+                thinking_spinner=None,
+                messages=messages,
+                api_messages=messages,
+                api_kwargs={},
+                active_system_prompt=None,
+                conversation_history=None,
+                finish_reason=None,
+                retry_count=0,
+                max_retries=3,
+                compression_attempts=0,
+                max_compression_attempts=3,
+                length_continue_retries=0,
+                truncated_response_parts=[],
+                truncated_tool_call_retries=0,
+                current_turn_user_idx=0,
+                api_call_count=1,
+                api_request_id=None,
+                api_start_time=0.0,
+                effective_task_id=None,
+                turn_id=None,
+                _preflight_compression_blocked=False,
+                _last_preflight_pressure=None,
+            )
+
+        assert raised.value is error
+        assert messages == [{"role": "user", "content": "unchanged"}]
 
 
 class TestRecoverFromTruncationOverflowTerminal:


### PR DESCRIPTION
## Summary

Follow-up to #106275 and #106260. Route a payload-too-large error that arrives after partial stream delivery back through the existing byte-scored 413 recovery owner instead of treating it as ordinary output truncation.

## Reproduction

A wire-compatible local fixture reproduced the missing path:

1. The provider returns HTTP 200 and delivers one SSE delta.
2. The stream then emits an in-band payload-too-large error.
3. The OpenAI SDK raises `APIError` after the partial delta.
4. Before this change, Hermes converted it into a normal `partial-stream-stub` and `recover_from_truncation()` appended the partial text plus a continuation nudge.
5. Repeated attempts grew the serialized transcript: 14,330 -> 28,625 -> 42,920 bytes in three continuation attempts.

A normal HTTP 413 remains a pre-stream error: the SDK receives `APIStatusError(status_code=413)` before any chunks, so it already reaches the dedicated 413 recovery path.

## Root cause

`_partial_stream_stub()` already classified the in-band error as `FailoverReason.payload_too_large`, but discarded that cause when building the synthetic length stub. `turn_response_check` therefore could only see `finish_reason="length"` and sent the response through `recover_from_truncation()`.

## Fix

- Preserve the original payload-too-large exception on the partial stub.
- Re-raise it from `turn_response_check` before truncation recovery mutates `messages`.
- Let the outer API-error handler call `turn_overflow._recover_payload_too_large`, preserving byte-based progress scoring and image/media recovery.
- Keep the existing `_overflow_terminal` behavior for `context_overflow` only.
- Keep ordinary network partials, content-policy handling, and genuine output-length continuation behavior unchanged.

## Tests

- `HERMES_PYTHON='C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe' scripts/run_tests.sh tests/run_agent/test_overflow_partial_terminal_106260.py tests/run_agent/test_413_compression.py tests/run_agent/test_partial_stream_finish_reason.py tests/run_agent/test_streaming.py tests/run_agent/test_1630_context_overflow_loop.py tests/run_agent/test_compression_lock_defer.py`
  - 6 files, 121 tests passed, 0 failed.
- Final changed-path regression run with `scripts/run_tests.sh`
  - 4 tests passed, 0 failed.
- `ruff check agent/chat_completion_helpers.py agent/turn_response_check.py tests/run_agent/test_overflow_partial_terminal_106260.py tests/run_agent/test_413_compression.py`
  - All checks passed.
- `git diff --check origin/main...HEAD`
  - Passed.
- The new response-check regression was verified RED on the pre-fix implementation: 2 selected tests failed with the expected missing reroute/marker behavior, then passed after the fix.

## Scope and compatibility

- This does not terminalize all 413s; the existing byte-scored owner remains active.
- Context-overflow stream deaths still use the terminal clean-session contract from #106260.
- The partial text is never appended to durable transcript history before 413 recovery runs.
- No new dependency, credential, system-prompt, or toolset behavior is introduced.

Related work:

- #106260 — original context-overflow partial-stub growth bug.
- #106275 — superseded implementation and maintainer discussion.
- #106567 — merged context-overflow fix.
- #66358 — related generic in-stream 4xx status classification; it does not implement this 413 recovery handoff.
