### PR TITLE
fix(cli): remove custom provider from both legacy and providers schemas

### DIFF
--- a/hermes_cli/main_provider_setup.py
+++ b/hermes_cli/main_provider_setup.py
@@ -484,10 +484,10 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None, n
 
 def _remove_custom_provider(config):
     """Let the user remove a saved custom provider from config.yaml."""
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import get_compatible_custom_providers, load_config, save_config
     cfg = load_config()
-    providers = cfg.get("custom_providers") or []
-    if not isinstance(providers, list) or not providers:
+    providers = get_compatible_custom_providers(cfg)
+    if not providers:
         print("No custom providers configured.")
         return
 
@@ -516,10 +516,52 @@ def _remove_custom_provider(config):
         print("No change.")
         return
 
-    removed = providers.pop(idx)
-    cfg["custom_providers"] = providers
+    removed = providers[idx]
+
+    def _normalize_identifier(value):
+        return str(value or "").strip().rstrip("/").lower()
+
+    removed_provider_key = _normalize_identifier(removed.get("provider_key"))
+    removed_name = _normalize_identifier(removed.get("name"))
+    removed_base_url = _normalize_identifier(removed.get("base_url"))
+    removed_model = _normalize_identifier(removed.get("model"))
+
+    def _matches_removed_provider(entry, provider_key=""):
+        if not isinstance(entry, dict):
+            return False
+        entry_provider_key = _normalize_identifier(provider_key or entry.get("provider_key"))
+        entry_base_url = _normalize_identifier(
+            entry.get("base_url") or entry.get("url") or entry.get("api")
+        )
+        entry_model = _normalize_identifier(
+            entry.get("model") or entry.get("default_model")
+        )
+        if removed_provider_key and entry_provider_key == removed_provider_key:
+            return True
+        return (
+            _normalize_identifier(entry.get("name")) == removed_name
+            and entry_base_url == removed_base_url
+            and entry_model == removed_model
+        )
+
+    legacy_providers = cfg.get("custom_providers")
+    if isinstance(legacy_providers, list):
+        cfg["custom_providers"] = [
+            entry for entry in legacy_providers if not _matches_removed_provider(entry)
+        ]
+
+    providers_cfg = cfg.get("providers")
+    if isinstance(providers_cfg, dict):
+        cfg["providers"] = {
+            key: entry
+            for key, entry in providers_cfg.items()
+            if not _matches_removed_provider(entry, provider_key=key)
+        }
+
     save_config(cfg)
-    removed_name = removed.get("name", "unnamed") if isinstance(removed, dict) else str(removed)
+    removed_name = (
+        removed.get("name", "unnamed") if isinstance(removed, dict) else str(removed)
+    )
     print(f'✅ Removed "{removed_name}" from custom providers.')
 
 

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -134,3 +134,58 @@ def test_remove_custom_provider_falls_back_on_menu_runtime_error(tmp_path, monke
     assert reloaded["custom_providers"] == [
         {"name": "Local B", "base_url": "http://localhost:8002/v1"},
     ]
+
+
+def test_remove_custom_provider_removes_matching_provider_from_both_schemas(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.config import get_compatible_custom_providers
+    from hermes_cli.main_provider_setup import _remove_custom_provider
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
+
+    cfg = load_config()
+    cfg["custom_providers"] = [
+        {
+            "name": "OpenAI Direct (Primary)",
+            "base_url": "https://api.openai.com/v1",
+            "model": "gpt-5-mini",
+        }
+    ]
+    cfg["providers"] = {
+        "openai-direct-primary": {
+            "name": "OpenAI Direct (Primary)",
+            "api": "https://api.openai.com/v1",
+            "default_model": "gpt-5-mini",
+        },
+        "secondary-proxy": {
+            "name": "Secondary Proxy",
+            "api": "https://proxy.example.com/v1",
+            "default_model": "gpt-4.1-mini",
+        },
+    }
+    save_config(cfg)
+
+    responses = iter(["1"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
+
+    _remove_custom_provider(cfg)
+
+    reloaded = load_config()
+    assert reloaded["custom_providers"] == []
+    assert reloaded["providers"] == {
+        "secondary-proxy": {
+            "name": "Secondary Proxy",
+            "api": "https://proxy.example.com/v1",
+            "default_model": "gpt-4.1-mini",
+        }
+    }
+    assert get_compatible_custom_providers(reloaded) == [
+        {
+            "name": "Secondary Proxy",
+            "base_url": "https://proxy.example.com/v1",
+            "provider_key": "secondary-proxy",
+            "model": "gpt-4.1-mini",
+        }
+    ]


### PR DESCRIPTION
## What / why

Removing a saved custom provider via `hermes setup model` > `Remove a saved custom provider` prints success but leaves the provider behind: `_remove_custom_provider` popped only from the legacy `custom_providers` list, while providers saved under the modern `providers.<key>` map survived removal (and reappeared on next setup).

## Related Issue

Fixes #5525.
Supersedes #14360 with credit to @LeonSGP43 — this PR reuses that PR's identifier-matching removal logic and its both-schemas test, redone at the logic's current location (`hermes_cli/main_provider_setup.py`; it has since moved out of `hermes_cli/main.py`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `hermes_cli/main_provider_setup.py`: `_remove_custom_provider` now lists candidates via `get_compatible_custom_providers(cfg)` (deduped view over both schemas) and, after the user picks one, removes every matching entry from both `custom_providers` (legacy list) and `providers` (modern map), matching on normalized `provider_key` or name + base URL + model.
- `tests/hermes_cli/test_terminal_menu_fallbacks.py`: added `test_remove_custom_provider_removes_matching_provider_from_both_schemas` (ported from #14360, adapted to the current `curses_radiolist` fallback harness): config with the same provider in both schemas — remove once, assert gone from both, unrelated provider untouched.

## How to Test

1. Set `HERMES_HOME` to a temp dir; save a config with the same provider in `custom_providers` and `providers`.
2. Run `_remove_custom_provider`, choose the provider.
3. `load_config()` shows it gone from both `custom_providers` and `providers`; other providers untouched.
4. `python -m pytest tests/hermes_cli/test_terminal_menu_fallbacks.py -k remove_custom_provider --basetemp=<tmp>` → 2 passed.

## Checklist

- [x] I have read the relevant workflow docs and followed repo conventions.
- [x] My change is minimal and focused on this issue (one logical change).
- [x] I have added/updated behavior-contract tests proving the fix.
- [x] All new and existing relevant tests pass (removal tests: 2 passed; wider file: 5 passed excluding 3 pre-existing Windows prompt_toolkit aborts identical before/after via `git stash` compare).
- [x] I ran `ruff check` on the changed files (clean).