### PR TITLE
fix(tts): strip a leading visible reasoning label before speech

### DIFF
--- a/tests/tools/test_tts_prepare_spoken.py
+++ b/tests/tools/test_tts_prepare_spoken.py
@@ -12,6 +12,7 @@ import json
 from tools.tts_text_normalize import (
     flatten_newlines_for_payload,
     prepare_spoken_text,
+    strip_leading_reasoning_label,
     strip_nonspoken_blocks,
 )
 
@@ -139,3 +140,55 @@ class TestSharedCleanerWiring:
         spoken = adapter.prepare_tts_text("<think>plan</think>Hello there")
         assert "plan" not in spoken
         assert "Hello there" in spoken
+
+
+class TestLeadingReasoningLabelStrip:
+    """A visible leading ``Reasoning:`` / ``思考：`` label is a UI affordance, not speech (#107044)."""
+
+    def test_english_label_stripped(self):
+        spoken = prepare_spoken_text("Reasoning: This is the visible answer.")
+        assert spoken.startswith("This is the visible answer")
+        assert "Reasoning" not in spoken
+
+    def test_fullwidth_colon_label_stripped(self):
+        spoken = prepare_spoken_text("thinking：请继续。")
+        assert spoken.startswith("请继续")
+        assert "thinking" not in spoken
+
+    def test_chinese_label_stripped(self):
+        spoken = prepare_spoken_text("推理：今天天气晴朗。")
+        assert spoken.startswith("今天天气晴朗")
+        assert "推理" not in spoken
+
+    def test_label_on_its_own_line_stripped(self):
+        # A bare ``Analysis`` heading line followed by content is also a leading label.
+        raw = "Analysis\nThe first step is to gather data."
+        spoken = prepare_spoken_text(raw)
+        assert "Analysis" not in spoken
+        assert "first step" in spoken
+
+    def test_label_with_surrounding_whitespace_stripped(self):
+        spoken = prepare_spoken_text("  Reasoning:  Answer here.")
+        assert spoken.startswith("Answer here")
+        assert "Reasoning" not in spoken
+
+    def test_label_word_in_prose_kept(self):
+        # The same word must remain audible when it is not a leading label.
+        spoken = prepare_spoken_text("The reasoning is clear.")
+        assert "reasoning" in spoken.lower()
+
+    def test_think_block_then_leading_label_stripped(self):
+        # After the tagged block is removed, a leading label must still be stripped.
+        raw = "Reasoning: The plan.\nThe answer is 42."
+        spoken = prepare_spoken_text(raw)
+        assert "Reasoning" not in spoken
+        assert "plan" in spoken and "42" in spoken
+
+    def test_no_label_untouched(self):
+        spoken = prepare_spoken_text("Just a normal reply.")
+        assert "normal reply" in spoken
+
+    def test_direct_function_strips_once(self):
+        assert strip_leading_reasoning_label("Reasoning: x") == "x"
+        assert strip_leading_reasoning_label("The reasoning is clear.") == "The reasoning is clear."
+        assert strip_leading_reasoning_label("") == ""

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -186,6 +186,27 @@ def strip_nonspoken_blocks(text: str) -> str:
     return text
 
 
+# A visible leading section label such as ``Reasoning:`` / ``思考：`` (some reply shapers
+# prepend it as a UI affordance) is not speech. Strip it only when it appears at the very
+# start of the text so the same word stays audible in normal prose. See #107044
+# (complements the tagged-block handling above).
+_LEADING_REASONING_LABEL_RE = re.compile(
+    r"^\s*(?:reasoning|thinking|analysis|推理|思考|分析)\s*[:：\n][ \t\r]*",
+    flags=re.IGNORECASE,
+)
+
+
+def strip_leading_reasoning_label(text: str) -> str:
+    """Remove a leading ``Reasoning:`` / ``思考：`` label that some reply shapers prepend.
+
+    Only a label at the very start of the text is removed; the same word in normal
+    prose (``The reasoning is clear.``) is kept intact.
+    """
+    if not text:
+        return ""
+    return _LEADING_REASONING_LABEL_RE.sub("", text, count=1)
+
+
 def flatten_newlines_for_payload(text: str) -> str:
     """Collapse newlines into sentence breaks for single-line TTS payloads: some OpenAI-compatible
     backends (e.g. Kokoro) truncate at the first newline; smoothing already ends each line with
@@ -206,7 +227,8 @@ def prepare_spoken_text(text: str, max_chars: int | None = 4000) -> str:
     Pipeline: non-spoken blocks > Markdown > symbols/units > line formatting into sentence
     pauses > single line (for newline-sensitive providers), then ``max_chars``."""
     spoken = text
-    for step in (strip_nonspoken_blocks, strip_markdown_for_tts, normalize_symbols_for_tts,
+    for step in (strip_nonspoken_blocks, strip_leading_reasoning_label,
+                 strip_markdown_for_tts, normalize_symbols_for_tts,
                  smooth_whitespace_for_tts, flatten_newlines_for_payload):
         spoken = step(spoken)
     if max_chars is not None and max_chars > 0 and len(spoken) > max_chars:


### PR DESCRIPTION
## Problem

With gateway voice TTS enabled, a reply beginning with a plain section label such as `Reasoning:` or `思考：` is spoken aloud before the response (observed on Telegram). `strip_nonspoken_blocks` only removes tagged `think` blocks (#34213); a **visible leading label** reached the TTS normalizer untouched.

Diagnosed and specified by @Dreamy-MoLing in #107044 (including a verified local patch outline + the exact test cases). This PR implements that approach.

## Fix

Add `strip_leading_reasoning_label` to the `prepare_spoken_text` pipeline (right after the tagged-block strip, before markdown cleanup). It matches `reasoning | thinking | analysis | 推理 | 思考 | 分析` at the **very start** of the text followed by `:` / `：` / a newline, and removes the label **only there** — so the same word stays audible in normal prose (`The reasoning is clear.` is unchanged).

```python
_LEADING_REASONING_LABEL_RE = re.compile(
    r"^\s*(?:reasoning|thinking|analysis|推理|思考|分析)\s*[:：\n][ \t\r]*",
    flags=re.IGNORECASE,
)
```

The step sits in the shared `prepare_spoken_text` path used by gateway auto-TTS, the TTS tool, voice-mode streaming and the web dashboard — so every entry path benefits.

## Tests

9 new cases in `tests/tools/test_tts_prepare_spoken.py`:
- English / fullwidth-colon / Chinese labels stripped
- bare-newline delimiter, surrounding whitespace
- prose preserved (`The reasoning is clear.`), no-label untouched
- tagged-block-then-leading-label (compositional)
- direct `strip_leading_reasoning_label` unit

**Mutation-verified:** reverting the pipeline step fails the 6 label-stripping cases; the 3 invariant cases (prose preserved, no label, direct call) pass either way. Full file: 22 passed (13 existing + 9 new), zero regressions.

## Scope

Complements (does not overlap with) #77079, which extends tagged-block coverage (`think` variants) — this handles the plain-label case #77079 explicitly does not.

Fixes #107044
