### PR TITLE
fix(opencode): send ephemeral x-opencode-session header on one-shot requests

### DIFF
--- a/agent/opencode_affinity.py
+++ b/agent/opencode_affinity.py
@@ -17,6 +17,7 @@ so the header cannot drift per code path.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Optional
 
 OPENCODE_SESSION_HEADER = "x-opencode-session"
@@ -72,7 +73,13 @@ def opencode_session_headers(
         )
     except Exception:
         key = str(session_id or "")
-    return {OPENCODE_SESSION_HEADER: key} if key else {}
+    if not key:
+        # Stateless one-shot requests (commit messages, summaries, standalone prompts outside
+        # a session) lack an ambient conversation or session id. OpenCode Go strictly requires
+        # x-opencode-session on every request (HTTP 400 MissingSessionID if absent, #105841)
+        # so generate an ephemeral session id fallback.
+        key = f"oneshot-{uuid.uuid4().hex[:16]}"
+    return {OPENCODE_SESSION_HEADER: key}
 
 
 def merge_opencode_session_headers(

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -60,3 +60,64 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_oneshot_and_unparented_opencode_calls_send_ephemeral_session_header():
+    from agent.opencode_affinity import opencode_session_headers
+
+    # Unparented opencode call (no active session or contextvar) generates an ephemeral session key
+    headers = opencode_session_headers("opencode-go", None, session_id=None)
+    assert "x-opencode-session" in headers
+    assert headers["x-opencode-session"].startswith("oneshot-")
+
+    # Direct auxiliary call without runtime-main session generates an ephemeral session header
+    kwargs = aux._build_call_kwargs("opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1")
+    assert "extra_headers" in kwargs
+    assert kwargs["extra_headers"]["x-opencode-session"].startswith("oneshot-")
+
+    # Non-OpenCode provider without session still returns empty headers without generating UUIDs
+    other = opencode_session_headers("openrouter", "https://openrouter.ai/api/v1", session_id=None)
+    assert other == {}
+
+
+def test_oneshot_commit_message_with_opencode_runtime(monkeypatch):
+    from unittest.mock import MagicMock
+    from agent.oneshot import run_oneshot
+
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock()]
+    mock_resp.choices[0].message.content = "feat(git): add commit helper"
+    mock_resp.choices[0].message.reasoning = None
+    mock_resp.choices[0].message.reasoning_content = None
+    mock_resp.choices[0].message.reasoning_details = None
+
+    captured_kwargs = {}
+
+    def fake_call_llm(**kwargs):
+        captured_kwargs.update(kwargs)
+        # Verify that when auxiliary_client._build_call_kwargs builds kwargs for this provider,
+        # it carries the x-opencode-session header
+        call_kwargs = aux._build_call_kwargs(
+            kwargs["main_runtime"]["provider"],
+            kwargs["main_runtime"]["model"],
+            kwargs["messages"],
+            base_url=kwargs["main_runtime"].get("base_url"),
+        )
+        assert "x-opencode-session" in call_kwargs["extra_headers"]
+        assert call_kwargs["extra_headers"]["x-opencode-session"].startswith("oneshot-")
+        return mock_resp
+
+    monkeypatch.setattr("agent.oneshot.call_llm", fake_call_llm)
+
+    msg = run_oneshot(
+        template="commit_message",
+        variables={"diff": "diff --git a/a b/a\n+hello"},
+        main_runtime={
+            "provider": "opencode-go",
+            "model": "glm-5",
+            "base_url": "https://opencode.ai/zen/go/v1",
+        },
+    )
+    assert msg == "feat(git): add commit helper"
+    assert captured_kwargs["main_runtime"]["provider"] == "opencode-go"
+


### PR DESCRIPTION
## Problem
OpenCode (specifically OpenCode Go relay) requires the `x-opencode-session` HTTP header on all incoming requests to route requests efficiently and avoid `HTTP 400 - MissingSessionID` errors.

In turn-based chats and session-parented auxiliary calls, `x-opencode-session` is derived from the active session ID or ambient conversation scope. However, for stateless one-shot requests (such as Git commit message generation via `agent.oneshot`, rename suggestions, standalone summaries, or unparented auxiliary queries), no session ID exists. `opencode_session_headers` previously returned `{}` when `key` was empty, causing one-shot calls against OpenCode Go to fail with:
```
HTTP 400 - {'type': 'error', 'error': {'type': 'MissingSessionID', 'message': 'Error from provider (Console Go): Request is missing x-opencode-session and cannot be routed efficiently. Please see https://opencode.ai/docs/go/#where-can-i-use-it'}}
```

## Solution
- In `agent/opencode_affinity.py::opencode_session_headers`: when targeting OpenCode without an active session or ambient conversation scope (e.g., stateless one-shot helpers), fall back to generating an ephemeral session ID (`oneshot-<uuid16>`).
- Guarantees that every request sent to OpenCode carries a valid `x-opencode-session` header.
- Non-OpenCode targets remain unaffected.
- Added regression tests in `tests/agent/test_opencode_session_affinity.py`.

Closes #105841
