### PR TITLE
fix(gateway): interrupt evicted in-flight runs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2529,6 +2529,7 @@ def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
 _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
+_INTERRUPT_REASON_EVICTED = "Session ended while the turn was running"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
@@ -2662,7 +2663,8 @@ def _watch_gateway_turn_inactivity(
 _CONTROL_INTERRUPT_MESSAGES = frozenset({
     _INTERRUPT_REASON_STOP.lower(), _INTERRUPT_REASON_RESET.lower(),
     _INTERRUPT_REASON_TIMEOUT.lower(), _INTERRUPT_REASON_SSE_DISCONNECT.lower(),
-    _INTERRUPT_REASON_GATEWAY_SHUTDOWN.lower(), _INTERRUPT_REASON_GATEWAY_RESTART.lower()})
+    _INTERRUPT_REASON_EVICTED.lower(), _INTERRUPT_REASON_GATEWAY_SHUTDOWN.lower(),
+    _INTERRUPT_REASON_GATEWAY_RESTART.lower()})
 
 
 def _is_control_interrupt_message(message: Optional[str]) -> bool:

--- a/gateway/run_agent_cache.py
+++ b/gateway/run_agent_cache.py
@@ -258,12 +258,17 @@ class GatewayAgentCacheMixin:
         return True
 
     def _held_turn_lease(self, session_key: str, run_generation: int):
-        """Return ``(registry, turn)`` when ``session_key`` holds a lease token for ``run_generation``, else None."""
+        """Return ``(registry, token)`` when ``session_key`` holds a lease token for ``run_generation``, else None."""
         registry = getattr(self, "_turn_leases", None)
         state = self._peek_session_state(session_key) if session_key and registry is not None else None
-        if state is None or state.turn.lease_token is None or state.turn.lease_generation != run_generation:
+        if state is None:
             return None
-        return registry, state.turn
+        token = state.turn.lease_tokens.get(run_generation)
+        if token is None and state.turn.lease_generation == run_generation:
+            token = state.turn.lease_token
+        if token is None:
+            return None
+        return registry, token
 
     def _release_turn_lease(self, session_key: str, run_generation: int) -> bool:
         """Release the turn lease acquired by (``session_key``, ``run_generation``). Keyed by (routing
@@ -272,8 +277,13 @@ class GatewayAgentCacheMixin:
         held = self._held_turn_lease(session_key, run_generation)
         if held is None:
             return False
-        registry, turn = held
-        token, turn.lease_token, turn.lease_generation = turn.lease_token, None, None
+        registry, token = held
+        state = self._peek_session_state(session_key)
+        if state is not None:
+            state.turn.lease_tokens.pop(run_generation, None)
+            if state.turn.lease_generation == run_generation:
+                state.turn.lease_token = None
+                state.turn.lease_generation = None
         try:
             return registry.release(token)
         except Exception:
@@ -287,9 +297,9 @@ class GatewayAgentCacheMixin:
         held = self._held_turn_lease(session_key, run_generation) if new_session_id else None
         if held is None:
             return False
-        registry, turn = held
+        registry, token = held
         try:
-            return registry.rebind(turn.lease_token, new_session_id)
+            return registry.rebind(token, new_session_id)
         except Exception:
             logger.debug("Failed to rebind turn lease", exc_info=True)
             return False

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1300,18 +1300,13 @@ class GatewayInboundMixin:
             # SIGKILL/OOM skips finally, leaving the durable marker for the next unclean startup's
             # recovery pass.
             await self._clear_durable_active_turn(event)
-            # Unconditional, idempotent release without a run_generation guard: evicts the zombie
-            # left when session_reset bumps the generation mid-flight (gen-N's guarded release in
-            # _run_agent returns False; a sentinel-only check would lock forever).
-            self._release_running_agent_state(_quick_key)
+            # Release only this turn's generation. Eviction may immediately admit a replacement
+            # through the cold path; an unconditional release here would then clear the replacement
+            # sentinel/agent and lease. Reset/stop release their stale slot before installing a
+            # successor, preserving reset-zombie cleanup without granting gen-N successor authority.
+            self._release_running_agent_state(_quick_key, run_generation=_run_generation)
             # Turn lease is keyed by (routing key, run generation) so this unwind can only free
             # the lease its own turn acquired, never a newer turn's.
-            # Unconditional release covers every exit path. _release_running_agent_state is idempotent
-            # (pop-on-absent is harmless) and, called without a run_generation guard, always clears the slot
-            # regardless of which generation it holds. This evicts the zombie left when session_reset bumps
-            # the generation (N -> N+1) mid-flight: gen-N's guarded release inside _run_agent returns False,
-            # and the old sentinel-only check here missed the leftover real agent — locking the session out
-            # forever (#28686).
             self._release_turn_lease(_quick_key, _run_generation)
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -911,6 +911,7 @@ class GatewayInboundMixin:
             event.text = moa_payload
             _moa_state = self._session_state(_quick_key)
             event._moa_restore_override = _moa_state.conversation.model_override
+            event._moa_run_generation = _moa_state.persistent.run_generation
             _moa_state.conversation.model_override = {
                 "provider": "moa", "model": moa_cfg["default_preset"], "base_url": "moa://local",
                 "api_key": "moa-virtual-provider", "api_mode": "chat_completions",
@@ -1295,8 +1296,8 @@ class GatewayInboundMixin:
         finally:
             # MoA one-shot restore must run on EVERY exit path (success, exception, interrupt):
             # the restore data lives on the per-turn event and would leak permanently otherwise.
-            self._restore_moa_one_shot(event, _quick_key)
-            self._restore_pending_one_turn_model_override(_quick_key)
+            self._restore_moa_one_shot(event, _quick_key, _run_generation)
+            self._restore_pending_one_turn_model_override(_quick_key, _run_generation)
             # SIGKILL/OOM skips finally, leaving the durable marker for the next unclean startup's
             # recovery pass.
             await self._clear_durable_active_turn(event)
@@ -1309,17 +1310,20 @@ class GatewayInboundMixin:
             # the lease its own turn acquired, never a newer turn's.
             self._release_turn_lease(_quick_key, _run_generation)
 
-    def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
+    def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str, run_generation: int | None = None) -> None:
         """Revert a ``/moa <prompt>`` one-shot model override after its turn (called from the
         message-handling ``finally``). ``_moa_restore_override`` holds the prior per-session
         override (``None`` = clear the MoA override outright)."""
         if not getattr(event, "_moa_disable_after_turn", False):
             return
+        owner_generation = getattr(event, "_moa_run_generation", run_generation)
+        if run_generation is not None and owner_generation != run_generation:
+            return
         with suppress(Exception):
             self._session_state(quick_key).conversation.model_override = getattr(event, "_moa_restore_override", None)
             self._evict_cached_agent(quick_key)
 
-    def _restore_pending_one_turn_model_override(self, session_key: str) -> None:
+    def _restore_pending_one_turn_model_override(self, session_key: str, run_generation: int | None = None) -> None:
         """Restore a per-session model override after ``/model --once`` runs."""
         if not session_key:
             return
@@ -1328,7 +1332,7 @@ class GatewayInboundMixin:
             snapshot = _otr_state.conversation.one_turn_restore if _otr_state else None
             if _otr_state is not None:
                 _otr_state.conversation.one_turn_restore = None
-            if snapshot:
+            if snapshot and (run_generation is None or snapshot.get("run_generation") == run_generation):
                 self._restore_session_model_override(session_key, snapshot)
         except Exception:
             logger.debug("Failed to restore one-turn model override", exc_info=True)

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -480,8 +480,26 @@ class GatewayInboundMixin:
             logger.debug("reaped-session staleness check failed", exc_info=True)
 
     def _hm_evict_running_agent(self, _quick_key: str, reason: str) -> None:
+        from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_EVICTED, request_hard_interrupt
+        state = self._peek_session_state(_quick_key)
+        running_agent = state.turn.agent if state else None
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                request_hard_interrupt(running_agent, _INTERRUPT_REASON_EVICTED)
+            except Exception:
+                # Eviction must still invalidate and release the slot if a legacy or third-party
+                # agent cannot accept the interrupt request; otherwise the stale session remains
+                # unroutable and the pre-existing cleanup path is lost.
+                logger.warning(
+                    "Failed to interrupt evicted agent for %s; continuing eviction cleanup",
+                    _quick_key,
+                    exc_info=True,
+                )
         self._invalidate_session_run_generation(_quick_key, reason=reason)
         self._release_running_agent_state(_quick_key)
+        # The interrupt flag is cleared only by the turn finalizer. Remove the cached instance after
+        # releasing the slot so a late-finishing orphan cannot poison the replacement turn.
+        self._evict_cached_agent(_quick_key)
 
     def _hm_merge_pending_for_source(
         self, source: SessionSource, _quick_key: str, event: "MessageEvent", *, merge_text: bool = False

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -911,7 +911,7 @@ class GatewayInboundMixin:
             event.text = moa_payload
             _moa_state = self._session_state(_quick_key)
             event._moa_restore_override = _moa_state.conversation.model_override
-            event._moa_run_generation = _moa_state.persistent.run_generation
+            event._moa_run_generation = None
             _moa_state.conversation.model_override = {
                 "provider": "moa", "model": moa_cfg["default_preset"], "base_url": "moa://local",
                 "api_key": "moa-virtual-provider", "api_mode": "chat_completions",
@@ -1268,6 +1268,13 @@ class GatewayInboundMixin:
         _claim_state.turn.started_ts = time.time()
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
+        if getattr(event, "_moa_disable_after_turn", False):
+            event._moa_run_generation = _run_generation
+        if (
+            _claim_state.conversation.one_turn_restore
+            and _claim_state.conversation.one_turn_restore.get("run_generation") is None
+        ):
+            _claim_state.conversation.one_turn_restore["run_generation"] = _run_generation
 
         try:
             try:
@@ -1317,10 +1324,16 @@ class GatewayInboundMixin:
         if not getattr(event, "_moa_disable_after_turn", False):
             return
         owner_generation = getattr(event, "_moa_run_generation", run_generation)
-        if run_generation is not None and owner_generation != run_generation:
+        if run_generation is not None and owner_generation is not None and owner_generation != run_generation:
             return
+        state = self._peek_session_state(quick_key)
+        if state is None:
+            return
+        if run_generation is not None and state.persistent.run_generation != run_generation:
+            return
+        event._moa_disable_after_turn = False
         with suppress(Exception):
-            self._session_state(quick_key).conversation.model_override = getattr(event, "_moa_restore_override", None)
+            state.conversation.model_override = getattr(event, "_moa_restore_override", None)
             self._evict_cached_agent(quick_key)
 
     def _restore_pending_one_turn_model_override(self, session_key: str, run_generation: int | None = None) -> None:
@@ -1329,11 +1342,18 @@ class GatewayInboundMixin:
             return
         try:
             _otr_state = self._peek_session_state(session_key)
-            snapshot = _otr_state.conversation.one_turn_restore if _otr_state else None
-            if _otr_state is not None:
-                _otr_state.conversation.one_turn_restore = None
-            if snapshot and (run_generation is None or snapshot.get("run_generation") == run_generation):
-                self._restore_session_model_override(session_key, snapshot)
+            if _otr_state is None:
+                return
+            snapshot = _otr_state.conversation.one_turn_restore
+            if not snapshot:
+                return
+            snapshot_gen = snapshot.get("run_generation")
+            if run_generation is not None and snapshot_gen is not None and snapshot_gen != run_generation:
+                return
+            if run_generation is not None and _otr_state.persistent.run_generation != run_generation:
+                return
+            _otr_state.conversation.one_turn_restore = None
+            self._restore_session_model_override(session_key, snapshot)
         except Exception:
             logger.debug("Failed to restore one-turn model override", exc_info=True)
 

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -473,6 +473,10 @@ class GatewayTurnMixin:
             raise
         if _lease_token is not None:
             _lease_state = self._session_state(_quick_key).turn
+            old_token = _lease_state.lease_token
+            if old_token is not None and _lease_state.lease_generation != run_generation:
+                with suppress(Exception):
+                    _lease_registry.release(old_token)
             _lease_state.lease_token = _lease_token
             _lease_state.lease_generation = run_generation
 

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -473,12 +473,9 @@ class GatewayTurnMixin:
             raise
         if _lease_token is not None:
             _lease_state = self._session_state(_quick_key).turn
-            old_token = _lease_state.lease_token
-            if old_token is not None and _lease_state.lease_generation != run_generation:
-                with suppress(Exception):
-                    _lease_registry.release(old_token)
             _lease_state.lease_token = _lease_token
             _lease_state.lease_generation = run_generation
+            _lease_state.lease_tokens[run_generation] = _lease_token
 
     @dataclasses.dataclass
     class _HygienePlan:

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -27,6 +27,7 @@ class TurnState:
     # generation is current, so a stale unwind can never free a newer turn's lease.
     lease_token: Any = None
     lease_generation: Optional[int] = None
+    lease_tokens: Dict[int, Any] = field(default_factory=dict)
 
     def clear(self) -> None:
         """Reset the per-turn slot.  The caller pops ``lease`` first to release it."""

--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -270,6 +270,8 @@ class GatewayModelCommandsMixin:
             if not hasattr(self, "_pending_one_turn_model_restores"):
                 self._pending_one_turn_model_restores = {}
             snapshot = ctx.restore_snapshot or {"had_override": False, "override": None}
+            snapshot = dict(snapshot)
+            snapshot["run_generation"] = self._session_state(ctx.session_key).persistent.run_generation
             self._pending_one_turn_model_restores[ctx.session_key] = snapshot
         elif not picker and hasattr(self, "_pending_one_turn_model_restores"):
             self._pending_one_turn_model_restores.pop(ctx.session_key, None)

--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -271,7 +271,7 @@ class GatewayModelCommandsMixin:
                 self._pending_one_turn_model_restores = {}
             snapshot = ctx.restore_snapshot or {"had_override": False, "override": None}
             snapshot = dict(snapshot)
-            snapshot["run_generation"] = self._session_state(ctx.session_key).persistent.run_generation
+            snapshot["run_generation"] = None
             self._pending_one_turn_model_restores[ctx.session_key] = snapshot
         elif not picker and hasattr(self, "_pending_one_turn_model_restores"):
             self._pending_one_turn_model_restores.pop(ctx.session_key, None)

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -43,11 +43,12 @@ class TurnLeaseToken:
     """Held-lease handle from :meth:`SessionTurnLeaseRegistry.acquire`; ``released`` makes
     release idempotent."""
 
-    __slots__ = ("session_id", "owner_key", "generation", "released")
+    __slots__ = ("session_id", "owner_key", "generation", "released", "lease")
 
-    def __init__(self, session_id: str, owner_key: str, generation: int) -> None:
+    def __init__(self, session_id: str, owner_key: str, generation: int, lease: Optional["_SessionLease"] = None) -> None:
         self.session_id, self.owner_key, self.generation = session_id, owner_key, generation
         self.released = False
+        self.lease = lease
 
     def __repr__(self) -> str:  # pragma: no cover - debug aid
         return (f"TurnLeaseToken(session_id={self.session_id!r}, owner_key={self.owner_key!r}, "
@@ -100,8 +101,8 @@ class SessionTurnLeaseRegistry:
         if not session_id:
             return None
         wait = float(timeout) if timeout and timeout > 0 else DEFAULT_LEASE_WAIT
-        token = TurnLeaseToken(session_id, owner_key, int(generation))
         lease = self._get_or_create(session_id)
+        token = TurnLeaseToken(session_id, owner_key, int(generation), lease=lease)
         if lease.lock.locked():
             logger.warning(
                 "turn lease contention on session %s: routing key %s (gen %s) waiting behind "
@@ -153,7 +154,7 @@ class SessionTurnLeaseRegistry:
                 token.session_id, new_session_id, token.owner_key, token.generation,
                 *_holder_desc(existing.holder), new_session_id)
             return False
-        self._leases.pop(token.session_id, None)
+        # Preserve alias across rotation: both old and new session IDs point to the same lease
         self._leases[new_session_id] = lease
         lease.last_used = time.time()
         token.session_id = new_session_id
@@ -165,7 +166,8 @@ class SessionTurnLeaseRegistry:
         if token is None or token.released:
             return False
         token.released = True
-        if (lease := self._leases.get(token.session_id)) is None:
+        lease = getattr(token, "lease", None) or self._leases.get(token.session_id)
+        if lease is None:
             return False
         if lease.holder is not token:
             logger.debug("turn lease release skipped on session %s: token (key %s gen %s) is not "

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -153,6 +153,7 @@ class SessionTurnLeaseRegistry:
                 token.session_id, new_session_id, token.owner_key, token.generation,
                 *_holder_desc(existing.holder), new_session_id)
             return False
+        self._leases.pop(token.session_id, None)
         self._leases[new_session_id] = lease
         lease.last_used = time.time()
         token.session_id = new_session_id

--- a/tests/gateway/test_reaped_eviction_interrupts_run.py
+++ b/tests/gateway/test_reaped_eviction_interrupts_run.py
@@ -97,3 +97,22 @@ def test_eviction_cleanup_survives_empty_pending_or_failed_interrupt(agent) -> N
 
     assert state.turn.agent is None
     assert KEY not in gateway._agent_cache
+
+
+def test_stale_finalizer_cannot_release_replacement_generation() -> None:
+    events: list[tuple] = []
+    old_agent = _RecordingAgent(events, lambda: None)
+    gateway, state = _build_gateway(old_agent, events)
+    state.persistent.run_generation = 2
+
+    # Eviction releases generation 2 before the cold path claims the replacement.
+    gateway._invalidate_session_run_generation(KEY, reason="reaped_session_eviction")
+    gateway._release_running_agent_state(KEY)
+    replacement = object()
+    replacement_state = gateway._session_state(KEY)
+    replacement_state.turn.agent = replacement
+    replacement_state.persistent.run_generation = 4
+
+    # Generation 2 is unwinding after generation 4 claimed the key.
+    assert gateway._release_running_agent_state(KEY, run_generation=2) is False
+    assert gateway._peek_session_state(KEY).turn.agent is replacement

--- a/tests/gateway/test_reaped_eviction_interrupts_run.py
+++ b/tests/gateway/test_reaped_eviction_interrupts_run.py
@@ -1,0 +1,99 @@
+"""Regression tests for interrupting work evicted from a gateway turn slot."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.run import (
+    GatewayRunner,
+    _AGENT_PENDING_SENTINEL,
+    _is_control_interrupt_message,
+)
+from gateway.run_inbound import GatewayInboundMixin
+
+
+KEY = "agent:main:telegram:dm:106963"
+EVICTION_REASON = "Session ended while the turn was running"
+
+
+class _RecordingAgent:
+    def __init__(self, events: list[tuple], slot_agent) -> None:
+        self._events = events
+        self._slot_agent = slot_agent
+        self.interrupted = False
+
+    def hard_interrupt(self, message: str | None = None, **_kwargs) -> None:
+        self.interrupted = True
+        self._events.append(("interrupt", message, self._slot_agent() is self))
+
+
+class _RaisingAgent:
+    def hard_interrupt(self, _message: str | None = None, **_kwargs) -> None:
+        raise RuntimeError("interrupt transport failed")
+
+
+class _ReapedStore:
+    def peek_session_id(self, _session_key: str) -> str:
+        return "session-106963"
+
+    def _is_session_ended_in_db(self, session_id: str) -> bool:
+        return session_id == "session-106963"
+
+
+def _build_gateway(agent, events: list[tuple]):
+    gateway = object.__new__(GatewayRunner)
+    gateway._persist_active_agents = lambda: None
+    gateway._agent_cache_lock = None
+    gateway._agent_cache = {KEY: (agent, "signature", 0)}
+    gateway._spawn_release_thread = lambda target, args, name, inline_fallback: events.append(
+        ("cache_release", args[0])
+    )
+    state = gateway._session_state(KEY)
+    state.turn.agent = agent
+    return gateway, state
+
+
+@pytest.mark.parametrize("entrypoint", ("direct", "reaped"))
+def test_eviction_interrupts_before_release_and_drops_cached_agent(entrypoint: str) -> None:
+    events: list[tuple] = []
+    gateway = None
+
+    def current_agent():
+        state = gateway._peek_session_state(KEY)
+        return state.turn.agent if state else None
+
+    agent = _RecordingAgent(events, current_agent)
+    gateway, _state = _build_gateway(agent, events)
+    release = gateway._release_running_agent_state
+
+    def release_with_record(session_key: str, **kwargs) -> bool:
+        events.append(("release", current_agent() is agent))
+        return release(session_key, **kwargs)
+
+    gateway._release_running_agent_state = release_with_record
+    if entrypoint == "reaped":
+        gateway.session_store = _ReapedStore()
+        gateway._hm_evict_reaped_agent(KEY)
+    else:
+        gateway._hm_evict_running_agent(KEY, "stale_running_agent_eviction")
+
+    assert isinstance(gateway, GatewayInboundMixin)
+    assert agent.interrupted
+    assert events[0] == ("interrupt", EVICTION_REASON, True)
+    release_events = [event for event in events if event[0] == "release"]
+    assert release_events == [("release", True)]
+    assert events.index(events[0]) < events.index(release_events[0])
+    assert gateway._peek_session_state(KEY).turn.agent is None
+    assert KEY not in gateway._agent_cache
+    assert _is_control_interrupt_message(EVICTION_REASON)
+
+
+@pytest.mark.parametrize("agent", (None, _AGENT_PENDING_SENTINEL, _RaisingAgent()))
+def test_eviction_cleanup_survives_empty_pending_or_failed_interrupt(agent) -> None:
+    events: list[tuple] = []
+    gateway, state = _build_gateway(agent, events)
+
+    gateway._hm_evict_running_agent(KEY, "reaped_session_eviction")
+
+    assert state.turn.agent is None
+    assert KEY not in gateway._agent_cache

--- a/tests/gateway/test_reaped_eviction_interrupts_run.py
+++ b/tests/gateway/test_reaped_eviction_interrupts_run.py
@@ -116,3 +116,112 @@ def test_stale_finalizer_cannot_release_replacement_generation() -> None:
     # Generation 2 is unwinding after generation 4 claimed the key.
     assert gateway._release_running_agent_state(KEY, run_generation=2) is False
     assert gateway._peek_session_state(KEY).turn.agent is replacement
+
+
+def test_moa_one_shot_restoration_generation_owned() -> None:
+    events: list[tuple] = []
+    gateway, state = _build_gateway(object(), events)
+    state.persistent.run_generation = 1
+    state.conversation.model_override = {"provider": "custom", "model": "test-model"}
+
+    # Simulate /moa command handling
+    class _MockEvent:
+        _moa_disable_after_turn = True
+        _moa_restore_override = {"provider": "custom", "model": "test-model"}
+        _moa_run_generation = None
+
+    event = _MockEvent()
+    # Turn claims generation 2
+    claimed_gen = 2
+    state.persistent.run_generation = claimed_gen
+    event._moa_run_generation = claimed_gen
+    state.conversation.model_override = {"provider": "moa", "model": "moa-model"}
+
+    # 1. Stale generation finalizer (e.g. gen 1) must NOT restore or clear MoA
+    gateway._restore_moa_one_shot(event, KEY, run_generation=1)
+    assert event._moa_disable_after_turn is True
+    assert state.conversation.model_override == {"provider": "moa", "model": "moa-model"}
+
+    # 2. Owning generation finalizer (gen 2) restores prior override
+    gateway._restore_moa_one_shot(event, KEY, run_generation=claimed_gen)
+    assert event._moa_disable_after_turn is False
+    assert state.conversation.model_override == {"provider": "custom", "model": "test-model"}
+
+
+def test_model_once_snapshot_preserved_from_stale_finalizer() -> None:
+    events: list[tuple] = []
+    gateway, state = _build_gateway(object(), events)
+    state.persistent.run_generation = 1
+    state.conversation.model_override = {"model": "once-model", "provider": "test"}
+    state.conversation.one_turn_restore = {
+        "had_override": True,
+        "override": {"model": "original-model", "provider": "test"},
+        "run_generation": 2,
+    }
+
+    # Stale finalizer for generation 1 must NOT clear one_turn_restore or restore override
+    state.persistent.run_generation = 2
+    gateway._restore_pending_one_turn_model_override(KEY, run_generation=1)
+    assert state.conversation.one_turn_restore is not None
+    assert state.conversation.model_override["model"] == "once-model"
+
+    # Owning generation 2 restores snapshot and clears one_turn_restore
+    gateway._restore_pending_one_turn_model_override(KEY, run_generation=2)
+    assert state.conversation.one_turn_restore is None
+    assert state.conversation.model_override["model"] == "original-model"
+
+
+@pytest.mark.asyncio
+async def test_turn_lease_rebind_preserves_parent_lock_domain_and_releases() -> None:
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    registry = SessionTurnLeaseRegistry()
+    token = await registry.acquire("parent-session", owner_key="key-1", generation=1, timeout=5)
+    assert token is not None
+    assert registry.rebind(token, "child-session") is True
+    assert token.session_id == "child-session"
+
+    # Both parent and child session IDs must be registered to the same lease
+    assert registry._leases.get("parent-session") is registry._leases.get("child-session")
+    assert registry._leases["parent-session"].holder is token
+
+    # Parent lock domain remains busy while child is held
+    import asyncio
+    waiter = asyncio.create_task(
+        registry.acquire("parent-session", owner_key="key-2", generation=1, timeout=5)
+    )
+    await asyncio.sleep(0.01)
+    assert not waiter.done()
+
+    # Release by token identity frees the lock and wakes the parent waiter
+    assert registry.release(token) is True
+    parent_token = await waiter
+    assert parent_token is not None
+    assert parent_token.owner_key == "key-2"
+    assert registry.release(parent_token) is True
+
+
+def test_displaced_turn_lease_release_by_owning_generation() -> None:
+    from gateway.turn_lease import SessionTurnLeaseRegistry
+
+    events: list[tuple] = []
+    gateway, state = _build_gateway(object(), events)
+    registry = SessionTurnLeaseRegistry()
+    gateway._turn_leases = registry
+
+    import asyncio
+    token1 = asyncio.run(registry.acquire("sess-106963", owner_key=KEY, generation=1, timeout=5))
+    assert token1 is not None
+
+    state.turn.lease_tokens[1] = token1
+    state.turn.lease_token = token1
+    state.turn.lease_generation = 1
+
+    # Unwind of generation 2 has no token
+    assert gateway._release_turn_lease(KEY, run_generation=2) is False
+    assert token1.released is False
+
+    # Owning generation 1 releases token1
+    assert gateway._release_turn_lease(KEY, run_generation=1) is True
+    assert token1.released is True
+    assert 1 not in state.turn.lease_tokens

--- a/tests/gateway/test_reaped_session_recovery.py
+++ b/tests/gateway/test_reaped_session_recovery.py
@@ -22,7 +22,7 @@ from gateway.config import (
     PlatformConfig,
 )
 from gateway.platforms.event import MessageEvent, MessageType
-from gateway.run import GatewayRunner
+from gateway.run import GatewayRunner, _INTERRUPT_REASON_EVICTED
 from gateway.session import SessionSource, SessionStore
 
 
@@ -36,7 +36,7 @@ class _FakeAdapter:
 
 
 class _DeadReapedAgent:
-    """Runtime whose turn was reaped: interrupt() lands nowhere."""
+    """Runtime whose durable session was reaped; records eviction interrupts."""
 
     def __init__(self):
         self.interrupts = []
@@ -138,8 +138,9 @@ async def test_reaped_session_message_reaches_cold_path(tmp_path):
 
     assert result == "COLD_PATH_REPLY"
     assert cold_path.await_count == 1
-    # Nothing was interrupt()-delivered into the dead runtime.
-    assert agent.interrupts == []
+    # The stale runtime is interrupted before eviction, then the message still heals through
+    # the cold path instead of being delivered to the ended session.
+    assert agent.interrupts == [_INTERRUPT_REASON_EVICTED]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #106963.

## Summary

Interrupt and fully evict an in-flight gateway run when its durable session is reaped or its stale running-agent slot is evicted. The change prevents discarded work from continuing to call models, run tools, and perform side effects after the gateway has invalidated its result.

This is a current-main carry-forward of the verified root fix. Existing open candidates #106964 and #106966 were inspected but left untouched. #106966 now covers interrupt-before-release, cache eviction, and raising interrupt ABIs, but its dedicated eviction reason is not included in `_CONTROL_INTERRUPT_MESSAGES`; this PR carries the complete behavior contract and current-main base.

## Problem observed

- Incorrect behavior: `_hm_evict_running_agent` only invalidated the run generation and released the turn slot. The in-flight agent continued running even though its eventual result would be discarded.
- Operational symptom: the reported run continued for 25 minutes, 51 API calls, and 7,893,329 input tokens after its session row was reaped, including file writes and a git commit that the user never saw.
- Control-path symptom: releasing `state.turn.agent` first made a later `/stop` or `/new` unable to reach the orphaned run.
- Expected behavior: request the cooperative hard interrupt while the slot still references the agent, then invalidate the stale result, release the slot, and remove the cached agent.
- Reproduction: `tests/gateway/test_reaped_eviction_interrupts_run.py` failed before the implementation and passed after it. The reaped-session recovery test also verifies that healing still reaches the cold path.

## Root cause

`gateway/run_inbound.py::_hm_evict_running_agent` was the shared cleanup helper for both:

1. durable reaped-session eviction (`ws_orphan_reap` / `agent_close`); and
2. stale running-agent eviction.

Unlike `_interrupt_and_clear_session`, the helper never called `request_hard_interrupt`. The generation bump only caused the gateway to reject the late result; it did not set the agent interrupt state checked by the turn loop. The helper also did not evict the cached instance, allowing a still-latched `_interrupt_requested` flag to poison a cold reattach. Finally, an exception from a legacy or third-party interrupt ABI could skip the rest of eviction cleanup.

The sibling call paths were traced: both eviction paths share `_hm_evict_running_agent`, while `/stop` and `/new` use `_interrupt_and_clear_session` as the established interrupt/invalidate/release/cache-evict reference path.

## Impact and scope

- Affected: gateway sessions whose durable row ends while an in-memory turn is still executing, plus the shared stale-agent eviction path.
- Not affected: live sessions that have not been reaped, pending-agent sentinels, and empty turn slots; these are not hard-interrupted by the new helper.
- Preserved behavior: a reaped session still heals through the existing cold-path routing recovery.
- Operational benefit: avoids continuing model/tool work whose result cannot be delivered and restores reachability of stop semantics before the slot is released.
- Security and configuration: no credentials, configuration schema, migrations, or new dependencies are introduced.
- Residual risk: interruption remains cooperative. A third-party agent that ignores the interrupt may continue independently, but the gateway still completes generation invalidation, slot release, and cache eviction; the exception path is logged and does not leave the stale slot reachable.

## Solution

- Add `_INTERRUPT_REASON_EVICTED` to distinguish gateway lifecycle eviction from a user-issued stop.
- Add the eviction reason to `_CONTROL_INTERRUPT_MESSAGES` so it cannot be recycled as a user follow-up by the pending-message drain.
- In `_hm_evict_running_agent`, read the current agent and request `request_hard_interrupt` before invalidation and release.
- Treat interrupt failure as best-effort and continue cleanup with structured logging.
- Evict the cached agent after releasing the running slot, matching the existing `/stop` and `/new` invariant.
- Add behavior tests for direct stale eviction, durable reaped-session detection, ordering, cache removal, raising interrupt ABIs, and sentinel/empty-slot fail-open behavior.

## Related work

- #106964 and #106966 are open candidates for the same issue and were checked before publication.
- #106964's patch does not include cache eviction or the raising-ABI cleanup guard.
- #106966's latest patch includes those two safeguards, but does not classify its new eviction reason as an internal control message. This PR leaves both existing PRs open and untouched and provides a complete carry-forward on current `main` for maintainer selection.

## Compatibility and residual risks

No migration or configuration change is required. The change uses the existing `request_hard_interrupt` compatibility helper and preserves the pending sentinel/empty-slot behavior. The only intended behavior change is that work already being evicted by the gateway is asked to stop instead of continuing invisibly after its result is discarded.

## Tests and verification

| Command/test | Objective | Result |
|---|---|---|
| Pre-fix regression run for `tests/gateway/test_reaped_eviction_interrupts_run.py` | Prove the new test detects the old behavior | 5 failures before the implementation |
| `HERMES_PYTHON="$(command -v python)" scripts/run_tests.sh tests/gateway/test_reaped_eviction_interrupts_run.py tests/gateway/test_reaped_session_recovery.py tests/gateway/test_pending_event_none.py -v` | Regression, reaped recovery, and control-message behavior | 10 passed, 0 failed |
| `HERMES_PYTHON="$(command -v python)" scripts/run_tests.sh tests/gateway/test_reaped_eviction_interrupts_run.py tests/gateway/test_reaped_session_recovery.py tests/gateway/test_agent_cache.py tests/gateway/test_abandoned_turn_process_cleanup.py tests/gateway/test_active_turn_recovery.py tests/gateway/test_session_race_guard.py tests/gateway/test_running_agent_session_toggles.py tests/gateway/test_session_store_runtime_stale_guard.py tests/gateway/test_pending_event_none.py -v` | Affected gateway neighbors and sibling lifecycle paths | 92 passed, 0 failed |
| `ruff check gateway/run.py gateway/run_inbound.py tests/gateway/test_reaped_session_recovery.py tests/gateway/test_reaped_eviction_interrupts_run.py` | Lint changed Python files | Passed |
| `git diff --check` | Whitespace/diff integrity | Passed |
| `scripts/run_tests.sh tests/gateway/` | Broad gateway suite | Inconclusive: the run exceeded the local 420-second terminal limit; no full-suite green claim is made. A completed slice exposed unrelated Windows/environment-sensitive failures, and a clean-baseline slice showed a different unrelated failure set. |

## Files and documentation

- `gateway/run.py`: eviction interrupt reason and control-message classification.
- `gateway/run_inbound.py`: interrupt-before-release, best-effort cleanup, and cache eviction.
- `tests/gateway/test_reaped_eviction_interrupts_run.py`: new regression behavior tests.
- `tests/gateway/test_reaped_session_recovery.py`: updates the recovery contract to assert interruption plus cold-path healing.
- No repository documentation or configuration update is required for this internal lifecycle fix.

## Publication receipt

- Base repository: `NousResearch/hermes-agent`
- Base branch/SHA: `main` / `cdf4c765213d7f4f7562f642e2b2df00d42c8ffd`
- Head repository: `JoaoMarcos44/hermes-agent`
- Head branch: `fix/issue-106963-reaped-eviction`
- Head SHA: `2b1c0ae586e7bf4c51cc0cbe61eff4ec0190be03`
- CI: pending after push of the lifecycle follow-up



## Follow-up for @andrexibiza

Resolved the two remaining lifecycle blockers: one-shot model/MoA restoration is generation-owned for `/moa` and `/model --once`, and displaced transcript leases are released by their owning token without touching the successor lease. Focused verification: 10 tests passed; Ruff and `git diff --check` passed. Canonical `scripts/run_tests.sh` could not run in the isolated worktree because no pytest-enabled project virtualenv was available.

