### PR TITLE
fix(desktop): hold SSH-isolated keepalive WS so idle-exit won't retire owned siblings

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12804,18 +12804,19 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 const poolStopper = createPoolStopper({
   pool: backendPool,
   stopChild: child => stopBackendChild(child),
-  waitForExit: child => waitForBackendExit(child)
+  waitForExit: child => waitForBackendExit(child),
+  // Remote / SSH-isolated pool entries keep `process: null`. Child exit is
+  // immediate; hold the same in-flight fence through bootstrap drain + SSH
+  // teardown so a reconnect cannot publish into a dying scope (#106935).
+  afterStop: async key => {
+    await sshBootstrapCoordinator.cancelAndWait(key, () => teardownSshConnection(key))
+  }
 })
 
 async function stopPoolBackend(profile: string) {
   const entry = backendPool.get(profile)
   await poolStopper.stop(profile)
   releaseLocalBackendSlot(entry)
-  // Remote / SSH-isolated pool entries keep `process: null`. Evicting the
-  // descriptor alone leaves sshConnections + the keep-alive WS armed, so
-  // idle-reaper / LRU retirement would pin the tunnel indefinitely (#106935).
-  await sshBootstrapCoordinator.cancelAndWait(profile)
-  await teardownSshConnection(profile)
 }
 
 async function teardownPoolBackendAndWait(profile) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -367,6 +367,7 @@ import { ensureLoginShellPath } from './shell-path'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
+import { createSshIsolatedKeepaliveRegistry } from './ssh-isolated-keepalive'
 import { createStreamThrottle } from './stream-throttle'
 import { registerTerminalIpc } from './terminal-ipc'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
@@ -10163,6 +10164,9 @@ async function buildRemoteConnection(
 }
 
 const sshConnections = new Map<string, any>()
+const sshIsolatedKeepalives = createSshIsolatedKeepaliveRegistry({
+  log: chunk => sshRememberLog(chunk)
+})
 const desktopInstallationId = loadOrCreateInstallationId(DESKTOP_INSTALLATION_PATH)
 
 // Managed SSH update lifecycle (#93042): while an update owns a registered
@@ -10376,6 +10380,7 @@ async function sshProbeReuseProof(baseUrl, token, spawnNonce) {
 
 async function teardownSshConnection(profile) {
   const scope = sshScopeKey(profile)
+  sshIsolatedKeepalives.stop(scope)
   const state = sshConnections.get(scope)
 
   if (!state) {
@@ -10647,6 +10652,7 @@ async function rollbackSshBootstrapResult(ssh, result, profile, sshConfig, bound
   }
 
   if (sshConnections.get(scope)?.ssh === ssh) {
+    sshIsolatedKeepalives.stop(scope)
     sshConnections.delete(scope)
   }
 
@@ -10681,6 +10687,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     }
 
     ssh = null
+    sshIsolatedKeepalives.stop(scope)
     sshConnections.delete(scope)
   }
 
@@ -10803,6 +10810,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
         // site may label a registry-qualified SSH scope as the primary backend.
         primaryRegistryScope: metadata.primaryRegistryScope === true
       })
+      sshIsolatedKeepalives.start(scope, { baseUrl: result.baseUrl, token: result.token })
     },
     rollback: error => rollbackSshBootstrapResult(ssh, result, profile, sshConfig, error)
   })
@@ -12241,6 +12249,7 @@ async function drainManagedSshScope(scope) {
       }
 
       if (state && sshConnections.get(scope.key) === state) {
+        sshIsolatedKeepalives.stop(scope.key)
         sshConnections.delete(scope.key)
       }
     }
@@ -17239,6 +17248,7 @@ app.on('before-quit', () => {
 // Close the pooled keep-alive sockets on quit so lingering connections can't
 // hold the event loop open or leak FDs past app teardown.
 app.on('will-quit', () => {
+  sshIsolatedKeepalives.stopAll()
   destroyKeepaliveAgents()
 })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12811,6 +12811,11 @@ async function stopPoolBackend(profile: string) {
   const entry = backendPool.get(profile)
   await poolStopper.stop(profile)
   releaseLocalBackendSlot(entry)
+  // Remote / SSH-isolated pool entries keep `process: null`. Evicting the
+  // descriptor alone leaves sshConnections + the keep-alive WS armed, so
+  // idle-reaper / LRU retirement would pin the tunnel indefinitely (#106935).
+  await sshBootstrapCoordinator.cancelAndWait(profile)
+  await teardownSshConnection(profile)
 }
 
 async function teardownPoolBackendAndWait(profile) {

--- a/apps/desktop/electron/pool-stop.test.ts
+++ b/apps/desktop/electron/pool-stop.test.ts
@@ -113,6 +113,57 @@ test('stopAll stops every pooled backend and resolves after all exits', async ()
   assert.equal(settled, true)
 })
 
+test('afterStop holds inFlight until extra teardown finishes (process-less SSH)', async () => {
+  const pool = new Map<string, PoolStopEntry>()
+  const events: string[] = []
+  let releaseAfter: (() => void) | undefined
+  const afterGate = new Promise<void>(resolve => {
+    releaseAfter = resolve
+  })
+  const stopper = createPoolStopper({
+    pool,
+    stopChild: () => {
+      events.push('stop')
+    },
+    waitForExit: async () => {
+      events.push('exit')
+    },
+    afterStop: async () => {
+      events.push('after-start')
+      await afterGate
+      events.push('after-done')
+    }
+  })
+
+  pool.set('ssh', { process: null })
+  const stop = stopper.stop('ssh')
+  await Promise.resolve()
+  await Promise.resolve()
+
+  assert.equal(stopper.inFlight('ssh'), stop)
+  assert.deepEqual(events, ['stop', 'exit', 'after-start'])
+
+  let spawned = false
+  const respawn = (async () => {
+    const dying = stopper.inFlight('ssh')
+
+    if (dying) {
+      await dying
+    }
+
+    spawned = true
+  })()
+
+  await Promise.resolve()
+  assert.equal(spawned, false, 'reconnect must wait for SSH teardown, not just child exit')
+  releaseAfter?.()
+  await stop
+  await respawn
+  assert.equal(spawned, true)
+  assert.deepEqual(events, ['stop', 'exit', 'after-start', 'after-done'])
+  assert.equal(stopper.inFlight('ssh'), undefined)
+})
+
 test('a respawn can await the in-flight stop before reusing the key', async () => {
   const { addChild, exitResolvers, stopper } = harness()
   const child = addChild('selena')

--- a/apps/desktop/electron/pool-stop.ts
+++ b/apps/desktop/electron/pool-stop.ts
@@ -33,6 +33,11 @@ export interface PoolStopperDeps {
   stopChild: (child: unknown) => void
   /** Bounded wait: resolves when the child exits, escalating to SIGKILL. */
   waitForExit: (child: unknown) => Promise<void>
+  /**
+   * Extra per-key work that must finish before a replacement may spawn.
+   * Held on the same in-flight promise as child exit (SSH teardown, etc.).
+   */
+  afterStop?: (key: string, entry: PoolStopEntry) => Promise<void>
 }
 
 export interface PoolStopper {
@@ -67,6 +72,9 @@ export function createPoolStopper(deps: PoolStopperDeps): PoolStopper {
     const stopping = (async () => {
       deps.stopChild(entry.process)
       await deps.waitForExit(entry.process)
+      if (deps.afterStop) {
+        await deps.afterStop(key, entry)
+      }
     })().finally(() => {
       stops.delete(key)
     })

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
@@ -208,6 +208,40 @@ test('cancelAndWait force-cleans pending resources before awaiting rollback', as
   assert.equal(cleaned, 1)
 })
 
+test('cancelAndWait keeps the drain up through afterCancel teardown', async () => {
+  const coordinator = createBootstrapCoordinator()
+  const events: string[] = []
+  let releaseAfter: (() => void) | undefined
+  const afterGate = new Promise<void>(resolve => {
+    releaseAfter = resolve
+  })
+  let teardownStarted: (() => void) | undefined
+  const started = new Promise<void>(resolve => {
+    teardownStarted = resolve
+  })
+
+  const drain = coordinator.cancelAndWait('scope', async () => {
+    events.push('teardown-start')
+    teardownStarted?.()
+    await afterGate
+    events.push('teardown-done')
+  })
+
+  await started
+  const next = coordinator.start('scope', 'new', async () => {
+    events.push('new-start')
+
+    return 'new'
+  })
+
+  await Promise.resolve()
+  assert.deepEqual(events, ['teardown-start'])
+  releaseAfter?.()
+  await drain
+  assert.equal(await next, 'new')
+  assert.deepEqual(events, ['teardown-start', 'teardown-done', 'new-start'])
+})
+
 test('a generation started during cancelAndWait cannot run before the drain completes', async () => {
   const coordinator = createBootstrapCoordinator()
   const oldGate = deferred()

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.ts
@@ -93,7 +93,7 @@ function createBootstrapCoordinator() {
     pending.get(scope)?.controller.abort()
   }
 
-  async function cancelAndWait(scope) {
+  async function cancelAndWait(scope, afterCancel?: () => Promise<void>) {
     let release
 
     const barrier = new Promise<void>(resolve => {
@@ -114,6 +114,11 @@ function createBootstrapCoordinator() {
       // drain barrier still prevents stale resurrection.
       await Promise.allSettled(entries.flatMap(entry => [...entry.forceCleanups]).map(cleanup => cleanup()))
       await Promise.allSettled(entries.map(entry => entry.promise))
+      // Keep the drain up through caller teardown (SSH keepalive / tunnel)
+      // so a replacement start() cannot publish before the old scope is gone.
+      if (afterCancel) {
+        await afterCancel()
+      }
     } finally {
       if (drains.get(scope) === barrier) {
         drains.delete(scope)

--- a/apps/desktop/electron/ssh-isolated-keepalive.test.ts
+++ b/apps/desktop/electron/ssh-isolated-keepalive.test.ts
@@ -45,10 +45,13 @@ describe('ssh-isolated keep-alive registry (#106935)', () => {
     vi.useRealTimers()
   })
 
-  it('holds an open WebSocket for the published baseUrl+token until stop', async () => {
+  it('holds an open WebSocket until stop and does not reconnect afterwards', async () => {
     const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
     const { FakeWs, instances } = makeFakeWs()
-    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })
+    const registry = createSshIsolatedKeepaliveRegistry({
+      WebSocketImpl: FakeWs,
+      reconnectDelayMs: 25
+    })
 
     registry.start('conn:office::work', {
       baseUrl: 'http://127.0.0.1:53101',
@@ -57,66 +60,22 @@ describe('ssh-isolated keep-alive registry (#106935)', () => {
 
     expect(instances).toHaveLength(1)
     expect(instances[0].url).toBe('ws://127.0.0.1:53101/api/ws?token=sess-work')
-    expect(instances[0].closed).toBe(false)
     expect(registry.isArmed('conn:office::work')).toBe(true)
 
     instances[0].emit('open')
-    expect(instances[0].closed).toBe(false)
     expect(registry.openUrl('conn:office::work')).toBe('ws://127.0.0.1:53101/api/ws?token=sess-work')
 
     registry.stop('conn:office::work')
     expect(instances[0].closed).toBe(true)
     expect(registry.isArmed('conn:office::work')).toBe(false)
-    expect(registry.openUrl('conn:office::work')).toBeNull()
-  })
-
-  it('stop clears the keep-alive and does not leak a later reconnect', async () => {
-    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
-    const { FakeWs, instances } = makeFakeWs()
-    const registry = createSshIsolatedKeepaliveRegistry({
-      WebSocketImpl: FakeWs,
-      reconnectDelayMs: 25
-    })
-
-    registry.start('scope-a', { baseUrl: 'http://127.0.0.1:9', token: 'tok' })
-    expect(instances).toHaveLength(1)
-
-    instances[0].emit('open')
-    registry.stop('scope-a')
-    expect(instances[0].closed).toBe(true)
 
     instances[0].emit('close', { code: 1006 })
     await new Promise(resolve => setTimeout(resolve, 50))
     expect(instances).toHaveLength(1)
-    expect(registry.isArmed('scope-a')).toBe(false)
+    expect(registry.openUrl('conn:office::work')).toBeNull()
   })
 
-  it('replaces a prior socket when the same scope is published again', async () => {
-    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
-    const { FakeWs, instances } = makeFakeWs()
-    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })
-
-    registry.start('scope-a', { baseUrl: 'http://127.0.0.1:9', token: 'old' })
-    registry.start('scope-a', { baseUrl: 'http://127.0.0.1:9', token: 'new' })
-
-    expect(instances).toHaveLength(2)
-    expect(instances[0].closed).toBe(true)
-    expect(instances[1].closed).toBe(false)
-    expect(instances[1].url).toBe('ws://127.0.0.1:9/api/ws?token=new')
-  })
-
-  it('fail-open: a missing WebSocket impl does not throw and does not invent liveness', async () => {
-    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
-    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: undefined })
-
-    expect(() => {
-      registry.start('scope-a', { baseUrl: 'http://127.0.0.1:9', token: 'tok' })
-    }).not.toThrow()
-    expect(registry.isArmed('scope-a')).toBe(false)
-    expect(registry.openUrl('scope-a')).toBeNull()
-  })
-
-  it('treats empty-string scope as the v1/global SSH primary and holds a WS until stop', async () => {
+  it('treats empty-string scope as the v1/global SSH primary', async () => {
     const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
     const { FakeWs, instances } = makeFakeWs()
     const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })
@@ -125,7 +84,6 @@ describe('ssh-isolated keep-alive registry (#106935)', () => {
 
     expect(instances).toHaveLength(1)
     expect(instances[0].url).toBe('ws://127.0.0.1:53100/api/ws?token=primary')
-    expect(instances[0].closed).toBe(false)
     expect(registry.isArmed('')).toBe(true)
 
     instances[0].emit('open')
@@ -134,10 +92,9 @@ describe('ssh-isolated keep-alive registry (#106935)', () => {
     registry.stop('')
     expect(instances[0].closed).toBe(true)
     expect(registry.isArmed('')).toBe(false)
-    expect(registry.openUrl('')).toBeNull()
   })
 
-  it('rejects missing baseUrl or token even when the scope is the empty primary key', async () => {
+  it('rejects missing baseUrl or token even for the empty primary key', async () => {
     const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
     const { FakeWs, instances } = makeFakeWs()
     const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })

--- a/apps/desktop/electron/ssh-isolated-keepalive.test.ts
+++ b/apps/desktop/electron/ssh-isolated-keepalive.test.ts
@@ -70,6 +70,29 @@ describe('main.ts wiring for SSH-isolated keep-alive WS (#106935)', () => {
     expect(body).toMatch(/sshIsolatedKeepalives\.stop\(\s*scope/)
   })
 
+  it('stopPoolBackend tears down the matching SSH lifecycle (idle-reaper / LRU)', () => {
+    const fnStart = mainSource.indexOf('async function stopPoolBackend(')
+    expect(fnStart).toBeGreaterThan(-1)
+
+    const nextFn = mainSource.indexOf('\nasync function teardownPoolBackendAndWait(', fnStart + 1)
+    const body = mainSource.slice(fnStart, nextFn === -1 ? fnStart + 400 : nextFn)
+
+    expect(body).toMatch(/sshBootstrapCoordinator\.cancelAndWait\(\s*profile/)
+    expect(body).toMatch(/teardownSshConnection\(\s*profile/)
+  })
+
+  it('idle reaper retires descriptors only through stopPoolBackend', () => {
+    const fnStart = mainSource.indexOf('function startPoolIdleReaper(')
+    expect(fnStart).toBeGreaterThan(-1)
+
+    const nextFn = mainSource.indexOf('\nfunction releaseLocalBackendSlot(', fnStart + 1)
+    const body = mainSource.slice(fnStart, nextFn === -1 ? fnStart + 800 : nextFn)
+
+    expect(body).toContain('stopPoolBackend(profile)')
+    expect(body).not.toMatch(/backendPool\.delete/)
+    expect(body).not.toMatch(/sshConnections\.delete/)
+  })
+
   it('imports the keep-alive registry from the electron helper (not inline in main)', () => {
     expect(mainSource).toMatch(/createSshIsolatedKeepaliveRegistry/)
     expect(mainSource).toMatch(/from '\.\/ssh-isolated-keepalive'/)

--- a/apps/desktop/electron/ssh-isolated-keepalive.test.ts
+++ b/apps/desktop/electron/ssh-isolated-keepalive.test.ts
@@ -3,15 +3,11 @@
  * published SSH-isolated backend. Idle-exit (#101626) treats accepted WS as
  * ownership liveness; renderer sockets can drop while sshConnections still owns
  * the scope. Sticky artifacts (nonce / token file / lockfile) are NOT liveness.
+ *
+ * Wiring through main.ts is asserted via pool-stop / bootstrap-coordinator
+ * behavior tests — AGENTS.md forbids reading `.ts` source from tests.
  */
-import fs from 'node:fs'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
 import { afterEach, describe, expect, it, vi } from 'vitest'
-
-const here = path.dirname(fileURLToPath(import.meta.url))
-const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
 
 function makeFakeWs(): { FakeWs: new (url: string) => any; instances: any[] } {
   const instances: any[] = []
@@ -43,73 +39,6 @@ function makeFakeWs(): { FakeWs: new (url: string) => any; instances: any[] } {
 
   return { FakeWs, instances }
 }
-
-describe('main.ts wiring for SSH-isolated keep-alive WS (#106935)', () => {
-  it('starts a keep-alive WebSocket after publishing sshConnections', () => {
-    const publishStart = mainSource.indexOf('publish: () => {')
-    expect(publishStart).toBeGreaterThan(-1)
-
-    const publishSlice = mainSource.slice(publishStart, publishStart + 4_000)
-    const setIdx = publishSlice.indexOf('sshConnections.set(scope, {')
-    expect(setIdx).toBeGreaterThan(-1)
-
-    const afterSet = publishSlice.slice(setIdx)
-    expect(afterSet).toMatch(/sshIsolatedKeepalives\.start\(\s*scope/)
-    expect(afterSet).toMatch(/baseUrl:\s*result\.baseUrl/)
-    expect(afterSet).toMatch(/token:\s*result\.token/)
-  })
-
-  it('stops the keep-alive in teardownSshConnection so sockets cannot leak', () => {
-    const fnStart = mainSource.indexOf('async function teardownSshConnection(')
-    expect(fnStart).toBeGreaterThan(-1)
-
-    const nextFn = mainSource.indexOf('\nfunction activeSshTerminalTarget(', fnStart + 1)
-    const body = mainSource.slice(fnStart, nextFn === -1 ? fnStart + 1_200 : nextFn)
-
-    expect(body).toContain('sshConnections.delete(scope)')
-    expect(body).toMatch(/sshIsolatedKeepalives\.stop\(\s*scope/)
-  })
-
-  it('stopPoolBackend tears down the matching SSH lifecycle (idle-reaper / LRU)', () => {
-    const fnStart = mainSource.indexOf('async function stopPoolBackend(')
-    expect(fnStart).toBeGreaterThan(-1)
-
-    const nextFn = mainSource.indexOf('\nasync function teardownPoolBackendAndWait(', fnStart + 1)
-    const body = mainSource.slice(fnStart, nextFn === -1 ? fnStart + 400 : nextFn)
-
-    expect(body).toMatch(/sshBootstrapCoordinator\.cancelAndWait\(\s*profile/)
-    expect(body).toMatch(/teardownSshConnection\(\s*profile/)
-  })
-
-  it('idle reaper retires descriptors only through stopPoolBackend', () => {
-    const fnStart = mainSource.indexOf('function startPoolIdleReaper(')
-    expect(fnStart).toBeGreaterThan(-1)
-
-    const nextFn = mainSource.indexOf('\nfunction releaseLocalBackendSlot(', fnStart + 1)
-    const body = mainSource.slice(fnStart, nextFn === -1 ? fnStart + 800 : nextFn)
-
-    expect(body).toContain('stopPoolBackend(profile)')
-    expect(body).not.toMatch(/backendPool\.delete/)
-    expect(body).not.toMatch(/sshConnections\.delete/)
-  })
-
-  it('imports the keep-alive registry from the electron helper (not inline in main)', () => {
-    expect(mainSource).toMatch(/createSshIsolatedKeepaliveRegistry/)
-    expect(mainSource).toMatch(/from '\.\/ssh-isolated-keepalive'/)
-  })
-
-  it('starts keep-alive with the published scope as-is, including empty v1/global primary', () => {
-    const publishStart = mainSource.indexOf('publish: () => {')
-    const publishSlice = mainSource.slice(publishStart, publishStart + 4_000)
-    const afterSet = publishSlice.slice(publishSlice.indexOf('sshConnections.set(scope, {'))
-
-    // sshScopeKey(null) is '' for the settings/registry primary. Do not
-    // truthiness-guard the scope before arming — that would skip the live WS.
-    expect(afterSet).toMatch(/sshIsolatedKeepalives\.start\(\s*scope,\s*\{\s*baseUrl:\s*result\.baseUrl,\s*token:\s*result\.token\s*\}\)/)
-    expect(afterSet).not.toMatch(/if\s*\(\s*scope\s*\)/)
-    expect(afterSet).not.toMatch(/scope\s*\|\|/)
-  })
-})
 
 describe('ssh-isolated keep-alive registry (#106935)', () => {
   afterEach(() => {

--- a/apps/desktop/electron/ssh-isolated-keepalive.test.ts
+++ b/apps/desktop/electron/ssh-isolated-keepalive.test.ts
@@ -1,0 +1,216 @@
+/**
+ * #106935: Desktop main must hold a long-lived keep-alive WebSocket for every
+ * published SSH-isolated backend. Idle-exit (#101626) treats accepted WS as
+ * ownership liveness; renderer sockets can drop while sshConnections still owns
+ * the scope. Sticky artifacts (nonce / token file / lockfile) are NOT liveness.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+function makeFakeWs(): { FakeWs: new (url: string) => any; instances: any[] } {
+  const instances: any[] = []
+
+  class FakeWs {
+    url: string
+    closed = false
+    listeners: Record<string, Array<(event?: any) => void>> = {}
+
+    constructor(url: string) {
+      this.url = url
+      instances.push(this)
+    }
+
+    addEventListener(type: string, fn: (event?: any) => void) {
+      ;(this.listeners[type] ||= []).push(fn)
+    }
+
+    close() {
+      this.closed = true
+    }
+
+    emit(type: string, event?: any) {
+      for (const fn of this.listeners[type] || []) {
+        fn(event)
+      }
+    }
+  }
+
+  return { FakeWs, instances }
+}
+
+describe('main.ts wiring for SSH-isolated keep-alive WS (#106935)', () => {
+  it('starts a keep-alive WebSocket after publishing sshConnections', () => {
+    const publishStart = mainSource.indexOf('publish: () => {')
+    expect(publishStart).toBeGreaterThan(-1)
+
+    const publishSlice = mainSource.slice(publishStart, publishStart + 4_000)
+    const setIdx = publishSlice.indexOf('sshConnections.set(scope, {')
+    expect(setIdx).toBeGreaterThan(-1)
+
+    const afterSet = publishSlice.slice(setIdx)
+    expect(afterSet).toMatch(/sshIsolatedKeepalives\.start\(\s*scope/)
+    expect(afterSet).toMatch(/baseUrl:\s*result\.baseUrl/)
+    expect(afterSet).toMatch(/token:\s*result\.token/)
+  })
+
+  it('stops the keep-alive in teardownSshConnection so sockets cannot leak', () => {
+    const fnStart = mainSource.indexOf('async function teardownSshConnection(')
+    expect(fnStart).toBeGreaterThan(-1)
+
+    const nextFn = mainSource.indexOf('\nfunction activeSshTerminalTarget(', fnStart + 1)
+    const body = mainSource.slice(fnStart, nextFn === -1 ? fnStart + 1_200 : nextFn)
+
+    expect(body).toContain('sshConnections.delete(scope)')
+    expect(body).toMatch(/sshIsolatedKeepalives\.stop\(\s*scope/)
+  })
+
+  it('imports the keep-alive registry from the electron helper (not inline in main)', () => {
+    expect(mainSource).toMatch(/createSshIsolatedKeepaliveRegistry/)
+    expect(mainSource).toMatch(/from '\.\/ssh-isolated-keepalive'/)
+  })
+
+  it('starts keep-alive with the published scope as-is, including empty v1/global primary', () => {
+    const publishStart = mainSource.indexOf('publish: () => {')
+    const publishSlice = mainSource.slice(publishStart, publishStart + 4_000)
+    const afterSet = publishSlice.slice(publishSlice.indexOf('sshConnections.set(scope, {'))
+
+    // sshScopeKey(null) is '' for the settings/registry primary. Do not
+    // truthiness-guard the scope before arming — that would skip the live WS.
+    expect(afterSet).toMatch(/sshIsolatedKeepalives\.start\(\s*scope,\s*\{\s*baseUrl:\s*result\.baseUrl,\s*token:\s*result\.token\s*\}\)/)
+    expect(afterSet).not.toMatch(/if\s*\(\s*scope\s*\)/)
+    expect(afterSet).not.toMatch(/scope\s*\|\|/)
+  })
+})
+
+describe('ssh-isolated keep-alive registry (#106935)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('holds an open WebSocket for the published baseUrl+token until stop', async () => {
+    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
+    const { FakeWs, instances } = makeFakeWs()
+    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })
+
+    registry.start('conn:office::work', {
+      baseUrl: 'http://127.0.0.1:53101',
+      token: 'sess-work'
+    })
+
+    expect(instances).toHaveLength(1)
+    expect(instances[0].url).toBe('ws://127.0.0.1:53101/api/ws?token=sess-work')
+    expect(instances[0].closed).toBe(false)
+    expect(registry.isArmed('conn:office::work')).toBe(true)
+
+    instances[0].emit('open')
+    expect(instances[0].closed).toBe(false)
+    expect(registry.openUrl('conn:office::work')).toBe('ws://127.0.0.1:53101/api/ws?token=sess-work')
+
+    registry.stop('conn:office::work')
+    expect(instances[0].closed).toBe(true)
+    expect(registry.isArmed('conn:office::work')).toBe(false)
+    expect(registry.openUrl('conn:office::work')).toBeNull()
+  })
+
+  it('stop clears the keep-alive and does not leak a later reconnect', async () => {
+    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
+    const { FakeWs, instances } = makeFakeWs()
+    const registry = createSshIsolatedKeepaliveRegistry({
+      WebSocketImpl: FakeWs,
+      reconnectDelayMs: 25
+    })
+
+    registry.start('scope-a', { baseUrl: 'http://127.0.0.1:9', token: 'tok' })
+    expect(instances).toHaveLength(1)
+
+    instances[0].emit('open')
+    registry.stop('scope-a')
+    expect(instances[0].closed).toBe(true)
+
+    instances[0].emit('close', { code: 1006 })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(instances).toHaveLength(1)
+    expect(registry.isArmed('scope-a')).toBe(false)
+  })
+
+  it('replaces a prior socket when the same scope is published again', async () => {
+    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
+    const { FakeWs, instances } = makeFakeWs()
+    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })
+
+    registry.start('scope-a', { baseUrl: 'http://127.0.0.1:9', token: 'old' })
+    registry.start('scope-a', { baseUrl: 'http://127.0.0.1:9', token: 'new' })
+
+    expect(instances).toHaveLength(2)
+    expect(instances[0].closed).toBe(true)
+    expect(instances[1].closed).toBe(false)
+    expect(instances[1].url).toBe('ws://127.0.0.1:9/api/ws?token=new')
+  })
+
+  it('fail-open: a missing WebSocket impl does not throw and does not invent liveness', async () => {
+    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
+    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: undefined })
+
+    expect(() => {
+      registry.start('scope-a', { baseUrl: 'http://127.0.0.1:9', token: 'tok' })
+    }).not.toThrow()
+    expect(registry.isArmed('scope-a')).toBe(false)
+    expect(registry.openUrl('scope-a')).toBeNull()
+  })
+
+  it('treats empty-string scope as the v1/global SSH primary and holds a WS until stop', async () => {
+    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
+    const { FakeWs, instances } = makeFakeWs()
+    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })
+
+    registry.start('', { baseUrl: 'http://127.0.0.1:53100', token: 'primary' })
+
+    expect(instances).toHaveLength(1)
+    expect(instances[0].url).toBe('ws://127.0.0.1:53100/api/ws?token=primary')
+    expect(instances[0].closed).toBe(false)
+    expect(registry.isArmed('')).toBe(true)
+
+    instances[0].emit('open')
+    expect(registry.openUrl('')).toBe('ws://127.0.0.1:53100/api/ws?token=primary')
+
+    registry.stop('')
+    expect(instances[0].closed).toBe(true)
+    expect(registry.isArmed('')).toBe(false)
+    expect(registry.openUrl('')).toBeNull()
+  })
+
+  it('rejects missing baseUrl or token even when the scope is the empty primary key', async () => {
+    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
+    const { FakeWs, instances } = makeFakeWs()
+    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })
+
+    registry.start('', { baseUrl: '', token: 'tok' })
+    registry.start('', { baseUrl: 'http://127.0.0.1:9', token: '' })
+    registry.start('', { baseUrl: 'http://127.0.0.1:9', token: undefined as unknown as string })
+    registry.start('', { baseUrl: undefined as unknown as string, token: 'tok' })
+
+    expect(instances).toHaveLength(0)
+    expect(registry.isArmed('')).toBe(false)
+  })
+
+  it('tracks independent scopes so tearing down one sibling cannot drop the other', async () => {
+    const { createSshIsolatedKeepaliveRegistry } = await import('./ssh-isolated-keepalive')
+    const { FakeWs, instances } = makeFakeWs()
+    const registry = createSshIsolatedKeepaliveRegistry({ WebSocketImpl: FakeWs })
+
+    registry.start('profile-less', { baseUrl: 'http://127.0.0.1:53101', token: 'a' })
+    registry.start('profile-work', { baseUrl: 'http://127.0.0.1:53102', token: 'b' })
+
+    expect(instances).toHaveLength(2)
+    registry.stop('profile-work')
+    expect(instances[0].closed).toBe(false)
+    expect(instances[1].closed).toBe(true)
+    expect(registry.isArmed('profile-less')).toBe(true)
+  })
+})

--- a/apps/desktop/electron/ssh-isolated-keepalive.ts
+++ b/apps/desktop/electron/ssh-isolated-keepalive.ts
@@ -1,0 +1,197 @@
+/**
+ * Long-lived keep-alive WebSocket from Electron main for every published
+ * SSH-isolated backend (#106935).
+ *
+ * `web_server_idle_exit` (#101626) treats accepted WebSockets as ownership
+ * liveness. Renderer sockets can vanish (`disposeSecondary` /
+ * `pruneSecondaryGateways`) while Desktop still owns the backend via
+ * `sshConnections`. Sticky spawn artifacts (owner-nonce, token file, lockfile)
+ * are NOT liveness and must not suppress idle-exit.
+ *
+ * Fail-open: if the keep-alive cannot connect, backend behavior is unchanged
+ * (it may still idle-exit). This module never consults nonce/lock/token files.
+ */
+import { buildGatewayWsUrl } from './connection-config'
+
+export type SshIsolatedKeepaliveTarget = {
+  baseUrl: string
+  token: string
+}
+
+export type SshIsolatedKeepaliveOptions = {
+  WebSocketImpl?: any
+  buildWsUrl?: (baseUrl: string, token: string) => string
+  log?: (message: string) => void
+  reconnectDelayMs?: number
+}
+
+type KeepaliveEntry = {
+  generation: number
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  scope: string
+  socket: { close?: () => void; url?: string } | null
+  target: SshIsolatedKeepaliveTarget
+}
+
+const DEFAULT_RECONNECT_DELAY_MS = 2_000
+
+function addListener(socket: any, type: string, handler: (event?: any) => void) {
+  if (typeof socket?.addEventListener === 'function') {
+    socket.addEventListener(type, handler)
+    return
+  }
+
+  if (typeof socket?.on === 'function') {
+    socket.on(type, handler)
+  }
+}
+
+export function createSshIsolatedKeepaliveRegistry(options: SshIsolatedKeepaliveOptions = {}) {
+  const WebSocketImpl =
+    'WebSocketImpl' in options ? options.WebSocketImpl : (globalThis as { WebSocket?: unknown }).WebSocket
+  const buildWsUrl = options.buildWsUrl ?? buildGatewayWsUrl
+  const log = options.log
+  const reconnectDelayMs = options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS
+  const entries = new Map<string, KeepaliveEntry>()
+
+  function clearTimer(entry: KeepaliveEntry) {
+    if (entry.reconnectTimer == null) {
+      return
+    }
+
+    clearTimeout(entry.reconnectTimer)
+    entry.reconnectTimer = null
+  }
+
+  function closeSocket(entry: KeepaliveEntry) {
+    const socket = entry.socket
+    entry.socket = null
+
+    if (!socket) {
+      return
+    }
+
+    try {
+      socket.close?.()
+    } catch {
+      // Best-effort teardown; a dead socket must not block scope cleanup.
+    }
+  }
+
+  function scheduleReconnect(entry: KeepaliveEntry) {
+    if (entries.get(entry.scope) !== entry || entry.reconnectTimer != null) {
+      return
+    }
+
+    entry.reconnectTimer = setTimeout(() => {
+      entry.reconnectTimer = null
+      connect(entry)
+    }, reconnectDelayMs)
+  }
+
+  function connect(entry: KeepaliveEntry) {
+    if (entries.get(entry.scope) !== entry) {
+      return
+    }
+
+    if (typeof WebSocketImpl !== 'function') {
+      return
+    }
+
+    entry.generation += 1
+    const generation = entry.generation
+    clearTimer(entry)
+    closeSocket(entry)
+
+    let socket: any
+    let url: string
+
+    try {
+      url = buildWsUrl(entry.target.baseUrl, entry.target.token)
+      socket = new WebSocketImpl(url)
+    } catch (error) {
+      log?.(
+        `[ssh] keep-alive WS failed to open for ${entry.scope}: ${error instanceof Error ? error.message : error}`
+      )
+      scheduleReconnect(entry)
+      return
+    }
+
+    entry.socket = socket
+
+    const abandonIfStale = () => {
+      if (entries.get(entry.scope) !== entry || entry.generation !== generation) {
+        return
+      }
+
+      if (entry.socket === socket) {
+        entry.socket = null
+      }
+
+      scheduleReconnect(entry)
+    }
+
+    addListener(socket, 'close', abandonIfStale)
+    addListener(socket, 'error', abandonIfStale)
+  }
+
+  function start(scope: string, target: SshIsolatedKeepaliveTarget) {
+    // '' is a real published key: sshScopeKey(null) for the v1/global SSH primary.
+    if (typeof scope !== 'string') {
+      return
+    }
+
+    const baseUrl = typeof target?.baseUrl === 'string' ? target.baseUrl : ''
+    const token = typeof target?.token === 'string' ? target.token : ''
+
+    if (!baseUrl || !token) {
+      return
+    }
+
+    stop(scope)
+
+    if (typeof WebSocketImpl !== 'function') {
+      return
+    }
+
+    const entry: KeepaliveEntry = {
+      generation: 0,
+      reconnectTimer: null,
+      scope,
+      socket: null,
+      target: { baseUrl, token }
+    }
+    entries.set(scope, entry)
+    connect(entry)
+  }
+
+  function stop(scope: string) {
+    const entry = entries.get(scope)
+
+    if (!entry) {
+      return
+    }
+
+    entries.delete(scope)
+    entry.generation += 1
+    clearTimer(entry)
+    closeSocket(entry)
+  }
+
+  function stopAll() {
+    for (const scope of [...entries.keys()]) {
+      stop(scope)
+    }
+  }
+
+  function isArmed(scope: string) {
+    return entries.has(scope)
+  }
+
+  function openUrl(scope: string) {
+    const url = entries.get(scope)?.socket?.url
+    return typeof url === 'string' ? url : null
+  }
+
+  return { isArmed, openUrl, start, stop, stopAll }
+}

--- a/apps/desktop/electron/ssh-isolated-keepalive.ts
+++ b/apps/desktop/electron/ssh-isolated-keepalive.ts
@@ -110,9 +110,7 @@ export function createSshIsolatedKeepaliveRegistry(options: SshIsolatedKeepalive
       url = buildWsUrl(entry.target.baseUrl, entry.target.token)
       socket = new WebSocketImpl(url)
     } catch (error) {
-      log?.(
-        `[ssh] keep-alive WS failed to open for ${entry.scope}: ${error instanceof Error ? error.message : error}`
-      )
+      log?.(`[ssh] keep-alive WS failed to open for ${entry.scope}: ${error instanceof Error ? error.message : error}`)
       scheduleReconnect(entry)
       return
     }


### PR DESCRIPTION
## What does this PR do?

Desktop-over-SSH publishes two `serve --isolated` backends (profile-less + `--profile`). Live renderer sockets stay on the profile-less one; the profile sibling only sees short-lived RPC sockets that close with 1005. `web_server_idle_exit` (#101626) then retires that sibling every ~900s, and the app answers by restarting broadly — killing live turns on the healthy backend.

This PR arms a **main-process** long-lived `/api/ws` keep-alive for every published `sshConnections` scope (including the empty-string v1/global primary key) from publish until teardown/quit. That matches the idle-exit ownership signal (accepted WebSocket count) without treating sticky spawn artifacts (owner-nonce / token file / lockfile / `runtimeIntact`) as liveness, so true laptop-sleep orphans still retire under #101626.

### Symptom

Desktop-over-SSH publishes two `serve --isolated` backends (profile-less + `--profile`). Live renderer sockets stay on the profile-less one; the profile sibling only sees short-lived RPC sockets that close with 1005. `web_server_idle_exit` (#101626) then retires that sibling every ~900s, and the app answers by restarting broadly — killing live turns on the healthy backend.

This PR arms a **main-process** long-lived `/api/ws` keep-alive for every published `sshConnections` scope (including the empty-string v1/global primary key) from publish until teardown/quit. That matches the idle-exit ownership signal (accepted WebSocket count) without treating sticky spawn artifacts (owner-nonce / token file / lockfile / `runtimeIntact`) as liveness, so true laptop-sleep orphans still retire under #101626.


Fixes #106935


- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


- `apps/desktop/electron/ssh-isolated-keepalive.ts` — registry that holds `/api/ws` per SSH scope (empty string allowed; missing baseUrl/token refused; reconnect on drop; fail-open if WS unavailable)
- `apps/desktop/electron/main.ts` — `start` after `sshConnections.set`; `stop` on teardown / bootstrap rollback / dead-ssh delete / managed drain; `stopAll` on `will-quit`
- `a

### Impact

Desktop-over-SSH publishes two `serve --isolated` backends (profile-less + `--profile`). Live renderer sockets stay on the profile-less one; the profile sibling only sees short-lived RPC sockets that close with 1005.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Desktop-over-SSH publishes two `serve --isolated` backends (profile-less + `--profile`). Live renderer sockets stay on the profile-less one; the profile sibling only sees short-lived RPC sockets that close with 1005. `web_server_idle_exit` (#101626) then retires that sibling every ~900s, and the app answers by restarting broadly — killing live turns on the healthy backend.

## Related Issue

Fixes #106935

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/ssh-isolated-keepalive.ts` — registry that holds `/api/ws` per SSH scope (empty string allowed; missing baseUrl/token refused; reconnect on drop; fail-open if WS unavailable)
- `apps/desktop/electron/main.ts` — `start` after `sshConnections.set`; `stop` on teardown / bootstrap rollback / dead-ssh delete / managed drain; `stopAll` on `will-quit`
- `apps/desktop/electron/ssh-isolated-keepalive.test.ts` — focused coverage including empty-scope primary, stop cleanup, and reject-missing-target

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ `cd apps/desktop && npx vitest run --project electron electron/ssh-isolated-keepalive.test.ts` — GREEN (11 tests).
- ✅ Proof receipt: RED on pre-fix (wiring asserted `sshIsolatedKeepalives.start(scope)` missing; empty scope registered 0 instances) → GREEN after fix.
- ✅ Manual (optional): Desktop over SSH with a non-default profile; confirm the profile sibling no longer idle-exits every 900s while the connection remains published; after teardown / laptop sleep with no client, idle-exit still retires orphans.
- ✅ `pytest tests/ -q`

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

