### PR TITLE
feat(mcp): add Octen hosted MCP to catalog

### DIFF
--- a/optional-mcps/octen/manifest.yaml
+++ b/optional-mcps/octen/manifest.yaml
@@ -1,0 +1,41 @@
+manifest_version: 1
+
+name: octen
+description: Web and news search, multi-query research, and URL extraction.
+source: https://github.com/Octen-Team/octen-mcp
+
+transport:
+  type: http
+  url: https://mcp.octen.ai/mcp
+
+# Hermes stores the Octen API key in its profile and sends it as a Bearer
+# header, which the hosted endpoint accepts. No credential goes in the URL.
+auth:
+  type: api_key
+  env:
+    - name: MCP_OCTEN_API_KEY
+      prompt: Octen API key (get one at https://octen.ai)
+      required: true
+      secret: true
+
+# Image and video search require Beta access and are not preselected.
+tools:
+  default_enabled:
+    - search
+    - news_search
+    - broad_search
+    - extract
+
+suggest:
+  keywords:
+    - octen
+  hosts:
+    - octen.ai
+
+post_install: |
+  Start a new Hermes session to load the selected tools. Calls use your
+  Octen account and API quota; an API key from https://octen.ai is required.
+
+  Search, news search, broad search, and URL extraction are selected by
+  default. Run `hermes mcp configure octen` to change the selection.
+  Image and video search require separate Beta access from Octen.


### PR DESCRIPTION
## What does this PR do?

Adds Octen's vendor-hosted MCP endpoint to `optional-mcps/octen/manifest.yaml`, making it discoverable in the MCP picker and installable with `hermes mcp install octen` after maintainer approval.

The entry uses Hermes' existing remote HTTP/API-key setup. Hermes prompts for an Octen API key, stores it as `MCP_OCTEN_API_KEY` in the active profile, and sends it as a Bearer header. The key is referenced by a placeholder in `config.yaml` and never placed in the endpoint URL.

This PR changes one manifest only. The MCP implementation stays in [Octen-Team/octen-mcp](https://github.com/Octen-Team/octen-mcp); no core changes, bootstrap commands, or new dependencies are introduced.

## Related Issue

No linked issue; existing issues and PRs were checked for Octen. The separate native web-provider catalog contribution is #107040. That plugin supplies the existing `web_search`/`web_extract` backend; this MCP entry exposes Octen's separate MCP tools, including news and multi-query search. Users can choose the integration they need.

## Type of Change

- [x] New feature: optional MCP catalog entry

## Changes Made

- Connect to `https://mcp.octen.ai/mcp` using remote HTTP and API-key authentication.
- Preselect `search`, `news_search`, `broad_search`, and `extract`. Image/video Beta tools remain available for explicit selection with the appropriate Octen access.
- Add Octen keyword/domain suggestions and setup notes explaining credentials, API quota, tool configuration, and Beta access.

The hosted server accepts Bearer API keys as documented upstream. This entry deliberately uses that existing credential path; it does not require or claim verification of browser OAuth. Remote HTTP transports have no downloaded executable to version-pin under the existing catalog test contract.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_mcp_catalog_env_boundary.py tests/hermes_cli/test_mcp_config.py --tb=short` using the project development environment.
2. With a disposable `HERMES_HOME`, run `hermes mcp install octen` and enter your Octen API key.
3. Keep the four preselected tools. Start a new session and exercise search, news search, broad search, and extraction of a public URL. For broad search the MCP arguments are flat, e.g. `query`, `max_queries: 2`, `count: 2`.
4. Run `hermes mcp configure octen` to confirm Beta tools are available but not preselected. Inspect the saved config to confirm its Authorization header contains a credential placeholder rather than a literal key.

## Validation

- macOS, Python 3.11.16, Hermes `f6ddd89692dff1f900983a16208f39a1485a14eb`.
- 83 existing catalog/config/credential-boundary tests passed through the canonical runner. The config suite needed an unsandboxed rerun because an existing OAuth test binds a loopback callback port; all 38 tests in that file passed on rerun.
- Independent read-only review found no actionable manifest issues.
- Live end-to-end verification used the real catalog installer, profile credential storage, HTTP probe, MCP discovery, and registered tool handlers in a disposable profile. All six tools were discoverable; only the four stable defaults were registered. No LLM call or user-profile modification was involved.
- Real calls passed: `search` (5,720 characters), `news_search` (1,615), `broad_search` (9,982), and `extract` (22,686). Result checks required source URLs and the corresponding result/group/page-success markers.
- An unauthenticated initialize request returned HTTP 401. The persisted config retained `Bearer ${MCP_OCTEN_API_KEY}`; the runtime resolved the credential correctly, and neither captured install output nor tool results contained the key.

## Checklist

- [x] Read contribution guidance and checked for duplicate issues/PRs.
- [x] Focused manifest-only change with a Conventional Commit.
- [x] Existing catalog contract and credential tests passed.
- [x] Live install, authentication, tool selection, and four tool calls verified.
- [x] Setup documentation is included in the manifest and linked source.
- [x] No config schema, core tools, bundled skills, or architecture changes.
- [ ] Maintainer review and approval.

The full Hermes suite and native Windows were not run for this manifest-only contribution.
