### PR TITLE
fix(agent): lift named custom provider key when a task base_url flattens it to bare custom

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4533,6 +4533,32 @@ def _resolve_xai_oauth_branch(req: _ResolveRequest) -> _ResolveResult:
                           "OAuth token found (run: hermes model -> xAI Grok OAuth — SuperGrok / Premium+)")
 
 
+def _named_custom_key_for_base_url(req: _ResolveRequest, custom_base: str) -> Any:
+    """Credential for the configured custom-provider entry whose endpoint equals ``custom_base``.
+
+    Closes the #34651 credential gap: a named custom provider pinned in ``auxiliary.<task>`` alongside a
+    task-level ``base_url`` (the shape the desktop GUI persists, #65254) is flattened to bare ``custom``
+    before ``_resolve_named_custom_branch`` can read the entry's own key — the entry is only reachable
+    from its URL here. Honors ``req.api_mode`` (skip when the caller already pinned a transport), and
+    never returns a key for an entry whose own ``api_mode`` contradicts the requested one (an
+    anthropic_messages entry must not donate a key to a chat_completions request and vice versa).
+    """
+    if not custom_base:
+        return ""
+    try:
+        from hermes_cli.runtime_provider import find_custom_provider_entry
+        entry = find_custom_provider_entry(custom_base)
+    except ImportError:
+        return ""
+    if not entry:
+        return ""
+    if req.api_mode:
+        entry_mode = str(entry.get("api_mode") or "").strip().lower()
+        if entry_mode and entry_mode != str(req.api_mode).strip().lower():
+            return ""
+    return _named_custom_api_key(entry, str(entry.get("name") or "custom"), custom_base) or ""
+
+
 def _resolve_custom_branch(req: _ResolveRequest) -> _ResolveResult:
     """Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY)."""
     provider, model, main_runtime = req.provider, req.model, req.main_runtime
@@ -4546,6 +4572,7 @@ def _resolve_custom_branch(req: _ResolveRequest) -> _ResolveResult:
             wrap_base = (req.explicit_base_url or "").strip().rstrip("/")
         custom_key = (
             (req.explicit_api_key or "").strip()
+            or _named_custom_key_for_base_url(req, custom_base)
             or _scoped_key_env("OPENAI_API_KEY")
             or _read_main_api_key_if_same_host(custom_base)
             or "no-key-required"  # local servers don't need auth
@@ -4617,7 +4644,14 @@ def _resolve_named_custom_branch(req: _ResolveRequest) -> Optional[_ResolveResul
     if not custom_entry:
         return None
     custom_base = (custom_entry.get("base_url") or "").strip()
-    custom_key = _named_custom_api_key(custom_entry, provider, custom_base)
+    # Explicit per-task api_key (e.g. auxiliary.vision.api_key) outranks the entry's stored key —
+    # #96232: the entry may deliberately leave api_key empty and carry credentials elsewhere.
+    custom_key = _named_custom_api_key(custom_entry, provider, custom_base) if req.explicit_api_key is None \
+        else ((req.explicit_api_key or "").strip() or _named_custom_api_key(custom_entry, provider, custom_base))
+    if custom_key == "no-key-required" and req.explicit_api_key:
+        # An explicit key that failed to parse as a string (callable) or came back empty must not
+        # degrade to the placeholder while the caller supplied a real credential.
+        custom_key = req.explicit_api_key
     if custom_key == "no-key-required":
         logger.warning("resolve_provider_client: named custom provider %r has no resolvable "
                        "api_key — request will be sent with placeholder no-key-required "
@@ -5121,7 +5155,8 @@ def resolve_vision_provider_client(
                 return _finalize_vision_client(requested, client, final_model, resolved_model, async_mode)
         # Fallback: try without explicit base_url (old behavior)
     client, final_model = _get_cached_client(
-        requested, resolved_model, async_mode, api_mode=resolved_api_mode, main_runtime=runtime, is_vision=True,
+        requested, resolved_model, async_mode, api_key=resolved_api_key or None,
+        api_mode=resolved_api_mode, main_runtime=runtime, is_vision=True,
     )
     return requested, client, (final_model if client is not None else None)
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -406,7 +406,7 @@ from hermes_cli.runtime_provider_custom import (  # noqa: E402,F401
     _apply_custom_provider_extras, _custom_provider_request_overrides, _filter_capabilities, _find_custom_identity,
     _get_named_custom_provider, _lift_common_custom_fields, _lift_extra_headers,
     _lift_model_capabilities, _normalize_base_url_for_match, _normalize_custom_provider_name, _resolve_named_custom_runtime,
-    _try_resolve_from_custom_pool, canonical_custom_identity, find_custom_provider_identity,
+    _try_resolve_from_custom_pool, canonical_custom_identity, find_custom_provider_entry, find_custom_provider_identity,
     find_custom_provider_identity_by_model, has_named_custom_provider, is_routable_provider,
 )
 from hermes_cli.runtime_provider_backends import (  # noqa: E402,F401

--- a/hermes_cli/runtime_provider_custom.py
+++ b/hermes_cli/runtime_provider_custom.py
@@ -224,6 +224,51 @@ def find_custom_provider_identity(base_url: str) -> Optional[str]:
     return _find_custom_identity(lambda entry: _normalize_base_url_for_match(_entry_url(entry)) == target)
 
 
+def find_custom_provider_entry(base_url: str) -> Optional[Dict[str, Any]]:
+    """Map an endpoint URL back to its full ``providers`` / ``custom_providers`` entry (not just
+    the identity slug), so callers can lift the entry's own ``api_key``/``api_mode``.
+
+    ``find_custom_provider_identity`` loses the entry (and its credential) by design —
+    persistence paths must not persist keys. Aux resolution is NOT a persistence path: a named
+    custom provider arriving with a task-level ``base_url`` (the desktop GUI writes this shape,
+    #65254/#34651) gets flattened to bare ``custom`` before ``_resolve_named_custom_branch`` can
+    read the entry's key, so the key must be recovered from the URL here. Normalization mirrors
+    the identity lookup exactly (same ``_entry_url``/``_normalize_base_url_for_match`` pair) so
+    the entry found here always matches the slug that helper returns.
+    """
+    target = _normalize_base_url_for_match(base_url)
+    if not target:
+        return None
+
+    def _matches(entry: Dict[str, Any]) -> bool:
+        return _normalize_base_url_for_match(_entry_url(entry)) == target
+
+    rp = _rp()
+    try:
+        config = rp.load_config()
+    except Exception:
+        return None
+    providers = config.get("providers")
+    if isinstance(providers, dict):
+        for ep_name, entry in providers.items():
+            if isinstance(entry, dict) and _matches(entry):
+                result = _match_new_style_provider(str(ep_name), {str(ep_name): entry})
+                if result is not None:
+                    return result
+    try:
+        custom_providers = rp.get_compatible_custom_providers(config)
+    except Exception:
+        custom_providers = None
+    for entry in custom_providers or []:
+        if isinstance(entry, dict) and _matches(entry):
+            name = str(entry.get("name") or "").strip()
+            base = _clean(entry.get("base_url"))
+            if not name or not base:
+                continue
+            return dict(entry)
+    return None
+
+
 def _model_id_matches(value: Any, target: str) -> bool:
     return isinstance(value, str) and value.strip().lower() == target
 

--- a/tests/agent/test_aux_custom_base_url_credential.py
+++ b/tests/agent/test_aux_custom_base_url_credential.py
@@ -1,0 +1,153 @@
+"""Credential recovery for named custom providers flattened by a task-level base_url (#34651).
+
+The desktop GUI persists ``auxiliary.<task> = {provider: custom:<name>, model, base_url}`` (#65254).
+``_resolve_task_provider_model`` flattens ``custom:<name>`` + task ``base_url`` to bare ``custom`` before
+the named branch can read the entry's key, so the credential chain degraded to OPENAI_API_KEY →
+main-runtime-same-host → ``no-key-required`` — a 401 on every aux call once the main model moved off
+that host. ``_resolve_custom_branch`` must now lift the configured entry's own key from the URL
+(``find_custom_provider_entry``), and the sibling gaps close with it: the named branch honoring an
+explicit per-task api_key (#96232), and the vision fallthrough forwarding the resolved key.
+"""
+
+import pytest
+
+import hermes_cli.runtime_provider as rp
+import agent.auxiliary_client as aux
+
+
+def _entry_config():
+    return {
+        "custom_providers": [
+            {
+                "name": "Local (127.0.0.1:8888)",
+                "base_url": "http://127.0.0.1:8888/v1",
+                "api_key": "sk-entry-key",
+                "model": "qwen-test",
+            }
+        ]
+    }
+
+
+def test_find_custom_provider_entry_lifts_full_entry(monkeypatch):
+    """URL → full entry (not just the identity slug), with the credential intact."""
+    monkeypatch.setattr(rp, "load_config", lambda: _entry_config())
+    entry = rp.find_custom_provider_entry("http://127.0.0.1:8888/v1")
+    assert entry is not None
+    assert entry["api_key"] == "sk-entry-key"
+    assert entry["base_url"] == "http://127.0.0.1:8888/v1"
+
+
+def test_find_custom_provider_entry_no_match_returns_none(monkeypatch):
+    monkeypatch.setattr(rp, "load_config", lambda: _entry_config())
+    assert rp.find_custom_provider_entry("https://elsewhere.example/v1") is None
+    assert rp.find_custom_provider_entry("") is None
+    assert rp.find_custom_provider_entry(None) is None
+
+
+def test_find_custom_provider_entry_matches_providers_dict(monkeypatch):
+    config = {"providers": {"local": {"api": "http://127.0.0.1:8000/v1", "api_key": "sk-keyed"}}}
+    monkeypatch.setattr(rp, "load_config", lambda: config)
+    entry = rp.find_custom_provider_entry("http://127.0.0.1:8000/v1")
+    assert entry is not None
+    assert entry["api_key"] == "sk-keyed"
+
+
+def test_custom_branch_uses_entry_key_for_task_base_url(monkeypatch):
+    """The #34651 shape end-to-end: named provider flattened to bare custom by the task base_url
+    still authenticates with the configured entry's key, not the no-key-required placeholder."""
+    monkeypatch.setattr(aux, "_scoped_key_env", lambda *_a, **_k: "")
+    monkeypatch.setattr(aux, "_read_main_api_key_if_same_host", lambda *_a, **_k: "")
+    monkeypatch.setattr(rp, "load_config", lambda: _entry_config())
+
+    req = aux._ResolveRequest(
+        provider="custom",
+        original_provider="custom:local-(127.0.0.1:8888)",
+        model="qwen-test",
+        async_mode=False,
+        raw_codex=False,
+        explicit_base_url="http://127.0.0.1:8888/v1",
+        explicit_api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        is_vision=True,
+        task="vision",
+    )
+    client, final_model = aux._resolve_custom_branch(req)
+    assert client is not None
+    assert final_model == "qwen-test"
+    assert getattr(client, "api_key", "") == "sk-entry-key"
+
+
+def test_custom_branch_explicit_key_outranks_entry(monkeypatch):
+    """An explicit per-task api_key (auxiliary.<task>.api_key) wins over the entry's stored key."""
+    monkeypatch.setattr(aux, "_scoped_key_env", lambda *_a, **_k: "")
+    monkeypatch.setattr(rp, "load_config", lambda: _entry_config())
+
+    req = aux._ResolveRequest(
+        provider="custom",
+        original_provider="custom:local-(127.0.0.1:8888)",
+        model="qwen-test",
+        async_mode=False,
+        raw_codex=False,
+        explicit_base_url="http://127.0.0.1:8888/v1",
+        explicit_api_key="sk-explicit-per-task",
+        api_mode=None,
+        main_runtime=None,
+        is_vision=True,
+        task="vision",
+    )
+    client, _ = aux._resolve_custom_branch(req)
+    assert getattr(client, "api_key", "") == "sk-explicit-per-task"
+
+
+def test_custom_branch_without_matching_entry_keeps_placeholder(monkeypatch):
+    """Unchanged fallback: an explicit base_url with NO configured entry still degrades to the
+    placeholder (local servers without auth) — the new lookup must not invent credentials."""
+    monkeypatch.setattr(aux, "_scoped_key_env", lambda *_a, **_k: "")
+    monkeypatch.setattr(aux, "_read_main_api_key_if_same_host", lambda *_a, **_k: "")
+    monkeypatch.setattr(rp, "load_config", lambda: {"custom_providers": []})
+
+    req = aux._ResolveRequest(
+        provider="custom",
+        original_provider="custom",
+        model="m",
+        async_mode=False,
+        raw_codex=False,
+        explicit_base_url="http://10.0.0.5:9000/v1",
+        explicit_api_key=None,
+        api_mode=None,
+        main_runtime=None,
+        is_vision=False,
+        task="vision",
+    )
+    client, _ = aux._resolve_custom_branch(req)
+    assert getattr(client, "api_key", "") == "no-key-required"
+
+
+def test_named_branch_honors_explicit_api_key(monkeypatch):
+    """#96232: the named branch must not drop an explicit per-task api_key when the entry's own
+    api_key field is empty (credentials deliberately stored elsewhere)."""
+    config = {
+        "custom_providers": [
+            {"name": "entry-no-key", "base_url": "https://api.example.test/v1", "model": "m"}
+        ]
+    }
+    monkeypatch.setattr(rp, "load_config", lambda: config)
+
+    req = aux._ResolveRequest(
+        provider="entry-no-key",
+        original_provider="custom:entry-no-key",
+        model="m",
+        async_mode=False,
+        raw_codex=False,
+        explicit_base_url=None,
+        explicit_api_key="sk-per-task-96232",
+        api_mode=None,
+        main_runtime=None,
+        is_vision=True,
+        task="vision",
+    )
+    result = aux._resolve_named_custom_branch(req)
+    assert result is not None
+    client = result[0]
+    assert getattr(client, "api_key", "") == "sk-per-task-96232"


### PR DESCRIPTION
## What & why

A named custom provider pinned in `auxiliary.<task>` **alongside a task-level `base_url`** — the exact shape the desktop GUI persists for every aux assignment (`d4ff566232`, sibling of #65254) — is flattened to bare `custom` by `_resolve_task_provider_model` before `_resolve_named_custom_branch` can read the `custom_providers` entry's `api_key`. The bare-custom credential chain then degrades to `OPENAI_API_KEY` → main-runtime key (same host only) → the `no-key-required` placeholder, which every auth-required endpoint rejects with a 401.

The pin silently worked **only while the main model happened to live on the same host**, so it broke the moment the main provider switched away — with zero config changes to the aux slot. This is the #34651 shape; the same-host masking is why it survived basic testing.

## Changes

- **`_resolve_custom_branch`** now lifts the configured entry's own key from the explicit `base_url` — new `find_custom_provider_entry()` in `hermes_cli/runtime_provider_custom.py` (URL → full entry incl. credential; sibling of `find_custom_provider_identity`, which by design returns only the slug) — ahead of the `OPENAI_API_KEY` / same-host / placeholder fallbacks. Entries whose `api_mode` contradicts the requested transport never donate a key.
- **`_resolve_named_custom_branch`** honors an explicit per-task `api_key` instead of dropping it (#96232: entries that deliberately leave `api_key` empty lost the caller's supplied key).
- **`resolve_vision_provider_client`** no-base_url fallthrough forwards the resolved per-task key instead of discarding it (the other #96232 half).

The GUI's write pattern from `d4ff566232` is **correct after this PR** — the fix is in the resolver, not the config shape.

## How to test

Repro (pre-fix): pin `auxiliary.vision` to a named custom provider with a valid key in its `custom_providers` entry, add the entry's `base_url` to the aux slot (or set vision via the desktop GUI Settings → Model), switch the **main** model to any other provider, then call `vision_analyze` → 401 from the pinned provider. Post-fix: same call succeeds; the bearer is the entry's own key.

Tests: `tests/agent/test_aux_custom_base_url_credential.py` (7 invariant tests) covers entry lifting (list + `providers:` dict + no-match), the #34651 end-to-end shape (entry key, not placeholder), explicit-key precedence, placeholder preserved for unknown endpoints, and the #96232 named-branch case.

Verified locally on Windows 11 (Python 3.11.16): new suite 7/7, sibling suites (custom_provider_identity, cli_custom_provider_vision, custom_provider_normalize_no_mutate, custom_provider_session_persistence) 54/54, and a live end-to-end run against a local OpenAI-compatible endpoint (Unsloth Studio) whose auth rejects the placeholder — pre-fix 401, post-fix HTTP 200 with the entry's key.

## Related issues

Fixes #34651
Closes #96232 (both gaps: named-branch explicit key + vision fallthrough)

Refs: #105721, #33333, #16290 (same bug class; this PR closes the named-custom-provider + task-`base_url` variant)