### PR TITLE
fix(desktop): make native notifications reveal their session tab

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -19,7 +19,6 @@ import {
   ipcMain,
   Menu,
   nativeTheme,
-  Notification,
   powerMonitor,
   powerSaveBlocker,
   protocol,
@@ -270,6 +269,7 @@ import {
 } from './native-oauth'
 import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
+import { registerNativeNotifications } from './notification-ipc'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
 import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-process-identity'
@@ -16773,92 +16773,11 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   return handleHermesApiRequest(request).finally(releaseProfileDeletion)
 })
 
-// One deduper per cross-window cue — the choke point every window shares. Main
-// handles IPC serially, so the first window to claim a key wins with no race.
-const isDuplicateNotification = createEventDeduper()
+// Main serializes cross-window ambient claims.
 const claimedAmbientCue = createEventDeduper()
-
-// A window asks "do I own this ambient cue (turn-end sound / spoken reply)?".
-// The first caller within the window gets true; peers get false and stay quiet.
 ipcMain.handle('hermes:ambient:claim', (_event, key) => !claimedAmbientCue(String(key ?? '')))
 
-ipcMain.handle('hermes:notify', (_event, payload) => {
-  if (!Notification.isSupported()) {
-    return false
-  }
-
-  // Multiple full windows each run their own renderer throttle, so the same
-  // kind+session can arrive here twice. Collapse it at this single choke point.
-  // Return true (not false): a notification for the event IS being shown by the
-  // first caller, so the settings "send test" success probe stays honest.
-  if (isDuplicateNotification(`${payload?.kind ?? ''}:${payload?.sessionId ?? payload?.tag ?? ''}`)) {
-    return true
-  }
-
-  // Action buttons render only on signed macOS builds; elsewhere they're dropped
-  // and the body click still works.
-  const actions = Array.isArray(payload?.actions) ? payload.actions : []
-  const icon = typeof payload?.icon === 'string' && payload.icon.trim() ? payload.icon.trim() : undefined
-
-  const notification = new Notification({
-    title: payload?.title || 'Hermes',
-    body: payload?.body || '',
-    silent: Boolean(payload?.silent),
-    ...(icon ? { icon } : {}),
-    actions: actions.map(action => ({ type: 'button', text: String(action?.text || '') }))
-  })
-
-  notification.on('click', () => {
-    if (!mainWindow || mainWindow.isDestroyed()) {
-      return
-    }
-
-    focusWindow(mainWindow)
-
-    if (payload?.sessionId) {
-      mainWindow.webContents.send('hermes:focus-session', payload.sessionId)
-    }
-
-    // Plugin / session-less activation — serializable path (+ optional notifyId
-    // for renderer callbacks). Same vocabulary as hermes://index-network/….
-    if (payload?.activate || payload?.notifyId) {
-      mainWindow.webContents.send('hermes:notification-activate', {
-        activate: payload?.activate,
-        notifyId: payload?.notifyId,
-        tag: payload?.tag
-      })
-    }
-  })
-  notification.on('action', (_actionEvent, index) => {
-    if (!mainWindow || mainWindow.isDestroyed()) {
-      return
-    }
-
-    const action = actions[index]
-
-    if (!action?.id) {
-      return
-    }
-
-    // Approvals keep the existing session-scoped channel.
-    if (payload?.sessionId && !payload?.notifyId && !payload?.activate) {
-      mainWindow.webContents.send('hermes:notification-action', { sessionId: payload.sessionId, actionId: action.id })
-
-      return
-    }
-
-    focusWindow(mainWindow)
-    mainWindow.webContents.send('hermes:notification-activate', {
-      actionId: action.id,
-      activate: action.activate || payload?.activate,
-      notifyId: payload?.notifyId,
-      tag: payload?.tag
-    })
-  })
-  notification.show()
-
-  return true
-})
+registerNativeNotifications({ getMainWindow: () => mainWindow, focusWindow })
 
 // Data-URL file load cap (composer attach + local previews). Main owns the
 // persisted MB value so every IPC read honours Settings → Chat without the

--- a/apps/desktop/electron/notification-actions.test.ts
+++ b/apps/desktop/electron/notification-actions.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { resolveNotificationAction } from './notification-actions'
+
+const actions = [
+  { id: 'approve', text: 'Approve' },
+  { id: 'reject', text: 'Reject' }
+]
+
+test('prefers Electron event details and supports the legacy positional index', () => {
+  assert.deepEqual(resolveNotificationAction(actions, { actionIndex: 1 }, undefined), actions[1])
+  assert.deepEqual(resolveNotificationAction(actions, {}, 0), actions[0])
+  assert.deepEqual(resolveNotificationAction(actions, { actionIndex: 1 }, 0), actions[1])
+})
+
+test('ignores missing and out-of-range action indexes', () => {
+  assert.equal(resolveNotificationAction(actions, {}, undefined), null)
+  assert.equal(resolveNotificationAction(actions, { actionIndex: -1 }, undefined), null)
+  assert.equal(resolveNotificationAction(actions, { actionIndex: 2 }, undefined), null)
+})

--- a/apps/desktop/electron/notification-actions.ts
+++ b/apps/desktop/electron/notification-actions.ts
@@ -1,0 +1,29 @@
+function isActionIndex(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value)
+}
+
+function notificationActionIndex(actionEvent: unknown, legacyIndex: unknown): number | null {
+  if (actionEvent && typeof actionEvent === 'object' && 'actionIndex' in actionEvent) {
+    const { actionIndex } = actionEvent as { actionIndex?: unknown }
+
+    if (isActionIndex(actionIndex)) {
+      return actionIndex
+    }
+  }
+
+  return isActionIndex(legacyIndex) ? legacyIndex : null
+}
+
+export function resolveNotificationAction<T>(
+  actions: readonly T[],
+  actionEvent: unknown,
+  legacyIndex: unknown
+): T | null {
+  const index = notificationActionIndex(actionEvent, legacyIndex)
+
+  if (index === null || index < 0 || index >= actions.length) {
+    return null
+  }
+
+  return actions[index] ?? null
+}

--- a/apps/desktop/electron/notification-ipc.test.ts
+++ b/apps/desktop/electron/notification-ipc.test.ts
@@ -1,0 +1,104 @@
+import { EventEmitter } from 'node:events'
+
+import type { BrowserWindow, IpcMainInvokeEvent } from 'electron'
+import { beforeEach, expect, it, vi } from 'vitest'
+
+import type { HermesNotification } from '../src/global'
+
+const host = vi.hoisted(() => ({
+  handle: vi.fn(),
+  fromWebContents: vi.fn(),
+  shown: [] as EventEmitter[]
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: host.fromWebContents },
+  ipcMain: { handle: host.handle },
+  Notification: class extends EventEmitter {
+    static isSupported() {
+      return true
+    }
+
+    show() {
+      host.shown.push(this)
+    }
+  }
+}))
+
+import { registerNativeNotifications } from './notification-ipc'
+
+function windowStub() {
+  return {
+    isDestroyed: vi.fn(() => false),
+    webContents: { isDestroyed: vi.fn(() => false), send: vi.fn() }
+  }
+}
+
+beforeEach(() => {
+  host.handle.mockReset()
+  host.fromWebContents.mockReset()
+  host.shown.length = 0
+})
+
+it('returns native clicks and approval actions to the emitting window, not the primary', () => {
+  const primary = windowStub()
+  const source = windowStub()
+  host.fromWebContents.mockReturnValue(source)
+  const focusWindow = vi.fn()
+  registerNativeNotifications({ getMainWindow: () => primary as unknown as BrowserWindow, focusWindow })
+  const notify = host.handle.mock.calls[0][1] as (event: IpcMainInvokeEvent, payload: HermesNotification) => boolean
+  const payload = {
+    kind: 'approval',
+    sessionId: 'runtime-source',
+    focusSessionId: 'stored-source',
+    title: 'Approval',
+    actions: [{ id: 'approve', text: 'Approve' }, { id: 'reject', text: 'Reject' }]
+  }
+  expect(notify({ sender: source.webContents } as unknown as IpcMainInvokeEvent, payload)).toBe(true)
+  expect(focusWindow).not.toHaveBeenCalled()
+  expect(primary.webContents.send).not.toHaveBeenCalled()
+  host.shown[0].emit('click')
+  expect(focusWindow).toHaveBeenCalledWith(source)
+  expect(source.webContents.send).toHaveBeenCalledWith('hermes:focus-session', payload.focusSessionId)
+  host.shown[0].emit('action', { actionIndex: 1 }, undefined)
+  expect(source.webContents.send).toHaveBeenCalledWith('hermes:notification-action', {
+    sessionId: payload.sessionId,
+    actionId: 'reject'
+  })
+  expect(primary.webContents.send).not.toHaveBeenCalled()
+
+  // A response must never jump to another window's gateway after its owner closes.
+  source.isDestroyed.mockReturnValue(true)
+  host.shown[0].emit('action', { actionIndex: 0 }, undefined)
+  expect(primary.webContents.send).not.toHaveBeenCalled()
+  host.shown[0].emit('click')
+  expect(primary.webContents.send).toHaveBeenCalledWith('hermes:focus-session', payload.focusSessionId)
+})
+
+it('delivers plugin callbacks to their source and falls back only for navigation after it closes', () => {
+  const primary = windowStub()
+  const source = windowStub()
+  host.fromWebContents.mockReturnValue(source)
+  const focusWindow = vi.fn()
+  registerNativeNotifications({ getMainWindow: () => primary as unknown as BrowserWindow, focusWindow })
+  const notify = host.handle.mock.calls[0][1] as (event: IpcMainInvokeEvent, payload: HermesNotification) => boolean
+  notify({ sender: source.webContents } as unknown as IpcMainInvokeEvent, {
+    kind: 'plugin',
+    notifyId: 'source-callback',
+    activate: '/plugin',
+    actions: [{ id: 'open', text: 'Open', activate: '/plugin/detail' }]
+  })
+  host.shown[0].emit('action', { actionIndex: 0 }, undefined)
+  expect(source.webContents.send).toHaveBeenCalledWith('hermes:notification-activate', expect.objectContaining({
+    actionId: 'open',
+    notifyId: 'source-callback',
+    activate: '/plugin/detail'
+  }))
+  expect(primary.webContents.send).not.toHaveBeenCalled()
+  source.isDestroyed.mockReturnValue(true)
+  host.shown[0].emit('click')
+  expect(primary.webContents.send).toHaveBeenCalledWith('hermes:notification-activate', expect.objectContaining({
+    activate: '/plugin',
+    notifyId: undefined
+  }))
+})

--- a/apps/desktop/electron/notification-ipc.test.ts
+++ b/apps/desktop/electron/notification-ipc.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events'
 import type { BrowserWindow, IpcMainInvokeEvent } from 'electron'
 import { beforeEach, expect, it, vi } from 'vitest'
 
-import type { HermesNotification } from '../src/global'
+import type { HermesNotification } from './notification-types'
 
 const host = vi.hoisted(() => ({
   handle: vi.fn(),

--- a/apps/desktop/electron/notification-ipc.ts
+++ b/apps/desktop/electron/notification-ipc.ts
@@ -1,0 +1,102 @@
+import { BrowserWindow, ipcMain, Notification } from 'electron'
+
+import type { HermesNotification } from '../src/global'
+
+import { createEventDeduper } from './event-dedupe'
+import { resolveNotificationAction } from './notification-actions'
+import { createNotificationRegistry } from './notification-registry'
+
+interface NotificationHost {
+  getMainWindow: () => BrowserWindow | null
+  focusWindow: (window: BrowserWindow) => void
+}
+
+export function registerNativeNotifications({ getMainWindow, focusWindow }: NotificationHost): void {
+  const isDuplicateNotification = createEventDeduper()
+  const notifications = createNotificationRegistry()
+
+  ipcMain.handle('hermes:notify', (event, payload: HermesNotification) => {
+    // The source renderer owns runtime bindings and plugin callbacks.
+    const sourceWindow = BrowserWindow.fromWebContents(event.sender)
+    const targetWindow = () => (sourceWindow && !sourceWindow.isDestroyed() ? sourceWindow : getMainWindow())
+
+    if (!Notification.isSupported()) {
+      return false
+    }
+
+    // Peer renderers share one OS notification for the same event.
+    if (isDuplicateNotification(`${payload?.kind ?? ''}:${payload?.sessionId ?? payload?.tag ?? ''}`)) {
+      return true
+    }
+
+    const actions = Array.isArray(payload?.actions) ? payload.actions : []
+    const icon = typeof payload?.icon === 'string' && payload.icon.trim() ? payload.icon.trim() : undefined
+    const notification = new Notification({
+      title: payload?.title || 'Hermes',
+      body: payload?.body || '',
+      silent: Boolean(payload?.silent),
+      ...(icon ? { icon } : {}),
+      actions: actions.map(action => ({ type: 'button', text: String(action?.text || '') }))
+    })
+
+    notification.on('click', () => {
+      const window = targetWindow()
+
+      if (!window || window.isDestroyed()) {
+        return
+      }
+
+      focusWindow(window)
+
+      const focusSessionId = payload?.focusSessionId || payload?.sessionId
+
+      if (focusSessionId) {
+        window.webContents.send('hermes:focus-session', focusSessionId)
+      }
+
+      if (payload?.activate || payload?.notifyId) {
+        window.webContents.send('hermes:notification-activate', {
+          activate: payload?.activate,
+          notifyId: window === sourceWindow ? payload?.notifyId : undefined,
+          tag: payload?.tag
+        })
+      }
+    })
+    notification.on('action', (actionEvent, index) => {
+      const window = targetWindow()
+
+      if (!window || window.isDestroyed()) {
+        return
+      }
+
+      const action = resolveNotificationAction(actions, actionEvent, index)
+
+      if (!action?.id) {
+        return
+      }
+
+      if (payload?.sessionId && !payload?.notifyId && !payload?.activate) {
+        // Runtime actions belong to the source renderer, never the fallback.
+        if (window !== sourceWindow) {
+          return
+        }
+
+        window.webContents.send('hermes:notification-action', { sessionId: payload.sessionId, actionId: action.id })
+
+        return
+      }
+
+      focusWindow(window)
+      window.webContents.send('hermes:notification-activate', {
+        actionId: action.id,
+        activate: action.activate || payload?.activate,
+        notifyId: window === sourceWindow ? payload?.notifyId : undefined,
+        tag: payload?.tag
+      })
+    })
+    notifications.retain(notification)
+    notification.show()
+
+    return true
+  })
+}

--- a/apps/desktop/electron/notification-ipc.ts
+++ b/apps/desktop/electron/notification-ipc.ts
@@ -1,10 +1,9 @@
 import { BrowserWindow, ipcMain, Notification } from 'electron'
 
-import type { HermesNotification } from '../src/global'
-
 import { createEventDeduper } from './event-dedupe'
 import { resolveNotificationAction } from './notification-actions'
 import { createNotificationRegistry } from './notification-registry'
+import type { HermesNotification } from './notification-types'
 
 interface NotificationHost {
   getMainWindow: () => BrowserWindow | null
@@ -31,6 +30,7 @@ export function registerNativeNotifications({ getMainWindow, focusWindow }: Noti
 
     const actions = Array.isArray(payload?.actions) ? payload.actions : []
     const icon = typeof payload?.icon === 'string' && payload.icon.trim() ? payload.icon.trim() : undefined
+
     const notification = new Notification({
       title: payload?.title || 'Hermes',
       body: payload?.body || '',

--- a/apps/desktop/electron/notification-registry.test.ts
+++ b/apps/desktop/electron/notification-registry.test.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from 'node:events'
+
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { createNotificationRegistry } from './notification-registry'
+
+afterEach(() => vi.useRealTimers())
+
+it('retains a dismissed banner until its later click or action is consumed', () => {
+  vi.useFakeTimers()
+  const registry = createNotificationRegistry()
+  for (const event of ['click', 'action']) {
+    const notification = Object.assign(new EventEmitter(), { close: vi.fn() })
+    const handler = vi.fn()
+    notification.on(event, handler)
+    registry.retain(notification)
+    notification.emit('close')
+    expect(registry.has(notification)).toBe(true)
+    notification.emit(event)
+    expect(handler).toHaveBeenCalledOnce()
+    expect(registry.has(notification)).toBe(false)
+  }
+  expect(vi.getTimerCount()).toBe(0)
+})
+
+it('dismisses an expired notification before releasing it and releases failed delivery immediately', () => {
+  vi.useFakeTimers()
+  const registry = createNotificationRegistry({ ttlMs: 1000 })
+  const notification = Object.assign(new EventEmitter(), { close: vi.fn(() => expect(registry.has(notification)).toBe(true)) })
+  registry.retain(notification)
+  vi.advanceTimersByTime(1000)
+  expect(notification.close).toHaveBeenCalledOnce()
+  expect(registry.has(notification)).toBe(false)
+
+  const failed = Object.assign(new EventEmitter(), { close: vi.fn() })
+  registry.retain(failed)
+  failed.emit('failed')
+  expect(registry.has(failed)).toBe(false)
+  expect(failed.close).not.toHaveBeenCalled()
+  expect(vi.getTimerCount()).toBe(0)
+})

--- a/apps/desktop/electron/notification-registry.ts
+++ b/apps/desktop/electron/notification-registry.ts
@@ -1,0 +1,39 @@
+import type { EventEmitter } from 'node:events'
+
+interface RetainedNotification extends EventEmitter {
+  close: () => void
+}
+
+// Windows emits close on banner timeout even while Action Center keeps the
+// notification clickable. Only consumption or failed delivery releases it.
+const RELEASE_EVENTS = ['click', 'action', 'failed']
+const NOTIFICATION_RETENTION_TTL_MS = 10 * 60 * 1000
+
+export function createNotificationRegistry({ ttlMs = NOTIFICATION_RETENTION_TTL_MS } = {}) {
+  const live = new Set<RetainedNotification>()
+
+  function retain(notification: RetainedNotification): void {
+    live.add(notification)
+    const release = () => {
+      clearTimeout(timer)
+      live.delete(notification)
+
+      for (const event of RELEASE_EVENTS) {
+        notification.removeListener(event, release)
+      }
+    }
+
+    for (const event of RELEASE_EVENTS) {
+      notification.on(event, release)
+    }
+
+    // Bound retention without leaving an OS notification whose handler is gone.
+    const timer = setTimeout(() => {
+      notification.close()
+      release()
+    }, ttlMs)
+    timer.unref()
+  }
+
+  return { retain, has: (notification: RetainedNotification) => live.has(notification) }
+}

--- a/apps/desktop/electron/notification-types.ts
+++ b/apps/desktop/electron/notification-types.ts
@@ -1,0 +1,19 @@
+export interface HermesNotification {
+  title?: string
+  body?: string
+  silent?: boolean
+  kind?: string
+  sessionId?: string
+  /** Durable click target captured before runtime bindings can be recycled. */
+  focusSessionId?: string
+  /** Dedupe discriminator for session-less notifications (e.g. plugin id). */
+  tag?: string
+  /** Absolute icon path for Electron `Notification`. */
+  icon?: string
+  /** Resolved hash-router path opened on body click (plugin / deeplink-compatible). */
+  activate?: string
+  /** Renderer handle for onActivate / onAction callbacks. */
+  notifyId?: string
+  actions?: { id: string; text: string; activate?: string }[]
+}
+

--- a/apps/desktop/src/app/contrib/hooks/notification-focus.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/notification-focus.test.tsx
@@ -1,0 +1,101 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from 'vitest'
+
+import { paneMirror } from '@/app/chat/pane-mirror'
+import { sessionRoute, syncWorkspaceRoute } from '@/app/routes'
+import { group } from '@/components/pane-shell/tree/model'
+import * as tree from '@/components/pane-shell/tree/store'
+import { registry } from '@/contrib/registry'
+import { $selectedStoredSessionId } from '@/store/session'
+import { $sessionTiles, closeSessionTile, discardSessionTile, openSessionTile, patchSessionTile } from '@/store/session-states'
+
+import { useDesktopIntegrations } from './use-desktop-integrations'
+
+const originalBridge = window.hermesDesktop
+
+beforeAll(() => {
+  const dispose = registry.register({
+    area: 'panes',
+    data: { placement: 'main', uncloseable: true },
+    id: 'workspace',
+    render: () => null,
+    title: 'Chat'
+  })
+  tree.watchContributedPanes()
+  paneMirror({
+    source: $sessionTiles,
+    key: tile => tile.storedSessionId,
+    prefix: 'session-tile',
+    dir: () => 'center',
+    minWidth: '20rem',
+    title: id => id,
+    render: () => null,
+    close: closeSessionTile
+  })()
+
+  return dispose
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+  tree.declareDefaultTree(group(['workspace'], { active: 'workspace', id: 'main' }))
+  tree.$layoutTree.set(group(['workspace'], { active: 'workspace', id: 'main' }))
+  $selectedStoredSessionId.set('main-chat')
+  syncWorkspaceRoute('/main-chat')
+})
+
+afterEach(() => {
+  for (const tile of $sessionTiles.get()) {
+    discardSessionTile(tile.storedSessionId)
+  }
+
+  $selectedStoredSessionId.set(null)
+  window.hermesDesktop = originalBridge
+  syncWorkspaceRoute('/')
+})
+
+it('a native click reveals the existing remote Bot tab without changing its owner or duplicating main', () => {
+  let fire!: (id: string) => void
+  window.hermesDesktop = {
+    onFocusSession: callback => {
+      fire = callback
+
+      return () => undefined
+    }
+  } as Window['hermesDesktop']
+  const navigate = vi.fn()
+  renderHook(() =>
+    useDesktopIntegrations({
+      activeProfile: 'default',
+      chatOpen: false,
+      hasPreview: false,
+      locationPathname: '/settings',
+      navigate,
+      profileReady: false,
+      refreshSessions: vi.fn(),
+      resumeLastSession: false,
+      resumeExhaustedSessionId: null,
+      routedSessionId: null,
+      runtimeIdByStoredSessionId: { current: new Map() },
+      sessions: []
+    })
+  )
+  const scope = {
+    ownerRoute: { connectionId: 'remote-writer', profile: 'writer', mode: 'remote' as const },
+    workspaceMode: 'bots' as const,
+    workspaceOwnerKey: 'remote-writer::writer',
+    workspaceTabTitle: 'Bot Chat'
+  }
+  openSessionTile('bot-chat', 'center', 'workspace', undefined, scope)
+  patchSessionTile('bot-chat', { runtimeId: 'bot-runtime' })
+  tree.revealTreePane('workspace')
+  const before = $sessionTiles.get()
+
+  act(() => fire('bot-runtime'))
+
+  expect(tree.isPaneVisible('session-tile:bot-chat')).toBe(true)
+  expect($sessionTiles.get()).toEqual(before)
+  expect($selectedStoredSessionId.get()).toBe('main-chat')
+  // Close the overlay without navigating main onto the tile's conversation.
+  expect(navigate).toHaveBeenCalledWith(sessionRoute('main-chat'), { replace: true })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -1,12 +1,15 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { requestMcpInstallFromDeepLink } from '@/store/mcp-deeplink-install'
 import { _resetLegacyDiscardForTests } from '@/store/session'
+import { dropSessionState, publishSessionState } from '@/store/session-states'
 import type * as WindowsStore from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
 
 import { makeSessionInfo } from '../../../test/session-info'
+import { sessionRoute } from '../../routes'
 
 import { useDesktopIntegrations } from './use-desktop-integrations'
 
@@ -565,6 +568,69 @@ describe('useDesktopIntegrations', () => {
       deepLink?.({ kind: 'mcp', name: 'install', params: { name: 'context7' } })
       expect(requestMcpInstallFromDeepLink).toHaveBeenCalledWith({ name: 'context7' })
       expect(navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('notification click -> focus-session id translation', () => {
+    function withFocusSession(): (sessionId: string) => void {
+      let handler: ((sessionId: string) => void) | undefined
+      desktopWindow.hermesDesktop = {
+        ...desktopWindow.hermesDesktop,
+        onFocusSession: (cb: (sessionId: string) => void) => {
+          handler = cb
+
+          return () => undefined
+        }
+      } as unknown as Window['hermesDesktop']
+
+      return sessionId => handler?.(sessionId)
+    }
+
+    function renderWithRuntimeMap(map: Map<string, string>) {
+      return renderHook(
+        ({ sessions }: { sessions: readonly SessionInfo[] }) =>
+          useDesktopIntegrations({
+            activeProfile: 'default',
+            chatOpen: false,
+            hasPreview: false,
+            locationPathname: '/',
+            navigate,
+            profileReady: true,
+            refreshSessions: vi.fn(),
+            resumeExhaustedSessionId: null,
+            resumeLastSession: false,
+            routedSessionId: null,
+            runtimeIdByStoredSessionId: { current: map },
+            sessions
+          }),
+        { initialProps: { sessions: [] as readonly SessionInfo[] } }
+      )
+    }
+
+    it('translates a runtime id via the window map before navigating', () => {
+      const fire = withFocusSession()
+
+      renderWithRuntimeMap(new Map([['stored-abc', 'runtime-123']]))
+      fire('runtime-123')
+
+      // 'stack' intent spends the unoccupied main draft → in-place navigate.
+      expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-abc'))
+    })
+
+    it('falls back to the durable per-runtime state mirror when the window map has no binding', () => {
+      const fire = withFocusSession()
+      const { unmount } = renderWithRuntimeMap(new Map())
+
+      // Simulate a main-pane runtime whose ensureSessionState binding lives in
+      // the shared store mirror, not this window's map (window reload /
+      // pop-out window / gateway respawn).
+      publishSessionState('runtime-999', createClientSessionState('stored-xyz'))
+      fire('runtime-999')
+
+      expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-xyz'))
+
+      unmount()
+      dropSessionState('runtime-999')
     })
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -17,12 +17,14 @@ import {
 import { openPluginInstallRequest } from '@/store/plugin-install-request'
 import { openFolderAsProject } from '@/store/projects'
 import {
+  $selectedStoredSessionId,
   getRememberedRoute,
   getRememberedSessionId,
   sessionBelongsToProfile,
   setRememberedRoute,
   setRememberedSessionId
 } from '@/store/session'
+import { $botChatScopes, $sessionTiles, storedSessionIdForRuntimeId } from '@/store/session-states'
 import { onSessionsChanged } from '@/store/session-sync'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '@/store/updates'
 import { isBrowserWindow, isHudWindow, isSecondaryWindow } from '@/store/windows'
@@ -209,12 +211,23 @@ export function useDesktopIntegrations({
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onFocusSession?.(sessionId => {
       if (sessionId) {
-        openSession(storedSessionIdForNotification(sessionId, runtimeIdByStoredSessionId.current), navigate, 'stack')
+        // Reloads and runtime recovery can leave only the shared mirror bound.
+        const viaLocalMap = storedSessionIdForNotification(sessionId, runtimeIdByStoredSessionId.current)
+        const storedId = viaLocalMap !== sessionId ? viaLocalMap : (storedSessionIdForRuntimeId(sessionId) ?? sessionId)
+
+        // A notification reveals a tab; it must not reclassify a Bot chat.
+        const scope = $sessionTiles.get().find(tile => tile.storedSessionId === storedId) ?? $botChatScopes.get()[storedId]
+
+        if (isOverlayView(appViewForPath(locationPathname))) {
+          navigate(sessionRoute($selectedStoredSessionId.get() ?? ''), { replace: true })
+        }
+
+        openSession(storedId, navigate, 'stack', scope && { ...scope, workspaceMode: scope.workspaceMode ?? 'sessions' })
       }
     })
 
     return () => unsubscribe?.()
-  }, [navigate, runtimeIdByStoredSessionId])
+  }, [locationPathname, navigate, runtimeIdByStoredSessionId])
 
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onNotificationAction?.(({ actionId, sessionId }) => {

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -165,6 +165,17 @@ describe('openSession', () => {
     expect(navigate).not.toHaveBeenCalled()
   })
 
+  it.each(['stack', 'tab'] as const)('%s uncovers the existing main chat when a page is showing', intent => {
+    $selectedStoredSessionId.set('s1')
+    focusOpenSession.mockReturnValue('main')
+    workspaceIsPageGet.mockReturnValue(true)
+
+    openSession('s1', navigate, intent)
+
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
   it('stack opens a tab rather than taking main from a loaded chat', () => {
     $selectedStoredSessionId.set('s0')
     focusOpenSession.mockReturnValue(null)

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -137,6 +137,10 @@ export function openSession(
     const focused = focusOpenSession(storedSessionId, workspaceScope)
 
     if (focused) {
+      if (focusedSessionNeedsRoute(focused, $workspaceIsPage.get())) {
+        navigate(sessionRoute(storedSessionId))
+      }
+
       return
     }
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1244,6 +1244,8 @@ export interface HermesNotification {
   silent?: boolean
   kind?: string
   sessionId?: string
+  /** Durable click target captured before runtime bindings can be recycled. */
+  focusSessionId?: string
   /** Dedupe discriminator for session-less notifications (e.g. plugin id). */
   tag?: string
   /** Absolute icon path for Electron `Notification`. */

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1,6 +1,7 @@
 import type { GatewayWsUrlResult } from '@hermes/shared'
 import type { TranslucencyState } from '@hermes/shared/translucency'
 
+import type { HermesNotification } from '../electron/notification-types'
 import type { PoolLimits } from '../electron/pool-limits'
 
 import type { WakeIndicatorState } from './lib/wake-indicator'
@@ -1236,25 +1237,6 @@ export interface HermesApiRequest {
   // through the owning connection, not the local profile pool. Omit / '' to
   // keep the legacy profile-routed path; explicit 'local' forces this device.
   connectionId?: string | null
-}
-
-export interface HermesNotification {
-  title?: string
-  body?: string
-  silent?: boolean
-  kind?: string
-  sessionId?: string
-  /** Durable click target captured before runtime bindings can be recycled. */
-  focusSessionId?: string
-  /** Dedupe discriminator for session-less notifications (e.g. plugin id). */
-  tag?: string
-  /** Absolute icon path for Electron `Notification`. */
-  icon?: string
-  /** Resolved hash-router path opened on body click (plugin / deeplink-compatible). */
-  activate?: string
-  /** Renderer handle for onActivate / onAction callbacks. */
-  notifyId?: string
-  actions?: { id: string; text: string; activate?: string }[]
 }
 
 export interface HermesPreviewTarget {

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createClientSessionState } from '@/lib/chat-runtime'
+
 import { $gateway } from './gateway'
 import {
   clearPluginNotifyHandlers,
@@ -17,6 +19,7 @@ import { __resetNativeNotifyBaselineForTests, markNativeNotifyBaseline } from '.
 import { $approvalRequest, setApprovalRequest } from './prompts'
 import { markSessionGone, resetBackgroundPollingGuard } from './runtime-gone'
 import { $activeSessionId, setActiveSessionId } from './session'
+import { dropSessionState, publishSessionState } from './session-states'
 
 const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
 const initialHermesDesktop = desktopWindow.hermesDesktop
@@ -63,6 +66,18 @@ afterEach(() => {
   }
 
   resetBackgroundPollingGuard()
+})
+
+it('captures durable navigation identity while keeping the runtime id for approval actions', () => {
+  const runtimeId = freshSession()
+  publishSessionState(runtimeId, createClientSessionState('durable-chat'))
+
+  try {
+    dispatchNativeNotification({ kind: 'approval', sessionId: runtimeId, title: 'Approval' })
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ sessionId: runtimeId, focusSessionId: 'durable-chat' }))
+  } finally {
+    dropSessionState(runtimeId)
+  }
 })
 
 describe('dispatchNativeNotification focus gating', () => {

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -8,7 +8,7 @@ import { withinNativeNotifyBaseline } from './notify-baseline'
 import { clearApprovalRequest } from './prompts'
 import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone } from './runtime-gone'
 import { $activeSessionId } from './session'
-import { requestForOwnedSession } from './session-states'
+import { requestForOwnedSession, storedSessionIdForRuntimeId } from './session-states'
 
 export type { HermesOpenTarget }
 
@@ -212,6 +212,7 @@ export function dispatchNativeNotification(input: NativeNotificationInput): bool
     actions: input.actions,
     activate: input.activate,
     body: input.body,
+    focusSessionId: input.sessionId ? storedSessionIdForRuntimeId(input.sessionId) ?? undefined : undefined,
     icon: input.icon,
     kind: input.kind,
     notifyId: input.notifyId,


### PR DESCRIPTION
## What does this PR do?

Fix native desktop notification clicks that raise Hermes without revealing the originating session. Clicks return to the emitting window, select the existing tab, and uncover chats hidden behind Settings or a full page without replacing the current conversation.

The fix also covers handler garbage collection, lost runtime-to-stored mappings, Bot tab ownership, and Electron's notification action-index format.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/100404
Fixes https://github.com/NousResearch/hermes-agent/issues/51444
Fixes https://github.com/NousResearch/hermes-agent/issues/65493

### Consolidated work

This is the consolidation PR for native notification activation. The following PRs are closed as superseded, with contributor credit retained in the commits:

- https://github.com/NousResearch/hermes-agent/pull/100405 — @everm1nd (Nikita Simakov)'s session-state mapping fallback.
- https://github.com/NousResearch/hermes-agent/pull/51893 — @outdog-hwh's current/legacy action-index resolver.
- https://github.com/NousResearch/hermes-agent/pull/65897 — @brian717 (Brian Sweatt)'s notification retention. This version addresses the blocking review: `close` does not release a notification that may remain clickable in Action Center. At the ten-minute retention limit, it explicitly dismisses the notification before releasing it.

The broader approval-authority changes in https://github.com/NousResearch/hermes-agent/pull/89023 remain separate. This PR does not claim to bind approvals to immutable connection/profile/request identities or recover OS notifications across an app restart.

## Type of Change

- [x] Bug fix
- [x] Regression tests

## Changes Made

- Move the native notification IPC handler from `electron/main.ts` to `electron/notification-ipc.ts`. Resolve the emitting BrowserWindow instead of always targeting the primary. Keep approval actions and plugin callbacks in the source renderer; after source closure, allow navigation fallback but never retarget runtime approval actions.
- Capture a durable `focusSessionId` at dispatch while retaining the runtime `sessionId` for actions. Keep the consumer-side mapping fallback for notifications without a captured target.
- Retain native notification instances until consumption, delivery failure, or explicit expiry dismissal. Read `actionIndex` from Electron event details with the legacy positional fallback.
- Reveal the target chat through the existing `openSession` path, close covering route overlays, and preserve Bot tab ownership and the occupied main chat.

## How to Test

From `apps/desktop`:

```sh
npx vitest run \
  electron/notification-ipc.test.ts \
  electron/notification-actions.test.ts \
  electron/notification-registry.test.ts \
  src/app/contrib/hooks/notification-focus.test.tsx \
  src/app/contrib/hooks/use-desktop-integrations.test.tsx \
  src/app/open-session.test.ts \
  src/store/native-notifications.test.ts \
  src/lib/session-ids.test.ts \
  src/store/session-states-runtime-map.test.ts
```

**Result: 9 files, 111 tests passed.** Regressions were observed failing before their fixes. The test cleanup consolidated action-index assertions without removing coverage. Existing Vite config-loader and Node localStorage warnings remain.

A separate local Electron probe exercised the real producer, native Notification object, actual IPC/preload, renderer hook, and pane stores in two isolated BrowserWindows. It discarded the runtime binding after notification dispatch, emitted `close`, forced garbage collection, then emitted `click`. The source window left Settings and activated its existing Bot tab; its main selection and Bot ownership were preserved, and the primary window was unchanged.

The probe suppressed OS banner posting and simulated the native events. It is not a physical macOS banner-click test or signed/packaged-app verification. All desktop typechecks and lint pass after moving the IPC payload type into a dependency-free module. A full local build and the full local suite have not been run; GitHub CI covers the workspace checks.

Manual signed-app checks still needed:

- [ ] With two app windows, click a notification from the second while another chat is selected. Only the source window should reveal its target tab.
- [ ] Repeat with Settings open and with a full page covering the main chat.
- [ ] Click Approve/Reject on a native notification; it should resolve on the source session without changing tabs.
- [ ] On Windows, let a banner move into Action Center, then click it before the retention limit.

## Checklist

- [x] Searched existing PRs and linked the consolidated work.
- [x] Changes are limited to native notification routing and related failures.
- [x] Added behavior regression tests and exercised real Electron IPC on macOS.
- [x] Preserved contributor credit.
- [x] No dependency, user configuration, tool-schema, or translation changes.
- [ ] Physical native-banner interaction verified on a signed build.
