### PR TITLE
fix(desktop): restore Cmd/Ctrl+Enter in clarify forms

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-submit-shortcut.ts
+++ b/apps/desktop/src/components/assistant-ui/clarify-submit-shortcut.ts
@@ -1,0 +1,25 @@
+import type { KeyboardEvent } from 'react'
+
+/** Use the form's enabled submit button so validation and pending state agree. */
+export function handleClarifySubmitShortcut(event: KeyboardEvent<HTMLFormElement>): void {
+  if (
+    event.key !== 'Enter' ||
+    !(event.metaKey || event.ctrlKey) ||
+    event.altKey ||
+    event.shiftKey ||
+    event.nativeEvent.isComposing ||
+    event.defaultPrevented
+  ) {
+    return
+  }
+
+  // Capture before a focused choice toggles or a textarea handles plain Enter.
+  event.preventDefault()
+  event.stopPropagation()
+
+  const submit = event.currentTarget.querySelector<HTMLButtonElement>('button[type="submit"]')
+
+  if (submit && !submit.disabled && !event.repeat) {
+    event.currentTarget.requestSubmit(submit)
+  }
+}

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -608,6 +608,47 @@ describe('readClarifyBatchResult', () => {
   })
 })
 
+describe('ClarifyTool submit shortcut', () => {
+  it('submits selected choices with Cmd/Ctrl+Enter without toggling the focused option', async () => {
+    for (const modifier of [{ metaKey: true }, { ctrlKey: true }]) {
+      const { request } = renderLiveClarify({ multiSelect: true })
+      const choice = screen.getByRole('button', { name: /staging/ })
+      fireEvent.click(choice)
+      choice.focus()
+      fireEvent.keyDown(choice, { key: 'Enter', ...modifier })
+      await waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        request_id: 'request-1',
+        answer: '["staging"]'
+      })
+      cleanup()
+    }
+  })
+
+  it('submits a complete batch from its text field while preserving incomplete and multiline input', async () => {
+    for (const modifier of [{ metaKey: true }, { ctrlKey: true }]) {
+      const request = renderLiveBatch()
+      const field = screen.getByPlaceholderText('Type your answer…')
+      fireEvent.change(field, { target: { value: 'packet' } })
+      field.focus()
+      fireEvent.keyDown(field, { key: 'Enter', ...modifier })
+      expect(request).not.toHaveBeenCalled()
+      fireEvent.click(screen.getByRole('button', { name: /red/ }))
+      fireEvent.keyDown(field, { key: 'Enter', shiftKey: true })
+      fireEvent.keyDown(field, { key: 'Enter', isComposing: true, ...modifier })
+      expect(request).not.toHaveBeenCalled()
+      fireEvent.keyDown(field, { key: 'Enter', ...modifier })
+      await waitFor(() => expect(request).toHaveBeenCalledTimes(2))
+      expect(request).toHaveBeenNthCalledWith(2, 'clarify.respond', {
+        answer: 'packet',
+        question_id: 'q1',
+        request_id: 'request-batch'
+      })
+      cleanup()
+    }
+  })
+})
+
 describe('ClarifyTool batch card', () => {
   it('renders every question at once', () => {
     renderLiveBatch()

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -40,6 +40,7 @@ import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { requestForOwnedSession } from '@/store/session-states'
 
+import { handleClarifySubmitShortcut } from './clarify-submit-shortcut'
 import { selectMessageRunning } from './tool/fallback-model'
 import { parseMaybeObject } from './tool/fallback-model/format'
 
@@ -732,6 +733,7 @@ function ClarifyToolSinglePending({
     <form
       className="my-1.5 grid gap-4"
       data-clarify-choices={hasChoices ? choices.length : undefined}
+      onKeyDownCapture={handleClarifySubmitShortcut}
       onSubmit={handleSubmit}
       ref={formRef}
     >
@@ -1132,7 +1134,12 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
   }
 
   return (
-    <form className="my-1.5 grid gap-4" data-clarify-batch={questions.length} onSubmit={handleSubmit}>
+    <form
+      className="my-1.5 grid gap-4"
+      data-clarify-batch={questions.length}
+      onKeyDownCapture={handleClarifySubmitShortcut}
+      onSubmit={handleSubmit}
+    >
       <ClarifyShell className="grid gap-3">
         <div className="flex items-start gap-2">
           <span className="flex-1 text-[0.6875rem] leading-4 text-(--ui-text-tertiary)">


### PR DESCRIPTION
## Summary
Restore Cmd+Enter and Ctrl+Enter submission within desktop clarify forms. Both single-question and batch forms handle the shortcut before a focused choice or text field consumes it, then submit through the existing enabled Continue button.

Incomplete answers and pending submissions remain blocked. The handler ignores key repeats, composition, and Shift/Alt combinations. Plain Enter behavior and session-owner routing are unchanged.

## Test plan
- [x] 42 clarify component tests pass, including both modifiers from a selected multi-select choice and a batch text field.
- [x] Incomplete batches, Shift+Enter, and composition do not submit in the regression test.
- [x] Real Chromium keyboard input submits single and batch forms with both Meta+Enter and Control+Enter. The isolated component preview records the expected `clarify.respond` calls, with no page errors.

Full build and full test suites were not run.
