### PR TITLE
fix(titles): strip ANSI escapes and bare OSC residue from session titles

### DIFF
--- a/hermes_state_titles.py
+++ b/hermes_state_titles.py
@@ -18,6 +18,7 @@ logger = logging.getLogger("hermes_state")
 _TITLE_CONTROL_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]')
 _TITLE_INVISIBLE_RE = re.compile(r'[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]')
 _NUMBERED_TITLE_RE = re.compile(r'^(.*?) #(\d+)$')
+_TITLE_BARE_OSC_RE = re.compile(r'(?<!\w)\][0-9]+;[^\s\x07\x1b]*')
 
 
 class SessionTitlesMixin:
@@ -32,12 +33,23 @@ class SessionTitlesMixin:
 
     @staticmethod
     def sanitize_title(title: Optional[str]) -> Optional[str]:
-        """Strip control/zero-width/bidi chars (and lone surrogates sqlite3 cannot bind),
-        collapse whitespace, normalize empty to None. ValueError past MAX_TITLE_LENGTH."""
+        """Strip terminal escape sequences plus control/zero-width/bidi chars (and lone
+        surrogates sqlite3 cannot bind), collapse whitespace, normalize empty to None.
+        ValueError past MAX_TITLE_LENGTH."""
         from hermes_state import SessionDB
+        from tools.ansi_strip import strip_ansi
         if not title:
             return None
-        cleaned = _TITLE_INVISIBLE_RE.sub('', _TITLE_CONTROL_RE.sub('', _sanitize_surrogates(title)))
+        # Strip ANSI/terminal escape sequences first, while the ESC anchor (0x1b) is still
+        # present: strip_ansi() (full ECMA-48) removes whole sequences.
+        cleaned = strip_ansi(_sanitize_surrogates(title))
+        # Transports such as Telegram drop the ESC control byte in transit, leaving a bare
+        # OSC body like "]11;rgb:..." or "]0;title". strip_ansi is ESC-anchored and cannot
+        # see those, so strip the bare OSC residue too. Narrow on purpose: digits + ';'
+        # required, non-word lead, stops at whitespace, so ordinary text like "[Note]" or
+        # "array[0]" is left untouched.
+        cleaned = _TITLE_BARE_OSC_RE.sub('', cleaned)
+        cleaned = _TITLE_INVISIBLE_RE.sub('', _TITLE_CONTROL_RE.sub('', cleaned))
         cleaned = re.sub(r'\s+', ' ', cleaned).strip()
         if not cleaned:
             return None

--- a/tests/test_sanitize_title_ansi.py
+++ b/tests/test_sanitize_title_ansi.py
@@ -1,0 +1,62 @@
+"""Regression tests for terminal-escape stripping in SessionDB.sanitize_title.
+
+Two classes of residue are covered:
+
+1. ESC-anchored sequences (``\\x1b[31m…``, ``\\x1b]11;…\\x07``). Before the fix,
+   sanitize_title deleted the ESC anchor byte (0x1b is within the 0x0e-0x1f
+   control-char class) but left the printable body, so "\\x1b[31mRed\\x1b[0m"
+   became the visible-garbage title "[31mRed[0m". strip_ansi() now runs first.
+
+2. Bare OSC residue (``]11;rgb:…``, ``]0;title``) with no ESC byte. Some transports
+   (e.g. Telegram) drop the 0x1b control byte in transit, leaving only the
+   printable OSC body, which strip_ansi (ESC-anchored) cannot see. A narrow,
+   digit-required, whitespace-terminated strip removes it without touching
+   ordinary bracketed text like "[Note]" or "array[0]".
+"""
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # ESC-anchored
+        ("\x1b[31mRed\x1b[0m", "Red"),
+        ("\x1b[1mHello\x1b[0m World", "Hello World"),
+        ("\x1b]11;rgb:2828/2c2c/3434\x07 deploy", "deploy"),
+        # bare OSC residue (transport dropped the ESC byte)
+        ("]11;rgb:2828/2c2c/3434 deploy", "deploy"),
+        ("]0;window-title done", "done"),
+        # must be preserved (no false positives)
+        ("plain title", "plain title"),
+        ("[Note] keeps brackets", "[Note] keeps brackets"),
+        ("array[0] index", "array[0] index"),
+        ("foo]3;bar baz", "foo]3;bar baz"),  # ]N; preceded by a word char -> not residue
+        ("Résumé \U0001f680", "Résumé \U0001f680"),
+    ],
+)
+def test_sanitize_title_strips_escapes_preserves_text(raw, expected):
+    assert SessionDB.sanitize_title(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "\x1b]11;rgb:2828/2c2c/3434\x07",                  # ESC OSC colour, BEL-terminated
+        "\x1b]8;;http://example.com\x1b\\\x1b]8;;\x1b\\",  # ESC OSC-8 hyperlink wrapper, no text
+        "\x1b[0m\x1b[1m\x1b[31m",                          # ESC escapes only
+        "]11;rgb:2828/2c2c/3434",                          # bare OSC only
+    ],
+)
+def test_sanitize_title_all_escape_input_becomes_none(raw):
+    # Stripped to empty -> normalized to None (existing contract).
+    assert SessionDB.sanitize_title(raw) is None
+
+
+def test_sanitize_title_leaves_no_escape_residue():
+    raw = "\x1b[32mDeploy\x1b[0m \x1b]0;window-title\x07 done"
+    out = SessionDB.sanitize_title(raw)
+    assert out is not None
+    assert "\x1b" not in out
+    assert "[32m" not in out and "]0;" not in out


### PR DESCRIPTION
## What / why

Session titles generated from a first message containing terminal escape sequences kept the escape *body* as visible garbage: `sanitize_title` deleted only the lone ESC anchor byte (0x1b falls in the stripped control range) with no ANSI-sequence stripping, so `\x1b[31mRed\x1b[0m` was stored as `[31mRed[0m`.

This change runs the shared ECMA-48 helper `tools/ansi_strip.py::strip_ansi` first (whole-sequence removal while the ESC anchor is present), then a narrow bare-OSC regex for transports that drop the ESC byte in transit (`]11;rgb:…`), before the existing control/invisible stripping.

## Related Issue

Fixes #40103; Supersedes #40105 (credit to the original author for the strip_ansi-first + narrow bare-OSC approach and regression tests — re-implemented here at the function's current home, `hermes_state_titles.py:34`, after its move from `hermes_state.py:1414`). Closed #40150/#40220 were narrower partials of the same problem.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security hardening (terminal-escape residue in stored/displayed titles)

## Changes Made

- `hermes_state_titles.py` — `sanitize_title` runs `strip_ansi` first, then new `_TITLE_BARE_OSC_RE` (`(?<!\w)\][0-9]+;[^\s\x07\x1b]*`), then existing control/invisible stripping
- `tests/test_sanitize_title_ansi.py` — new: ESC-anchored cases, bare-OSC cases, all-escape→None cases, false-positive guards (`[Note]`, `array[0]`, `foo]3;bar`), emoji preservation

## How to Test

1. `SessionDB.sanitize_title("\x1b[31mRed\x1b[0m")` → `"Red"`; bare OSC `","']11;rgb:… deploy"` → `"deploy"`; `"[Note] keeps brackets"` and `"array[0] index"` untouched
2. Run: `python -m pytest tests/test_sanitize_title_ansi.py -q`

## Checklist

- [x] I verified the bug (residue reproduced pre-fix) and the fix (15 passed; 10 residue cases fail pre-fix, 5 preservation cases pass both ways by design)
- [x] Existing `TestSanitizeTitle` tests still pass
- [x] I ran `ruff check` on all changed files (clean)
- [x] No breaking changes (empty→None and max-length contracts unchanged)