### PR TITLE
fix(browser): return Camofox navigation titles

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -107,6 +107,25 @@ class TestCamofoxNavigate:
         assert result["url"] == "https://example.com"
 
 
+    @patch("tools.browser_camofox._fetch_snapshot", return_value=("", 0))
+    @patch("tools.browser_camofox.get_vnc_url", return_value=None)
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_reads_title_from_owned_tab_when_navigation_response_omits_it(
+            self, mock_post, mock_get, _mock_vnc, _mock_snapshot, monkeypatch):
+        """Camofox navigation replies omit title although the owned tab listing has it."""
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab-title", "url": "https://example.com"})
+        mock_get.return_value = _mock_response(json_data={"tabs": [{
+            "tabId": "tab-title", "title": "Example Domain", "url": "https://example.com",
+        }]})
+
+        result = json.loads(camofox_navigate("https://example.com", task_id="t_title"))
+
+        assert result["success"] is True
+        assert result["title"] == "Example Domain"
+        assert mock_get.call_args.kwargs["params"] == {"userId": mock_post.call_args.kwargs["json"]["userId"]}
+
     def test_connection_error_returns_helpful_message(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")
         result = json.loads(camofox_navigate("https://example.com", task_id="t_err"))

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -371,12 +371,28 @@ def _navigate_tab(task_id: Optional[str], browser_url: str) -> tuple[Dict[str, A
     return _ensure_tab(task_id, browser_url), {"ok": True, "url": browser_url}
 
 
+def _navigate_title(session: Dict[str, Any], data: dict) -> str:
+    """Return the navigation title, looking up this owned tab when Camofox omits it."""
+    response_title = data.get("title")
+    if isinstance(response_title, str) and response_title:
+        return response_title
+    try:
+        tabs = _get("/tabs", params=_user_params(session)).get("tabs", [])
+        for tab in tabs if isinstance(tabs, list) else []:
+            if isinstance(tab, dict) and tab.get("tabId") == session["tab_id"]:
+                title = tab.get("title")
+                return title if isinstance(title, str) else ""
+    except Exception as exc:
+        logger.debug("Camofox title lookup failed for tab %s: %s", session.get("tab_id"), exc)
+    return ""
+
+
 def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
     """Navigate to a URL via Camofox."""
     try:
         browser_url, rewrite_info = _rewrite_loopback_url_for_camofox(url)
         session, data = _navigate_tab(task_id, browser_url)
-        result = {"success": True, "url": data.get("url", browser_url), "title": data.get("title", "")}
+        result = {"success": True, "url": data.get("url", browser_url), "title": _navigate_title(session, data)}
         if rewrite_info:
             result["requested_url"], result["url_rewrite"] = url, rewrite_info
             result["warning"] = ("Rewrote loopback URL for Docker-hosted Camofox: "


### PR DESCRIPTION
## Summary
- Camofox navigation mutation responses omit page-title metadata even though the task-owned tab listing exposes it.
- Recover the title with a read-only `GET /tabs?userId=<owned-user>` lookup for the exact task tab, while preserving the legacy empty-title fallback on lookup failure.
- Add a handler-level synthetic response regression.

## Verification
- `PYTHONPATH="$PWD" /Users/brianle/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_ensure_tab.py -q` (23 passed)
- `uv run ruff check tools/browser_camofox.py tests/tools/test_browser_camofox.py`
- Live disposable Camofox probe against `127.0.0.1:9377` using a local synthetic fixture returned its title.

No Camofox runtime/engine changes; no Chrome/manual routing or identity changes. Related Camofox #8380 concerns console capture and is intentionally untouched.