### PR TITLE
fix(memory): state the unattended replace/remove gate in /memory and staging notices

### DIFF
--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -9,9 +9,20 @@ from typing import List, Optional
 from tools import write_approval as wa
 
 
+def _unattended_memory_gate_note() -> str:
+    """One-line effective-policy note for memory: the unattended background-review gate
+    (#106310) stages replace/remove even when the general write-approval gate is off, so
+    ``memory.write_approval = off`` alone reads as a contradiction without it."""
+    return ("Unattended background reviews still stage replace/remove (a whole batch with either) "
+            "for approval; adds apply automatically. Attended /refine is not restricted.")
+
+
 def _fmt_state(subsystem: str) -> str:
     on = wa.write_approval_enabled(subsystem)
-    return f"{subsystem}.write_approval = {'on' if on else 'off'}"
+    lines = [f"{subsystem}.write_approval = {'on' if on else 'off'}"]
+    if subsystem == wa.MEMORY and not on:
+        lines.append(_unattended_memory_gate_note())
+    return "\n".join(lines)
 
 
 def _fmt_pending_list(subsystem: str) -> str:
@@ -149,4 +160,7 @@ def _set_approval(subsystem: str, rest: List[str], set_mode_fn) -> str:
         set_mode_fn(enabled)
     except Exception as e:
         return f"Failed to set {subsystem}.write_approval: {e}"
-    return f"{subsystem}.write_approval set to '{'on' if enabled else 'off'}'."
+    out = f"{subsystem}.write_approval set to '{'on' if enabled else 'off'}'."
+    if subsystem == wa.MEMORY and not enabled:
+        out += "\n" + _unattended_memory_gate_note()
+    return out

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -849,3 +849,16 @@ class TestBackgroundReviewDeleteGate:
             reset_current_write_origin(token)
         assert result["success"] is True
         assert "rewritten by refine" in store._entries_for("memory")
+
+    def test_staging_message_names_both_operations(self, store, tmp_path, monkeypatch):
+        # The gate covers replace AND remove (whole batches too), so the staging notice must
+        # not name only "delete" (#106918).
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        store.add("memory", "entry the fork must not rewrite")
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(action="remove", old_text="must not rewrite", store=store))
+        finally:
+            reset_current_write_origin(token)
+        assert result["staged"] is True
+        assert "replace or remove" in result["message"]

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -201,6 +201,50 @@ def test_handle_approval_off(hermes_home):
     assert "off" in out
 
 
+def test_memory_state_off_explains_unattended_gate(hermes_home, monkeypatch):
+    # /memory with the general gate off must still explain the unattended background-review
+    # restriction (#106310), or "write_approval = off" reads as a contradiction (#106918).
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    monkeypatch.setattr(wa, "write_approval_enabled", lambda subsystem: False)
+    out = handle_pending_subcommand(wa.MEMORY, [])
+    assert "memory.write_approval = off" in out
+    assert "replace/remove" in out
+    assert "/refine" in out
+
+
+def test_memory_state_on_has_no_unattended_note(hermes_home, monkeypatch):
+    # With the general gate on, everything is staged anyway — no note needed.
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    monkeypatch.setattr(wa, "write_approval_enabled", lambda subsystem: True)
+    out = handle_pending_subcommand(wa.MEMORY, [])
+    assert "memory.write_approval = on" in out
+    assert "/refine" not in out
+
+
+def test_skills_state_off_has_no_unattended_note(hermes_home, monkeypatch):
+    # The unattended replace/remove gate is memory-only; /skills must not claim it.
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    monkeypatch.setattr(wa, "write_approval_enabled", lambda subsystem: False)
+    out = handle_pending_subcommand(wa.SKILLS, [])
+    assert "skills.write_approval = off" in out
+    assert "/refine" not in out
+
+
+def test_memory_approval_off_notes_unattended_gate(hermes_home, monkeypatch):
+    # Turning the general gate off is exactly when the standing background restriction
+    # needs restating (#106918).
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    monkeypatch.setattr(wa, "write_approval_enabled", lambda subsystem: False)
+    out = handle_pending_subcommand(
+        wa.MEMORY, ["approval", "off"], set_mode_fn=lambda enabled: None)
+    assert "set to 'off'" in out
+    assert "replace/remove" in out
+
+
 # ---------------------------------------------------------------------------
 # Inline (interactive CLI) approval path — regression for the bug where the
 # per-thread approval callback was never passed to prompt_dangerous_approval,

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -158,8 +158,8 @@ def _background_delete_gate(action, operations, target="memory", content=None, o
             origin=wa.current_origin())
         return json.dumps({
             "success": True, "staged": True, "proposal_staged": True, "pending_id": record["id"],
-            "message": ("Background review may not delete memory entries unattended. The proposed "
-                        f"{'batch' if operations is not None else action} was staged for your approval — "
+            "message": ("Background review may not replace or remove memory entries unattended. "
+                        f"The proposed {'batch' if operations is not None else action} was staged for your approval — "
                         "review it with /memory pending (approve to apply, discard to drop)."),
         }, ensure_ascii=False)
     except Exception:


### PR DESCRIPTION
## What does this PR do?

`/memory` currently reports `memory.write_approval = off` with no further context, even though the unattended background-review gate from #106310 still stages `replace`/`remove` (whole batches included) for approval regardless of that setting. A user who receives a staging notification and then checks `/memory` sees an apparent contradiction. This PR makes the effective policy visible at the three places where it is read:

- `/memory` (no args) and `/memory approval` now append one line, when the general gate is off, stating that unattended background reviews still stage replace/remove (adds apply automatically) and that attended `/refine` is not restricted.
- `/memory approval off` repeats the same note right after turning the gate off — the moment the misconception would form.
- The staging notification now says "may not **replace or remove** memory entries unattended" instead of the narrower "may not delete", naming both operations the gate actually covers. (The fail-closed denial path already named both.)

No change to which writes are allowed or staged — display and notification wording only.

## Related Issue

Fixes #106918

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/write_approval_commands.py` — added `_unattended_memory_gate_note()`; `_fmt_state()` appends it for the memory subsystem when the general gate is off (CLI and gateway share this handler, so both surfaces get it); `_set_approval()` repeats it after `approval off`.
- `tools/memory_tool.py` — staging notice in `_background_delete_gate` now says "replace or remove" instead of "delete".
- `tests/tools/test_write_approval.py` — regression tests: memory state off explains the unattended gate, state on adds no note, skills state never claims the memory-only gate, and `approval off` restates it.
- `tests/tools/test_memory_tool.py` — regression test asserting the staging message names both operations.

## How to Test

1. `pytest tests/tools/test_write_approval.py tests/tools/test_memory_tool.py -q` — Observed result: 71 passed (includes the 5 new regression tests).
2. `pytest tests/gateway/test_slash_config_writes_routed_profile.py -q` — Observed result: 1 passed (gateway consumer unaffected).
3. Manual: run `/memory` with `memory.write_approval` unset (off by default) — Observed result: output shows `memory.write_approval = off` followed by the unattended-gate note; run `/memory approval off` — Observed result: confirmation line followed by the same note; `/skills` output is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: tests/tools/test_write_approval.py, tests/tools/test_memory_tool.py, tests/gateway/test_slash_config_writes_routed_profile.py all green locally; full suite left to CI — a bare-metal full run is impractical here, tests/acp and tests/acp_adapter need a separate acp install)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (user-facing wording is the change itself)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys touched)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (plain string output)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no behavior change)

## For New Skills

N/A
