### PR TITLE
fix(anthropic): honor model.api_key from config.yaml

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -686,15 +686,22 @@ def _anthropic_env_runtime(requested_provider: str, model_cfg: Dict[str, Any]) -
     """Native Anthropic (Messages API) from env/auth store; ``model.base_url`` honoured only when
     the configured provider is anthropic (else a Codex endpoint would leak into Anthropic requests)."""
     base_url = _anthropic_cfg_base_url(model_cfg) or _ANTHROPIC_DEFAULT_BASE_URL
+    # Honour model.api_key from config.yaml before falling back to env (consistent with other providers).
+    cfg_api_key = ""
+    for k in ("api_key", "api"):
+        v = model_cfg.get(k)
+        if isinstance(v, str) and v.strip():
+            cfg_api_key = v.strip()
+            break
     # Microsoft Foundry endpoints reject Claude Code OAuth tokens, which resolve_anthropic_token()
     # would return first — use the env key directly.
     if base_url_host_matches(base_url, "azure.com"):
-        token = _azure_anthropic_env_key(model_cfg)
+        token = cfg_api_key or _azure_anthropic_env_key(model_cfg)
         if not token:
             raise AuthError("No Azure Anthropic API key found. Set AZURE_ANTHROPIC_KEY or ANTHROPIC_API_KEY, or point "
                             "key_env/api_key_env in your config.yaml model section at a custom env var.")
     else:
-        token = _anthropic_token_or_raise()
+        token = cfg_api_key or _anthropic_token_or_raise()
     return _runtime("anthropic", "anthropic_messages", base_url, token, source="env", requested_provider=requested_provider)
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1783,3 +1783,68 @@ def test_custom_provider_pool_target_model_wins(monkeypatch):
 
     assert resolved is not None
     assert resolved["model"] == "myproxy/gemini-flash"
+
+
+def test_resolve_runtime_provider_anthropic_respects_config_api_key(monkeypatch):
+    """Anthropic provider uses model.api_key from config.yaml when set (issue #7579),
+    without requiring ANTHROPIC_API_KEY or ANTHROPIC_TOKEN env vars."""
+
+    def _unexpected_anthropic_token():
+        raise AssertionError("resolve_anthropic_token should not be called when config api_key is set")
+
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "config-anthropic-key",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.resolve_anthropic_token",
+        _unexpected_anthropic_token,
+    )
+    # Ensure no env vars are set
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["api_key"] == "config-anthropic-key"
+    assert resolved["base_url"] == "https://api.anthropic.com"
+
+
+def test_resolve_runtime_provider_anthropic_config_api_field(monkeypatch):
+    """Anthropic provider also accepts the 'api' field from config.yaml."""
+
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+            "api": "config-api-field-key",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_key"] == "config-api-field-key"


### PR DESCRIPTION
## What / why

With `provider: anthropic` in `config.yaml`, the `model.api_key` field was completely ignored: the native-Anthropic rung went straight to `resolve_anthropic_token()` (env vars / credential files only), forcing users to duplicate the key into `ANTHROPIC_API_KEY`. Every other provider (openrouter, custom, minimax, z.ai, kimi, …) already reads `model.api_key` as a candidate source.

This change checks `model.api_key` (and the `api` alias) from config.yaml first in `_anthropic_env_runtime`, falling back to env/auth-store only when unset.

## Related Issue

Fixes #7579; Supersedes #7581 (credit to @FrankSen for the original `for k in ('api_key','api')` lookup — reapplied here at the live post-decomposition site, `_anthropic_env_runtime`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — `_anthropic_env_runtime` reads `model_cfg['api_key']`/`['api']` before env (both native and Azure-Foundry branches)
- `tests/hermes_cli/test_runtime_provider_resolution.py` — config-`api_key` and `api`-alias tests with empty env

## How to Test

1. Set `provider: anthropic` + `api_key: sk-ant-…` under `model:` in `config.yaml` with no `ANTHROPIC_*` env vars
2. Resolve the runtime — the config key should be used instead of raising `AuthError`
3. Run: `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`

## Checklist

- [x] I verified the bug (config key raised `AuthError` pre-fix) and the fix (67 passed)
- [x] New tests fail pre-fix (env lookup invoked / AuthError) and pass post-fix
- [x] I ran `ruff check` on all changed files (clean)
- [x] No breaking changes (env/auth-store fallback order preserved when no config key is set)