### PR TITLE
fix(tools): reject read_file calls with missing or empty path

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -12,6 +12,7 @@ import pytest
 
 from tools.file_tools import (
     PATCH_SCHEMA,
+    READ_FILE_SCHEMA,
 )
 
 
@@ -56,6 +57,44 @@ class TestReadFileHandler:
         result = json.loads(read_file_tool("/tmp/test.txt"))
         assert "error" in result
         assert "terminal not available" in result["error"]
+
+    @patch("tools.file_tools.read_file_tool")
+    def test_missing_path_key_returns_error(self, mock_read):
+        """#31791 — handler must reject calls where 'path' key is absent rather than
+        defaulting to "" and producing a confusing 'File not found: ' error with
+        unrelated similar_files suggestions."""
+        from tools.file_tools import _handle_read_file
+
+        result = json.loads(_handle_read_file({}))
+        assert "error" in result
+        assert "path" in result["error"].lower()
+        mock_read.assert_not_called()
+
+    @patch("tools.file_tools.read_file_tool")
+    def test_empty_path_returns_error(self, mock_read):
+        """#31791 — explicit empty string path is rejected before resolution."""
+        from tools.file_tools import _handle_read_file
+
+        result = json.loads(_handle_read_file({"path": ""}))
+        assert "error" in result
+        assert "path" in result["error"].lower()
+        mock_read.assert_not_called()
+
+    @patch("tools.file_tools.read_file_tool")
+    def test_non_string_path_returns_error(self, mock_read):
+        """#31791 — non-string path (e.g. None, int) is rejected."""
+        from tools.file_tools import _handle_read_file
+
+        for bad in (None, 123, ["x"]):
+            result = json.loads(_handle_read_file({"path": bad}))
+            assert "error" in result
+            assert "path" in result["error"].lower()
+        mock_read.assert_not_called()
+
+    def test_read_file_schema_requires_non_empty_path(self):
+        """#31791 — schema declares minLength: 1 so providers that honor JSON Schema
+        can reject empty paths before the call reaches the handler."""
+        assert READ_FILE_SCHEMA["parameters"]["properties"]["path"].get("minLength") == 1
 
 
 class TestWriteFileHandler:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1031,7 +1031,7 @@ READ_FILE_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
+            "path": {"type": "string", "minLength": 1, "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
             "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": DEFAULT_READ_LIMIT, "maximum": 2000}
         },
@@ -1177,7 +1177,12 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", DEFAULT_READ_LIMIT), task_id=tid)
+    if not args.get("path") or not isinstance(args.get("path"), str):
+        return tool_error(
+            "read_file: missing required field 'path'. Re-emit the tool call with "
+            "a valid file path (absolute, relative, or ~/path)."
+        )
+    return read_file_tool(path=args["path"], offset=args.get("offset", 1), limit=args.get("limit", DEFAULT_READ_LIMIT), task_id=tid)
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## What / why

When the model calls `read_file` without a `path` (or with `""`/non-string), `_handle_read_file` defaulted to `""` and the empty path propagated through the whole read pipeline into `_suggest_similar_files`, producing the confusing `"File not found: ", "similar_files": [...random CWD files...]` — unhelpful and wasting follow-up API calls. `_handle_write_file` right below already had a presence/type guard; read had none.

## Related Issue

Fixes #31791.
Supersedes #31801 with credit to its author — same approach (handler guard mirroring write + `minLength: 1` schema), including both review asks: `READ_FILE_SCHEMA` is imported at the top of the test module, and the invalid-path tests mock `read_file_tool` and assert it was never called.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `tools/file_tools.py`: `_handle_read_file` now returns a clear `tool_error` (`read_file: missing required field 'path'...`) when `path` is absent, empty, or non-string, mirroring `_handle_write_file`; `READ_FILE_SCHEMA` path gains `"minLength": 1` so schema-honoring providers can reject empty paths pre-dispatch.
- `tests/tools/test_file_tools.py`: added `test_missing_path_key_returns_error`, `test_empty_path_returns_error`, `test_non_string_path_returns_error` (each asserts the error mentions path and `read_file_tool` was not called) and `test_read_file_schema_requires_non_empty_path`.

## How to Test

1. Call `_handle_read_file({})`, `_handle_read_file({"path": ""})`, `_handle_read_file({"path": 123})` → clear `tool_error` naming `path`, `read_file_tool` never invoked.
2. `python -m pytest tests/tools/test_file_tools.py --basetemp=<tmp>` → 47 passed + 6 pre-existing Windows-env failures identical before/after via `git stash` compare (POSIX-perm asserts, macOS carveouts, mock-serialization noise).

## Checklist

- [x] I have read the relevant workflow docs and followed repo conventions.
- [x] My change is minimal and focused on this issue (one logical change).
- [x] I have added/updated behavior-contract tests proving the fix.
- [x] All new and existing relevant tests pass (4 new tests pass; failure set identical to baseline).
- [x] I ran `ruff check` on the changed files (clean).