### PR TITLE
fix(webhook): scope delivery idempotency keys by route

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -174,7 +174,7 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_order: Deque[tuple[float, str]] = deque()
         self.gateway_runner = None  # set externally; needed for cross-platform delivery
         # Idempotency: TTL cache of recently processed delivery IDs.
-        self._seen_deliveries: Dict[str, float] = {}
+        self._seen_deliveries: Dict[tuple, float] = {}
         self._idempotency_ttl: int = 3600  # 1 hour
         self._seen_deliveries_next_prune_at: float = 0.0
         self._rate_counts: Dict[str, Deque[float]] = {}  # per-route hit timestamps in a fixed window
@@ -297,13 +297,16 @@ class WebhookAdapter(BasePlatformAdapter):
         window.append(now)
         return True
 
-    def _record_delivery_id(self, delivery_id: str, now: float) -> bool:
-        """Return True when this delivery should be processed."""
-        if (seen_at := self._seen_deliveries.get(delivery_id)) is not None and now - seen_at < self._idempotency_ttl:
+    def _record_delivery_id(self, route_name: str, delivery_id: str, now: float) -> bool:
+        """Return True when this delivery should be processed.  Keyed by
+        ``(route, delivery)`` so one delivery ID fanning out to several routes
+        processes once per route; same-route retries still dedupe (#7448)."""
+        key = (route_name, delivery_id)
+        if (seen_at := self._seen_deliveries.get(key)) is not None and now - seen_at < self._idempotency_ttl:
             return False
         if seen_at is not None:
-            self._seen_deliveries.pop(delivery_id, None)
-        self._seen_deliveries[delivery_id] = now
+            self._seen_deliveries.pop(key, None)
+        self._seen_deliveries[key] = now
         if len(self._seen_deliveries) > max(self._rate_limit * 2, 128):
             self._prune_seen_deliveries(now)
         return True
@@ -552,7 +555,7 @@ class WebhookAdapter(BasePlatformAdapter):
         delivery_id = headers.get("X-GitHub-Delivery", headers.get("svix-id", headers.get(
             "webhook-id", headers.get("X-Request-ID", str(int(time.time() * 1000))))))
         now = time.time()  # idempotency: skip duplicate deliveries (webhook retries)
-        if not self._record_delivery_id(delivery_id, now):
+        if not self._record_delivery_id(route_name, delivery_id, now):
             logger.info("[webhook] Skipping duplicate delivery %s", delivery_id)
             return web.json_response({"status": "duplicate", "delivery_id": delivery_id}, status=200)
         if route_config.get("deliver_only"):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -568,6 +568,30 @@ class TestIdempotency:
             data = await resp2.json()
             assert data["status"] == "duplicate"
 
+    @pytest.mark.asyncio
+    async def test_same_delivery_id_on_different_routes_is_not_deduped(self):
+        """One delivery ID fanning out to two routes runs on both (#7448)."""
+        routes = {
+            "one": {"secret": _INSECURE_NO_AUTH, "prompt": "test"},
+            "two": {"secret": _INSECURE_NO_AUTH, "prompt": "test"},
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"X-GitHub-Delivery": "delivery-123"}
+            resp1 = await cli.post("/webhooks/one", json={"a": 1}, headers=headers)
+            assert resp1.status == 202
+
+            resp2 = await cli.post("/webhooks/two", json={"a": 1}, headers=headers)
+            assert resp2.status == 202
+
+            resp3 = await cli.post("/webhooks/one", json={"a": 1}, headers=headers)
+            assert resp3.status == 200
+            data = await resp3.json()
+            assert data["status"] == "duplicate"
+
 
 # ===================================================================
 # Rate limiting


### PR DESCRIPTION
## What does this PR do?

`_record_delivery_id` keyed bare delivery IDs, so one delivery fanning out to several routes ran on the first route and 200-duplicated the rest. Key by `(route, delivery)`: fan-out processes once per route, same-route retries still dedupe. Single call site; prune path is key-opaque so tuple keys are safe.

## Related Issue

Fixes #7448
Supersedes #24633 (stale since July, predates the `_record_delivery_id` refactor so its hunks no longer apply — same route-scoped-key approach, ported, with credit to Sylw3ster)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/webhook.py`: `route_name` threaded into `_record_delivery_id`, key is now the tuple
- `tests/gateway/test_webhook_adapter.py`: fan-out test (202 on both routes, duplicate on same-route retry)

## How to Test

1. `pytest tests/gateway/test_webhook_adapter.py -q` → 43 passed, 1 pre-existing failure (profile-skills 500, fails identically without this change)
2. The new test fails on main (second route 200-duplicated) and passes with the fix

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#24633 stale/superseded, noted above)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
- [x] `ruff check` on both changed files passes

### Documentation & Housekeeping

- [x] N/A (no docs/config/schema changes)