### PR TITLE
fix(desktop): wait for session discovery without discarding queued prompts

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -256,4 +256,36 @@ describe('useComposerQueue park integration', () => {
     expect(isQueueParked(SESSION_KEY)).toBe(false)
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(1)
   })
+
+  it('does not auto-drain restored queues while the session list is still loading', async () => {
+    setSessionsLoading(true)
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'wait for session list' })
+
+    const { onSubmit } = renderQueueHook()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(1)
+  })
+
+  it('auto-drains a restored queue once the session list finishes loading', async () => {
+    setSessionsLoading(true)
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'send after load' })
+
+    const { hook, onSubmit } = renderQueueHook()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    setSessionsLoading(false)
+    hook.rerender({ busy: false })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
+  })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -10,6 +10,7 @@ import {
   MAX_AUTO_DRAIN_ATTEMPTS,
   parkQueuedPrompts
 } from '@/store/composer-queue'
+import { setSessionsLoading } from '@/store/session'
 
 import type { QueueEditState } from '../composer-utils'
 import type { ChatBarProps } from '../types'
@@ -58,6 +59,7 @@ describe('useComposerQueue park integration', () => {
     window.localStorage.clear()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    setSessionsLoading(false)
   })
 
   afterEach(() => {
@@ -65,6 +67,7 @@ describe('useComposerQueue park integration', () => {
     vi.restoreAllMocks()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    setSessionsLoading(true)
   })
 
   it('reschedules rejected foreground drains to a bounded stop and keeps manual recovery', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -22,6 +22,7 @@ import {
   updateQueuedPrompt
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
+import { $sessionsLoading } from '@/store/session'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { useComposerScope } from '../scope'
@@ -80,6 +81,7 @@ export function useComposerQueue({
   // is fine; the auto-drain effect below reads it as a gate.
   const parkedSessions = useStore($parkedQueueSessions)
   const queueParked = Boolean(activeQueueSessionKey && parkedSessions[activeQueueSessionKey])
+  const sessionsLoading = useStore($sessionsLoading)
 
   const [queueEdit, setQueueEdit] = useState<QueueEditState | null>(null)
   queueEditRef.current = queueEdit
@@ -402,10 +404,18 @@ export function useComposerQueue({
   // strand them. A park (explicit Stop/Esc) is the one gate: those entries wait
   // for the user. To cancel queued turns, the user deletes them from the panel.
   useEffect(() => {
+    // Same gate as the background drainer: while the session list is
+    // unavailable, a restored localStorage entry has no resumable runtime to
+    // target, so draining only burns its retry budget and toasts. Covers app
+    // boot, a gateway/profile switch, and any refresh over an empty list.
+    if (sessionsLoading) {
+      return
+    }
+
     if (shouldAutoDrain({ isBusy: busy, parked: queueParked, queueLength: queuedPrompts.length })) {
       return autoDrainNext()
     }
-  }, [autoDrainNext, busy, drainRetryTick, queueParked, queuedPrompts.length])
+  }, [autoDrainNext, busy, drainRetryTick, queueParked, queuedPrompts.length, sessionsLoading])
 
   // Queue-edit cleanup: on session swap the scope effect already stashed the
   // edit snapshot; only restore into the composer when still on the same scope.

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -404,10 +404,8 @@ export function useComposerQueue({
   // strand them. A park (explicit Stop/Esc) is the one gate: those entries wait
   // for the user. To cancel queued turns, the user deletes them from the panel.
   useEffect(() => {
-    // Same gate as the background drainer: while the session list is
-    // unavailable, a restored localStorage entry has no resumable runtime to
-    // target, so draining only burns its retry budget and toasts. Covers app
-    // boot, a gateway/profile switch, and any refresh over an empty list.
+    // Match the background drainer: preserve the retry budget while session
+    // discovery runs at boot, on a gateway/profile switch, or over an empty list.
     if (sessionsLoading) {
       return
     }

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -10,7 +10,7 @@ import {
   getQueuedPrompts,
   parkQueuedPrompts
 } from '@/store/composer-queue'
-import { $sessions, setSessions } from '@/store/session'
+import { $sessions, setSessions, setSessionsLoading } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
 
@@ -62,6 +62,9 @@ describe('useBackgroundQueueDrain', () => {
   beforeEach(() => {
     vi.useRealTimers()
     clearAllSessionStates()
+    // Production drain waits for the sidebar list. Tests that assert drain
+    // behavior are post-load unless they opt into the loading gate.
+    setSessionsLoading(false)
   })
 
   afterEach(() => {
@@ -71,6 +74,7 @@ describe('useBackgroundQueueDrain', () => {
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
     $sessions.set([])
+    setSessionsLoading(true)
     clearAllSessionStates()
   })
 

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -226,4 +226,52 @@ describe('useBackgroundQueueDrain', () => {
     expect(submitText).toHaveBeenCalledTimes(2)
     expect(getQueuedPrompts('stored-session-a')).toHaveLength(0)
   })
+
+  it('does not drain restored queues while the session list is still loading', async () => {
+    vi.useFakeTimers()
+    setSessionsLoading(true)
+
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => true)
+
+    enqueueQueuedPrompt('stored-session-a', { text: 'wait for session list', attachments: [] })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    // Four 750ms retries is what used to burn the drain budget and toast on boot.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(750 * 4)
+      await Promise.resolve()
+    })
+
+    expect(submitText).not.toHaveBeenCalled()
+    expect(getQueuedPrompts('stored-session-a')).toHaveLength(1)
+  })
+
+  it('drains a restored background queue once the session list finishes loading', async () => {
+    setSessionsLoading(true)
+
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => true)
+
+    enqueueQueuedPrompt('stored-session-a', { text: 'send after load', attachments: [] })
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(submitText).not.toHaveBeenCalled()
+
+    setSessionsLoading(false)
+
+    await waitFor(() => {
+      expect(submitText).toHaveBeenCalledWith('send after load', {
+        attachments: [],
+        fromQueue: true,
+        sessionId: 'rt-session-a',
+        storedSessionId: 'stored-session-a'
+      })
+    })
+
+    await waitFor(() => expect(getQueuedPrompts('stored-session-a')).toHaveLength(0))
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -13,7 +13,7 @@ import {
   shouldAutoDrain
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
-import { $sessions, idsShareLineage } from '@/store/session'
+import { $sessions, $sessionsLoading, idsShareLineage } from '@/store/session'
 import { $workingSessionIds } from '@/store/session-states'
 
 import type { SubmitTextOptions } from './use-prompt-actions/utils'
@@ -46,6 +46,7 @@ export function useBackgroundQueueDrain({
   const { t } = useI18n()
   const queuedPromptsBySession = useStore($queuedPromptsBySession)
   const parkedQueueSessions = useStore($parkedQueueSessions)
+  const sessionsLoading = useStore($sessionsLoading)
   const workingSessionIds = useStore($workingSessionIds)
   const submitTextRef = useRef(submitText)
   const drainingSessionIdsRef = useRef(new Set<string>())
@@ -151,13 +152,19 @@ export function useBackgroundQueueDrain({
   )
 
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || sessionsLoading) {
       return
     }
 
     // Queue keys prefer the lineage root (resolveComposerSessionKey) while
     // $workingSessionIds / selection may hold the compression tip. Strict
     // equality then mis-classifies a busy or selected chat as idle/offscreen.
+    //
+    // Boot/reconnect: the composer queue survives in localStorage, but session
+    // runtimes are reaped. Draining before the sidebar list has loaded burns
+    // MAX_AUTO_DRAIN_ATTEMPTS against a backend that cannot resume yet, then
+    // toasts "Queued message not sent" on every launch even when the user has
+    // no visible queue (#98015).
     const sessions = $sessions.get()
     const working = [...workingSessionIds]
 
@@ -194,6 +201,7 @@ export function useBackgroundQueueDrain({
     queuedPromptsBySession,
     retryTick,
     selectedStoredSessionId,
+    sessionsLoading,
     workingSessionIds
   ])
 }

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -152,6 +152,9 @@ export function useBackgroundQueueDrain({
   )
 
   useEffect(() => {
+    // Preserve the retry budget while session discovery runs at boot, on a
+    // gateway/profile switch, or during a refresh over an empty list.
+    // Once discovery settles, submitText can resume by stored id.
     if (!enabled || sessionsLoading) {
       return
     }
@@ -159,12 +162,6 @@ export function useBackgroundQueueDrain({
     // Queue keys prefer the lineage root (resolveComposerSessionKey) while
     // $workingSessionIds / selection may hold the compression tip. Strict
     // equality then mis-classifies a busy or selected chat as idle/offscreen.
-    //
-    // Boot/reconnect: the composer queue survives in localStorage, but session
-    // runtimes are reaped. Draining before the sidebar list has loaded burns
-    // MAX_AUTO_DRAIN_ATTEMPTS against a backend that cannot resume yet, then
-    // toasts "Queued message not sent" on every launch even when the user has
-    // no visible queue (#98015).
     const sessions = $sessions.get()
     const working = [...workingSessionIds]
 

--- a/apps/desktop/src/app/session/hooks/use-background-queue-preservation.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-preservation.test.tsx
@@ -1,0 +1,72 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import {
+  $parkedQueueSessions,
+  $queuedPromptsBySession,
+  enqueueQueuedPrompt,
+  getQueuedPrompts,
+  MAX_AUTO_DRAIN_ATTEMPTS
+} from '@/store/composer-queue'
+import { clearNotifications } from '@/store/notifications'
+import { $sessions, forgetSessionOwnerHintsForSession, setSessionOwnerHint, setSessionsLoading } from '@/store/session'
+import { clearAllSessionStates } from '@/store/session-states'
+
+import { useBackgroundQueueDrain } from './use-background-queue-drain'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  $queuedPromptsBySession.set({})
+  $parkedQueueSessions.set({})
+  $sessions.set([])
+  setSessionsLoading(true)
+  forgetSessionOwnerHintsForSession('hidden-bot-chat')
+  clearNotifications()
+  clearAllSessionStates()
+})
+
+it.each(['rejection', 'transport error'])(
+  'preserves a known hidden session queue after transient %s',
+  async failure => {
+    vi.useFakeTimers()
+    $sessions.set([])
+    setSessionsLoading(false)
+    clearAllSessionStates()
+    setSessionOwnerHint('hidden-bot-chat', { connectionId: 'remote-a', profile: 'bot' })
+    const first = enqueueQueuedPrompt('hidden-bot-chat', { text: 'retry this later', attachments: [] })!
+    const second = enqueueQueuedPrompt('hidden-bot-chat', { text: 'not attempted yet', attachments: [] })!
+    const submitText = vi.fn<(text: string) => Promise<boolean>>()
+
+    if (failure === 'transport error') {
+      submitText.mockRejectedValue(new Error('WebSocket temporarily disconnected'))
+    } else {
+      submitText.mockResolvedValue(false)
+    }
+
+    const runtimeMap = { current: new Map([['hidden-bot-chat', 'live-runtime']]) }
+
+    renderHook(() =>
+      useBackgroundQueueDrain({
+        enabled: true,
+        runtimeIdByStoredSessionIdRef: runtimeMap,
+        selectedStoredSessionId: 'foreground',
+        submitText
+      })
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    for (let attempt = 1; attempt < MAX_AUTO_DRAIN_ATTEMPTS; attempt++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(750)
+      })
+    }
+
+    expect(submitText).toHaveBeenCalledTimes(MAX_AUTO_DRAIN_ATTEMPTS)
+    expect(submitText.mock.calls.every(call => call[0] === first.text)).toBe(true)
+    expect(getQueuedPrompts('hidden-bot-chat').map(entry => entry.id)).toEqual([first.id, second.id])
+  }
+)


### PR DESCRIPTION
## Summary

Wait for session discovery before auto-draining restored composer queues. Both foreground and background drainers preserve their retry budget while the session list is loading, then use the existing stored-session resume path. Bounded retries, failure notifications, and manual recovery remain unchanged.

This keeps @xxxigm's loading-gate fix and tests, cherry-picked with their original authorship, plus the maintainer's retry dependency and comment corrections. It excludes the later list-based queue deletion: loaded rows are a partial cache, and a hidden or off-page session can have a valid owner and runtime even when a send fails. Clearing the queue at that point also deletes messages that were never attempted.

Supersedes [#102973](https://github.com/NousResearch/hermes-agent/pull/102973). The earlier duplicate [#102919](https://github.com/NousResearch/hermes-agent/pull/102919) is already closed.

Related: [#98015](https://github.com/NousResearch/hermes-agent/issues/98015). This fixes early drain scheduling; it does not claim authoritative orphan detection or complete recovery for every missing-runtime case. Foreground-connectivity scheduling in [#105984](https://github.com/NousResearch/hermes-agent/pull/105984) is not included.

## Test plan

- [x] Targeted and adjacent Vitest suites: 6 files, 61 tests passed (both drainers, queue store, runtime target resolution, single-flight resume, hidden-session preservation).
- [x] Loading-gate tests against current-main source: 4 failures; all pass with the fix.
- [x] Preservation probes: a hidden session with a known remote owner and runtime retains both queued entries after repeated false returns or transport errors. Both cases fail against the superseded drainer, which deletes the entire queue after attempting only the first entry.
- [x] Desktop typecheck passed (renderer, Electron, E2E projects).
- [x] ESLint on changed files and `git diff --check` passed.

The preservation tests exercise the real hook and stores, with submission mocked at its boundary. No live gateway or native Electron E2E run was performed.
