### PR TITLE
fix(desktop/settings): searchable-select popover sized to content, not the shrink-wrapped trigger

### DIFF
--- a/apps/desktop/src/app/settings/combobox-input.tsx
+++ b/apps/desktop/src/app/settings/combobox-input.tsx
@@ -81,7 +81,7 @@ export function ComboboxInput({
       </PopoverAnchor>
       <PopoverContent
         align="start"
-        className="w-[var(--radix-popover-trigger-width)] p-0"
+        className="min-w-(--radix-popover-trigger-width) p-0"
         onOpenAutoFocus={e => e.preventDefault()}
       >
         <Command shouldFilter={false}>

--- a/apps/desktop/src/app/settings/searchable-select.test.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.test.tsx
@@ -83,6 +83,22 @@ describe('SearchableSelect', () => {
     expect(screen.queryByText('System default')).toBeNull()
   })
 
+  it('lets the option list size to its content instead of the shrink-wrapped trigger', () => {
+    // The trigger shrink-wraps to its current value inside the settings grid
+    // (~120px for "Europe/Berlin"); pinning the popover width to it clipped
+    // every IANA row after "Africa/A…". The popover may grow to cover a wider
+    // trigger, but must never be capped at the trigger's width.
+    render(<SearchableSelect onChange={vi.fn()} options={options} value="Europe/Berlin" />)
+
+    fireEvent.click(screen.getByRole('combobox'))
+
+    const content = screen.getByRole('listbox', { hidden: true }).closest('[data-slot="popover-content"]')
+    const classes = content?.className.split(/\s+/) ?? []
+
+    expect(classes.some(c => c.startsWith('min-w-') && c.includes('radix-popover-trigger-width'))).toBe(true)
+    expect(classes.some(c => /^w-[[(].*radix-popover-trigger-width/.test(c))).toBe(false)
+  })
+
   it('shows the placeholder when the value is blank', () => {
     render(<SearchableSelect onChange={vi.fn()} options={options} placeholder="Search…" value="" />)
 

--- a/apps/desktop/src/app/settings/searchable-select.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.tsx
@@ -88,7 +88,11 @@ export function SearchableSelect({
           <Codicon className="shrink-0 opacity-60" name={open ? 'chevron-up' : 'chevron-down'} size="1rem" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+      {/* min-w, not w: the trigger shrink-wraps to its current value inside the
+          settings grid, so a width pinned to it clipped every IANA row after
+          "Africa/A…". The popover keeps its own width and only grows to cover a
+          trigger wider than that. */}
+      <PopoverContent align="start" className="min-w-(--radix-popover-trigger-width) p-0">
         <Command filter={rankSearchOption}>
           <CommandInput autoFocus placeholder={placeholder} />
           <CommandList>


### PR DESCRIPTION
## Symptom
Settings → Chat → Timezone: the dropdown opens but every entry is clipped to `Afric…` / `System defa…`, so the picker is unusable by eye. (Selection itself worked when you could guess a row; the failure is visual.)

## Cause
`SearchableSelect` (and the voice/model `ComboboxInput`) set `w-[var(--radix-popover-trigger-width)]` on the `PopoverContent`. In the settings `ListRow` grid the control cell is `justify-self-end`, so the trigger shrink-wraps to its current value (~90–123px). The list inherited that width and clipped every IANA identifier.

## Fix
`w-(…)` → `min-w-(--radix-popover-trigger-width)`: the popover keeps its own width and only grows to cover a trigger wider than that. Same one-line change in `combobox-input.tsx`, which shares the pattern.

## Verification
Live on a sandboxed Electron instance (throwaway `HOME`/`HERMES_HOME`, real `hermes serve` backend, driven over CDP):
- popover width 123px → 288px; `scrollWidth > clientWidth` on rows: true → false
- click-select, type + Enter, and the debounced autosave all land (`timezone: Europe/Berlin` in the sandbox `config.yaml`)

Before / after screenshots attached in the first comment.

Test: `searchable-select.test.tsx` gains one contract test (popover class is `min-w-…trigger-width`, never `w-…trigger-width`), red on base / green with the fix. `npx vitest run src/app/settings/searchable-select.test.tsx` → 13 passed; eslint + prettier + tsc clean.