### PR TITLE
fix(desktop): HUD band matches aui_message-group transcript rows

### DIFF
--- a/apps/desktop/src/app/hud/transcript-band.test.tsx
+++ b/apps/desktop/src/app/hud/transcript-band.test.tsx
@@ -1,12 +1,20 @@
 import { act, render } from '@testing-library/react'
-import { useRef } from 'react'
+import { type ReactNode, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { stubResizeObserver } from '@/test/jsdom'
 
 import { useHudTranscriptBand } from './transcript-band'
 
-function Harness({ withViewport }: { withViewport: boolean }) {
+function Harness({
+  children,
+  withThreadContent = true,
+  withViewport
+}: {
+  children?: ReactNode
+  withThreadContent?: boolean
+  withViewport: boolean
+}) {
   const ref = useRef<HTMLDivElement | null>(null)
 
   useHudTranscriptBand(ref)
@@ -16,13 +24,27 @@ function Harness({ withViewport }: { withViewport: boolean }) {
       <div data-slot="composer-dock" />
       {withViewport && (
         <div data-slot="aui_thread-viewport">
-          <div data-slot="aui_thread-content">
-            <div>row</div>
-          </div>
+          {withThreadContent && <div data-slot="aui_thread-content">{children ?? <div>row</div>}</div>}
         </div>
       )}
     </div>
   )
+}
+
+function bandHeight(container: HTMLElement): number {
+  const root = container.firstElementChild as HTMLElement
+
+  return Number.parseFloat(root.style.getPropertyValue('--hud-band-height') || '0')
+}
+
+function stubMeasuredRects() {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    if (this.dataset.slot === 'composer-dock') {
+      return { bottom: 768, height: 58, top: 710 } as DOMRect
+    }
+
+    return { bottom: 172, height: 72, top: 100 } as DOMRect
+  })
 }
 
 beforeEach(() => {
@@ -32,6 +54,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.restoreAllMocks()
 })
 
 describe('useHudTranscriptBand', () => {
@@ -60,5 +83,49 @@ describe('useHudTranscriptBand', () => {
     const muchLater = measureSpy.mock.calls.length
 
     expect(muchLater).toBe(justAfterFound)
+  })
+
+  // TurnRow roots now carry data-slot="aui_message-group". The band must still
+  // treat them as transcript rows; matching only *:not([data-slot]) leaves a
+  // short session at --hud-band-height: 0px and clips the transcript.
+  it('measures a TurnRow with data-slot="aui_message-group" as transcript height', () => {
+    stubMeasuredRects()
+    const { container } = render(
+      <Harness withViewport>
+        <div data-slot="aui_message-group">turn</div>
+      </Harness>
+    )
+
+    expect(bandHeight(container)).toBeGreaterThan(0)
+  })
+
+  it('still measures slot-less direct children such as show-earlier', () => {
+    stubMeasuredRects()
+    const { container } = render(
+      <Harness withViewport>
+        <button type="button">Show earlier</button>
+      </Harness>
+    )
+
+    expect(bandHeight(container)).toBeGreaterThan(0)
+  })
+
+  it('does not treat clearance or background-resume spacers as message rows', () => {
+    stubMeasuredRects()
+    const { container } = render(
+      <Harness withViewport>
+        <div data-slot="aui_background-resume">resume</div>
+        <div data-slot="aui_composer-clearance" />
+      </Harness>
+    )
+
+    expect(bandHeight(container)).toBe(0)
+  })
+
+  it('keeps an empty band when aui_thread-content is missing', () => {
+    stubMeasuredRects()
+    const { container } = render(<Harness withThreadContent={false} withViewport />)
+
+    expect(bandHeight(container)).toBe(0)
   })
 })

--- a/apps/desktop/src/app/hud/transcript-band.ts
+++ b/apps/desktop/src/app/hud/transcript-band.ts
@@ -49,7 +49,9 @@ export function useHudTranscriptBand(rootRef: RefObject<HTMLDivElement | null>):
       // rows only. Measuring to the viewport edge counted the full-window scroll
       // container (min-height: 100%) as transcript and painted a empty slab almost
       // the size of the HUD.
-      const rows = el?.querySelectorAll<HTMLElement>('[data-slot="aui_thread-content"] > *:not([data-slot])')
+      const rows = el?.querySelectorAll<HTMLElement>(
+        '[data-slot="aui_thread-content"] > [data-slot="aui_message-group"], [data-slot="aui_thread-content"] > *:not([data-slot])'
+      )
 
       // Zero-height rows are not a transcript. A fresh thread still renders
       // scaffolding inside the content box (clearance, empty state), so


### PR DESCRIPTION
## Summary
- HUD transcript band selector only matched slot-less children of `aui_thread-content`. After TurnRow gained `data-slot="aui_message-group"`, short sessions measured `rows=[]` → `--hud-band-height: 0px` and clipped the visible reply.
- Update the selector to include `[data-slot="aui_message-group"]` while keeping `*:not([data-slot])` for the "show earlier" control.
- Add regression coverage that mirrors the real DOM shape (message-group row + fail-open / non-message slot controls).

Fixes #107050

## Proof
- **RED (pre-fix):** `vitest run --project ui src/app/hud/transcript-band.test.tsx` — message-group case failed with `--hud-band-height` expected `> 0`, got `0`.
- **GREEN (post-fix):** same focused suite — 5/5 passed.
- **Self-review P0:** 0 (Detection / Fail-open / Forbidden / RED evidence / diff scope all PASS).

## Test plan
- [x] Focused HUD `transcript-band` vitest (message-group, slot-less CONTROL, clearance/resume exclusion, missing content no-op)
- [ ] Manual: enter HUD on a fresh short session; assistant reply should appear in the band (not only in a11y tree)

## Risks
- If assistant-ui later introduces another message-row slot name besides `aui_message-group`, the band could miss rows again (same class of bug). Tests assert non-zero height, not exact pixel span.

Made with [Cursor](https://cursor.com)