### PR TITLE
fix(desktop): keep Bot workspace New session discoverable

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4138,6 +4138,33 @@ describe('openNewSessionTile workspace target', () => {
     })
 
     expect(createParams).not.toHaveProperty('cwd')
+    expect(createParams).not.toHaveProperty('hidden')
+  })
+
+  it('does not pass hidden:true for generic New session tile in bots workspace (#107016)', async () => {
+    let createParams: Record<string, unknown> | undefined
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+        return {
+          info: { cwd: '', model: 'test-model', tools: {}, skills: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: 'stored-bots-generic-tile'
+        } as never
+      }
+      return {} as never
+    })
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+    await act(async () => {
+      await handle!.openNewSessionTile('center', {
+        listed: false,
+        workspaceScope: { workspaceMode: 'bots', workspaceOwnerKey: 'bot:default' }
+      })
+    })
+    expect(createParams).toBeDefined()
+    expect(createParams).not.toHaveProperty('hidden')
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -758,10 +758,7 @@ export function useSessionActions({
         const cwd =
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
 
-        const params = {
-          ...(await desktopSessionCreateParams(cwd, capturedRoute)),
-          ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
-        }
+        const params = await desktopSessionCreateParams(cwd, capturedRoute)
 
         // Same lease chain as createBackendSessionForSend: owner socket held
         // across the create, then the foreground hold carries it until the


### PR DESCRIPTION
## What does this PR do?

`openNewSessionTile()` was passing `hidden: true` whenever `workspaceMode === 'bots'`. That made ordinary user-created **New session** chats (opened from the Bots workspace) persist as hidden rows, so they disappeared from the global Sessions sidebar and search after the first turn.

This is distinct from intentional Bot Mode plumbing: canonical **Bot Chat** and group-member sessions already pass `hidden: true` on their own create paths (`canonical-chat.ts`, `group-turns.ts`). Those are unchanged.

## Related Issue

Fixes #107016

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`: stop attaching `hidden: true` to generic `openNewSessionTile` creates solely because the tile is in the Bots workspace.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`: regression asserting bots-workspace New session `session.create` params omit `hidden`; CONTROL that sessions/Home path also omits `hidden`.

## How to Test

```bash
cd apps/desktop
npx vitest run --project ui src/app/session/hooks/use-session-actions.test.tsx -t "openNewSessionTile workspace target"
```

Proof receipt (base `cdf4c765`):
- BEFORE (RED): `#107016` case failed with `expected … to not have property "hidden"` / Received `true`; CONTROL passed.
- AFTER (GREEN): 2 passed | 96 skipped.

## Claim scope

Only the generic New session / tab create path via `openNewSessionTile`. Canonical Bot Chat and group-member hidden creation are out of scope and remain explicit.

## Checklist

- [x] Conventional Commits
- [x] Searched for existing open PRs referencing #107016 (none)
- [x] Focused change only
- [x] Focused vitest RED→GREEN locally
- [x] Self-review P0 = 0 (Detection / Fail-open / Forbidden / RED evidence / diff scope)


Made with [Cursor](https://cursor.com)