### PR TITLE
fix(memory): name both restricted ops in background gate, show effective policy in /memory

### DIFF
--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -11,7 +11,21 @@ from tools import write_approval as wa
 
 def _fmt_state(subsystem: str) -> str:
     on = wa.write_approval_enabled(subsystem)
-    return f"{subsystem}.write_approval = {'on' if on else 'off'}"
+    state = f"{subsystem}.write_approval = {'on' if on else 'off'}"
+    if subsystem != wa.MEMORY:
+        return state
+    if on:
+        return (
+            f"{state}\n"
+            "Every memory write — attended or background, any action — is staged for "
+            "approval (/memory pending)."
+        )
+    return (
+        f"{state}\n"
+        "Attended memory writes (incl. /refine) apply immediately. Background review "
+        "adds apply automatically; replace/remove — or a whole batch containing either — "
+        "are always staged for approval (/memory pending), independent of this setting."
+    )
 
 
 def _fmt_pending_list(subsystem: str) -> str:

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -816,6 +816,9 @@ class TestBackgroundReviewDeleteGate:
         finally:
             reset_current_write_origin(token)
         assert result["staged"] is True
+        assert result["proposal_staged"] is True
+        # The notification names BOTH restricted operations, not just "delete".
+        assert "replace or remove" in result["message"]
         # Atomic: the batch is only a proposal — its add must not land either.
         assert "fork consolidation" not in store._entries_for("memory")
 

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -201,6 +201,36 @@ def test_handle_approval_off(hermes_home):
     assert "off" in out
 
 
+def test_memory_state_off_explains_background_gate(hermes_home):
+    # Gate off must not read as "everything applies": the unattended replace/remove
+    # restriction still stages background consolidation proposals.
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    out = handle_pending_subcommand(wa.MEMORY, [])
+    assert "memory.write_approval = off" in out
+    assert "apply immediately" in out
+    assert "always staged" in out
+
+
+def test_memory_state_on_says_all_writes_staged(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    _set_approval("memory", True)
+    out = handle_pending_subcommand(wa.MEMORY, [])
+    assert "memory.write_approval = on" in out
+    assert "staged for approval" in out
+
+
+def test_skills_state_stays_compact(hermes_home):
+    # The skills state line is unchanged — the unattended gate is memory-only.
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    out = handle_pending_subcommand(wa.SKILLS, [])
+    first_line = out.splitlines()[0]
+    assert first_line == "skills.write_approval = off"
+    assert "always staged" not in out
+
+
 # ---------------------------------------------------------------------------
 # Inline (interactive CLI) approval path — regression for the bug where the
 # per-thread approval callback was never passed to prompt_dangerous_approval,

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -158,15 +158,18 @@ def _background_delete_gate(action, operations, target="memory", content=None, o
             origin=wa.current_origin())
         return json.dumps({
             "success": True, "staged": True, "proposal_staged": True, "pending_id": record["id"],
-            "message": ("Background review may not delete memory entries unattended. The proposed "
-                        f"{'batch' if operations is not None else action} was staged for your approval — "
-                        "review it with /memory pending (approve to apply, discard to drop)."),
+            "message": (
+                    "Background review may not replace or remove memory entries unattended. "
+                    f"The proposed {'batch' if operations is not None else action} was staged "
+                    "for your approval — review it with /memory pending (approve to apply, "
+                    "discard to drop)."
+            ),
         }, ensure_ascii=False)
     except Exception:
         logger.warning("Failed to stage background-review consolidation; denying", exc_info=True)
         return tool_error(
-            "Background review may not delete memory entries ('replace'/'remove', including in a "
-            "batch); 'add' is still available.", success=False)
+            "Background review may not replace or remove memory entries ('replace'/'remove', "
+            "including in a batch); 'add' is still available.", success=False)
 
 
 def memory_tool(action: str = None, target: str = "memory", content: str = None, old_text: str = None,


### PR DESCRIPTION
## What
Text-only clarity fix for the background memory gate (#106918). **No change to which writes are allowed or staged.**

**1. The staging notification and fail-closed denial now name both restricted operations.**
`_background_delete_gate` in `tools/memory_tool.py` stages `replace`/`remove` (single or inside a batch — `_BG_DELETE_ACTIONS`), but both user-facing strings said "may not delete memory entries", hiding that `replace` is covered too.

**2. `/memory` now shows the effective policy, not just the general boolean.**
`_fmt_state` in `hermes_cli/write_approval_commands.py` rendered only `memory.write_approval = off`, leaving a staged background consolidation unexplained. With the gate **off** it now states that attended writes (incl. `/refine`) apply immediately, background adds apply automatically, and replace/remove — or a whole batch containing either — are always staged, independent of the setting. With the gate **on** it says every write is staged. The shared handler feeds both the CLI and the gateway `/memory`, so both surfaces get it. Skills state line is unchanged (the unattended gate is memory-only).

## Testing
- `tests/tools/test_memory_tool.py`: the batch-staging test now asserts the message says "replace or remove".
- `tests/tools/test_write_approval.py`: three new tests — off-state explanation, on-state explanation, skills line unchanged.
- Full local run: `79 passed` (both specs + `tests/agent/test_background_review_memory_scope.py`); mutation-checked both fixes (reverted wording → RED).
- `ruff check` clean; `ruff format --diff` shows no new complaints on touched lines.

Closes #106918
