### PR TITLE
fix(gateway): interrupt the run when its session's turn slot is evicted

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2529,6 +2529,7 @@ def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
 _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
+_INTERRUPT_REASON_EVICTED = "Session ended while the turn was running"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
@@ -2661,7 +2662,8 @@ def _watch_gateway_turn_inactivity(
 
 _CONTROL_INTERRUPT_MESSAGES = frozenset({
     _INTERRUPT_REASON_STOP.lower(), _INTERRUPT_REASON_RESET.lower(),
-    _INTERRUPT_REASON_TIMEOUT.lower(), _INTERRUPT_REASON_SSE_DISCONNECT.lower(),
+    _INTERRUPT_REASON_TIMEOUT.lower(), _INTERRUPT_REASON_EVICTED.lower(),
+    _INTERRUPT_REASON_SSE_DISCONNECT.lower(),
     _INTERRUPT_REASON_GATEWAY_SHUTDOWN.lower(), _INTERRUPT_REASON_GATEWAY_RESTART.lower()})
 
 

--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -223,27 +223,69 @@ class GatewayAgentCacheMixin:
         override = self._session_model_override(session_key)
         return override is not None and override.get("model") == agent_model
 
+    def _claim_running_agent_state(self, session_key: str, lease: Any = None) -> int:
+        """Claim the running-turn slot for a new turn (pending sentinel until ``_run_agent`` installs
+        the real agent) and return the turn's fresh run generation. The generation is also recorded
+        as the slot's OWNER, so ``_release_running_agent_state(owner_generation=...)`` lets the
+        turn's finalizer tell "still my slot" from "a replacement turn's slot" (#106966)."""
+        from gateway.run import _AGENT_PENDING_SENTINEL
+        state = self._session_state(session_key)
+        turn = state.turn
+        if lease is not None:
+            turn.lease = lease
+        turn.agent = _AGENT_PENDING_SENTINEL
+        turn.started_ts = time.time()
+        turn.owner_generation = self._begin_session_run_generation(session_key)
+        # Adopt the pending one-shot snapshot (/model --once, /moa <prompt>): from here on the
+        # restore belongs to this turn and rides its slot release, not a shared finalizer.
+        turn.model_restore, state.conversation.one_turn_restore = state.conversation.one_turn_restore, None
+        self._persist_active_agents()
+        return turn.owner_generation
+
     def _release_running_agent_state(
-        self, session_key: str, *, run_generation: Optional[int] = None
+        self, session_key: str, *, run_generation: Optional[int] = None,
+        owner_generation: Optional[int] = None,
     ) -> bool:
         """Pop ALL per-running-agent state for ``session_key`` (call at every site that ends a running
         turn); True when cleared. Persistent state (model overrides, voice mode, approvals) is NOT
         touched. With ``run_generation``, only clear if still current — a stale async unwind bumped
-        by /stop or /new must not clobber a newer run (returns False)."""
+        by /stop or /new must not clobber a newer run (returns False). With ``owner_generation``,
+        only clear while the slot is still owned by the turn that claimed it under that generation
+        (``_claim_running_agent_state``): the finalizer's guard. Unlike ``run_generation`` it still
+        releases after the generation moved on (session_reset mid-flight leaves the slot to the dead
+        turn, #28686), and it never touches a slot that a replacement turn re-claimed after an
+        eviction (#106966)."""
         if not session_key or (
             run_generation is not None and not self._is_session_run_current(session_key, run_generation)
         ):
             return False
         state = self._peek_session_state(session_key)
+        if owner_generation is not None and (
+            state is None or state.turn.owner_generation != owner_generation
+        ):
+            return False
+        model_restore = None
         if state is not None:
             if state.turn.lease is not None:
                 try:
                     state.turn.lease.release()
                 except Exception:
                     logger.debug("Failed to release active session slot", exc_info=True)
+            model_restore = state.turn.model_restore
             # One structured reset instead of a drifting pop-list. Turn-lease tokens are deliberately NOT
             # cleared here — _release_turn_lease owns them.
             state.turn.clear()
+        if model_restore:
+            # The one-shot override (/model --once, /moa <prompt>) ends with the slot, not with the
+            # turn's finalizer: an evicted turn puts the prior model back before the replacement
+            # turn claims the slot, and its late finalizer (owner guard above) can no longer write
+            # a stale snapshot over the replacement's override or evict the replacement's cached
+            # agent (#106966 review). After clear(): the agent is no longer "mid-turn", so the
+            # cache eviction soft-releases its client pool as before.
+            try:
+                self._restore_session_model_override(session_key, model_restore)
+            except Exception:
+                logger.debug("Failed to restore one-shot model override", exc_info=True)
         # Turn boundary: a running-agent slot was just released; persist the new (lower) in-flight count
         # so the dashboard readout stays current. Preserves gateway_state (see _persist_active_agents).
         self._persist_active_agents()
@@ -263,7 +305,15 @@ class GatewayAgentCacheMixin:
         refuses it if a newer turn holds the lease. Idempotent."""
         held = self._held_turn_lease(session_key, run_generation)
         if held is None:
-            return False
+            # No token for this generation in the slot: never acquired / already released, or a
+            # replacement turn on this routing key overwrote it with its own while this turn was
+            # still unwinding (eviction mid-flight, #106966). In that case this turn's token is
+            # still the holder of ITS session id: release it by (owner key, generation) identity so
+            # a reaped id does not stay leased forever, without touching the replacement's lease.
+            registry = getattr(self, "_turn_leases", None)
+            if registry is None or not session_key:
+                return False
+            return bool(registry.release_owned(owner_key=session_key, generation=run_generation))
         registry, turn = held
         token, turn.lease_token, turn.lease_generation = turn.lease_token, None, None
         try:
@@ -290,8 +340,10 @@ class GatewayAgentCacheMixin:
         """THE single conversation-boundary funnel (/new, /resume, suspension replacement,
         compression-exhausted reset). New conversation-scoped dicts go in _CONVERSATION_SCOPED_STATE
         so every boundary picks them up. Turn-scoped state (_running_agents/_ts, slot leases, turn-
-        lease tokens) is owned by _release_running_agent_state and NOT cleared. Idle agent-cache
-        eviction is NOT a boundary (a resumed turn rebuilds from these). getattr-guarded.
+        lease tokens) is owned by _release_running_agent_state and NOT cleared — except the turn's
+        adopted one-shot model restore, whose "prior" belongs to the conversation being closed.
+        Idle agent-cache eviction is NOT a boundary (a resumed turn rebuilds from these).
+        getattr-guarded.
 
         Why a funnel: these boundaries used to each carry a hand-copied pop-list of the per-session dicts,
         and the lists drifted every time a new dict was added (#48031, #58403, #10702, #35809 were all
@@ -305,6 +357,10 @@ class GatewayAgentCacheMixin:
         state = self._peek_session_state(session_key)
         if state is not None:
             state.conversation.clear()
+            # A boundary reached MID-TURN (compression-exhaustion auto-reset) closes the conversation
+            # while the turn still owns its slot: drop the one-shot snapshot it adopted, or the slot
+            # release writes the OLD conversation's override into the fresh session (#106966 review).
+            state.turn.model_restore = None
         # Legacy plain-dict stores still in _CONVERSATION_SCOPED_STATE (not yet folded into
         # SessionState), e.g. _pending_model_notes. SessionState-backed names resolve to MutableMapping
         # views (not dict), so the isinstance(dict) guard skips them — already handled above.

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -484,8 +484,28 @@ class GatewayInboundMixin:
             logger.debug("reaped-session staleness check failed", exc_info=True)
 
     def _hm_evict_running_agent(self, _quick_key: str, reason: str) -> None:
+        # Evicting the turn slot does NOT stop the agent that is still executing: the
+        # generation bump only makes the gateway discard its eventual result, so the run
+        # keeps calling the model and running tools (file writes, git commits) until it
+        # finishes on its own. Ask for the interrupt FIRST — releasing the slot also
+        # leaves /stop and /new with nothing to interrupt, so nobody could stop it later.
+        from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_EVICTED, request_hard_interrupt
+        state = self._peek_session_state(_quick_key)
+        running_agent = state.turn.agent if state else None
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            # Best effort: a third-party/legacy agent ABI can raise, and the cleanup
+            # below must still run or the dead runtime slot stays reachable.
+            try:
+                request_hard_interrupt(running_agent, _INTERRUPT_REASON_EVICTED)
+            except Exception:
+                logger.debug("Evicted agent interrupt failed", exc_info=True)
         self._invalidate_session_run_generation(_quick_key, reason=reason)
         self._release_running_agent_state(_quick_key)
+        # ``_interrupt_requested`` is only cleared by the turn finalizer, so the evicted
+        # agent must leave the cache too: otherwise a cold reattach reuses it latched and
+        # the session's NEXT message dies before its first API call (#44212). Same
+        # invariant /stop and /new already keep in ``_interrupt_and_clear_session``.
+        self._evict_cached_agent(_quick_key)
 
     def _hm_merge_pending_for_source(
         self, source: SessionSource, _quick_key: str, event: "MessageEvent", *, merge_text: bool = False
@@ -896,13 +916,20 @@ class GatewayInboundMixin:
         try:
             event.text = moa_payload
             _moa_state = self._session_state(_quick_key)
-            event._moa_restore_override = _moa_state.conversation.model_override
+            # One-shot: stage the prior override for the turn about to claim the slot (adopted by
+            # _claim_running_agent_state, put back when that slot is released). A /model --once
+            # snapshot already pending is the older prior and wins: both one-shots end with this
+            # turn, and the override to restore is the one from before either of them.
+            if _moa_state.conversation.one_turn_restore is None:
+                _moa_prior = _moa_state.conversation.model_override
+                _moa_state.conversation.one_turn_restore = {
+                    "had_override": _moa_prior is not None, "override": _moa_prior,
+                }
             _moa_state.conversation.model_override = {
                 "provider": "moa", "model": moa_cfg["default_preset"], "base_url": "moa://local",
                 "api_key": "moa-virtual-provider", "api_mode": "chat_completions",
             }
             self._evict_cached_agent(_quick_key)
-            event._moa_disable_after_turn = True
         except Exception:
             return True, "Failed to prepare MoA turn."
         return False, None
@@ -1183,7 +1210,6 @@ class GatewayInboundMixin:
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """Handle an incoming message from any platform: auth → command check → running-agent
         interrupt → get/create session → build context → run agent → return response."""
-        from gateway.run import _AGENT_PENDING_SENTINEL
         _admitted = await self._hm_admit_event(event)
         if _admitted is None:
             return None
@@ -1246,13 +1272,9 @@ class GatewayInboundMixin:
 
         event, source, is_internal = self._hm_rescue_orphaned_fifo(event, source, is_internal, _quick_key)
 
-        _claim_state = self._session_state(_quick_key)
-        if _active_session_lease is not None:
-            _claim_state.turn.lease = _active_session_lease
-        _claim_state.turn.agent = _AGENT_PENDING_SENTINEL
-        _claim_state.turn.started_ts = time.time()
-        self._persist_active_agents()
-        _run_generation = self._begin_session_run_generation(_quick_key)
+        # The claim records this turn's generation as the slot's owner; the finalizer below
+        # releases the slot only while that is still true.
+        _run_generation = self._claim_running_agent_state(_quick_key, _active_session_lease)
 
         try:
             try:
@@ -1279,50 +1301,27 @@ class GatewayInboundMixin:
                 logger.debug("post-turn hook failed: %s", _goal_exc)
             return _agent_result
         finally:
-            # MoA one-shot restore must run on EVERY exit path (success, exception, interrupt):
-            # the restore data lives on the per-turn event and would leak permanently otherwise.
-            self._restore_moa_one_shot(event, _quick_key)
-            self._restore_pending_one_turn_model_override(_quick_key)
+            # The one-shot model restore (/moa <prompt>, /model --once) is NOT applied here: it is
+            # turn-owned (turn.model_restore, adopted at claim) and rides the slot release below,
+            # so it still runs on every exit path (success, exception, interrupt) but never after
+            # an evictor already handed the slot to a replacement turn (#106966 review).
             # SIGKILL/OOM skips finally, leaving the durable marker for the next unclean startup's
             # recovery pass.
             await self._clear_durable_active_turn(event)
-            # Unconditional, idempotent release without a run_generation guard: evicts the zombie
-            # left when session_reset bumps the generation mid-flight (gen-N's guarded release in
-            # _run_agent returns False; a sentinel-only check would lock forever).
-            self._release_running_agent_state(_quick_key)
-            # Turn lease is keyed by (routing key, run generation) so this unwind can only free
-            # the lease its own turn acquired, never a newer turn's.
-            # Unconditional release covers every exit path. _release_running_agent_state is idempotent
-            # (pop-on-absent is harmless) and, called without a run_generation guard, always clears the slot
-            # regardless of which generation it holds. This evicts the zombie left when session_reset bumps
-            # the generation (N -> N+1) mid-flight: gen-N's guarded release inside _run_agent returns False,
-            # and the old sentinel-only check here missed the leftover real agent — locking the session out
-            # forever (#28686).
+            # Release the slot only while THIS turn still owns it (the generation recorded at claim
+            # time), on every exit path. Not "only if my generation is still current": session_reset
+            # bumps the generation mid-flight without re-claiming, gen-N's guarded release inside
+            # _run_agent then returns False, and the ownership guard is what still clears that
+            # zombie (#28686). And not unconditional: _hm_evict_running_agent frees the slot while
+            # this turn is still unwinding, the same inbound message re-claims it for a replacement
+            # turn, and an unconditional release here erased the replacement's sentinel and
+            # active-session lease — leaving that turn untracked and admitting a concurrent one
+            # (#106966).
+            self._release_running_agent_state(_quick_key, owner_generation=_run_generation)
+            # Turn lease is keyed by (routing key, run generation): this unwind frees only the lease
+            # its own turn acquired, never a newer turn's — also when the replacement already
+            # overwrote the slot's token (then released through the registry by identity).
             self._release_turn_lease(_quick_key, _run_generation)
-
-    def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
-        """Revert a ``/moa <prompt>`` one-shot model override after its turn (called from the
-        message-handling ``finally``). ``_moa_restore_override`` holds the prior per-session
-        override (``None`` = clear the MoA override outright)."""
-        if not getattr(event, "_moa_disable_after_turn", False):
-            return
-        with suppress(Exception):
-            self._session_state(quick_key).conversation.model_override = getattr(event, "_moa_restore_override", None)
-            self._evict_cached_agent(quick_key)
-
-    def _restore_pending_one_turn_model_override(self, session_key: str) -> None:
-        """Restore a per-session model override after ``/model --once`` runs."""
-        if not session_key:
-            return
-        try:
-            _otr_state = self._peek_session_state(session_key)
-            snapshot = _otr_state.conversation.one_turn_restore if _otr_state else None
-            if _otr_state is not None:
-                _otr_state.conversation.one_turn_restore = None
-            if snapshot:
-                self._restore_session_model_override(session_key, snapshot)
-        except Exception:
-            logger.debug("Failed to restore one-turn model override", exc_info=True)
 
     def _prefix_inbound_sender_context(self, event: MessageEvent, source: SessionSource, message_text: str) -> str:
         """Attribute the sender in shared multi-user sessions and prepend history-backfill channel context."""

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -23,6 +23,17 @@ class TurnState:
     started_ts: float = 0.0  # 0.0 = not running
     lease: Any = None  # cross-process active-session slot lease
     busy_ack_ts: float = 0.0  # debounce; 0.0 = never acked
+    # Run generation of the turn that CLAIMED this slot (None = unclaimed). The turn's finalizer
+    # releases the slot only while it is still the owner: an eviction can hand the slot to a
+    # replacement turn before the evicted turn has unwound (#106966), and the session's current
+    # generation is no proxy for ownership (session_reset bumps it without re-claiming, #28686).
+    owner_generation: Optional[int] = None
+    # One-shot model override to put back when this turn ends: the ``/model --once`` or
+    # ``/moa <prompt>`` snapshot ({"had_override", "override"}) the turn adopted at claim time.
+    # Turn-owned and applied by ``_release_running_agent_state`` exactly once, so an evicted turn
+    # restores it BEFORE a replacement turn claims the slot and can never write over the
+    # replacement's own override from its late finalizer (#106966).
+    model_restore: Optional[Dict[str, Any]] = None
     # Held turn-lease token + acquiring generation: release/rebind match only when the
     # generation is current, so a stale unwind can never free a newer turn's lease.
     lease_token: Any = None
@@ -30,7 +41,7 @@ class TurnState:
 
     def clear(self) -> None:
         """Reset the per-turn slot.  The caller pops ``lease`` first to release it."""
-        self.agent = self.lease = None
+        self.agent = self.lease = self.owner_generation = self.model_restore = None
         self.started_ts = self.busy_ack_ts = 0.0
 
 

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -174,3 +174,15 @@ class SessionTurnLeaseRegistry:
         if lease.lock.locked():
             lease.lock.release()
         return True
+
+    def release_owned(self, *, owner_key: str, generation: int) -> bool:
+        """Release the lease whose holder token was acquired by (``owner_key``, ``generation``), for
+        a caller that no longer has the token itself: a replacement turn on the same routing key
+        overwrote the one slot that stored it (#106966). Identity is the holder token's own
+        (owner_key, generation), so a newer turn's lease is never released. Idempotent."""
+        for lease in list(self._leases.values()):
+            holder = lease.holder
+            if (holder is not None and holder.owner_key == owner_key
+                    and int(holder.generation) == int(generation)):
+                return self.release(holder)
+        return False

--- a/tests/gateway/test_gateway_command_dispatch_minimal.py
+++ b/tests/gateway/test_gateway_command_dispatch_minimal.py
@@ -98,7 +98,7 @@ def _make_runner():
     runner._should_send_telegram_lobby_reminder = lambda _source: False
     runner._check_slash_access = lambda _source, _command: None
     runner._begin_session_run_generation = lambda _key: 1
-    runner._release_running_agent_state = lambda key: runner._running_agents.pop(key, None)
+    runner._release_running_agent_state = lambda key, **kwargs: runner._running_agents.pop(key, None)
     return runner, adapter
 
 

--- a/tests/gateway/test_moa_one_shot_restore.py
+++ b/tests/gateway/test_moa_one_shot_restore.py
@@ -1,55 +1,204 @@
-"""MoA one-shot model override must be restored on both success and failure.
+"""One-shot model overrides (``/moa <prompt>``, ``/model --once``) are TURN-OWNED.
 
-These exercise the real ``GatewayRunner._restore_moa_one_shot`` helper that the
-message-handling ``finally`` block calls, so they prove the production logic —
-not a re-implementation of it. The bug being guarded: the restore used to live
-in the ``try`` block, so a turn that raised skipped it and the MoA override
-leaked permanently (every later message silently fanned out through MoA).
+The snapshot to put back is adopted by the turn when it claims the slot
+(``_claim_running_agent_state``) and applied exactly once when that slot is
+released (``_release_running_agent_state``), whoever releases it: the turn's own
+finalizer on every exit path (success, exception, interrupt) or an evictor.
+
+Bugs guarded:
+
+- the restore used to live in the ``try`` block, so a raising turn skipped it and
+  the MoA override leaked permanently (every later message fanned out through MoA);
+- the restore used to run from the evicted turn's late ``finally`` against SHARED
+  conversation state: a replacement turn B that had already claimed the slot and
+  installed its own override got it overwritten (and its cached agent evicted) by
+  turn A's stale snapshot, so B silently ran on the wrong model (#106966 review).
+
+These drive the real producers and lifecycle helpers, not a re-implementation.
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.event import MessageEvent, MessageType
 from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+KEY = "agent:main:telegram:dm:999"
+OPENROUTER = {"provider": "openrouter", "model": "gpt-4"}
 
 
 def _make_runner():
-    """Minimal GatewayRunner with only the fields _restore_moa_one_shot reads."""
+    """Bare GatewayRunner; cache evictions are recorded instead of executed."""
     runner = object.__new__(GatewayRunner)
     runner._session_model_overrides = {}
-    runner._evict_cached_agent = MagicMock()
+    runner._pending_one_turn_model_restores = {}
+    runner.cache_evictions = []
+    runner._evict_cached_agent = lambda key: runner.cache_evictions.append(key)
     return runner
 
 
-def _make_event(moa_disable=False, moa_restore=None):
-    event = SimpleNamespace()
-    if moa_disable:
-        event._moa_disable_after_turn = True
-        event._moa_restore_override = moa_restore
-    return event
+def _moa_event(text: str) -> MessageEvent:
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="999", chat_type="dm", user_id="999")
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
 
 
-def test_restore_runs_from_finally_even_when_turn_raises():
-    """The whole point of the fix: a raising turn still reverts the override.
+async def _stage_moa(runner, text="/moa do this") -> None:
+    """Run the real ``/moa <prompt>`` one-shot producer (idle dispatch, before the claim)."""
+    event = _moa_event(text)
+    handled, reply = await runner._hm_cmd_moa(event, event.source, KEY)
+    assert (handled, reply) == (False, None), reply
+    assert runner._session_model_overrides[KEY]["provider"] == "moa"
 
-    Mirrors the real call site — the restore is invoked from a ``finally`` block,
-    so it fires after an exception propagates out of the turn body.
-    """
-    runner = _make_runner()
-    key = "agent:main:telegram:dm:999"
-    runner._session_model_overrides[key] = {"provider": "moa", "model": "default"}
-    event = _make_event(
-        moa_disable=True,
-        moa_restore={"provider": "openrouter", "model": "gpt-4"},
-    )
 
-    with __import__("pytest").raises(RuntimeError):
-        try:
-            raise RuntimeError("provider error mid-turn")
-        finally:
-            runner._restore_moa_one_shot(event, key)
+def _override(runner):
+    return runner._session_model_overrides.get(KEY)
 
-    assert runner._session_model_overrides[key] == {
-        "provider": "openrouter",
-        "model": "gpt-4",
-    }
+
+class TestOneShotRestoreOnRelease:
+    @pytest.mark.asyncio
+    async def test_restore_runs_when_the_slot_is_released_even_if_the_turn_raised(self):
+        """Mirrors the finalizer: the release is what the ``finally`` runs, so a raising
+        turn still reverts the override."""
+        runner = _make_runner()
+        runner._session_model_overrides[KEY] = dict(OPENROUTER)
+        await _stage_moa(runner)
+        gen = runner._claim_running_agent_state(KEY, MagicMock())
+
+        with pytest.raises(RuntimeError):
+            try:
+                raise RuntimeError("provider error mid-turn")
+            finally:
+                runner._release_running_agent_state(KEY, owner_generation=gen)
+
+        assert _override(runner) == OPENROUTER
+        assert runner._pending_one_turn_model_restores.get(KEY) is None
+
+    def test_model_once_snapshot_is_adopted_by_the_claiming_turn(self):
+        """``/model --once`` stages its snapshot for the NEXT turn; that turn owns it."""
+        runner = _make_runner()
+        runner._session_model_overrides[KEY] = {"provider": "openai", "model": "gpt-5.5"}
+        runner._pending_one_turn_model_restores[KEY] = {"had_override": False, "override": None}
+
+        gen = runner._claim_running_agent_state(KEY, MagicMock())
+
+        assert runner._peek_session_state(KEY).turn.model_restore == {
+            "had_override": False, "override": None,
+        }
+        assert KEY not in runner._pending_one_turn_model_restores, "still pending: a second turn could adopt it too"
+        assert runner._release_running_agent_state(KEY, owner_generation=gen) is True
+        assert _override(runner) is None
+
+    @pytest.mark.asyncio
+    async def test_earliest_pending_snapshot_wins_when_moa_follows_model_once(self):
+        """``/model --once X`` then ``/moa <prompt>``: both one-shots end with this turn, so
+        the turn puts back the override from BEFORE ``--once``, not X."""
+        runner = _make_runner()
+        runner._session_model_overrides[KEY] = {"provider": "openai", "model": "gpt-5.5"}  # X
+        runner._pending_one_turn_model_restores[KEY] = {"had_override": True, "override": dict(OPENROUTER)}
+        await _stage_moa(runner)
+        gen = runner._claim_running_agent_state(KEY, MagicMock())
+
+        runner._release_running_agent_state(KEY, owner_generation=gen)
+
+        assert _override(runner) == OPENROUTER
+
+
+class TestOneShotRestoreVsConversationBoundary:
+    """The prior a one-shot puts back belongs to the conversation it was taken in. A boundary
+    reached MID-TURN (compression exhaustion auto-reset) closes that conversation while the
+    turn still owns the slot: the snapshot must die with it, or the release writes the old
+    conversation's override into the fresh session (#106966 review)."""
+
+    @pytest.mark.asyncio
+    async def test_model_once_restore_does_not_cross_a_compression_exhaustion_reset(self):
+        runner = _make_runner()
+        runner._session_model_overrides[KEY] = {"provider": "openai", "model": "gpt-5.5"}  # --once model
+        runner._pending_one_turn_model_restores[KEY] = {"had_override": True, "override": dict(OPENROUTER)}
+        gen = runner._claim_running_agent_state(KEY, MagicMock())
+        assert runner._peek_session_state(KEY).turn.model_restore is not None
+
+        # Mid-turn the context can no longer be compressed: the real auto-reset rotates the
+        # durable session and clears the conversation scope (fresh session, no override).
+        runner.session_store = SimpleNamespace()
+        runner._async_session_store = SimpleNamespace(
+            _store=runner.session_store, reset_session=AsyncMock(return_value=None),
+        )
+        response, _entry = await runner._hmwa_compression_exhaustion_reset(
+            {"compression_exhausted": True}, "reply", SimpleNamespace(session_id="old-sid"), KEY, None,
+        )
+        assert "auto-reset" in response
+        assert _override(runner) is None
+
+        # The turn ends and releases its slot: nothing from the closed conversation comes back.
+        assert runner._release_running_agent_state(KEY, owner_generation=gen) is True
+        assert _override(runner) is None, "the old conversation's override was restored into the fresh session"
+
+    def test_moa_restore_is_dropped_at_a_conversation_boundary(self):
+        """Same contract through the boundary funnel every reset path shares (/new, /resume,
+        auto-reset): the adopted snapshot does not survive it."""
+        runner = _make_runner()
+        runner._session_model_overrides[KEY] = dict(OPENROUTER)
+        runner._pending_one_turn_model_restores[KEY] = {"had_override": True, "override": dict(OPENROUTER)}
+        gen = runner._claim_running_agent_state(KEY, MagicMock())
+
+        runner._clear_conversation_scope(KEY, reason="test_boundary")
+
+        assert runner._peek_session_state(KEY).turn.model_restore is None
+        assert runner._release_running_agent_state(KEY, owner_generation=gen) is True
+        assert _override(runner) is None
+
+
+class TestOneShotRestoreVsReplacementTurn:
+    """#106966 review interleaving: turn A (``/moa``) is evicted, replacement turn B claims
+    the slot and installs its own override, then A's finalizer runs."""
+
+    @pytest.mark.asyncio
+    async def test_evicted_turn_restores_before_the_replacement_and_never_clobbers_it(self):
+        runner = _make_runner()
+        runner._session_model_overrides[KEY] = dict(OPENROUTER)
+        await _stage_moa(runner, "/moa turn A")
+        gen_a = runner._claim_running_agent_state(KEY, MagicMock())
+        runner._session_state(KEY).turn.agent = MagicMock(name="agent-a")
+        assert _override(runner)["provider"] == "moa"
+
+        # Message 2 finds A's durable row reaped: A's one-shot ends HERE, with its slot.
+        runner._hm_evict_running_agent(KEY, "reaped_session_eviction")
+        assert _override(runner) == OPENROUTER, "the replacement must start from the prior override"
+
+        # B is a /moa one-shot too: it snapshots the (restored) prior and installs its own MoA.
+        await _stage_moa(runner, "/moa message 2")
+        gen_b = runner._claim_running_agent_state(KEY, MagicMock())
+        assert runner._peek_session_state(KEY).turn.model_restore == {"had_override": True, "override": OPENROUTER}
+        evictions_before_a_finalizer = len(runner.cache_evictions)
+
+        # A unwinds late and runs its finalizer: nothing of B's may change.
+        assert runner._release_running_agent_state(KEY, owner_generation=gen_a) is False
+        assert _override(runner)["provider"] == "moa", "A's stale snapshot overwrote B's override"
+        assert len(runner.cache_evictions) == evictions_before_a_finalizer, "A's finalizer evicted B's cached agent"
+
+        # B's own finalizer puts the prior back exactly once.
+        assert runner._release_running_agent_state(KEY, owner_generation=gen_b) is True
+        assert _override(runner) == OPENROUTER
+
+    def test_model_once_turn_evicted_then_replaced_keeps_the_replacement_override(self):
+        runner = _make_runner()
+        runner._session_model_overrides[KEY] = {"provider": "openai", "model": "gpt-5.5"}  # --once model
+        runner._pending_one_turn_model_restores[KEY] = {"had_override": True, "override": dict(OPENROUTER)}
+        gen_a = runner._claim_running_agent_state(KEY, MagicMock())
+        runner._session_state(KEY).turn.agent = MagicMock(name="agent-a")
+
+        runner._hm_evict_running_agent(KEY, "stale_running_agent_eviction")
+        assert _override(runner) == OPENROUTER
+
+        # Replacement B switches the session model for good (plain /model, no --once).
+        runner._session_model_overrides[KEY] = {"provider": "anthropic", "model": "claude"}
+        gen_b = runner._claim_running_agent_state(KEY, MagicMock())
+
+        assert runner._release_running_agent_state(KEY, owner_generation=gen_a) is False
+        assert _override(runner) == {"provider": "anthropic", "model": "claude"}
+        assert runner._release_running_agent_state(KEY, owner_generation=gen_b) is True
+        assert _override(runner) == {"provider": "anthropic", "model": "claude"}, "B had no one-shot: nothing to restore"

--- a/tests/gateway/test_pending_event_none.py
+++ b/tests/gateway/test_pending_event_none.py
@@ -11,7 +11,9 @@ do not get recycled into the pending-user-message follow-up path.
 
 from types import SimpleNamespace
 
-from gateway.run import _is_control_interrupt_message
+import pytest
+
+from gateway.run import _INTERRUPT_REASON_EVICTED, _is_control_interrupt_message
 
 
 def _extract_channel_prompt(pending_event):
@@ -52,5 +54,63 @@ class TestControlInterruptMessages:
     def test_stop_requested_is_not_treated_as_pending_user_message(self):
         result = _extract_pending_text(True, None, "Stop requested")
         assert result is None
+
+    def test_evicted_reason_is_not_treated_as_pending_user_message(self):
+        """The reason ``_hm_evict_running_agent`` hands to ``request_hard_interrupt`` when a
+        session's turn slot is evicted (reaped durable row / stale turn, #106963) is gateway
+        control flow exactly like "Stop requested": it must never re-enter the conversation
+        as the user's next turn."""
+        assert _extract_pending_text(True, None, _INTERRUPT_REASON_EVICTED) is None
+
+    def test_every_gateway_interrupt_reason_is_control_flow(self):
+        """Invariant behind the frozenset: a reason the gateway itself produces is never user
+        input. Enumerating the ``_INTERRUPT_REASON_*`` constants catches the next reason that
+        is added without being classified (how the eviction reason was missed at first)."""
+        import gateway.run as gateway_run
+
+        reasons = {
+            name: value for name, value in vars(gateway_run).items()
+            if name.startswith("_INTERRUPT_REASON_")
+        }
+        assert _INTERRUPT_REASON_EVICTED in reasons.values()
+        unclassified = sorted(
+            name for name, value in reasons.items() if not _is_control_interrupt_message(value)
+        )
+        assert unclassified == []
+
+
+class TestDrainPendingRealConsumer:
+    """The production consumer, ``_run_agent_drain_pending``, applies the same rule: the mirror
+    above documents the selection, this pins the code path that actually builds the next turn."""
+
+    @staticmethod
+    def _drain(result):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._draining = False
+        adapter = SimpleNamespace(_pending_messages={}, get_pending_message=lambda key: None)
+        source = SimpleNamespace(thread_id=None)
+        return runner._run_agent_drain_pending(result, adapter, source, "agent:main:telegram:dm:0")
+
+    @pytest.mark.asyncio
+    async def test_evicted_reason_does_not_become_the_next_user_turn(self):
+        result = {"interrupted": True, "interrupt_message": _INTERRUPT_REASON_EVICTED}
+
+        pending_event, pending = await self._drain(result)
+
+        assert pending_event is None
+        assert pending is None, "the eviction reason re-entered the conversation as user input"
+
+    @pytest.mark.asyncio
+    async def test_user_supplied_interrupt_text_still_becomes_the_next_turn(self):
+        """Control: an interrupt that carries the user's own follow-up is still recycled, so the
+        classification is what discriminates, not a blanket drop of interrupt messages."""
+        result = {"interrupted": True, "interrupt_message": "actually, use the other file"}
+
+        pending_event, pending = await self._drain(result)
+
+        assert pending_event is None
+        assert pending == "actually, use the other file"
 
 

--- a/tests/gateway/test_reaped_eviction_interrupts_run.py
+++ b/tests/gateway/test_reaped_eviction_interrupts_run.py
@@ -1,0 +1,171 @@
+"""Regression test: evicting a session's turn slot must interrupt the in-flight run.
+
+``_hm_evict_reaped_agent`` (``ws_orphan_reap`` / ``agent_close`` / a durable session
+row ended while the gateway lived) and the stale-turn path both call
+``_hm_evict_running_agent``. Bumping the run generation only makes the gateway
+*discard* the eventual result — it does not stop the agent, which kept calling the
+model and running tools until it finished on its own. Releasing the slot first also
+left ``/stop`` and ``/new`` with nothing to interrupt (``_interrupt_and_clear_session``
+reads ``state.turn.agent``), so the orphan could not be stopped by any means.
+
+Reported with a 25-minute / 51-call / 7.9M-input-token orphan in #106963.
+
+Behaviour tests: they pin the contract ("evicting a session interrupts the run it
+evicts, before the slot — and the cache — stop pointing at it"), not the shape of
+the source.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gateway.run import _AGENT_PENDING_SENTINEL
+from gateway.run_inbound import GatewayInboundMixin
+
+KEY = "agent:main:telegram:dm:0"
+
+
+class _RecordingAgent:
+    """Minimal agent exposing the ``hard_interrupt`` ABI the gateway uses."""
+
+    def __init__(self, eventos: list[tuple], en_slot) -> None:
+        self._eventos = eventos
+        self._en_slot = en_slot
+
+    def hard_interrupt(self, message: str | None = None, **kwargs) -> None:
+        # ``en_slot`` lets a test assert the interrupt arrived while the turn slot
+        # still held this agent — releasing it first is the bug being pinned.
+        self._eventos.append(("interrupt", message, self._en_slot() is self))
+
+
+class _ThrowingAgent:
+    """Third-party/legacy ABI that raises instead of latching the interrupt."""
+
+    def hard_interrupt(self, message: str | None = None, **kwargs) -> None:
+        raise RuntimeError("legacy interrupt ABI blew up")
+
+
+class _FakeStore:
+    """Durable session store that reports the row as ended — what triggers the
+    reaped-session eviction in production."""
+
+    def peek_session_id(self, session_key: str) -> str:
+        return "20260909_121453_ee99a4"
+
+    def _is_session_ended_in_db(self, session_id: str) -> bool:
+        return True
+
+
+class _FakeGateway(GatewayInboundMixin):
+    """Just enough gateway for the eviction path; the cache mixin's collaborators
+    are recorded instead of executed."""
+
+    def __init__(self, eventos: list[tuple]) -> None:
+        self._sessions: dict = {}
+        self._eventos = eventos
+        self.session_store = _FakeStore()
+        self.cache: set = set()
+
+    def _peek_session_state(self, session_key: str):
+        return self._sessions.get(session_key)
+
+    def _invalidate_session_run_generation(self, session_key: str, reason: str | None = None) -> int:
+        self._eventos.append(("invalidate", reason))
+        return 2
+
+    def _release_running_agent_state(self, session_key: str, **kwargs) -> bool:
+        self._eventos.append(("release", session_key))
+        self._sessions.pop(session_key, None)
+        return True
+
+    def _evict_cached_agent(self, session_key: str) -> None:
+        self._eventos.append(("cache_evict", session_key))
+        self.cache.discard(session_key)
+
+
+def _montar(ocupante: object = "agente"):
+    """Gateway con un ocupante en el turn slot (y en el cache); devuelve
+    (gateway, agente, eventos)."""
+    eventos: list[tuple] = []
+    gateway = _FakeGateway(eventos)
+    agente = _RecordingAgent(
+        eventos,
+        lambda: (gateway._sessions.get(KEY) or SimpleNamespace(turn=SimpleNamespace(agent=None))).turn.agent,
+    )
+    if ocupante == "agente":
+        gateway._sessions = {KEY: SimpleNamespace(turn=SimpleNamespace(agent=agente))}
+    elif ocupante is not None:
+        gateway._sessions = {KEY: SimpleNamespace(turn=SimpleNamespace(agent=ocupante))}
+    gateway.cache = {KEY}  # el agente cacheado que un reattach en frío reusaría
+    return gateway, agente, eventos
+
+
+def _orden(eventos: list[tuple], tipo: str) -> int:
+    return next(i for i, e in enumerate(eventos) if e[0] == tipo)
+
+
+def test_evicting_interrupts_while_the_slot_still_holds_the_run() -> None:
+    gateway, _agente, eventos = _montar()
+
+    gateway._hm_evict_running_agent(KEY, "reaped_session_eviction")
+
+    interrupciones = [e for e in eventos if e[0] == "interrupt"]
+    assert interrupciones, (
+        "the evicted run was never interrupted: it keeps calling the model and running tools "
+        "after the gateway discarded its result"
+    )
+    assert interrupciones[0][1], "the interrupt must carry a reason for the transcript"
+    assert interrupciones[0][2] is True, (
+        "the interrupt must be requested while the turn slot still holds the agent, "
+        "otherwise a later /stop cannot reach it"
+    )
+    assert _orden(eventos, "interrupt") < _orden(eventos, "release"), (
+        "interrupt MUST come before _release_running_agent_state empties the slot"
+    )
+    assert gateway._peek_session_state(KEY) is None
+    assert _orden(eventos, "release") < _orden(eventos, "cache_evict"), (
+        "the evicted agent must also leave the agent cache, or a cold reattach reuses it "
+        "still latched and the next message dies before its first API call (#44212)"
+    )
+    assert gateway.cache == set()
+
+
+def test_reaped_session_detection_reaches_the_interrupt() -> None:
+    """Same contract through the caller that detects the reaped durable row."""
+    gateway, _agente, eventos = _montar()
+
+    gateway._hm_evict_reaped_agent(KEY)
+
+    assert [e for e in eventos if e[0] == "interrupt"], (
+        "the reaped-session path evicted the slot without interrupting the run"
+    )
+    assert gateway.cache == set()
+
+
+def test_a_raising_interrupt_abi_still_evicts() -> None:
+    """A third-party/legacy ``hard_interrupt`` that raises must not skip cleanup:
+    invalidate, release and cache evict are the eviction's own contract."""
+    eventos: list[tuple] = []
+    gateway = _FakeGateway(eventos)
+    gateway._sessions = {KEY: SimpleNamespace(turn=SimpleNamespace(agent=_ThrowingAgent()))}
+    gateway.cache = {KEY}
+
+    gateway._hm_evict_running_agent(KEY, "reaped_session_eviction")
+
+    tipos = [e[0] for e in eventos]
+    assert "invalidate" in tipos and "release" in tipos and "cache_evict" in tipos, (
+        f"a raising interrupt left the dead runtime slot reachable: {tipos}"
+    )
+    assert gateway._peek_session_state(KEY) is None
+    assert gateway.cache == set()
+
+
+def test_pending_sentinel_and_empty_slot_are_not_interrupted() -> None:
+    """The placeholder sentinel and an empty slot have nothing to interrupt, and
+    the eviction still completes."""
+    for ocupante in (_AGENT_PENDING_SENTINEL, None):
+        gateway, _agente, eventos = _montar(ocupante)
+
+        gateway._hm_evict_running_agent(KEY, "stale_running_agent_eviction")
+
+        assert [e for e in eventos if e[0] == "interrupt"] == [], f"no debe interrumpir a {ocupante!r}"
+        assert [e for e in eventos if e[0] == "release"], "la evicción debe completarse igual"

--- a/tests/gateway/test_reaped_session_recovery.py
+++ b/tests/gateway/test_reaped_session_recovery.py
@@ -11,7 +11,9 @@ stale slot at routing time so the message falls through to the cold path.
 Salvaged from PR #99183 (@Finn763).
 """
 
+import asyncio
 import time
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,8 +24,9 @@ from gateway.config import (
     PlatformConfig,
 )
 from gateway.platforms.event import MessageEvent, MessageType
-from gateway.run import GatewayRunner
+from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_EVICTED, GatewayRunner
 from gateway.session import SessionSource, SessionStore
+from gateway.turn_lease import SessionTurnLeaseRegistry
 
 
 class _FakeAdapter:
@@ -138,8 +141,10 @@ async def test_reaped_session_message_reaches_cold_path(tmp_path):
 
     assert result == "COLD_PATH_REPLY"
     assert cold_path.await_count == 1
-    # Nothing was interrupt()-delivered into the dead runtime.
-    assert agent.interrupts == []
+    # The user's message was never interrupt()-delivered into the dead runtime. The only thing
+    # that reached it is the gateway's own stop request, so the orphaned run stops instead of
+    # finishing invisibly after its result was discarded (#106963).
+    assert agent.interrupts == [_INTERRUPT_REASON_EVICTED]
 
 
 @pytest.mark.asyncio
@@ -210,3 +215,208 @@ async def test_guard_is_inert_with_stubbed_session_store(tmp_path):
     assert runner._is_session_running(key) is True
     assert result is None
     assert agent.interrupts == ["stub store follow-up"]
+
+
+# ---------------------------------------------------------------------------
+# Eviction vs. the evicted turn's own finalizer (#106966 review interleaving)
+# ---------------------------------------------------------------------------
+
+
+class _EvictableAgent(_DeadReapedAgent):
+    """Reaped runtime that honours the hard interrupt: it records the reason and wakes the
+    turn blocked inside it, the way an interrupted agent loop unwinds in production."""
+
+    def __init__(self, interrupted: asyncio.Event):
+        super().__init__()
+        self.hard_interrupts = []
+        self._interrupted = interrupted
+
+    def hard_interrupt(self, message=None, **kwargs):
+        self.hard_interrupts.append(message)
+        self._interrupted.set()
+
+
+def _event(text: str, src: SessionSource) -> MessageEvent:
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=src)
+
+
+async def _run_eviction_interleaving(tmp_path, *, end_reason: str, moa: bool = False) -> SimpleNamespace:
+    """Drive the review interleaving through the real ``_handle_message``:
+
+    1. turn A runs on the session (real agent in the slot, real turn lease on its session id);
+    2. the durable row is ended with ``end_reason``; message 2 evicts A (interrupt ->
+       invalidate -> release) and claims the slot for a replacement turn, whose cold path
+       self-heals the routing (reopening the row, or creating a fresh session id) and takes
+       its own turn lease;
+    3. the interrupted A unwinds and runs its ``_handle_message`` finalizer while the
+       replacement is still running;
+    4. a third message arrives while the replacement is still running.
+
+    With ``moa`` both messages are ``/moa <prompt>`` one-shots (the real idle-path producer
+    runs before the claim) and the session starts with a plain override to put back.
+
+    Only the agent-turn body is stubbed: it installs the agent and, once interrupted, keeps
+    unwinding only after the replacement has claimed the slot. That is the production timing:
+    the interrupt is cooperative, the evicted run notices it when its model call or tool
+    returns (seconds to minutes), while message 2 claims the slot within milliseconds.
+    Admission, eviction, claim, routing heal, turn leases and the finalizer are production code."""
+    store = _store(tmp_path)
+    src = _source(chat_id="555004")
+    entry = store.get_or_create_session(src)
+    key = store._generate_session_key(src)
+    runner = _make_runner(store)
+    runner._turn_leases = SessionTurnLeaseRegistry()
+    runner._session_model_overrides = {}
+    if moa:
+        runner._session_model_overrides[key] = {"provider": "openrouter", "model": "gpt-4"}
+
+    interrupted, a_running, replacement_claimed = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    agent_a = _EvictableAgent(interrupted)
+    leases, turns, seen = [], [], SimpleNamespace()
+    timeline = []  # ("override", phase, value) and ("cache_evict", key) in order
+    runner._evict_cached_agent = lambda k: timeline.append(("cache_evict", k))
+
+    def _note(phase):
+        timeline.append(("override", phase, dict(runner._session_model_overrides.get(key) or {})))
+
+    def acquire_slot(**kwargs):
+        lease = MagicMock(name=f"lease-{len(leases)}")
+        leases.append(lease)
+        return lease, None
+
+    async def agent_turn(self, event, source, quick_key, run_generation):
+        turns.append(event.text)
+        turn = self._session_state(quick_key).turn
+        if event.text == "turn A":
+            _note("A running")
+            await self._hmwa_acquire_turn_lease(quick_key, run_generation, entry, None)
+            seen.token_a = turn.lease_token
+            turn.agent = agent_a
+            a_running.set()
+            await interrupted.wait()  # in the model/tool loop until the eviction interrupts it
+            await replacement_claimed.wait()  # ...and still unwinding when the slot is re-claimed
+            return {"final_response": "", "interrupted": True}
+        if event.text != "message 2":
+            return "UNEXPECTED_TURN"
+        seen.b_model_restore = turn.model_restore  # what B will put back when IT ends
+        _note("B running")
+        healed = store.get_or_create_session(source)  # cold-path routing self-heal (#54878)
+        seen.healed_session_id = healed.session_id
+        if healed.session_id == entry.session_id:
+            # Reopened row: this turn's lease waits for A's, so A must be allowed to unwind (and
+            # run its finalizer against the already re-claimed slot) before the acquire returns.
+            replacement_claimed.set()
+            await self._hmwa_acquire_turn_lease(quick_key, run_generation, healed, None)
+        else:
+            # Fresh id: take this turn's lease first, overwriting the slot's token while A still
+            # holds its own — the overwrite the finalizer's identity-based release exists for.
+            await self._hmwa_acquire_turn_lease(quick_key, run_generation, healed, None)
+            replacement_claimed.set()
+        seen.token_b = turn.lease_token
+        await task_a  # A has unwound completely: its finalizer ran, mid-replacement
+        _note("after A finalizer")
+        seen.agent_after_a_finalizer = turn.agent
+        seen.lease_after_a_finalizer = turn.lease
+        seen.lease_b_releases_after_a_finalizer = leases[1].release.call_count
+        seen.running_after_a_finalizer = self._is_session_running(quick_key)
+        seen.token_b_still_held = (
+            runner._turn_leases._leases[healed.session_id].holder is seen.token_b
+        )
+        seen.old_session_holder = runner._turn_leases._leases[entry.session_id].holder
+        seen.third_reply = await self._handle_message(_event("third", src))
+        return "REPLACEMENT_REPLY"
+
+    with (
+        patch.object(GatewayRunner, "_handle_message_with_agent", agent_turn),
+        patch.object(GatewayRunner, "_run_post_turn_hooks", AsyncMock()),
+        patch.object(GatewayRunner, "_clear_durable_active_turn", AsyncMock()),
+        patch.object(GatewayRunner, "_persist_active_agents", lambda self: None),
+        patch("hermes_cli.active_sessions.try_acquire_active_session", side_effect=acquire_slot),
+    ):
+        prefix = "/moa " if moa else ""
+        task_a = asyncio.create_task(runner._handle_message(_event(prefix + "turn A", src)))
+        await asyncio.wait_for(a_running.wait(), timeout=5)
+        store._db.end_session(entry.session_id, end_reason)
+        seen.reply_2 = await asyncio.wait_for(
+            runner._handle_message(_event(prefix + "message 2", src)), timeout=5
+        )
+        await task_a
+    _note("after B finalizer")
+    seen.timeline = timeline
+    seen.original_session_id = entry.session_id
+    seen.leases, seen.turns, seen.agent_a, seen.runner, seen.key = leases, turns, agent_a, runner, key
+    return seen
+
+
+def _assert_replacement_turn_survived_the_old_finalizer(seen: SimpleNamespace) -> None:
+    assert seen.reply_2 == "REPLACEMENT_REPLY"
+    assert seen.agent_a.hard_interrupts == [_INTERRUPT_REASON_EVICTED]
+    assert seen.agent_a.interrupts == []  # message 2 never went into the dead runtime (#99106)
+
+    assert seen.agent_after_a_finalizer is _AGENT_PENDING_SENTINEL, (
+        "the evicted turn's finalizer erased the replacement turn's slot"
+    )
+    assert seen.lease_after_a_finalizer is seen.leases[1]
+    assert seen.lease_b_releases_after_a_finalizer == 0
+    assert seen.token_b_still_held is True
+    assert seen.running_after_a_finalizer is True
+    assert seen.third_reply is None
+    assert seen.turns == ["turn A", "message 2"], "a concurrent turn was admitted"
+
+    # The evicted turn released what was its own: its slot lease once (by the eviction) and
+    # its turn lease; the replacement's own finalizer then cleaned up after it (no zombie).
+    assert seen.leases[0].release.call_count == 1
+    assert seen.token_a.released is True
+    assert seen.runner._is_session_running(seen.key) is False
+    assert seen.leases[1].release.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_old_turn_finalizer_does_not_erase_the_replacement_turn(tmp_path):
+    """``ws_orphan_reap``: recovery reopens the same session id, so the replacement's turn lease
+    waits for the evicted turn's finalizer — which must release only the slot IT claimed. The
+    replacement's sentinel, active-session lease and turn lease survive it, and a third message
+    is still refused as a concurrent turn."""
+    seen = await _run_eviction_interleaving(tmp_path, end_reason="ws_orphan_reap")
+
+    assert seen.healed_session_id == seen.original_session_id
+    _assert_replacement_turn_survived_the_old_finalizer(seen)
+
+
+@pytest.mark.asyncio
+async def test_evicted_turn_releases_its_turn_lease_when_the_replacement_moved_to_a_fresh_session(tmp_path):
+    """A row ended for a reason recovery does not reopen: the cold path creates a fresh session
+    id, the replacement's turn lease is acquired at once and overwrites the slot's token while
+    the evicted turn still holds its own. The evicted turn's finalizer must still release the
+    lease on the old session id (or it stays held forever and a later /resume of it times out
+    on every turn), without touching the replacement's."""
+    seen = await _run_eviction_interleaving(tmp_path, end_reason="idle")
+
+    assert seen.healed_session_id != seen.original_session_id
+    _assert_replacement_turn_survived_the_old_finalizer(seen)
+    assert seen.old_session_holder is None, "the reaped session id stayed leased by the evicted turn"
+
+
+@pytest.mark.asyncio
+async def test_evicted_moa_one_shot_restores_before_the_replacement_and_never_clobbers_it(tmp_path):
+    """Review of #106966 (ehz0ah): the one-shot restore used to run from A's late ``finally``
+    against shared conversation state, after replacement B had installed its own override —
+    B then resolved A's prior model and lost its cached agent. The restore is turn-owned now:
+    it rides A's slot release (the eviction), before B claims, and A's finalizer touches
+    nothing of B's."""
+    seen = await _run_eviction_interleaving(tmp_path, end_reason="ws_orphan_reap", moa=True)
+    _assert_replacement_turn_survived_the_old_finalizer(seen)
+
+    overrides = {phase: value for kind, phase, value in
+                 (e for e in seen.timeline if e[0] == "override")}
+    assert overrides["A running"]["provider"] == "moa"
+    # A's one-shot ended with its slot: B snapshots the prior override, not A's MoA.
+    assert seen.b_model_restore == {"had_override": True, "override": {"provider": "openrouter", "model": "gpt-4"}}
+    assert overrides["B running"]["provider"] == "moa"
+    assert overrides["after A finalizer"]["provider"] == "moa", "A's stale snapshot overwrote B's override"
+    b_running = seen.timeline.index(("override", "B running", overrides["B running"]))
+    a_done = seen.timeline.index(("override", "after A finalizer", overrides["after A finalizer"]))
+    assert [e for e in seen.timeline[b_running:a_done] if e[0] == "cache_evict"] == [], (
+        "A's finalizer evicted B's cached agent mid-turn"
+    )
+    assert overrides["after B finalizer"] == {"provider": "openrouter", "model": "gpt-4"}

--- a/tests/gateway/test_session_state_cleanup.py
+++ b/tests/gateway/test_session_state_cleanup.py
@@ -160,3 +160,70 @@ class TestSessionResetZombieRace:
         assert key not in runner._running_agents_ts
         assert key not in runner._busy_ack_ts
 
+
+
+class TestEvictedTurnFinalizerIsGenerationSafe:
+    """#106966 review interleaving: ``_hm_evict_running_agent`` frees the slot of an in-flight
+    turn (reaped durable row / stale turn) and the same inbound message claims it for a
+    replacement turn; the evicted turn then unwinds and runs its ``_handle_message`` finalizer.
+
+    The finalizer's guard is slot OWNERSHIP (the generation recorded when the slot was claimed),
+    not "is my generation still the session's current one": that proxy is what produced the
+    #28686 zombie, and the unconditional release that worked around it is what erased the
+    replacement here. Ownership answers both cases: release while the slot is still mine (even
+    after the generation moved on), never once a newer turn claimed it.
+    """
+
+    KEY = "agent:main:telegram:private:1"
+
+    def test_old_turn_finalizer_release_leaves_the_replacement_turn_intact(self):
+        from gateway.run import _AGENT_PENDING_SENTINEL
+
+        runner = _make_runner()
+        lease_a, lease_b = MagicMock(name="lease-a"), MagicMock(name="lease-b")
+        gen_a = runner._claim_running_agent_state(self.KEY, lease_a)
+        agent_a = MagicMock(name="agent-a")
+        runner._session_state(self.KEY).turn.agent = agent_a  # _run_agent installs the real agent
+
+        # Message 2 finds the durable row reaped: interrupt A, invalidate, free the slot...
+        runner._hm_evict_running_agent(self.KEY, "reaped_session_eviction")
+        agent_a.interrupt.assert_called_once()
+        lease_a.release.assert_called_once()
+        assert runner._is_session_running(self.KEY) is False
+        # ...and claims it for the replacement turn before A has unwound.
+        gen_b = runner._claim_running_agent_state(self.KEY, lease_b)
+        assert gen_b > gen_a
+
+        # A unwinds: its finalizer must recognise that the slot is no longer its own.
+        assert runner._release_running_agent_state(self.KEY, owner_generation=gen_a) is False
+        turn = runner._peek_session_state(self.KEY).turn
+        assert turn.agent is _AGENT_PENDING_SENTINEL, "the replacement's sentinel was erased"
+        assert turn.lease is lease_b
+        lease_b.release.assert_not_called()
+        assert runner._is_session_running(self.KEY) is True, (
+            "with the slot erased, a third message would be admitted as a concurrent turn"
+        )
+
+        # The replacement's own finalizer still cleans up: no zombie in the other direction.
+        assert runner._release_running_agent_state(self.KEY, owner_generation=gen_b) is True
+        lease_b.release.assert_called_once()
+        assert runner._is_session_running(self.KEY) is False
+
+    def test_reset_zombie_is_still_evicted_by_the_ownership_guarded_release(self):
+        """#28686 shape, preserved: session_reset bumps the generation while gen-N is in flight
+        and nobody re-claims the slot. The current-generation guard blocks (the pre-fix zombie);
+        the ownership guard releases, because the slot is still gen-N's."""
+        runner = _make_runner()
+        lease = MagicMock(name="lease")
+        gen_n = runner._claim_running_agent_state(self.KEY, lease)
+        dead_agent = MagicMock(name="dead-agent")
+        runner._session_state(self.KEY).turn.agent = dead_agent
+
+        runner._invalidate_session_run_generation(self.KEY, reason="session_reset")
+
+        assert runner._release_running_agent_state(self.KEY, run_generation=gen_n) is False
+        assert runner._running_agents.get(self.KEY) is dead_agent
+        assert runner._release_running_agent_state(self.KEY, owner_generation=gen_n) is True
+        lease.release.assert_called_once()
+        assert self.KEY not in runner._running_agents
+        assert self.KEY not in runner._running_agents_ts

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -494,3 +494,38 @@ def test_runner_release_turn_lease_is_token_scoped_and_bare_safe():
     _run(scenario())
 
 
+
+
+def test_runner_release_turn_lease_finds_its_token_after_a_replacement_turn_took_the_slot():
+    """A reaped/stale eviction lets a replacement turn on the SAME routing key acquire its own
+    lease (on the healed session id) while the evicted turn is still unwinding, so the
+    replacement's token overwrites the slot's ``lease_token``. The evicted turn's finalizer must
+    still release the token IT acquired, by (owner_key, generation) identity through the
+    registry, or the old session id stays held forever and a later /resume of it times out on
+    every turn (#106966 review interleaving)."""
+    from gateway.run import GatewayRunner
+
+    async def scenario():
+        runner = object.__new__(GatewayRunner)
+        runner._turn_leases = SessionTurnLeaseRegistry()
+        runner._turn_lease_tokens = {}
+        token_old = await runner._turn_leases.acquire(
+            "sess-old", owner_key="key-a", generation=1, timeout=5
+        )
+        runner._turn_lease_tokens[("key-a", 1)] = token_old
+        # The eviction bumped the generation (2); the replacement turn (3) records its own token
+        # in the one slot the routing key has.
+        token_new = await runner._turn_leases.acquire(
+            "sess-new", owner_key="key-a", generation=3, timeout=5
+        )
+        runner._turn_lease_tokens[("key-a", 3)] = token_new
+
+        assert runner._release_turn_lease("key-a", 1) is True
+        assert runner._turn_leases._leases["sess-old"].holder is None
+        # The replacement's lease is untouched and still releasable by its own finalizer.
+        assert runner._turn_leases._leases["sess-new"].holder is token_new
+        assert runner._release_turn_lease("key-a", 3) is True
+        # Idempotent through the fallback path too.
+        assert runner._release_turn_lease("key-a", 1) is False
+
+    _run(scenario())

--- a/tests/hermes_cli/test_pre_command_hook.py
+++ b/tests/hermes_cli/test_pre_command_hook.py
@@ -284,7 +284,7 @@ def _make_runner():
     runner._check_slash_access = lambda _source, _command: None
     runner._begin_session_run_generation = lambda _key: 1
     runner._release_running_agent_state = (
-        lambda key: runner._running_agents.pop(key, None)
+        lambda key, **kwargs: runner._running_agents.pop(key, None)
     )
     return runner, adapter
 


### PR DESCRIPTION
Fixes #106963.

## What

`GatewayInboundMixin._hm_evict_running_agent` — the shared helper behind the reaped-session eviction (`ws_orphan_reap` / `agent_close` / a durable row ended while the gateway lives) and the stale-turn eviction — bumped the run generation and released the turn slot, but never asked the agent that was still executing to stop.

The generation bump only makes the gateway **discard** the eventual result. The run itself kept going: in the reported incident it continued for 25 minutes / 51 API calls / 7,893,329 input tokens after its session row was reaped, wrote files into the workspace and made a git commit — all of it invisible to the user. Because `_release_running_agent_state` empties `state.turn.agent`, a later `/stop` or `/new` (`_interrupt_and_clear_session`) found nothing to interrupt either, so the orphan could not be stopped by any means.

## Change

Ask for the interrupt **before** dropping the slot, mirroring what `/stop` already does, and finish the eviction with the same invariants `_interrupt_and_clear_session` keeps:

```python
def _hm_evict_running_agent(self, _quick_key: str, reason: str) -> None:
    from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_EVICTED, request_hard_interrupt
    state = self._peek_session_state(_quick_key)
    running_agent = state.turn.agent if state else None
    if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
        try:
            request_hard_interrupt(running_agent, _INTERRUPT_REASON_EVICTED)
        except Exception:
            logger.debug("Evicted agent interrupt failed", exc_info=True)
    self._invalidate_session_run_generation(_quick_key, reason=reason)
    self._release_running_agent_state(_quick_key)
    self._evict_cached_agent(_quick_key)
```

Three deliberate details:

- **Interrupt before release.** `request_hard_interrupt` is cooperative (it sets the flag the turn loop checks between steps), so it is safe mid-tool; doing it after `_release_running_agent_state` would leave nothing to interrupt.
- **Best-effort interrupt.** `request_hard_interrupt` calls a third-party/legacy `hard_interrupt`/`interrupt` directly and can raise; the cleanup must not depend on that ABI being noexcept, or the dead runtime slot stays reachable. Same fail-safe shape as the inactivity-timeout producer (`gateway/run.py`).
- **Cache eviction.** `_interrupt_requested` is only cleared by the turn finalizer, so the evicted agent must leave `_agent_cache` too — otherwise a cold reattach reuses it latched and the session's NEXT message dies before its first API call (#44212). `/stop` and `/new` already keep this invariant.

`_INTERRUPT_REASON_EVICTED` (`"Session ended while the turn was running"`) sits next to the existing `_INTERRUPT_REASON_*` constants: this is gateway lifecycle authority, not a user-issued stop, so the transcript should not invent user intent. The stale-turn path shares the helper, so it gets the same guarantee.

## Test

`tests/gateway/test_reaped_eviction_interrupts_run.py` — behaviour tests over the real `GatewayInboundMixin`, with a recording agent, a throwing agent, and a fake session store that reports the row as ended:

1. evicting interrupts **while the turn slot still holds the agent**, before `_release_running_agent_state`, and the cache eviction follows the release;
2. the reaped-session detection path (`_hm_evict_reaped_agent`) reaches that interrupt and the cache eviction;
3. an interrupt ABI that raises still leaves invalidate + release + cache evict done (no reachable dead slot);
4. the pending sentinel and an empty slot are not interrupted, and the eviction still completes.

Red on `main` before this change, green after:

```
# base (origin/main)
...:112 AssertionError: the evicted run was never interrupted: it keeps calling the model
              and running tools after the gateway discarded its result
...:138 AssertionError: the reaped-session path evicted the slot without interrupting the run
...:155 AssertionError: a raising interrupt left the dead runtime slot reachable: ['invalidate', 'release']
=== 1 files, 1 tests passed, 3 failed ===

# with this change
=== 1 files, 4 tests passed, 0 failed ===
```

Neighbouring gateway files (`scripts/run_tests.sh`, 12 files: `test_10710_auto_reset_evicts_cached_agent`, `test_35809_auto_reset_clean_context`, `test_35994_reset_button_deadlock`, `test_48031_model_switch_after_auto_reset`, `test_73297_memory_flush_on_reset`, `test_compression_interrupt_demotion_56391`, `test_fallback_eviction`, `test_internal_event_never_interrupts_busy_session`, `test_interrupt_key_match`, `test_agent_cache`, `test_abandoned_turn_process_cleanup`, `test_active_turn_recovery`) → **80 passed**. One pre-existing, unrelated failure reproduces on `main` without this change: `test_abandoned_turn_process_cleanup.py::test_reaper_dumps_wedged_worker_stack_before_interrupt` (asserts a frame name inside a stack dump; environment-dependent).

## Intent check

If letting in-flight work finish and only discarding its result is deliberate, this PR is the wrong fix and the issue is a documentation gap — but then the slot release should not silently disable `/stop` for that run.
