### PR TITLE
fix(tui-gateway): session.create reports the named profile's model

### DIFF
--- a/tests/tui_gateway/test_session_create_profile_model.py
+++ b/tests/tui_gateway/test_session_create_profile_model.py
@@ -1,0 +1,88 @@
+"""``session.create`` reports the named profile's model, not the launch-context model.
+
+Why: the desktop's app-global remote mode points every profile at one backend, so
+``session.create`` carries a ``profile``. The handler resolves the profile home
+correctly (and the AIAgent build re-binds it), but the immediate provisional
+``info.model`` it returns fell back to the launch-context ``_resolve_model()``
+when no explicit model override was supplied. The composer therefore painted the
+launch profile's model for a session that would run under the named profile's.
+
+This is the same bug class as ``terminal.cwd`` (issue #40334): the process-global
+launch value belongs to the *launch* profile, so a non-launch profile's value must
+be read from ITS config.yaml. Pinned here:
+
+* a named profile with no explicit model override → ``info.model`` is that
+  profile's configured model, not the launch-context model;
+* the launch profile (no ``profile``) is unchanged → launch-context model;
+* an explicit model override still wins over the profile's configured model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tui_gateway import server
+
+
+@pytest.fixture()
+def profile_env(monkeypatch, tmp_path):
+    """A disposable launch home + a named profile home with a distinct configured
+    model, driving the real ``session.create`` handler."""
+    launch = tmp_path / "launch"
+    named = tmp_path / "named"
+    for home in (launch, named):
+        home.mkdir()
+    # The named profile's config names a model the launch context does not.
+    (named / "config.yaml").write_text("model: named-profile-model\n")
+
+    monkeypatch.setenv("HERMES_HOME", str(launch))
+    monkeypatch.setattr(server, "_hermes_home", launch)
+    monkeypatch.setattr(server, "_profile_home", lambda p: named if p == "work" else None)
+    # Launch-context model: what the bug used to leak into a named-profile session.
+    monkeypatch.setattr(server, "_resolve_model", lambda: "launch-context-model")
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(server, "_default_session_cwd", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: True)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
+    known = set(server._sessions)
+    yield {"launch": launch, "named": named}
+    with server._sessions_lock:
+        for sid in [s for s in server._sessions if s not in known]:
+            server._sessions.pop(sid, None)
+
+
+def _create(**params):
+    """Drive the real ``session.create`` handler and return its result envelope."""
+    resp = server.handle_request({"id": "1", "method": "session.create", "params": params})
+    assert "error" not in resp, resp.get("error")
+    return resp["result"]
+
+
+class TestNamedProfileProvisionalModel:
+    def test_named_profile_reports_its_own_model(self, profile_env):
+        """A named profile with no explicit model override reports its configured model,
+        not the launch-context model."""
+        result = _create(profile="work", source="desktop")
+        assert result["info"]["model"] == "named-profile-model"
+
+    def test_launch_profile_unchanged(self, profile_env):
+        """No ``profile`` → launch-context model (the pre-existing single-profile contract)."""
+        result = _create(source="desktop")
+        assert result["info"]["model"] == "launch-context-model"
+
+    def test_explicit_model_override_still_wins(self, profile_env):
+        """An explicit composer model beats the named profile's configured model."""
+        result = _create(profile="work", source="desktop", model="explicit-model")
+        assert result["info"]["model"] == "explicit-model"
+
+    def test_named_profile_without_configured_model_falls_back(self, profile_env):
+        """A named profile whose config has no model falls back to the launch-context model."""
+        (profile_env["named"] / "config.yaml").write_text("terminal:\n  backend: local\n")
+        result = _create(profile="work", source="desktop")
+        assert result["info"]["model"] == "launch-context-model"

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -352,8 +352,10 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {
         "session_id": sid, "stored_session_id": key, "message_count": len(history),
         "messages": _history_to_messages(history),
-        # Reflect the override now so the client doesn't clobber its sticky pick.
-        "info": {"model": override.get("model") if override else _resolve_model(),
+        # Reflect the override now so the client doesn't clobber its sticky pick. A named
+        # profile without an explicit override reports its OWN configured model, not the
+        # launch-context model (mirrors _profile_configured_cwd / issue #40334).
+        "info": {"model": override.get("model") if override else (_profile_model(profile_home) or _resolve_model()),
                  **({"provider": override["provider"]} if override.get("provider") else {}),
                  "tools": {}, "skills": {}, "cwd": cwd, "branch": git_probe.branch(cwd),
                  "project": _project_info_for_cwd(cwd), "lazy": True, "desktop_contract": DESKTOP_BACKEND_CONTRACT,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -556,6 +556,28 @@ def _profile_configured_cwd(profile_home: Path | None) -> str | None:
     return None
 
 
+def _profile_model(profile_home: Path | None) -> str:
+    """A non-launch profile's configured model from ITS config.yaml (fail-open → \"\"): the launch-context
+    ``_resolve_model()`` resolves the *launch* profile, so a session bound to another profile must not
+    report the launch model. Same pattern as :func:`_profile_configured_cwd` (issue #40334). Empty
+    (no configured model) → the caller keeps the launch-context fallback, unchanged for single-profile
+    and model-less profiles."""
+    if profile_home is None:
+        return ""
+    with contextlib.suppress(Exception):
+        from hermes_cli.config import read_user_config_raw
+        p = Path(profile_home) / "config.yaml"
+        if not p.exists():
+            return ""
+        cfg = _expand_cfg(_apply_managed(read_user_config_raw(p)))
+        m = cfg.get("model", "")
+        if isinstance(m, dict):
+            return str(m.get("default", "") or "").strip()
+        if isinstance(m, str) and m:
+            return m.strip()
+    return ""
+
+
 def _launch_configured_cwd() -> str | None:
     """Launch profile's ``terminal.cwd`` from config.yaml: the dashboard's in-memory gateway gets no bridged
     ``TERMINAL_CWD`` env (only the Node PTY child does), so a fresh /chat would otherwise start in ``os.getcwd()``."""


### PR DESCRIPTION
## What does this PR do?

Fixes a provisional-model mismatch in `session.create`. When the desktop's app-global remote mode creates a session bound to a named profile (a `profile` param, no explicit model), the handler resolved the profile home correctly and the AIAgent build re-binds it, but the immediate `info.model` it returns fell back to the launch-context resolver. The composer therefore painted the launch profile's model for a session that would run under the named profile's model.

The fix reads the named profile's model from its own configuration (the same pattern already used for that profile's `terminal.cwd`, issue #40334). The launch-context fallback is preserved for the launch profile and for named profiles with no configured model, so single-profile behavior is byte-identical.

## Related Issue

No open issue owns this seam. Related but distinct: [#62503](https://github.com/NousResearch/hermes-agent/issues/62503) (WebSocket profile dispatch, closed).

## Type of Change

- ☑ 🐛 Bug fix (non-breaking change that fixes an issue)
- ☐ ✨ New feature (non-breaking change that adds functionality)
- ☐ 🔒 Security fix
- ☐ 📝 Documentation update
- ☐ ✅ Tests (adding or improving test coverage)
- ☐ ♻️ Refactor (no behavior change)
- ☐ 🎯 New skill (bundled or hub)

## Changes Made

- `session.create` now resolves the provisional `info.model` from the named profile's own configuration when no explicit model override is supplied, instead of the launch-context resolver.
- Added a narrow profile-model resolver mirroring the existing profile `terminal.cwd` resolver (reads the profile's config directly; fail-open to the launch fallback).
- Added a deterministic regression test driving the real `session.create` handler with disposable launch and named-profile homes.

## How to Test

1. Reproduction (before the fix): create a session with a named profile and no explicit model. The returned `info.model` was the launch profile's model, not the named profile's.
2. Focused regression suite: 4 passed (named profile reports its own model; launch profile unchanged; explicit override still wins; model-less named profile falls back).
3. Adjacent profile-scoping suites (same code path): 50 passed.
4. Lint on the two changed source files: all checks passed.
5. Platform: verified on Ubuntu 24.04 (Linux). The change is host-independent (config read + model-string selection).

## Checklist

### Code

- ☑ I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- ☑ My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- ☑ I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- ☑ My PR contains **only** changes related to this fix/feature (no unrelated commits)
- ☐ I've run `pytest tests/ -q` and all tests pass
- ☑ I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- ☑ I've tested on my platform: Ubuntu 24.04 (Linux)

### Documentation & Housekeeping

- ☑ I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- ☑ I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- ☑ I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- ☑ I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

## Screenshots / Logs

N/A — behavior change in the provisional `info.model` field of the `session.create` RPC response; covered by the focused regression suite.
