### PR TITLE
Fix HUD band selector after TurnRow got aui_message-group slot

### DIFF
--- a/apps/desktop/src/app/hud/transcript-band.test.tsx
+++ b/apps/desktop/src/app/hud/transcript-band.test.tsx
@@ -35,6 +35,57 @@ afterEach(() => {
 })
 
 describe('useHudTranscriptBand', () => {
+  // Regression for #107050: after every TurnRow got `data-slot="aui_message-group"`
+  // the selector stopped matching anything and the band collapsed to 0px. A
+  // fixture with slot-less rows (what the old code expected) wouldn't see it,
+  // so we verify the app's current DOM shape produces a non-zero band.
+  it('sizes the band when message rows carry aui_message-group slot', () => {
+    const measureSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+    const stubY = 100
+    const stubHeight = 710
+
+    measureSpy.mockImplementation(function (this: HTMLElement) {
+      const el = this
+      // The row: bottom 710px beyond its top (a realistic turn row)
+      if (el.getAttribute('data-slot') === 'aui_message-group') {
+        return { top: stubY, bottom: stubY + stubHeight, height: stubHeight, left: 0, right: 0, width: 0, x: 0, y: stubY, toJSON: () => ({}) } as DOMRect
+      }
+      // Composer dock: arbitrary
+      if (el.getAttribute('data-slot') === 'composer-dock') {
+        return { top: 0, bottom: 64, height: 64, left: 0, right: 0, width: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+      }
+      // Everything else: zero
+      return { top: 0, bottom: 0, height: 0, left: 0, right: 0, width: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+    })
+
+    function TestComponent() {
+      const ref = useRef<HTMLDivElement | null>(null)
+      useHudTranscriptBand(ref)
+
+      return (
+        <div ref={ref}>
+          <div data-slot="composer-dock" />
+          <div data-slot="aui_thread-viewport">
+            <div data-slot="aui_thread-content">
+              <div data-slot="aui_message-group">row</div>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    const { container } = render(<TestComponent />)
+
+    act(() => vi.advanceTimersByTime(100))
+
+    // Not testing the exact pixel value (that's what layout.test.ts owns), but
+    // the hook must recognize the row and compute a non-zero band. Before #107050
+    // this was 0px: rows = [], contentSpan = 0, hudTranscriptHeight(...) -> 0.
+    const rootDiv = container.firstElementChild as HTMLElement
+    expect(rootDiv?.style.getPropertyValue('--hud-band-height')).not.toBe('0px')
+    expect(rootDiv?.style.getPropertyValue('--hud-band-height')).not.toBe('')
+  })
+
   // The bug this replaced: the probe polled every 500ms for the lifetime of
   // the HUD window, duplicating every measurement the ResizeObserver already
   // owned once the viewport existed — a permanent idle timer firing re-renders

--- a/apps/desktop/src/app/hud/transcript-band.ts
+++ b/apps/desktop/src/app/hud/transcript-band.ts
@@ -48,8 +48,11 @@ export function useHudTranscriptBand(rootRef: RefObject<HTMLDivElement | null>):
       // How tall the band actually needs to be — the tight bbox of the message
       // rows only. Measuring to the viewport edge counted the full-window scroll
       // container (min-height: 100%) as transcript and painted a empty slab almost
-      // the size of the HUD.
-      const rows = el?.querySelectorAll<HTMLElement>('[data-slot="aui_thread-content"] > *:not([data-slot])')
+      // the size of the HUD. Turn rows carry `aui_message-group`; the slot-less
+      // branch keeps the "show earlier" button reachable when it renders.
+      const rows = el?.querySelectorAll<HTMLElement>(
+        '[data-slot="aui_thread-content"] > [data-slot="aui_message-group"], [data-slot="aui_thread-content"] > *:not([data-slot])'
+      )
 
       // Zero-height rows are not a transcript. A fresh thread still renders
       // scaffolding inside the content box (clearance, empty state), so


### PR DESCRIPTION
Closes #107050

After TurnRow gained `data-slot="aui_message-group"` in `list.tsx:380`, the band selector `'[data-slot="aui_thread-content"] > *:not([data-slot])'` stopped matching rows entirely — `rows=[]` → `contentSpan=0` → band 0px. HUD mode painted an empty white sheet with no transcript visible.

**Selector now includes both:**
- `[data-slot="aui_message-group"]` — current turn rows
- `> *:not([data-slot])` — preserves the "show earlier" button reachability when it renders

**Added regression test** verifying that a fixture with `aui_message-group` rows produces a non-zero `--hud-band-height` instead of the 0px the bug left.

**Verified:**
- `npx vitest run src/app/hud/transcript-band.test.tsx` — 2/2 pass
- `npx tsc --build tsconfig.json` — clean build
