### PR TITLE
fix(metadata): GLM context windows from the live catalog; hyphenated slugs, entry-level overrides, aux inherits main pin

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1768,6 +1768,15 @@ def _lower_threshold_to_aux_context(
     )
 
 
+def _aux_inherits_main_route(agent: Any, aux_model: str, aux_base_url: str) -> bool:
+    """True when the auxiliary compression client is the main model on the main endpoint."""
+    from hermes_cli.route_identity import normalize_route_base_url
+    if str(aux_model or "").strip().lower() != str(getattr(agent, "model", "") or "").strip().lower():
+        return False
+    main_base = normalize_route_base_url(str(getattr(agent, "base_url", "") or ""))
+    return not main_base or normalize_route_base_url(aux_base_url) == main_base
+
+
 def check_compression_model_feasibility(agent: Any) -> None:
     """Warn at session start if the aux compression context is below the threshold.
     Called from ``AIAgent.__init__`` (CLI sees it via ``_vprint``); the gateway wires ``status_callback``
@@ -1822,11 +1831,17 @@ def check_compression_model_feasibility(agent: Any) -> None:
         _aux_provider = (
             _aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(agent, "provider", "")
         )
-        aux_context = get_model_context_length(
-            aux_model, base_url=aux_base_url, api_key=aux_api_key,
-            config_context_length=getattr(agent, "_aux_compression_context_length_config", None),
-            provider=_aux_provider, custom_providers=agent._custom_providers,
-        )
+        _aux_cfg_ctx = getattr(agent, "_aux_compression_context_length_config", None)
+        if _aux_cfg_ctx is None and _aux_inherits_main_route(agent, aux_model, aux_base_url):
+            # Same model on the same route: reuse the main model's already-resolved window (which honours
+            # model.context_length / provider pins). Re-resolving from scratch lost the pin and auto-lowered
+            # the session threshold to a catch-all catalog value (#89500, #45519).
+            aux_context = int(agent.context_compressor.context_length)
+        else:
+            aux_context = get_model_context_length(
+                aux_model, base_url=aux_base_url, api_key=aux_api_key, config_context_length=_aux_cfg_ctx,
+                provider=_aux_provider, custom_providers=agent._custom_providers,
+            )
         # Aux model must meet MINIMUM_CONTEXT_LENGTH like the main model, else it cannot summarise a full window.
         if aux_context and aux_context < MINIMUM_CONTEXT_LENGTH:
             raise ValueError(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -353,9 +353,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     "qwen3-coder-plus": 1000000, "qwen3-coder": 262144, "qwen3-max": 262144, "qwen": 131072,
     # MiniMax — M3 is 1M; M2.x is 204,800. https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000, "minimax": 204800,
-    # GLM — 5.2/5.3 are 1M (5.2 verified empirically at 789K on api.z.ai); older GLM ~202K.
+    # GLM — Nous + OpenRouter /v1/models (2026-09-09): 5.3 / 5.3-flash 1,310,720 (:batch/:US 1,048,576);
+    # 5.2 1,048,576; 5 / 5.1 / 4.7 / 4.6 204,800; *-turbo / 4.7-flash 202,752 (the catch-all).
     # The OpenRouter :free variant is capped; the longer key wins.
-    "glm-5.2": 1_048_576, "glm-5.2:free": 256_000, "glm-5.3": 1_048_576, "glm": 202752,
+    "glm-5.3": 1_310_720, "glm-5.3-flash": 1_310_720, "glm-5.3:batch": 1_048_576, "glm-5.3:us": 1_048_576,
+    "glm-5.3-flash:batch": 1_048_576, "glm-5.3-flash:us": 1_048_576,
+    "glm-5.2": 1_048_576, "glm-5.2:free": 256_000,
+    "glm-5.1": 204_800, "glm-5-turbo": 202752, "glm-5v-turbo": 202752, "glm-5": 204_800,
+    "glm-4.7-flash": 202752, "glm-4.7": 204_800, "glm-4.6v": 131072, "glm-4.6": 204_800, "glm": 202752,
     # xAI — /v1/models returns no context_length, so these prevent probe-down on api.x.ai
     # custom providers (docs.x.ai). grok-composer(-2.5-fast, Grok Build CLI) is OAuth-only:
     # 200k usable (the /v1/responses ~262144 input+output budget is a separate limit).
@@ -488,11 +493,17 @@ def _server_root(base_url: str) -> str:
     return server_url[:-3] if server_url.endswith("/v1") else server_url
 
 
+def _catalog_key_matches(key: str, model_lower: str) -> bool:
+    """Substring match with version separators normalised on both sides, so a relay slug like
+    ``z-ai-glm-5-3`` still hits the ``glm-5.3`` entry instead of the ``glm`` catch-all (#97398)."""
+    return key in model_lower or _normalize_model_version(key) in _normalize_model_version(model_lower)
+
+
 def _longest_key_match(table: Dict[str, int], model_lower: str) -> Optional[Tuple[str, int]]:
     """First ``(key, value)`` whose key is a substring of ``model_lower``, longest key first so
     specific entries (``gpt-5.4-mini``) beat their family catch-all (``gpt-5``); ties keep table order."""
     for key, value in sorted(table.items(), key=lambda x: len(x[0]), reverse=True):
-        if key in model_lower:
+        if _catalog_key_matches(key, model_lower):
             return key, value
     return None
 
@@ -1297,7 +1308,7 @@ def _stale_pre_catalog_cache_entry(model: str, cached: int) -> bool:
     """True when a persisted window is a pre-catalog leftover: the model resolves (longest-key-first) to a
     _PRE_CATALOG_STALE_KEYS key and the cached value is <= the largest shorter matching catch-all (or 256K)."""
     model_lower = model.lower()
-    matches = [(key, value) for key, value in DEFAULT_CONTEXT_LENGTHS.items() if key in model_lower]
+    matches = [(key, value) for key, value in DEFAULT_CONTEXT_LENGTHS.items() if _catalog_key_matches(key, model_lower)]
     if not matches:
         return False
     specific_key, specific_value = max(matches, key=lambda kv: len(kv[0]))

--- a/hermes_cli/config_providers.py
+++ b/hermes_cli/config_providers.py
@@ -500,15 +500,23 @@ def get_custom_provider_context_length(
             raw = config.get("custom_providers")
             custom_providers = raw if isinstance(raw, list) else []
 
-    for model_cfg in _route_model_cfgs(model, base_url, custom_providers, config):
-        raw_ctx = model_cfg.get("context_length")
-        if raw_ctx is None:
-            continue
+    def _positive_int(raw: Any) -> Optional[int]:
         try:
-            ctx = int(raw_ctx)
+            ctx = int(raw)
         except (TypeError, ValueError):
-            continue
-        if ctx > 0:
+            return None
+        return ctx if ctx > 0 else None
+
+    for model_cfg in _route_model_cfgs(model, base_url, custom_providers, config):
+        ctx = _positive_int(model_cfg.get("context_length"))
+        if ctx is not None:
+            return ctx
+    # Entry-level ``context_length`` (a documented key) backs every model the entry serves when no
+    # per-model override exists; without it the /model switch re-derivation fell to the hardcoded
+    # catalog while a cold start honoured the same setting via model.context_length (#98387).
+    for entry in _entries_for_route(base_url, custom_providers, config):
+        ctx = _positive_int(entry.get("context_length"))
+        if ctx is not None:
             return ctx
     return None
 

--- a/tests/agent/test_glm_context_window_resolution.py
+++ b/tests/agent/test_glm_context_window_resolution.py
@@ -1,0 +1,42 @@
+"""GLM context windows: hyphenated relay slugs, provider-level custom overrides, and the aux feasibility
+check inherit the right window instead of the ``glm`` 202,752 catch-all (#97398, #98387, #89500)."""
+from types import SimpleNamespace
+
+from agent import conversation_compression as cc
+from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS, get_model_context_length
+from hermes_cli.config_providers import get_custom_provider_context_length
+
+
+def test_hyphenated_relay_slug_resolves_to_specific_catalog_entry():
+    """``z-ai-glm-5-3`` must hit ``glm-5.3``, not the shorter ``glm`` family entry."""
+    assert get_model_context_length("z-ai-glm-5-3", provider="custom") == DEFAULT_CONTEXT_LENGTHS["glm-5.3"]
+    assert DEFAULT_CONTEXT_LENGTHS["glm-5.3"] > DEFAULT_CONTEXT_LENGTHS["glm"]
+
+
+def test_entry_level_custom_provider_context_length_backs_models_without_per_model_override():
+    providers = [{"name": "relay", "base_url": "https://relay.example/v1", "context_length": 1_000_000,
+                  "models": {"pinned": {"context_length": 65536}}}]
+    assert get_custom_provider_context_length("pinned", "https://relay.example/v1", providers) == 65536
+    assert get_custom_provider_context_length("z-ai-glm-5-3", "https://relay.example/v1", providers) == 1_000_000
+    assert get_custom_provider_context_length("x", "https://other.example/v1", providers) is None
+
+
+def test_feasibility_check_inherits_main_window_when_aux_is_the_main_model(monkeypatch):
+    """Main pinned at 1M via model.context_length; aux compression = same model on the same route → the
+    threshold must NOT be auto-lowered to a re-resolved catalog value."""
+    lowered = []
+    monkeypatch.setattr(cc, "_lower_threshold_to_aux_context", lambda *a, **k: lowered.append(k))
+    import agent.auxiliary_client as aux
+    monkeypatch.setattr(aux, "_resolve_task_provider_model", lambda task: ("auto", None, None, None, None))
+    client = SimpleNamespace(base_url="https://relay.example/v1/", api_key="k")
+    monkeypatch.setattr(aux, "get_text_auxiliary_client", lambda task, main_runtime=None: (client, "uncatalogued-relay-model"))
+    import agent.model_metadata as mm
+    monkeypatch.setattr(mm, "get_model_context_length", lambda *a, **k: 128_000)
+    agent = SimpleNamespace(
+        compression_enabled=True, model="uncatalogued-relay-model", base_url="https://relay.example/v1", provider="custom",
+        _custom_providers=None, _aux_compression_context_length_config=None,
+        _current_main_runtime=lambda: None, status_callback=None, _emit_status=lambda m: None,
+        context_compressor=SimpleNamespace(context_length=1_000_000, threshold_tokens=500_000),
+    )
+    cc.check_compression_model_feasibility(agent)
+    assert lowered == []

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1088,13 +1088,14 @@ class TestGetModelContextLength:
         mock_fetch.return_value = {}
         mock_endpoint_fetch.return_value = {}
 
-        # GLM-5-TEE matches the "glm" entry in DEFAULT_CONTEXT_LENGTHS
+        # GLM-5-TEE resolves through DEFAULT_CONTEXT_LENGTHS (longest matching GLM key), not the generic default.
         result = get_model_context_length(
             "zai-org/GLM-5-TEE",
             base_url="https://llm.chutes.ai/v1",
             api_key="test-key",
         )
-        assert result == 202752  # "glm" entry in DEFAULT_CONTEXT_LENGTHS
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS, _longest_key_match
+        assert result == _longest_key_match(DEFAULT_CONTEXT_LENGTHS, "zai-org/glm-5-tee")[1]
 
 
 


### PR DESCRIPTION
One cluster fix for the GLM "202,752" context-window reports. This is also the threshold number in the Coatue compression incident (session on a GLM model via Nous → compression fired against a 202K window, then stalled).

## Root cause

Any GLM slug that misses an explicit `DEFAULT_CONTEXT_LENGTHS` key falls to the `"glm": 202752` catch-all. Three independent ways to miss: hyphenated relay slugs (`z-ai-glm-5-3` vs key `glm-5.3`), the `/model` switch dropping entry-level `custom_providers[].context_length`, and the aux feasibility check re-resolving the main model's window without its pin and auto-lowering the session threshold.

## Changes

- **Catalog from the live providers** (Nous + OpenRouter `/v1/models`, 2026-09-09): `glm-5.3` / `glm-5.3-flash` 1,310,720 (`:batch` / `:US` 1,048,576), `glm-5.2` 1,048,576, `glm-5` / `glm-5.1` / `glm-4.7` / `glm-4.6` 204,800, `*-turbo` / `glm-4.7-flash` 202,752.
- **`_catalog_key_matches`**: version separators normalised on both sides of the substring match (#97398; approach from #97412 by @shellybotmoyer, re-implemented on current main because the PR predates the metadata refactor).
- **`get_custom_provider_context_length`**: entry-level `context_length` backs models without a per-model override (#98387; from #98396 by @liuhao1024, re-implemented on the `config_providers` sibling).
- **`check_compression_model_feasibility`**: aux = main model on the main route reuses the main model's resolved window instead of re-resolving (#89500 mechanism 2; the #45519 recurrence).

## Validation

| Slug / case | origin/main | this PR | live catalog |
|---|---|---|---|
| `z-ai-glm-5-3` (custom relay) | 202,752 | 1,310,720 | 1,310,720 |
| `z-ai/glm-5.3-flash:floor` (openrouter) | 1,310,720 | 1,310,720 | 1,310,720 |
| `z-ai/glm-5.3:US` (nous) | 1,048,576 | 1,048,576 | 1,048,576 |
| `z-ai/glm-5`, `glm-5.1`, `zai-org/GLM-5` | 202,752 | 204,800 | 204,800 |
| `z-ai/glm-5-turbo`, `glm-4.7-flash` | 202,752 | 202,752 | 202,752 |
| entry-level `context_length: 1000000`, model without per-model override | `None` → catalog | 1,000,000 | — |
| main pinned 1M, aux = same model/route → threshold lowered? | yes (to catalog) | no | — |
| `tests/agent/test_glm_context_window_resolution.py` on origin/main | 3 failed | 3 passed | |
| metadata / custom-provider / feasibility test files (15) | — | 296 passed | |

One existing test (`test_custom_endpoint_without_metadata_falls_back_to_catalog`) froze `202752` for `GLM-5-TEE`; converted to assert against the catalog's longest match (it now resolves to `glm-5`).

Closes #97398, #98387, #89500, #87825, #97595, #97820.
Supersedes #87866, #87325, #86993, #87688 (glm-5.3 entry already on main), #97412, #98396 (re-implemented with credit).
