### PR TITLE
fix(memory): archive evicted entries to ARCHIVE.jsonl before rewrites

### DIFF
--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -5,7 +5,9 @@ Node ids (from ``agent.learning_graph``): skills → the skill name; memories �
 for USER.md; ``index`` = position in the combined card list, MEMORY.md first).
 Shared by CLI ``hermes journey``, the TUI ``/journey`` overlay and the desktop.
 Deleting a skill *archives* it (``hermes curator restore`` recovers it);
-deleting a memory rewrites its file.
+deleting or editing a memory also archives the evicted/superseded chunk to
+``ARCHIVE.jsonl`` before rewriting its file (#76883), same as the memory tool's
+own ``remove``/``replace``.
 """
 
 from __future__ import annotations
@@ -14,6 +16,35 @@ from pathlib import Path
 from typing import Any, Callable
 
 _MEMORY_FILES = {"memory": "MEMORY.md", "profile": "USER.md"}
+
+
+def _archive_target_for_source(source: str) -> str:
+    """Journey ``source`` -> memory-tool archive target. ``profile`` nodes live in
+    USER.md, so they must archive (when configured in) as ``user`` and honor the
+    same privacy gate (``memory.archive_user``) as direct USER.md mutations --
+    never as ``memory``, which would both mislabel the archive record and bypass
+    the opt-in default (#76883)."""
+    return "user" if source == "profile" else "memory"
+
+
+def _archive_evicted(target: str, action: str, entry: str) -> tuple[str | None, str | None]:
+    """Archive one evicted memory chunk through the memory tool's shared
+    ARCHIVE.jsonl, gated the same way as ``MemoryStore.remove()``/``replace()``
+    (MEMORY.md by default, USER.md only when ``memory.archive_user`` is set).
+
+    Returns ``(record_id, None)`` when archived, ``(None, None)`` when the
+    store's privacy default skips archiving, ``(None, error)`` when the write
+    failed. This path never aborts on a failure -- unlike a background
+    consolidation batch, a journey delete/edit is a deliberate, foreground,
+    user-initiated action, so a degraded archive note is surfaced but the
+    mutation still proceeds (#76883)."""
+    try:
+        from tools.memory_tool import _should_archive_target, archive_entry
+        if not _should_archive_target(target):
+            return None, None
+        return archive_entry(target, action, entry)
+    except Exception as exc:  # pragma: no cover - import/IO edge; never block a user-initiated delete
+        return None, str(exc)
 
 
 def parse_node_kind(node_id: str) -> str:
@@ -125,10 +156,26 @@ def _delete_skill(name: str) -> dict[str, Any]:
 
 
 def _delete_memory(node_id: str) -> dict[str, Any]:
+    source, _ = _parse_memory_id(node_id)
     path, chunks, local = _locate_memory(node_id)
+    evicted = chunks[local]
+
+    # Reversible deletion: archive the evicted chunk before the rewrite, same
+    # ARCHIVE.jsonl as the memory tool's remove/replace. Profile nodes archive
+    # as `user` and honor the `archive_user` gate -- never mislabeled as
+    # `memory` (#76883). Failure degrades (mutation proceeds + note) rather
+    # than blocking a user-initiated delete.
+    archived_id, archived_error = _archive_evicted(_archive_target_for_source(source), "removed", evicted)
+
     del chunks[local]
     _write_memory(path, chunks)
-    return {"ok": True, "message": f"deleted memory from {path.name}"}
+
+    message = f"deleted memory from {path.name}"
+    if archived_id:
+        message += f" — evicted content archived to ARCHIVE.jsonl#{archived_id} (reversible)"
+    elif archived_error:
+        message += f" — note: archive write failed ({archived_error}), content is gone"
+    return {"ok": True, "message": message}
 
 
 # ── Edit ────────────────────────────────────────────────────────────────────
@@ -147,11 +194,23 @@ def _edit_skill(name: str, content: str) -> dict[str, Any]:
 
 
 def _edit_memory(node_id: str, content: str) -> dict[str, Any]:
-    _parse_memory_id(node_id)  # id errors win over the empty-body message
+    source, _ = _parse_memory_id(node_id)  # id errors win over the empty-body message
     body = content.strip()
     if not body:
         return {"ok": False, "message": "empty memory — use delete to remove it"}
     path, chunks, local = _locate_memory(node_id)
+    evicted = chunks[local]
+
+    # Reversible edit: the superseded chunk is archived before the rewrite,
+    # same gate as delete (profile -> user store, honor archive_user) (#76883).
+    archived_id, archived_error = _archive_evicted(_archive_target_for_source(source), "superseded", evicted)
+
     chunks[local] = body
     _write_memory(path, chunks)
-    return {"ok": True, "message": f"updated memory in {path.name}"}
+
+    message = f"updated memory in {path.name}"
+    if archived_id:
+        message += f" — superseded content archived to ARCHIVE.jsonl#{archived_id} (reversible)"
+    elif archived_error:
+        message += f" — note: archive write failed ({archived_error})"
+    return {"ok": True, "message": message}

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -909,6 +909,13 @@ memory:
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.
   nudge_interval: 10        # Nudge every 10 user turns (0 = disabled)
 
+  # Reversible mutations: remove/replace/apply_batch (and `/journey delete|edit`
+  # on memory nodes) archive the evicted entry to
+  # ~/.hermes/memories/ARCHIVE.jsonl before the file rewrite, so consolidation
+  # can never destroy distilled content irreversibly.
+  archive_user: false        # true = also archive USER.md evictions (default: MEMORY.md only)
+  archive_on_failure: warn   # warn (default, mutation proceeds) | abort (mutation refused)
+
 # =============================================================================
 # Session Continuity (Messaging Platforms)
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -911,8 +911,10 @@ memory:
 
   # Reversible mutations: remove/replace/apply_batch (and `/journey delete|edit`
   # on memory nodes) archive the evicted entry to
-  # ~/.hermes/memories/ARCHIVE.jsonl before the file rewrite, so consolidation
-  # can never destroy distilled content irreversibly.
+  # ~/.hermes/memories/ARCHIVE.jsonl before the file rewrite when archiving succeeds.
+  # Batches are locked with best-effort rollback, not crash-atomic transactions.
+  # Failed rollback can leave partial records; retries reuse IDs for deduplication.
+  # /journey always proceeds with a warning on failure, even when abort is set.
   archive_user: false        # true = also archive USER.md evictions (default: MEMORY.md only)
   archive_on_failure: warn   # warn (default, mutation proceeds) | abort (mutation refused)
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1204,6 +1204,21 @@ DEFAULT_CONFIG = {
         # External memory provider plugin (empty = built-in only); only ONE at a time: "openviking",
         # "mem0", "hindsight", "holographic", "retaindb", "byterover".
         "provider": "",
+        # Reversible memory mutations (#76883): evicted entries (remove/replace,
+        # apply_batch, and `/journey delete|edit` on memory nodes) are appended to
+        # ~/.hermes/memories/ARCHIVE.jsonl before the main file rewrite, so
+        # consolidation can never destroy distilled content irreversibly.
+        #   archive_user: false (default) -- USER.md evictions are NOT archived
+        #                 (data minimization for profile data). MEMORY.md is
+        #                 always archived. Set true to archive both stores.
+        #   archive_on_failure: "warn" (default) -- an archive write failure lets
+        #                 the mutation proceed and the tool result carries
+        #                 "archive_status": "degraded". "abort" restores strict
+        #                 behavior (mutation refused, file untouched) but can
+        #                 deadlock the memory-full consolidation path, hence the
+        #                 default.
+        "archive_user": False,
+        "archive_on_failure": "warn",
     },
     # Subagent delegation — override the provider:model used by delegate_task so children run on a
     # cheaper/faster model. Uses the same runtime provider resolution as CLI/gateway startup, so

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1206,8 +1206,8 @@ DEFAULT_CONFIG = {
         "provider": "",
         # Reversible memory mutations (#76883): evicted entries (remove/replace,
         # apply_batch, and `/journey delete|edit` on memory nodes) are appended to
-        # ~/.hermes/memories/ARCHIVE.jsonl before the main file rewrite, so
-        # consolidation can never destroy distilled content irreversibly.
+        # ~/.hermes/memories/ARCHIVE.jsonl before the main file rewrite when
+        # archiving succeeds; rollback is best-effort, not crash-atomic.
         #   archive_user: false (default) -- USER.md evictions are NOT archived
         #                 (data minimization for profile data). MEMORY.md is
         #                 always archived. Set true to archive both stores.
@@ -1216,7 +1216,7 @@ DEFAULT_CONFIG = {
         #                 "archive_status": "degraded". "abort" restores strict
         #                 behavior (mutation refused, file untouched) but can
         #                 deadlock the memory-full consolidation path, hence the
-        #                 default.
+        #                 default. /journey always degrades, even with "abort".
         "archive_user": False,
         "archive_on_failure": "warn",
     },

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -91,3 +91,112 @@ def test_memory_writes_match_memory_tool_format(home):
 
     assert entries == ["alpha rewritten", "beta note"]
     assert path.read_text(encoding="utf-8") == ENTRY_DELIMITER.join(entries)
+
+
+# =========================================================================
+# Reversible deletion/edit — eviction archive (ARCHIVE.jsonl, #76883)
+#
+# `/journey delete`|`edit` on a memory node bypasses MemoryStore.remove()/
+# replace() entirely (it edits the raw §-delimited chunks directly), so it
+# needs its OWN archive-before-rewrite call through the same shared
+# ARCHIVE.jsonl and the same MEMORY.md/USER.md privacy gate (#77154 review:
+# journey `profile` nodes map to USER.md and must never be mislabeled as the
+# `memory` archive target, which would silently bypass `archive_user: false`).
+# =========================================================================
+
+def test_delete_memory_archives_evicted_chunk(home):
+    """/journey delete on a memory node archives the evicted chunk to
+    ARCHIVE.jsonl before the rewrite — the same reversible-delete semantics
+    as the memory tool's remove() (#76883)."""
+    import json
+
+    res = lm.delete_node("memory:memory:0")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" in res["message"]
+
+    archive = home / "memories" / "ARCHIVE.jsonl"
+    assert archive.exists()
+    records = [json.loads(line) for line in archive.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(records) == 1
+    assert records[0]["store"] == "memory"
+    assert records[0]["action"] == "removed"
+    assert records[0]["entry"] == "alpha note\nline two"
+
+    # The delete itself still happened.
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "beta note"
+
+
+def test_delete_profile_memory_not_archived_by_default(home):
+    """Journey profile nodes map to USER.md — archiving must honor the
+    ``memory.archive_user: false`` privacy default (#77154 review), never
+    silently archiving profile data as if it were plain `memory`."""
+    res = lm.delete_node("memory:profile:2")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" not in res["message"]
+    assert not (home / "memories" / "ARCHIVE.jsonl").exists()
+    # The delete itself still happened.
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8").strip() == ""
+
+
+def test_delete_profile_memory_archived_when_configured(home):
+    """With ``memory.archive_user: true``, profile deletes archive as the
+    ``user`` store — never mislabeled as ``memory`` (#77154 review's core
+    complaint about the original, unpatched attempt)."""
+    import json
+
+    (home / "config.yaml").write_text("memory:\n  archive_user: true\n", encoding="utf-8")
+
+    res = lm.delete_node("memory:profile:2")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" in res["message"]
+    archive = home / "memories" / "ARCHIVE.jsonl"
+    records = [json.loads(line) for line in archive.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(records) == 1
+    assert records[0]["store"] == "user"
+    assert records[0]["action"] == "removed"
+    assert records[0]["entry"] == "user profile note"
+
+
+def test_edit_memory_archives_superseded(home):
+    """/journey edit archives the superseded chunk (reversible edits, same
+    ARCHIVE.jsonl) instead of destroying it (#77154 review's third defect:
+    the sibling _edit_memory path stayed irreversible)."""
+    import json
+
+    res = lm.edit_node("memory:memory:0", "alpha rewritten")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" in res["message"]
+    archive = home / "memories" / "ARCHIVE.jsonl"
+    records = [json.loads(line) for line in archive.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(records) == 1
+    assert records[0]["store"] == "memory"
+    assert records[0]["action"] == "superseded"
+    assert records[0]["entry"] == "alpha note\nline two"
+    # The edit itself landed.
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8").startswith("alpha rewritten")
+
+
+def test_edit_profile_memory_not_archived_by_default(home):
+    """Profile edits honor the same privacy gate as profile deletes — nothing
+    archived by default."""
+    res = lm.edit_node("memory:profile:2", "rewritten profile")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" not in res["message"]
+    assert not (home / "memories" / "ARCHIVE.jsonl").exists()
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8").strip() == "rewritten profile"
+
+
+def test_delete_memory_degrades_when_archive_write_fails(home, monkeypatch):
+    """A journey delete is a deliberate, foreground user action: it must never
+    block on an archive-write failure (unlike a background consolidation
+    batch, which can honor ``archive_on_failure: abort``) — it degrades with
+    a note instead."""
+    monkeypatch.setattr("tools.memory_tool.archive_entries", lambda *a, **k: ([], "disk full"))
+
+    res = lm.delete_node("memory:memory:0")
+
+    assert res["ok"]
+    assert "archive write failed" in res["message"]
+    assert not (home / "memories" / "ARCHIVE.jsonl").exists()
+    # The delete itself still happened -- never blocked.
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "beta note"

--- a/tests/tools/test_memory_archive_concurrency.py
+++ b/tests/tools/test_memory_archive_concurrency.py
@@ -1,0 +1,84 @@
+"""Real-file regressions for archive rollback and no-op batches."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from tools import memory_tool as mt
+
+
+def test_empty_archive_batch_does_not_touch_disk(tmp_path, monkeypatch):
+    monkeypatch.setattr(mt, "get_memory_dir", lambda: tmp_path / "memories")
+    assert mt.archive_entries("memory", []) == ([], None)
+    assert not (tmp_path / "memories").exists()
+
+
+def test_failed_append_cannot_erase_another_process_record(tmp_path, monkeypatch):
+    """Hold the failing writer open while a second real process tries to append."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(mt, "get_memory_dir", lambda: tmp_path / "memories")
+    path = mt.get_memory_archive_path()
+    path.parent.mkdir()
+    original = '{"id": "existing"}\n'
+    concurrent = '{"id": "concurrent"}\n'
+    path.write_text(original, encoding="utf-8")
+    real_open = open
+    children: list[subprocess.Popen[str]] = []
+
+    class FailingWriter:
+        def __init__(self, handle):
+            self.handle = handle
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return self.handle.__exit__(*args)
+
+        def __getattr__(self, name):
+            return getattr(self.handle, name)
+
+        def write(self, data):
+            # Persist a real partial write, not just an exception before any I/O.
+            self.handle.write(data[:5])
+            self.handle.flush()
+            child = subprocess.Popen(
+                [sys.executable, "-c",
+                 "from tools import memory_tool as mt; "
+                 "print('ready', flush=True); "
+                 f"mt._archive_append_lines([{concurrent!r}])"],
+                cwd=Path(__file__).resolve().parents[2],
+                env=os.environ.copy(), stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, text=True,
+            )
+            children.append(child)
+            assert child.stdout is not None
+            assert child.stdout.readline().strip() == "ready"
+            try:
+                child.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass  # Expected: the other process waits for our archive lock.
+            raise OSError("disk full after partial write")
+
+    def failing_open(file, mode="r", *args, **kwargs):
+        handle = real_open(file, mode, *args, **kwargs)
+        if Path(file) == path and mode in ("a", "ab"):
+            return FailingWriter(handle)
+        return handle
+
+    monkeypatch.setattr(mt, "open", failing_open, raising=False)
+    try:
+        with pytest.raises(OSError, match="disk full"):
+            mt._archive_append_lines(['{"id": "failed"}\n'])
+        assert children
+        child = children[0]
+        _, stderr = child.communicate(timeout=20)
+        assert child.returncode == 0, stderr
+        assert path.read_text(encoding="utf-8") == original + concurrent
+    finally:
+        for child in children:
+            if child.poll() is None:
+                child.kill()
+                child.communicate(timeout=10)

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -849,3 +849,236 @@ class TestBackgroundReviewDeleteGate:
             reset_current_write_origin(token)
         assert result["success"] is True
         assert "rewritten by refine" in store._entries_for("memory")
+
+
+# =========================================================================
+# Reversible mutations — eviction archive (ARCHIVE.jsonl, #76883)
+#
+# remove/replace/apply_batch archive the evicted entry to ARCHIVE.jsonl
+# BEFORE the main file rewrite, so consolidation can never destroy distilled
+# content irreversibly. See tools/memory_tool.py's archive_entries()/
+# archive_entry() and MemoryStore._archive_evicted()/_mutate().
+# =========================================================================
+
+def _read_archive(tmp_path):
+    """ARCHIVE.jsonl records written under the store fixture's memory dir
+    (`store` monkeypatches tools.memory_tool.get_memory_dir to tmp_path)."""
+    path = tmp_path / "ARCHIVE.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+class TestMemoryArchive:
+    def test_remove_archives_evicted_entry(self, store, tmp_path):
+        store.add("memory", "Retired fact about the old stack")
+        result = store.remove("memory", "Retired fact")
+
+        assert result["success"] is True
+        records = _read_archive(tmp_path)
+        assert len(records) == 1
+        assert records[0]["store"] == "memory"
+        assert records[0]["action"] == "removed"
+        assert records[0]["entry"] == "Retired fact about the old stack"
+        assert result["archived"][0]["id"] == records[0]["id"]
+        assert result["archived"][0]["action"] == "removed"
+
+    def test_replace_archives_superseded_entry(self, store, tmp_path):
+        store.add("memory", "Python 3.11 project")
+        result = store.replace("memory", "3.11", "Python 3.12 project")
+
+        assert result["success"] is True
+        records = _read_archive(tmp_path)
+        assert len(records) == 1
+        assert records[0]["action"] == "superseded"
+        assert records[0]["entry"] == "Python 3.11 project"
+        assert result["archived"][0]["action"] == "superseded"
+        # The replacement itself still landed.
+        assert "Python 3.12 project" in store.memory_entries
+
+    def test_user_target_not_archived_by_default(self, store, tmp_path):
+        """Privacy default: USER.md evictions are NOT archived unless opted in (#77154 review)."""
+        store.add("user", "Name: Alice")
+        result = store.remove("user", "Name: Alice")
+
+        assert result["success"] is True
+        assert "archived" not in result
+        assert _read_archive(tmp_path) == []
+
+    def test_user_target_archived_when_configured(self, store, tmp_path):
+        # Config is read through the sanctioned loader (hermes_cli.config), which
+        # resolves the sandboxed per-test HERMES_HOME (a DIFFERENT dir than
+        # tmp_path here) — write the opt-in there.
+        from hermes_constants import get_hermes_home
+        (get_hermes_home() / "config.yaml").write_text("memory:\n  archive_user: true\n", encoding="utf-8")
+
+        store.add("user", "Name: Alice")
+        result = store.remove("user", "Name: Alice")
+
+        assert result["success"] is True
+        records = _read_archive(tmp_path)
+        assert len(records) == 1
+        assert records[0]["store"] == "user"
+        assert result["archived"][0]["store"] == "user"
+
+    def test_apply_batch_archives_evicted_entries_on_commit(self, store, tmp_path):
+        store.add("memory", "Entry one")
+        store.add("memory", "Entry two")
+
+        result = store.apply_batch("memory", [
+            {"action": "replace", "old_text": "Entry one", "content": "Entry one v2"},
+            {"action": "remove", "old_text": "Entry two"},
+        ])
+
+        assert result["success"] is True
+        records = _read_archive(tmp_path)
+        assert [r["action"] for r in records] == ["superseded", "removed"]
+        assert len(result["archived"]) == 2
+
+    def test_failed_batch_never_archives(self, store, tmp_path):
+        """A malformed/unmatched op refuses the WHOLE batch (all-or-nothing) —
+        the archive must stay untouched too, same as the memory file (#76883
+        review: 'a failed batch never touches the archive')."""
+        store.add("memory", "Keep me")
+
+        result = store.apply_batch("memory", [
+            {"action": "remove", "old_text": "Keep me"},
+            {"action": "replace", "old_text": "no such entry", "content": "x"},
+        ])
+
+        assert result["success"] is False
+        assert _read_archive(tmp_path) == []
+        assert "Keep me" in store.memory_entries
+
+    def test_archive_write_failure_degrades_by_default(self, store, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.archive_entries", lambda *a, **k: ([], "disk full"))
+        store.add("memory", "Doomed entry")
+
+        result = store.remove("memory", "Doomed entry")
+
+        assert result["success"] is True
+        assert result["archive_status"] == "degraded"
+        assert "archived" not in result
+        assert "Doomed entry" not in store.memory_entries  # the removal itself still landed
+        assert _read_archive(tmp_path) == []
+
+    def test_archive_write_failure_aborts_when_configured(self, store, tmp_path, monkeypatch):
+        from hermes_constants import get_hermes_home
+        (get_hermes_home() / "config.yaml").write_text("memory:\n  archive_on_failure: abort\n", encoding="utf-8")
+        monkeypatch.setattr("tools.memory_tool.archive_entries", lambda *a, **k: ([], "disk full"))
+        store.add("memory", "Precious entry")
+
+        result = store.remove("memory", "Precious entry")
+
+        assert result["success"] is False
+        assert "abort" in result["error"]
+        assert "Precious entry" in store.memory_entries  # refused -- file untouched
+
+    def test_batch_abort_never_leaves_partial_archive(self, store, tmp_path, monkeypatch):
+        """Abort-mode archive handling is caller-visible atomic FOR THE WHOLE
+        BATCH: a two-entry batch's archive write fails once and is refused —
+        no partial records from earlier evictions in the SAME call survive a
+        later one's failure, because the whole batch is written as one call
+        to archive_entries(), not per-op (#77154 review)."""
+        from hermes_constants import get_hermes_home
+        (get_hermes_home() / "config.yaml").write_text("memory:\n  archive_on_failure: abort\n", encoding="utf-8")
+        monkeypatch.setattr("tools.memory_tool.archive_entries", lambda *a, **k: ([], "disk full"))
+        store.add("memory", "Entry one")
+        store.add("memory", "Entry two")
+
+        result = store.apply_batch("memory", [
+            {"action": "remove", "old_text": "Entry one"},
+            {"action": "replace", "old_text": "Entry two", "content": "Entry two v2"},
+        ])
+
+        assert result["success"] is False
+        assert "abort" in result["error"]
+        assert _read_archive(tmp_path) == []
+        assert "Entry one" in store.memory_entries
+        assert "Entry two" in store.memory_entries
+
+    def test_batch_archive_failure_degrades_atomically(self, store, tmp_path, monkeypatch):
+        """Default warn mode: a failed archive write for a two-entry batch
+        leaves NO records behind (the single combined write never partially
+        lands), the mutation still proceeds, and the result says degraded."""
+        monkeypatch.setattr("tools.memory_tool.archive_entries", lambda *a, **k: ([], "disk full"))
+        store.add("memory", "Entry one")
+        store.add("memory", "Entry two")
+        store.add("memory", "Entry to keep")
+
+        result = store.apply_batch("memory", [
+            {"action": "remove", "old_text": "Entry one"},
+            {"action": "remove", "old_text": "Entry two"},
+        ])
+
+        assert result["success"] is True
+        assert result["archive_status"] == "degraded"
+        assert _read_archive(tmp_path) == []
+        assert store.memory_entries == ["Entry to keep"]
+
+    def test_archive_append_rolls_back_on_write_failure(self, tmp_path, monkeypatch):
+        """`_archive_append_lines` itself: when the underlying write fails, the
+        file is rolled back to its pre-call length rather than keeping a
+        truncated/partial line -- the primitive the batch-atomicity guarantee
+        above is built on. `tell()`/`truncate()` delegate to a REAL file
+        handle on the REAL path; only `write()` is faked to simulate a
+        mid-write disk failure, so the rollback under test runs for real."""
+        from tools import memory_tool as mt
+        monkeypatch.setattr(mt, "get_memory_dir", lambda: tmp_path)
+        archive_path = tmp_path / "ARCHIVE.jsonl"
+        archive_path.write_text('{"id": "existing"}\n', encoding="utf-8")
+        real_open = open
+
+        class _FailingWriteFile:
+            def __init__(self, real_file):
+                self._real = real_file
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return self._real.__exit__(*exc_info)
+
+            def tell(self):
+                return self._real.tell()
+
+            def truncate(self, *args):
+                return self._real.truncate(*args)
+
+            def write(self, data):
+                raise OSError("disk full mid-write")
+
+        def _fake_open(file, mode="r", *args, **kwargs):
+            if Path(file) == archive_path and mode == "a":
+                return _FailingWriteFile(real_open(file, mode, *args, **kwargs))
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+
+        with pytest.raises(OSError):
+            mt._archive_append_lines(['{"id": "new"}\n'])
+
+        # Rolled back to exactly the pre-call content -- no partial line appended.
+        assert archive_path.read_text(encoding="utf-8") == '{"id": "existing"}\n'
+
+
+class TestLearningMutationsArchiveIntegration:
+    """MemoryStore._path_for()/_read_file() are the same primitives
+    agent/learning_mutations.py uses to locate journey memory nodes, so a
+    round trip through the real on-disk files here exercises the same
+    ARCHIVE.jsonl path `/journey delete`|`edit` use (full coverage lives in
+    tests/agent/test_learning_mutations.py)."""
+
+    def test_remove_then_archive_round_trips_through_real_files(self, store, tmp_path):
+        store.add("memory", "alpha note")
+        store.add("memory", "beta note")
+        result = store.remove("memory", "alpha note")
+        assert result["success"] is True
+
+        # The memory file round-trips through the same MemoryStore parser
+        # learning_mutations.py's _locate_memory() uses.
+        path = store._path_for("memory")
+        assert MemoryStore._read_file(path) == ["beta note"]
+
+        records = _read_archive(tmp_path)
+        assert records[0]["entry"] == "alpha note"

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1049,7 +1049,7 @@ class TestMemoryArchive:
                 raise OSError("disk full mid-write")
 
         def _fake_open(file, mode="r", *args, **kwargs):
-            if Path(file) == archive_path and mode == "a":
+            if Path(file) == archive_path and mode == "ab":
                 return _FailingWriteFile(real_open(file, mode, *args, **kwargs))
             return real_open(file, mode, *args, **kwargs)
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -7,6 +7,8 @@ Single `memory` tool: add/replace/remove or a batch `operations` list."""
 import copy
 import json
 import logging
+import time
+import uuid
 from contextvars import ContextVar
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -38,6 +40,117 @@ _memory_surface_flags: ContextVar[Optional[Tuple[bool, bool]]] = ContextVar("mem
 def get_memory_dir() -> Path:
     """Profile-scoped memories dir, resolved per call (HERMES_HOME may switch after import)."""
     return get_hermes_home() / "memories"
+
+
+# ---------------------------------------------------------------------------
+# Reversible mutations — local eviction archive (ARCHIVE.jsonl)
+#
+# remove/replace/apply_batch (and `/journey delete`|`edit` on memory nodes, see
+# agent/learning_mutations.py) append the evicted entry to
+# ~/.hermes/memories/ARCHIVE.jsonl BEFORE the main file rewrite, so
+# consolidation can never destroy distilled content irreversibly (issue #76883).
+# Zero-dependency, provider-independent, per-profile (the file lives under
+# get_memory_dir(), which is already profile-scoped).
+#
+# Semantics:
+#   - At-least-once: a crash between the archive append and the main rewrite
+#     leaves a ghost record (reconcilable by `id`) but never loses content.
+#   - A batch of evicted entries is archived as ONE write (see
+#     `_archive_append_lines`), so a failure can never leave part of a single
+#     call's records archived while the rest are refused.
+#   - Failure degradation: an archive write failure is retried once; if it
+#     still fails, the mutation proceeds by default and the tool result
+#     carries `"archive_status": "degraded"`. `memory.archive_on_failure:
+#     "abort"` restores strict behavior (mutation refused) at the cost of
+#     being able to deadlock the memory-full consolidation path.
+#   - Privacy: MEMORY.md evictions are archived by default; USER.md is not
+#     (`memory.archive_user: false`) — data minimization for profile data.
+# ---------------------------------------------------------------------------
+
+ARCHIVE_FILENAME = "ARCHIVE.jsonl"
+
+
+def get_memory_archive_path() -> Path:
+    """Profile-scoped eviction-archive path, resolved per call (mirrors ``get_memory_dir()``)."""
+    return get_memory_dir() / ARCHIVE_FILENAME
+
+
+def _should_archive_target(target: str) -> bool:
+    """MEMORY.md evictions are archived by default; USER.md only when
+    ``memory.archive_user`` is set (data minimization for profile data)."""
+    if target != "user":
+        return True
+    return is_truthy_value(get_builtin_memory_config().get("archive_user"), default=False)
+
+
+def _archive_abort_on_failure() -> bool:
+    """``memory.archive_on_failure: "abort"`` refuses the mutation on an archive
+    write failure instead of the default degrade-and-warn."""
+    return str(get_builtin_memory_config().get("archive_on_failure", "warn")).strip().lower() == "abort"
+
+
+def _archive_append_lines(lines: List[str]) -> None:
+    """Append prebuilt JSONL *lines* to ARCHIVE.jsonl in a single write.
+
+    Raises OSError on failure. Writing the whole batch as one ``write()`` call,
+    with a best-effort truncate rollback on failure, keeps THIS call's records
+    caller-visible atomic: either every evicted entry in the call lands, or
+    none does — a failure partway through a multi-entry batch can never leave
+    some of that batch's entries archived while the rest are refused.
+    """
+    path = get_memory_archive_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        start = f.tell()
+        try:
+            f.write("".join(lines))
+            f.flush()
+        except OSError:
+            try:
+                f.truncate(start)
+            except OSError:
+                pass
+            raise
+
+
+def archive_entries(target: str, actions_entries: List[Tuple[str, str]]
+                    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Append evicted entries to ARCHIVE.jsonl as one atomic batch, before the
+    caller's memory-file rewrite.
+
+    Returns ``(records, None)`` on success — each record carries ``id``/``ts``/
+    ``store``/``action``/``entry`` — or ``([], error)`` after one retry when
+    the write keeps failing, in which case NOTHING in *actions_entries* was
+    appended (see ``_archive_append_lines``). Never raises; callers decide
+    whether a failure degrades the mutation (default) or aborts it
+    (``memory.archive_on_failure: "abort"``).
+    """
+    records = [{
+        "id": uuid.uuid4().hex,
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "store": target,
+        "action": action,  # "removed" | "superseded"
+        "entry": entry,
+    } for action, entry in actions_entries]
+    lines = [json.dumps(record, ensure_ascii=False) + "\n" for record in records]
+    last_error: Optional[str] = None
+    for _ in (1, 2):  # one retry, then degrade/abort per config
+        try:
+            _archive_append_lines(lines)
+            return records, None
+        except OSError as exc:
+            last_error = str(exc)
+    return [], last_error
+
+
+def archive_entry(target: str, action: str, entry: str) -> Tuple[Optional[str], Optional[str]]:
+    """Append one evicted entry to ARCHIVE.jsonl. Returns ``(record_id, None)``
+    on success, ``(None, error)`` after one retry when the write keeps
+    failing. Never raises."""
+    records, error = archive_entries(target, [(action, entry)])
+    if error:
+        return None, error
+    return records[0]["id"], None
 
 
 from tools.memory_tool_store import (  # noqa: E402,F401  (re-exports)
@@ -270,7 +383,8 @@ MEMORY_SCHEMA = {
         "to free room AND add new ones, even when an add alone would overflow. The response "
         "reports current/limit chars and confirms completion; one batch call finishes the "
         "update, so don't repeat it. Use the bare action/content/old_text fields only for a "
-        "single lone change.\n\n"
+        "single lone change. A 'replace'/'remove' is recoverable: the evicted entry is archived "
+        "to ARCHIVE.jsonl (not destroyed) and the response's 'archived' field confirms it.\n\n"
         "WHEN: only for facts that apply to EVERY session regardless of task: who the user "
         "is, stable environment facts, standing conventions with no task home. Anything "
         "learned while doing a task (procedures, pitfalls, and the user's preferences and "

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -47,17 +47,17 @@ def get_memory_dir() -> Path:
 #
 # remove/replace/apply_batch (and `/journey delete`|`edit` on memory nodes, see
 # agent/learning_mutations.py) append the evicted entry to
-# ~/.hermes/memories/ARCHIVE.jsonl BEFORE the main file rewrite, so
-# consolidation can never destroy distilled content irreversibly (issue #76883).
+# ~/.hermes/memories/ARCHIVE.jsonl BEFORE the main file rewrite to preserve
+# evicted content when archiving succeeds (issue #76883).
 # Zero-dependency, provider-independent, per-profile (the file lives under
 # get_memory_dir(), which is already profile-scoped).
 #
 # Semantics:
-#   - At-least-once: a crash between the archive append and the main rewrite
-#     leaves a ghost record (reconcilable by `id`) but never loses content.
-#   - A batch of evicted entries is archived as ONE write (see
-#     `_archive_append_lines`), so a failure can never leave part of a single
-#     call's records archived while the rest are refused.
+#   - Best-effort recovery: append precedes rewrite, but the two files are
+#     not a crash-atomic transaction and no power-loss durability is promised.
+#   - Batches are serialized by a per-profile archive lock with best-effort
+#     rollback. A crash or rollback failure can leave partial records. Retries
+#     reuse record IDs so complete duplicates can be reconciled by `id`.
 #   - Failure degradation: an archive write failure is retried once; if it
 #     still fails, the mutation proceeds by default and the tool result
 #     carries `"archive_status": "degraded"`. `memory.archive_on_failure:
@@ -90,41 +90,50 @@ def _archive_abort_on_failure() -> bool:
 
 
 def _archive_append_lines(lines: List[str]) -> None:
-    """Append prebuilt JSONL *lines* to ARCHIVE.jsonl in a single write.
+    """Append a batch under the shared cross-process archive lock.
 
-    Raises OSError on failure. Writing the whole batch as one ``write()`` call,
-    with a best-effort truncate rollback on failure, keeps THIS call's records
-    caller-visible atomic: either every evicted entry in the call lands, or
-    none does — a failure partway through a multi-entry batch can never leave
-    some of that batch's entries archived while the rest are refused.
+    Rollback is best-effort, not a crash-atomic transaction. Hold the lock
+    from before opening the archive through close/rollback so a failed writer
+    cannot truncate another writer's committed records. Unbuffered bytes avoid
+    a close-time flush re-appending failed data after rollback.
     """
+    if not lines:
+        return
+    if fcntl is None and msvcrt is None:
+        raise OSError("archive requires cross-process file locking")
     path = get_memory_archive_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with open(path, "a", encoding="utf-8") as f:
-        start = f.tell()
-        try:
-            f.write("".join(lines))
-            f.flush()
-        except OSError:
+    data = "".join(lines).encode("utf-8")
+    with MemoryStore._file_lock(path):
+        with open(path, "ab", buffering=0) as f:
+            start = f.tell()
             try:
-                f.truncate(start)
+                remaining = memoryview(data)
+                while remaining:
+                    written = f.write(remaining)
+                    if not written:
+                        raise OSError("short archive write")
+                    remaining = remaining[written:]
             except OSError:
-                pass
-            raise
+                try:
+                    f.truncate(start)
+                except OSError:
+                    pass  # Retry may duplicate records; IDs are stable across attempts.
+                raise
 
 
 def archive_entries(target: str, actions_entries: List[Tuple[str, str]]
                     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
-    """Append evicted entries to ARCHIVE.jsonl as one atomic batch, before the
-    caller's memory-file rewrite.
+    """Append one serialized batch before the caller's memory-file rewrite.
 
     Returns ``(records, None)`` on success — each record carries ``id``/``ts``/
-    ``store``/``action``/``entry`` — or ``([], error)`` after one retry when
-    the write keeps failing, in which case NOTHING in *actions_entries* was
-    appended (see ``_archive_append_lines``). Never raises; callers decide
-    whether a failure degrades the mutation (default) or aborts it
-    (``memory.archive_on_failure: "abort"``).
+    ``store``/``action``/``entry`` — or ``([], error)`` after one retry on I/O
+    failure. Rollback is best-effort: partial data may remain if it also fails,
+    and retries reuse IDs for deduplication of complete records. Callers choose
+    degradation (default) or abort via ``memory.archive_on_failure``; journey
+    always degrades. Empty batches do not touch disk.
     """
+    if not actions_entries:
+        return [], None
     records = [{
         "id": uuid.uuid4().hex,
         "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -383,8 +392,9 @@ MEMORY_SCHEMA = {
         "to free room AND add new ones, even when an add alone would overflow. The response "
         "reports current/limit chars and confirms completion; one batch call finishes the "
         "update, so don't repeat it. Use the bare action/content/old_text fields only for a "
-        "single lone change. A 'replace'/'remove' is recoverable: the evicted entry is archived "
-        "to ARCHIVE.jsonl (not destroyed) and the response's 'archived' field confirms it.\n\n"
+        "single lone change. When archiving is enabled and succeeds, 'replace'/'remove' saves "
+        "evicted entries to ARCHIVE.jsonl; the response's 'archived' field confirms it. "
+        "USER.md archiving is opt-in, and archive failures may degrade.\n\n"
         "WHEN: only for facts that apply to EVERY session regardless of task: who the user "
         "is, stable environment facts, standing conventions with no task home. Anything "
         "learned while doing a task (procedures, pitfalls, and the user's preferences and "

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -1,7 +1,7 @@
 """MemoryStore — bounded, file-backed curated memory (MEMORY.md / USER.md).
 Entries are joined by ``ENTRY_DELIMITER``; budgets are in chars (model-independent).
-Module state that tests monkeypatch (``get_memory_dir``, ``fcntl``/``msvcrt``) stays
-in ``tools.memory_tool`` and is read lazily."""
+Module state that tests monkeypatch (``get_memory_dir``, the eviction-archive
+helpers, ``fcntl``/``msvcrt``) stays in ``tools.memory_tool`` and is read lazily."""
 
 import logging
 import time
@@ -187,12 +187,48 @@ class MemoryStore:
         return self._consolidation_failure(
             _error(message, current_entries=self._entries_for(target), usage=self._usage(target)))
 
+    def _archive_evicted(self, target: str, evicted: List[Tuple[str, str]]
+                         ) -> Tuple[List[Dict[str, Any]], Optional[str], Optional[str]]:
+        """Archive *evicted* ``(action, entry)`` pairs to the shared ARCHIVE.jsonl
+        BEFORE the caller's file rewrite, so remove/replace/apply_batch can never
+        destroy distilled content irreversibly (#76883). A single edit (one pair)
+        and a whole batch (many pairs, evaluated once at the commit point) go
+        through this SAME call, so an abort-mode failure can never leave part of
+        one call's records archived while the rest are refused.
+
+        Returns ``(records, status, error)``:
+          records -- archive record dicts (``[]`` when nothing was evicted, the
+                     store is gated off — USER.md by default — or the write failed).
+          status  -- ``None`` (nothing to archive, or archived cleanly), ``"degraded"``
+                     (write failed, mutation proceeds per the default
+                     ``memory.archive_on_failure: "warn"``), or ``"abort"`` (write
+                     failed and ``archive_on_failure: "abort"`` — the caller must
+                     refuse the mutation and leave the file untouched).
+          error   -- the underlying write error when *status* is not ``None``.
+        """
+        from tools import memory_tool as _mt
+        if not evicted or not _mt._should_archive_target(target):
+            return [], None, None
+        records, error = _mt.archive_entries(target, evicted)
+        if error is None:
+            return [{"file": _mt.ARCHIVE_FILENAME, **record} for record in records], None, None
+        if _mt._archive_abort_on_failure():
+            return [], "abort", error
+        logger.warning("Memory archive write failed (degraded): %s", error)
+        return [], "degraded", error
+
     def _mutate(self, target: str, mutate, *, skip_drift: bool = False) -> Dict[str, Any]:
-        """Lock, re-read from disk, run ``mutate(entries, limit)`` -> ``(new_entries, message)``
-        or an error dict, then persist and return the success response. The reload aborts
-        on an existing-but-unreadable file (even append-only ``add`` rewrites the whole
-        file) and, unless *skip_drift*, on external drift (flushing would discard
-        un-roundtrippable content). Drift check and parse use the SAME raw snapshot —
+        """Lock, re-read from disk, run ``mutate(entries, limit)`` -> ``(new_entries, message)``,
+        ``(new_entries, message, evicted)``, or an error dict, then persist and return the
+        success response. ``evicted`` (optional 3rd element) is a list of ``(action, entry)``
+        pairs for content the mutation is about to overwrite/drop; when present it is archived
+        to ARCHIVE.jsonl BEFORE the file rewrite (#76883) — an archive failure under
+        ``memory.archive_on_failure: "abort"`` refuses the whole mutation and leaves the file
+        untouched, so content is never lost unarchived.
+
+        The reload aborts on an existing-but-unreadable file (even append-only ``add``
+        rewrites the whole file) and, unless *skip_drift*, on external drift (flushing would
+        discard un-roundtrippable content). Drift check and parse use the SAME raw snapshot —
         a failed second read used to count as "no drift"."""
         path = self._path_for(target)
         with self._file_lock(path):
@@ -206,10 +242,22 @@ class MemoryStore:
             result = mutate(self._entries_for(target), self._char_limit(target))
             if isinstance(result, dict):
                 return result
-            self._set_entries(target, result[0])
+            new_entries, message, *rest = result
+            evicted: List[Tuple[str, str]] = rest[0] if rest else []
+            archived, archive_status, archive_error = self._archive_evicted(target, evicted)
+            if archive_status == "abort":
+                return self._failure_with_entries(target, (
+                    f"Archive write failed ({archive_error}) and memory.archive_on_failure=abort "
+                    "-- the write was refused so no content was lost unarchived. Nothing changed; retry."))
+            self._set_entries(target, new_entries)
             path.parent.mkdir(parents=True, exist_ok=True)
-            self._write_file(path, result[0])
-            return self._success_response(target, result[1])
+            self._write_file(path, new_entries)
+            response = self._success_response(target, message)
+            if archived:
+                response["archived"] = archived
+            elif archive_status == "degraded":
+                response["archive_status"] = "degraded"
+            return response
 
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
@@ -251,7 +299,10 @@ class MemoryStore:
         return self._edit(target, old_text.strip(), None)
 
     def _edit(self, target: str, old_text: str, new_content: Optional[str]) -> Dict[str, Any]:
-        """Locked replace (``new_content`` set) or remove (None) of the entry matching *old_text*."""
+        """Locked replace (``new_content`` set) or remove (None) of the entry matching
+        *old_text*. The evicted entry is archived to ARCHIVE.jsonl by ``_mutate`` before
+        the rewrite (#76883) -- MEMORY.md by default, USER.md only when
+        ``memory.archive_user`` is set."""
         def _apply(entries, limit):
             idx, ambiguous = _find_unique_match(entries, old_text)
             if ambiguous:
@@ -261,21 +312,27 @@ class MemoryStore:
                 return self._consolidation_failure(_error(
                     f"No entry matched '{old_text}'. Check current_entries below and retry with the exact text "
                     f"of the entry you want to {'replace' if new_content else 'remove'}.", current_entries=entries))
+            evicted_entry = entries[idx]
+            evicted = [("removed" if new_content is None else "superseded", evicted_entry)]
             replaced = entries[:idx] + ([] if new_content is None else [new_content]) + entries[idx + 1:]
             if new_content is None:
-                return replaced, "Entry removed."
+                return replaced, "Entry removed.", evicted
             new_total = len(ENTRY_DELIMITER.join(replaced))
             if new_total > limit:
                 return self._failure_with_entries(target, (
                     f"Replacement would put memory at {new_total:,}/{limit:,} chars. Shorten the new content, "
                     f"or 'remove' other stale or less important entries to make room (see current_entries "
                     f"below), then retry — all in this turn."))
-            return replaced, "Entry replaced."
+            return replaced, "Entry replaced.", evicted
         return self._mutate(target, _apply)
 
     @staticmethod
-    def _apply_batch_op(working: List[str], act: str, content: str, old_text: str, pos: str) -> Optional[str]:
-        """Apply one batch op to *working* in place; return an error message or None."""
+    def _apply_batch_op(working: List[str], act: str, content: str, old_text: str, pos: str,
+                        evicted: List[Tuple[str, str]]) -> Optional[str]:
+        """Apply one batch op to *working* in place, appending any evicted
+        ``(action, entry)`` pair to *evicted* so the caller can archive the whole
+        batch as one atomic write at the commit point (#76883). Return an error
+        message or None."""
         if act == "add":
             if not content:
                 return f"{pos}: content is required."
@@ -293,13 +350,17 @@ class MemoryStore:
             return f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific."
         if idx is None:
             return f"{pos}: no entry matched '{old_text}'."
+        evicted.append(("superseded" if act == "replace" else "removed", working[idx]))
         working[idx:idx + 1] = [content] if act == "replace" else []
         return None
 
     def apply_batch(self, target: str, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Apply add/replace/remove ops atomically against the FINAL budget, so one call
         can free space and add entries. All-or-nothing: any malformed / unmatched op or
-        an over-limit result writes NOTHING and returns the first failure plus live state."""
+        an over-limit result writes NOTHING and returns the first failure plus live state.
+        Every entry a replace/remove op evicts is archived to ARCHIVE.jsonl as ONE atomic
+        write at the commit point (#76883) -- a failed batch never touches the archive
+        either."""
         if not operations:
             return _error("operations list is empty.")
         ops = [op or {} for op in operations]
@@ -311,10 +372,12 @@ class MemoryStore:
 
         def _apply(entries, limit):
             working = list(entries)  # only committed if the whole batch validates
+            evicted: List[Tuple[str, str]] = []  # (action, entry) -- archived as ONE batch on commit
             for i, op in enumerate(ops):
                 act = op.get("action")
                 msg = self._apply_batch_op(working, act, (op.get("content") or op.get("new_text") or "").strip(),
-                                           (op.get("old_text") or "").strip(), f"Operation {i + 1} ({act or 'unknown'})")
+                                           (op.get("old_text") or "").strip(), f"Operation {i + 1} ({act or 'unknown'})",
+                                           evicted)
                 if msg:
                     return self._failure_with_entries(target, msg + " No operations were applied (batch is all-or-nothing).")
             if entries and not working:
@@ -334,7 +397,7 @@ class MemoryStore:
                     f"After applying all {len(operations)} operations, memory would be at "
                     f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
                     f"entries in the same batch (see current_entries below), then retry."))
-            return working, f"Applied {len(operations)} operation(s)."
+            return working, f"Applied {len(operations)} operation(s).", evicted
         return self._mutate(target, _apply)
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -79,6 +79,19 @@ memory(action="replace", target="memory",
 
 If the substring matches multiple entries, an error is returned asking for a more specific match.
 
+### Reversible Mutations (Eviction Archive)
+
+`replace` and `remove` (single or inside `apply_batch`) never destroy an entry outright: the evicted content is appended to `~/.hermes/memories/ARCHIVE.jsonl` **before** the main file rewrite, so consolidation can never lose distilled content irreversibly. Each line is a JSON record — `id`, `ts`, `store`, `action` (`"removed"` or `"superseded"`), and the evicted `entry` text.
+
+The tool result carries the archive id and the evicted entry itself (`"archived": [...]`), so the model sees exactly what was captured at the moment of the mutation — no system-prompt addition, prompt cache untouched.
+
+Privacy defaults differ by store:
+
+- **`memory` (MEMORY.md)** — archived by default.
+- **`user` (USER.md)** — **not** archived by default (`memory.archive_user: false`); set it to `true` to opt in. This is a data-minimization default for profile data, not a correctness gap.
+
+If the archive write itself fails, the mutation still proceeds by default and the result carries `"archive_status": "degraded"` — a failed archive must never block a memory-full consolidation. Set `memory.archive_on_failure: abort` to refuse the mutation instead (the file is left untouched). See [Configuration](#configuration) below.
+
 ## Two Targets Explained
 
 ### `memory` — Agent's Personal Notes
@@ -223,7 +236,7 @@ Beyond viewing, the journey is also where you **prune and correct** what Hermes 
 | Command | What it does |
 |---------|--------------|
 | `hermes journey list` | List node ids — skill names and `memory:<source>:<index>` ids for memory chunks. |
-| `hermes journey delete <node> [-y]` | Delete a node. Skills are **archived** (restorable), memory chunks are removed. `-y` skips the confirmation. |
+| `hermes journey delete <node> [-y]` | Delete a node. Skills are **archived** (restorable). Memory chunks are also archived to `ARCHIVE.jsonl` before removal (MEMORY.md by default; USER.md only when `memory.archive_user` is set). `-y` skips the confirmation. |
 | `hermes journey edit <node>` | Open the node's content (a skill's `SKILL.md` or the memory chunk) in `$EDITOR`. |
 
 The same `list` / `delete <id>` / `edit <id>` subcommands work from the in-chat `/journey` command on the CLI, and the desktop panel offers edit/delete on nodes directly.
@@ -238,6 +251,8 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # false = write freely (default) | true = require approval
+  archive_user: false       # true = also archive USER.md evictions (default: MEMORY.md only)
+  archive_on_failure: warn  # warn (default, mutation proceeds) | abort (mutation refused)
 ```
 
 Setting **both** `memory_enabled` and `user_profile_enabled` to `false` turns the

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -81,7 +81,9 @@ If the substring matches multiple entries, an error is returned asking for a mor
 
 ### Reversible Mutations (Eviction Archive)
 
-`replace` and `remove` (single or inside `apply_batch`) never destroy an entry outright: the evicted content is appended to `~/.hermes/memories/ARCHIVE.jsonl` **before** the main file rewrite, so consolidation can never lose distilled content irreversibly. Each line is a JSON record — `id`, `ts`, `store`, `action` (`"removed"` or `"superseded"`), and the evicted `entry` text.
+`replace` and `remove` (single or inside `apply_batch`) append evicted content to `~/.hermes/memories/ARCHIVE.jsonl` **before** the main file rewrite when archiving is enabled and succeeds. Each line is a JSON record — `id`, `ts`, `store`, `action` (`"removed"` or `"superseded"`), and the evicted `entry` text.
+
+Writers share a per-profile archive lock, including rollback, so one failing process cannot truncate another writer's records. Rollback is best-effort, not a crash-atomic transaction: a crash or failed rollback can leave partial records, and power-loss durability is not guaranteed. Retries reuse IDs, allowing complete duplicate records to be reconciled by `id`.
 
 The tool result carries the archive id and the evicted entry itself (`"archived": [...]`), so the model sees exactly what was captured at the moment of the mutation — no system-prompt addition, prompt cache untouched.
 
@@ -90,7 +92,7 @@ Privacy defaults differ by store:
 - **`memory` (MEMORY.md)** — archived by default.
 - **`user` (USER.md)** — **not** archived by default (`memory.archive_user: false`); set it to `true` to opt in. This is a data-minimization default for profile data, not a correctness gap.
 
-If the archive write itself fails, the mutation still proceeds by default and the result carries `"archive_status": "degraded"` — a failed archive must never block a memory-full consolidation. Set `memory.archive_on_failure: abort` to refuse the mutation instead (the file is left untouched). See [Configuration](#configuration) below.
+If the archive write itself fails, the mutation still proceeds by default and the result carries `"archive_status": "degraded"` — a failed archive must never block a memory-full consolidation. Set `memory.archive_on_failure: abort` to refuse memory-tool mutations instead (the memory file is left untouched; archive rollback remains best-effort). **Exception:** `/journey delete|edit` always proceeds with a warning if archiving fails, even when `abort` is configured. See [Configuration](#configuration) below.
 
 ## Two Targets Explained
 


### PR DESCRIPTION
## What changed and why

`memory_remove`, `memory_replace`, `memory_apply_batch` (and `/journey delete|edit`
on memory nodes) rewrote `MEMORY.md` / `USER.md` with no trace of the evicted
content. Once consolidated away, a distilled fact was simply gone — there was no
archive, no tombstone, and no way to recover it.

Skills already get archive-not-delete semantics via the curator. This closes the
same gap for memory entries.

Evicted entries are now appended to `~/.hermes/memories/ARCHIVE.jsonl` before the
main file rewrite in `MemoryStore._mutate`, so consolidation can never destroy
distilled content irreversibly.

- `MEMORY.md` archives by default.
- `USER.md` archives only when `memory.archive_user` is set (privacy default).
- An archive write failure degrades by default (mutation proceeds,
  `archive_status: degraded`) or aborts when `memory.archive_on_failure: abort`
  (mutation refused, file untouched).
- The whole evicted batch is archived as one atomic write, so an abort can never
  leave part of a call's records archived while the rest are refused.
- The `/journey delete|edit` sibling path, which bypasses
  `MemoryStore.remove()`/`replace()` entirely, gets the same
  archive-before-rewrite treatment, with journey profile nodes mapped to the user
  archive target so they honour the same privacy gate.

## How to test

Reproduce the original loss on `main`:

1. Add two related memory entries, then run a consolidation that merges them
   (`memory_replace` or `memory_apply_batch`).
2. Inspect `MEMORY.md` — the evicted wording is gone, and nothing on disk retains it.

With this branch, step 2 leaves `~/.hermes/memories/ARCHIVE.jsonl` containing the
evicted records with their original text.

Automated coverage added:

- `tests/tools/test_memory_tool.py` — archive-before-rewrite across
  remove/replace/apply_batch, the `USER.md` privacy gate, degrade vs abort on
  archive failure, and batch atomicity.
- `tests/agent/test_learning_mutations.py` — the `/journey delete|edit` path and
  profile-node target mapping.

## Platforms tested

macOS (Apple silicon, Python 3.13). The change is pure file I/O through
`pathlib` / `tempfile` with no platform-specific primitives, so Linux and WSL2
behaviour should be identical, but I have not run the suite there.

## Related

Fixes #76883

Prior art: #77154 attempted this and was closed by its author without merging;
this implementation is independent and additionally covers the `/journey` path,
the privacy gate, and batch atomicity.
