### PR TITLE
fix(agent): honor documented HERMES_AGENT_HELP_GUIDANCE env append

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -626,6 +626,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # in the rendered index (pure string check — inherits the index's stability).
     if "skill_view" in (agent.valid_tool_names or set()) and "- hermes-agent:" in skills_prompt:
         stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE
+    # Documented append for custom deployments (environment-variables.md): extra
+    # guidance rides the same slot, whichever variant won it. Blank = untouched.
+    if extra_guidance := os.environ.get("HERMES_AGENT_HELP_GUIDANCE", "").strip():
+        stable_parts[_help_guidance_slot] += "\n\n" + extra_guidance
     stable_parts.extend(_alibaba_identity_part(agent))
     # Coding posture: the operating brief stays in the stable prefix. The
     # environment block contains the current cwd/backend and belongs after

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -835,3 +835,28 @@ class TestConversationStartedTwoLine:
         assert "Conversation started:" not in vol
         assert "as of the last context rebuild" not in vol
 
+
+
+class TestHelpGuidanceEnvAppend:
+    """Documented HERMES_AGENT_HELP_GUIDANCE append is honored (#24438)."""
+
+    def _stable(self, agent):
+        from unittest.mock import patch
+
+        with (
+            patch("agent.prompt_builder.load_soul_md", return_value=""),
+            patch("agent.prompt_builder.build_environment_hints", return_value=""),
+        ):
+            return build_system_prompt_parts(agent)["stable"]
+
+    def test_env_guidance_appended_to_stable_tier(self, monkeypatch):
+        monkeypatch.setenv("HERMES_AGENT_HELP_GUIDANCE", "Custom deployment note.")
+        stable = self._stable(_make_agent())
+        assert "Custom deployment note." in stable
+
+    def test_blank_env_leaves_prompt_untouched(self, monkeypatch):
+        monkeypatch.delenv("HERMES_AGENT_HELP_GUIDANCE", raising=False)
+        before = self._stable(_make_agent())
+        monkeypatch.setenv("HERMES_AGENT_HELP_GUIDANCE", "   ")
+        after = self._stable(_make_agent())
+        assert before == after


### PR DESCRIPTION
## What does this PR do?

`environment-variables.md` promises `HERMES_AGENT_HELP_GUIDANCE` appends custom guidance text, but `build_system_prompt_parts` never read it. Non-blank values now append to the help-guidance slot, whichever variant (skill-pointer or docs-only) won it. Blank/unset leaves the prompt byte-identical.

## Related Issue

Partially fixes #24438 (the skill-gating half already landed via the NO_SKILLS slot variant; no disable toggle added — beyond the documented contract)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/system_prompt.py`: 4-line env append after slot resolution
- `tests/agent/test_system_prompt.py`: `TestHelpGuidanceEnvAppend` (appended when set, untouched when blank)

## How to Test

1. `HERMES_AGENT_HELP_GUIDANCE='Custom note.' hermes ...` → stable tier contains the note
2. `pytest tests/agent/test_system_prompt.py -q -k HelpGuidance` → 2 passed; full files show only 2 pre-existing failures (missing optional dep, date-sensitive test — identical without this change)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (closed #24442/#24550 only; nothing open)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
- [x] `ruff check` on both changed files passes

### Documentation & Housekeeping

- [x] N/A (implements already-documented behavior; no new env var — the variable was already documented)