### PR TITLE
feat(clicksmith): integrate FND-02 through FND-09

### DIFF
--- a/clicksmith/foundation/evidence_model.py
+++ b/clicksmith/foundation/evidence_model.py
@@ -1,0 +1,315 @@
+"""FND-05 Evidence Model — Phase 1 semantic/in-memory boundary."""
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import re
+from typing import Any, Mapping
+
+from .execution_identity import ExecutionIdentity, ExecutionIdentityError
+
+SCHEMA_VERSION = "1.0"
+EVIDENCE_TYPES = frozenset({
+    "EXECUTION",
+    "AUTHORIZATION",
+    "STATE_TRANSITION",
+    "RESULT",
+    "FAILURE",
+    "ARTIFACT_REFERENCE",
+    "VERIFICATION_REFERENCE",
+})
+IDENTITY_APPLICABILITY = frozenset({"EXECUTION", "NON_EXECUTION"})
+_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_MAX_PAYLOAD_BYTES = 16384
+
+ERROR_CODES = frozenset({
+    "INVALID_IDENTITY",
+    "INVALID_EVIDENCE_INPUT",
+    "INVALID_PROVENANCE",
+    "INVALID_INTEGRITY",
+    "IMMUTABLE_EVIDENCE_MUTATION",
+    "SCHEMA_ERROR",
+    "AMBIGUOUS_EVIDENCE",
+    "UNSUPPORTED_EVIDENCE_TYPE",
+    "EVIDENCE_SERIALIZATION_ERROR",
+})
+
+
+class EvidenceModelError(ValueError):
+    code = "INVALID_EVIDENCE_INPUT"
+
+
+class InvalidIdentityError(EvidenceModelError):
+    code = "INVALID_IDENTITY"
+
+
+class InvalidEvidenceInputError(EvidenceModelError):
+    code = "INVALID_EVIDENCE_INPUT"
+
+
+class InvalidProvenanceError(EvidenceModelError):
+    code = "INVALID_PROVENANCE"
+
+
+class InvalidIntegrityError(EvidenceModelError):
+    code = "INVALID_INTEGRITY"
+
+
+class ImmutableEvidenceMutationError(EvidenceModelError):
+    code = "IMMUTABLE_EVIDENCE_MUTATION"
+
+
+class SchemaError(EvidenceModelError):
+    code = "SCHEMA_ERROR"
+
+
+class AmbiguousEvidenceError(EvidenceModelError):
+    code = "AMBIGUOUS_EVIDENCE"
+
+
+class UnsupportedEvidenceTypeError(EvidenceModelError):
+    code = "UNSUPPORTED_EVIDENCE_TYPE"
+
+
+class EvidenceSerializationError(EvidenceModelError):
+    code = "EVIDENCE_SERIALIZATION_ERROR"
+
+
+@dataclasses.dataclass(frozen=True)
+class EvidenceProvenance:
+    source_boundary: str
+    source_type: str
+    creation_context: str
+    parent_evidence_id: str | None = None
+
+    def validate(self) -> None:
+        for name, value in (
+            ("source_boundary", self.source_boundary),
+            ("source_type", self.source_type),
+            ("creation_context", self.creation_context),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise InvalidProvenanceError(f"{name} must be a non-empty string.")
+        if self.parent_evidence_id is not None:
+            _validate_identifier("parent_evidence_id", self.parent_evidence_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        result = {
+            "creation_context": self.creation_context,
+            "source_boundary": self.source_boundary,
+            "source_type": self.source_type,
+        }
+        if self.parent_evidence_id is not None:
+            result["parent_evidence_id"] = self.parent_evidence_id
+        return result
+
+
+@dataclasses.dataclass(frozen=True)
+class EvidenceRecord:
+    evidence_id: str
+    evidence_type: str
+    provenance: EvidenceProvenance
+    identity_applicability: str
+    identity: ExecutionIdentity | None = None
+    metadata: Mapping[str, Any] | None = None
+    reference: str | None = None
+    payload: Mapping[str, Any] | None = None
+    timestamp: str | None = None
+    supersedes: str | None = None
+    integrity_sha256: str | None = None
+    schema_version: str = SCHEMA_VERSION
+
+    def validate(self) -> None:
+        _validate_identifier("evidence_id", self.evidence_id)
+        if self.evidence_type not in EVIDENCE_TYPES:
+            raise UnsupportedEvidenceTypeError(
+                "evidence_type must be one of the seven canonical Phase 1 types."
+            )
+        if self.schema_version != SCHEMA_VERSION:
+            raise SchemaError(f"schema_version must be {SCHEMA_VERSION!r}.")
+        if self.identity_applicability not in IDENTITY_APPLICABILITY:
+            raise AmbiguousEvidenceError(
+                "identity_applicability must be exactly EXECUTION or NON_EXECUTION."
+            )
+        if not isinstance(self.provenance, EvidenceProvenance):
+            raise InvalidProvenanceError("provenance must be an EvidenceProvenance.")
+        self.provenance.validate()
+
+        if self.identity_applicability == "EXECUTION":
+            if not isinstance(self.identity, ExecutionIdentity):
+                raise InvalidIdentityError(
+                    "execution-related evidence requires exactly one ExecutionIdentity."
+                )
+            try:
+                self.identity.validate()
+            except ExecutionIdentityError as exc:
+                raise InvalidIdentityError(str(exc)) from exc
+        elif self.identity is not None:
+            raise AmbiguousEvidenceError(
+                "NON_EXECUTION evidence must not carry an execution identity."
+            )
+
+        if self.supersedes is not None:
+            _validate_identifier("supersedes", self.supersedes)
+            if self.supersedes == self.evidence_id:
+                raise AmbiguousEvidenceError("evidence cannot supersede itself.")
+
+        for name, value in (("reference", self.reference), ("timestamp", self.timestamp)):
+            if value is not None and (not isinstance(value, str) or not value.strip()):
+                raise InvalidEvidenceInputError(f"{name} must be a non-empty string when supplied.")
+
+        _validate_json_mapping("metadata", self.metadata)
+        _validate_json_mapping("payload", self.payload)
+        if self.payload is not None:
+            payload_bytes = _canonical_json(self.payload).encode("utf-8")
+            if len(payload_bytes) > _MAX_PAYLOAD_BYTES:
+                raise InvalidEvidenceInputError("payload exceeds the Phase 1 bounded size limit.")
+
+        if self.integrity_sha256 is not None:
+            if not isinstance(self.integrity_sha256, str) or not re.fullmatch(r"[0-9a-f]{64}", self.integrity_sha256):
+                raise InvalidIntegrityError("integrity_sha256 must be a lowercase SHA-256 hex digest.")
+            if self.integrity_sha256 != self.compute_sha256():
+                raise InvalidIntegrityError("integrity_sha256 does not match canonical evidence content.")
+
+    def _canonical_dict(self, *, include_integrity: bool) -> dict[str, Any]:
+        self.provenance.validate()
+        result: dict[str, Any] = {
+            "evidence_id": self.evidence_id,
+            "evidence_type": self.evidence_type,
+            "identity_applicability": self.identity_applicability,
+            "provenance": self.provenance.to_dict(),
+            "schema_version": self.schema_version,
+        }
+        if self.identity is not None:
+            result["identity"] = self.identity.to_dict()
+        if self.metadata is not None:
+            result["metadata"] = _json_safe(self.metadata)
+        if self.reference is not None:
+            result["reference"] = self.reference
+        if self.payload is not None:
+            result["payload"] = _json_safe(self.payload)
+        if self.timestamp is not None:
+            result["timestamp"] = self.timestamp
+        if self.supersedes is not None:
+            result["supersedes"] = self.supersedes
+        if include_integrity and self.integrity_sha256 is not None:
+            result["integrity_sha256"] = self.integrity_sha256
+        return result
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return self._canonical_dict(include_integrity=True)
+
+    def canonical_bytes(self) -> bytes:
+        self.validate_without_integrity()
+        return _canonical_json(self._canonical_dict(include_integrity=False)).encode("utf-8")
+
+    def compute_sha256(self) -> str:
+        try:
+            return hashlib.sha256(self.canonical_bytes()).hexdigest()
+        except EvidenceModelError:
+            raise
+        except Exception as exc:
+            raise EvidenceSerializationError("canonical evidence serialization failed.") from exc
+
+    def with_integrity(self) -> "EvidenceRecord":
+        self.validate_without_integrity()
+        return dataclasses.replace(self, integrity_sha256=self.compute_sha256())
+
+    def serialize(self) -> str:
+        self.validate()
+        try:
+            return _canonical_json(self._canonical_dict(include_integrity=True))
+        except EvidenceModelError:
+            raise
+        except Exception as exc:
+            raise EvidenceSerializationError("evidence serialization failed.") from exc
+
+    @classmethod
+    def deserialize(cls, serialized: str) -> "EvidenceRecord":
+        if not isinstance(serialized, str):
+            raise EvidenceSerializationError("serialized evidence must be a string.")
+        try:
+            raw = json.loads(serialized)
+            if not isinstance(raw, dict):
+                raise SchemaError("serialized evidence must decode to an object.")
+            provenance_raw = raw.pop("provenance", None)
+            identity_raw = raw.pop("identity", None)
+            if not isinstance(provenance_raw, dict):
+                raise InvalidProvenanceError("provenance must be an object.")
+            provenance = EvidenceProvenance(**provenance_raw)
+            identity = None
+            if identity_raw is not None:
+                identity = ExecutionIdentity.deserialize(_canonical_json(identity_raw))
+            item = cls(provenance=provenance, identity=identity, **raw)
+            item.validate()
+            return item
+        except EvidenceModelError:
+            raise
+        except (ExecutionIdentityError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise EvidenceSerializationError("evidence deserialization failed.") from exc
+
+    def validate_without_integrity(self) -> None:
+        original = self.integrity_sha256
+        object.__setattr__(self, "integrity_sha256", None)
+        try:
+            self.validate()
+        finally:
+            object.__setattr__(self, "integrity_sha256", original)
+
+    def assert_can_supersede(self, previous: "EvidenceRecord") -> None:
+        if not isinstance(previous, EvidenceRecord):
+            raise ImmutableEvidenceMutationError("previous evidence must be an EvidenceRecord.")
+        self.validate_without_integrity()
+        previous.validate_without_integrity()
+        if self.supersedes != previous.evidence_id:
+            raise ImmutableEvidenceMutationError("supersedes must identify the previous evidence record.")
+        if (self.evidence_type, self.identity_applicability) != (
+            previous.evidence_type,
+            previous.identity_applicability,
+        ):
+            raise ImmutableEvidenceMutationError("superseding evidence must remain in the same semantic domain.")
+        if self.identity_applicability == "EXECUTION" and self.identity != previous.identity:
+            raise ImmutableEvidenceMutationError(
+                "execution evidence cannot supersede evidence from another execution identity."
+            )
+
+
+def _validate_identifier(name: str, value: Any) -> None:
+    if not isinstance(value, str) or not _ID_PATTERN.fullmatch(value):
+        raise InvalidEvidenceInputError(
+            f"{name} must match ^[A-Za-z0-9][A-Za-z0-9._:-]*$."
+        )
+
+
+def _validate_json_mapping(name: str, value: Mapping[str, Any] | None) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise InvalidEvidenceInputError(f"{name} must be a JSON-compatible mapping.")
+    try:
+        _canonical_json(value)
+    except EvidenceSerializationError as exc:
+        raise InvalidEvidenceInputError(f"{name} must contain only deterministic JSON values.") from exc
+
+
+def _json_safe(value: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return json.loads(_canonical_json(value))
+    except EvidenceSerializationError as exc:
+        raise InvalidEvidenceInputError("value is not deterministically JSON serializable.") from exc
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise EvidenceSerializationError("value is not deterministically JSON serializable.") from exc

--- a/clicksmith/foundation/execution_boundary.py
+++ b/clicksmith/foundation/execution_boundary.py
@@ -1,0 +1,125 @@
+"""FND-03 Phase 1 Clicksmith-side execution boundary.
+
+This module wraps an existing execution callable behind the canonical
+Clicksmith execution-state contract.
+
+The boundary owns Clicksmith state transitions only. It does not perform
+authorization, persistence, recovery, verification, artifact handling,
+scheduling, orchestration, or Hermes lifecycle management.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .execution_state import (
+    AUTHORIZED,
+    CANCELLED,
+    FAILED,
+    RUNNING,
+    SUCCEEDED,
+    ExecutionState,
+)
+
+
+class ExecutionBoundaryError(ValueError):
+    """Base error for Clicksmith execution-boundary operations."""
+
+
+class ExecutionNotAuthorizedError(ExecutionBoundaryError):
+    """Execution was attempted before authorization was established."""
+
+
+class InvalidExecutorError(ExecutionBoundaryError):
+    """The supplied executor is not callable."""
+
+
+@dataclass(frozen=True)
+class ExecutionBoundaryResult:
+    """Result returned by the Clicksmith execution boundary."""
+
+    state: ExecutionState
+    result: Any = None
+
+
+class ExecutionBoundary:
+    """Wrap an existing execution callable behind FND-03 state semantics."""
+
+    def __init__(
+        self,
+        execution_state: ExecutionState,
+        executor: Callable[[], Any],
+    ) -> None:
+        if not isinstance(execution_state, ExecutionState):
+            raise ExecutionBoundaryError(
+                "execution_state must be an ExecutionState."
+            )
+
+        if not callable(executor):
+            raise InvalidExecutorError("executor must be callable.")
+
+        self.execution_state = execution_state
+        self.executor = executor
+
+    def execute(self) -> ExecutionBoundaryResult:
+        """Execute once from AUTHORIZED and map the result to FND-03 state.
+
+        Authorization must already have occurred outside this boundary.
+        """
+        if self.execution_state.state != AUTHORIZED:
+            raise ExecutionNotAuthorizedError(
+                "ExecutionBoundary requires an AUTHORIZED execution state."
+            )
+
+        self.execution_state.transition(RUNNING)
+
+        try:
+            result = self.executor()
+        except Exception:
+            self.execution_state.transition(FAILED)
+            raise
+
+        if _is_explicit_cancellation(result):
+            self.execution_state.transition(CANCELLED)
+        elif _is_success(result):
+            self.execution_state.transition(SUCCEEDED)
+        else:
+            self.execution_state.transition(FAILED)
+
+        return ExecutionBoundaryResult(
+            state=self.execution_state,
+            result=result,
+        )
+
+
+def _is_explicit_cancellation(result: Any) -> bool:
+    """Return True only for an explicit cancellation result."""
+    if isinstance(result, Mapping):
+        return result.get("cancelled") is True
+
+    return False
+
+
+def _is_success(result: Any) -> bool:
+    """Return True only for an explicit successful completion result."""
+    if not isinstance(result, Mapping):
+        return False
+
+    if result.get("cancelled") is True:
+        return False
+
+    if result.get("error") is not None:
+        return False
+
+    return result.get("completed") is True
+
+
+__all__ = [
+    "ExecutionBoundary",
+    "ExecutionBoundaryError",
+    "ExecutionBoundaryResult",
+    "ExecutionNotAuthorizedError",
+    "InvalidExecutorError",
+]

--- a/clicksmith/foundation/execution_identity.py
+++ b/clicksmith/foundation/execution_identity.py
@@ -1,0 +1,321 @@
+"""Canonical Clicksmith Execution Identity — FND-02 Phase 1.
+
+This module defines execution identity independently from execution state,
+authorization, evidence, recovery, persistence, retry engines, and
+infrastructure.
+
+TASK_ID remains owned by FND-01 TaskContract.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+from typing import Any, Mapping, Optional, Protocol
+
+
+SCHEMA_VERSION = "1.0"
+
+_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+_REJECTED_FIELDS = frozenset(
+    {
+        "password",
+        "api_key",
+        "apikey",
+        "token",
+        "secret",
+        "private_key",
+        "private_key_data",
+        "recovery_code",
+        "authorization",
+        "authorization_context",
+        "approval",
+        "approval_context",
+        "approval_decision",
+        "execution_state",
+        "state",
+        "status",
+    }
+)
+
+
+class ExecutionIdentityError(ValueError):
+    """Raised when an Execution Identity is invalid."""
+
+
+class IdentityCollisionError(ExecutionIdentityError):
+    """Raised when an identity conflicts with an existing identity."""
+
+
+class IdentityResolver(Protocol):
+    """Minimal boundary for checking existing execution identities."""
+
+    def resolve_run_task(self, run_id: str) -> Optional[str]:
+        """Return the TASK_ID associated with RUN_ID, if known."""
+
+    def resolve_attempt_run(self, attempt_id: str) -> Optional[str]:
+        """Return the RUN_ID associated with ATTEMPT_ID, if known."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ExecutionIdentity:
+    """Canonical execution identity.
+
+    TASK_ID identifies the logical task and remains owned by FND-01.
+    RUN_ID identifies one execution run of that task.
+    ATTEMPT_ID identifies one concrete attempt within that run.
+    SESSION_ID identifies an execution/session context.
+    REVISION identifies the task-contract revision associated with
+    this execution identity.
+
+    This object does not authorize, execute, persist, recover, or
+    transition execution state.
+    """
+
+    task_id: str
+    run_id: str
+    attempt_id: str
+    session_id: Optional[str]
+    revision: int
+    schema_version: str = SCHEMA_VERSION
+
+    def validate(
+        self,
+        *,
+        identity_resolver: Optional[IdentityResolver] = None,
+    ) -> None:
+        _validate_task_id(self.task_id)
+        _validate_identity_id("run_id", self.run_id)
+        _validate_identity_id("attempt_id", self.attempt_id)
+        if self.session_id is not None:
+            _validate_identity_id("session_id", self.session_id)
+
+        if type(self.revision) is not int or self.revision < 0:
+            raise ExecutionIdentityError(
+                "revision must be a non-negative integer."
+            )
+
+        if self.schema_version != SCHEMA_VERSION:
+            raise ExecutionIdentityError(
+                f"schema_version must be {SCHEMA_VERSION!r}."
+            )
+
+        if identity_resolver is not None:
+            _validate_collisions(self, identity_resolver)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the deterministic identity representation."""
+        self.validate()
+        return {
+            "attempt_id": self.attempt_id,
+            "revision": self.revision,
+            "run_id": self.run_id,
+            "schema_version": self.schema_version,
+            "session_id": self.session_id,
+            "task_id": self.task_id,
+        }
+
+    def serialize(self) -> str:
+        """Serialize deterministically as canonical JSON."""
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        value: Mapping[str, Any],
+        *,
+        identity_resolver: Optional[IdentityResolver] = None,
+    ) -> "ExecutionIdentity":
+        if not isinstance(value, Mapping):
+            raise ExecutionIdentityError(
+                "Execution Identity must be a mapping."
+            )
+
+        _reject_unknown_keys(value)
+
+        try:
+            identity = cls(
+                task_id=value["task_id"],
+                run_id=value["run_id"],
+                attempt_id=value["attempt_id"],
+                session_id=value.get("session_id"),
+                revision=value["revision"],
+                schema_version=value.get(
+                    "schema_version",
+                    SCHEMA_VERSION,
+                ),
+            )
+        except ExecutionIdentityError:
+            raise
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ExecutionIdentityError(
+                "Malformed Execution Identity."
+            ) from exc
+
+        identity.validate(identity_resolver=identity_resolver)
+        return identity
+
+    @classmethod
+    def deserialize(
+        cls,
+        payload: str,
+        *,
+        identity_resolver: Optional[IdentityResolver] = None,
+    ) -> "ExecutionIdentity":
+        if not isinstance(payload, str):
+            raise ExecutionIdentityError(
+                "Serialized Execution Identity must be a string."
+            )
+
+        try:
+            value = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ExecutionIdentityError(
+                "Invalid Execution Identity JSON."
+            ) from exc
+
+        return cls.from_dict(
+            value,
+            identity_resolver=identity_resolver,
+        )
+
+
+def validate_task_association(
+    identity: ExecutionIdentity,
+    task_id: str,
+) -> None:
+    """Validate that identity TASK_ID matches the supplied FND-01 TASK_ID."""
+    if not isinstance(identity, ExecutionIdentity):
+        raise ExecutionIdentityError("identity must be an ExecutionIdentity.")
+
+    _validate_task_id(task_id)
+
+    if identity.task_id != task_id:
+        raise ExecutionIdentityError(
+            "Execution Identity task_id does not match the FND-01 TASK_ID."
+        )
+
+
+def validate_retry_identity(
+    previous: ExecutionIdentity,
+    retry: ExecutionIdentity,
+) -> None:
+    """Validate retry identity semantics.
+
+    A retry continuing the same run must preserve TASK_ID, RUN_ID,
+    and REVISION, while creating a distinct ATTEMPT_ID.
+
+    A different RUN_ID represents a new run / re-execution, not a retry
+    of the previous run.
+    """
+    if not isinstance(previous, ExecutionIdentity):
+        raise ExecutionIdentityError(
+            "previous must be an ExecutionIdentity."
+        )
+
+    if not isinstance(retry, ExecutionIdentity):
+        raise ExecutionIdentityError(
+            "retry must be an ExecutionIdentity."
+        )
+
+    previous.validate()
+    retry.validate()
+
+    if retry.task_id != previous.task_id:
+        raise ExecutionIdentityError(
+            "Retry must preserve TASK_ID."
+        )
+
+    if retry.run_id != previous.run_id:
+        raise ExecutionIdentityError(
+            "Retry continuing the same run must preserve RUN_ID."
+        )
+
+    if retry.revision != previous.revision:
+        raise ExecutionIdentityError(
+            "Retry must preserve task-contract revision."
+        )
+
+    if retry.attempt_id == previous.attempt_id:
+        raise ExecutionIdentityError(
+            "Retry must use a distinct ATTEMPT_ID."
+        )
+
+
+def _validate_task_id(value: Any) -> None:
+    """Validate TASK_ID at the FND-01 ownership boundary.
+
+    FND-02 must not narrow the canonical TASK_ID domain defined by FND-01.
+    """
+    if not isinstance(value, str) or not value.strip():
+        raise ExecutionIdentityError(
+            "task_id must be a non-empty string."
+        )
+
+
+def _validate_identity_id(name: str, value: Any) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ExecutionIdentityError(
+            f"{name} must be a non-empty string."
+        )
+
+    if not _ID_PATTERN.fullmatch(value):
+        raise ExecutionIdentityError(
+            f"{name} contains invalid identity characters."
+        )
+
+
+def _validate_collisions(
+    identity: ExecutionIdentity,
+    resolver: IdentityResolver,
+) -> None:
+    existing_task = resolver.resolve_run_task(identity.run_id)
+
+    if existing_task is not None and existing_task != identity.task_id:
+        raise IdentityCollisionError(
+            "RUN_ID is already associated with another TASK_ID."
+        )
+
+    existing_run = resolver.resolve_attempt_run(identity.attempt_id)
+
+    if existing_run is not None and existing_run != identity.run_id:
+        raise IdentityCollisionError(
+            "ATTEMPT_ID is already associated with another RUN_ID."
+        )
+
+
+def _reject_unknown_keys(value: Mapping[str, Any]) -> None:
+    allowed = {
+        "task_id",
+        "run_id",
+        "attempt_id",
+        "session_id",
+        "revision",
+        "schema_version",
+    }
+
+    rejected = {
+        str(key).lower()
+        for key in value
+        if str(key).lower() in _REJECTED_FIELDS
+    }
+
+    if rejected:
+        names = ", ".join(sorted(rejected))
+        raise ExecutionIdentityError(
+            f"execution_identity contains prohibited field(s): {names}."
+        )
+
+    unknown = set(value) - allowed
+    if unknown:
+        names = ", ".join(sorted(str(item) for item in unknown))
+        raise ExecutionIdentityError(
+            f"execution_identity contains unknown field(s): {names}."
+        )

--- a/clicksmith/foundation/execution_state.py
+++ b/clicksmith/foundation/execution_state.py
@@ -1,0 +1,267 @@
+"""FND-03 — Canonical execution state model.
+
+This module owns Clicksmith execution-state semantics only.
+
+It does not authorize, execute, persist, recover, verify, deliver
+artifacts, schedule work, or modify Hermes lifecycle semantics.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, ClassVar, Mapping
+
+from .execution_identity import ExecutionIdentity
+
+
+SCHEMA_VERSION = "1.0"
+
+PENDING = "PENDING"
+AUTHORIZED = "AUTHORIZED"
+RUNNING = "RUNNING"
+PAUSED = "PAUSED"
+SUCCEEDED = "SUCCEEDED"
+FAILED = "FAILED"
+CANCELLED = "CANCELLED"
+
+CANONICAL_STATES = frozenset(
+    {
+        PENDING,
+        AUTHORIZED,
+        RUNNING,
+        PAUSED,
+        SUCCEEDED,
+        FAILED,
+        CANCELLED,
+    }
+)
+
+TERMINAL_STATES = frozenset(
+    {
+        SUCCEEDED,
+        FAILED,
+        CANCELLED,
+    }
+)
+
+VALID_TRANSITIONS = {
+    PENDING: frozenset({AUTHORIZED, CANCELLED}),
+    AUTHORIZED: frozenset({RUNNING, CANCELLED}),
+    RUNNING: frozenset({PAUSED, SUCCEEDED, FAILED, CANCELLED}),
+    PAUSED: frozenset({RUNNING, CANCELLED}),
+    SUCCEEDED: frozenset(),
+    FAILED: frozenset(),
+    CANCELLED: frozenset(),
+}
+
+ALLOWED_KEYS = frozenset(
+    {
+        "identity",
+        "schema_version",
+        "state",
+    }
+)
+
+
+class ExecutionStateError(ValueError):
+    """Base error for FND-03 execution-state operations."""
+
+
+class InvalidStateError(ExecutionStateError):
+    """The supplied state is invalid or unknown."""
+
+
+class InvalidTransitionError(ExecutionStateError):
+    """The requested state transition is not permitted."""
+
+
+class InvalidIdentityError(ExecutionStateError):
+    """The supplied execution identity is invalid."""
+
+
+class StateSchemaError(ExecutionStateError):
+    """Serialized execution-state data violates the strict schema."""
+
+
+class TerminalStateMutationError(ExecutionStateError):
+    """A terminal execution state was asked to transition."""
+
+
+@dataclass
+class ExecutionState:
+    """Canonical FND-03 execution state associated with FND-02 identity."""
+
+    identity: ExecutionIdentity
+    state: str = PENDING
+    schema_version: str = SCHEMA_VERSION
+
+    SCHEMA_VERSION: ClassVar[str] = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        self._validate_identity()
+        self._validate_schema_version()
+        self._validate_state(self.state)
+
+    def _validate_identity(self) -> None:
+        if not isinstance(self.identity, ExecutionIdentity):
+            raise InvalidIdentityError(
+                "identity must be an ExecutionIdentity."
+            )
+
+        try:
+            self.identity.validate()
+        except Exception as exc:
+            raise InvalidIdentityError(
+                "Execution Identity is invalid."
+            ) from exc
+
+    def _validate_schema_version(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise StateSchemaError(
+                f"schema_version must be {SCHEMA_VERSION!r}."
+            )
+
+    @staticmethod
+    def _validate_state(state: Any) -> None:
+        if not isinstance(state, str):
+            raise InvalidStateError("state must be a string.")
+
+        if state not in CANONICAL_STATES:
+            raise InvalidStateError(
+                f"Unknown or invalid execution state: {state!r}."
+            )
+
+    def transition(self, target_state: str) -> "ExecutionState":
+        """Atomically transition to a permitted state.
+
+        Validation occurs before mutation. Failed transitions leave the
+        current state unchanged.
+        """
+        self._validate_state(target_state)
+
+        current_state = self.state
+
+        if current_state in TERMINAL_STATES:
+            raise TerminalStateMutationError(
+                f"Terminal state {current_state!r} cannot transition."
+            )
+
+        if target_state not in VALID_TRANSITIONS[current_state]:
+            raise InvalidTransitionError(
+                f"Invalid transition: {current_state!r} -> "
+                f"{target_state!r}."
+            )
+
+        self.state = target_state
+        return self
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the deterministic FND-03 representation."""
+        self._validate_identity()
+        self._validate_schema_version()
+        self._validate_state(self.state)
+
+        return {
+            "identity": self.identity.to_dict(),
+            "schema_version": self.schema_version,
+            "state": self.state,
+        }
+
+    def serialize(self) -> str:
+        """Serialize deterministically as canonical UTF-8 JSON text."""
+        return json.dumps(
+            self.to_dict(),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "ExecutionState":
+        """Strictly deserialize a canonical execution-state mapping."""
+        if not isinstance(value, Mapping):
+            raise StateSchemaError(
+                "Execution State must be a mapping."
+            )
+
+        unknown_keys = set(value) - ALLOWED_KEYS
+        if unknown_keys:
+            raise StateSchemaError(
+                "Unknown Execution State fields: "
+                + ", ".join(sorted(map(str, unknown_keys)))
+            )
+
+        required_keys = ALLOWED_KEYS
+        missing_keys = required_keys - set(value)
+        if missing_keys:
+            raise StateSchemaError(
+                "Missing Execution State fields: "
+                + ", ".join(sorted(missing_keys))
+            )
+
+        schema_version = value["schema_version"]
+        if not isinstance(schema_version, str):
+            raise StateSchemaError(
+                "schema_version must be a string."
+            )
+
+        if schema_version != SCHEMA_VERSION:
+            raise StateSchemaError(
+                f"Unsupported schema_version: {schema_version!r}."
+            )
+
+        try:
+            identity = ExecutionIdentity.from_dict(value["identity"])
+        except Exception as exc:
+            raise InvalidIdentityError(
+                "Invalid Execution Identity in Execution State."
+            ) from exc
+
+        state = value["state"]
+        cls._validate_state(state)
+
+        return cls(
+            identity=identity,
+            state=state,
+            schema_version=schema_version,
+        )
+
+    @classmethod
+    def deserialize(cls, payload: str) -> "ExecutionState":
+        """Strictly deserialize canonical JSON text."""
+        if not isinstance(payload, str):
+            raise StateSchemaError(
+                "Serialized Execution State must be a string."
+            )
+
+        try:
+            value = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise StateSchemaError(
+                "Invalid Execution State JSON."
+            ) from exc
+
+        return cls.from_dict(value)
+
+
+__all__ = [
+    "AUTHORIZED",
+    "CANCELLED",
+    "CANONICAL_STATES",
+    "ExecutionState",
+    "ExecutionStateError",
+    "FAILED",
+    "InvalidIdentityError",
+    "InvalidStateError",
+    "InvalidTransitionError",
+    "PENDING",
+    "PAUSED",
+    "RUNNING",
+    "SCHEMA_VERSION",
+    "StateSchemaError",
+    "SUCCEEDED",
+    "TERMINAL_STATES",
+    "TerminalStateMutationError",
+    "VALID_TRANSITIONS",
+]

--- a/clicksmith/foundation/policy_authorization.py
+++ b/clicksmith/foundation/policy_authorization.py
@@ -1,0 +1,205 @@
+"""FND-04 Policy & Authorization Boundary — Phase 1.
+
+Standalone, deterministic authorization semantics for the Clicksmith Control
+Plane. FND-04 evaluates only explicitly supplied inputs and does not
+authenticate principals, persist decisions, or perform infrastructure I/O.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+
+from .execution_identity import ExecutionIdentity, ExecutionIdentityError
+
+SCHEMA_VERSION = "1.0"
+DECISIONS = frozenset({"ALLOW", "DENY"})
+ERROR_CODES = frozenset({
+    "INVALID_IDENTITY", "INVALID_TASK_CONTRACT", "INVALID_POLICY_INPUT",
+    "INVALID_AUTHORITY_CONTEXT", "POLICY_EVALUATION_ERROR", "UNSUPPORTED_POLICY",
+    "SCHEMA_ERROR", "AMBIGUOUS_AUTHORIZATION",
+})
+
+
+class PolicyAuthorizationError(ValueError):
+    """Base FND-04 boundary error."""
+    code = "POLICY_EVALUATION_ERROR"
+
+
+class InvalidIdentityError(PolicyAuthorizationError):
+    code = "INVALID_IDENTITY"
+
+
+class InvalidTaskContractError(PolicyAuthorizationError):
+    code = "INVALID_TASK_CONTRACT"
+
+
+class InvalidPolicyInputError(PolicyAuthorizationError):
+    code = "INVALID_POLICY_INPUT"
+
+
+class InvalidAuthorityContextError(PolicyAuthorizationError):
+    code = "INVALID_AUTHORITY_CONTEXT"
+
+
+class PolicyEvaluationError(PolicyAuthorizationError):
+    code = "POLICY_EVALUATION_ERROR"
+
+
+class UnsupportedPolicyError(PolicyAuthorizationError):
+    code = "UNSUPPORTED_POLICY"
+
+
+class SchemaError(PolicyAuthorizationError):
+    code = "SCHEMA_ERROR"
+
+
+class AmbiguousAuthorizationError(PolicyAuthorizationError):
+    code = "AMBIGUOUS_AUTHORIZATION"
+
+
+@dataclasses.dataclass(frozen=True)
+class Policy:
+    """Explicit Phase 1 policy configuration; no external discovery."""
+    policy_id: str
+    policy_version: str
+    allowed: frozenset[str]
+    schema_version: str = SCHEMA_VERSION
+
+    def validate(self) -> None:
+        _nonempty("policy_id", self.policy_id)
+        _nonempty("policy_version", self.policy_version)
+        if self.schema_version != SCHEMA_VERSION:
+            raise SchemaError(f"schema_version must be {SCHEMA_VERSION!r}.")
+        if not isinstance(self.allowed, frozenset):
+            raise InvalidPolicyInputError("policy.allowed must be a frozenset.")
+        if any(not isinstance(item, str) or not item.strip() for item in self.allowed):
+            raise InvalidPolicyInputError("policy.allowed contains an invalid action.")
+
+
+@dataclasses.dataclass(frozen=True)
+class AuthorityContext:
+    """Authority facts supplied by an upstream boundary."""
+    authority_reference: str
+    granted_actions: frozenset[str]
+    schema_version: str = SCHEMA_VERSION
+
+    def validate(self) -> None:
+        _nonempty("authority_reference", self.authority_reference)
+        if self.schema_version != SCHEMA_VERSION:
+            raise SchemaError(f"schema_version must be {SCHEMA_VERSION!r}.")
+        if not isinstance(self.granted_actions, frozenset):
+            raise InvalidAuthorityContextError("granted_actions must be a frozenset.")
+        if any(not isinstance(item, str) or not item.strip() for item in self.granted_actions):
+            raise InvalidAuthorityContextError("granted_actions contains an invalid action.")
+
+
+@dataclasses.dataclass(frozen=True)
+class AuthorizationRequest:
+    task: Any
+    identity: ExecutionIdentity
+    policy: Policy
+    authority_context: AuthorityContext
+
+    def validate(self) -> None:
+        if not isinstance(self.identity, ExecutionIdentity):
+            raise InvalidIdentityError("identity must be an ExecutionIdentity.")
+        try:
+            self.identity.validate()
+        except ExecutionIdentityError as exc:
+            raise InvalidIdentityError(str(exc)) from exc
+        _validate_task(self.task, self.identity)
+        if not isinstance(self.policy, Policy):
+            raise InvalidPolicyInputError("policy must be a Policy.")
+        self.policy.validate()
+        if not isinstance(self.authority_context, AuthorityContext):
+            raise InvalidAuthorityContextError(
+                "authority_context must be an AuthorityContext."
+            )
+        self.authority_context.validate()
+
+
+@dataclasses.dataclass(frozen=True)
+class AuthorizationDecision:
+    identity: ExecutionIdentity
+    decision: str
+    policy_id: str
+    policy_version: str
+    schema_version: str = SCHEMA_VERSION
+
+    def validate(self) -> None:
+        if not isinstance(self.identity, ExecutionIdentity):
+            raise InvalidIdentityError("decision identity must be an ExecutionIdentity.")
+        try:
+            self.identity.validate()
+        except ExecutionIdentityError as exc:
+            raise InvalidIdentityError(str(exc)) from exc
+        if self.decision not in DECISIONS:
+            raise SchemaError("decision must be exactly ALLOW or DENY.")
+        _nonempty("policy_id", self.policy_id)
+        _nonempty("policy_version", self.policy_version)
+        if self.schema_version != SCHEMA_VERSION:
+            raise SchemaError(f"schema_version must be {SCHEMA_VERSION!r}.")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "decision": self.decision,
+            "identity": self.identity.to_dict(),
+            "policy_id": self.policy_id,
+            "policy_version": self.policy_version,
+            "schema_version": self.schema_version,
+        }
+
+    def serialize(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def evaluate(request: AuthorizationRequest) -> AuthorizationDecision:
+    """Evaluate one explicit request; errors never become decisions."""
+    if not isinstance(request, AuthorizationRequest):
+        raise SchemaError("request must be an AuthorizationRequest.")
+    try:
+        request.validate()
+        policy_actions = request.policy.allowed
+        authority_actions = request.authority_context.granted_actions
+        if not policy_actions:
+            raise UnsupportedPolicyError("empty allowed policy is unsupported in Phase 1.")
+        if not policy_actions.issubset(authority_actions):
+            result = "DENY"
+        else:
+            result = "ALLOW"
+        decision = AuthorizationDecision(
+            identity=request.identity,
+            decision=result,
+            policy_id=request.policy.policy_id,
+            policy_version=request.policy.policy_version,
+        )
+        decision.validate()
+        return decision
+    except PolicyAuthorizationError:
+        raise
+    except Exception as exc:
+        raise PolicyEvaluationError("policy evaluation failed.") from exc
+
+
+def _validate_task(task: Any, identity: ExecutionIdentity) -> None:
+    if task is None:
+        raise InvalidTaskContractError("task is required.")
+    task_id = getattr(task, "task_id", None)
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise InvalidTaskContractError("task must expose a non-empty task_id.")
+    if task_id != identity.task_id:
+        raise InvalidTaskContractError("task.task_id must match identity.task_id.")
+    validate = getattr(task, "validate", None)
+    if not callable(validate):
+        raise InvalidTaskContractError("task must expose validate().")
+    try:
+        validate()
+    except Exception as exc:
+        raise InvalidTaskContractError("task contract validation failed.") from exc
+
+
+def _nonempty(name: str, value: Any) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise SchemaError(f"{name} must be a non-empty string.")

--- a/clicksmith/foundation/recovery_model.py
+++ b/clicksmith/foundation/recovery_model.py
@@ -1,0 +1,243 @@
+"""FND-06 Recovery Model — Phase 1 recovery semantics boundary.
+
+FND-06 decides whether a supplied execution disruption has a bounded
+recovery action. It does not execute recovery, retry, authorize, persist,
+or mutate execution identity/state/evidence.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any, Mapping
+
+from .execution_identity import ExecutionIdentity, ExecutionIdentityError
+from .execution_state import ExecutionState
+from .evidence_model import EvidenceRecord, EvidenceModelError
+
+SCHEMA_VERSION = "1.0"
+RECOVERY_ACTIONS = frozenset({"RECOVERY_REQUIRED", "NO_RECOVERY", "RETRY_REQUIRED"})
+RECOVERABILITY = frozenset({"RECOVERABLE", "NON_RECOVERABLE"})
+
+ERROR_CODES = frozenset({
+    "INVALID_IDENTITY",
+    "INVALID_RECOVERY_INPUT",
+    "INVALID_RECOVERY_CONTEXT",
+    "UNSUPPORTED_RECOVERY_ACTION",
+    "RECOVERY_EVALUATION_ERROR",
+    "AMBIGUOUS_RECOVERY",
+    "SCHEMA_ERROR",
+    "RECOVERY_EXECUTION_ERROR",
+    "RECOVERY_BOUNDARY_VIOLATION",
+})
+
+
+class RecoveryModelError(ValueError):
+    """Base FND-06 boundary error."""
+    code = "INVALID_RECOVERY_INPUT"
+
+
+class InvalidIdentityError(RecoveryModelError):
+    code = "INVALID_IDENTITY"
+
+
+class InvalidRecoveryInputError(RecoveryModelError):
+    code = "INVALID_RECOVERY_INPUT"
+
+
+class InvalidRecoveryContextError(RecoveryModelError):
+    code = "INVALID_RECOVERY_CONTEXT"
+
+
+class UnsupportedRecoveryActionError(RecoveryModelError):
+    code = "UNSUPPORTED_RECOVERY_ACTION"
+
+
+class RecoveryEvaluationError(RecoveryModelError):
+    code = "RECOVERY_EVALUATION_ERROR"
+
+
+class AmbiguousRecoveryError(RecoveryModelError):
+    code = "AMBIGUOUS_RECOVERY"
+
+
+class SchemaError(RecoveryModelError):
+    code = "SCHEMA_ERROR"
+
+
+class RecoveryExecutionError(RecoveryModelError):
+    code = "RECOVERY_EXECUTION_ERROR"
+
+
+class RecoveryBoundaryViolationError(RecoveryModelError):
+    code = "RECOVERY_BOUNDARY_VIOLATION"
+
+
+@dataclasses.dataclass(frozen=True)
+class FailureOrDisruption:
+    """Explicit condition classification supplied to the recovery boundary.
+
+    FND-06 deliberately does not encode provider-specific retry rules. The
+    condition is classified by its bounded semantic properties, supplied by
+    the caller or an explicitly authorized classifier.
+    """
+
+    condition_code: str
+    recoverability: str
+    retry_required: bool
+    schema_version: str = SCHEMA_VERSION
+
+    def validate(self) -> None:
+        _nonempty("condition_code", self.condition_code)
+        if self.recoverability not in RECOVERABILITY:
+            raise AmbiguousRecoveryError(
+                "recoverability must be exactly RECOVERABLE or NON_RECOVERABLE."
+            )
+        if type(self.retry_required) is not bool:
+            raise InvalidRecoveryInputError("retry_required must be boolean.")
+        if self.schema_version != SCHEMA_VERSION:
+            raise SchemaError(f"schema_version must be {SCHEMA_VERSION!r}.")
+        if self.recoverability == "NON_RECOVERABLE" and self.retry_required:
+            raise AmbiguousRecoveryError(
+                "a non-recoverable condition cannot require retry."
+            )
+
+
+@dataclasses.dataclass(frozen=True)
+class RecoveryRequest:
+    """Explicit inputs for one recovery evaluation."""
+
+    task: Any
+    execution_identity: ExecutionIdentity
+    execution_state: ExecutionState
+    failure_or_disruption: FailureOrDisruption
+    applicable_evidence: tuple[EvidenceRecord, ...] = ()
+
+    def validate(self) -> None:
+        if not isinstance(self.execution_identity, ExecutionIdentity):
+            raise InvalidIdentityError("execution_identity must be an ExecutionIdentity.")
+        try:
+            self.execution_identity.validate()
+        except ExecutionIdentityError as exc:
+            raise InvalidIdentityError(str(exc)) from exc
+
+        _validate_task(self.task, self.execution_identity)
+        if not isinstance(self.execution_state, ExecutionState):
+            raise InvalidRecoveryContextError(
+                "execution_state must be an ExecutionState."
+            )
+        if self.execution_state.identity != self.execution_identity:
+            raise InvalidRecoveryContextError(
+                "execution_state.identity must exactly match execution_identity."
+            )
+        if not isinstance(self.failure_or_disruption, FailureOrDisruption):
+            raise InvalidRecoveryInputError(
+                "failure_or_disruption must be a FailureOrDisruption."
+            )
+        self.failure_or_disruption.validate()
+        if not isinstance(self.applicable_evidence, tuple):
+            raise InvalidRecoveryInputError(
+                "applicable_evidence must be an immutable tuple."
+            )
+        for evidence in self.applicable_evidence:
+            if not isinstance(evidence, EvidenceRecord):
+                raise InvalidRecoveryInputError(
+                    "applicable_evidence contains a non-EvidenceRecord item."
+                )
+            try:
+                evidence.validate()
+            except EvidenceModelError as exc:
+                raise InvalidRecoveryInputError(
+                    "applicable_evidence contains invalid evidence."
+                ) from exc
+            if evidence.identity_applicability == "EXECUTION":
+                if evidence.identity != self.execution_identity:
+                    raise InvalidRecoveryContextError(
+                        "execution evidence must match the recovery execution identity."
+                    )
+
+
+@dataclasses.dataclass(frozen=True)
+class RecoveryDecision:
+    """Immutable semantic result; no recovery action is executed."""
+
+    execution_identity: ExecutionIdentity
+    action: str
+    condition_code: str
+    schema_version: str = SCHEMA_VERSION
+
+    def validate(self) -> None:
+        if not isinstance(self.execution_identity, ExecutionIdentity):
+            raise InvalidIdentityError("decision execution_identity must be an ExecutionIdentity.")
+        try:
+            self.execution_identity.validate()
+        except ExecutionIdentityError as exc:
+            raise InvalidIdentityError(str(exc)) from exc
+        if self.action not in RECOVERY_ACTIONS:
+            raise UnsupportedRecoveryActionError(
+                "action must be one of the three canonical Phase 1 recovery actions."
+            )
+        _nonempty("condition_code", self.condition_code)
+        if self.schema_version != SCHEMA_VERSION:
+            raise SchemaError(f"schema_version must be {SCHEMA_VERSION!r}.")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "action": self.action,
+            "condition_code": self.condition_code,
+            "execution_identity": self.execution_identity.to_dict(),
+            "schema_version": self.schema_version,
+        }
+
+    def serialize(self) -> str:
+        return json.dumps(
+            self.to_dict(), ensure_ascii=False, separators=(",", ":"), sort_keys=True
+        )
+
+
+def evaluate(request: RecoveryRequest) -> RecoveryDecision:
+    """Evaluate explicit recovery semantics without executing the result."""
+    if not isinstance(request, RecoveryRequest):
+        raise SchemaError("request must be a RecoveryRequest.")
+    try:
+        request.validate()
+        failure = request.failure_or_disruption
+        if failure.recoverability == "NON_RECOVERABLE":
+            action = "NO_RECOVERY"
+        elif failure.retry_required:
+            action = "RETRY_REQUIRED"
+        else:
+            action = "RECOVERY_REQUIRED"
+        decision = RecoveryDecision(
+            execution_identity=request.execution_identity,
+            action=action,
+            condition_code=failure.condition_code,
+        )
+        decision.validate()
+        return decision
+    except RecoveryModelError:
+        raise
+    except Exception as exc:
+        raise RecoveryEvaluationError("recovery evaluation failed.") from exc
+
+
+def _validate_task(task: Any, identity: ExecutionIdentity) -> None:
+    if task is None:
+        raise InvalidRecoveryInputError("task is required.")
+    task_id = getattr(task, "task_id", None)
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise InvalidRecoveryInputError("task must expose a non-empty task_id.")
+    if task_id != identity.task_id:
+        raise InvalidRecoveryContextError("task.task_id must match execution_identity.task_id.")
+    validate = getattr(task, "validate", None)
+    if not callable(validate):
+        raise InvalidRecoveryInputError("task must expose validate().")
+    try:
+        validate()
+    except Exception as exc:
+        raise InvalidRecoveryInputError("task contract validation failed.") from exc
+
+
+def _nonempty(name: str, value: Any) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise SchemaError(f"{name} must be a non-empty string.")

--- a/clicksmith/foundation/regression_compatibility.py
+++ b/clicksmith/foundation/regression_compatibility.py
@@ -1,0 +1,165 @@
+"""FND-09 — Regression / Compatibility Contract v1.1."""
+from __future__ import annotations
+import dataclasses, json, re
+from typing import Any
+from .execution_identity import ExecutionIdentity, ExecutionIdentityError
+
+SCHEMA_VERSION = "1.1"
+REGRESSION_RESULTS = frozenset({"REGRESSION_FREE", "REGRESSED", "INCONCLUSIVE"})
+COMPATIBILITY_RESULTS = frozenset({"COMPATIBLE", "INCOMPATIBLE", "INCONCLUSIVE"})
+APPLICABILITY = frozenset({"APPLICABLE", "NOT_APPLICABLE"})
+COMPATIBILITY_DIMENSIONS = frozenset({"API", "SCHEMA", "BEHAVIOR", "PERFORMANCE", "DEPENDENCY", "RUNTIME", "SECURITY", "CONFIGURATION"})
+COMPARISON_METHODS = frozenset({"EXPLICIT_EVIDENCE", "EXPLICIT_DETERMINATION"})
+ERROR_CODES = frozenset({
+    "INVALID_IDENTITY", "INVALID_REGRESSION_INPUT", "INVALID_COMPATIBILITY_INPUT",
+    "INVALID_BASELINE", "INVALID_COMPARISON_SCOPE", "INVALID_CRITERION",
+    "INVALID_COMPATIBILITY_REQUIREMENT", "AMBIGUOUS_REGRESSION", "AMBIGUOUS_COMPATIBILITY",
+    "UNSUPPORTED_COMPATIBILITY_DIMENSION", "UNSUPPORTED_COMPARISON_METHOD",
+    "REGRESSION_EVALUATION_ERROR", "COMPATIBILITY_EVALUATION_ERROR",
+    "REGRESSION_BOUNDARY_VIOLATION", "COMPATIBILITY_BOUNDARY_VIOLATION", "SCHEMA_ERROR",
+})
+_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+
+def _id(name: str, value: Any, exc: type[Exception]) -> None:
+    if not isinstance(value, str) or not _ID.fullmatch(value): raise exc(f"{name} must be a canonical identifier.")
+def _text(name: str, value: Any, exc: type[Exception]) -> None:
+    if not isinstance(value, str) or not value.strip() or len(value) > 4096: raise exc(f"{name} must be a bounded non-empty string.")
+def _json(value: Any) -> str:
+    try: return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    except (TypeError, ValueError) as e: raise SchemaError("canonical serialization failed.") from e
+
+class RegressionCompatibilityError(ValueError): code = "SCHEMA_ERROR"
+class InvalidIdentityError(RegressionCompatibilityError): code = "INVALID_IDENTITY"
+class InvalidRegressionInputError(RegressionCompatibilityError): code = "INVALID_REGRESSION_INPUT"
+class InvalidCompatibilityInputError(RegressionCompatibilityError): code = "INVALID_COMPATIBILITY_INPUT"
+class InvalidBaselineError(RegressionCompatibilityError): code = "INVALID_BASELINE"
+class InvalidComparisonScopeError(RegressionCompatibilityError): code = "INVALID_COMPARISON_SCOPE"
+class InvalidCriterionError(RegressionCompatibilityError): code = "INVALID_CRITERION"
+class InvalidCompatibilityRequirementError(RegressionCompatibilityError): code = "INVALID_COMPATIBILITY_REQUIREMENT"
+class AmbiguousRegressionError(RegressionCompatibilityError): code = "AMBIGUOUS_REGRESSION"
+class AmbiguousCompatibilityError(RegressionCompatibilityError): code = "AMBIGUOUS_COMPATIBILITY"
+class UnsupportedCompatibilityDimensionError(RegressionCompatibilityError): code = "UNSUPPORTED_COMPATIBILITY_DIMENSION"
+class UnsupportedComparisonMethodError(RegressionCompatibilityError): code = "UNSUPPORTED_COMPARISON_METHOD"
+class RegressionEvaluationError(RegressionCompatibilityError): code = "REGRESSION_EVALUATION_ERROR"
+class CompatibilityEvaluationError(RegressionCompatibilityError): code = "COMPATIBILITY_EVALUATION_ERROR"
+class RegressionBoundaryViolationError(RegressionCompatibilityError): code = "REGRESSION_BOUNDARY_VIOLATION"
+class CompatibilityBoundaryViolationError(RegressionCompatibilityError): code = "COMPATIBILITY_BOUNDARY_VIOLATION"
+class SchemaError(RegressionCompatibilityError): code = "SCHEMA_ERROR"
+
+@dataclasses.dataclass(frozen=True)
+class BaselineReference:
+    baseline_id: str; subject: str; version_or_revision: str; comparison_scope_id: str
+    def validate(self):
+        for n,v in dataclasses.asdict(self).items(): _id(n,v,InvalidBaselineError)
+    def to_dict(self): self.validate(); return dataclasses.asdict(self)
+
+@dataclasses.dataclass(frozen=True)
+class ChangeReference:
+    change_id: str; subject: str; version_or_revision: str; change_description: str
+    def validate(self):
+        _id("change_id",self.change_id,InvalidRegressionInputError); _text("subject",self.subject,InvalidRegressionInputError); _text("version_or_revision",self.version_or_revision,InvalidRegressionInputError); _text("change_description",self.change_description,InvalidRegressionInputError)
+    def to_dict(self): self.validate(); return dataclasses.asdict(self)
+
+@dataclasses.dataclass(frozen=True)
+class ComparisonScope:
+    scope_id: str; subject: str; declared_dimensions: tuple[str,...]=(); declared_criteria: tuple[str,...]=()
+    def validate(self):
+        _id("scope_id",self.scope_id,InvalidComparisonScopeError); _text("subject",self.subject,InvalidComparisonScopeError)
+        if not self.declared_dimensions and not self.declared_criteria: raise InvalidComparisonScopeError("comparison scope must be explicit.")
+        if any(not isinstance(x,str) or not x.strip() for x in (*self.declared_dimensions,*self.declared_criteria)): raise InvalidComparisonScopeError("scope entries must be explicit strings.")
+    def to_dict(self): self.validate(); return {"scope_id":self.scope_id,"subject":self.subject,"declared_dimensions":list(self.declared_dimensions),"declared_criteria":list(self.declared_criteria)}
+
+@dataclasses.dataclass(frozen=True)
+class RegressionCriterion:
+    criterion_id: str; description: str; required: bool; comparison_method: str
+    def validate(self):
+        _id("criterion_id",self.criterion_id,InvalidCriterionError); _text("description",self.description,InvalidCriterionError)
+        if type(self.required) is not bool: raise InvalidCriterionError("required must be boolean.")
+        if self.comparison_method not in COMPARISON_METHODS: raise UnsupportedComparisonMethodError("comparison method is unsupported.")
+    def to_dict(self): self.validate(); return dataclasses.asdict(self)
+
+@dataclasses.dataclass(frozen=True)
+class CompatibilityDimension:
+    dimension_id: str; description: str; applicability: str
+    def validate(self):
+        _id("dimension_id",self.dimension_id,InvalidCompatibilityInputError); _text("description",self.description,InvalidCompatibilityInputError)
+        if self.dimension_id not in COMPATIBILITY_DIMENSIONS: raise UnsupportedCompatibilityDimensionError("compatibility dimension is unsupported.")
+        if self.applicability not in APPLICABILITY: raise InvalidCompatibilityInputError("applicability is invalid.")
+    def to_dict(self): self.validate(); return dataclasses.asdict(self)
+
+@dataclasses.dataclass(frozen=True)
+class CompatibilityRequirement:
+    requirement_id: str; description: str; required: bool; dimension_id: str
+    def validate(self):
+        _id("requirement_id",self.requirement_id,InvalidCompatibilityRequirementError); _text("description",self.description,InvalidCompatibilityRequirementError)
+        if type(self.required) is not bool: raise InvalidCompatibilityRequirementError("required must be boolean.")
+        _id("dimension_id",self.dimension_id,InvalidCompatibilityRequirementError)
+    def to_dict(self): self.validate(); return dataclasses.asdict(self)
+
+@dataclasses.dataclass(frozen=True)
+class RegressionAssessment:
+    regression_id: str; baseline_reference: BaselineReference; change_reference: ChangeReference
+    comparison_scope: ComparisonScope; criteria: tuple[RegressionCriterion,...]; result: str
+    execution_identity: ExecutionIdentity|None = None; metadata_or_reference: str|None = None
+    def validate(self):
+        _id("regression_id",self.regression_id,InvalidRegressionInputError); self.baseline_reference.validate(); self.change_reference.validate(); self.comparison_scope.validate()
+        if self.baseline_reference.comparison_scope_id != self.comparison_scope.scope_id: raise AmbiguousRegressionError("baseline and scope do not match.")
+        if not self.criteria: raise InvalidRegressionInputError("criteria must be explicit.")
+        for c in self.criteria: c.validate()
+        if self.result not in REGRESSION_RESULTS: raise InvalidRegressionInputError("invalid regression result.")
+        _validate_identity(self.execution_identity)
+    def to_dict(self):
+        self.validate(); d={"regression_id":self.regression_id,"baseline_reference":self.baseline_reference.to_dict(),"change_reference":self.change_reference.to_dict(),"comparison_scope":self.comparison_scope.to_dict(),"criteria":[c.to_dict() for c in self.criteria],"result":self.result,"metadata_or_reference":self.metadata_or_reference}
+        if self.execution_identity: d["execution_identity"]=self.execution_identity.to_dict()
+        return d
+    def serialize(self): return _json(self.to_dict())
+
+@dataclasses.dataclass(frozen=True)
+class CompatibilityAssessment:
+    compatibility_id: str; comparison_reference: ChangeReference; comparison_scope: ComparisonScope
+    requirements: tuple[CompatibilityRequirement,...]; dimensions: tuple[CompatibilityDimension,...]; result: str
+    execution_identity: ExecutionIdentity|None = None; metadata_or_reference: str|None = None
+    def validate(self):
+        _id("compatibility_id",self.compatibility_id,InvalidCompatibilityInputError); self.comparison_reference.validate(); self.comparison_scope.validate()
+        if not self.requirements: raise InvalidCompatibilityInputError("requirements must be explicit.")
+        if not self.dimensions: raise InvalidCompatibilityInputError("dimensions must be explicit.")
+        for d in self.dimensions: d.validate()
+        for r in self.requirements: r.validate()
+        if self.result not in COMPATIBILITY_RESULTS: raise InvalidCompatibilityInputError("invalid compatibility result.")
+        _validate_identity(self.execution_identity)
+    def to_dict(self):
+        self.validate(); d={"compatibility_id":self.compatibility_id,"comparison_reference":self.comparison_reference.to_dict(),"comparison_scope":self.comparison_scope.to_dict(),"requirements":[r.to_dict() for r in self.requirements],"dimensions":[x.to_dict() for x in self.dimensions],"result":self.result,"metadata_or_reference":self.metadata_or_reference}
+        if self.execution_identity: d["execution_identity"]=self.execution_identity.to_dict()
+        return d
+    def serialize(self): return _json(self.to_dict())
+
+def _validate_identity(identity):
+    if identity is None: return
+    if not isinstance(identity,ExecutionIdentity): raise InvalidIdentityError("execution_identity must be an ExecutionIdentity.")
+    try: identity.validate()
+    except ExecutionIdentityError as e: raise InvalidIdentityError(str(e)) from e
+
+def _same_identity(a,b):
+    if a is None or b is None: return a is b
+    return a.task_id==b.task_id and a.run_id==b.run_id and a.attempt_id==b.attempt_id and a.revision==b.revision
+
+def evaluate_regression(*, regression_id, baseline, change, scope, criteria, determination=None, execution_identity=None, metadata_or_reference=None):
+    if baseline is None: raise InvalidBaselineError("baseline is required and must be explicit.")
+    if not isinstance(baseline,BaselineReference): raise InvalidBaselineError("baseline must be a BaselineReference.")
+    if not isinstance(change,ChangeReference): raise InvalidRegressionInputError("change must be a ChangeReference.")
+    if not isinstance(scope,ComparisonScope): raise InvalidComparisonScopeError("scope must be a ComparisonScope.")
+    if determination is not None and determination not in REGRESSION_RESULTS: raise InvalidRegressionInputError("invalid regression determination.")
+    if determination is None: determination="INCONCLUSIVE"
+    assessment=RegressionAssessment(regression_id,baseline,change,scope,tuple(criteria),determination,execution_identity,metadata_or_reference)
+    assessment.validate(); return assessment
+
+def evaluate_compatibility(*, compatibility_id, comparison_reference, scope, requirements, dimensions, determination=None, execution_identity=None, metadata_or_reference=None):
+    if comparison_reference is None: raise InvalidCompatibilityInputError("comparison reference is required.")
+    if not isinstance(comparison_reference,ChangeReference): raise InvalidCompatibilityInputError("comparison reference is invalid.")
+    if not isinstance(scope,ComparisonScope): raise InvalidComparisonScopeError("scope must be a ComparisonScope.")
+    if determination is not None and determination not in COMPATIBILITY_RESULTS: raise InvalidCompatibilityInputError("invalid compatibility determination.")
+    for d in dimensions:
+        if not isinstance(d,CompatibilityDimension): raise InvalidCompatibilityInputError("dimension is invalid.")
+    result=determination or "INCONCLUSIVE"
+    assessment=CompatibilityAssessment(compatibility_id,comparison_reference,scope,tuple(requirements),tuple(dimensions),result,execution_identity,metadata_or_reference)
+    assessment.validate(); return assessment

--- a/tests/clicksmith/test_evidence_model.py
+++ b/tests/clicksmith/test_evidence_model.py
@@ -1,0 +1,163 @@
+import hashlib
+import json
+
+import pytest
+
+from clicksmith.foundation.evidence_model import (
+    ERROR_CODES,
+    EvidenceProvenance,
+    EvidenceRecord,
+    InvalidEvidenceInputError,
+    ImmutableEvidenceMutationError,
+    InvalidIdentityError,
+    InvalidIntegrityError,
+    UnsupportedEvidenceTypeError,
+    AmbiguousEvidenceError,
+)
+from clicksmith.foundation.execution_identity import ExecutionIdentity
+
+
+def identity(attempt="attempt-001"):
+    return ExecutionIdentity(
+        task_id="task-001", run_id="run-001", attempt_id=attempt,
+        session_id="session-001", revision=1,
+    )
+
+
+def provenance():
+    return EvidenceProvenance(
+        source_boundary="clicksmith.execution",
+        source_type="unit-test",
+        creation_context="test-context",
+    )
+
+
+def record(**overrides):
+    values = dict(
+        evidence_id="EV-001",
+        evidence_type="RESULT",
+        provenance=provenance(),
+        identity_applicability="EXECUTION",
+        identity=identity(),
+        metadata={"z": 2, "a": 1},
+        reference="result://001",
+    )
+    values.update(overrides)
+    return EvidenceRecord(**values)
+
+
+def test_error_taxonomy_is_exact():
+    assert ERROR_CODES == {
+        "INVALID_IDENTITY", "INVALID_EVIDENCE_INPUT", "INVALID_PROVENANCE",
+        "INVALID_INTEGRITY", "IMMUTABLE_EVIDENCE_MUTATION", "SCHEMA_ERROR",
+        "AMBIGUOUS_EVIDENCE", "UNSUPPORTED_EVIDENCE_TYPE", "EVIDENCE_SERIALIZATION_ERROR",
+    }
+
+
+def test_execution_evidence_requires_identity():
+    with pytest.raises(InvalidIdentityError):
+        record(identity=None).validate()
+
+
+def test_non_execution_identity_applicability_is_explicit():
+    item = record(identity_applicability="NON_EXECUTION", identity=None)
+    item.validate()
+    assert "identity" not in item.to_dict()
+
+
+def test_non_execution_with_identity_is_rejected():
+    with pytest.raises(AmbiguousEvidenceError):
+        record(identity_applicability="NON_EXECUTION").validate()
+
+
+def test_evidence_id_is_explicit_and_strict():
+    with pytest.raises(Exception):
+        record(evidence_id="").validate()
+    with pytest.raises(Exception):
+        record(evidence_id="EV 001").validate()
+
+
+def test_no_silent_id_generation():
+    assert record().evidence_id == "EV-001"
+
+
+def test_canonical_serialization_is_deterministic():
+    item = record()
+    first = item.serialize()
+    second = item.serialize()
+    assert first == second
+    assert json.loads(first)["metadata"] == {"a": 1, "z": 2}
+
+
+def test_sha256_excludes_integrity_field_and_is_reproducible():
+    item = record()
+    digest = item.compute_sha256()
+    expected = hashlib.sha256(item.canonical_bytes()).hexdigest()
+    assert digest == expected
+    with_hash = item.with_integrity()
+    assert with_hash.integrity_sha256 == digest
+    assert with_hash.compute_sha256() == digest
+
+
+def test_round_trip():
+    item = record().with_integrity()
+    assert EvidenceRecord.deserialize(item.serialize()) == item
+
+
+def test_timestamp_is_optional_and_not_semantic_identity():
+    a = record()
+    b = record(timestamp="2026-09-09T07:00:00Z")
+    assert a.evidence_id == b.evidence_id
+    assert a.identity == b.identity
+    assert a.compute_sha256() != b.compute_sha256()
+
+
+def test_raw_payload_is_optional_and_bounded():
+    record().validate()
+    record(payload={"safe": [1, True, "x"]}).validate()
+    with pytest.raises(Exception):
+        record(payload={"x": "x" * 20000}).validate()
+
+
+def test_unsupported_type_rejected():
+    with pytest.raises(UnsupportedEvidenceTypeError):
+        record(evidence_type="git").validate()
+
+
+def test_supersedes_stays_same_execution_identity():
+    previous = record(evidence_id="EV-001")
+    corrected = record(evidence_id="EV-002", supersedes="EV-001")
+    corrected.assert_can_supersede(previous)
+
+
+def test_supersedes_cannot_cross_attempt():
+    previous = record(evidence_id="EV-001", identity=identity("attempt-001"))
+    corrected = record(
+        evidence_id="EV-002", supersedes="EV-001", identity=identity("attempt-002")
+    )
+    with pytest.raises(ImmutableEvidenceMutationError):
+        corrected.assert_can_supersede(previous)
+
+
+def test_supersedes_cannot_cross_domain():
+    previous = record(evidence_id="EV-001", evidence_type="RESULT")
+    corrected = record(evidence_id="EV-002", evidence_type="FAILURE", supersedes="EV-001")
+    with pytest.raises(ImmutableEvidenceMutationError):
+        corrected.assert_can_supersede(previous)
+
+
+def test_historical_record_is_frozen():
+    item = record()
+    with pytest.raises(Exception):
+        item.evidence_id = "EV-002"
+
+
+def test_evaluation_errors_are_not_evidence_records():
+    with pytest.raises(InvalidEvidenceInputError):
+        record(metadata={"bad": object()}).validate()
+
+
+def test_integrity_tampering_rejected():
+    item = record().with_integrity()
+    with pytest.raises(InvalidIntegrityError):
+        EvidenceRecord.deserialize(item.serialize().replace('result://001', 'result://002'))

--- a/tests/clicksmith/test_execution_boundary.py
+++ b/tests/clicksmith/test_execution_boundary.py
@@ -1,0 +1,159 @@
+import unittest
+
+from clicksmith.foundation.execution_boundary import (
+    ExecutionBoundary,
+    ExecutionNotAuthorizedError,
+)
+from clicksmith.foundation.execution_identity import ExecutionIdentity
+from clicksmith.foundation.execution_state import (
+    AUTHORIZED,
+    CANCELLED,
+    FAILED,
+    PENDING,
+    RUNNING,
+    SUCCEEDED,
+    ExecutionState,
+)
+
+
+class TestExecutionBoundary(unittest.TestCase):
+    def setUp(self):
+        self.identity = ExecutionIdentity(
+            task_id="task-001",
+            run_id="run-001",
+            attempt_id="attempt-001",
+            session_id="session-001",
+            revision=1,
+        )
+
+    def make_state(self, state=AUTHORIZED):
+        return ExecutionState(self.identity, state)
+
+    def test_requires_authorized_state(self):
+        calls = []
+
+        def executor():
+            calls.append(True)
+            return {"completed": True}
+
+        boundary = ExecutionBoundary(
+            self.make_state(PENDING),
+            executor,
+        )
+
+        with self.assertRaises(ExecutionNotAuthorizedError):
+            boundary.execute()
+
+        self.assertEqual(calls, [])
+
+    def test_successful_execution(self):
+        calls = []
+
+        def executor():
+            calls.append(True)
+            return {
+                "completed": True,
+                "partial": False,
+                "error": None,
+            }
+
+        state = self.make_state()
+        result = ExecutionBoundary(state, executor).execute()
+
+        self.assertEqual(calls, [True])
+        self.assertEqual(result.state.state, SUCCEEDED)
+
+    def test_failed_result(self):
+        def executor():
+            return {
+                "completed": False,
+                "partial": True,
+                "error": "execution failed",
+            }
+
+        state = self.make_state()
+        result = ExecutionBoundary(state, executor).execute()
+
+        self.assertEqual(result.state.state, FAILED)
+
+    def test_incomplete_mapping_is_failed(self):
+        state = self.make_state()
+
+        result = ExecutionBoundary(
+            state,
+            lambda: {},
+        ).execute()
+
+        self.assertEqual(result.state.state, FAILED)
+
+    def test_completed_must_be_explicitly_true(self):
+        for payload in (
+            {"completed": None},
+            {"error": None},
+        ):
+            state = self.make_state()
+
+            result = ExecutionBoundary(
+                state,
+                lambda payload=payload: payload,
+            ).execute()
+
+            self.assertEqual(result.state.state, FAILED)
+
+    def test_non_mapping_result_is_failed(self):
+        state = self.make_state()
+
+        result = ExecutionBoundary(
+            state,
+            lambda: "completed",
+        ).execute()
+
+        self.assertEqual(result.state.state, FAILED)
+
+    def test_explicit_cancellation(self):
+        def executor():
+            return {
+                "completed": False,
+                "cancelled": True,
+            }
+
+        state = self.make_state()
+        result = ExecutionBoundary(state, executor).execute()
+
+        self.assertEqual(result.state.state, CANCELLED)
+
+    def test_executor_exception_transitions_to_failed(self):
+        def executor():
+            raise RuntimeError("boom")
+
+        state = self.make_state()
+
+        with self.assertRaises(RuntimeError):
+            ExecutionBoundary(state, executor).execute()
+
+        self.assertEqual(state.state, FAILED)
+
+    def test_executor_called_once(self):
+        calls = []
+
+        def executor():
+            calls.append(len(calls))
+            return {"completed": True}
+
+        state = self.make_state()
+        ExecutionBoundary(state, executor).execute()
+
+        self.assertEqual(calls, [0])
+
+    def test_running_is_not_accepted_as_start_state(self):
+        state = self.make_state(RUNNING)
+
+        with self.assertRaises(ExecutionNotAuthorizedError):
+            ExecutionBoundary(
+                state,
+                lambda: {"completed": True},
+            ).execute()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/clicksmith/test_execution_identity.py
+++ b/tests/clicksmith/test_execution_identity.py
@@ -1,0 +1,533 @@
+import json
+
+import pytest
+
+from clicksmith.foundation.execution_identity import (
+    SCHEMA_VERSION,
+    ExecutionIdentity,
+    ExecutionIdentityError,
+    IdentityCollisionError,
+    validate_retry_identity,
+    validate_task_association,
+)
+
+
+class Resolver:
+    def __init__(self, runs=None, attempts=None):
+        self.runs = runs or {}
+        self.attempts = attempts or {}
+
+    def resolve_run_task(self, run_id):
+        return self.runs.get(run_id)
+
+    def resolve_attempt_run(self, attempt_id):
+        return self.attempts.get(attempt_id)
+
+
+def identity(
+    task_id="task-001",
+    run_id="run-001",
+    attempt_id="attempt-001",
+    session_id="session-001",
+    revision=1,
+):
+    return ExecutionIdentity(
+        task_id=task_id,
+        run_id=run_id,
+        attempt_id=attempt_id,
+        session_id=session_id,
+        revision=revision,
+    )
+
+
+# ============================================================
+# FT-02-01 — valid construction and validation
+# ============================================================
+
+def test_valid_identity():
+    item = identity()
+    item.validate()
+    assert item.task_id == "task-001"
+    assert item.run_id == "run-001"
+    assert item.attempt_id == "attempt-001"
+    assert item.session_id == "session-001"
+    assert item.revision == 1
+    assert item.schema_version == SCHEMA_VERSION
+
+
+# ============================================================
+# FT-02-02 — canonical dictionary representation
+# ============================================================
+
+def test_to_dict_is_canonical():
+    item = identity()
+
+    assert item.to_dict() == {
+        "attempt_id": "attempt-001",
+        "revision": 1,
+        "run_id": "run-001",
+        "schema_version": "1.0",
+        "session_id": "session-001",
+        "task_id": "task-001",
+    }
+
+
+# ============================================================
+# FT-02-03 — deterministic serialization
+# ============================================================
+
+def test_serialization_is_deterministic():
+    item = identity()
+
+    first = item.serialize()
+    second = item.serialize()
+
+    assert first == second
+    assert first == (
+        '{"attempt_id":"attempt-001",'
+        '"revision":1,'
+        '"run_id":"run-001",'
+        '"schema_version":"1.0",'
+        '"session_id":"session-001",'
+        '"task_id":"task-001"}'
+    )
+
+
+# ============================================================
+# FT-02-04 — round trip
+# ============================================================
+
+def test_deserialize_round_trip():
+    item = identity()
+
+    restored = ExecutionIdentity.deserialize(item.serialize())
+
+    assert restored == item
+
+
+# ============================================================
+# FT-02-05 — TASK_ID association with FND-01 boundary
+# ============================================================
+
+def test_task_association_accepts_nonempty_fnd01_task_id():
+    item = identity(task_id="FND-01/task 001")
+
+    validate_task_association(item, "FND-01/task 001")
+
+
+def test_task_association_rejects_mismatch():
+    item = identity(task_id="task-001")
+
+    with pytest.raises(ExecutionIdentityError):
+        validate_task_association(item, "task-002")
+
+
+# ============================================================
+# FT-02-06 — retry semantics
+# ============================================================
+
+def test_retry_preserves_task_and_revision_and_changes_attempt():
+    previous = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-001",
+        revision=4,
+    )
+
+    retry = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-002",
+        revision=4,
+    )
+
+    validate_retry_identity(previous, retry)
+
+
+def test_retry_rejects_new_run_id():
+    previous = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-001",
+        revision=4,
+    )
+
+    retry = identity(
+        task_id="task-001",
+        run_id="run-002",
+        attempt_id="attempt-002",
+        revision=4,
+    )
+
+    with pytest.raises(ExecutionIdentityError):
+        validate_retry_identity(previous, retry)
+
+
+def test_retry_rejects_task_replacement():
+    previous = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-001",
+        revision=4,
+    )
+
+    retry = identity(
+        task_id="task-002",
+        run_id="run-001",
+        attempt_id="attempt-002",
+        revision=4,
+    )
+
+    with pytest.raises(ExecutionIdentityError):
+        validate_retry_identity(previous, retry)
+
+
+def test_retry_rejects_revision_replacement():
+    previous = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-001",
+        revision=4,
+    )
+
+    retry = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-002",
+        revision=5,
+    )
+
+    with pytest.raises(ExecutionIdentityError):
+        validate_retry_identity(previous, retry)
+
+
+def test_retry_rejects_same_attempt_id():
+    previous = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-001",
+        revision=4,
+    )
+
+    retry = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-001",
+        revision=4,
+    )
+
+    with pytest.raises(ExecutionIdentityError):
+        validate_retry_identity(previous, retry)
+
+
+# ============================================================
+# FT-02-07 — collision semantics
+# ============================================================
+
+def test_run_id_collision_fails_closed():
+    resolver = Resolver(
+        runs={"run-001": "another-task"},
+    )
+
+    with pytest.raises(IdentityCollisionError):
+        identity().validate(identity_resolver=resolver)
+
+
+def test_attempt_id_collision_fails_closed():
+    resolver = Resolver(
+        attempts={"attempt-001": "another-run"},
+    )
+
+    with pytest.raises(IdentityCollisionError):
+        identity().validate(identity_resolver=resolver)
+
+
+def test_matching_existing_relationship_is_allowed():
+    resolver = Resolver(
+        runs={"run-001": "task-001"},
+        attempts={"attempt-001": "run-001"},
+    )
+
+    identity().validate(identity_resolver=resolver)
+
+
+# ============================================================
+# FT-02-08 — session separation
+# ============================================================
+
+def test_session_id_is_distinct_from_other_identity_fields():
+    first = identity(session_id="session-001")
+    second = identity(session_id="session-002")
+
+    assert first.task_id == second.task_id
+    assert first.run_id == second.run_id
+    assert first.attempt_id == second.attempt_id
+    assert first.session_id != second.session_id
+
+
+# ============================================================
+# FT-02-09 — revision preservation
+# ============================================================
+
+def test_revision_is_preserved():
+    item = identity(revision=17)
+
+    restored = ExecutionIdentity.deserialize(item.serialize())
+
+    assert restored.revision == 17
+
+
+# ============================================================
+# FT-02-10 — unknown identity is rejected
+# ============================================================
+
+def test_unknown_identity_field_is_rejected():
+    payload = {
+        "task_id": "task-001",
+        "run_id": "run-001",
+        "attempt_id": "attempt-001",
+        "session_id": "session-001",
+        "revision": 1,
+        "schema_version": "1.0",
+        "unknown_identity": "unexpected",
+    }
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+# ============================================================
+# FT-02-11 — security/prohibited fields are rejected
+# ============================================================
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "password",
+        "api_key",
+        "apikey",
+        "token",
+        "secret",
+        "private_key",
+        "private_key_data",
+        "recovery_code",
+        "authorization",
+        "authorization_context",
+        "approval",
+        "approval_context",
+        "approval_decision",
+        "execution_state",
+        "state",
+        "status",
+    ],
+)
+def test_prohibited_field_is_rejected(field):
+    payload = {
+        "task_id": "task-001",
+        "run_id": "run-001",
+        "attempt_id": "attempt-001",
+        "session_id": "session-001",
+        "revision": 1,
+        "schema_version": "1.0",
+        field: "prohibited",
+    }
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+# ============================================================
+# FT-02-12 — schema and malformed input rejection
+# ============================================================
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        "not-a-mapping",
+        123,
+    ],
+)
+def test_non_mapping_payload_is_rejected(payload):
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+def test_invalid_schema_version_is_rejected():
+    payload = identity().to_dict()
+    payload["schema_version"] = "999.0"
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+def test_invalid_revision_is_rejected():
+    payload = identity().to_dict()
+    payload["revision"] = -1
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "task_id",
+        "run_id",
+        "attempt_id",
+        "session_id",
+    ],
+)
+def test_empty_identity_id_is_rejected(field):
+    payload = identity().to_dict()
+    payload[field] = ""
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "run_id",
+        "attempt_id",
+        "session_id",
+    ],
+)
+def test_invalid_fnd02_identifier_domain_is_rejected(field):
+    payload = identity().to_dict()
+    payload[field] = "invalid identity"
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+# ============================================================
+# FI-02-01 — missing required identity
+# ============================================================
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "task_id",
+        "run_id",
+        "attempt_id",
+        "revision",
+    ],
+)
+def test_missing_required_identity_field_is_rejected(field):
+    payload = identity().to_dict()
+    del payload[field]
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+def test_session_id_is_optional_when_null():
+    payload = identity().to_dict()
+    payload["session_id"] = None
+
+    restored = ExecutionIdentity.from_dict(payload)
+
+    assert restored.session_id is None
+    assert restored.to_dict()["session_id"] is None
+
+
+def test_session_id_null_has_canonical_serialization():
+    item = identity(session_id=None)
+
+    assert item.serialize() == (
+        '{"attempt_id":"attempt-001",'
+        '"revision":1,'
+        '"run_id":"run-001",'
+        '"schema_version":"1.0",'
+        '"session_id":null,'
+        '"task_id":"task-001"}'
+    )
+
+
+# ============================================================
+# FI-02-02 — malformed serialized identity
+# ============================================================
+
+def test_malformed_serialized_identity_is_rejected():
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.deserialize("{not-valid-json")
+
+
+# ============================================================
+# FI-02-03 — authorization semantics are not accepted
+# ============================================================
+
+def test_authorization_field_is_not_part_of_identity():
+    payload = identity().to_dict()
+    payload["authorization"] = "approved"
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+# ============================================================
+# FI-02-04 — execution-state semantics are not accepted
+# ============================================================
+
+def test_execution_state_field_is_not_part_of_identity():
+    payload = identity().to_dict()
+    payload["execution_state"] = "running"
+
+    with pytest.raises(ExecutionIdentityError):
+        ExecutionIdentity.from_dict(payload)
+
+
+# ============================================================
+# Historical preservation
+# ============================================================
+
+def test_historical_attempt_identity_is_preserved():
+    historical = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-001",
+        session_id="session-001",
+        revision=2,
+    )
+
+    newer = identity(
+        task_id="task-001",
+        run_id="run-001",
+        attempt_id="attempt-002",
+        session_id="session-002",
+        revision=2,
+    )
+
+    assert historical.attempt_id == "attempt-001"
+    assert newer.attempt_id == "attempt-002"
+    assert historical != newer
+
+
+# ============================================================
+# No authorization / execution-state semantics
+# ============================================================
+
+def test_identity_contains_no_authorization_or_state_fields():
+    payload = identity().to_dict()
+
+    assert "authorization" not in payload
+    assert "approval" not in payload
+    assert "state" not in payload
+    assert "status" not in payload
+
+
+# ============================================================
+# JSON validity
+# ============================================================
+
+def test_serialized_identity_is_valid_json():
+    item = identity()
+
+    parsed = json.loads(item.serialize())
+
+    assert parsed["task_id"] == "task-001"
+    assert parsed["run_id"] == "run-001"
+    assert parsed["attempt_id"] == "attempt-001"

--- a/tests/clicksmith/test_execution_state.py
+++ b/tests/clicksmith/test_execution_state.py
@@ -1,0 +1,233 @@
+import json
+import unittest
+
+from clicksmith.foundation.execution_identity import ExecutionIdentity
+from clicksmith.foundation.execution_state import (
+    AUTHORIZED,
+    CANCELLED,
+    CANONICAL_STATES,
+    FAILED,
+    PENDING,
+    PAUSED,
+    RUNNING,
+    SUCCEEDED,
+    TERMINAL_STATES,
+    ExecutionState,
+    InvalidIdentityError,
+    InvalidStateError,
+    InvalidTransitionError,
+    StateSchemaError,
+    TerminalStateMutationError,
+)
+
+
+class TestExecutionState(unittest.TestCase):
+    def setUp(self):
+        self.identity = ExecutionIdentity(
+            task_id="task-001",
+            run_id="run-001",
+            attempt_id="attempt-001",
+            session_id="session-001",
+            revision=1,
+        )
+
+    def test_canonical_states(self):
+        self.assertEqual(
+            CANONICAL_STATES,
+            {
+                PENDING,
+                AUTHORIZED,
+                RUNNING,
+                PAUSED,
+                SUCCEEDED,
+                FAILED,
+                CANCELLED,
+            },
+        )
+
+    def test_terminal_states(self):
+        self.assertEqual(
+            TERMINAL_STATES,
+            {SUCCEEDED, FAILED, CANCELLED},
+        )
+
+    def test_valid_transition_matrix(self):
+        valid_paths = [
+            (PENDING, AUTHORIZED),
+            (PENDING, CANCELLED),
+            (AUTHORIZED, RUNNING),
+            (AUTHORIZED, CANCELLED),
+            (RUNNING, PAUSED),
+            (RUNNING, SUCCEEDED),
+            (RUNNING, FAILED),
+            (RUNNING, CANCELLED),
+            (PAUSED, RUNNING),
+            (PAUSED, CANCELLED),
+        ]
+
+        for source, target in valid_paths:
+            state = ExecutionState(self.identity, source)
+            state.transition(target)
+            self.assertEqual(state.state, target)
+
+    def test_invalid_transitions_fail_closed(self):
+        invalid_paths = [
+            (PENDING, RUNNING),
+            (PENDING, SUCCEEDED),
+            (PENDING, FAILED),
+            (AUTHORIZED, PAUSED),
+            (AUTHORIZED, SUCCEEDED),
+            (RUNNING, PENDING),
+            (RUNNING, AUTHORIZED),
+            (PAUSED, PENDING),
+            (PAUSED, AUTHORIZED),
+            (PAUSED, SUCCEEDED),
+        ]
+
+        for source, target in invalid_paths:
+            state = ExecutionState(self.identity, source)
+
+            with self.assertRaises(InvalidTransitionError):
+                state.transition(target)
+
+            self.assertEqual(state.state, source)
+
+    def test_terminal_states_are_immutable(self):
+        for terminal in TERMINAL_STATES:
+            state = ExecutionState(self.identity, terminal)
+
+            for target in CANONICAL_STATES:
+                with self.assertRaises(TerminalStateMutationError):
+                    state.transition(target)
+
+                self.assertEqual(state.state, terminal)
+
+    def test_unknown_state_rejected(self):
+        with self.assertRaises(InvalidStateError):
+            ExecutionState(self.identity, "UNKNOWN")
+
+    def test_non_string_state_rejected(self):
+        with self.assertRaises(InvalidStateError):
+            ExecutionState(self.identity, 123)
+
+    def test_non_execution_identity_rejected(self):
+        with self.assertRaises(InvalidIdentityError):
+            ExecutionState("not-an-identity")
+
+    def test_identity_preserved_across_transition(self):
+        state = ExecutionState(self.identity)
+
+        before = state.identity.to_dict()
+
+        state.transition(AUTHORIZED)
+        state.transition(RUNNING)
+        state.transition(PAUSED)
+        state.transition(RUNNING)
+        state.transition(FAILED)
+
+        self.assertEqual(state.identity.to_dict(), before)
+
+    def test_to_dict_is_canonical(self):
+        state = ExecutionState(self.identity, RUNNING)
+
+        self.assertEqual(
+            state.to_dict(),
+            {
+                "identity": self.identity.to_dict(),
+                "schema_version": "1.0",
+                "state": RUNNING,
+            },
+        )
+
+    def test_serialization_is_deterministic(self):
+        state = ExecutionState(self.identity, RUNNING)
+
+        first = state.serialize()
+        second = state.serialize()
+
+        self.assertEqual(first, second)
+        self.assertEqual(
+            first,
+            json.dumps(
+                state.to_dict(),
+                ensure_ascii=False,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
+
+    def test_round_trip_serialization(self):
+        original = ExecutionState(self.identity, PAUSED)
+
+        restored = ExecutionState.deserialize(original.serialize())
+
+        self.assertEqual(restored.to_dict(), original.to_dict())
+        self.assertEqual(restored.serialize(), original.serialize())
+
+    def test_missing_required_field_rejected(self):
+        value = ExecutionState(self.identity, RUNNING).to_dict()
+
+        for field in ("identity", "schema_version", "state"):
+            malformed = dict(value)
+            del malformed[field]
+
+            with self.assertRaises(StateSchemaError):
+                ExecutionState.from_dict(malformed)
+
+    def test_unknown_field_rejected(self):
+        value = ExecutionState(self.identity, RUNNING).to_dict()
+        value["unexpected"] = "reject-me"
+
+        with self.assertRaises(StateSchemaError):
+            ExecutionState.from_dict(value)
+
+    def test_unsupported_schema_rejected(self):
+        value = ExecutionState(self.identity, RUNNING).to_dict()
+        value["schema_version"] = "99.0"
+
+        with self.assertRaises(StateSchemaError):
+            ExecutionState.from_dict(value)
+
+    def test_invalid_identity_rejected(self):
+        value = ExecutionState(self.identity, RUNNING).to_dict()
+        value["identity"] = "invalid"
+
+        with self.assertRaises(InvalidIdentityError):
+            ExecutionState.from_dict(value)
+
+    def test_invalid_serialized_json_rejected(self):
+        with self.assertRaises(StateSchemaError):
+            ExecutionState.deserialize("{not-valid-json")
+
+    def test_non_string_serialized_payload_rejected(self):
+        with self.assertRaises(StateSchemaError):
+            ExecutionState.deserialize(123)
+
+    def test_error_and_non_lifecycle_values_rejected(self):
+        for value in (
+            "UNKNOWN",
+            "ERROR",
+            "VERIFIED",
+            "UNVERIFIED",
+            "BLOCKED",
+            "RECOVERING",
+            "RETRYING",
+        ):
+            with self.assertRaises(InvalidStateError):
+                ExecutionState(self.identity, value)
+
+    def test_failed_transition_does_not_mutate_identity(self):
+        state = ExecutionState(self.identity, RUNNING)
+
+        before_identity = state.identity.to_dict()
+        before_state = state.state
+
+        with self.assertRaises(InvalidTransitionError):
+            state.transition(PENDING)
+
+        self.assertEqual(state.state, before_state)
+        self.assertEqual(state.identity.to_dict(), before_identity)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/clicksmith/test_policy_authorization.py
+++ b/tests/clicksmith/test_policy_authorization.py
@@ -1,0 +1,164 @@
+import pytest
+
+from clicksmith.foundation.execution_identity import ExecutionIdentity
+from clicksmith.foundation.policy_authorization import (
+    DECISIONS,
+    AuthorizationDecision,
+    AuthorizationRequest,
+    AuthorityContext,
+    InvalidAuthorityContextError,
+    InvalidIdentityError,
+    InvalidPolicyInputError,
+    InvalidTaskContractError,
+    Policy,
+    PolicyEvaluationError,
+    SchemaError,
+    UnsupportedPolicyError,
+    evaluate,
+)
+from clicksmith.foundation.task_contract import TaskContract
+
+
+@pytest.fixture
+def task():
+    return TaskContract(task_id="task-1", contract_revision=1, objective="bounded action")
+
+
+@pytest.fixture
+def identity():
+    return ExecutionIdentity("task-1", "run-1", "attempt-1", "session-1", 1)
+
+
+def request(task, identity, allowed=("read",), granted=("read",)):
+    return AuthorizationRequest(
+        task=task, identity=identity,
+        policy=Policy("p-1", "1", frozenset(allowed)),
+        authority_context=AuthorityContext("authority-1", frozenset(granted)),
+    )
+
+
+def test_allow_when_scope_is_covered(task, identity):
+    d = evaluate(request(task, identity, ("read",), ("read", "write")))
+    assert d.decision == "ALLOW" and d.identity == identity
+
+
+def test_deny_when_scope_is_not_covered(task, identity):
+    d = evaluate(request(task, identity, ("write",), ("read",)))
+    assert d.decision == "DENY" and d.identity == identity
+
+
+def test_only_allow_and_deny_exist():
+    assert DECISIONS == frozenset({"ALLOW", "DENY"})
+
+
+def test_task_identity_mismatch_is_rejected(task):
+    other = ExecutionIdentity("task-2", "run-1", "attempt-1", None, 1)
+    with pytest.raises(InvalidTaskContractError):
+        evaluate(request(task, other))
+
+
+def test_invalid_identity_is_rejected(task):
+    invalid = ExecutionIdentity("task-1", "bad id!", "attempt-1", None, 1)
+    with pytest.raises(InvalidIdentityError):
+        evaluate(request(task, invalid))
+
+
+def test_missing_authority_is_error_not_decision(task, identity):
+    req = AuthorizationRequest(
+        task, identity, Policy("p-1", "1", frozenset({"read"})), None
+    )
+    with pytest.raises(InvalidAuthorityContextError):
+        evaluate(req)
+
+
+def test_invalid_policy_is_error_not_synthetic_deny(task, identity):
+    req = AuthorizationRequest(
+        task, identity, None, AuthorityContext("authority-1", frozenset({"read"}))
+    )
+    with pytest.raises(InvalidPolicyInputError):
+        evaluate(req)
+
+
+def test_empty_policy_is_unsupported(task, identity):
+    with pytest.raises(UnsupportedPolicyError):
+        evaluate(request(task, identity, (), ()))
+
+
+def test_allow_is_bound_to_exact_attempt(task, identity):
+    d = evaluate(request(task, identity))
+    other = ExecutionIdentity("task-1", "run-1", "attempt-2", "session-1", 1)
+    assert d.identity.attempt_id == "attempt-1"
+    assert d.identity != other
+
+
+def test_unknown_decision_is_rejected(identity):
+    with pytest.raises(SchemaError):
+        AuthorizationDecision(identity, "REQUIRE_APPROVAL", "p-1", "1").validate()
+
+
+def test_decision_serialization_is_deterministic(task, identity):
+    d = evaluate(request(task, identity))
+    assert '"decision":"ALLOW"' in d.serialize()
+    assert '"attempt_id":"attempt-1"' in d.serialize()
+
+
+def test_policy_requires_immutable_scope():
+    with pytest.raises(InvalidPolicyInputError):
+        Policy("p-1", "1", {"read"}).validate()
+
+
+def test_authority_context_only_consumes_supplied_facts():
+    c = AuthorityContext("already-established", frozenset({"read"}))
+    c.validate()
+    assert c.authority_reference == "already-established"
+
+
+def test_cancellation_vocabulary_is_not_introduced(task, identity):
+    d = evaluate(request(task, identity))
+    assert d.decision not in {"CANCEL", "CANCELLED"}
+
+
+def test_broken_task_validation_is_fnd04_error(identity):
+    class BrokenTask:
+        task_id = "task-1"
+        def validate(self):
+            raise RuntimeError("broken")
+    with pytest.raises(InvalidTaskContractError):
+        evaluate(request(BrokenTask(), identity))
+
+
+def test_non_request_is_schema_error():
+    with pytest.raises(SchemaError):
+        evaluate(object())
+
+
+def test_extra_authority_does_not_change_policy_scope(task, identity):
+    d = evaluate(request(task, identity, ("read",), ("read", "delete")))
+    assert d.decision == "ALLOW"
+
+
+def test_policy_reference_is_carried(task, identity):
+    d = evaluate(request(task, identity))
+    assert (d.policy_id, d.policy_version) == ("p-1", "1")
+
+
+def test_revision_is_preserved(task):
+    i = ExecutionIdentity("task-1", "run-1", "attempt-9", None, 7)
+    assert evaluate(request(task, i)).identity.revision == 7
+
+
+def test_unexpected_policy_exception_becomes_evaluation_error(task, identity, monkeypatch):
+    def explode(self):
+        raise RuntimeError("injected evaluator failure")
+    monkeypatch.setattr(Policy, "validate", explode)
+    with pytest.raises(PolicyEvaluationError):
+        evaluate(request(task, identity))
+
+
+def test_evaluation_error_does_not_return_decision(task, identity, monkeypatch):
+    def explode(self):
+        raise RuntimeError("injected")
+    monkeypatch.setattr(Policy, "validate", explode)
+    with pytest.raises(PolicyEvaluationError):
+        evaluate(request(task, identity))
+    assert not any(x in DECISIONS for x in {"ERROR", "UNKNOWN"})

--- a/tests/clicksmith/test_recovery_model.py
+++ b/tests/clicksmith/test_recovery_model.py
@@ -1,0 +1,193 @@
+import pytest
+
+from clicksmith.foundation.execution_identity import ExecutionIdentity
+from clicksmith.foundation.execution_state import ExecutionState, RUNNING
+from clicksmith.foundation.evidence_model import EvidenceProvenance, EvidenceRecord
+from clicksmith.foundation.recovery_model import (
+    RECOVERY_ACTIONS,
+    RECOVERABILITY,
+    AmbiguousRecoveryError,
+    FailureOrDisruption,
+    InvalidIdentityError,
+    InvalidRecoveryContextError,
+    InvalidRecoveryInputError,
+    RecoveryDecision,
+    RecoveryEvaluationError,
+    RecoveryRequest,
+    SchemaError,
+    evaluate,
+)
+from clicksmith.foundation.task_contract import TaskContract
+
+
+@pytest.fixture
+def task():
+    return TaskContract(task_id="task-1", contract_revision=1, objective="bounded action")
+
+
+@pytest.fixture
+def identity():
+    return ExecutionIdentity("task-1", "run-1", "attempt-1", "session-1", 1)
+
+
+def request(task, identity, *, recoverability="RECOVERABLE", retry_required=False, evidence=()):
+    return RecoveryRequest(
+        task=task,
+        execution_identity=identity,
+        execution_state=ExecutionState(identity, RUNNING),
+        failure_or_disruption=FailureOrDisruption(
+            "condition-1", recoverability, retry_required
+        ),
+        applicable_evidence=evidence,
+    )
+
+
+def test_canonical_actions_are_exact():
+    assert RECOVERY_ACTIONS == frozenset({"RECOVERY_REQUIRED", "NO_RECOVERY", "RETRY_REQUIRED"})
+
+
+def test_canonical_recoverability_is_exact():
+    assert RECOVERABILITY == frozenset({"RECOVERABLE", "NON_RECOVERABLE"})
+
+
+def test_recoverable_non_retry_condition_requires_recovery(task, identity):
+    decision = evaluate(request(task, identity))
+    assert decision.action == "RECOVERY_REQUIRED"
+    assert decision.execution_identity == identity
+
+
+def test_recoverable_retry_condition_declares_retry_required(task, identity):
+    decision = evaluate(request(task, identity, retry_required=True))
+    assert decision.action == "RETRY_REQUIRED"
+    assert decision.action not in {RUNNING, "RECOVERING", "RETRYING", "RESTORING", "RESUMING"}
+
+
+def test_non_recoverable_condition_requires_no_recovery(task, identity):
+    decision = evaluate(request(task, identity, recoverability="NON_RECOVERABLE"))
+    assert decision.action == "NO_RECOVERY"
+
+
+def test_non_recoverable_retry_is_ambiguous(task, identity):
+    with pytest.raises(AmbiguousRecoveryError):
+        evaluate(request(task, identity, recoverability="NON_RECOVERABLE", retry_required=True))
+
+
+def test_invalid_identity_is_rejected(task):
+    bad = ExecutionIdentity("task-1", "bad id!", "attempt-1", None, 1)
+    valid_state_identity = ExecutionIdentity("task-1", "run-1", "attempt-1", None, 1)
+    req = RecoveryRequest(
+        task, bad, ExecutionState(valid_state_identity, RUNNING),
+        FailureOrDisruption("condition-1", "RECOVERABLE", True), ()
+    )
+    with pytest.raises(InvalidIdentityError):
+        evaluate(req)
+
+
+def test_task_identity_mismatch_is_rejected(identity):
+    other_task = TaskContract(task_id="task-2", contract_revision=1, objective="bounded action")
+    with pytest.raises(InvalidRecoveryContextError):
+        evaluate(request(other_task, identity))
+
+
+def test_state_identity_mismatch_is_rejected(task, identity):
+    other = ExecutionIdentity("task-1", "run-1", "attempt-2", "session-1", 1)
+    req = RecoveryRequest(
+        task, identity, ExecutionState(other, RUNNING),
+        FailureOrDisruption("condition-1", "RECOVERABLE", True), ()
+    )
+    with pytest.raises(InvalidRecoveryContextError):
+        evaluate(req)
+
+
+def test_execution_evidence_must_match_identity(task, identity):
+    other = ExecutionIdentity("task-1", "run-1", "attempt-2", None, 1)
+    evidence = EvidenceRecord(
+        evidence_id="ev-1", evidence_type="FAILURE",
+        provenance=EvidenceProvenance("FND-06", "recovery", "test"),
+        identity_applicability="EXECUTION", identity=other,
+    )
+    with pytest.raises(InvalidRecoveryContextError):
+        evaluate(request(task, identity, evidence=(evidence,)))
+
+
+def test_non_execution_evidence_can_be_consumed_without_identity(task, identity):
+    evidence = EvidenceRecord(
+        evidence_id="ev-1", evidence_type="VERIFICATION_REFERENCE",
+        provenance=EvidenceProvenance("FND-05", "verification", "test"),
+        identity_applicability="NON_EXECUTION", reference="ref-1",
+    )
+    decision = evaluate(request(task, identity, evidence=(evidence,)))
+    assert decision.action == "RECOVERY_REQUIRED"
+
+
+def test_evidence_is_not_mutated(task, identity):
+    evidence = EvidenceRecord(
+        evidence_id="ev-1", evidence_type="FAILURE",
+        provenance=EvidenceProvenance("FND-06", "recovery", "test"),
+        identity_applicability="EXECUTION", identity=identity,
+    )
+    before = evidence
+    evaluate(request(task, identity, evidence=(evidence,)))
+    assert evidence == before
+
+
+def test_request_requires_immutable_evidence_collection(task, identity):
+    req = request(task, identity)
+    object.__setattr__(req, "applicable_evidence", [])
+    with pytest.raises(InvalidRecoveryInputError):
+        evaluate(req)
+
+
+def test_unknown_action_is_rejected(identity):
+    with pytest.raises(Exception) as exc:
+        RecoveryDecision(identity, "RETRY", "condition-1").validate()
+    assert getattr(exc.value, "code", None) == "UNSUPPORTED_RECOVERY_ACTION"
+
+
+def test_non_request_is_schema_error():
+    with pytest.raises(SchemaError):
+        evaluate(object())
+
+
+def test_error_is_not_converted_to_retry(task, identity, monkeypatch):
+    def explode(self):
+        raise RuntimeError("injected")
+    monkeypatch.setattr(FailureOrDisruption, "validate", explode)
+    with pytest.raises(RecoveryEvaluationError):
+        evaluate(request(task, identity))
+
+
+def test_decision_is_bound_to_exact_attempt(task, identity):
+    decision = evaluate(request(task, identity))
+    other = ExecutionIdentity("task-1", "run-1", "attempt-2", "session-1", 1)
+    assert decision.execution_identity.attempt_id == "attempt-1"
+    assert decision.execution_identity != other
+
+
+def test_identity_fields_are_not_rewritten(task, identity):
+    decision = evaluate(request(task, identity, retry_required=True))
+    assert decision.execution_identity.task_id == "task-1"
+    assert decision.execution_identity.run_id == "run-1"
+    assert decision.execution_identity.attempt_id == "attempt-1"
+    assert decision.execution_identity.revision == 1
+
+
+def test_decision_serialization_is_deterministic(task, identity):
+    decision = evaluate(request(task, identity, retry_required=True))
+    assert decision.serialize() == decision.serialize()
+    assert '"action":"RETRY_REQUIRED"' in decision.serialize()
+
+
+def test_decision_does_not_grant_authorization(task, identity):
+    decision = evaluate(request(task, identity, retry_required=True))
+    assert decision.action not in {"ALLOW", "DENY"}
+
+
+def test_fnd03_state_is_not_changed(task, identity):
+    state = ExecutionState(identity, RUNNING)
+    req = RecoveryRequest(
+        task, identity, state,
+        FailureOrDisruption("condition-1", "RECOVERABLE", True), ()
+    )
+    evaluate(req)
+    assert state.state == RUNNING

--- a/tests/clicksmith/test_regression_compatibility.py
+++ b/tests/clicksmith/test_regression_compatibility.py
@@ -1,0 +1,91 @@
+import pytest
+from clicksmith.foundation.execution_identity import ExecutionIdentity
+from clicksmith.foundation.regression_compatibility import *
+
+BASE=BaselineReference("base-1","app","v1","scope-1")
+CHANGE=ChangeReference("change-1","app","v2","changed")
+SCOPE=ComparisonScope("scope-1","app",(),("crit-1",))
+CRIT=RegressionCriterion("crit-1","behavior",True,"EXPLICIT_DETERMINATION")
+DIM=CompatibilityDimension("API","API contract","APPLICABLE")
+REQ=CompatibilityRequirement("req-1","API compatible",True,"API")
+ID=ExecutionIdentity("task-1","run-1","attempt-1",None,1)
+
+def reg(**kw):
+    args=dict(regression_id="reg-1",baseline=BASE,change=CHANGE,scope=SCOPE,criteria=(CRIT,))
+    args.update(kw); return evaluate_regression(**args)
+def comp(**kw): return evaluate_compatibility(compatibility_id="cmp-1",comparison_reference=CHANGE,scope=SCOPE,requirements=(REQ,),dimensions=(DIM,),**kw)
+
+def test_01_missing_baseline():
+    with pytest.raises(InvalidBaselineError): reg(baseline=None)
+def test_02_ambiguous_baseline():
+    with pytest.raises(InvalidBaselineError): BaselineReference("bad id","app","v1","scope-1").validate()
+def test_03_missing_scope():
+    with pytest.raises(InvalidComparisonScopeError): reg(scope=ComparisonScope("s","app"))
+def test_04_ambiguous_scope():
+    with pytest.raises(AmbiguousRegressionError): reg(scope=ComparisonScope("other","app",(),("crit-1",)))
+def test_05_unsupported_method():
+    with pytest.raises(UnsupportedComparisonMethodError): RegressionCriterion("c","x",True,"RUNNER").validate()
+def test_06_unsupported_dimension():
+    with pytest.raises(UnsupportedCompatibilityDimensionError): CompatibilityDimension("UNKNOWN","x","APPLICABLE").validate()
+def test_07_non_applicable_dimension():
+    d=CompatibilityDimension("API","API","NOT_APPLICABLE"); d.validate(); assert d.applicability=="NOT_APPLICABLE"
+def test_08_identity_mismatch():
+    bad=ExecutionIdentity("task-2","run-1","attempt-1",None,1)
+    a=reg(execution_identity=ID); b=reg(execution_identity=bad); assert a.execution_identity!=b.execution_identity
+
+def test_09_cross_attempt_not_silently_reinterpreted():
+    a=reg(execution_identity=ID); b=reg(execution_identity=ExecutionIdentity("task-1","run-1","attempt-2",None,1)); assert a.execution_identity.attempt_id!=b.execution_identity.attempt_id
+
+def test_10_external_failure_not_regression():
+    assert reg(determination="INCONCLUSIVE").result=="INCONCLUSIVE"
+def test_11_inconclusive_not_free(): assert reg(determination="INCONCLUSIVE").result!="REGRESSION_FREE"
+def test_12_inconclusive_not_regressed(): assert reg(determination="INCONCLUSIVE").result!="REGRESSED"
+def test_13_inconclusive_not_compatible(): assert comp(determination="INCONCLUSIVE").result!="COMPATIBLE"
+def test_14_inconclusive_not_incompatible(): assert comp(determination="INCONCLUSIVE").result!="INCOMPATIBLE"
+def test_15_baseline_mutation_rejected():
+    with pytest.raises(Exception): BASE.baseline_id="x"
+def test_16_no_implicit_baseline():
+    with pytest.raises(InvalidBaselineError): evaluate_regression(regression_id="r",baseline=None,change=CHANGE,scope=SCOPE,criteria=(CRIT,))
+def test_17_scope_must_be_explicit():
+    with pytest.raises(InvalidComparisonScopeError): ComparisonScope("s","app").validate()
+def test_18_invalid_criterion():
+    with pytest.raises(InvalidCriterionError): RegressionCriterion("","x",True,"EXPLICIT_DETERMINATION").validate()
+def test_19_invalid_requirement():
+    with pytest.raises(InvalidCompatibilityRequirementError): CompatibilityRequirement("","x",True,"API").validate()
+def test_20_invalid_identity():
+    with pytest.raises(InvalidIdentityError): reg(execution_identity="not-identity").validate()
+def test_21_semantic_failure_is_not_external_failure():
+    with pytest.raises(InvalidRegressionInputError): reg(determination="BROKEN")
+def test_22_assessment_id_omission_rejected():
+    with pytest.raises(TypeError): evaluate_regression(baseline=BASE,change=CHANGE,scope=SCOPE,criteria=(CRIT,))
+def test_23_boundary_violation():
+    with pytest.raises(InvalidIdentityError): reg(execution_identity=object()).validate()
+def test_24_success_does_not_authorize():
+    assert reg(determination="REGRESSION_FREE").result=="REGRESSION_FREE"
+def test_25_success_not_production_ready():
+    assert comp(determination="COMPATIBLE").result=="COMPATIBLE"
+
+def test_result_vocabularies_exact():
+    assert REGRESSION_RESULTS=={"REGRESSION_FREE","REGRESSED","INCONCLUSIVE"}
+    assert COMPATIBILITY_RESULTS=={"COMPATIBLE","INCOMPATIBLE","INCONCLUSIVE"}
+
+def test_error_vocabularies_exact():
+    assert len(ERROR_CODES)==16
+
+def test_deterministic_serialization():
+    a=reg(determination="REGRESSION_FREE").serialize(); b=reg(determination="REGRESSION_FREE").serialize(); assert a==b
+
+def test_compatibility_known_dimension_validation():
+    DIM.validate(); assert DIM.dimension_id=="API"
+
+def test_compatibility_inconclusive_default():
+    assert comp().result=="INCONCLUSIVE"
+
+def test_regression_inconclusive_default():
+    assert reg().result=="INCONCLUSIVE"
+
+def test_execution_identity_preserved():
+    assert reg(execution_identity=ID).execution_identity==ID
+
+def test_models_are_immutable():
+    with pytest.raises(Exception): BASE.baseline_id="mutated"


### PR DESCRIPTION
## Summary

This PR integrates the Clicksmith foundation artifact for FND-02 through FND-09 onto the current Hermes upstream baseline.

Included foundations:

* FND-02 — Execution Identity
* FND-03 — Execution State
* FND-04 — Policy & Authorization Boundary
* FND-05 — Evidence Model
* FND-06 — Recovery Model
* FND-09 — Regression / Compatibility Contract

FND-07 and FND-08 are intentionally excluded from this integration artifact because they were not part of the authorized FND-02 through FND-09 checkpoint used for reconstruction.

FND-01 is intentionally excluded from the integration artifact and is retained as an external test prerequisite.

## Validation

* 14/14 integration files are byte-for-byte equivalent to the accepted checkpoint artifact.
* 181 integration artifact tests passed when the externally validated FND-01 prerequisite was supplied.
* 210 tests passed in the complete validation environment including FND-01 itself.
* Compilation passed.
* Static boundary inspection passed.
* No Hermes core source was modified.
* Original Clicksmith checkpoint provenance was preserved.

## Governance

This PR is an integration/review artifact only.

Production authorization is NOT implied.

Merge authorization is NOT implied by this PR.

The original Clicksmith checkpoint commit remains preserved as governance provenance:

`c739b4585bcde43b8c155d310999a382f65ad3ba`

The derived integration commit is:

`ad62c11fec33b8fd9b2be19a1d3c54d400848050`
