### PR TITLE
fix(gateway): apply group sender policies to thread messages

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -19,7 +19,7 @@ from gateway.whatsapp_identity import (
     normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
 )
 
-_GROUP_CHAT_TYPES = frozenset({"group", "forum", "channel"})
+_GROUP_CHAT_TYPES = frozenset({"group", "forum", "channel", "thread"})
 _GROUP_FORUM_TYPES = frozenset({"group", "forum"})
 _TRUTHY = frozenset({"true", "1", "yes"})
 

--- a/tests/gateway/test_discord_thread_group_auth.py
+++ b/tests/gateway/test_discord_thread_group_auth.py
@@ -1,0 +1,41 @@
+"""Discord channel participation and DM grants remain separate in threads."""
+import pytest
+from gateway.config import load_gateway_config, Platform
+from gateway.session import SessionSource
+
+
+def _runner(tmp_path, monkeypatch, policy):
+    from gateway.run import GatewayRunner
+    from plugins.platforms.discord.adapter import DiscordAdapter
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("discord:\n  allowed_channels: ['123']\n" + policy)
+    config = load_gateway_config()
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {Platform.DISCORD: DiscordAdapter(config.platforms[Platform.DISCORD])}
+    runner.pairing_store = None
+    return runner
+
+
+@pytest.mark.parametrize("grant", ["*", "456"])
+def test_group_grant_applies_to_discord_threads_but_not_dms(tmp_path, monkeypatch, grant):
+    runner = _runner(tmp_path, monkeypatch, f"  group_allow_from: ['{grant}']\n")
+    for chat_type in ("group", "thread"):
+        source = SessionSource(platform=Platform.DISCORD, chat_id="123", user_id="456", chat_type=chat_type)
+        assert runner._is_user_authorized(source)
+    dm = SessionSource(platform=Platform.DISCORD, chat_id="789", user_id="456", chat_type="dm")
+    assert not runner._is_user_authorized(dm)
+    adapter = runner.adapters[Platform.DISCORD]
+    assert adapter._is_allowed_user("456", is_dm=False, channel_ids={"123"})
+    assert not adapter._is_allowed_user("456", is_dm=False, channel_ids={"999"})
+    assert not adapter._is_allowed_user("456", is_dm=True)
+
+
+def test_dm_config_grant_does_not_become_a_thread_grant(tmp_path, monkeypatch):
+    # Use the generic config fallback without Discord's platform-wide env bridge.
+    runner = _runner(tmp_path, monkeypatch, "  group_allow_from: ['someone-else']\n")
+    runner.adapters[Platform.DISCORD].config.extra['allow_from'] = ['456']
+    dm = SessionSource(platform=Platform.DISCORD, chat_id="789", user_id="456", chat_type="dm")
+    thread = SessionSource(platform=Platform.DISCORD, chat_id="123", user_id="456", chat_type="thread")
+    assert runner._is_user_authorized(dm)
+    assert not runner._is_user_authorized(thread)


### PR DESCRIPTION
Discord threads are classified as `thread`, but gateway authorization omitted that type from group chats. A group-only sender grant therefore admitted channel messages and rejected thread replies, including the default automatically created Discord threads.

Include threads in the existing group classification. Two regression tests exercise the real YAML loader, Discord adapter and gateway authorization: group grants cover threads while DM grants remain separate, and the project channel restriction stays enforced.

Validation: the new cases failed on upstream main b88e6776f before the fix. The canonical test runner passed all 71 cases in the new file, config-driven access policy suite and Discord slash authorization suite through a local World. A backport to a pinned local runtime also passed those suites, then accepted a real browser-authored Discord thread message and delivered a reply.
