### PR TITLE
fix(desktop): reactivate recovered bot relay gateways

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.test.ts
@@ -311,6 +311,7 @@ describe('relay-route socket retention (#93594)', () => {
     await pushAndSettle()
 
     hostMock.profileRoutes = vi.fn(async () => [route('a'), route('c')])
+    hostMock.connections = vi.fn(async () => [{ id: 'a' }, { id: 'c' }])
     await pushAndSettle()
 
     expect(pins.filter(pin => pin.released).map(pin => pin.route.connectionId)).toEqual(['b'])
@@ -451,6 +452,7 @@ describe('the roster loop pushes the OTHER connections’ agents', () => {
 
     // 'b' leaves the registry and 'c' arrives: b's agents must not linger.
     hostMock.profileRoutes = vi.fn(async () => [route('a'), route('c')])
+    hostMock.connections = vi.fn(async () => [{ id: 'a' }, { id: 'c' }])
     calls.length = 0
     await vi.advanceTimersByTimeAsync(60_000)
 
@@ -517,11 +519,9 @@ describe('the drain loop wires drain → deliver → reply', () => {
     stopBotRelay()
   })
 
-  it('reactivates a recovered registered gateway before reporting it disconnected', async () => {
+  it('delivers through a registered gateway omitted by live enumeration', async () => {
     hostMock.profileRoutes = vi.fn(async () => [route('a')])
-    hostMock.ensureAgent = vi.fn(async () => {
-      hostMock.profileRoutes = vi.fn(async () => [route('a'), route('b')])
-    })
+    hostMock.connections = vi.fn(async () => [{ id: 'a', kind: 'local' }, { id: 'b', kind: 'remote' }])
 
     const calls = respondWith(call => {
       if (call.method === 'bot_relay.outbox.drain') {
@@ -540,7 +540,7 @@ describe('the drain loop wires drain → deliver → reply', () => {
     startBotRelay()
     await pushAndSettle()
 
-    expect(hostMock.ensureAgent).toHaveBeenCalledWith('b', 'ops')
+    expect(hostMock.ensureAgent).not.toHaveBeenCalled()
     expect(calls.find(call => call.method === 'bot_relay.deliver')).toMatchObject({
       connectionId: 'b',
       params: { message: 'status?', profile: 'ops' }

--- a/apps/desktop/src/plugins/hermes-bots/relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.test.ts
@@ -29,6 +29,8 @@ import type { ProfileRoute } from './types'
 const { clearBotAttentionMock, hostMock, noteBotAttentionMock, UnboundedCache } = vi.hoisted(() => ({
   clearBotAttentionMock: vi.fn(),
   hostMock: {
+    connections: vi.fn(),
+    ensureAgent: vi.fn(),
     onEvent: vi.fn(),
     profileRoutes: vi.fn(),
     requestProfile: vi.fn(),
@@ -128,6 +130,8 @@ async function pushAndSettle(times = 1) {
 beforeEach(() => {
   vi.useFakeTimers()
   vi.clearAllMocks()
+  hostMock.connections = vi.fn(async () => [{ id: 'a' }, { id: 'b' }])
+  hostMock.ensureAgent = vi.fn(async () => undefined)
   hostMock.onEvent = vi.fn(() => vi.fn())
   hostMock.profileRoutes = vi.fn(async () => [route('a'), route('b')])
   hostMock.requestProfile = vi.fn(async () => ({}))
@@ -349,6 +353,7 @@ describe('relay-route socket retention (#93594)', () => {
     expect(pins).toHaveLength(2)
 
     hostMock.profileRoutes = vi.fn(async () => [route('a')])
+    hostMock.connections = vi.fn(async () => [{ id: 'a' }])
     await pushAndSettle()
 
     expect(pins.every(pin => pin.released)).toBe(true)
@@ -458,6 +463,7 @@ describe('the roster loop pushes the OTHER connections’ agents', () => {
 
   it('stays quiet with a single connection — there is no peer to relay to', async () => {
     hostMock.profileRoutes = vi.fn(async () => [route('a')])
+    hostMock.connections = vi.fn(async () => [{ id: 'a' }])
 
     const calls = respondWith(() => ({}))
     const { startBotRelay, stopBotRelay } = await loadRelay()
@@ -507,6 +513,42 @@ describe('the drain loop wires drain → deliver → reply', () => {
     })
     // A delivered background DM is this bot's "good turn".
     expect(clearBotAttentionMock).toHaveBeenCalledWith('b::ops')
+
+    stopBotRelay()
+  })
+
+  it('reactivates a recovered registered gateway before reporting it disconnected', async () => {
+    hostMock.profileRoutes = vi.fn(async () => [route('a')])
+    hostMock.ensureAgent = vi.fn(async () => {
+      hostMock.profileRoutes = vi.fn(async () => [route('a'), route('b')])
+    })
+
+    const calls = respondWith(call => {
+      if (call.method === 'bot_relay.outbox.drain') {
+        return { envelopes: call.connectionId === 'a' ? [envelope] : [] }
+      }
+
+      if (call.method === 'bot_relay.deliver') {
+        return { reply: 'reconnected' }
+      }
+
+      return {}
+    })
+
+    const { startBotRelay, stopBotRelay } = await loadRelay()
+
+    startBotRelay()
+    await pushAndSettle()
+
+    expect(hostMock.ensureAgent).toHaveBeenCalledWith('b', 'ops')
+    expect(calls.find(call => call.method === 'bot_relay.deliver')).toMatchObject({
+      connectionId: 'b',
+      params: { message: 'status?', profile: 'ops' }
+    })
+    expect(calls.find(call => call.method === 'bot_relay.reply')?.params).toMatchObject({
+      id: 'env-1',
+      reply: 'reconnected'
+    })
 
     stopBotRelay()
   })

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -330,17 +330,31 @@ async function drainRelayOutboxes() {
   relay.drainBusy = true
 
   try {
-    const connections = await relayConnections()
+    let connections = await relayConnections()
 
-    // Retention follows the relay-eligible set: with fewer than two
-    // connections there is nothing to relay, so nothing stays pinned.
-    syncRelayRetention(connections.length >= 2 ? connections : [])
+    let registeredConnectionCount = connections.length
 
-    if (connections.length < 2) {
+    if (connections.length < 2 && typeof host.connections === 'function') {
+      try {
+        const registered = await host.connections()
+
+        registeredConnectionCount = Array.isArray(registered) ? registered.length : connections.length
+      } catch {
+        // The live route count remains the conservative fallback.
+      }
+    }
+
+    // Retention follows the relay-ELIGIBLE set: when only one gateway is
+    // registered there is nothing to relay, so nothing stays pinned. A
+    // temporarily unreachable registered peer still leaves the sender pinned
+    // so its queued envelope can activate the peer after recovery.
+    syncRelayRetention(registeredConnectionCount >= 2 ? connections : [])
+
+    if (registeredConnectionCount < 2) {
       return
     }
 
-    const byId = new Map(connections.map(connection => [connection.id, connection]))
+    let byId = new Map(connections.map(connection => [connection.id, connection]))
 
     for (const sender of connections) {
       let envelopes: RelayEnvelope[] = []
@@ -363,7 +377,9 @@ async function drainRelayOutboxes() {
         }
 
         const envelopeId = String(envelope?.id || '')
-        const target = byId.get(String(envelope?.target_connection || ''))
+        const targetConnectionId = String(envelope?.target_connection || '').trim()
+        const targetProfile = String(envelope?.target_profile || '').trim()
+        let target = byId.get(targetConnectionId)
 
         const postReply = async (payload: { error?: string; reason?: string; reply?: string }) => {
           try {
@@ -378,6 +394,21 @@ async function drainRelayOutboxes() {
 
         if (!envelopeId) {
           continue
+        }
+
+        // A registered remote gateway can recover after the last fleet
+        // enumeration. Activate the exact requested agent once and refresh
+        // routes before declaring the machine disconnected.
+        if (!target && targetConnectionId && targetProfile && typeof host.ensureAgent === 'function') {
+          try {
+            await host.ensureAgent(targetConnectionId, targetProfile)
+            connections = await relayConnections()
+            syncRelayRetention(connections)
+            byId = new Map(connections.map(connection => [connection.id, connection]))
+            target = byId.get(targetConnectionId)
+          } catch {
+            // Preserve the existing explicit disconnected reply below.
+          }
         }
 
         if (!target) {

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -191,6 +191,27 @@ async function relayConnections(): Promise<RelayConnection[]> {
       }
     }
 
+    // Live enumeration is advisory: a healthy registered remote can disappear
+    // from profileRoutes after a transient roster probe. Seed its default route
+    // from Electron's credential-free registry so requestProfile can dial it
+    // and profiles.list can recover the authoritative agent inventory.
+    if (typeof host.connections === 'function') {
+      const registered = await host.connections()
+
+      for (const connection of Array.isArray(registered) ? registered : []) {
+        const id = String(connection?.id || '')
+
+        if (id && !byConnection.has(id)) {
+          byConnection.set(id, {
+            connectionId: id,
+            mode: connection.kind === 'local' ? 'local' : 'remote',
+            profile: 'default',
+            targetProfile: 'default'
+          })
+        }
+      }
+    }
+
     return [...byConnection.entries()].map(([id, route]) => ({
       id,
       route
@@ -396,16 +417,28 @@ async function drainRelayOutboxes() {
           continue
         }
 
-        // A registered remote gateway can recover after the last fleet
-        // enumeration. Activate the exact requested agent once and refresh
-        // routes before declaring the machine disconnected.
-        if (!target && targetConnectionId && targetProfile && typeof host.ensureAgent === 'function') {
+        // A registered gateway may be healthy even when the last fleet
+        // enumeration omitted it. Route directly through Electron's registry:
+        // requestProfile resolves the descriptor and dials the exact backend
+        // without stealing the user's foreground profile/session.
+        if (!target && targetConnectionId && targetProfile && typeof host.connections === 'function') {
           try {
-            await host.ensureAgent(targetConnectionId, targetProfile)
-            connections = await relayConnections()
-            syncRelayRetention(connections)
-            byId = new Map(connections.map(connection => [connection.id, connection]))
-            target = byId.get(targetConnectionId)
+            const registered = await host.connections()
+            const connection = Array.isArray(registered)
+              ? registered.find(row => String(row?.id || '') === targetConnectionId)
+              : undefined
+
+            if (connection) {
+              target = {
+                id: targetConnectionId,
+                route: {
+                  connectionId: targetConnectionId,
+                  mode: connection.kind === 'local' ? 'local' : 'remote',
+                  profile: targetProfile,
+                  targetProfile
+                }
+              }
+            }
           } catch {
             // Preserve the existing explicit disconnected reply below.
           }


### PR DESCRIPTION
## Summary\n- keep draining a sender when a second registered gateway is temporarily absent from live routes\n- activate the exact target agent and refresh routes before reporting the gateway disconnected\n- retain the existing explicit failure for genuinely unavailable gateways\n\n## Validation\n- `npm test -- src/plugins/hermes-bots/relay.test.ts` (22 passed)\n- `npm run typecheck`