### PR TITLE
fix(sessions): foreign session import honors CLAUDE_CONFIG_DIR and CODEX_HOME (port cline#13827)

### DIFF
--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -163,19 +163,40 @@ def parse_codex_session(path: Path) -> Dict[str, Any]:
     return _parsed(turns, cwd, session_id)
 
 
-# source -> (default root under ~, glob pattern, recursive, parser)
+# source -> (default root under ~, env override var, subdir under the env root, glob pattern,
+#            recursive, parser)
 _SOURCES = {
-    "claude": ((".claude", "projects"), "*/*.jsonl", False, parse_claude_session),
-    "codex": ((".codex", "sessions"), "rollout-*.jsonl", True, parse_codex_session),
+    "claude": ((".claude", "projects"), "CLAUDE_CONFIG_DIR", "projects", "*/*.jsonl", False,
+               parse_claude_session),
+    "codex": ((".codex", "sessions"), "CODEX_HOME", "sessions", "rollout-*.jsonl", True,
+              parse_codex_session),
 }
 
 
+def _parser(source: str):
+    return _SOURCES[source][5]
+
+
+def _default_root(source: str) -> Path:
+    """Default session store for *source*, honoring the tool's own relocation env var.
+
+    Claude Code moves its whole config dir with ``CLAUDE_CONFIG_DIR``; Codex CLI with
+    ``CODEX_HOME``. A blank/whitespace value is treated as unset (an empty override must not
+    resolve to a relative ``"projects"`` under the CWD). Ported from cline/cline#13827."""
+    default_parts, env_var, env_subdir, *_ = _SOURCES[source]
+    override = os.environ.get(env_var, "").strip()
+    if override:
+        return Path(override).expanduser() / env_subdir
+    return Path.home().joinpath(*default_parts)
+
+
 def _walk(source: str, root: Optional[Path] = None) -> List[Tuple[Path, os.stat_result]]:
-    """Regular log files of *source* under *root* (default ``~/<tool dir>``) as ``(path, stat)``,
-    newest first. Symlinks escaping the root and unreadable/rotated entries are skipped, so one
-    bad file never hides the rest. Shared by the CLI picker and the desktop browser."""
-    default_root, pattern, recursive, _ = _SOURCES[source]
-    root = (Path(root) if root else Path.home().joinpath(*default_root)).resolve()
+    """Regular log files of *source* under *root* (default: the tool's env-aware store, see
+    ``_default_root``) as ``(path, stat)``, newest first. Symlinks escaping the root and
+    unreadable/rotated entries are skipped, so one bad file never hides the rest. Shared by the
+    CLI picker and the desktop browser."""
+    pattern, recursive = _SOURCES[source][3], _SOURCES[source][4]
+    root = (Path(root) if root else _default_root(source)).resolve()
     found: List[Tuple[Path, os.stat_result]] = []
     for path in (root.rglob(pattern) if recursive else root.glob(pattern)) if root.is_dir() else ():
         try:
@@ -190,7 +211,7 @@ def _walk(source: str, root: Optional[Path] = None) -> List[Tuple[Path, os.stat_
 
 
 def _list_sessions(source: str, root: Optional[Path]) -> List[ForeignSession]:
-    parse = _SOURCES[source][3]
+    parse = _parser(source)
     results: List[ForeignSession] = []
     for path, st in _walk(source, root):
         parsed = parse(path)
@@ -210,7 +231,7 @@ def import_foreign_session(source: str, path, db=None) -> str:
     path = Path(path).expanduser()
     if not path.is_file():
         raise ValueError(f"Session file not found: {path}")
-    parsed = _SOURCES[source][3](path)
+    parsed = _parser(source)(path)
     turns = parsed["turns"]
     if not turns:
         raise ValueError(f"No user/assistant conversation turns found in {path}")

--- a/hermes_cli/foreign_sessions_browser.py
+++ b/hermes_cli/foreign_sessions_browser.py
@@ -5,7 +5,7 @@ import re
 import socket
 from pathlib import Path
 
-from hermes_cli.foreign_sessions import _SOURCE_DB_NAMES, _SOURCE_LABELS, _SOURCES, _walk
+from hermes_cli.foreign_sessions import _SOURCE_DB_NAMES, _SOURCE_LABELS, _SOURCES, _parser, _walk
 
 MAX_LOG_BYTES = 32 * 1024 * 1024
 
@@ -33,7 +33,7 @@ def _parse(candidate):
     _, _, source, path, size = candidate
     if size > MAX_LOG_BYTES:
         raise ValueError("This log exceeds the 32 MB preview and import limit")
-    parsed = _SOURCES[source][3](path)
+    parsed = _parser(source)(path)
     if not parsed["turns"]:
         raise ValueError("This session has no readable conversation messages")
     return parsed

--- a/tests/hermes_cli/test_foreign_sessions.py
+++ b/tests/hermes_cli/test_foreign_sessions.py
@@ -5,6 +5,7 @@ against a temp path so nothing touches the real HERMES_HOME store.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -187,6 +188,32 @@ def test_list_sessions(tmp_path):
 def test_list_sessions_missing_roots(tmp_path):
     assert _list_sessions("claude", tmp_path / "nope") == []
     assert _list_sessions("codex", tmp_path / "nope") == []
+
+
+def test_env_overrides_relocate_default_roots(tmp_path, monkeypatch):
+    """CLAUDE_CONFIG_DIR / CODEX_HOME relocate discovery (ported from cline/cline#13827)."""
+    claude_cfg = tmp_path / "relocated-claude"
+    codex_home = tmp_path / "relocated-codex"
+    _write_claude_fixture(tmp_path)  # writes under tmp_path/.claude — becomes the store root below
+    (tmp_path / ".claude").rename(claude_cfg)
+    _write_codex_fixture(tmp_path)
+    (tmp_path / ".codex").rename(codex_home)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)  # default roots are empty
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_cfg))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    both = gather_foreign_sessions()
+    assert {s.source for s in both} == {"claude", "codex"}
+
+
+def test_blank_env_overrides_fall_back_to_home(tmp_path, monkeypatch):
+    """A blank/whitespace override is unset, not a CWD-relative path (cline/cline#13827)."""
+    _write_claude_fixture(tmp_path)
+    _write_codex_fixture(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "")
+    monkeypatch.setenv("CODEX_HOME", "   ")
+    both = gather_foreign_sessions()
+    assert {s.source for s in both} == {"claude", "codex"}
 
 
 # ── import into SessionDB ────────────────────────────────────────────────

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -641,8 +641,9 @@ routing is the only thing the repair changes. Back up first
 
 Started a conversation in another agent CLI? You can pull it into Hermes and
 continue it here. Hermes reads Claude Code's session logs
-(`~/.claude/projects/`) and Codex CLI's rollouts (`~/.codex/sessions/`) —
-the foreign files are only read, never modified.
+(`~/.claude/projects/`, or `$CLAUDE_CONFIG_DIR/projects/` when Claude Code's
+config dir is relocated) and Codex CLI's rollouts (`~/.codex/sessions/`, or
+`$CODEX_HOME/sessions/`) — the foreign files are only read, never modified.
 
 ```bash
 # Interactive picker across both tools, newest first


### PR DESCRIPTION
Foreign session import now finds Claude Code and Codex CLI stores relocated with `CLAUDE_CONFIG_DIR` / `CODEX_HOME` instead of silently reporting "No sessions found."

Port of [cline/cline#13827](https://github.com/cline/cline/pull/13827) (session-import path resolution), adapted to `hermes_cli/foreign_sessions.py`.

## Changes
- `_default_root(source)`: resolves each tool's session store from its official relocation env var (`CLAUDE_CONFIG_DIR` → `<dir>/projects`, `CODEX_HOME` → `<dir>/sessions`), falling back to `~/.claude/projects` / `~/.codex/sessions`. Blank/whitespace overrides are treated as unset, so an empty `CODEX_HOME=""` can never resolve to a CWD-relative path.
- `_SOURCES` gained the env-var fields; the parser is now read through a `_parser()` accessor in both `foreign_sessions.py` and the `foreign_sessions_browser.py` sibling (which indexed the tuple positionally and would have broken silently).
- Docs: `website/docs/user-guide/sessions.md` mentions both env vars.

Hermes already honors `CODEX_HOME` for credentials (`hermes_cli/auth_codex.py`) and there is an open PR (#81252) doing the same for `CLAUDE_CONFIG_DIR` credentials — session *discovery* was the remaining hardcoded path.

## Validation
**Live repro:** on `origin/main`, with `CODEX_HOME` and `CLAUDE_CONFIG_DIR` pointing at populated stores, `gather_foreign_sessions()` returned only `~/.codex` sessions — the env-rooted stores were invisible. On this branch the same probe discovers both, `import_foreign_session` imports the env-rooted Claude session end-to-end into a temp `HERMES_HOME`, and a blank `CODEX_HOME="  "` falls back to `~` (negative case).

| Check | Result |
|---|---|
| `tests/hermes_cli/test_foreign_sessions*.py` + xdg runtime (26 tests) | pass |
| New invariants: env override honored; blank override = unset | pass (red on base) |
| ruff, windows-footguns, compat pointers, `git diff --check` | clean |

## Infographic
![infographic](https://v3b.fal.media/files/b/0aa9cbd3/Y8Bu8QJSLuRde_mOo9z9U_y19pIgM6.png)
