### PR TITLE
fix(desktop): keep artifact links at the bottom of the status stack

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -247,7 +247,8 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
   open the rail automatically.
 - Composer status groups start collapsed except todos. Progress updates and queue
   pause/resume preserve the user's disclosure choice. Error banners meet the
-  stack's top edge without a blank padding strip.
+  stack's top edge without a blank padding strip. File and preview links remain
+  visible at the bottom of the stack, below the queue and all status groups.
 - Install, onboarding, connecting, boot failure, and reauthentication are
   distinct states with shared visual primitives. Preserve their recovery
   semantics when unifying appearance.

--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -81,8 +81,7 @@ const hasRunningTodo = (group: StatusGroup) =>
 
 interface ComposerStatusStackProps {
   onSubmit?: (value: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
-  /** The queue, built by the composer (it owns the queue's callbacks). Rendered
-   *  as the last group so it stays fused to the composer like before. */
+  /** The queue, built by the composer (it owns the queue's callbacks). */
   queue: ReactNode
   sessionId: null | string
 }
@@ -168,19 +167,12 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
   const openSubagent = (item: ComposerStatusItem) =>
     item.sessionId ? void openSessionInNewWindow(item.sessionId, { watch: true }) : openAgents()
 
-  // Preview links live as child rows of the background group — a localhost dev
-  // server and its preview are the same thing — so they no longer float as an
-  // odd, differently-indented standalone block under the stack.
   const previewRows =
     visiblePreviews.length > 0 && sessionId
       ? visiblePreviews.map(item => (
           <PreviewStatusRow item={item} key={item.id} onDismiss={id => dismissPreviewArtifact(sessionId, id)} />
         ))
       : []
-
-  const hasBackgroundGroup = groups.some(g => g.type === 'background')
-
-  const previewBlock = <div className="px-1 py-0.5">{previewRows}</div>
 
   const sections: { key: string; node: ReactNode }[] = []
 
@@ -257,25 +249,16 @@ export function ComposerStatusStack({ onSubmit, queue, sessionId }: ComposerStat
         </StatusSection>
       )
     })
-
-    // Preview links belong to the background group (a localhost dev server and
-    // its preview are the same thing), but they must stay VISIBLE even when that
-    // group is collapsed — the whole point is a one-tap open. Render them as an
-    // always-visible block right after the background section, not as collapsible
-    // children that get swallowed the moment a background task appears.
-    if (group.type === 'background' && previewRows.length > 0) {
-      sections.push({ key: 'preview', node: previewBlock })
-    }
-  }
-
-  // No background group to host them (e.g. a standalone on-disk file preview):
-  // still render them as their own always-visible block.
-  if (previewRows.length > 0 && !hasBackgroundGroup) {
-    sections.push({ key: 'preview', node: previewBlock })
   }
 
   if (queue) {
     sections.push({ key: 'queue', node: queue })
+  }
+
+  // Artifact links stay visible at the bottom, nearest the composer, even when
+  // the queue or background group expands.
+  if (previewRows.length > 0) {
+    sections.push({ key: 'preview', node: <div className="px-1 py-0.5">{previewRows}</div> })
   }
 
   // Micro actions are the TOP-MOST thing in the whole overlay lane — above the

--- a/apps/desktop/src/app/chat/composer/status-stack/preview-order.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/preview-order.test.tsx
@@ -1,0 +1,81 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, expect, it } from 'vitest'
+
+import { $backgroundStatusBySession } from '@/store/composer-status'
+import { $previewStatusBySession } from '@/store/preview-status'
+import { $todosBySession } from '@/store/todos'
+
+import { QueuePanel } from '../queue-panel'
+
+import { ComposerStatusStack } from './index'
+
+const noop = () => {}
+
+const queue = (
+  <QueuePanel
+    busy
+    editingId={null}
+    entries={[{ attachments: [], id: 'queued', queuedAt: 1, text: 'Queued request' }]}
+    onDelete={noop}
+    onEdit={noop}
+    onResume={noop}
+    onSendNow={noop}
+    parked={false}
+  />
+)
+
+const stack = (queued: boolean) => (
+  <MemoryRouter>
+    <ComposerStatusStack queue={queued ? queue : null} sessionId="owner" />
+  </MemoryRouter>
+)
+
+function expectBefore(before: HTMLElement, after: HTMLElement) {
+  expect(before.compareDocumentPosition(after) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+}
+
+afterEach(() => {
+  cleanup()
+  $backgroundStatusBySession.set({})
+  $previewStatusBySession.set({})
+  $todosBySession.set({})
+})
+
+it.each([false, true])('keeps artifact links below the queue with background work: %s', background => {
+  $todosBySession.set({ owner: [{ id: 'todo', content: 'Task item', status: 'in_progress' }] })
+  $previewStatusBySession.set({
+    owner: [
+      { cwd: '/tmp', id: 'file', label: 'index.html', target: '/tmp/index.html' },
+      { cwd: '/tmp', id: 'url', label: 'Live preview', target: 'http://localhost:5174' }
+    ]
+  })
+
+  if (background) {
+    $backgroundStatusBySession.set({
+      owner: [{ id: 'process', type: 'background', state: 'running', title: 'Preview server' }]
+    })
+  }
+
+  const view = render(stack(true))
+  const file = screen.getByText('index.html')
+  const header = screen.getByRole('button', { name: /1 Queued/ })
+  expectBefore(screen.getByText('Task item'), file)
+  expectBefore(header, file)
+  expect(screen.queryAllByText('Live preview')).toHaveLength(background ? 1 : 0)
+
+  fireEvent.click(header)
+  expectBefore(screen.getByText('Queued request'), file)
+
+  if (background) {
+    expectBefore(file, screen.getByText('Live preview'))
+    act(() => $backgroundStatusBySession.set({}))
+    expect(screen.queryByText('Live preview')).toBeNull()
+    expectBefore(screen.getByText('Queued request'), file)
+  }
+
+  view.rerender(stack(false))
+  expectBefore(screen.getByText('Task item'), file)
+  view.rerender(stack(true))
+  expectBefore(screen.getByRole('button', { name: /1 Queued/ }), file)
+})


### PR DESCRIPTION
## Summary
Keep file and preview links at the bottom of the composer status stack, below the queue and all status groups. Previously, links followed the background group or appeared before the queue, leaving `index.html` between Background and Queued.

Use one final preview block regardless of whether background work is present. Links remain visible when groups collapse or expand. Localhost previews still disappear when their background process ends; file links remain available.

## Test plan
- [x] Both ordering regression cases failed before the fix and pass afterward, with and without background work.
- [x] 8 targeted tests pass across preview ordering, preview opening, and collapse defaults.
- [x] Playwright with the real ChatView and isolated fixture state verifies link placement in light and dark themes, including queue expansion, queue removal, and background-process removal. No page errors.
- [x] Screenshot confirms Tasks, Background, Queued, then file/preview links directly above the composer.

Full build and full test suites were not run.
