### PR TITLE
fix(skills): exit non-zero when skills install fails to resolve

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -656,10 +656,14 @@ def _confirm_install(c: Console, bundle, category: str) -> bool:
 def do_install(identifier: str, category: str = "", force: bool = False,
                console: Optional[Console] = None, skip_confirm: bool = False,
                invalidate_cache: bool = True, name_override: str = "",
-               source_id: Optional[str] = None) -> None:
+               source_id: Optional[str] = None) -> bool:
     """Fetch, quarantine, scan, confirm, and install a skill. ``source_id`` pins resolution to one
     adapter; callers that know the provenance (``do_update``) must pass it so a bare identifier
-    cannot resolve to a same-named skill elsewhere."""
+    cannot resolve to a same-named skill elsewhere.
+
+    Returns ``True`` when the requested skill is installed or already present,
+    and ``False`` when resolution, fetch, scan, confirmation, or installation
+    prevents the install from completing."""
     from tools.skills_hub import HubLockFile, ensure_hub_dirs
     from tools.skills_hub_install import install_from_quarantine, quarantine_bundle
     from tools.skills_guard import should_allow_install
@@ -667,17 +671,17 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     ensure_hub_dirs()
     sources = _pinned_sources(c, _sources(), source_id, identifier)
     if sources is None:
-        return
+        return False
     identifier = _full_identifier(identifier, sources, c)
     if not identifier:
-        return
+        return False
     c.print(f"\n[bold]Fetching:[/] {identifier}")
     meta, bundle, _matched_source = _resolve_source_meta_and_bundle(identifier, sources)
     if not bundle:
         _print_fetch_failure(c, sources, identifier, meta=meta, source=_matched_source)
-        return
+        return False
     if not _resolve_url_bundle_name(c, bundle, meta, identifier, name_override, skip_confirm):
-        return
+        return False
 
     # URL-sourced skills: pick a category interactively when none was given (TTY only;
     # non-interactive installs fall through to flat install like every other source).
@@ -693,7 +697,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
         if not force:
             c.print("Use --force to reinstall.\n")
-            return
+            return True
 
     extra_metadata = {**(getattr(meta, "extra", {}) or {}), **bundle.metadata}
 
@@ -701,7 +705,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         q_path = quarantine_bundle(bundle)
     except ValueError as exc:
         _invalid_path(c, bundle, exc)
-        return
+        return False
     c.print(f"[dim]Quarantined to {q_path.relative_to(q_path.parent.parent.parent)}[/]")
 
     result = _scan_quarantined(c, q_path, bundle, meta, identifier)
@@ -709,7 +713,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     if not allowed:
         _install_blocked(c, bundle, reason, result.verdict, f"{len(result.findings)}_findings",
                          q_path=q_path, lead="\n")
-        return
+        return False
     # Advisory second opinion — warn-and-continue by design (PII-class findings are
     # informational); the install confirmation below is where the user decides.
     _print_tier1_advisory(q_path, c)
@@ -720,18 +724,19 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     # skip_confirm bypasses the prompt (TUI mode, where input() hangs).
     if not force and not skip_confirm and not _confirm_install(c, bundle, category):
         shutil.rmtree(q_path, ignore_errors=True)
-        return
+        return False
 
     try:
         install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
     except ValueError as exc:
         _invalid_path(c, bundle, exc, q_path)
-        return
+        return False
     from tools.skills_hub import SKILLS_DIR
     c.print(f"[bold green]Installed:[/] {install_dir.resolve().relative_to(Path(SKILLS_DIR).resolve()).as_posix()}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
     _announce_blueprint(c, bundle.name)
     _finish_change(c, invalidate_cache, "Skill will be available", "activate")
+    return True
 
 
 def _print_tier1_advisory(skill_dir, console) -> None:
@@ -1319,13 +1324,22 @@ def _tap_cli(args) -> None:
 
 # `hermes skills <action>` -> handler(args). Lambdas late-bind the do_* names so
 # tests that patch("hermes_cli.skills_hub.do_install") still intercept.
+def _install_cli_action(args) -> None:
+    """`hermes skills install`: exit non-zero when the install did not complete (#30631).
+    SystemExit lives only in this CLI wrapper — the slash-command path drops the
+    result as before so in-chat installs never raise."""
+    installed = do_install(args.identifier, category=args.category, force=args.force,
+                           skip_confirm=getattr(args, "yes", False),
+                           name_override=getattr(args, "name", "") or "")
+    if installed is False:
+        sys.exit(1)
+
+
 _CLI_ACTIONS = {
     "browse": lambda a: do_browse(page=a.page, page_size=a.size, source=a.source),
     "search": lambda a: do_search(a.query, source=a.source, limit=a.limit,
                                   as_json=getattr(a, "json", False)),
-    "install": lambda a: do_install(a.identifier, category=a.category, force=a.force,
-                                    skip_confirm=getattr(a, "yes", False),
-                                    name_override=getattr(a, "name", "") or ""),
+    "install": _install_cli_action,
     "inspect": lambda a: do_inspect(a.identifier),
     "list": lambda a: do_list(source_filter=a.source,
                               enabled_only=getattr(a, "enabled_only", False)),

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -565,3 +565,93 @@ def test_do_install_generic_when_no_index_hit_or_rate_limited(monkeypatch, meta_
     assert "Could not fetch" in out
     assert "Stale index entry" not in out
     assert ("rate limit" in out) is meta_hit
+
+
+def test_do_install_unknown_short_name_returns_false(monkeypatch):
+    import tools.skills_hub as hub
+    import tools.skills_hub_search as search
+    import hermes_cli.skills_hub as cli_hub
+
+    monkeypatch.setattr(hub, "ensure_hub_dirs", lambda: None)
+    monkeypatch.setattr(cli_hub, "_sources", lambda: ["fake-source"])
+    monkeypatch.setattr(
+        search,
+        "unified_search",
+        lambda query, sources, source_filter="all", limit=20: [],
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    assert do_install(
+        "definitely-not-a-real-skill-zzz",
+        console=console,
+        skip_confirm=True,
+    ) is False
+    assert "No skill named 'definitely-not-a-real-skill-zzz' found" in sink.getvalue()
+
+
+def test_do_install_suggested_short_name_returns_false(monkeypatch):
+    from types import SimpleNamespace
+
+    import tools.skills_hub as hub
+    import tools.skills_hub_search as search
+    import hermes_cli.skills_hub as cli_hub
+
+    monkeypatch.setattr(hub, "ensure_hub_dirs", lambda: None)
+    monkeypatch.setattr(cli_hub, "_sources", lambda: ["fake-source"])
+    monkeypatch.setattr(
+        search,
+        "unified_search",
+        lambda query, sources, source_filter="all", limit=20: [
+            SimpleNamespace(
+                name="conceptual-diagram",
+                identifier="official/creative/conceptual-diagram",
+            )
+        ],
+    )
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    assert do_install("concept-diagram", console=console, skip_confirm=True) is False
+    output = sink.getvalue()
+    assert "No exact match for 'concept-diagram'" in output
+    assert "official/creative/conceptual-diagram" in output
+
+
+def test_skills_command_exits_nonzero_when_install_fails(monkeypatch):
+    from types import SimpleNamespace
+
+    import hermes_cli.skills_hub as cli_hub
+
+    monkeypatch.setattr(cli_hub, "do_install", lambda *args, **kwargs: False)
+
+    args = SimpleNamespace(
+        skills_action="install",
+        identifier="definitely-not-a-real-skill-zzz",
+        category="",
+        force=False,
+        yes=True,
+        name="",
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli_hub.skills_command(args)
+
+    assert exc.value.code == 1
+
+
+def test_skills_slash_install_does_not_raise_on_failure(monkeypatch):
+    """The in-chat slash path drops the install result (no SystemExit in chat)."""
+    import hermes_cli.skills_hub as cli_hub
+    from io import StringIO as _Sink
+    from rich.console import Console as _Console
+
+    monkeypatch.setattr(cli_hub, "do_install", lambda *args, **kwargs: False)
+
+    sink = _Sink()
+    cli_hub.handle_skills_slash(
+        "/skills install definitely-not-a-real-skill-zzz",
+        console=_Console(file=sink, force_terminal=False, color_system=None),
+    )


### PR DESCRIPTION
## What / why

`hermes skills install <unresolvable> --yes` exited 0 on resolution failure: `do_install` used bare returns on every failure path and the CLI dispatcher dropped the result, so scripts/CI/automation treating the exit code as the success signal silently mis-reported failed installs as successful.

This change threads a failure bool up: `do_install` returns `True` (installed or already present) / `False` (anything preventing completion), and the CLI wrapper `SystemExit(1)`s on explicit `False`. The slash-command path drops the result as before (no exception in chat).

## Related Issue

Fixes #30631; Supersedes #30633 (credit to the original author for the thread-failure-bool-up / SystemExit-only-in-CLI-wrapper approach and tests — re-applied here against the refactored install flow with `source_id` pinning kept intact).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/skills_hub.py` — `do_install(...) -> bool`: 8 failure returns → `False`, already-installed → `True`, success → `True`; new `_install_cli_action` wrapper exits 1 on `False`, wired into `_CLI_ACTIONS["install"]`; `_SLASH_ACTIONS["install"]` untouched
- `tests/hermes_cli/test_skills_hub.py` — unknown-name → `False`, suggested-name → `False`, `skills_command` raises `SystemExit(1)` on failure, slash path never raises

## How to Test

1. `hermes skills install definitely-not-a-real-skill-zzz --yes; echo $?` → 1 (was 0)
2. Run: `python -m pytest tests/hermes_cli/test_skills_hub.py -q`

## Checklist

- [x] I verified the bug (failure printed, exit 0 pre-fix) and the fix (12 passed)
- [x] New tests fail pre-fix (None instead of False; DID NOT RAISE) and pass post-fix; slash no-raise test passes both ways by design
- [x] Other `do_install` callers (`do_update`, repair, TUI, slash) ignore the return — behavior unchanged there
- [x] I ran `ruff check` on all changed files (clean)
- [x] No breaking changes