### PR TITLE
fix(doctor): warn instead of traceback on unregistered browser.cloud_provider (#106930)

### DIFF
--- a/hermes_cli/doctor_tools.py
+++ b/hermes_cli/doctor_tools.py
@@ -305,7 +305,16 @@ def _check_chromium() -> None:
         from tools.browser_tool_lightpanda_fallback import _using_lightpanda_engine
     except Exception:
         return
-    if _is_camofox_mode() or bool(_get_cdp_override_raw()) or _get_cloud_provider() is not None or _using_lightpanda_engine():
+    if _is_camofox_mode() or bool(_get_cdp_override_raw()):
+        return
+    try:
+        if _get_cloud_provider() is not None:
+            return
+    except ValueError as e:
+        check_warn("browser.cloud_provider misconfigured", f"({e})")
+        check_info("Fix: Run 'hermes tools' → Browser Automation, or set browser.cloud_provider: local")
+        return
+    if _using_lightpanda_engine():
         return
     if not check_bool(_chromium_installed(), ("Playwright Chromium", "(browser engine)"),
                       ("Playwright Chromium not installed", "(browser_* tools will be hidden from the agent)")):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -889,6 +889,59 @@ def test_run_doctor_fix_reports_when_npx_warmup_fails(monkeypatch, tmp_path):
     assert "Warmed npx cache for agent-browser" not in out
 
 
+def _raise_unregistered_cloud_provider():
+    raise ValueError(
+        "browser is configured to use 'browserbase' (set via hermes tools), but no "
+        "registered browser plugin has that name (install the corresponding plugin or "
+        "fix the config key spelling). Run 'hermes tools' to change it."
+    )
+
+
+def test_check_chromium_reports_misconfigured_cloud_provider_instead_of_crashing(monkeypatch):
+    """A browser.cloud_provider naming no registered plugin (stale pointer left after the
+    plugin was disabled) must surface as a doctor warning, never a ValueError traceback."""
+    import tools.browser_tool as bt
+    import tools.browser_tool_cdp as bt_cdp
+    import tools.browser_tool_cloud as bt_cloud
+    import tools.browser_tool_lightpanda_fallback as bt_lp
+
+    monkeypatch.setattr(bt, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(bt_cdp, "_get_cdp_override_raw", lambda: "")
+    monkeypatch.setattr(bt_lp, "_using_lightpanda_engine", lambda: False)
+    monkeypatch.setattr(bt_cloud, "_get_cloud_provider", _raise_unregistered_cloud_provider)
+    chromium_calls = []
+    monkeypatch.setattr(
+        bt_install, "_chromium_installed", lambda: chromium_calls.append(1) or True
+    )
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_tools._check_chromium()  # must not raise
+    out = buf.getvalue()
+
+    assert "browser.cloud_provider misconfigured" in out
+    assert not chromium_calls
+
+
+def test_run_doctor_survives_misconfigured_browser_cloud_provider(monkeypatch, tmp_path):
+    """End-to-end of the reported crash: node + agent-browser present, but
+    browser.cloud_provider names a disabled plugin — run_doctor must warn, not traceback."""
+    _doctor_env_for_agent_browser(monkeypatch, tmp_path)
+
+    import tools.browser_tool_cloud as bt_cloud
+
+    monkeypatch.setattr(bt_cloud, "_get_cloud_provider", _raise_unregistered_cloud_provider)
+    monkeypatch.setattr(bt_install, "_find_agent_browser", lambda **_kw: "/usr/bin/agent-browser")
+    monkeypatch.setattr(doctor_tools, "agent_browser_runnable", lambda _p: True)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))  # must not raise
+    out = buf.getvalue()
+
+    assert "browser.cloud_provider misconfigured" in out
+
+
 def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` died with an unhandled `ValueError` traceback whenever `browser.cloud_provider` named no registered browser plugin (stale pointer, e.g. plugin later disabled). `_check_chromium` now catches that `ValueError` and reports a `browser.cloud_provider misconfigured` warning with the `hermes tools` remedy, then continues with the remaining checks. The narrow catch is deliberate: `ValueError` is the only documented raise of the resolver (strict by design, never a silent reroute), so anything else still surfaces.

## Related Issue

Fixes #106930

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor_tools.py` (`_check_chromium`): guard the `_get_cloud_provider()` call with `try/except ValueError` → `check_warn` + `check_info` remedy; cloud is now evaluated before the Lightpanda early-return so a stale pointer still warns under `browser.engine: lightpanda` (Camofox/CDP stay first: the runtime never consults the provider in those modes).
- `tests/hermes_cli/test_doctor.py`: unit test (`_check_chromium` warns, never raises, never reaches the Chromium check) + end-to-end test (full `run_doctor` survives the exact reported configuration).

## How to Test

1. Repro (pre-fix): set `browser.cloud_provider: browserbase` with `browser/browserbase` under `plugins.disabled`, run `hermes doctor` → traceback at `_check_chromium`.
2. With this PR: same setup → `⚠ browser.cloud_provider misconfigured (...)` + `→ Fix: Run 'hermes tools' → Browser Automation...`, doctor completes.
3. `scripts/run_tests.sh tests/hermes_cli/test_doctor.py` — 73 passed, 0 failed.
4. Sabotage check: revert `hermes_cli/doctor_tools.py` only → the 2 new tests fail; re-apply → green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass (targeted suite only: `tests/hermes_cli/test_doctor.py`, 73 passed; full matrix left to CI per local-targeted convention)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64 — Hermes Agent v0.21.1 (v2026.9.7), upstream b88e6776f4

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (fix carries its own user-facing remedy line; no docs touch behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added/changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A (pure-Python control flow, no OS calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
