### PR TITLE
fix(kanban): run auto-decompose as a background task so a slow triage decompose can't starve ready-task spawns

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -35,6 +36,10 @@ _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
 _GC_INTERVAL_SECONDS = 3600.0
 _HEALTH_WINDOW = 6
+# How long shutdown waits for an in-flight auto-decompose pass to quiesce
+# before releasing the dispatcher lease anyway (a hung LLM call must not
+# wedge gateway shutdown forever).
+_AD_DRAIN_TIMEOUT_S = 30.0
 
 
 def _log_ad_tick_result(task: asyncio.Task) -> None:
@@ -44,6 +49,54 @@ def _log_ad_tick_result(task: asyncio.Task) -> None:
     exc = task.exception()
     if exc is not None:
         logger.warning("kanban auto-decompose: background tick failed: %s", exc)
+
+
+class _AdPassState:
+    """Lifecycle flags for one background auto-decompose pass.
+
+    ``started`` is set on the executor thread before the callable runs;
+    ``quiesced`` is set in its ``finally``, so it fires even when the pass
+    raises.
+    """
+
+    __slots__ = ("started", "quiesced")
+
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.quiesced = threading.Event()
+
+
+async def _drain_background_ad(
+    ad_task: Optional[asyncio.Task], ad_state: Optional[_AdPassState]
+) -> None:
+    """Wait out an in-flight background auto-decompose pass before the lease goes.
+
+    Cancelling a task parked on ``asyncio.to_thread`` does not stop the
+    already-running worker callable, and the machine-global dispatcher lock
+    must not be released while that callable is still mutating boards — a
+    replacement gateway could otherwise acquire the lock and start a second
+    concurrent decompose pass (#106998). A pass that was queued but never
+    reached the executor thread is simply cancelled (nothing is running);
+    a started pass is awaited for at most ``_AD_DRAIN_TIMEOUT_S`` so a hung
+    LLM call cannot wedge shutdown.
+    """
+    if ad_task is None or ad_task.done():
+        return
+    if not ad_state.started.is_set():
+        # Queued but not yet picked up by the executor: cancelling the task
+        # leaves nothing running.
+        ad_task.cancel()
+        if not ad_state.started.is_set():
+            return
+        # Lost the race with the executor thread mid-cancel: keep waiting
+        # like a started pass.
+    quiesced = await asyncio.to_thread(ad_state.quiesced.wait, _AD_DRAIN_TIMEOUT_S)
+    if not quiesced:
+        logger.warning(
+            "kanban dispatcher: background auto-decompose still running after "
+            "%.0fs drain; releasing dispatcher lock anyway",
+            _AD_DRAIN_TIMEOUT_S,
+        )
 
 
 class GatewayKanbanWatchersMixin:
@@ -247,8 +300,10 @@ class GatewayKanbanWatchersMixin:
         tick runs :func:`kanban_db_dispatch.dispatch_once` in a thread; one tick's
         failure never stops the next. The auto-decompose pass runs as a single
         in-flight background task so a slow triage LLM call never delays the
-        spawn step. Shutdown: ``self._running`` is checked between ticks and
-        the in-flight ``to_thread`` returns on its own.
+        spawn step. Shutdown: ``self._running`` is checked between ticks, and
+        an in-flight background decompose pass is drained before the
+        dispatcher lease is released so a replacement gateway cannot start a
+        second concurrent pass.
         """
         boot = self._kanban_dispatcher_boot()
         if boot is None:
@@ -257,9 +312,6 @@ class GatewayKanbanWatchersMixin:
         settings = _resolve_dispatcher_settings(kanban_cfg, _kb)
         interval = settings.interval
 
-        # Initial delay so adapters are wired before workers spawn (matches the notifier).
-        await asyncio.sleep(5)
-
         # Health telemetry (mirrors `_cmd_daemon`): warn when the ready queue
         # is non-empty but spawns are 0 for N consecutive ticks — usually a
         # broken PATH, missing venv, or credential loss.
@@ -267,66 +319,94 @@ class GatewayKanbanWatchersMixin:
         last_warn_at = 0
         dispatcher = _KanbanDispatcher(_kb, settings)
         ad_task: Optional[asyncio.Task] = None
+        ad_state: Optional[_AdPassState] = None
 
-        logger.info("kanban dispatcher: embedded in gateway (interval=%.1fs)", interval)
-        while self._running:
-            try:
-                # Reap zombies before per-board work so a board DB failure
-                # cannot block cleanup of unrelated workers.
-                from hermes_cli import kanban_db_dispatch as _kbd
-                pids = await _to_thread_process_service(_kbd.reap_worker_zombies)
-                if pids:
-                    logger.info("kanban dispatcher: reaped %d zombie worker(s), pids=%s", len(pids), pids)
-            except Exception:
-                logger.exception("kanban dispatcher: zombie reaper failed")
+        try:
+            # Initial delay so adapters are wired before workers spawn
+            # (matches the notifier).
+            await asyncio.sleep(5)
 
-            try:
-                # Emergency stop (`hermes pause`): no auto-decompose or
-                # dispatch while paused; running workers finish naturally.
-                if not _kanban_dispatch_allowed():
-                    bad_ticks = 0
-                else:
-                    # Re-read the auto-decompose toggle live so disabling it
-                    # takes effect on the next tick, not on restart.
-                    _ad_enabled, _ad_per_tick = _resolve_auto_decompose_settings(_load_config)
-                    # See #49638. #106985: the decompose call is a whole-board
-                    # LLM pass, so it runs as a single in-flight background task
-                    # instead of being awaited inline — otherwise one slow or
-                    # stuck triage decompose delays every unrelated ready-task
-                    # spawn on every board sharing this dispatcher.
-                    if _ad_enabled and (ad_task is None or ad_task.done()):
-                        ad_task = asyncio.create_task(
-                            _to_thread_process_service(dispatcher.auto_decompose_tick, _ad_per_tick)
+            logger.info("kanban dispatcher: embedded in gateway (interval=%.1fs)", interval)
+            while self._running:
+                try:
+                    # Reap zombies before per-board work so a board DB failure
+                    # cannot block cleanup of unrelated workers.
+                    from hermes_cli import kanban_db_dispatch as _kbd
+                    pids = await _to_thread_process_service(_kbd.reap_worker_zombies)
+                    if pids:
+                        logger.info(
+                            "kanban dispatcher: reaped %d zombie worker(s), pids=%s",
+                            len(pids),
+                            pids,
                         )
-                        ad_task.add_done_callback(_log_ad_tick_result)
-                    results = await _to_thread_process_service(dispatcher.tick_once)
-                    any_spawned = _log_spawn_results(results)
-                    ready_pending = await _to_thread_process_service(dispatcher.ready_nonempty)
-                    bad_ticks = bad_ticks + 1 if ready_pending and not any_spawned else 0
-                now = int(time.time())
-                if bad_ticks >= _HEALTH_WINDOW and now - last_warn_at >= 300:
-                    logger.warning(
-                        "kanban dispatcher stuck: ready queue non-empty for "
-                        "%d consecutive ticks but 0 workers spawned. Check "
-                        "profile health (venv, PATH, credentials) and "
-                        "`hermes kanban list --status ready`.",
-                        bad_ticks,
-                    )
-                    last_warn_at = now
+                except Exception:
+                    logger.exception("kanban dispatcher: zombie reaper failed")
+
+                try:
+                    # Emergency stop (`hermes pause`): no auto-decompose or
+                    # dispatch while paused; running workers finish naturally.
+                    if not _kanban_dispatch_allowed():
+                        bad_ticks = 0
+                    else:
+                        # Re-read the auto-decompose toggle live so disabling it
+                        # takes effect on the next tick, not on restart.
+                        _ad_enabled, _ad_per_tick = _resolve_auto_decompose_settings(_load_config)
+                        # See #49638. #106985: the decompose call is a whole-board
+                        # LLM pass, so it runs as a single in-flight background task
+                        # instead of being awaited inline — otherwise one slow or
+                        # stuck triage decompose delays every unrelated ready-task
+                        # spawn on every board sharing this dispatcher.
+                        if _ad_enabled and (ad_task is None or ad_task.done()):
+                            pass_state = _AdPassState()
+
+                            def _ad_pass(state: _AdPassState = pass_state) -> int:
+                                state.started.set()
+                                try:
+                                    return dispatcher.auto_decompose_tick(_ad_per_tick)
+                                finally:
+                                    state.quiesced.set()
+
+                            ad_state = pass_state
+                            ad_task = asyncio.create_task(
+                                _to_thread_process_service(_ad_pass)
+                            )
+                            ad_task.add_done_callback(_log_ad_tick_result)
+                        results = await _to_thread_process_service(dispatcher.tick_once)
+                        any_spawned = _log_spawn_results(results)
+                        ready_pending = await _to_thread_process_service(dispatcher.ready_nonempty)
+                        bad_ticks = bad_ticks + 1 if ready_pending and not any_spawned else 0
+                    now = int(time.time())
+                    if bad_ticks >= _HEALTH_WINDOW and now - last_warn_at >= 300:
+                        logger.warning(
+                            "kanban dispatcher stuck: ready queue non-empty for "
+                            "%d consecutive ticks but 0 workers spawned. Check "
+                            "profile health (venv, PATH, credentials) and "
+                            "`hermes kanban list --status ready`.",
+                            bad_ticks,
+                        )
+                        last_warn_at = now
+                except asyncio.CancelledError:
+                    logger.debug("kanban dispatcher: cancelled")
+                    raise
+                except Exception:
+                    logger.exception("kanban dispatcher: unexpected watcher error")
+
+                await self._sleep_between_ticks(interval)
+        finally:
+            # Loop exit and cancellation — in tick work or between ticks — all
+            # land here. Cancelling the wrapper task does not stop a
+            # to_thread worker that is already mutating boards; the
+            # machine-global dispatcher lease is released only after the
+            # in-flight pass has quiesced (or its bounded drain window
+            # expired), so a replacement gateway cannot start a second
+            # concurrent decompose pass (#106998).
+            try:
+                await _drain_background_ad(ad_task, ad_state)
             except asyncio.CancelledError:
-                logger.debug("kanban dispatcher: cancelled")
-                if ad_task is not None and not ad_task.done():
-                    ad_task.cancel()
-                self._release_kanban_dispatcher_lock()
-                raise
-            except Exception:
-                logger.exception("kanban dispatcher: unexpected watcher error")
-
-            await self._sleep_between_ticks(interval)
-
-        if ad_task is not None and not ad_task.done():
-            ad_task.cancel()
-        self._release_kanban_dispatcher_lock()
+                # Repeated cancellation during shutdown: release the lease
+                # rather than leak it (pre-#106985 teardown semantics).
+                pass
+            self._release_kanban_dispatcher_lock()
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -37,6 +37,15 @@ _GC_INTERVAL_SECONDS = 3600.0
 _HEALTH_WINDOW = 6
 
 
+def _log_ad_tick_result(task: asyncio.Task) -> None:
+    """Surface a failed background auto-decompose tick (per-task outcomes are logged inline)."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.warning("kanban auto-decompose: background tick failed: %s", exc)
+
+
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
@@ -236,8 +245,10 @@ class GatewayKanbanWatchersMixin:
         Gated by `kanban.dispatch_in_gateway` (default True); when false the
         loop exits and an external `hermes kanban daemon` is expected. Each
         tick runs :func:`kanban_db_dispatch.dispatch_once` in a thread; one tick's
-        failure never stops the next. Shutdown: ``self._running`` is checked
-        between ticks and the in-flight ``to_thread`` returns on its own.
+        failure never stops the next. The auto-decompose pass runs as a single
+        in-flight background task so a slow triage LLM call never delays the
+        spawn step. Shutdown: ``self._running`` is checked between ticks and
+        the in-flight ``to_thread`` returns on its own.
         """
         boot = self._kanban_dispatcher_boot()
         if boot is None:
@@ -255,6 +266,7 @@ class GatewayKanbanWatchersMixin:
         bad_ticks = 0
         last_warn_at = 0
         dispatcher = _KanbanDispatcher(_kb, settings)
+        ad_task: Optional[asyncio.Task] = None
 
         logger.info("kanban dispatcher: embedded in gateway (interval=%.1fs)", interval)
         while self._running:
@@ -277,9 +289,16 @@ class GatewayKanbanWatchersMixin:
                     # Re-read the auto-decompose toggle live so disabling it
                     # takes effect on the next tick, not on restart.
                     _ad_enabled, _ad_per_tick = _resolve_auto_decompose_settings(_load_config)
-                    # See #49638.
-                    if _ad_enabled:
-                        await _to_thread_process_service(dispatcher.auto_decompose_tick, _ad_per_tick)
+                    # See #49638. #106985: the decompose call is a whole-board
+                    # LLM pass, so it runs as a single in-flight background task
+                    # instead of being awaited inline — otherwise one slow or
+                    # stuck triage decompose delays every unrelated ready-task
+                    # spawn on every board sharing this dispatcher.
+                    if _ad_enabled and (ad_task is None or ad_task.done()):
+                        ad_task = asyncio.create_task(
+                            _to_thread_process_service(dispatcher.auto_decompose_tick, _ad_per_tick)
+                        )
+                        ad_task.add_done_callback(_log_ad_tick_result)
                     results = await _to_thread_process_service(dispatcher.tick_once)
                     any_spawned = _log_spawn_results(results)
                     ready_pending = await _to_thread_process_service(dispatcher.ready_nonempty)
@@ -296,6 +315,8 @@ class GatewayKanbanWatchersMixin:
                     last_warn_at = now
             except asyncio.CancelledError:
                 logger.debug("kanban dispatcher: cancelled")
+                if ad_task is not None and not ad_task.done():
+                    ad_task.cancel()
                 self._release_kanban_dispatcher_lock()
                 raise
             except Exception:
@@ -303,6 +324,8 @@ class GatewayKanbanWatchersMixin:
 
             await self._sleep_between_ticks(interval)
 
+        if ad_task is not None and not ad_task.done():
+            ad_task.cancel()
         self._release_kanban_dispatcher_lock()
 
 

--- a/tests/gateway/test_kanban_dispatcher_ad_nonblocking.py
+++ b/tests/gateway/test_kanban_dispatcher_ad_nonblocking.py
@@ -1,0 +1,136 @@
+"""Regression tests for #106985: the embedded dispatcher's auto-decompose pass
+must not block the spawn step of the same tick.
+
+``auto_decompose_tick`` used to be awaited inline before ``tick_once``, so one
+slow triage LLM call delayed every unrelated ready-task spawn on every board
+sharing the dispatcher. It now runs as a single in-flight background task: the
+spawn step proceeds immediately, and a new decompose pass only starts once the
+previous one has finished.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import gateway.kanban_watchers as kww
+from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+
+
+class _FakeDispatcher:
+    """Records call times; ``auto_decompose_tick`` blocks for ``ad_delay``.
+
+    ``ad_crash`` simulates a decompose pass that raises instead of returning.
+    """
+
+    def __init__(self, state: dict) -> None:
+        self.state = state
+
+    def auto_decompose_tick(self, per_tick: int) -> int:
+        self.state["ad_calls"] = self.state.get("ad_calls", 0) + 1
+        if self.state.get("ad_crash"):
+            raise RuntimeError("boom")
+        time.sleep(self.state["ad_delay"])
+        return 0
+
+    def tick_once(self):
+        self.state["spawn_times"] = self.state.get("spawn_times", []) + [time.monotonic()]
+        if len(self.state["spawn_times"]) >= self.state["stop_after"]:
+            self.state["runner"]._running = False
+        return []
+
+    def ready_nonempty(self) -> bool:
+        return False
+
+
+class _StubRunner(GatewayKanbanWatchersMixin):
+    def __init__(self) -> None:
+        self._running = True
+        self.released = False
+
+    def _kanban_dispatcher_boot(self):
+        return (lambda: {}, SimpleNamespace(), {})
+
+    def _release_kanban_dispatcher_lock(self) -> None:
+        self.released = True
+
+
+@pytest.fixture
+def fast_sleep(monkeypatch):
+    """Shrink every ``asyncio.sleep`` the watcher takes (boot delay, tick slices)."""
+    real_sleep = asyncio.sleep
+
+    async def _fast(delay, *args, **kwargs):
+        return await real_sleep(min(delay, 0.01))
+
+    monkeypatch.setattr(asyncio, "sleep", _fast)
+
+
+def _patch_watcher(monkeypatch, state: dict) -> None:
+    from hermes_cli import kanban_db_dispatch
+
+    monkeypatch.setattr(kanban_db_dispatch, "reap_worker_zombies", lambda: [])
+    monkeypatch.setattr(kww, "_resolve_dispatcher_settings", lambda cfg, kb: SimpleNamespace(interval=0.05))
+    monkeypatch.setattr(kww, "_resolve_auto_decompose_settings", lambda loader: (state.get("ad_enabled", True), 3))
+    monkeypatch.setattr(kww, "_kanban_dispatch_allowed", lambda: True)
+    monkeypatch.setattr(kww, "_KanbanDispatcher", lambda kb, settings: _FakeDispatcher(state))
+    monkeypatch.setattr(
+        kww,
+        "_to_thread_process_service",
+        staticmethod(lambda func, *args: asyncio.to_thread(func, *args)),
+    )
+
+
+def _run_watcher_sync(monkeypatch, state: dict):
+    runner = _StubRunner()
+    state["runner"] = runner
+    _patch_watcher(monkeypatch, state)
+
+    async def _drive() -> None:
+        await asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=10.0)
+
+    asyncio.run(_drive())
+    assert runner.released, "dispatcher lock must be released on exit"
+    return runner
+
+
+def test_slow_decompose_does_not_block_spawns(monkeypatch, fast_sleep):
+    state = {"ad_delay": 0.5, "stop_after": 3}
+    _run_watcher_sync(monkeypatch, state)
+
+    spawn_times = state["spawn_times"]
+    assert len(spawn_times) == 3
+    # Inline await would serialize 3 ticks behind two 0.5s decompose calls;
+    # unblocked spawns finish well inside one decompose delay.
+    assert spawn_times[-1] - spawn_times[0] < 0.4
+    # Single-flight guard: the first decompose is still in flight, so no retry.
+    assert state["ad_calls"] == 1
+
+
+def test_new_decompose_starts_after_previous_finishes(monkeypatch, fast_sleep):
+    state = {"ad_delay": 0.02, "stop_after": 6}
+    _run_watcher_sync(monkeypatch, state)
+
+    assert len(state["spawn_times"]) == 6
+    assert state["ad_calls"] >= 2, "single-flight guard must lift once a pass finishes"
+
+
+def test_decompose_disabled_skips_pass(monkeypatch, fast_sleep):
+    state = {"ad_delay": 0.0, "ad_enabled": False, "stop_after": 2}
+    _run_watcher_sync(monkeypatch, state)
+
+    assert len(state["spawn_times"]) == 2
+    assert state.get("ad_calls", 0) == 0
+
+
+def test_crashed_background_pass_never_stops_the_loop(monkeypatch, fast_sleep):
+    state = {"ad_delay": 0.0, "ad_crash": True, "stop_after": 3}
+    _run_watcher_sync(monkeypatch, state)
+
+    # A crashing decompose pass is contained to its background task; the
+    # spawn step still runs every tick and the loop shuts down cleanly.
+    assert state["ad_calls"] >= 1
+    assert len(state["spawn_times"]) == 3

--- a/tests/gateway/test_kanban_dispatcher_ad_nonblocking.py
+++ b/tests/gateway/test_kanban_dispatcher_ad_nonblocking.py
@@ -11,6 +11,7 @@ previous one has finished.
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from types import SimpleNamespace
 
@@ -24,6 +25,8 @@ class _FakeDispatcher:
     """Records call times; ``auto_decompose_tick`` blocks for ``ad_delay``.
 
     ``ad_crash`` simulates a decompose pass that raises instead of returning.
+    ``ad_gate`` is a ``(started, unblock)`` event pair that parks the pass on
+    the unblock event, for shutdown-ownership tests.
     """
 
     def __init__(self, state: dict) -> None:
@@ -31,13 +34,22 @@ class _FakeDispatcher:
 
     def auto_decompose_tick(self, per_tick: int) -> int:
         self.state["ad_calls"] = self.state.get("ad_calls", 0) + 1
+        gate = self.state.get("ad_gate")
+        if gate is not None:
+            started, unblock = gate
+            started.set()
+            assert unblock.wait(timeout=30.0), "test harness failed to unblock the pass"
+            self.state["ad_finished_at"] = time.monotonic()
+            return 0
         if self.state.get("ad_crash"):
             raise RuntimeError("boom")
         time.sleep(self.state["ad_delay"])
         return 0
 
     def tick_once(self):
-        self.state["spawn_times"] = self.state.get("spawn_times", []) + [time.monotonic()]
+        self.state["spawn_times"] = self.state.get("spawn_times", []) + [
+            time.monotonic()
+        ]
         if len(self.state["spawn_times"]) >= self.state["stop_after"]:
             self.state["runner"]._running = False
         return []
@@ -50,12 +62,14 @@ class _StubRunner(GatewayKanbanWatchersMixin):
     def __init__(self) -> None:
         self._running = True
         self.released = False
+        self.released_at: float | None = None
 
     def _kanban_dispatcher_boot(self):
         return (lambda: {}, SimpleNamespace(), {})
 
     def _release_kanban_dispatcher_lock(self) -> None:
         self.released = True
+        self.released_at = time.monotonic()
 
 
 @pytest.fixture
@@ -73,10 +87,20 @@ def _patch_watcher(monkeypatch, state: dict) -> None:
     from hermes_cli import kanban_db_dispatch
 
     monkeypatch.setattr(kanban_db_dispatch, "reap_worker_zombies", lambda: [])
-    monkeypatch.setattr(kww, "_resolve_dispatcher_settings", lambda cfg, kb: SimpleNamespace(interval=0.05))
-    monkeypatch.setattr(kww, "_resolve_auto_decompose_settings", lambda loader: (state.get("ad_enabled", True), 3))
+    monkeypatch.setattr(
+        kww,
+        "_resolve_dispatcher_settings",
+        lambda cfg, kb: SimpleNamespace(interval=0.05),
+    )
+    monkeypatch.setattr(
+        kww,
+        "_resolve_auto_decompose_settings",
+        lambda loader: (state.get("ad_enabled", True), 3),
+    )
     monkeypatch.setattr(kww, "_kanban_dispatch_allowed", lambda: True)
-    monkeypatch.setattr(kww, "_KanbanDispatcher", lambda kb, settings: _FakeDispatcher(state))
+    monkeypatch.setattr(
+        kww, "_KanbanDispatcher", lambda kb, settings: _FakeDispatcher(state)
+    )
     monkeypatch.setattr(
         kww,
         "_to_thread_process_service",
@@ -134,3 +158,82 @@ def test_crashed_background_pass_never_stops_the_loop(monkeypatch, fast_sleep):
     # spawn step still runs every tick and the loop shuts down cleanly.
     assert state["ad_calls"] >= 1
     assert len(state["spawn_times"]) == 3
+
+
+def _run_watcher_thread(
+    monkeypatch, state: dict, runner: _StubRunner, drive
+) -> threading.Thread:
+    _patch_watcher(monkeypatch, state)
+    thread = threading.Thread(target=asyncio.run, args=(drive(),), daemon=True)
+    thread.start()
+    return thread
+
+
+def test_stop_holds_dispatcher_lock_until_decompose_quiesces(monkeypatch, fast_sleep):
+    """Normal loop exit must not release the lease while the pass is in flight.
+
+    Cancelling the wrapper task would not stop a ``to_thread`` worker that is
+    already running (#106998): releasing the machine-global dispatcher lock at
+    that point lets a replacement gateway start a second concurrent decompose
+    pass. The lock may only be released after the callable has returned.
+    """
+    started, unblock = threading.Event(), threading.Event()
+    state = {"ad_delay": 0.0, "stop_after": 1, "ad_gate": (started, unblock)}
+    runner = _StubRunner()
+    state["runner"] = runner
+
+    async def _drive() -> None:
+        await asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=30.0)
+
+    thread = _run_watcher_thread(monkeypatch, state, runner, _drive)
+    assert started.wait(timeout=5.0), "decompose pass must be in flight"
+    time.sleep(0.3)  # let the loop observe _running=False and park in the drain
+    assert not runner.released, (
+        "lock must stay held while the decompose callable is in flight"
+    )
+    unblock.set()
+    thread.join(timeout=15.0)
+
+    assert not thread.is_alive(), "watcher thread must finish after the pass unblocks"
+    assert runner.released
+    assert state["ad_finished_at"] < runner.released_at, (
+        "lease release must happen strictly after the decompose callable quiesces"
+    )
+
+
+def test_cancel_holds_dispatcher_lock_until_decompose_quiesces(monkeypatch, fast_sleep):
+    """Cancelling the watcher (gateway shutdown) must drain the pass first too.
+
+    The replacement-gateway window from #106998 is most reachable on this
+    path: the old gateway is cancelled while a slow decompose is running, and
+    the next gateway would immediately re-acquire the released lease.
+    """
+    started, unblock = threading.Event(), threading.Event()
+    state = {"ad_delay": 0.0, "stop_after": 99, "ad_gate": (started, unblock)}
+    runner = _StubRunner()
+    state["runner"] = runner
+
+    async def _drive() -> None:
+        task = asyncio.create_task(runner._kanban_dispatcher_watcher())
+        while not started.is_set():
+            await asyncio.sleep(0.01)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    thread = _run_watcher_thread(monkeypatch, state, runner, _drive)
+    assert started.wait(timeout=5.0), "decompose pass must be in flight"
+    time.sleep(0.3)  # let the CancelledError handler park in the drain
+    assert not runner.released, (
+        "cancelled watcher must still hold the lease during the pass"
+    )
+    unblock.set()
+    thread.join(timeout=15.0)
+
+    assert not thread.is_alive(), "watcher thread must finish after the pass unblocks"
+    assert runner.released
+    assert state["ad_finished_at"] < runner.released_at, (
+        "lease release must happen strictly after the decompose callable quiesces"
+    )

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1085,8 +1085,11 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
         # BEFORE the per-board tick work. Each tick now issues 3 ``to_thread``
         # calls (reaper + ``_tick_once`` + ``_ready_nonempty``) instead of 2,
         # so this counter must reach 6 to allow the same 2 dispatch ticks the
-        # pre-reaper test expected at 4. Connect counts in the assertion below
-        # are unchanged.
+        # pre-reaper test expected at 4.
+        # #106985: the auto-decompose pass moved to a background task, so it
+        # no longer issues a synchronous ``to_thread`` inside the tick (this
+        # yield-free mock never schedules it). 3 calls per tick still holds
+        # and the 6-call budget still covers exactly 2 dispatch ticks.
         calls["to_thread"] += 1
         result = fn(*args, **kwargs)
         if calls["to_thread"] >= 6:
@@ -1112,13 +1115,13 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     assert sum("not a valid SQLite database" in msg for msg in messages) == 1
     assert not any("tick failed on board" in msg for msg in messages)
     assert not any(record.exc_info for record in caplog.records)
-    # First tick connect (dispatch) + two probes per `_has_ready_work` call
-    # (ready then review, both via _kbc.connect). The second dispatch tick
-    # skips the dispatch connect because the corrupt board fingerprint is
-    # disabled, but the ready/review probes still each connect. PR f55d94a1e
-    # added the review-column probe alongside the existing ready-column
-    # probe, bumping this from 3 → 5.
-    assert calls["connect"] == 5
+    # First tick connect (dispatch) + ready/review probe. The second dispatch
+    # tick skips the dispatch connect because the corrupt board fingerprint is
+    # disabled, but the ready/review probe still connects. The auto-decompose
+    # pass used to add a connect per tick (its list_triage_ids ran inline);
+    # since #106985 it runs as a background task that this yield-free mock
+    # never schedules, so those two connects drop out: 5 → 3.
+    assert calls["connect"] == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

The embedded gateway dispatcher awaited `auto_decompose_tick` inline **before** `tick_once`, so when `kanban.auto_decompose: true` and a `triage` task's decompose LLM call was slow (reasoning-heavy model, `auxiliary.transient_retries` retrying a malformed response), the **entire dispatch tick** was delayed — every unrelated `ready` task on every board sharing the dispatcher stopped being spawned until that one call returned (#106985).

The decompose pass now runs as a **single in-flight background task**: the spawn step proceeds immediately, and a new decompose pass only starts once the previous one has finished (single-flight guard, so passes never overlap). A crashing pass is contained to its task and surfaced by a done-callback log; the background task is cancelled on watcher shutdown/cancel.

This deliberately does **not** add a per-call timeout config: with the pass off the critical path, a slow decompose only throttles itself, and a hard timeout would introduce a new tuning knob plus double-decompose races against the still-running thread. That can be layered on separately if a hung-call case shows up.

## Related Issue

Fixes #106985

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/kanban_watchers.py`: `_kanban_dispatcher_watcher` starts `auto_decompose_tick` via `asyncio.create_task` (guarded by `ad_task.done()`) instead of awaiting it inline before `tick_once`; cancels the in-flight task on `CancelledError` and normal loop exit; new module-level `_log_ad_tick_result` done-callback logs a failed background pass.
- `tests/gateway/test_kanban_dispatcher_ad_nonblocking.py`: new regression tests — slow decompose must not block spawns (3 ticks finish well inside one 0.5s decompose delay), single-flight guard holds while a pass is in flight and lifts after it finishes, `auto_decompose: false` skips the pass entirely, and a crashing pass never stops the spawn loop.
- `tests/hermes_cli/test_kanban_core_functionality.py`: updated the to_thread-mock notes and `connect` count (5 → 3) in `test_gateway_dispatcher_disables_corrupt_board_without_traceback` — the auto-decompose pass no longer issues a synchronous `to_thread`/`connect` inside the tick sequence, which this test's tick-budget mock counts.

## How to Test

1. `pytest tests/gateway/test_kanban_dispatcher_ad_nonblocking.py -v` — Observed result: 4 passed (slow-decompose unblocking, single-flight lift, disabled skip, crash containment).
2. `pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_dispatch_tick_hook.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py -q` — Observed result: 39 passed, 1 skipped.
3. `pytest tests/gateway/ -k kanban -q` — Observed result: 62 passed, 2 skipped.
4. Bug-level check per the issue report: with a fake dispatcher whose `auto_decompose_tick` sleeps 0.5s, three spawn ticks now complete in < 0.4s (test 1) instead of being serialized behind two decompose calls; the issue's `kanban dispatcher stuck` warning can no longer be caused by a slow triage decompose.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full kanban/dispatcher/watcher suites green; pre-existing order-dependent flakes in `test_web_oauth_dispatch`/`test_wecom_callback` reproduce identically on unmodified upstream/main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring of `_kanban_dispatcher_watcher` now documents the background auto-decompose pass
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure asyncio change, no platform-specific I/O
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ pytest tests/gateway/test_kanban_dispatcher_ad_nonblocking.py -v
tests/gateway/test_kanban_dispatcher_ad_nonblocking.py::test_slow_decompose_does_not_block_spawns PASSED
tests/gateway/test_kanban_dispatcher_ad_nonblocking.py::test_new_decompose_starts_after_previous_finishes PASSED
tests/gateway/test_kanban_dispatcher_ad_nonblocking.py::test_decompose_disabled_skips_pass PASSED
tests/gateway/test_kanban_dispatcher_ad_nonblocking.py::test_crashed_background_pass_never_stops_the_loop PASSED
4 passed in 0.89s
```