### PR TITLE
fix(api-server): send CORS headers on run events SSE stream

### DIFF
--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -727,8 +727,14 @@ async def _handle_run_events(self, request: "web.Request", *, _api_server) -> "w
         return _run_not_found(_api_server._openai_error, run_id)
     q = self._run_streams[run_id]
     self._run_stream_subscribers.add(run_id)
-    response = web.StreamResponse(status=200, headers={
-        "Content-Type": "text/event-stream", "Cache-Control": "no-cache", "X-Accel-Buffering": "no"})
+    # The CORS middleware can't inject headers after prepare() flushes them, so resolve
+    # the origin's CORS headers up front (same pattern as the chat/responses SSE paths).
+    sse_headers = {
+        "Content-Type": "text/event-stream", "Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+    origin = request.headers.get("Origin", "")
+    if origin:
+        sse_headers.update(self._cors_headers_for_origin(origin) or {})
+    response = web.StreamResponse(status=200, headers=sse_headers)
     await response.prepare(request)
     try:
         while True:

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -463,6 +463,81 @@ class TestRunEvents:
 
 
 # ---------------------------------------------------------------------------
+# GET /v1/runs/{run_id}/events — CORS on the SSE stream
+# ---------------------------------------------------------------------------
+
+
+class TestRunEventsCORS:
+    """StreamResponse flushes headers on prepare(), so the CORS middleware cannot
+    inject them afterwards — the handler must resolve them up front (#6358)."""
+
+    @staticmethod
+    def _primed_adapter(api_key="sk-secret"):
+        adapter = _make_adapter(api_key=api_key)
+        adapter._cors_origins = ("http://localhost:3000",)
+        return adapter
+
+    @staticmethod
+    def _prime_closed_stream(adapter, run_id):
+        _claim_run(adapter, run_id)
+        q: asyncio.Queue = asyncio.Queue()
+        q.put_nowait(None)  # run finished: handler writes ": stream closed" and returns
+        adapter._run_streams[run_id] = q
+
+    @pytest.mark.asyncio
+    async def test_events_cors_headers_present_for_allowed_origin(self):
+        adapter = self._primed_adapter()
+        self._prime_closed_stream(adapter, "cors_run_1")
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/v1/runs/cors_run_1/events",
+                headers={
+                    "Authorization": "Bearer sk-secret",
+                    "Origin": "http://localhost:3000",
+                    "Accept": "text/event-stream",
+                },
+            )
+            assert resp.status == 200
+            assert resp.headers.get("Content-Type") == "text/event-stream"
+            assert resp.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+            assert "GET" in resp.headers.get("Access-Control-Allow-Methods", "")
+            assert "Authorization" in resp.headers.get("Access-Control-Allow-Headers", "")
+            await resp.text()
+
+    @pytest.mark.asyncio
+    async def test_events_cors_headers_absent_without_origin(self):
+        adapter = self._primed_adapter()
+        self._prime_closed_stream(adapter, "cors_run_2")
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/v1/runs/cors_run_2/events",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert resp.status == 200
+            assert resp.headers.get("Access-Control-Allow-Origin") is None
+            await resp.text()
+
+    @pytest.mark.asyncio
+    async def test_events_rejects_disallowed_origin(self):
+        adapter = self._primed_adapter()
+        self._prime_closed_stream(adapter, "cors_run_3")
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/v1/runs/cors_run_3/events",
+                headers={
+                    "Authorization": "Bearer sk-secret",
+                    "Origin": "http://evil.example",
+                },
+            )
+            assert resp.status == 403
+            assert resp.headers.get("Access-Control-Allow-Origin") is None
+            await resp.text()
+
+
+# ---------------------------------------------------------------------------
 # POST /v1/runs/{run_id}/steer — steer a running agent
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What / why
GET `/v1/runs/{run_id}/events` builds its `StreamResponse` with only `Content-Type`/`Cache-Control`/`X-Accel-Buffering`. The CORS middleware can only patch headers post-handler, but `prepare()` already flushed them — so browser frontends on an allowed origin get an opaque response with no `Access-Control-Allow-Origin`.

## Related Issue
Fixes #6358.
Supersedes #6367 by @kawanoii (Jul 12) — same pre-prepare CORS resolution plus `TestRunEventsCORS`; redone at the moved handler path (`api_server.py` → `gateway/platforms/api_server_runs.py`). Credit to @kawanoii for the original approach. Sibling PR #72945 proved the same pattern for the session chat stream.

## Type of Change
- [x] Bug fix

## Changes Made
- `gateway/platforms/api_server_runs.py`: `_handle_run_events` resolves the request origin's CORS headers via `_cors_headers_for_origin` up front and merges them into the SSE headers before `prepare()` (mirrors the merged `_prepare_sse_response` pattern).
- `tests/gateway/test_api_server_runs.py`: new `TestRunEventsCORS` — allowed origin gets `Access-Control-Allow-Origin/Methods/Headers` on the live SSE response; no `Origin` means no CORS headers; disallowed origin is still 403ed by the middleware.

## How to Test
1. `python -m pytest tests/gateway/test_api_server_runs.py -k "TestRunEventsCORS or TestRunEvents" -q` — 5 passed (the present-headers test fails pre-fix: 200 with SSE headers but `Access-Control-Allow-Origin` missing).
2. Full file: `python -m pytest tests/gateway/test_api_server_runs.py -q` — 61 passed.
3. `python -m ruff check gateway/platforms/api_server_runs.py tests/gateway/test_api_server_runs.py` — clean.

## Checklist
- [x] One logical change per PR
- [x] Behavior-contract tests added (fail pre-fix, pass post-fix)
- [x] Relevant test files run locally
- [x] Ruff clean on changed files