### PR TITLE
feat(desktop): show more recent sessions in project grouping

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -31,6 +31,7 @@ import {
   $sidebarProfileFilter,
   $sidebarProjectFilter,
   $sidebarRowMeta,
+  $sidebarShowAllSessions,
   $sidebarShowArchived,
   $sidebarStatusFilter,
   $sidebarViewCustomized,
@@ -39,6 +40,7 @@ import {
   setSidebarCardRows,
   setSidebarGrouping,
   setSidebarOrdering,
+  setSidebarShowAllSessions,
   setSidebarShowArchived,
   setWorkspaceNodesOpen,
   type SidebarGrouping,
@@ -155,6 +157,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
   const ordering = useStore($sidebarOrdering)
   const rowMeta = useStore($sidebarRowMeta)
   const cardRows = useStore($sidebarCardRows)
+  const showAllSessions = useStore($sidebarShowAllSessions)
   const statusFilter = useStore($sidebarStatusFilter)
   const projectFilter = useStore($sidebarProjectFilter)
   const profileFilter = useStore($sidebarProfileFilter)
@@ -287,6 +290,14 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
               ))}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+
+          {grouping === 'project' && (
+            <OptionCheckbox
+              checked={showAllSessions}
+              onCheck={() => setSidebarShowAllSessions(!showAllSessions)}
+              option={{ icon: 'list-unordered', id: 'all-sessions', label: t.sidebar.projects.showAllSessions }}
+            />
+          )}
 
           {/* A render variant, not a grouping: three-line cards (project · age /
               title / model · size) compose with whichever grouping is active. */}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -51,6 +51,7 @@ import {
   $sidebarRecentsOpen,
   $sidebarSessionOrderIds,
   $sidebarSessionOrderManual,
+  $sidebarShowAllSessions,
   $sidebarShowArchived,
   $sidebarStatusFilter,
   $sidebarWorkspaceOrderIds,
@@ -383,6 +384,7 @@ export function ChatSidebar({
   // dividers; groups apply it to their own lanes.
   const sortOrderIds = useStore($sidebarSessionRankIds)
   const agentsGrouped = grouping === 'project'
+  const showAllSessions = useStore($sidebarShowAllSessions)
   const pinnedSessionIds = useStore($pinnedSessionIds)
   const unconfirmedPinWrites = useStore($unconfirmedPinWrites)
   const pinsOpen = useStore($sidebarPinsOpen)
@@ -788,6 +790,18 @@ export function ChatSidebar({
     return () => window.clearTimeout(warm)
   }, [activeConnectionId, worktreeGroupingActive, showAllProfiles, profileScope, gatewayReady])
 
+  // Widen the existing tree query when the user expands previews, without
+  // repeating repo discovery. Initial load/scope changes use the effect above.
+  useEffect(
+    () =>
+      $sidebarShowAllSessions.listen(() => {
+        if (gatewayReady && worktreeGroupingActive) {
+          void refreshProjectTree()
+        }
+      }),
+    [gatewayReady, worktreeGroupingActive]
+  )
+
   // Sessions the branch join can't answer for get one look at their own
   // transcript — a `gh pr create` in there names the PR outright. Backfills
   // whatever is loaded, whether or not the badge is on: gating it on the badge
@@ -1132,13 +1146,19 @@ export function ChatSidebar({
   // matching the flat Recents list. Keyed by project id for the rows.
   const overviewPreviews = useMemo<Record<string, SessionInfo[]>>(
     () =>
-      overlayLivePreviews(projectOverview ?? [], agentSessions, projects, PROJECT_PREVIEW_COUNT, {
-        removed: removedSessionIds,
-        // Rank before the trim, so "3 priciest in this project" isn't "3 most
-        // recent, priciest first".
-        rankIds: sortOrderIds
-      }),
-    [projectOverview, agentSessions, projects, removedSessionIds, sortOrderIds]
+      overlayLivePreviews(
+        projectOverview ?? [],
+        agentSessions,
+        projects,
+        showAllSessions ? Infinity : PROJECT_PREVIEW_COUNT,
+        {
+          removed: removedSessionIds,
+          // Rank before the trim, so "3 priciest in this project" isn't "3 most
+          // recent, priciest first".
+          rankIds: sortOrderIds
+        }
+      ),
+    [projectOverview, agentSessions, projects, removedSessionIds, sortOrderIds, showAllSessions]
   )
 
   const onEnterProject = useCallback(

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -1,3 +1,4 @@
+import { useStore } from '@nanostores/react'
 import type * as React from 'react'
 import { useRef } from 'react'
 
@@ -7,6 +8,7 @@ import { Tip } from '@/components/ui/tooltip'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { $sidebarShowAllSessions } from '@/store/layout'
 
 import {
   SIDEBAR_LEAD_ICON_SIZE,
@@ -106,8 +108,10 @@ export function ProjectOverviewRow({
   // The appearance popover anchors here (the full row) so it opens flush with
   // the sidebar's content edge regardless of which side the sidebar is on.
   const rowRef = useRef<HTMLDivElement>(null)
-  const fetched = (previewSessions ?? []).slice(0, PROJECT_PREVIEW_COUNT)
-  const preview = renderRows ? (fetched.length ? fetched : latestProjectSessions(project, PROJECT_PREVIEW_COUNT)) : []
+  const showAllSessions = useStore($sidebarShowAllSessions)
+  const limit = showAllSessions ? Infinity : PROJECT_PREVIEW_COUNT
+  const fetched = (previewSessions ?? []).slice(0, limit)
+  const preview = renderRows ? (fetched.length ? fetched : latestProjectSessions(project, limit)) : []
 
   const lead = reorderable ? (
     <SidebarRowGrab

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -22,6 +22,7 @@ import { sessionBucketLabel } from '@/lib/time'
 import { cn } from '@/lib/utils'
 import {
   $sidebarListGroupIds,
+  $sidebarShowAllSessions,
   $sidebarWorkspaceNodeOpen,
   listGroupNodeId,
   toggleWorkspaceNodeCollapsed
@@ -227,6 +228,7 @@ export function SidebarSessionsSection({
   card = false
 }: SidebarSessionsSectionProps) {
   const { t } = useI18n()
+  const showAllSessions = useStore($sidebarShowAllSessions)
   const dividerLabels = t.sidebar.dateDivider
   const statusDividerLabels = t.sidebar.statusDivider
   const dotStates = useStore($sessionDotStateById)
@@ -372,6 +374,21 @@ export function SidebarSessionsSection({
     [renderRow]
   )
 
+  // Limit complete groups, not sessions, so a burst and its branches stay
+  // together. Compute boundaries from the whole pool, just like Updated.
+  const renderPreviewRows = useCallback(
+    (items: SessionInfo[], projectId: string) => {
+      const rows = groupEntriesByRecency(flattenSessionsWithBranches(items), undefined, undefined, 2).map(row =>
+        row.kind === 'divider' ? { ...row, key: `project:${projectId}:${row.key}` } : row
+      )
+
+      const ordered = manualOrderIds?.length ? orderRowsWithinGroups(rows, manualOrderIds) : rows
+
+      return hideCollapsedGroupRows(ordered, isListGroupOpen).map(row => renderListRow(row, false))
+    },
+    [isListGroupOpen, manualOrderIds, renderListRow]
+  )
+
   // Same as `renderRows`, but with date dividers folded in — used for
   // entered-project lanes so a lane spanning multiple days reads
   // chronologically, matching the flat recents list.
@@ -503,7 +520,7 @@ export function SidebarSessionsSection({
         // preview rows instead of the live overlay.
         previewSessions={projectOverviewPreviews?.[project.id]}
         project={project}
-        renderRows={renderRows}
+        renderRows={showAllSessions ? items => renderPreviewRows(items, project.id) : renderRows}
       />
     )
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1779,6 +1779,7 @@ export const ar = defineLocale({
     noSessions: 'لا توجد جلسات بعد',
     noFilterMatches: 'لا توجد جلسات تطابق عوامل التصفية هذه',
     projects: {
+      showAllSessions: 'عرض جميع الجلسات',
       sectionLabel: 'المشاريع',
       home: 'الرئيسية',
       autoDiscovered: 'مكتشف تلقائيًا',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2437,6 +2437,7 @@ export const en: Translations = {
     noSessions: 'No sessions yet',
     noFilterMatches: 'No sessions match these filters',
     projects: {
+      showAllSessions: 'Show all sessions',
       sectionLabel: 'Projects',
       home: 'Home',
       autoDiscovered: 'Auto-discovered',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2086,6 +2086,7 @@ export const ja = defineLocale({
     noSessions: 'セッションはまだありません',
     noFilterMatches: 'このフィルターに一致するセッションはありません',
     projects: {
+      showAllSessions: 'すべてのセッションを表示',
       sectionLabel: 'プロジェクト',
       home: 'ホーム',
       autoDiscovered: '自動検出',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2431,6 +2431,7 @@ export const ru = defineLocale({
     noSessions: 'Сеансов пока нет',
     noFilterMatches: 'Нет сеансов по этим фильтрам',
     projects: {
+      showAllSessions: 'Показать все сессии',
       sectionLabel: 'Проекты',
       home: 'Главная',
       newButton: 'Новый проект',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2078,6 +2078,7 @@ export interface Translations {
     noSessions: string
     noFilterMatches: string
     projects: {
+      showAllSessions: string
       sectionLabel: string
       home: string
       autoDiscovered: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2010,6 +2010,7 @@ export const zhHant = defineLocale({
     noSessions: '尚無工作階段',
     noFilterMatches: '沒有工作階段符合這些篩選條件',
     projects: {
+      showAllSessions: '顯示所有工作階段',
       sectionLabel: '專案',
       home: '主頁',
       autoDiscovered: '自動探索',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2600,6 +2600,7 @@ export const zh: Translations = {
     noSessions: '暂无会话',
     noFilterMatches: '没有会话符合这些筛选条件',
     projects: {
+      showAllSessions: '显示所有会话',
       sectionLabel: '项目',
       home: '主页',
       autoDiscovered: '自动发现',

--- a/apps/desktop/src/lib/session-date-groups.test.ts
+++ b/apps/desktop/src/lib/session-date-groups.test.ts
@@ -27,6 +27,28 @@ const dividerKeys = (rows: ReturnType<typeof groupEntriesByRecency>): string[] =
   rows.flatMap(row => (row.kind === 'divider' ? [row.key] : []))
 
 describe('groupEntriesByRecency', () => {
+  it('limits complete Updated groups without splitting bursts or branch clusters', () => {
+    const burst = Array.from({ length: 11 }, (_, i) =>
+      entry(session(`burst-${i}`, { last_active: at(2026, 5, 18, 11) - i * 120 }))
+    )
+
+    const entries = [
+      ...burst,
+      entry(session('yesterday', { last_active: at(2026, 5, 17, 15) })),
+      entry(session('branch', { last_active: at(2026, 4, 1) }), '└'),
+      entry(session('older', { last_active: at(2026, 5, 16, 15) }))
+    ]
+
+    const full = group(entries)
+    const dividers = full.flatMap((row, index) => row.kind === 'divider' ? [index] : [])
+    const limited = groupEntriesByRecency(entries, NOW, MONDAY, 2)
+
+    expect(limited).toEqual(full.slice(0, dividers[1]))
+    expect(limited.at(-1)).toMatchObject({ entry: { session: { id: 'branch' } } })
+    expect(groupEntriesByRecency(burst, NOW, MONDAY, 2)).toEqual(group(burst))
+    expect(groupEntriesByRecency([], NOW, MONDAY, 2)).toEqual([])
+  })
+
   it('cuts the head after the most recent handful, then divides by coarse ranges', () => {
     // The morning run (30m/30m/4h/30m gaps, then a 14h silence) is the
     // unlabelled head; each older group gets one divider, coarsening with age.

--- a/apps/desktop/src/lib/session-date-groups.ts
+++ b/apps/desktop/src/lib/session-date-groups.ts
@@ -97,12 +97,14 @@ function headRunCutoffMs(entries: readonly SidebarSessionEntry[], nowMs: number,
 export function groupEntriesByRecency(
   entries: readonly SidebarSessionEntry[],
   nowMs = Date.now(),
-  weekStartsOn = localeWeekStartDay()
+  weekStartsOn = localeWeekStartDay(),
+  maxGroups = Number.POSITIVE_INFINITY
 ): SidebarListRow[] {
   const rows: SidebarListRow[] = []
   const emitted = new Set<string>()
   const cutoff = headRunCutoffMs(entries, nowMs, weekStartsOn)
   let lastKey: null | string = null
+  let groups = 1
 
   for (const entry of entries) {
     // Nested branch rows travel with their parent cluster; they never open a new
@@ -136,6 +138,11 @@ export function groupEntriesByRecency(
       // A divider only ever separates two groups — never label the very first
       // rendered row, whatever group it belongs to.
       if (rows.length > 0 && !alreadyEmitted) {
+        if (groups >= maxGroups) {
+          break
+        }
+
+        groups++
         rows.push({ bucket, key: bucket.key, kind: 'divider' })
       }
     }

--- a/apps/desktop/src/store/layout-sidebar-view.test.ts
+++ b/apps/desktop/src/store/layout-sidebar-view.test.ts
@@ -4,10 +4,12 @@ import {
   $sidebarGrouping,
   $sidebarOrdering,
   $sidebarRowMeta,
+  $sidebarShowAllSessions,
   $sidebarViewCustomized,
   resetSidebarView,
   setSidebarGrouping,
   setSidebarOrdering,
+  setSidebarShowAllSessions,
   toggleSidebarRowMeta,
   toggleSidebarStatusFilter
 } from './layout'
@@ -19,6 +21,23 @@ beforeEach(() => {
 })
 
 describe('the sidebar as it ships', () => {
+  it('remembers expanded project previews across grouping changes and clears them on reset', () => {
+    expect($sidebarShowAllSessions.get()).toBe(false)
+    setSidebarGrouping('project')
+    setSidebarShowAllSessions(true)
+    setSidebarGrouping('date')
+
+    expect($sidebarShowAllSessions.get()).toBe(true)
+    expect($sidebarViewCustomized.get()).toBe(true)
+    expect(window.localStorage.getItem('hermes.desktop.sidebarShowAllSessions')).toBe('true')
+
+    resetSidebarView()
+
+    expect($sidebarShowAllSessions.get()).toBe(false)
+    expect($sidebarViewCustomized.get()).toBe(false)
+    expect(window.localStorage.getItem('hermes.desktop.sidebarShowAllSessions')).toBe('false')
+  })
+
   it('groups by date, sorts by recency, and pins the timestamp and preview', () => {
     expect($sidebarGrouping.get()).toBe('date')
     expect($sidebarOrdering.get()).toBe('updated')

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -40,6 +40,7 @@ const SIDEBAR_ALL_PROFILES_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.sidebarA
 const SIDEBAR_SORT_KEY_STORAGE_KEY = 'hermes.desktop.sidebarSortKey'
 const SIDEBAR_ROW_META_STORAGE_KEY = 'hermes.desktop.sidebarRowMeta'
 const SIDEBAR_CARD_ROWS_STORAGE_KEY = 'hermes.desktop.sidebarCardRows'
+const SIDEBAR_SHOW_ALL_SESSIONS_STORAGE_KEY = 'hermes.desktop.sidebarShowAllSessions'
 const SIDEBAR_STATUS_FILTER_STORAGE_KEY = 'hermes.desktop.sidebarStatusFilter'
 const SIDEBAR_SHOW_ARCHIVED_STORAGE_KEY = 'hermes.desktop.sidebarShowArchived'
 const SIDEBAR_PROJECT_FILTER_STORAGE_KEY = 'hermes.desktop.sidebarProjectFilter'
@@ -320,6 +321,13 @@ export const $sidebarRowMeta = persistentAtom<SidebarRowMeta[]>(
  *  grouping is active. Off by default; dense tree surfaces never use it. */
 export const $sidebarCardRows = persistentAtom(SIDEBAR_CARD_ROWS_STORAGE_KEY, false, Codecs.bool)
 
+/** Project overview: two complete recency groups instead of three preview rows. */
+export const $sidebarShowAllSessions = persistentAtom(SIDEBAR_SHOW_ALL_SESSIONS_STORAGE_KEY, false, Codecs.bool)
+
+export function setSidebarShowAllSessions(on: boolean) {
+  $sidebarShowAllSessions.set(on)
+}
+
 export function setSidebarCardRows(on: boolean) {
   $sidebarCardRows.set(on)
 }
@@ -387,12 +395,13 @@ export const $sidebarFiltersActive: ReadableAtom<boolean> = computed(
  *  offering. Broader than `$sidebarFiltersActive`, which only knows about what
  *  hides rows, not about how they're grouped, sorted or labelled. */
 export const $sidebarViewCustomized: ReadableAtom<boolean> = computed(
-  [$sidebarGrouping, $sidebarOrdering, $sidebarRowMeta, $sidebarCardRows, $sidebarFiltersActive],
-  (grouping, ordering, rowMeta, cardRows, filtersActive) =>
+  [$sidebarGrouping, $sidebarOrdering, $sidebarRowMeta, $sidebarCardRows, $sidebarShowAllSessions, $sidebarFiltersActive],
+  (grouping, ordering, rowMeta, cardRows, showAllSessions, filtersActive) =>
     grouping !== SIDEBAR_DEFAULT_GROUPING ||
     ordering !== SIDEBAR_DEFAULT_ORDERING ||
     !sameRowMeta(rowMeta, SIDEBAR_DEFAULT_ROW_META) ||
     cardRows ||
+    showAllSessions ||
     filtersActive
 )
 
@@ -696,6 +705,7 @@ export function resetSidebarView() {
   setSidebarOrdering(SIDEBAR_DEFAULT_ORDERING)
   $sidebarRowMeta.set(SIDEBAR_DEFAULT_ROW_META)
   $sidebarCardRows.set(false)
+  $sidebarShowAllSessions.set(false)
   clearSidebarFilters()
 }
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -15,7 +15,7 @@ import { isMissingRestEndpoint, isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { isUnderPath } from '@/lib/path-compare'
 import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
-import { setSidebarAgentsGrouped } from '@/store/layout'
+import { $sidebarShowAllSessions, setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -379,7 +379,9 @@ interface ProjectTreePayload {
   scoped_session_ids: string[]
 }
 
-const PROJECT_TREE_PREVIEW_LIMIT = 3
+// Expanded previews need the complete existing tree window before the renderer
+// finds its two recency groups. Keep the normal three-row payload unchanged.
+const projectTreePreviewLimit = () => ($sidebarShowAllSessions.get() ? 2000 : 3)
 // The all-profiles fan-out reads one database per profile, so it is allowed the
 // same headroom as the cross-profile session list rather than the interactive
 // default.
@@ -421,7 +423,7 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
       res = await gatewayRequestOn<ProjectTreePayload>(
         gateway,
         'projects.tree',
-        projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
+        projectParams({ preview_limit: projectTreePreviewLimit() }, profile)
       )
     } catch (error) {
       // A remote source switch can leave the first read RPC on a newly-opened
@@ -435,7 +437,7 @@ async function refreshProjectTreeOn(context: ActiveProjectsContext): Promise<voi
       res = await gatewayRequestOn<ProjectTreePayload>(
         gateway,
         'projects.tree',
-        projectParams({ preview_limit: PROJECT_TREE_PREVIEW_LIMIT }, profile)
+        projectParams({ preview_limit: projectTreePreviewLimit() }, profile)
       )
     }
 
@@ -483,7 +485,7 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
 
   try {
     const res = await hermesApi<ProjectTreePayload>({
-      path: `/api/profiles/projects/tree?preview_limit=${PROJECT_TREE_PREVIEW_LIMIT}`,
+      path: `/api/profiles/projects/tree?preview_limit=${projectTreePreviewLimit()}`,
       timeoutMs: PROJECT_TREE_REQUEST_TIMEOUT_MS
     })
 


### PR DESCRIPTION
## Summary
Adds **Show all sessions** to the sidebar filter menu only when grouping is **Project**. The default stays at three sessions per project. Enabling it shows each project's first two complete smart recency groups using the existing Updated grouping logic, with independently collapsible date dividers.

The preference persists and Reset to defaults clears it. Expanded previews request more rows through the existing project-tree query, within its current 2,000-session window. Other grouping modes and project drill-in remain unchanged.

## Verification
- 75 targeted tests passed across recency grouping, sidebar preferences, project RPCs, and project overview rows.
- Exercised the real sidebar in an isolated browser fixture: on/off, first-two-group boundaries, persistence, reset, per-project collapse, Inbox style, and light/dark appearance.
- Sample-data preview only; no live user sessions were modified. Existing Inbox-style nested-button console warnings remain outside this change.
