### PR TITLE
fix(desktop): ignore composer-only resizes when restoring transcript scroll

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list-restore-composer-resize.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list-restore-composer-resize.test.tsx
@@ -1,0 +1,201 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { rescopeConnectionScopedStores } from '@/lib/connection-scoped'
+import { setActiveProfile } from '@/store/profile'
+import { saveThreadScrollPosition, threadScrollTargetTop } from '@/store/thread-scroll'
+
+import { stubThreadEnvironment, stubThreadViewportSize } from '../test-utils'
+
+import { Thread } from '.'
+
+// Node 25 exposes a localStorage accessor that is neither undefined nor a
+// Storage (no clear/setItem). Force an in-memory store so persist/restore works.
+{
+  const store = new Map<string, string>()
+  const storage: Storage = {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(String(key)) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => void store.delete(String(key)),
+    setItem: (key: string, value: string) => void store.set(String(key), String(value))
+  }
+
+  for (const target of [globalThis, globalThis.window].filter(Boolean)) {
+    Object.defineProperty(target, 'localStorage', { configurable: true, value: storage, writable: true })
+  }
+}
+
+const observers = new Set<{ fire: () => void }>()
+
+class TestResizeObserver {
+  private readonly callback: ResizeObserverCallback
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    observers.add(this)
+  }
+
+  disconnect() {
+    observers.delete(this)
+  }
+
+  fire() {
+    const target = document.body
+    this.callback(
+      [
+        {
+          borderBoxSize: [],
+          contentBoxSize: [],
+          contentRect: { bottom: 1, height: 1, left: 0, right: 1, toJSON: () => ({}), top: 0, width: 1, x: 0, y: 0 } as DOMRect,
+          devicePixelContentBoxSize: [],
+          target
+        } as ResizeObserverEntry
+      ],
+      this as unknown as ResizeObserver
+    )
+  }
+
+  observe() {}
+  unobserve() {}
+}
+
+stubThreadEnvironment()
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+stubThreadViewportSize()
+
+const SCROLL_H = 5000
+const CLIENT_H = 600
+const FROM_BOTTOM = 800
+const VIEWPORT_SLOT = 'aui_thread-viewport'
+const CLEARANCE_SLOT = 'aui_composer-clearance'
+
+let viewportScrollHeight = SCROLL_H
+let viewportClientHeight = CLIENT_H
+let clearanceHeight = 120
+
+Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+  configurable: true,
+  get() {
+    return viewportScrollHeight
+  }
+})
+Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+  configurable: true,
+  get() {
+    if (this.getAttribute?.('data-slot') === CLEARANCE_SLOT) {
+      return clearanceHeight
+    }
+
+    return viewportClientHeight
+  }
+})
+
+beforeEach(() => {
+  viewportScrollHeight = SCROLL_H
+  viewportClientHeight = CLIENT_H
+  clearanceHeight = 120
+  observers.clear()
+  window.localStorage.clear()
+  setActiveProfile('default')
+  rescopeConnectionScopedStores(null)
+})
+
+function viewportEl(container: HTMLElement): HTMLElement {
+  const el = container.querySelector(`[data-slot="${VIEWPORT_SLOT}"]`) as HTMLElement | null
+  expect(el).toBeTruthy()
+
+  return el!
+}
+
+function fireContentResizes() {
+  act(() => {
+    for (const observer of [...observers]) {
+      observer.fire()
+    }
+  })
+}
+
+async function settleScroll(ticks = 3) {
+  await act(async () => {
+    for (let tick = 0; tick < ticks; tick += 1) {
+      await new Promise<void>(resolve => window.setTimeout(resolve, 0))
+    }
+  })
+}
+
+const createdAt = new Date('2026-08-01T00:00:00.000Z')
+
+function sessionMessages(key: string, turns = 1): ThreadMessage[] {
+  return Array.from({ length: turns }, (_, index) => [
+    {
+      id: `u-${key}-${index}`,
+      role: 'user',
+      content: [{ type: 'text', text: `message ${index} in ${key}` }],
+      attachments: [],
+      createdAt,
+      metadata: { custom: {} }
+    } as ThreadMessage,
+    {
+      id: `a-${key}-${index}`,
+      role: 'assistant',
+      content: [{ type: 'text', text: `response ${index} in ${key}` }],
+      status: { type: 'complete', reason: 'stop' },
+      createdAt,
+      metadata: { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+    } as ThreadMessage
+  ]).flat()
+}
+
+function ScrollHarness({ messages, sessionKey }: { messages: ThreadMessage[]; sessionKey: string | null }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    isRunning: false,
+    messages,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread clampToComposer sessionKey={sessionKey} />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('list post-settle restore vs composer-only resize', () => {
+  it('does not rewrite scrollTop when only composer clearance grows; content growth still restores', async () => {
+    saveThreadScrollPosition('a', { fromBottom: FROM_BOTTOM, kind: 'offset' })
+
+    const { container } = render(<ScrollHarness messages={sessionMessages('a')} sessionKey="a" />)
+    const vp = viewportEl(container)
+
+    await settleScroll()
+
+    const restoredTop = SCROLL_H - CLIENT_H - FROM_BOTTOM
+    expect(vp.scrollTop).toBe(restoredTop)
+
+    const userRoot = container.querySelector('[data-slot="aui_user-message-root"]')
+    expect(userRoot).toBeTruthy()
+    expect(container.querySelector(`[data-slot="${CLEARANCE_SLOT}"]`)).toBeTruthy()
+
+    // Composer-only: clearance + viewport box move together; transcript rows do not.
+    viewportScrollHeight = SCROLL_H + 80
+    viewportClientHeight = CLIENT_H - 80
+    clearanceHeight = 200
+    fireContentResizes()
+
+    expect(vp.scrollTop).toBe(restoredTop)
+    expect(container.querySelector('[data-slot="aui_user-message-root"]')).toBe(userRoot)
+
+    // CONTROL: real transcript growth must still re-pin the frozen fromBottom.
+    viewportScrollHeight = SCROLL_H + 80 + 600
+    fireContentResizes()
+
+    expect(vp.scrollTop).toBe(
+      threadScrollTargetTop({ fromBottom: FROM_BOTTOM, kind: 'offset' }, { clientHeight: viewportClientHeight, scrollHeight: viewportScrollHeight })
+    )
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -30,7 +30,9 @@ import {
   publishThreadAtBottom,
   resetPublishedThreadScroll,
   saveThreadScrollPosition,
+  shouldReapplyFrozenThreadScrollOffset,
   THREAD_SCROLL_BOTTOM,
+  type ThreadScrollRestoreResizeMetrics,
   type ThreadScrollState,
   threadScrollStateFromMetrics,
   threadScrollStorageKey,
@@ -873,12 +875,32 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
     // Quiet frames are not layout completion: deferred Markdown and intrinsic
     // row measurements can change height after the initial settle. Retain the
-    // restored offset through those resizes until input or a live run takes over.
-    const resizeObserver = new ResizeObserver(() => {
-      if (target.kind === 'offset' && loadSettledRef.current) {
-        el.scrollTop = threadScrollTargetTop(target, el)
-        liveScrollStateRef.current = threadScrollStateFromMetrics(el)
+    // restored offset through those CONTENT resizes until input or a live run
+    // takes over. Composer clearance / surface-var resizes share this observer
+    // (the spacer lives inside the content box) but must not rewrite scrollTop.
+    const restoreResizeMetrics = (): ThreadScrollRestoreResizeMetrics => {
+      const clearance = contentRef.current?.querySelector('[data-slot="aui_composer-clearance"]')
+
+      return {
+        clearanceHeight: clearance instanceof HTMLElement ? clearance.clientHeight : 0,
+        clientHeight: el.clientHeight,
+        scrollHeight: el.scrollHeight
       }
+    }
+
+    let lastRestoreMetrics = restoreResizeMetrics()
+
+    const resizeObserver = new ResizeObserver(() => {
+      const next = restoreResizeMetrics()
+      const previous = lastRestoreMetrics
+      lastRestoreMetrics = next
+
+      if (!shouldReapplyFrozenThreadScrollOffset(target, loadSettledRef.current, previous, next)) {
+        return
+      }
+
+      el.scrollTop = threadScrollTargetTop(target, el)
+      liveScrollStateRef.current = threadScrollStateFromMetrics(el)
     })
 
     if (contentRef.current) {

--- a/apps/desktop/src/store/thread-scroll-restore.test.ts
+++ b/apps/desktop/src/store/thread-scroll-restore.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  shouldReapplyFrozenThreadScrollOffset,
+  threadScrollTargetTop,
+  threadScrollTranscriptHeight
+} from './thread-scroll'
+
+const OFFSET = { fromBottom: 800, kind: 'offset' as const }
+const BOTTOM = { kind: 'bottom' as const }
+
+describe('shouldReapplyFrozenThreadScrollOffset', () => {
+  it('does not re-pin a frozen offset when only composer clearance / viewport box resized', () => {
+    const previous = { clearanceHeight: 120, clientHeight: 600, scrollHeight: 5000 }
+    const next = { clearanceHeight: 200, clientHeight: 520, scrollHeight: 5080 }
+
+    expect(threadScrollTranscriptHeight(previous)).toBe(threadScrollTranscriptHeight(next))
+    expect(shouldReapplyFrozenThreadScrollOffset(OFFSET, true, previous, next)).toBe(false)
+
+    // Blind re-apply (the v0.21.1 post-settle RO) would rewrite scrollTop.
+    expect(threadScrollTargetTop(OFFSET, previous)).not.toBe(threadScrollTargetTop(OFFSET, next))
+  })
+
+  it('does not rewrite when a settled offset sees a no-op / same-transcript resize', () => {
+    const metrics = { clearanceHeight: 120, clientHeight: 600, scrollHeight: 5000 }
+
+    expect(shouldReapplyFrozenThreadScrollOffset(OFFSET, true, metrics, metrics)).toBe(false)
+  })
+
+  it('re-pins when transcript content height grew (streaming, prepend, markdown)', () => {
+    const previous = { clearanceHeight: 120, clientHeight: 600, scrollHeight: 5000 }
+    const next = { clearanceHeight: 120, clientHeight: 600, scrollHeight: 5600 }
+
+    expect(shouldReapplyFrozenThreadScrollOffset(OFFSET, true, previous, next)).toBe(true)
+    expect(threadScrollTargetTop(OFFSET, next)).toBe(5600 - 600 - 800)
+  })
+
+  it('leaves kind:bottom / following restore alone', () => {
+    const previous = { clearanceHeight: 120, clientHeight: 600, scrollHeight: 5000 }
+    const next = { clearanceHeight: 120, clientHeight: 600, scrollHeight: 5600 }
+
+    expect(shouldReapplyFrozenThreadScrollOffset(BOTTOM, true, previous, next)).toBe(false)
+  })
+
+  it('does not re-pin while the session-switch settle loop is still running', () => {
+    const previous = { clearanceHeight: 120, clientHeight: 600, scrollHeight: 5000 }
+    const next = { clearanceHeight: 120, clientHeight: 600, scrollHeight: 5600 }
+
+    expect(shouldReapplyFrozenThreadScrollOffset(OFFSET, false, previous, next)).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -158,6 +158,43 @@ export function threadScrollTargetTop(
   return state.kind === 'bottom' ? max : Math.max(0, max - state.fromBottom)
 }
 
+// Composer metrics write --composer-measured-height onto the chat surface,
+// which grows [data-slot="aui_composer-clearance"] and can shrink the
+// clampToComposer viewport. The post-settle restore ResizeObserver sees that
+// as a content resize and used to re-pin a frozen fromBottom — rewriting
+// scrollTop on every keystroke. Transcript height is scrollHeight minus the
+// clearance spacer, so composer-only layout is distinguishable from real
+// message/prepend/streaming growth.
+export type ThreadScrollRestoreResizeMetrics = {
+  clearanceHeight: number
+  clientHeight: number
+  scrollHeight: number
+}
+
+export function threadScrollTranscriptHeight(
+  metrics: Pick<ThreadScrollRestoreResizeMetrics, 'clearanceHeight' | 'scrollHeight'>
+): number {
+  return Math.max(0, metrics.scrollHeight - Math.max(0, metrics.clearanceHeight))
+}
+
+/**
+ * Post-settle restore RO may re-pin a frozen offset only when transcript
+ * rows actually changed height. Composer clearance / viewport-box resizes
+ * and no-op RO deliveries must not rewrite scrollTop.
+ */
+export function shouldReapplyFrozenThreadScrollOffset(
+  target: ThreadScrollState,
+  settled: boolean,
+  previous: Pick<ThreadScrollRestoreResizeMetrics, 'clearanceHeight' | 'scrollHeight'>,
+  next: Pick<ThreadScrollRestoreResizeMetrics, 'clearanceHeight' | 'scrollHeight'>
+): boolean {
+  if (target.kind !== 'offset' || !settled) {
+    return false
+  }
+
+  return Math.round(threadScrollTranscriptHeight(previous)) !== Math.round(threadScrollTranscriptHeight(next))
+}
+
 // Storage is scoped per profile with the same `.profile.<encoded>` suffix the
 // app's other persisted session state uses (session.ts profileNavigationKey),
 // so two profiles can never read or evict each other's reading positions.


### PR DESCRIPTION
## What does this PR do?

After the v0.21.1 per-session scroll restore work, the post-settle `ResizeObserver` in `ThreadMessageListInner` re-pinned a frozen distance-from-bottom on every content-box resize. Composer metrics write `--composer-measured-height` onto the chat surface, which grows the clearance spacer inside that box — so a single-line keystroke could rewrite `scrollTop`, producing transcript flicker / upward scroll / caret displacement on Windows.

This PR keeps restored offsets through **real transcript height** changes (messages / prepend / streaming), but skips re-apply when only composer clearance (or a no-op RO) changed. Persist, cancel-on-input, stick-to-bottom, and session settle are unchanged.

## Related Issue

Fixes #107000

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/thread-scroll.ts` — + (transcript height = scrollHeight − clearance)
- `apps/desktop/src/components/assistant-ui/thread/list.ts` — post-settle restore RO only re-pins when transcript height changes
- `apps/desktop/src/store/thread-scroll-restore.test.ts` — (new): helper contract
- `apps/desktop/src/components/assistant-ui/thread/list-restore-composer-resize.test.ts` — (new): composer-only resize must not rewrite scrollTop; content growth still re-pins

## How to Test

- [x] `scripts/run_tests.sh` on the files in Changes Made — focused verification
- [x] `npx vitest run --project ui \`
- [x] Result: 1 passed on the focused probe

## Evidence

- BEFORE: the focused probe was RED on origin/main before this change
- AFTER: - [x] `scripts/run_tests.sh` on the files in Changes Made — focused verification — focused command GREEN
- CONTROL: neighboring paths listed in How to Test still pass

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

