### PR TITLE
fix(compressor): return fallback summary when max_retries=0

### DIFF
--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -342,6 +342,34 @@ class TestGenerateSummary:
 
         assert summary == "[CONTEXT SUMMARY]:"
 
+    def test_generate_summary_with_zero_retries_returns_string_not_none(self):
+        """With max_retries=0 the retry loop never runs.
+
+        Regression guard for issue #32847: previously the function returned
+        implicit None, which was then injected as a conversation "value" and
+        crashed downstream string operations.
+        """
+        from trajectory_compressor import _SUMMARY_FALLBACK
+
+        config = CompressionConfig(max_retries=0)
+        tc = _make_compressor(config)
+        tc.client = MagicMock()
+        # Even if the client somehow returned a value, range(0) is empty,
+        # so the loop body — and this mock — are never reached.
+        tc.client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="unused"))]
+        )
+        metrics = TrajectoryMetrics()
+
+        summary = tc._generate_summary("Turn content", metrics)
+
+        assert summary is not None
+        assert isinstance(summary, str)
+        assert summary == _SUMMARY_FALLBACK
+        # The retry loop did not execute, so no API call was attempted.
+        assert metrics.summarization_api_calls == 0
+        tc.client.chat.completions.create.assert_not_called()
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -199,3 +199,36 @@ async def test_generate_summary_async_public_moonshot_cn_kimi_k2_5_omits_tempera
 
     assert result.startswith("[CONTEXT SUMMARY]:")
     assert "temperature" not in async_client.chat.completions.create.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_async_with_zero_retries_returns_string_not_none():
+    """Async variant of the max_retries=0 regression guard for issue #32847."""
+    from trajectory_compressor import (
+        _SUMMARY_FALLBACK,
+        CompressionConfig,
+        TrajectoryCompressor,
+        TrajectoryMetrics,
+    )
+
+    config = CompressionConfig(max_retries=0)
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = config
+    compressor.logger = MagicMock()
+    compressor._use_call_llm = False
+    async_client = MagicMock()
+    async_client.chat.completions.create = MagicMock(
+        return_value=SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="unused"))]
+        )
+    )
+    compressor._get_async_client = MagicMock(return_value=async_client)
+    metrics = TrajectoryMetrics()
+
+    summary = await compressor._generate_summary_async("Turn content", metrics)
+
+    assert summary is not None
+    assert isinstance(summary, str)
+    assert summary == _SUMMARY_FALLBACK
+    assert metrics.summarization_api_calls == 0
+    async_client.chat.completions.create.assert_not_called()

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -471,6 +471,10 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 if delay is None:
                     return _SUMMARY_FALLBACK
                 time.sleep(delay)
+        # The retry loop never executes when max_retries=0 — without this the
+        # function returns implicit None, which is then injected as message
+        # content downstream and crashes string ops.
+        return _SUMMARY_FALLBACK
 
     async def _generate_summary_async(self, content: str, metrics: TrajectoryMetrics) -> str:
         """Async twin of ``_generate_summary``."""
@@ -490,6 +494,10 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 if delay is None:
                     return _SUMMARY_FALLBACK
                 await asyncio.sleep(delay)
+        # The retry loop never executes when max_retries=0 — without this the
+        # function returns implicit None, which is then injected as message
+        # content downstream and crashes string ops.
+        return _SUMMARY_FALLBACK
 
     def _plan_compression(self, trajectory: List[Dict[str, str]], metrics: TrajectoryMetrics) -> Optional[Tuple[int, int]]:
         """Choose the ``[start, until)`` region to summarize, or None if nothing can be.


### PR DESCRIPTION
## What / why

`_generate_summary` and `_generate_summary_async` in `trajectory_compressor.py` loop `for attempt in range(self.config.max_retries)`. With `max_retries=0` the loop body never executes and the functions fall off the end, returning implicit `None` despite `-> str`. That `None` is then injected into the compressed conversation as message content, crashing downstream string operations.

## Related Issue

Fixes #32847.
Supersedes #32868 with credit to its author for the correct 10-line fix direction — redone here against current main (which has since refactored the loop body into `_finish_summary`/`_summary_attempt_failed` helpers, and has no `_ensure_summary_prefix` helper, so the post-loop path returns the existing `_SUMMARY_FALLBACK` constant instead). Sync/async zero-retry regression tests salvaged from #33107 and adapted to that fallback value.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `trajectory_compressor.py`: `_generate_summary` and `_generate_summary_async` now `return _SUMMARY_FALLBACK` after the retry loop, covering both `max_retries=0` and any future fall-through.
- `tests/test_trajectory_compressor.py`: added `test_generate_summary_with_zero_retries_returns_string_not_none` — `CompressionConfig(max_retries=0)`, mocked client, asserts the summary is a `str` equal to `_SUMMARY_FALLBACK`, `summarization_api_calls == 0`, client never called.
- `tests/test_trajectory_compressor_async.py`: added the async twin `test_generate_summary_async_with_zero_retries_returns_string_not_none`.

## How to Test

1. `CompressionConfig(max_retries=0)`, compress a trajectory with a mock client.
2. Assert the summary is a `str` (no `None` injected) and the client was never called.
3. `python -m pytest tests/test_trajectory_compressor.py tests/test_trajectory_compressor_async.py --basetemp=<tmp>` → 31 passed.

## Checklist

- [x] I have read the relevant workflow docs and followed repo conventions.
- [x] My change is minimal and focused on this issue (one logical change).
- [x] I have added/updated behavior-contract tests proving the fix.
- [x] All new and existing relevant tests pass (31 passed across both compressor test files).
- [x] I ran `ruff check` on the changed files (clean).