### PR TITLE
fix(desktop): keep settings search opaque under Glass

### DIFF
--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -334,8 +334,8 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
   // Fake search pill riding the card's top edge, dead-center and half off it.
   // Clicking (or just typing) opens the ⌘K palette scoped to settings; while
   // the palette is up the pill hands over to it — grows slightly and fades,
-  // then fades back when the palette closes. It renders as chrome, not an
-  // input — no border, recessed fill, live ⌘K hint.
+  // then fades back when the palette closes. It sits outside the raised card,
+  // so it needs its own opaque glass surface to mask the content underneath.
   const searchCombo = bindingsFor('nav.commandPalette')[0]
   const paletteOpen = useStore($commandPaletteOpen)
 
@@ -345,6 +345,7 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
         'flex h-(--titlebar-control-height) items-center gap-1.5 rounded-full border border-(--ui-stroke-secondary) bg-(--ui-chat-surface-background) px-2.5 text-(--ui-text-tertiary) shadow-sm transition-all duration-200 ease-out hover:text-foreground motion-reduce:transition-none',
         paletteOpen && 'pointer-events-none scale-110 opacity-0'
       )}
+      data-glass-opaque=""
       onClick={() => {
         triggerHaptic('open')
         openCommandPalettePage('settings')


### PR DESCRIPTION
## What does this PR do?

Keeps the Settings search pill opaque when Glass is enabled, so the panel edge and content behind it no longer show through. The pill sits outside the raised Settings card and therefore does not inherit its restored surface colors.

This uses the existing `data-glass-opaque` contract and theme tokens. The pill's dimensions, border, shadow, and palette handoff are unchanged.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/98484

Supersedes [#98513](https://github.com/NousResearch/hermes-agent/pull/98513), which identified the same cause and attribute fix. Thanks to @moisesvalero for that contribution. This version applies the attribute only to the search pill; the shared wrapper does not need it as well.

## Type of Change

- [x] Bug fix

## Changes Made

- Mark the search pill in `apps/desktop/src/app/settings/index.tsx` with `data-glass-opaque` and explain why it needs its own surface.

## How to Test

1. Open Settings with Glass enabled and nonzero Tint. The search pill should have a solid fill across the panel edge.
2. Check light and dark appearances with Glass disabled, sidebar-only Glass, and whole-window Glass.
3. Click the pill or focus it and press Enter. It should open settings-scoped search, fade out, and return when the palette closes.

## Verification

- [x] Rendered the real `SettingsView` with the application stylesheet in an isolated Chrome preview on macOS.
- [x] Before the fix, the opacity probe failed: the pill's background alpha was 0 under both Glass scopes in both appearances.
- [x] After the fix, background alpha was 255 in all six appearance/scope combinations, with unchanged geometry and no renderer errors.
- [x] Verified pointer and Enter activation set the settings-scoped palette state; closing restores the pill.
- [x] Inspected light/dark screenshots and a high-resolution crop.
- [x] `git diff --check`.

The targeted browser probe is worktree-local, not a committed regression test. The full test suite and native Windows rendering were not run.
