### PR TITLE
fix(local): prevent gateway self-kill during process cleanup

### DIFF
--- a/tests/tools/test_local_killpg_own_pgid_guard.py
+++ b/tests/tools/test_local_killpg_own_pgid_guard.py
@@ -1,0 +1,122 @@
+"""Process-group teardown contracts for the Darwin spawn-safety follow-on (#107029)."""
+
+import signal
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
+from tools.environments import local as local_mod
+from tools.environments.local import _kill_process_group_posix
+
+
+class _FakeChild:
+    def __init__(self, pid: int):
+        self.pid = pid
+        self.kill_calls = 0
+
+    def kill(self):
+        self.kill_calls += 1
+
+
+class _FakeProc:
+    def __init__(self, pid: int):
+        self.pid = pid
+        self.kill_calls = 0
+        self.wait_calls = []
+
+    def kill(self):
+        self.kill_calls += 1
+
+    def wait(self, timeout=None):
+        self.wait_calls.append(timeout)
+        return 0
+
+
+def _install_descendants(monkeypatch, descendants):
+    monkeypatch.setattr(
+        psutil,
+        "Process",
+        lambda _pid: SimpleNamespace(children=lambda recursive=True: list(descendants)),
+    )
+
+
+@pytest.mark.parametrize("getpgrp_fails", [False, True])
+def test_teardown_never_killpgs_own_or_unknown_process_group(
+    monkeypatch, getpgrp_fails
+):
+    """A shared or unverifiable gateway group must use per-process cleanup."""
+    gateway_pgid = 4242
+    proc = _FakeProc(101)
+    descendant = _FakeChild(202)
+    killpg_calls = []
+
+    monkeypatch.setattr(
+        local_mod.os, "getpgid", lambda _pid: gateway_pgid, raising=False
+    )
+    if getpgrp_fails:
+
+        def getpgrp():
+            raise OSError("process group unavailable")
+
+    else:
+        getpgrp = lambda: gateway_pgid
+    monkeypatch.setattr(local_mod.os, "getpgrp", getpgrp, raising=False)
+
+    def killpg(pgid, sig):
+        killpg_calls.append((pgid, sig))
+        raise ProcessLookupError
+
+    monkeypatch.setattr(
+        local_mod.os,
+        "killpg",
+        killpg,
+        raising=False,
+    )
+    _install_descendants(monkeypatch, [descendant])
+
+    _kill_process_group_posix(proc)
+
+    assert killpg_calls == []
+    assert descendant.kill_calls == 1
+    assert proc.kill_calls == 1
+    assert proc.wait_calls == [2.0]
+
+
+@pytest.mark.parametrize("group_becomes_own", [False, True])
+def test_teardown_rechecks_group_before_escalating(monkeypatch, group_becomes_own):
+    """Keep group teardown for a distinct group, but recheck before SIGKILL."""
+    child_pgid = 4343
+    gateway_pgid = 4242
+    proc = _FakeProc(101)
+    descendant = _FakeChild(202)
+    killpg_calls = []
+    getpgrp_calls = 0
+
+    monkeypatch.setattr(local_mod.os, "getpgid", lambda _pid: child_pgid, raising=False)
+
+    def getpgrp():
+        nonlocal getpgrp_calls
+        getpgrp_calls += 1
+        return child_pgid if group_becomes_own and getpgrp_calls > 1 else gateway_pgid
+
+    monkeypatch.setattr(local_mod.os, "getpgrp", getpgrp, raising=False)
+    monkeypatch.setattr(
+        local_mod.os,
+        "killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        local_mod,
+        "_wait_for_group_exit",
+        lambda *_args: not group_becomes_own,
+    )
+    monkeypatch.setattr(local_mod, "_sweep_escaped_descendants", lambda *_args: None)
+    _install_descendants(monkeypatch, [descendant])
+
+    _kill_process_group_posix(proc)
+
+    assert killpg_calls == [(child_pgid, signal.SIGTERM)]
+    assert proc.kill_calls == int(group_becomes_own)
+    assert descendant.kill_calls == int(group_becomes_own)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -644,11 +644,47 @@ def _sweep_escaped_descendants(descendants: list, pgid: int) -> None:
             continue
 
 
+def _kill_processes_individually(proc, descendants: list) -> None:
+    """Kill the known wrapper and descendants without broadcasting to a process group.
+
+    This is the safe fallback when the wrapper shares the caller's process group or
+    the caller's group cannot be determined. Each operation is best effort so one
+    process that already exited cannot prevent the remaining known processes from
+    being terminated.
+    """
+    for child in descendants:
+        try:
+            child.kill()
+        except Exception:
+            logger.debug("Could not kill snapshotted descendant %s", getattr(child, "pid", "?"), exc_info=True)
+    try:
+        proc.kill()
+    except Exception:
+        logger.debug("Could not kill process %s", getattr(proc, "pid", "?"), exc_info=True)
+    with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+        proc.wait(timeout=2.0)
+
+
+def _process_group_is_safe_to_signal(pgid: int) -> bool:
+    """Return whether *pgid* is known not to be this process's group.
+
+    Darwin's spawn workaround can make a tool inherit the gateway's group. If the
+    current group cannot be read, fail closed: an uncertain group must not receive
+    a broadcast signal.
+    """
+    try:
+        return pgid != os.getpgrp()
+    except (AttributeError, OSError):
+        logger.debug("Could not determine current process group; skipping killpg")
+        return False
+
+
 def _kill_process_group_posix(proc) -> None:
     """TERM the group, wait, KILL, then sweep setsid escapees. Descendants are
     snapshotted BEFORE the first signal — once the wrapper dies they reparent to
     init — and we wait on the group, not the wrapper, which can exit before
-    grandchildren under load. POSIX-only (_IS_WINDOWS handled by the caller)."""
+    grandchildren under load. A group matching this process's group is never
+    broadcast to; POSIX-only (_IS_WINDOWS handled by the caller)."""
     try:
         pgid = os.getpgid(proc.pid)
     except ProcessLookupError:
@@ -659,9 +695,15 @@ def _kill_process_group_posix(proc) -> None:
         descendants = psutil.Process(proc.pid).children(recursive=True)
     except Exception:
         descendants = []
+    if not _process_group_is_safe_to_signal(pgid):
+        _kill_processes_individually(proc, descendants)
+        return
     try:
         os.killpg(pgid, signal.SIGTERM)  # windows-footgun: ok — POSIX only (see _IS_WINDOWS gate in caller)
         if not _wait_for_group_exit(proc, pgid, 1.0):
+            if not _process_group_is_safe_to_signal(pgid):
+                _kill_processes_individually(proc, descendants)
+                return
             os.killpg(pgid, signal.SIGKILL)  # windows-footgun: ok — POSIX only (see _IS_WINDOWS gate in caller)
             _wait_for_group_exit(proc, pgid, 2.0)
             with contextlib.suppress(subprocess.TimeoutExpired, OSError):


### PR DESCRIPTION
## Summary

Prevent POSIX process-group teardown from terminating the gateway when a Darwin spawn workaround causes a tool child to inherit the gateway's process group.

The fix keeps group-based TERM/KILL cleanup for verified child-owned groups, but switches to per-process cleanup when the group is the caller's group or cannot be verified. It also repeats the ownership check before SIGKILL escalation.

Fixes #107029

## Problem observed

- Incorrect behavior: `tools/environments/local.py:_kill_process_group_posix` unconditionally called `os.killpg(pgid, SIGTERM)` and, after the wait, `os.killpg(pgid, SIGKILL)`.
- Expected behavior: a cleanup operation must never broadcast a signal to the gateway's own process group. If the tool shares that group, only the known wrapper and its snapshotted descendants should be terminated.
- Reported reproduction: on Darwin, the #97296 fork-avoidance workaround drops `start_new_session`; a terminal or native `rg` child then inherits the gateway PGID. Cleanup treats that PGID as child-owned and launchd observes `Killed: 9` before KeepAlive respawns the gateway.
- Local limitation: this Windows host cannot reproduce the Darwin Network.framework/launchd process topology. The exact ownership boundary was reproduced deterministically with a mocked POSIX teardown and a red regression test on a clean `origin/main` worktree.

## Investigation trail

- Issue and thread read: #107029 (open, no comments); the issue body distinguishes this follow-on from the child SIGSEGV in #97296.
- Baseline: `origin/main` at `f97a4102dd3864eed0c85132850ce7e06f13e09a`.
- Production path traced:
  - `tools/environments/local.py:815-830`: local bash spawn uses `start_new_session=True` and records the spawn PGID.
  - `tools/environments/local.py:647-712`: descendant snapshot and process-group teardown.
  - `tools/environments/local.py:837-840`: `LocalEnvironment._kill_process` dispatches to the POSIX helper on every non-Windows host.
  - `tools/file_operations_search.py:336-375`: native local search calls the same helper, so the fix covers terminal and native `rg` cleanup through one choke point.
- History checked with `git log -S '_kill_process_group_posix'` and `git blame`: the unconditional signals are part of the existing teardown implementation, not an uncommitted artifact.
- Current source confirmation: before this change, there was no `os.getpgrp()` comparison before either `killpg` call.

## Root cause

The teardown code assumed that the PGID returned by `os.getpgid(proc.pid)` always represented an isolated child process group. That assumption is normally established by `start_new_session=True`, but the Darwin mitigation for #97296 must remove that fork-forcing option. The child consequently inherits the gateway PGID.

The missing ownership check made both escalation signals broadcast to the gateway's group. The second broadcast is the observed fatal event: `killpg(gateway_pgid, SIGKILL)` terminates the gateway itself.

The same helper is also used by the native local search path, so the exposure is not limited to the terminal tool. Remote execution backends do not call this local helper.

## Impact and scope

- Affected: Darwin local terminal cleanup and native local `rg` cleanup when a child shares the gateway process group; the same safety guard also protects any POSIX caller that encounters this topology.
- Not affected: verified child-owned process groups retain the existing group TERM -> wait -> KILL -> escaped-descendant sweep behavior; Windows still dispatches to `_kill_process_windows`; remote backends use their own lifecycle implementations.
- Consequences prevented: gateway SIGTERM/SIGKILL, launchd KeepAlive restart loops, and dropped chat/platform sessions.
- Security/operations: signaling is fail-closed when the current process group cannot be read. No credentials, configuration secrets, or environment files are involved.
- Performance: the normal distinct-group path adds one inexpensive `getpgrp()` check before TERM and, only after a timeout, before SIGKILL. No new dependency or persistent state is added.

## Solution

- Added `_process_group_is_safe_to_signal` in `tools/environments/local.py:668-679`.
  - Returns false when the target PGID equals `os.getpgrp()`.
  - Also returns false when `getpgrp()` is unavailable or raises, because an unverifiable group must not receive a broadcast signal.
- Added `_kill_processes_individually` in `tools/environments/local.py:647-665`.
  - Kills the psutil-snapshotted descendants and then the wrapper individually.
  - Waits for the wrapper for up to two seconds.
  - Handles already-exited processes independently so one stale member does not prevent cleanup of the remaining known members.
- Applied the safe fallback before the first TERM broadcast and rechecked the group before SIGKILL escalation (`tools/environments/local.py:697-706`).
- Preserved the existing group teardown and escaped-descendant sweep for a group that is still verified as distinct.

Alternatives considered and rejected:

- Keep unconditional `killpg`: reproduces the reported gateway self-kill.
- Only patch the Darwin spawn sites: incomplete because the shim changes process-group ownership at runtime and `tools/file_operations_search.py` shares the teardown helper.
- Kill only the wrapper: safe for the gateway but leaves snapshotted grandchildren alive.
- Rely on a venv `sitecustomize.py`: the issue reports that `hermes update` rewrites `local.py` and removes local mitigations; the durable safety boundary belongs in the in-tree teardown helper.
- Copy the existing open PR #107032 verbatim: it is a valid direct candidate, but its head is based on an older `main`, intentionally continues to `killpg` when `getpgrp()` raises, and does not recheck before SIGKILL. This branch is a carry-forward with fail-closed behavior and refreshed baseline evidence; #107032 remains open and untouched.

## Compatibility and residual risks

No migration, configuration change, or dependency change is required.

Normal distinct-PGID cleanup is preserved. Same-PGID cleanup intentionally trades complete unknown-group coverage for gateway safety: only the wrapper and descendants captured before signaling are individually killed. A descendant created after the snapshot, or a process that changes group during teardown, may remain rather than risking a broadcast to the gateway. PID-reuse and cross-group TOCTOU concerns in process teardown remain separate existing limitations; this change prevents the reported self-kill boundary and rechecks before escalation.

## Tests and verification

| Command/test | Objective | Result |
|---|---|---|
| `scripts/run_tests.sh tests/tools/test_local_killpg_own_pgid_guard.py` on clean baseline `origin/main` (`f97a4102dd3864eed0c85132850ce7e06f13e09a`) with the new test temporarily copied into the baseline worktree | Prove the regression test bites before the fix | RED: 1 passed, 3 failed. The old helper entered the `killpg` path for the shared/unknown-group cases and the escalation case. |
| `scripts/run_tests.sh tests/tools/test_local_killpg_own_pgid_guard.py` on this head | Shared/unknown PGID fallback, distinct PGID control, and pre-escalation recheck | GREEN: 4 passed, 0 failed |
| `scripts/run_tests.sh tests/tools/test_file_operations_edge_cases.py tests/tools/test_search_error_guard.py tests/tools/test_search_files_engine_selection.py tests/tools/test_search_native_rg.py` | Exercise related file/search plumbing; native `rg` test is host-gated | 74 passed, 3 skipped, 0 failed |
| `scripts/run_tests.sh tests/tools/test_file_operations.py` on clean baseline | Establish baseline for the related file-operation failures | 63 passed, 6 failed. Failures are Windows umask behavior and symlink privilege (`WinError 1314`), unrelated to this diff. |
| `scripts/run_tests.sh tests/tools/test_file_operations.py` on this head | Check for regressions in the related file-operation path | 63 passed, 6 failed, same six Windows-only failures as baseline |
| `scripts/run_tests.sh tests/tools/test_local_setsid_descendant_sweep.py tests/tools/test_local_interrupt_cleanup.py -k kill_process` on clean baseline and this head | Check adjacent teardown contracts | Both states fail the same two unchanged Windows tests because their fixtures call unavailable `os.getpgid`; the new regression file passes on the head. No new failure was introduced. |
| `C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe -m ruff check tools/environments/local.py tests/tools/test_local_killpg_own_pgid_guard.py` | Static lint for changed files | Passed |
| `C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe -m ruff format --check tests/tools/test_local_killpg_own_pgid_guard.py` | Formatting for the new test | Passed; file already formatted |
| `C:/Users/Nitro/hermes-agent/.venv/Scripts/python.exe -m compileall -q tools/environments/local.py tests/tools/test_local_killpg_own_pgid_guard.py` | Syntax validation | Passed |
| `git diff --check` | Whitespace validation | Passed |
| `npm run check` | Repository JS quality gate | Not completed: the isolated worktree has no installed Node workspace dependencies (`@types/node`, React/Vitest packages, `esbuild`, and others are missing); it exited with code 2 before any JS validation relevant to this Python-only change. |
| `ruff format --check tools/environments/local.py tests/tools/test_local_killpg_own_pgid_guard.py` | Whole-file formatting check | Not clean because the pre-existing `local.py` contains unrelated formatter drift across the file; no drive-by reformat was applied. The new test passes the formatter check individually. |

The full repository test suite was not run in this Windows environment. Live Darwin/launchd and Network.framework verification was not possible here; CI/macOS is required for that topology.

## Independent review

An independent review of the final diff found no P0/P1 correctness, lifecycle, compatibility, or scope blockers. It recorded one P2 limitation: the new regression cases use mocked process objects and therefore do not exercise live POSIX process-group signaling, descendant reparenting, or PID reuse. That live Darwin coverage remains a CI/macOS responsibility; the deterministic mock contracts isolate the ownership decision and are the only executable reproduction available on this Windows host. No review files were changed.

## Files and documentation

- `tools/environments/local.py`: shared POSIX process-group safety guard and individual cleanup fallback.
- `tests/tools/test_local_killpg_own_pgid_guard.py`: four deterministic behavior-contract cases covering shared/unknown groups, distinct groups, and ownership change before escalation.
- No changelog or separate repository technical document was updated; the issue and this PR body contain the detailed operational investigation and reproduction record.

## Delivery metadata

- Base: `main` at `f97a4102dd3864eed0c85132850ce7e06f13e09a` when validated.
- Local head: `7b23e4d0dcfe02e697f6e9e02d48b4900f48f446` (`fix(local): guard process-group teardown from self-kill`).
- Local branch: `fix/issue-107029-killpg-own-pgid`.
- PR: `https://github.com/NousResearch/hermes-agent/pull/107054`.
- Remote base: `main` at `f97a4102dd3864eed0c85132850ce7e06f13e09a`.
- Remote head: `7b23e4d0dcfe02e697f6e9e02d48b4900f48f446`.
- Initial checks: `gh pr checks --json name,state,link` reported no checks for the branch; CI was not reported/executed at this read-back.
