### PR TITLE
fix(backup): exclude profile caches from full backups

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -59,14 +59,16 @@ _EXCLUDED_DIRS = {
     ".cache", ".tox", ".nox", ".pytest_cache", ".mypy_cache", ".ruff_cache",
 }
 
-# Hermes-managed runtime downloads (GGUF models, llama.cpp runtimes, managed Node): re-downloaded
-# on demand and routinely tens to hundreds of GB. Matched ONLY at the root of HERMES_HOME and at
-# ``profiles/<name>/`` — a deeper dir of the same name (a skill's ``models/``) is user data.
-_EXCLUDED_ROOT_DIRS = {"models", "runtimes", "node"}
+# Hermes-managed runtime downloads (GGUF models, llama.cpp runtimes, managed Node) and caches are
+# regenerable. Runtime trees routinely reach tens to hundreds of GB; live browser/tool caches may
+# also contain locked SQLite databases that cannot be snapshotted consistently. Match these names
+# ONLY at the root of HERMES_HOME and at ``profiles/<name>/`` — a deeper directory of the same name
+# (for example, a skill's ``models/`` or ``cache/``) is user data and must survive.
+_EXCLUDED_ROOT_DIRS = {"cache", "models", "runtimes", "node"}
 
 
 def _in_excluded_root_dir(rel_path: Path) -> bool:
-    """True when *rel_path* is, or sits inside, a managed runtime tree at a profile-home root."""
+    """True when *rel_path* is inside a regenerable tree at a profile-home root."""
     parts = rel_path.parts
     return bool(parts) and (
         parts[0] in _EXCLUDED_ROOT_DIRS

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -171,6 +171,13 @@ class TestShouldExclude:
         assert _should_exclude(Path("profiles/clean/models/big.gguf"))
         assert _should_exclude(Path("profiles/clean/runtimes/llamacpp/x.dll"))
 
+    def test_excludes_regenerable_cache_at_profile_roots(self):
+        """Live browser/tool caches are mutable and unsafe to snapshot."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("cache/chrome-debug/Default/Cookies"))
+        assert _should_exclude(Path("profiles/sage/cache/chrome-debug/cache.db"))
+        assert not _should_exclude(Path("skills/example/cache/notes.md"))
+
     def test_keeps_nested_dirs_named_like_runtime_trees(self):
         """A deeper directory that happens to be called models/ or node/ is
         user data (a skill's assets, project files) and must survive."""
@@ -231,6 +238,30 @@ class TestIterBackupFiles:
         assert rel_nested in selected
         assert str(Path("models/big.gguf")) not in selected
         assert not any(s.startswith("hermes-agent") for s in selected)
+
+    def test_prunes_profile_root_caches_but_keeps_nested_user_cache(self, tmp_path):
+        from hermes_cli.backup import _iter_backup_files
+
+        root = tmp_path / ".hermes"
+        root.mkdir()
+        root_cache = root / "cache" / "browser"
+        profile_cache = root / "profiles" / "sage" / "cache" / "browser"
+        nested_cache = root / "skills" / "example" / "cache"
+        for directory in (root_cache, profile_cache, nested_cache):
+            directory.mkdir(parents=True)
+            (directory / "state.db").write_bytes(b"cache contents")
+
+        skipped: set = set()
+        selected = {
+            str(rel)
+            for _, rel in _iter_backup_files(root, tmp_path / "out.zip", skipped)
+        }
+
+        assert str(Path("cache/browser/state.db")) not in selected
+        assert str(Path("profiles/sage/cache/browser/state.db")) not in selected
+        assert str(Path("skills/example/cache/state.db")) in selected
+        assert "cache" in skipped
+        assert str(Path("profiles/sage/cache")) in skipped
 
     def test_skipped_dirs_collected_for_summary(self, tmp_path):
         from hermes_cli.backup import _iter_backup_files


### PR DESCRIPTION
## What does this PR do?

Exclude the regenerable `cache/` tree at the default Hermes home and at each named profile root from full backups.

Hermes intentionally stores generated media, tool caches, browser state, and other rebuildable artifacts under `$HERMES_HOME/cache`. A live headless Chrome profile under `profiles/<name>/cache/chrome-debug-*` can contain locked SQLite databases. The backup walker tries to snapshot those databases, emits skipped-file warnings, and produces an incomplete backup even though the files are disposable cache state.

The exclusion is profile-root scoped. Nested user-authored content such as `skills/example/cache/notes.md` remains backup-eligible.

## Related Issue

No existing issue found. This was reproduced on a live Hermes installation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/backup.py` — add `cache` to the root/profile-root regenerable directory set and document why live caches are unsafe to snapshot.
- `tests/hermes_cli/test_backup.py` — cover default-root and named-profile cache exclusion, nested user-cache retention, and the actual backup iterator's pruning behavior.

## How to Test

1. Start a tool or headless browser that writes live SQLite files below `$HERMES_HOME/cache` or `$HERMES_HOME/profiles/<name>/cache`.
2. Run `hermes backup -o /tmp/hermes-backup.zip`.
3. Confirm the root/profile cache directories are pruned, nested user-authored `cache/` directories remain included, and locked cache databases no longer make the backup incomplete.

Verification performed:

- `python -m pytest tests/hermes_cli/test_backup.py -q` — **81 passed**
- `ruff check hermes_cli/backup.py tests/hermes_cli/test_backup.py` — passed
- `git diff --check` — passed
- Live end-to-end disaster-recovery backup after applying the equivalent local fix — encrypted 7.29 GB archive completed and passed remote readback verification
- Independent pre-commit review — passed with no security or logic findings

## Checklist

### Code

- [x] I've read the Contributing Guide and repository instructions
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (the focused backup module was run: 81 passed)
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04

### Documentation & Housekeeping

- [x] Relevant inline documentation/docstrings updated; external docs N/A
- [x] `cli-config.yaml.example` N/A — no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no architecture or workflow change
- [x] Cross-platform impact considered — uses existing `pathlib` path classification
- [x] Tool descriptions/schemas N/A
