### PR TITLE
fix(desktop): preserve sibling SSH backends during pool recovery

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11580,10 +11580,11 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
           )
           await stopPoolBackend(key)
 
-          if (source.kind === 'ssh') {
-            await sshBootstrapCoordinator.cancelAndWait(key)
-            await teardownSshConnection(key)
-          }
+          // The SSH transport is shared by the primary backend and its pooled
+          // siblings. Retiring one remote serve must not close that transport:
+          // doing so also disconnects the primary backend and interrupts live
+          // turns there (#106935). The next ensure path reuses the still-live
+          // SSH connection and starts only this pool entry again.
         }
       })
     )


### PR DESCRIPTION
## Summary

Fixes #106935.

When Desktop revalidated a registry-scoped pooled backend and found its remote serve unavailable, the recovery path stopped the pool entry and then cancelled/closed the SSH connection for that key. In the Desktop-over-SSH topology, that transport can still be owned by a sibling backend, including the primary backend. Closing it disconnected the sibling and caused the renderer to restart the connection, interrupting live turns.

## Root cause

`ensureRegistryBackend()` used the pooled backend key to enter `teardownSshConnection()` after `stopPoolBackend()`. SSH transport lifetime was therefore coupled to one pooled serve's recovery, instead of the transport's owner set.

## Fix

Pooled remote recovery now retires only the failed pool entry. It leaves the SSH transport available for sibling backends; the subsequent ensure path reuses the live transport and recreates only the failed backend.

Primary-backend teardown and explicit connection teardown remain unchanged.

## Verification

- Reproduced the unsafe sequence in the current code path by tracing `ensureHealthyPooledRemoteBackendForDispatch()` → `stopPoolBackend()` → `teardownSshConnection()`.
- `git diff --check` passed.
- Commit: `62c3387dca`.
- `graphify update .` was attempted but exceeded the local five-minute timeout.
- Automated Vitest execution was blocked in the isolated worktree because dependencies are not installed (`vitest` unavailable).
