### PR TITLE
fix(tools): honor override intent on same-toolset re-registration

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -703,3 +703,58 @@ class TestDeregisterAuthorization:
             evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
             reg.register(name="protected", toolset="evil-ts", schema={}, handler=evil_handler, override=True)
         assert reg._tools["protected"].handler({}) == "built-in"
+
+
+class TestSameToolsetOverride:
+    """register() must honor override=True when toolsets match (#30568).
+
+    Previously only the ``existing.toolset != toolset`` branch was
+    override-aware; same-toolset re-registration fell through to an
+    unconditional overwrite, so whichever side registered last won and
+    ``override=True`` was meaningless.
+    """
+
+    def _reg(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="image_generate",
+            toolset="media",
+            schema={"name": "image_generate", "description": "", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda *a, **k: "built-in",
+        )
+        return reg
+
+    def test_opted_in_plugin_override_survives_builtin_reregister(self):
+        """End-to-end: opted-in plugin overrides built-in (same toolset), then a
+        built-in re-registration without override (e.g. discover re-run) must
+        not clobber the plugin entry."""
+        reg = self._reg()
+        reg.register_plugin_override_policy("hermes_plugins.img", True)
+        plugin_handler = eval("lambda *a, **k: 'plugin'", {"__name__": "hermes_plugins.img"})
+        reg.register(
+            name="image_generate", toolset="media",
+            schema={"name": "image_generate", "description": "", "parameters": {"type": "object", "properties": {}}},
+            handler=plugin_handler, override=True)
+        assert reg._tools["image_generate"].handler({}) == "plugin"
+        # Built-in re-registers (load-order loser) without override.
+        reg.register(
+            name="image_generate", toolset="media",
+            schema={"name": "image_generate", "description": "", "parameters": {"type": "object", "properties": {}}},
+            handler=lambda *a, **k: "built-in")
+        assert reg._tools["image_generate"].handler({}) == "plugin", \
+            "plugin override entry must survive a later same-toolset registration without override"
+
+    def test_unopted_plugin_first_override_still_raises(self):
+        """An unopted plugin calling register(override=True) with no entry yet
+        must raise instead of squatting the slot (which would then block the
+        built-in via the override-entry protection)."""
+        reg = ToolRegistry()
+        reg.register_plugin_override_policy("hermes_plugins.evil", False)
+        evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
+        with patch.object(ToolRegistry, "_caller_module", return_value="hermes_plugins.evil"):
+            import pytest
+            with pytest.raises(PermissionError, match="allow_tool_override"):
+                reg.register(
+                    name="fresh_tool", toolset="evil-ts", schema={},
+                    handler=evil_handler, override=True)
+        assert "fresh_tool" not in reg._tools

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -178,6 +178,10 @@ class ToolEntry:
     # Zero-arg callable whose dict is shallow-merged onto the schema at every get_definitions()
     # — for fields tracking runtime config (delegate_task's description reflects limits).
     dynamic_schema_overrides: Optional[Callable] = None
+    # True when this entry was registered with override=True (declarative replacement
+    # intent). A later re-registration without override must not silently clobber it —
+    # otherwise load order decides the winner instead of the explicit opt-in.
+    _override: bool = False
 
 
 class _PluginOverridePolicy:
@@ -612,6 +616,20 @@ class ToolRegistry:
             existing = (self._tools if scope is None else self._merged_tools(scope)).get(name)
             plugin_override_denied = (
                 owner is not None and not self._plugin_override_allowed(scope, owner))
+            if override and plugin_override_denied:
+                # Plugin-first override gate: plugins load before built-ins, so an
+                # unopted plugin calling register(..., override=True) when no entry
+                # exists yet would bypass the existing-entry check below, create the
+                # entry, and then the _override protection would block the built-in
+                # from registering. Gate plugin-originated override=True always.
+                logger.error(
+                    "Tool registration REJECTED: plugin %r attempted to "
+                    "register tool %r with override=True without operator "
+                    "opt-in. Set "
+                    "plugins.entries.<plugin_id>.allow_tool_override: true "
+                    "in config.yaml to allow it.",
+                    owner, name)
+                raise PermissionError(_OVERRIDE_DENIED_MSG.format(owner=owner, name=name))
             shadows_global = (
                 owner is not None and scope is not None
                 and name not in target and name in self._tools)
@@ -623,16 +641,23 @@ class ToolRegistry:
                     return
                 if plugin_override_denied:
                     raise PermissionError(_OVERRIDE_DENIED_MSG.format(owner=owner, name=name))
+            if existing and existing._override and not override:
+                # Existing entry was itself registered with override=True.
+                # Protect it from silent overwrite by a later re-registration that
+                # lacks override (e.g. discover_builtin_tools re-running after a
+                # plugin has already overridden a built-in) — otherwise whichever
+                # side registers last wins and override=True is meaningless.
+                # Logged at INFO so the kept override stays auditable.
+                logger.info(
+                    "Tool '%s': keeping existing override=True entry from "
+                    "toolset '%s' — rejecting re-registration from toolset '%s' "
+                    "without override",
+                    name, existing.toolset, toolset)
+                return
             if existing and existing.toolset != toolset:
                 if override:
-                    if plugin_override_denied:
-                        logger.error(
-                            "Tool registration REJECTED: plugin %r attempted to override built-in "
-                            "tool %r (existing toolset %r) without operator opt-in. Set "
-                            "plugins.entries.<plugin_id>.allow_tool_override: true in config.yaml "
-                            "to allow it.",
-                            owner, name, existing.toolset)
-                        raise PermissionError(_OVERRIDE_DENIED_MSG.format(owner=owner, name=name))
+                    # Plugin policy was already gated above; non-plugin
+                    # override callers reach here legitimately.
                     # Explicit opt-in (or non-plugin caller): INFO so the override is auditable.
                     logger.info(
                         "Tool '%s': toolset '%s' overriding existing toolset '%s' "
@@ -651,7 +676,8 @@ class ToolRegistry:
                 requires_env=requires_env or [], is_async=is_async,
                 description=description or schema.get("description", ""), emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
-                dynamic_schema_overrides=dynamic_schema_overrides)
+                dynamic_schema_overrides=dynamic_schema_overrides,
+                _override=override)
             # Availability is derived per-tool (_toolset_has_exposable_tools), so this map no
             # longer gates a toolset; it still feeds get_toolset_requirements ->
             # TOOLSET_REQUIREMENTS["check_fn"], which banner.py reads (presence only,


### PR DESCRIPTION
## What / why

`ToolRegistry.register()` only consulted `override` inside the `existing.toolset != toolset` branch. Same-toolset same-name re-registration fell through to an unconditional overwrite, so `override=True` was silently ignored and whichever side registered last won. In practice an opted-in plugin override (e.g. `image_generate`) was clobbered whenever built-in discovery re-ran — overrides were load-order sensitive instead of declarative.

## Related Issue

Fixes #30568.
Supersedes #30628 with credit to its author — same approach (override-intent field on the entry + protection + plugin-first gate), rebased onto the current `register()` which has since gained scoped-overlay / `shadows_global` logic the old diff predates (the old manual `__slots__` patch becomes a `_override` dataclass field; the old MCP-to-MCP exception is not resurrected — current main rejects all cross-toolset shadows without override).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `tools/registry.py`: `ToolEntry` gains `_override: bool = False`; `register()` stores `_override=override`, rejects a re-registration without override when the existing entry was registered with `override=True` (INFO-logged, auditable), and gates plugin-originated `override=True` with a PermissionError even when no entry exists yet (otherwise a plugin-first squat would wedge the built-in out via the new protection).
- `tests/tools/test_registry.py`: new `TestSameToolsetOverride` — `test_opted_in_plugin_override_survives_builtin_reregister` (end-to-end: plugin override sticks after built-in re-register) and `test_unopted_plugin_first_override_still_raises` (unopted plugin-first `override=True` raises, slot stays empty).

## How to Test

1. Register built-in `image_generate` (toolset `media`), re-register same name+toolset as opted-in plugin with `override=True`, re-register built-in without override → plugin handler still serves.
2. Unopted plugin `register(override=True)` with no existing entry → PermissionError.
3. `python -m pytest tests/tools/test_registry.py --basetemp=<tmp>` → 41 passed.

## Checklist

- [x] I have read the relevant workflow docs and followed repo conventions.
- [x] My change is minimal and focused on this issue (one logical change).
- [x] I have added/updated behavior-contract tests proving the fix.
- [x] All new and existing relevant tests pass (41 passed, full file).
- [x] I ran `ruff check` on the changed files (clean).