### PR TITLE
feat(memory): opt in to unattended consolidation

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1197,6 +1197,10 @@ DEFAULT_CONFIG = {
         # true = foreground writes prompt inline; background writes are staged (/memory
         # pending|approve <id>|reject <id>). To disable memory: memory_enabled.
         "write_approval": False,
+        # Explicit opt-in for automatic background reviews to replace/remove built-in memory
+        # entries. False keeps consolidation proposals staged even when write_approval is off;
+        # write_approval remains the final gate when this is true. External providers are unaffected.
+        "allow_unattended_consolidation": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
         # Periodic built-in memory review; 0 when an external provider auto-extracts.

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -763,11 +763,10 @@ class TestBatchRefusesToEmptyNonEmptyStore:
 # =========================================================================
 
 class TestBackgroundReviewDeleteGate:
-    """An unattended background-review fork may append, never delete: the near-limit
-    'consolidate now' hint is otherwise an instruction to decide what to forget,
-    executed with no human in the loop. Denied ops are staged as pending proposals
-    (surfaced via /memory pending) instead of silently dropped — the fork's own review
-    summary is never published back."""
+    """Unattended reviews stage replace/remove operations by default, but users may
+    explicitly opt in to applying them when the general write-approval gate is off.
+    Staged operations surface through /memory pending instead of being silently dropped
+    because the fork's own review summary is never published back."""
 
     def test_remove_staged_not_applied(self, store, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -819,6 +819,50 @@ class TestBackgroundReviewDeleteGate:
         # Atomic: the batch is only a proposal — its add must not land either.
         assert "fork consolidation" not in store._entries_for("memory")
 
+    def test_opted_in_unattended_review_applies_atomic_consolidation(self, store, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.config import load_config, save_config
+
+        config = load_config()
+        config["memory"]["allow_unattended_consolidation"] = True
+        config["memory"]["write_approval"] = False
+        save_config(config)
+        store.add("memory", "stale duplicated fact")
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(operations=[
+                {"action": "remove", "old_text": "stale duplicated fact"},
+                {"action": "add", "content": "concise durable fact"},
+            ], store=store))
+        finally:
+            reset_current_write_origin(token)
+
+        assert result["success"] is True
+        assert result.get("staged") is not True
+        assert store._entries_for("memory") == ["concise durable fact"]
+
+    def test_general_approval_still_gates_opted_in_consolidation(self, store, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.config import load_config, save_config
+
+        config = load_config()
+        config["memory"]["allow_unattended_consolidation"] = True
+        config["memory"]["write_approval"] = True
+        save_config(config)
+        store.add("user", "stale profile fact")
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(
+                action="replace", target="user", old_text="stale profile fact",
+                content="corrected profile fact", store=store,
+            ))
+        finally:
+            reset_current_write_origin(token)
+
+        assert result["staged"] is True
+        assert "stale profile fact" in store._entries_for("user")
+        assert "corrected profile fact" not in store._entries_for("user")
+
     def test_add_still_allowed_in_background_review(self, store):
         token = set_current_write_origin("background_review")
         try:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -131,14 +131,17 @@ _BG_DELETE_ACTIONS = ("replace", "remove")
 
 def _background_delete_gate(action, operations, target="memory", content=None, old_text=None) -> Optional[str]:
     """Fail-closed operation gate for unattended background-review forks (#105921): ``add``
-    stays available (it is all any review prompt asks for), while ``replace``/``remove`` —
-    single or inside a batch — are never applied unattended. The op is staged in the pending
-    store instead of merely denied: the fork's own review summary is never published back, so
-    a plain denial would drop the consolidation request with no surfacing path at all. A
-    staging failure fails closed to a plain denial."""
+    stays available, while ``replace``/``remove`` — single or inside a batch — are staged by
+    default. An explicit memory policy may admit consolidation to the general write-approval
+    gate; otherwise staging preserves the proposal for supervised review."""
     from tools.skill_provenance import is_unattended_review
 
     if not is_unattended_review():
+        return None
+    memory_config = get_builtin_memory_config()
+    allow_consolidation = is_truthy_value(
+        memory_config.get("allow_unattended_consolidation"), default=False)
+    if allow_consolidation:
         return None
     hit = action in _BG_DELETE_ACTIONS or any(
         isinstance(op, dict) and op.get("action") in _BG_DELETE_ACTIONS for op in (operations or []))

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -779,9 +779,10 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # true = require approval before any memory write
+  allow_unattended_consolidation: false  # opt in to automatic replace/remove
 ```
 
-With `memory.write_approval: true`, memory writes need your approval before they land: interactive CLI turns prompt inline; messaging sessions and the background self-improvement review stage the write for `/memory pending` → `/memory approve <id>` / `/memory reject <id>` review. Toggle at runtime with `/memory approval on|off`. See [Controlling memory writes](/user-guide/features/memory#controlling-memory-writes-write_approval).
+Unattended background reviews can add entries by default, but stage replacements/removals for approval. Set `memory.allow_unattended_consolidation: true` to let them consolidate the built-in memory and user-profile stores automatically. `memory.write_approval: true` still takes precedence and stages every write. See [Controlling memory writes](/user-guide/features/memory#controlling-memory-writes-write_approval).
 
 ## Context File Truncation
 

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -238,6 +238,7 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # false = write freely (default) | true = require approval
+  allow_unattended_consolidation: false  # opt in to background replace/remove
 ```
 
 Setting **both** `memory_enabled` and `user_profile_enabled` to `false` turns the
@@ -257,14 +258,27 @@ The inverse configuration advertises only `memory` and rejects `USER.md` writes.
 
 ## Controlling memory writes (`write_approval`)
 
-By default the agent saves memory freely — including from the background
-self-improvement review that runs after a turn. If you'd rather approve saves
-first, set `memory.write_approval: true`. It's a simple on/off gate applied to
-**both** foreground turns and the background review:
+By default foreground turns save freely, while an unattended background review
+may add entries but stages any replacement/removal (including a mixed batch) for
+approval. This protects existing entries even when the general approval gate is
+off. Users who accept autonomous consolidation can opt in explicitly:
+
+```yaml
+memory:
+  allow_unattended_consolidation: true
+```
+
+The opt-in applies only to the built-in `MEMORY.md` and `USER.md` stores and only
+when a memory-triggered review already has memory access. It does not grant
+memory access to skill-only reviews or alter external memory-provider retention.
+Batch writes remain atomic, and normal review notifications continue to apply.
+
+`memory.write_approval` remains the final gate for **both** foreground and
+background writes:
 
 | `write_approval` | Behaviour |
 |------------------|-----------|
-| `false` (default) | Write freely — the gate is off (the pre-gate behaviour). |
+| `false` (default) | Foreground writes flow freely. Unattended replacement/removal still requires `allow_unattended_consolidation: true`; otherwise it is staged. |
 | `true` | Require approval before anything is saved. In the interactive CLI, foreground writes prompt you inline (entries are small enough to read in full). Everywhere else — messaging platforms, scripts, and the background self-improvement review — writes are **staged** for review with `/memory pending`. |
 
 > To turn memory off entirely (not just gate it), set both `memory_enabled: false` and `user_profile_enabled: false`. When both built-in stores are disabled, the built-in `memory` tool is automatically hidden.


### PR DESCRIPTION
## What does this PR do?

Adds an explicit, default-off policy for users who want unattended background memory reviews to consolidate the built-in MEMORY.md and USER.md stores. With `memory.allow_unattended_consolidation: true`, background `replace` and `remove` operations can pass to the existing general write-approval gate; default users retain staged proposals, and `memory.write_approval: true` still stages every unattended write.

### Motivation

Near the built-in stores' capacity limits, addition-only background maintenance cannot merge duplicates, shorten stale entries, or apply corrections without accumulating pending proposals. Some operators intentionally prefer autonomous maintenance, but the current unconditional background gate offers no explicit way to choose it.

### Behavior

- The new option defaults to `false`, preserving the existing unattended replacement/removal protection.
- Opted-in background consolidation applies automatically only when the general write-approval gate is off.
- Mixed batches remain atomic because the existing batch path still stages or applies the batch as one unit.
- Trigger-scoped memory access, attended `/refine`, pending proposals, review notifications, and external memory providers are unchanged.

### Implementation

The unattended destructive-operation gate reads the built-in memory policy before staging a proposal. Tests cover an opted-in atomic consolidation and verify that the general approval gate still takes precedence for an opted-in user-profile replacement. User documentation describes the default and opted-in policy.

## Related Issue

Closes #106919

## Type of Change

- [x] New feature

## Changes Made

- `hermes_cli/config_defaults.py` - add the default-off memory policy.
- `tools/memory_tool.py` - defer opted-in unattended consolidation to the existing approval gate.
- `tests/tools/test_memory_tool.py` - cover atomic opt-in and general-gate precedence.
- `website/docs/user-guide/configuration.md` - document the configuration key.
- `website/docs/user-guide/features/memory.md` - explain effective foreground and background behavior.

## How to Test

1. Set `memory.allow_unattended_consolidation: true` and `memory.write_approval: false`; an unattended mixed remove/add batch applies atomically.
2. Turn `memory.write_approval` on; the same unattended destructive write is staged instead of applied.
3. Automated verification already run locally (78 passed):

```bash
scripts/run_tests.sh tests/tools/test_memory_tool.py tests/tools/test_write_approval.py tests/agent/test_background_review_memory_scope.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A; the existing example does not enumerate the memory write-approval controls
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the change uses the existing config and memory-store paths
- [x] Tool descriptions/schemas are N/A; no model-facing tool contract changed
