### PR TITLE
feat(kanban): paste clipboard images into tasks

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1020,13 +1020,10 @@
         loadBoardList();  // refresh counts in the switcher
         if (!taskId || !attachments || !attachments.length) return res;
         uploadTaskAttachments(taskId, board, attachments).catch(function (e) {
-          // The task already exists; resolve so the create dialog closes rather
-          // than letting a retry create a duplicate card.
+          // The task already exists; report the background failure without
+          // reopening the create flow where a retry could duplicate the card.
           setActionError(tx(t, "taskCreatedUploadFailed",
             "Task created, but attachment upload failed: ") + String(e.message || e));
-        }).then(function () {
-          loadBoard();
-          loadBoardList();  // pick up attachment state after the background upload
         });
         return res;
       });

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -22,7 +22,7 @@
     Badge, Button, Input, Label, Select, SelectOption,
   } = SDK.components;
   const { useState, useEffect, useCallback, useMemo, useRef } = SDK.hooks;
-  const { cn, timeAgo } = SDK.utils;
+  const { cn, timeAgo, handleImagePaste } = SDK.utils;
 
   // Newer host dashboards expose a DS-styled Checkbox on the plugin SDK.
   // Fall back to a native <input type="checkbox"> shim so older hosts that
@@ -311,6 +311,26 @@
     if (!board) return url;
     const sep = url.indexOf("?") >= 0 ? "&" : "?";
     return `${url}${sep}board=${encodeURIComponent(board)}`;
+  }
+
+  function uploadTaskAttachments(taskId, board, fileList) {
+    const files = Array.prototype.slice.call(fileList || []);
+    if (!files.length) return Promise.resolve();
+    const url = withBoard(`${API}/tasks/${encodeURIComponent(taskId)}/attachments`, board);
+    let chain = Promise.resolve();
+    files.forEach(function (file, index) {
+      chain = chain.then(function () {
+        const fd = new FormData();
+        fd.append("file", file, file.name || `clipboard-image-${index + 1}`);
+        return SDK.authedFetch(url, { method: "POST", body: fd }).then(function (resp) {
+          if (resp.ok) return undefined;
+          return resp.text().then(function (txt) {
+            throw new Error(parseApiErrorMessage(new Error(resp.status + ": " + txt)));
+          });
+        });
+      });
+    });
+    return chain;
   }
 
   // The SDK's Select component fires ``onValueChange(value)`` directly
@@ -980,7 +1000,7 @@
         .catch(function () { /* dialog cancelled */ });
     }, [selectedIds, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
 
-    const createTask = useCallback(function (body) {
+    const createTask = useCallback(function (body, attachments) {
       return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -993,9 +1013,20 @@
         if (res && res.warning) {
           setError(tx(t, "taskCreatedWarning", "Task created, but: ") + res.warning);
         }
-        loadBoard();
-        loadBoardList();  // refresh counts in the switcher
-        return res;
+        const taskId = res && res.task && res.task.id;
+        const upload = taskId
+          ? uploadTaskAttachments(taskId, board, attachments)
+          : Promise.resolve();
+        return upload.catch(function (e) {
+          // The task already exists; resolve so the create dialog closes rather
+          // than letting a retry create a duplicate card.
+          setError(tx(t, "taskCreatedUploadFailed",
+            "Task created, but attachment upload failed: ") + String(e.message || e));
+        }).then(function () {
+          loadBoard();
+          loadBoardList();  // refresh counts in the switcher
+          return res;
+        });
       });
     }, [loadBoard, loadBoardList, board, t]);
 
@@ -2922,8 +2953,8 @@
         allTasks: props.allTasks,
         defaultWorkspaceKind: (props.boardMeta && props.boardMeta.default_workspace_kind) || "scratch",
         defaultWorkspacePath: (props.boardMeta && props.boardMeta.default_workdir) || "",
-        onSubmit: function (body) {
-          props.onCreate(body).then(function () { setShowCreate(false); });
+        onSubmit: function (body, attachments) {
+          return props.onCreate(body, attachments).then(function () { setShowCreate(false); });
         },
         onCancel: function () { setShowCreate(false); },
       }) : null,
@@ -3164,6 +3195,10 @@
   function InlineCreate(props) {
     const { t } = useI18n();
     const [title, setTitle] = useState("");
+    const [description, setDescription] = useState("");
+    const [pendingImages, setPendingImages] = useState([]);
+    const [submitBusy, setSubmitBusy] = useState(false);
+    const [submitErr, setSubmitErr] = useState(null);
     const [assignee, setAssignee] = useState("");
     const [priority, setPriority] = useState(0);
     const [parent, setParent] = useState("");
@@ -3185,9 +3220,10 @@
 
     const submit = function () {
       const trimmed = title.trim();
-      if (!trimmed) return;
+      if (!trimmed || submitBusy) return;
       const body = {
         title: trimmed,
+        body: description.trim() || null,
         assignee: assignee.trim() || null,
         priority: Number(priority) || 0,
         triage: props.columnName === "triage",
@@ -3215,10 +3251,16 @@
         const gmt = parseInt(goalMaxTurns, 10);
         if (Number.isFinite(gmt) && gmt > 0) body.goal_max_turns = gmt;
       }
-      props.onSubmit(body);
-      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills("");
-      setWorkspaceKind(defaultWorkspaceKind); setWorkspacePath(defaultWorkspacePath);
-      setGoalMode(false); setGoalMaxTurns("");
+      setSubmitBusy(true);
+      setSubmitErr(null);
+      props.onSubmit(body, pendingImages).then(function () {
+        setTitle(""); setDescription(""); setPendingImages([]);
+        setAssignee(""); setPriority(0); setParent(""); setSkills("");
+        setWorkspaceKind(defaultWorkspaceKind); setWorkspacePath(defaultWorkspacePath);
+        setGoalMode(false); setGoalMaxTurns("");
+      }).catch(function (e) {
+        setSubmitErr(String(e.message || e));
+      }).finally(function () { setSubmitBusy(false); });
     };
 
     const showPathInput = workspaceKind !== "scratch";
@@ -3260,6 +3302,26 @@
               className: "text-sm min-h-[3rem] max-h-48 resize-y w-full border border-input bg-transparent px-2 py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-ring",
               rows: 3,
             }),
+          ),
+          h("div", { className: "flex flex-col gap-1" },
+            fieldLabel(tx(t, "description", "Description")),
+            h("textarea", {
+              value: description,
+              onChange: function (e) { setDescription(e.target.value); },
+              onPaste: function (e) {
+                handleImagePaste(e, function (files) {
+                  setPendingImages(function (current) { return current.concat(files); });
+                });
+              },
+              placeholder: tx(t, "taskDescriptionPlaceholder",
+                "Task details… Paste screenshots here to attach them."),
+              className: "text-sm min-h-[5rem] max-h-64 resize-y w-full border border-input bg-transparent px-2 py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-ring",
+              rows: 5,
+            }),
+            pendingImages.length > 0 ? h("div", {
+              className: "text-xs text-muted-foreground",
+            }, `${pendingImages.length} pasted image${pendingImages.length === 1 ? "" : "s"} will be attached`) : null,
+            submitErr ? h("div", { className: "text-xs text-destructive" }, submitErr) : null,
           ),
           h("div", { className: "flex gap-2" },
             h("div", { className: "flex flex-col gap-1 flex-1" },
@@ -3383,8 +3445,8 @@
           h(Button, {
             type: "submit",
             size: "sm",
-            disabled: !title.trim(),
-          }, tx(t, "create", "Create")),
+            disabled: !title.trim() || submitBusy,
+          }, submitBusy ? tx(t, "creating", "Creating…") : tx(t, "create", "Create")),
         ),
       ),
     );
@@ -3463,28 +3525,7 @@
       if (!files.length) return;
       setUploadBusy(true);
       setUploadErr(null);
-      const url = withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/attachments`, boardSlug);
-      // Upload sequentially so a partial failure leaves a clear state.
-      let chain = Promise.resolve();
-      files.forEach(function (f) {
-        chain = chain.then(function () {
-          const fd = new FormData();
-          fd.append("file", f, f.name);
-          // SDK.authedFetch handles auth in BOTH modes (loopback token header /
-          // gated cookie) and applies the dashboard base-path prefix. The old
-          // hand-rolled Authorization:Bearer + credentials:'same-origin' sent
-          // an empty token and 401'd in gated mode.
-          return SDK.authedFetch(url, { method: "POST", body: fd })
-            .then(function (resp) {
-              if (!resp.ok) {
-                return resp.text().then(function (txt) {
-                  throw new Error(parseApiErrorMessage(new Error(resp.status + ": " + txt)));
-                });
-              }
-            });
-        });
-      });
-      chain.then(function () {
+      uploadTaskAttachments(props.taskId, boardSlug, files).then(function () {
         load();
         props.onRefresh();
       }).catch(function (e) {
@@ -3730,6 +3771,9 @@
             h(Input, {
               value: newComment,
               onChange: function (e) { setNewComment(e.target.value); },
+              onPaste: function (e) {
+                if (!uploadBusy) handleImagePaste(e, handleUpload);
+              },
               onKeyDown: function (e) {
                 if (e.key === "Enter" && !e.shiftKey) {
                   e.preventDefault(); handleComment();
@@ -3936,6 +3980,8 @@
         task: t,
         renderMarkdown: props.renderMarkdown,
         onPatch: props.onPatch,
+        onUpload: props.onUpload,
+        uploadBusy: props.uploadBusy,
       }),
       h(DependencyEditor, {
         task: t,
@@ -4504,6 +4550,9 @@
             value: v,
             rows: 8,
             onChange: function (e) { setV(e.target.value); },
+            onPaste: function (e) {
+              if (!props.uploadBusy) handleImagePaste(e, props.onUpload);
+            },
           })
         : props.task.body
           ? h(MarkdownBlock, { source: props.task.body, enabled: props.renderMarkdown })

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -640,6 +640,7 @@
     const [config, setConfig] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [actionError, setActionError] = useState(null);
 
     const [tenantFilter, setTenantFilter] = useState("");
     const [assigneeFilter, setAssigneeFilter] = useState("");
@@ -1001,6 +1002,7 @@
     }, [selectedIds, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
 
     const createTask = useCallback(function (body, attachments) {
+      setActionError(null);
       return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1011,7 +1013,7 @@
         // the task was created successfully — but the user should know
         // their ready task will sit idle until the gateway is up.
         if (res && res.warning) {
-          setError(tx(t, "taskCreatedWarning", "Task created, but: ") + res.warning);
+          setActionError(tx(t, "taskCreatedWarning", "Task created, but: ") + res.warning);
         }
         const taskId = res && res.task && res.task.id;
         const upload = taskId
@@ -1020,7 +1022,7 @@
         return upload.catch(function (e) {
           // The task already exists; resolve so the create dialog closes rather
           // than letting a retry create a duplicate card.
-          setError(tx(t, "taskCreatedUploadFailed",
+          setActionError(tx(t, "taskCreatedUploadFailed",
             "Task created, but attachment upload failed: ") + String(e.message || e));
         }).then(function () {
           loadBoard();
@@ -1339,6 +1341,7 @@
          onDelete: deleteSelected,
        }) : null,
         error ? h("div", { className: "text-xs text-destructive px-2" }, error) : null,
+        actionError ? h("div", { className: "text-xs text-destructive px-2" }, actionError) : null,
         h(KanbanDialogs, {
           dialogProps: kanbanDialogs.dialogProps,
           dialogState: kanbanDialogs.dialogState,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1016,19 +1016,19 @@
           setActionError(tx(t, "taskCreatedWarning", "Task created, but: ") + res.warning);
         }
         const taskId = res && res.task && res.task.id;
-        const upload = taskId
-          ? uploadTaskAttachments(taskId, board, attachments)
-          : Promise.resolve();
-        return upload.catch(function (e) {
+        loadBoard();
+        loadBoardList();  // refresh counts in the switcher
+        if (!taskId || !attachments || !attachments.length) return res;
+        uploadTaskAttachments(taskId, board, attachments).catch(function (e) {
           // The task already exists; resolve so the create dialog closes rather
           // than letting a retry create a duplicate card.
           setActionError(tx(t, "taskCreatedUploadFailed",
             "Task created, but attachment upload failed: ") + String(e.message || e));
         }).then(function () {
           loadBoard();
-          loadBoardList();  // refresh counts in the switcher
-          return res;
+          loadBoardList();  // pick up attachment state after the background upload
         });
+        return res;
       });
     }, [loadBoard, loadBoardList, board, t]);
 

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -667,6 +667,7 @@
     const wsRef = useRef(null);
     const wsBackoffRef = useRef(1000);
     const wsClosedRef = useRef(false);
+    const boardRequestRef = useRef(0);
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
@@ -685,20 +686,25 @@
 
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
+      const requestId = ++boardRequestRef.current;
       const qs = new URLSearchParams();
       if (tenantFilter) qs.set("tenant", tenantFilter);
       if (includeArchived) qs.set("include_archived", "true");
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
       return SDK.fetchJSON(withBoard(url, board))
         .then(function (data) {
+          if (requestId !== boardRequestRef.current) return;
           setBoardData(data);
           cursorRef.current = data.latest_event_id || 0;
           setError(null);
         })
         .catch(function (err) {
+          if (requestId !== boardRequestRef.current) return;
           setError(String(err && err.message ? err.message : err));
         })
-        .finally(function () { setLoading(false); });
+        .finally(function () {
+          if (requestId === boardRequestRef.current) setLoading(false);
+        });
     }, [tenantFilter, includeArchived, board]);
 
     // --- load list of boards for the switcher ------------------------------
@@ -1173,6 +1179,7 @@
       // Optimistic UI: clear the current grid + show loading, reset the
       // event cursor so the WS reopens aligned to the new board's
       // latest_event_id on the next loadBoard.
+      boardRequestRef.current += 1;
       setBoardData(null);
       cursorRef.current = 0;
       setLoading(true);

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -664,10 +664,11 @@
 
     const cursorRef = useRef(0);
     const reloadTimerRef = useRef(null);
-    const wsRef = useRef(null);
     const wsBackoffRef = useRef(1000);
-    const wsClosedRef = useRef(false);
+    const boardSelectionRef = useRef(board);
     const boardRequestRef = useRef(0);
+    const createOperationRef = useRef(0);
+    boardSelectionRef.current = board;
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
@@ -686,6 +687,8 @@
 
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
+      if (board !== boardSelectionRef.current) return Promise.resolve();
+      const requestedBoard = board;
       const requestId = ++boardRequestRef.current;
       const qs = new URLSearchParams();
       if (tenantFilter) qs.set("tenant", tenantFilter);
@@ -693,17 +696,19 @@
       const url = qs.toString() ? `${API}/board?${qs}` : `${API}/board`;
       return SDK.fetchJSON(withBoard(url, board))
         .then(function (data) {
-          if (requestId !== boardRequestRef.current) return;
+          if (requestId !== boardRequestRef.current || requestedBoard !== boardSelectionRef.current) return;
           setBoardData(data);
           cursorRef.current = data.latest_event_id || 0;
           setError(null);
         })
         .catch(function (err) {
-          if (requestId !== boardRequestRef.current) return;
+          if (requestId !== boardRequestRef.current || requestedBoard !== boardSelectionRef.current) return;
           setError(String(err && err.message ? err.message : err));
         })
         .finally(function () {
-          if (requestId === boardRequestRef.current) setLoading(false);
+          if (requestId === boardRequestRef.current && requestedBoard === boardSelectionRef.current) {
+            setLoading(false);
+          }
         });
     }, [tenantFilter, includeArchived, board]);
 
@@ -752,9 +757,11 @@
     // --- WebSocket ---------------------------------------------------------
     useEffect(function () {
       if (!boardData) return undefined;
-      wsClosedRef.current = false;
+      let cancelled = false;
+      let reconnectTimer = null;
+      let ws = null;
       function openWs() {
-        if (wsClosedRef.current) return;
+        if (cancelled) return;
         // Build the WS URL via the host SDK so the correct auth param is used
         // in BOTH modes: single-use ?ticket= in gated OAuth mode, ?token= in
         // loopback. Reading window.__HERMES_SESSION_TOKEN__ directly (the old
@@ -770,12 +777,11 @@
         // Regression: #20879.
         if (board) wsParams.board = board;
         SDK.buildWsUrl(`${API}/events`, wsParams).then(function (url) {
-          if (wsClosedRef.current) return;
-          let ws;
+          if (cancelled) return;
           try { ws = new WebSocket(url); } catch (_e) { return; }
-          wsRef.current = ws;
           ws.onopen = function () { wsBackoffRef.current = 1000; };
           ws.onmessage = function (ev) {
+            if (cancelled) return;
             try {
               const msg = JSON.parse(ev.data);
               if (msg && Array.isArray(msg.events) && msg.events.length > 0) {
@@ -793,7 +799,7 @@
             } catch (_e) { /* ignore */ }
           };
           ws.onclose = function (ev) {
-            if (wsClosedRef.current) return;
+            if (cancelled) return;
             if (ev && ev.code === 1008) {
               setError(tx(t, "wsAuthFailed",
                 "WebSocket auth failed — reload the page to refresh the session token."));
@@ -801,21 +807,22 @@
             }
             const delay = Math.min(wsBackoffRef.current, 30000);
             wsBackoffRef.current = Math.min(wsBackoffRef.current * 2, 30000);
-            setTimeout(openWs, delay);
+            reconnectTimer = setTimeout(openWs, delay);
           };
         }).catch(function () {
           // Ticket mint / URL build failed (e.g. session expired). Back off
           // and retry; a hard auth failure surfaces via the 1008 close path.
-          if (wsClosedRef.current) return;
+          if (cancelled) return;
           const delay = Math.min(wsBackoffRef.current, 30000);
           wsBackoffRef.current = Math.min(wsBackoffRef.current * 2, 30000);
-          setTimeout(openWs, delay);
+          reconnectTimer = setTimeout(openWs, delay);
         });
       }
       openWs();
       return function () {
-        wsClosedRef.current = true;
-        try { wsRef.current && wsRef.current.close(); } catch (_e) { /* noop */ }
+        cancelled = true;
+        if (reconnectTimer) clearTimeout(reconnectTimer);
+        try { ws && ws.close(); } catch (_e) { /* noop */ }
       };
     }, [!!boardData, board, scheduleReload]);
 
@@ -1008,6 +1015,13 @@
     }, [selectedIds, requestMoveConfirm, requestCompletionSummary, performMoveTask]);
 
     const createTask = useCallback(function (body, attachments) {
+      const operationId = ++createOperationRef.current;
+      const originBoard = board;
+      const showActionError = function (message) {
+        if (operationId === createOperationRef.current) {
+          setActionError({ board: originBoard, message: message });
+        }
+      };
       setActionError(null);
       return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
         method: "POST",
@@ -1019,7 +1033,7 @@
         // the task was created successfully — but the user should know
         // their ready task will sit idle until the gateway is up.
         if (res && res.warning) {
-          setActionError(tx(t, "taskCreatedWarning", "Task created, but: ") + res.warning);
+          showActionError(tx(t, "taskCreatedWarning", "Task created, but: ") + res.warning);
         }
         const taskId = res && res.task && res.task.id;
         loadBoard();
@@ -1028,7 +1042,7 @@
         uploadTaskAttachments(taskId, board, attachments).catch(function (e) {
           // The task already exists; report the background failure without
           // reopening the create flow where a retry could duplicate the card.
-          setActionError(tx(t, "taskCreatedUploadFailed",
+          showActionError(tx(t, "taskCreatedUploadFailed",
             "Task created, but attachment upload failed: ") + String(e.message || e));
         });
         return res;
@@ -1179,6 +1193,7 @@
       // Optimistic UI: clear the current grid + show loading, reset the
       // event cursor so the WS reopens aligned to the new board's
       // latest_event_id on the next loadBoard.
+      boardSelectionRef.current = nextSlug;
       boardRequestRef.current += 1;
       setBoardData(null);
       cursorRef.current = 0;
@@ -1345,7 +1360,9 @@
          onDelete: deleteSelected,
        }) : null,
         error ? h("div", { className: "text-xs text-destructive px-2" }, error) : null,
-        actionError ? h("div", { className: "text-xs text-destructive px-2" }, actionError) : null,
+        actionError && actionError.board === board
+          ? h("div", { className: "text-xs text-destructive px-2" }, actionError.message)
+          : null,
         h(KanbanDialogs, {
           dialogProps: kanbanDialogs.dialogProps,
           dialogState: kanbanDialogs.dialogState,

--- a/web/src/lib/chatImagePaste.test.ts
+++ b/web/src/lib/chatImagePaste.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   firstImageFromClipboard,
+  handleImagePaste,
   imageFilesFromTransfer,
   transferMayContainImage,
 } from "./chatImagePaste";
@@ -79,6 +80,34 @@ describe("imageFilesFromTransfer", () => {
       files: [png, gif],
     });
     expect(imageFilesFromTransfer(data)).toEqual([png, gif]);
+  });
+});
+
+describe("handleImagePaste", () => {
+  it("prevents native paste and forwards every clipboard image", () => {
+    let prevented = false;
+    let received: File[] = [];
+    const event = {
+      clipboardData: makeData({ files: [png, gif] }),
+      preventDefault: () => { prevented = true; },
+    };
+
+    expect(handleImagePaste(event, files => { received = files; })).toBe(true);
+    expect(prevented).toBe(true);
+    expect(received).toEqual([png, gif]);
+  });
+
+  it("leaves text-only paste untouched", () => {
+    let prevented = false;
+    const event = {
+      clipboardData: makeData({
+        items: [makeItem("string", "text/plain", null)],
+      }),
+      preventDefault: () => { prevented = true; },
+    };
+
+    expect(handleImagePaste(event, () => undefined)).toBe(false);
+    expect(prevented).toBe(false);
   });
 });
 

--- a/web/src/lib/chatImagePaste.ts
+++ b/web/src/lib/chatImagePaste.ts
@@ -62,6 +62,18 @@ export function imageFilesFromTransfer(
   return files;
 }
 
+/** Consume a paste only when its clipboard payload contains image files. */
+export function handleImagePaste(
+  event: Pick<ClipboardEvent, "clipboardData" | "preventDefault">,
+  onImages: (files: File[]) => void,
+): boolean {
+  const files = imageFilesFromTransfer(event.clipboardData);
+  if (files.length === 0) return false;
+  event.preventDefault();
+  onImages(files);
+  return true;
+}
+
 /** Pull the first image blob out of a DataTransfer, or null if none present. */
 export function firstImageFromClipboard(
   data: DataTransfer | null,

--- a/web/src/plugins/kanbanDashboard.test.tsx
+++ b/web/src/plugins/kanbanDashboard.test.tsx
@@ -28,6 +28,7 @@ const emptyBoard = {
 
 let container: HTMLDivElement;
 let root: Root;
+let resolveUpload: ((response: { ok: boolean; status: number; text: () => Promise<string> }) => void) | undefined;
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 class FakeWebSocket {
@@ -59,11 +60,7 @@ beforeEach(async () => {
   vi.resetAllMocks();
   localStorage.clear();
   apiMocks.buildWsUrl.mockResolvedValue("ws://localhost/api/plugins/kanban/events");
-  apiMocks.authedFetch.mockResolvedValue({
-    ok: false,
-    status: 413,
-    text: async () => JSON.stringify({ detail: "image too large" }),
-  });
+  apiMocks.authedFetch.mockResolvedValue({ ok: true });
 
   let boardLoads = 0;
   apiMocks.fetchJSON.mockImplementation(async (url: string, init?: RequestInit) => {
@@ -106,19 +103,24 @@ afterEach(async () => {
 });
 
 describe("kanban dashboard clipboard uploads", () => {
-  it("keeps a post-create upload failure visible after the board reload", async () => {
+  it("refreshes after create without waiting for upload and keeps a later failure visible", async () => {
     await act(async () => click(container.querySelector('[title="Create task in this column"]')));
 
-    const textareas = Array.from(container.querySelectorAll("textarea"));
-    expect(textareas).toHaveLength(2);
-    await act(async () => setTextareaValue(textareas[0], "Task with screenshot"));
+    const description = container.querySelector<HTMLTextAreaElement>('textarea[placeholder*="Paste screenshots here"]');
+    const title = Array.from(container.querySelectorAll<HTMLTextAreaElement>("textarea"))
+      .find(element => element !== description);
+    if (!title || !description) throw new Error("create fields not rendered");
+    await act(async () => setTextareaValue(title, "Task with screenshot"));
+    apiMocks.authedFetch.mockImplementationOnce(() => new Promise(resolve => {
+      resolveUpload = resolve;
+    }));
 
     const image = new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
     const paste = new Event("paste", { bubbles: true, cancelable: true });
     Object.defineProperty(paste, "clipboardData", {
       value: { items: [], files: { 0: image, length: 1 } },
     });
-    await act(async () => textareas[1].dispatchEvent(paste));
+    await act(async () => description.dispatchEvent(paste));
 
     const form = container.querySelector("form");
     if (!form) throw new Error("create form not rendered");
@@ -128,12 +130,22 @@ describe("kanban dashboard clipboard uploads", () => {
     await waitFor(() => apiMocks.fetchJSON.mock.calls.filter(
       ([url]) => String(url).includes("/board") && !String(url).includes("/boards"),
     ).length >= 2);
+    expect(container.textContent).not.toContain("Task created, but attachment upload failed:");
 
     const taskPosts = apiMocks.fetchJSON.mock.calls.filter(
       ([url, init]) => String(url).includes("/tasks") && init?.method === "POST",
     );
     expect(taskPosts).toHaveLength(1);
     expect(apiMocks.authedFetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveUpload?.({
+      ok: false,
+      status: 413,
+      text: async () => JSON.stringify({ detail: "image too large" }),
+    }));
+    await waitFor(() => apiMocks.fetchJSON.mock.calls.filter(
+      ([url]) => String(url).includes("/board") && !String(url).includes("/boards"),
+    ).length >= 3);
     expect(container.textContent).toContain(
       "Task created, but attachment upload failed: image too large",
     );

--- a/web/src/plugins/kanbanDashboard.test.tsx
+++ b/web/src/plugins/kanbanDashboard.test.tsx
@@ -29,10 +29,26 @@ const emptyBoard = {
 let container: HTMLDivElement;
 let root: Root;
 let resolveUpload: ((response: { ok: boolean; status: number; text: () => Promise<string> }) => void) | undefined;
+let fakeSockets: FakeWebSocket[];
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 class FakeWebSocket {
-  close() {}
+  onclose: ((event: { code: number }) => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  constructor() {
+    fakeSockets.push(this);
+  }
+
+  close() {
+    this.onclose?.({ code: 1000 });
+  }
+
+  emitTaskEvent() {
+    this.onmessage?.({
+      data: JSON.stringify({ cursor: 2, events: [{ task_id: "t_old_board" }] }),
+    });
+  }
 }
 
 async function waitFor(condition: () => boolean, timeoutMs = 5000) {
@@ -59,6 +75,7 @@ function setTextareaValue(element: HTMLTextAreaElement, value: string) {
 beforeEach(async () => {
   vi.resetAllMocks();
   localStorage.clear();
+  fakeSockets = [];
   apiMocks.buildWsUrl.mockResolvedValue("ws://localhost/api/plugins/kanban/events");
   apiMocks.authedFetch.mockResolvedValue({ ok: true });
 
@@ -69,7 +86,13 @@ beforeEach(async () => {
     }
     if (url.includes("/config")) return { render_markdown: true };
     if (url.includes("/boards")) {
-      return { boards: [{ slug: "default", name: "Default" }], current: "default" };
+      return {
+        boards: [
+          { slug: "default", name: "Default", total: 1 },
+          { slug: "other", name: "Other", total: 1 },
+        ],
+        current: "default",
+      };
     }
     if (url.includes("/board")) {
       boardLoads += 1;
@@ -95,6 +118,18 @@ beforeEach(async () => {
   await act(async () => root.render(<KanbanPage />));
   await waitFor(() => Boolean(container.querySelector('[title="Create task in this column"]')));
 });
+
+async function switchToOtherBoard() {
+  const trigger = Array.from(container.querySelectorAll("button"))
+    .find(element => element.textContent?.includes("Default"));
+  await act(async () => click(trigger ?? null));
+  const option = Array.from(container.querySelectorAll('[role="option"]'))
+    .find(element => element.textContent?.includes("Other"));
+  await act(async () => click(option ?? null));
+  await waitFor(() => apiMocks.fetchJSON.mock.calls.some(
+    ([url]) => String(url).includes("board=other"),
+  ));
+}
 
 afterEach(async () => {
   await act(async () => root?.unmount());
@@ -153,6 +188,57 @@ describe("kanban dashboard clipboard uploads", () => {
       ([url]) => String(url).includes("/board") && !String(url).includes("/boards"),
     )).toHaveLength(boardLoadsBeforeUploadSettlement);
     expect(container.textContent).toContain(
+      "Task created, but attachment upload failed: image too large",
+    );
+  });
+
+  it("ignores events from a WebSocket closed by a board switch", async () => {
+    await waitFor(() => fakeSockets.length > 0);
+    const oldSocket = fakeSockets[fakeSockets.length - 1];
+    await switchToOtherBoard();
+    const boardLoadsAfterSwitch = apiMocks.fetchJSON.mock.calls.filter(
+      ([url]) => String(url).includes("/board") && !String(url).includes("/boards"),
+    ).length;
+
+    await act(async () => {
+      oldSocket.emitTaskEvent();
+      await new Promise(resolve => setTimeout(resolve, 300));
+    });
+
+    expect(apiMocks.fetchJSON.mock.calls.filter(
+      ([url]) => String(url).includes("/board") && !String(url).includes("/boards"),
+    )).toHaveLength(boardLoadsAfterSwitch);
+  });
+
+  it("does not show a delayed upload error on another board", async () => {
+    await act(async () => click(container.querySelector('[title="Create task in this column"]')));
+    const description = container.querySelector<HTMLTextAreaElement>('textarea[placeholder*="Paste screenshots here"]');
+    const title = Array.from(container.querySelectorAll<HTMLTextAreaElement>("textarea"))
+      .find(element => element !== description);
+    if (!title || !description) throw new Error("create fields not rendered");
+    await act(async () => setTextareaValue(title, "Task with delayed screenshot"));
+    apiMocks.authedFetch.mockImplementationOnce(() => new Promise(resolve => {
+      resolveUpload = resolve;
+    }));
+    const image = new File([new Uint8Array([1])], "shot.png", { type: "image/png" });
+    const paste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, "clipboardData", {
+      value: { items: [], files: { 0: image, length: 1 } },
+    });
+    await act(async () => description.dispatchEvent(paste));
+    await act(async () => container.querySelector("form")?.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    ));
+    await waitFor(() => !container.querySelector("form"));
+
+    await switchToOtherBoard();
+    await act(async () => resolveUpload?.({
+      ok: false,
+      status: 413,
+      text: async () => JSON.stringify({ detail: "image too large" }),
+    }));
+
+    expect(container.textContent).not.toContain(
       "Task created, but attachment upload failed: image too large",
     );
   });

--- a/web/src/plugins/kanbanDashboard.test.tsx
+++ b/web/src/plugins/kanbanDashboard.test.tsx
@@ -137,15 +137,21 @@ describe("kanban dashboard clipboard uploads", () => {
     );
     expect(taskPosts).toHaveLength(1);
     expect(apiMocks.authedFetch).toHaveBeenCalledTimes(1);
+    const boardLoadsBeforeUploadSettlement = apiMocks.fetchJSON.mock.calls.filter(
+      ([url]) => String(url).includes("/board") && !String(url).includes("/boards"),
+    ).length;
 
     await act(async () => resolveUpload?.({
       ok: false,
       status: 413,
       text: async () => JSON.stringify({ detail: "image too large" }),
     }));
-    await waitFor(() => apiMocks.fetchJSON.mock.calls.filter(
+    await waitFor(() => container.textContent?.includes(
+      "Task created, but attachment upload failed: image too large",
+    ) === true);
+    expect(apiMocks.fetchJSON.mock.calls.filter(
       ([url]) => String(url).includes("/board") && !String(url).includes("/boards"),
-    ).length >= 3);
+    )).toHaveLength(boardLoadsBeforeUploadSettlement);
     expect(container.textContent).toContain(
       "Task created, but attachment upload failed: image too large",
     );

--- a/web/src/plugins/kanbanDashboard.test.tsx
+++ b/web/src/plugins/kanbanDashboard.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  authedFetch: vi.fn(),
+  buildWsAuthParam: vi.fn(),
+  buildWsUrl: vi.fn(),
+  fetchJSON: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {},
+  authedFetch: apiMocks.authedFetch,
+  buildWsAuthParam: apiMocks.buildWsAuthParam,
+  buildWsUrl: apiMocks.buildWsUrl,
+  fetchJSON: apiMocks.fetchJSON,
+}));
+
+const emptyBoard = {
+  assignees: [],
+  columns: ["triage", "todo", "ready", "running", "blocked", "review", "done"].map(
+    name => ({ name, tasks: [] }),
+  ),
+  latest_event_id: 0,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+class FakeWebSocket {
+  close() {}
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 5000) {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) throw new Error("condition never became true");
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 20));
+    });
+  }
+}
+
+function click(element: Element | null) {
+  if (!element) throw new Error("element not rendered");
+  element.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+}
+
+function setTextareaValue(element: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+  setter?.call(element, value);
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  localStorage.clear();
+  apiMocks.buildWsUrl.mockResolvedValue("ws://localhost/api/plugins/kanban/events");
+  apiMocks.authedFetch.mockResolvedValue({
+    ok: false,
+    status: 413,
+    text: async () => JSON.stringify({ detail: "image too large" }),
+  });
+
+  let boardLoads = 0;
+  apiMocks.fetchJSON.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (url.includes("/tasks") && init?.method === "POST") {
+      return { task: { id: "t_created" } };
+    }
+    if (url.includes("/config")) return { render_markdown: true };
+    if (url.includes("/boards")) {
+      return { boards: [{ slug: "default", name: "Default" }], current: "default" };
+    }
+    if (url.includes("/board")) {
+      boardLoads += 1;
+      return { ...emptyBoard, latest_event_id: boardLoads };
+    }
+    throw new Error(`unexpected request: ${url}`);
+  });
+
+  vi.stubGlobal("WebSocket", FakeWebSocket);
+  vi.stubGlobal("ResizeObserver", class { disconnect() {} observe() {} unobserve() {} });
+
+  const { exposePluginSDK, getPluginComponent } = await import("./registry");
+  exposePluginSDK();
+  // The kanban dashboard intentionally ships as a plain IIFE plugin bundle.
+  // @ts-expect-error -- no module declarations are generated for plugin bundles.
+  await import("../../../plugins/kanban/dashboard/dist/index.js");
+  const KanbanPage = getPluginComponent("kanban");
+  if (!KanbanPage) throw new Error("kanban plugin did not register");
+
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root.render(<KanbanPage />));
+  await waitFor(() => Boolean(container.querySelector('[title="Create task in this column"]')));
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("kanban dashboard clipboard uploads", () => {
+  it("keeps a post-create upload failure visible after the board reload", async () => {
+    await act(async () => click(container.querySelector('[title="Create task in this column"]')));
+
+    const textareas = Array.from(container.querySelectorAll("textarea"));
+    expect(textareas).toHaveLength(2);
+    await act(async () => setTextareaValue(textareas[0], "Task with screenshot"));
+
+    const image = new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+    const paste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, "clipboardData", {
+      value: { items: [], files: { 0: image, length: 1 } },
+    });
+    await act(async () => textareas[1].dispatchEvent(paste));
+
+    const form = container.querySelector("form");
+    if (!form) throw new Error("create form not rendered");
+    await act(async () => form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })));
+
+    await waitFor(() => !container.querySelector("form"));
+    await waitFor(() => apiMocks.fetchJSON.mock.calls.filter(
+      ([url]) => String(url).includes("/board") && !String(url).includes("/boards"),
+    ).length >= 2);
+
+    const taskPosts = apiMocks.fetchJSON.mock.calls.filter(
+      ([url, init]) => String(url).includes("/tasks") && init?.method === "POST",
+    );
+    expect(taskPosts).toHaveLength(1);
+    expect(apiMocks.authedFetch).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain(
+      "Task created, but attachment upload failed: image too large",
+    );
+  });
+});

--- a/web/src/plugins/registry.ts
+++ b/web/src/plugins/registry.ts
@@ -18,6 +18,7 @@ import React, {
   createContext,
 } from "react";
 import { api, fetchJSON, authedFetch, buildWsUrl, buildWsAuthParam } from "@/lib/api";
+import { handleImagePaste } from "@/lib/chatImagePaste";
 import { cn, timeAgo, isoTimeAgo } from "@/lib/utils";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
@@ -184,7 +185,7 @@ export function exposePluginSDK() {
     },
 
     // Utilities
-    utils: { cn, timeAgo, isoTimeAgo },
+    utils: { cn, timeAgo, isoTimeAgo, handleImagePaste },
 
     // Hooks
     useI18n,

--- a/web/src/plugins/sdk.d.ts
+++ b/web/src/plugins/sdk.d.ts
@@ -164,6 +164,11 @@ export interface HermesPluginSDK {
     timeAgo: (ts: number) => string;
     /** Relative-time formatter for an ISO-8601 string. */
     isoTimeAgo: (iso: string) => string;
+    /** Consume a paste only when it contains image files. */
+    handleImagePaste: (
+      event: Pick<ClipboardEvent, "clipboardData" | "preventDefault">,
+      onImages: (files: File[]) => void,
+    ) => boolean;
   };
 
   /**


### PR DESCRIPTION
## What does this PR do?

Adds clipboard image paste support to the Kanban dashboard's new-task description, task description editor, and comment input. Pasted images use the existing authenticated attachment upload path and appear in the existing attachment list, removing the file-picker step from screenshot-driven task workflows.

### Motivation

The Kanban dashboard currently requires users to save clipboard screenshots to disk and select them through the attachment file picker. This adds unnecessary friction when attaching error dialogs, diagrams, receipts, and similar visual context.

### Behavior

- Pasting one or more image files into a new task description queues them and uploads them after the task receives an ID.
- Pasting images into an existing task description or comment input uploads them immediately as task attachments.
- Text-only paste remains unchanged.
- Upload failures are shown through the existing error surfaces. A failed post-create upload does not leave the dialog open where retrying could create a duplicate task.
- Images render through the existing attachment-row workflow; inline Markdown image rendering is not added.

### Implementation

A tested `handleImagePaste` helper extracts image files from clipboard `DataTransfer` values, consumes only image-bearing paste events, and is exposed through the additive dashboard plugin SDK utility surface. The Kanban plugin routes those files through the existing authenticated multipart endpoint and shares one sequential uploader between file-picker, paste, and post-create flows.

## Related Issue

Closes #107061

## Type of Change

- [x] New feature

## Changes Made

- `plugins/kanban/dashboard/dist/index.js` - add paste handlers, queued new-task image uploads, shared multipart upload handling, and a task description field.
- `web/src/lib/chatImagePaste.ts` - add the reusable image-paste event helper.
- `web/src/lib/chatImagePaste.test.ts` - cover image consumption and unchanged text-only paste.
- `web/src/plugins/registry.ts` and `web/src/plugins/sdk.d.ts` - expose and type the additive helper for dashboard plugins.

## How to Test

1. Open Kanban, create a task, paste an image into Description, and submit. Open the task and verify the image appears under Attachments.
2. In an existing task, paste images into the description editor and comment input. Verify each upload appears under Attachments and normal text paste still edits the field.
3. Run:

```bash
cd web
npm run check
```

Local result: 41 test files passed, 300 tests passed, typecheck passed, and lint completed with 0 errors.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the relevant web test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; the UI labels and behavior are self-contained
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the implementation uses standard ClipboardEvent, DataTransfer, File, and FormData browser APIs
- [x] Tool description and schema changes are N/A; no agent tool behavior changed

## Screenshots / Logs

Automated verification is listed above; no screenshot is included.
