### PR TITLE
fix(cli): classify systemd-managed dashboard as systemd in update inventory

### DIFF
--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -150,8 +150,26 @@ def _restart_managed_dashboard_service(reason: str, unit: str = _DASHBOARD_SYSTE
     return True
 
 
+def _cgroup_paths_from_proc_text(text: str):
+    """Yield cgroup paths from a ``/proc/<pid>/cgroup`` body.
+
+    Unified hierarchy (v2) uses ``0::<path>``. Legacy systemd (v1) uses
+    ``<id>:name=systemd:<path>``. Other v1 controllers are ignored.
+    """
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if "::" in line:
+            yield line.split("::", 1)[1]
+            continue
+        parts = line.split(":", 2)
+        if len(parts) == 3 and "name=systemd" in parts[1]:
+            yield parts[2]
+
+
 def _pid_unified_cgroup_entries(pid: int):
-    """Yield the ``0::<path>`` cgroup paths from ``/proc/<pid>/cgroup``; nothing when unreadable."""
+    """Yield cgroup paths from ``/proc/<pid>/cgroup``; nothing when unreadable."""
     try:
         cgroup_path = Path(f"/proc/{pid}/cgroup")
         if not cgroup_path.is_file():
@@ -159,10 +177,17 @@ def _pid_unified_cgroup_entries(pid: int):
         text = cgroup_path.read_text(encoding="utf-8", errors="replace")
     except (OSError, PermissionError):
         return
-    for line in text.splitlines():
-        parts = line.strip().split("::", 1)
-        if len(parts) == 2:
-            yield parts[1]
+    yield from _cgroup_paths_from_proc_text(text)
+
+
+def _systemd_unit_from_cgroup_text(text: str) -> str | None:
+    """Leaf ``*.service`` name from a ``/proc/<pid>/cgroup`` body, or None."""
+    for cg_path in _cgroup_paths_from_proc_text(text):
+        if cg_path.endswith(".service"):
+            svc_name = cg_path.rsplit("/", 1)[-1]
+            if svc_name:
+                return svc_name
+    return None
 
 
 def _get_systemd_service_for_pid(pid: int) -> str | None:
@@ -170,12 +195,14 @@ def _get_systemd_service_for_pid(pid: int) -> str | None:
 
     None when the PID isn't part of a service, the file is unreadable, or off Linux.
     """
-    for cg_path in _pid_unified_cgroup_entries(pid):
-        if cg_path.endswith(".service"):
-            svc_name = cg_path.rsplit("/", 1)[-1]
-            if svc_name:
-                return svc_name
-    return None
+    try:
+        cgroup_path = Path(f"/proc/{pid}/cgroup")
+        if not cgroup_path.is_file():
+            return None
+        text = cgroup_path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, PermissionError):
+        return None
+    return _systemd_unit_from_cgroup_text(text)
 
 
 def _extract_scope_from_cgroup(cgroup_entry: str) -> str | None:

--- a/hermes_cli/update_cmd_windows.py
+++ b/hermes_cli/update_cmd_windows.py
@@ -363,16 +363,23 @@ def _ledger_manual_serve_holders(matches: list[tuple[int, str, str]]) -> list[di
 
     Positive identity only: self-registered purpose serve/dashboard, live (pid, create_time), recorded spawner
     NOT alive (a Desktop-owned backend keeps its live Electron spawner and must keep the refusal — the app would
-    respawn what we kill). Full entries let the relauncher rebuild from host/port/profile, not argv."""
+    respawn what we kill). systemd unit-backed PIDs are excluded: ``Restart=always`` beats stop-before-swap.
+    Full entries let the relauncher rebuild from host/port/profile, not argv."""
     try:
         from hermes_cli.process_identity import ledger_entries, spawner_is_dead
     except Exception:
         return []
+    try:
+        from hermes_cli.update_inventory import _pid_is_unit_backed_serve_or_dashboard
+    except Exception:
+        def _pid_is_unit_backed_serve_or_dashboard(pid: int) -> bool:
+            return False
     holder_pids = {int(pid) for pid, _name, _cmd in matches}
     return [
         entry for entry in ledger_entries()
         if entry.get("purpose") in _BACKEND_PURPOSES and isinstance(entry.get("pid"), int) and entry["pid"] in holder_pids
         and spawner_is_dead(entry) is not False  # False = live Desktop supervisor owns it; keep refusing
+        and not _pid_is_unit_backed_serve_or_dashboard(entry["pid"])
     ]
 
 

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -245,8 +245,10 @@ def _ledger_serve_supervisor(
     """Live Desktop parent, else the same PID classifier gateways use, else cgroup unit, else manual-serve.
 
     ``_get_service_pids`` is gateway-unit only, so a handwritten ``hermes-dashboard.service`` is
-    absent from that set; cgroup recovers it. Classifying those as ``manual-serve`` selects
-    ``respawn-argv`` (stop-before-swap), which ``Restart=always`` beats with the old process.
+    absent from that set; cgroup recovers it. The Linux update path does not consume
+    ``respawn-argv`` as a pre-swap stop (that holder sweep is Windows-only). Classification
+    still has to be ``systemd`` so the plan/receipt names ``systemctl`` instead of
+    ``stop before code swap``.
     """
     if spawner_dead is False:
         return "desktop"
@@ -269,7 +271,7 @@ def _collect_ledger_runtimes(
     (a manual `hermes serve --host <ip>` for a remote Desktop, a long-lived `hermes dashboard`).
     ledger_entries() live-verifies (pid, create_time) so PID reuse never fabricates a row. Desktop-
     supervised backends (spawner still alive) restart via the Desktop's own respawn, not ours.
-    Unit-backed backends restart via ``systemctl`` after the swap — not stop-before-swap."""
+    Unit-backed backends are planned as ``systemd`` (``systemctl``), not ``manual-serve``."""
     if classify_pid is None:
         classify_pid = _supervisor_classifier()
     with _probe("Serve/dashboard ledger inventory"):

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -82,6 +82,7 @@ _MECHANISM_DESCRIPTIONS = {
 }
 
 _SERVE_KINDS = ("serve", "dashboard")
+_LEDGER_SUPERVISED = frozenset({"systemd", "launchd", "service", "windows-service"})
 
 
 def _restart_mechanism(supervisor: str, profile: str) -> str:
@@ -166,11 +167,17 @@ def _supervisor_classifier() -> Callable[[int], str]:
     return lambda pid: _detect_supervisor_for_pid(pid, service_pids, windows_service_pids)
 
 
-def _collect_gateway_runtimes(plan: UpdatePlan, profile_homes: list, seen: set[int]) -> None:
+def _collect_gateway_runtimes(
+    plan: UpdatePlan,
+    profile_homes: list,
+    seen: set[int],
+    supervisor: Callable[[int], str] | None = None,
+) -> None:
     """Per-profile gateways: control-socket identity first (declared by the process itself, including
     supervisor provenance — no argv/PID inference), ``gateway_state.json`` fallback, then PID-file
     mapped gateways no status record covers."""
-    supervisor = _supervisor_classifier()
+    if supervisor is None:
+        supervisor = _supervisor_classifier()
     with _probe("Gateway-state inventory"):
         from gateway.status import _pid_exists, read_runtime_status
         from hermes_cli.update_receipt import _socket_identity
@@ -204,11 +211,67 @@ def _collect_gateway_runtimes(plan: UpdatePlan, profile_homes: list, seen: set[i
                 plan.runtimes.append(_runtime("gateway", proc.profile, proc.pid, supervisor(proc.pid)))
 
 
-def _collect_ledger_runtimes(plan: UpdatePlan, seen: set[int]) -> None:
+def _is_hermes_serve_or_dashboard_unit(unit: object) -> bool:
+    """Exact base unit or hyphenated profile family for serve/dashboard.
+
+    ``startswith("hermes-serve")`` would also accept ``hermes-server.service`` (#83595).
+    """
+    name = str(unit).removesuffix(".service").rsplit("/", 1)[-1]
+    return (
+        name == "hermes-serve" or name.startswith("hermes-serve-")
+        or name == "hermes-dashboard" or name.startswith("hermes-dashboard-")
+    )
+
+
+def _systemd_unit_for_pid(pid: int) -> str | None:
+    """Linux cgroup service name for *pid*, or None off Linux / unreadable / not a ``.service``."""
+    try:
+        from hermes_cli.main_dashboard import _get_systemd_service_for_pid
+
+        return _get_systemd_service_for_pid(pid)
+    except Exception:
+        return None
+
+
+def _pid_is_unit_backed_serve_or_dashboard(pid: int) -> bool:
+    """True when *pid*'s cgroup names a ``hermes-serve*`` / ``hermes-dashboard*`` unit."""
+    unit = _systemd_unit_for_pid(pid)
+    return bool(unit and _is_hermes_serve_or_dashboard_unit(unit))
+
+
+def _ledger_serve_supervisor(
+    entry: dict, *, spawner_dead: bool | None, classify_pid: Callable[[int], str] | None = None,
+) -> str:
+    """Live Desktop parent, else the same PID classifier gateways use, else cgroup unit, else manual-serve.
+
+    ``_get_service_pids`` is gateway-unit only, so a handwritten ``hermes-dashboard.service`` is
+    absent from that set; cgroup recovers it. Classifying those as ``manual-serve`` selects
+    ``respawn-argv`` (stop-before-swap), which ``Restart=always`` beats with the old process.
+    """
+    if spawner_dead is False:
+        return "desktop"
+    pid = entry.get("pid")
+    if not isinstance(pid, int):
+        return "manual-serve"
+    if classify_pid is not None:
+        detected = classify_pid(pid)
+        if detected in _LEDGER_SUPERVISED:
+            return detected
+    if _pid_is_unit_backed_serve_or_dashboard(pid):
+        return "systemd"
+    return "manual-serve"
+
+
+def _collect_ledger_runtimes(
+    plan: UpdatePlan, seen: set[int], classify_pid: Callable[[int], str] | None = None,
+) -> None:
     """Serve/dashboard backends from the spawn ledger — runtimes the gateway collectors can never see
     (a manual `hermes serve --host <ip>` for a remote Desktop, a long-lived `hermes dashboard`).
     ledger_entries() live-verifies (pid, create_time) so PID reuse never fabricates a row. Desktop-
-    supervised backends (spawner still alive) restart via the Desktop's own respawn, not ours."""
+    supervised backends (spawner still alive) restart via the Desktop's own respawn, not ours.
+    Unit-backed backends restart via ``systemctl`` after the swap — not stop-before-swap."""
+    if classify_pid is None:
+        classify_pid = _supervisor_classifier()
     with _probe("Serve/dashboard ledger inventory"):
         from hermes_cli.process_identity import ledger_entries, spawner_is_dead
 
@@ -221,7 +284,9 @@ def _collect_ledger_runtimes(plan: UpdatePlan, seen: set[int]) -> None:
             # survivor probe comparing PIDs alone calls a NEW serve that reused the number a survivor.
             plan.runtimes.append(_runtime(
                 str(purpose), str(entry.get("profile") or "default"), pid,
-                "desktop" if spawner_is_dead(entry) is False else "manual-serve",
+                _ledger_serve_supervisor(
+                    entry, spawner_dead=spawner_is_dead(entry), classify_pid=classify_pid,
+                ),
                 detail={
                     "argv": entry.get("argv") or "", "host": entry.get("host") or "",
                     "port": entry.get("port"), "create_time": entry.get("create_time"),
@@ -249,8 +314,9 @@ def collect_runtime_inventory() -> UpdatePlan:
         profile_homes = _profile_homes()
         plan.profiles = [name for name, _ in profile_homes]
     seen: set[int] = set()
-    _collect_gateway_runtimes(plan, profile_homes, seen)
-    _collect_ledger_runtimes(plan, seen)
+    supervisor = _supervisor_classifier()
+    _collect_gateway_runtimes(plan, profile_homes, seen, supervisor)
+    _collect_ledger_runtimes(plan, seen, supervisor)
     return plan
 
 

--- a/tests/hermes_cli/test_serve_runtime_inventory.py
+++ b/tests/hermes_cli/test_serve_runtime_inventory.py
@@ -149,6 +149,19 @@ def test_hermes_server_unit_is_not_serve_or_dashboard():
     assert not update_inventory._is_hermes_serve_or_dashboard_unit("ssh.service")
 
 
+def test_cgroup_v1_name_systemd_and_v2_unified_yield_dashboard_unit():
+    """Classification must not require cgroup v2 ``0::`` — v1 ``name=systemd`` is enough."""
+    v2 = "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-dashboard.service\n"
+    v1 = (
+        "2:cpu:/user.slice\n"
+        "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/"
+        "app.slice/hermes-dashboard.service\n"
+    )
+    assert main_dashboard._systemd_unit_from_cgroup_text(v2) == "hermes-dashboard.service"
+    assert main_dashboard._systemd_unit_from_cgroup_text(v1) == "hermes-dashboard.service"
+    assert main_dashboard._systemd_unit_from_cgroup_text("2:cpu:/user.slice\n") is None
+
+
 def test_inventory_classifies_desktop_owned_serve(monkeypatch):
     entry = _ledger_entry(spawner_pid=999, spawner_create=1.0)
     fake_pi = SimpleNamespace(

--- a/tests/hermes_cli/test_serve_runtime_inventory.py
+++ b/tests/hermes_cli/test_serve_runtime_inventory.py
@@ -87,6 +87,7 @@ def test_inventory_includes_manual_serve_from_ledger(monkeypatch):
         spawner_is_dead=lambda e: None,  # no spawner recorded → manual
     )
     monkeypatch.setitem(sys.modules, "hermes_cli.process_identity", fake_pi)
+    monkeypatch.setattr(update_inventory, "_systemd_unit_for_pid", lambda pid: None)
     plan = update_inventory.collect_runtime_inventory()
     serves = [r for r in plan.runtimes if r.kind == "serve"]
     assert serves, "manual serve must appear in the inventory"
@@ -98,6 +99,56 @@ def test_inventory_includes_manual_serve_from_ledger(monkeypatch):
     assert row.detail["port"] == 9119
 
 
+def test_inventory_classifies_systemd_dashboard_from_cgroup(monkeypatch):
+    """A handwritten hermes-dashboard.service has no HERMES_SPAWN; cgroup is the supervisor."""
+    entry = _ledger_entry(purpose="dashboard", host="127.0.0.1", port=9119)
+    fake_pi = SimpleNamespace(
+        ledger_entries=lambda **k: [entry],
+        spawner_is_dead=lambda e: None,
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.process_identity", fake_pi)
+    monkeypatch.setattr(
+        update_inventory, "_systemd_unit_for_pid", lambda pid: "hermes-dashboard.service"
+    )
+    plan = update_inventory.collect_runtime_inventory()
+    rows = [r for r in plan.runtimes if r.kind == "dashboard"]
+    assert rows, "systemd dashboard must appear in the inventory"
+    row = rows[0]
+    assert row.pid == 4321
+    assert row.supervisor == "systemd"
+    assert row.restart_via == "systemd"
+    assert "stop before" not in update_inventory.describe_restart_mechanism(
+        row.restart_via, row.profile
+    )
+
+
+def test_inventory_classifies_ledger_pid_in_service_pids_as_systemd(monkeypatch):
+    """Same detector as gateways: a ledger PID in service_pids is systemd, not manual-serve."""
+    entry = _ledger_entry(purpose="dashboard", pid=4321, host="127.0.0.1", port=9119)
+    fake_pi = SimpleNamespace(
+        ledger_entries=lambda **k: [entry],
+        spawner_is_dead=lambda e: None,
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.process_identity", fake_pi)
+    monkeypatch.setattr(update_inventory, "_systemd_unit_for_pid", lambda pid: None)
+    monkeypatch.setattr(
+        "hermes_cli.gateway._get_service_pids", lambda all_profiles=False: {4321}
+    )
+    monkeypatch.setattr("hermes_cli.gateway.supports_systemd_services", lambda: True)
+    plan = update_inventory.collect_runtime_inventory()
+    rows = [r for r in plan.runtimes if r.kind == "dashboard"]
+    assert rows and rows[0].supervisor == "systemd"
+    assert rows[0].restart_via == "systemd"
+
+
+def test_hermes_server_unit_is_not_serve_or_dashboard():
+    assert update_inventory._is_hermes_serve_or_dashboard_unit("hermes-dashboard.service")
+    assert update_inventory._is_hermes_serve_or_dashboard_unit("hermes-dashboard-work.service")
+    assert update_inventory._is_hermes_serve_or_dashboard_unit("hermes-serve.service")
+    assert not update_inventory._is_hermes_serve_or_dashboard_unit("hermes-server.service")
+    assert not update_inventory._is_hermes_serve_or_dashboard_unit("ssh.service")
+
+
 def test_inventory_classifies_desktop_owned_serve(monkeypatch):
     entry = _ledger_entry(spawner_pid=999, spawner_create=1.0)
     fake_pi = SimpleNamespace(
@@ -105,6 +156,7 @@ def test_inventory_classifies_desktop_owned_serve(monkeypatch):
         spawner_is_dead=lambda e: False,  # Electron parent alive
     )
     monkeypatch.setitem(sys.modules, "hermes_cli.process_identity", fake_pi)
+    monkeypatch.setattr(update_inventory, "_systemd_unit_for_pid", lambda pid: None)
     plan = update_inventory.collect_runtime_inventory()
     serves = [r for r in plan.runtimes if r.kind == "serve"]
     assert serves and serves[0].supervisor == "desktop"
@@ -126,19 +178,31 @@ def test_ledger_manual_serve_holders_filters_correctly(monkeypatch):
     desktop_owned = _ledger_entry(pid=200, spawner_pid=999, spawner_create=1.0)
     gateway = _ledger_entry(pid=300, purpose="gateway")
     not_a_holder = _ledger_entry(pid=400)
+    systemd_dashboard = _ledger_entry(pid=500, purpose="dashboard")
 
     fake_pi = SimpleNamespace(
-        ledger_entries=lambda **k: [manual, desktop_owned, gateway, not_a_holder],
+        ledger_entries=lambda **k: [manual, desktop_owned, gateway, not_a_holder, systemd_dashboard],
         spawner_is_dead=lambda e: False if e["pid"] == 200 else None,
     )
     monkeypatch.setitem(sys.modules, "hermes_cli.process_identity", fake_pi)
-    holders = [(100, "python.exe", "..."), (200, "python.exe", "..."), (300, "python.exe", "...")]
+    monkeypatch.setattr(
+        update_inventory,
+        "_systemd_unit_for_pid",
+        lambda pid: "hermes-dashboard.service" if pid == 500 else None,
+    )
+    holders = [
+        (100, "python.exe", "..."),
+        (200, "python.exe", "..."),
+        (300, "python.exe", "..."),
+        (500, "python.exe", "..."),
+    ]
 
     result = update_cmd._ledger_manual_serve_holders(holders)
     pids = [e["pid"] for e in result]
     assert pids == [100], (
         "only the manual serve holder qualifies: desktop-owned keeps the "
-        "refusal, gateways belong to the pause machinery, non-holders skipped"
+        "refusal, gateways belong to the pause machinery, systemd dashboard "
+        "must not be stop-before-swap, non-holders skipped"
     )
 
 
@@ -242,6 +306,7 @@ def test_inventory_records_the_serve_process_incarnation(monkeypatch):
         spawner_is_dead=lambda e: None,
     )
     monkeypatch.setitem(sys.modules, "hermes_cli.process_identity", fake_pi)
+    monkeypatch.setattr(update_inventory, "_systemd_unit_for_pid", lambda pid: None)
     plan = update_inventory.collect_runtime_inventory()
     serves = [r for r in plan.runtimes if r.kind == "serve"]
     assert serves and serves[0].detail["create_time"] == 1712345678.5

--- a/tests/hermes_cli/test_update_fleet_restart_timeout.py
+++ b/tests/hermes_cli/test_update_fleet_restart_timeout.py
@@ -108,6 +108,28 @@ class TestFleetRestartTimeoutIsolation:
 
         assert seen == ["hermes-serve", "hermes-serve-work", "hermes-gateway"]
 
+    def test_hermes_dashboard_units_are_not_in_the_fleet_loop(self):
+        # Managed dashboard restart is `_finish_dashboard_update_cleanup` /
+        # `_restart_managed_dashboard_service`. Putting `hermes-dashboard*`
+        # here double-restarts a Serve-only install's sibling (#83595).
+        seen: list[str] = []
+
+        _for_each_systemd_gateway_unit(
+            "\n".join(
+                [
+                    "ssh.service loaded active running",
+                    "hermes-dashboard.service loaded active running",
+                    "hermes-dashboard-work.service loaded active running",
+                    "hermes-gateway.service loaded active running",
+                    "",
+                ]
+            ),
+            process_unit=seen.append,
+            on_unit_timeout=lambda *_: pytest.fail("unexpected timeout"),
+        )
+
+        assert seen == ["hermes-gateway"]
+
     def test_hermes_server_near_prefix_is_rejected(self):
         # Review on #83595: a bare ``startswith("hermes-serve")`` gate also
         # accepts the unrelated ``hermes-server.service``. Only the exact
@@ -151,6 +173,10 @@ class TestGracefulSigusr1Eligibility:
         assert not _service_unit_supports_graceful_sigusr1_restart("hermes-serve")
         assert not _service_unit_supports_graceful_sigusr1_restart(
             "hermes-serve-work"
+        )
+        assert not _service_unit_supports_graceful_sigusr1_restart("hermes-dashboard")
+        assert not _service_unit_supports_graceful_sigusr1_restart(
+            "hermes-dashboard-work"
         )
 
     def test_process_errors_other_than_timeout_still_propagate(self):


### PR DESCRIPTION
Ledger serve/dashboard PIDs with no live Electron parent were always `manual-serve`. A handwritten `hermes-dashboard.service` is not in the gateway unit PID set, so the cgroup is the supervisor.

This change classifies those PIDs as `systemd`. It parses both cgroup v2 `0::` and v1 `name=systemd`. `hermes-dashboard*` stays out of the gateway fleet loop.

This classification change does not itself restart the live Linux process.

## Test plan

- `tests/hermes_cli/test_serve_runtime_inventory.py`
- `tests/hermes_cli/test_update_fleet_restart_timeout.py` (dashboard units stay out of the fleet loop)
- `scripts/run_tests.sh` on those two files (26 passed on `66410fd465`)

Fixes #106960
