### PR TITLE
fix(egress): refuse setup/start when rootless bind would be unreachable

### DIFF
--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -506,6 +506,48 @@ def _detect_docker_bridge_ip() -> Optional[str]:
     return str(addr)
 
 
+def _docker_rootless() -> bool:
+    """True when the Docker daemon is rootless.  Primary signal: the ``rootless``
+    member of ``docker info`` SecurityOptions.  Fallback: DOCKER_HOST pointing
+    under the user's runtime dir.  Fail-open (False) when docker is missing or
+    unparseable — an unknown daemon keeps today's behavior."""
+    try:
+        res = _run(["docker", "info", "--format", "{{json .SecurityOptions}}"],
+                   timeout=5, text=True)
+    except (OSError, subprocess.TimeoutExpired):
+        res = None
+    if res is not None and res.returncode == 0:
+        try:
+            options = json.loads(res.stdout or "[]")
+        except ValueError:
+            options = []
+        if any(str(opt).split(",")[0].strip() == "name=rootless" for opt in options):
+            return True
+    host = os.environ.get("DOCKER_HOST", "")
+    xdg = os.environ.get("XDG_RUNTIME_DIR", "")
+    return bool(host and xdg and host.startswith("unix://" + xdg))
+
+
+def rootless_unreachable_bind_reason() -> Optional[str]:
+    """Operator-facing reason when a Linux proxy bind would be unreachable from Docker
+    sandboxes, else None.  Rootless Docker has no host-visible bridge, so the loopback
+    fallback is unreachable from containers on the default slirp4netns driver — writing
+    it and reporting healthy is a fail-open lie (#106909).  Callers (egress setup/start)
+    must refuse with this reason instead."""
+    if platform.system() != "Linux":
+        return None
+    if _detect_docker_bridge_ip() is not None:
+        return None
+    if not _docker_rootless():
+        return None
+    return (
+        "rootless Docker detected with no host-visible bridge: iron-proxy would bind "
+        "loopback, which Docker sandboxes cannot reach (slirp4netns has no route to "
+        "host listeners). Re-run setup once Docker provides a host-visible bridge "
+        "(rootful daemon, or a rootless driver that exposes one)."
+    )
+
+
 def build_proxy_config(
     *, mappings: List[TokenMapping], ca_cert: Path, ca_key: Path, tunnel_port: int = _DEFAULT_TUNNEL_PORT, audit_log: Optional[Path] = None,
     allowed_hosts: Optional[List[str]] = None, upstream_deny_cidrs: Optional[List[str]] = None, http_listen: Optional[List[str]] = None,

--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -92,6 +92,10 @@ def cmd_setup(args: argparse.Namespace) -> int:
         "[dim]Project: https://github.com/ironsh/iron-proxy  (Apache-2.0)[/dim]",
         border_style="cyan",
     ))
+    if (bind_reason := ip.rootless_unreachable_bind_reason()) is not None:
+        console.print(f"[red]✗ Refusing setup: {bind_reason}[/red]")
+        console.print("  See issue #106909 for the per-driver endpoint work; re-run setup once fixed.")
+        return 1
     if not _setup_install_binary(console):
         return 1
     ca = _setup_ca_cert(console)
@@ -339,6 +343,9 @@ def cmd_start(args: argparse.Namespace) -> int:
     if not proxy_cfg.get("enabled"):
         console.print("[yellow]proxy.enabled is false — run `hermes egress setup` first.[/yellow]")
         return 1
+    if (bind_reason := ip.rootless_unreachable_bind_reason()) is not None:
+        return _refuse(console, bind_reason,
+                       "Re-run `hermes egress setup` once Docker provides a host-visible bridge.")
     # ``credential_source: bitwarden`` refreshes upstream secrets from BSM at startup — that is
     # the rotation guarantee distinguishing it from ``env``.
     credential_source = proxy_cfg.get("credential_source", "env")

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -814,3 +814,74 @@ def test_bitwarden_importerror_raise_without_fallback(
         )
 
 
+
+# ---------------------------------------------------------------------------
+# Rootless-docker unreachable-bind refusal (#106909)
+# ---------------------------------------------------------------------------
+
+
+def _completed(stdout, returncode=0):
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.returncode = returncode
+    return proc
+
+
+def test_docker_rootless_true_on_security_option(monkeypatch):
+    """`docker info` SecurityOptions containing name=rootless → True."""
+    monkeypatch.setattr(
+        ip, "_run",
+        lambda *a, **k: _completed('["name=seccomp,profile=builtin","name=rootless","name=cgroupns"]'))
+    assert ip._docker_rootless() is True
+
+
+def test_docker_rootless_false_without_option(monkeypatch):
+    """Rootful daemon output → False."""
+    monkeypatch.setattr(
+        ip, "_run", lambda *a, **k: _completed('["name=seccomp,profile=builtin"]'))
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    assert ip._docker_rootless() is False
+
+
+def test_docker_rootless_fail_open_when_docker_missing(monkeypatch):
+    """No docker binary and no DOCKER_HOST hint → False (old behavior kept)."""
+    import subprocess
+
+    def boom(*a, **k):
+        raise OSError("no docker")
+    monkeypatch.setattr(ip, "_run", boom)
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    assert ip._docker_rootless() is False
+
+
+def test_unreachable_bind_reason_on_rootless_without_bridge(monkeypatch):
+    """Linux + rootless + no host bridge → actionable reason (#106909)."""
+    import platform
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(ip, "_detect_docker_bridge_ip", lambda: None)
+    monkeypatch.setattr(ip, "_docker_rootless", lambda: True)
+    reason = ip.rootless_unreachable_bind_reason()
+    assert reason is not None
+    assert "rootless" in reason
+    assert "loopback" in reason
+
+
+def test_unreachable_bind_reason_none_when_bridge_present(monkeypatch):
+    """A host-visible bridge means sandboxes can be served → None."""
+    import platform
+
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    monkeypatch.setattr(ip, "_detect_docker_bridge_ip", lambda: "172.17.0.1")
+    monkeypatch.setattr(
+        ip, "_docker_rootless", lambda: True,
+        raising=False)
+    assert ip.rootless_unreachable_bind_reason() is None
+
+
+def test_unreachable_bind_reason_none_off_linux(monkeypatch):
+    """Docker Desktop (macOS/Windows) loopback binds stay reachable → None."""
+    import platform
+
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    assert ip.rootless_unreachable_bind_reason() is None

--- a/tests/test_iron_proxy_cli.py
+++ b/tests/test_iron_proxy_cli.py
@@ -338,3 +338,47 @@ def test_cmd_setup_audit_log_failure_is_warning_not_abort(hermes_home, monkeypat
 
     rc = proxy_cli.cmd_setup(_args())
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Rootless-docker unreachable-bind refusal (#106909)
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_setup_refuses_before_side_effects_when_bind_unreachable(
+    hermes_home, monkeypatch, capsys,
+):
+    """Rootless + no bridge: setup aborts before installing anything, loudly."""
+    monkeypatch.setattr(
+        ip, "rootless_unreachable_bind_reason", lambda: "synthetic: rootless, no bridge")
+
+    def must_not_call(*a, **kw):
+        pytest.fail("setup must abort before side effects")
+    monkeypatch.setattr(ip, "find_iron_proxy", must_not_call)
+
+    rc = proxy_cli.cmd_setup(_args())
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Refusing setup" in out
+    assert "rootless" in out
+
+
+def test_cmd_start_refuses_without_starting_when_bind_unreachable(
+    hermes_home, monkeypatch,
+):
+    """An existing loopback config on a rootless-no-bridge host: start refuses."""
+    from hermes_cli.config import load_config, save_config
+    cfg = load_config()
+    cfg.setdefault("proxy", {})["enabled"] = True
+    save_config(cfg)
+
+    monkeypatch.setattr(
+        ip, "rootless_unreachable_bind_reason", lambda: "synthetic: rootless, no bridge")
+
+    def must_not_call(**kw):
+        pytest.fail("start_proxy must not run when the bind is unreachable")
+    monkeypatch.setattr(ip, "start_proxy", must_not_call)
+    monkeypatch.setattr(ip, "discover_uncovered_providers", lambda **kw: [])
+
+    rc = proxy_cli.cmd_start(_args())
+    assert rc == 1


### PR DESCRIPTION
## What does this PR do?

On rootless Linux without a host-visible bridge, `_default_http_listen` falls back to loopback and setup/start report healthy while every sandbox connection fails (ECONNREFUSED). Detect rootless up front (`docker info` SecurityOptions, plus DOCKER_HOST heuristic) and fail loudly in `egress setup`/`start` instead of writing a known-unreachable config — exactly the issue's accepted behavior. Fail-open when docker is missing/unparseable.

## Related Issue

Fixes #106909
Related #88729 (bind_host override + podman probing, different mechanism — warn-and-override vs refuse; maintainer picks)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/proxy_sources/iron_proxy.py`: `_docker_rootless()` + `rootless_unreachable_bind_reason()` (Linux-only, bridge-present and non-rootless short-circuit)
- `hermes_cli/proxy_cli.py`: preflight refusal in `cmd_setup` (before side effects) and `cmd_start` (via established `_refuse` shape)
- `tests/test_iron_proxy.py` + `tests/test_iron_proxy_cli.py`: 8 tests (detection true/false/fail-open, reason present/absent ×3, setup/start refusal without side effects)

## How to Test

1. `pytest tests/test_iron_proxy.py tests/test_iron_proxy_cli.py -q` → all pass except 5 pre-existing Windows POSIX-perm failures (0o600/0o700 assertions, fail identically without this change)
2. On rootless Linux with no bridge: `hermes egress setup` exits 1 before installing anything; `start` refuses without launching

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#88729 related, noted above)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (refusal paths unit-tested with mocks; live rootless-Docker path needs Linux)

### Documentation & Housekeeping

- [x] N/A (no docs/config/schema changes; refusal message points at #106909 for the per-driver endpoint follow-up)