### PR TITLE
fix(mcp): honor workdir as cwd alias for stdio servers

### DIFF
--- a/tests/tools/test_mcp_stdio_workdir.py
+++ b/tests/tools/test_mcp_stdio_workdir.py
@@ -1,0 +1,77 @@
+"""End-to-end coverage for stdio MCP subprocess working directories."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import textwrap
+
+import pytest
+pytest.importorskip("mcp.server")
+
+
+def test_real_stdio_server_uses_configured_workdir(tmp_path, monkeypatch):
+    """The configured workdir reaches the real MCP child process."""
+    from tools import mcp_tool
+
+    server_script = tmp_path / "cwd_probe_server.py"
+    server_script.write_text(
+        textwrap.dedent(
+            """
+            import os
+
+            try:
+                from mcp.server.fastmcp import FastMCP as _Server
+            except ImportError:
+                from mcp.server import MCPServer as _Server
+
+            mcp = _Server("cwd-probe")
+
+            @mcp.tool()
+            def report_cwd() -> str:
+                return os.getcwd()
+
+            if __name__ == "__main__":
+                mcp.run(transport="stdio")
+            """
+        ),
+        encoding="utf-8",
+    )
+    configured_cwd = tmp_path / "configured-cwd"
+    configured_cwd.mkdir()
+
+    # Keep this regression hermetic: the subprocess and MCP transport are real,
+    # while network malware checks and process-wide orphan cleanup are not part
+    # of the behavior under test.
+    monkeypatch.setattr(
+        "tools.osv_check.check_package_for_malware",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "tools.mcp_tool_lifecycle._kill_orphaned_mcp_children",
+        lambda *_args, **_kwargs: None,
+    )
+
+    async def drive_server():
+        server = mcp_tool.MCPServerTask("cwd-probe")
+        try:
+            await asyncio.wait_for(
+                server.start(
+                    {
+                        "command": sys.executable,
+                        "args": [str(server_script)],
+                        "workdir": str(configured_cwd),
+                        "connect_timeout": 30,
+                    }
+                ),
+                timeout=60,
+            )
+            result = await asyncio.wait_for(
+                server.session.call_tool("report_cwd", {}),
+                timeout=30,
+            )
+            assert result.content[0].text == str(configured_cwd)
+        finally:
+            await server.shutdown()
+
+    asyncio.run(drive_server())

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1021,6 +1021,41 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    @pytest.mark.parametrize(
+        ("workdir_config", "expected_cwd"),
+        [
+            ({"workdir": "~/repo"}, os.path.expanduser("~/repo")),
+            ({"cwd": "/tmp/mcp-server"}, "/tmp/mcp-server"),
+            (
+                {"cwd": "/tmp/canonical", "workdir": "/tmp/compat-alias"},
+                "/tmp/canonical",
+            ),
+        ],
+    )
+    def test_stdio_honors_configured_workdir(self, workdir_config, expected_cwd):
+        """Stdio MCP servers pass configured workdir/cwd through to the SDK."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params, p_stdio, p_cs:
+                server = MCPServerTask("srv")
+                await server.start({"command": "node", **workdir_config})
+
+                call_kwargs = mock_params.call_args
+                assert call_kwargs.kwargs.get("cwd") == expected_cwd
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
 
     def test_stdio_recycle_deadline_pauses_while_rpc_active(self):
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -214,10 +214,13 @@ class MCPServerTransportMixin:
         if not command:
             raise ValueError(f"MCP server '{self.name}' has no 'command' in config")
         command, safe_env = _config._resolve_stdio_command(command, _config._build_safe_env(config.get("env")))
+        workdir = config.get("cwd") or config.get("workdir")
+        if workdir:
+            workdir = os.path.expanduser(str(workdir))
         # OSV malware preflight, then the cached-npx swap (ordering enforced there).
         command, args = await _core._preflight_stdio_command(self.name, command, config.get("args", []))
         server_params = _core.StdioServerParameters(
-            command=command, args=args, env=safe_env or None, cwd=config.get("cwd"),
+            command=command, args=args, env=safe_env or None, cwd=workdir,
             # Windows pipes can split non-UTF-8 bytes at chunk boundaries; substitute, don't raise.
             encoding_error_handler="replace")
         # Reap orphans of prior attempts first (else retries pile up zombie pairs); unscoped on purpose;


### PR DESCRIPTION
## What / why

When configuring a stdio MCP server, the `workdir` field was silently ignored — `_run_stdio()` passed only `config.get("cwd")`, so the subprocess inherited Hermes' own working directory. Servers invoked via `python -m <module>` (or anything depending on cwd-relative resolution) then failed at startup with `ModuleNotFoundError`, surfacing as `Connection closed`.

This change reads `cwd` with a `workdir` compatibility fallback (canonical `cwd` wins when both are set), expands `~`, and passes the result to `StdioServerParameters(cwd=...)`.

## Related Issue

Fixes #5467; Supersedes #10438 (credit to @masonjames for the original workdir-alias patch and tests — source hunk redone here against the post-split `tools/mcp_tool_transport.py`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool_transport.py` — `_run_stdio` resolves `config.get("cwd") or config.get("workdir")` with `~" expansion, passes `cwd=workdir`
- `tests/tools/test_mcp_tool.py` — parametrized `test_stdio_honors_configured_workdir` (workdir alias, cwd, precedence)
- `tests/tools/test_mcp_stdio_workdir.py` — new hermetic test: real local subprocess + tmp cwd probe using the `workdir` key

## How to Test

1. Configure a stdio server with `workdir:` pointing at the server project and start Hermes — the child process cwd should be the configured dir
2. Run: `python -m pytest tests/tools/test_mcp_stdio_workdir.py "tests/tools/test_mcp_tool.py::TestMCPServerTask" -q`

## Checklist

- [x] I verified the bug (workdir key passed `cwd=None` pre-fix) and the fix (7 passed, incl. live-subprocess probe)
- [x] I added behavior-contract tests (mock-level params + hermetic subprocess test)
- [x] I ran `ruff check` on all changed files (clean)
- [x] Wider file run matches main's failure set exactly (one pre-existing Windows-env `ProgramFiles` failure, unrelated)
- [x] No breaking changes