### PR TITLE
fix(desktop): stop abandoned artifact indexing

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -524,7 +524,7 @@ export function getOlderSessionMessages(
 export async function getAllSessionMessages(
   id: string,
   profile?: ProfileScope,
-  options: { maxJsonChars?: number } = {}
+  options: { maxJsonChars?: number; signal?: AbortSignal } = {}
 ): Promise<SessionMessagesResponse> {
   const messages: SessionMessage[] = []
   const pageSize = 500
@@ -533,13 +533,23 @@ export async function getAllSessionMessages(
   let offset = 0
   let resolvedSessionId = id
 
+  const throwIfAborted = () => {
+    if (options.signal?.aborted) {
+      throw new DOMException('Transcript loading was aborted', 'AbortError')
+    }
+  }
+
   while (true) {
+    throwIfAborted()
+
     const page = await getSessionMessages(id, profile, {
       limit: pageSize,
       offset,
       order: 'oldest',
       includeCompacted: true
     })
+
+    throwIfAborted()
 
     resolvedSessionId = page.session_id
     jsonChars += (JSON.stringify(page.messages) ?? '').length

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -27,6 +27,12 @@ export interface ArtifactLoadResult {
   failures: ArtifactLoadFailure[]
 }
 
+interface ArtifactLoadOptions {
+  onProgress?: (result: ArtifactLoadResult) => void
+  signal?: AbortSignal
+  yieldToMainThread?: () => Promise<void>
+}
+
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)\)/g
 const MEDIA_RE = /[`"']?MEDIA:\s*(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
@@ -421,21 +427,34 @@ export function collectArtifactsForSession(session: SessionInfo, messages: Sessi
 
 export async function loadArtifactsForSessions(
   sessions: SessionInfo[],
-  loadMessages: (session: SessionInfo) => Promise<SessionMessage[]>
+  loadMessages: (session: SessionInfo) => Promise<SessionMessage[]>,
+  options: ArtifactLoadOptions = {}
 ): Promise<ArtifactLoadResult> {
   const artifacts: ArtifactRecord[] = []
   const failures: ArtifactLoadFailure[] = []
+
+  const throwIfAborted = () => {
+    if (options.signal?.aborted) {
+      throw new DOMException('Artifact indexing was aborted', 'AbortError')
+    }
+  }
 
   // Keep only one transcript resident at a time. Recent sessions can each be
   // tens of megabytes, so loading the whole page concurrently can exhaust both
   // the Desktop renderer and a remote dashboard backend.
   for (const session of sessions) {
+    throwIfAborted()
+
     try {
       const messages = await loadMessages(session)
       artifacts.push(...collectArtifactsForSession(session, messages))
     } catch (error) {
       failures.push({ error, session })
     }
+
+    options.onProgress?.({ artifacts: [...artifacts], failures: [...failures] })
+    await options.yieldToMainThread?.()
+    throwIfAborted()
   }
 
   return { artifacts, failures }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -345,6 +345,30 @@ ${payload}
 })
 
 describe('loadArtifactsForSessions', () => {
+  it('publishes completed sessions and stops before starting more work after cancellation', async () => {
+    const controller = new AbortController()
+    const sessions = [makeSession({ id: 'session-1' }), makeSession({ id: 'session-2' })]
+    const published: string[][] = []
+
+    const loadMessages = vi.fn(async (session: SessionInfo) => {
+      if (session.id === 'session-1') {
+        controller.abort()
+      }
+
+      return [{ content: `https://example.com/${session.id}.png`, role: 'assistant' as const, timestamp: 2000 }]
+    })
+
+    await expect(
+      loadArtifactsForSessions(sessions, loadMessages, {
+        onProgress: result => published.push(result.artifacts.map(artifact => artifact.sessionId)),
+        signal: controller.signal
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(loadMessages).toHaveBeenCalledOnce()
+    expect(published).toEqual([['session-1']])
+  })
+
   it('loads transcripts serially and continues after a session fails', async () => {
     const sessions = [
       makeSession({ id: 'session-1' }),
@@ -355,31 +379,36 @@ describe('loadArtifactsForSessions', () => {
     const callOrder: string[] = []
     let activeLoads = 0
     let maxActiveLoads = 0
+    const yieldToMainThread = vi.fn(async () => undefined)
 
-    const result = await loadArtifactsForSessions(sessions, async session => {
-      activeLoads += 1
-      maxActiveLoads = Math.max(maxActiveLoads, activeLoads)
-      callOrder.push(`start:${session.id}`)
+    const result = await loadArtifactsForSessions(
+      sessions,
+      async session => {
+        activeLoads += 1
+        maxActiveLoads = Math.max(maxActiveLoads, activeLoads)
+        callOrder.push(`start:${session.id}`)
 
-      try {
-        await Promise.resolve()
+        try {
+          await Promise.resolve()
 
-        if (session.id === 'session-2') {
-          throw new Error('Session transcript exceeds the Desktop safe-load limit')
-        }
-
-        return [
-          {
-            content: `https://example.com/${session.id}.png`,
-            role: 'assistant',
-            timestamp: 2000
+          if (session.id === 'session-2') {
+            throw new Error('Session transcript exceeds the Desktop safe-load limit')
           }
-        ]
-      } finally {
-        callOrder.push(`end:${session.id}`)
-        activeLoads -= 1
-      }
-    })
+
+          return [
+            {
+              content: `https://example.com/${session.id}.png`,
+              role: 'assistant',
+              timestamp: 2000
+            }
+          ]
+        } finally {
+          callOrder.push(`end:${session.id}`)
+          activeLoads -= 1
+        }
+      },
+      { yieldToMainThread }
+    )
 
     expect(maxActiveLoads).toBe(1)
     expect(callOrder).toEqual([
@@ -393,5 +422,6 @@ describe('loadArtifactsForSessions', () => {
     expect(result.artifacts.map(artifact => artifact.sessionId)).toEqual(['session-1', 'session-3'])
     expect(result.failures).toHaveLength(1)
     expect(result.failures[0]?.session.id).toBe('session-2')
+    expect(yieldToMainThread).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -50,6 +50,10 @@ import {
   loadArtifactsForSessions
 } from './artifact-utils'
 
+function yieldToMainThread(): Promise<void> {
+  return new Promise(resolve => window.requestAnimationFrame(() => resolve()))
+}
+
 function formatArtifactTime(timestamp: number): string {
   return fmtDayTime.format(new Date(timestamp))
 }
@@ -125,14 +129,12 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
   const [filePage, setFilePage] = useState(1)
 
   const [refreshing, setRefreshing] = useState(false)
-  const refreshInFlightRef = useRef(false)
+  const refreshAbortRef = useRef<AbortController | null>(null)
 
   const refreshArtifacts = useCallback(async () => {
-    if (refreshInFlightRef.current) {
-      return
-    }
-
-    refreshInFlightRef.current = true
+    refreshAbortRef.current?.abort()
+    const controller = new AbortController()
+    refreshAbortRef.current = controller
     setRefreshing(true)
 
     try {
@@ -140,8 +142,22 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
       const { artifacts: nextArtifacts, failures } = await loadArtifactsForSessions(
         sessions,
-        async session => (await getAllSessionMessages(session.id, session.profile)).messages
+        async session =>
+          (await getAllSessionMessages(session.id, session.profile, { signal: controller.signal })).messages,
+        {
+          onProgress: result => {
+            if (!controller.signal.aborted) {
+              setArtifacts([...result.artifacts].sort((left, right) => right.timestamp - left.timestamp))
+            }
+          },
+          signal: controller.signal,
+          yieldToMainThread
+        }
       )
+
+      if (controller.signal.aborted) {
+        return
+      }
 
       if (failures.length > 0) {
         const safeLimitFailures = failures.filter(({ error }) =>
@@ -169,11 +185,17 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
       setArtifacts(nextArtifacts.sort((left, right) => right.timestamp - left.timestamp))
     } catch (err) {
+      if (controller.signal.aborted) {
+        return
+      }
+
       notifyError(err, a.failedLoad)
       setArtifacts([])
     } finally {
-      refreshInFlightRef.current = false
-      setRefreshing(false)
+      if (refreshAbortRef.current === controller) {
+        refreshAbortRef.current = null
+        setRefreshing(false)
+      }
     }
   }, [a])
 
@@ -181,6 +203,8 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
   useEffect(() => {
     void refreshArtifacts()
+
+    return () => refreshAbortRef.current?.abort()
   }, [refreshArtifacts])
 
   useEffect(() => {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -625,6 +625,25 @@ describe('Hermes REST helpers', () => {
     })
   })
 
+  it('stops complete transcript pagination after cancellation', async () => {
+    const controller = new AbortController()
+
+    api.mockImplementationOnce(async () => {
+      controller.abort()
+
+      return {
+        messages: Array.from({ length: 500 }, (_, id) => ({ id })),
+        session_id: 'session-1',
+        pagination: { limit: 500, offset: 0, order: 'oldest', returned: 500 }
+      }
+    })
+
+    await expect(
+      getAllSessionMessages('session-1', 'xiaoxuxu', { signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(api).toHaveBeenCalledOnce()
+  })
+
   it('stops complete transcript loads before Desktop memory becomes unbounded', async () => {
     api.mockResolvedValueOnce({
       messages: [{ id: 1, content: 'large transcript page' }],


### PR DESCRIPTION
## Summary

- publish artifact results after each completed session instead of waiting for every transcript
- cancel replacement or unmounted refreshes before they start another session or transcript page
- yield to the renderer between sessions so indexing does not monopolize the UI thread

## Why

Artifacts currently withholds all content until it has loaded and parsed every selected transcript. Navigating away leaves that scan running, so abandoned indexing can keep consuming renderer time and profile-backend slots while the user is back in chat.

On a live multi-profile installation, the page remained on its loading state while scanning 30 sessions containing 3,202 message rows and about 20.5 million transcript characters. The abandoned work correlated with renderer CPU spikes and chat loading flashes after leaving Artifacts.

## What changes

The existing sequential scan remains intact. This PR adds only three controls around it:

1. Publish accumulated results after each session.
2. Abort superseded or unmounted scans, with checks between the existing 500-message transcript pages.
3. Yield one animation frame between sessions.

An IPC request already executing may still finish. The renderer checks cancellation before consuming its response or requesting the next page. No `AbortSignal` crosses Electron IPC.

## Non-goals

- no cache or persistent index
- no database migration or backend API
- no change to artifact detection rules
- no parallel transcript loading

## Follow-up recommendation

The Artifacts page is currently a Desktop renderer feature. Artifact production itself is not Desktop-only: tools and sessions already produce files, images, links, media references, and generated previews across Hermes surfaces. What is missing is a shared artifact data model and query path.

A durable follow-up should:

- maintain a per-profile artifact index when messages are appended or imported
- backfill existing messages in small checkpointed batches
- expose cursor pagination ordered by `(timestamp, artifact_id)`, with kind, query, profile, and connection filters
- return artifact metadata directly, without starting profile agent backends or downloading complete transcripts
- let Desktop consume that API incrementally while preserving request cancellation

That would make the index reusable by Desktop, the web dashboard, CLI commands, and messaging integrations instead of defining Artifacts as renderer-side transcript parsing.

## Verification

- `npx vitest run src/hermes.test.ts src/app/artifacts/index.test.ts` (53 passed)
- cancellation regression test fails against the pre-fix loader
- `npx eslint src/hermes.test.ts src/api/sessions.ts src/app/artifacts/index.tsx src/app/artifacts/artifact-utils.ts src/app/artifacts/index.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Credit

Builds on the cancellation, serialized indexing, and renderer-yield work proposed by @LikelyLucid in #99165. This PR keeps the immediate fix narrow, adds incremental publication, and checks cancellation between renderer-owned transcript pages without treating an `AbortSignal` as an Electron IPC payload.

Related investigation and P2 evidence: https://github.com/NousResearch/hermes-agent/pull/99165#issuecomment-5605483442
