### PR TITLE
feat(desktop): expose the native update overlay to runtime plugins

### DIFF
--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -231,3 +231,21 @@ describe('host workspace scope', () => {
     expect($workspaceNewSessionTarget.get()).toEqual({ kind: 'route', route })
   })
 })
+
+describe('host.updates', () => {
+  afterEach(async () => {
+    const { setUpdateOverlayOpen } = await import('@/store/updates')
+    setUpdateOverlayOpen(false)
+  })
+
+  it('opens the native update overlay on the requested lane', async () => {
+    const { $updateOverlayOpen, $updateOverlayTarget } = await import('@/store/updates')
+
+    host.updates.open()
+    expect($updateOverlayOpen.get()).toBe(true)
+    expect($updateOverlayTarget.get()).toBe('client')
+
+    host.updates.open('backend')
+    expect($updateOverlayTarget.get()).toBe('backend')
+  })
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -99,6 +99,7 @@ import {
   sessionTileDelegate
 } from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
+import { openUpdateOverlayFor, type UpdateTarget } from '@/store/updates'
 import type { PaginatedSessions, UsageStats } from '@/types/hermes'
 
 import { planPluginOpenSession } from './plugin-open-session-plan'
@@ -663,6 +664,17 @@ export const host = {
   /** Navigate the app router (hash routes, e.g. '/command-center?section=system'). */
   navigate: (path: string) => {
     window.location.hash = path.startsWith('#') ? path : `#${path}`
+  },
+
+  /** Open the app's own update overlay — the guarded apply flow (blocker
+   *  checks, pre-update backup, detached close-and-update handoff). This is a
+   *  LAUNCHER, not an updater: a plugin must never run `hermes update` itself.
+   *  A running Windows client cannot swap its own files, so the overlay's
+   *  handoff script owns that lifecycle and the app quits mid-update by
+   *  design. 'client' = this desktop app; 'backend' = the connected backend
+   *  (remote connections). */
+  updates: {
+    open: (target: UpdateTarget = 'client'): void => openUpdateOverlayFor(target)
   },
 
   /** Pre-dial a profile's gateway socket in the background — pool-only, no


### PR DESCRIPTION
## What

Adds a narrow `host.updates.open(target)` door to the desktop plugin SDK (`apps/desktop/src/sdk/index.ts`), letting runtime plugins launch the app's own **UpdatesOverlay** (`openUpdateOverlayFor`, the same entry the status-bar version pills use). 12 lines, one file.

## Why

Runtime plugins loaded through the on-disk door (`<hermes home>/desktop-plugins/<name>/plugin.js`) currently have **no sanctioned way to reach the guarded self-update flow**:

- the SDK does not export the updates store or overlay,
- `ctx.rest` is namespace-scoped to `/api/plugins/<id>`,
- `host.request('cli.exec')` *can* run `hermes update`, but doing so from a plugin races the running app — on Windows the client cannot swap its own files, which is exactly why the detached handoff script (`scripts/desktop-update/windows.ps1`) exists.

Concrete consumer: a drift/status plugin that surfaces "N commits behind" in the title bar. Its natural next step is a button that takes the user to the updater — today it can only render text.

## Design

This is a **launcher, not an updater**. The plugin-facing door only opens the native overlay; blocker checks, pre-update backup, the close-and-update handoff, and result receipts all stay with the existing flow. Per the contribution rubric, this widens the *generic plugin surface* rather than special-casing anything in core, and the consumer (a real, running disk plugin) already exists.

`target` is `'client' | 'backend'` (default `'client'`), matching `UpdateTarget` — remote-connection plugins can open the backend lane.

## Test plan

- `npm run typecheck` clean (renderer, electron, e2e tsconfigs) on the consuming checkout.
- The consuming disk plugin's node test harness asserts the door is invoked with `'client'` and that the plugin stays read-only when the door is absent (older desktop builds).
- No behavior change for the app itself: the overlay, its store, and both update lanes are untouched.