### PR TITLE
fix(web): Firecrawl waitFor for lazily loaded extracts

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -352,6 +352,9 @@ DEFAULT_CONFIG = {
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
         # per-page char budget for web_extract; larger pages truncate, full text kept in cache/web
         "extract_char_limit": 15000,
+        # Firecrawl scrape waitFor (ms) so lazily hydrated pages (comments, dashboards) are in the
+        # snapshot. 0 omits the field (legacy first-paint). Other extract backends ignore this.
+        "extract_wait_ms": 3000,
         # Keyless free-tier ring: with NO web backend configured or keyed, web_search/web_extract
         # rotate round-robin across exa, parallel, firecrawl, keenable public free tiers, failing
         # over on rate limits. Never pre-empts a configured/keyed backend. false = disable.

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -114,7 +114,16 @@ class _KeylessFirecrawlClient:
         return response.json()
 
     search = lambda self, *, query, limit=5: self._post("/v2/search", {"query": query, "limit": limit})  # noqa: E731
-    scrape = lambda self, *, url, formats: self._post("/v2/scrape", {"url": url, "formats": formats})  # noqa: E731
+
+    def scrape(self, *, url: str, formats: List[str], wait_for: Any = None, waitFor: Any = None, **_ignored: Any) -> Dict[str, Any]:
+        """REST scrape. SDK-shaped ``wait_for`` (or REST ``waitFor``) maps to JSON ``waitFor``.
+        When the caller omits wait, resolve ``web.extract_wait_ms`` so the keyless ring
+        inherits the same wait as ``_scrape_one``."""
+        payload: Dict[str, Any] = {"url": url, "formats": formats}
+        wait = _coerce_wait_ms(wait_for if wait_for is not None else waitFor, fallback=_extract_wait_ms())
+        if wait > 0:
+            payload["waitFor"] = wait
+        return self._post("/v2/scrape", payload)
 
 
 def _get_firecrawl_gateway_url() -> str:
@@ -237,6 +246,37 @@ def _error_entry(url: str, error: str, *, title: str = "", raw: bool = False, bl
 
 _SCRAPE_TIMEOUT_MSG = "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead."
 _UNSAFE_REDIRECT_MSG = "Blocked: URL targets a private or internal network address"
+_DEFAULT_EXTRACT_WAIT_MS = 3000
+# Stay under the 60s asyncio scrape ceiling so a huge config wait cannot look like a hung page.
+_MAX_EXTRACT_WAIT_MS = 50_000
+
+
+def _coerce_wait_ms(value: Any, *, fallback: int = _DEFAULT_EXTRACT_WAIT_MS) -> int:
+    """Positive wait in ms, 0 to omit, invalid → *fallback*. Clamped below the scrape timeout."""
+    if value is None:
+        return fallback
+    try:
+        wait = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    if wait <= 0:
+        return 0
+    return min(wait, _MAX_EXTRACT_WAIT_MS)
+
+
+def _extract_wait_ms() -> int:
+    """``web.extract_wait_ms`` (default 3000). Lazy ``_load_web_config`` so tests can patch it."""
+    from tools.web_tools import _load_web_config
+    cfg = _load_web_config()
+    if "extract_wait_ms" not in cfg:
+        return _DEFAULT_EXTRACT_WAIT_MS
+    return _coerce_wait_ms(cfg.get("extract_wait_ms"), fallback=_DEFAULT_EXTRACT_WAIT_MS)
+
+
+def _scrape_wait_kwargs() -> Dict[str, int]:
+    """SDK scrape kwargs: ``wait_for=N`` or empty when the user opted out with ``<=0``."""
+    wait = _extract_wait_ms()
+    return {"wait_for": wait} if wait > 0 else {}
 
 
 async def _scrape_one(url: str, formats: List[str], format: Optional[str]) -> Dict[str, Any]:
@@ -248,7 +288,10 @@ async def _scrape_one(url: str, formats: List[str], format: Optional[str]) -> Di
     try:
         logger.info("Firecrawl scraping: %s", url)
         try:
-            scrape_result = await asyncio.wait_for(asyncio.to_thread(_get_firecrawl_client().scrape, url=url, formats=formats), timeout=60)
+            scrape_result = await asyncio.wait_for(
+                asyncio.to_thread(_get_firecrawl_client().scrape, url=url, formats=formats, **_scrape_wait_kwargs()),
+                timeout=60,
+            )
         except asyncio.TimeoutError:
             logger.warning("Firecrawl scrape timed out for %s", url)
             return _error_entry(url, _SCRAPE_TIMEOUT_MSG)

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -8,6 +8,7 @@ Coverage:
   check_web_api_key() — unified availability check across all web backends.
 """
 
+import asyncio
 import importlib
 import json
 import os
@@ -187,9 +188,140 @@ class TestFirecrawlClientConfig:
 
         assert result["success"] is True
         assert captured["url"] == "https://api.firecrawl.dev/v2/scrape"
-        assert captured["json"] == {"url": "https://example.com", "formats": ["markdown"]}
+        assert captured["json"]["url"] == "https://example.com"
+        assert captured["json"]["formats"] == ["markdown"]
         assert captured["headers"] == {"Content-Type": "application/json"}
         assert "Authorization" not in captured["headers"]
+
+
+class TestFirecrawlExtractWaitFor:
+    """web.extract_wait_ms must reach Firecrawl scrape (REST waitFor / SDK wait_for).
+
+    Issue #106904: first-paint snapshots look complete because scrape sent only url+formats.
+    Search must stay wait-free. extract_wait_ms<=0 omits the field (legacy).
+    """
+
+    def _capture_httpx(self, monkeypatch):
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        captured = {}
+
+        class _Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"success": True, "data": {"markdown": "# ok"}}
+
+        def _fake_post(url, *, json, headers, timeout):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return _Response()
+
+        monkeypatch.setattr(firecrawl_provider.httpx, "post", _fake_post)
+        return firecrawl_provider, captured
+
+    def test_default_config_declares_extract_wait_ms_3000(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["web"]["extract_wait_ms"] == 3000
+
+    def test_default_keyless_scrape_sends_waitFor_3000(self, monkeypatch):
+        firecrawl_provider, captured = self._capture_httpx(monkeypatch)
+        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {})
+
+        firecrawl_provider._KeylessFirecrawlClient().scrape(
+            url="https://example.com", formats=["markdown"]
+        )
+
+        assert captured["url"] == "https://api.firecrawl.dev/v2/scrape"
+        assert captured["json"]["url"] == "https://example.com"
+        assert captured["json"]["formats"] == ["markdown"]
+        assert captured["json"]["waitFor"] == 3000
+        assert "Authorization" not in captured["headers"]
+
+    def test_custom_extract_wait_ms_reaches_waitFor(self, monkeypatch):
+        firecrawl_provider, captured = self._capture_httpx(monkeypatch)
+        monkeypatch.setattr(
+            "tools.web_tools._load_web_config",
+            lambda: {"extract_wait_ms": 8000},
+        )
+
+        firecrawl_provider._KeylessFirecrawlClient().scrape(
+            url="https://example.com", formats=["markdown"]
+        )
+
+        assert captured["json"]["waitFor"] == 8000
+
+    def test_zero_extract_wait_ms_omits_waitFor(self, monkeypatch):
+        firecrawl_provider, captured = self._capture_httpx(monkeypatch)
+        monkeypatch.setattr(
+            "tools.web_tools._load_web_config",
+            lambda: {"extract_wait_ms": 0},
+        )
+
+        firecrawl_provider._KeylessFirecrawlClient().scrape(
+            url="https://example.com", formats=["markdown"]
+        )
+
+        assert "waitFor" not in captured["json"]
+        assert captured["json"] == {"url": "https://example.com", "formats": ["markdown"]}
+
+    def test_scrape_one_passes_wait_for_to_sdk(self, monkeypatch):
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        captured = {}
+
+        class _FakeClient:
+            def scrape(self, *, url, formats, **kwargs):
+                captured["kwargs"] = {"url": url, "formats": formats, **kwargs}
+                return {
+                    "markdown": "# ok",
+                    "metadata": {"title": "t", "sourceURL": url},
+                }
+
+        monkeypatch.setattr(firecrawl_provider, "check_website_access", lambda _url: None)
+        monkeypatch.setattr(firecrawl_provider, "is_safe_url", lambda _url: True)
+        monkeypatch.setattr(firecrawl_provider, "_get_firecrawl_client", lambda: _FakeClient())
+        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {})
+
+        result = asyncio.run(
+            firecrawl_provider._scrape_one(
+                "https://example.com/issue", ["markdown"], "markdown"
+            )
+        )
+
+        assert result.get("error") is None
+        assert captured["kwargs"]["url"] == "https://example.com/issue"
+        assert captured["kwargs"]["formats"] == ["markdown"]
+        assert captured["kwargs"].get("wait_for") == 3000
+
+    def test_keyless_search_control_omits_waitFor(self, monkeypatch):
+        firecrawl_provider, captured = self._capture_httpx(monkeypatch)
+        monkeypatch.setattr(
+            "tools.web_tools._load_web_config",
+            lambda: {"extract_wait_ms": 8000},
+        )
+
+        firecrawl_provider._KeylessFirecrawlClient().search(query="firecrawl", limit=1)
+
+        assert captured["url"] == "https://api.firecrawl.dev/v2/search"
+        assert captured["json"] == {"query": "firecrawl", "limit": 1}
+        assert "waitFor" not in captured["json"]
+
+    def test_firecrawl_extract_keyless_sends_waitFor(self, monkeypatch):
+        from plugins.web import keyless_mcp
+
+        firecrawl_provider, captured = self._capture_httpx(monkeypatch)
+        monkeypatch.setattr("tools.web_tools._load_web_config", lambda: {})
+
+        results = keyless_mcp.firecrawl_extract_keyless(["https://example.com/lazy"])
+
+        assert captured["json"]["waitFor"] == 3000
+        assert results[0]["url"] == "https://example.com/lazy"
+        assert not results[0].get("error")
 
 
 class TestBackendSelection:


### PR DESCRIPTION
## What does this PR do?

Firecrawl `web_extract` scraped with only `url` + `formats`, so pages that hydrate after first paint (GitHub issue comments, collapsed lists, dashboards) returned a complete-looking markdown snapshot with no error. Firecrawl's `waitFor` default is 0, and Hermes had no config knob.

This adds `web.extract_wait_ms` (default `3000`) and passes it on the Firecrawl scrape path:

- Python SDK: `wait_for`
- Keyless REST `/v2/scrape`: `waitFor` (also when the keyless ring calls scrape without going through `_scrape_one`)

`extract_wait_ms <= 0` omits the field (legacy first-paint). Search is unchanged. The 60s asyncio scrape timeout is unchanged. Invalid non-int config falls back to 3000.

A cold extract after this change still hits Firecrawl with wait. The on-disk extract cache keys by url+format+provider only, so a TTL hit from before the upgrade can still serve a first-paint snapshot until it expires (~20 min). That cache-key change is out of scope.

## Related Issue

Fixes #106904

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `hermes_cli/config_defaults.py`: `web.extract_wait_ms: 3000` (no `_config_version` bump)
- `plugins/web/firecrawl/provider.py`: resolve wait, pass SDK `wait_for`, map REST `waitFor`; keyless scrape applies the resolver when the caller omits wait
- `tests/tools/test_web_tools_config.py`: default/custom/zero-omit, `_scrape_one` SDK kwargs, keyless ring extract, search CONTROL

## How to Test

```
# RED on origin/main (this class): TestFirecrawlExtractWaitFor 5 failed / 2 CONTROL passed
HERMES_PYTHON=/home/stass21/.hermes/hermes-agent/venv/bin/python scripts/run_tests.sh tests/tools/test_web_tools_config.py -k 'TestFirecrawlExtractWaitFor or test_keyless_firecrawl_scrape or test_keyless_firecrawl_search' -q --tb=short
# after fix: 9 passed (plus TestFirecrawlClientConfig: 14 passed in a later focused run)
```

Platform: Linux, Python 3.12. Live self-hosted Firecrawl hydration is not in CI; the contract is scrape kwargs/JSON.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.12

Focused Firecrawl tests: 14 passed. Unrelated `TestParallelClientConfig` two tests fail in this environment (`parallel-web` lazy install disabled); not touched by this diff.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
