### PR TITLE
feat(footer): show routed combo member via response.model

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1609,6 +1609,14 @@ def run_conversation(
         moa_config=moa_config,
         turn_author=turn_author,
     )
+    # Stamp the member that actually answered (see turn_response_check capture)
+    # onto every envelope — the single seam all success/error paths pass through.
+    try:
+        _routed = getattr(agent, "_last_routed_model", None)
+        if isinstance(result, dict) and _routed:
+            result["routed_model"] = _routed
+    except Exception:
+        pass
     return export_current_turn_boundary(agent, result, user_message)
 
 

--- a/agent/turn_response_check.py
+++ b/agent/turn_response_check.py
@@ -120,6 +120,16 @@ def check_api_response(
         resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
         logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
 
+    # Remember the member that actually answered (proxies echo the routed
+    # member in response.model, not the requested combo). Powers the
+    # `routed_model` footer field; session-scoped by construction.
+    try:
+        _resp_model = getattr(response, "model", None) if response is not None else None
+        if _resp_model:
+            agent._last_routed_model = str(_resp_model)
+    except Exception:
+        pass
+
     response_invalid, error_details = validate_response_shape(agent, response)
     if response_invalid:
         _iv = retry_invalid_response(

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1486,6 +1486,7 @@ class GatewayTurnMixin:
                 context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                 context_length=agent_result.get("context_length") or None,
                 cwd=_terminal_scope_cwd(""), turn_seconds=_turn_seconds,
+                routed_model=agent_result.get("routed_model"),
             )
         except Exception as _footer_err:
             logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,8 +1,11 @@
 """Gateway runtime-metadata footer (model · context % · cwd), off by default to keep replies
-minimal. Config: ``display.runtime_footer: {enabled: bool, fields: [model, context_pct, cwd]}``
-(order shown; drop any to hide), per-platform override ``display.platforms.<p>.runtime_footer``,
-toggled by ``/footer on|off``. Fields: ``model`` (vendor prefix dropped), ``context_pct`` (last-call
-occupancy), ``latency`` (turn wall-clock, opt-in — NOT in the default set so an unset ``fields``
+minimal. Config: ``display.runtime_footer: {enabled: bool, fields: [model, routed_model,
+context_pct, cwd]}`` (order shown; drop any to hide), ``display.combo_prefix`` (default
+``"combo-"``: only models starting with it are treated as proxy combos), per-platform
+override ``display.platforms.<p>.runtime_footer``, toggled by ``/footer on|off``. Fields:
+``model`` (vendor prefix dropped), ``routed_model`` (``→member`` that actually answered a
+combo call, from the turn result — never scraped), ``context_pct`` (last-call occupancy),
+``latency`` (turn wall-clock, opt-in — NOT in the default set so an unset ``fields``
 renders exactly as before), ``cwd`` (home-relative). ``gateway/run.py`` appends the footer to the
 final response only (never to tool-progress or streaming partials); when streaming already
 delivered the text, it goes out as a trailing message via ``send_trailing_footer()``."""
@@ -13,6 +16,7 @@ import os
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+COMBO_PREFIX_DEFAULT = "combo-"
 _SEP = " · "
 
 
@@ -33,6 +37,36 @@ def _home_relative_cwd(cwd: str) -> str:
 def _model_short(model: Optional[str]) -> str:
     """Drop ``vendor/`` prefix (``openai/gpt-5.4`` → ``gpt-5.4``)."""
     return model.rsplit("/", 1)[-1] if model else ""
+
+
+def _combo_prefix(user_config: dict[str, Any] | None = None) -> str:
+    """Combo-name prefix from ``display.combo_prefix`` (default ``"combo-"``).
+
+    Only models starting with this prefix are treated as proxy combos whose
+    answering member is worth showing. Proxy-agnostic: the operator names
+    their combos accordingly; no proxy brand appears in code."""
+    try:
+        cfg = (user_config or {}).get("display") or {}
+        prefix = cfg.get("combo_prefix", COMBO_PREFIX_DEFAULT)
+        if isinstance(prefix, str) and prefix:
+            return prefix
+    except Exception:
+        pass
+    return COMBO_PREFIX_DEFAULT
+
+
+def _routed_suffix(*, model: Optional[str], routed_model: Optional[str],
+                   combo_prefix: str = COMBO_PREFIX_DEFAULT) -> str:
+    """``→short`` for the member that answered a combo call, else ``""``.
+
+    Pure function over values the caller already holds (the proxy echoes the
+    member in ``response.model``) — no log scraping, no subprocess."""
+    if not model or not str(model).startswith(combo_prefix):
+        return ""
+    if not routed_model or str(routed_model) == str(model):
+        return ""
+    short = _model_short(str(routed_model))
+    return f"→{short}" if short else ""
 
 
 def _env_cwd() -> str:
@@ -74,6 +108,8 @@ def _format_latency(seconds: float) -> str:
 def format_runtime_footer(*, model: Optional[str], context_tokens: int,
                           context_length: Optional[int], cwd: Optional[str] = None,
                           turn_seconds: Optional[float] = None,
+                          routed_model: Optional[str] = None,
+                          combo_prefix: str = COMBO_PREFIX_DEFAULT,
                           fields: Iterable[str] = _DEFAULT_FIELDS) -> str:
     """Render the footer line, or "" if no fields have data. Fields whose data is missing (and
     unknown field names) are skipped silently — a partial footer beats ``?%`` or empty slots."""
@@ -84,6 +120,8 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
 
     renderers = {
         "model": lambda: _model_short(model),
+        "routed_model": lambda: _routed_suffix(
+            model=model, routed_model=routed_model, combo_prefix=combo_prefix),
         "context_pct": context_pct,
         # Skipped when the caller did not measure (None) or the value is negative.
         "latency": lambda: _format_latency(turn_seconds) if turn_seconds is not None and turn_seconds >= 0 else "",
@@ -94,7 +132,8 @@ def format_runtime_footer(*, model: Optional[str], context_tokens: int,
 
 def build_footer_line(*, user_config: dict[str, Any] | None, platform_key: str | None,
                       model: Optional[str], context_tokens: int, context_length: Optional[int],
-                      cwd: Optional[str] = None, turn_seconds: Optional[float] = None) -> str:
+                      cwd: Optional[str] = None, turn_seconds: Optional[float] = None,
+                      routed_model: Optional[str] = None) -> str:
     """Entry point for gateway/run.py: footer text, or "" when disabled / no data. Callers append it
     to the final response themselves, preserving a single blank line of separation.
     ``turn_seconds`` is the caller-measured (``time.monotonic()``) run duration; ``None`` skips the
@@ -104,4 +143,6 @@ def build_footer_line(*, user_config: dict[str, Any] | None, platform_key: str |
         return ""
     return format_runtime_footer(model=model, context_tokens=context_tokens,
                                  context_length=context_length, cwd=cwd, turn_seconds=turn_seconds,
+                                 routed_model=routed_model,
+                                 combo_prefix=_combo_prefix(user_config),
                                  fields=cfg.get("fields") or _DEFAULT_FIELDS)

--- a/hermes_cli/cli_status_bar_mixin.py
+++ b/hermes_cli/cli_status_bar_mixin.py
@@ -191,6 +191,7 @@ class CLIStatusBarMixin:
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "routed_model": getattr(agent, "_last_routed_model", None),
             "duration": format_duration_compact(elapsed_seconds),
             "session_title": self._get_status_bar_session_title(),
             "prompt_elapsed": self._format_prompt_elapsed(
@@ -1004,6 +1005,15 @@ class CLIStatusBarMixin:
                 segs.append([(_SB, " ☤ "), (_STRONG, model_short)])
             else:
                 segs.append([("", f"☤ {model_short}")])
+            # Routed member (→laguna-s) when on a combo — from the turn result, session-scoped
+            from gateway.runtime_footer import _combo_prefix, _routed_suffix
+            from cli import CLI_CONFIG
+            _prefix = _combo_prefix(CLI_CONFIG if isinstance(CLI_CONFIG, dict) else None)
+            routed = _routed_suffix(model=snapshot.get("model_name"),
+                                    routed_model=snapshot.get("routed_model"),
+                                    combo_prefix=_prefix)
+            if routed and _ok("routed_model"):
+                segs.append([(_DIM, f" {routed}")])
         narrow, wide = width < 52, width >= 76
         if narrow:
             # Narrow bars put duration ahead of the goal segment; the other tiers reverse it.

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -317,3 +317,49 @@ def test_default_build_footer_line_ignores_turn_seconds(monkeypatch):
     with_timing = build_footer_line(**common, turn_seconds=125.0)
     assert baseline == "gpt-5.4 · 5% · /var/data"
     assert with_timing == baseline
+
+
+# ---------------------------------------------------------------------------
+# routed_model (proxy-agnostic combo member display)
+# ---------------------------------------------------------------------------
+
+from gateway.runtime_footer import _combo_prefix, _routed_suffix
+
+
+def test_routed_suffix_combo_shows_member():
+    assert _routed_suffix(model="combo-1m-free-9r",
+                          routed_model="poolside/laguna-s-2.1:free") == "→laguna-s-2.1:free"
+
+
+def test_routed_suffix_non_combo_hidden():
+    assert _routed_suffix(model="opencode-zen/muse-spark-1.3",
+                          routed_model="poolside/laguna-s-2.1:free") == ""
+
+
+def test_routed_suffix_missing_or_echo_hidden():
+    assert _routed_suffix(model="combo-1m-free-9r", routed_model=None) == ""
+    assert _routed_suffix(model="combo-1m-free-9r",
+                          routed_model="combo-1m-free-9r") == ""
+
+
+def test_routed_suffix_custom_prefix():
+    assert _routed_suffix(model="hermes-combo-x", routed_model="a/b",
+                          combo_prefix="hermes-combo") == "→b"
+    assert _routed_suffix(model="combo-1m-free-9r", routed_model="a/b",
+                          combo_prefix="hermes-combo") == ""
+
+
+def test_combo_prefix_default_and_override():
+    assert _combo_prefix(None) == "combo-"
+    assert _combo_prefix({}) == "combo-"
+    assert _combo_prefix({"display": {"combo_prefix": "mycombo-"}}) == "mycombo-"
+    assert _combo_prefix({"display": {"combo_prefix": ""}}) == "combo-"
+
+
+def test_format_footer_routed_model_field():
+    out = format_runtime_footer(
+        model="combo-1m-free-9r", context_tokens=25_300, context_length=1_000_000,
+        routed_model="poolside/laguna-s-2.1:free", cwd=None,
+        fields=["model", "routed_model", "context_pct"],
+    )
+    assert out == "combo-1m-free-9r · →laguna-s-2.1:free · 3%"


### PR DESCRIPTION
## Summary

When the model is a proxy combo (`combo-1m-free-9r`), the CLI status bar and gateway footer show only the requested name. The member that actually answers (e.g. `poolside/laguna-s-2.1:free`) is hidden, yet it determines real cost/latency. The proxy already echoes the member in `response.model` — this PR surfaces it as a `routed_model` footer field (`→member`), gated on `display.combo_prefix` (default `combo-`).

Fixes #106968

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/turn_response_check.py`
  - Capture `response.model` per turn into `agent._last_routed_model` (truthy only, fail-open).
- `agent/conversation_loop.py`
  - Stamp `result["routed_model"]` in `run_conversation` (single seam, all envelopes).
- `gateway/runtime_footer.py`
  - Pure `_routed_suffix()` + `_combo_prefix()` (no subprocess, no proxy brand in code); `format_runtime_footer` / `build_footer_line` take `routed_model` + `combo_prefix`.
- `gateway/run_turn.py`
  - Pass `agent_result.get("routed_model")` into the footer.
- `hermes_cli/cli_status_bar_mixin.py`
  - Snapshot carries `routed_model` from the agent; segment renders it behind `_ok("routed_model")`; journal scraper deleted.
- `tests/gateway/test_runtime_footer.py`
  - 6 new tests (combo/member, non-combo hidden, echo hidden, custom prefix, config default/override, full-field render).

## How to Test

1. Default (no `display.combo_prefix`): footer unchanged, no `→` anywhere.
2. Chat on a `combo-` model → `combo-1m-free-9r →laguna-s-2.1:free`; direct model → no `→`.
3. Run the suites:
   ```bash
   scripts/run_tests.sh tests/gateway/test_runtime_footer.py
   # 43 passed
   scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py
   # 63 passed (touched turn files regression check)
   ```

## Duplicate search

- `footer routed model` open → only #106968; closed → none.
- No open PR implements response.model-based routed display.

## Checklist

- [x] Backward compatible (new field defaults off/empty; unknown fields skipped silently)
- [x] Tests added (6) and passing (43/43 footer, 63/63 run_agent codex responses)
- [x] Branch rebased on latest upstream `main` (8e85b276f1)
- [x] Config covered (`display.combo_prefix`, default `combo-`; set via `hermes config set`)
- [x] Fixes #106968

## Notes for Reviewers

### Suggested labels
`type/feature` `comp/cli` `comp/gateway` `P3`
