### PR TITLE
feat(mcp): add PostOnce hosted draft workflow to catalog

### DIFF
--- a/optional-mcps/postonce/manifest.yaml
+++ b/optional-mcps/postonce/manifest.yaml
@@ -1,0 +1,48 @@
+manifest_version: 1
+name: postonce
+description: Discover connected social accounts and save social content as PostOnce drafts for review.
+source: https://postonce.to/integrations/hermes
+transport:
+  type: http
+  url: https://postonce.to/mcp
+auth:
+  type: api_key
+  env:
+    - name: MCP_POSTONCE_API_KEY
+      prompt: PostOnce API key (Creator or Pro; create in Preferences > API Keys)
+      required: true
+      secret: true
+tools:
+  default_enabled:
+    - list_accounts
+    - create_draft
+    - get_draft
+post_install: |
+  Requires a PostOnce Creator or Pro account. Create a dedicated API key at
+  https://postonce.to/dashboard/preferences with accounts:read, posts:read,
+  and posts:write for the default account-discovery and draft workflow.
+  Hermes stores the key privately in this profile's .env as
+  MCP_POSTONCE_API_KEY and adds the Bearer header automatically.
+
+  Before starting a new session or reloading: installing over an existing
+  postonce entry can replace trust fields while preserving its previous
+  tool selection. Review and restore your previous trust restrictions and
+  tool selection first. The three draft-workflow defaults apply only to a
+  fresh entry; an existing selection may include publishing tools.
+
+  Then restart Hermes or use /reload followed by /reload-mcp. Ask Hermes to list
+  your connected PostOnce accounts, then save your supplied content as a
+  draft without destinations. Use a stable idempotency_key on create_draft,
+  and get_draft with the returned id to confirm inbox status and content.
+  Reuse the same key and payload after an uncertain creation response.
+  The fresh-entry starter selection does not publish or schedule social posts.
+
+  Review the tool checklist and retain only the operations you need.
+  Additional operations need their corresponding API-key scopes and your
+  explicit direction. Keep any existing trust restrictions in place.
+  Setup and optional shared skill: https://postonce.to/integrations/hermes
+
+  To disconnect, remove the postonce MCP entry from this profile and revoke
+  this dedicated API key in PostOnce Preferences. Removing a skill or MCP
+  configuration alone does not revoke the key. Remove the unused
+  MCP_POSTONCE_API_KEY value from the profile's .env afterward.


### PR DESCRIPTION
## Summary

Add a URL-only PostOnce MCP catalog entry so users can discover their connected social accounts and save content as unpublished drafts for review. It connects to the vendor-hosted `https://postonce.to/mcp`; no local process, package installation or bootstrap command is introduced.

PostOnce requires a Creator or Pro account. The manifest declares the required secret `MCP_POSTONCE_API_KEY`; Hermes supplies its Bearer header automatically. The default tool selection is `list_accounts`, `create_draft`, and `get_draft`, requiring `accounts:read`, `posts:write`, and `posts:read`. Installation notes cover the first draft, returned-ID verification, stable retry keys, reconnecting and credential revocation. Additional server operations are not selected by default.

## Validation

- Parsed with installed Hermes 0.21.0 and the current upstream catalog parser at `f6ddd89692dff1f900983a16208f39a1485a14eb`.
- Ran native `install_entry` in a disposable profile: correct private environment persistence, generated Bearer reference, tool-default fallback and preservation of unrelated server configuration. Credential prompting and the network probe were fixtures, not a hosted catalog-install test.
- Independently exercised the hosted service through installed Hermes: canonical skill installation, account discovery, draft creation/readback/identical replay, owned PNG upload and media draft readback, plus missing/revoked credential rejection. No model run or social publication was used. One media connection interruption recovered in a fresh native session using the existing upload.

This changes only `optional-mcps/postonce/manifest.yaml`. The separate existing manual setup remains available at https://postonce.to/integrations/hermes. We are requesting catalog review; this proposal does not claim Nous approval.

Existing-profile note: the current installer overwrites a same-name server block. Users with a manual `postonce` entry should keep that working configuration or test the catalog in a separate profile rather than assume arbitrary trust fields survive reinstallation.
