### PR TITLE
fix(desktop): keep bots-workspace new sessions discoverable

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4139,6 +4139,53 @@ describe('openNewSessionTile workspace target', () => {
 
     expect(createParams).not.toHaveProperty('cwd')
   })
+
+  it('creates a bots-workspace tile as a visible session — the scope is placement, not plumbing', async () => {
+    // Regression: a generic New-session tab opened while the Bots workspace is
+    // active is an ordinary user conversation. It used to be persisted with
+    // `hidden: true` purely because of its workspace scope, so it disappeared
+    // from the Sessions sidebar and its search once persisted. Canonical Bot
+    // Chats and group-member rooms keep their own hidden flags, set by the
+    // hermes-bots plugin in its own session.create calls.
+    let createParams: Record<string, unknown> | undefined
+
+    // A route rides along, so the create goes through the routed gateway
+    // (requestGatewayForAgent), not the harness's ambient requestGateway.
+    const routedCreate = vi.mocked(requestGatewayForAgent)
+
+    routedCreate.mockImplementation(async (_connectionId: null | string, _profile: string, method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return {
+          info: { cwd: '', model: 'test-model', tools: {}, skills: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: 'stored-bots-tile'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={vi.fn(async () => ({}) as never)} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await act(async () => {
+      await handle!.openNewSessionTile('center', {
+        listed: false,
+        route: {
+          connectionId: 'connection-a',
+          mode: 'local',
+          profile: 'default',
+          targetProfile: 'default'
+        },
+        workspaceScope: { workspaceMode: 'bots', workspaceOwnerKey: 'bot:connection-a::default' }
+      })
+    })
+
+    expect(createParams).not.toHaveProperty('hidden')
+  })
 })
 describe('selectSidebarItem', () => {
   it('fronts the workspace pane when navigating to a sidebar route (issue #72602)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -758,10 +758,14 @@ export function useSessionActions({
         const cwd =
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
 
-        const params = {
-          ...(await desktopSessionCreateParams(cwd, capturedRoute)),
-          ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
-        }
+        // A generic New-session tile is a normal user conversation even when
+        // the user opened it from the Bots workspace — its scope only decides
+        // WHERE the tab docks, not whether the conversation is plumbing.
+        // Plugin-owned hidden sessions (canonical Bot Chat, group-member
+        // rooms) set `hidden: true` in their own session.create calls; marking
+        // every bots-scoped tile hidden here made ordinary side chats vanish
+        // from the Sessions sidebar and its search with no way back.
+        const params = await desktopSessionCreateParams(cwd, capturedRoute)
 
         // Same lease chain as createBackendSessionForSend: owner socket held
         // across the create, then the foreground hold carries it until the


### PR DESCRIPTION
## Summary

Fixes #107016.

A generic **New session** tile opened while the Bots workspace is active was persisted with `hidden: 1` purely because of its workspace scope, so an ordinary user side chat vanished from the global Sessions sidebar and its search once the first turn persisted a row — with no user-facing way to reopen it by title or session ID.

## Root cause

`openNewSessionTile()` unconditionally added `hidden: true` to `session.create` params for every tile created under `workspaceMode === 'bots'`:

```ts
const params = {
  ...(await desktopSessionCreateParams(cwd, capturedRoute)),
  ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
}
```

The condition was based on **where** the user opened the draft, not on whether the new session is Bot Mode plumbing. The workspace scope only decides where the tab docks — it says nothing about whether the conversation is plugin-owned.

## Fix

Stop deriving `hidden` from the workspace scope in the generic create path. Nothing else needed to change:

- **Canonical Bot Chat** sets `hidden: true` in its own `session.create` (`canonical-chat.ts`) — covered by `canonical-chat-creation.test.ts` ("always creates hidden").
- **Group-member room sessions** set `hidden: true` themselves (`group-turns.ts`) — covered by `group-turns.test.ts` (room_plumbing contract).
- **Legacy plumbing rows** are still re-hidden by the title-based ownership sweep (`session-sweep.ts`) — covered by `hide-bot-chats.runtime.test.ts`.

So bot chats stay out of the sidebar exactly as before; only ordinary user conversations stop disappearing.

## Test added

Regression test in `use-session-actions.test.tsx`: a generic tile created with `workspaceMode: 'bots'` sends `session.create` with **no** `hidden` flag. Previously the flag was present.

## Verification

- `vitest run src/app/session/hooks/use-session-actions.test.tsx` — 98 passed (incl. new regression)
- `vitest run` on the touched contract suites (`canonical-chat-creation`, `group-turns`, `hide-bot-chats.runtime`, `session-states`) — 220 passed
- `tsc -p . --noEmit` — clean
- `eslint` on both touched files — clean