### PR TITLE
fix(desktop): preserve active SSH sibling backends

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -367,6 +367,7 @@ import { ensureLoginShellPath } from './shell-path'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
+import { createSshSpawnBatchCoordinator } from './ssh-spawn-batch'
 import { createStreamThrottle } from './stream-throttle'
 import { registerTerminalIpc } from './terminal-ipc'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
@@ -10343,6 +10344,7 @@ function clearManagedSshRecovery(connectionId, correlationId) {
 }
 
 const sshBootstrapCoordinator = createBootstrapCoordinator()
+const sshSpawnBatches = createSshSpawnBatchCoordinator()
 
 let sshQuitTeardownDone = false
 let sshQuitTeardownPromise: Promise<void> | null = null
@@ -10379,10 +10381,12 @@ async function teardownSshConnection(profile) {
   const state = sshConnections.get(scope)
 
   if (!state) {
+    sshSpawnBatches.release(scope)
     return
   }
 
   sshConnections.delete(scope)
+  sshSpawnBatches.release(scope)
 
   terminalIpc.disposeTerminalSessionsForSshScope(scope)
 
@@ -10590,12 +10594,22 @@ async function bootstrapSshConnection(
   const resolvedConfig = { ...sshConfig, effectiveConfigFingerprint }
   const fingerprint = sshConfigFingerprint(scope, resolvedConfig)
 
-  return sshBootstrapCoordinator.start(
-    scope,
-    fingerprint,
-    lease => bootstrapSshConnectionInner(profile, resolvedConfig, reuseToken, source, metadata, fingerprint, lease),
-    metadata
-  )
+  return sshBootstrapCoordinator
+    .start(
+      scope,
+      fingerprint,
+      lease => bootstrapSshConnectionInner(profile, resolvedConfig, reuseToken, source, metadata, fingerprint, lease),
+      metadata
+    )
+    .catch(error => {
+      // A failed pre-publication bootstrap has no live connection entry to
+      // own this batch. Do not let its opaque batch ID leak into a later dial.
+      if (!sshConnections.has(scope)) {
+        sshSpawnBatches.release(scope)
+      }
+
+      throw error
+    })
 }
 
 // Tear down a bootstrap result whose publication lost the managed-update
@@ -10648,6 +10662,7 @@ async function rollbackSshBootstrapResult(ssh, result, profile, sshConfig, bound
 
   if (sshConnections.get(scope)?.ssh === ssh) {
     sshConnections.delete(scope)
+    sshSpawnBatches.release(scope)
   }
 
   if (cleanupErrors.length > 0) {
@@ -10682,8 +10697,10 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
 
     ssh = null
     sshConnections.delete(scope)
+    sshSpawnBatches.release(scope)
   }
 
+  const reusingPublishedBatch = sshConnections.get(scope)?.fingerprint === fingerprint
   const created = !ssh
 
   let removeForceCleanup = () => {}
@@ -10702,6 +10719,11 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     await ssh.open({ signal: lease.signal })
   }
 
+  const registryConnectionId = String(
+    metadata.registryConnectionId ||
+      (typeof source === 'string' && source.startsWith('registry:') ? source.slice('registry:'.length) : '')
+  ).trim()
+  const sshSpawnBatchId = sshSpawnBatches.acquire(scope, registryConnectionId)
   let result: any
 
   try {
@@ -10717,6 +10739,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
       profile: resolveRemoteSshDashboardProfile(sshConfig.remoteProfile, profile),
       remoteHermesPath: sshConfig.remoteHermesPath || '',
       ownershipId: sshOwnershipKey(profile),
+      sshSpawnBatchId: sshSpawnBatchId || '',
       reuseToken: reuseToken || '',
       forward: (localPort, remotePort) => ssh.forward(localPort, remotePort),
       cancelForward: (localPort, remotePort) => ssh.cancelForward(localPort, remotePort),
@@ -10754,6 +10777,14 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     err.sshError = error.kind || 'unknown'
     err.isSshBootstrap = true
     throw err
+  }
+
+  // A server discovered from a prior Desktop process cannot know this newly
+  // minted batch ID. Keep batch membership only when this Electron process was
+  // already managing the exact published scope; otherwise a later sibling
+  // spawn must form its own coherent server batch.
+  if (result.reused && !reusingPublishedBatch) {
+    sshSpawnBatches.release(scope)
   }
 
   try {
@@ -12242,6 +12273,7 @@ async function drainManagedSshScope(scope) {
 
       if (state && sshConnections.get(scope.key) === state) {
         sshConnections.delete(scope.key)
+        sshSpawnBatches.release(scope.key)
       }
     }
   }

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -43,6 +43,7 @@ import {
 
 const OWNERSHIP_ID = '0123456789abcdef0123456789abcdef'
 const SPAWN_NONCE = '0123456789abcdef'
+const SPAWN_BATCH_ID = 'fedcba9876543210fedcba9876543210'
 const exec = promisify(execCallback)
 
 test('SSH reuse proof rejects a backend whose runtime was replaced', () => {
@@ -908,6 +909,30 @@ test('spawnRemoteDashboard always spawns serve (legacy dashboard path removed)',
   const spawn = ssh.calls.find(c => /setsid|nohup/.test(c))
   assert.match(spawn, /serve --isolated/)
   assert.doesNotMatch(spawn, /\bdashboard\b/)
+})
+
+test('spawnRemoteDashboard carries one validated Desktop connection batch into the server command', async () => {
+  const ssh = fakeSsh([
+    [/grep -q ssh-session-token-file/, 'YES\n'],
+    [/python3 -c/, ''],
+    [/printf '%s\\n'/, ''],
+    [/setsid|nohup/, '4242\n']
+  ])
+
+  await spawnRemoteDashboard(ssh, {
+    hermesPath: '/x/hermes',
+    profile: '',
+    token: 'tk',
+    ownershipId: OWNERSHIP_ID,
+    spawnBatchId: SPAWN_BATCH_ID
+  })
+
+  const spawn = ssh.calls.find(c => /setsid|nohup/.test(c)) || ''
+  assert.match(spawn, new RegExp(`--ssh-spawn-batch-id ${SPAWN_BATCH_ID}`))
+  assert.throws(
+    () => buildSpawnCommand('/x/hermes', '', { logPath: '/tmp/hermes.log', spawnBatchId: 'unsafe' }),
+    /SSH spawn batch ID is invalid/
+  )
 })
 
 test('READY_RE accepts both serve and dashboard sentinels', () => {
@@ -1805,6 +1830,9 @@ test('remote SSH ownership capability requires both secure bootstrap flags', asy
   assert.equal(await remoteSupportsSshOwnership(supported, '/x/hermes'), true)
   assert.match(helpProbe, /ssh-session-token-file/)
   assert.match(helpProbe, /ssh-owner-nonce/)
+
+  assert.equal(await remoteSupportsSshOwnership(supported, '/x/hermes', true), true)
+  assert.match(helpProbe, /ssh-spawn-batch-id/)
 
   const unsupported = fakeSsh([[/serve --help/, 'NO\n']])
   assert.equal(await remoteSupportsSshOwnership(unsupported, '/x/hermes'), false)

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -90,6 +90,16 @@ function validateSpawnNonce(spawnNonce) {
   return value
 }
 
+function validateSpawnBatchId(spawnBatchId) {
+  const value = String(spawnBatchId || '')
+
+  if (!/^[0-9a-f]{32}$/.test(value)) {
+    throw new Error('SSH spawn batch ID is invalid.')
+  }
+
+  return value
+}
+
 function ownershipDirectory(ownershipId) {
   return `${REMOTE_LOCK_DIR}/${validateOwnershipId(ownershipId)}`
 }
@@ -1045,7 +1055,8 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   const tokenFilePath = opts.tokenFilePath
   const tokenArg = tokenFilePath ? ` --ssh-session-token-file ${expandRemotePath(tokenFilePath)}` : ''
   const ownerArg = opts.spawnNonce ? ` --ssh-owner-nonce ${validateSpawnNonce(opts.spawnNonce)}` : ''
-  const subCmd = `serve --isolated --host 127.0.0.1 --port 0${tokenArg}${ownerArg}`
+  const batchArg = opts.spawnBatchId ? ` --ssh-spawn-batch-id ${validateSpawnBatchId(opts.spawnBatchId)}` : ''
+  const subCmd = `serve --isolated --host 127.0.0.1 --port 0${tokenArg}${ownerArg}${batchArg}`
   const marker = expandRemotePath(`${remoteInstallRoot(opts.hermesHome || '~/.hermes')}/.hermes-update-in-progress`)
 
   const updateMutex = expandRemotePath(
@@ -1120,13 +1131,14 @@ function buildSpawnCommand(hermesPath, profile, opts: any = {}) {
   )
 }
 
-async function remoteSupportsSshOwnership(ssh, hermesPath) {
+async function remoteSupportsSshOwnership(ssh, hermesPath, needsSpawnBatch = false) {
   const hermes = expandRemotePath(hermesPath)
+  const batchCapability = needsSpawnBatch ? ` && printf '%s' "$help" | grep -q ssh-spawn-batch-id` : ''
 
   const out = await ssh.exec(
     `help="$(${hermes} serve --help 2>&1)"; ` +
       `printf '%s' "$help" | grep -q ssh-session-token-file && ` +
-      `printf '%s' "$help" | grep -q ssh-owner-nonce && echo YES || echo NO`
+      `printf '%s' "$help" | grep -q ssh-owner-nonce${batchCapability} && echo YES || echo NO`
   )
 
   return String(out || '')
@@ -1171,12 +1183,26 @@ async function scrapeReadyPort(ssh, logPath, { timeoutMs = DEFAULT_READY_TIMEOUT
 
 async function spawnRemoteDashboard(
   ssh,
-  { hermesPath, profile, token, ownershipId, hermesHome = '~/.hermes', assertInstallClear = async () => {} }
+  {
+    hermesPath,
+    profile,
+    token,
+    ownershipId,
+    spawnBatchId = '',
+    hermesHome = '~/.hermes',
+    assertInstallClear = async () => {}
+  }
 ) {
-  if (!(await remoteSupportsSshOwnership(ssh, hermesPath))) {
+  const requiresSpawnBatch = Boolean(spawnBatchId)
+
+  if (requiresSpawnBatch) {
+    validateSpawnBatchId(spawnBatchId)
+  }
+
+  if (!(await remoteSupportsSshOwnership(ssh, hermesPath, requiresSpawnBatch))) {
     const err: any = new Error(
-      'The remote Hermes install does not support --ssh-session-token-file and --ssh-owner-nonce. ' +
-        'Update Hermes on the remote host to continue using Desktop SSH mode.'
+      'The remote Hermes install does not support the required Desktop SSH ownership flags. ' +
+      'Update Hermes on the remote host to continue using Desktop SSH mode.'
     )
 
     err.kind = 'update-required'
@@ -1239,6 +1265,7 @@ async function spawnRemoteDashboard(
       buildSpawnCommand(hermesPath, profile, {
         spawnNonce,
         tokenFilePath,
+        spawnBatchId,
         logPath,
         hermesHome,
         ownershipId,
@@ -1390,6 +1417,7 @@ async function connect(deps) {
     adoptServedToken,
     rememberLog = () => {},
     readyTimeoutMs = DEFAULT_READY_TIMEOUT_MS,
+    sshSpawnBatchId = '',
     signal
   } = deps
 
@@ -1542,6 +1570,7 @@ async function connect(deps) {
     profile,
     token: spawnToken,
     ownershipId,
+    spawnBatchId: sshSpawnBatchId,
     hermesHome,
     assertInstallClear: () => assertRemoteInstallUpdateClear(ssh, hermesHome)
   })

--- a/apps/desktop/electron/ssh-spawn-batch.test.ts
+++ b/apps/desktop/electron/ssh-spawn-batch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSshSpawnBatchCoordinator } from './ssh-spawn-batch'
+
+const FIRST_BATCH = 'a'.repeat(32)
+const SECOND_BATCH = 'b'.repeat(32)
+
+describe('SSH spawn batch coordinator', () => {
+  it('shares one opaque batch identity only between scopes of the same registry connection', () => {
+    const ids = [FIRST_BATCH, SECOND_BATCH]
+    const batches = createSshSpawnBatchCoordinator({ createId: () => ids.shift()! })
+
+    const primary = batches.acquire('', 'connection-one')
+    const sibling = batches.acquire('registry:one:writer', 'connection-one')
+    const otherConnection = batches.acquire('registry:two:default', 'connection-two')
+
+    expect(primary).toBe(FIRST_BATCH)
+    expect(sibling).toBe(FIRST_BATCH)
+    expect(otherConnection).toBe(SECOND_BATCH)
+  })
+
+  it('retires the batch identity only after its final scoped backend is released', () => {
+    const ids = [FIRST_BATCH, SECOND_BATCH]
+    const batches = createSshSpawnBatchCoordinator({ createId: () => ids.shift()! })
+
+    batches.acquire('registry:one:default', 'connection-one')
+    batches.acquire('registry:one:writer', 'connection-one')
+    batches.release('registry:one:default')
+
+    expect(batches.acquire('registry:one:reader', 'connection-one')).toBe(FIRST_BATCH)
+
+    batches.release('registry:one:writer')
+    batches.release('registry:one:reader')
+
+    expect(batches.acquire('registry:one:next', 'connection-one')).toBe(SECOND_BATCH)
+  })
+
+  it('does not create a batch for legacy SSH routes without a registry identity', () => {
+    const batches = createSshSpawnBatchCoordinator({ createId: () => FIRST_BATCH })
+
+    expect(batches.acquire('legacy:default', '')).toBeNull()
+    expect(batches.acquire('legacy:writer', undefined)).toBeNull()
+  })
+})

--- a/apps/desktop/electron/ssh-spawn-batch.ts
+++ b/apps/desktop/electron/ssh-spawn-batch.ts
@@ -1,0 +1,96 @@
+import crypto from 'node:crypto'
+
+const BATCH_ID_RE = /^[0-9a-f]{32}$/
+const MAX_SCOPE_PART_LENGTH = 256
+
+function normalizeScope(value) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim()
+
+  // connectionScopeKey() intentionally represents the registry primary with
+  // an empty string. It is still a real scoped backend that must join its
+  // profile siblings, not an absent identity.
+  return normalized.length <= MAX_SCOPE_PART_LENGTH ? normalized : null
+}
+
+function normalizeConnectionId(value) {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+
+  return normalized && normalized.length <= MAX_SCOPE_PART_LENGTH ? normalized : null
+}
+
+function mintSpawnBatchId() {
+  return crypto.randomBytes(16).toString('hex')
+}
+
+function createSshSpawnBatchCoordinator({ createId = mintSpawnBatchId } = {}) {
+  const batchesByConnection = new Map<string, { id: string; scopes: Set<string> }>()
+  const connectionByScope = new Map<string, string>()
+
+  function release(scope) {
+    const normalizedScope = normalizeScope(scope)
+
+    if (normalizedScope === null) {
+      return
+    }
+
+    const connectionId = connectionByScope.get(normalizedScope)
+
+    if (!connectionId) {
+      return
+    }
+
+    connectionByScope.delete(normalizedScope)
+    const batch = batchesByConnection.get(connectionId)
+
+    if (!batch) {
+      return
+    }
+
+    batch.scopes.delete(normalizedScope)
+
+    if (batch.scopes.size === 0) {
+      batchesByConnection.delete(connectionId)
+    }
+  }
+
+  function acquire(scope, connectionId) {
+    const normalizedScope = normalizeScope(scope)
+    const normalizedConnectionId = normalizeConnectionId(connectionId)
+
+    if (normalizedScope === null || normalizedConnectionId === null) {
+      release(normalizedScope)
+
+      return null
+    }
+
+    if (connectionByScope.get(normalizedScope) !== normalizedConnectionId) {
+      release(normalizedScope)
+    }
+
+    let batch = batchesByConnection.get(normalizedConnectionId)
+
+    if (!batch) {
+      const id = String(createId())
+
+      if (!BATCH_ID_RE.test(id)) {
+        throw new Error('SSH spawn-batch generator returned an invalid ID.')
+      }
+
+      batch = { id, scopes: new Set() }
+      batchesByConnection.set(normalizedConnectionId, batch)
+    }
+
+    batch.scopes.add(normalizedScope)
+    connectionByScope.set(normalizedScope, normalizedConnectionId)
+
+    return batch.id
+  }
+
+  return { acquire, release }
+}
+
+export { createSshSpawnBatchCoordinator, mintSpawnBatchId }

--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -20,6 +20,7 @@ import {
 } from './windows-remote-lifecycle'
 
 const ownershipId = '0123456789abcdef0123456789abcdef'
+const spawnBatchId = 'fedcba9876543210fedcba9876543210'
 
 test('Windows spawn holds the update mutex across marker check and helper spawn', () => {
   const command = atomicWindowsSpawnCommand({
@@ -64,6 +65,74 @@ test('Windows spawn publishes the initial ownership record before releasing the 
 function sshWith(exec) {
   return { exec }
 }
+
+test('Windows remote spawn carries the registry-owned batch ID to the server helper', async () => {
+  const spawnPayloads: string[] = []
+  const runtime = {
+    os: 'Windows',
+    arch: 'AMD64',
+    hermesHome: 'C:\\Users\\alice\\.hermes',
+    hermesPath: 'C:\\Hermes\\hermes.exe',
+    python: 'C:\\Hermes\\python.exe'
+  }
+  const ssh = sshWith(async (command, options: any = {}) => {
+    const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+
+    if (script.includes('Get-Command hermes.exe')) {
+      return JSON.stringify(runtime)
+    }
+    if (script.includes("windows_ssh_runtime' 'spawn'")) {
+      spawnPayloads.push(options.stdinData)
+      return JSON.stringify({ pid: 41, creationTimeNs: '1784219690452757504' })
+    }
+    if (script.includes('.hermes-update-in-progress')) {
+      return 'CLEAR'
+    }
+    if (script.includes("'inspect'")) {
+      return JSON.stringify({
+        supported: true,
+        supportsSpawnBatch: true,
+        path: runtime.hermesPath,
+        version: 'Hermes Agent test'
+      })
+    }
+    if (script.includes("'upload-token'")) {
+      return JSON.stringify({ path: 'C:\\runtime\\token' })
+    }
+    if (script.includes("'remove-token'")) {
+      return JSON.stringify({ removed: true })
+    }
+    if (script.includes("'read-lock'")) {
+      return 'null'
+    }
+    if (script.includes("'write-lock'")) {
+      return JSON.stringify({ ok: true })
+    }
+    if (script.includes("'process-state'")) {
+      return JSON.stringify({ alive: true, owned: true, indeterminate: false })
+    }
+    if (script.includes("'read-log'")) {
+      return JSON.stringify({ content: 'HERMES_BACKEND_READY port=43000\n' })
+    }
+
+    throw new Error(`unexpected remote command: ${script}`)
+  })
+
+  const result = await connectWindowsRemote({
+    ssh,
+    ownershipId,
+    sshSpawnBatchId: spawnBatchId,
+    pickLocalPort: async () => 51000,
+    forward: async () => {},
+    cancelForward: async () => {},
+    waitForHermes: async () => {},
+    probeReuseProof: async () => 'authenticated-ok'
+  })
+
+  assert.equal(result.reused, false)
+  assert.equal(spawnPayloads.length, 1)
+  assert.equal(JSON.parse(spawnPayloads[0]).spawnBatchId, spawnBatchId)
+})
 
 test('PowerShell transport uses UTF-16LE encoded commands and literal escaping', () => {
   assert.equal(Buffer.from(encodedPowerShell("'ok'"), 'base64').toString('utf16le'), "'ok'")

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -7,6 +7,16 @@ const PROTOCOL_VERSION = 1
 const READY_RE = /^HERMES_(?:BACKEND|DASHBOARD)_READY port=(\d+)/gm
 const READY_POLL_INTERVAL_MS = 750
 
+function validateSpawnBatchId(value) {
+  const batchId = String(value || '')
+
+  if (!/^[0-9a-f]{32}$/.test(batchId)) {
+    throw new Error('SSH spawn batch ID is invalid.')
+  }
+
+  return batchId
+}
+
 function psLiteral(value) {
   return `'${String(value).replace(/'/g, "''")}'`
 }
@@ -559,7 +569,8 @@ async function connectWindowsRemote(deps) {
     waitForHermes,
     probeReuseProof,
     rememberLog = () => {},
-    readyTimeoutMs = 45_000
+    readyTimeoutMs = 45_000,
+    sshSpawnBatchId = ''
   } = deps
 
   assertBootstrapNotSuperseded(signal)
@@ -567,7 +578,13 @@ async function connectWindowsRemote(deps) {
   await assertWindowsRemoteInstallUpdateClear(ssh, runtime.hermesHome)
   const inspection = await helper(ssh, runtime, 'inspect', [runtime.hermesPath])
 
-  if (!inspection.supported) {
+  const requiresSpawnBatch = Boolean(sshSpawnBatchId)
+
+  if (requiresSpawnBatch) {
+    validateSpawnBatchId(sshSpawnBatchId)
+  }
+
+  if (!inspection.supported || (requiresSpawnBatch && !inspection.supportsSpawnBatch)) {
     const error: any = new Error('Update Hermes on the remote Windows host before connecting with Desktop SSH.')
     error.kind = 'update-required'
     throw error
@@ -654,7 +671,13 @@ async function connectWindowsRemote(deps) {
     spawned = await atomicWindowsSpawn(
       ssh,
       runtime,
-      JSON.stringify({ ownershipId, spawnNonce, profile, hermesPath: runtime.hermesPath }),
+      JSON.stringify({
+        ownershipId,
+        spawnNonce,
+        profile,
+        hermesPath: runtime.hermesPath,
+        ...(requiresSpawnBatch ? { spawnBatchId: sshSpawnBatchId } : {})
+      }),
       {
         ownershipId,
         spawnNonce,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2388,7 +2388,7 @@ def _dashboard_lifecycle_flags(args, token_file) -> None:
 
 
 def _dashboard_validate_serve_args(args, headless_backend, token_file):
-    """Headless-serve argument checks -> ssh_owner_nonce (or None)."""
+    """Headless-serve argument checks -> (SSH owner nonce, spawn batch ID)."""
     # `hermes serve` is headless/non-interactive: fail closed on a corrupt
     # config.yaml instead of silently starting on defaults where provider
     # auto-detection can adopt unnamed .env credentials (issue #81952).
@@ -2407,11 +2407,16 @@ def _dashboard_validate_serve_args(args, headless_backend, token_file):
             print(f"Error: {exc}", file=sys.stderr)
             raise SystemExit(2) from exc
     ssh_owner_nonce = getattr(args, "ssh_owner_nonce", None)
+    ssh_spawn_batch_id = getattr(args, "ssh_spawn_batch_id", None)
     if ssh_owner_nonce and not re.fullmatch(r"[0-9a-f]{16}", ssh_owner_nonce):
         raise SystemExit("--ssh-owner-nonce must be 16 lowercase hex characters")
+    if ssh_spawn_batch_id and not re.fullmatch(r"[0-9a-f]{32}", ssh_spawn_batch_id):
+        raise SystemExit("--ssh-spawn-batch-id must be 32 lowercase hex characters")
+    if ssh_spawn_batch_id and not (token_file and ssh_owner_nonce):
+        raise SystemExit("--ssh-spawn-batch-id requires --ssh-session-token-file and --ssh-owner-nonce")
     if token_file and not headless_backend:
         raise SystemExit("--ssh-session-token-file is only valid with hermes serve")
-    return ssh_owner_nonce
+    return ssh_owner_nonce, ssh_spawn_batch_id
 
 
 def _dashboard_sanitize_desktop_env(headless_backend) -> None:
@@ -2530,10 +2535,14 @@ def cmd_dashboard(args):
     # ready sentinel. Resolved once and threaded through the re-exec, the
     # build gate, and start_server.
     _headless_backend = getattr(args, "headless_backend", False)
-    _ssh_owner_nonce = _dashboard_validate_serve_args(args, _headless_backend, _token_file)
+    _ssh_owner_nonce, _ssh_spawn_batch_id = _dashboard_validate_serve_args(
+        args, _headless_backend, _token_file
+    )
     _dashboard_sanitize_desktop_env(_headless_backend)
 
-    _route_named_profile_dashboard(args, _headless_backend, _ssh_owner_nonce, _token_file)
+    _route_named_profile_dashboard(
+        args, _headless_backend, _ssh_owner_nonce, _ssh_spawn_batch_id, _token_file
+    )
 
     # Apply the final process/profile policy after dashboard routing, but before
     # importing the web server or opening dashboard state. Applying it before a
@@ -2567,6 +2576,7 @@ def cmd_dashboard(args):
         headless=_headless_backend,
         ssh_session_token=_ssh_session_token,
         ssh_owner_nonce=_ssh_owner_nonce,
+        ssh_spawn_batch_id=_ssh_spawn_batch_id,
         start_mcp_discovery_after_bind=_mcp_discovery_after_bind,
     )
 

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -633,7 +633,12 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
 
 
 def _route_named_profile_dashboard(
-    args, _headless_backend: bool, _ssh_owner_nonce: str, _token_file: str) -> None:
+    args,
+    _headless_backend: bool,
+    _ssh_owner_nonce: str,
+    _ssh_spawn_batch_id: str,
+    _token_file: str,
+) -> None:
     """Route a named-profile launch to the single MACHINE dashboard (per-request ``?profile=`` scoping
     makes one server per profile pure fragmentation).
 
@@ -681,6 +686,7 @@ def _route_named_profile_dashboard(
         "--open-profile", _launch_profile]
     for enabled, extra in (
         (_ssh_owner_nonce, ["--ssh-owner-nonce", _ssh_owner_nonce]),
+        (_ssh_spawn_batch_id, ["--ssh-spawn-batch-id", _ssh_spawn_batch_id]),
         (_token_file, ["--ssh-session-token-file", _token_file]),
         (args.no_open, ["--no-open"]),
         (getattr(args, "insecure", False), ["--insecure"]),

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -56,6 +56,9 @@ def _configure_serve_parser(parser, *, cmd_dashboard: Callable) -> None:
     parser.add_argument(
         "--ssh-owner-nonce", dest="ssh_owner_nonce", metavar="NONCE", default=None,
         help="Identify a Desktop-owned SSH backend process")
+    parser.add_argument(
+        "--ssh-spawn-batch-id", dest="ssh_spawn_batch_id", metavar="BATCH_ID", default=None,
+        help="Group Desktop SSH isolated backends spawned for one connection")
     parser.set_defaults(func=cmd_dashboard, no_open=True, headless_backend=True, command="serve")
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1192,6 +1192,8 @@ def _on_server_started(
     open_browser: bool,
     initial_profile: str,
     start_mcp_discovery_after_bind: bool,
+    ssh_owner_nonce: Optional[str] = None,
+    ssh_spawn_batch_id: Optional[str] = None,
 ) -> None:
     """Post-bind arming on the serving loop right after ``server.startup()``.
 
@@ -1229,7 +1231,17 @@ def _on_server_started(
             grace = float((load_config().get("dashboard") or {}).get("ssh_isolated_idle_grace_s", DEFAULT_IDLE_GRACE_S))
         except (TypeError, ValueError):
             grace = DEFAULT_IDLE_GRACE_S
-        start_idle_watchdog(server, app.state.ssh_isolated_clients, grace_s=grace)
+        batch_lease = None
+        if ssh_spawn_batch_id:
+            from hermes_cli.web_server_ssh_batch import SshSpawnBatchLease
+
+            batch_lease = SshSpawnBatchLease(ssh_spawn_batch_id, ssh_owner_nonce or "")
+        start_idle_watchdog(
+            server,
+            app.state.ssh_isolated_clients,
+            grace_s=grace,
+            batch_lease=batch_lease,
+        )
 
     actual_port = _read_bound_port(server, fallback=port)
     app.state.bound_port = actual_port
@@ -1358,6 +1370,7 @@ def start_server(
     headless: bool = False,
     ssh_session_token: Optional[str] = None,
     ssh_owner_nonce: Optional[str] = None,
+    ssh_spawn_batch_id: Optional[str] = None,
     start_mcp_discovery_after_bind: bool = False,
 ):
     """Start the web UI server.
@@ -1365,14 +1378,20 @@ def start_server(
     ``initial_profile`` is appended to the auto-opened URL as ``?profile=<name>``
     (profile alias ``<profile> dashboard``). ``headless`` is the ``serve`` path:
     JSON-RPC/WS backend, no UI build, no SPA mount (``HERMES_SERVE_HEADLESS``).
-    ``ssh_session_token``/``ssh_owner_nonce`` are process-local Desktop SSH
-    bootstrap state, never persisted or exported to children.
+    ``ssh_session_token``/``ssh_owner_nonce``/``ssh_spawn_batch_id`` are
+    process-local Desktop SSH bootstrap state, never persisted or exported to
+    children.  The batch ID permits server-owned sibling liveness only when
+    accompanied by the credential-bound token and owner nonce.
     ``start_mcp_discovery_after_bind`` (Desktop ``serve``) defers MCP discovery
     until the ready sentinel is written so its SDK import can't hold the GIL
     against the pre-bind path.
     """
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
+    if ssh_spawn_batch_id and not (ssh_session_token and ssh_owner_nonce):
+        raise ValueError(
+            "ssh_spawn_batch_id requires ssh_session_token and ssh_owner_nonce"
+        )
 
     # Dashboard-mode starts don't route through main.py's `serve` path, which
     # applies the same RLIMIT_NOFILE floor (policy in resource_limits, #81547).
@@ -1434,6 +1453,8 @@ def start_server(
                 open_browser=open_browser,
                 initial_profile=initial_profile,
                 start_mcp_discovery_after_bind=start_mcp_discovery_after_bind,
+                ssh_owner_nonce=ssh_owner_nonce,
+                ssh_spawn_batch_id=ssh_spawn_batch_id,
             )
 
             await server.main_loop()

--- a/hermes_cli/web_server_idle_exit.py
+++ b/hermes_cli/web_server_idle_exit.py
@@ -111,27 +111,83 @@ def turn_in_flight() -> Optional[bool]:
         return None
 
 
-def should_exit_idle(tracker: IdleClientTracker, grace_s: float,
-                     probe: Callable[[], Optional[bool]] = turn_in_flight) -> bool:
+def should_exit_idle(
+    tracker: IdleClientTracker,
+    grace_s: float,
+    probe: Callable[[], Optional[bool]] = turn_in_flight,
+    peer_probe: Callable[[], Optional[bool]] = lambda: False,
+) -> bool:
     """Exit only when no client has been connected for ``grace_s`` AND no turn is provably running.
-    A probe that cannot answer keeps the process (fail closed)."""
-    return tracker.idle_for() >= grace_s and probe() is False  # idle_for() is 0 while a client is connected
+    An indeterminate local or sibling probe keeps the process (fail closed)."""
+    return (
+        tracker.idle_for() >= grace_s  # idle_for() is 0 while a client is connected
+        and probe() is False
+        and peer_probe() is False
+    )
 
 
-def start_idle_watchdog(server, tracker: IdleClientTracker, *, grace_s: float = DEFAULT_IDLE_GRACE_S,
-                        poll_s: float = 15.0, probe: Callable[[], Optional[bool]] = turn_in_flight) -> threading.Thread:
+def _batch_peer_state(batch_lease, tracker: IdleClientTracker, turn_state: Optional[bool], ttl_s: float) -> Optional[bool]:
+    """Publish this backend's server-owned state and then read a sibling.
+
+    The protocol cannot prove peer liveness if its private runtime directory is
+    unavailable or malformed.  Return ``None`` in that case so the caller
+    defers idle exit instead of retiring a potentially live sibling.
+    """
+    try:
+        # A connected dashboard or an unknown/running turn means this backend
+        # is still useful to the Desktop connection even if it is otherwise
+        # past its own idle grace window.
+        active = tracker.live_count() > 0 or turn_state is not False
+        if not batch_lease.publish(active=active):
+            return None
+        return batch_lease.has_active_peer(ttl_s=ttl_s)
+    except Exception:
+        _log.warning("SSH spawn-batch liveness probe unavailable; idle exit will fail closed", exc_info=True)
+        return None
+
+
+def start_idle_watchdog(
+    server,
+    tracker: IdleClientTracker,
+    *,
+    grace_s: float = DEFAULT_IDLE_GRACE_S,
+    poll_s: float = 15.0,
+    probe: Callable[[], Optional[bool]] = turn_in_flight,
+    batch_lease=None,
+) -> threading.Thread:
     """Daemon thread that sets ``server.should_exit`` once :func:`should_exit_idle` holds."""
 
     poll_s = min(poll_s, max(0.5, grace_s / 4))
+    batch_ttl_s = max(5.0, poll_s * 3)
 
     def _loop() -> None:
-        while not getattr(server, "should_exit", False):
-            if should_exit_idle(tracker, grace_s, probe):
-                _log.warning("SSH-isolated backend idle for %.0fs with no client and no running turn; exiting.",
-                             tracker.idle_for())
-                server.should_exit = True
-                return
-            time.sleep(poll_s)
+        try:
+            while not getattr(server, "should_exit", False):
+                turn_state = probe()
+                peer_state = (
+                    _batch_peer_state(batch_lease, tracker, turn_state, batch_ttl_s)
+                    if batch_lease is not None
+                    else False
+                )
+                if should_exit_idle(
+                    tracker,
+                    grace_s,
+                    probe=lambda: turn_state,
+                    peer_probe=lambda: peer_state,
+                ):
+                    _log.warning(
+                        "SSH-isolated backend idle for %.0fs with no client, no running turn, and no active sibling; exiting.",
+                        tracker.idle_for(),
+                    )
+                    server.should_exit = True
+                    return
+                time.sleep(poll_s)
+        finally:
+            if batch_lease is not None:
+                try:
+                    batch_lease.close()
+                except Exception:
+                    _log.warning("SSH spawn-batch lease cleanup failed", exc_info=True)
 
     thread = threading.Thread(target=_loop, daemon=True, name="ssh-isolated-idle-watchdog")
     thread.start()

--- a/hermes_cli/web_server_ssh_batch.py
+++ b/hermes_cli/web_server_ssh_batch.py
@@ -1,0 +1,218 @@
+"""Server-owned liveness leases for one Desktop SSH spawn batch.
+
+A Desktop SSH connection can publish several detached ``serve --isolated``
+backends.  Each backend owns its WebSocket/turn state, but sibling backends
+must not self-retire while one of them is actively serving the same Desktop
+connection.  This module communicates only that bounded server-side fact; it
+never treats a client artifact or a process environment variable as liveness.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+import stat
+import tempfile
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+_log = logging.getLogger(__name__)
+
+_BATCH_ID_RE = re.compile(r"[0-9a-f]{32}\Z")
+_MEMBER_NONCE_RE = re.compile(r"[0-9a-f]{16}\Z")
+_MAX_BATCH_MEMBERS = 64
+
+
+def _default_runtime_root() -> Path:
+    if os.name == "nt":
+        # The one-shot token reader uses the machine-rooted, DACL-protected
+        # Windows runtime directory rather than profile-relative ~/.hermes.
+        from hermes_cli.windows_ssh_runtime import _root
+
+        return _root()
+    return Path.home() / ".hermes" / "desktop-ssh"
+
+
+class SshSpawnBatchLease:
+    """Atomic, expiring liveness record for one isolated server process.
+
+    Leases live below the same per-user ``desktop-ssh`` runtime root that
+    carries the one-shot bootstrap token.  Each member writes only its own
+    nonce-named record, so sibling writers do not need a shared lock.  A stale
+    record is ignored rather than deleted: a process may be paused or killed at
+    any point, and this process has no authority to remove another member's
+    record.
+    """
+
+    def __init__(
+        self,
+        batch_id: str,
+        owner_nonce: str,
+        *,
+        root: Optional[Path] = None,
+        now: Callable[[], float] = time.time,
+    ) -> None:
+        if not _BATCH_ID_RE.fullmatch(str(batch_id)):
+            raise ValueError("SSH spawn batch ID must be 32 lowercase hex characters")
+        if not _MEMBER_NONCE_RE.fullmatch(str(owner_nonce)):
+            raise ValueError("SSH spawn member nonce must be 16 lowercase hex characters")
+
+        self._batch_id = batch_id
+        self._owner_nonce = owner_nonce
+        self._root = root or _default_runtime_root()
+        # An injected root is a deterministic unit-test seam. Production uses
+        # the native runtime root, where every component gets the Windows
+        # no-reparse-point/DACL validation below.
+        self._secure_windows_runtime = root is None
+        self._now = now
+        self._failure_logged = False
+
+    @property
+    def _lease_name(self) -> str:
+        return f"{self._owner_nonce}.json"
+
+    def _check_directory(self, directory: Path, *, create: bool) -> None:
+        if os.name == "nt" and self._secure_windows_runtime:
+            if not create and not directory.exists():
+                raise OSError("SSH batch runtime root is not accessible")
+            # Reuse the native runtime's no-reparse-point + protected-DACL
+            # checks instead of trusting Path operations on a Windows remote.
+            from hermes_cli.windows_ssh_runtime import _ensure_directory
+
+            _ensure_directory(directory)
+            return
+        if create:
+            directory.mkdir(mode=0o700, exist_ok=True)
+
+        entry = directory.lstat()
+        if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+            raise OSError("SSH batch runtime path is not a real directory")
+
+        if os.name != "nt":
+            if entry.st_uid != os.getuid():
+                raise OSError("SSH batch runtime path has the wrong owner")
+            if create and (entry.st_mode & 0o077):
+                os.chmod(directory, 0o700)
+
+    def _batch_directory(self) -> Path:
+        # The token-file parser already required this root to exist and belong
+        # to the current account.  Do not create a new root from a server flag.
+        self._check_directory(self._root, create=False)
+        batches = self._root / "batches"
+        self._check_directory(batches, create=True)
+        batch = batches / self._batch_id
+        self._check_directory(batch, create=True)
+        return batch
+
+    def _log_failure_once(self) -> None:
+        if not self._failure_logged:
+            self._failure_logged = True
+            _log.warning("SSH spawn-batch lease unavailable; idle exit will fail closed", exc_info=True)
+
+    def publish(self, *, active: bool) -> bool:
+        """Publish this process's current liveness without exposing credentials."""
+        try:
+            batch = self._batch_directory()
+            payload = json.dumps(
+                {"active": bool(active), "updated_at": self._now()},
+                separators=(",", ":"),
+            ).encode("utf-8")
+            descriptor, temporary = tempfile.mkstemp(
+                dir=batch,
+                prefix=f".{self._owner_nonce}.",
+                suffix=".tmp",
+            )
+            try:
+                with os.fdopen(descriptor, "wb") as stream:
+                    descriptor = -1
+                    stream.write(payload)
+                    stream.flush()
+                    os.fsync(stream.fileno())
+                if os.name != "nt":
+                    os.chmod(temporary, 0o600)
+                os.replace(temporary, batch / self._lease_name)
+            finally:
+                if descriptor >= 0:
+                    os.close(descriptor)
+                try:
+                    os.unlink(temporary)
+                except FileNotFoundError:
+                    pass
+            return True
+        except OSError:
+            self._log_failure_once()
+            return False
+
+    def _read_peer(self, path: Path, now: float, ttl_s: float) -> Optional[bool]:
+        try:
+            descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        except OSError:
+            return None
+
+        try:
+            entry = os.fstat(descriptor)
+            if not stat.S_ISREG(entry.st_mode):
+                return None
+            if os.name != "nt" and (entry.st_uid != os.getuid() or entry.st_mode & 0o077):
+                return None
+            with os.fdopen(descriptor, "r", encoding="utf-8") as stream:
+                descriptor = -1
+                payload = json.load(stream)
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            return None
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+
+        if not isinstance(payload, dict) or not isinstance(payload.get("active"), bool):
+            return None
+        updated_at = payload.get("updated_at")
+        if not isinstance(updated_at, (int, float)) or not math.isfinite(updated_at):
+            return None
+        if updated_at > now + ttl_s:
+            return None
+        if updated_at < now - ttl_s:
+            return False
+        return payload["active"]
+
+    def has_active_peer(self, *, ttl_s: float) -> Optional[bool]:
+        """Return peer activity, or ``None`` when the shared state is unsafe.
+
+        ``None`` is deliberately distinct from ``False``: callers fail closed
+        rather than retiring when they cannot prove that every fresh sibling is
+        inactive.
+        """
+        if not math.isfinite(ttl_s) or ttl_s <= 0:
+            raise ValueError("SSH spawn-batch lease TTL must be positive")
+
+        try:
+            batch = self._batch_directory()
+            names = [path for path in batch.iterdir() if _MEMBER_NONCE_RE.fullmatch(path.stem) and path.suffix == ".json"]
+        except OSError:
+            self._log_failure_once()
+            return None
+
+        if len(names) > _MAX_BATCH_MEMBERS:
+            return None
+
+        now = self._now()
+        for path in names:
+            if path.name == self._lease_name:
+                continue
+            active = self._read_peer(path, now, ttl_s)
+            if active is None:
+                return None
+            if active:
+                return True
+        return False
+
+    def close(self) -> None:
+        """Remove only this member's record during graceful server shutdown."""
+        try:
+            (self._batch_directory() / self._lease_name).unlink(missing_ok=True)
+        except OSError:
+            self._log_failure_once()

--- a/hermes_cli/windows_ssh_runtime.py
+++ b/hermes_cli/windows_ssh_runtime.py
@@ -48,6 +48,10 @@ def _nonce(value: str) -> str:
     return _check(_HEX16, value, "invalid spawn nonce")
 
 
+def _spawn_batch_id(value: str) -> str:
+    return _check(_HEX32, value, "invalid SSH spawn batch ID")
+
+
 def _root() -> Path:
     # The helper uploads the token before the child applies `--profile`; read_token() runs after
     # profile activation. Anchor both to the machine root so a named profile (or custom
@@ -374,6 +378,9 @@ def _resolve_direct_interpreter(python_entry: str) -> tuple[str, list[str]]:
 def spawn_backend(payload: dict[str, Any]) -> dict[str, Any]:
     ownership_id = _ownership(str(payload["ownershipId"]))
     spawn_nonce = _nonce(str(payload["spawnNonce"]))
+    spawn_batch_id = str(payload.get("spawnBatchId") or "")
+    if spawn_batch_id:
+        spawn_batch_id = _spawn_batch_id(spawn_batch_id)
     configured_path = str(payload["hermesPath"])
     if not os.path.isabs(configured_path):
         raise ValueError("Hermes path must be absolute")
@@ -398,6 +405,8 @@ def spawn_backend(payload: dict[str, Any]) -> dict[str, Any]:
         args.extend(["--profile", profile])
     args.extend(["serve", "--isolated", "--host", "127.0.0.1", "--port", "0",
                  "--ssh-session-token-file", token_path, "--ssh-owner-nonce", spawn_nonce])
+    if spawn_batch_id:
+        args.extend(["--ssh-spawn-batch-id", spawn_batch_id])
     env = dict(os.environ)
     env["VIRTUAL_ENV"] = os.path.dirname(venv_dir)
     env.pop("PYTHONPATH", None)
@@ -428,7 +437,8 @@ def inspect_hermes(hermes_path: str) -> dict[str, Any]:
     return {
         "path": path,
         "version": (version.stdout + version.stderr).splitlines()[0] if version.returncode == 0 else "",
-        "supported": "--ssh-session-token-file" in help_text and "--ssh-owner-nonce" in help_text}
+        "supported": "--ssh-session-token-file" in help_text and "--ssh-owner-nonce" in help_text,
+        "supportsSpawnBatch": "--ssh-spawn-batch-id" in help_text}
 
 
 def _probe(*_: str) -> dict[str, Any]:

--- a/tests/hermes_cli/test_ssh_session_token_parser.py
+++ b/tests/hermes_cli/test_ssh_session_token_parser.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from hermes_constants import set_hermes_home_override, reset_hermes_home_override
 
-from hermes_cli.main import cmd_dashboard
+from hermes_cli.main import _dashboard_validate_serve_args, cmd_dashboard
 from hermes_cli.main_dashboard import _read_ssh_session_token_file
 from hermes_cli.subcommands.dashboard import build_dashboard_parser
 
@@ -27,6 +27,25 @@ def test_serve_help_advertises_secure_ssh_bootstrap_flags(capsys):
     output = capsys.readouterr().out
     assert "--ssh-session-token-file PATH" in output
     assert "--ssh-owner-nonce NONCE" in output
+    assert "--ssh-spawn-batch-id BATCH_ID" in output
+
+
+def test_serve_parser_accepts_the_desktop_ssh_spawn_batch_identity():
+    args = dashboard_parser().parse_args([
+        "serve",
+        "--ssh-session-token-file", "/runtime/token",
+        "--ssh-owner-nonce", "a" * 16,
+        "--ssh-spawn-batch-id", "b" * 32,
+    ])
+
+    assert args.ssh_spawn_batch_id == "b" * 32
+
+
+def test_spawn_batch_identity_requires_the_credential_bound_ssh_flags():
+    args = dashboard_parser().parse_args(["serve", "--ssh-spawn-batch-id", "b" * 32])
+
+    with pytest.raises(SystemExit, match="requires --ssh-session-token-file and --ssh-owner-nonce"):
+        _dashboard_validate_serve_args(args, False, None)
 
 
 

--- a/tests/hermes_cli/test_ssh_spawn_batch.py
+++ b/tests/hermes_cli/test_ssh_spawn_batch.py
@@ -1,0 +1,66 @@
+import json
+
+import pytest
+
+from hermes_cli.web_server_ssh_batch import SshSpawnBatchLease
+
+
+BATCH_ID = "a" * 32
+FIRST_MEMBER = "b" * 16
+SECOND_MEMBER = "c" * 16
+
+
+def test_fresh_active_sibling_blocks_idle_exit_until_it_becomes_inactive(tmp_path):
+    clock = {"now": 1_000.0}
+    first = SshSpawnBatchLease(BATCH_ID, FIRST_MEMBER, root=tmp_path, now=lambda: clock["now"])
+    second = SshSpawnBatchLease(BATCH_ID, SECOND_MEMBER, root=tmp_path, now=lambda: clock["now"])
+
+    assert first.publish(active=True) is True
+    assert second.publish(active=False) is True
+    assert second.has_active_peer(ttl_s=30.0) is True
+
+    clock["now"] += 1
+    assert first.publish(active=False) is True
+    assert second.has_active_peer(ttl_s=30.0) is False
+
+
+def test_stale_sibling_lease_does_not_keep_an_idle_batch_alive(tmp_path):
+    clock = {"now": 1_000.0}
+    first = SshSpawnBatchLease(BATCH_ID, FIRST_MEMBER, root=tmp_path, now=lambda: clock["now"])
+    second = SshSpawnBatchLease(BATCH_ID, SECOND_MEMBER, root=tmp_path, now=lambda: clock["now"])
+
+    assert first.publish(active=True) is True
+    clock["now"] += 31.0
+
+    assert second.has_active_peer(ttl_s=30.0) is False
+
+
+def test_unreadable_peer_record_fails_closed_instead_of_retiring_a_live_sibling(tmp_path):
+    clock = {"now": 1_000.0}
+    second = SshSpawnBatchLease(BATCH_ID, SECOND_MEMBER, root=tmp_path, now=lambda: clock["now"])
+
+    assert second.publish(active=False) is True
+    peer_path = tmp_path / "batches" / BATCH_ID / f"{FIRST_MEMBER}.json"
+    peer_path.write_text(json.dumps({"active": "not-a-bool", "updated_at": clock["now"]}))
+
+    assert second.has_active_peer(ttl_s=30.0) is None
+
+
+def test_closing_a_member_removes_its_lease_without_touching_a_sibling(tmp_path):
+    clock = {"now": 1_000.0}
+    first = SshSpawnBatchLease(BATCH_ID, FIRST_MEMBER, root=tmp_path, now=lambda: clock["now"])
+    second = SshSpawnBatchLease(BATCH_ID, SECOND_MEMBER, root=tmp_path, now=lambda: clock["now"])
+
+    assert first.publish(active=True) is True
+    assert second.publish(active=True) is True
+    first.close()
+
+    assert not (tmp_path / "batches" / BATCH_ID / f"{FIRST_MEMBER}.json").exists()
+    assert (tmp_path / "batches" / BATCH_ID / f"{SECOND_MEMBER}.json").exists()
+    assert second.has_active_peer(ttl_s=30.0) is False
+
+
+@pytest.mark.parametrize("batch_id, owner_nonce", [("bad", FIRST_MEMBER), (BATCH_ID, "bad")])
+def test_batch_identifiers_are_strictly_validated(tmp_path, batch_id, owner_nonce):
+    with pytest.raises(ValueError):
+        SshSpawnBatchLease(batch_id, owner_nonce, root=tmp_path)

--- a/tests/hermes_cli/test_web_server_idle_exit.py
+++ b/tests/hermes_cli/test_web_server_idle_exit.py
@@ -49,6 +49,12 @@ def test_exit_only_after_grace_with_no_client_and_no_running_turn():
     assert should_exit_idle(tracker, grace, probe=lambda: False) is True
     assert should_exit_idle(tracker, grace, probe=lambda: True) is False   # turn running
     assert should_exit_idle(tracker, grace, probe=lambda: None) is False   # indeterminate: fail closed
+    assert should_exit_idle(
+        tracker, grace, probe=lambda: False, peer_probe=lambda: True
+    ) is False  # an active sibling owns the same Desktop SSH spawn batch
+    assert should_exit_idle(
+        tracker, grace, probe=lambda: False, peer_probe=lambda: None
+    ) is False  # unreadable sibling state is indeterminate: fail closed
     tracker.on_open()
     clock["t"] = 5000.0
     assert should_exit_idle(tracker, grace, probe=lambda: False) is False  # a client is connected
@@ -56,6 +62,46 @@ def test_exit_only_after_grace_with_no_client_and_no_running_turn():
     assert should_exit_idle(tracker, grace, probe=lambda: False) is False  # grace restarts on close
     clock["t"] = 5000.0 + grace + 1
     assert should_exit_idle(tracker, grace, probe=lambda: False) is True
+
+
+def test_watchdog_publishes_server_liveness_and_closes_its_batch_lease():
+    class _Server:
+        should_exit = False
+
+    class _Lease:
+        def __init__(self):
+            self.published = []
+            self.closed = False
+
+        def publish(self, *, active):
+            self.published.append(active)
+            return True
+
+        def has_active_peer(self, *, ttl_s):
+            assert ttl_s > 0
+            return False
+
+        def close(self):
+            self.closed = True
+
+    clock = {"t": 0.0}
+    tracker = IdleClientTracker(now=lambda: clock["t"])
+    clock["t"] = 2.0
+    server = _Server()
+    lease = _Lease()
+
+    start_idle_watchdog(
+        server,
+        tracker,
+        grace_s=1.0,
+        poll_s=0.01,
+        probe=lambda: False,
+        batch_lease=lease,
+    ).join(timeout=5)
+
+    assert server.should_exit is True
+    assert lease.published == [False]
+    assert lease.closed is True
 
 
 def test_watchdog_sets_should_exit_and_only_arms_for_ssh_isolated_backends(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #106935.

Desktop SSH launches one isolated `hermes serve` process per registry connection/profile scope. The idle-exit mechanism from #101626 previously evaluated each server independently. When one sibling had no WebSocket and no running turn, it exited even while another sibling from the same Desktop connection remained active. The desktop then treated the resulting backend retirement as a connection-wide outage and restarted the group, interrupting live turns.

This change introduces a server-owned SSH spawn-batch liveness protocol:

- Desktop creates an opaque 128-bit batch ID per live registry SSH connection, never for legacy/unidentified routes.
- Every newly spawned sibling receives the ID through `--ssh-spawn-batch-id`; POSIX and Windows launch paths require remote support before using it.
- `hermes serve` validates the batch ID only when paired with the existing token-file and owner-nonce trust boundary.
- Each isolated server publishes its own atomic, expiring lease below the protected `desktop-ssh` runtime root. It exits only when its own WebSocket/turn state and every readable fresh sibling lease are inactive.
- Malformed, inaccessible, future-dated, or otherwise indeterminate sibling state fails closed, preserving the server rather than retiring a potentially live sibling.
- Scope teardown, dead-master cleanup, rollback, and managed-update drain release local batch membership so stale Electron process state cannot join a later spawn batch.

## Root cause

The original idle watchdog had only local process knowledge:

```text
no WebSocket client && no local running turn => exit
```

That was insufficient for Desktop's one-connection/many-isolated-server topology. No stable, server-visible relation existed between siblings, so a valid idle exit for one server was indistinguishable from a connection-wide backend failure to the app.

The fix preserves the original single-server idle behavior for legacy and old-client routes. It adds only bounded, explicitly scoped coordination for newly spawned registry SSH siblings.

## Security and failure behavior

- Batch IDs are strict 32-character lowercase hexadecimal values generated with Node cryptographic randomness.
- Member nonces remain the existing strict 16-character owner nonces.
- Lease records use nonce-derived filenames, owner-only runtime directories, atomic replace, regular-file checks, and TTL expiry.
- The Windows path uses the existing protected-DACL/no-reparse-point runtime directory guard.
- The protocol does not use environment variables as a surface or liveness gate, does not persist secrets, and does not infer process identity from command substrings.
- A lease read/write failure blocks idle exit instead of manufacturing liveness or terminating a sibling.

## Validation

Passed locally:

- `scripts/run_tests.sh tests/hermes_cli/test_ssh_spawn_batch.py tests/hermes_cli/test_web_server_idle_exit.py`
  - 10 tests passed.
- `scripts/run_tests.sh tests/hermes_cli/test_ssh_session_token_parser.py -k 'serve_parser or spawn_batch_identity'`
  - selected parser/validation tests passed.
- `npm --workspace apps/desktop run typecheck`
  - passed.
- Earlier focused Electron lifecycle coverage exercised the POSIX lifecycle, Windows lifecycle, batch coordinator, and existing SSH keepalive behavior. A newly added Windows test fixture initially had matching-order/type errors; those were fixed before publication. Per requester direction, no additional test rounds were run after that correction.

Known baseline-only failure, reproduced on `origin/main` before this change:

- `tests/hermes_cli/test_ssh_session_token_parser.py::test_token_file_rejects_parent_escape` fails on this Windows host because the runtime reports `--ssh-session-token-file must be under the desktop-ssh directory` while the historical assertion expects `invalid runtime path`. This change does not modify that code path.

## Scope

Only Desktop SSH spawn/ownership propagation and the SSH-isolated server idle-exit behavior are changed. No connection routing, generic backend pooling, local backend lifecycle, or user-facing configuration behavior is broadened.