### PR TITLE
fix(a2a): honor A2A_REPLY_TIMEOUT in orphan-task sweep

### DIFF
--- a/plugins/platforms/a2a/README.md
+++ b/plugins/platforms/a2a/README.md
@@ -83,7 +83,7 @@ via `tasks/get`.
 | `A2A_ALLOW_ALL_USERS` | `false` | Allow any authed peer (dev only). |
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity. |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20). |
-| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply. |
+| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply (also the orphan-task sweep timeout). |
 | `A2A_PUSH_SECRET` | bearer token | HMAC secret for push signing. |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict skills on the Agent Card. |
 

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -33,7 +33,7 @@ from . import protocol, security
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 9900
-_ORPHAN_TIMEOUT, _WATCHDOG_INTERVAL = 300, 60  # seconds: pending task considered orphaned / watchdog period
+_WATCHDOG_INTERVAL = 60  # seconds between orphan-task sweeps
 _MAX_BODY = 1_048_576  # 1MB max request body — prevents DoS via memory exhaustion
 _SSE_KEEPALIVE = 5  # seconds between SSE keepalive comments
 _DEFAULT_DESCRIPTION = "Hermes Agent — a general-purpose agent reachable over A2A."
@@ -67,6 +67,15 @@ def _reply_timeout() -> float:
         return max(1.0, float(os.getenv("A2A_REPLY_TIMEOUT", "300")))
     except (ValueError, TypeError):
         return 300.0
+
+
+def _orphan_timeout() -> float:
+    """Seconds before a pending inbound task is treated as orphaned.
+
+    Same source as the HTTP reply wait so raising ``A2A_REPLY_TIMEOUT``
+    also extends the watchdog sweep (issue #106972).
+    """
+    return _reply_timeout()
 
 
 def _default_agent_name() -> str:
@@ -334,8 +343,9 @@ class A2AAdapter(BasePlatformAdapter):
         """Background thread that fails orphaned tasks (keeps them queryable)."""
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL):
             try:
-                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT):
-                    logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, _ORPHAN_TIMEOUT)
+                timeout = int(_orphan_timeout())
+                for tid in self.tasks.fail_orphans(timeout):
+                    logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, timeout)
                     protocol.metrics.tasks_failed += 1
             except Exception:
                 logger.debug("A2A: watchdog error", exc_info=True)

--- a/tests/plugins/test_a2a_orphan_timeout.py
+++ b/tests/plugins/test_a2a_orphan_timeout.py
@@ -1,0 +1,72 @@
+"""Orphan-task sweep must honor A2A_REPLY_TIMEOUT (issue #106972).
+
+Raising A2A_REPLY_TIMEOUT used to only extend the HTTP reply wait; the
+watchdog still swept with a hardcoded 300s, so long tasks were marked
+TASK_STATE_FAILED and the real reply was silently discarded.
+"""
+
+from __future__ import annotations
+
+import inspect
+import time
+
+from plugins.platforms.a2a import adapter, protocol
+
+
+def _age_nonterminal_task(store: protocol.TaskStore, task_id: str, age_seconds: float) -> None:
+    rec = store.get(task_id)
+    assert rec is not None
+    store._tasks[task_id]["created_at"] = time.time() - age_seconds
+
+
+def test_orphan_timeout_follows_a2a_reply_timeout(monkeypatch):
+    monkeypatch.setenv("A2A_REPLY_TIMEOUT", "600")
+    assert adapter._orphan_timeout() == adapter._reply_timeout()
+    assert adapter._orphan_timeout() == 600.0
+
+
+def test_orphan_timeout_default_is_300(monkeypatch):
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    assert adapter._orphan_timeout() == adapter._reply_timeout()
+    assert adapter._orphan_timeout() == 300.0
+
+
+def test_orphan_timeout_invalid_env_falls_back(monkeypatch):
+    monkeypatch.setenv("A2A_REPLY_TIMEOUT", "not-a-number")
+    assert adapter._orphan_timeout() == adapter._reply_timeout()
+    assert adapter._orphan_timeout() == 300.0
+
+
+def test_orphan_timeout_clamps_below_one(monkeypatch):
+    monkeypatch.setenv("A2A_REPLY_TIMEOUT", "0")
+    assert adapter._orphan_timeout() == adapter._reply_timeout()
+    assert adapter._orphan_timeout() == 1.0
+
+
+def test_orphan_sweep_spares_task_younger_than_raised_timeout(monkeypatch):
+    """age=400s must survive when A2A_REPLY_TIMEOUT=600 (hardcoded 300 would fail it)."""
+    monkeypatch.setenv("A2A_REPLY_TIMEOUT", "600")
+    store = protocol.TaskStore()
+    store.create("t-long", "ctx", "peer")
+    _age_nonterminal_task(store, "t-long", 400)
+    failed = store.fail_orphans(int(adapter._orphan_timeout()))
+    assert failed == []
+    assert store.get("t-long")["state"] not in protocol.TERMINAL_STATES
+
+
+def test_orphan_sweep_still_fails_when_timeout_is_default(monkeypatch):
+    """CONTROL: sweep still works — age=400s fails under the default 300s timeout."""
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    store = protocol.TaskStore()
+    store.create("t-stale", "ctx", "peer")
+    _age_nonterminal_task(store, "t-stale", 400)
+    failed = store.fail_orphans(int(adapter._orphan_timeout()))
+    assert failed == ["t-stale"]
+    assert store.get("t-stale")["state"] == protocol.STATE_FAILED
+
+
+def test_watchdog_loop_uses_orphan_timeout_helper():
+    """_watchdog_loop must pass the env-derived timeout, not the old 300s constant."""
+    src = inspect.getsource(adapter.A2AAdapter._watchdog_loop)
+    assert "_orphan_timeout()" in src
+    assert "fail_orphans(_ORPHAN_TIMEOUT)" not in src

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -102,7 +102,7 @@ Secure by default; every widening step is explicit:
 | `A2A_ALLOW_ALL_USERS` | `false` | Allow any authenticated peer (dev only) |
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20) |
-| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply |
+| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply (also the orphan-task sweep timeout) |
 | `A2A_PUSH_SECRET` | bearer token | HMAC secret for push-notification signing |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict which skills appear on the Agent Card |
 


### PR DESCRIPTION
## What does this PR do?

Raising `A2A_REPLY_TIMEOUT` previously only extended the inbound HTTP reply wait. The orphan-task watchdog still swept with a hardcoded 300s timeout, so long-running tasks were marked `TASK_STATE_FAILED` first and the real late reply was silently discarded by `complete()`'s terminal-state guard.

This change makes the orphan sweep use the same timeout source as `_reply_timeout()` (`A2A_REPLY_TIMEOUT`), and documents that shared meaning.

## Related Issue

Fixes #106972

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/a2a/adapter.py`: add `_orphan_timeout()` that delegates to `_reply_timeout()`; `_watchdog_loop` passes that value to `fail_orphans` and logs the actual timeout
- `tests/plugins/test_a2a_orphan_timeout.py`: focused regression — raised timeout spares age=400s tasks; default 300s CONTROL still fails them; invalid/missing env fail-open
- `plugins/platforms/a2a/README.md` + `website/docs/user-guide/messaging/a2a.md`: note that orphan sweep uses the same env var

## How to Test

1. `scripts/run_tests.sh tests/plugins/test_a2a_orphan_timeout.py -q`
2. With `A2A_REPLY_TIMEOUT=600`, a pending task aged ~400s must not be orphan-failed by the sweep timeout helper
3. With env unset, the same age=400s task is still failed (CONTROL)

## Proof Receipt

- BEFORE (pre-fix): focused suite RED — `_orphan_timeout` missing / watchdog still bound to `_ORPHAN_TIMEOUT` (7 failed)
- AFTER: same suite GREEN (7 passed)
- CONTROL: default 300s still fails age=400s orphans

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — focused unit proof only.

Made with [Cursor](https://cursor.com)