### PR TITLE
fix(agent): accumulate nameless streaming tool-call deltas into one call

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2478,7 +2478,27 @@ class _ToolCallAccumulator:
 
         self._active_slot_by_idx.setdefault(raw_idx, raw_idx)
         if delta_id and raw_idx in self._last_id_at_idx and delta_id != self._last_id_at_idx[raw_idx]:
-            self._active_slot_by_idx[raw_idx] = max(self.acc, default=-1) + 1
+            # ID changed at a reused raw index — ambiguous. It could be:
+            #   1. A new parallel tool call (Ollama)     → redirect to fresh slot
+            #   2. Argument fragmentation (LM-Studio)    → keep accumulating
+            #   3. Redundant name on every chunk (MiniMax) → keep accumulating
+            #
+            # Per the OpenAI streaming spec, a delta without a function.name
+            # cannot be the start of a new tool call — always accumulate.
+            #
+            # For deltas that DO carry a name, only create a new slot if the
+            # name differs from the current slot's name. A matching name means
+            # the provider is redundantly resending the name on every chunk,
+            # which is still the same tool call, not a new one.
+            tc_function = getattr(tc_delta, "function", None)
+            has_name = tc_function is not None and getattr(tc_function, "name", None)
+            if has_name:
+                cur_slot = self._active_slot_by_idx[raw_idx]
+                cur_name = (
+                    (self.acc.get(cur_slot, {}).get("function", {}) or {}).get("name", "") or ""
+                )
+                if cur_name != tc_function.name:
+                    self._active_slot_by_idx[raw_idx] = max(self.acc, default=-1) + 1
         if delta_id:
             self._last_id_at_idx[raw_idx] = delta_id
         idx = self._active_slot_by_idx[raw_idx]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6548,6 +6548,83 @@ class TestStreamingApiCall:
         assert tc[1].function.name == "read"
         assert tc[1].function.arguments == '{}'
 
+    def test_lmstudio_fragmented_tool_calls(self, agent):
+        """LM-Studio sends each argument chunk with a unique id.
+
+        Without the fix, each chunk becomes a separate tool call.
+        With the fix, all chunks accumulate into one tool call.
+        """
+        chunks = [
+            # First chunk: has name, empty args
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_123", "shell", "")]),
+            # Subsequent chunks: no name, unique ids, short args
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-call-1", None, "{\n")]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-call-2", None, " ")]),
+            _make_chunk(
+                tool_calls=[_make_tc_delta(0, "tool-call-3", None, '"command"')]
+            ),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-call-4", None, ': "ls"}')]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert len(tc) == 1, f"Expected 1 tool call, got {len(tc)}"
+        assert tc[0].function.name == "shell"
+        assert tc[0].function.arguments == '{\n "command": "ls"}'
+
+    def test_lmstudio_multiple_fragmented_tool_calls(self, agent):
+        """LM-Studio with two tool calls, each fragmented across chunks."""
+        chunks = [
+            # Tool call 1: name
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_a", "search", "")]),
+            # Tool call 1: args fragments
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-1", None, '{"q":')]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-2", None, '"hello"}')]),
+            # Tool call 2: name (new tool, same index)
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_b", "read_file", "")]),
+            # Tool call 2: args fragments
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-3", None, '{"path":')]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-4", None, '"x.py"}')]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert len(tc) == 2, f"Expected 2 tool calls, got {len(tc)}"
+        assert tc[0].function.name == "search"
+        assert tc[0].function.arguments == '{"q":"hello"}'
+        assert tc[1].function.name == "read_file"
+        assert tc[1].function.arguments == '{"path":"x.py"}'
+
+    def test_fragmented_with_redundant_name_every_chunk(self, agent):
+        """Provider resends function name on every fragment chunk (MiniMax pattern).
+
+        Some providers (MiniMax M2.7 via NVIDIA NIM) send the function name
+        on every delta chunk, combined with unique IDs per chunk. The name
+        comparison guard should prevent this from creating extra tool call slots.
+        """
+        chunks = [
+            # First chunk: has name, empty args
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_1", "shell", "")]),
+            # Fragments: same name repeated, unique IDs
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_2", "shell", '{"cmd"')]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_3", "shell", ':"ls"}')]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert len(tc) == 1, f"Expected 1 tool call, got {len(tc)}"
+        assert tc[0].function.name == "shell"
+        assert tc[0].function.arguments == '{"cmd":"ls"}'
+
     def test_content_and_tool_calls_together(self, agent):
         chunks = [
             _make_chunk(content="I'll search"),


### PR DESCRIPTION
## What / why

With LM-Studio (e.g. Gemma 4), a single tool call arrives fragmented: the first delta carries the function name with empty arguments, then 40+ deltas each carry a new unique `call_id` with an empty name and a single-character argument chunk. `_ToolCallAccumulator.feed` forked a fresh slot on every changed id at a reused index, so one tool call exploded into dozens of separate calls and the agent repeated tool calls.

## Related Issue

Fixes #5254.
Supersedes #5331 with credit to @Chukwuebuka-2003 — this PR reuses that PR's OpenAI-spec rule and its tests, redone against the current class-based `_ToolCallAccumulator`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` (`_ToolCallAccumulator.feed`): on a changed id at a reused raw index, a nameless delta now always accumulates into the current slot (per the OpenAI streaming spec a delta without `function.name` cannot start a new call); a named delta forks a fresh slot only when its name differs from the current slot's name (preserves the Ollama parallel-call case where same-index new calls carry new names, and absorbs MiniMax-style redundant-name resends).
- `tests/run_agent/test_run_agent.py`: added `test_lmstudio_fragmented_tool_calls` (empty-name single-char chunks accumulate to one call), `test_lmstudio_multiple_fragmented_tool_calls` (two fragmented calls at the same index stay distinct), `test_fragmented_with_redundant_name_every_chunk` (repeated-name fragments stay one call).

## How to Test

1. Feed a recorded LM-Studio-style delta sequence (name-first chunk, then empty-name single-char argument chunks with unique ids) through `_interruptible_streaming_api_call` with a mocked client — fully offline.
2. Assert exactly one accumulated tool call with the joined arguments (and two calls for the two-tool sequence).
3. `python -m pytest tests/run_agent/test_run_agent.py --basetemp=<tmp>` → 287 passed.

## Checklist

- [x] I have read the relevant workflow docs and followed repo conventions.
- [x] My change is minimal and focused on this issue (one logical change).
- [x] I have added/updated behavior-contract tests proving the fix.
- [x] All new and existing relevant tests pass (full file: 287 passed, including the pre-existing Ollama same-index parallel-call test).
- [x] I ran `ruff check` on the changed files (clean).