### PR TITLE
fix(agent): derive agent_context from platform so provider skip logic is live (#80646)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1202,11 +1202,16 @@ def _apply_display_config(agent, _agent_cfg, platform):
 def _memory_provider_init_kwargs(agent, platform) -> Dict[str, Any]:
     """Scoping kwargs for ``MemoryManager.initialize_all`` (status_callback is CLI-only:
     gateway status travels a different path and the indicator no-ops without it)."""
+    # agent_context feeds the provider skip-writes contract (MemoryProvider.initialize:
+    # "primary" | "subagent" | "cron" | "flush"). The scheduler passes platform="cron" and
+    # delegate_task children platform="subagent", so deriving from platform keeps the
+    # contract live; anything else (cli, gateway platforms, batch, empty) is primary.
+    _platform = platform or "cli"
     kwargs = {
         "session_id": agent.session_id,
-        "platform": platform or "cli",
+        "platform": _platform,
         "hermes_home": str(get_hermes_home()),
-        "agent_context": "primary",
+        "agent_context": _platform if _platform in ("cron", "subagent", "flush") else "primary",
     }
     if kwargs["platform"] == "cli":
         kwargs["warning_callback"] = agent._emit_warning

--- a/tests/agent/test_memory_agent_context.py
+++ b/tests/agent/test_memory_agent_context.py
@@ -1,0 +1,114 @@
+"""Regression tests for issue #80646: agent_context derivation.
+
+The memory-provider contract (agent/memory_provider.py) documents ``agent_context``
+as "primary" | "subagent" | "cron" | "flush" with skip-writes semantics for
+non-primary contexts, but ``_memory_provider_init_kwargs`` hardcoded "primary" for
+every session — leaving every provider's context-skip logic (supermemory's
+``_write_enabled``, honcho's cron/flush skip, external providers' ``skip_contexts``)
+dead. Cron runs since ef04d846e9 (skip_memory=False) wrote their turns into stores
+operators had configured to skip them.
+
+These tests pin the contract through the REAL production function so a future
+re-hardcode fails loudly.
+"""
+
+from types import SimpleNamespace
+
+from agent.agent_init import _memory_provider_init_kwargs
+
+
+def _fake_agent():
+    """Minimum attribute surface _memory_provider_init_kwargs reads."""
+    return SimpleNamespace(
+        session_id="sess-80646",
+        _session_db=None,
+        _emit_warning=None,
+        _emit_status=None,
+        **{
+            f"_{name}": None
+            for name in (
+                "user_id",
+                "user_id_alt",
+                "user_name",
+                "chat_id",
+                "chat_name",
+                "chat_type",
+                "thread_id",
+                "gateway_session_key",
+            )
+        },
+    )
+
+
+class TestAgentContextDerivation:
+    def test_cron_platform_yields_cron_context(self):
+        """Scheduler passes platform='cron' (cron/scheduler.py) — providers must
+        receive agent_context='cron' so skip-configured stores stop capturing
+        cron turns (the reported production symptom)."""
+        kwargs = _memory_provider_init_kwargs(_fake_agent(), "cron")
+        assert kwargs["agent_context"] == "cron"
+        assert kwargs["platform"] == "cron"
+
+    def test_subagent_platform_yields_subagent_context(self):
+        """delegate_task children pass platform='subagent' (tools/delegate_tool.py)
+        — providers must receive agent_context='subagent' (supermemory branches on it)."""
+        kwargs = _memory_provider_init_kwargs(_fake_agent(), "subagent")
+        assert kwargs["agent_context"] == "subagent"
+        assert kwargs["platform"] == "subagent"
+
+    def test_primary_platforms_stay_primary(self):
+        """Interactive surfaces (cli + gateway platforms + batch) are primary
+        contexts: memory writes must keep flowing exactly as before."""
+        for platform in ("cli", "telegram", "discord", "slack", "batch"):
+            kwargs = _memory_provider_init_kwargs(_fake_agent(), platform)
+            assert kwargs["agent_context"] == "primary", platform
+            assert kwargs["platform"] == platform
+
+    def test_none_and_empty_platform_fall_back_to_primary(self):
+        """platform=None / '' must never crash nor misclassify: they normalize to
+        cli (as kwargs['platform'] already does) and stay a primary context."""
+        for platform in (None, ""):
+            kwargs = _memory_provider_init_kwargs(_fake_agent(), platform)
+            assert kwargs["agent_context"] == "primary", repr(platform)
+            assert kwargs["platform"] == "cli", repr(platform)
+
+    def test_derivation_reaches_initialize_all(self):
+        """End-to-end through MemoryManager.initialize_all: a recording provider
+        initialized with the cron-scoping kwargs actually observes
+        agent_context='cron' — proving the plumbing providers rely on."""
+        from agent.memory_manager import MemoryManager
+        from tests.agent.test_memory_user_id import RecordingProvider
+
+        mgr = MemoryManager()
+        provider = RecordingProvider()
+        mgr.add_provider(provider)
+        mgr.initialize_all(**_memory_provider_init_kwargs(_fake_agent(), "cron"))
+        assert provider._init_kwargs.get("agent_context") == "cron"
+
+
+class TestSupermemorySkipContract:
+    """The bundled provider whose skip logic was dead: initialize() must disable
+    writes for cron contexts once agent_context is live. Uses an empty hermes_home
+    (config defaults, no API key) so no network or env dependency."""
+
+    def test_cron_context_disables_supermemory_writes(self, tmp_path):
+        from plugins.memory.supermemory import SupermemoryMemoryProvider
+
+        provider = SupermemoryMemoryProvider()
+        provider.initialize(
+            session_id="sess-cron",
+            hermes_home=str(tmp_path),
+            agent_context="cron",
+        )
+        assert provider._write_enabled is False
+
+    def test_primary_context_keeps_supermemory_writes(self, tmp_path):
+        from plugins.memory.supermemory import SupermemoryMemoryProvider
+
+        provider = SupermemoryMemoryProvider()
+        provider.initialize(
+            session_id="sess-primary",
+            hermes_home=str(tmp_path),
+            agent_context="primary",
+        )
+        assert provider._write_enabled is True


### PR DESCRIPTION
## What

The memory-provider contract documents `agent_context` as `"primary" | "subagent" | "cron" | "flush"` with skip-writes semantics (`agent/memory_provider.py`), but `_memory_provider_init_kwargs` hardcoded `"primary"` for every session — so every provider's context-skip logic was dead code:

- `supermemory`'s `_write_enabled` gate (`agent_context not in {"cron","flush","subagent"}`) never fired
- `honcho`'s cron/flush skip only worked via its `or platform == "cron"` fallback
- external providers' `skip_contexts` options had no effect

Since ef04d846e9 cron agents run with `skip_memory=False`, scheduled jobs were writing their turns into memory stores operators had configured to skip them — a silent data-governance gap (production report: 124 cron-preamble rows in a mnemosyne store configured to skip cron).

## Fix

Derive `agent_context` from the `platform` the scheduler (`platform="cron"`) and `delegate_task` (`platform="subagent"`) already pass; every other surface (cli, gateway platforms, batch, empty/None) stays `"primary"`. Minimal 3-line production change in `agent/agent_init.py`.

## Verification

- 7 new regression tests in `tests/agent/test_memory_agent_context.py`, pinning the contract through the **real** production function (`_memory_provider_init_kwargs`), the real `MemoryManager.initialize_all` plumbing, and the real bundled supermemory provider (cron disables writes, primary keeps them)
- 3 tests RED on baseline `f6ddd89692` (hardcode still present) → all 7 GREEN with the fix
- Nearby suites post-rebase onto `f97a4102dd`: 94 passed (agent memory suites incl. `test_memory_user_id`, `test_memory_provider`, `test_memory_provider_init`) + 37 passed (supermemory + honcho provider suites)
- Branch is exactly one commit ahead of current `upstream/main`

## Competing PRs

- #80691 (open 34 days): same one-line derivation idea, but zero tests and `mergeable: UNKNOWN`. This PR supersedes it with contract tests and a proven fail-without-fix.
- #105171: a +898/-28 superset PR also carrying this change amid much larger scope (provider certification, provenance stamps, docs). This PR is the minimal root-cause subset, per the project's minimal-diff preference.

Closes #80646.

Auto-published by Moonsong via Path B automated pipeline.
