### PR TITLE
fix(goals): thread session id into goal-judge aux calls for opencode affinity

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3378,7 +3378,7 @@ def _prepare_same_provider_retry(
     final_model: Optional[str], messages: list, temperature: Optional[float],
     max_tokens: Optional[int], tools: Optional[list], effective_timeout: float,
     effective_extra_body: dict, reasoning_config: Optional[dict], async_mode: bool,
-    extra_headers: Optional[Dict[str, str]] = None,
+    extra_headers: Optional[Dict[str, str]] = None, session_id: Optional[str] = None,
 ) -> Tuple[Any, Dict[str, Any]]:
     """Rebuild (client, request kwargs) for a same-provider retry after credential recovery."""
     if task == "vision":
@@ -3401,7 +3401,7 @@ def _prepare_same_provider_retry(
         effective_provider or resolved_provider, retry_model or final_model, messages,
         temperature=temperature, max_tokens=max_tokens, tools=tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
-        base_url=retry_base or resolved_base_url, task=task,
+        base_url=retry_base or resolved_base_url, task=task, session_id=session_id,
     )
     # Preserve per-request attribution headers (e.g. Copilot ``x-initiator``) so the retry keeps capability gating.
     if extra_headers:
@@ -3636,6 +3636,7 @@ def _fallback_request_kwargs(
     tools: Optional[list], temperature: Optional[float], max_tokens: Optional[int],
     effective_timeout: float, effective_extra_body: dict, reasoning_config: Optional[dict],
     fallback_entry: dict, task_config: dict, apply_fast_lane: bool,
+    session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build request kwargs for one fallback destination (cache-section replan + fast-lane cap)."""
     fallback_max_tokens, fallback_extra_body = max_tokens, effective_extra_body
@@ -3650,7 +3651,8 @@ def _fallback_request_kwargs(
     fb_kwargs = _build_call_kwargs(
         destination.provider, destination.model, fallback_messages,
         temperature=temperature, max_tokens=fallback_max_tokens, tools=fallback_tools, timeout=effective_timeout,
-        extra_body=fallback_extra_body, reasoning_config=reasoning_config, base_url=destination.base_url, task=task)
+        extra_body=fallback_extra_body, reasoning_config=reasoning_config, base_url=destination.base_url, task=task,
+        session_id=session_id)
     return fb_kwargs
 
 
@@ -3725,6 +3727,7 @@ def _call_fallback_candidate_sync(
     fb_client: Any, fb_model: Optional[str], fb_label: str, *, task: Optional[str], messages: list,
     temperature: Optional[float], max_tokens: Optional[int], tools: Optional[list],
     effective_timeout: float, effective_extra_body: dict, reasoning_config: Optional[dict],
+    session_id: Optional[str] = None,
 ) -> Optional[Any]:
     """Call one fallback candidate with stale-credential recovery: on an auth error refresh its
     credentials and retry once with a rebuilt client; if that also auth-fails, quarantine the
@@ -3738,7 +3741,7 @@ def _call_fallback_candidate_sync(
         fb_client, fb_model, fb_label, task=task, effective_timeout=effective_timeout,
         apply_fast_lane=True, messages=messages, tools=tools, temperature=temperature,
         max_tokens=max_tokens, effective_extra_body=effective_extra_body,
-        reasoning_config=reasoning_config,
+        reasoning_config=reasoning_config, session_id=session_id,
     )
 
     def _send(client: Any, request_kwargs: Dict[str, Any], dest: _FallbackDestination) -> Any:
@@ -3777,13 +3780,14 @@ async def _call_fallback_candidate_async(
     fb_client: Any, fb_model: Optional[str], fb_label: str, *, task: Optional[str], messages: list,
     temperature: Optional[float], max_tokens: Optional[int], tools: Optional[list],
     effective_timeout: float, effective_extra_body: dict, reasoning_config: Optional[dict],
+    session_id: Optional[str] = None,
 ) -> Optional[Any]:
     """Async mirror of :func:`_call_fallback_candidate_sync` (no fast-lane cap on this wire)."""
     destination, fb_kwargs, rebuild = _plan_fallback_candidate(
         fb_client, fb_model, fb_label, task=task, effective_timeout=effective_timeout,
         apply_fast_lane=False, messages=messages, tools=tools, temperature=temperature,
         max_tokens=max_tokens, effective_extra_body=effective_extra_body,
-        reasoning_config=reasoning_config,
+        reasoning_config=reasoning_config, session_id=session_id,
     )
 
     async def _send(client: Any, request_kwargs: Dict[str, Any], dest: _FallbackDestination) -> Any:
@@ -6011,6 +6015,7 @@ def _build_call_kwargs(
     max_tokens: Optional[int] = None, tools: Optional[list] = None, timeout: float = 30.0,
     extra_body: Optional[dict] = None, reasoning_config: Optional[dict] = None,
     base_url: Optional[str] = None, task: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {"model": model, "messages": messages, "timeout": timeout}
@@ -6051,7 +6056,7 @@ def _build_call_kwargs(
     # OpenCode relay session affinity — same key as the main turn so compression/title/vision
     # calls stay on the conversation's warm backend.
     from agent.opencode_affinity import merge_opencode_session_headers
-    return merge_opencode_session_headers(kwargs, provider, base_url, _runtime_main_value("session_id") or None)
+    return merge_opencode_session_headers(kwargs, provider, base_url, session_id or _runtime_main_value("session_id") or None)
 
 
 def _validate_llm_response(
@@ -6642,6 +6647,7 @@ def _prepare_aux_request(
     timeout: Optional[float], extra_body: Optional[dict], reasoning_config: Optional[dict],
     extra_headers: Optional[Dict[str, str]], api_mode: Optional[str],
     route_info: Optional[Dict[str, str]], async_mode: bool,
+    session_id: Optional[str] = None,
 ) -> _PreparedAuxRequest:
     """Shared head of call_llm/async_call_llm: resolve route + client, publish it, build request kwargs.
     Sync-only: compression fast lane, per-request ``extra_headers``, and ``base_info`` falling
@@ -6683,7 +6689,8 @@ def _prepare_aux_request(
     kwargs = _build_call_kwargs(
         request_provider, final_model, messages, temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
-        reasoning_config=reasoning_config, base_url=base_info or resolved_base_url, task=task)
+        reasoning_config=reasoning_config, base_url=base_info or resolved_base_url, task=task,
+        session_id=session_id)
     if extra_headers:
         kwargs["extra_headers"] = dict(extra_headers)
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
@@ -7067,7 +7074,7 @@ def call_llm(
     timeout: float = None, extra_body: dict = None, reasoning_config: Optional[dict] = None,
     extra_headers: Optional[Dict[str, str]] = None, api_mode: str = None, stream: bool = False,
     stream_options: dict = None, route_info: Optional[Dict[str, str]] = None,
-    latency_info: Optional[Dict[str, int]] = None,
+    latency_info: Optional[Dict[str, int]] = None, session_id: Optional[str] = None,
 ) -> Any:
     """Run an auxiliary LLM request, applying the configured task limit."""
     queue_started_at = time.monotonic()
@@ -7096,6 +7103,7 @@ def call_llm(
                 max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
                 reasoning_config=reasoning_config, extra_headers=extra_headers, api_mode=api_mode,
                 stream=stream, stream_options=stream_options, route_info=route_info,
+                session_id=session_id,
             )
         if stream and semaphore is not None:
             stream_semaphore = semaphore
@@ -7128,7 +7136,7 @@ def _plan_aux_call(
     messages: list, temperature: Optional[float], max_tokens: Optional[int], tools: Optional[list],
     timeout: Optional[float], extra_body: Optional[dict], reasoning_config: Optional[dict],
     extra_headers: Optional[Dict[str, str]], api_mode: Optional[str],
-    route_info: Optional[Dict[str, str]],
+    route_info: Optional[Dict[str, str]], session_id: Optional[str] = None,
 ) -> Tuple[_PreparedAuxRequest, Dict[str, Any], Dict[str, Any]]:
     """Shared head of both call impls: prepare the request and bundle the kwargs the recovery
     drivers pass to ``_retry_same_provider_*`` / ``_call_fallback_candidate_*``. One immutable
@@ -7141,11 +7149,13 @@ def _plan_aux_call(
         max_tokens=max_tokens, tools=tools, timeout=timeout, extra_body=extra_body,
         reasoning_config=reasoning_config, extra_headers=extra_headers,
         api_mode=api_mode, route_info=route_info, async_mode=async_mode,
+        session_id=session_id,
     )
     candidate_kwargs = dict(
         task=task, messages=messages, temperature=temperature, max_tokens=max_tokens,
         tools=tools, effective_timeout=req.effective_timeout,
         effective_extra_body=req.effective_extra_body, reasoning_config=reasoning_config,
+        session_id=session_id,
     )
     retry_kwargs = dict(
         candidate_kwargs, resolved_base_url=req.resolved_base_url,
@@ -7201,6 +7211,7 @@ def _call_llm_impl(
     timeout: float = None, extra_body: dict = None, reasoning_config: Optional[dict] = None,
     extra_headers: Optional[Dict[str, str]] = None, api_mode: str = None, stream: bool = False,
     stream_options: dict = None, route_info: Optional[Dict[str, str]] = None,
+    session_id: Optional[str] = None,
 ) -> Any:
     """Centralized synchronous LLM call: resolve provider/model, auth, kwargs, fallbacks.
     task: aux task whose provider:model comes from config (ignored if provider set); api_mode
@@ -7213,6 +7224,7 @@ def _call_llm_impl(
         temperature=temperature, max_tokens=max_tokens, tools=tools, timeout=timeout,
         extra_body=extra_body, reasoning_config=reasoning_config,
         extra_headers=extra_headers, api_mode=api_mode, route_info=route_info,
+        session_id=session_id,
     )
     client, kwargs, request_provider = req.client, req.kwargs, req.request_provider
     # Streaming path (MoA aggregator): return the raw SDK stream, skipping validation and

--- a/cli.py
+++ b/cli.py
@@ -4044,7 +4044,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     _run_loop(
         task_id=task_id, goal_text=goal_text, run_turn=_run_turn, task_status_fn=_task_status, block_fn=_block,
         max_turns=task.goal_max_turns or _DEF_TURNS, first_response=first_response or "",
-        log=lambda m: logger.info("%s", m),
+        log=lambda m: logger.info("%s", m), session_id=getattr(cli, "session_id", None),
     )
 
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -851,7 +851,8 @@ def _render_background_block(background_processes: Optional[List[Dict[str, Any]]
     return JUDGE_BACKGROUND_BLOCK_TEMPLATE.format(background_lines="\n".join(lines))
 
 
-def _call_goal_judge_llm(call_llm, system_prompt: str, user_prompt: str, timeout: Optional[float]) -> str:
+def _call_goal_judge_llm(call_llm, system_prompt: str, user_prompt: str, timeout: Optional[float],
+                         session_id: Optional[str] = None) -> str:
     """Route through call_llm so auxiliary.goal_judge.* config (provider/model, extra_body,
     reasoning_effort, retries) all apply. Returns the raw reply text."""
     # See #35566.
@@ -860,6 +861,7 @@ def _call_goal_judge_llm(call_llm, system_prompt: str, user_prompt: str, timeout
         task="goal_judge",
         messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
         temperature=0, max_tokens=_goal_judge_max_tokens(), timeout=timeout,
+        session_id=session_id,
     )
     try:
         return resp.choices[0].message.content or ""
@@ -876,6 +878,7 @@ def judge_goal(
     background_processes: Optional[List[Dict[str, Any]]] = None,
     contract: Optional[GoalContract] = None,
     active_delegations: int = 0,
+    session_id: Optional[str] = None,
 ) -> Tuple[str, str, bool, Optional[Dict[str, Any]], bool]:
     """Ask the auxiliary model whether the goal is satisfied.
 
@@ -918,7 +921,7 @@ def judge_goal(
         prompt = JUDGE_USER_PROMPT_TEMPLATE.format(**common)
 
     try:
-        raw = _call_goal_judge_llm(call_llm, JUDGE_SYSTEM_PROMPT, prompt, timeout)
+        raw = _call_goal_judge_llm(call_llm, JUDGE_SYSTEM_PROMPT, prompt, timeout, session_id=session_id)
     except Exception as exc:
         logger.info("goal judge: API call failed (%s) — falling through to continue", exc)
         return "continue", f"judge error: {type(exc).__name__}", False, None, True
@@ -1464,6 +1467,7 @@ class GoalManager:
         verdict, reason, parse_failed, wait_directive, transport_failed = judge_goal(
             state.goal, last_response, subgoals=state.subgoals or None, background_processes=background_processes,
             contract=state.contract if state.has_contract() else None, active_delegations=active_delegations,
+            session_id=self.session_id,
         )
         state.last_verdict = verdict
         state.last_reason = reason
@@ -1587,6 +1591,7 @@ def run_kanban_goal_loop(
     max_turns: int = DEFAULT_MAX_TURNS,
     first_response: str = "",
     log=None,
+    session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Drive a kanban worker through a Ralph-style goal loop.
 
@@ -1637,7 +1642,7 @@ def run_kanban_goal_loop(
             _log(f"kanban goal loop: task {task_id} status={status!r}; stopping")
             return _result("stopped", f"status={status}")
 
-        verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response)
+        verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response, session_id=session_id)
         if verdict == "wait":
             verdict = "continue"
         _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -60,3 +60,57 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def _clear_aux_thread_state():
+    """Simulate an executor-thread caller: no turn-scoped runtime, scope, or conversation."""
+    aux.clear_runtime_main()
+    from agent.portal_tags import set_affinity_scope, set_conversation_context
+
+    set_affinity_scope(None)
+    set_conversation_context(None)
+
+
+def test_auxiliary_explicit_session_id_survives_cleared_context():
+    """Post-turn callers (goal judge) run without turn contextvars: an explicit session_id
+    must still produce the header (issue #105802)."""
+    _clear_aux_thread_state()
+    kwargs = aux._build_call_kwargs(
+        "opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1",
+        session_id="sess-judge-1",
+    )
+    assert kwargs["extra_headers"]["x-opencode-session"] == "sess-judge-1"
+
+
+def test_auxiliary_bare_context_sends_no_header():
+    """Without any session id anywhere there is nothing to pin: no header (the pre-fix
+    judge behavior that OpenCode's relay rejects with MissingSessionID)."""
+    _clear_aux_thread_state()
+    kwargs = aux._build_call_kwargs(
+        "opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1",
+    )
+    assert "x-opencode-session" not in (kwargs.get("extra_headers") or {})
+
+
+def test_goal_judge_threads_session_id_to_call_llm(monkeypatch):
+    """judge_goal(session_id=...) reaches call_llm so the header merge sees it."""
+    from types import SimpleNamespace
+
+    from hermes_cli import goals as goals_mod
+
+    seen = {}
+
+    def _fake_call_llm(**kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(
+                content='{"verdict": "done", "reason": "all criteria met"}'))]
+        )
+
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", _fake_call_llm)
+    verdict, reason, parse_failed, _wait, transport_failed = goals_mod.judge_goal(
+        "ship it", "the feature works", session_id="sess-judge-1",
+    )
+    assert seen.get("session_id") == "sess-judge-1"
+    assert verdict == "done"
+    assert transport_failed is False


### PR DESCRIPTION
## What / why

`/goal` judge calls fail whenever the auxiliary fallback walk selects an OpenCode provider: post-turn callers run on executor threads where the turn-scoped affinity contextvars and `_runtime_main_value('session_id')` are empty, so `opencode_session_headers()` returns `{}` and the relay rejects the headerless request with 400 MissingSessionID. The judge then falls through to continue every turn and the goal loop makes no judged progress.

This change threads the available session id into the header merge: `GoalManager.evaluate_after_turn` passes its session id through `judge_goal` → `call_llm` → `_build_call_kwargs` (primary, same-provider retry, and fallback-walk kwargs), and the kanban goal loop accepts and forwards one too (wired from the CLI driver).

## Related Issue

Fixes #105802. No open competitor PRs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — new optional `session_id` kwarg on `call_llm`, `_call_llm_impl`, `_plan_aux_call`, `_prepare_aux_request`, `_build_call_kwargs` (explicit id wins, runtime value is the fallback), plus `_prepare_same_provider_retry`, `_fallback_request_kwargs`, `_call_fallback_candidate_sync/async` so retries and fallback candidates keep it
- `hermes_cli/goals.py` — `judge_goal` / `_call_goal_judge_llm` accept `session_id`; `GoalManager.evaluate_after_turn` passes `self.session_id`; `run_kanban_goal_loop` accepts and forwards it
- `cli.py` — kanban loop driver passes `cli.session_id`
- `tests/agent/test_opencode_session_affinity.py` — cleared-contextvars + explicit session_id ⇒ header present; bare-context ⇒ no header; judge threads the id to `call_llm`

## How to Test

1. Run a `/goal` with an opencode-go fallback in the auxiliary chain and confirm judge calls carry `x-opencode-session` instead of 400ing with MissingSessionID
2. Run: `python -m pytest tests/agent/test_opencode_session_affinity.py tests/hermes_cli/test_kanban_goal_mode.py tests/hermes_cli/test_goals.py -q`

## Checklist

- [x] I verified the bug (bare executor-like context produced no header) and the fix (explicit id ⇒ header present)
- [x] New tests fail pre-fix (TypeError: no such kwarg) and pass post-fix (9 passed in the affinity file)
- [x] I ran `ruff check` on all changed files (clean)
- [x] Wider suites match main's failure set exactly (one pre-existing `test_run_gate_fail_captures_output` failure, unrelated)
- [x] No breaking changes (all new params keyword-optional, defaulting to current behavior)