### PR TITLE
fix(dashboard-auth): offer every configured provider in native sign-in

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -12,7 +12,7 @@ href to walk the OAuth flow.
 from __future__ import annotations
 
 import html
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 from hermes_cli.dashboard_auth import list_session_providers
 
@@ -464,6 +464,27 @@ def render_login_html(*, next_path: str = "") -> str:
         provider_buttons="\n".join(buttons),
         password_script=_PASSWORD_FORM_SCRIPT if needs_password_script else "",
     )
+
+
+def render_native_provider_choice_html(
+        *, providers, authorize_path: str, code_challenge: str,
+        code_challenge_method: str, redirect_uri: str, state: str) -> str:
+    """Provider picker for a native authorize request with more than one interactive provider.
+
+    Every link re-enters ``/auth/native/authorize`` with the SAME desktop PKCE inputs plus an
+    explicit ``provider``, so the choice never leaves the validated native flow.
+    """
+    common = {"code_challenge": code_challenge, "code_challenge_method": code_challenge_method,
+              "redirect_uri": redirect_uri, "state": state}
+    buttons = []
+    for p in providers:
+        href = html.escape(f"{authorize_path}?{urlencode({**common, 'provider': p.name})}",
+                           quote=True)
+        buttons.append(f'      <a class="provider-btn" href="{href}">'
+                       f'Sign in with {html.escape(p.display_name)}</a>')
+    if not buttons:
+        return _EMPTY_HTML
+    return _LOGIN_HTML_TEMPLATE.format(provider_buttons="\n".join(buttons), password_script="")
 
 
 def _render_password_form(provider, next_path: str) -> str:

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -38,7 +38,8 @@ from hermes_cli.dashboard_auth.cookies import (
     clear_pkce_cookie, clear_session_cookies, clear_sso_attempt_cookie, detect_https,
     parse_pkce_payload, read_pkce_cookie, read_session_cookies, set_pkce_cookie,
     set_session_cookies)
-from hermes_cli.dashboard_auth.login_page import render_login_html
+from hermes_cli.dashboard_auth.login_page import (
+    render_login_html, render_native_provider_choice_html)
 from hermes_cli.dashboard_auth.request_utils import (
     access_token_max_age, client_ip as _client_ip, is_safe_next_path, scan_session_providers)
 
@@ -228,14 +229,11 @@ def _validate_loopback_redirect_uri(raw: str) -> str:
 
 def _select_native_provider(provider: str):
     """Resolve the provider for a native authorize request. An empty ``provider`` auto-selects
-    the single brokerable (non-password) session provider — so an OIDC+basic deployment does not
-    fail with "Unknown provider"; with none, a lone password provider is still returned so the
-    caller emits a 400 rather than 404."""
+    the ONLY interactive session provider (password providers included — native sign-in brokers
+    them via ``/login``); with several the caller renders a chooser instead of guessing."""
     if provider:
         return get_provider(provider)
-    sess_providers = list_session_providers()
-    native_eligible = [pp for pp in sess_providers if not getattr(pp, "supports_password", False)]
-    candidates = native_eligible or sess_providers
+    candidates = list_session_providers()
     return candidates[0] if len(candidates) == 1 else None
 
 
@@ -253,6 +251,19 @@ async def auth_native_authorize(
         raise _http(400, "code_challenge required")
     _validate_loopback_redirect_uri(redirect_uri)
     p = _select_native_provider(provider)
+    if p is None and not provider:
+        candidates = list_session_providers()
+        if len(candidates) > 1:
+            # Render the chooser BEFORE allocating broker state or setting a cookie: every link
+            # re-enters this same validated route with an explicit provider.
+            return HTMLResponse(
+                render_native_provider_choice_html(
+                    providers=candidates,
+                    authorize_path=f"{_prefix(request)}/auth/native/authorize",
+                    code_challenge=code_challenge,
+                    code_challenge_method=code_challenge_method,
+                    redirect_uri=redirect_uri, state=state),
+                headers=_NO_STORE)
     if p is None:
         raise _http(404, f"Unknown provider: {provider!r}")
     if not getattr(p, "supports_session", True):

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import hashlib
 import base64
+import html
+import re
 import time
 from urllib.parse import parse_qs, urlparse
 
@@ -224,23 +226,39 @@ def _native_authorize_params(challenge, **overrides):
     return params
 
 
-def test_native_authorize_empty_provider_auto_selects_oauth_with_password_also_registered(
-    gated_client,
-):
-    """Regression for #78906: a password provider is a session provider but
-    can never be the target of the native OAuth broker flow, so it must not
-    count toward the empty-provider auto-select. With one OAuth provider +
-    one password provider (the normal SSO-with-password-fallback setup) the
-    desktop's empty-provider request must auto-select the OAuth provider
-    (302), not fail with ``Unknown provider: ''`` (404)."""
+def test_native_authorize_mixed_providers_offers_both_choices(gated_client):
+    """SSO-with-password-fallback (one OAuth + the bundled password provider): the desktop
+    sends no ``provider``, so BOTH configured methods must stay reachable. #78906's symptom
+    (a misleading ``Unknown provider: ''`` 404) stays fixed; the password option is no longer
+    silently dropped by auto-selecting OAuth."""
     register_provider(_PasswordOnlyProvider())
     _verifier, challenge = _make_pkce()
     r = gated_client.get(
-        "/auth/native/authorize",
-        params=_native_authorize_params(challenge),
-    )
-    assert r.status_code == 302, r.text
-    assert "code=stub_code" in r.headers["location"]
+        "/auth/native/authorize", params=_native_authorize_params(challenge))
+    assert r.status_code == 200, r.text
+    hrefs = re.findall(r'<a class="provider-btn" href="([^"]+)"', r.text)
+    assert {parse_qs(urlparse(html.unescape(h)).query)["provider"][0] for h in hrefs} == {
+        "stub", "pwonly"}
+    # Each link carries the desktop's PKCE inputs unchanged, and the chooser itself
+    # allocates no broker state / sets no cookie.
+    q = parse_qs(urlparse(html.unescape(hrefs[0])).query)
+    assert q["code_challenge"] == [challenge] and q["code_challenge_method"] == ["S256"]
+    assert "set-cookie" not in r.headers
+
+
+def test_native_authorize_chooser_link_completes_the_native_flow(gated_client):
+    """The chooser is inside the flow, not beside it: following an OAuth link re-enters the
+    same validated route and starts the normal broker round trip."""
+    register_provider(_PasswordOnlyProvider())
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize", params=_native_authorize_params(challenge))
+    href = next(html.unescape(h) for h in
+                re.findall(r'<a class="provider-btn" href="([^"]+)"', r.text)
+                if "provider=stub" in h)
+    follow = gated_client.get(href)
+    assert follow.status_code == 302, follow.text
+    assert "code=stub_code" in follow.headers["location"]
 
 
 def test_native_authorize_empty_provider_auto_selects_single_oauth(gated_client):
@@ -256,17 +274,17 @@ def test_native_authorize_empty_provider_auto_selects_single_oauth(gated_client)
     assert "code=stub_code" in r.headers["location"]
 
 
-def test_native_authorize_empty_provider_ambiguous_multiple_oauth_404(gated_client):
-    """Two brokerable providers: the empty-provider convenience cannot pick
-    unambiguously, so the request still fails — the desktop must pass
-    ``?provider=`` explicitly."""
+def test_native_authorize_empty_provider_multiple_oauth_offers_a_choice(gated_client):
+    """Two brokerable providers: the empty-provider convenience cannot pick unambiguously, so
+    the user chooses in the browser instead of the desktop eating a 404."""
     register_provider(_SecondStubProvider())
     _verifier, challenge = _make_pkce()
     r = gated_client.get(
         "/auth/native/authorize",
         params=_native_authorize_params(challenge),
     )
-    assert r.status_code == 404
+    assert r.status_code == 200, r.text
+    assert r.text.count('class="provider-btn"') == 2
 
 
 def test_native_authorize_empty_provider_password_only_brokers_to_login(


### PR DESCRIPTION
Desktop opens `/auth/native/authorize` without naming a provider, and the empty-provider auto-select filtered password providers out of the candidate set. A deployment with one OAuth provider plus username/password therefore went straight to OAuth and never offered the password option — so when OAuth could not complete, users had no way to reach their working alternative through that entry point.

Native sign-in has brokered password providers through `/login` since 56f1afc834. The filter's rationale — "a password provider can never be the target of the native flow" (ed5e17f4b8) — predates that change and is now stale.

This renders a provider chooser when more than one interactive session provider is registered. Each link re-enters the same validated authorize route with an explicit `provider`, so the choice never leaves the native PKCE flow. A single provider still auto-selects.

## Salvage

Supersedes [#101713](https://github.com/NousResearch/hermes-agent/pull/101713) (@helix4u) and [#76941](https://github.com/NousResearch/hermes-agent/pull/76941) (@phuongvm), both credited as co-authors.

#76941 contributed the native chooser design; #101713 ported it to current main and extended it to password providers. Both were written against the pre-refactor inline block in `auth_native_authorize` — `ca8f68774a` has since collapsed that into `_select_native_provider()`, so both conflict. This rebases the idea onto the current shape, reuses `_NO_STORE` instead of a hand-rolled cache header, and drops an unused import pair.

The desktop-side PRs on this topic ([#97248](https://github.com/NousResearch/hermes-agent/pull/97248), [#75045](https://github.com/NousResearch/hermes-agent/pull/75045), [#70580](https://github.com/NousResearch/hermes-agent/pull/70580)) change `apps/desktop/electron/native-oauth*.ts` and share no files with this; they are left open.

## Compatibility

The chooser returns 200 HTML where a mixed-provider deployment previously returned a 302. The desktop only shell-opens the authorize URL and never fetches or parses its response (`deps.openExternal(authorizeUrl)`, `apps/desktop/electron/native-oauth-login.ts:202`), so existing desktop builds — including older ones — are unaffected.

## Security shape

The chooser is rendered **before** `native_flow.register_pending` and sets no cookie, so an unauthenticated GET allocates no broker state. PKCE method, `code_challenge`, and the loopback `redirect_uri` are all validated before anything is rendered. Link parameters are `urlencode`d and the resulting href is `html.escape`d.

## Tests

Three invariant tests, all proven red with the production change reverted (3 failed, 13 passed) and green with it (29 passed across `test_dashboard_auth_native_flow.py` + `test_dashboard_auth_password_login.py`):

- mixed OAuth + password: both providers reachable, PKCE inputs preserved on each link, no `set-cookie` on the chooser
- following a chooser link completes the normal broker round trip
- two OAuth providers: a choice instead of the previous 404

The #78906 regression tests were rewritten rather than deleted — its symptom (a misleading `Unknown provider: ''` 404 for OIDC + `basic`) stays pinned under the new contract.
