### PR TITLE
fix(config): accept model.context_window as alias for context_length

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1685,7 +1685,7 @@ def _resolve_context_length(agent, _agent_cfg, base_url):
     _model_cfg = _agent_cfg.get("model", {})
     _model_section = _model_cfg if isinstance(_model_cfg, dict) else {}
 
-    _config_context_length = _model_section.get("context_length")
+    _config_context_length = _model_section.get("context_length") or _model_section.get("context_window")
     if _config_context_length is not None:
         try:
             _config_context_length = int(_config_context_length)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2286,7 +2286,7 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
         model_cfg = data.get("model", {})
         if isinstance(model_cfg, dict):
             configured_model = model_cfg.get("default") or model_cfg.get("model")
-            raw_ctx = model_cfg.get("context_length")
+            raw_ctx = model_cfg.get("context_length") or model_cfg.get("context_window")
             if raw_ctx is not None:
                 with suppress(TypeError, ValueError):
                     config_context_length = int(raw_ctx)
@@ -4212,7 +4212,7 @@ class GatewayRunner(
     # cached agent or a mid-gateway edit is silently ignored. Add new baked-in settings here.
     # _MAX_INTERRUPT_DEPTH = 3  # Cap recursive interrupt handling (#816)
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
-        ("model", "context_length"), ("compression", "enabled"),
+        ("model", "context_length"), ("model", "context_window"), ("compression", "enabled"),
         ("compression", "progress_notices"), ("compression", "threshold"),
         ("compression", "model_thresholds"), ("compression", "threshold_tokens"),
         ("compression", "codex_gpt55_autoraise"), ("compression", "codex_app_server_auto"),

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1529,7 +1529,7 @@ class GatewayInboundMixin:
             _msg_cfg = _load_gateway_config()
             _msg_model_cfg = _msg_cfg.get("model", {})
             if isinstance(_msg_model_cfg, dict):
-                _msg_raw_ctx = _msg_model_cfg.get("context_length")
+                _msg_raw_ctx = _msg_model_cfg.get("context_length") or _msg_model_cfg.get("context_window")
                 if _msg_raw_ctx is not None:
                     _msg_config_ctx = int(_msg_raw_ctx)
             try:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -494,7 +494,7 @@ class GatewayTurnMixin:
             hs.model = _model_cfg
         elif isinstance(_model_cfg, dict):
             hs.model = _model_cfg.get("default") or _model_cfg.get("model") or hs.model
-            _raw_ctx = _model_cfg.get("context_length")
+            _raw_ctx = _model_cfg.get("context_length") or _model_cfg.get("context_window")
             if _raw_ctx is not None:
                 with suppress(TypeError, ValueError):
                     hs.config_context_length = int(_raw_ctx)

--- a/tests/gateway/test_context_window_alias.py
+++ b/tests/gateway/test_context_window_alias.py
@@ -1,0 +1,60 @@
+"""context_window is accepted as an alias for model.context_length (issue #8015)."""
+
+import types
+from unittest.mock import patch
+
+
+def test_gateway_model_context_resolves_context_window():
+    """_resolve_gateway_model_context honors model.context_window alone."""
+    from gateway import run as gw_run
+
+    cfg = {"model": {"default": "gpt5.4", "provider": "custom",
+                     "base_url": "http://localhost:4000/v1",
+                     "context_window": 1000000}}
+    with (
+        patch.object(gw_run, "_load_gateway_config", return_value=cfg),
+        patch.object(gw_run, "_resolve_runtime_agent_kwargs", return_value={}),
+        patch("agent.model_metadata.get_model_context_length",
+              side_effect=lambda model, **kw: kw.get("config_context_length") or 128000),
+    ):
+        resolved = gw_run._resolve_gateway_model_context()
+    assert resolved.context_length == 1000000
+    assert resolved.context_source == "config"
+
+
+def test_gateway_model_context_prefers_context_length():
+    """When both keys are set, the canonical context_length wins."""
+    from gateway import run as gw_run
+
+    cfg = {"model": {"default": "gpt5.4", "provider": "custom",
+                     "base_url": "http://localhost:4000/v1",
+                     "context_length": 256000, "context_window": 1000000}}
+    with (
+        patch.object(gw_run, "_load_gateway_config", return_value=cfg),
+        patch.object(gw_run, "_resolve_runtime_agent_kwargs", return_value={}),
+        patch("agent.model_metadata.get_model_context_length",
+              side_effect=lambda model, **kw: kw.get("config_context_length") or 128000),
+    ):
+        resolved = gw_run._resolve_gateway_model_context()
+    assert resolved.context_length == 256000
+
+
+def test_hygiene_read_config_resolves_context_window():
+    """_hmwa_hygiene_read_config honors model.context_window alone."""
+    from gateway.run_turn import GatewayTurnMixin
+
+    hs = types.SimpleNamespace(model="m", config_context_length=None,
+                               provider=None, base_url=None, compression_enabled=True,
+                               hard_msg_limit=5000, timeout_seconds=30.0,
+                               total_ceiling_seconds=600.0, max_turn_hold_seconds=10.0,
+                               failure_cooldown_seconds=300.0)
+    GatewayTurnMixin._hmwa_hygiene_read_config(
+        hs, {"model": {"default": "gpt5.4", "context_window": 1000000}})
+    assert hs.config_context_length == 1000000
+
+
+def test_context_window_busts_agent_cache():
+    """A context_window edit must invalidate the cached gateway agent."""
+    from gateway.run import GatewayRunner
+
+    assert ("model", "context_window") in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS

--- a/tests/run_agent/test_invalid_context_length_warning.py
+++ b/tests/run_agent/test_invalid_context_length_warning.py
@@ -82,3 +82,19 @@ def test_custom_providers_valid_context_length():
         )
     for c in mock_logger.warning.call_args_list:
         assert "Invalid" not in str(c)
+
+
+def test_context_window_alias_resolves():
+    """model.context_window is accepted as an alias for model.context_length (issue #8015)."""
+    agent = _build_agent({"default": "gpt5.4", "provider": "custom",
+                          "base_url": "http://localhost:4000/v1",
+                          "context_window": 1000000})
+    assert agent._config_context_length == 1000000
+
+
+def test_context_length_takes_precedence_over_context_window():
+    """When both keys are set, the canonical context_length wins."""
+    agent = _build_agent({"default": "gpt5.4", "provider": "custom",
+                          "base_url": "http://localhost:4000/v1",
+                          "context_length": 256000, "context_window": 1000000})
+    assert agent._config_context_length == 256000


### PR DESCRIPTION
## What / why

The config reader only checked `model.context_length`, silently ignoring `model.context_window` — a common key name already accepted by the API response parser in `model_metadata.py` (`_CONTEXT_LENGTH_KEYS`). Users who set `context_window: 1000000` fell through to the 128K probe default, causing premature context compression warnings at ~50% of the actual window.

This change reads `context_window` as a fallback wherever `model.context_length` is resolved from config, with the canonical `context_length` taking precedence when both are set.

## Related Issue

Fixes #8015; Supersedes #8010 (credit to @warrent9030-maker for the original patch shape — redone here against the current post-split modules).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py` — `_resolve_context_length` falls back to `model.context_window`
- `gateway/run.py` — `_resolve_gateway_model_context` falls back to `context_window`; `_CACHE_BUSTING_CONFIG_KEYS` gains `("model", "context_window")` so edits invalidate the cached agent
- `gateway/run_inbound.py` — `_inbound_model_context_length` falls back to `context_window`
- `gateway/run_turn.py` — `_hmwa_hygiene_read_config` falls back to `context_window`
- `tests/run_agent/test_invalid_context_length_warning.py` — alias-resolves + precedence tests
- `tests/gateway/test_context_window_alias.py` — new: gateway resolution, hygiene config, cache-busting tests

## How to Test

1. Set `context_window: 1000000` (and no `context_length`) under `model:` in `config.yaml`
2. Start the agent/gateway and check the resolved context window / status — it should report 1000000, not the 128K default
3. Run: `python -m pytest tests/run_agent/test_invalid_context_length_warning.py tests/gateway/test_context_window_alias.py tests/gateway/test_agent_cache.py -q`

## Checklist

- [x] I have verified the bug (new tests fail pre-fix: alias resolves to None/128K default) and the fix (41 passed)
- [x] I have added behavior-contract tests covering the alias and precedence
- [x] I ran `ruff check` on all changed files (clean)
- [x] No breaking changes