### PR TITLE
fix(aux): honor resolved codex base_url on raw_codex path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4539,12 +4539,24 @@ def _resolve_openai_codex_branch(req: _ResolveRequest) -> _ResolveResult:
     no_token_msg = "resolve_provider_client: openai-codex requested but no Codex OAuth token found (run: hermes model)"
     if req.raw_codex:
         # Raw OpenAI client for callers needing responses.stream() (main agent loop).
-        codex_token = _read_codex_access_token()
+        # Use the runtime credential resolver so token refreshes and base URL
+        # overrides (HERMES_CODEX_BASE_URL) are honored, consistent with the
+        # primary Codex runtime path.
+        codex_token = ""
+        base_url = _CODEX_AUX_BASE_URL
+        try:
+            from hermes_cli.auth import resolve_codex_runtime_credentials
+
+            creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+            codex_token = str(creds.get("api_key") or "").strip()
+            base_url = str(creds.get("base_url") or base_url).strip().rstrip("/") or base_url
+        except Exception:
+            codex_token = _read_codex_access_token() or ""
         if not codex_token:
             logger.warning(no_token_msg)
             return None, None
-        raw_client = _create_openai_client(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL,
-                                           default_headers=_codex_cloudflare_headers(codex_token))
+        raw_client = _create_openai_client(api_key=codex_token, base_url=base_url,
+                                           default_headers=_codex_cloudflare_headers(codex_token, base_url=base_url))
         return raw_client, _normalize_resolved_model(model, req.provider)
     client, default = _build_codex_client(model)
     return _route_or_warn(req, client, default, no_token_msg)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -724,6 +724,63 @@ class TestBuildCodexClient:
         assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
 
+    def test_raw_codex_uses_runtime_resolved_base_url(self, monkeypatch):
+        """raw_codex honors HERMES_CODEX_BASE_URL via the runtime resolver (#5875)."""
+        class DummyClient:
+            def __init__(self, *, api_key, base_url, default_headers=None, **kwargs):
+                self.api_key = api_key
+                self.base_url = base_url
+                self.default_headers = default_headers
+
+        monkeypatch.setattr("agent.auxiliary_client.OpenAI", DummyClient)
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_codex_runtime_credentials",
+            lambda refresh_if_expiring=True: {
+                "api_key": "codex-runtime-token",
+                "base_url": "https://runtime.example/codex",
+            },
+        )
+
+        client, model = resolve_provider_client(
+            "openai-codex",
+            "gpt-5.4",
+            async_mode=False,
+            raw_codex=True,
+        )
+
+        assert isinstance(client, DummyClient)
+        assert client.api_key == "codex-runtime-token"
+        assert client.base_url == "https://runtime.example/codex"
+        assert model == "gpt-5.4"
+
+    def test_raw_codex_falls_back_to_auth_store_token(self, monkeypatch):
+        """Resolver failure still yields the legacy auth-store token at the default base URL."""
+        class DummyClient:
+            def __init__(self, *, api_key, base_url, default_headers=None, **kwargs):
+                self.api_key = api_key
+                self.base_url = base_url
+
+        def _boom(*, refresh_if_expiring=True):
+            raise RuntimeError("no runtime creds")
+
+        monkeypatch.setattr("agent.auxiliary_client.OpenAI", DummyClient)
+        monkeypatch.setattr("hermes_cli.auth.resolve_codex_runtime_credentials", _boom)
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_codex_access_token", lambda: "codex-auth-token"
+        )
+
+        client, model = resolve_provider_client(
+            "openai-codex",
+            "gpt-5.4",
+            async_mode=False,
+            raw_codex=True,
+        )
+
+        assert isinstance(client, DummyClient)
+        assert client.api_key == "codex-auth-token"
+        assert client.base_url == "https://chatgpt.com/backend-api/codex"
+        assert model == "gpt-5.4"
+
     def test_rejects_missing_model(self):
         """Callers must pass an explicit model; no hardcoded default."""
         from agent.auxiliary_client import _build_codex_client


### PR DESCRIPTION
## What / why
The main-agent `raw_codex=True` branch in `_resolve_openai_codex_branch` hardcoded `_CODEX_AUX_BASE_URL` and read the token via `_read_codex_access_token()`, so a custom proxy configured through `HERMES_CODEX_BASE_URL` was silently ignored on the main agent path while the wrapped aux path (`_build_codex_client`) honored it.

## Related Issue
Fixes #5875.
Supersedes #5988 by @Tranquil-Flow (Jul 13) — same diagnosis and resolver approach (`resolve_codex_runtime_credentials` + regression test); hunk location drifted since, so this redoes the change at the current `_resolve_openai_codex_branch` site. Credit to @Tranquil-Flow for the original approach.

## Type of Change
- [x] Bug fix

## Changes Made
- `agent/auxiliary_client.py`: `_resolve_openai_codex_branch` raw_codex branch now resolves credentials via `resolve_codex_runtime_credentials(refresh_if_expiring=True)` (token refresh + resolved `base_url`), falling back to `_read_codex_access_token()` at the default base URL on resolver failure; Cloudflare headers now take the resolved `base_url`.
- `tests/agent/test_auxiliary_client.py`: added `test_raw_codex_uses_runtime_resolved_base_url` (DummyClient asserts `base_url` equals the resolver-provided proxy) and `test_raw_codex_falls_back_to_auth_store_token` (resolver failure keeps legacy behavior).

## How to Test
1. Set `HERMES_CODEX_BASE_URL=https://<proxy>/codex` with a valid Codex login.
2. `python -m pytest tests/agent/test_auxiliary_client.py -k "TestBuildCodexClient or raw_codex" -q` — all 5 selected tests pass.
3. `python -m ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` — clean.

## Checklist
- [x] One logical change per PR
- [x] Behavior-contract tests added (fail pre-fix, pass post-fix)
- [x] Relevant test files run locally
- [x] Ruff clean on changed files