### PR TITLE
fix(mcp): forward proxy env vars to stdio MCP subprocesses

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1442,6 +1442,51 @@ class TestBuildSafeEnv:
         assert "GITHUB_TOKEN" not in result
         assert "OPENAI_API_KEY" not in result
 
+    def test_proxy_env_vars_forwarded_from_parent(self):
+        """Parent http(s)/no_proxy keys (both cases) must reach stdio MCP children."""
+        from tools.mcp_tool_config import _build_safe_env
+
+        fake_env = {
+            "PATH": "/usr/bin",
+            "http_proxy": "http://proxy.example:8080",
+            "https_proxy": "http://proxy.example:8080",
+            "no_proxy": "localhost,127.0.0.1",
+            "HTTP_PROXY": "http://proxy.example:8080",
+            "HTTPS_PROXY": "http://proxy.example:8443",
+            "NO_PROXY": "localhost",
+            "SECRET_KEY": "should_not_appear",
+        }
+        with patch.dict("os.environ", fake_env, clear=True):
+            result = _build_safe_env(None)
+        assert result["http_proxy"] == "http://proxy.example:8080"
+        assert result["https_proxy"] == "http://proxy.example:8080"
+        assert result["no_proxy"] == "localhost,127.0.0.1"
+        assert result["HTTP_PROXY"] == "http://proxy.example:8080"
+        assert result["HTTPS_PROXY"] == "http://proxy.example:8443"
+        assert result["NO_PROXY"] == "localhost"
+        assert "SECRET_KEY" not in result
+
+    def test_user_env_proxy_overrides_parent(self):
+        """Server config env: wins; unset parent proxy keys are not invented."""
+        from tools.mcp_tool_config import _build_safe_env
+
+        fake_env = {
+            "PATH": "/usr/bin",
+            "http_proxy": "http://parent-proxy:8080",
+            "HTTPS_PROXY": "http://parent-proxy:8443",
+        }
+        user_env = {
+            "http_proxy": "http://server-config-proxy:9000",
+        }
+        with patch.dict("os.environ", fake_env, clear=True):
+            result = _build_safe_env(user_env)
+        assert result["http_proxy"] == "http://server-config-proxy:9000"
+        assert result["HTTPS_PROXY"] == "http://parent-proxy:8443"
+        assert "https_proxy" not in result
+        assert "no_proxy" not in result
+        assert "NO_PROXY" not in result
+        assert "HTTP_PROXY" not in result
+
 
 # ---------------------------------------------------------------------------
 # _sanitize_error

--- a/tools/mcp_tool_config.py
+++ b/tools/mcp_tool_config.py
@@ -54,7 +54,15 @@ def _write_stderr_log_header(server_name: str) -> None:
 
 
 # Env vars safe to pass to stdio subprocesses (no secrets).
-_SAFE_ENV_KEYS = frozenset({"PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL", "TMPDIR"})
+# Proxy keys are forwarded independently in both common cases so stdio MCP
+# children inherit the parent process's outbound proxy (http/https/no_proxy
+# and ALL_PROXY, matching other Hermes proxy consumers). Unset keys stay
+# absent; do not glob on "PROXY" — that would leak custom secret-named vars.
+_SAFE_ENV_KEYS = frozenset({
+    "PATH", "HOME", "USER", "LANG", "LC_ALL", "TERM", "SHELL", "TMPDIR",
+    "http_proxy", "https_proxy", "no_proxy", "all_proxy",
+    "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY",
+})
 
 # Windows process/location vars needed by launcher-style tools (e.g. Docker Desktop's MCP plugin discovery).
 _SAFE_ENV_KEYS_CASE_INSENSITIVE = frozenset({
@@ -93,8 +101,10 @@ _CONTEXT_VAR_RESOLVERS = {
 
 def _build_safe_env(user_env: Optional[dict]) -> dict:
     """Filtered env for stdio subprocesses so API keys/tokens don't leak: the safe baseline
-    keys, ``XDG_*``, vars injected by an external secret source (users configured that backend
-    precisely so subprocesses can consume them), plus the server config's own ``env``."""
+    keys (including parent ``http_proxy``/``https_proxy``/``no_proxy``/``ALL_PROXY`` in both
+    common cases, when set), ``XDG_*``, vars injected by an external secret source (users
+    configured that backend precisely so subprocesses can consume them), plus the server
+    config's own ``env`` (which still overrides the parent for the same key)."""
     from agent.secret_scope import get_secret
     from hermes_cli.env_loader import secret_source_names
     env = {


### PR DESCRIPTION
## What does this PR do?

`_build_safe_env` builds the environment for spawned stdio MCP servers but previously omitted proxy variables. In deployments that require outbound traffic through an L7 proxy, MCP tool handlers that make raw HTTP calls silently time out even though the MCP handshake itself succeeds.

This change adds an explicit allowlist entry for `http_proxy` / `https_proxy` / `no_proxy` / `all_proxy` and their uppercase forms so children inherit the parent process proxy settings when set. Server config `env:` still overrides the parent for the same key. Secrets and non-allowlisted vars remain filtered.

## Related Issue

Fixes #106984

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `tools/mcp_tool_config.py`: extend `_SAFE_ENV_KEYS` with common proxy env vars; document inheritance/override semantics
- `tests/tools/test_mcp_tool.py`: RED/GREEN coverage for parent forwarding, user_env override, and fail-open when unset

## How to Test

```bash
# focused suite (TestBuildSafeEnv)
./scripts/run_tests.sh tests/tools/test_mcp_tool.py::TestBuildSafeEnv -q
  -> 6 passed
```

Pre-fix (same tests on main without the allowlist change): 2 failed with `KeyError` for `http_proxy` / `HTTPS_PROXY`.

## Review follow-up

- Allowlist is exact-match only (no `*PROXY*` glob) to avoid leaking custom secret-named vars.
- Mixed-case forms like `Http_Proxy` are intentionally not forwarded; only the common lower/upper pairs used across Hermes proxy consumers.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] Conventional Commits (`fix(mcp): ...`)
- [x] Searched existing PRs for duplicates
- [x] Only changes related to this fix
- [x] Ran relevant tests locally
- [x] Added tests for the change
- [x] Tested on macOS

### Documentation & Housekeeping
- [x] Docs N/A (behavior aligns with existing proxy env conventions)
- [x] cli-config.yaml.example N/A
- [x] Cross-platform: case variants preserved independently
- [x] Tool schemas N/A


Made with [Cursor](https://cursor.com)