### PR TITLE
fix(cli): detect Windows default browser via Shell API

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -232,19 +232,89 @@ def _classify_default(value: str, channels, table, match) -> str | None:
     return next((browser for frag, browser in table if match(value, frag)), None)
 
 
-def _detect_default_windows() -> str | None:
+def _windows_shell_progid(scheme: str) -> str | None:
+    """Return the effective ProgId for a URL scheme via the Windows Shell API."""
     try:
-        import winreg  # type: ignore
+        import ctypes
+        from ctypes import wintypes
 
-        key = winreg.OpenKey(
-            winreg.HKEY_CURRENT_USER,
-            r"Software\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice")
-        prog_id, _ = winreg.QueryValueEx(key, "ProgId")
-        winreg.CloseKey(key)
-    except Exception:  # non-Windows host (no winreg) or unreadable key
+        # ASSOCSTR_PROGID from shlwapi.h.
+        assocstr_progid = 20
+
+        assoc_query = ctypes.WinDLL(
+            "Shlwapi.dll",
+            use_last_error=True,
+        ).AssocQueryStringW
+
+        assoc_query.argtypes = [
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.LPCWSTR,
+            wintypes.LPCWSTR,
+            wintypes.LPWSTR,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        assoc_query.restype = ctypes.c_long
+
+        length = wintypes.DWORD(0)
+
+        # First call obtains the required output buffer size.
+        assoc_query(
+            0,
+            assocstr_progid,
+            scheme,
+            None,
+            None,
+            ctypes.byref(length),
+        )
+
+        if not length.value:
+            return None
+
+        buffer = ctypes.create_unicode_buffer(length.value)
+
+        result = assoc_query(
+            0,
+            assocstr_progid,
+            scheme,
+            None,
+            buffer,
+            ctypes.byref(length),
+        )
+
+        return buffer.value if result == 0 else None
+
+    except (AttributeError, OSError):
         return None
-    return _classify_default(str(prog_id or "").lower(), _WINDOWS_CHANNEL_PROGIDS,
-                             _WINDOWS_PROGID_MAP, str.startswith)
+
+
+def _detect_default_windows() -> str | None:
+    # Prefer the effective association reported by the Windows Shell.
+    # Modern Windows builds may no longer expose it through the legacy
+    # UserChoice\ProgId registry value.
+    prog_id = _windows_shell_progid("https")
+
+    # Compatibility fallback for older Windows versions/environments.
+    if not prog_id:
+        try:
+            import winreg  # type: ignore
+
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\Shell\Associations"
+                r"\UrlAssociations\https\UserChoice",
+            ) as key:
+                prog_id, _ = winreg.QueryValueEx(key, "ProgId")
+
+        except (ImportError, OSError):
+            return None
+
+    return _classify_default(
+        str(prog_id or "").lower(),
+        _WINDOWS_CHANNEL_PROGIDS,
+        _WINDOWS_PROGID_MAP,
+        str.startswith,
+    )
 
 
 def _run_stdout(argv: list[str]) -> str | None:

--- a/tests/hermes_cli/test_browser_connect_default_chromium.py
+++ b/tests/hermes_cli/test_browser_connect_default_chromium.py
@@ -57,6 +57,55 @@ class TestLaunchServicesHttpsHandler:
         assert bc._launchservices_https_handler(dump) == "com.microsoft.edgemac"
 
 
+class TestDetectDefaultWindows:
+    @pytest.mark.parametrize(
+        "prog_id,expected",
+        [
+            ("ChromeHTML", "chrome"),
+            ("ChromeHTML.123", "chrome"),
+            ("MSEdgeHTM", "edge"),
+            ("BraveHTML", "brave"),
+            ("BraveOHTML", "brave-origin"),
+            ("ChromiumHTM", "chromium"),
+            ("ChromeBHTML", bc.UNSUPPORTED_CHANNEL),
+            ("FirefoxURL", None),
+        ],
+    )
+    def test_shell_progid_maps_to_browser(self, prog_id, expected):
+        with patch.object(bc, "_windows_shell_progid", return_value=prog_id):
+            assert bc._detect_default_windows() == expected
+
+    def test_shell_progid_takes_precedence_over_legacy_registry(self):
+        with patch.object(bc, "_windows_shell_progid", return_value="ChromeHTML"):
+            assert bc._detect_default_windows() == "chrome"
+
+    def test_shell_miss_falls_back_to_legacy_userchoice(self):
+        class FakeKey:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+        class FakeWinreg:
+            HKEY_CURRENT_USER = object()
+
+            @staticmethod
+            def OpenKey(*args, **kwargs):
+                return FakeKey()
+
+            @staticmethod
+            def QueryValueEx(key, name):
+                assert name == "ProgId"
+                return "MSEdgeHTM", 1
+
+        with (
+            patch.object(bc, "_windows_shell_progid", return_value=None),
+            patch.dict("sys.modules", {"winreg": FakeWinreg()}),
+        ):
+            assert bc._detect_default_windows() == "edge"
+
+
 class TestDetectDefaultDarwin:
     def _run_with(self, dump: str):
         class _Proc:


### PR DESCRIPTION
## What does this PR do?

Fixes default Chromium detection on modern Windows builds by querying the
effective HTTPS association through the Windows Shell `AssocQueryStringW`
API before falling back to the existing `UserChoice\ProgId` registry lookup.

## Problem

`detect_default_chromium()` currently relies on:

`HKCU\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\https\UserChoice\ProgId`

On newer Windows 11 builds, the effective default browser can be correctly
configured while this legacy value is unavailable.

In that situation Hermes returns `None` and rejects real-profile browser use,
even though Windows itself resolves the default browser correctly.

On the affected Windows 11 25H2 machine:

- Windows Settings shows Google Chrome as the HTTP and HTTPS handler.
- `AssocQueryStringW(ASSOCSTR_PROGID, "https")` returns `ChromeHTML`.
- `AssocQueryStringW(ASSOCSTR_EXECUTABLE, "https")` resolves to `chrome.exe`.
- The existing legacy `UserChoice\ProgId` lookup does not provide the active association.
- Before this patch, `detect_default_chromium("Windows")` returns `None`.
- After this patch, it returns `"chrome"`.

## Fix

- Query the effective HTTPS ProgId using the documented Windows Shell
  `AssocQueryStringW` API.
- Preserve the existing browser and channel classification logic.
- Keep the legacy registry lookup as a compatibility fallback.
- Add Windows regression coverage for:
  - Chrome
  - Edge
  - Brave
  - Brave Origin
  - Chromium
  - unsupported Chrome channels
  - non-Chromium ProgIds
  - legacy registry fallback

No new dependencies are introduced.

## Verification

Environment:

- Windows 11 25H2
- Python 3.11.16
- Google Chrome as the effective HTTP/HTTPS default

Real-system verification:

```text
_windows_shell_progid("https")      -> ChromeHTML
detect_default_chromium("Windows") -> chrome
```

Windows-specific regression tests:

```text
10 passed
```

The complete `tests/hermes_cli/test_browser_connect_default_chromium.py`
run on Windows produced:

```text
42 passed, 4 failed
```

The four failures are pre-existing `TestLinuxProfileDir` failures and reproduce
unchanged on clean `origin/main` under the same Windows environment, so they are
unrelated to this patch.