### PR TITLE
fix(gateway): preserve timestamps + origin_json on seeded desktop branches

### DIFF
--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -228,14 +228,21 @@ def _billing_pending_change(result: dict) -> dict:
 
 # ── session.create / list / most_recent / facts ──────────────────────
 def _persist_branch(db, new_key: str, parent_key: str, title: str, history: list, *, source, cwd, profile_name,
-                    copy_fields=(), compensate: bool = False) -> None:
+                    copy_fields=(), compensate: bool = False, origin_json: str = None) -> None:
     """Branch child row + parent transcript (bounded-chunk transactions) + title. ``_branched_from`` keeps the
     row visible in list_sessions_rich() (the live parent never matches the legacy end_reason='branched'
     heuristic); NULL ``profile_name`` rows drop out of profile-keyed sidebar matching / deep links. ``compensate``
     deletes a committed row whose transcript/title failed (a durable-but-empty row would defeat the INSERT OR
-    IGNORE first-prompt seed) — except on disk-full, where the delete cannot land."""
+    IGNORE first-prompt seed) — except on disk-full, where the delete cannot land.
+
+    ``origin_json`` (default None) is the parent's gateway routing identity — branch children must inherit it
+    explicitly here because ``_INHERIT_PARENT_ROUTING_SQL`` only fires when the parent's ``end_reason =
+    'compression'`` (a crash before the gateway re-records a compression-fork peer would strand it unroutable;
+    branch children whose parent ended normally fall outside that gate and would otherwise be left without
+    a recoverable routing mapping)."""
     db.create_session(new_key, source=source, model=_resolve_model(), model_config={"_branched_from": parent_key},
-                      parent_session_id=parent_key, cwd=cwd, profile_name=profile_name)
+                      parent_session_id=parent_key, cwd=cwd, profile_name=profile_name,
+                      origin_json=origin_json)
     try:
         # Compensation guard (#93959 review): if the transcript copy or title write fails AFTER the row
         # committed, the durable-but-empty row would defeat the lazy first-prompt fallback
@@ -261,14 +268,25 @@ def _persist_branch(db, new_key: str, parent_key: str, title: str, history: list
 def _seed_branch_row(record: dict, key: str, parent_session_id: str, history: list, source: str, profile_home):
     """Persist a seeded desktop branch child NOW (the one session.create exception to lazy rows): the
     renderer's post-create resume re-fetches it via REST/defer_history, so an unpersisted child 404s and
-    the fail-latch spins forever. Best-effort — on failure the lazy first-prompt path is the fallback."""
+    the fail-latch spins forever. Best-effort — on failure the lazy first-prompt path is the fallback.
+
+    Mirrors ``session.branch`` (above) on three points it was missing: passes ``_BRANCH_COPY_FIELDS`` so the
+    copied transcript keeps its real timestamps / display markers / reasoning (the default ``copy_fields=()``
+    drops every field past ``role``+``content`` and ``_insert_message_rows`` collapses the survivors to one
+    ``time.time()`` per batch — observable as three identical timestamps across the seeded history), and
+    threads the parent's ``origin_json`` so the gateway can still route to the child on a fresh process
+    (the sibling compression-fork path inherits it via ``_INHERIT_PARENT_ROUTING_SQL``; this branch path
+    does not — parent ended with a normal ``end_reason``, not ``'compression'``)."""
     try:
         with _session_db(record) as db:
             if db is None:
                 return
+            parent = db.get_session(parent_session_id) or {}
             _persist_branch(db, key, parent_session_id, _branch_title(db, parent_session_id), history,
                             source=source, cwd=record["cwd"],
-                            profile_name=profile_name_for_home(profile_home) or _current_profile_name(), compensate=True)
+                            profile_name=profile_name_for_home(profile_home) or _current_profile_name(),
+                            copy_fields=_BRANCH_COPY_FIELDS, origin_json=parent.get("origin_json"),
+                            compensate=True)
             record["pending_title"] = None
     except Exception:
         logger.warning("seeded-branch persistence failed for %s; falling back to lazy row creation", key,


### PR DESCRIPTION
## Desktop `session.create` seeded branch loses message timestamps and `origin_json`

### Symptoms (observed in production session)

Forking a Desktop session via `session.create` with `parent_session_id` + `messages`:

- Every copied message lands with **one of three identical timestamps** (one `time.time()` per `append_messages_batch` chunk), instead of the parent's real timeline. With typical forks this is visible as `02:25:11 ×91, 02:26:01 ×91, 02:30:00 ×88` for a single "New chat from this point" — 270 rows that lost their order-of-arrival.
- The child's `origin_json` is `NULL` after creation. A process restart loses the gateway routing mapping and the child is unroutable.
- `delegate_task(action="list")` correctly returns `count: 0` for the forked session (it is session-scoped), but the child inherits the parent's narration about dispatched subagents. The forked agent then "explains" that the subagents were truncated when they were in fact delivered to the parent.

### Root cause

In `tui_gateway/methods_session.py`, two paths create branch children and only one of them does this correctly.

**`session.branch` (the TUI `/branch` path, lines ~1908-1935):** passes `copy_fields=_BRANCH_COPY_FIELDS` to `_persist_branch`. `_persist_branch` then includes `timestamp`, `display_kind`, `display_metadata`, `reasoning`, `reasoning_content`, `reasoning_details`, `codex_reasoning_items`, `codex_message_items` in every appended row. Works as intended.

**`_seed_branch_row` (the Desktop `session.create` path, line ~261):** calls `_persist_branch` with the default `copy_fields=()`, so only `role` and `content` survive the dict construction at line ~248. `_insert_message_rows` then stamps one `time.time()` per batch on the survivors and `_coerce_timestamp` keeps the default — every row in a batch gets the same instant. Three batches in a typical seed → three timestamps.

For routing: `_persist_branch` calls `db.create_session(...)` without `origin_json`. The fallback in `_insert_session_row` → `_inherit_parent_session_metadata` runs two queries:

- `_INHERIT_PARENT_META_SQL` — backfills `cwd`, `git_repo_root`, `git_branch`, `profile_name` from the parent. Fires for any child with `parent_session_id` set.
- `_INHERIT_PARENT_ROUTING_SQL` — backfills `user_id`, `session_key`, `chat_id`, `chat_type`, `thread_id`, `display_name`, `origin_json`. **Only fires when `parent.end_reason = 'compression'`** (the SQL explicitly checks for this — comment in `_inherit_parent_session_metadata` says "Gateway routing columns are inherited ONLY by compression forks … delegate children must NOT inherit them").

Branch children end normally on the parent side, so their parent never carries `end_reason='compression'` — the routing inheritance never fires. `origin_json` stays NULL.

### Fix

Mirror `session.branch` in the seed path:

1. Add an `origin_json` kwarg to `_persist_branch` and forward it to `db.create_session`.
2. In `_seed_branch_row`, fetch the parent's row with `db.get_session(parent_session_id)` and pass `origin_json=parent.get("origin_json")` plus `copy_fields=_BRANCH_COPY_FIELDS` through to `_persist_branch`.

This is a 23-line change in one file. Existing `session.branch` callers are unaffected — they pass `copy_fields=_BRANCH_COPY_FIELDS` explicitly and don't supply `origin_json` (default `None` preserves current behaviour).

### Why it matters beyond timestamps

The `origin_json` loss is the more dangerous half: a user who forks a chat, restarts their desktop, and tries to resume the fork gets a session the gateway can't route — silently dropped from any cross-session lookup that uses the gateway peer table. The triage pipeline (`tonbistudio/hermes-multi-agent-workflow`) relies on this mapping for branch lineage.

### Reproduction

1. Open any chat with 50+ turns.
2. Fork it via the Desktop "New chat from this point" button (RPC `session.create` with `parent_session_id` + `messages`).
3. `sqlite3 ~/.hermes/profiles/<active>/state.db "SELECT timestamp, COUNT(*) FROM messages WHERE session_id = (SELECT id FROM sessions WHERE parent_session_id IS NOT NULL ORDER BY id DESC LIMIT 1) GROUP BY timestamp ORDER BY 2 DESC LIMIT 5;"` — expect to see a single timestamp covering the whole copy, not the parent's real timeline.
4. `… "SELECT id, origin_json FROM sessions WHERE parent_session_id IS NOT NULL ORDER BY id DESC LIMIT 1;"` — `origin_json` is NULL.

### Patch

Attached: `desktop-seed-branch-timestamps-origin.patch` (also published as PR #TBD from `fix/seeded-branch-preserve-metadata`).
