### PR TITLE
fix(agent): stop background reviews creating phantom plugin sessions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -595,8 +595,8 @@ _SESSION_STATE: Dict[str, Any] = {
     # False on helper agents (compression / hygiene / review forks) that hand the session to
     # a continuation row that must stay open.
     "_end_session_on_close": True,
-    # True on the background review fork: never persist, so its harness turn can't hijack
-    # the live session.
+    # True on the background review fork: never persist or publish session lifecycle hooks,
+    # so its harness turn can't hijack or appear under the live session.
     "_persist_disabled": False,
 }
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -756,15 +756,16 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # request naming a surface the conversation has left (#104414).
     stage_surface_switch_note(agent, agent._cached_system_prompt, conversation_history)
 
-    # Plugin hook: on_session_start — fired once for a brand-new session, not on continuation.
-    try:
-        from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_start", session_id=agent.session_id, model=agent.model,
-            platform=getattr(agent, "platform", None) or "",
-        )
-    except Exception as exc:
-        logger.warning("on_session_start hook failed: %s", exc)
+    # Persistence-disabled forks share their parent's session ID and are not real sessions.
+    if not getattr(agent, "_persist_disabled", False):
+        try:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_start", session_id=agent.session_id, model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+        except Exception as exc:
+            logger.warning("on_session_start hook failed: %s", exc)
 
     # Cold-start credits seed (L3) fallback for the first-turn path; TUI/desktop seed at
     # session open, so this is idempotent (skips when _credits_state exists). Fail-open.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -661,6 +661,8 @@ def _collect_pre_llm_call_context(
     """Run ``pre_llm_call`` plugins; their context is injected into the user message
     (never the system prompt). Oversized per-hook context is spilled to disk so a
     runaway plugin can't inflate every subsequent turn's prompt."""
+    if getattr(agent, "_persist_disabled", False):
+        return ""
     try:
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -623,18 +623,19 @@ def finalize_turn(
 
     # Memory provider on_session_end()/shutdown_all() are NOT called here:
     # run_conversation() runs once per message; CLI/gateway own session-end cleanup.
-    _invoke_hook_safely(
-        "on_session_end", logger,
-        session_id=agent.session_id,
-        task_id=effective_task_id,
-        turn_id=turn_id,
-        completed=completed,
-        failed=failed,
-        interrupted=interrupted,
-        turn_exit_reason=_turn_exit_reason,
-        model=agent.model,
-        platform=_platform,
-    )
+    if not getattr(agent, "_persist_disabled", False):
+        _invoke_hook_safely(
+            "on_session_end", logger,
+            session_id=agent.session_id,
+            task_id=effective_task_id,
+            turn_id=turn_id,
+            completed=completed,
+            failed=failed,
+            interrupted=interrupted,
+            turn_exit_reason=_turn_exit_reason,
+            model=agent.model,
+            platform=_platform,
+        )
 
     agent._turn_preflight_display_snapshot = None
     agent._turn_received_provider_response = False

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -415,18 +415,19 @@ def _apply_output_hooks(
         if isinstance(_hook_result, str) and _hook_result:
             pre_transform, final_response, transformed = final_response, _hook_result, True
             break
-    # post_llm_call (e.g. sync conversation data to an external memory system).
-    _invoke_hook_safely(
-        "post_llm_call", logger,
-        session_id=agent.session_id,
-        task_id=effective_task_id,
-        turn_id=turn_id,
-        user_message=original_user_message,
-        assistant_response=final_response,
-        conversation_history=list(messages),
-        model=agent.model,
-        platform=platform,
-    )
+    # Detached forks are internal work and must not publish turns under the parent's session ID.
+    if not getattr(agent, "_persist_disabled", False):
+        _invoke_hook_safely(
+            "post_llm_call", logger,
+            session_id=agent.session_id,
+            task_id=effective_task_id,
+            turn_id=turn_id,
+            user_message=original_user_message,
+            assistant_response=final_response,
+            conversation_history=list(messages),
+            model=agent.model,
+            platform=platform,
+        )
     return final_response, transformed, pre_transform
 
 

--- a/tests/agent/test_detached_fork_lifecycle_hooks.py
+++ b/tests/agent/test_detached_fork_lifecycle_hooks.py
@@ -1,0 +1,105 @@
+"""Lifecycle-hook isolation for persistence-disabled internal forks."""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from agent.conversation_loop import _restore_or_build_system_prompt
+from agent.turn_context import _collect_pre_llm_call_context
+from agent.turn_finalizer import _apply_output_hooks
+
+
+def _agent(*, persist_disabled: bool):
+    return SimpleNamespace(
+        _cached_system_prompt=None,
+        _parent_session_id=None,
+        _persist_disabled=persist_disabled,
+        _session_db=None,
+        model="test/model",
+        platform="cli",
+        session_id="shared-session",
+        _build_system_prompt=Mock(return_value="system prompt"),
+    )
+
+
+def _apply_hooks(agent):
+    return _apply_output_hooks(
+        agent,
+        "response",
+        logging.getLogger(__name__),
+        platform="cli",
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+
+def test_persist_disabled_fork_skips_session_and_turn_lifecycle_hooks():
+    agent = _agent(persist_disabled=True)
+
+    with (
+        patch("hermes_cli.lifecycle.invoke_hook") as lifecycle_hook,
+        patch("agent.credits_tracker.seed_credits_at_session_start"),
+    ):
+        _restore_or_build_system_prompt(agent, None, [])
+        context = _collect_pre_llm_call_context(
+            agent,
+            effective_task_id="task-1",
+            turn_id="turn-1",
+            original_user_message="hello",
+            messages=[{"role": "user", "content": "hello"}],
+            conversation_history=None,
+        )
+
+    output_calls = []
+
+    def invoke_output_hook(name, _logger, **_kwargs):
+        output_calls.append(name)
+        return ["transformed"] if name == "transform_llm_output" else []
+
+    with patch("agent.turn_finalizer._invoke_hook_safely", side_effect=invoke_output_hook):
+        response, transformed, _original = _apply_hooks(agent)
+
+    lifecycle_hook.assert_not_called()
+    assert context == ""
+    assert output_calls == ["transform_llm_output"]
+    assert response == "transformed"
+    assert transformed is True
+
+
+def test_persisted_agent_still_fires_session_and_turn_lifecycle_hooks():
+    agent = _agent(persist_disabled=False)
+
+    with (
+        patch("hermes_cli.lifecycle.invoke_hook") as lifecycle_hook,
+        patch("agent.credits_tracker.seed_credits_at_session_start"),
+    ):
+        lifecycle_hook.side_effect = lambda name, **_kwargs: (
+            [{"context": "plugin context"}] if name == "pre_llm_call" else []
+        )
+        _restore_or_build_system_prompt(agent, None, [])
+        context = _collect_pre_llm_call_context(
+            agent,
+            effective_task_id="task-1",
+            turn_id="turn-1",
+            original_user_message="hello",
+            messages=[{"role": "user", "content": "hello"}],
+            conversation_history=None,
+        )
+
+    output_calls = []
+
+    def invoke_output_hook(name, _logger, **_kwargs):
+        output_calls.append(name)
+        return []
+
+    with patch("agent.turn_finalizer._invoke_hook_safely", side_effect=invoke_output_hook):
+        _apply_hooks(agent)
+
+    assert [call.args[0] for call in lifecycle_hook.call_args_list] == [
+        "on_session_start",
+        "pre_llm_call",
+    ]
+    assert context == "plugin context"
+    assert output_calls == ["transform_llm_output", "post_llm_call"]

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -8,6 +8,8 @@ for must still be returned.  Previously any of those raised straight out of
 traceback and lost the whole turn.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from agent.turn_finalizer import finalize_turn
@@ -162,5 +164,34 @@ def test_clean_turn_has_no_cleanup_errors_key():
     assert result["final_response"] == "PARTIAL SUMMARY FROM MODEL"
     assert result["completed"] is False
     assert "cleanup_errors" not in result
+
+
+@pytest.mark.parametrize(
+    ("persist_disabled", "expected_calls"),
+    [
+        (True, ["transform_llm_output"]),
+        (False, ["transform_llm_output", "post_llm_call", "on_session_end"]),
+    ],
+)
+def test_persist_disabled_turn_skips_session_end_hook(
+    persist_disabled, expected_calls
+):
+    agent = _StubAgent(raise_in=())
+    agent._persist_disabled = persist_disabled
+    calls = []
+
+    def capture(name, _logger, **_kwargs):
+        calls.append(name)
+        return []
+
+    with patch("agent.turn_finalizer._invoke_hook_safely", side_effect=capture):
+        _run(
+            agent,
+            final_response="done",
+            api_call_count=1,
+            turn_exit_reason="text_response(stop)",
+        )
+
+    assert calls == expected_calls
 
 


### PR DESCRIPTION
## What does this PR do?

Background skill and memory reviews no longer publish session or turn lifecycle events under the live conversation's session ID. Same-model forks normally reach the per-turn `pre_llm_call` and `post_llm_call` hooks, while routed or cold-prompt forks can also reach `on_session_start`; all of those paths are now isolated. `on_session_end` is isolated as the matching boundary. Output transforms remain active, and per-request `pre_api_request`, `post_api_request`, and `api_request_error` events remain observable because they describe real outbound model requests from the fork, whether billed or not.

### Symptom

Hook consumers can observe a new session and LLM turn for each background review, even though the review is internal machinery sharing the live session ID.

### Impact

Consumers that materialize lifecycle events as sessions can create duplicate or phantom session records. If downstream title generation falls back to turn content, the internal review prompt can also appear as a session title.

### Bug Cause

**Trigger:** `agent/background_review.py::build_cache_parity_fork` creates a fork with `_persist_disabled=True`, then the fork enters the normal conversation loop.

**Causal chain:**
1. A background review fork reuses its parent's `session_id` for prompt-cache parity.
2. The normal conversation loop invokes `on_session_start`, `pre_llm_call`, and `post_llm_call` without checking whether persistence is disabled.
3. External hook consumers receive internal fork activity attributed to the real session and may create phantom records.

**Why it is wrong:** `_persist_disabled` marks work that must not participate in the persisted session lifecycle, but the shell lifecycle hooks did not honor that boundary.

**Working sibling / contrast:** Session persistence and in-flight turn tracking already skip `_persist_disabled` forks so they cannot write to or take ownership of the parent's session.

**Ruled out:** This is not caused by a new physical session ID. The fork explicitly copies the parent's ID, so changing downstream title generation would only hide the lifecycle misclassification.

### Fix

Guard the three session/turn lifecycle hooks with the existing `_persist_disabled` marker. Keep `transform_llm_output` active because it affects only the detached fork's returned text and does not publish a session lifecycle event. Add regression coverage for both detached and normal agents.

## Related Issue

Fixes #107062

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` - skip `on_session_start` for persistence-disabled forks.
- `agent/turn_context.py` - skip `pre_llm_call` context collection for persistence-disabled forks.
- `agent/turn_finalizer.py` - skip `post_llm_call` publication while retaining output transforms.
- `tests/agent/test_detached_fork_lifecycle_hooks.py` - cover detached-fork isolation and the normal-agent control path.

## How to Test

1. Run the lifecycle isolation and adjacent agent tests.
2. Confirm detached forks invoke only `transform_llm_output` while normal agents still invoke all lifecycle hooks.

```bash
scripts/run_tests.sh tests/agent/test_detached_fork_lifecycle_hooks.py tests/test_background_review_session_isolation.py tests/agent/test_system_prompt_restore.py tests/agent/test_turn_finalizer_cleanup_guard.py
```

Result: 41 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation: N/A; no user-facing configuration or API changed
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the guard is platform-independent
- [x] Tool descriptions/schemas: N/A; no tool behavior changed

## Screenshots / Logs

Not applicable. The automated regression exercises the lifecycle contract directly.
