### PR TITLE
fix(desktop): name the real precondition when a remote-mode install has no venv to update

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -406,8 +406,8 @@ import {
   wrapHandoffForDetachedConsole
 } from './updater-process'
 import {
+  classifyProbeFailure,
   formatBlockerMessage,
-  formatProbeFailedMessage,
   scanVenvBlockers,
   stopSafeVenvBlockers
 } from './venv-blocker-scan'
@@ -4143,7 +4143,10 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
       }
 
       if (scanOutcome.kind === 'probe-failure') {
-        const message = formatProbeFailedMessage(scanOutcome.error)
+        const { code, message } = classifyProbeFailure(
+          scanOutcome.error,
+          modeIsRemoteLike(readDesktopConnectionConfig().mode)
+        )
 
         rememberLog(`[updates] venv-blocker probe failed: ${scanOutcome.error}`)
         emitUpdateProgress({ stage: 'error', message, percent: null })
@@ -4151,7 +4154,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         // Same drain-semantics restore as the venv-blocked abort above.
         startGatewaysAfterUpdateAbort(venvHermesShimPath(updateRoot))
 
-        return { ok: false, error: 'venv-probe-failed', message }
+        return { ok: false, error: code, message }
       }
     }
 

--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -15,6 +15,7 @@ import path from 'node:path'
 import { describe, it } from 'vitest'
 
 import {
+  classifyProbeFailure,
   formatBlockerMessage,
   formatProbeFailedMessage,
   parseVenvBlockerScanOutput,
@@ -80,6 +81,28 @@ describe('formatProbeFailedMessage', () => {
     const msg = formatProbeFailedMessage('timed out after 60 seconds')
     assert.ok(msg.includes('timed out after 60 seconds'))
     assert.ok(msg.includes('no blocking process was confirmed'))
+  })
+})
+
+describe('classifyProbeFailure', () => {
+  it('reports no-local-venv, not a generic probe failure, when a remote-mode install has no venv', () => {
+    const { code, message } = classifyProbeFailure('venv python not found', true)
+    assert.equal(code, 'no-local-venv')
+    assert.ok(message.includes('remote'))
+    assert.ok(!message.includes('installation is not free'))
+    assert.ok(!message.includes('Close other Hermes windows'))
+  })
+
+  it('still reports a generic probe failure for a missing venv on a local install', () => {
+    const { code, message } = classifyProbeFailure('venv python not found', false)
+    assert.equal(code, 'venv-probe-failed')
+    assert.equal(message, formatProbeFailedMessage('venv python not found'))
+  })
+
+  it('does not reclassify a real probe failure (e.g. a timeout) even in remote mode', () => {
+    const { code, message } = classifyProbeFailure('timed out after 60 seconds', true)
+    assert.equal(code, 'venv-probe-failed')
+    assert.equal(message, formatProbeFailedMessage('timed out after 60 seconds'))
   })
 })
 

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -306,6 +306,38 @@ export function formatBlockerMessage(result: VenvBlockerScanResult): string {
 }
 
 /**
+ * Build the message for a remote-mode install with no local venv.  Distinct
+ * from formatProbeFailedMessage: there is nothing wrong with the install and
+ * no reason to ask the user to close windows/terminals or run `hermes
+ * update` — a remote-mode Desktop has no local Hermes CLI to run it with.
+ */
+export function formatNoLocalVenvMessage(): string {
+  return (
+    'Update aborted: no local Hermes install found to update.\n\n' +
+    'This Desktop is connected to a remote backend (remote mode) and has no ' +
+    'local Python install to update. Update the remote host directly, or ' +
+    'switch this Desktop out of remote mode to manage a local install here.'
+  )
+}
+
+/**
+ * Classify a probe-failure outcome.  A remote-mode Desktop never provisions a
+ * local venv — there is no local backend for the scan to guard — so
+ * `resolveVenvPython()` legitimately finding nothing there is not the same
+ * failure as an unreadable/timed-out scan on a local install.
+ */
+export function classifyProbeFailure(
+  error: string | undefined,
+  isRemoteMode: boolean
+): { code: 'no-local-venv' | 'venv-probe-failed'; message: string } {
+  if (error === 'venv python not found' && isRemoteMode) {
+    return { code: 'no-local-venv', message: formatNoLocalVenvMessage() }
+  }
+
+  return { code: 'venv-probe-failed', message: formatProbeFailedMessage(error) }
+}
+
+/**
  * Build a probe-failure error message.
  */
 export function formatProbeFailedMessage(error?: string): string {


### PR DESCRIPTION
## What does this PR do?

On Windows, a Hermes Desktop running in remote-gateway mode has no local Python `venv\` — there's no local backend for it to guard. When the update preflight's `scanVenvBlockers()` can't find `venv\Scripts\python.exe`, it currently reports that as an unverifiable **probe failure**, and the user sees:

> Update aborted: Desktop could not verify the Hermes installation is free.
>
> Close other Hermes windows and terminals, then retry. If the problem persists, run `hermes update` in a terminal for detailed diagnostics.

Nothing is locked and nothing needs closing — the message is simply wrong for this install shape, and the suggested `hermes update` command doesn't even exist there (no local CLI). This PR distinguishes "no venv because this install never needed one (remote mode)" from a genuine probe failure and reports the real precondition instead.

Note on scope: this does **not** make the update itself proceed for remote-mode installs — `scripts/desktop-update/windows.ps1` independently hardcodes `venv\Scripts\python.exe`/`hermes.exe` paths for the actual hand-off (git pull + `hermes_cli.main update`), and building a Python-free update path for a venv-less remote-mode Desktop is a larger design change (also flagged in the issue). This PR fixes the immediate, narrower bug: the misleading message and error code shown before the hand-off is even attempted.

## Related Issue

Fixes #106712

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/venv-blocker-scan.ts`: added `formatNoLocalVenvMessage()` and `classifyProbeFailure(error, isRemoteMode)`, which returns `{ code: 'no-local-venv', message }` when the scan's `probe-failure` is exactly "venv python not found" on a remote-like connection, and `{ code: 'venv-probe-failed', message }` (unchanged behavior) otherwise.
- `apps/desktop/electron/main.ts`: `applyUpdates()`'s Windows preflight now calls `classifyProbeFailure(scanOutcome.error, modeIsRemoteLike(readDesktopConnectionConfig().mode))` instead of always building the generic probe-failure message, and returns the classified `code` as the IPC `error` field.
- `apps/desktop/electron/venv-blocker-scan.test.ts`: added tests for `classifyProbeFailure` covering the remote-mode-no-venv case, the local-install-no-venv case (unchanged generic message), and a real probe failure (timeout) in remote mode (not reclassified).

## How to Test

1. `cd apps/desktop && npx vitest run --project electron electron/venv-blocker-scan.test.ts`
2. Proof the new tests fail without the fix:
   ```
   git checkout HEAD~1 -- apps/desktop/electron/venv-blocker-scan.ts
   npx vitest run --project electron electron/venv-blocker-scan.test.ts
   # 3 failing: "classifyProbeFailure is not a function"
   git checkout HEAD -- apps/desktop/electron/venv-blocker-scan.ts
   ```

### Actual test output (with the fix applied)

```
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

### Full electron test project (regression check)

```
npx vitest run --project electron
 Test Files  153 passed | 2 skipped (155)
      Tests  2147 passed | 6 skipped (2153)
```

### Typecheck / lint

```
npx tsc -p tsconfig.electron.json --noEmit   # clean
npx eslint electron/main.ts electron/venv-blocker-scan.ts electron/venv-blocker-scan.test.ts   # clean
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the desktop electron test suite and all tests pass (this repo's Desktop code has no `pytest tests/` equivalent; used `npx vitest run --project electron`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: this is a Windows-specific code path (`venv\Scripts\python.exe`, `modeIsRemoteLike`); verified via unit tests only, not a live Windows Desktop build (no Windows host available in this environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no doc changes needed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the change only affects the `IS_WINDOWS` preflight branch and reads the existing cross-platform `modeIsRemoteLike`/connection-config helpers; no other platform's code path is touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Disclosure

This PR was prepared with AI assistance (Claude Code) under human/pipeline supervision: code changes, tests, and verification (test failure without the fix, passing test/typecheck/lint runs) were all executed and checked as part of preparing this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
