### PR TITLE
fix(web): dashboard plugin discovery and management follow the selected profile

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1565,22 +1565,25 @@ def discover_plugins(force: bool = False) -> None:
     """Discover and load all plugins (idempotent; ``force=True`` rescans). Joins an in-flight
     background discovery instead of racing a second scan.
 
-    A request scoped to another profile (task-local ``HERMES_HOME`` override — e.g. the
-    dashboard's ``?profile=<name>`` handling) must NOT load that profile's plugin modules.
-    Plugin registration has PROCESS-GLOBAL side effects: dashboard-auth providers are upserted
-    by name into a process-global registry, so loading another profile's manager would replace
-    the provider validating the running dashboard's sessions and 401 every live cookie
-    (#106608). The process's own plugins are discovered by its startup path, not by a scoped
-    request, so skipping here changes nothing for the launch profile.
+    A REQUEST scoped to another profile (``is_request_scoped_hermes_home()`` — the dashboard's
+    ``?profile=<name>`` handling) must NOT load that profile's plugin modules. Plugin registration
+    has PROCESS-GLOBAL side effects: dashboard-auth providers are upserted by name into a
+    process-global registry, so loading another profile's manager would replace the provider
+    validating the running dashboard's sessions and 401 every live cookie (#106608). The process's
+    own plugins are discovered by its startup path, not by a request, so the skip changes nothing
+    for the launch profile.
+
+    A plain override is NOT a request: the cron external worker and a multiplexed gateway turn each
+    scope the profile the process is acting AS, and both need that profile's plugin tools
+    (``agent/agent_init.py::_load_tools`` calls this under those scopes) — so they still load.
     """
     _join_background_discovery()
-    from hermes_constants import get_hermes_home_override
-    override = get_hermes_home_override()
-    if override:
+    from hermes_constants import is_request_scoped_hermes_home
+    if is_request_scoped_hermes_home():
         logger.debug(
-            "Skipping plugin discovery under profile override %s: a scoped request must not "
-            "load another profile's plugin modules (process-global side effects, #106608)",
-            override,
+            "Skipping plugin discovery for a request scoped to another profile: plugin "
+            "registration has process-global side effects and would replace this process's own "
+            "registrations (#106608)",
         )
         return
     get_plugin_manager().discover_and_load(force=force)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1573,10 +1573,16 @@ def discover_plugins(force: bool = False) -> None:
     (#106608). The process's own plugins are discovered by its startup path, not by a scoped
     request, so skipping here changes nothing for the launch profile.
     """
-    from hermes_constants import get_hermes_home_override
-    if get_hermes_home_override():
-        return
     _join_background_discovery()
+    from hermes_constants import get_hermes_home_override
+    override = get_hermes_home_override()
+    if override:
+        logger.debug(
+            "Skipping plugin discovery under profile override %s: a scoped request must not "
+            "load another profile's plugin modules (process-global side effects, #106608)",
+            override,
+        )
+        return
     get_plugin_manager().discover_and_load(force=force)
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1563,7 +1563,19 @@ def has_enabled_agent_plugin_mcp(raw_config: Mapping[str, Any]) -> bool:
 
 def discover_plugins(force: bool = False) -> None:
     """Discover and load all plugins (idempotent; ``force=True`` rescans). Joins an in-flight
-    background discovery instead of racing a second scan."""
+    background discovery instead of racing a second scan.
+
+    A request scoped to another profile (task-local ``HERMES_HOME`` override — e.g. the
+    dashboard's ``?profile=<name>`` handling) must NOT load that profile's plugin modules.
+    Plugin registration has PROCESS-GLOBAL side effects: dashboard-auth providers are upserted
+    by name into a process-global registry, so loading another profile's manager would replace
+    the provider validating the running dashboard's sessions and 401 every live cookie
+    (#106608). The process's own plugins are discovered by its startup path, not by a scoped
+    request, so skipping here changes nothing for the launch profile.
+    """
+    from hermes_constants import get_hermes_home_override
+    if get_hermes_home_override():
+        return
     _join_background_discovery()
     get_plugin_manager().discover_and_load(force=force)
 

--- a/hermes_cli/web_routers/dashboard_ui.py
+++ b/hermes_cli/web_routers/dashboard_ui.py
@@ -7,12 +7,13 @@ Extracted from ``hermes_cli.web_server``; helpers/state that tests monkeypatch o
 import asyncio
 import logging
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
 
 from hermes_cli.web_deps import LateState, late
+from hermes_cli.web_routers._common import scoped_to_thread
 from hermes_cli.config import cfg_get
 from hermes_cli.web_server_dashboard import (
     _BUILTIN_DASHBOARD_THEMES, _discover_user_themes, _invalidate_plugins_hub_cache, _merged_plugins_hub,
@@ -124,14 +125,19 @@ def _plugin_activated(plugin: dict, enabled_set: set, disabled_set: set) -> bool
 
 
 @router.get("/api/dashboard/plugins")
-async def get_dashboard_plugins():
-    """Return discovered dashboard plugins (excludes user-hidden and non-enabled ones)."""
+async def get_dashboard_plugins(profile: Optional[str] = None):
+    """Return discovered dashboard plugins (excludes user-hidden and non-enabled ones).
+
+    Scoped to ``profile`` (the dashboard's selected management profile) so the
+    enabled/disabled gate and ``dashboard.hidden_plugins`` resolve against the
+    requested profile, not the dashboard process's own (issue #46408).
+    """
     def _run():
         plugins = _get_dashboard_plugins()
         hidden: list = cfg_get(load_config(), "dashboard", "hidden_plugins", default=[]) or []
         return plugins, hidden, *_plugin_enable_sets()
 
-    plugins, hidden, enabled_set, disabled_set = await asyncio.to_thread(_run)
+    plugins, hidden, enabled_set, disabled_set = await scoped_to_thread(profile, _run)
 
     # Strip internal fields before sending to frontend.
     return [
@@ -142,18 +148,22 @@ async def get_dashboard_plugins():
 
 
 @router.get("/api/dashboard/plugins/rescan")
-async def rescan_dashboard_plugins():
+async def rescan_dashboard_plugins(profile: Optional[str] = None):
     """Force re-scan of dashboard plugins."""
-    plugins = _get_dashboard_plugins(force_rescan=True)
+    def _run():
+        return _get_dashboard_plugins(force_rescan=True)
+    plugins = await scoped_to_thread(profile, _run)
     return {"ok": True, "count": len(plugins)}
 
 
 @router.get("/api/dashboard/plugins/hub")
-async def get_plugins_hub(request: Request):
+async def get_plugins_hub(request: Request, profile: Optional[str] = None):
     """Unified agent plugins + dashboard extension metadata (session protected)."""
     _require_token(request)
     try:
-        return _merged_plugins_hub()
+        def _run():
+            return _merged_plugins_hub()
+        return await scoped_to_thread(profile, _run)
     except Exception as exc:
         _log.warning("plugins/hub failed: %s", exc)
         raise HTTPException(status_code=500, detail="Failed to build plugins hub.") from exc
@@ -171,7 +181,7 @@ def _plugin_action(result: dict, fallback_error: str, *, rescan: bool) -> dict:
 
 
 @router.get("/api/dashboard/plugins/catalog")
-async def get_plugins_catalog(request: Request):
+async def get_plugins_catalog(request: Request, profile: Optional[str] = None):
     """Curated plugin catalog merged with installed state (session protected)."""
     _require_token(request)
 
@@ -188,14 +198,14 @@ async def get_plugins_catalog(request: Request):
         return installed_catalog_state(installed)
 
     try:
-        return await asyncio.to_thread(_run)
+        return await scoped_to_thread(profile, _run)
     except Exception as exc:
         _log.warning("plugins/catalog failed: %s", exc)
         raise HTTPException(status_code=500, detail="Failed to build plugins catalog.") from exc
 
 
 @router.post("/api/dashboard/agent-plugins/install")
-async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallBody):
+async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallBody, profile: Optional[str] = None):
     _require_token(request)
     from hermes_cli.plugins_cmd import dashboard_install_plugin
 
@@ -203,9 +213,13 @@ async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallB
     identifier = body.identifier.strip()
     if not identifier and not catalog_name:
         raise HTTPException(status_code=400, detail="Provide an identifier or a catalog_name.")
-    result = dashboard_install_plugin(
-        identifier, force=body.force, enable=body.enable, catalog_name=catalog_name or None, ref=body.ref)
-    result = _plugin_action(result, "Install failed.", rescan=True)
+    def _run():
+        result = dashboard_install_plugin(
+            identifier, force=body.force, enable=body.enable, catalog_name=catalog_name or None,
+            ref=body.ref)
+        return _plugin_action(result, "Install failed.", rescan=True)
+
+    result = await scoped_to_thread(profile, _run)
     # Strip internal paths from the response
     result.pop("after_install_path", None)
     return result
@@ -219,39 +233,41 @@ def _validate_plugin_name(name: str) -> str:
     return name
 
 
-def _named_plugin_action(request: Request, name: str, action: Callable[[str], dict], fallback_error: str, *, rescan: bool) -> dict:
+async def _named_plugin_action(request: Request, name: str, action: Callable[[str], dict], fallback_error: str, *, rescan: bool, profile: Optional[str] = None) -> dict:
     _require_token(request)
-    return _plugin_action(action(_validate_plugin_name(name)), fallback_error, rescan=rescan)
+    def _run():
+        return _plugin_action(action(_validate_plugin_name(name)), fallback_error, rescan=rescan)
+    return await scoped_to_thread(profile, _run)
 
 
 @router.post("/api/dashboard/agent-plugins/{name:path}/enable")
-async def post_agent_plugin_enable(request: Request, name: str):
+async def post_agent_plugin_enable(request: Request, name: str, profile: Optional[str] = None):
     from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
-    return _named_plugin_action(request, name, lambda n: dashboard_set_agent_plugin_enabled(n, enabled=True),
-                                "Enable failed.", rescan=False)
+    return await _named_plugin_action(request, name, lambda n: dashboard_set_agent_plugin_enabled(n, enabled=True),
+                                "Enable failed.", rescan=False, profile=profile)
 
 
 @router.post("/api/dashboard/agent-plugins/{name:path}/disable")
-async def post_agent_plugin_disable(request: Request, name: str):
+async def post_agent_plugin_disable(request: Request, name: str, profile: Optional[str] = None):
     from hermes_cli.plugins_cmd import dashboard_set_agent_plugin_enabled
-    return _named_plugin_action(request, name, lambda n: dashboard_set_agent_plugin_enabled(n, enabled=False),
-                                "Disable failed.", rescan=False)
+    return await _named_plugin_action(request, name, lambda n: dashboard_set_agent_plugin_enabled(n, enabled=False),
+                                "Disable failed.", rescan=False, profile=profile)
 
 
 @router.post("/api/dashboard/agent-plugins/{name:path}/update")
-async def post_agent_plugin_update(request: Request, name: str):
+async def post_agent_plugin_update(request: Request, name: str, profile: Optional[str] = None):
     from hermes_cli.plugins_cmd import dashboard_update_user_plugin
-    return _named_plugin_action(request, name, dashboard_update_user_plugin, "Update failed.", rescan=True)
+    return await _named_plugin_action(request, name, dashboard_update_user_plugin, "Update failed.", rescan=True, profile=profile)
 
 
 @router.delete("/api/dashboard/agent-plugins/{name:path}")
-async def delete_agent_plugin(request: Request, name: str):
+async def delete_agent_plugin(request: Request, name: str, profile: Optional[str] = None):
     from hermes_cli.plugins_cmd import dashboard_remove_user_plugin
-    return _named_plugin_action(request, name, dashboard_remove_user_plugin, "Remove failed.", rescan=True)
+    return await _named_plugin_action(request, name, dashboard_remove_user_plugin, "Remove failed.", rescan=True, profile=profile)
 
 
 @router.put("/api/dashboard/plugin-providers")
-async def put_plugin_providers(request: Request, body: _PluginProvidersPutBody):
+async def put_plugin_providers(request: Request, body: _PluginProvidersPutBody, profile: Optional[str] = None):
     """Persist memory provider / context engine selection (writes config.yaml)."""
     _require_token(request)
     from hermes_cli.plugins_cmd import _save_context_engine, _save_memory_provider
@@ -267,11 +283,11 @@ async def put_plugin_providers(request: Request, body: _PluginProvidersPutBody):
         _invalidate_plugins_hub_cache()
         return {"ok": True}
 
-    return await asyncio.to_thread(_run)
+    return await scoped_to_thread(profile, _run)
 
 
 @router.post("/api/dashboard/plugins/{name:path}/visibility")
-async def post_plugin_visibility(request: Request, name: str, body: _PluginVisibilityBody):
+async def post_plugin_visibility(request: Request, name: str, body: _PluginVisibilityBody, profile: Optional[str] = None):
     """Toggle a plugin's sidebar visibility (persists to config.yaml dashboard.hidden_plugins)."""
     _require_token(request)
     name = _validate_plugin_name(name)
@@ -293,7 +309,7 @@ async def post_plugin_visibility(request: Request, name: str, body: _PluginVisib
         _invalidate_plugins_hub_cache()
         return {"ok": True, "name": name, "hidden": body.hidden}
 
-    return await asyncio.to_thread(_run)
+    return await scoped_to_thread(profile, _run)
 
 
 # Browser-asset suffix allowlist. Everything else is 404'd so we never leak ``.py`` backend

--- a/hermes_cli/web_routers/dashboard_ui.py
+++ b/hermes_cli/web_routers/dashboard_ui.py
@@ -324,32 +324,39 @@ _PLUGIN_ASSET_CONTENT_TYPES = {
 
 
 @router.get("/dashboard-plugins/{plugin_name}/{file_path:path}")
-async def serve_plugin_asset(plugin_name: str, file_path: str):
+async def serve_plugin_asset(plugin_name: str, file_path: str, profile: Optional[str] = None):
     """Serve static assets from a dashboard plugin's ``dashboard/`` directory.
 
     Unauthenticated on purpose: the SPA loads plugin JS via ``<script src>`` and CSS
-    via ``<link href>``, which cannot attach an auth header. Hence the suffix
+    via ``<link href>``, which cannot attach an auth header; the SPA passes the selected
+    management profile as ``?profile=<name>`` instead. Hence the suffix
     allowlist — user plugins ship a ``plugin_api.py`` backend the browser never
     fetches, and without it anyone on the loopback port could curl a private
     plugin's source. Path traversal is blocked via ``resolve().is_relative_to()``;
     user plugins must be enabled (bundled ones not disabled) (GHSA-mcfc-hp25-cjv7).
 
+    Scoped to ``profile`` so a plugin installed under the selected profile resolves
+    there rather than 404ing against the process home (#46408).
+
     See #46435.
     """
-    plugins = _get_dashboard_plugins()
-    plugin = next((p for p in plugins if p["name"] == plugin_name), None)
-    if not plugin or not _plugin_activated(plugin, *_plugin_enable_sets()):
-        raise HTTPException(status_code=404, detail="Plugin not found")
+    def _run():
+        plugins = _get_dashboard_plugins()
+        plugin = next((p for p in plugins if p["name"] == plugin_name), None)
+        if not plugin or not _plugin_activated(plugin, *_plugin_enable_sets()):
+            raise HTTPException(status_code=404, detail="Plugin not found")
 
-    base = Path(plugin["_dir"])
-    target = (base / file_path).resolve()
+        base = Path(plugin["_dir"])
+        target = (base / file_path).resolve()
 
-    if not target.is_relative_to(base.resolve()):
-        raise HTTPException(status_code=403, detail="Path traversal blocked")
-    if not target.exists() or not target.is_file():
-        raise HTTPException(status_code=404, detail="File not found")
+        if not target.is_relative_to(base.resolve()):
+            raise HTTPException(status_code=403, detail="Path traversal blocked")
+        if not target.exists() or not target.is_file():
+            raise HTTPException(status_code=404, detail="File not found")
 
-    media_type = _PLUGIN_ASSET_CONTENT_TYPES.get(target.suffix.lower())
-    if media_type is None:
-        raise HTTPException(status_code=404, detail="File not found")
-    return FileResponse(target, media_type=media_type, headers={"Cache-Control": "no-store, no-cache, must-revalidate"})
+        media_type = _PLUGIN_ASSET_CONTENT_TYPES.get(target.suffix.lower())
+        if media_type is None:
+            raise HTTPException(status_code=404, detail="File not found")
+        return FileResponse(target, media_type=media_type, headers={"Cache-Control": "no-store, no-cache, must-revalidate"})
+
+    return await scoped_to_thread(profile, _run)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -918,28 +918,22 @@ _ACTION_LOG_FILES.setdefault("computer-use-grant", "action-computer-use-grant.lo
 # task-local home (see ``_dashboard_plugin_search_dirs``), so it must not be shared
 # across profiles.
 _dashboard_plugins_cache: dict[str, list] = {}
+_dashboard_plugins_cache_lock = threading.Lock()
 
 
 def _get_dashboard_plugins(force_rescan: bool = False) -> list:
     global _dashboard_plugins_cache
     from hermes_cli.config import get_hermes_home
+    # Cache keyed by resolved home: discovery depends on the task-local home, so a
+    # request scoped to a different profile (?profile=<name>) gets its own result
+    # and never another profile's (#46408).
     home = str(get_hermes_home())
-    # The cache is a per-process dict keyed by resolved home so a request scoped
-    # to a different profile gets its own discovery result (#46408). Tests that
-    # seed/reset it with a bare list or None keep working: treat those as the
-    # current value (None => re-discover).
-    if isinstance(_dashboard_plugins_cache, dict):
+    with _dashboard_plugins_cache_lock:
         cached = _dashboard_plugins_cache.get(home)
-    else:
-        cached = _dashboard_plugins_cache
-    if cached is None or force_rescan or any(not Path(p["_dir"]).is_dir() for p in cached):
-        cached = _discover_dashboard_plugins()
-        if isinstance(_dashboard_plugins_cache, dict) or _dashboard_plugins_cache is None:
-            _dashboard_plugins_cache = {}
+        if cached is None or force_rescan or any(not Path(p["_dir"]).is_dir() for p in cached):
+            cached = _discover_dashboard_plugins()
             _dashboard_plugins_cache[home] = cached
-        else:
-            _dashboard_plugins_cache = cached
-    return cached
+        return cached
 
 
 # Router mounting. ORDER IS ROUTE-MATCHING ORDER: literal paths must land before

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -912,18 +912,34 @@ def _voice_list_error_logged_once(signature: Optional[str]) -> bool:
 
 _ACTION_LOG_FILES.setdefault("computer-use-grant", "action-computer-use-grant.log")
 
-# Cache discovered plugins per-process (refresh on explicit re-scan).
-_dashboard_plugins_cache: Optional[list] = None
+# Cache discovered plugins per-process, keyed by the resolved home so a request
+# scoped to a different profile (via ``?profile=<name>``) gets its own discovery
+# result instead of another profile's (issue #46408). Discovery now depends on the
+# task-local home (see ``_dashboard_plugin_search_dirs``), so it must not be shared
+# across profiles.
+_dashboard_plugins_cache: dict[str, list] = {}
 
 
 def _get_dashboard_plugins(force_rescan: bool = False) -> list:
     global _dashboard_plugins_cache
-    stale = _dashboard_plugins_cache is None or force_rescan or any(
-        not Path(p["_dir"]).is_dir() for p in _dashboard_plugins_cache
-    )
-    if stale:
-        _dashboard_plugins_cache = _discover_dashboard_plugins()
-    return _dashboard_plugins_cache
+    from hermes_cli.config import get_hermes_home
+    home = str(get_hermes_home())
+    # The cache is a per-process dict keyed by resolved home so a request scoped
+    # to a different profile gets its own discovery result (#46408). Tests that
+    # seed/reset it with a bare list or None keep working: treat those as the
+    # current value (None => re-discover).
+    if isinstance(_dashboard_plugins_cache, dict):
+        cached = _dashboard_plugins_cache.get(home)
+    else:
+        cached = _dashboard_plugins_cache
+    if cached is None or force_rescan or any(not Path(p["_dir"]).is_dir() for p in cached):
+        cached = _discover_dashboard_plugins()
+        if isinstance(_dashboard_plugins_cache, dict) or _dashboard_plugins_cache is None:
+            _dashboard_plugins_cache = {}
+            _dashboard_plugins_cache[home] = cached
+        else:
+            _dashboard_plugins_cache = cached
+    return cached
 
 
 # Router mounting. ORDER IS ROUTE-MATCHING ORDER: literal paths must land before

--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -462,6 +462,7 @@ def _dashboard_plugin_search_dirs() -> List[tuple]:
     a bare non-empty check let ``=0``/``=false`` silently enable it (GHSA-5qr3-c538-wm9j).
     """
     from hermes_cli.plugins import get_bundled_plugins_dir
+    from hermes_cli.config import get_hermes_home
     from hermes_constants import get_default_hermes_root
 
     bundled_root = get_bundled_plugins_dir()
@@ -475,10 +476,14 @@ def _dashboard_plugin_search_dirs() -> List[tuple]:
     # *is* the root), mirroring how ``hermes_cli.plugins`` resolves plugin install locations. The
     # ``seen_names`` dedupe below keeps profile-local plugins (if any) authoritative over same-named root
     # plugins.
+    #
+    # Also scan the task-local home (the selected management profile, ``?profile=<name>``) because a
+    # profile-scoped ``install`` writes there; without it the newly installed plugin is orphaned from
+    # discovery (issue #46408). Deduped against the process + root homes.
     user_plugin_roots = [get_process_hermes_home() / "plugins"]
-    root_plugins = get_default_hermes_root() / "plugins"
-    if root_plugins.resolve(strict=False) != user_plugin_roots[0].resolve(strict=False):
-        user_plugin_roots.append(root_plugins)
+    for candidate in (get_hermes_home() / "plugins", get_default_hermes_root() / "plugins"):
+        if all(candidate.resolve(strict=False) != existing.resolve(strict=False) for existing in user_plugin_roots):
+            user_plugin_roots.append(candidate)
     search_dirs = [(d, "user") for d in user_plugin_roots]
     search_dirs += [(bundled_root / "memory", "bundled"), (bundled_root, "bundled")]
     # GHSA-5qr3-c538-wm9j (#29156): the previous ``os.environ.get(...)`` check treated *any* non-empty
@@ -566,16 +571,17 @@ def _strip_dashboard_manifest(p: Dict[str, Any]) -> Dict[str, Any]:
 
 
 _PLUGINS_HUB_CACHE_TTL_SECONDS = 5.0
-_plugins_hub_cache: Optional[Dict[str, Any]] = None
-_plugins_hub_cache_expires_at = 0.0
+# Payloads keyed by resolved home: the hub reflects per-profile plugin state
+# (enabled/disabled, hidden, plugins root), so on a multiplex dashboard a
+# profile-scoped request must not be served another profile's cached hub (#46408).
+_plugins_hub_cache: Dict[str, tuple] = {}
 _plugins_hub_cache_lock = threading.Lock()
 
 
 def _invalidate_plugins_hub_cache() -> None:
-    global _plugins_hub_cache, _plugins_hub_cache_expires_at
+    global _plugins_hub_cache
     with _plugins_hub_cache_lock:
-        _plugins_hub_cache = None
-        _plugins_hub_cache_expires_at = 0.0
+        _plugins_hub_cache = {}
 
 
 _plugins_hub_probe_inflight: set = set()
@@ -650,12 +656,14 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
     from hermes_cli.web_server_memory import _discover_memory_provider_statuses, _normalize_memory_provider_name
     from hermes_cli.web_server import _get_dashboard_plugins
     from hermes_cli.config import get_hermes_home, load_config
-    global _plugins_hub_cache, _plugins_hub_cache_expires_at
+    global _plugins_hub_cache
+    home = str(get_hermes_home())
     now = time.monotonic()
     if not force_refresh:
         with _plugins_hub_cache_lock:
-            if _plugins_hub_cache is not None and now < _plugins_hub_cache_expires_at:
-                return _plugins_hub_cache
+            cached = _plugins_hub_cache.get(home)
+            if cached is not None and now < cached[1]:
+                return cached[0]
 
     started_at = time.monotonic()
     from hermes_cli.plugins_cmd import (
@@ -736,8 +744,7 @@ def _merged_plugins_hub(force_refresh: bool = False) -> Dict[str, Any]:
             "plugins/hub rebuilt in %.3fs (plugins=%d memory_options=%d)", duration, len(rows), len(memory_providers)
         )
     with _plugins_hub_cache_lock:
-        _plugins_hub_cache = payload
-        _plugins_hub_cache_expires_at = time.monotonic() + _PLUGINS_HUB_CACHE_TTL_SECONDS
+        _plugins_hub_cache[home] = (payload, time.monotonic() + _PLUGINS_HUB_CACHE_TTL_SECONDS)
     return payload
 
 

--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -477,11 +477,13 @@ def _dashboard_plugin_search_dirs() -> List[tuple]:
     # ``seen_names`` dedupe below keeps profile-local plugins (if any) authoritative over same-named root
     # plugins.
     #
-    # Also scan the task-local home (the selected management profile, ``?profile=<name>``) because a
-    # profile-scoped ``install`` writes there; without it the newly installed plugin is orphaned from
-    # discovery (issue #46408). Deduped against the process + root homes.
-    user_plugin_roots = [get_process_hermes_home() / "plugins"]
-    for candidate in (get_hermes_home() / "plugins", get_default_hermes_root() / "plugins"):
+    # Scan the task-local home (the selected management profile, ``?profile=<name>``) FIRST so the
+    # selected profile's own plugins win over same-named process/root ones; a profile-scoped
+    # ``install`` writes there, so without it the plugin is also orphaned from discovery (#46408).
+    # Then the process launch home + default root, so #87197 still holds (process-home plugins stay
+    # visible under a scope). Deduped by resolved path.
+    user_plugin_roots = [get_hermes_home() / "plugins"]
+    for candidate in (get_process_hermes_home() / "plugins", get_default_hermes_root() / "plugins"):
         if all(candidate.resolve(strict=False) != existing.resolve(strict=False) for existing in user_plugin_roots):
             user_plugin_roots.append(candidate)
     search_dirs = [(d, "user") for d in user_plugin_roots]

--- a/hermes_cli/web_server_profiles.py
+++ b/hermes_cli/web_server_profiles.py
@@ -35,15 +35,26 @@ def _is_current_profile(profile: Optional[str]) -> bool:
 
 
 @contextmanager
-def _hermes_home_scope(path) -> Any:
+def _hermes_home_scope(path, *, request_scoped: bool = True) -> Any:
     """Scope ``load_config``/``save_config`` (anything resolving ``get_hermes_home()`` at call
-    time) to ``path`` for the block via the context-local HERMES_HOME override."""
-    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
-    token = set_hermes_home_override(str(path))
-    try:
+    time) to ``path`` for the block via the context-local HERMES_HOME override.
+
+    ``request_scoped`` marks the override as a web request serving ANOTHER profile's data, which
+    must not trigger a cross-profile plugin MODULE load whose registration has process-global side
+    effects (``discover_plugins``, #106608). Pass ``False`` for a scope that is this process's own
+    profile — an explicit name resolving to the process home, where the override is only a nesting
+    guard and this process's own plugins stay loadable.
+    """
+    from hermes_constants import request_scoped_hermes_home, reset_hermes_home_override, set_hermes_home_override
+    if not request_scoped:
+        token = set_hermes_home_override(str(path))
+        try:
+            yield
+        finally:
+            reset_hermes_home_override(token)
+        return
+    with request_scoped_hermes_home(path):
         yield
-    finally:
-        reset_hermes_home_override(token)
 
 
 def _is_other_profile(profile: Optional[str]) -> bool:
@@ -242,8 +253,12 @@ def _config_profile_scope(profile: Optional[str]):
         yield None
         return
     profile_dir = _resolve_profile_dir(profile.strip())
-    with _hermes_home_scope(profile_dir):
-        yield None if profile_dir.resolve() == get_process_hermes_home().resolve() else profile_dir
+    # An explicit name for THIS process's own profile keeps current-profile semantics: the override
+    # is entered only so a nested scope cannot retain another profile, and this process's own
+    # plugins stay loadable (``request_scoped=False``).
+    is_other = profile_dir.resolve() != get_process_hermes_home().resolve()
+    with _hermes_home_scope(profile_dir, request_scoped=is_other):
+        yield profile_dir if is_other else None
 
 
 # Terminal backend picker rows — GUI counterpart of terminal.backend. Keep in sync with

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -11,10 +11,14 @@ import stat
 import sys
 from contextvars import ContextVar, Token
 from pathlib import Path
+from typing import Iterator
 
 _profile_fallback_warned: bool = False
 _UNSET = object()
 _HERMES_HOME_OVERRIDE: ContextVar[str | object] = ContextVar("_HERMES_HOME_OVERRIDE", default=_UNSET)
+# Marks an override as belonging to a *request* scope (``is_request_scoped_hermes_home``): a web
+# request serving another profile's config/state, not a workload that owns the profile it scopes.
+_REQUEST_SCOPED_HOME: ContextVar[bool] = ContextVar("_REQUEST_SCOPED_HOME", default=False)
 
 # TUI busy-indicator styles (CLI /indicator, TUI gateway config, /help registry).
 # Keep in sync with INDICATOR_STYLES / DEFAULT_INDICATOR_STYLE in ui-tui/src/app/interfaces.ts.
@@ -40,6 +44,34 @@ def get_hermes_home_override() -> str | None:
     """Return the active context-local Hermes home override, if any."""
     override = _HERMES_HOME_OVERRIDE.get()
     return str(override) if override is not _UNSET and override else None
+
+
+def is_request_scoped_hermes_home() -> bool:
+    """Whether the active Hermes-home override belongs to a request scope.
+
+    A request scope changes which profile's config/state ONE REQUEST reads and writes; it does not
+    make the process that profile. Readers with process-global side effects must not act under one:
+    loading another profile's plugin modules registers providers in process-wide registries by name,
+    which replaces the running dashboard's own (#106608).
+    """
+    return bool(_REQUEST_SCOPED_HOME.get())
+
+
+@contextlib.contextmanager
+def request_scoped_hermes_home(path: str | Path) -> Iterator[None]:
+    """Scope ``path`` as the Hermes home for one request, marked request-scoped.
+
+    For web requests that serve another profile's data. Do NOT use it for work the process itself
+    owns: the cron external worker and a multiplexed gateway turn scope their OWN profile, and must
+    keep discovering that profile's plugins.
+    """
+    override_token = set_hermes_home_override(path)
+    scoped_token = _REQUEST_SCOPED_HOME.set(True)
+    try:
+        yield
+    finally:
+        _REQUEST_SCOPED_HOME.reset(scoped_token)
+        reset_hermes_home_override(override_token)
 
 
 def _get_platform_default_hermes_home() -> Path:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19595,6 +19595,7 @@
       "devDependencies": {
         "@babel/core": "8.0.1",
         "@rolldown/plugin-babel": "0.2.3",
+        "@testing-library/react": "16.3.2",
         "@types/babel__core": "7.20.5",
         "@types/node": "22.20.1",
         "@types/qrcode": "1.5.6",
@@ -19603,6 +19604,7 @@
         "@vitejs/plugin-react": "6.0.3",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint-plugin-react-refresh": "0.5.3",
+        "jsdom": "29.1.1",
         "three": "0.180.0",
         "typescript": "6.0.3",
         "vite": "8.2.0",

--- a/tests/hermes_cli/test_dashboard_plugin_profile_scope.py
+++ b/tests/hermes_cli/test_dashboard_plugin_profile_scope.py
@@ -1,0 +1,75 @@
+"""Dashboard plugin discovery/state follows the selected management profile (#46408).
+
+The dashboard is a machine-level management surface: one header switcher decides
+which profile the pages read/write. Plugin discovery and the enabled/disabled +
+visibility state must follow that selected profile rather than the dashboard
+process's own profile.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _write_plugin(home: Path, name: str) -> Path:
+    """Create a minimal user dashboard plugin under ``<home>/plugins/<name>``."""
+    dashboard_dir = home / "plugins" / name / "dashboard"
+    dashboard_dir.mkdir(parents=True)
+    dist_dir = dashboard_dir / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "index.js").write_text("console.log('x');")
+    (dashboard_dir / "manifest.json").write_text(json.dumps({
+        "name": name,
+        "label": name.title(),
+        "entry": "dist/index.js",
+    }))
+    return dashboard_dir
+
+
+def test_search_dirs_include_request_profile_home(tmp_path, monkeypatch):
+    """A plugin installed into the selected profile's plugins dir must be
+    discoverable while a request is scoped to that profile — otherwise a
+    profile-scoped install is orphaned from the UI (issue #46408)."""
+    from hermes_cli import web_server_dashboard as wsd
+
+    root = tmp_path / "hermes"
+    root.mkdir()
+    profile = root / "profiles" / "worker"
+    (profile / "plugins").mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    token = set_hermes_home_override(str(profile))
+    try:
+        roots = {str(d) for d, _src in wsd._dashboard_plugin_search_dirs()}
+    finally:
+        reset_hermes_home_override(token)
+
+    assert str(profile / "plugins") in roots
+
+
+def test_discovery_and_cache_are_profile_scoped(tmp_path, monkeypatch):
+    """Discovery under a profile scope returns that profile's local plugins,
+    and the per-process cache must not leak one profile's result into another."""
+    from hermes_cli import web_server
+
+    root = tmp_path / "hermes"
+    root.mkdir()
+    worker = root / "profiles" / "worker"
+    worker.mkdir(parents=True)
+    _write_plugin(worker, "worker-only")
+
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    token = set_hermes_home_override(str(worker))
+    try:
+        scoped = {p["name"] for p in web_server._get_dashboard_plugins()}
+    finally:
+        reset_hermes_home_override(token)
+    # Same-process, unscoped: the process home has no plugins/ of its own.
+    unscoped = {p["name"] for p in web_server._get_dashboard_plugins()}
+
+    assert "worker-only" in scoped
+    assert "worker-only" not in unscoped

--- a/tests/hermes_cli/test_dashboard_plugin_profile_scope.py
+++ b/tests/hermes_cli/test_dashboard_plugin_profile_scope.py
@@ -103,3 +103,37 @@ async def test_profile_only_plugin_asset_resolves_under_profile_scope(tmp_path, 
     with pytest.raises(HTTPException) as exc:
         await dashboard_ui.serve_plugin_asset("worker-only", "dist/index.js")
     assert exc.value.status_code == 404
+
+
+def test_web_profile_scope_marks_only_cross_profile_requests(tmp_path, monkeypatch):
+    """The dashboard's request scope is what suppresses the cross-profile plugin-module load
+    (``discover_plugins``, #106608). A plain override — the cron external worker's own home, or a
+    multiplexed gateway turn — is not a request scope and keeps loading that profile's plugins,
+    and neither is a request that names the process's OWN profile (current-profile semantics)."""
+    from hermes_cli import web_server_profiles as wsp
+    from hermes_constants import get_hermes_home, is_request_scoped_hermes_home
+
+    profiles_root = tmp_path / ".hermes" / "profiles"
+    worker = profiles_root / "worker"
+    worker.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    # Dashboard running for the default profile.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    # Its own profile: no override at all, so nothing to mark.
+    with wsp._config_profile_scope(""):
+        assert is_request_scoped_hermes_home() is False
+
+    # Another profile: the request scope that must not load that profile's plugin modules.
+    with wsp._config_profile_scope("worker"):
+        assert is_request_scoped_hermes_home() is True
+
+    # Dashboard running FOR the named profile, request naming that same profile: the override is
+    # only a nesting guard, so this process's own plugins stay loadable.
+    monkeypatch.setenv("HERMES_HOME", str(worker))
+    with wsp._config_profile_scope("worker"):
+        assert is_request_scoped_hermes_home() is False
+        assert get_hermes_home().resolve() == worker.resolve()
+
+    assert is_request_scoped_hermes_home() is False

--- a/tests/hermes_cli/test_dashboard_plugin_profile_scope.py
+++ b/tests/hermes_cli/test_dashboard_plugin_profile_scope.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+import yaml
+from fastapi import HTTPException
+
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
 
@@ -73,3 +77,29 @@ def test_discovery_and_cache_are_profile_scoped(tmp_path, monkeypatch):
 
     assert "worker-only" in scoped
     assert "worker-only" not in unscoped
+
+
+@pytest.mark.asyncio
+async def test_profile_only_plugin_asset_resolves_under_profile_scope(tmp_path, monkeypatch):
+    """End-to-end: a plugin present only in the selected profile's dir is both discovered
+    AND served by the profile-scoped static-asset route — the "carry the fix through asset
+    resolution" ask (asset URLs + server resolution carry ``?profile=``)."""
+    from hermes_cli.web_routers import dashboard_ui
+
+    root = tmp_path / "hermes"
+    root.mkdir()
+    profile = root / "profiles" / "worker"
+    _write_plugin(profile, "worker-only")
+    (profile / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["worker-only"]}})
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    resp = await dashboard_ui.serve_plugin_asset("worker-only", "dist/index.js", profile="worker")
+    assert resp.status_code == 200
+    assert str(resp.path).endswith("dist/index.js")
+
+    # Unscoped, the profile-only plugin is not discoverable, so its asset 404s.
+    with pytest.raises(HTTPException) as exc:
+        await dashboard_ui.serve_plugin_asset("worker-only", "dist/index.js")
+    assert exc.value.status_code == 404

--- a/tests/hermes_cli/test_plugin_discovery_profile_scope.py
+++ b/tests/hermes_cli/test_plugin_discovery_profile_scope.py
@@ -1,39 +1,79 @@
-"""discover_plugins() must not load another profile's plugins from a request scope (#106608).
+"""discover_plugins() must not load another profile's plugins from a REQUEST scope (#106608).
 
-A request scoped to another profile sets a task-local ``HERMES_HOME`` override (the
-dashboard's ``?profile=<name>`` handling). Plugin registration has process-global side
-effects — dashboard-auth providers are upserted by name into a process-global registry —
-so loading that profile's manager would replace the provider validating the running
-dashboard's sessions and 401 every live cookie.
+A web request scoped to another profile (the dashboard's ``?profile=<name>`` handling) enters the
+context-local ``HERMES_HOME`` override marked request-scoped. Plugin registration has process-global
+side effects — dashboard-auth providers are upserted by name into a process-global registry — so
+loading that profile's manager would replace the provider validating the running dashboard's
+sessions and 401 every live cookie.
+
+The override ALONE must not suppress the load: the cron external worker and a multiplexed gateway
+turn each scope the profile the process is acting AS, and both need that profile's plugin tools
+(``agent/agent_init.py::_load_tools`` calls this under those scopes).
 """
 
 from __future__ import annotations
 
 from unittest.mock import patch
 
-from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from hermes_constants import (
+    is_request_scoped_hermes_home,
+    request_scoped_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 
 
-def test_discover_plugins_skips_load_under_profile_override(tmp_path, monkeypatch):
+def test_discover_plugins_skips_load_under_request_scope(tmp_path, monkeypatch):
     from hermes_cli import plugins as P
 
     other = tmp_path / "profiles" / "worker"
     other.mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-    token = set_hermes_home_override(str(other))
-    try:
+    with request_scoped_hermes_home(other):
         with patch.object(P, "get_plugin_manager") as mgr, \
              patch.object(P, "_join_background_discovery") as join:
             P.discover_plugins()
-    finally:
-        reset_hermes_home_override(token)
 
     # The manager for the overridden home is never loaded (the #106608 trigger), but the
     # process-global startup discovery is still joined — skipping that would let a scoped
     # request race in-flight process-global registration.
     mgr.assert_not_called()
     join.assert_called_once()
+
+
+def test_discover_plugins_loads_under_override_without_the_request_marker(tmp_path, monkeypatch):
+    """Both non-request override shapes keep loading their profile's plugins.
+
+    * cron external worker — ``cron/scheduler.py`` sets the override to the worker's OWN home
+      (its ``HERMES_HOME`` env), and nothing has discovered plugins before that point.
+    * multiplexed gateway turn — ``gateway/run.py::_profile_runtime_scope`` scopes one turn to a
+      secondary profile's home, and ``agent/agent_init.py::_load_tools`` discovers that profile's
+      plugins for the turn's tool snapshot.
+
+    Both reach ``discover_plugins()`` through ``_load_tools``, so a request-only skip is what keeps
+    their plugin-provided tools.
+    """
+    from hermes_cli import plugins as P
+
+    default_home = tmp_path / "default"
+    worker_home = tmp_path / "profiles" / "worker"
+    for home in (default_home, worker_home):
+        home.mkdir(parents=True)
+
+    for env_home, override_home in ((worker_home, worker_home), (default_home, worker_home)):
+        monkeypatch.setenv("HERMES_HOME", str(env_home))
+        token = set_hermes_home_override(str(override_home))
+        try:
+            with patch.object(P, "get_plugin_manager") as mgr, \
+                 patch.object(P, "_join_background_discovery") as join:
+                P.discover_plugins()
+        finally:
+            reset_hermes_home_override(token)
+
+        join.assert_called_once()
+        mgr.assert_called_once()
+        mgr.return_value.discover_and_load.assert_called_once()
 
 
 def test_discover_plugins_loads_without_override(tmp_path, monkeypatch):
@@ -48,3 +88,10 @@ def test_discover_plugins_loads_without_override(tmp_path, monkeypatch):
     join.assert_called_once()
     mgr.assert_called_once()
     mgr.return_value.discover_and_load.assert_called_once()
+
+
+def test_request_scope_marker_lives_only_for_the_block(tmp_path):
+    assert is_request_scoped_hermes_home() is False
+    with request_scoped_hermes_home(tmp_path / "profiles" / "worker"):
+        assert is_request_scoped_hermes_home() is True
+    assert is_request_scoped_hermes_home() is False

--- a/tests/hermes_cli/test_plugin_discovery_profile_scope.py
+++ b/tests/hermes_cli/test_plugin_discovery_profile_scope.py
@@ -29,8 +29,11 @@ def test_discover_plugins_skips_load_under_profile_override(tmp_path, monkeypatc
     finally:
         reset_hermes_home_override(token)
 
+    # The manager for the overridden home is never loaded (the #106608 trigger), but the
+    # process-global startup discovery is still joined — skipping that would let a scoped
+    # request race in-flight process-global registration.
     mgr.assert_not_called()
-    join.assert_not_called()
+    join.assert_called_once()
 
 
 def test_discover_plugins_loads_without_override(tmp_path, monkeypatch):
@@ -39,8 +42,9 @@ def test_discover_plugins_loads_without_override(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     with patch.object(P, "get_plugin_manager") as mgr, \
-         patch.object(P, "_join_background_discovery"):
+         patch.object(P, "_join_background_discovery") as join:
         P.discover_plugins()
 
+    join.assert_called_once()
     mgr.assert_called_once()
     mgr.return_value.discover_and_load.assert_called_once()

--- a/tests/hermes_cli/test_plugin_discovery_profile_scope.py
+++ b/tests/hermes_cli/test_plugin_discovery_profile_scope.py
@@ -1,0 +1,46 @@
+"""discover_plugins() must not load another profile's plugins from a request scope (#106608).
+
+A request scoped to another profile sets a task-local ``HERMES_HOME`` override (the
+dashboard's ``?profile=<name>`` handling). Plugin registration has process-global side
+effects — dashboard-auth providers are upserted by name into a process-global registry —
+so loading that profile's manager would replace the provider validating the running
+dashboard's sessions and 401 every live cookie.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def test_discover_plugins_skips_load_under_profile_override(tmp_path, monkeypatch):
+    from hermes_cli import plugins as P
+
+    other = tmp_path / "profiles" / "worker"
+    other.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    token = set_hermes_home_override(str(other))
+    try:
+        with patch.object(P, "get_plugin_manager") as mgr, \
+             patch.object(P, "_join_background_discovery") as join:
+            P.discover_plugins()
+    finally:
+        reset_hermes_home_override(token)
+
+    mgr.assert_not_called()
+    join.assert_not_called()
+
+
+def test_discover_plugins_loads_without_override(tmp_path, monkeypatch):
+    from hermes_cli import plugins as P
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with patch.object(P, "get_plugin_manager") as mgr, \
+         patch.object(P, "_join_background_discovery"):
+        P.discover_plugins()
+
+    mgr.assert_called_once()
+    mgr.return_value.discover_and_load.assert_called_once()

--- a/tests/hermes_cli/test_plugin_runtime_disable_gate.py
+++ b/tests/hermes_cli/test_plugin_runtime_disable_gate.py
@@ -25,9 +25,9 @@ from hermes_cli import web_server
 @pytest.fixture(autouse=True)
 def _reset_plugin_cache():
     """Bust the plugin cache before and after each test."""
-    web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache = {}
     yield
-    web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache = {}
 
 
 @pytest.fixture

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -38,6 +38,7 @@ from unittest.mock import patch
 import pytest
 
 from hermes_cli import web_server
+from hermes_cli.config import get_hermes_home
 import hermes_cli.web_server_dashboard as _web_server_dashboard
 
 
@@ -47,9 +48,9 @@ def _reset_plugin_cache(monkeypatch):
     cache before *and* after each test so leakage between tests can't
     mask a regression — and so the production cache the import-time
     ``_mount_plugin_api_routes()`` populated doesn't bleed in."""
-    web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache = {}
     yield
-    web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache = {}
 
 
 def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:
@@ -230,7 +231,7 @@ class TestMountApiRoutesRefusesUntrusted:
 
     def test_project_source_api_is_not_imported(self, tmp_path):
         plugin = self._payload_plugin(tmp_path, source="project")
-        web_server._dashboard_plugins_cache = [plugin]
+        web_server._dashboard_plugins_cache = {str(get_hermes_home()): [plugin]}
         with patch("importlib.util.spec_from_file_location") as spec:
             _web_server_dashboard._mount_plugin_api_routes()
         assert spec.call_count == 0, (
@@ -245,7 +246,7 @@ class TestMountApiRoutesRefusesUntrusted:
         file outside the dashboard dir."""
         plugin = self._payload_plugin(tmp_path, source="user",
                                        api_file="../../../tmp/evil.py")
-        web_server._dashboard_plugins_cache = [plugin]
+        web_server._dashboard_plugins_cache = {str(get_hermes_home()): [plugin]}
         with patch("importlib.util.spec_from_file_location") as spec:
             _web_server_dashboard._mount_plugin_api_routes()
         assert spec.call_count == 0

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -116,7 +116,7 @@ def _install_example_plugin(_isolate_hermes_home):
     # list dynamically per request, so the rescan alone is enough for
     # the static-asset tests; the API auth tests additionally need the
     # route reorder below.
-    web_server._dashboard_plugins_cache = None
+    web_server._dashboard_plugins_cache = {}
     web_server._get_dashboard_plugins(force_rescan=True)
     _web_server_dashboard._mount_plugin_api_routes()
 
@@ -142,7 +142,7 @@ def _install_example_plugin(_isolate_hermes_home):
         # routes so the next test sees a clean app — and clear the
         # cache for the same reason.
         app.router.routes[:] = original_routes
-        web_server._dashboard_plugins_cache = None
+        web_server._dashboard_plugins_cache = {}
 
 
 # ---------------------------------------------------------------------------
@@ -4425,7 +4425,7 @@ class TestDashboardPluginManifestExtensions:
         })
         from hermes_cli import web_server
         # Bust the process-level cache so the test plugin is picked up.
-        web_server._dashboard_plugins_cache = None
+        web_server._dashboard_plugins_cache = {}
         plugins = web_server._get_dashboard_plugins(force_rescan=True)
         entry = next(p for p in plugins if p["name"] == "skin-home")
         assert entry["tab"]["override"] == "/"

--- a/web/package.json
+++ b/web/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@babel/core": "8.0.1",
     "@rolldown/plugin-babel": "0.2.3",
+    "@testing-library/react": "16.3.2",
     "@types/babel__core": "7.20.5",
     "@types/node": "22.20.1",
     "@types/qrcode": "1.5.6",
@@ -50,6 +51,7 @@
     "@vitejs/plugin-react": "6.0.3",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint-plugin-react-refresh": "0.5.3",
+    "jsdom": "29.1.1",
     "three": "0.180.0",
     "typescript": "6.0.3",
     "vite": "8.2.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import {
   Navigate,
   useLocation,
   useNavigate,
+  useSearchParams,
 } from "react-router";
 import {
   Activity,
@@ -372,7 +373,12 @@ const SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
-  const { manifests, loading: pluginsLoading } = usePlugins();
+  // The management profile is ProfileProvider state projected onto the URL
+  // (`?profile=`). App sits ABOVE the provider, so read the URL to keep the
+  // plugin list — and the sidebar tabs it drives — scoped to the selected
+  // profile instead of the dashboard process's own (#46408).
+  const [searchParams] = useSearchParams();
+  const { manifests, loading: pluginsLoading } = usePlugins(searchParams.get("profile") ?? "");
   const { theme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
   const closeMobile = useCallback(() => setMobileOpen(false), []);

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -200,3 +200,48 @@ describe("api OAuth helpers", () => {
     ]);
   });
 });
+
+describe("api dashboard-plugin endpoints follow the selected management profile", () => {
+  it("appends ?profile= to every dashboard-plugin operation", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("worker");
+
+    await api.getPlugins();
+    await api.rescanPlugins();
+    await api.getPluginsHub();
+    await api.getPluginsCatalog();
+    await api.installAgentPlugin({ identifier: "gh:owner/repo" });
+    await api.enableAgentPlugin("hot");
+    await api.disableAgentPlugin("hot");
+    await api.updateAgentPlugin("hot");
+    await api.removeAgentPlugin("hot");
+    await api.savePluginProviders({ memory_provider: "honcho" });
+    await api.setPluginVisibility("hot", true);
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/api/dashboard/plugins?profile=worker",
+      "/api/dashboard/plugins/rescan?profile=worker",
+      "/api/dashboard/plugins/hub?profile=worker",
+      "/api/dashboard/plugins/catalog?profile=worker",
+      "/api/dashboard/agent-plugins/install?profile=worker",
+      "/api/dashboard/agent-plugins/hot/enable?profile=worker",
+      "/api/dashboard/agent-plugins/hot/disable?profile=worker",
+      "/api/dashboard/agent-plugins/hot/update?profile=worker",
+      "/api/dashboard/agent-plugins/hot?profile=worker",
+      "/api/dashboard/plugin-providers?profile=worker",
+      "/api/dashboard/plugins/hot/visibility?profile=worker",
+    ]);
+  });
+
+  it("leaves plugin URLs untouched when no management profile is selected", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getPlugins();
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual(["/api/dashboard/plugins"]);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -88,6 +88,13 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/auxiliary",
   "/api/model/moa",
   "/api/model/options",
+  // Dashboard plugin discovery/management state is profile-owned: the plugin
+  // list gate, hub/catalog, install/enable/disable/update/remove, visibility,
+  // and memory-provider/context-engine selection must all follow the selected
+  // management profile rather than the dashboard process's own (issue #46408).
+  "/api/dashboard/plugins",
+  "/api/dashboard/agent-plugins",
+  "/api/dashboard/plugin-providers",
   // A named profile keeps its own pairing whitelist, and its gateway only
   // consults that one — approving into the global store would grant access
   // the running gateway never sees.

--- a/web/src/plugins/usePlugins.test.ts
+++ b/web/src/plugins/usePlugins.test.ts
@@ -1,11 +1,17 @@
+// @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { render, act, cleanup } from "@testing-library/react";
 import {
   getCachedManifests,
   cacheManifests,
   canSeedLoadedFromCache,
+  profileSwitchReloadTarget,
+  usePlugins,
   MANIFEST_CACHE_KEY,
 } from "./usePlugins";
-import type { PluginManifest } from "./types";
+import { api } from "@/lib/api";
+import type { PluginManifest, RegisteredPlugin } from "./types";
 
 function makeStorage(): Storage {
   const store = new Map<string, string>();
@@ -155,5 +161,132 @@ describe("canSeedLoadedFromCache (loading seed gate)", () => {
       { ...exampleManifest, tab: undefined },
     ] as unknown as PluginManifest[];
     expect(canSeedLoadedFromCache(malformed)).toBe(true);
+  });
+});
+
+describe("profileSwitchReloadTarget (review P1 on #107006)", () => {
+  it("targets the same path with the new profile param, dropping the stale one", () => {
+    const params = new URLSearchParams("profile=alpha");
+    expect(profileSwitchReloadTarget("/x/y?profile=alpha", params, "beta")).toBe(
+      "/x/y?profile=beta",
+    );
+  });
+
+  it("drops ?profile= entirely when switching back to the dashboard's own profile", () => {
+    const params = new URLSearchParams("profile=alpha&foo=1");
+    expect(profileSwitchReloadTarget("/x/y?profile=alpha&foo=1", params, "")).toBe(
+      "/x/y?foo=1",
+    );
+  });
+
+  it("preserves unrelated query params and strips the hash", () => {
+    const params = new URLSearchParams("foo=1");
+    expect(profileSwitchReloadTarget("/x/y?foo=1#frag", params, "beta")).toBe(
+      "/x/y?foo=1&profile=beta",
+    );
+  });
+});
+
+describe("usePlugins profile-switch execution retirement (#46408)", () => {
+  // jsdom: window.location.assign needs a stub, and the hook reads
+  // sessionStorage for the manifest cache.
+  let storage: Storage;
+  let assigned: string[] | null;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    vi.stubGlobal("sessionStorage", storage);
+    assigned = [];
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...window.location,
+        href: "http://localhost:3000/",
+        search: "",
+        assign: (url: string) => {
+          assigned!.push(url);
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    assigned = null;
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+  });
+
+  function renderPlugins(initialProfile = "") {
+    let latest!: {
+      plugins: RegisteredPlugin[];
+      manifests: PluginManifest[];
+      loading: boolean;
+    };
+    function Probe({ profile }: { profile: string }) {
+      latest = usePlugins(profile);
+      return null;
+    }
+    const { rerender } = render(React.createElement(Probe, { profile: initialProfile }));
+    return {
+      setProfile: (profile: string) =>
+        rerender(React.createElement(Probe, { profile })),
+      state: () => latest,
+      assigned: () => assigned!,
+    };
+  }
+
+  function mockGetPlugins(pages: Record<string, PluginManifest[]>) {
+    vi.spyOn(api, "getPlugins").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(pages["default"] ?? []), 5);
+        }),
+    );
+  }
+
+  it("reloads the document on profile switch instead of resolving the new profile against the old JS realm", async () => {
+    const onlyA: PluginManifest[] = [
+      { ...exampleManifest, name: "alpha-only" },
+    ];
+    storage.setItem(
+      `${MANIFEST_CACHE_KEY}:alpha`,
+      JSON.stringify(onlyA),
+    );
+    mockGetPlugins({ default: [] });
+
+    const view = renderPlugins("alpha");
+    // Cache seed must not arm the loading gate while a /chat override could
+    // exist — the switch path itself is what this test pins.
+    await act(async () => {
+      view.setProfile("beta");
+    });
+
+    // The switch defers to a full document reload — the ONLY closure that
+    // retires profile A's executed registrations (_registered/_slotRegistry)
+    // and side effects before profile B's manifests resolve.
+    expect(view.assigned()).toEqual(["http://localhost:3000/?profile=beta"]);
+  });
+
+  it("keeps plugin fetching/assets frozen while the reload is pending", async () => {
+    storage.setItem(
+      `${MANIFEST_CACHE_KEY}:alpha`,
+      JSON.stringify([{ ...exampleManifest, name: "alpha-only" }]),
+    );
+    // Mount fetches once for the initial profile; the switch must not fetch again.
+    const getPlugins = vi.spyOn(api, "getPlugins").mockResolvedValue([]);
+
+    const view = renderPlugins("alpha");
+    await act(async () => {
+      view.setProfile("beta");
+    });
+
+    expect(getPlugins).toHaveBeenCalledTimes(1);
+    expect(view.assigned()).toEqual(["http://localhost:3000/?profile=beta"]);
+    // No asset injection: the pending document is going away.
+    expect(document.querySelectorAll("script[data-hermes-plugin]")).toHaveLength(0);
+    expect(document.querySelectorAll("link[rel=stylesheet]")).toHaveLength(0);
   });
 });

--- a/web/src/plugins/usePlugins.test.ts
+++ b/web/src/plugins/usePlugins.test.ts
@@ -100,6 +100,21 @@ describe("plugin manifest cache helpers", () => {
     vi.stubGlobal("sessionStorage", badStorage);
     expect(() => cacheManifests([exampleManifest])).not.toThrow();
   });
+
+  it("namespaces the manifest cache per management profile (#46408)", () => {
+    const a: PluginManifest[] = [exampleManifest];
+    const b: PluginManifest[] = [{ ...exampleManifest, name: "worker-plugin" }];
+    cacheManifests(a, "alpha");
+    cacheManifests(b, "beta");
+    // Profiles never read each other's cached list.
+    expect(getCachedManifests("alpha")).toEqual(a);
+    expect(getCachedManifests("beta")).toEqual(b);
+    // The unset profile keeps the legacy base key (the dashboard's own profile).
+    expect(getCachedManifests()).toBeNull();
+    cacheManifests(a);
+    expect(getCachedManifests()).toEqual(a);
+    expect(getCachedManifests("alpha")).toEqual(a);
+  });
 });
 
 describe("canSeedLoadedFromCache (loading seed gate)", () => {

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -19,6 +19,21 @@ import {
 
 export const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
 
+/** URL a profile switch reloads to. Drops the stale `?profile=` value so the
+ * freshly loaded document boots under the selected profile with no profile-A
+ * execution surface carried over (#46408, review P1 on #107006). */
+export function profileSwitchReloadTarget(
+  href: string,
+  params: URLSearchParams,
+  profile: string,
+): string {
+  params.delete("profile");
+  if (profile) params.set("profile", profile);
+  const qs = params.toString();
+  const base = href.split("#")[0].split("?")[0];
+  return qs ? `${base}?${qs}` : base;
+}
+
 /** Cache slot for a management profile. Plugins differ per selected profile, so
  * the manifest cache must not bleed one profile's list into another (#46408). */
 function manifestCacheKey(profile: string): string {
@@ -85,6 +100,18 @@ export function usePlugins(profile = "") {
   );
   const loadedScripts = useRef<Set<string>>(new Set());
   const [activeProfile, setActiveProfile] = useState(profile);
+  // A profile switch must retire the PREVIOUS profile's plugin execution
+  // authority before the new profile's manifests resolve. Bundles register
+  // into process-global maps (registry.ts `_registered`, slots.ts
+  // `_slotRegistry`) keyed only by plugin/slot name, and a plugin bundle's
+  // arbitrary side effects (listeners, sockets, timers) cannot be undone by
+  // removing its <script> node. Resolving profile B's names against those
+  // maps can resurrect profile A's component (same-name plugin, or B's asset
+  // failing to load), and A-only slot/CSS surfaces would stay live under B.
+  // A full document reload resets the whole JS realm, so defer to it and
+  // freeze plugin loading until it lands (the state reset below stays as the
+  // data-layer safety net for non-plugin state).
+  const [pendingReload, setPendingReload] = useState(false);
 
   // Adjusting state when the selected profile changes. A hook cannot remount, so
   // reset the per-profile plugin state during render (React's "adjust state when
@@ -99,19 +126,40 @@ export function usePlugins(profile = "") {
     setManifests(cached ?? []);
     setPlugins([]);
     setLoading(!canSeedLoadedFromCache(cached));
+    // The render-phase update re-renders before effects commit, so the reload
+    // effect below is driven by this flag, not by comparing profile/activeProfile
+    // (which are already equal by the time effects run).
+    setPendingReload(true);
   }
+
+  // Full document reload on management-profile change — retires the previous
+  // profile's plugin execution generation before the new profile's manifests
+  // resolve (#46408, review P1 on #107006). window is read directly (not the
+  // render props) so the target always reflects the CURRENT document URL.
+  useEffect(() => {
+    if (!pendingReload) return;
+    window.location.assign(
+      profileSwitchReloadTarget(
+        window.location.href,
+        new URLSearchParams(window.location.search),
+        profile,
+      ),
+    );
+  }, [pendingReload, profile]);
 
   // Always re-fetch in the background to keep the cache fresh.
   // This handles: new plugins added, plugins removed, manifest changes.
   // setManifests(list) will update routes if the server list differs from cache.
   // Re-runs when the selected management profile changes so the plugin list and
-  // the sidebar tabs it drives follow the selected profile (#46408).
+  // the sidebar tabs it drives follow the selected profile (#46408). pendingReload
+  // only ever changes together with profile, and gates the body instead.
   useEffect(() => {
     // Runs BEFORE the asset effect (effects fire in declaration order), so the
     // new profile's bundles load even when a same-named plugin was injected
     // under the previous profile. Keep this effect declared above the asset
     // effect.
     loadedScripts.current = new Set();
+    if (pendingReload) return; // reload owns the switch; nothing to fetch
     api
       .getPlugins()
       .then((list) => {
@@ -120,11 +168,11 @@ export function usePlugins(profile = "") {
         if (list.length === 0) setLoading(false);
       })
       .catch(() => setLoading(false));
-  }, [profile]);
+  }, [profile, pendingReload]);
 
   // Load plugin assets when manifests arrive.
   useEffect(() => {
-    if (manifests.length === 0) return;
+    if (pendingReload || manifests.length === 0) return;
 
     const injectedScripts: HTMLScriptElement[] = [];
     // Assets load via <script src>/<link href>, which cannot attach the profile
@@ -198,7 +246,7 @@ export function usePlugins(profile = "") {
         }
       }
     };
-  }, [manifests, profile]);
+  }, [manifests, profile, pendingReload]);
 
   // Listen for plugin registrations and resolve them against manifests.
   useEffect(() => {

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -19,9 +19,15 @@ import {
 
 export const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
 
-export function getCachedManifests(): PluginManifest[] | null {
+/** Cache slot for a management profile. Plugins differ per selected profile, so
+ * the manifest cache must not bleed one profile's list into another (#46408). */
+function manifestCacheKey(profile: string): string {
+  return profile ? `${MANIFEST_CACHE_KEY}:${profile}` : MANIFEST_CACHE_KEY;
+}
+
+export function getCachedManifests(profile = ""): PluginManifest[] | null {
   try {
-    const raw = sessionStorage.getItem(MANIFEST_CACHE_KEY);
+    const raw = sessionStorage.getItem(manifestCacheKey(profile));
     if (!raw) return null;
     const parsed = JSON.parse(raw);
     return Array.isArray(parsed) ? (parsed as PluginManifest[]) : null;
@@ -30,9 +36,9 @@ export function getCachedManifests(): PluginManifest[] | null {
   }
 }
 
-export function cacheManifests(manifests: PluginManifest[]): void {
+export function cacheManifests(manifests: PluginManifest[], profile = ""): void {
   try {
-    sessionStorage.setItem(MANIFEST_CACHE_KEY, JSON.stringify(manifests));
+    sessionStorage.setItem(manifestCacheKey(profile), JSON.stringify(manifests));
   } catch {
     // sessionStorage unavailable (private browsing, storage full, etc.)
   }
@@ -57,13 +63,13 @@ export function canSeedLoadedFromCache(
   return !cached.some((m) => m.tab?.override === "/chat");
 }
 
-export function usePlugins() {
+export function usePlugins(profile = "") {
   // Lazy initialisers run once at mount — safe to read sessionStorage here.
   // This avoids the "cannot access ref during render" lint error that would
   // occur if we stored the cached value in a useRef and read .current in the
   // useState initial value expression.
   const [manifests, setManifests] = useState<PluginManifest[]>(
-    () => getCachedManifests() ?? [],
+    () => getCachedManifests(profile) ?? [],
   );
   const [plugins, setPlugins] = useState<RegisteredPlugin[]>([]);
   // Start loading=false when the cache has manifests so plugin routes are
@@ -75,34 +81,40 @@ export function usePlugins() {
   // loading=true — App.tsx's pluginsLoading gate around the persistent
   // ChatPage host is load-bearing (see canSeedLoadedFromCache).
   const [loading, setLoading] = useState<boolean>(
-    () => !canSeedLoadedFromCache(getCachedManifests()),
+    () => !canSeedLoadedFromCache(getCachedManifests(profile)),
   );
   const loadedScripts = useRef<Set<string>>(new Set());
 
   // Always re-fetch in the background to keep the cache fresh.
   // This handles: new plugins added, plugins removed, manifest changes.
   // setManifests(list) will update routes if the server list differs from cache.
+  // Re-runs when the selected management profile changes so the plugin list
+  // (and the sidebar tabs it drives) follows the selected profile (#46408).
   useEffect(() => {
     api
       .getPlugins()
       .then((list) => {
-        cacheManifests(list);
+        cacheManifests(list, profile);
         setManifests(list);
         if (list.length === 0) setLoading(false);
       })
       .catch(() => setLoading(false));
-  }, []);
+  }, [profile]);
 
   // Load plugin assets when manifests arrive.
   useEffect(() => {
     if (manifests.length === 0) return;
 
     const injectedScripts: HTMLScriptElement[] = [];
+    // Assets load via <script src>/<link href>, which cannot attach the profile
+    // header; pass the selected management profile as ?profile= so a plugin
+    // installed only under that profile resolves instead of 404ing (#46408).
+    const profileQuery = profile ? `?profile=${encodeURIComponent(profile)}` : "";
 
     for (const manifest of manifests) {
       // Inject CSS if specified.
       if (manifest.css) {
-        const cssUrl = `${HERMES_BASE_PATH}/dashboard-plugins/${manifest.name}/${manifest.css}`;
+        const cssUrl = `${HERMES_BASE_PATH}/dashboard-plugins/${manifest.name}/${manifest.css}${profileQuery}`;
         if (!document.querySelector(`link[href="${cssUrl}"]`)) {
           const link = document.createElement("link");
           link.rel = "stylesheet";
@@ -115,12 +127,13 @@ export function usePlugins() {
       // in-memory registry while the browser would otherwise never
       // re-execute a previously cached <script> URL.
       const baseUrl = `${HERMES_BASE_PATH}/dashboard-plugins/${manifest.name}/${manifest.entry}`;
+      const assetUrl = `${baseUrl}${profileQuery}`;
       const scriptSrc = import.meta.env.DEV
-        ? `${baseUrl}?hermes_dv=${Date.now()}`
-        : baseUrl;
+        ? `${assetUrl}${profileQuery ? "&" : "?"}hermes_dv=${Date.now()}`
+        : assetUrl;
       if (!import.meta.env.DEV) {
-        if (loadedScripts.current.has(baseUrl)) continue;
-        loadedScripts.current.add(baseUrl);
+        if (loadedScripts.current.has(assetUrl)) continue;
+        loadedScripts.current.add(assetUrl);
       }
 
       const script = document.createElement("script");
@@ -164,7 +177,7 @@ export function usePlugins() {
         }
       }
     };
-  }, [manifests]);
+  }, [manifests, profile]);
 
   // Listen for plugin registrations and resolve them against manifests.
   useEffect(() => {

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -107,8 +107,10 @@ export function usePlugins(profile = "") {
   // Re-runs when the selected management profile changes so the plugin list and
   // the sidebar tabs it drives follow the selected profile (#46408).
   useEffect(() => {
-    // Drop the per-profile dedupe so the new profile's bundles load even when a
-    // same-named plugin was injected under the previous profile.
+    // Runs BEFORE the asset effect (effects fire in declaration order), so the
+    // new profile's bundles load even when a same-named plugin was injected
+    // under the previous profile. Keep this effect declared above the asset
+    // effect.
     loadedScripts.current = new Set();
     api
       .getPlugins()

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -84,13 +84,32 @@ export function usePlugins(profile = "") {
     () => !canSeedLoadedFromCache(getCachedManifests(profile)),
   );
   const loadedScripts = useRef<Set<string>>(new Set());
+  const [activeProfile, setActiveProfile] = useState(profile);
+
+  // Adjusting state when the selected profile changes. A hook cannot remount, so
+  // reset the per-profile plugin state during render (React's "adjust state when
+  // a prop changes" pattern) — the equivalent of ProfileKeyedRoutes' remount for
+  // pages. Without this the asset effect below would run with the PREVIOUS
+  // profile's manifests and the NEW profile (requesting ?profile=new for old
+  // plugin names → 404s, and poisoning the loadedScripts dedupe), and the
+  // pluginsLoading gate would not re-arm.
+  if (profile !== activeProfile) {
+    const cached = getCachedManifests(profile);
+    setActiveProfile(profile);
+    setManifests(cached ?? []);
+    setPlugins([]);
+    setLoading(!canSeedLoadedFromCache(cached));
+  }
 
   // Always re-fetch in the background to keep the cache fresh.
   // This handles: new plugins added, plugins removed, manifest changes.
   // setManifests(list) will update routes if the server list differs from cache.
-  // Re-runs when the selected management profile changes so the plugin list
-  // (and the sidebar tabs it drives) follows the selected profile (#46408).
+  // Re-runs when the selected management profile changes so the plugin list and
+  // the sidebar tabs it drives follow the selected profile (#46408).
   useEffect(() => {
+    // Drop the per-profile dedupe so the new profile's bundles load even when a
+    // same-named plugin was injected under the previous profile.
+    loadedScripts.current = new Set();
     api
       .getPlugins()
       .then((list) => {


### PR DESCRIPTION
## What

This PR scopes dashboard plugin discovery, state, and management to the profile selected in the dashboard header switcher (`?profile=<name>`), instead of always resolving against the dashboard process's own profile.

Closes #46408

## Root cause

The dashboard is a machine-level management surface: one header switcher decides which profile the pages read/write, and `fetchJSON` appends `?profile=<name>` to the profile-scoped endpoint families (`web/src/lib/api.ts`). The dashboard-plugin routes were neither in that allowlist nor accepting a `profile` argument, so:

- the plugin list / hub / catalog activation gates read `plugins.enabled`, `plugins.disabled`, and `dashboard.hidden_plugins` from the process profile, and
- install / enable / disable / update / remove / visibility / memory-provider selection all read and wrote the process profile's config.

## Changes

- **web** — add `/api/dashboard/plugins`, `/api/dashboard/agent-plugins`, `/api/dashboard/plugin-providers` to `PROFILE_SCOPED_PREFIXES` so `fetchJSON` scopes those calls.
- **`hermes_cli/web_routers/dashboard_ui.py`** — every plugin route accepts `profile: Optional[str] = None` and runs its body under `scoped_to_thread(profile, ...)`, so `get_hermes_home()` / `load_config()` / `save_config()` follow the requested profile.
- **`web_server_dashboard._dashboard_plugin_search_dirs()`** — scan the task-local home **first** (deduped against the process home + root) so a profile-scoped install is discovered rather than orphaned, and the selected profile's plugins take precedence. The #87197 behaviour is preserved: process-home plugins stay visible under a scope, and its three regression tests still pass.
- **Caches** — the discovery and plugins-hub caches are keyed by resolved home so a profile-scoped request is never served another profile's payload; the discovery cache is a plain dict mutated under a lock.
- **Static assets** — `serve_plugin_asset` accepts `?profile=` and the SPA appends the selected profile (asset `<script>`/`<link>` cannot carry the auth header) so a profile-owned plugin's JS/CSS resolves.
- **SPA** — `usePlugins` resets its per-profile state and re-fetches when the management profile changes (App reads the URL projection), and its manifest cache is namespaced per profile.
- **`discover_plugins()`** — skips loading under a *request* scope only (after joining the in-flight startup discovery). `hermes_constants.request_scoped_hermes_home()` marks an override as a web request serving another profile's data, and the dashboard's `_hermes_home_scope` is the only setter; a plain override — the cron external worker's own home (`cron/scheduler.py::_run_external_worker_payload`), or a multiplexed gateway turn's secondary profile (`gateway/run.py::_profile_runtime_scope`) — still discovers that profile's plugins, which `agent/agent_init.py::_load_tools` needs for the turn's tool snapshot. The reason for the skip is unchanged: plugin registration has process-global side effects (dashboard-auth providers upsert into a process-global registry by name), so a request must not load another profile's plugin modules. This prevents tripping #106608 (an isolated dashboard's Basic Auth provider being replaced by another profile's); the underlying registry-ownership fix belongs in a dedicated #106608 change, not here.

## Tests

- `tests/hermes_cli/test_dashboard_plugin_profile_scope.py` — invariant tests: discovery under a profile scope returns that profile's local plugins; the per-process cache does not leak one profile's result into another; a profile-only plugin's asset resolves through the profile-scoped asset route (404 unscoped); and the web scope marks cross-profile requests for the discovery guard while an own-profile request stays unmarked.
- `tests/hermes_cli/test_plugin_discovery_profile_scope.py` — `discover_plugins()` skips loading under a request scope, and still loads under a plain override (both shapes: override == own home, and override != process home) and with no override. Mutation-checked: reverting the guard, or dropping the skip, fails exactly the matching test.
- `web/src/lib/api.test.ts` — asserts `?profile=` on every dashboard-plugin operation, and no param when unset.
- `web/src/plugins/usePlugins.test.ts` — per-profile manifest-cache namespacing and the profile-switch execution retirement.
- `web/package.json` — declares `@testing-library/react` 16.3.2 and `jsdom` 29.1.1 (exact pins matching `apps/desktop`) for the dashboard suite, which imported/loaded both through `apps/desktop`'s hoisted copies; without the manifest entries a clean checkout failed `tsc -b` (`TS2307`) and the file could not run.
- `scripts/run_tests.sh` on the affected suites: 225 passed, 0 failed. Full vitest: 41 files / 306 tests passed. `tsc -b` exits 0 and `eslint` reports no errors on the changed files.
- Rebased onto current `main`; the one conflict (`dashboard_ui.py`) was main's added `ref=body.ref` argument to the install call, kept inside the new scoped `_run()` closure.

## Notes

- **Open question for maintainers:** the static-asset route is intentionally unauthenticated (the browser loads plugin JS via `<script src>`, which cannot attach an auth header), so the selected profile now travels as a `?profile=` query param. That lets a loopback caller request a named profile's plugin JS/CSS (still gated by that profile's enabled set plus the existing suffix allowlist). If widening the unauthenticated surface is unwanted, the alternative is to drop the param and keep asset serving process-scoped — profile-owned plugin assets would then 404 in the multiplex dashboard.
- **Known limitation / out of scope:** a plugin that exists *only* under a non-launch profile is now listed and its static assets resolve, but its declared **backend API routes are not dynamically mounted** — `_mount_plugin_api_routes()` runs once at server startup against the launch profile's discovery. Mounting per-profile APIs would require rebuilding the router table per request, which is explicitly out of scope for this change. (Raised as problem 2 in the maintainer review of the earlier PR #46432; happy to take it as a follow-up.)
- **Known limitation / out of scope:** with a non-launch profile selected, a plugin-provided **context engine is not listed** in the hub's provider picker. Listing it means loading that profile's plugin modules, which is exactly the load that trips #106608 (a cross-profile load replaces the process-global dashboard-auth provider). The guard keeps that load out of request scopes; once #106608's registry-ownership fix lands, the guard can be relaxed and scoped plugin loading re-enabled.
- **Design note:** process-home plugins stay visible across profiles as shared/fallback assets (per #87197), but the selected profile's directory is now authoritative when one exists, and plugin installs plus the per-profile state (enabled/disabled, hidden, provider selection) are scoped to that profile.
