### PR TITLE
fix(image-routing): config-declared supports_vision beats aux de-facto rule + capability-first toggle

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -5,7 +5,9 @@
 non-vision models). :func:`decide_image_input_mode` picks once per turn from
 ``agent.image_input_mode`` (``auto`` | ``native`` | ``text``): in ``auto`` an
 explicit ``auxiliary.vision`` backend forces ``text`` even for vision-capable
-main models (``native`` is the absolute override); else ``supports_vision``
+main models (``native`` is the absolute override) — EXCEPT when the model's
+vision capability is explicitly declared in config (``supports_vision: true``
+on the model entry), which always routes native; else ``supports_vision``
 (config override or catalog) decides. ``vision_analyze`` stays a tool regardless.
 """
 
@@ -254,7 +256,9 @@ def _coerce_mode(raw: Any) -> str:
 def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
     """True when the user configured a specific ``auxiliary.vision`` backend — the
     de-facto image route in ``auto`` mode even when the main model has native vision.
-    ``auto``/empty provider with no model and no base_url is not explicit."""
+    Exception: a per-model ``supports_vision: true`` declaration in config beats
+    this rule (see :func:`decide_image_input_mode`). ``auto``/empty provider with
+    no model and no base_url is not explicit."""
     vision = _dict_or_empty(_dict_or_empty(_dict_or_empty(cfg).get("auxiliary")).get("vision"))
     return bool(vision) and not (
         _clean_str(vision.get("provider")).lower() in {"", "auto"}
@@ -360,11 +364,63 @@ def decide_image_input_mode(
     requested_provider: str = "",
 ) -> str:
     """Return ``"native"`` or ``"text"`` for the given turn (``cfg`` None behaves as
-    auto; ``requested_provider`` is the identity before runtime canonicalization)."""
+    auto; ``requested_provider`` is the identity before runtime canonicalization).
+
+    Precedence in ``auto`` mode (highest first):
+
+    1. ``agent.image_input_mode`` ``native``/``text`` — explicit mode override.
+    2. ``agent.vision_capability_first: true`` — capability-first preference:
+       ANY model with resolvable vision capability attaches natively and a
+       configured ``auxiliary.vision`` backend falls back to its documented
+       role (text-only mains). The WebUI Settings toggle writes this key.
+    3. A per-model ``supports_vision: true`` **declared in config** (``model.``,
+       ``providers.<p>.models.<m>``, or legacy ``custom_providers[].models.<m>``)
+       — the user explicitly told Hermes this model takes images; #97339's
+       aux-de-facto rule applies to catalog/discovered capability, not to a
+       direct user declaration that contradicts it.
+    4. An explicitly configured ``auxiliary.vision`` backend — de-facto image
+       route per #97339 for everything not covered by (2)/(3).
+    5. Capability lookup (managed runtime → models.dev → Ollama probe).
+    """
     mode_cfg = _coerce_mode(_dict_or_empty(_dict_or_empty(cfg).get("agent")).get("image_input_mode"))
     if mode_cfg != "auto":
         return mode_cfg
+    agent_cfg = _dict_or_empty(_dict_or_empty(cfg).get("agent"))
+    capability_first = agent_cfg.get("vision_capability_first") is True
+    if capability_first:
+        # Keep the three-argument call contract for callers/tests that replace the lookup hook.
+        extra = {"requested_provider": requested_provider} if requested_provider else {}
+        verdict = _lookup_supports_vision(provider, model, cfg, **extra)
+        if verdict is True:
+            logger.info(
+                "Image routing: native — vision_capability_first is on and model %s "
+                "advertises vision (auxiliary.vision stays available for text-only models)",
+                model,
+            )
+            return "native"
+        if verdict is False:
+            logger.info("Image routing: text — model %s does not advertise vision", model)
+            return "text"
+        # verdict None (unknown capability): fall through to the aux check below
+        # so a configured auxiliary.vision backend still decides for unknown
+        # models (the declaration check is already covered — it is step one of
+        # _lookup_supports_vision, so None implies no declaration exists).
+    if (
+        _supports_vision_override(cfg, provider, model, requested_provider=requested_provider) is True
+    ):  # user-declared capability beats the #97339 aux-de-facto rule
+        logger.info(
+            "Image routing: native — model %s has an explicit supports_vision "
+            "declaration in config (overrides auxiliary.vision de-facto routing)",
+            model,
+        )
+        return "native"
     if _explicit_aux_vision_override(cfg):  # auto: an explicit auxiliary.vision backend wins
+        logger.info(
+            "Image routing: text — auxiliary.vision backend is configured; model %s "
+            "demoted from native (de-facto route per #97339; set a per-model "
+            "supports_vision declaration or image_input_mode: native to override)",
+            model,
+        )
         return "text"
     # Keep the three-argument call contract for callers/tests that replace the lookup hook.
     extra = {"requested_provider": requested_provider} if requested_provider else {}

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -238,6 +238,14 @@ DEFAULT_CONFIG = {
         # provider or get a last-chance text fallback); "text" = always pre-analyze with
         # vision_analyze and prepend the description. vision_analyze stays a tool regardless.
         "image_input_mode": "auto",
+        # Capability-first image routing (WebUI Settings toggle writes this). True: in "auto"
+        # mode, ANY model whose vision capability resolves to True attaches images natively —
+        # a configured auxiliary.vision backend keeps its documented fallback role (describing
+        # images for text-only mains) instead of capturing every image. False (default):
+        # an explicitly configured auxiliary.vision backend is the de-facto image route for all
+        # models (#97339). Explicit per-model supports_vision declarations and
+        # image_input_mode overrides win over this either way.
+        "vision_capability_first": False,
         "disabled_toolsets": [],
         # Model name (any reasonable spelling) -> effort level; overrides agent.reasoning_effort
         # when the current model matches. Edit in config.yaml (no CLI support: dots in keys).

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -88,6 +88,83 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "native"
 
+    def test_declared_capability_beats_aux_backend_custom_provider(self):
+        """A per-model ``supports_vision: true`` declared in config is a direct
+        user statement that this model takes images — it beats the #97339
+        aux-de-facto rule. Regression shape: a custom provider serving a
+        non-catalog vision model with supports_vision set (per
+        providers.md, 'single knob') silently demoted to vision_analyze the
+        moment auxiliary.vision was configured (#104743-class)."""
+        cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}},
+               "custom_providers": [{"name": "vllm-cw3e6e",
+                                     "models": {"GLM-5.3-Flash-512K": {"supports_vision": True}}}]}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True) as lk:
+            assert decide_image_input_mode(
+                "custom:vllm-cw3e6e", "GLM-5.3-Flash-512K", cfg,
+                requested_provider="custom:vllm-cw3e6e",
+            ) == "native"
+        lk.assert_not_called()  # declaration resolves without any probe/network
+
+    def test_declared_capability_beats_aux_backend_top_level_model(self):
+        """``model.supports_vision: true`` (top-level form) gets the same
+        precedence as the per-provider form."""
+        cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}},
+               "model": {"supports_vision": True}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("custom:gw", "some-model", cfg) == "native"
+
+    def test_aux_backend_still_wins_without_declaration(self):
+        """#97339 preserved: with NO explicit per-model declaration, a
+        configured auxiliary.vision backend stays the de-facto route even
+        when probes (models.dev) report the model vision-capable."""
+        cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "text"
+
+    def test_declared_false_does_not_beat_aux_backend(self):
+        """``supports_vision: false`` in config must not enable native
+        routing (declaration says text-only); aux backend still wins."""
+        cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}},
+               "custom_providers": [{"name": "gw", "models": {"m1": {"supports_vision": False}}}]}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("custom:gw", "m1", cfg,
+                                           requested_provider="custom:gw") == "text"
+
+    def test_vision_capability_first_native_for_advertised_models(self):
+        """``agent.vision_capability_first: true`` (the WebUI Settings
+        toggle) makes ANY model that advertises vision attach natively —
+        a configured auxiliary.vision backend falls back to its documented
+        role for text-only mains instead of capturing every image."""
+        cfg = {"agent": {"vision_capability_first": True},
+               "auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("openrouter", "zai-org/glm-5.3", cfg) == "native"
+
+    def test_vision_capability_first_text_only_model_still_text(self):
+        """Capability-first helps vision-capable models only; a model that
+        reports no vision still routes through the aux description."""
+        cfg = {"agent": {"vision_capability_first": True},
+               "auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=False):
+            assert decide_image_input_mode("openrouter", "text-only-model", cfg) == "text"
+
+    def test_vision_capability_first_unknown_model_falls_to_aux(self):
+        """Unknown capability under capability-first must not guess native:
+        a configured aux backend keeps deciding (fail-closed), matching the
+        no-toggle default for unknown models."""
+        cfg = {"agent": {"vision_capability_first": True},
+               "auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert decide_image_input_mode("openrouter", "brand-new-slug", cfg) == "text"
+
+    def test_vision_capability_first_off_keeps_aux_defacto(self):
+        """Default (key absent/false) is untouched #97339: aux wins for a
+        catalog-vision model."""
+        for value in (False, None):
+            cfg = {"agent": {"vision_capability_first": value} if value is not None else {},
+                   "auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
+            with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+                assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "text"
 
     def test_none_config_is_auto(self):
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):

--- a/tests/tools/test_computer_use_vision_routing.py
+++ b/tests/tools/test_computer_use_vision_routing.py
@@ -138,6 +138,23 @@ class TestRouteDecision:
                 "custom", "Qwen3.6-35B-A3B-local-vlm", cfg
             ) is False
 
+    def test_user_declared_vision_beats_aux_override(self):
+        """Parity with agent.image_routing: a config-declared
+        ``supports_vision: true`` beats an explicitly configured
+        ``auxiliary.vision`` backend. #97339's de-facto rule governs
+        catalog/discovered capability, not a direct user declaration."""
+        from tools.computer_use import vision_routing
+
+        cfg = {
+            "auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}},
+            "custom_providers": [
+                {"name": "vllm", "models": {"GLM-5.3-Flash-512K": {"supports_vision": True}}}
+            ],
+        }
+        assert vision_routing.should_route_capture_to_aux_vision(
+            "custom:vllm", "GLM-5.3-Flash-512K", cfg
+        ) is False
+
 
     def test_unknown_provider_capabilities_fail_closed(self):
         """When tool-result lookup returns None, route to aux (safe default)."""

--- a/tools/computer_use/vision_routing.py
+++ b/tools/computer_use/vision_routing.py
@@ -83,10 +83,17 @@ def should_route_capture_to_aux_vision(provider: str, model: str, cfg: Optional[
     # native vision (maintainer decision, 2026-08-28, reversing #29135's fallback-only posture: config that
     # only takes effect when the main model gets worse is a trap, not a setting). Native vision remains the
     # default for unconfigured installs, and the fallback when the aux backend is unset.
+    #
+    # Exception (parity with agent.image_routing): a per-model ``supports_vision: true`` DECLARED in config
+    # is a direct user statement that this model takes images, and it beats the aux-de-facto rule — same
+    # precedence the declaration already has on the no-aux path below (``test_user_declared_vision_support_
+    # keeps_custom_provider_native``), so the declaration means one thing regardless of aux config.
+    user_declared = _lookup_user_declared_supports_vision(provider, model, cfg)
+    if user_declared is True:
+        return False
     if _explicit_aux_vision_override(cfg):
         return True
-    user_declared = _lookup_user_declared_supports_vision(provider, model, cfg)
-    if isinstance(user_declared, bool):  # True → multimodal, False → aux
+    if isinstance(user_declared, bool):  # False → aux (declaration says text-only)
         return not user_declared
     if not _provider_accepts_multimodal_tool_result(provider, model):
         return True

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1410,7 +1410,7 @@ The configured `extra_body` follows the provider everywhere: it is merged at age
 
 The `hermes model` → Custom Endpoint wizard now prompts for the API mode explicitly and persists your answer to `config.yaml` (as `transport` on the provider entry). URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 
-**Native vision for custom-provider models.** If your custom endpoint serves a vision-capable model that isn't in models.dev, set `model.supports_vision: true` so Hermes routes attached images natively (as `image_url` parts) instead of pre-processing them through `vision_analyze`. Single knob — no need to also set `agent.image_input_mode: native`.
+**Native vision for custom-provider models.** If your custom endpoint serves a vision-capable model that isn't in models.dev, set `model.supports_vision: true` so Hermes routes attached images natively (as `image_url` parts) instead of pre-processing them through `vision_analyze`. Single knob — no need to also set `agent.image_input_mode: native`. An explicit `supports_vision: true` declaration takes precedence even when an `auxiliary.vision` backend is configured: a direct capability declaration for a specific model is not overridden by side-task routing preferences (catalog-discovered vision capability still defers to a configured `auxiliary.vision` backend).
 
 ```yaml
 model:


### PR DESCRIPTION
# fix(image-routing): config-declared `supports_vision` beats the aux de-facto rule + capability-first toggle

## User story

> I set `supports_vision: true` on my custom-provider model — the docs call it a single knob, "no need to also set `agent.image_input_mode: native`." Then every screenshot I attached silently detoured through the auxiliary vision backend anyway: my vision-capable model got a lossy text description instead of pixels, the aux model billed me for describing images it never needed to describe, and nothing anywhere said why. It took journal forensics to find the cause.

## What happened

#97339 (2026-08-28, "explicit aux vision backend becomes the de-facto route — reverses #29135 (maintainer decision)") made a configured `auxiliary.vision` backend outrank **all** vision capability in `auto` mode. That includes `supports_vision: true` declarations a user wrote in config for a specific model — and `website/docs/integrations/providers.md` **still promises the opposite**:

> set `model.supports_vision: true` so Hermes routes attached images natively … **Single knob — no need to also set `agent.image_input_mode: native`.**

So since #97339, following the docs verbatim for a custom-provider vision model produces exactly the silent detour above. The failure is invisible: the decision point logged nothing.

## What this PR changes

**#97339's default is preserved.** Two surgical changes:

1. **A per-model `supports_vision: true` *declared in config* beats the aux-de-facto rule.**
   Forms: `model.supports_vision`, `providers.<p>.models.<m>.supports_vision`, legacy `custom_providers[].models.<m>.supports_vision`.
   Rationale: #97339's de-facto rule governs *discovered* capability (models.dev / probes — the user never spoke about this model). A config declaration is the user explicitly telling Hermes "this model takes images" — the same statement that already wins on the no-aux path (documented escape hatch; see the existing `test_user_declared_vision_support_keeps_custom_provider_native`). The declaration now means one thing regardless of aux config. The `computer_use` screenshot router gets the same exception for parity (it shares the aux-first rule and the same config-declaration helper).
   Catalog/discovered vision models still defer to a configured aux backend, exactly as #97339 decided.

2. **`agent.vision_capability_first` (default `false`) — the user-facing toggle.**
   In `auto` mode, any model whose capability resolves `True` attaches natively; the aux backend returns to its documented fallback role (describing images for text-only mains). Unknown capability fails closed to the existing decision chain. This is the key the paired WebUI Settings checkbox (next to the Auxiliary Models picker) writes — giving users a discoverable control instead of requiring them to know an undocumented precedence rule exists.

Also:
- **INFO logs at every decision branch** — the silent detour was undiagnosable without journal forensics; now it's one grep in `agent.log`.
- **providers.md updated** to match the restored behavior (explicit declaration wins; catalog capability still defers to aux).

## Explicitly out of scope / unchanged

- No `image_input_mode: native/text` behavior changes (still the absolute override).
- Audio input routing is untouched (separate pipeline, `audio_input_mode`).
- `vision_analyze` remains a tool in every session.

## Siblings check (fix the class)

The aux-first rule existed in exactly two decision functions: `agent/image_routing.py` (user-attached images) and `tools/computer_use/vision_routing.py` (screenshot tool-results). Both patched; both tested. The WebUI has no independent routing logic — it delegates to the canonical router (its own carve-out only fires for *unknown* models, which this PR doesn't touch).

## Test evidence

- **Red → green:** every new invariant was run against the unpatched router (failed as expected) then the patched one (passed):
  - `test_declared_capability_beats_aux_backend_custom_provider` / `_top_level_model` — declaration + aux configured → native, **probe never called** (declaration resolves locally, no network)
  - `test_aux_backend_still_wins_without_declaration` — #97339 preserved (catalog-vision + aux → text)
  - `test_declared_false_does_not_beat_aux_backend` — `supports_vision: false` never enables native
  - `test_vision_capability_first_*` — on → native for advertised models, text-only stays text, unknown fails closed to aux, off → untouched #97339
  - `test_user_declared_vision_beats_aux_override` (computer_use parity)
- **Suites:** `test_image_routing.py` 61/61, `test_computer_use_vision_routing.py` 19/19, `test_vision_aware_preprocessing.py` 18/18, config defaults/validation/loader 134 pass.
- **E2E on a real user config** (custom provider + `supports_vision: true` + `auxiliary.vision` configured, auto mode): routed `native` after the fix; the exact same config routed `text` before (A/B-proven pre-PR).
- 5 failures in `tests/gateway/test_*native_image*` / `test_image_input_routing_runtime.py` are **pre-existing on current `main`** (verified by stashing this diff) and unrelated to routing precedence.

## Verification limits

- Not live-tested against every provider adapter (Anthropic/Gemini/Bedrock passthroughs) — but this change only alters *which* routing decision is made, not any content-part format; the adapters are downstream of the decision.
- The `capability-first` + unknown-catalog-model path falls through to the aux rule by design; a user with an unknown custom model should declare `supports_vision` (documented) — this is stated in the toggle description.

## Paired PR

WebUI toggle (Settings checkbox + `/api/vision-capability-first` GET/POST + behavioral tests): CharlesMcquade/hermes-webui `feat/vision-capability-first-toggle`.
