### PR TITLE
fix(tools): stop stale MCP OAuth tabs when refresh can recover

### DIFF
--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -122,15 +122,8 @@ async def test_hermes_provider_forwards_asend_values(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_hermes_provider_forwards_401_triggers_refresh(tmp_path, monkeypatch):
-    """A 401 response MUST flow into the inner generator and trigger the
-    SDK's 401 recovery branch.
-
-    With the broken wrapper, the inner generator sees ``response = None``
-    and the 401 check short-circuits into AttributeError. With the correct
-    bridge, the 401 is routed into the SDK's ``response.status_code == 401``
-    branch which begins discovery (yielding a metadata-discovery request).
-    """
+async def test_hermes_provider_refreshes_before_authorizing_after_401(tmp_path, monkeypatch):
+    """A resource 401 with a refresh token silently refreshes before browser auth."""
     # The SDK's httpx flavour (httpx2 on mcp >= 2.0): the provider is an
     # Auth subclass from that module and its auth_flow only accepts its own
     # Request/Response types.
@@ -185,27 +178,33 @@ async def test_hermes_provider_forwards_401_triggers_refresh(tmp_path, monkeypat
     # Drive to the first yield (outbound MCP request).
     outbound = await flow.__anext__()
 
-    # Reply with a 401 including a minimal WWW-Authenticate so the SDK's
-    # 401 branch can parse resource metadata from it. We just need something
-    # the SDK accepts before it tries to yield the metadata-discovery request.
     fake_401 = httpx.Response(
         401,
         request=outbound,
         headers={"www-authenticate": 'Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"'},
     )
 
-    # The correct bridge forwards the 401 into the SDK; the SDK then yields
-    # its NEXT request (a metadata-discovery GET). We assert we get a request
-    # back — any request. The broken bridge would have crashed with
-    # AttributeError before we ever reach this point.
-    next_request = await flow.asend(fake_401)
-    assert isinstance(next_request, httpx.Request), (
-        "wrapper must forward .asend() so the SDK's 401 branch can yield the "
-        "next request in the discovery flow"
-    )
+    refresh_request = await flow.asend(fake_401)
+    assert refresh_request.method == "POST"
+    assert b"grant_type=refresh_token" in refresh_request.content
 
-    # Clean up the generator — we don't need to complete the full dance.
-    await flow.aclose()
+    retry = await flow.asend(
+        httpx.Response(
+            200,
+            request=refresh_request,
+            json={
+                "access_token": "new_access",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "new_refresh",
+            },
+        )
+    )
+    assert retry is req
+    assert retry.headers["authorization"] == "Bearer new_access"
+
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx.Response(200, request=retry))
 
 
 @pytest.mark.asyncio

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -218,7 +218,7 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
         # into the inner generator via inner.asend(incoming), preserving the bidirectional contract.
         # Regression from PR #11383 caught by tests/tools/test_mcp_oauth_bidirectional.py.
         inner = super().async_auth_flow(request)
-        resource_lock_released = retry_after_concurrent_auth = False
+        resource_lock_released = retry_after_auth_recovery = False
         sent_access_token = None
         try:
             outgoing = await inner.__anext__()
@@ -241,8 +241,20 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                         and tokens is not None and tokens.access_token != sent_access_token):
                     self._add_auth_header(request)
                     await inner.aclose()
-                    retry_after_concurrent_auth = True
+                    retry_after_auth_recovery = True
                     break
+                # The SDK jumps directly from a resource 401 to authorization-code flow. Servers can
+                # reject an access token before its local expiry, so try the still-usable refresh token
+                # before allowing that branch to open a browser (#107059).
+                if getattr(incoming, "status_code", None) == 401 and self.context.can_refresh_token():
+                    refresh_request = await self._refresh_token()
+                    refresh_response = yield refresh_request
+                    await self._maybe_flag_poisoned_client(refresh_response)
+                    if await self._handle_refresh_response(refresh_response):
+                        self._add_auth_header(request)
+                        await inner.aclose()
+                        retry_after_auth_recovery = True
+                        break
                 # Sniff the response for a dead-client-registration signal before handing it back to the SDK
                 # (best-effort, GH#36767).
                 await self._maybe_flag_poisoned_client(incoming)
@@ -256,7 +268,7 @@ class HermesMCPOAuthProvider(HermesProviderMixin, *_SDK_BASES):
                 import anyio
                 with anyio.CancelScope(shield=True):
                     await self.context.lock.acquire()
-        if retry_after_concurrent_auth:
+        if retry_after_auth_recovery:
             yield request
             self._persist_oauth_metadata_if_changed()
 


### PR DESCRIPTION
## What does this PR do?

Stops MCP servers from opening a browser authorization tab after a resource 401 when the stored refresh token can recover the connection silently. The provider now attempts one refresh while its OAuth state lock is held, retries the original resource request with the refreshed bearer token on success, and enters the SDK authorization-code flow only when silent recovery is unavailable or fails.

### Symptom

After a gateway restart or an overnight shutdown, a provider can reject the cached access token with HTTP 401. Hermes then opens an OAuth authorization tab even though the stored refresh token is still usable, leaving an orphan tab after the connection recovers.

### Impact

Affected Windows gateway users can accumulate stale authorization tabs and may be prompted to reauthorize an MCP server that did not lose refresh credentials. The affected provider population is unknown.

### Bug Cause

**Trigger:** `tools/mcp_oauth_manager.py:205` / `HermesMCPOAuthProvider.async_auth_flow()` receives HTTP 401 for a resource request that used the current access token.

**Causal chain:**
1. The resource server rejects a locally valid-looking access token before its recorded expiry.
2. The wrapper forwards the 401 to the SDK inner auth generator.
3. The SDK's 401 branch proceeds directly to metadata discovery and authorization-code flow without trying the available refresh token, so the redirect handler can open a browser tab.

**Why it is wrong:** A resource-side 401 is not proof that the refresh credential is unusable. Browser authorization should be the fallback after silent refresh fails, not the first recovery action.

**Working sibling / contrast:** Cold-loaded tokens with an expired local TTL already use the SDK's pre-request refresh branch. The missing case is a resource 401 for an access token that still appears locally valid.

**Ruled out:** Token expiry persistence is not the cause on current main; `HermesMCPOAuthProvider._initialize()` already seeds the SDK expiry clock from the stored absolute expiry.

### Fix

On a resource 401, the provider checks whether its current OAuth context can refresh. If so, it yields the refresh request before forwarding the 401 into the SDK authorization branch. A successful refresh closes the stale inner flow and retries the resource with the new bearer token; a failed refresh leaves the existing browser fallback intact.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_oauth_manager.py` - attempt silent refresh before the SDK's browser authorization path on resource 401 responses.
- `tests/tools/test_mcp_oauth_bidirectional.py` - exercise the full bidirectional generator sequence from resource 401 through refresh and authenticated retry.

## How to Test

1. Store a valid MCP refresh token with an access token that the resource server rejects.
2. Send an MCP request and return HTTP 401 from the resource endpoint.
3. Verify Hermes sends a refresh-token request and retries the resource with the new access token before invoking browser authorization.
4. Run:

```bash
scripts/run_tests.sh tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_cold_load_expiry.py -v
```

Result: 30 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant OAuth tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is documented in code and the regression test
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the async OAuth flow is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no model tool contract changed

## Screenshots / Logs

N/A. The focused automated suite passed 30 tests on Windows 11.
