### PR TITLE
fix(dashboard): honor profile secret mappings and QR platform setup

### DIFF
--- a/hermes_cli/web_routers/messaging.py
+++ b/hermes_cli/web_routers/messaging.py
@@ -158,6 +158,16 @@ def _require_platform(platform_id: str) -> dict[str, Any]:
     return entry
 
 
+def _scoped_secret_keys() -> frozenset[str]:
+    try:
+        config = load_config()
+        onepassword = ((config.get("secrets") or {}).get("onepassword") or {})
+        mappings = onepassword.get("env") or {}
+        return frozenset(key for key, reference in mappings.items() if key and reference)
+    except Exception:
+        return frozenset()
+
+
 def _platform_enablement(
     platform_id: str, entry: dict[str, Any], env_on_disk: dict[str, str], scoped: bool
 ) -> tuple[bool, bool, dict | None]:
@@ -166,10 +176,13 @@ def _platform_enablement(
     os.environ and would leak the root install's tokens into the profile's state."""
     required = entry["required_env"]
     if scoped:
-        configured = bool(required) and all(env_on_disk.get(key) for key in required)
+        secret_keys = _scoped_secret_keys()
+        configured = all(env_on_disk.get(key) or key in secret_keys for key in required) if required else False
         try:
             plat_cfg = (load_config().get("platforms") or {}).get(platform_id)
             plat_cfg = plat_cfg if isinstance(plat_cfg, dict) else {}
+            if not required:
+                configured = bool(plat_cfg)
             hc = plat_cfg.get("home_channel")
             # Setup writes credentials without a platforms entry; explicit disable wins.
             raw_enabled = plat_cfg.get("enabled")
@@ -222,7 +235,8 @@ def _messaging_platform_payload(
 
     env_vars = [
         {
-            "key": key, "required": key in entry["required_env"], "is_set": bool(value),
+            "key": key, "required": key in entry["required_env"],
+            "is_set": bool(value) or (scoped and key in _scoped_secret_keys()),
             "redacted_value": redact_key(value) if value else None, **_messaging_env_info(key),
         }
         for key, value in ((key, env_value(key)) for key in entry["env_vars"])

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -67,6 +67,63 @@ def _env_field(platform, key):
     return next(f for f in platform["env_vars"] if f["key"] == key)
 
 
+def test_scoped_platform_without_required_env_is_configured_when_declared(
+    client, isolated_profiles, monkeypatch
+):
+    """QR/onboarding platforms with no required env must use their config declaration."""
+    import hermes_cli.web_routers.messaging as messaging
+
+    worker_home = isolated_profiles["worker_alpha"]
+    (worker_home / "config.yaml").write_text(
+        yaml.safe_dump({"platforms": {"whatsapp": {"enabled": True}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(messaging, "load_env", lambda: {})
+    monkeypatch.setattr(messaging, "load_config", lambda: {"platforms": {"whatsapp": {"enabled": True}}})
+
+    resp = client.get(
+        "/api/messaging/platforms", params={"profile": "worker_alpha"}
+    )
+
+    assert resp.status_code == 200
+    whatsapp = next(p for p in resp.json()["platforms"] if p["id"] == "whatsapp")
+    assert whatsapp["configured"] is True
+
+
+def test_scoped_platform_with_onepassword_mapping_is_configured(
+    client, isolated_profiles, monkeypatch
+):
+    """Profile-scoped dashboard reads must recognize secret-source mappings."""
+    import hermes_cli.web_routers.messaging as messaging
+
+    worker_home = isolated_profiles["worker_alpha"]
+    (worker_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "platforms": {"telegram": {"enabled": True}},
+            "secrets": {"onepassword": {"env": {"TELEGRAM_BOT_TOKEN": "op://vault/item/credential"}}},
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(messaging, "load_env", lambda: {})
+    monkeypatch.setattr(
+        messaging,
+        "load_config",
+        lambda: {
+            "platforms": {"telegram": {"enabled": True}},
+            "secrets": {"onepassword": {"env": {"TELEGRAM_BOT_TOKEN": "op://vault/item/credential"}}},
+        },
+    )
+
+    resp = client.get(
+        "/api/messaging/platforms", params={"profile": "worker_alpha"}
+    )
+
+    assert resp.status_code == 200
+    telegram = _telegram(resp.json())
+    assert telegram["configured"] is True
+    assert _env_field(telegram, "TELEGRAM_BOT_TOKEN")["is_set"] is True
+
+
 class TestProfileScopedMessagingReads:
     def test_scoped_read_does_not_show_root_credentials(
         self, client, isolated_profiles


### PR DESCRIPTION
## Summary

Fixes two false "Not configured" states on the profile-scoped Channels dashboard:

- A QR/onboarding platform such as WhatsApp declares no required environment variables. The scoped status path incorrectly treated `required_env=()` as always unconfigured, even when the platform was explicitly declared in the selected profile's `config.yaml` and the gateway was connected.
- Profile-scoped status reads recognized credentials in the profile `.env`, but not an enabled 1Password mapping in that profile's `secrets.onepassword.env`. The gateway could resolve and use the secret while Channels still displayed it as missing.

The fix only uses the mapping's variable names and never resolves, returns, or logs secret values. It preserves profile isolation and explicit `enabled: false` handling.

## Related upstream work

This is complementary to #104619 (env credentials enabling scoped platforms), #45463 (runtime evidence for service-manager-injected credentials), and #78009 (WhatsApp onboarding profile scope). None of those changes covers both the no-required-env QR case and profile-scoped 1Password mappings.

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_web_server_messaging_profiles.py -q`
- Result: **11 passed**
- `python3 -m py_compile hermes_cli/web_routers/messaging.py`
- `git diff --check origin/main...HEAD`

## Security notes

- No secret values are read into the response for this status check.
- A mapping counts as configured only in the selected profile's own config.
- The root process environment is not used for named-profile status.
